### PR TITLE
Meta: Auto-enable quiet build output under coding agents

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -318,8 +318,15 @@ def ensure_ladybird_source_dir() -> Path:
     return ladybird_source_dir
 
 
+def is_running_under_coding_agent() -> bool:
+    return "CLAUDECODE" in os.environ or "CODEX_SANDBOX" in os.environ
+
+
 def build_main(build_dir: Path, jobs: Optional[str], target: Optional[str] = None, args: Optional[list[str]] = None):
     build_args = ["ninja", "-C", str(build_dir)]
+
+    if is_running_under_coding_agent():
+        build_args.append("--quiet")
 
     if not jobs:
         jobs = os.environ.get("MAKEJOBS", None)


### PR DESCRIPTION
When running under a coding agent (Claude Code, OpenAI Codex), pass --quiet to ninja to suppress progress status lines. Errors and warnings are still shown.

Coding agents parse build output programmatically and don't benefit from ninja's real-time progress display. Suppressing it reduces noise and keeps the agent focused on actionable output like compilation errors.