### PR TITLE
LibWeb: Remove "signal to continue SHTQ" from document loading

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -64,7 +64,7 @@ bool build_xml_document(DOM::Document& document, ByteBuffer const& data, Optiona
 }
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#navigate-html
-static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing)
+static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::NavigationParams const& navigation_params)
 {
     // To load an HTML document, given navigation params navigationParams:
 
@@ -77,8 +77,6 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
     if (document->url_string() == "about:blank"_string
         && navigation_params.response->body()->length().value_or(0) == 0) {
         TRY(document->populate_with_html_head_and_body());
-        // NB: Nothing else is added to the document, so mark it as loaded and resolve the signal_to_continue_session_history_processing.
-        signal_to_continue_session_history_processing->resolve({});
         HTML::HTMLParser::the_end(document);
     }
 
@@ -96,10 +94,8 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
     //    causes a load event to be fired.
     else {
         // FIXME: Parse as we receive the document data, instead of waiting for the whole document to be fetched first.
-        auto process_body = GC::create_function(document->heap(), [document, signal_to_continue_session_history_processing, url = navigation_params.response->url().value(), mime_type = Fetch::Infrastructure::extract_mime_type(navigation_params.response->header_list())](ByteBuffer data) mutable {
-            Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(document->heap(), [signal_to_continue_session_history_processing, document = document, data = move(data), url = url, mime_type = move(mime_type)] {
-                // NB: If document is part of a session history entry's traversal, resolve the signal_to_continue_session_history_processing.
-                signal_to_continue_session_history_processing->resolve({});
+        auto process_body = GC::create_function(document->heap(), [document, url = navigation_params.response->url().value(), mime_type = Fetch::Infrastructure::extract_mime_type(navigation_params.response->header_list())](ByteBuffer data) mutable {
+            Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(document->heap(), [document = document, data = move(data), url = url, mime_type = move(mime_type)] {
                 auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, data, mime_type);
                 if (document->ready_to_run_scripts()) {
                     parser->run(url);
@@ -124,7 +120,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
 }
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-xml
-static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::NavigationParams const& navigation_params, MimeSniff::MimeType type, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing)
+static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::NavigationParams const& navigation_params, MimeSniff::MimeType type)
 {
     // When faced with displaying an XML file inline, provided navigation params navigationParams and a string type, user agents
     // must follow the requirements defined in XML and Namespaces in XML, XML Media Types, DOM, and other relevant specifications
@@ -159,7 +155,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
     if (auto maybe_encoding = type.parameters().get("charset"sv); maybe_encoding.has_value())
         content_encoding = maybe_encoding.value();
 
-    auto process_body = GC::create_function(document->heap(), [document, signal_to_continue_session_history_processing, url = navigation_params.response->url().value(), content_encoding = move(content_encoding), mime = type](ByteBuffer data) {
+    auto process_body = GC::create_function(document->heap(), [document, url = navigation_params.response->url().value(), content_encoding = move(content_encoding), mime = type](ByteBuffer data) {
         Optional<TextCodec::Decoder&> decoder;
         // The actual HTTP headers and other metadata, not the headers as mutated or implied by the algorithms given in this specification,
         // are the ones that must be used when determining the character encoding according to the rules given in the above specifications.
@@ -178,8 +174,6 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
 
             // NB: This ensures that the `load` event gets fired for the frame loading this document.
             document->completely_finish_loading();
-            // NB: If document is part of a session history entry's traversal, resolve the signal_to_continue_session_history_processing.
-            signal_to_continue_session_history_processing->resolve({});
             return;
         }
         auto source = decoder->to_utf8(data);
@@ -190,12 +184,8 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
 
             // NB: This ensures that the `load` event gets fired for the frame loading this document.
             document->completely_finish_loading();
-            // NB: If document is part of session history traversal, resolve the signal_to_continue_session_history_processing.
-            signal_to_continue_session_history_processing->resolve({});
             return;
         }
-        // NB: If document is part of session history traversal, resolve the signal_to_continue_session_history_processing.
-        signal_to_continue_session_history_processing->resolve({});
         auto run_xml_parser = [document, source_string = source.release_value()] {
             XML::Parser parser(source_string, { .preserve_cdata = true, .preserve_comments = true, .resolve_named_html_entity = resolve_named_html_entity });
             XMLDocumentBuilder builder { document };
@@ -226,7 +216,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
 }
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#navigate-text
-static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_text_document(HTML::NavigationParams const& navigation_params, MimeSniff::MimeType type, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing)
+static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_text_document(HTML::NavigationParams const& navigation_params, MimeSniff::MimeType type)
 {
     // To load a text document, given a navigation params navigationParams and a string type:
 
@@ -253,12 +243,10 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_text_document(HTML::Navi
     //    document's relevant global object to have the parser to process the implied EOF character, which eventually causes a
     //    load event to be fired.
     // FIXME: Parse as we receive the document data, instead of waiting for the whole document to be fetched first.
-    auto process_body = GC::create_function(document->heap(), [document, signal_to_continue_session_history_processing, url = navigation_params.response->url().value(), mime = type](ByteBuffer data) {
+    auto process_body = GC::create_function(document->heap(), [document, url = navigation_params.response->url().value(), mime = type](ByteBuffer data) {
         auto encoding = run_encoding_sniffing_algorithm(document, data, mime);
         dbgln_if(HTML_PARSER_DEBUG, "The encoding sniffing algorithm returned encoding '{}'", encoding);
 
-        // NB: If document is part of session history traversal, resolve the signal_to_continue_session_history_processing.
-        signal_to_continue_session_history_processing->resolve({});
         auto run_text_parser = [document, data = move(data), url, encoding = move(encoding)] {
             auto parser = HTML::HTMLParser::create_for_scripting(document);
             parser->tokenizer().update_insertion_point();
@@ -300,7 +288,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_text_document(HTML::Navi
 }
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#navigate-media
-static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_media_document(HTML::NavigationParams const& navigation_params, MimeSniff::MimeType type, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing)
+static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_media_document(HTML::NavigationParams const& navigation_params, MimeSniff::MimeType type)
 {
     // To load a media document, given navigationParams and a string type:
 
@@ -385,10 +373,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_media_document(HTML::Nav
     auto& realm = document->realm();
     navigation_params.response->body()->fully_read(
         realm,
-        GC::create_function(document->heap(), [document, signal_to_continue_session_history_processing](ByteBuffer) {
-            // NB: If document is part of session history traversal, resolve the signal_to_continue_session_history_processing.
-            signal_to_continue_session_history_processing->resolve({});
-            HTML::HTMLParser::the_end(document); }),
+        GC::create_function(document->heap(), [document](ByteBuffer) { HTML::HTMLParser::the_end(document); }),
         GC::create_function(document->heap(), [](JS::Value) {}),
         GC::Ref { realm.global_object() });
 
@@ -433,7 +418,7 @@ bool can_load_document_with_type(MimeSniff::MimeType const& type)
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#loading-a-document
-GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing, ReadonlyBytes sniff_bytes)
+GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, ReadonlyBytes sniff_bytes)
 {
     // To load a document given navigation params navigationParams, source snapshot params sourceSnapshotParams,
     // and origin initiatorOrigin, perform the following steps. They return a Document or null.
@@ -457,14 +442,14 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     // -> an HTML MIME type
     if (type.is_html()) {
         // Return the result of loading an HTML document, given navigationParams.
-        return load_html_document(navigation_params, signal_to_continue_session_history_processing).release_value_but_fixme_should_propagate_errors();
+        return load_html_document(navigation_params).release_value_but_fixme_should_propagate_errors();
     }
 
     // -> an XML MIME type that is not an explicitly supported XML MIME type
     //    FIXME: that is not an explicitly supported XML MIME type
     if (type.is_xml()) {
         // Return the result of loading an XML document given navigationParams and type.
-        return load_xml_document(navigation_params, type, signal_to_continue_session_history_processing).release_value_but_fixme_should_propagate_errors();
+        return load_xml_document(navigation_params, type).release_value_but_fixme_should_propagate_errors();
     }
 
     // -> a JavaScript MIME type
@@ -478,7 +463,7 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
         || type.essence() == "text/plain"_string
         || type.essence() == "text/vtt"_string) {
         // Return the result of loading a text document given navigationParams and type.
-        return load_text_document(navigation_params, type, signal_to_continue_session_history_processing).release_value_but_fixme_should_propagate_errors();
+        return load_text_document(navigation_params, type).release_value_but_fixme_should_propagate_errors();
     }
 
     // -> "multipart/x-mixed-replace"
@@ -491,7 +476,7 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     if (type.is_image()
         || type.is_audio_or_video()) {
         // Return the result of loading a media document given navigationParams and type.
-        return load_media_document(navigation_params, type, signal_to_continue_session_history_processing).release_value_but_fixme_should_propagate_errors();
+        return load_media_document(navigation_params, type).release_value_but_fixme_should_propagate_errors();
     }
 
     // -> "application/pdf"

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -14,7 +14,7 @@
 namespace Web {
 
 bool build_xml_document(DOM::Document& document, ByteBuffer const& data, Optional<String> content_encoding);
-GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing, ReadonlyBytes sniff_bytes);
+GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, ReadonlyBytes sniff_bytes);
 bool can_load_document_with_type(MimeSniff::MimeType const&);
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-ua-inline

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1522,7 +1522,6 @@ void Navigable::populate_session_history_entry_document(
     GC::Ref<SourceSnapshotParams> source_snapshot_params,
     TargetSnapshotParams const& target_snapshot_params,
     UserNavigationInvolvement user_involvement,
-    NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing,
     Optional<String> navigation_id,
     NavigationParamsVariant navigation_params,
     ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type,
@@ -1542,20 +1541,18 @@ void Navigable::populate_session_history_entry_document(
     // 3. Let documentResource be entry's document state's resource.
     // NOTE: documentResource is passed as a parameter.
 
-    auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, user_involvement, completion_steps, csp_navigation_type, signal_to_continue_session_history_processing](GC::Ref<InternalNavigationResult> result) {
+    auto received_navigation_params = GC::create_function(heap(), [this, url, navigation_id, user_involvement, completion_steps, csp_navigation_type](GC::Ref<InternalNavigationResult> result) {
         // AD-HOC: Not in the spec but subsequent steps will fail if the navigable doesn't have an active window.
         if (!active_window())
             return;
 
         // 5. Queue a global task on the navigation and traversal task source, given navigable's active window, to run these steps:
-        queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(heap(), [this, url, result, navigation_id, user_involvement, completion_steps, csp_navigation_type, signal_to_continue_session_history_processing]() mutable {
+        queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(heap(), [this, url, result, navigation_id, user_involvement, completion_steps, csp_navigation_type]() mutable {
             auto& navigation_params = result->navigation_params;
 
             // 1. If navigable's ongoing navigation no longer equals navigationId, then run completionSteps and abort these steps.
             if (navigation_id.has_value() && ongoing_navigation() != navigation_id) {
                 if (completion_steps) {
-                    // NB: Use Core::Promise to signal SessionHistoryTraversalQueue that it can continue to execute next entry.
-                    signal_to_continue_session_history_processing->resolve({});
                     completion_steps->function()(nullptr);
                 }
                 return;
@@ -1655,12 +1652,11 @@ void Navigable::populate_session_history_entry_document(
                 if (!sniff_bytes.has_value()) {
                     // Async path: bytes not yet available, wait for them
                     body->wait_for_sniff_bytes(GC::create_function(heap(),
-                        [output, nav_params, signal_to_continue_session_history_processing,
-                            navigation_params, completion_steps](ReadonlyBytes sniff_bytes) {
+                        [output, nav_params, navigation_params, completion_steps](ReadonlyBytes sniff_bytes) {
                             // AD-HOC: The document may have been destroyed between when the fetch started and when the
                             //         bytes arrived.
                             if (nav_params->navigable->active_browsing_context())
-                                output->document = load_document(nav_params, signal_to_continue_session_history_processing, sniff_bytes);
+                                output->document = load_document(nav_params, sniff_bytes);
                             output->navigation_params = navigation_params;
                             if (completion_steps)
                                 completion_steps->function()(output);
@@ -1669,7 +1665,7 @@ void Navigable::populate_session_history_entry_document(
                 }
 
                 // Sync path: bytes available immediately
-                output->document = load_document(nav_params, signal_to_continue_session_history_processing, sniff_bytes.value());
+                output->document = load_document(nav_params, sniff_bytes.value());
             }
 
             output->navigation_params = navigation_params;
@@ -2105,9 +2101,6 @@ void Navigable::begin_navigation(NavigateParams params)
                 // 9. Attempt to populate the history entry's document for historyEntry, given navigable, "navigate",
                 //    sourceSnapshotParams, targetSnapshotParams, userInvolvement, navigationId, navigationParams,
                 //    cspNavigationType, with allowPOST set to true and completionSteps set to the following step:
-
-                // NB: Use Core::Promise to signal SessionHistoryTraversalQueue that it can continue to execute next entry.
-                auto signal_to_continue_session_history_processing = Core::Promise<Empty>::construct();
                 populate_session_history_entry_document(
                     history_entry->url(),
                     history_entry->document_state()->resource(),
@@ -2120,7 +2113,7 @@ void Navigable::begin_navigation(NavigateParams params)
                     history_entry->document_state()->navigable_target_name(),
                     history_entry->document_state()->reload_pending(),
                     history_entry->document_state()->ever_populated(),
-                    source_snapshot_params, target_snapshot_params, user_involvement, signal_to_continue_session_history_processing, navigation_id, navigation_params, csp_navigation_type, true, GC::create_function(heap(), [this, signal_to_continue_session_history_processing, history_entry, history_handling, navigation_id, user_involvement](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
+                    source_snapshot_params, target_snapshot_params, user_involvement, navigation_id, navigation_params, csp_navigation_type, true, GC::create_function(heap(), [this, history_entry, history_handling, navigation_id, user_involvement](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
                         if (output)
                             output->apply_to(*history_entry);
                         // 1. Append session history traversal steps to navigable's traversable to finalize a cross-document navigation given navigable, historyHandling, userInvolvement, and historyEntry.
@@ -2336,7 +2329,7 @@ GC::Ptr<DOM::Document> Navigable::evaluate_javascript_url(URL::URL const& url, U
 
     // 17. Return the result of loading an HTML document given navigationParams.
     // NB: The response body is a known byte sequence, so we can pass it directly for sniffing.
-    return load_document(navigation_params, Core::Promise<Empty>::construct(), result.bytes());
+    return load_document(navigation_params, result.bytes());
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-to-a-javascript:-url

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -150,7 +150,6 @@ public:
         GC::Ref<SourceSnapshotParams> source_snapshot_params,
         TargetSnapshotParams const& target_snapshot_params,
         UserNavigationInvolvement user_involvement,
-        NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing,
         Optional<String> navigation_id,
         NavigationParamsVariant navigation_params,
         ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type,

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -755,14 +755,13 @@ void ApplyHistoryStepState::start()
                 //    queue a global task on the navigation and traversal task source given navigable's active window to
                 //    run afterDocumentPopulated.
                 Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [input_url = move(input_url), input_document_resource = move(input_document_resource), input_request_referrer = move(input_request_referrer), input_request_referrer_policy, input_initiator_origin = move(input_initiator_origin), input_origin = move(input_origin), input_history_policy_container = move(input_history_policy_container), input_about_base_url = move(input_about_base_url), input_navigable_target_name = move(input_navigable_target_name), input_ever_populated, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated, user_involvement = m_user_involvement] {
-                    auto signal = Core::Promise<Empty>::construct();
                     navigable->populate_session_history_entry_document(
                         move(input_url), move(input_document_resource), move(input_request_referrer),
                         input_request_referrer_policy, move(input_initiator_origin), move(input_origin),
                         input_history_policy_container, move(input_about_base_url), move(input_navigable_target_name),
                         false, input_ever_populated,
                         *potentially_target_specific_source_snapshot_params, target_snapshot_params,
-                        user_involvement, signal, {}, Navigable::NullOrError {},
+                        user_involvement, {}, Navigable::NullOrError {},
                         ContentSecurityPolicy::Directives::Directive::NavigationType::Other, allow_POST,
                         GC::create_function(this->heap(), [this, after_document_populated](GC::Ptr<PopulateSessionHistoryEntryDocumentOutput> output) {
                             VERIFY(m_traversable->active_window());


### PR DESCRIPTION
This promise was previously used to signal the session history traversal queue that it could continue processing, but is no longer needed.