### PR TITLE
LibCore: Add a CORE_API annotation to `log_timing_info()`

### DIFF
--- a/Libraries/LibCore/ReportTime.h
+++ b/Libraries/LibCore/ReportTime.h
@@ -9,6 +9,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/Time.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibCore/Export.h>
 
 namespace Core {
 
@@ -17,7 +18,7 @@ struct TimingInfo {
     u64 call_count { 0 };
 };
 
-void log_timing_info(ByteString const& name, AK::Duration const& elapsed_time, u64 print_every_n_calls);
+CORE_API void log_timing_info(ByteString const& name, AK::Duration const& elapsed_time, u64 print_every_n_calls);
 
 #define CONCAT(a, b) a##b
 #define UNIQUE_NAME(base) CONCAT(base, __LINE__)


### PR DESCRIPTION
This is required to use the `REPORT_TIME` and `REPORT_TIME_EVERY` macros.