### PR TITLE
AK: Decimal number formatting

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/ByteBuffer.h>
 #include <AK/ByteString.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Error.h>
@@ -93,6 +94,63 @@ static constexpr size_t convert_unsigned_to_string(u64 value, Array<u8, 128>& bu
         swap(buffer[i], buffer[used - i - 1]);
 
     return used;
+}
+
+static ErrorOr<void> append_grouped_digits(StringBuilder& builder, StringView digits)
+{
+    if (digits.length() <= 3)
+        return builder.try_append(digits);
+
+    for (size_t i = 0; i < digits.length(); ++i) {
+        auto const index_from_end = digits.length() - i - 1;
+        TRY(builder.try_append(digits[i]));
+        if (index_from_end > 0 && index_from_end % 3 == 0)
+            TRY(builder.try_append(','));
+    }
+    return {};
+}
+
+static bool round_up_decimal_digits(ByteBuffer& digits)
+{
+    int current_position = digits.size() - 1;
+    while (current_position >= 0) {
+        ++digits[current_position];
+        if (digits[current_position] <= '9')
+            break;
+        digits[current_position] = '0';
+        --current_position;
+    }
+
+    if (current_position < 0) {
+        for (size_t i = 0; i < digits.size(); ++i)
+            digits[i] = '0';
+        return true;
+    }
+    return false;
+}
+
+static ErrorOr<void> append_formatted_integral_part(StringBuilder& builder, u64 whole_part, u8 base, bool upper_case, bool use_separator, FormatBuilder::SignMode sign_mode, bool is_negative)
+{
+    if (is_negative)
+        TRY(builder.try_append('-'));
+    else if (sign_mode == FormatBuilder::SignMode::Always)
+        TRY(builder.try_append('+'));
+    else if (sign_mode == FormatBuilder::SignMode::Reserved)
+        TRY(builder.try_append(' '));
+
+    StringBuilder digits_builder;
+    FormatBuilder format_builder { digits_builder };
+    TRY(format_builder.put_u64(whole_part, base, false, upper_case, false, false, FormatBuilder::Align::Right, 0, ' '));
+
+    if (use_separator)
+        return append_grouped_digits(builder, digits_builder.string_view());
+    return builder.try_append(digits_builder.string_view());
+}
+
+static void trim_trailing_zeroes(ByteBuffer& digits)
+{
+    while (!digits.is_empty() && digits[digits.size() - 1] == '0')
+        digits.trim(digits.size() - 1, false);
 }
 
 ErrorOr<void> vformat_impl(TypeErasedFormatParams& params, FormatBuilder& builder, FormatParser& parser)
@@ -461,29 +519,6 @@ ErrorOr<void> FormatBuilder::put_fixed_point(
     return {};
 }
 
-static ErrorOr<void> round_up_digits(StringBuilder& digits_builder)
-{
-    auto digits_buffer = TRY(digits_builder.to_byte_buffer());
-    int current_position = digits_buffer.size() - 1;
-
-    while (current_position >= 0) {
-        if (digits_buffer[current_position] == '.') {
-            --current_position;
-            continue;
-        }
-        ++digits_buffer[current_position];
-        if (digits_buffer[current_position] <= '9')
-            break;
-        digits_buffer[current_position] = '0';
-        --current_position;
-    }
-
-    digits_builder.clear();
-    if (current_position < 0)
-        TRY(digits_builder.try_append('1'));
-    return digits_builder.try_append(digits_buffer);
-}
-
 ErrorOr<void> FormatBuilder::put_f64_with_precision(
     double value,
     u8 base,
@@ -497,30 +532,30 @@ ErrorOr<void> FormatBuilder::put_f64_with_precision(
     SignMode sign_mode,
     RealNumberDisplayMode display_mode)
 {
-    StringBuilder string_builder;
-    FormatBuilder format_builder { string_builder };
+    bool const is_fixed_point_base10 = base == 10 && display_mode == RealNumberDisplayMode::FixedPoint;
 
     bool is_negative = value < 0.0;
     if (is_negative)
         value = -value;
 
-    TRY(format_builder.put_u64(static_cast<u64>(value), base, false, upper_case, false, use_separator, Align::Right, 0, ' ', sign_mode, is_negative));
-    value -= static_cast<i64>(value);
+    u64 whole_part = static_cast<u64>(value);
+    if (!is_fixed_point_base10)
+        value -= static_cast<i64>(value);
 
-    bool did_emit_decimals = false;
+    auto fractional_digits = TRY(ByteBuffer::create_uninitialized(0));
 
     if (precision > 0) {
         // FIXME: This is a terrible approximation but doing it properly would be a lot of work. If someone is up for that, a good
         // place to start would be the following video from CppCon 2019:
         // https://youtu.be/4P_kbF0EbZM (Stephan T. Lavavej “Floating-Point <charconv>: Making Your Code 10x Faster With C++17's Final Boss”)
         double epsilon = 0.5;
-        if (!zero_pad && display_mode != RealNumberDisplayMode::FixedPoint) {
+        if (!is_fixed_point_base10 && !zero_pad && display_mode != RealNumberDisplayMode::FixedPoint) {
             for (size_t i = 0; i < precision; ++i)
                 epsilon /= 10.0;
         }
 
         for (size_t digit = 0; digit < precision; ++digit) {
-            if (!zero_pad && display_mode != RealNumberDisplayMode::FixedPoint && value - static_cast<i64>(value) < epsilon)
+            if (!is_fixed_point_base10 && !zero_pad && display_mode != RealNumberDisplayMode::FixedPoint && value - static_cast<i64>(value) < epsilon)
                 break;
 
             value *= 10.0;
@@ -529,32 +564,25 @@ ErrorOr<void> FormatBuilder::put_f64_with_precision(
             if (value > NumericLimits<u32>::max())
                 value -= static_cast<u64>(value) - (static_cast<u64>(value) % 10);
 
-            if (digit == 0)
-                TRY(string_builder.try_append('.'));
-
-            TRY(string_builder.try_append('0' + (static_cast<u32>(value) % 10)));
-            did_emit_decimals = true;
+            TRY(fractional_digits.try_append('0' + (static_cast<u32>(value) % 10)));
         }
     }
 
-    // Round up if the following decimal is 5 or higher
-    if (static_cast<u64>(value * 10.0) % 10 >= 5)
-        TRY(round_up_digits(string_builder));
+    if (static_cast<u64>(value * 10.0) % 10 >= 5) {
+        if (precision == 0)
+            ++whole_part;
+        else if (round_up_decimal_digits(fractional_digits))
+            ++whole_part;
+    }
 
-    if (did_emit_decimals && display_mode == RealNumberDisplayMode::Default) {
-        while (!string_builder.is_empty()) {
-            // Strip trailing zero decimals.
-            if (string_builder.string_view().ends_with('0')) {
-                string_builder.trim(1);
-                continue;
-            }
-            // Strip trailing decimal point.
-            if (string_builder.string_view().ends_with('.')) {
-                string_builder.trim(1);
-                break;
-            }
-            break;
-        }
+    if (display_mode == RealNumberDisplayMode::Default)
+        trim_trailing_zeroes(fractional_digits);
+
+    StringBuilder string_builder;
+    TRY(append_formatted_integral_part(string_builder, whole_part, base, upper_case, use_separator, sign_mode, is_negative));
+    if (!fractional_digits.is_empty()) {
+        TRY(string_builder.try_append('.'));
+        TRY(string_builder.try_append(StringView { fractional_digits }));
     }
 
     return put_string(string_builder.string_view(), align, min_width, NumericLimits<size_t>::max(), fill);
@@ -697,16 +725,16 @@ ErrorOr<void> FormatBuilder::put_f32_or_f64(
         integral_part_end = 1;
     }
 
-    if (use_separator && integral_part_end > 3) {
-        // Go backwards from the end of the integral part, inserting commas every 3 consecutive digits.
+    size_t integral_part_start = 0;
+    if (!builder.is_empty() && (builder.string_view()[0] == '-' || builder.string_view()[0] == '+' || builder.string_view()[0] == ' '))
+        integral_part_start = 1;
+
+    if (use_separator && integral_part_end - integral_part_start > 3) {
         StringBuilder separated_builder;
         auto const string_view = builder.string_view();
-        for (size_t i = 0; i < integral_part_end; ++i) {
-            auto const index_from_end = integral_part_end - i - 1;
-            if (index_from_end > 0 && index_from_end != integral_part_end - 1 && index_from_end % 3 == 2)
-                TRY(separated_builder.try_append(','));
-            TRY(separated_builder.try_append(string_view[i]));
-        }
+        if (integral_part_start == 1)
+            TRY(separated_builder.try_append(string_view[0]));
+        TRY(append_grouped_digits(separated_builder, string_view.substring_view(integral_part_start, integral_part_end - integral_part_start)));
         TRY(separated_builder.try_append(string_view.substring_view(integral_part_end)));
         builder = move(separated_builder);
     }
@@ -718,6 +746,7 @@ ErrorOr<void> FormatBuilder::put_f80(
     long double value,
     u8 base,
     bool upper_case,
+    bool zero_pad,
     bool use_separator,
     Align align,
     size_t min_width,
@@ -726,10 +755,9 @@ ErrorOr<void> FormatBuilder::put_f80(
     SignMode sign_mode,
     RealNumberDisplayMode display_mode)
 {
-    StringBuilder string_builder;
-    FormatBuilder format_builder { string_builder };
-
     if (isnan(value) || isinf(value)) [[unlikely]] {
+        StringBuilder string_builder;
+
         if (value < 0.0l)
             TRY(string_builder.try_append('-'));
         else if (sign_mode == SignMode::Always)
@@ -745,25 +773,30 @@ ErrorOr<void> FormatBuilder::put_f80(
         return {};
     }
 
+    bool const is_fixed_point_base10 = base == 10 && display_mode == RealNumberDisplayMode::FixedPoint;
+
     bool is_negative = value < 0.0l;
     if (is_negative)
         value = -value;
 
-    TRY(format_builder.put_u64(static_cast<u64>(value), base, false, upper_case, false, use_separator, Align::Right, 0, ' ', sign_mode, is_negative));
-    value -= static_cast<i64>(value);
+    u64 whole_part = static_cast<u64>(value);
+    if (!is_fixed_point_base10)
+        value -= static_cast<i64>(value);
+
+    auto fractional_digits = TRY(ByteBuffer::create_uninitialized(0));
 
     if (precision > 0) {
         // FIXME: This is a terrible approximation but doing it properly would be a lot of work. If someone is up for that, a good
         // place to start would be the following video from CppCon 2019:
         // https://youtu.be/4P_kbF0EbZM (Stephan T. Lavavej “Floating-Point <charconv>: Making Your Code 10x Faster With C++17's Final Boss”)
         long double epsilon = 0.5l;
-        if (display_mode != RealNumberDisplayMode::FixedPoint) {
+        if (!is_fixed_point_base10 && !zero_pad && display_mode != RealNumberDisplayMode::FixedPoint) {
             for (size_t i = 0; i < precision; ++i)
                 epsilon /= 10.0l;
         }
 
         for (size_t digit = 0; digit < precision; ++digit) {
-            if (display_mode != RealNumberDisplayMode::FixedPoint && value - static_cast<i64>(value) < epsilon)
+            if (!is_fixed_point_base10 && !zero_pad && display_mode != RealNumberDisplayMode::FixedPoint && value - static_cast<i64>(value) < epsilon)
                 break;
 
             value *= 10.0l;
@@ -772,16 +805,26 @@ ErrorOr<void> FormatBuilder::put_f80(
             if (value > NumericLimits<u32>::max())
                 value -= static_cast<u64>(value) - (static_cast<u64>(value) % 10);
 
-            if (digit == 0)
-                TRY(string_builder.try_append('.'));
-
-            TRY(string_builder.try_append('0' + (static_cast<u32>(value) % 10)));
+            TRY(fractional_digits.try_append('0' + (static_cast<u32>(value) % 10)));
         }
     }
 
-    // Round up if the following decimal is 5 or higher
-    if (static_cast<u64>(value * 10.0l) % 10 >= 5)
-        TRY(round_up_digits(string_builder));
+    if (static_cast<u64>(value * 10.0l) % 10 >= 5) {
+        if (precision == 0)
+            ++whole_part;
+        else if (round_up_decimal_digits(fractional_digits))
+            ++whole_part;
+    }
+
+    if (display_mode == RealNumberDisplayMode::Default)
+        trim_trailing_zeroes(fractional_digits);
+
+    StringBuilder string_builder;
+    TRY(append_formatted_integral_part(string_builder, whole_part, base, upper_case, use_separator, sign_mode, is_negative));
+    if (!fractional_digits.is_empty()) {
+        TRY(string_builder.try_append('.'));
+        TRY(string_builder.try_append(StringView { fractional_digits }));
+    }
 
     TRY(put_string(string_builder.string_view(), align, min_width, NumericLimits<size_t>::max(), fill));
     return {};
@@ -1075,7 +1118,7 @@ ErrorOr<void> Formatter<long double>::format(FormatBuilder& builder, long double
     m_width = m_width.value_or(0);
     m_precision = m_precision.value_or(6);
 
-    return builder.put_f80(value, base, upper_case, m_use_separator, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
+    return builder.put_f80(value, base, upper_case, m_zero_pad, m_use_separator, m_align, m_width.value(), m_precision.value(), m_fill, m_sign_mode, real_number_display_mode);
 }
 
 ErrorOr<void> Formatter<f16>::format(FormatBuilder& builder, f16 value)

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -277,6 +277,7 @@ public:
         long double value,
         u8 base = 10,
         bool upper_case = false,
+        bool zero_pad = false,
         bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,

--- a/AK/NumberFormat.cpp
+++ b/AK/NumberFormat.cpp
@@ -4,26 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Assertions.h>
 #include <AK/NumberFormat.h>
-#include <AK/NumericLimits.h>
 #include <AK/Time.h>
 
 namespace AK {
-
-// FIXME: Remove this hackery once printf() supports floats.
-static String number_string_with_one_decimal(u64 number, u64 unit, StringView suffix, UseThousandsSeparator use_thousands_separator)
-{
-    constexpr auto max_unit_size = NumericLimits<u64>::max() / 10;
-    VERIFY(unit < max_unit_size);
-
-    auto integer_part = number / unit;
-    auto decimal_part = (number % unit) * 10 / unit;
-    if (use_thousands_separator == UseThousandsSeparator::Yes)
-        return MUST(String::formatted("{:'d}.{} {}", integer_part, decimal_part, suffix));
-
-    return MUST(String::formatted("{}.{} {}", integer_part, decimal_part, suffix));
-}
 
 String human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on, StringView unit, UseThousandsSeparator use_thousands_separator)
 {
@@ -36,6 +20,12 @@ String human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on, Stri
     };
 
     auto size_of_current_unit = size_of_unit;
+    auto format_quantity_with_one_decimal = [&](u64 quantity, u64 unit_size, StringView suffix) {
+        auto value = static_cast<long double>(quantity) / static_cast<long double>(unit_size);
+        if (use_thousands_separator == UseThousandsSeparator::Yes)
+            return MUST(String::formatted("{:'.1f} {}", value, suffix));
+        return MUST(String::formatted("{:.1f} {}", value, suffix));
+    };
 
     if (quantity < size_of_unit)
         return MUST(String::formatted("{} {}", quantity, full_unit_suffix(0)));
@@ -43,14 +33,13 @@ String human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on, Stri
     for (size_t i = 1; i < unit_prefixes.size() - 1; i++) {
         auto suffix = full_unit_suffix(i);
         if (quantity < size_of_unit * size_of_current_unit) {
-            return number_string_with_one_decimal(quantity, size_of_current_unit, suffix, use_thousands_separator);
+            return format_quantity_with_one_decimal(quantity, size_of_current_unit, suffix);
         }
 
         size_of_current_unit *= size_of_unit;
     }
 
-    return number_string_with_one_decimal(quantity,
-        size_of_current_unit, full_unit_suffix(unit_prefixes.size() - 1), use_thousands_separator);
+    return format_quantity_with_one_decimal(quantity, size_of_current_unit, full_unit_suffix(unit_prefixes.size() - 1));
 }
 
 String human_readable_size(u64 size, HumanReadableBasedOn based_on, UseThousandsSeparator use_thousands_separator)

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -285,6 +285,10 @@ TEST_CASE(floating_point_numbers)
     EXPECT_EQ(ByteString::formatted("{:.1f}", 1.4), "1.4");
     EXPECT_EQ(ByteString::formatted("{:.1f}", 1.99), "2.0");
     EXPECT_EQ(ByteString::formatted("{:.1f}", 9.999), "10.0");
+    EXPECT_EQ(ByteString::formatted("{:'.1f}", 999.96), "1,000.0");
+    EXPECT_EQ(ByteString::formatted("{:'.1f}", 999999.96l), "1,000,000.0");
+    EXPECT_EQ(ByteString::formatted("{:0.3}", 1.12l), "1.12");
+    EXPECT_EQ(ByteString::formatted("{:0.3f}", 1.12l), "1.120");
 
     EXPECT_EQ(ByteString::formatted("{}", NAN), "nan");
     EXPECT_EQ(ByteString::formatted("{}", INFINITY), "inf");

--- a/Tests/AK/TestNumberFormat.cpp
+++ b/Tests/AK/TestNumberFormat.cpp
@@ -40,22 +40,16 @@ TEST_CASE(border_B_KiB)
 TEST_CASE(fraction_KiB)
 {
     EXPECT_EQ(human_readable_size(1050), "1.0 KiB");
-    EXPECT_EQ(human_readable_size(1075), "1.0 KiB");
     // 1024 * 1.05 = 1075.2
-    EXPECT_EQ(human_readable_size(1076), "1.0 KiB");
+    EXPECT_EQ(human_readable_size(1076), "1.1 KiB");
 
-    EXPECT_EQ(human_readable_size(1100), "1.0 KiB");
-
-    EXPECT_EQ(human_readable_size(1126), "1.0 KiB");
     // 1024 * 1.1 = 1126.4
     EXPECT_EQ(human_readable_size(1127), "1.1 KiB");
-    EXPECT_EQ(human_readable_size(1146), "1.1 KiB");
 }
 
 TEST_CASE(border_KiB_MiB)
 {
     EXPECT_EQ(human_readable_size(1000 * KiB), "1000.0 KiB");
-    EXPECT_EQ(human_readable_size(1024 * KiB - 1), "1023.9 KiB");
     // MiB
     EXPECT_EQ(human_readable_size(1024 * KiB), "1.0 MiB");
     EXPECT_EQ(human_readable_size(1024 * KiB + 1), "1.0 MiB");
@@ -63,15 +57,9 @@ TEST_CASE(border_KiB_MiB)
 
 TEST_CASE(fraction_MiB)
 {
-    EXPECT_EQ(human_readable_size(1069547), "1.0 MiB");
     EXPECT_EQ(human_readable_size(1101004), "1.0 MiB");
     // 1024 * 1024 * 1.05 = 1101004.8
-    EXPECT_EQ(human_readable_size(1101005), "1.0 MiB");
-    EXPECT_EQ(human_readable_size(1101006), "1.0 MiB");
-
-    EXPECT_EQ(human_readable_size(1120000), "1.0 MiB");
-
-    EXPECT_EQ(human_readable_size(1153433), "1.0 MiB");
+    EXPECT_EQ(human_readable_size(1101005), "1.1 MiB");
     // 1024 * 1024 * 1.1 = 1153433.6
     EXPECT_EQ(human_readable_size(1153434), "1.1 MiB");
 }
@@ -79,35 +67,24 @@ TEST_CASE(fraction_MiB)
 TEST_CASE(border_MiB_GiB)
 {
     EXPECT_EQ(human_readable_size(1000 * MiB), "1000.0 MiB");
-    EXPECT_EQ(human_readable_size(1024 * MiB - 1), "1023.9 MiB");
     EXPECT_EQ(human_readable_size(1024 * MiB), "1.0 GiB");
     EXPECT_EQ(human_readable_size(1024 * MiB + 1), "1.0 GiB");
 }
 
 TEST_CASE(fraction_GiB)
 {
-    EXPECT_EQ(human_readable_size(1095216660), "1.0 GiB");
     EXPECT_EQ(human_readable_size(1127428915), "1.0 GiB");
     // 1024 * 1024 * 1024 * 1.05 = 1127428915.2
-    EXPECT_EQ(human_readable_size(1127428916), "1.0 GiB");
-    EXPECT_EQ(human_readable_size(1127536289), "1.0 GiB");
-
-    EXPECT_EQ(human_readable_size(1154272461), "1.0 GiB");
-
-    EXPECT_EQ(human_readable_size(1181115968), "1.0 GiB");
-    EXPECT_EQ(human_readable_size(1181115969), "1.0 GiB");
-    EXPECT_EQ(human_readable_size(1181116000), "1.0 GiB");
-    EXPECT_EQ(human_readable_size(1181116006), "1.0 GiB");
+    EXPECT_EQ(human_readable_size(1127428916), "1.1 GiB");
     // 1024 * 1024 * 1024 * 1.1 = 1181116006.4
     EXPECT_EQ(human_readable_size(1181116007), "1.1 GiB");
-    EXPECT_EQ(human_readable_size(1202590842), "1.1 GiB");
 }
 
 TEST_CASE(extremes_4byte)
 {
-    EXPECT_EQ(human_readable_size(0x7fffffff), "1.9 GiB");
+    EXPECT_EQ(human_readable_size(0x7fffffff), "2.0 GiB");
     EXPECT_EQ(human_readable_size(0x80000000), "2.0 GiB");
-    EXPECT_EQ(human_readable_size(0xffffffff), "3.9 GiB");
+    EXPECT_EQ(human_readable_size(0xffffffff), "4.0 GiB");
 }
 
 TEST_CASE(extremes_8byte)
@@ -119,9 +96,9 @@ TEST_CASE(extremes_8byte)
         EXPECT_EQ(human_readable_size(0x800000000ULL), "32.0 GiB");
         EXPECT_EQ(human_readable_size(0x10000000000ULL), "1.0 TiB");
         EXPECT_EQ(human_readable_size(0x4000000000000ULL), "1.0 PiB");
-        EXPECT_EQ(human_readable_size(0x7fffffffffffffffULL), "7.9 EiB");
+        EXPECT_EQ(human_readable_size(0x7fffffffffffffffULL), "8.0 EiB");
         EXPECT_EQ(human_readable_size(0x8000000000000000ULL), "8.0 EiB");
-        EXPECT_EQ(human_readable_size(0xffffffffffffffffULL), "15.9 EiB");
+        EXPECT_EQ(human_readable_size(0xffffffffffffffffULL), "16.0 EiB");
     } else {
         warnln("(Skipping 8-byte-size_t test on 32-bit platform)");
     }
@@ -133,6 +110,31 @@ TEST_CASE(base10_units)
     EXPECT_EQ(human_readable_size(1024, AK::HumanReadableBasedOn::Base10), "1.0 KB");
     EXPECT_EQ(human_readable_size(1100, AK::HumanReadableBasedOn::Base10), "1.1 KB");
     EXPECT_EQ(human_readable_size(1000000, AK::HumanReadableBasedOn::Base10), "1.0 MB");
+}
+
+TEST_CASE(rounding_boundaries_base2)
+{
+    EXPECT_EQ(human_readable_size(1075), "1.0 KiB");
+    EXPECT_EQ(human_readable_size(1076), "1.1 KiB");
+    EXPECT_EQ(human_readable_size(1177), "1.1 KiB");
+    EXPECT_EQ(human_readable_size(1178), "1.2 KiB");
+
+    EXPECT_EQ(human_readable_size(1024 * KiB - 52), "1023.9 KiB");
+    EXPECT_EQ(human_readable_size(1024 * KiB - 51), "1024.0 KiB");
+    EXPECT_EQ(human_readable_size(1024 * KiB - 1), "1024.0 KiB");
+    EXPECT_EQ(human_readable_size(1024 * KiB), "1.0 MiB");
+}
+
+TEST_CASE(rounding_boundaries_base10)
+{
+    EXPECT_EQ(human_readable_size(1049, AK::HumanReadableBasedOn::Base10), "1.0 KB");
+    EXPECT_EQ(human_readable_size(1050, AK::HumanReadableBasedOn::Base10), "1.0 KB");
+    EXPECT_EQ(human_readable_size(1051, AK::HumanReadableBasedOn::Base10), "1.1 KB");
+    EXPECT_EQ(human_readable_size(1150, AK::HumanReadableBasedOn::Base10), "1.1 KB");
+    EXPECT_EQ(human_readable_size(1151, AK::HumanReadableBasedOn::Base10), "1.2 KB");
+
+    EXPECT_EQ(human_readable_size(999949, AK::HumanReadableBasedOn::Base10), "999.9 KB");
+    EXPECT_EQ(human_readable_size(999950, AK::HumanReadableBasedOn::Base10), "1000.0 KB");
 }
 
 TEST_CASE(human_readable_short_time)

--- a/Tests/AK/TestNumberFormat.cpp
+++ b/Tests/AK/TestNumberFormat.cpp
@@ -112,6 +112,16 @@ TEST_CASE(base10_units)
     EXPECT_EQ(human_readable_size(1000000, AK::HumanReadableBasedOn::Base10), "1.0 MB");
 }
 
+TEST_CASE(use_thousands_separator)
+{
+    EXPECT_EQ(human_readable_size(1000 * KiB, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes), "1,000.0 KiB");
+    EXPECT_EQ(human_readable_size(1024 * KiB - 51, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes), "1,024.0 KiB");
+    EXPECT_EQ(human_readable_size(999950, AK::HumanReadableBasedOn::Base10, UseThousandsSeparator::Yes), "1,000.0 KB");
+
+    EXPECT_EQ(human_readable_size_long(1234, UseThousandsSeparator::Yes), "1.2 KiB (1,234 bytes)");
+    EXPECT_EQ(human_readable_size_long(1000000, UseThousandsSeparator::Yes), "976.6 KiB (1,000,000 bytes)");
+}
+
 TEST_CASE(rounding_boundaries_base2)
 {
     EXPECT_EQ(human_readable_size(1075), "1.0 KiB");
@@ -128,9 +138,9 @@ TEST_CASE(rounding_boundaries_base2)
 TEST_CASE(rounding_boundaries_base10)
 {
     EXPECT_EQ(human_readable_size(1049, AK::HumanReadableBasedOn::Base10), "1.0 KB");
-    EXPECT_EQ(human_readable_size(1050, AK::HumanReadableBasedOn::Base10), "1.0 KB");
+    EXPECT_EQ(human_readable_size(1050, AK::HumanReadableBasedOn::Base10), "1.1 KB");
     EXPECT_EQ(human_readable_size(1051, AK::HumanReadableBasedOn::Base10), "1.1 KB");
-    EXPECT_EQ(human_readable_size(1150, AK::HumanReadableBasedOn::Base10), "1.1 KB");
+    EXPECT_EQ(human_readable_size(1150, AK::HumanReadableBasedOn::Base10), "1.2 KB");
     EXPECT_EQ(human_readable_size(1151, AK::HumanReadableBasedOn::Base10), "1.2 KB");
 
     EXPECT_EQ(human_readable_size(999949, AK::HumanReadableBasedOn::Base10), "999.9 KB");

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/animation/rotate-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/animation/rotate-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 360 tests
 
-352 Pass
-8 Fail
+356 Pass
+4 Fail
 Pass	CSS Transitions: property <rotate> from [100deg] to [180deg] at (-1) should be [20deg]
 Pass	CSS Transitions: property <rotate> from [100deg] to [180deg] at (0) should be [100deg]
 Pass	CSS Transitions: property <rotate> from [100deg] to [180deg] at (0.125) should be [110deg]
@@ -33,25 +33,25 @@ Pass	CSS Transitions: property <rotate> from [45deg] to [-1 1 0 60deg] at (0) sh
 Pass	CSS Transitions: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg]
 Pass	CSS Transitions: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg]
 Pass	CSS Transitions: property <rotate> from [45deg] to [-1 1 0 60deg] at (1) should be [-0.71 0.71 0 60deg]
-Fail	CSS Transitions: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
+Pass	CSS Transitions: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
 Pass	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (-1) should be [0.447214 -0.447214 0.774597 104.478deg]
 Pass	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (0) should be [45deg]
 Pass	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg]
 Pass	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg]
 Pass	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (1) should be [-0.71 0.71 0 60deg]
-Fail	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
+Pass	CSS Transitions with transition: all: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
 Pass	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (-1) should be [0.447214 -0.447214 0.774597 104.478deg]
 Pass	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (0) should be [45deg]
 Pass	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg]
 Pass	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg]
 Pass	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (1) should be [-0.71 0.71 0 60deg]
-Fail	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
+Pass	CSS Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
 Pass	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (-1) should be [0.447214 -0.447214 0.774597 104.478deg]
 Pass	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (0) should be [45deg]
 Pass	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg]
 Pass	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg]
 Pass	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (1) should be [-0.71 0.71 0 60deg]
-Fail	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
+Pass	Web Animations: property <rotate> from [45deg] to [-1 1 0 60deg] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg]
 Pass	CSS Transitions: property <rotate> from [none] to [7 -8 9 400grad] at (-1) should be [0.5 -0.57 0.65 -400grad]
 Pass	CSS Transitions: property <rotate> from [none] to [7 -8 9 400grad] at (0) should be [0.5 -0.57 0.65 0deg]
 Pass	CSS Transitions: property <rotate> from [none] to [7 -8 9 400grad] at (0.125) should be [0.5 -0.57 0.65 50grad]


### PR DESCRIPTION
Solve FIXME by using string formatting for decimal rather than adhoc implementation.

Fix insertion of thousands separators when rounding.
For example `ByteString::formatted("{:'.1f}", 999.96)` would previously not add a thousands separator.