### PR TITLE
LibWeb: Use the fallback base URL for document.cookie

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3509,7 +3509,7 @@ WebIDL::ExceptionOr<String> Document::cookie()
             return m_cookie;
     }
 
-    auto [cookie_version, cookie] = page().client().page_did_request_cookie(m_url, HTTP::Cookie::Source::NonHttp);
+    auto [cookie_version, cookie] = page().client().page_did_request_cookie(fallback_base_url(), HTTP::Cookie::Source::NonHttp);
 
     if (cookie_version.has_value()) {
         m_cookie_version = *cookie_version;
@@ -3532,8 +3532,9 @@ WebIDL::ExceptionOr<void> Document::set_cookie(StringView cookie_string)
 
     // Otherwise, the user agent must act as it would when receiving a set-cookie-string for the document's URL via a
     // "non-HTTP" API, consisting of the new value encoded as UTF-8.
-    if (auto cookie = HTTP::Cookie::parse_cookie(url(), cookie_string); cookie.has_value())
-        page().client().page_did_set_cookie(m_url, cookie.value(), HTTP::Cookie::Source::NonHttp);
+    auto cookie_url = fallback_base_url();
+    if (auto cookie = HTTP::Cookie::parse_cookie(cookie_url, cookie_string); cookie.has_value())
+        page().client().page_did_set_cookie(cookie_url, cookie.value(), HTTP::Cookie::Source::NonHttp);
 
     return {};
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/cookies/navigated-away.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/cookies/navigated-away.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	document.cookie behavior on documents without browser context

--- a/Tests/LibWeb/Text/input/wpt-import/cookies/navigated-away.html
+++ b/Tests/LibWeb/Text/input/wpt-import/cookies/navigated-away.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<head>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+</head>
+<body>
+  <iframe id="if" src="about:blank"></iframe>
+  <script>
+    var t = async_test("document.cookie behavior on documents without browser context");
+    t.add_cleanup(function() {
+      document.cookie = "nav_away_test=yes;max-age=0";
+    });
+
+    function step2() {
+      t.step(function() {
+        // Get from saved doc should fail.
+        assert_equals(window.iframeDoc.cookie, "");
+
+        // Try set from saved doc, should do nothing.
+        window.iframeDoc.cookie = "nav_away_test=second";
+        assert_equals(window.iframeDoc.cookie, "");
+        assert_not_equals(document.cookie.indexOf("nav_away_test=yes"), -1);
+      });
+      t.done();
+    }
+
+    t.step(function() {
+      document.cookie = "nav_away_test=yes";
+      var iframe = document.getElementById("if");
+      // Save original document.
+      window.iframeDoc = iframe.contentDocument;
+      assert_not_equals(window.iframeDoc.cookie.indexOf("nav_away_test=yes"), -1);
+
+      // Navigate away.
+      iframe.onload = step2;
+      iframe.contentWindow.location = "/common/blank.html";
+    })
+  </script>
+</body>


### PR DESCRIPTION
Use the document's fallback base URL for
  document.cookie get/set instead of the
  literal document URL.

  This makes initial about:blank documents
  use their inherited HTTP(S) context for
  cookie access, which matches the WHATWG
  HTML Standard and fixes
  cookies/navigated-away.html.

  Spec:
  https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie
  https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url