### PR TITLE
LibWeb: Prevent deeply nested boxes from overflowing parent BFCs

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -928,6 +928,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             }
         }
 
+        // Boxes with indefinite width being laid out within contexts with non-indefinite available width inherit
+        // available width of their parent. This prevents those boxes from overflowing horizontally instead of
+        // increasing the height of their parent.
+        if (inner_available_space.width.is_indefinite() && !available_space.width.is_indefinite()) {
+            inner_available_space.width = available_space.width;
+        }
+
         independent_formatting_context->run(inner_available_space);
     } else {
         // This box participates in the current block container's flow.

--- a/Tests/LibWeb/Layout/expected/nested-inline-box-width-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/nested-inline-box-width-overflow.txt
@@ -1,0 +1,58 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 94 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 78 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div#wrapper> at [8,8] [0+0+0 140 0+0+644] [0+0+0 78 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <a> at [8,8] [0+0+0 140 0+0+0] [0+0+0 78 0+0+0]
+          frag 0 from TableWrapper start: 0, length: 0, rect: [8,8 140x78] baseline: 43.296875
+          TextNode <#text> (not painted)
+          TableWrapper <(anonymous)> at [8,8] inline-block [0+0+0 140 0+0+0] [0+0+0 78 0+0+0] [BFC] children: not-inline
+            Box <table> at [8,8] inline-table table-box [0+0+0 140 0+0+0] [0+0+0 78 0+0+0] [TFC] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              Box <tbody> at [10,10] table-row-group [0+0+0 136 0+0+0] [0+0+0 74 0+0+0] children: not-inline
+                Box <tr> at [10,10] table-row [0+0+0 136 0+0+0] [0+0+0 74 0+0+0] children: not-inline
+                  BlockContainer <(anonymous)> (not painted) children: inline
+                    TextNode <#text> (not painted)
+                  BlockContainer <td> at [11,11] table-cell [0+0+1 134 1+0+0] [0+0+1 72 1+0+0] [BFC] children: inline
+                    frag 0 from TextNode start: 13, length: 14, rect: [11,11 120x18] baseline: 13.796875
+                        "A nested table"
+                    frag 1 from TextNode start: 28, length: 17, rect: [11,29 128.59375x18] baseline: 13.796875
+                        "cell that's wider"
+                    frag 2 from TextNode start: 46, length: 8, rect: [11,47 67.984375x18] baseline: 13.796875
+                        "than the"
+                    frag 3 from TextNode start: 55, length: 8, rect: [11,65 70.125x18] baseline: 13.796875
+                        "wrapper."
+                    TextNode <#text> (not painted)
+                  BlockContainer <(anonymous)> at [8,8] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: inline
+                    TextNode <#text> (not painted)
+                BlockContainer <(anonymous)> at [8,8] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,86] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x94]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x78]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>#wrapper) [8,8 140x78]
+        PaintableWithLines (InlineNode<A>) [8,8 140x78]
+          PaintableWithLines (TableWrapper(anonymous)) [8,8 140x78]
+            PaintableBox (Box<TABLE>) [8,8 140x78]
+              PaintableBox (Box<TBODY>) [10,10 136x74]
+                PaintableBox (Box<TR>) [10,10 136x74]
+                  PaintableWithLines (BlockContainer<TD>) [10,10 136x74]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [8,8 0x0]
+                PaintableWithLines (BlockContainer(anonymous)) [8,8 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,86 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x94] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/nested-inline-box-width-overflow.html
+++ b/Tests/LibWeb/Layout/input/nested-inline-box-width-overflow.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="">
+
+<head>
+  <style>
+    #wrapper {
+      max-width: 140px;
+    }
+    
+    table {
+      display: inline-table;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="wrapper">
+    <a>
+      <table>
+        <tr>
+          <td>
+            A nested table cell that's wider than the wrapper.
+          </td>
+        </tr>
+      </table>
+    </a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Clamp available width when laying out boxes if parent BFC has a definite available width. 
This prevents inline boxes nested in inline nodes from overflowing ancestors with width constraints.

Fixes #8666 

This fixes table of contents element on [Minecraft Wiki](https://minecraft.wiki/w/Minecraft_Wiki:Minwi)
Before this change:
<img width="161" height="409" alt="image" src="https://github.com/user-attachments/assets/cadc48bd-5054-4bcf-b42f-2f2e5f100265" />
After this change:
<img width="161" height="461" alt="image" src="https://github.com/user-attachments/assets/8922d764-ce22-477b-9eb3-142f5f5231b0" />