### PR TITLE
LibWebView: Don't always close WebContent on cross-site navigation

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -126,7 +126,6 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
 {
     if (m_client_state.client) {
         m_client_state.client->unregister_view(m_client_state.page_index);
-        client().async_close_server();
     }
 
     initialize_client();


### PR DESCRIPTION
When a page opens a popup, the child tab shares the parent's WebContent process via initialize_client_as_child(). Both tabs register as views on the same WebContentClient.

If the child tab then does a cross-site navigation, create_new_process_for_cross_site_navigation() would call unregister_view() (correct) and then unconditionally send CloseServer (wrong). This killed the WebContent process even though the parent tab was still using it.

The unconditional async_close_server() predates the shared-process popup model. It is no longer needed since unregister_view() already sends CloseServer when the last view is removed.