### PR TITLE
Meta: Add SSL_CERT_FILE env variable to flatpak

### DIFF
--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -16,7 +16,8 @@
     "--socket=wayland",
     "--socket=fallback-x11",
     "--socket=pulseaudio",
-    "--socket=session-bus"
+    "--socket=session-bus",
+    "--env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
   ],
   "cleanup": [
     "/sbin",


### PR DESCRIPTION
This prevents certification errors when visiting https sites in the flatpak build

Fixes #8817