### PR TITLE
LibWeb: Skip intersection observation when document has no paintable

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5266,7 +5266,7 @@ static CSSPixelRect compute_intersection(GC::Ref<Element> target, IntersectionOb
 
     // 2. Let container be the containing block of target.
     // 3. While container is not root:
-    if (auto const* target_paintable = target->paintable_box()) {
+    if (auto const* target_paintable = target->paintable_box(); target_paintable && target->document().paintable()) {
         for (auto const* container = target_paintable->containing_block(); container; container = container->containing_block()) {
             // Stop when we reach the intersection root.
             if (container == root_paintable)


### PR DESCRIPTION
When navigating to a page with images inside `overflow: hidden` containers (e.g. https://cyan.com/games/obduction/), a document's intersection observer can fire while the document's `ViewportPaintable` is null. 

The intersection observer updates before the document has a valid paint tree. The containing block walk in `compute_intersection()` then dereferences the null paintable, causing the SIGSEGV in the attached issue.

No test is included because I wasn't able to reliably reproduce the timing needed for it to crash in a local test server. 

fixes https://github.com/LadybirdBrowser/ladybird/issues/8670