### PR TITLE
RequestServer: Use Security.framework for TLS verification on macOS

### DIFF
--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     RequestPipe.cpp
     Resolver.cpp
     ResourceSubstitutionMap.cpp
+    SystemTrustVerifier.cpp
     WebSocketImplCurl.cpp
 )
 
@@ -43,6 +44,10 @@ target_link_libraries(requestserverservice PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 if (WIN32)
     lagom_windows_bin(RequestServer CONSOLE)
+endif()
+
+if (APPLE)
+    target_link_libraries(requestserverservice PRIVATE "-framework Security")
 endif()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -111,6 +111,7 @@ Request::Request(
     , m_curl_multi_handle(curl_multi)
     , m_resolver(resolver)
     , m_url(move(url))
+    , m_tls_verification_context { .url = m_url }
     , m_method(move(method))
     , m_request_headers(move(request_headers))
     , m_request_body(move(request_body))
@@ -133,6 +134,7 @@ Request::Request(
     , m_curl_multi_handle(curl_multi)
     , m_resolver(resolver)
     , m_url(move(url))
+    , m_tls_verification_context { .url = m_url }
     , m_request_headers(HTTP::HeaderList::create())
     , m_response_headers(HTTP::HeaderList::create())
 {
@@ -490,6 +492,7 @@ void Request::handle_connect_state()
     set_option(CURLOPT_NOSIGNAL, 1L);
     m_curl_error_buffer[0] = '\0';
     set_option(CURLOPT_ERRORBUFFER, m_curl_error_buffer.data());
+    set_option(CURLOPT_SSL_CTX_DATA, &m_tls_verification_context);
 
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());
@@ -528,9 +531,13 @@ void Request::handle_fetch_state()
     set_option(CURLOPT_NOSIGNAL, 1L);
     m_curl_error_buffer[0] = '\0';
     set_option(CURLOPT_ERRORBUFFER, m_curl_error_buffer.data());
+    set_option(CURLOPT_SSL_CTX_DATA, &m_tls_verification_context);
 
     if (auto const& path = default_certificate_path(); !path.is_empty())
         set_option(CURLOPT_CAINFO, path.characters());
+
+    if (auto callback = ssl_ctx_setup_callback())
+        set_option(CURLOPT_SSL_CTX_FUNCTION, callback);
 
     set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -23,6 +23,7 @@
 #include <RequestServer/CacheLevel.h>
 #include <RequestServer/Forward.h>
 #include <RequestServer/RequestPipe.h>
+#include <RequestServer/SystemTrustVerifier.h>
 
 struct curl_slist;
 
@@ -197,6 +198,7 @@ private:
     RefPtr<DNS::LookupResult const> m_dns_result;
 
     URL::URL m_url;
+    TLSVerificationContext m_tls_verification_context;
     ByteString m_method;
 
     UnixDateTime m_request_start_time { UnixDateTime::now() };

--- a/Services/RequestServer/Resolver.cpp
+++ b/Services/RequestServer/Resolver.cpp
@@ -11,6 +11,7 @@
 namespace RequestServer {
 
 static ByteString g_default_certificate_path;
+static SSLCtxSetupCallback g_ssl_ctx_setup_callback = nullptr;
 
 ByteString const& default_certificate_path()
 {
@@ -20,6 +21,16 @@ ByteString const& default_certificate_path()
 void set_default_certificate_path(ByteString default_certificate_path)
 {
     g_default_certificate_path = move(default_certificate_path);
+}
+
+SSLCtxSetupCallback ssl_ctx_setup_callback()
+{
+    return g_ssl_ctx_setup_callback;
+}
+
+void set_ssl_ctx_setup_callback(SSLCtxSetupCallback callback)
+{
+    g_ssl_ctx_setup_callback = callback;
 }
 
 DNSInfo& DNSInfo::the()

--- a/Services/RequestServer/Resolver.h
+++ b/Services/RequestServer/Resolver.h
@@ -42,4 +42,8 @@ private:
 ByteString const& default_certificate_path();
 void set_default_certificate_path(ByteString);
 
+using SSLCtxSetupCallback = int (*)(void*, void*, void*);
+SSLCtxSetupCallback ssl_ctx_setup_callback();
+void set_ssl_ctx_setup_callback(SSLCtxSetupCallback);
+
 }

--- a/Services/RequestServer/SystemTrustVerifier.cpp
+++ b/Services/RequestServer/SystemTrustVerifier.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
+#include <AK/Optional.h>
+#include <AK/ScopeGuard.h>
+#include <AK/Vector.h>
+#include <RequestServer/CURL.h>
+#include <RequestServer/SystemTrustVerifier.h>
+
+#ifdef AK_OS_MACOS
+#    include <Security/Security.h>
+#    include <openssl/ssl.h>
+#    include <openssl/x509.h>
+#    include <openssl/x509_vfy.h>
+#endif
+
+namespace RequestServer {
+
+#ifdef AK_OS_MACOS
+static Optional<ByteString> copy_cf_string(CFStringRef string)
+{
+    auto length = CFStringGetLength(string);
+    auto maximum_size = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+    auto buffer = MUST(ByteBuffer::create_uninitialized(maximum_size));
+    if (!CFStringGetCString(string, reinterpret_cast<char*>(buffer.data()), maximum_size, kCFStringEncodingUTF8))
+        return {};
+
+    return ByteString { reinterpret_cast<char const*>(buffer.data()) };
+}
+
+static Optional<Vector<SecCertificateRef>> create_sec_certificate_chain(X509_STORE_CTX& store_context)
+{
+    auto* leaf_certificate = X509_STORE_CTX_get0_cert(&store_context);
+    if (!leaf_certificate)
+        return {};
+
+    auto certificates = Vector<SecCertificateRef> {};
+    ScopeGuard cleanup = [&] {
+        for (auto* cert : certificates)
+            CFRelease(cert);
+    };
+
+    auto append_certificate = [&](X509& certificate) -> bool {
+        auto encoded_size = i2d_X509(&certificate, nullptr);
+        if (encoded_size <= 0)
+            return false;
+
+        auto encoded_certificate = MUST(ByteBuffer::create_uninitialized(encoded_size));
+        auto* encoded_data = encoded_certificate.data();
+        if (i2d_X509(&certificate, &encoded_data) != encoded_size)
+            return false;
+
+        auto const* data = CFDataCreate(kCFAllocatorDefault, encoded_certificate.data(), encoded_size);
+        if (!data)
+            return false;
+        ScopeGuard release_data = [data] { CFRelease(data); };
+
+        auto* sec_certificate = SecCertificateCreateWithData(kCFAllocatorDefault, data);
+        if (!sec_certificate)
+            return false;
+
+        certificates.append(sec_certificate);
+        return true;
+    };
+
+    if (!append_certificate(*leaf_certificate))
+        return {};
+
+    if (auto* untrusted_certificates = X509_STORE_CTX_get0_untrusted(&store_context)) {
+        for (auto index = 0; index < sk_X509_num(untrusted_certificates); ++index) {
+            auto* certificate = sk_X509_value(untrusted_certificates, index);
+            if (!certificate || certificate == leaf_certificate)
+                continue;
+            if (!append_certificate(*certificate))
+                return {};
+        }
+    }
+
+    return certificates;
+}
+
+static int sec_trust_verify_callback(X509_STORE_CTX* store_context, void* argument)
+{
+    auto const* context = static_cast<TLSVerificationContext const*>(argument);
+    VERIFY(context);
+    auto hostname = context->url.serialized_host().to_byte_string();
+    VERIFY(!hostname.is_empty());
+
+    auto* ssl = static_cast<SSL*>(X509_STORE_CTX_get_ex_data(store_context, SSL_get_ex_data_X509_STORE_CTX_idx()));
+    if (!ssl) {
+        X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+        return 0;
+    }
+
+    auto certificate_chain = create_sec_certificate_chain(*store_context);
+    if (!certificate_chain.has_value()) {
+        dbgln("RequestServer: Failed to convert OpenSSL peer certificates into Security.framework certificates for {}", hostname);
+        X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+        return 0;
+    }
+
+    auto* certificate_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if (!certificate_array) {
+        X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+        return 0;
+    }
+    ScopeGuard release_certificate_array = [certificate_array] { CFRelease(certificate_array); };
+    ScopeGuard release_certificates = [&certificate_chain] {
+        for (auto const* certificate : *certificate_chain)
+            CFRelease(certificate);
+    };
+
+    for (auto const* certificate : *certificate_chain)
+        CFArrayAppendValue(certificate_array, certificate);
+
+    auto const* hostname_string = CFStringCreateWithCString(kCFAllocatorDefault, hostname.characters(), kCFStringEncodingUTF8);
+    if (!hostname_string) {
+        X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+        return 0;
+    }
+    ScopeGuard release_hostname = [hostname_string] { CFRelease(hostname_string); };
+
+    auto const* policy = SecPolicyCreateSSL(true, hostname_string);
+    if (!policy) {
+        X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+        return 0;
+    }
+    ScopeGuard release_policy = [policy] { CFRelease(policy); };
+
+    SecTrustRef trust = nullptr;
+    if (SecTrustCreateWithCertificates(certificate_array, policy, &trust) != errSecSuccess || !trust) {
+        X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+        return 0;
+    }
+    ScopeGuard release_trust = [trust] { CFRelease(trust); };
+
+    SecTrustSetNetworkFetchAllowed(trust, true);
+
+    CFErrorRef error = nullptr;
+    auto is_trusted = SecTrustEvaluateWithError(trust, &error);
+    ScopeGuard release_error = [&] {
+        if (error)
+            CFRelease(error);
+    };
+
+    if (is_trusted)
+        return 1;
+
+    Optional<ByteString> error_description;
+    if (error) {
+        if (auto const* description = CFErrorCopyDescription(error)) {
+            error_description = copy_cf_string(description);
+            CFRelease(description);
+        }
+    }
+    if (error_description.has_value())
+        dbgln("RequestServer: Security.framework rejected TLS certificate for {}: {}", hostname, *error_description);
+    else
+        dbgln("RequestServer: Security.framework rejected TLS certificate for {}", hostname);
+
+    X509_STORE_CTX_set_error(store_context, X509_V_ERR_APPLICATION_VERIFICATION);
+    return 0;
+}
+#endif
+
+int setup_system_trust_verifier(void*, void* ssl_ctx, void* user_data)
+{
+#ifdef AK_OS_MACOS
+    SSL_CTX_set_cert_verify_callback(static_cast<SSL_CTX*>(ssl_ctx), sec_trust_verify_callback, user_data);
+    return CURLE_OK;
+#else
+    (void)ssl_ctx;
+    (void)user_data;
+    return CURLE_NOT_BUILT_IN;
+#endif
+}
+
+}

--- a/Services/RequestServer/SystemTrustVerifier.h
+++ b/Services/RequestServer/SystemTrustVerifier.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibURL/URL.h>
+
+namespace RequestServer {
+
+struct TLSVerificationContext {
+    URL::URL url;
+};
+
+int setup_system_trust_verifier(void*, void* ssl_ctx, void*);
+
+}

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -6,6 +6,7 @@
 
 #include <RequestServer/CURL.h>
 #include <RequestServer/ConnectionFromClient.h>
+#include <RequestServer/Resolver.h>
 #include <RequestServer/WebSocketImplCurl.h>
 
 namespace RequestServer {
@@ -62,11 +63,16 @@ void WebSocketImplCurl::connect(WebSocket::ConnectionInfo const& info)
     // FIXME: Add a header function to validate the Sec-WebSocket headers that curl currently doesn't validate
 
     auto const& url = info.url();
+    m_tls_verification_context.url = url;
     set_option(CURLOPT_URL, url.to_byte_string().characters());
     set_option(CURLOPT_PORT, url.port_or_default());
+    set_option(CURLOPT_SSL_CTX_DATA, &m_tls_verification_context);
 
     if (auto root_certs = info.root_certificates_path(); root_certs.has_value())
         set_option(CURLOPT_CAINFO, root_certs->characters());
+
+    if (auto callback = ssl_ctx_setup_callback())
+        set_option(CURLOPT_SSL_CTX_FUNCTION, callback);
 
     auto const origin_header = ByteString::formatted("Origin: {}", info.origin());
     curl_slist* curl_headers = curl_slist_append(nullptr, origin_header.characters());

--- a/Services/RequestServer/WebSocketImplCurl.h
+++ b/Services/RequestServer/WebSocketImplCurl.h
@@ -9,6 +9,7 @@
 #include <AK/MemoryStream.h>
 #include <LibCore/Forward.h>
 #include <LibWebSocket/Impl/WebSocketImpl.h>
+#include <RequestServer/SystemTrustVerifier.h>
 
 typedef void CURL;
 typedef void CURLM;
@@ -44,6 +45,7 @@ private:
     RefPtr<Core::Notifier> m_read_notifier;
     RefPtr<Core::Notifier> m_error_notifier;
     Vector<curl_slist*> m_curl_string_lists;
+    TLSVerificationContext m_tls_verification_context;
     AllocatingMemoryStream m_read_buffer;
 };
 

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -19,6 +19,7 @@
 #include <RequestServer/ConnectionFromClient.h>
 #include <RequestServer/Resolver.h>
 #include <RequestServer/ResourceSubstitutionMap.h>
+#include <RequestServer/SystemTrustVerifier.h>
 
 namespace RequestServer {
 
@@ -58,6 +59,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     // FIXME: Update RequestServer to support multiple custom root certificates.
     if (!certificates.is_empty())
         RequestServer::set_default_certificate_path(certificates.first());
+
+#ifdef AK_OS_MACOS
+    if (RequestServer::default_certificate_path().is_empty())
+        RequestServer::set_ssl_ctx_setup_callback(RequestServer::setup_system_trust_verifier);
+#endif
 
     if (!resource_map_path.is_empty()) {
         auto map = RequestServer::ResourceSubstitutionMap::load_from_file(resource_map_path);


### PR DESCRIPTION
Replace the certificate injection with a custom verify callback.

This allows us to add support AIA (Authority Information Access)
fetching, fixing TLS failures on sites that omit intermediate
certificates and rely on clients fetching them from the network.

This is done by the call to SecTrustEvaluateWithError with network
fetching allowed. This lets SecTrust resolve incomplete chains via
AIA. This allows sites such as https://start.stockholm/ to load.


Unfortunately this does only apply to MacOS, and other browsers
seem to handle this all in different ways. Not sure if this is the
approach we should go for.