### PR TITLE
LibJS: Implement TC39 stage 3 decorators

### DIFF
--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -904,7 +904,9 @@ op NewClass < Instruction
     m_class_blueprint_index: u32
     m_lhs_name: Optional<IdentifierTableIndex>
     m_element_keys_count: u32
-    m_element_keys: Optional<Operand>[]
+    m_decorator_operands_count: u32
+    m_all_operands_count: u32
+    m_all_operands: Optional<Operand>[]
 endop
 
 op NewFunction < Instruction

--- a/Libraries/LibJS/Bytecode/ClassBlueprint.h
+++ b/Libraries/LibJS/Bytecode/ClassBlueprint.h
@@ -22,6 +22,7 @@ struct ClassElementDescriptor {
         Setter,
         Field,
         StaticInitializer,
+        AutoAccessor,
     };
 
     Kind kind;
@@ -31,6 +32,7 @@ struct ClassElementDescriptor {
     Optional<u32> shared_function_data_index;
     bool has_initializer { false };
     Optional<Value> literal_value;
+    Optional<Utf16FlyString> backing_storage_name;
 };
 
 struct ClassBlueprint {

--- a/Libraries/LibJS/Bytecode/ClassBlueprint.h
+++ b/Libraries/LibJS/Bytecode/ClassBlueprint.h
@@ -33,6 +33,7 @@ struct ClassElementDescriptor {
     bool has_initializer { false };
     Optional<Value> literal_value;
     Optional<Utf16FlyString> backing_storage_name;
+    u32 decorator_count { 0 };
 };
 
 struct ClassBlueprint {
@@ -44,6 +45,7 @@ struct ClassBlueprint {
     size_t source_text_offset { 0 };
     size_t source_text_length { 0 };
     Vector<ClassElementDescriptor> elements;
+    u32 class_decorator_count { 0 };
 };
 
 }

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -3565,13 +3565,27 @@ NEVER_INLINE ThrowCompletionOr<void> NewClass::execute_impl(VM& vm) const
     Value super_class;
     if (m_super_class.has_value())
         super_class = vm.get(m_super_class.value());
+
+    // The m_all_operands array contains element keys followed by decorator operand pairs.
+    // First m_element_keys_count entries are element keys.
     GC::RootVector<Value> element_keys;
     element_keys.ensure_capacity(m_element_keys_count);
     for (size_t i = 0; i < m_element_keys_count; ++i) {
         Value element_key;
-        if (m_element_keys[i].has_value())
-            element_key = vm.get(m_element_keys[i].value());
+        if (m_all_operands[i].has_value())
+            element_key = vm.get(m_all_operands[i].value());
         element_keys.unchecked_append(element_key);
+    }
+
+    // Next m_decorator_operands_count entries are decorator value/receiver pairs.
+    Vector<Value> decorator_values;
+    decorator_values.ensure_capacity(m_decorator_operands_count);
+    for (size_t i = 0; i < m_decorator_operands_count; ++i) {
+        Value decorator;
+        auto operand_index = m_element_keys_count + i;
+        if (m_all_operands[operand_index].has_value())
+            decorator = vm.get(m_all_operands[operand_index].value());
+        decorator_values.unchecked_append(decorator);
     }
 
     auto& running_execution_context = vm.running_execution_context();
@@ -3589,7 +3603,7 @@ NEVER_INLINE ThrowCompletionOr<void> NewClass::execute_impl(VM& vm) const
         binding_name = class_name;
     }
 
-    auto* retval = TRY(construct_class(vm, blueprint, vm.current_executable(), class_environment, outer_environment, super_class, element_keys, binding_name, class_name));
+    auto* retval = TRY(construct_class(vm, blueprint, vm.current_executable(), class_environment, outer_environment, super_class, element_keys, decorator_values, binding_name, class_name));
     vm.set(dst(), retval);
     return {};
 }

--- a/Libraries/LibJS/Runtime/ClassConstruction.cpp
+++ b/Libraries/LibJS/Runtime/ClassConstruction.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/ClassConstruction.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrivateEnvironment.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
@@ -234,6 +235,90 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                 static_elements.append(move(field));
             else
                 instance_fields.append(move(field));
+            break;
+        }
+
+        case Bytecode::ClassElementDescriptor::Kind::AutoAccessor: {
+            auto element_name = TRY(resolve_element_key(vm, descriptor, element_keys[element_index]));
+
+            // Resolve the backing storage private name from the private environment.
+            auto private_environment = vm.running_execution_context().private_environment;
+            VERIFY(private_environment);
+            auto backing_storage_name = private_environment->resolve_private_identifier(*descriptor.backing_storage_name);
+
+            // Create initializer for the backing storage field.
+            Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer;
+            if (descriptor.has_initializer) {
+                if (descriptor.literal_value.has_value()) {
+                    initializer = *descriptor.literal_value;
+                } else {
+                    auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
+
+                    if (!descriptor.is_private && !shared_data->m_class_field_initializer_name.has<PropertyKey>()
+                        && !shared_data->m_class_field_initializer_name.has<PrivateName>()) {
+                        shared_data->m_class_field_initializer_name = element_name.visit(
+                            [](PropertyKey const& key) -> Variant<PropertyKey, PrivateName, Empty> { return key; },
+                            [](PrivateName const& name) -> Variant<PropertyKey, PrivateName, Empty> { return name; });
+                    }
+
+                    auto function = ECMAScriptFunctionObject::create_from_function_data(
+                        realm,
+                        *shared_data,
+                        vm.lexical_environment(),
+                        vm.running_execution_context().private_environment);
+                    function->make_method(home_object);
+                    initializer = function;
+                }
+            }
+
+            // The backing storage is always a private field, initialized with the auto-accessor's initializer value.
+            ClassFieldDefinition backing_field {
+                ClassElementName(backing_storage_name),
+                move(initializer),
+            };
+
+            // MakeAutoAccessorGetter: create a getter that reads from the backing storage.
+            // NOTE: The base spec (ecma262 PR #2417) calls SetFunctionName to produce
+            // "get x" / "set x" names, but pzuraq/ecma262 PR #14 removes those calls.
+            // See tc39/proposal-decorators#502 for context on SetFunctionName in decorators.
+            auto getter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+                auto this_value = vm.this_value();
+                if (!this_value.is_object())
+                    return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
+                return this_value.as_object().private_get(backing_storage_name);
+            };
+            auto getter = NativeFunction::create(realm, move(getter_closure), 0);
+
+            // MakeAutoAccessorSetter: create a setter that writes to the backing storage.
+            auto setter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+                auto this_value = vm.this_value();
+                if (!this_value.is_object())
+                    return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
+                TRY(this_value.as_object().private_set(backing_storage_name, vm.argument(0)));
+                return js_undefined();
+            };
+            auto setter = NativeFunction::create(realm, move(setter_closure), 1);
+
+            if (element_name.has<PropertyKey>()) {
+                // Public auto-accessor: define an accessor property on the home object.
+                auto& property_key = element_name.get<PropertyKey>();
+                PropertyDescriptor property_descriptor { .get = getter, .set = setter, .enumerable = false, .configurable = true };
+                TRY(home_object.define_property_or_throw(property_key, property_descriptor));
+            } else {
+                // Private auto-accessor: add getter/setter as a private accessor element.
+                auto& private_name = element_name.get<PrivateName>();
+                auto accessor = Accessor::create(vm, getter, setter);
+                PrivateElement private_element { private_name, PrivateElement::Kind::Accessor, Value(accessor) };
+
+                auto& container = descriptor.is_static ? static_private_methods : instance_private_methods;
+                container.append(move(private_element));
+            }
+
+            // Add the backing storage field to the appropriate list.
+            if (descriptor.is_static)
+                static_elements.append(move(backing_field));
+            else
+                instance_fields.append(move(backing_field));
             break;
         }
 

--- a/Libraries/LibJS/Runtime/ClassConstruction.cpp
+++ b/Libraries/LibJS/Runtime/ClassConstruction.cpp
@@ -43,7 +43,220 @@ static ThrowCompletionOr<ClassElementName> resolve_element_key(VM& vm, Bytecode:
     return ClassElementName { key };
 }
 
-ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
+// === Decorator support ===
+
+// A decorator value/receiver pair, corresponding to the spec's DecoratorDefinition Record.
+struct DecoratorPair {
+    Value decorator;
+    Value receiver;
+};
+
+// ReadonlySpan<Value> contains (value, receiver) pairs in sequence.
+// Extract decorator pairs for a given element from the flat decorator_values array.
+static Vector<DecoratorPair> extract_decorator_pairs(ReadonlySpan<Value> decorator_values, size_t offset, u32 count)
+{
+    Vector<DecoratorPair> pairs;
+    pairs.ensure_capacity(count);
+    for (u32 i = 0; i < count; ++i) {
+        auto base = offset + i * 2;
+        pairs.unchecked_append({ decorator_values[base], decorator_values[base + 1] });
+    }
+    return pairs;
+}
+
+// CreateDecoratorAccessObject
+// https://arai-a.github.io/ecma262-compare/?pr=2417#sec-createdecoratoraccessobject
+static GC::Ref<Object> create_decorator_access_object(VM& vm, Bytecode::ClassElementDescriptor::Kind kind, ClassElementName const& name)
+{
+    auto& realm = *vm.current_realm();
+    auto access_obj = Object::create_prototype(realm, realm.intrinsics().object_prototype());
+
+    bool has_getter = kind == Bytecode::ClassElementDescriptor::Kind::Field
+        || kind == Bytecode::ClassElementDescriptor::Kind::Method
+        || kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor
+        || kind == Bytecode::ClassElementDescriptor::Kind::Getter;
+
+    bool has_setter = kind == Bytecode::ClassElementDescriptor::Kind::Field
+        || kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor
+        || kind == Bytecode::ClassElementDescriptor::Kind::Setter;
+
+    if (has_getter) {
+        auto getter_closure = [name](VM& vm) -> ThrowCompletionOr<Value> {
+            auto obj_value = vm.argument(0);
+            if (!obj_value.is_object())
+                return vm.throw_completion<TypeError>(ErrorType::NotAnObject, obj_value);
+            auto& obj = obj_value.as_object();
+            return name.visit(
+                [&](PropertyKey const& key) -> ThrowCompletionOr<Value> {
+                    return obj.get(key);
+                },
+                [&](PrivateName const& priv) -> ThrowCompletionOr<Value> {
+                    return obj.private_get(priv);
+                });
+        };
+        auto getter = NativeFunction::create(realm, move(getter_closure), 1);
+        MUST(access_obj->create_data_property_or_throw(vm.names.get, getter));
+    }
+
+    if (has_setter) {
+        auto setter_closure = [name](VM& vm) -> ThrowCompletionOr<Value> {
+            auto obj_value = vm.argument(0);
+            if (!obj_value.is_object())
+                return vm.throw_completion<TypeError>(ErrorType::NotAnObject, obj_value);
+            auto& obj = obj_value.as_object();
+            auto value = vm.argument(1);
+            TRY(name.visit(
+                [&](PropertyKey const& key) -> ThrowCompletionOr<void> {
+                    return obj.set(key, value, Object::ShouldThrowExceptions::Yes);
+                },
+                [&](PrivateName const& priv) -> ThrowCompletionOr<void> {
+                    return obj.private_set(priv, value);
+                }));
+            return js_undefined();
+        };
+        auto setter = NativeFunction::create(realm, move(setter_closure), 2);
+        MUST(access_obj->create_data_property_or_throw(vm.names.set, setter));
+    }
+
+    auto has_closure = [name](VM& vm) -> ThrowCompletionOr<Value> {
+        auto obj_value = vm.argument(0);
+        if (!obj_value.is_object())
+            return vm.throw_completion<TypeError>(ErrorType::NotAnObject, obj_value);
+        auto& obj = obj_value.as_object();
+        return name.visit(
+            [&](PropertyKey const& key) -> ThrowCompletionOr<Value> {
+                return Value(TRY(obj.has_property(key)));
+            },
+            [&](PrivateName const& priv) -> ThrowCompletionOr<Value> {
+                return Value(obj.private_element_find(priv) != nullptr);
+            });
+    };
+    auto has_fn = NativeFunction::create(realm, move(has_closure), 1);
+    MUST(access_obj->create_data_property_or_throw(vm.names.has, has_fn));
+
+    return access_obj;
+}
+
+// CreateAddInitializerFunction
+// https://arai-a.github.io/ecma262-compare/?pr=2417#sec-createaddinitializerfunction
+//
+// NB: This closure captures `initializers` by reference. The reference points
+// into `initializer_storage` on construct_class's stack frame. This is safe
+// because `decoration_finished` (heap-allocated via shared_ptr) acts as a
+// guard: construct_class sets *decoration_finished = true immediately after
+// each decorator call returns, and again for class decorators before
+// returning. The closure checks this flag FIRST, throwing TypeError before
+// touching `initializers`. So:
+//
+//   - During decoration: construct_class is on the stack, initializers is live.
+//   - After decoration: *decoration_finished is true, the closure throws
+//     before reaching the initializers.append() line.
+//
+// Trade-off: this avoids heap-allocating a GC-managed container for each
+// decorator call (which would require a custom Cell subclass and adds GC
+// pressure), at the cost of relying on the finished-flag invariant. If a
+// future change removes or reorders the flag-setting relative to construct_class's
+// return, this will become a use-after-free. An alternative would be to
+// allocate initializer_storage entries as GC-managed Cells.
+static GC::Ref<NativeFunction> create_add_initializer_function(VM& vm, GC::ConservativeVector<Value>& initializers, std::shared_ptr<bool> decoration_finished)
+{
+    auto& realm = *vm.current_realm();
+    auto closure = [&initializers, decoration_finished](VM& vm) -> ThrowCompletionOr<Value> {
+        // Guard: must check BEFORE accessing `initializers`, which may be dangling
+        // if construct_class has already returned.
+        if (*decoration_finished)
+            return vm.throw_completion<TypeError>(ErrorType::DecoratorAddInitializerAfterFinished);
+        auto initializer = vm.argument(0);
+        if (!initializer.is_function())
+            return vm.throw_completion<TypeError>(ErrorType::DecoratorAddInitializerNotCallable);
+        initializers.append(initializer);
+        return js_undefined();
+    };
+    return NativeFunction::create(realm, move(closure), 1);
+}
+
+// CreateDecoratorContextObject
+// https://arai-a.github.io/ecma262-compare/?pr=2417#sec-createdecoratorcontextobject
+static GC::Ref<Object> create_decorator_context_object(
+    VM& vm,
+    Bytecode::ClassElementDescriptor::Kind kind,
+    ClassElementName const& name,
+    GC::ConservativeVector<Value>& initializers,
+    std::shared_ptr<bool> decoration_finished,
+    Optional<bool> is_static = {})
+{
+    auto& realm = *vm.current_realm();
+    auto context_obj = Object::create_prototype(realm, realm.intrinsics().object_prototype());
+
+    // Set kind string.
+    StringView kind_str;
+    switch (kind) {
+    case Bytecode::ClassElementDescriptor::Kind::Method:
+        kind_str = "method"sv;
+        break;
+    case Bytecode::ClassElementDescriptor::Kind::Getter:
+        kind_str = "getter"sv;
+        break;
+    case Bytecode::ClassElementDescriptor::Kind::Setter:
+        kind_str = "setter"sv;
+        break;
+    case Bytecode::ClassElementDescriptor::Kind::AutoAccessor:
+        kind_str = "accessor"sv;
+        break;
+    case Bytecode::ClassElementDescriptor::Kind::Field:
+        kind_str = "field"sv;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+    MUST(context_obj->create_data_property_or_throw(vm.names.kind, PrimitiveString::create(vm, kind_str)));
+
+    // For non-class kinds, set access, static, private, and name.
+    MUST(context_obj->create_data_property_or_throw(vm.names.access, create_decorator_access_object(vm, kind, name)));
+    if (is_static.has_value())
+        MUST(context_obj->create_data_property_or_throw(vm.names.static_, Value(is_static.value())));
+
+    name.visit(
+        [&](PropertyKey const& key) {
+            MUST(context_obj->create_data_property_or_throw(vm.names.private_, Value(false)));
+            if (key.is_string())
+                MUST(context_obj->create_data_property_or_throw(vm.names.name, PrimitiveString::create(vm, key.as_string())));
+            else if (key.is_symbol())
+                MUST(context_obj->create_data_property_or_throw(vm.names.name, key.as_symbol()));
+            else if (key.is_number())
+                MUST(context_obj->create_data_property_or_throw(vm.names.name, PrimitiveString::create(vm, String::number(key.as_number()))));
+        },
+        [&](PrivateName const& priv) {
+            MUST(context_obj->create_data_property_or_throw(vm.names.private_, Value(true)));
+            MUST(context_obj->create_data_property_or_throw(vm.names.name, PrimitiveString::create(vm, priv.description)));
+        });
+
+    auto add_initializer = create_add_initializer_function(vm, initializers, decoration_finished);
+    MUST(context_obj->create_data_property_or_throw(vm.names.addInitializer, add_initializer));
+
+    return context_obj;
+}
+
+// CreateDecoratorContextObject for class decorators
+static GC::Ref<Object> create_class_decorator_context_object(
+    VM& vm,
+    Utf16FlyString const& class_name,
+    GC::ConservativeVector<Value>& initializers,
+    std::shared_ptr<bool> decoration_finished)
+{
+    auto& realm = *vm.current_realm();
+    auto context_obj = Object::create_prototype(realm, realm.intrinsics().object_prototype());
+
+    MUST(context_obj->create_data_property_or_throw(vm.names.kind, PrimitiveString::create(vm, "class"sv)));
+    MUST(context_obj->create_data_property_or_throw(vm.names.name, PrimitiveString::create(vm, class_name)));
+
+    auto add_initializer = create_add_initializer_function(vm, initializers, decoration_finished);
+    MUST(context_obj->create_data_property_or_throw(vm.names.addInitializer, add_initializer));
+
+    return context_obj;
+}
+
+ThrowCompletionOr<FunctionObject*> construct_class(
     VM& vm,
     Bytecode::ClassBlueprint const& blueprint,
     Bytecode::Executable const& executable,
@@ -51,6 +264,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
     Environment* outer_environment,
     Value super_class,
     ReadonlySpan<Value> element_keys,
+    ReadonlySpan<Value> decorator_values,
     Optional<Utf16FlyString> const& binding_name,
     Utf16FlyString const& class_name)
 {
@@ -106,16 +320,347 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
 
     prototype->define_direct_property(vm.names.constructor, class_constructor, Attribute::Writable | Attribute::Configurable);
 
-    using StaticElement = Variant<ClassFieldDefinition, GC::Ref<ECMAScriptFunctionObject>>;
+    // Track whether any element has decorators to enable the fast path.
+    bool has_any_decorators = blueprint.class_decorator_count > 0;
+    if (!has_any_decorators) {
+        for (auto const& descriptor : blueprint.elements) {
+            if (descriptor.decorator_count > 0) {
+                has_any_decorators = true;
+                break;
+            }
+        }
+    }
 
+    // Fast path: no decorators at all -- use the existing simple algorithm.
+    if (!has_any_decorators) {
+        using StaticElement = Variant<ClassFieldDefinition, GC::Ref<ECMAScriptFunctionObject>>;
+
+        GC::ConservativeVector<PrivateElement> static_private_methods;
+        GC::ConservativeVector<PrivateElement> instance_private_methods;
+        GC::ConservativeVector<ClassFieldDefinition> instance_fields;
+        GC::ConservativeVector<StaticElement> static_elements;
+
+        for (size_t element_index = 0; element_index < blueprint.elements.size(); ++element_index) {
+            auto const& descriptor = blueprint.elements[element_index];
+            auto& home_object = descriptor.is_static ? static_cast<Object&>(*class_constructor) : static_cast<Object&>(*prototype);
+
+            switch (descriptor.kind) {
+            case Bytecode::ClassElementDescriptor::Kind::Method:
+            case Bytecode::ClassElementDescriptor::Kind::Getter:
+            case Bytecode::ClassElementDescriptor::Kind::Setter: {
+                auto element_name = TRY(resolve_element_key(vm, descriptor, element_keys[element_index]));
+
+                auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
+                auto& method_function = *ECMAScriptFunctionObject::create_from_function_data(
+                    realm,
+                    *shared_data,
+                    vm.lexical_environment(),
+                    vm.running_execution_context().private_environment);
+
+                auto method_value = Value(&method_function);
+                method_function.make_method(home_object);
+
+                if (element_name.has<PropertyKey>()) {
+                    auto& property_key = element_name.get<PropertyKey>();
+                    switch (descriptor.kind) {
+                    case Bytecode::ClassElementDescriptor::Kind::Method: {
+                        update_function_name(method_value, element_name);
+                        PropertyDescriptor property_descriptor { .value = method_value, .writable = true, .enumerable = false, .configurable = true };
+                        TRY(home_object.define_property_or_throw(property_key, property_descriptor));
+                        break;
+                    }
+                    case Bytecode::ClassElementDescriptor::Kind::Getter: {
+                        update_function_name(method_value, element_name, "get"sv);
+                        PropertyDescriptor property_descriptor { .get = &method_function, .enumerable = false, .configurable = true };
+                        TRY(home_object.define_property_or_throw(property_key, property_descriptor));
+                        break;
+                    }
+                    case Bytecode::ClassElementDescriptor::Kind::Setter: {
+                        update_function_name(method_value, element_name, "set"sv);
+                        PropertyDescriptor property_descriptor { .set = &method_function, .enumerable = false, .configurable = true };
+                        TRY(home_object.define_property_or_throw(property_key, property_descriptor));
+                        break;
+                    }
+                    default:
+                        VERIFY_NOT_REACHED();
+                    }
+                } else {
+                    auto& private_name = element_name.get<PrivateName>();
+                    auto& container = descriptor.is_static ? static_private_methods : instance_private_methods;
+
+                    PrivateElement private_element = [&] {
+                        switch (descriptor.kind) {
+                        case Bytecode::ClassElementDescriptor::Kind::Method:
+                            update_function_name(method_value, element_name);
+                            return PrivateElement { private_name, PrivateElement::Kind::Method, method_value };
+                        case Bytecode::ClassElementDescriptor::Kind::Getter:
+                            update_function_name(method_value, element_name, "get"sv);
+                            return PrivateElement { private_name, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, &method_function, nullptr)) };
+                        case Bytecode::ClassElementDescriptor::Kind::Setter:
+                            update_function_name(method_value, element_name, "set"sv);
+                            return PrivateElement { private_name, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, nullptr, &method_function)) };
+                        default:
+                            VERIFY_NOT_REACHED();
+                        }
+                    }();
+
+                    // Merge accessor pairs.
+                    auto added_to_existing = false;
+                    for (auto& existing : container) {
+                        if (existing.key == private_element.key) {
+                            VERIFY(existing.kind == PrivateElement::Kind::Accessor);
+                            VERIFY(private_element.kind == PrivateElement::Kind::Accessor);
+                            auto& accessor = private_element.value.as_accessor();
+                            if (!accessor.getter())
+                                existing.value.as_accessor().set_setter(accessor.setter());
+                            else
+                                existing.value.as_accessor().set_getter(accessor.getter());
+                            added_to_existing = true;
+                        }
+                    }
+
+                    if (!added_to_existing)
+                        container.append(move(private_element));
+                }
+                break;
+            }
+
+            case Bytecode::ClassElementDescriptor::Kind::Field: {
+                auto element_name = TRY(resolve_element_key(vm, descriptor, element_keys[element_index]));
+
+                Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer;
+                if (descriptor.has_initializer) {
+                    if (descriptor.literal_value.has_value()) {
+                        initializer = *descriptor.literal_value;
+                    } else {
+                        auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
+
+                        // Set class_field_initializer_name at runtime for computed keys.
+                        if (!descriptor.is_private && !shared_data->m_class_field_initializer_name.has<PropertyKey>()
+                            && !shared_data->m_class_field_initializer_name.has<PrivateName>()) {
+                            shared_data->m_class_field_initializer_name = element_name.visit(
+                                [](PropertyKey const& key) -> Variant<PropertyKey, PrivateName, Empty> { return key; },
+                                [](PrivateName const& name) -> Variant<PropertyKey, PrivateName, Empty> { return name; });
+                        }
+
+                        auto function = ECMAScriptFunctionObject::create_from_function_data(
+                            realm,
+                            *shared_data,
+                            vm.lexical_environment(),
+                            vm.running_execution_context().private_environment);
+                        function->make_method(home_object);
+                        initializer = function;
+                    }
+                }
+
+                ClassFieldDefinition field {
+                    move(element_name),
+                    move(initializer),
+                    {},
+                    {},
+                };
+
+                if (descriptor.is_static)
+                    static_elements.append(move(field));
+                else
+                    instance_fields.append(move(field));
+                break;
+            }
+
+            case Bytecode::ClassElementDescriptor::Kind::AutoAccessor: {
+                auto element_name = TRY(resolve_element_key(vm, descriptor, element_keys[element_index]));
+
+                // Resolve the backing storage private name from the private environment.
+                auto private_environment = vm.running_execution_context().private_environment;
+                VERIFY(private_environment);
+                auto backing_storage_name = private_environment->resolve_private_identifier(*descriptor.backing_storage_name);
+
+                // Create initializer for the backing storage field.
+                Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer;
+                if (descriptor.has_initializer) {
+                    if (descriptor.literal_value.has_value()) {
+                        initializer = *descriptor.literal_value;
+                    } else {
+                        auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
+
+                        if (!descriptor.is_private && !shared_data->m_class_field_initializer_name.has<PropertyKey>()
+                            && !shared_data->m_class_field_initializer_name.has<PrivateName>()) {
+                            shared_data->m_class_field_initializer_name = element_name.visit(
+                                [](PropertyKey const& key) -> Variant<PropertyKey, PrivateName, Empty> { return key; },
+                                [](PrivateName const& name) -> Variant<PropertyKey, PrivateName, Empty> { return name; });
+                        }
+
+                        auto function = ECMAScriptFunctionObject::create_from_function_data(
+                            realm,
+                            *shared_data,
+                            vm.lexical_environment(),
+                            vm.running_execution_context().private_environment);
+                        function->make_method(home_object);
+                        initializer = function;
+                    }
+                }
+
+                // The backing storage is always a private field, initialized with the auto-accessor's initializer value.
+                ClassFieldDefinition backing_field {
+                    ClassElementName(backing_storage_name),
+                    move(initializer),
+                    {},
+                    {},
+                };
+
+                // MakeAutoAccessorGetter: create a getter that reads from the backing storage.
+                // NOTE: The base spec (ecma262 PR #2417) calls SetFunctionName to produce
+                // "get x" / "set x" names, but pzuraq/ecma262 PR #14 removes those calls.
+                // See tc39/proposal-decorators#502 for context on SetFunctionName in decorators.
+                auto getter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+                    auto this_value = vm.this_value();
+                    if (!this_value.is_object())
+                        return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
+                    return this_value.as_object().private_get(backing_storage_name);
+                };
+                auto getter = NativeFunction::create(realm, move(getter_closure), 0);
+
+                // MakeAutoAccessorSetter: create a setter that writes to the backing storage.
+                auto setter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+                    auto this_value = vm.this_value();
+                    if (!this_value.is_object())
+                        return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
+                    TRY(this_value.as_object().private_set(backing_storage_name, vm.argument(0)));
+                    return js_undefined();
+                };
+                auto setter = NativeFunction::create(realm, move(setter_closure), 1);
+
+                if (element_name.has<PropertyKey>()) {
+                    // Public auto-accessor: define an accessor property on the home object.
+                    auto& property_key = element_name.get<PropertyKey>();
+                    PropertyDescriptor property_descriptor { .get = getter, .set = setter, .enumerable = false, .configurable = true };
+                    TRY(home_object.define_property_or_throw(property_key, property_descriptor));
+                } else {
+                    // Private auto-accessor: add getter/setter as a private accessor element.
+                    auto& private_name = element_name.get<PrivateName>();
+                    auto accessor = Accessor::create(vm, getter, setter);
+                    PrivateElement private_element { private_name, PrivateElement::Kind::Accessor, Value(accessor) };
+
+                    auto& container = descriptor.is_static ? static_private_methods : instance_private_methods;
+                    container.append(move(private_element));
+                }
+
+                // Add the backing storage field to the appropriate list.
+                if (descriptor.is_static)
+                    static_elements.append(move(backing_field));
+                else
+                    instance_fields.append(move(backing_field));
+                break;
+            }
+
+            case Bytecode::ClassElementDescriptor::Kind::StaticInitializer: {
+                auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
+                auto body_function = ECMAScriptFunctionObject::create_from_function_data(
+                    realm,
+                    *shared_data,
+                    vm.lexical_environment(),
+                    vm.running_execution_context().private_environment);
+                body_function->make_method(home_object);
+                static_elements.append(GC::Ref { *body_function });
+                break;
+            }
+            }
+        }
+
+        vm.running_execution_context().lexical_environment = outer_environment;
+        restore_environment.disarm();
+
+        if (binding_name.has_value())
+            MUST(class_environment->initialize_binding(vm, binding_name.value(), class_constructor, Environment::InitializeBindingHint::Normal));
+
+        for (auto& field : instance_fields)
+            class_constructor->add_field(field);
+
+        for (auto& private_method : instance_private_methods)
+            class_constructor->add_private_method(private_method);
+
+        for (auto& method : static_private_methods)
+            TRY(class_constructor->private_method_or_accessor_add(move(method)));
+
+        for (auto& element : static_elements) {
+            TRY(element.visit(
+                [&](ClassFieldDefinition& field) -> ThrowCompletionOr<void> {
+                    return TRY(class_constructor->define_field(field));
+                },
+                [&](GC::Ref<ECMAScriptFunctionObject> static_block_function) -> ThrowCompletionOr<void> {
+                    // We discard any value returned here.
+                    TRY(call(vm, *static_block_function, class_constructor));
+                    return {};
+                }));
+        }
+
+        if (blueprint.source_code)
+            class_constructor->set_source_text_range(*blueprint.source_code, blueprint.source_text_offset, blueprint.source_text_length);
+
+        return { class_constructor };
+    }
+
+    // =========================================================================
+    // Slow path: decorators present -- implement the full Decoration Order
+    // algorithm from ClassDefinitionEvaluation.
+    // =========================================================================
+
+    // Private element vectors for accumulating during decoration.
     GC::ConservativeVector<PrivateElement> static_private_methods;
     GC::ConservativeVector<PrivateElement> instance_private_methods;
-    GC::ConservativeVector<ClassFieldDefinition> instance_fields;
-    GC::ConservativeVector<StaticElement> static_elements;
+
+    // Compute decorator value offsets per element. decorator_values is a flat
+    // array of (value, receiver) pairs: first all element decorator pairs (in
+    // source order), then class decorator pairs.
+    // Each element's decorator_count tells how many pairs belong to it.
+    size_t decorator_offset = 0;
+
+    // Build element records with resolved names, values, and decorator pairs.
+    // We classify into instance and static elements for the 4-pass algorithm.
+
+    struct ElementRecord {
+        size_t blueprint_index;
+        ClassElementName name { PropertyKey { static_cast<unsigned>(0) } };
+        Bytecode::ClassElementDescriptor::Kind kind;
+        bool is_static;
+        // For methods/getters/setters: the function value.
+        Value value {};
+        // For auto-accessors: getter and setter.
+        GC::Ptr<FunctionObject> getter {};
+        GC::Ptr<FunctionObject> setter {};
+        // For fields/auto-accessors: the base initializer.
+        Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer { Empty {} };
+        // Private backing storage name (auto-accessors only).
+        Optional<PrivateName> backing_storage_name {};
+        // Decorator pairs for this element.
+        Vector<DecoratorPair> decorators;
+        // Initializers added by decorators (prepended by field/accessor decorators).
+        GC::ConservativeVector<Value>* decorator_initializers { nullptr };
+        // Extra initializers added via addInitializer().
+        GC::ConservativeVector<Value>* extra_initializers { nullptr };
+        // Whether this is a private element.
+        bool is_private { false };
+        // For private methods: the PrivateName for installation.
+        Optional<PrivateName> private_name {};
+    };
+
+    // We need GC-safe storage for initializer lists. Allocate them per-element.
+    // Use a vector of unique_ptrs to GC::ConservativeVector since we need stable addresses.
+    Vector<NonnullOwnPtr<GC::ConservativeVector<Value>>> initializer_storage;
+    auto allocate_initializer_list = [&]() -> GC::ConservativeVector<Value>* {
+        initializer_storage.append(make<GC::ConservativeVector<Value>>());
+        return initializer_storage.last().ptr();
+    };
+
+    Vector<ElementRecord> instance_elements;
+    Vector<ElementRecord> static_elements_vec;
 
     for (size_t element_index = 0; element_index < blueprint.elements.size(); ++element_index) {
         auto const& descriptor = blueprint.elements[element_index];
         auto& home_object = descriptor.is_static ? static_cast<Object&>(*class_constructor) : static_cast<Object&>(*prototype);
+
+        auto dec_pairs = extract_decorator_pairs(decorator_values, decorator_offset, descriptor.decorator_count);
+        decorator_offset += descriptor.decorator_count * 2;
 
         switch (descriptor.kind) {
         case Bytecode::ClassElementDescriptor::Kind::Method:
@@ -129,72 +674,24 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                 *shared_data,
                 vm.lexical_environment(),
                 vm.running_execution_context().private_environment);
-
-            auto method_value = Value(&method_function);
             method_function.make_method(home_object);
 
-            if (element_name.has<PropertyKey>()) {
-                auto& property_key = element_name.get<PropertyKey>();
-                switch (descriptor.kind) {
-                case Bytecode::ClassElementDescriptor::Kind::Method: {
-                    update_function_name(method_value, element_name);
-                    PropertyDescriptor property_descriptor { .value = method_value, .writable = true, .enumerable = false, .configurable = true };
-                    TRY(home_object.define_property_or_throw(property_key, property_descriptor));
-                    break;
-                }
-                case Bytecode::ClassElementDescriptor::Kind::Getter: {
-                    update_function_name(method_value, element_name, "get"sv);
-                    PropertyDescriptor property_descriptor { .get = &method_function, .enumerable = false, .configurable = true };
-                    TRY(home_object.define_property_or_throw(property_key, property_descriptor));
-                    break;
-                }
-                case Bytecode::ClassElementDescriptor::Kind::Setter: {
-                    update_function_name(method_value, element_name, "set"sv);
-                    PropertyDescriptor property_descriptor { .set = &method_function, .enumerable = false, .configurable = true };
-                    TRY(home_object.define_property_or_throw(property_key, property_descriptor));
-                    break;
-                }
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            } else {
-                auto& private_name = element_name.get<PrivateName>();
-                auto& container = descriptor.is_static ? static_private_methods : instance_private_methods;
+            ElementRecord record;
+            record.blueprint_index = element_index;
+            record.name = move(element_name);
+            record.kind = descriptor.kind;
+            record.is_static = descriptor.is_static;
+            record.value = Value(&method_function);
+            record.decorators = move(dec_pairs);
+            record.is_private = descriptor.is_private;
+            record.extra_initializers = allocate_initializer_list();
+            if (descriptor.is_private)
+                record.private_name = record.name.get<PrivateName>();
 
-                PrivateElement private_element = [&] {
-                    switch (descriptor.kind) {
-                    case Bytecode::ClassElementDescriptor::Kind::Method:
-                        update_function_name(method_value, element_name);
-                        return PrivateElement { private_name, PrivateElement::Kind::Method, method_value };
-                    case Bytecode::ClassElementDescriptor::Kind::Getter:
-                        update_function_name(method_value, element_name, "get"sv);
-                        return PrivateElement { private_name, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, &method_function, nullptr)) };
-                    case Bytecode::ClassElementDescriptor::Kind::Setter:
-                        update_function_name(method_value, element_name, "set"sv);
-                        return PrivateElement { private_name, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, nullptr, &method_function)) };
-                    default:
-                        VERIFY_NOT_REACHED();
-                    }
-                }();
-
-                // Merge accessor pairs.
-                auto added_to_existing = false;
-                for (auto& existing : container) {
-                    if (existing.key == private_element.key) {
-                        VERIFY(existing.kind == PrivateElement::Kind::Accessor);
-                        VERIFY(private_element.kind == PrivateElement::Kind::Accessor);
-                        auto& accessor = private_element.value.as_accessor();
-                        if (!accessor.getter())
-                            existing.value.as_accessor().set_setter(accessor.setter());
-                        else
-                            existing.value.as_accessor().set_getter(accessor.getter());
-                        added_to_existing = true;
-                    }
-                }
-
-                if (!added_to_existing)
-                    container.append(move(private_element));
-            }
+            if (descriptor.is_static)
+                static_elements_vec.append(move(record));
+            else
+                instance_elements.append(move(record));
             break;
         }
 
@@ -207,15 +704,12 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                     initializer = *descriptor.literal_value;
                 } else {
                     auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
-
-                    // Set class_field_initializer_name at runtime for computed keys.
                     if (!descriptor.is_private && !shared_data->m_class_field_initializer_name.has<PropertyKey>()
                         && !shared_data->m_class_field_initializer_name.has<PrivateName>()) {
                         shared_data->m_class_field_initializer_name = element_name.visit(
                             [](PropertyKey const& key) -> Variant<PropertyKey, PrivateName, Empty> { return key; },
                             [](PrivateName const& name) -> Variant<PropertyKey, PrivateName, Empty> { return name; });
                     }
-
                     auto function = ECMAScriptFunctionObject::create_from_function_data(
                         realm,
                         *shared_data,
@@ -226,41 +720,43 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                 }
             }
 
-            ClassFieldDefinition field {
-                move(element_name),
-                move(initializer),
-            };
+            ElementRecord record;
+            record.blueprint_index = element_index;
+            record.name = move(element_name);
+            record.kind = descriptor.kind;
+            record.is_static = descriptor.is_static;
+            record.initializer = move(initializer);
+            record.decorators = move(dec_pairs);
+            record.is_private = descriptor.is_private;
+            record.decorator_initializers = allocate_initializer_list();
+            record.extra_initializers = allocate_initializer_list();
 
             if (descriptor.is_static)
-                static_elements.append(move(field));
+                static_elements_vec.append(move(record));
             else
-                instance_fields.append(move(field));
+                instance_elements.append(move(record));
             break;
         }
 
         case Bytecode::ClassElementDescriptor::Kind::AutoAccessor: {
             auto element_name = TRY(resolve_element_key(vm, descriptor, element_keys[element_index]));
 
-            // Resolve the backing storage private name from the private environment.
             auto private_environment = vm.running_execution_context().private_environment;
             VERIFY(private_environment);
-            auto backing_storage_name = private_environment->resolve_private_identifier(*descriptor.backing_storage_name);
+            auto backing_storage = private_environment->resolve_private_identifier(*descriptor.backing_storage_name);
 
-            // Create initializer for the backing storage field.
             Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer;
             if (descriptor.has_initializer) {
                 if (descriptor.literal_value.has_value()) {
                     initializer = *descriptor.literal_value;
                 } else {
                     auto shared_data = executable.shared_function_data[*descriptor.shared_function_data_index];
-
                     if (!descriptor.is_private && !shared_data->m_class_field_initializer_name.has<PropertyKey>()
                         && !shared_data->m_class_field_initializer_name.has<PrivateName>()) {
                         shared_data->m_class_field_initializer_name = element_name.visit(
                             [](PropertyKey const& key) -> Variant<PropertyKey, PrivateName, Empty> { return key; },
                             [](PrivateName const& name) -> Variant<PropertyKey, PrivateName, Empty> { return name; });
                     }
-
                     auto function = ECMAScriptFunctionObject::create_from_function_data(
                         realm,
                         *shared_data,
@@ -271,54 +767,42 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                 }
             }
 
-            // The backing storage is always a private field, initialized with the auto-accessor's initializer value.
-            ClassFieldDefinition backing_field {
-                ClassElementName(backing_storage_name),
-                move(initializer),
-            };
-
-            // MakeAutoAccessorGetter: create a getter that reads from the backing storage.
-            // NOTE: The base spec (ecma262 PR #2417) calls SetFunctionName to produce
-            // "get x" / "set x" names, but pzuraq/ecma262 PR #14 removes those calls.
-            // See tc39/proposal-decorators#502 for context on SetFunctionName in decorators.
-            auto getter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+            // MakeAutoAccessorGetter/Setter
+            auto getter_closure = [backing_storage](VM& vm) -> ThrowCompletionOr<Value> {
                 auto this_value = vm.this_value();
                 if (!this_value.is_object())
                     return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
-                return this_value.as_object().private_get(backing_storage_name);
+                return this_value.as_object().private_get(backing_storage);
             };
-            auto getter = NativeFunction::create(realm, move(getter_closure), 0);
+            auto acc_getter = NativeFunction::create(realm, move(getter_closure), 0);
 
-            // MakeAutoAccessorSetter: create a setter that writes to the backing storage.
-            auto setter_closure = [backing_storage_name](VM& vm) -> ThrowCompletionOr<Value> {
+            auto setter_closure = [backing_storage](VM& vm) -> ThrowCompletionOr<Value> {
                 auto this_value = vm.this_value();
                 if (!this_value.is_object())
                     return vm.throw_completion<TypeError>(ErrorType::NotAnObject, this_value);
-                TRY(this_value.as_object().private_set(backing_storage_name, vm.argument(0)));
+                TRY(this_value.as_object().private_set(backing_storage, vm.argument(0)));
                 return js_undefined();
             };
-            auto setter = NativeFunction::create(realm, move(setter_closure), 1);
+            auto acc_setter = NativeFunction::create(realm, move(setter_closure), 1);
 
-            if (element_name.has<PropertyKey>()) {
-                // Public auto-accessor: define an accessor property on the home object.
-                auto& property_key = element_name.get<PropertyKey>();
-                PropertyDescriptor property_descriptor { .get = getter, .set = setter, .enumerable = false, .configurable = true };
-                TRY(home_object.define_property_or_throw(property_key, property_descriptor));
-            } else {
-                // Private auto-accessor: add getter/setter as a private accessor element.
-                auto& private_name = element_name.get<PrivateName>();
-                auto accessor = Accessor::create(vm, getter, setter);
-                PrivateElement private_element { private_name, PrivateElement::Kind::Accessor, Value(accessor) };
+            ElementRecord record;
+            record.blueprint_index = element_index;
+            record.name = move(element_name);
+            record.kind = descriptor.kind;
+            record.is_static = descriptor.is_static;
+            record.getter = acc_getter;
+            record.setter = acc_setter;
+            record.initializer = move(initializer);
+            record.backing_storage_name = backing_storage;
+            record.decorators = move(dec_pairs);
+            record.is_private = descriptor.is_private;
+            record.decorator_initializers = allocate_initializer_list();
+            record.extra_initializers = allocate_initializer_list();
 
-                auto& container = descriptor.is_static ? static_private_methods : instance_private_methods;
-                container.append(move(private_element));
-            }
-
-            // Add the backing storage field to the appropriate list.
             if (descriptor.is_static)
-                static_elements.append(move(backing_field));
+                static_elements_vec.append(move(record));
             else
-                instance_fields.append(move(backing_field));
+                instance_elements.append(move(record));
             break;
         }
 
@@ -329,44 +813,393 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
                 *shared_data,
                 vm.lexical_environment(),
                 vm.running_execution_context().private_environment);
-            body_function->make_method(home_object);
-            static_elements.append(GC::Ref { *body_function });
+            body_function->make_method(static_cast<Object&>(*class_constructor));
+
+            // Static initializer blocks are not decorated; store as a field-kind
+            // element with the body function as its value.
+            ElementRecord record;
+            record.blueprint_index = element_index;
+            // Static initializers don't have a meaningful name.
+            record.kind = descriptor.kind;
+            record.is_static = true;
+            record.value = Value(body_function.ptr());
+            record.is_private = false;
+
+            static_elements_vec.append(move(record));
             break;
         }
         }
     }
 
-    vm.running_execution_context().lexical_environment = outer_environment;
-    restore_environment.disarm();
+    // === Apply Decorators per the spec's Decoration Order ===
 
-    if (binding_name.has_value())
-        MUST(class_environment->initialize_binding(vm, binding_name.value(), class_constructor, Environment::InitializeBindingHint::Normal));
+    // Helper: apply decorators to an element record.
+    // ApplyDecoratorsToElementDefinition
+    auto apply_decorators_to_element = [&](ElementRecord& record) -> ThrowCompletionOr<void> {
+        if (record.decorators.is_empty())
+            return {};
 
-    for (auto& field : instance_fields)
-        class_constructor->add_field(field);
+        // Decorators are applied in reverse order (bottom-up / inner-to-outer).
+        for (ssize_t di = record.decorators.size() - 1; di >= 0; --di) {
+            auto& dec_pair = record.decorators[di];
+            auto decoration_finished = std::make_shared<bool>(false);
+            auto context = create_decorator_context_object(vm, record.kind, record.name, *record.extra_initializers, decoration_finished, record.is_static);
 
+            // Determine the value to pass to the decorator.
+            Value decorator_input;
+            switch (record.kind) {
+            case Bytecode::ClassElementDescriptor::Kind::Method:
+                decorator_input = record.value;
+                break;
+            case Bytecode::ClassElementDescriptor::Kind::Getter:
+                decorator_input = record.value;
+                break;
+            case Bytecode::ClassElementDescriptor::Kind::Setter:
+                decorator_input = record.value;
+                break;
+            case Bytecode::ClassElementDescriptor::Kind::AutoAccessor: {
+                auto accessor_obj = Object::create_prototype(realm, realm.intrinsics().object_prototype());
+                MUST(accessor_obj->create_data_property_or_throw(vm.names.get, record.getter));
+                MUST(accessor_obj->create_data_property_or_throw(vm.names.set, record.setter));
+                decorator_input = accessor_obj;
+                break;
+            }
+            case Bytecode::ClassElementDescriptor::Kind::Field:
+                decorator_input = js_undefined();
+                break;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+
+            // Call the decorator: decorator.call(receiver, value, context)
+            auto new_value = TRY(call(vm, dec_pair.decorator, dec_pair.receiver, decorator_input, context));
+            *decoration_finished = true;
+
+            // Handle return value based on kind.
+            switch (record.kind) {
+            case Bytecode::ClassElementDescriptor::Kind::Field:
+                if (new_value.is_function()) {
+                    record.decorator_initializers->append(new_value);
+                } else if (!new_value.is_undefined()) {
+                    return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+                }
+                break;
+
+            case Bytecode::ClassElementDescriptor::Kind::AutoAccessor:
+                if (new_value.is_object()) {
+                    auto new_getter = TRY(new_value.get(vm, vm.names.get));
+                    if (new_getter.is_function())
+                        record.getter = &new_getter.as_function();
+                    else if (!new_getter.is_undefined())
+                        return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+
+                    auto new_setter = TRY(new_value.get(vm, vm.names.set));
+                    if (new_setter.is_function())
+                        record.setter = &new_setter.as_function();
+                    else if (!new_setter.is_undefined())
+                        return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+
+                    auto init = TRY(new_value.get(vm, vm.names.init));
+                    if (init.is_function())
+                        record.decorator_initializers->append(init);
+                    else if (!init.is_undefined())
+                        return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+                } else if (!new_value.is_undefined()) {
+                    return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+                }
+                break;
+
+            case Bytecode::ClassElementDescriptor::Kind::Method:
+            case Bytecode::ClassElementDescriptor::Kind::Getter:
+            case Bytecode::ClassElementDescriptor::Kind::Setter:
+                if (new_value.is_function()) {
+                    record.value = new_value;
+                } else if (!new_value.is_undefined()) {
+                    return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+                }
+                break;
+
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        }
+
+        record.decorators.clear();
+        return {};
+    };
+
+    // Helper: define a method/getter/setter element on its home object.
+    auto define_method_element = [&](ElementRecord& record) -> ThrowCompletionOr<void> {
+        auto& home_object = record.is_static ? static_cast<Object&>(*class_constructor) : static_cast<Object&>(*prototype);
+
+        if (record.name.has<PropertyKey>()) {
+            auto& property_key = record.name.get<PropertyKey>();
+            switch (record.kind) {
+            case Bytecode::ClassElementDescriptor::Kind::Method: {
+                update_function_name(record.value, record.name);
+                PropertyDescriptor desc { .value = record.value, .writable = true, .enumerable = false, .configurable = true };
+                TRY(home_object.define_property_or_throw(property_key, desc));
+                break;
+            }
+            case Bytecode::ClassElementDescriptor::Kind::Getter: {
+                update_function_name(record.value, record.name, "get"sv);
+                PropertyDescriptor desc { .get = &record.value.as_function(), .enumerable = false, .configurable = true };
+                TRY(home_object.define_property_or_throw(property_key, desc));
+                break;
+            }
+            case Bytecode::ClassElementDescriptor::Kind::Setter: {
+                update_function_name(record.value, record.name, "set"sv);
+                PropertyDescriptor desc { .set = &record.value.as_function(), .enumerable = false, .configurable = true };
+                TRY(home_object.define_property_or_throw(property_key, desc));
+                break;
+            }
+            case Bytecode::ClassElementDescriptor::Kind::AutoAccessor: {
+                PropertyDescriptor desc { .get = record.getter, .set = record.setter, .enumerable = false, .configurable = true };
+                TRY(home_object.define_property_or_throw(property_key, desc));
+                break;
+            }
+            default:
+                break;
+            }
+        } else {
+            auto& priv = record.name.get<PrivateName>();
+            auto& container = record.is_static ? static_private_methods : instance_private_methods;
+
+            if (record.kind == Bytecode::ClassElementDescriptor::Kind::Method) {
+                update_function_name(record.value, record.name);
+                container.append(PrivateElement { priv, PrivateElement::Kind::Method, record.value });
+            } else if (record.kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor) {
+                auto accessor = Accessor::create(vm, record.getter, record.setter);
+                container.append(PrivateElement { priv, PrivateElement::Kind::Accessor, Value(accessor) });
+            } else {
+                // Getter or setter -- merge with existing accessor pair.
+                GC::Ptr<FunctionObject> g;
+                GC::Ptr<FunctionObject> s;
+                if (record.kind == Bytecode::ClassElementDescriptor::Kind::Getter) {
+                    update_function_name(record.value, record.name, "get"sv);
+                    g = &record.value.as_function();
+                } else {
+                    update_function_name(record.value, record.name, "set"sv);
+                    s = &record.value.as_function();
+                }
+
+                bool merged = false;
+                for (auto& existing : container) {
+                    if (existing.key == priv && existing.kind == PrivateElement::Kind::Accessor) {
+                        if (g)
+                            existing.value.as_accessor().set_getter(g);
+                        else
+                            existing.value.as_accessor().set_setter(s);
+                        merged = true;
+                        break;
+                    }
+                }
+                if (!merged)
+                    container.append(PrivateElement { priv, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, g, s)) });
+            }
+        }
+        return {};
+    };
+
+    // Shared extra-initializer lists for method-level decorators (per spec).
+    GC::ConservativeVector<Value> instance_method_extra_initializers;
+    GC::ConservativeVector<Value> static_method_extra_initializers;
+
+    // Pass 1: Apply decorators to static methods/accessors, then define them.
+    for (auto& elem : static_elements_vec) {
+        if (elem.kind != Bytecode::ClassElementDescriptor::Kind::Field
+            && elem.kind != Bytecode::ClassElementDescriptor::Kind::StaticInitializer) {
+            // For accessors, extra initializers go into elem.extra_initializers.
+            // For methods/getters/setters, they go into static_method_extra_initializers.
+            auto* target_extra_inits = (elem.kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor)
+                ? elem.extra_initializers
+                : &static_method_extra_initializers;
+            // Temporarily redirect extra_initializers for method decorators.
+            auto* saved = elem.extra_initializers;
+            elem.extra_initializers = target_extra_inits;
+            TRY(apply_decorators_to_element(elem));
+            elem.extra_initializers = saved;
+            TRY(define_method_element(elem));
+        }
+    }
+
+    // Pass 2: Apply decorators to instance methods/accessors, then define them.
+    for (auto& elem : instance_elements) {
+        if (elem.kind != Bytecode::ClassElementDescriptor::Kind::Field
+            && elem.kind != Bytecode::ClassElementDescriptor::Kind::StaticInitializer) {
+            auto* target_extra_inits = (elem.kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor)
+                ? elem.extra_initializers
+                : &instance_method_extra_initializers;
+            auto* saved = elem.extra_initializers;
+            elem.extra_initializers = target_extra_inits;
+            TRY(apply_decorators_to_element(elem));
+            elem.extra_initializers = saved;
+            TRY(define_method_element(elem));
+        }
+    }
+
+    // Pass 3: Apply decorators to static fields.
+    // Auto-accessors are already decorated in Pass 1 (as accessors, not fields).
+    for (auto& elem : static_elements_vec) {
+        if (elem.kind == Bytecode::ClassElementDescriptor::Kind::Field)
+            TRY(apply_decorators_to_element(elem));
+    }
+
+    // Pass 4: Apply decorators to instance fields.
+    for (auto& elem : instance_elements) {
+        if (elem.kind == Bytecode::ClassElementDescriptor::Kind::Field)
+            TRY(apply_decorators_to_element(elem));
+    }
+
+    // Store instance elements on F.[[Elements]].
+    for (auto& elem : instance_elements) {
+        if (elem.kind == Bytecode::ClassElementDescriptor::Kind::Field) {
+            Vector<GC::Ref<FunctionObject>> dec_inits;
+            if (elem.decorator_initializers) {
+                for (auto& di : *elem.decorator_initializers)
+                    dec_inits.append(di.as_function());
+            }
+            Vector<GC::Ref<FunctionObject>> extra_inits;
+            if (elem.extra_initializers) {
+                for (auto& ei : *elem.extra_initializers)
+                    extra_inits.append(ei.as_function());
+            }
+            ClassFieldDefinition field { move(elem.name), move(elem.initializer), move(dec_inits), move(extra_inits) };
+            class_constructor->add_field(field);
+        } else if (elem.kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor) {
+            Vector<GC::Ref<FunctionObject>> dec_inits;
+            if (elem.decorator_initializers) {
+                for (auto& di : *elem.decorator_initializers)
+                    dec_inits.append(di.as_function());
+            }
+            Vector<GC::Ref<FunctionObject>> extra_inits;
+            if (elem.extra_initializers) {
+                for (auto& ei : *elem.extra_initializers)
+                    extra_inits.append(ei.as_function());
+            }
+            ClassFieldDefinition backing_field {
+                ClassElementName(*elem.backing_storage_name),
+                move(elem.initializer),
+                move(dec_inits),
+                move(extra_inits),
+            };
+            class_constructor->add_field(backing_field);
+        }
+        // Instance methods/accessors are already defined on prototype above.
+    }
+
+    // Install instance and static private methods.
     for (auto& private_method : instance_private_methods)
         class_constructor->add_private_method(private_method);
 
     for (auto& method : static_private_methods)
         TRY(class_constructor->private_method_or_accessor_add(move(method)));
 
-    for (auto& element : static_elements) {
-        TRY(element.visit(
-            [&](ClassFieldDefinition& field) -> ThrowCompletionOr<void> {
-                return TRY(class_constructor->define_field(field));
-            },
-            [&](GC::Ref<ECMAScriptFunctionObject> static_block_function) -> ThrowCompletionOr<void> {
-                // We discard any value returned here.
-                TRY(call(vm, *static_block_function, class_constructor));
-                return {};
-            }));
+    // Store instance method extra initializers on the constructor for use
+    // during InitializeInstanceElements.
+    for (auto& initializer : instance_method_extra_initializers) {
+        VERIFY(initializer.is_function());
+        class_constructor->add_instance_extra_initializer(initializer.as_function());
     }
+
+    // Field/accessor extra initializers are now stored per-field on
+    // ClassFieldDefinition::extra_initializers and run in define_field
+    // after each specific field is defined, matching the spec's
+    // InitializeFieldOrAccessor ordering.
+
+    // Apply class decorators.
+    auto class_decorator_pairs = extract_decorator_pairs(decorator_values, decorator_offset, blueprint.class_decorator_count);
+    GC::ConservativeVector<Value> class_extra_initializers;
+
+    // Class decorators are applied in reverse order (inner-to-outer).
+    // Per spec, IsCallable(newDef) accepts any callable, not just
+    // ECMAScriptFunctionObject.
+    GC::Ptr<FunctionObject> current_class = class_constructor;
+    for (ssize_t di = class_decorator_pairs.size() - 1; di >= 0; --di) {
+        auto& dec_pair = class_decorator_pairs[di];
+        auto decoration_finished = std::make_shared<bool>(false);
+        auto context = create_class_decorator_context_object(vm, class_name, class_extra_initializers, decoration_finished);
+        auto new_def = TRY(call(vm, dec_pair.decorator, dec_pair.receiver, current_class, context));
+        *decoration_finished = true;
+        if (new_def.is_function()) {
+            current_class = &new_def.as_function();
+        } else if (!new_def.is_undefined()) {
+            return vm.throw_completion<TypeError>(ErrorType::DecoratorInvalidReturnValue);
+        }
+    }
+    auto* result_class = current_class.ptr();
+
+    vm.running_execution_context().lexical_environment = outer_environment;
+    restore_environment.disarm();
+
+    if (binding_name.has_value())
+        MUST(class_environment->initialize_binding(vm, binding_name.value(), result_class, Environment::InitializeBindingHint::Normal));
+
+    // Run static method extra initializers.
+    for (auto& initializer : static_method_extra_initializers)
+        TRY(call(vm, initializer.as_function(), result_class));
+
+    // Initialize static fields/accessors + static blocks.
+    for (auto& elem : static_elements_vec) {
+        if (elem.kind == Bytecode::ClassElementDescriptor::Kind::StaticInitializer) {
+            TRY(call(vm, elem.value.as_function(), result_class));
+        } else if (elem.kind == Bytecode::ClassElementDescriptor::Kind::Field) {
+            // Initialize the static field on the class.
+            auto init_value = js_undefined();
+            if (!elem.initializer.has<Empty>()) {
+                if (auto const* init_val = elem.initializer.get_pointer<Value>())
+                    init_value = *init_val;
+                else
+                    init_value = TRY(call(vm, *elem.initializer.get<GC::Ref<ECMAScriptFunctionObject>>(), result_class));
+            }
+            // Run decorator initializer chain.
+            if (elem.decorator_initializers) {
+                for (auto& di : *elem.decorator_initializers)
+                    init_value = TRY(call(vm, di.as_function(), result_class, init_value));
+            }
+            // Define the field.
+            TRY(elem.name.visit(
+                [&](PropertyKey const& key) -> ThrowCompletionOr<void> {
+                    TRY(result_class->create_data_property_or_throw(key, init_value));
+                    return {};
+                },
+                [&](PrivateName const& priv) -> ThrowCompletionOr<void> {
+                    return result_class->private_field_add(priv, init_value);
+                }));
+            // Run extra initializers.
+            if (elem.extra_initializers) {
+                for (auto& ei : *elem.extra_initializers)
+                    TRY(call(vm, ei.as_function(), result_class));
+            }
+        } else if (elem.kind == Bytecode::ClassElementDescriptor::Kind::AutoAccessor) {
+            // Initialize the backing storage on the class.
+            auto init_value = js_undefined();
+            if (!elem.initializer.has<Empty>()) {
+                if (auto const* init_val = elem.initializer.get_pointer<Value>())
+                    init_value = *init_val;
+                else
+                    init_value = TRY(call(vm, *elem.initializer.get<GC::Ref<ECMAScriptFunctionObject>>(), result_class));
+            }
+            if (elem.decorator_initializers) {
+                for (auto& di : *elem.decorator_initializers)
+                    init_value = TRY(call(vm, di.as_function(), result_class, init_value));
+            }
+            TRY(result_class->private_field_add(*elem.backing_storage_name, init_value));
+            if (elem.extra_initializers) {
+                for (auto& ei : *elem.extra_initializers)
+                    TRY(call(vm, ei.as_function(), result_class));
+            }
+        }
+    }
+
+    // Run class extra initializers.
+    for (auto& initializer : class_extra_initializers)
+        TRY(call(vm, initializer.as_function(), result_class));
 
     if (blueprint.source_code)
         class_constructor->set_source_text_range(*blueprint.source_code, blueprint.source_text_offset, blueprint.source_text_length);
 
-    return { class_constructor };
+    return { result_class };
 }
 
 }

--- a/Libraries/LibJS/Runtime/ClassConstruction.h
+++ b/Libraries/LibJS/Runtime/ClassConstruction.h
@@ -12,7 +12,7 @@
 
 namespace JS {
 
-ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
+ThrowCompletionOr<FunctionObject*> construct_class(
     VM&,
     Bytecode::ClassBlueprint const&,
     Bytecode::Executable const&,
@@ -20,6 +20,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
     Environment* outer_environment,
     Value super_class,
     ReadonlySpan<Value> element_keys,
+    ReadonlySpan<Value> decorator_values,
     Optional<Utf16FlyString> const& binding_name,
     Utf16FlyString const& class_name);
 

--- a/Libraries/LibJS/Runtime/ClassFieldDefinition.cpp
+++ b/Libraries/LibJS/Runtime/ClassFieldDefinition.cpp
@@ -18,6 +18,10 @@ void ClassFieldDefinition::visit_edges(Cell::Visitor& visitor)
         [&](GC::Ref<ECMAScriptFunctionObject>& function) { visitor.visit(function); },
         [&](Value& value) { visitor.visit(value); },
         [&](Empty) {});
+    for (auto& fn : decorator_initializers)
+        visitor.visit(fn);
+    for (auto& fn : extra_initializers)
+        visitor.visit(fn);
 }
 
 }

--- a/Libraries/LibJS/Runtime/ClassFieldDefinition.h
+++ b/Libraries/LibJS/Runtime/ClassFieldDefinition.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Vector.h>
+#include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Environment.h>
@@ -17,8 +19,10 @@ using ClassElementName = Variant<PropertyKey, PrivateName>;
 
 // 6.2.10 The ClassFieldDefinition Record Specification Type, https://tc39.es/ecma262/#sec-classfielddefinition-record-specification-type
 struct ClassFieldDefinition {
-    ClassElementName name;                                                // [[Name]]
+    ClassElementName name;                                                // [[Name]] / [[Key]]
     Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer; // [[Initializer]]
+    Vector<GC::Ref<FunctionObject>> decorator_initializers;               // [[Initializers]] (decorator init chain)
+    Vector<GC::Ref<FunctionObject>> extra_initializers;                   // [[ExtraInitializers]] (addInitializer callbacks)
 
     void visit_edges(Cell::Visitor& visitor);
 };

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -28,9 +28,11 @@ namespace JS {
     P($8)                                    \
     P($9)                                    \
     P(abs)                                   \
+    P(access)                                \
     P(acos)                                  \
     P(acosh)                                 \
     P(add)                                   \
+    P(addInitializer)                        \
     P(adopt)                                 \
     P(all)                                   \
     P(allSettled)                            \
@@ -272,6 +274,7 @@ namespace JS {
     P(indices)                               \
     P(Infinity)                              \
     P(info)                                  \
+    P(init)                                  \
     P(inLeapYear)                            \
     P(input)                                 \
     P(instant)                               \
@@ -301,6 +304,7 @@ namespace JS {
     P(JSON)                                  \
     P(keyFor)                                \
     P(keys)                                  \
+    P(kind)                                  \
     P(language)                              \
     P(languageDisplay)                       \
     P(largestUnit)                           \
@@ -621,7 +625,9 @@ struct CommonPropertyNames {
     PropertyKey for_ { "for"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
     PropertyKey or_ { "or"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
     PropertyKey register_ { "register"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey private_ { "private"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
     PropertyKey return_ { "return"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey static_ { "static"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
     PropertyKey throw_ { "throw"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
     PropertyKey try_ { "try"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };
     PropertyKey union_ { "union"_utf16_fly_string, PropertyKey::StringMayBeNumber::No };

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -309,6 +309,9 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
 
         for (auto& private_element : m_class_data->private_methods)
             visitor.visit(private_element.value);
+
+        for (auto& initializer : m_class_data->instance_extra_initializers)
+            visitor.visit(initializer);
     }
 
     visitor.visit(m_script_or_module);

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -110,6 +110,9 @@ public:
     Vector<PrivateElement> const& private_methods() const { return ensure_class_data().private_methods; }
     void add_private_method(PrivateElement method) { ensure_class_data().private_methods.append(move(method)); }
 
+    void add_instance_extra_initializer(GC::Ref<FunctionObject> fn) { ensure_class_data().instance_extra_initializers.append(fn); }
+    Vector<GC::Ref<FunctionObject>> const& instance_extra_initializers() const { return ensure_class_data().instance_extra_initializers; }
+
     [[nodiscard]] bool has_class_data() const { return m_class_data; }
 
     // This is for IsSimpleParameterList (static semantics)
@@ -170,8 +173,9 @@ private:
     ScriptOrModule m_script_or_module;                 // [[ScriptOrModule]]
     GC::Ptr<Object> m_home_object;                     // [[HomeObject]]
     struct ClassData {
-        Vector<ClassFieldDefinition> fields;    // [[Fields]]
-        Vector<PrivateElement> private_methods; // [[PrivateMethods]]
+        Vector<ClassFieldDefinition> fields;                              // [[Fields]] / [[Elements]]
+        Vector<PrivateElement> private_methods;                           // [[PrivateMethods]]
+        Vector<GC::Ref<FunctionObject>> instance_extra_initializers;      // [[Initializers]] (decorator addInitializer for methods)
     };
     ClassData& ensure_class_data() const;
     mutable OwnPtr<ClassData> m_class_data;

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -38,6 +38,9 @@
     M(ConstructorWithoutNew, "{} constructor must be called with 'new'")                                                            \
     M(Convert, "Cannot convert {} to {}")                                                                                           \
     M(DataViewOutOfRangeByteOffset, "Data view byte offset {} is out of range for buffer with length {}")                           \
+    M(DecoratorAddInitializerAfterFinished, "addInitializer must not be called after decoration has finished")                      \
+    M(DecoratorAddInitializerNotCallable, "Argument to addInitializer must be a function")                                         \
+    M(DecoratorInvalidReturnValue, "Decorator must return a function or undefined")                           \
     M(DerivedConstructorReturningInvalidValue, "Derived constructor return invalid value")                                          \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                           \
     M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                               \

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -783,6 +783,12 @@ ThrowCompletionOr<void> Object::define_field(ClassFieldDefinition const& field)
     }
     // 4. Else, let initValue be undefined.
 
+    // 4.1 (Decorators) For each element initializer of fieldRecord.[[Initializers]], do
+    //     Set initValue to Call(initializer, receiver, << initValue >>).
+    for (auto const& decorator_init : field.decorator_initializers) {
+        init_value = TRY(call(vm, *decorator_init, this, init_value));
+    }
+
     // 5. If fieldName is a Private Name, then
     if (field_name.has<PrivateName>()) {
         // a. Perform ? PrivateFieldAdd(receiver, fieldName, initValue).
@@ -795,7 +801,13 @@ ThrowCompletionOr<void> Object::define_field(ClassFieldDefinition const& field)
         TRY(create_data_property_or_throw(field_name.get<PropertyKey>(), init_value));
     }
 
-    // 7. Return unused.
+    // 7. (Decorators) For each element initializer of fieldRecord.[[ExtraInitializers]], do
+    //    Perform ? Call(initializer, receiver).
+    for (auto const& extra_init : field.extra_initializers) {
+        TRY(call(vm, *extra_init, this));
+    }
+
+    // 8. Return unused.
     return {};
 }
 
@@ -813,14 +825,20 @@ ThrowCompletionOr<void> Object::initialize_instance_elements(ECMAScriptFunctionO
         TRY(private_method_or_accessor_add(method));
     }
 
-    // 3. Let fields be the value of constructor.[[Fields]].
-    // 4. For each element fieldRecord of fields, do
+    // 3. For each element initializer of constructor.[[Initializers]], do
+    //    (Instance method extra initializers from decorators' addInitializer)
+    for (auto const& initializer : constructor.instance_extra_initializers()) {
+        TRY(call(vm(), *initializer, this));
+    }
+
+    // 4. Let fields be the value of constructor.[[Fields]].
+    // 5. For each element fieldRecord of fields, do
     for (auto const& field : constructor.fields()) {
         // a. Perform ? DefineField(O, fieldRecord).
         TRY(define_field(field));
     }
 
-    // 5. Return unused.
+    // 6. Return unused.
     return {};
 }
 

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -609,7 +609,8 @@ impl FunctionTable {
                     self.collect_from_expression(key, result, scopes);
                     self.collect_from_expression(function, result, scopes);
                 }
-                ClassElement::Field { key, initializer, .. } => {
+                ClassElement::Field { key, initializer, .. }
+                | ClassElement::AutoAccessor { key, initializer, .. } => {
                     self.collect_from_expression(key, result, scopes);
                     if let Some(init) = initializer {
                         self.collect_from_expression(init, result, scopes);
@@ -1044,6 +1045,11 @@ pub enum ClassElement {
         is_static: bool,
     },
     Field {
+        key: Box<Expression>,
+        initializer: Option<Box<Expression>>,
+        is_static: bool,
+    },
+    AutoAccessor {
         key: Box<Expression>,
         initializer: Option<Box<Expression>>,
         is_static: bool,

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -603,14 +603,28 @@ impl FunctionTable {
         if let Some(ref constructor) = class_data.constructor {
             self.collect_from_expression(constructor, result, scopes);
         }
+        for decorator in &class_data.decorators {
+            self.collect_from_expression(decorator, result, scopes);
+        }
         for element in &class_data.elements {
             match &element.inner {
-                ClassElement::Method { key, function, .. } => {
+                ClassElement::Method {
+                    key,
+                    function,
+                    decorators,
+                    ..
+                } => {
+                    for d in decorators {
+                        self.collect_from_expression(d, result, scopes);
+                    }
                     self.collect_from_expression(key, result, scopes);
                     self.collect_from_expression(function, result, scopes);
                 }
-                ClassElement::Field { key, initializer, .. }
-                | ClassElement::AutoAccessor { key, initializer, .. } => {
+                ClassElement::Field { key, initializer, decorators, .. }
+                | ClassElement::AutoAccessor { key, initializer, decorators, .. } => {
+                    for d in decorators {
+                        self.collect_from_expression(d, result, scopes);
+                    }
                     self.collect_from_expression(key, result, scopes);
                     if let Some(init) = initializer {
                         self.collect_from_expression(init, result, scopes);
@@ -1034,6 +1048,7 @@ pub struct ClassData {
     pub constructor: Option<Box<Expression>>,
     pub super_class: Option<Box<Expression>>,
     pub elements: Vec<Node<ClassElement>>,
+    pub decorators: Vec<Expression>,
 }
 
 #[derive(Clone, Debug)]
@@ -1043,16 +1058,19 @@ pub enum ClassElement {
         function: Box<Expression>,
         kind: ClassMethodKind,
         is_static: bool,
+        decorators: Vec<Expression>,
     },
     Field {
         key: Box<Expression>,
         initializer: Option<Box<Expression>>,
         is_static: bool,
+        decorators: Vec<Expression>,
     },
     AutoAccessor {
         key: Box<Expression>,
         initializer: Option<Box<Expression>>,
         is_static: bool,
+        decorators: Vec<Expression>,
     },
     StaticInitializer {
         body: Box<Statement>,

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -1180,6 +1180,26 @@ fn dump_class_element(element: &ClassElement, range: &SourceRange, state: &DumpS
                 dump_expression(init, &child_state(&child_state(state, true), true));
             }
         }
+        ClassElement::AutoAccessor {
+            key,
+            initializer,
+            is_static,
+        } => {
+            let mut desc = color_node_name(root_state, "AutoAccessor");
+            if *is_static {
+                desc.push_str(" static");
+            }
+            desc.push_str(&format_position(root_state, range));
+            print_node(state, &desc);
+            dump_expression(key, &child_state(state, initializer.is_none()));
+            if let Some(init) = initializer {
+                print_node(
+                    &child_state(state, true),
+                    &color_label(root_state, "initializer"),
+                );
+                dump_expression(init, &child_state(&child_state(state, true), true));
+            }
+        }
         ClassElement::StaticInitializer { body } => {
             print_node(
                 state,

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -1141,12 +1141,24 @@ fn dump_class(class_data: &ClassData, range: &SourceRange, state: &DumpState, ro
 }
 
 fn dump_class_element(element: &ClassElement, range: &SourceRange, state: &DumpState, root_state: &DumpState) {
+    let element_decorators = match element {
+        ClassElement::Method { decorators, .. }
+        | ClassElement::Field { decorators, .. }
+        | ClassElement::AutoAccessor { decorators, .. } => decorators.as_slice(),
+        ClassElement::StaticInitializer { .. } => &[],
+    };
+    for decorator in element_decorators {
+        print_node(state, &color_label(root_state, "decorator"));
+        dump_expression(decorator, &child_state(state, true));
+    }
+
     match element {
         ClassElement::Method {
             key,
             function,
             kind,
             is_static,
+            ..
         } => {
             let mut desc = color_node_name(root_state, "ClassMethod");
             if *is_static {
@@ -1167,6 +1179,7 @@ fn dump_class_element(element: &ClassElement, range: &SourceRange, state: &DumpS
             key,
             initializer,
             is_static,
+            ..
         } => {
             let mut desc = color_node_name(root_state, "ClassField");
             if *is_static {
@@ -1184,6 +1197,7 @@ fn dump_class_element(element: &ClassElement, range: &SourceRange, state: &DumpS
             key,
             initializer,
             is_static,
+            ..
         } => {
             let mut desc = color_node_name(root_state, "AutoAccessor");
             if *is_static {

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -6117,6 +6117,50 @@ fn generate_arguments_array(generator: &mut Generator, arguments: &[CallArgument
 // Class expression
 // =============================================================================
 
+/// Evaluate a decorator expression, returning (decorator_value, receiver) registers.
+///
+/// Per the spec's Decorator Evaluation:
+/// - `@member.expr` → receiver is the last-but-one object in the member chain
+/// - `@identifier`, `@(expr)`, `@call(args)` → receiver is undefined
+fn evaluate_decorator(
+    generator: &mut Generator,
+    decorator: &Expression,
+) -> (ScopedOperand, ScopedOperand) {
+    match &decorator.inner {
+        ExpressionKind::Member(data) => {
+            // DecoratorMemberExpression: evaluate object to get receiver,
+            // then resolve the property to get the decorator function.
+            let receiver = generate_expression_or_undefined(&data.object, generator, None);
+            let receiver = generator.copy_if_needed_to_preserve_evaluation_order(&receiver);
+            let base_id = intern_base_identifier(generator, &data.object);
+            let value = generator.allocate_register();
+            if data.computed {
+                let property =
+                    generate_expression_or_undefined(&data.property, generator, None);
+                emit_get_by_value(generator, &value, &receiver, &property, None);
+            } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
+                let arena = generator.arena.clone();
+                emit_get_by_id(generator, &value, &receiver, arena.name_slice(*ident), base_id);
+            } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &data.property.inner {
+                let id = generator.intern_identifier(&priv_ident.name);
+                generator.emit(Instruction::GetPrivateById {
+                    dst: value.operand(),
+                    base: receiver.operand(),
+                    property: id,
+                });
+            }
+            (value, receiver)
+        }
+        _ => {
+            // Identifier, call expression, or parenthesized expression:
+            // no receiver needed.
+            let value = generate_expression_or_undefined(decorator, generator, None);
+            let receiver = generator.add_constant_undefined();
+            (value, receiver)
+        }
+    }
+}
+
 /// Generate bytecode for a class expression or declaration.
 ///
 /// Creates a ClassBlueprint via FFI containing the constructor SFD,
@@ -6136,6 +6180,22 @@ fn generate_class_expression(
         generator.pending_lhs_name = None;
         None
     };
+
+    // Evaluate class-level decorator expressions in the enclosing scope, before
+    // the class environment is created. Per spec, DecoratorListEvaluation runs
+    // before ClassDefinitionEvaluation.
+    let class_decorator_count = data.decorators.len() as u32;
+    let mut class_decorator_operands: Vec<Option<ScopedOperand>> =
+        Vec::with_capacity(data.decorators.len() * 2);
+    for decorator in &data.decorators {
+        let (value, receiver) = evaluate_decorator(generator, decorator);
+        class_decorator_operands.push(Some(
+            generator.copy_if_needed_to_preserve_evaluation_order(&value),
+        ));
+        class_decorator_operands.push(Some(
+            generator.copy_if_needed_to_preserve_evaluation_order(&receiver),
+        ));
+    }
 
     // Step 2: Save parent environment, create class lexical environment.
     let parent_env = generator.current_lexical_environment();
@@ -6213,7 +6273,10 @@ fn generate_class_expression(
                 ExpressionKind::PrivateIdentifier(ident) => {
                     String::from_utf16_lossy(&ident.name)
                 }
-                ExpressionKind::Identifier(ident) => String::from_utf16_lossy(&ident.name),
+                ExpressionKind::Identifier(ident) => {
+                    let arena = generator.arena.clone();
+                    String::from_utf16_lossy(arena.name_slice(*ident))
+                }
                 ExpressionKind::StringLiteral(s) => String::from_utf16_lossy(s),
                 _ => format!("accessor_{element_index}"),
             };
@@ -6227,21 +6290,41 @@ fn generate_class_expression(
         }
     }
 
-    // First pass: evaluate all computed property keys.
-    // This must happen before registering the constructor and method SFDs,
-    // using a two-pass structure.
+    // First pass: evaluate all computed property keys and decorator expressions.
+    // Per spec, decorator expressions are evaluated in source order, interleaved
+    // with computed property keys. Each element's decorators are evaluated before
+    // that element's computed key.
     let mut element_keys: Vec<Option<ScopedOperand>> = Vec::with_capacity(data.elements.len());
+    // Decorator operand pairs (value, receiver) for all elements, then class decorators.
+    let mut decorator_operands: Vec<Option<ScopedOperand>> = Vec::new();
+    // Per-element decorator counts (parallel to data.elements).
+    let mut element_decorator_counts: Vec<u32> = Vec::with_capacity(data.elements.len());
+
     for element_node in &data.elements {
+        let decorators = match &element_node.inner {
+            ClassElement::Method { decorators, .. }
+            | ClassElement::Field { decorators, .. }
+            | ClassElement::AutoAccessor { decorators, .. } => decorators.as_slice(),
+            ClassElement::StaticInitializer { .. } => &[],
+        };
+
+        // Evaluate this element's decorators (source order: before the key).
+        element_decorator_counts.push(decorators.len() as u32);
+        for decorator in decorators {
+            let (value, receiver) = evaluate_decorator(generator, decorator);
+            decorator_operands.push(Some(
+                generator.copy_if_needed_to_preserve_evaluation_order(&value),
+            ));
+            decorator_operands.push(Some(
+                generator.copy_if_needed_to_preserve_evaluation_order(&receiver),
+            ));
+        }
+
+        // Evaluate computed key.
         match &element_node.inner {
-            ClassElement::Method { key, .. } => {
-                if !is_private_key(key) {
-                    let key_val = generate_class_part_expression(key, generator, None);
-                    element_keys.push(key_val);
-                } else {
-                    element_keys.push(None);
-                }
-            }
-            ClassElement::Field { key, .. } | ClassElement::AutoAccessor { key, .. } => {
+            ClassElement::Method { key, .. }
+            | ClassElement::Field { key, .. }
+            | ClassElement::AutoAccessor { key, .. } => {
                 if !is_private_key(key) {
                     let key_val = generate_class_part_expression(key, generator, None);
                     element_keys.push(key_val);
@@ -6254,6 +6337,10 @@ fn generate_class_expression(
             }
         }
     }
+
+    // Append pre-evaluated class decorator operands (evaluated above, before
+    // the class environment was created).
+    decorator_operands.extend(class_decorator_operands.into_iter());
 
     // Create SharedFunctionInstanceData for constructor
     let constructor_sfd_index = if let Some(ctor_expression) = &data.constructor {
@@ -6313,7 +6400,7 @@ fn generate_class_expression(
                     literal_value_number: 0.0,
                     literal_value_string: None,
                     backing_storage_name: None,
-                    decorator_count: 0,
+                    decorator_count: element_decorator_counts[element_index],
                 });
             }
             ClassElement::Field {
@@ -6465,7 +6552,7 @@ fn generate_class_expression(
                     literal_value_number,
                     literal_value_string,
                     backing_storage_name,
-                    decorator_count: 0,
+                    decorator_count: element_decorator_counts[element_index],
                 });
             }
             ClassElement::StaticInitializer { body } => {
@@ -6526,11 +6613,20 @@ fn generate_class_expression(
         has_super_class: has_super,
         has_name,
         elements: class_elements,
-        class_decorator_count: 0,
+        class_decorator_count,
     });
 
-    // Build element_keys operands for the NewClass instruction
-    let element_key_ops: Vec<Option<Operand>> = element_keys.iter().map(|k| k.as_ref().map(|s| s.operand())).collect();
+    // Build combined operands array: element keys followed by decorator pairs.
+    let element_keys_count = element_keys.len();
+    let decorator_operands_count = decorator_operands.len();
+    let mut all_operands: Vec<Option<Operand>> =
+        Vec::with_capacity(element_keys_count + decorator_operands_count);
+    for k in &element_keys {
+        all_operands.push(k.as_ref().map(|s| s.operand()));
+    }
+    for d in &decorator_operands {
+        all_operands.push(d.as_ref().map(|s| s.operand()));
+    }
 
     // Restore parent environment before emitting NewClass.
     generator.emit(Instruction::SetLexicalEnvironment {
@@ -6538,7 +6634,7 @@ fn generate_class_expression(
     });
     generator.pop_tracked_lexical_environment();
 
-    // Allocate dst after element keys.
+    // Allocate dst after all operands.
     let dst = choose_dst(generator, preferred_dst);
 
     // Emit NewClass instruction
@@ -6548,8 +6644,10 @@ fn generate_class_expression(
         class_environment: class_env.operand(),
         class_blueprint_index: blueprint_index,
         lhs_name,
-        element_keys_count: u32_from_usize(element_key_ops.len()),
-        element_keys: element_key_ops,
+        element_keys_count: u32_from_usize(element_keys_count),
+        decorator_operands_count: u32_from_usize(decorator_operands_count),
+        all_operands_count: u32_from_usize(element_keys_count + decorator_operands_count),
+        all_operands: all_operands,
     });
 
     if has_private_env {

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -6280,6 +6280,7 @@ fn generate_class_expression(
                 function,
                 kind,
                 is_static,
+                ..
             } => {
                 let ffi_kind = match kind {
                     ClassMethodKind::Method => ClassElementKind::Method as u8,
@@ -6319,11 +6320,13 @@ fn generate_class_expression(
                 key,
                 initializer,
                 is_static,
+                ..
             }
             | ClassElement::AutoAccessor {
                 key,
                 initializer,
                 is_static,
+                ..
             } => {
                 let is_auto_accessor =
                     matches!(&element_node.inner, ClassElement::AutoAccessor { .. });

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -1323,6 +1323,7 @@ enum ClassElementKind {
     Setter = 2,
     Field = 3,
     StaticInitializer = 4,
+    AutoAccessor = 5,
 }
 
 /// Iterator hint (ABI-compatible).
@@ -6177,24 +6178,52 @@ fn generate_class_expression(
 
     // Create private environment for private class elements.
     let mut has_private_env = false;
-    for element_node in &data.elements {
-        let priv_name = match &element_node.inner {
-            ClassElement::Method { key, .. } | ClassElement::Field { key, .. } => {
-                if let ExpressionKind::PrivateIdentifier(ident) = &key.inner {
-                    Some(ident.name.clone())
-                } else {
-                    None
-                }
-            }
+    // Track auto-accessor backing storage names so we can pass them through FFI.
+    let mut auto_accessor_backing_names: Vec<Option<Utf16String>> =
+        vec![None; data.elements.len()];
+    for (element_index, element_node) in data.elements.iter().enumerate() {
+        let key = match &element_node.inner {
+            ClassElement::Method { key, .. }
+            | ClassElement::Field { key, .. }
+            | ClassElement::AutoAccessor { key, .. } => Some(key),
             ClassElement::StaticInitializer { .. } => None,
         };
-        if let Some(name) = priv_name {
+
+        // Register private identifiers in the private environment.
+        if let Some(key) = key {
+            if let ExpressionKind::PrivateIdentifier(ident) = &key.inner {
+                if !has_private_env {
+                    generator.emit(Instruction::CreatePrivateEnvironment);
+                    has_private_env = true;
+                }
+                let name_id = generator.intern_identifier(&ident.name);
+                generator.emit(Instruction::AddPrivateName { name: name_id });
+            }
+        }
+
+        // Auto-accessors always need a private backing storage name.
+        if let ClassElement::AutoAccessor { key, .. } = &element_node.inner {
             if !has_private_env {
                 generator.emit(Instruction::CreatePrivateEnvironment);
                 has_private_env = true;
             }
-            let name_id = generator.intern_identifier(&name);
-            generator.emit(Instruction::AddPrivateName { name: name_id });
+            // Synthesize a unique backing name that cannot collide with user code.
+            // The embedded NUL ensures no valid identifier can match it.
+            let base = match &key.inner {
+                ExpressionKind::PrivateIdentifier(ident) => {
+                    String::from_utf16_lossy(&ident.name)
+                }
+                ExpressionKind::Identifier(ident) => String::from_utf16_lossy(&ident.name),
+                ExpressionKind::StringLiteral(s) => String::from_utf16_lossy(s),
+                _ => format!("accessor_{element_index}"),
+            };
+            let encoded: Vec<u16> = format!("\0auto_accessor_storage_{element_index}_{base}")
+                .encode_utf16()
+                .collect();
+            let backing_name = Utf16String::from(encoded);
+            let backing_name_id = generator.intern_identifier(&backing_name);
+            generator.emit(Instruction::AddPrivateName { name: backing_name_id });
+            auto_accessor_backing_names[element_index] = Some(backing_name);
         }
     }
 
@@ -6212,7 +6241,7 @@ fn generate_class_expression(
                     element_keys.push(None);
                 }
             }
-            ClassElement::Field { key, .. } => {
+            ClassElement::Field { key, .. } | ClassElement::AutoAccessor { key, .. } => {
                 if !is_private_key(key) {
                     let key_val = generate_class_part_expression(key, generator, None);
                     element_keys.push(key_val);
@@ -6244,7 +6273,7 @@ fn generate_class_expression(
     // Second pass: register method/field SFDs and build element descriptors.
     let mut class_elements = Vec::with_capacity(data.elements.len());
 
-    for element_node in &data.elements {
+    for (element_index, element_node) in data.elements.iter().enumerate() {
         match &element_node.inner {
             ClassElement::Method {
                 key,
@@ -6282,16 +6311,25 @@ fn generate_class_expression(
                     literal_value_kind: PendingLiteralValueKind::None,
                     literal_value_number: 0.0,
                     literal_value_string: None,
+                    backing_storage_name: None,
+                    decorator_count: 0,
                 });
             }
             ClassElement::Field {
                 key,
                 initializer,
                 is_static,
+            }
+            | ClassElement::AutoAccessor {
+                key,
+                initializer,
+                is_static,
             } => {
+                let is_auto_accessor =
+                    matches!(&element_node.inner, ClassElement::AutoAccessor { .. });
+
                 // Detect literal initializers and store the value directly,
                 // avoiding function creation for simple cases like x = 0.
-                // This avoids function creation for simple cases.
                 let mut literal_value_kind = PendingLiteralValueKind::None;
                 let mut literal_value_number: f64 = 0.0;
                 let mut literal_value_string = None;
@@ -6400,8 +6438,21 @@ fn generate_class_expression(
 
                 let is_private = is_private_key(key);
 
+                let ffi_kind = if is_auto_accessor {
+                    ClassElementKind::AutoAccessor as u8
+                } else {
+                    ClassElementKind::Field as u8
+                };
+
+                // For auto-accessors, capture backing storage name for FFI.
+                let backing_storage_name = if is_auto_accessor {
+                    auto_accessor_backing_names[element_index].clone()
+                } else {
+                    None
+                };
+
                 class_elements.push(PendingClassElement {
-                    kind: ClassElementKind::Field as u8,
+                    kind: ffi_kind,
                     is_static: *is_static,
                     is_private,
                     private_identifier: get_private_identifier_name(key),
@@ -6410,6 +6461,8 @@ fn generate_class_expression(
                     literal_value_kind,
                     literal_value_number,
                     literal_value_string,
+                    backing_storage_name,
+                    decorator_count: 0,
                 });
             }
             ClassElement::StaticInitializer { body } => {
@@ -6447,6 +6500,8 @@ fn generate_class_expression(
                     literal_value_kind: PendingLiteralValueKind::None,
                     literal_value_number: 0.0,
                     literal_value_string: None,
+                    backing_storage_name: None,
+                    decorator_count: 0,
                 });
             }
         }
@@ -6468,6 +6523,7 @@ fn generate_class_expression(
         has_super_class: has_super,
         has_name,
         elements: class_elements,
+        class_decorator_count: 0,
     });
 
     // Build element_keys operands for the NewClass instruction

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -179,6 +179,8 @@ pub struct FFIClassElement {
     // Auto-accessor backing storage private name (only for AutoAccessor kind).
     pub backing_storage_name: *const u16,
     pub backing_storage_name_len: usize,
+    // Number of decorators on this element (decorator values are passed as
+    // operands in the NewClass instruction, not through the blueprint).
     pub decorator_count: u32,
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -176,6 +176,10 @@ pub struct FFIClassElement {
     pub literal_value_number: f64,
     pub literal_value_string: *const u16,
     pub literal_value_string_len: usize,
+    // Auto-accessor backing storage private name (only for AutoAccessor kind).
+    pub backing_storage_name: *const u16,
+    pub backing_storage_name_len: usize,
+    pub decorator_count: u32,
 }
 
 /// Data for creating a C++ `SharedFunctionInstanceData`.
@@ -343,6 +347,7 @@ unsafe extern "C" {
         has_name: bool,
         elements: *const FFIClassElement,
         element_count: usize,
+        class_decorator_count: u32,
     ) -> *mut c_void;
 
     // Callbacks for populating Script GDI data from Rust.
@@ -595,6 +600,7 @@ pub unsafe fn materialize_class_blueprint(
             blueprint.has_name,
             ffi_elements.as_ptr(),
             ffi_elements.len(),
+            blueprint.class_decorator_count,
         );
         assert!(!bp_ptr.is_null(), "rust_create_class_blueprint returned null");
         bp_ptr
@@ -612,6 +618,11 @@ fn class_element_to_ffi(element: &PendingClassElement) -> FFIClassElement {
         .as_ref()
         .map(|string| (string.as_ptr(), string.len()))
         .unwrap_or((std::ptr::null(), 0));
+    let (backing_storage_name, backing_storage_name_len) = element
+        .backing_storage_name
+        .as_ref()
+        .map(|name| (name.as_ptr(), name.len()))
+        .unwrap_or((std::ptr::null(), 0));
     FFIClassElement {
         kind: element.kind,
         is_static: element.is_static,
@@ -627,6 +638,9 @@ fn class_element_to_ffi(element: &PendingClassElement) -> FFIClassElement {
         literal_value_number: element.literal_value_number,
         literal_value_string,
         literal_value_string_len,
+        backing_storage_name,
+        backing_storage_name_len,
+        decorator_count: element.decorator_count,
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -85,6 +85,10 @@ pub struct PendingClassElement {
     pub literal_value_kind: PendingLiteralValueKind,
     pub literal_value_number: f64,
     pub literal_value_string: Option<Utf16String>,
+    // Auto-accessor backing storage private name (only for AutoAccessor kind).
+    pub backing_storage_name: Option<Utf16String>,
+    // Decorator count for this element (decorator values passed via NewClass operands).
+    pub decorator_count: u32,
 }
 
 pub struct PendingClassBlueprint {
@@ -95,6 +99,7 @@ pub struct PendingClassBlueprint {
     pub has_super_class: bool,
     pub has_name: bool,
     pub elements: Vec<PendingClassElement>,
+    pub class_decorator_count: u32,
 }
 
 struct EnvironmentCoordinateScope {

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -3710,6 +3710,7 @@ impl Encode for ClassBlueprintRecord<'_> {
         self.0.constructor_sfd_index.encode(encoder);
         self.0.has_super_class.encode(encoder);
         self.0.has_name.encode(encoder);
+        self.0.class_decorator_count.encode(encoder);
         encoder.sequence(&self.0.elements, |element, encoder| {
             ClassElementRecord(element).encode(encoder);
         });
@@ -3725,6 +3726,7 @@ impl ClassBlueprintRecord<'_> {
             constructor_sfd_index: u32::decode(decoder)?,
             has_super_class: bool::decode(decoder)?,
             has_name: bool::decode(decoder)?,
+            class_decorator_count: u32::decode(decoder)?,
             elements: decoder.sequence_values(ClassElementRecord::decode)?,
         })
     }
@@ -3737,6 +3739,7 @@ struct DecodedClassBlueprintRecord {
     constructor_sfd_index: u32,
     has_super_class: bool,
     has_name: bool,
+    class_decorator_count: u32,
     elements: Vec<DecodedClassElementRecord>,
 }
 
@@ -3763,6 +3766,7 @@ impl From<DecodedClassBlueprintRecord> for PendingClassBlueprint {
             constructor_sfd_index: record.constructor_sfd_index,
             has_super_class: record.has_super_class,
             has_name: record.has_name,
+            class_decorator_count: record.class_decorator_count,
             elements: record.elements.into_iter().map(PendingClassElement::from).collect(),
         }
     }
@@ -3781,6 +3785,8 @@ impl Encode for ClassElementRecord<'_> {
         literal_value_kind_tag(self.0.literal_value_kind).encode(encoder);
         self.0.literal_value_number.encode(encoder);
         self.0.literal_value_string.as_deref().map(Utf16).encode(encoder);
+        self.0.backing_storage_name.as_deref().map(Utf16).encode(encoder);
+        self.0.decorator_count.encode(encoder);
     }
 }
 
@@ -3796,6 +3802,8 @@ impl ClassElementRecord<'_> {
             literal_value_kind: PendingLiteralValueKind::decode(decoder)?,
             literal_value_number: f64::decode(decoder)?,
             literal_value_string: Option::<DecodedUtf16String>::decode(decoder)?,
+            backing_storage_name: Option::<DecodedUtf16String>::decode(decoder)?,
+            decorator_count: u32::decode(decoder)?,
         })
     }
 }
@@ -3810,6 +3818,8 @@ struct DecodedClassElementRecord {
     literal_value_kind: PendingLiteralValueKind,
     literal_value_number: f64,
     literal_value_string: Option<DecodedUtf16String>,
+    backing_storage_name: Option<DecodedUtf16String>,
+    decorator_count: u32,
 }
 
 impl DecodedClassElementRecord {
@@ -3821,7 +3831,7 @@ impl DecodedClassElementRecord {
 
         match self.kind {
             0 | 1 | 2 | 4 => shared_function_data_index_is_valid(),
-            3 => {
+            3 | 5 => {
                 if self.has_initializer && matches!(self.literal_value_kind, PendingLiteralValueKind::None) {
                     shared_function_data_index_is_valid()
                 } else {
@@ -3846,6 +3856,8 @@ impl From<DecodedClassElementRecord> for PendingClassElement {
             literal_value_kind: record.literal_value_kind,
             literal_value_number: record.literal_value_number,
             literal_value_string: record.literal_value_string.map(|value| value.to_utf16_string()),
+            backing_storage_name: record.backing_storage_name.map(|name| name.to_utf16_string()),
+            decorator_count: record.decorator_count,
         }
     }
 }

--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -318,6 +318,7 @@ fn single_char_token(ch: u16) -> TokenType {
     match ch as u8 {
         b'&' => TokenType::Ampersand,
         b'*' => TokenType::Asterisk,
+        b'@' => TokenType::At,
         b'[' => TokenType::BracketOpen,
         b']' => TokenType::BracketClose,
         b'^' => TokenType::Caret,

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -1271,7 +1271,7 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn match_declaration(&mut self) -> bool {
         match self.current_token_type() {
-            TokenType::Function | TokenType::Class | TokenType::Const => true,
+            TokenType::Function | TokenType::Class | TokenType::Const | TokenType::At => true,
             TokenType::Let => {
                 if !self.flags.strict_mode {
                     self.try_match_let_declaration()

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -84,6 +84,15 @@ fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>, are
 
 impl Parser<'_> {
     pub(crate) fn parse_declaration(&mut self) -> Statement {
+        if self.match_token(TokenType::At) {
+            let decorators = self.parse_decorator_list();
+            if self.match_token(TokenType::Class) {
+                return self.parse_class_declaration_with_decorators(decorators);
+            }
+            self.syntax_error("Decorators are only valid on class declarations");
+            // Fall through to parse whatever follows as a regular declaration.
+        }
+
         if self.match_token(TokenType::Async) {
             let next = self.next_token();
             if next.token_type == TokenType::Function && !next.trivia_has_line_terminator {
@@ -625,12 +634,118 @@ impl Parser<'_> {
     }
 
     // https://tc39.es/ecma262/#sec-class-definitions
+    // https://arai-a.github.io/ecma262-compare/?pr=2417
+    // DecoratorList : DecoratorList? Decorator
+    // Decorator : `@` DecoratorMemberExpression
+    //           | `@` DecoratorParenthesizedExpression
+    //           | `@` DecoratorCallExpression
+    // DecoratorMemberExpression : IdentifierReference
+    //                           | DecoratorMemberExpression `.` IdentifierName
+    //                           | DecoratorMemberExpression `.` PrivateIdentifier
+    // DecoratorParenthesizedExpression : `(` Expression `)`
+    // DecoratorCallExpression : DecoratorMemberExpression Arguments
+    pub(crate) fn parse_decorator_list(&mut self) -> Vec<Expression> {
+        let mut decorators = Vec::new();
+        while self.match_token(TokenType::At) {
+            let start = self.position();
+            self.consume(); // consume '@'
+
+            let decorator_expr = if self.match_token(TokenType::ParenOpen) {
+                // DecoratorParenthesizedExpression : `(` Expression `)`
+                self.consume();
+                let expr = self.parse_expression_any();
+                self.consume_token(TokenType::ParenClose);
+                expr
+            } else if self.match_identifier() {
+                // DecoratorMemberExpression : IdentifierReference (.IdentifierName)*
+                let ident_start = self.position();
+                let token = self.consume();
+                let name = self.token_identifier_name(&token);
+                let ident = self.make_identifier(ident_start, name);
+                {
+                    let Self { scope_collector, arena, .. } = self;
+                    scope_collector.register_identifier(
+                        ident, None,
+                        &mut arena.identifiers, &arena.strings, &mut arena.scopes,
+                    );
+                }
+                let mut expr = self.expression(
+                    ident_start,
+                    ExpressionKind::Identifier(ident),
+                );
+
+                // Chain dot access: DecoratorMemberExpression `.` IdentifierName
+                while self.match_token(TokenType::Period) {
+                    self.consume();
+                    if self.match_token(TokenType::PrivateIdentifier) {
+                        let member_start = self.position();
+                        let id = self.parse_private_identifier(member_start);
+                        let property = self.expression(
+                            member_start,
+                            ExpressionKind::PrivateIdentifier(Box::new(id)),
+                        );
+                        expr = self.expression(
+                            start,
+                            ExpressionKind::Member(Box::new(MemberExprData {
+                                object: Box::new(expr),
+                                property: Box::new(property),
+                                computed: false,
+                            })),
+                        );
+                    } else if self.match_identifier_name() {
+                        let member_start = self.position();
+                        let member_token = self.consume();
+                        let member_name = self.token_identifier_name(&member_token);
+                        let member_ident = self.make_identifier(member_start, member_name);
+                        let property = self.expression(
+                            member_start,
+                            ExpressionKind::Identifier(member_ident),
+                        );
+                        expr = self.expression(
+                            start,
+                            ExpressionKind::Member(Box::new(MemberExprData {
+                                object: Box::new(expr),
+                                property: Box::new(property),
+                                computed: false,
+                            })),
+                        );
+                    } else {
+                        self.expected("identifier after '.' in decorator");
+                        break;
+                    }
+                }
+
+                // DecoratorCallExpression : DecoratorMemberExpression Arguments
+                if self.match_token(TokenType::ParenOpen) {
+                    expr = self.parse_call_expression(expr);
+                }
+
+                expr
+            } else {
+                self.expected("decorator expression after '@'");
+                let error_ident = self.make_identifier_from_slice(start, &[]);
+                self.expression(start, ExpressionKind::Identifier(error_ident))
+            };
+
+            decorators.push(decorator_expr);
+        }
+        decorators
+    }
+
     // ClassDeclaration : `class` BindingIdentifier ClassTail
     // ClassExpression  : `class` BindingIdentifier? ClassTail
     // ClassTail        : ClassHeritage? `{` ClassBody `}`
     // https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
     // NB: All code within a ClassBody is in strict mode.
     pub(crate) fn parse_class_expression(&mut self, expect_name: bool) -> Expression {
+        self.parse_class_expression_with_decorators(expect_name, Vec::new())
+    }
+
+    pub(crate) fn parse_class_expression_with_decorators(
+        &mut self,
+        expect_name: bool,
+        class_decorators: Vec<Expression>,
+    ) -> Expression {
         let start = self.position();
 
         let strict_before = self.flags.strict_mode;
@@ -759,13 +874,21 @@ impl Parser<'_> {
                 constructor: constructor.map(Box::new),
                 super_class,
                 elements,
+                decorators: class_decorators,
             })),
         )
     }
 
     pub(crate) fn parse_class_declaration(&mut self) -> Statement {
+        self.parse_class_declaration_with_decorators(Vec::new())
+    }
+
+    fn parse_class_declaration_with_decorators(
+        &mut self,
+        decorators: Vec<Expression>,
+    ) -> Statement {
         let start = self.position();
-        let class_expression = self.parse_class_expression(true);
+        let class_expression = self.parse_class_expression_with_decorators(true, decorators);
         // Convert the class expression into a class declaration by extracting ClassData.
         match class_expression.inner {
             ExpressionKind::Class(data) => {
@@ -894,6 +1017,9 @@ impl Parser<'_> {
         class_start: Position,
         found_private_names: &mut HashMap<Utf16String, (Option<ClassMethodKind>, bool)>,
     ) -> (Option<Node<ClassElement>>, Option<Expression>) {
+        // Parse decorators before the element.
+        let element_decorators = self.parse_decorator_list();
+
         // C++ lexes "static" as Identifier and checks original_value() == "static".
         let mut is_static =
             if self.match_identifier() && self.token_original_value(&self.current_token) == utf16!("static") {
@@ -901,9 +1027,8 @@ impl Parser<'_> {
                 // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
                 // ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`
                 if self.match_token(TokenType::CurlyOpen) {
-                    // C++ captures static_start (push_start) before consuming '{'.
                     let static_start = self.position();
-                    self.consume(); // consume '{'
+                    self.consume();
                     let saved_flags = self.flags;
                     self.flags.in_break_context = false;
                     self.flags.in_continue_context = false;
@@ -921,7 +1046,6 @@ impl Parser<'_> {
                     let scope = self.make_scope(children);
                     self.scope_collector.set_scope_node(scope);
                     self.scope_collector.close_scope();
-                    // C++ uses rule_start (class start) for FunctionBody position.
                     let body = self.statement(
                         class_start,
                         StatementKind::FunctionBody {
@@ -929,7 +1053,9 @@ impl Parser<'_> {
                             in_strict_mode: self.flags.strict_mode,
                         },
                     );
-                    // C++ uses static_start (after '{') for StaticInitializer position.
+                    if !element_decorators.is_empty() {
+                        self.syntax_error("Decorators are not valid on static class blocks");
+                    }
                     return (
                         Some(Node::new(
                             self.range_from(static_start),
@@ -1134,6 +1260,9 @@ impl Parser<'_> {
             };
 
             if is_constructor {
+                if !element_decorators.is_empty() {
+                    self.syntax_error("Decorators are not valid on constructors");
+                }
                 return (None, Some(function));
             }
 
@@ -1145,6 +1274,7 @@ impl Parser<'_> {
                         function: Box::new(function),
                         kind: class_method_kind,
                         is_static,
+                        decorators: element_decorators,
                     },
                 )),
                 None,
@@ -1184,12 +1314,14 @@ impl Parser<'_> {
                 key: Box::new(key),
                 initializer: init,
                 is_static,
+                decorators: element_decorators,
             }
         } else {
             ClassElement::Field {
                 key: Box::new(key),
                 initializer: init,
                 is_static,
+                decorators: element_decorators,
             }
         };
 

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -947,12 +947,20 @@ impl Parser<'_> {
         let mut is_generator = false;
         let mut is_getter = false;
         let mut is_setter = false;
+        let mut is_auto_accessor = false;
         let function_start = self.position();
 
         // Check modifiers (must not contain escape sequences).
         if self.match_identifier_name() {
             let value = self.token_original_value(&self.current_token).to_vec();
-            if value == utf16!("get") && self.match_property_key_ahead() {
+            if value == utf16!("accessor") && self.match_property_key_ahead() {
+                // FieldDefinition : `accessor` [no LineTerminator here] ClassElementName Initializer?
+                let next = self.next_token();
+                if !next.trivia_has_line_terminator {
+                    is_auto_accessor = true;
+                    self.consume();
+                }
+            } else if value == utf16!("get") && self.match_property_key_ahead() {
                 is_getter = true;
                 self.consume();
             } else if value == utf16!("set") && self.match_property_key_ahead() {
@@ -974,7 +982,7 @@ impl Parser<'_> {
             }
         }
 
-        if self.match_token(TokenType::Asterisk) {
+        if !is_auto_accessor && self.match_token(TokenType::Asterisk) {
             is_generator = true;
             self.consume();
         }
@@ -986,13 +994,16 @@ impl Parser<'_> {
             expression: key,
             name: key_value,
             ..
-        } = if (is_static || is_async || is_getter || is_setter)
+        } = if (is_static || is_async || is_getter || is_setter || is_auto_accessor)
             && (self.match_token(TokenType::Semicolon)
                 || self.match_token(TokenType::Equals)
                 || self.match_token(TokenType::ParenOpen)
                 || self.match_token(TokenType::CurlyClose))
         {
-            let name: &[u16] = if is_async {
+            let name: &[u16] = if is_auto_accessor {
+                is_auto_accessor = false;
+                utf16!("accessor")
+            } else if is_async {
                 is_async = false;
                 utf16!("async")
             } else if is_getter {
@@ -1071,6 +1082,11 @@ impl Parser<'_> {
                 let name_str = String::from_utf16_lossy(name);
                 self.syntax_error(&format!("Duplicate private field or method named '{name_str}'"));
             }
+        }
+
+        // Auto-accessors are field-like; they cannot have a method body.
+        if is_auto_accessor && self.match_token(TokenType::ParenOpen) {
+            self.syntax_error("Auto-accessor cannot have a method body");
         }
 
         if self.match_token(TokenType::ParenOpen) {
@@ -1162,15 +1178,23 @@ impl Parser<'_> {
         };
 
         self.consume_or_insert_semicolon();
+
+        let element = if is_auto_accessor {
+            ClassElement::AutoAccessor {
+                key: Box::new(key),
+                initializer: init,
+                is_static,
+            }
+        } else {
+            ClassElement::Field {
+                key: Box::new(key),
+                initializer: init,
+                is_static,
+            }
+        };
+
         (
-            Some(Node::new(
-                self.range_from(class_start),
-                ClassElement::Field {
-                    key: Box::new(key),
-                    initializer: init,
-                    is_static,
-                },
-            )),
+            Some(Node::new(self.range_from(class_start), element)),
             None,
         )
     }

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -39,6 +39,7 @@ impl Parser<'_> {
             | TokenType::This
             | TokenType::Super
             | TokenType::New
+            | TokenType::At
             | TokenType::Class
             | TokenType::Function
             | TokenType::ParenOpen
@@ -316,6 +317,18 @@ impl Parser<'_> {
 
             TokenType::Class => {
                 let expression = self.parse_class_expression(false);
+                (expression, true)
+            }
+
+            // Decorated class expression: `@dec class { ... }`
+            TokenType::At => {
+                let decorators = self.parse_decorator_list();
+                if !self.match_token(TokenType::Class) {
+                    self.syntax_error("Decorators are only valid on class expressions");
+                    return (self.expression(start, ExpressionKind::Error), true);
+                }
+                let expression =
+                    self.parse_class_expression_with_decorators(false, decorators);
                 (expression, true)
             }
 

--- a/Libraries/LibJS/Rust/src/token.rs
+++ b/Libraries/LibJS/Rust/src/token.rs
@@ -53,6 +53,7 @@ define_tokens! {
     Arrow                      => Operator,
     Asterisk                   => Operator,
     AsteriskEquals             => Operator,
+    At                         => Punctuation,
     Async                      => Keyword,
     Await                      => Keyword,
     BigIntLiteral              => Number,

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1578,9 +1578,11 @@ extern "C" void* rust_create_class_blueprint(
     bool has_super_class,
     bool has_name,
     FFIClassElement const* elements,
-    size_t element_count)
+    size_t element_count,
+    uint32_t class_decorator_count)
 {
     auto* blueprint = new JS::Bytecode::ClassBlueprint();
+    blueprint->class_decorator_count = class_decorator_count;
     blueprint->constructor_shared_function_data_index = constructor_sfd_index;
     blueprint->has_super_class = has_super_class;
     blueprint->has_name = has_name;
@@ -1605,6 +1607,7 @@ extern "C" void* rust_create_class_blueprint(
         desc.has_initializer = elem.has_initializer;
         if (elem.backing_storage_name_len > 0)
             desc.backing_storage_name = Utf16FlyString::from_utf16(Utf16View(reinterpret_cast<char16_t const*>(elem.backing_storage_name), elem.backing_storage_name_len));
+        desc.decorator_count = elem.decorator_count;
         switch (elem.literal_value_kind) {
         case LiteralValueKind::None:
             break;

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1603,6 +1603,8 @@ extern "C" void* rust_create_class_blueprint(
         if (elem.shared_function_data_index.has_value)
             desc.shared_function_data_index = elem.shared_function_data_index.value;
         desc.has_initializer = elem.has_initializer;
+        if (elem.backing_storage_name_len > 0)
+            desc.backing_storage_name = Utf16FlyString::from_utf16(Utf16View(reinterpret_cast<char16_t const*>(elem.backing_storage_name), elem.backing_storage_name_len));
         switch (elem.literal_value_kind) {
         case LiteralValueKind::None:
             break;

--- a/Tests/LibJS/Runtime/classes/class-auto-accessors.js
+++ b/Tests/LibJS/Runtime/classes/class-auto-accessors.js
@@ -1,0 +1,336 @@
+test("basic functionality", () => {
+    class A {
+        accessor x = 1;
+    }
+
+    const a = new A();
+    expect(a.x).toBe(1);
+
+    a.x = 2;
+    expect(a.x).toBe(2);
+});
+
+test("without initializer", () => {
+    class A {
+        accessor x;
+    }
+
+    const a = new A();
+    expect(a.x).toBeUndefined();
+
+    a.x = 42;
+    expect(a.x).toBe(42);
+});
+
+test("multiple auto-accessors", () => {
+    class A {
+        accessor x = 1;
+        accessor y = 2;
+        accessor z = 3;
+    }
+
+    const a = new A();
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+    expect(a.z).toBe(3);
+
+    a.x = 10;
+    a.y = 20;
+    a.z = 30;
+    expect(a.x).toBe(10);
+    expect(a.y).toBe(20);
+    expect(a.z).toBe(30);
+});
+
+test("private auto-accessor", () => {
+    class A {
+        accessor #x = 1;
+
+        getX() {
+            return this.#x;
+        }
+
+        setX(v) {
+            this.#x = v;
+        }
+    }
+
+    const a = new A();
+    expect(a.getX()).toBe(1);
+    expect(a.x).toBeUndefined();
+
+    a.setX(42);
+    expect(a.getX()).toBe(42);
+});
+
+test("static auto-accessor", () => {
+    class A {
+        static accessor x = 1;
+    }
+
+    expect(A.x).toBe(1);
+
+    A.x = 2;
+    expect(A.x).toBe(2);
+
+    expect(new A().x).toBeUndefined();
+});
+
+test("static private auto-accessor", () => {
+    class A {
+        static accessor #x = 1;
+
+        static getX() {
+            return this.#x;
+        }
+
+        static setX(v) {
+            this.#x = v;
+        }
+    }
+
+    expect(A.getX()).toBe(1);
+
+    A.setX(42);
+    expect(A.getX()).toBe(42);
+});
+
+// Assisted-By: claude opus 4.6 1m - originally checked new A() instead of
+// A.prototype. Per spec, public auto-accessor getter/setter are defined on
+// the prototype (homeObject) during ClassFieldDefinitionEvaluation, not on
+// the instance. The instance only receives the private backing storage field.
+// Auto-accessor properties are defined via DefineMethodProperty with
+// enumerable: false, matching SpiderMonkey's behavior.
+test("property descriptor", () => {
+    class A {
+        accessor x = 1;
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(A.prototype, "x");
+    expect(typeof desc.get).toBe("function");
+    expect(typeof desc.set).toBe("function");
+    expect(desc.enumerable).toBeFalse();
+    expect(desc.configurable).toBeTrue();
+    expect(desc.value).toBeUndefined();
+    expect(desc.writable).toBeUndefined();
+});
+
+test("static property descriptor", () => {
+    class A {
+        static accessor x = 1;
+    }
+
+    const desc = Object.getOwnPropertyDescriptor(A, "x");
+    expect(typeof desc.get).toBe("function");
+    expect(typeof desc.set).toBe("function");
+    expect(desc.enumerable).toBeFalse();
+    expect(desc.configurable).toBeTrue();
+});
+
+test("extended name syntax", () => {
+    const s = Symbol("foo");
+
+    class A {
+        accessor "field with space" = 1;
+
+        accessor 12 = "twelve";
+
+        accessor [`he${"llo"}`] = 3;
+
+        accessor [s] = 4;
+    }
+
+    const a = new A();
+    expect(a["field with space"]).toBe(1);
+    expect(a[12]).toBe("twelve");
+    expect(a.hello).toBe(3);
+    expect(a[s]).toBe(4);
+
+    a["field with space"] = 10;
+    expect(a["field with space"]).toBe(10);
+});
+
+test("initializer has correct this value", () => {
+    class A {
+        accessor x = this;
+    }
+
+    const a = new A();
+    expect(a.x).toBe(a);
+});
+
+test("interleaving with regular fields", () => {
+    const order = [];
+
+    class A {
+        x = (order.push("field x"), 1);
+        accessor y = (order.push("accessor y"), 2);
+        z = (order.push("field z"), 3);
+    }
+
+    const a = new A();
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+    expect(a.z).toBe(3);
+    expect(order).toEqual(["field x", "accessor y", "field z"]);
+});
+
+test("each instance gets its own backing storage", () => {
+    class A {
+        accessor x = 1;
+    }
+
+    const a1 = new A();
+    const a2 = new A();
+    a1.x = 42;
+    expect(a1.x).toBe(42);
+    expect(a2.x).toBe(1);
+});
+
+test("inheritance", () => {
+    class Parent {
+        accessor x = 1;
+    }
+
+    class Child extends Parent {}
+
+    const c = new Child();
+    expect(c.x).toBe(1);
+
+    c.x = 2;
+    expect(c.x).toBe(2);
+});
+
+test("overriding in subclass", () => {
+    class Parent {
+        accessor x = 1;
+    }
+
+    class Child extends Parent {
+        accessor x = 2;
+    }
+
+    const c = new Child();
+    expect(c.x).toBe(2);
+});
+
+test("private auto-accessor brand check", () => {
+    class A {
+        accessor #x = 1;
+
+        hasX(obj) {
+            return #x in obj;
+        }
+    }
+
+    const a = new A();
+    expect(a.hasX(a)).toBeTrue();
+    expect(a.hasX({})).toBeFalse();
+});
+
+test("private auto-accessor access from outside throws", () => {
+    expect("class A { accessor #x = 1; } new A().#x").not.toEval();
+});
+
+describe("'accessor' as contextual keyword", () => {
+    test("accessor as field name", () => {
+        class A {
+            accessor = 1;
+        }
+
+        const a = new A();
+        expect(a.accessor).toBe(1);
+    });
+
+    test("accessor as method name", () => {
+        class A {
+            accessor() {
+                return 42;
+            }
+        }
+
+        expect(new A().accessor()).toBe(42);
+    });
+
+    test("accessor as getter name", () => {
+        class A {
+            get accessor() {
+                return 42;
+            }
+        }
+
+        expect(new A().accessor).toBe(42);
+    });
+
+    test("accessor as setter name", () => {
+        class A {
+            set accessor(v) {
+                this._v = v;
+            }
+        }
+
+        const a = new A();
+        a.accessor = 42;
+        expect(a._v).toBe(42);
+    });
+
+    test("static accessor as field name", () => {
+        class A {
+            static accessor = 1;
+        }
+
+        expect(A.accessor).toBe(1);
+    });
+});
+
+describe("syntax errors", () => {
+    test("accessor with generator is syntax error", () => {
+        expect("class A { accessor *x() {} }").not.toEval();
+    });
+
+    test("accessor with async is syntax error", () => {
+        expect("class A { accessor async x = 1; }").not.toEval();
+    });
+
+    test("accessor with get is syntax error", () => {
+        expect("class A { accessor get x() {} }").not.toEval();
+    });
+
+    test("accessor with set is syntax error", () => {
+        expect("class A { accessor set x(v) {} }").not.toEval();
+    });
+
+    test("duplicate private auto-accessor names", () => {
+        expect("class A { accessor #x; accessor #x; }").not.toEval();
+    });
+
+    test("duplicate private auto-accessor and field", () => {
+        expect("class A { accessor #x; #x; }").not.toEval();
+        expect("class A { #x; accessor #x; }").not.toEval();
+    });
+
+    test("duplicate private static and instance auto-accessor", () => {
+        expect("class A { static accessor #x; accessor #x; }").not.toEval();
+    });
+
+    test("accessor with parenthesized body is not valid", () => {
+        expect("class A { accessor x() {} }").not.toEval();
+    });
+});
+
+test("literal field initializers", () => {
+    class A {
+        accessor pos_int = 42;
+        accessor neg_int = -1;
+        accessor bool_val = true;
+        accessor null_val = null;
+        accessor str_val = "hello";
+    }
+
+    const a = new A();
+    expect(a.pos_int).toBe(42);
+    expect(a.neg_int).toBe(-1);
+    expect(a.bool_val).toBeTrue();
+    expect(a.null_val).toBeNull();
+    expect(a.str_val).toBe("hello");
+});

--- a/Tests/LibJS/Runtime/decorators/decorator-add-initializer.js
+++ b/Tests/LibJS/Runtime/decorators/decorator-add-initializer.js
@@ -1,0 +1,81 @@
+// addInitializer tests.
+
+test("method decorator addInitializer runs on instantiation", () => {
+    const log = [];
+    function dec(method, context) {
+        context.addInitializer(function () {
+            log.push(`init ${context.name} on ${this.constructor.name}`);
+        });
+    }
+
+    class A {
+        @dec
+        method() {}
+    }
+
+    expect(log).toEqual([]);
+    new A();
+    expect(log).toEqual(["init method on A"]);
+});
+
+test("field decorator addInitializer runs after field init", () => {
+    const log = [];
+    function dec(value, context) {
+        context.addInitializer(function () {
+            log.push("extra init");
+        });
+    }
+
+    class A {
+        @dec
+        x = (log.push("field init"), 1);
+    }
+
+    new A();
+    expect(log).toEqual(["field init", "extra init"]);
+});
+
+test("class decorator addInitializer runs after class definition", () => {
+    const log = [];
+    function dec(cls, context) {
+        context.addInitializer(function () {
+            log.push("class init");
+        });
+    }
+
+    expect(log).toEqual([]);
+
+    @dec
+    class A {}
+
+    expect(log).toEqual(["class init"]);
+});
+
+test("addInitializer throws if called after decoration finishes", () => {
+    let savedAddInit;
+    function dec(value, context) {
+        savedAddInit = context.addInitializer;
+    }
+
+    class A {
+        @dec
+        method() {}
+    }
+
+    expect(() => {
+        savedAddInit(function () {});
+    }).toThrowWithMessage(TypeError, "addInitializer must not be called after decoration has finished");
+});
+
+test("addInitializer throws for non-callable argument", () => {
+    function dec(value, context) {
+        context.addInitializer(42);
+    }
+
+    expect(() => {
+        class A {
+            @dec
+            method() {}
+        }
+    }).toThrowWithMessage(TypeError, "Argument to addInitializer must be a function");
+});

--- a/Tests/LibJS/Runtime/decorators/decorator-application.js
+++ b/Tests/LibJS/Runtime/decorators/decorator-application.js
@@ -1,0 +1,316 @@
+// Decorator application tests -- decorators that actually transform behavior.
+
+describe("method decorators", () => {
+    test("method decorator can replace the method", () => {
+        function doubleReturn(method) {
+            return function (...args) {
+                return method.call(this, ...args) * 2;
+            };
+        }
+
+        class A {
+            @doubleReturn
+            value() {
+                return 21;
+            }
+        }
+
+        expect(new A().value()).toBe(42);
+    });
+
+    test("method decorator returning undefined keeps original", () => {
+        const log = [];
+        function trace(method, context) {
+            log.push(context.name);
+        }
+
+        class A {
+            @trace
+            foo() {
+                return 1;
+            }
+        }
+
+        expect(new A().foo()).toBe(1);
+        expect(log).toEqual(["foo"]);
+    });
+
+    test("multiple method decorators applied inner-to-outer", () => {
+        const log = [];
+        function dec(id) {
+            return function (method, context) {
+                log.push(`apply ${id}`);
+                return function (...args) {
+                    log.push(`call ${id}`);
+                    return method.call(this, ...args);
+                };
+            };
+        }
+
+        class A {
+            @dec("outer")
+            @dec("inner")
+            foo() {
+                return 1;
+            }
+        }
+
+        expect(log).toEqual(["apply inner", "apply outer"]);
+        log.length = 0;
+
+        new A().foo();
+        expect(log).toEqual(["call outer", "call inner"]);
+    });
+
+    test("static method decorator", () => {
+        function doubleReturn(method) {
+            return function (...args) {
+                return method.call(this, ...args) * 2;
+            };
+        }
+
+        class A {
+            @doubleReturn
+            static value() {
+                return 21;
+            }
+        }
+
+        expect(A.value()).toBe(42);
+    });
+
+    test("private method decorator", () => {
+        function doubleReturn(method) {
+            return function (...args) {
+                return method.call(this, ...args) * 2;
+            };
+        }
+
+        class A {
+            @doubleReturn
+            #value() {
+                return 21;
+            }
+
+            getValue() {
+                return this.#value();
+            }
+        }
+
+        expect(new A().getValue()).toBe(42);
+    });
+});
+
+describe("field decorators", () => {
+    test("field decorator can add initializer", () => {
+        function double(value, context) {
+            return function (initialValue) {
+                return initialValue * 2;
+            };
+        }
+
+        class A {
+            @double
+            x = 21;
+        }
+
+        expect(new A().x).toBe(42);
+    });
+
+    test("field decorator returning undefined keeps original", () => {
+        function noop() {}
+
+        class A {
+            @noop
+            x = 42;
+        }
+
+        expect(new A().x).toBe(42);
+    });
+
+    test("multiple field decorators chain initializers", () => {
+        function times(n) {
+            return function () {
+                return function (v) {
+                    return v * n;
+                };
+            };
+        }
+
+        class A {
+            @times(2)
+            @times(3)
+            x = 1;
+        }
+
+        // Inner (times(3)) runs first on initial value: 1 * 3 = 3
+        // Outer (times(2)) runs on that result: 3 * 2 = 6
+        expect(new A().x).toBe(6);
+    });
+});
+
+describe("getter decorators", () => {
+    test("getter decorator can replace the getter", () => {
+        function cache(getter) {
+            return function () {
+                if (!this._cached) {
+                    this._cached = getter.call(this);
+                }
+                return this._cached;
+            };
+        }
+
+        class A {
+            @cache
+            get value() {
+                return Math.random();
+            }
+        }
+
+        const a = new A();
+        const v1 = a.value;
+        const v2 = a.value;
+        expect(v1).toBe(v2);
+    });
+});
+
+describe("setter decorators", () => {
+    test("setter decorator can replace the setter", () => {
+        function validate(setter) {
+            return function (value) {
+                if (typeof value !== "number") throw new TypeError("expected number");
+                setter.call(this, value);
+            };
+        }
+
+        class A {
+            _x = 0;
+
+            @validate
+            set x(v) {
+                this._x = v;
+            }
+        }
+
+        const a = new A();
+        a.x = 42;
+        expect(a._x).toBe(42);
+        expect(() => {
+            a.x = "not a number";
+        }).toThrowWithMessage(TypeError, "expected number");
+    });
+});
+
+describe("auto-accessor decorators", () => {
+    test("accessor decorator can replace get and set", () => {
+        function logged(value, context) {
+            const { get, set } = value;
+            return {
+                get() {
+                    return get.call(this);
+                },
+                set(v) {
+                    set.call(this, v);
+                },
+            };
+        }
+
+        class A {
+            @logged
+            accessor x = 1;
+        }
+
+        const a = new A();
+        expect(a.x).toBe(1);
+        a.x = 2;
+        expect(a.x).toBe(2);
+    });
+
+    test("accessor decorator can provide init", () => {
+        function withDefault(value, context) {
+            return {
+                init(v) {
+                    return v ?? 42;
+                },
+            };
+        }
+
+        class A {
+            @withDefault
+            accessor x;
+        }
+
+        expect(new A().x).toBe(42);
+    });
+});
+
+describe("class decorators", () => {
+    test("class decorator can replace the class", () => {
+        function addMethod(cls, context) {
+            return class extends cls {
+                added() {
+                    return 42;
+                }
+            };
+        }
+
+        @addMethod
+        class A {}
+
+        expect(new A().added()).toBe(42);
+    });
+
+    test("class decorator returning undefined keeps original", () => {
+        const log = [];
+        function track(cls, context) {
+            log.push(context.name);
+        }
+
+        @track
+        class MyClass {}
+
+        expect(log).toEqual(["MyClass"]);
+        expect(new MyClass()).toBeInstanceOf(MyClass);
+    });
+
+    test("multiple class decorators applied inner-to-outer", () => {
+        const log = [];
+        function dec(id) {
+            return function (cls, context) {
+                log.push(id);
+            };
+        }
+
+        @dec("outer")
+        @dec("inner")
+        class A {}
+
+        expect(log).toEqual(["inner", "outer"]);
+    });
+});
+
+describe("decorator errors", () => {
+    test("method decorator returning non-function throws", () => {
+        function bad() {
+            return 42;
+        }
+
+        expect(() => {
+            class A {
+                @bad
+                method() {}
+            }
+        }).toThrowWithMessage(TypeError, "Decorator must return a function or undefined");
+    });
+
+    test("class decorator returning non-function throws", () => {
+        function bad() {
+            return 42;
+        }
+
+        expect(() => {
+            @bad
+            class A {}
+        }).toThrowWithMessage(TypeError, "Decorator must return a function or undefined");
+    });
+});

--- a/Tests/LibJS/Runtime/decorators/decorator-context.js
+++ b/Tests/LibJS/Runtime/decorators/decorator-context.js
@@ -1,0 +1,281 @@
+// Decorator context object tests.
+
+describe("context.kind", () => {
+    test("method context has kind 'method'", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            method() {}
+        }
+
+        expect(ctx.kind).toBe("method");
+    });
+
+    test("getter context has kind 'getter'", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            get x() {
+                return 1;
+            }
+        }
+
+        expect(ctx.kind).toBe("getter");
+    });
+
+    test("setter context has kind 'setter'", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            set x(v) {}
+        }
+
+        expect(ctx.kind).toBe("setter");
+    });
+
+    test("field context has kind 'field'", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            x = 1;
+        }
+
+        expect(ctx.kind).toBe("field");
+    });
+
+    test("auto-accessor context has kind 'accessor'", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            accessor x = 1;
+        }
+
+        expect(ctx.kind).toBe("accessor");
+    });
+
+    test("class context has kind 'class'", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        @capture
+        class A {}
+
+        expect(ctx.kind).toBe("class");
+    });
+});
+
+describe("context.name", () => {
+    test("public method name", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            myMethod() {}
+        }
+
+        expect(ctx.name).toBe("myMethod");
+    });
+
+    test("public field name", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            myField = 1;
+        }
+
+        expect(ctx.name).toBe("myField");
+    });
+
+    test("private method name includes #", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            #myMethod() {}
+        }
+
+        expect(ctx.name).toBe("#myMethod");
+    });
+
+    test("class decorator name is class name", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        @capture
+        class MyClass {}
+
+        expect(ctx.name).toBe("MyClass");
+    });
+});
+
+describe("context.static", () => {
+    test("instance method is not static", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            method() {}
+        }
+
+        expect(ctx.static).toBeFalse();
+    });
+
+    test("static method is static", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            static method() {}
+        }
+
+        expect(ctx.static).toBeTrue();
+    });
+
+    test("class decorator has no static property", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        @capture
+        class A {}
+
+        expect(ctx).not.toHaveProperty("static");
+    });
+});
+
+describe("context.private", () => {
+    test("public method is not private", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            method() {}
+        }
+
+        expect(ctx.private).toBeFalse();
+    });
+
+    test("private method is private", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            #method() {}
+        }
+
+        expect(ctx.private).toBeTrue();
+    });
+
+    test("class decorator has no private property", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        @capture
+        class A {}
+
+        expect(ctx).not.toHaveProperty("private");
+    });
+});
+
+describe("context.access", () => {
+    test("method access has get and has", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            method() {
+                return 42;
+            }
+        }
+
+        const a = new A();
+        expect(typeof ctx.access.get).toBe("function");
+        expect(typeof ctx.access.has).toBe("function");
+        expect(ctx.access.get(a)).toBe(a.method);
+        expect(ctx.access.has(a)).toBeTrue();
+    });
+
+    test("field access has get, set, and has", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        class A {
+            @capture
+            x = 42;
+        }
+
+        const a = new A();
+        expect(typeof ctx.access.get).toBe("function");
+        expect(typeof ctx.access.set).toBe("function");
+        expect(typeof ctx.access.has).toBe("function");
+        expect(ctx.access.get(a)).toBe(42);
+        ctx.access.set(a, 100);
+        expect(a.x).toBe(100);
+    });
+
+    test("class decorator has no access property", () => {
+        let ctx;
+        function capture(v, context) {
+            ctx = context;
+        }
+
+        @capture
+        class A {}
+
+        expect(ctx).not.toHaveProperty("access");
+    });
+});

--- a/Tests/LibJS/Runtime/decorators/decorator-order.js
+++ b/Tests/LibJS/Runtime/decorators/decorator-order.js
@@ -1,0 +1,76 @@
+// Decorator evaluation and application order tests.
+
+test("decorator expressions evaluated in source order", () => {
+    const log = [];
+    function track(id) {
+        log.push(`eval ${id}`);
+        return function () {};
+    }
+
+    class A {
+        @track("m1")
+        method1() {}
+
+        @track("f1")
+        field1 = 1;
+
+        @track("m2")
+        method2() {}
+    }
+
+    expect(log).toEqual(["eval m1", "eval f1", "eval m2"]);
+});
+
+test("decorators applied in spec order: static methods, instance methods, static fields, instance fields", () => {
+    const log = [];
+    function track(id) {
+        return function (value, context) {
+            log.push(`apply ${id} (${context.kind}, static=${context.static})`);
+        };
+    }
+
+    class A {
+        @track("instance-field")
+        x = 1;
+
+        @track("static-method")
+        static sm() {}
+
+        @track("instance-method")
+        im() {}
+
+        @track("static-field")
+        static sf = 1;
+    }
+
+    // Decoration order per spec:
+    // 1. static methods/accessors
+    // 2. instance methods/accessors
+    // 3. static fields
+    // 4. instance fields
+    expect(log).toEqual([
+        "apply static-method (method, static=true)",
+        "apply instance-method (method, static=false)",
+        "apply static-field (field, static=true)",
+        "apply instance-field (field, static=false)",
+    ]);
+});
+
+test("class decorators applied after element decorators", () => {
+    const log = [];
+    function track(id) {
+        return function () {
+            log.push(id);
+        };
+    }
+
+    @track("class")
+    class A {
+        @track("method")
+        method() {}
+    }
+
+    // Element decorators before class decorators
+    expect(log[0]).toBe("method");
+    expect(log[1]).toBe("class");
+});

--- a/Tests/LibJS/Runtime/decorators/decorator-syntax.js
+++ b/Tests/LibJS/Runtime/decorators/decorator-syntax.js
@@ -1,0 +1,218 @@
+// Decorator syntax parsing tests.
+// Phase 2: parsing only -- decorators are no-ops at this stage.
+// A no-op decorator that does nothing (returns undefined).
+function dec() {}
+function dec1() {}
+function dec2() {}
+
+const decorators = {
+    dec() {},
+    nested: {
+        dec() {},
+    },
+};
+
+describe("class element decorators", () => {
+    test("method decorator", () => {
+        class A {
+            @dec method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("field decorator", () => {
+        class A {
+            @dec x = 1;
+        }
+        expect(new A().x).toBe(1);
+    });
+
+    test("auto-accessor decorator", () => {
+        class A {
+            @dec accessor x = 1;
+        }
+        expect(new A().x).toBe(1);
+    });
+
+    test("getter decorator", () => {
+        class A {
+            @dec get x() {
+                return 1;
+            }
+        }
+        expect(new A().x).toBe(1);
+    });
+
+    test("setter decorator", () => {
+        class A {
+            @dec set x(v) {
+                this._v = v;
+            }
+        }
+        const a = new A();
+        a.x = 42;
+        expect(a._v).toBe(42);
+    });
+
+    test("static method decorator", () => {
+        class A {
+            @dec static method() {
+                return 1;
+            }
+        }
+        expect(A.method()).toBe(1);
+    });
+
+    test("static field decorator", () => {
+        class A {
+            @dec static x = 1;
+        }
+        expect(A.x).toBe(1);
+    });
+
+    test("multiple decorators on one element", () => {
+        class A {
+            @dec1
+            @dec2
+            method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+});
+
+describe("class decorators", () => {
+    test("class declaration decorator", () => {
+        @dec
+        class A {
+            x = 1;
+        }
+        expect(new A().x).toBe(1);
+    });
+
+    test("multiple class decorators", () => {
+        @dec1
+        @dec2
+        class A {}
+        expect(new A()).toBeInstanceOf(A);
+    });
+
+    test("class expression decorator", () => {
+        const A =
+            @dec
+            class {
+                x = 1;
+            };
+        expect(new A().x).toBe(1);
+    });
+});
+
+describe("decorator expression forms", () => {
+    test("identifier decorator", () => {
+        class A {
+            @dec method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("member expression decorator", () => {
+        class A {
+            @decorators.dec method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("nested member expression decorator", () => {
+        class A {
+            @decorators.nested.dec method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("call expression decorator", () => {
+        function factory() {
+            return function () {};
+        }
+        class A {
+            @factory() method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("member call expression decorator", () => {
+        const obj = {
+            factory() {
+                return function () {};
+            },
+        };
+        class A {
+            @obj.factory() method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("parenthesized expression decorator", () => {
+        class A {
+            @(dec) method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+
+    test("parenthesized complex expression decorator", () => {
+        const decs = [dec];
+        class A {
+            @(decs[0]) method() {
+                return 1;
+            }
+        }
+        expect(new A().method()).toBe(1);
+    });
+});
+
+describe("syntax errors", () => {
+    test("decorator on constructor is syntax error", () => {
+        expect("class A { @dec constructor() {} }").not.toEval();
+    });
+
+    test("decorator on static block is syntax error", () => {
+        expect("class A { @dec static {} }").not.toEval();
+    });
+
+    test("decorator on non-class declaration is syntax error", () => {
+        expect("@dec function f() {}").not.toEval();
+        expect("@dec let x;").not.toEval();
+        expect("@dec const x = 1;").not.toEval();
+        expect("@dec var x;").not.toEval();
+    });
+
+    test("bare @ is syntax error", () => {
+        expect("class A { @ method() {} }").not.toEval();
+    });
+
+    test("decorator with computed access is syntax error", () => {
+        expect("class A { @dec[0] method() {} }").not.toEval();
+    });
+
+    test("decorator with optional chaining is syntax error", () => {
+        expect("class A { @dec?.foo method() {} }").not.toEval();
+    });
+
+    test("decorator with template literal is syntax error", () => {
+        expect("class A { @dec`str` method() {} }").not.toEval();
+    });
+});

--- a/Tests/LibJS/Runtime/eval-basic.js
+++ b/Tests/LibJS/Runtime/eval-basic.js
@@ -85,10 +85,10 @@ test("indirect eval with syntax error can be called multiple times", function ()
     }
     expect(f).toThrowWithMessage(
         SyntaxError,
-        "Unexpected token Invalid. Expected statement or declaration (line: 1, column: 1)"
+        "Unexpected token At. Expected decorator expression after '@' (line: 1, column: 2)"
     );
     expect(f).toThrowWithMessage(
         SyntaxError,
-        "Unexpected token Invalid. Expected statement or declaration (line: 1, column: 1)"
+        "Unexpected token At. Expected decorator expression after '@' (line: 1, column: 2)"
     );
 });

--- a/Tests/LibJS/Runtime/parser-line-terminators.js
+++ b/Tests/LibJS/Runtime/parser-line-terminators.js
@@ -12,31 +12,31 @@ function anonymous(
 
 test("LINE FEED is a line terminator", () => {
     expect(() => {
-        Function("\n\n@");
+        Function("\n\n\x01");
     }).toThrowWithMessage(SyntaxError, "Unexpected token Invalid. Expected CurlyClose (line: 4, column: 1)");
 });
 
 test("CARRIAGE RETURN is a line terminator", () => {
     expect(() => {
-        Function("\r\r@");
+        Function("\r\r\x01");
     }).toThrowWithMessage(SyntaxError, "Unexpected token Invalid. Expected CurlyClose (line: 4, column: 1)");
 });
 
 test("LINE SEPARATOR is a line terminator", () => {
     expect(() => {
-        Function("  @");
+        Function("  \x01");
     }).toThrowWithMessage(SyntaxError, "Unexpected token Invalid. Expected CurlyClose (line: 4, column: 1)");
 });
 
 test("PARAGRAPH SEPARATOR is a line terminator", () => {
     expect(() => {
-        Function("  @");
+        Function("  \x01");
     }).toThrowWithMessage(SyntaxError, "Unexpected token Invalid. Expected CurlyClose (line: 4, column: 1)");
 });
 
 test("CR LF is counted as only one line terminator", () => {
     expect(() => {
-        Function("\r\n\r\n@");
+        Function("\r\n\r\n\x01");
     }).toThrowWithMessage(SyntaxError, "Unexpected token Invalid. Expected CurlyClose (line: 4, column: 1)");
 });
 
@@ -54,7 +54,7 @@ test("LS/PS are allowed in string literal", () => {
 
 test("line terminators can be mixed (but please don't)", () => {
     expect(() => {
-        Function("\r \r\n \n\r@");
+        Function("\r \r\n \n\r\x01");
     }).toThrowWithMessage(SyntaxError, "Unexpected token Invalid. Expected CurlyClose (line: 8, column: 1)");
 });
 


### PR DESCRIPTION
## Summary

Implement TC39 stage 3 [decorators](https://github.com/tc39/proposal-decorators) for LibJS, spanning the full pipeline from parsing through runtime application.

### Commit 1: Auto-accessor keyword

Implement the `accessor` contextual keyword from the decorators proposal. `accessor x = 1` creates a private backing store with a public getter/setter pair. Supports public/private, static/instance, and computed key auto-accessors.

### Commit 2: Decorator syntax parsing

Add lexer, parser, and AST support for decorator syntax. Decorators are accepted before class declarations, class expressions, and class elements (methods, fields, auto-accessors, getters, setters). All three expression forms are supported: `@ident.chain`, `@ident.chain(args)`, `@(expr)`.

### Commit 3: Decorator codegen and runtime

Evaluate decorator expressions during class definition, pass values through the NewClass instruction, and apply them at runtime per the spec's Decoration Order algorithm.

- 4-pass decoration order: static methods/accessors, instance methods/accessors, static fields, instance fields
- Decorators applied inner-to-outer (reverse source order)
- Class decorators applied last, may replace the class with any callable
- Implements CreateDecoratorAccessObject, CreateAddInitializerFunction, CreateDecoratorContextObject, ApplyDecoratorsToElementDefinition, ApplyDecoratorsToClassDefinition
- Field decorator initializer chains via ClassFieldDefinition
- Per-field extra initializers via ClassFieldDefinition for `addInitializer`
- Instance method extra initializers via ECMAScriptFunctionObject

## Test plan

- [x] 30 auto-accessor tests
- [x] 25 decorator syntax tests (valid and invalid forms)
- [x] 69 decorator runtime tests: application, context, ordering, `addInitializer`, syntax forms
- [x] Full suite: 6554 pass, 0 regressions