### PR TITLE
AK: Don't convert `encode_base64_impl()` input to `StringView`

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -80,18 +80,18 @@ static ErrorOr<ByteBuffer> decode_base64_impl(StringView input, LastChunkHandlin
     return output;
 }
 
-static ErrorOr<String> encode_base64_impl(StringView input, simdutf::base64_options options)
+static ErrorOr<String> encode_base64_impl(ReadonlyBytes input, simdutf::base64_options options)
 {
     if (input.is_empty())
         return String {};
 
     u8* buffer = nullptr;
     auto output = TRY(AK::Detail::StringData::create_uninitialized(
-        simdutf::base64_length_from_binary(input.length(), options), buffer));
+        simdutf::base64_length_from_binary(input.size(), options), buffer));
 
     simdutf::binary_to_base64(
-        input.characters_without_null_termination(),
-        input.length(),
+        reinterpret_cast<char const*>(input.data()),
+        input.size(),
         reinterpret_cast<char*>(buffer),
         options);
 


### PR DESCRIPTION
Since e47cdc6b, converting `ReadonlyBytes` to a `StringView` will crash if the `ReadonlyBytes` given is empty. This caused a crash when calling `btoa("")`, which called encode_base64() with an empty `ReadonlyBytes`. We now don't convert the input from `ReadonlyBytes` to `StringView,` which avoids this problem.

It may be worth broadening the assertion here to accept ReadonlyBytes with size 0: https://github.com/LadybirdBrowser/ladybird/blob/201e615aad8967f033365ded5d6e333c70eb300c/AK/StringView.h#L45-L50

That wasn't necessary in this particular case though.

Fixes a crash in http://wpt.live/html/webappapis/atob/base64.any.html, which I've imported.