### PR TITLE
LibWeb: Mark ellipsized fragments as hidden rather than removing them

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -331,8 +331,8 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
 
             fragment.set_inline_length(CSSPixels::nearest_value_for(last_kept_end + ellipsis_width));
 
-            if (i + 1 < fragments.size())
-                fragments.remove(i + 1, fragments.size() - i - 1);
+            for (size_t j = i + 1; j < fragments.size(); ++j)
+                fragments[j].set_fully_truncated(true);
 
             line_box.m_inline_length = available_width;
             break;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -391,6 +391,8 @@ void LayoutState::commit(Box& root)
                 for (size_t line_index = 0; line_index < used_values.line_boxes.size(); ++line_index) {
                     auto& line_box = used_values.line_boxes[line_index];
                     for (auto const& fragment : line_box.fragments()) {
+                        if (fragment.is_fully_truncated())
+                            continue;
                         if (auto const* text_node = as_if<TextNode>(fragment.layout_node()))
                             text_nodes.set(const_cast<TextNode*>(text_node));
                         auto did_relocate_fragment = try_to_relocate_fragment_in_inline_node(fragment, line_index);

--- a/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -57,6 +57,9 @@ public:
     bool has_trailing_whitespace() const { return m_has_trailing_whitespace; }
     void set_has_trailing_whitespace(bool value) { m_has_trailing_whitespace = value; }
 
+    bool is_fully_truncated() const { return m_is_fully_truncated; }
+    void set_fully_truncated(bool value) { m_is_fully_truncated = value; }
+
 private:
     CSS::Direction resolve_glyph_run_direction(Gfx::GlyphRun::TextType) const;
     void append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_width);
@@ -78,6 +81,7 @@ private:
     float m_insert_position { 0 };
     CSS::Direction m_current_insert_direction { CSS::Direction::Ltr };
     bool m_has_trailing_whitespace { false };
+    bool m_is_fully_truncated { false };
 };
 
 }

--- a/Tests/LibWeb/Crash/Layout/text-overflow-ellipsis-atomic-inline.html
+++ b/Tests/LibWeb/Crash/Layout/text-overflow-ellipsis-atomic-inline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+</style>
+<div>
+    This text is long enough to overflow <img src="" width="20" height="20">
+</div>
+<script>
+    document.querySelector("div").clientWidth;
+</script>


### PR DESCRIPTION
Previously, when applying `text-overflow: ellipsis`, line box fragments after the  ellipsis point were removed from the line box. This invalidated fragment indices stored in `containing_line_box_fragment`, causing an out-of-bounds access in `LayoutState::commit()` when resolving atomic inline positions.

Instead of removing fragments, mark them as hidden. This preserves index stability while preventing hidden fragments from being displayed.

Fixes: #8684