### PR TITLE
LibWeb: Load unrecognized document types as plain text

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -501,6 +501,10 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     //        response, navigationParams's navigable, navigationParams's final sandboxing flag set,
     //        sourceSnapshotParams's has transient activation, and initiatorOrigin.
 
+    // AD-HOC: In lieu of an implementation for steps 3. and 4., fall back to loading a file of an unrecognized
+    //         type as a plain text document.
+    return load_text_document(navigation_params, type).release_value_but_fixme_should_propagate_errors();
+
     // 5. Return null.
     return nullptr;
 }


### PR DESCRIPTION
Files with extensions that Ladybird does not recognize previously did not get loaded. A markdown file, for example, would be labeled "text/markdown" instead of "text/plain", which does not have handling logic in load_document(), as per spec. While spec step 4. for unrecognized file types remains unimplemented, load files as plain text by default.