### PR TITLE
Meta: Remove ENABLE_RUST build configuration option

### DIFF
--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -294,25 +294,22 @@ endif()
 
 target_link_libraries(LibJS PUBLIC JSClangPlugin)
 
-if (ENABLE_RUST)
-    import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libjs_rust FFI_HEADER RustFFI.h)
-    target_link_libraries(LibJS PRIVATE libjs_rust)
-    target_compile_definitions(LibJS PRIVATE ENABLE_RUST)
+import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libjs_rust FFI_HEADER RustFFI.h)
+target_link_libraries(LibJS PRIVATE libjs_rust)
 
-    # The Rust library and LibJS have a circular dependency (C++ calls Rust
-    # entry points, Rust calls C++ callbacks). For static builds, merge the
-    # Rust archive into the LibJS archive so all symbols are in one place.
-    if(NOT BUILD_SHARED_LIBS)
-        add_custom_command(TARGET LibJS POST_BUILD
-            COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libjs_rust>
-            COMMAND ${CMAKE_AR} -qS $<TARGET_FILE:LibJS> *.o
-            COMMAND ${CMAKE_RANLIB} $<TARGET_FILE:LibJS>
-            COMMAND ${CMAKE_COMMAND} -E remove -f *.o
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp
-            COMMENT "Merging Rust archive into LibJS"
-        )
-        file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
-    endif()
+# The Rust library and LibJS have a circular dependency (C++ calls Rust
+# entry points, Rust calls C++ callbacks). For static builds, merge the
+# Rust archive into the LibJS archive so all symbols are in one place.
+if(NOT BUILD_SHARED_LIBS)
+    add_custom_command(TARGET LibJS POST_BUILD
+        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libjs_rust>
+        COMMAND ${CMAKE_AR} -qS $<TARGET_FILE:LibJS> *.o
+        COMMAND ${CMAKE_RANLIB} $<TARGET_FILE:LibJS>
+        COMMAND ${CMAKE_COMMAND} -E remove -f *.o
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp
+        COMMENT "Merging Rust archive into LibJS"
+    )
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
 endif()
 
 # AsmInterpreter: generate platform-specific assembly from DSL

--- a/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -8,13 +8,10 @@
 #include <AK/Debug.h>
 #include <AK/Utf16String.h>
 #include <LibGfx/Palette.h>
+#include <LibJS/RustFFI.h>
 #include <LibJS/SourceCode.h>
 #include <LibJS/SyntaxHighlighter.h>
 #include <LibJS/Token.h>
-
-#ifdef ENABLE_RUST
-#    include <LibJS/RustFFI.h>
-#endif
 
 namespace JS {
 
@@ -143,12 +140,8 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         .folding_region_starts = {},
     };
 
-#ifdef ENABLE_RUST
     FFI::rust_tokenize(source_data, source_len, &state,
         [](void* ctx, FFI::FFIToken const* token) { on_token(ctx, token); });
-#else
-    (void)source_len;
-#endif
 
     m_client->do_set_spans(move(spans));
     m_client->do_set_folding_regions(move(folding_regions));

--- a/Libraries/LibRegex/CMakeLists.txt
+++ b/Libraries/LibRegex/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (NOT ENABLE_RUST)
-    message(FATAL_ERROR "LibRegex requires ENABLE_RUST; the legacy C++ regex engine has been removed")
-endif()
-
 set(SOURCES
     ECMAScriptRegex.cpp
     RustRegex.cpp
@@ -12,4 +8,3 @@ target_link_libraries(LibRegex PRIVATE LibUnicode)
 
 import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libregex_rust FFI_HEADER RustFFI.h)
 target_link_libraries(LibRegex PRIVATE libregex_rust)
-target_compile_definitions(LibRegex PRIVATE ENABLE_RUST)

--- a/Libraries/LibRegex/RustRegex.cpp
+++ b/Libraries/LibRegex/RustRegex.cpp
@@ -5,10 +5,7 @@
  */
 
 #include <LibRegex/RustRegex.h>
-
-#ifdef ENABLE_RUST
-
-#    include <LibUnicode/CharacterTypes.h>
+#include <LibUnicode/CharacterTypes.h>
 
 // Forward declarations for C++ functions called from Rust.
 extern "C" {
@@ -562,5 +559,3 @@ unsigned int CompiledRustRegex::capture_count() const
 }
 
 } // namespace regex
-
-#endif // ENABLE_RUST

--- a/Libraries/LibRegex/RustRegex.h
+++ b/Libraries/LibRegex/RustRegex.h
@@ -6,15 +6,13 @@
 
 #pragma once
 
-#ifdef ENABLE_RUST
-
-#    include <AK/Error.h>
-#    include <AK/Noncopyable.h>
-#    include <AK/String.h>
-#    include <AK/Utf16View.h>
-#    include <AK/Vector.h>
-#    include <LibRegex/Export.h>
-#    include <RustFFI.h>
+#include <AK/Error.h>
+#include <AK/Noncopyable.h>
+#include <AK/String.h>
+#include <AK/Utf16View.h>
+#include <AK/Vector.h>
+#include <LibRegex/Export.h>
+#include <RustFFI.h>
 
 namespace regex {
 
@@ -74,5 +72,3 @@ private:
 };
 
 } // namespace regex
-
-#endif // ENABLE_RUST

--- a/Meta/CMake/cmake_options.cmake
+++ b/Meta/CMake/cmake_options.cmake
@@ -47,8 +47,6 @@ ladybird_option(LAGOM_LINK_POOL_SIZE "" CACHE STRING "The maximum number of para
 ladybird_option(ENABLE_LTO_FOR_RELEASE ${RELEASE_LTO_DEFAULT} CACHE BOOL "Enable link-time optimization for release builds")
 ladybird_option(ENABLE_LAGOM_COVERAGE_COLLECTION OFF CACHE STRING "Enable code coverage instrumentation for lagom binaries in clang")
 
-ladybird_option(ENABLE_RUST ON CACHE BOOL "Build Rust components")
-
 if (ENABLE_FUZZERS_LIBFUZZER)
     # With libfuzzer, we need to avoid a duplicate main() linker error giving false negatives
     set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE STRING "Type of target to use for try_compile()" FORCE)


### PR DESCRIPTION
This now is required to be set for the browser to function.