### PR TITLE
LibJS: Add auto-accessor keyword for class fields

### DIFF
--- a/Libraries/LibJS/Bytecode/ClassBlueprint.h
+++ b/Libraries/LibJS/Bytecode/ClassBlueprint.h
@@ -21,6 +21,7 @@ struct ClassElementDescriptor {
         Setter,
         Field,
         StaticInitializer,
+        AutoAccessor,
     };
 
     Kind kind;
@@ -30,6 +31,7 @@ struct ClassElementDescriptor {
     Optional<u32> shared_function_data_index;
     bool has_initializer { false };
     Optional<Value> literal_value;
+    Optional<Utf16FlyString> backing_storage_name;
 };
 
 struct ClassBlueprint {

--- a/Libraries/LibJS/Runtime/ClassConstruction.cpp
+++ b/Libraries/LibJS/Runtime/ClassConstruction.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/ClassConstruction.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrivateEnvironment.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
@@ -253,6 +254,90 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                 static_elements.append(move(field));
             else
                 instance_fields.append(move(field));
+            break;
+        }
+
+        case Bytecode::ClassElementDescriptor::Kind::AutoAccessor: {
+            auto element_name = TRY(resolve_element_key(vm, descriptor, element_keys[element_index]));
+
+            // Resolve the backing storage private name from the private environment.
+            auto private_environment = vm.running_execution_context().private_environment;
+            VERIFY(private_environment);
+            auto backing_storage_name = private_environment->resolve_private_identifier(*descriptor.backing_storage_name);
+
+            // Create initializer for the backing storage field.
+            Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer;
+            if (descriptor.has_initializer) {
+                if (descriptor.literal_value.has_value()) {
+                    initializer = *descriptor.literal_value;
+                } else {
+                    auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
+
+                    if (!descriptor.is_private && !shared_data->m_class_field_initializer_name.has<PropertyKey>()
+                        && !shared_data->m_class_field_initializer_name.has<PrivateName>()) {
+                        shared_data->m_class_field_initializer_name = element_name.visit(
+                            [](PropertyKey const& key) -> Variant<PropertyKey, PrivateName, Empty> { return key; },
+                            [](PrivateName const& name) -> Variant<PropertyKey, PrivateName, Empty> { return name; });
+                    }
+
+                    auto function = ECMAScriptFunctionObject::create_from_function_data(
+                        realm,
+                        *shared_data,
+                        vm.lexical_environment(),
+                        vm.running_execution_context().private_environment);
+                    function->make_method(home_object);
+                    initializer = function;
+                }
+            }
+
+            // The backing storage is always a private field, initialized with the auto-accessor's initializer value.
+            ClassFieldDefinition backing_field {
+                ClassElementName(backing_storage_name),
+                move(initializer),
+            };
+
+            // MakeAutoAccessorGetter: create a getter that reads from the backing storage.
+            // NOTE: The base spec (ecma262 PR #2417) calls SetFunctionName to produce
+            // "get x" / "set x" names, but pzuraq/ecma262 PR #14 removes those calls.
+            // See tc39/proposal-decorators#502 for context on SetFunctionName in decorators.
+            auto getter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+                auto this_value = vm.this_value();
+                if (!this_value.is_object())
+                    return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
+                return this_value.as_object().private_get(backing_storage_name);
+            };
+            auto getter = NativeFunction::create(realm, move(getter_closure), 0);
+
+            // MakeAutoAccessorSetter: create a setter that writes to the backing storage.
+            auto setter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+                auto this_value = vm.this_value();
+                if (!this_value.is_object())
+                    return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
+                TRY(this_value.as_object().private_set(backing_storage_name, vm.argument(0)));
+                return js_undefined();
+            };
+            auto setter = NativeFunction::create(realm, move(setter_closure), 1);
+
+            if (element_name.has<PropertyKey>()) {
+                // Public auto-accessor: define an accessor property on the home object.
+                auto& property_key = element_name.get<PropertyKey>();
+                PropertyDescriptor property_descriptor { .get = getter, .set = setter, .enumerable = true, .configurable = true };
+                TRY(home_object.define_property_or_throw(property_key, property_descriptor));
+            } else {
+                // Private auto-accessor: add getter/setter as a private accessor element.
+                auto& private_name = element_name.get<PrivateName>();
+                auto accessor = Accessor::create(vm, getter, setter);
+                PrivateElement private_element { private_name, PrivateElement::Kind::Accessor, Value(accessor) };
+
+                auto& container = descriptor.is_static ? static_private_methods : instance_private_methods;
+                container.append(move(private_element));
+            }
+
+            // Add the backing storage field to the appropriate list.
+            if (descriptor.is_static)
+                static_elements.append(move(backing_field));
+            else
+                instance_fields.append(move(backing_field));
             break;
         }
 

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -406,6 +406,9 @@ impl FunctionTable {
                 }
                 ClassElement::Field {
                     key, initializer, ..
+                }
+                | ClassElement::AutoAccessor {
+                    key, initializer, ..
                 } => {
                     self.collect_from_expression(key, result);
                     if let Some(init) = initializer {
@@ -828,6 +831,11 @@ pub enum ClassElement {
         is_static: bool,
     },
     Field {
+        key: Box<Expression>,
+        initializer: Option<Box<Expression>>,
+        is_static: bool,
+    },
+    AutoAccessor {
         key: Box<Expression>,
         initializer: Option<Box<Expression>>,
         is_static: bool,

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -1284,6 +1284,26 @@ fn dump_class_element(
                 dump_expression(init, &child_state(&child_state(state, true), true));
             }
         }
+        ClassElement::AutoAccessor {
+            key,
+            initializer,
+            is_static,
+        } => {
+            let mut desc = color_node_name(root_state, "AutoAccessor");
+            if *is_static {
+                desc.push_str(" static");
+            }
+            desc.push_str(&format_position(root_state, range));
+            print_node(state, &desc);
+            dump_expression(key, &child_state(state, initializer.is_none()));
+            if let Some(init) = initializer {
+                print_node(
+                    &child_state(state, true),
+                    &color_label(root_state, "initializer"),
+                );
+                dump_expression(init, &child_state(&child_state(state, true), true));
+            }
+        }
         ClassElement::StaticInitializer { body } => {
             print_node(
                 state,

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -1240,6 +1240,7 @@ enum ClassElementKind {
     Setter = 2,
     Field = 3,
     StaticInitializer = 4,
+    AutoAccessor = 5,
 }
 
 /// Iterator hint (ABI-compatible).
@@ -5896,24 +5897,52 @@ fn generate_class_expression(
 
     // Create private environment for private class elements.
     let mut has_private_env = false;
-    for element_node in &data.elements {
-        let priv_name = match &element_node.inner {
-            ClassElement::Method { key, .. } | ClassElement::Field { key, .. } => {
-                if let ExpressionKind::PrivateIdentifier(ident) = &key.inner {
-                    Some(ident.name.clone())
-                } else {
-                    None
-                }
-            }
+    // Track auto-accessor backing storage names so we can pass them through FFI.
+    let mut auto_accessor_backing_names: Vec<Option<Utf16String>> =
+        vec![None; data.elements.len()];
+    for (element_index, element_node) in data.elements.iter().enumerate() {
+        let key = match &element_node.inner {
+            ClassElement::Method { key, .. }
+            | ClassElement::Field { key, .. }
+            | ClassElement::AutoAccessor { key, .. } => Some(key),
             ClassElement::StaticInitializer { .. } => None,
         };
-        if let Some(name) = priv_name {
+
+        // Register private identifiers in the private environment.
+        if let Some(key) = key {
+            if let ExpressionKind::PrivateIdentifier(ident) = &key.inner {
+                if !has_private_env {
+                    generator.emit(Instruction::CreatePrivateEnvironment);
+                    has_private_env = true;
+                }
+                let name_id = generator.intern_identifier(&ident.name);
+                generator.emit(Instruction::AddPrivateName { name: name_id });
+            }
+        }
+
+        // Auto-accessors always need a private backing storage name.
+        if let ClassElement::AutoAccessor { key, .. } = &element_node.inner {
             if !has_private_env {
                 generator.emit(Instruction::CreatePrivateEnvironment);
                 has_private_env = true;
             }
-            let name_id = generator.intern_identifier(&name);
-            generator.emit(Instruction::AddPrivateName { name: name_id });
+            // Synthesize a unique backing name that cannot collide with user code.
+            // The embedded NUL ensures no valid identifier can match it.
+            let base = match &key.inner {
+                ExpressionKind::PrivateIdentifier(ident) => {
+                    String::from_utf16_lossy(&ident.name)
+                }
+                ExpressionKind::Identifier(ident) => String::from_utf16_lossy(&ident.name),
+                ExpressionKind::StringLiteral(s) => String::from_utf16_lossy(s),
+                _ => format!("accessor_{element_index}"),
+            };
+            let encoded: Vec<u16> = format!("\0auto_accessor_storage_{element_index}_{base}")
+                .encode_utf16()
+                .collect();
+            let backing_name = Utf16String::from(encoded);
+            let backing_name_id = generator.intern_identifier(&backing_name);
+            generator.emit(Instruction::AddPrivateName { name: backing_name_id });
+            auto_accessor_backing_names[element_index] = Some(backing_name);
         }
     }
 
@@ -5931,7 +5960,7 @@ fn generate_class_expression(
                     element_keys.push(None);
                 }
             }
-            ClassElement::Field { key, .. } => {
+            ClassElement::Field { key, .. } | ClassElement::AutoAccessor { key, .. } => {
                 if !is_private_key(key) {
                     let key_val = generate_expression(key, generator, None);
                     element_keys.push(key_val);
@@ -5964,8 +5993,10 @@ fn generate_class_expression(
     let mut ffi_elements = Vec::with_capacity(data.elements.len());
     // Keep literal string data alive until FFI call.
     let mut literal_string_storage: Vec<Utf16String> = Vec::new();
+    // Keep backing storage names alive until FFI call.
+    let mut backing_name_storage: Vec<Utf16String> = Vec::new();
 
-    for element_node in &data.elements {
+    for (element_index, element_node) in data.elements.iter().enumerate() {
         match &element_node.inner {
             ClassElement::Method {
                 key,
@@ -6012,16 +6043,25 @@ fn generate_class_expression(
                     literal_value_number: 0.0,
                     literal_value_string: std::ptr::null(),
                     literal_value_string_len: 0,
+                    backing_storage_name: std::ptr::null(),
+                    backing_storage_name_len: 0,
                 });
             }
             ClassElement::Field {
                 key,
                 initializer,
                 is_static,
+            }
+            | ClassElement::AutoAccessor {
+                key,
+                initializer,
+                is_static,
             } => {
+                let is_auto_accessor =
+                    matches!(&element_node.inner, ClassElement::AutoAccessor { .. });
+
                 // Detect literal initializers and store the value directly,
                 // avoiding function creation for simple cases like x = 0.
-                // This avoids function creation for simple cases.
                 let mut literal_value_kind = LiteralValueKind::None;
                 let mut literal_value_number: f64 = 0.0;
                 let mut literal_value_string = Utf16String::new();
@@ -6140,7 +6180,6 @@ fn generate_class_expression(
                 }
 
                 let is_private = is_private_key(key);
-
                 let (priv_ptr, priv_len) = get_private_identifier_ptr(key);
 
                 // Keep literal string data alive until FFI call.
@@ -6154,8 +6193,28 @@ fn generate_class_expression(
                     (std::ptr::null(), 0)
                 };
 
+                // Auto-accessors pass the backing storage private name through FFI.
+                let (backing_ptr, backing_len) = if is_auto_accessor {
+                    let backing_name = auto_accessor_backing_names[element_index]
+                        .as_ref()
+                        .expect("auto-accessor must have a backing storage name");
+                    backing_name_storage.push(backing_name.clone());
+                    let bs = backing_name_storage
+                        .last()
+                        .expect("just pushed an element");
+                    (bs.as_ptr(), bs.len())
+                } else {
+                    (std::ptr::null(), 0)
+                };
+
+                let ffi_kind = if is_auto_accessor {
+                    ClassElementKind::AutoAccessor as u8
+                } else {
+                    ClassElementKind::Field as u8
+                };
+
                 ffi_elements.push(super::ffi::FFIClassElement {
-                    kind: ClassElementKind::Field as u8,
+                    kind: ffi_kind,
                     is_static: *is_static,
                     is_private,
                     private_identifier: priv_ptr,
@@ -6166,6 +6225,8 @@ fn generate_class_expression(
                     literal_value_number,
                     literal_value_string: str_ptr,
                     literal_value_string_len: str_len,
+                    backing_storage_name: backing_ptr,
+                    backing_storage_name_len: backing_len,
                 });
             }
             ClassElement::StaticInitializer { body } => {
@@ -6205,6 +6266,8 @@ fn generate_class_expression(
                     literal_value_number: 0.0,
                     literal_value_string: std::ptr::null(),
                     literal_value_string_len: 0,
+                    backing_storage_name: std::ptr::null(),
+                    backing_storage_name_len: 0,
                 });
             }
         }

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -139,6 +139,9 @@ pub struct FFIClassElement {
     pub literal_value_number: f64,
     pub literal_value_string: *const u16,
     pub literal_value_string_len: usize,
+    // Auto-accessor backing storage private name (only for AutoAccessor kind).
+    pub backing_storage_name: *const u16,
+    pub backing_storage_name_len: usize,
 }
 
 /// Data for creating a C++ `SharedFunctionInstanceData`.

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -924,12 +924,20 @@ impl Parser<'_> {
         let mut is_generator = false;
         let mut is_getter = false;
         let mut is_setter = false;
+        let mut is_auto_accessor = false;
         let function_start = self.position();
 
         // Check modifiers (must not contain escape sequences).
         if self.match_identifier_name() {
             let value = self.token_original_value(&self.current_token).to_vec();
-            if value == utf16!("get") && self.match_property_key_ahead() {
+            if value == utf16!("accessor") && self.match_property_key_ahead() {
+                // FieldDefinition : `accessor` [no LineTerminator here] ClassElementName Initializer?
+                let next = self.next_token();
+                if !next.trivia_has_line_terminator {
+                    is_auto_accessor = true;
+                    self.consume();
+                }
+            } else if value == utf16!("get") && self.match_property_key_ahead() {
                 is_getter = true;
                 self.consume();
             } else if value == utf16!("set") && self.match_property_key_ahead() {
@@ -951,7 +959,7 @@ impl Parser<'_> {
             }
         }
 
-        if self.match_token(TokenType::Asterisk) {
+        if !is_auto_accessor && self.match_token(TokenType::Asterisk) {
             is_generator = true;
             self.consume();
         }
@@ -963,13 +971,16 @@ impl Parser<'_> {
             expression: key,
             name: key_value,
             ..
-        } = if (is_static || is_async || is_getter || is_setter)
+        } = if (is_static || is_async || is_getter || is_setter || is_auto_accessor)
             && (self.match_token(TokenType::Semicolon)
                 || self.match_token(TokenType::Equals)
                 || self.match_token(TokenType::ParenOpen)
                 || self.match_token(TokenType::CurlyClose))
         {
-            let name: &[u16] = if is_async {
+            let name: &[u16] = if is_auto_accessor {
+                is_auto_accessor = false;
+                utf16!("accessor")
+            } else if is_async {
                 is_async = false;
                 utf16!("async")
             } else if is_getter {
@@ -1066,6 +1077,11 @@ impl Parser<'_> {
             }
         }
 
+        // Auto-accessors are field-like; they cannot have a method body.
+        if is_auto_accessor && self.match_token(TokenType::ParenOpen) {
+            self.syntax_error("Auto-accessor cannot have a method body");
+        }
+
         if self.match_token(TokenType::ParenOpen) {
             let ctor_name = utf16!("constructor");
             let is_constructor =
@@ -1154,15 +1170,23 @@ impl Parser<'_> {
         };
 
         self.consume_or_insert_semicolon();
+
+        let element = if is_auto_accessor {
+            ClassElement::AutoAccessor {
+                key: Box::new(key),
+                initializer: init,
+                is_static,
+            }
+        } else {
+            ClassElement::Field {
+                key: Box::new(key),
+                initializer: init,
+                is_static,
+            }
+        };
+
         (
-            Some(Node::new(
-                self.range_from(class_start),
-                ClassElement::Field {
-                    key: Box::new(key),
-                    initializer: init,
-                    is_static,
-                },
-            )),
+            Some(Node::new(self.range_from(class_start), element)),
             None,
         )
     }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -963,6 +963,8 @@ extern "C" void* rust_create_class_blueprint(
         if (elem.shared_function_data_index.has_value)
             desc.shared_function_data_index = elem.shared_function_data_index.value;
         desc.has_initializer = elem.has_initializer;
+        if (elem.backing_storage_name_len > 0)
+            desc.backing_storage_name = Utf16FlyString::from_utf16(Utf16View(reinterpret_cast<char16_t const*>(elem.backing_storage_name), elem.backing_storage_name_len));
         switch (elem.literal_value_kind) {
         case LiteralValueKind::None:
             break;

--- a/Tests/LibJS/Runtime/classes/class-auto-accessors.js
+++ b/Tests/LibJS/Runtime/classes/class-auto-accessors.js
@@ -1,0 +1,336 @@
+test("basic functionality", () => {
+    class A {
+        accessor x = 1;
+    }
+
+    const a = new A();
+    expect(a.x).toBe(1);
+
+    a.x = 2;
+    expect(a.x).toBe(2);
+});
+
+test("without initializer", () => {
+    class A {
+        accessor x;
+    }
+
+    const a = new A();
+    expect(a.x).toBeUndefined();
+
+    a.x = 42;
+    expect(a.x).toBe(42);
+});
+
+test("multiple auto-accessors", () => {
+    class A {
+        accessor x = 1;
+        accessor y = 2;
+        accessor z = 3;
+    }
+
+    const a = new A();
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+    expect(a.z).toBe(3);
+
+    a.x = 10;
+    a.y = 20;
+    a.z = 30;
+    expect(a.x).toBe(10);
+    expect(a.y).toBe(20);
+    expect(a.z).toBe(30);
+});
+
+test("private auto-accessor", () => {
+    class A {
+        accessor #x = 1;
+
+        getX() {
+            return this.#x;
+        }
+
+        setX(v) {
+            this.#x = v;
+        }
+    }
+
+    const a = new A();
+    expect(a.getX()).toBe(1);
+    expect(a.x).toBeUndefined();
+
+    a.setX(42);
+    expect(a.getX()).toBe(42);
+});
+
+test("static auto-accessor", () => {
+    class A {
+        static accessor x = 1;
+    }
+
+    expect(A.x).toBe(1);
+
+    A.x = 2;
+    expect(A.x).toBe(2);
+
+    expect(new A().x).toBeUndefined();
+});
+
+test("static private auto-accessor", () => {
+    class A {
+        static accessor #x = 1;
+
+        static getX() {
+            return this.#x;
+        }
+
+        static setX(v) {
+            this.#x = v;
+        }
+    }
+
+    expect(A.getX()).toBe(1);
+
+    A.setX(42);
+    expect(A.getX()).toBe(42);
+});
+
+// Assisted-By: claude opus 4.6 1m - originally checked new A() instead of
+// A.prototype. Per spec, public auto-accessor getter/setter are defined on
+// the prototype (homeObject) during ClassFieldDefinitionEvaluation, not on
+// the instance. The instance only receives the private backing storage field.
+// NB: spec says [[Enumerable]]: true, contradicting SpiderMonkey's test which
+// asserts enumerable: false (gecko-dev accessors.js line 8).
+test("property descriptor", () => {
+    class A {
+        accessor x = 1;
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(A.prototype, "x");
+    expect(typeof desc.get).toBe("function");
+    expect(typeof desc.set).toBe("function");
+    expect(desc.enumerable).toBeTrue();
+    expect(desc.configurable).toBeTrue();
+    expect(desc.value).toBeUndefined();
+    expect(desc.writable).toBeUndefined();
+});
+
+test("static property descriptor", () => {
+    class A {
+        static accessor x = 1;
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(A, "x");
+    expect(typeof desc.get).toBe("function");
+    expect(typeof desc.set).toBe("function");
+    expect(desc.enumerable).toBeTrue();
+    expect(desc.configurable).toBeTrue();
+});
+
+test("extended name syntax", () => {
+    const s = Symbol("foo");
+
+    class A {
+        accessor "field with space" = 1;
+
+        accessor 12 = "twelve";
+
+        accessor [`he${"llo"}`] = 3;
+
+        accessor [s] = 4;
+    }
+
+    const a = new A();
+    expect(a["field with space"]).toBe(1);
+    expect(a[12]).toBe("twelve");
+    expect(a.hello).toBe(3);
+    expect(a[s]).toBe(4);
+
+    a["field with space"] = 10;
+    expect(a["field with space"]).toBe(10);
+});
+
+test("initializer has correct this value", () => {
+    class A {
+        accessor x = this;
+    }
+
+    const a = new A();
+    expect(a.x).toBe(a);
+});
+
+test("interleaving with regular fields", () => {
+    const order = [];
+
+    class A {
+        x = (order.push("field x"), 1);
+        accessor y = (order.push("accessor y"), 2);
+        z = (order.push("field z"), 3);
+    }
+
+    const a = new A();
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+    expect(a.z).toBe(3);
+    expect(order).toEqual(["field x", "accessor y", "field z"]);
+});
+
+test("each instance gets its own backing storage", () => {
+    class A {
+        accessor x = 1;
+    }
+
+    const a1 = new A();
+    const a2 = new A();
+    a1.x = 42;
+    expect(a1.x).toBe(42);
+    expect(a2.x).toBe(1);
+});
+
+test("inheritance", () => {
+    class Parent {
+        accessor x = 1;
+    }
+
+    class Child extends Parent {}
+
+    const c = new Child();
+    expect(c.x).toBe(1);
+
+    c.x = 2;
+    expect(c.x).toBe(2);
+});
+
+test("overriding in subclass", () => {
+    class Parent {
+        accessor x = 1;
+    }
+
+    class Child extends Parent {
+        accessor x = 2;
+    }
+
+    const c = new Child();
+    expect(c.x).toBe(2);
+});
+
+test("private auto-accessor brand check", () => {
+    class A {
+        accessor #x = 1;
+
+        hasX(obj) {
+            return #x in obj;
+        }
+    }
+
+    const a = new A();
+    expect(a.hasX(a)).toBeTrue();
+    expect(a.hasX({})).toBeFalse();
+});
+
+test("private auto-accessor access from outside throws", () => {
+    expect("class A { accessor #x = 1; } new A().#x").not.toEval();
+});
+
+describe("'accessor' as contextual keyword", () => {
+    test("accessor as field name", () => {
+        class A {
+            accessor = 1;
+        }
+
+        const a = new A();
+        expect(a.accessor).toBe(1);
+    });
+
+    test("accessor as method name", () => {
+        class A {
+            accessor() {
+                return 42;
+            }
+        }
+
+        expect(new A().accessor()).toBe(42);
+    });
+
+    test("accessor as getter name", () => {
+        class A {
+            get accessor() {
+                return 42;
+            }
+        }
+
+        expect(new A().accessor).toBe(42);
+    });
+
+    test("accessor as setter name", () => {
+        class A {
+            set accessor(v) {
+                this._v = v;
+            }
+        }
+
+        const a = new A();
+        a.accessor = 42;
+        expect(a._v).toBe(42);
+    });
+
+    test("static accessor as field name", () => {
+        class A {
+            static accessor = 1;
+        }
+
+        expect(A.accessor).toBe(1);
+    });
+});
+
+describe("syntax errors", () => {
+    test("accessor with generator is syntax error", () => {
+        expect("class A { accessor *x() {} }").not.toEval();
+    });
+
+    test("accessor with async is syntax error", () => {
+        expect("class A { accessor async x = 1; }").not.toEval();
+    });
+
+    test("accessor with get is syntax error", () => {
+        expect("class A { accessor get x() {} }").not.toEval();
+    });
+
+    test("accessor with set is syntax error", () => {
+        expect("class A { accessor set x(v) {} }").not.toEval();
+    });
+
+    test("duplicate private auto-accessor names", () => {
+        expect("class A { accessor #x; accessor #x; }").not.toEval();
+    });
+
+    test("duplicate private auto-accessor and field", () => {
+        expect("class A { accessor #x; #x; }").not.toEval();
+        expect("class A { #x; accessor #x; }").not.toEval();
+    });
+
+    test("duplicate private static and instance auto-accessor", () => {
+        expect("class A { static accessor #x; accessor #x; }").not.toEval();
+    });
+
+    test("accessor with parenthesized body is not valid", () => {
+        expect("class A { accessor x() {} }").not.toEval();
+    });
+});
+
+test("literal field initializers", () => {
+    class A {
+        accessor pos_int = 42;
+        accessor neg_int = -1;
+        accessor bool_val = true;
+        accessor null_val = null;
+        accessor str_val = "hello";
+    }
+
+    const a = new A();
+    expect(a.pos_int).toBe(42);
+    expect(a.neg_int).toBe(-1);
+    expect(a.bool_val).toBeTrue();
+    expect(a.null_val).toBeNull();
+    expect(a.str_val).toBe("hello");
+});


### PR DESCRIPTION
## Summary

Implement the `accessor` keyword for class fields, which automatically creates getter/setter pairs backed by a private storage slot. This is part of the TC39 stage 3 [decorators proposal](https://github.com/tc39/proposal-decorators).

- Parse `accessor` as a contextual keyword in class field definitions
- Generate a private backing storage name, getter, and setter per auto-accessor
- Support public/private, static/instance, and computed key auto-accessors
- Public auto-accessor properties are enumerable per spec (unlike class methods)

Auto-accessors are a prerequisite for the decorator proposal's accessor decoration, but are independently useful without decorators.

### PR train

1. **This PR** -- `accessor` keyword
2. #8708 -- decorator syntax parsing
3. #8709 -- decorator codegen + runtime

## Test plan

- 30 new tests in `Tests/LibJS/Runtime/classes/class-auto-accessors.js`
- All 6526 existing tests pass with no regressions
