### PR TITLE
LibWeb: Register JS-created FontFace objects for font matching

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -132,7 +132,6 @@ void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_namespace_rules);
     visitor.visit(m_import_rules);
     visitor.visit(m_owning_documents_or_shadow_roots);
-    visitor.visit(m_associated_font_loaders);
     for (auto& subresource : m_critical_subresources)
         subresource.visit_edges(visitor);
 }
@@ -482,15 +481,6 @@ void CSSStyleSheet::set_source_text(String source)
 Optional<String> CSSStyleSheet::source_text(Badge<DOM::Document>) const
 {
     return m_source_text;
-}
-
-bool CSSStyleSheet::has_associated_font_loader(FontLoader& font_loader) const
-{
-    for (auto& loader : m_associated_font_loaders) {
-        if (loader.ptr() == &font_loader)
-            return true;
-    }
-    return false;
 }
 
 void CSSStyleSheet::add_critical_subresource(Subresource& subresource)

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -22,7 +22,6 @@
 namespace Web::CSS {
 
 class CSSImportRule;
-class FontLoader;
 
 struct CSSStyleSheetInit {
     Optional<String> base_url {};
@@ -120,12 +119,6 @@ public:
     void set_source_text(String);
     Optional<String> source_text(Badge<DOM::Document>) const;
 
-    void add_associated_font_loader(GC::Ref<FontLoader const> font_loader)
-    {
-        m_associated_font_loaders.append(font_loader);
-    }
-    bool has_associated_font_loader(FontLoader& font_loader) const;
-
     void add_critical_subresource(Subresource&);
     void remove_critical_subresource(Subresource&);
     LoadingState loading_state() const;
@@ -159,8 +152,6 @@ private:
     bool m_constructed { false };
     bool m_disallow_modification { false };
     Optional<bool> m_did_match;
-
-    Vector<GC::Ptr<FontLoader const>> m_associated_font_loaders;
 
     Vector<Subresource&> m_critical_subresources;
 

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -198,22 +198,29 @@ ErrorOr<NonnullRefPtr<Gfx::Typeface const>> FontLoader::try_load_font(Fetch::Inf
 
 struct FontComputer::MatchingFontCandidate {
     FontFaceKey key;
-    Variant<FontLoaderList*, Gfx::Typeface const*> loader_or_typeface;
+    Gfx::Typeface const* system_typeface { nullptr };
 
-    [[nodiscard]] RefPtr<Gfx::FontCascadeList const> font_with_point_size(float point_size, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values) const
+    [[nodiscard]] RefPtr<Gfx::FontCascadeList const> font_with_point_size(HashMap<FontFaceKey, Vector<GC::Ref<FontFace>>> const& font_faces, float point_size, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values) const
     {
         auto const& shape_features = font_feature_data.to_shape_features(font_feature_values);
 
-        auto font_list = Gfx::FontCascadeList::create();
-        if (auto const* loader_list = loader_or_typeface.get_pointer<FontLoaderList*>(); loader_list) {
-            for (auto const& loader : **loader_list) {
-                if (auto font = loader->font_with_point_size(point_size, variations, shape_features); font)
-                    font_list->add(*font, loader->unicode_ranges());
-            }
+        if (system_typeface) {
+            auto font_list = Gfx::FontCascadeList::create();
+            font_list->add(system_typeface->font(point_size, variations, shape_features));
             return font_list;
         }
 
-        font_list->add(loader_or_typeface.get<Gfx::Typeface const*>()->font(point_size, variations, shape_features));
+        auto it = font_faces.find(key);
+        if (it == font_faces.end())
+            return {};
+
+        auto font_list = Gfx::FontCascadeList::create();
+        for (auto const& face : it->value) {
+            if (auto face_fonts = face->font_with_point_size(point_size, variations, shape_features))
+                font_list->extend(*face_fonts);
+        }
+        if (font_list->is_empty())
+            return {};
         return font_list;
     }
 };
@@ -222,30 +229,31 @@ void FontComputer::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_document);
-    visitor.visit(m_loaded_fonts);
+    for (auto& [_, faces] : m_font_faces)
+        visitor.visit(faces);
 }
 
-RefPtr<Gfx::FontCascadeList const> FontComputer::find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive)
+RefPtr<Gfx::FontCascadeList const> FontComputer::find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const
 {
     using Fn = AK::Function<bool(MatchingFontCandidate const&)>;
     auto pred = inclusive ? Fn([&](auto const& matching_font_candidate) { return matching_font_candidate.key.weight.min >= target_weight; })
                           : Fn([&](auto const& matching_font_candidate) { return matching_font_candidate.key.weight.min > target_weight; });
     auto it = find_if(candidates.begin(), candidates.end(), pred);
     for (; it != candidates.end(); ++it) {
-        if (auto found_font = it->font_with_point_size(font_size_in_pt, variations, font_feature_data, font_feature_values))
+        if (auto found_font = it->font_with_point_size(m_font_faces, font_size_in_pt, variations, font_feature_data, font_feature_values))
             return found_font;
     }
     return {};
 }
 
-RefPtr<Gfx::FontCascadeList const> FontComputer::find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive)
+RefPtr<Gfx::FontCascadeList const> FontComputer::find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const
 {
     using Fn = AK::Function<bool(MatchingFontCandidate const&)>;
     auto pred = inclusive ? Fn([&](auto const& matching_font_candidate) { return matching_font_candidate.key.weight.max <= target_weight; })
                           : Fn([&](auto const& matching_font_candidate) { return matching_font_candidate.key.weight.max < target_weight; });
     auto it = find_if(candidates.rbegin(), candidates.rend(), pred);
     for (; it != candidates.rend(); ++it) {
-        if (auto found_font = it->font_with_point_size(font_size_in_pt, variations, font_feature_data, font_feature_values))
+        if (auto found_font = it->font_with_point_size(m_font_faces, font_size_in_pt, variations, font_feature_data, font_feature_values))
             return found_font;
     }
     return {};
@@ -258,19 +266,21 @@ RefPtr<Gfx::FontCascadeList const> FontComputer::font_matching_algorithm(FlyStri
     // If a font family match occurs, the user agent assembles the set of font faces in that family and then
     // narrows the set to a single face using other font properties in the order given below.
     Vector<MatchingFontCandidate> matching_family_fonts;
-    for (auto const& font_key_and_loader : m_loaded_fonts) {
-        if (font_key_and_loader.key.family_name.equals_ignoring_ascii_case(family_name))
-            matching_family_fonts.empend(font_key_and_loader.key, const_cast<FontLoaderList*>(&font_key_and_loader.value));
+    // FIXME: URL-backed faces with no typeface yet should trigger a load on demand, matching other engines.
+    for (auto const& [map_key, faces] : m_font_faces) {
+        if (map_key.family_name.equals_ignoring_ascii_case(family_name))
+            matching_family_fonts.empend(map_key);
     }
     Gfx::FontDatabase::the().for_each_typeface_with_family_name(family_name, [&](Gfx::Typeface const& typeface) {
-        matching_family_fonts.empend(
-            FontFaceKey {
+        matching_family_fonts.append({
+            .key = {
                 .family_name = typeface.family(),
                 // FIXME: Support system fonts that have a range of weights, etc.
                 .weight = { static_cast<int>(typeface.weight()), static_cast<int>(typeface.weight()) },
                 .slope = typeface.slope(),
             },
-            &typeface);
+            .system_typeface = &typeface,
+        });
     });
 
     if (matching_family_fonts.is_empty())
@@ -304,7 +314,7 @@ RefPtr<Gfx::FontCascadeList const> FontComputer::font_matching_algorithm(FlyStri
         return candidate.key.weight.contains_inclusive(weight);
     });
     for (; matching_weight_it != matching_family_fonts.end(); ++matching_weight_it) {
-        if (auto found_font = matching_weight_it->font_with_point_size(font_size_in_pt, variations, font_feature_data, font_feature_values))
+        if (auto found_font = matching_weight_it->font_with_point_size(m_font_faces, font_size_in_pt, variations, font_feature_data, font_feature_values))
             return found_font;
     }
 
@@ -317,13 +327,13 @@ RefPtr<Gfx::FontCascadeList const> FontComputer::font_matching_algorithm(FlyStri
         auto it = find_if(matching_family_fonts.begin(), matching_family_fonts.end(),
             [&](auto const& matching_font_candidate) { return matching_font_candidate.key.weight.min >= weight; });
         for (; it != matching_family_fonts.end() && it->key.weight.min <= 500; ++it) {
-            if (auto found_font = it->font_with_point_size(font_size_in_pt, variations, font_feature_data, font_feature_values))
+            if (auto found_font = it->font_with_point_size(m_font_faces, font_size_in_pt, variations, font_feature_data, font_feature_values))
                 return found_font;
         }
         if (auto found_font = find_matching_font_weight_descending(matching_family_fonts, weight, font_size_in_pt, variations, font_feature_data, font_feature_values, false))
             return found_font;
         for (; it != matching_family_fonts.end(); ++it) {
-            if (auto found_font = it->font_with_point_size(font_size_in_pt, variations, font_feature_data, font_feature_values))
+            if (auto found_font = it->font_with_point_size(m_font_faces, font_size_in_pt, variations, font_feature_data, font_feature_values))
                 return found_font;
         }
     }
@@ -344,7 +354,7 @@ RefPtr<Gfx::FontCascadeList const> FontComputer::font_matching_algorithm(FlyStri
             return found_font;
     }
 
-    VERIFY_NOT_REACHED();
+    return {};
 }
 
 HashMap<FontFeatureValueKey, Vector<u32>> const& FontComputer::font_feature_values_for_family(FlyString const& family_name) const
@@ -432,22 +442,20 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
 
         // OPTIMIZATION: Look for an exact match in loaded fonts first.
         // FIXME: Respect the other font-* descriptors
-        FontFaceKey key {
+        FontFaceKey lookup_key {
             .family_name = family,
             .weight = { weight, weight },
             .slope = slope,
         };
-        if (auto it = m_loaded_fonts.find(key); it != m_loaded_fonts.end()) {
+        if (auto it = m_font_faces.find(lookup_key); it != m_font_faces.end()) {
+            auto shape_features = font_feature_data.to_shape_features(font_feature_values);
             auto result = Gfx::FontCascadeList::create();
-            auto const& loaders = it->value;
-            for (auto const& loader : loaders) {
-                auto shape_features = font_feature_data.to_shape_features(font_feature_values);
-
-                if (auto found_font = loader->font_with_point_size(font_size_in_pt, variation, shape_features))
-                    result->add(*found_font, loader->unicode_ranges());
+            for (auto const& font_face : it->value) {
+                if (auto face_fonts = font_face->font_with_point_size(font_size_in_pt, variation, shape_features))
+                    result->extend(*face_fonts);
             }
-
-            return result;
+            if (!result->is_empty())
+                return result;
         }
 
         if (auto found_font = font_matching_algorithm(family, weight, slope, font_size_in_pt, variation, font_feature_data, font_feature_values); found_font && !found_font->is_empty())
@@ -617,6 +625,43 @@ void FontComputer::clear_font_feature_values_cache(FlyString const& family_name)
     m_font_feature_values_cache.remove(family_name);
 }
 
+void FontComputer::did_load_font(FlyString const& family_name)
+{
+    clear_computed_font_cache(family_name);
+}
+
+void FontComputer::register_font_face(GC::Ref<FontFace> face)
+{
+    VERIFY(face->should_be_registered_with_font_computer());
+
+    FontFaceKey key {
+        .family_name = FlyString(face->family()),
+        .weight = face->declared_weight_range(),
+        .slope = face->declared_slope(),
+    };
+    auto& faces = m_font_faces.ensure(key);
+    if (!faces.contains_slow(face))
+        faces.append(face);
+    did_load_font(key.family_name);
+}
+
+void FontComputer::unregister_font_face(GC::Ref<FontFace> face)
+{
+    VERIFY(face->should_be_registered_with_font_computer());
+
+    FontFaceKey key {
+        .family_name = FlyString(face->family()),
+        .weight = face->declared_weight_range(),
+        .slope = face->declared_slope(),
+    };
+    if (auto it = m_font_faces.find(key); it != m_font_faces.end()) {
+        it->value.remove_all_matching([&](auto const& entry) { return entry == face; });
+        if (it->value.is_empty())
+            m_font_faces.remove(it);
+    }
+    did_load_font(key.family_name);
+}
+
 GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load)
 {
     if (font_face.sources().is_empty()) {
@@ -624,12 +669,6 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
             on_load->function()({});
         return {};
     }
-
-    FontFaceKey key {
-        .family_name = font_face.font_family(),
-        .weight = font_face.weight().value_or({ 0, 0 }),
-        .slope = font_face.slope().value_or(0),
-    };
 
     // FIXME: Handle local() font sources.
     Vector<URL> urls;
@@ -651,18 +690,7 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
         }
     };
 
-    auto loader = heap().allocate<FontLoader>(*this, rule_or_declaration, font_face.font_family(), font_face.unicode_ranges(), move(urls), move(on_load));
-    auto& loader_ref = *loader;
-    auto maybe_font_loaders_list = m_loaded_fonts.get(key);
-    if (maybe_font_loaders_list.has_value()) {
-        maybe_font_loaders_list->append(move(loader));
-    } else {
-        FontLoaderList loaders;
-        loaders.append(loader);
-        m_loaded_fonts.set(key, move(loaders));
-    }
-    // Actual object owned by font loader list inside m_loaded_fonts, this isn't use-after-move/free
-    return loader_ref;
+    return heap().allocate<FontLoader>(*this, rule_or_declaration, font_face.font_family(), font_face.unicode_ranges(), move(urls), move(on_load));
 }
 
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
@@ -692,17 +720,14 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
 {
     // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
-    for (auto& [_, font_loader_list] : m_loaded_fonts) {
-        font_loader_list.remove_all_matching([&](auto& font_loader) {
-            return sheet.has_associated_font_loader(*font_loader);
-        });
-    }
-
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
     for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule))
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
+            if (auto font_face = font_face_rule->css_connected_font_face())
+                unregister_font_face(*font_face);
             font_face_rule->disconnect_font_face();
+        }
 
         if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
             font_feature_values_rule->clear_caches();

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -110,6 +110,10 @@ public:
 
     void clear_computed_font_cache(FlyString const& family_name);
     void clear_font_feature_values_cache(FlyString const& family_name);
+    void did_load_font(FlyString const& family_name);
+
+    void register_font_face(GC::Ref<FontFace>);
+    void unregister_font_face(GC::Ref<FontFace>);
 
     GC::Ptr<FontLoader> load_font_face(ParsedFontFace const&, GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> on_load = {});
 
@@ -122,8 +126,8 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     struct MatchingFontCandidate;
-    static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive);
-    static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive);
+    RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const;
+    RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const;
     NonnullRefPtr<Gfx::FontCascadeList const> compute_font_for_style_values_impl(StyleValue const& font_family, CSSPixels const& font_size, int font_slope, double font_weight, Percentage const& font_width, FontOpticalSizing font_optical_sizing, HashMap<FlyString, double> const& font_variation_settings, FontFeatureData const& font_feature_data) const;
     RefPtr<Gfx::FontCascadeList const> font_matching_algorithm(FlyString const& family_name, int weight, int slope, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values) const;
 
@@ -131,8 +135,7 @@ private:
 
     GC::Ref<DOM::Document> m_document;
 
-    using FontLoaderList = Vector<GC::Ref<FontLoader>>;
-    HashMap<FontFaceKey, FontLoaderList> m_loaded_fonts;
+    HashMap<FontFaceKey, Vector<GC::Ref<FontFace>>> m_font_faces;
 
     mutable HashMap<ComputedFontCacheKey, NonnullRefPtr<Gfx::FontCascadeList const>> m_computed_font_cache;
     mutable HashMap<FlyString, HashMap<FontFeatureValueKey, Vector<u32>>> m_font_feature_values_cache;

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -213,6 +213,9 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
                 font->m_status = Bindings::FontFaceLoadStatus::Loaded;
                 WebIDL::resolve_promise(font->realm(), font->m_font_status_promise, font);
 
+                if (auto font_computer = font->font_computer(); font_computer.has_value())
+                    font_computer->register_font_face(*font);
+
                 // For each FontFaceSet font face is in:
                 for (auto& font_face_set : font->m_containing_sets) {
                     // 1. Add font face to the FontFaceSet’s [[LoadedFonts]] list.
@@ -343,6 +346,7 @@ void FontFace::visit_edges(JS::Cell::Visitor& visitor)
 
     visitor.visit(m_font_status_promise);
     visitor.visit(m_css_font_face_rule);
+    visitor.visit(m_font_loader);
     for (auto const& font_face_set : m_containing_sets)
         visitor.visit(font_face_set);
 }
@@ -361,9 +365,33 @@ void FontFace::reject_status_promise(JS::Value reason)
     }
 }
 
+Optional<FontComputer&> FontFace::font_computer() const
+{
+    for (auto& font_face_set : m_containing_sets) {
+        auto& global = HTML::relevant_global_object(font_face_set);
+        if (auto* window = as_if<HTML::Window>(global))
+            return window->associated_document().font_computer();
+    }
+    return {};
+}
+
 void FontFace::disconnect_from_css_rule()
 {
     m_css_font_face_rule = nullptr;
+}
+
+RefPtr<Gfx::FontCascadeList const> FontFace::font_with_point_size(float point_size, Gfx::FontVariationSettings const& variations, Gfx::ShapeFeatures const& shape_features) const
+{
+    auto font_list = Gfx::FontCascadeList::create();
+    if (m_font_loader) {
+        if (auto font = m_font_loader->font_with_point_size(point_size, variations, shape_features))
+            font_list->add(*font, m_font_loader->unicode_ranges());
+    } else if (m_parsed_font) {
+        font_list->add(m_parsed_font->font(point_size, variations, shape_features), m_unicode_ranges);
+    }
+    if (font_list->is_empty())
+        return {};
+    return font_list;
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-family
@@ -380,7 +408,17 @@ WebIDL::ExceptionOr<void> FontFace::set_family(String const& string)
     if (m_css_font_face_rule)
         TRY(m_css_font_face_rule->descriptors()->set_font_family(string));
 
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->unregister_font_face(*this);
+    }
+
     set_family_impl(property.release_nonnull());
+
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->register_font_face(*this);
+    }
 
     return {};
 }
@@ -404,7 +442,17 @@ WebIDL::ExceptionOr<void> FontFace::set_style(String const& string)
     if (m_css_font_face_rule)
         TRY(m_css_font_face_rule->descriptors()->set_font_style(string));
 
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->unregister_font_face(*this);
+    }
+
     set_style_impl(property.release_nonnull());
+
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->register_font_face(*this);
+    }
 
     return {};
 }
@@ -429,7 +477,17 @@ WebIDL::ExceptionOr<void> FontFace::set_weight(String const& string)
     if (m_css_font_face_rule)
         TRY(m_css_font_face_rule->descriptors()->set_font_weight(string));
 
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->unregister_font_face(*this);
+    }
+
     set_weight_impl(property.release_nonnull());
+
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->register_font_face(*this);
+    }
 
     return {};
 }
@@ -457,6 +515,11 @@ WebIDL::ExceptionOr<void> FontFace::set_stretch(String const& string)
 
     set_stretch_impl(property.release_nonnull());
 
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->did_load_font(FlyString(m_family));
+    }
+
     return {};
 }
 
@@ -480,6 +543,11 @@ WebIDL::ExceptionOr<void> FontFace::set_unicode_range(String const& string)
         TRY(m_css_font_face_rule->descriptors()->set_unicode_range(string));
 
     set_unicode_range_impl(property.release_nonnull());
+
+    if (should_be_registered_with_font_computer()) {
+        if (auto font_computer = this->font_computer(); font_computer.has_value())
+            font_computer->did_load_font(FlyString(m_family));
+    }
 
     return {};
 }
@@ -693,6 +761,9 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                     if (m_css_font_face_rule)
                         m_css_font_face_rule->set_loading_state(CSSStyleSheet::LoadingState::Loaded);
 
+                    if (auto font_computer = this->font_computer(); font_computer.has_value())
+                        font_computer->register_font_face(*this);
+
                     // For each FontFaceSet font face is in:
                     for (auto& font_face_set : m_containing_sets) {
                         // 1. Add font face to the FontFaceSet’s [[LoadedFonts]] list.
@@ -705,6 +776,8 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                             font_face_set->switch_to_loaded();
                     }
                 }
+
+                m_font_loader = nullptr;
             }));
         });
 
@@ -713,8 +786,10 @@ GC::Ref<WebIDL::Promise> FontFace::load()
         if (auto* window = as_if<HTML::Window>(global)) {
             auto& font_computer = const_cast<FontComputer&>(window->document()->font_computer());
 
-            if (auto loader = font_computer.load_font_face(parsed_font_face(), move(on_load)))
+            if (auto loader = font_computer.load_font_face(parsed_font_face(), move(on_load))) {
+                m_font_loader = loader;
                 loader->start_loading_next_url();
+            }
         } else {
             // FIXME: Don't know how to load fonts in workers! They don't have a StyleComputer
             dbgln("FIXME: Worker font loading not implemented");

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -7,12 +7,15 @@
 #pragma once
 
 #include <LibGfx/Font/Typeface.h>
+#include <LibGfx/FontCascadeList.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/FontFacePrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/ParsedFontFace.h>
 
 namespace Web::CSS {
+
+class FontLoader;
 
 struct FontFaceDescriptors {
     String style = "normal"_string;
@@ -88,6 +91,14 @@ public:
 
     ParsedFontFace parsed_font_face() const;
 
+    RefPtr<Gfx::Typeface const> typeface() const { return m_parsed_font; }
+
+    FontWeightRange declared_weight_range() const { return m_cached_weight_range; }
+    int declared_slope() const { return m_cached_slope; }
+    bool should_be_registered_with_font_computer() const { return is_css_connected() || status() == Bindings::FontFaceLoadStatus::Loaded; }
+
+    RefPtr<Gfx::FontCascadeList const> font_with_point_size(float point_size, Gfx::FontVariationSettings const&, Gfx::ShapeFeatures const&) const;
+
     Bindings::FontFaceLoadStatus status() const { return m_status; }
 
     GC::Ref<WebIDL::Promise> load();
@@ -105,6 +116,8 @@ private:
     virtual void visit_edges(Visitor&) override;
     void reject_status_promise(JS::Value reason);
 
+    Optional<FontComputer&> font_computer() const;
+
     // FIXME: Should we be storing StyleValues instead?
     String m_family;
     String m_style;
@@ -121,6 +134,7 @@ private:
 
     FontWeightRange m_cached_weight_range { 400, 400 };
     int m_cached_slope { 0 };
+    GC::Ptr<FontLoader> m_font_loader;
 
     // https://drafts.csswg.org/css-font-loading/#dom-fontface-status
     Bindings::FontFaceLoadStatus m_status { Bindings::FontFaceLoadStatus::Unloaded };

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/FontFaceSetPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/FontFaceSetLoadEvent.h>
@@ -21,7 +22,9 @@
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -84,6 +87,12 @@ void FontFaceSet::add_css_connected_font(GC::Ref<FontFace> face)
     m_set_entries->set_add(face);
     face->add_to_set(*this);
 
+    if (face->should_be_registered_with_font_computer()) {
+        auto& global = HTML::relevant_global_object(*this);
+        if (auto* window = as_if<HTML::Window>(global))
+            window->associated_document().font_computer().register_font_face(face);
+    }
+
     // 4. If font’s status attribute is "loading"
     if (face->status() == Bindings::FontFaceLoadStatus::Loading) {
 
@@ -102,6 +111,12 @@ bool FontFaceSet::delete_(GC::Root<FontFace> face)
     // 1. If font is CSS-connected, return false and exit this algorithm immediately.
     if (face->is_css_connected()) {
         return false;
+    }
+
+    if (face->should_be_registered_with_font_computer()) {
+        auto& global = HTML::relevant_global_object(*this);
+        if (auto* window = as_if<HTML::Window>(global))
+            window->associated_document().font_computer().unregister_font_face(*face);
     }
 
     // 2. Let deleted be the result of removing font from the FontFaceSet’s set entries.
@@ -126,10 +141,13 @@ void FontFaceSet::clear()
 {
     // 1. Remove all non-CSS-connected items from the FontFaceSet's set entries,
     //    its [[LoadedFonts]] list, and its [[FailedFonts]] list.
+    auto* window = as_if<HTML::Window>(HTML::relevant_global_object(*this));
     Vector<JS::Value> to_remove;
     for (auto font_face_value : *m_set_entries) {
         auto& font_face = as<FontFace>(font_face_value.key.as_object());
         if (!font_face.is_css_connected()) {
+            if (window && font_face.should_be_registered_with_font_computer())
+                window->associated_document().font_computer().unregister_font_face(font_face);
             to_remove.append(font_face_value.key);
             font_face.remove_from_set(*this);
         }

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -5,6 +5,7 @@ Text/input/cookie-working.html
 ; fetching a file only works from an HTTP server.
 Text/input/HTML/media-source-buffered.html
 Text/input/HTML/media-source-setup.html
+Text/input/css/FontFace-arraybuffer-matching.html
 
 ; pushState with path URL requires HTTP(s) scheme.
 Text/input/navigation/history-replace-push-then-back.html

--- a/Tests/LibWeb/Text/expected/css/FontFace-arraybuffer-matching.txt
+++ b/Tests/LibWeb/Text/expected/css/FontFace-arraybuffer-matching.txt
@@ -1,0 +1,3 @@
+face.status: loaded
+font matched: true
+font unmatched after delete: true

--- a/Tests/LibWeb/Text/input/css/FontFace-arraybuffer-matching.html
+++ b/Tests/LibWeb/Text/input/css/FontFace-arraybuffer-matching.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const fontData = await fetch("../../../Assets/HashSans.woff").then(
+            response => response.arrayBuffer());
+
+        const face = new FontFace("TestFont", fontData);
+        document.fonts.add(face);
+
+        await face.loaded;
+
+        const element = document.createElement("span");
+        element.style.fontFamily = "TestFont, serif";
+        element.style.fontSize = "20px";
+        element.textContent = "test";
+        document.body.appendChild(element);
+
+        const fallbackElement = document.createElement("span");
+        fallbackElement.style.fontFamily = "serif";
+        fallbackElement.style.fontSize = "20px";
+        fallbackElement.textContent = "test";
+        document.body.appendChild(fallbackElement);
+
+        // Force layout
+        document.body.offsetHeight;
+
+        const testWidth = element.offsetWidth;
+        const fallbackWidth = fallbackElement.offsetWidth;
+
+        println(`face.status: ${face.status}`);
+        println(`font matched: ${testWidth !== fallbackWidth}`);
+
+        document.fonts.delete(face);
+
+        // Force layout after removal
+        document.body.offsetHeight;
+
+        const afterDeleteWidth = element.offsetWidth;
+        println(`font unmatched after delete: ${afterDeleteWidth === fallbackWidth}`);
+    });
+</script>


### PR DESCRIPTION
Previously, FontFace objects created via the JS and added to `document.fonts` were stored in the FontFaceSet but never participated in font matching during style resolution. We now store both
CSS-connected and JS-created font faces in a unified map on `FontComputer`, keyed by family name, and include them all as candidates in the font matching algorithm.

This prevents fonts being garbled when viewing documents in pdf.js (from: https://mozilla.github.io/pdf.js/web/viewer.html):


Before:

<img width="1037" height="963" alt="image" src="https://github.com/user-attachments/assets/9f903f04-e9f1-4c4b-b806-4b192d37153a" />


After:

<img width="1037" height="963" alt="image" src="https://github.com/user-attachments/assets/5e31f629-46a3-44f5-bc25-488d4a21e254" />
