### PR TITLE
LibJS: Add sampling profiler

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -18,6 +18,7 @@
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/PropertyAccess.h>
 #include <LibJS/Export.h>
+#include <LibJS/Profiler.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Accessor.h>
 #include <LibJS/Runtime/Array.h>
@@ -424,7 +425,10 @@ void Interpreter::run_bytecode(size_t entry_point)
         return env && env[0] == '1';
     }();
 
-    if (!use_cpp_interpreter && AsmInterpreter::is_available()) {
+    auto* profiler = vm().profiler();
+    auto const force_cpp_interpreter = profiler && profiler->needs_bytecode_safe_points();
+
+    if (!use_cpp_interpreter && !force_cpp_interpreter && AsmInterpreter::is_available()) {
         AsmInterpreter::run(*this, entry_point);
         return;
     }
@@ -449,6 +453,11 @@ void Interpreter::run_bytecode(size_t entry_point)
         else                                                                                        \
             program_counter += sizeof(Op::name);                                                    \
         m_running_execution_context->program_counter = program_counter;                             \
+        /* sample_if_needed() is a flag-check no-op on platforms that sample asynchronously         \
+           (e.g. macOS Mach path); it only does work when m_sample_pending has been set             \
+           by a signal handler or explicitly via request_sample_for_test(). */                      \
+        if (auto* profiler = vm().profiler()) [[unlikely]]                                          \
+            profiler->sample_if_needed();                                                           \
         auto& next_instruction = *reinterpret_cast<Instruction const*>(&bytecode[program_counter]); \
         goto* bytecode_dispatch_table[static_cast<size_t>(next_instruction.type())];                \
     } while (0)
@@ -469,6 +478,8 @@ void Interpreter::run_bytecode(size_t entry_point)
     for (;;) {
     start:
         m_running_execution_context->program_counter = program_counter;
+        if (auto* profiler = vm().profiler()) [[unlikely]]
+            profiler->sample_if_needed();
         for (;;) {
             goto* bytecode_dispatch_table[static_cast<size_t>((*reinterpret_cast<Instruction const*>(&bytecode[program_counter])).type())];
 

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
     ParserError.cpp
     Print.cpp
     Profiler.cpp
+    GeckoProfileWriter.cpp
 )
 
 if (APPLE)

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -21,6 +21,20 @@ set(SOURCES
     Module.cpp
     ParserError.cpp
     Print.cpp
+    Profiler.cpp
+)
+
+if (APPLE)
+    list(APPEND SOURCES ProfilerMacOS.cpp)
+elseif (WIN32)
+    list(APPEND SOURCES ProfilerWindows.cpp)
+elseif (LINUX)
+    list(APPEND SOURCES ProfilerLinux.cpp)
+else()
+    message(FATAL_ERROR "LibJS profiler backend is only implemented for APPLE, WIN32, and LINUX")
+endif()
+
+set(SOURCES ${SOURCES}
     RustIntegration.cpp
     Runtime/AbstractOperations.cpp
     Runtime/Accessor.cpp
@@ -274,7 +288,7 @@ ladybird_lib(LibJS js EXPLICIT_SYMBOL_EXPORT)
 find_package(simdjson CONFIG REQUIRED)
 target_link_libraries(LibJS PRIVATE simdjson::simdjson)
 
-target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibGC)
+target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibGC LibThreading)
 
 # Link LibUnicode publicly to ensure ICU data (which is in libicudata.a) is available in any process using LibJS.
 target_link_libraries(LibJS PUBLIC LibUnicode)

--- a/Libraries/LibJS/GeckoProfileWriter.cpp
+++ b/Libraries/LibJS/GeckoProfileWriter.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <LibCore/System.h>
+#include <LibJS/GeckoProfileWriter.h>
+#include <LibJS/Profiler.h>
+
+namespace JS {
+
+// Gecko Profile Format version 34
+// https://github.com/firefox-devtools/profiler/blob/main/src/app-logic/constants.ts
+String write_gecko_profile(Profiler const& profiler)
+{
+    // Categories (GeckoProfileFullMeta.categories)
+    JsonObject js_category;
+    js_category.set("name"sv, "JavaScript"sv);
+    js_category.set("color"sv, "yellow"sv);
+    JsonArray subcategories;
+    subcategories.must_append("Other"sv);
+    js_category.set("subcategories"sv, move(subcategories));
+    JsonArray categories;
+    categories.must_append(move(js_category));
+
+    // Meta (GeckoProfileFullMeta)
+    // interval: ms between samples; use 1ms as the nominal value for safe-point-only profilers
+    // (interval_us == 0) since the spec expects a positive number.
+    double interval_ms = profiler.interval_us() > 0
+        ? static_cast<double>(profiler.interval_us()) / 1000.0
+        : 1.0;
+    JsonObject meta;
+    meta.set("version"sv, 34);
+    meta.set("interval"sv, interval_ms);
+    meta.set("startTime"sv, static_cast<double>(profiler.start_time_epoch_ms()));
+    auto stop_ms = profiler.stop_time_epoch_ms();
+    if (stop_ms > 0)
+        meta.set("shutdownTime"sv, static_cast<double>(stop_ms));
+    else
+        meta.set("shutdownTime"sv, JsonValue {});
+    meta.set("processType"sv, 0);
+    meta.set("product"sv, "Ladybird LibJS"sv);
+    meta.set("stackwalk"sv, 0);
+    meta.set("debug"sv, 0);
+    meta.set("gcpoison"sv, 0);
+    meta.set("asyncstack"sv, 0);
+    meta.set("categories"sv, move(categories));
+    meta.set("markerSchema"sv, JsonArray {});
+
+    // Samples (GeckoSamples): [stack, time, responsiveness]
+    JsonObject samples_schema;
+    samples_schema.set("stack"sv, 0);
+    samples_schema.set("time"sv, 1);
+    samples_schema.set("responsiveness"sv, 2);
+    JsonArray samples_data;
+    for (auto const& sample : profiler.samples()) {
+        JsonArray row;
+        row.must_append(sample.stack_index);
+        row.must_append(sample.time_ms);
+        row.must_append(0);
+        samples_data.must_append(move(row));
+    }
+    JsonObject samples;
+    samples.set("schema"sv, move(samples_schema));
+    samples.set("data"sv, move(samples_data));
+
+    // Stack table (GeckoStackTable): [prefix, frame]
+    JsonObject stack_schema;
+    stack_schema.set("prefix"sv, 0);
+    stack_schema.set("frame"sv, 1);
+    JsonArray stack_data;
+    for (auto const& stack : profiler.stack_table()) {
+        JsonArray row;
+        if (stack.prefix.has_value())
+            row.must_append(stack.prefix.value());
+        else
+            row.must_append(JsonValue {});
+        row.must_append(stack.frame_index);
+        stack_data.must_append(move(row));
+    }
+    JsonObject stack_table;
+    stack_table.set("schema"sv, move(stack_schema));
+    stack_table.set("data"sv, move(stack_data));
+
+    // Frame table (GeckoFrameTable)
+    JsonObject frame_schema;
+    frame_schema.set("location"sv, 0);
+    frame_schema.set("relevantForJS"sv, 1);
+    frame_schema.set("innerWindowID"sv, 2);
+    frame_schema.set("implementation"sv, 3);
+    frame_schema.set("line"sv, 4);
+    frame_schema.set("column"sv, 5);
+    frame_schema.set("category"sv, 6);
+    frame_schema.set("subcategory"sv, 7);
+    JsonArray frame_data;
+    for (auto const& frame : profiler.frame_table()) {
+        JsonArray row;
+        row.must_append(frame.string_index);
+        row.must_append(true);
+        row.must_append(JsonValue {});
+        row.must_append(JsonValue {});
+        row.must_append(frame.line);
+        row.must_append(frame.column);
+        row.must_append(0);
+        row.must_append(0);
+        frame_data.must_append(move(row));
+    }
+    JsonObject frame_table;
+    frame_table.set("schema"sv, move(frame_schema));
+    frame_table.set("data"sv, move(frame_data));
+
+    // String table
+    JsonArray string_table;
+    for (auto const& str : profiler.string_table())
+        string_table.must_append(str);
+
+    // Markers (GeckoMarkers) — empty
+    JsonObject markers_schema;
+    markers_schema.set("name"sv, 0);
+    markers_schema.set("startTime"sv, 1);
+    markers_schema.set("endTime"sv, 2);
+    markers_schema.set("phase"sv, 3);
+    markers_schema.set("category"sv, 4);
+    markers_schema.set("data"sv, 5);
+    JsonObject markers;
+    markers.set("schema"sv, move(markers_schema));
+    markers.set("data"sv, JsonArray {});
+
+    // Thread (GeckoThread)
+    JsonObject thread;
+    thread.set("name"sv, "GeckoMain"sv);
+    thread.set("processType"sv, "default"sv);
+    thread.set("tid"sv, profiler.os_tid());
+    thread.set("pid"sv, Core::System::getpid());
+    thread.set("registerTime"sv, static_cast<double>(profiler.start_time_epoch_ms()));
+    thread.set("unregisterTime"sv, JsonValue {});
+    thread.set("markers"sv, move(markers));
+    thread.set("samples"sv, move(samples));
+    thread.set("frameTable"sv, move(frame_table));
+    thread.set("stackTable"sv, move(stack_table));
+    thread.set("stringTable"sv, move(string_table));
+
+    JsonArray threads;
+    threads.must_append(move(thread));
+
+    // Root (GeckoProfile)
+    JsonObject root;
+    root.set("meta"sv, move(meta));
+    root.set("libs"sv, JsonArray {});
+    root.set("sources"sv, JsonArray {});
+    root.set("threads"sv, move(threads));
+    root.set("processes"sv, JsonArray {});
+    root.set("pausedRanges"sv, JsonArray {});
+
+    return root.serialized();
+}
+
+}

--- a/Libraries/LibJS/GeckoProfileWriter.h
+++ b/Libraries/LibJS/GeckoProfileWriter.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibJS/Export.h>
+#include <LibJS/Forward.h>
+
+namespace JS {
+
+class Profiler;
+
+JS_API String write_gecko_profile(Profiler const&);
+
+}

--- a/Libraries/LibJS/Profiler.cpp
+++ b/Libraries/LibJS/Profiler.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Time.h>
+#include <LibJS/Bytecode/Executable.h>
+#include <LibJS/Profiler.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibJS/SourceRange.h>
+
+namespace JS {
+
+static i64 current_epoch_ms()
+{
+    return UnixDateTime::now().milliseconds_since_epoch();
+}
+
+Profiler::Profiler(VM& vm, int interval_us)
+    : m_vm(vm)
+    , m_interval_us(interval_us)
+{
+}
+
+Profiler::~Profiler()
+{
+    stop();
+}
+
+void Profiler::sample_if_needed()
+{
+    if (!m_sample_pending.exchange(false, AK::MemoryOrder::memory_order_relaxed))
+        return;
+    capture_sample({});
+}
+
+void Profiler::request_sample_for_test()
+{
+    m_sample_pending.store(true, AK::MemoryOrder::memory_order_relaxed);
+}
+
+void Profiler::reset_state_for_start()
+{
+    m_start_time = MonotonicTime::now();
+    m_start_epoch_ms = current_epoch_ms();
+    m_stop_epoch_ms = 0;
+    m_js_thread = pthread_self();
+    m_raw_sample_count.store(0, AK::MemoryOrder::memory_order_relaxed);
+    m_sample_pending.store(false, AK::MemoryOrder::memory_order_relaxed);
+    m_raw_samples = new RawSample[MAX_RAW_SAMPLES];
+    m_string_table.clear();
+    m_string_map.clear();
+    m_frame_table.clear();
+    m_frame_map.clear();
+    m_stack_table.clear();
+    m_stack_map.clear();
+    m_samples.clear();
+}
+
+void Profiler::reserve_output_tables()
+{
+    m_string_table.ensure_capacity(256);
+    m_frame_table.ensure_capacity(256);
+    m_stack_table.ensure_capacity(1024);
+}
+
+void Profiler::allocate_raw_samples()
+{
+    delete[] m_raw_samples;
+    m_raw_samples = new RawSample[MAX_RAW_SAMPLES];
+}
+
+void Profiler::process_and_free_raw_samples()
+{
+    if (!m_raw_samples)
+        return;
+
+    process_raw_samples();
+    delete[] m_raw_samples;
+    m_raw_samples = nullptr;
+}
+
+void Profiler::stop_timer_thread()
+{
+    m_timer_running.store(false, AK::MemoryOrder::memory_order_relaxed);
+    if (!m_timer_thread)
+        return;
+
+    (void)m_timer_thread->join();
+    m_timer_thread = nullptr;
+}
+
+double Profiler::elapsed_ms_since_start() const
+{
+    auto elapsed = MonotonicTime::now() - m_start_time;
+    return static_cast<double>(max(elapsed.to_microseconds(), static_cast<i64>(0))) / 1000.0;
+}
+
+void Profiler::allocate_sample_buffer()
+{
+    reset_state_for_start();
+    allocate_raw_samples();
+    reserve_output_tables();
+}
+
+void Profiler::collect_and_free_samples()
+{
+    m_stop_epoch_ms = current_epoch_ms();
+    stop_timer_thread();
+    process_and_free_raw_samples();
+}
+
+void Profiler::capture_frames(RawSample& tick, Optional<u32> leaf_program_counter)
+{
+    auto const& ec_stack = m_vm.execution_context_stack();
+    u32 frame_count = 0;
+
+    for (ssize_t i = static_cast<ssize_t>(ec_stack.size()) - 1; i >= 0 && frame_count < MAX_STACK_DEPTH; --i) {
+        auto* ctx = ec_stack[i];
+        if (!ctx || !ctx->executable)
+            continue;
+
+        // Use the register-derived offset only for the topmost frame (macOS Mach path).
+        // On the Linux safe-point path leaf_program_counter is absent and ctx->program_counter
+        // is used for all frames. For inner frames on macOS (frame_count > 0),
+        // ctx->program_counter may be stale when the ASM interpreter is running.
+        auto program_counter = (frame_count == 0 && leaf_program_counter.has_value())
+            ? *leaf_program_counter
+            : ctx->program_counter;
+
+        auto& frame = tick.frames[frame_count++];
+        frame.executable = bit_cast<FlatPtr>(ctx->executable.ptr());
+        frame.program_counter = program_counter;
+        frame.name = ctx->executable->name;
+    }
+
+    tick.frame_count = frame_count;
+}
+
+void Profiler::capture_sample(Optional<u32> leaf_program_counter)
+{
+    auto index = m_raw_sample_count.load(AK::MemoryOrder::memory_order_relaxed);
+    if (index >= MAX_RAW_SAMPLES || !m_raw_samples)
+        return;
+
+    auto& tick = m_raw_samples[index];
+    tick.time_ms = elapsed_ms_since_start();
+    capture_frames(tick, leaf_program_counter);
+    m_raw_sample_count.store(index + 1, AK::MemoryOrder::memory_order_relaxed);
+}
+
+void Profiler::process_raw_samples()
+{
+    auto count = min(m_raw_sample_count.load(AK::MemoryOrder::memory_order_relaxed), MAX_RAW_SAMPLES);
+    m_samples.ensure_capacity(count);
+
+    for (u32 i = 0; i < count; ++i) {
+        auto const& tick = m_raw_samples[i];
+        if (tick.frame_count == 0 || tick.frame_count > MAX_STACK_DEPTH)
+            continue;
+        m_samples.append({ tick.time_ms, intern_stack_trace(tick) });
+    }
+}
+
+u32 Profiler::intern_stack_trace(RawSample const& tick)
+{
+    Optional<u32> prefix;
+
+    for (ssize_t i = static_cast<ssize_t>(tick.frame_count) - 1; i >= 0; --i) {
+        auto const& frame = tick.frames[i];
+        auto const* executable = bit_cast<Bytecode::Executable const*>(frame.executable);
+
+        u32 line = 0;
+        u32 column = 0;
+        String filename;
+
+        if (executable && frame.program_counter < executable->bytecode.size()) {
+            auto unrealized = executable->source_range_at(frame.program_counter);
+            if (unrealized.source_code) {
+                auto range = unrealized.realize();
+                line = range.start.line;
+                column = range.start.column;
+                filename = MUST(String::from_byte_string(range.filename()));
+            }
+        }
+
+        String function_name = frame.name.is_empty()
+            ? "(anonymous)"_string
+            : MUST(String::formatted("{}", frame.name));
+
+        String location = filename.is_empty()
+            ? function_name
+            : MUST(String::formatted("{} ({}:{}:{})", function_name, filename, line, column));
+
+        auto frame_index = intern_frame(location, line, column);
+        u64 key = (static_cast<u64>(frame_index) << 32) | prefix.value_or(UINT32_MAX);
+
+        if (auto it = m_stack_map.find(key); it != m_stack_map.end()) {
+            prefix = it->value;
+        } else {
+            u32 stack_index = m_stack_table.size();
+            m_stack_table.append({ frame_index, prefix });
+            m_stack_map.set(key, stack_index);
+            prefix = stack_index;
+        }
+    }
+
+    return prefix.value_or(0);
+}
+
+u32 Profiler::intern_string(String const& str)
+{
+    if (auto it = m_string_map.find(str); it != m_string_map.end())
+        return it->value;
+    u32 index = m_string_table.size();
+    m_string_table.append(str);
+    m_string_map.set(str, index);
+    return index;
+}
+
+u32 Profiler::intern_frame(String const& location, u32 line, u32 column)
+{
+    // The location string encodes function name + source position, so string_index
+    // is a unique key for each distinct (function, file, line, col) combination.
+    auto string_index = intern_string(location);
+    if (auto it = m_frame_map.find(string_index); it != m_frame_map.end())
+        return it->value;
+    u32 index = m_frame_table.size();
+    m_frame_table.append({ string_index, line, column });
+    m_frame_map.set(string_index, index);
+    return index;
+}
+
+}

--- a/Libraries/LibJS/Profiler.h
+++ b/Libraries/LibJS/Profiler.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/Time.h>
+#include <AK/Utf16FlyString.h>
+#include <AK/Vector.h>
+#include <LibJS/Export.h>
+#include <LibJS/Forward.h>
+#include <LibThreading/Thread.h>
+#include <pthread.h>
+
+namespace JS {
+
+class JS_API Profiler {
+public:
+    explicit Profiler(VM&, int interval_us = 1000);
+    ~Profiler();
+
+    void start();
+    void stop();
+
+    // Captures a pending sample at the next bytecode dispatch boundary. Linux uses
+    // this for signal-driven safe-point sampling; tests also use it explicitly.
+    void sample_if_needed();
+    void request_sample_for_test();
+    bool supports_timed_sampling() const;
+    bool needs_bytecode_safe_points() const;
+    void capture_sample(Optional<u32> leaf_program_counter);
+
+    struct Frame {
+        u32 string_index;
+        u32 line;
+        u32 column;
+    };
+    struct Stack {
+        u32 frame_index;
+        Optional<u32> prefix;
+    };
+    struct Sample {
+        double time_ms;
+        u32 stack_index;
+    };
+
+    Vector<String> const& string_table() const { return m_string_table; }
+    Vector<Frame> const& frame_table() const { return m_frame_table; }
+    Vector<Stack> const& stack_table() const { return m_stack_table; }
+    Vector<Sample> const& samples() const { return m_samples; }
+    int interval_us() const { return m_interval_us; }
+    i64 start_time_epoch_ms() const;
+    i64 stop_time_epoch_ms() const;
+    u64 os_tid() const;
+
+private:
+    static constexpr u32 MAX_STACK_DEPTH = 64;
+    static constexpr u32 MAX_RAW_SAMPLES = 16384;
+
+    // capture_sample() runs either in a signal handler (Linux) or while the JS thread
+    // is suspended via Mach (macOS).  In both cases the GC cannot run, so GC-managed
+    // objects on the execution-context stack are alive — but only for the duration of
+    // capture_sample() itself.  Once the JS thread resumes the GC is free to collect them,
+    // so by the time process_raw_samples() runs they may be gone.
+    //
+    // Consequences for UnprocessedFrame:
+    //  - No GC::Ptr: raw GC pointers are only safe to read during capture_sample().
+    //  - No heap allocation: malloc may deadlock if the suspended thread was inside it.
+    //  - The frame name is copied from Bytecode::Executable::name while the executable is live.
+    struct UnprocessedFrame {
+        FlatPtr executable;  // Bytecode::Executable const* — GC cell, valid only during capture_sample()
+        u32 program_counter; // offset into executable->bytecode (not a machine PC)
+        Utf16FlyString name;
+    };
+    struct RawSample {
+        double time_ms;
+        u32 frame_count;
+        UnprocessedFrame frames[MAX_STACK_DEPTH];
+    };
+
+    // Async-signal-safe: called from a POSIX signal handler (Linux) or while the JS
+    // thread is Mach-suspended (macOS).  Must not allocate or call non-reentrant
+    // functions — see UnprocessedFrame comment above.
+    // leaf_program_counter: register-derived PC for the topmost frame (macOS path);
+    // absent on the Linux safe-point path, where ctx->program_counter is used instead.
+    void reset_state_for_start();
+    void reserve_output_tables();
+    void allocate_raw_samples();
+    void process_and_free_raw_samples();
+    void capture_frames(RawSample&, Optional<u32> leaf_program_counter);
+    void stop_timer_thread();
+    double elapsed_ms_since_start() const;
+    void allocate_sample_buffer();
+    void collect_and_free_samples();
+
+    void process_raw_samples();
+    u32 intern_string(String const&);
+    u32 intern_frame(String const& location, u32 line, u32 column);
+    u32 intern_stack_trace(RawSample const&);
+
+    VM& m_vm;
+    int m_interval_us;
+    ::MonotonicTime m_start_time { ::MonotonicTime::now() };
+    i64 m_start_epoch_ms { 0 };
+    i64 m_stop_epoch_ms { 0 };
+    Atomic<bool> m_timer_running { false };
+    RefPtr<Threading::Thread> m_timer_thread;
+    pthread_t m_js_thread {};
+
+    RawSample* m_raw_samples { nullptr };
+    Atomic<u32> m_raw_sample_count { 0 };
+
+    // Set either by the Linux signal handler or by tests requesting a sample,
+    // then consumed by sample_if_needed() at the next safe bytecode boundary.
+    Atomic<bool> m_sample_pending { false };
+    bool m_platform_sampling_active { false };
+
+    Vector<String> m_string_table;
+    HashMap<String, u32> m_string_map;
+    Vector<Frame> m_frame_table;
+    // Key: string_index (location string uniquely encodes function + source position)
+    HashMap<u32, u32> m_frame_map;
+    Vector<Stack> m_stack_table;
+    HashMap<u64, u32> m_stack_map;
+    Vector<Sample> m_samples;
+};
+
+inline i64 Profiler::start_time_epoch_ms() const
+{
+    return m_start_epoch_ms;
+}
+
+inline i64 Profiler::stop_time_epoch_ms() const
+{
+    return m_stop_epoch_ms;
+}
+
+}

--- a/Libraries/LibJS/ProfilerLinux.cpp
+++ b/Libraries/LibJS/ProfilerLinux.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Profiler.h>
+#include <signal.h>
+#include <ucontext.h>
+#include <unistd.h>
+
+// ASM interpreter register conventions (callee-saved, survive C++ calls):
+//   x86_64:  r13 = pc
+//   aarch64: x21 = pb+pc, x26 = pb  =>  pc = x21 - x26
+static Optional<u32> read_program_counter_from_ucontext(ucontext_t const* uc)
+{
+#if defined(__x86_64__)
+    auto r13 = static_cast<u64>(uc->uc_mcontext.gregs[REG_R13]);
+    return static_cast<u32>(r13);
+#elif defined(__aarch64__)
+    auto x21 = static_cast<u64>(uc->uc_mcontext.regs[21]);
+    auto x26 = static_cast<u64>(uc->uc_mcontext.regs[26]);
+    return static_cast<u32>(x21 - x26);
+#else
+    (void)uc;
+    return {};
+#endif
+}
+
+namespace JS {
+
+// The signal handler runs on the JS thread, which is effectively suspended
+// while the handler executes — so the execution-context stack is stable and
+// we can capture directly, same as the macOS Mach thread-suspend path.
+static Atomic<Profiler*> s_active_profiler { nullptr };
+static struct sigaction s_old_sigaction {};
+
+static void signal_handler(int, siginfo_t*, void* ucontext)
+{
+    auto* profiler = s_active_profiler.load(AK::MemoryOrder::memory_order_relaxed);
+    if (profiler) {
+        auto pc = read_program_counter_from_ucontext(static_cast<ucontext_t const*>(ucontext));
+        profiler->capture_sample(pc);
+    }
+}
+
+u64 Profiler::os_tid() const
+{
+    return static_cast<u64>(m_js_thread);
+}
+
+bool Profiler::supports_timed_sampling() const
+{
+    return m_interval_us > 0;
+}
+
+bool Profiler::needs_bytecode_safe_points() const
+{
+    // Timed sampling captures from the signal handler directly (reads PC from
+    // ucontext registers), so no safe points needed — ASM interpreter can run.
+    // Without timed sampling (interval <= 0), tests use request_sample_for_test()
+    // which requires safe-point polling in the CPP interpreter dispatch loop.
+    return m_interval_us <= 0;
+}
+
+void Profiler::start()
+{
+    allocate_sample_buffer();
+    if (m_interval_us <= 0)
+        return;
+
+    s_active_profiler.store(this, AK::MemoryOrder::memory_order_relaxed);
+    m_sample_pending.store(false, AK::MemoryOrder::memory_order_relaxed);
+
+    struct sigaction sa = {};
+    sa.sa_sigaction = signal_handler;
+    sa.sa_flags = SA_SIGINFO | SA_RESTART;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR2, &sa, &s_old_sigaction);
+    m_platform_sampling_active = true;
+
+    m_timer_running.store(true, AK::MemoryOrder::memory_order_relaxed);
+    m_timer_thread = Threading::Thread::construct("JS Profiler"sv, [this]() -> intptr_t {
+        while (m_timer_running.load(AK::MemoryOrder::memory_order_relaxed)) {
+            usleep(m_interval_us);
+            pthread_kill(m_js_thread, SIGUSR2);
+        }
+        return 0;
+    });
+    m_timer_thread->start();
+}
+
+void Profiler::stop()
+{
+    collect_and_free_samples();
+    if (!m_platform_sampling_active)
+        return;
+
+    s_active_profiler.store(nullptr, AK::MemoryOrder::memory_order_relaxed);
+
+    // Block SIGUSR2, drain any signal queued just before the timer thread exited,
+    // then restore the previous handler.  Without the drain a pending SIGUSR2
+    // delivered after restoration would use the old handler — potentially SIG_DFL (fatal).
+    sigset_t only_usr2, old_mask;
+    sigemptyset(&only_usr2);
+    sigaddset(&only_usr2, SIGUSR2);
+    pthread_sigmask(SIG_BLOCK, &only_usr2, &old_mask);
+    struct timespec zero = { 0, 0 };
+    sigtimedwait(&only_usr2, nullptr, &zero);
+    sigaction(SIGUSR2, &s_old_sigaction, nullptr);
+    pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+    m_platform_sampling_active = false;
+}
+
+}

--- a/Libraries/LibJS/ProfilerMacOS.cpp
+++ b/Libraries/LibJS/ProfilerMacOS.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Profiler.h>
+#include <mach/mach.h>
+#include <unistd.h>
+
+// ASM interpreter register conventions (callee-saved, survive C++ calls):
+//   aarch64: x26 = bytecode base (pb), x21 = pb+pc  =>  pc = x21 - x26
+//   x86_64:  r13 = pc
+static Optional<u32> read_program_counter_from_suspended_thread(mach_port_t mach_thread)
+{
+#if defined(__aarch64__)
+    arm_thread_state64_t state {};
+    mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
+    bool ok = thread_get_state(mach_thread, ARM_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &count) == KERN_SUCCESS;
+    return ok ? Optional<u32>(static_cast<u32>(state.__x[21] - state.__x[26])) : Optional<u32> {};
+#elif defined(__x86_64__)
+    x86_thread_state64_t state {};
+    mach_msg_type_number_t count = x86_THREAD_STATE64_COUNT;
+    bool ok = thread_get_state(mach_thread, x86_THREAD_STATE64, reinterpret_cast<thread_state_t>(&state), &count) == KERN_SUCCESS;
+    return ok ? Optional<u32>(static_cast<u32>(state.__r13)) : Optional<u32> {};
+#else
+    return {};
+#endif
+}
+
+namespace JS {
+
+bool Profiler::supports_timed_sampling() const { return m_interval_us > 0; }
+bool Profiler::needs_bytecode_safe_points() const { return m_interval_us <= 0; }
+
+void Profiler::start()
+{
+    allocate_sample_buffer();
+    if (m_interval_us <= 0)
+        return;
+
+    auto mach_thread = pthread_mach_thread_np(m_js_thread);
+    m_platform_sampling_active = true;
+
+    m_timer_running.store(true, AK::MemoryOrder::memory_order_relaxed);
+    m_timer_thread = Threading::Thread::construct("JS Profiler"sv, [this, mach_thread]() -> intptr_t {
+        while (m_timer_running.load(AK::MemoryOrder::memory_order_relaxed)) {
+            usleep(m_interval_us);
+            if (thread_suspend(mach_thread) != KERN_SUCCESS)
+                continue;
+            if (auto pc = read_program_counter_from_suspended_thread(mach_thread); pc.has_value())
+                capture_sample(pc);
+            thread_resume(mach_thread);
+        }
+        return 0;
+    });
+    m_timer_thread->start();
+}
+
+void Profiler::stop()
+{
+    collect_and_free_samples();
+    m_platform_sampling_active = false;
+}
+
+u64 Profiler::os_tid() const
+{
+    return reinterpret_cast<u64>(m_js_thread);
+}
+
+}

--- a/Libraries/LibJS/ProfilerWindows.cpp
+++ b/Libraries/LibJS/ProfilerWindows.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Profiler.h>
+
+namespace JS {
+
+// TODO: Implement the same sampler-thread + SuspendThread/GetThreadContext path
+// used by V8 on Windows. The sampling path must stay minimal and non-blocking.
+bool Profiler::supports_timed_sampling() const { return false; }
+bool Profiler::needs_bytecode_safe_points() const { return true; }
+void Profiler::start() { allocate_sample_buffer(); }
+void Profiler::stop() { collect_and_free_samples(); }
+
+u64 Profiler::os_tid() const
+{
+    // pthreads-win32 defines pthread_t as __ptw32_handle_t { void* p; unsigned x }.
+    return reinterpret_cast<u64>(m_js_thread.p);
+}
+
+}

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -556,6 +556,9 @@ ECMAScriptFunctionObject::ClassData& ECMAScriptFunctionObject::ensure_class_data
 
 Utf16String ECMAScriptFunctionObject::name_for_call_stack() const
 {
+    auto const& display_name = shared_data().m_display_name;
+    if (!display_name.is_empty())
+        return Utf16String::from_utf16(display_name.view());
     return m_name_string->utf16_string();
 }
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -143,7 +143,9 @@ void ECMAScriptFunctionObject::get_stack_frame_info(size_t& registers_and_locals
         auto rust_executable = RustIntegration::compile_function(vm(), *m_shared_data, false);
         VERIFY(rust_executable);
         executable = rust_executable;
-        executable->name = m_shared_data->m_name;
+        executable->name = m_shared_data->m_display_name.is_empty()
+            ? m_shared_data->m_name
+            : m_shared_data->m_display_name;
         if (Bytecode::g_dump_bytecode)
             executable->dump();
         m_shared_data->clear_compile_inputs();

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
@@ -67,6 +67,11 @@ public:
 
     Utf16FlyString m_name;
 
+    // Non-spec: display name for profiler/debugger (like SpiderMonkey's
+    // guessedAtom). Set for member assignment patterns like
+    // `Foo.prototype.bar = function() {}`. Does not affect .name.
+    Utf16FlyString m_display_name;
+
     // NB: m_source_text is normally a view into the underlying JS::SourceCode we parsed the AST from,
     //     kept alive by m_source_code. m_source_text_owner is used if the source text needs to be
     //     owned by the function data (e.g. for dynamically created functions via Function constructor).

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -16,6 +16,7 @@
 #include <LibFileSystem/FileSystem.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Profiler.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/ArrayBuffer.h>

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -54,6 +54,8 @@ enum class CompilationType {
     Timer,
 };
 
+class Profiler;
+
 class JS_API VM : public RefCounted<VM> {
 public:
     static NonnullRefPtr<VM> create();
@@ -135,6 +137,9 @@ public:
     {
         m_execution_context_stack.append(&context);
     }
+
+    void set_profiler(Profiler* profiler) { m_profiler = profiler; }
+    Profiler* profiler() { return m_profiler; }
 
     void pop_execution_context()
     {
@@ -331,6 +336,8 @@ private:
     AK::Array<GC::Ptr<PrimitiveString>, numeric_string_cache_size> m_numeric_string_cache;
 
     GC::Heap m_heap;
+
+    Profiler* m_profiler { nullptr };
 
     Vector<ExecutionContext*> m_execution_context_stack;
 

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -599,20 +599,31 @@ fn generate_function_expression(
 
     let dst = choose_dst(generator, preferred_dst);
     // For anonymous function expressions, use the pending LHS name
-    // as the function's .name property.
+    // as the function's .name property (spec NamedEvaluation).
     let lhs_name = if !has_name {
         generator.pending_lhs_name.take()
     } else {
         None
     };
+    // Display name for profiler/debugger (from member assignments).
+    // Does not affect .name — only name_for_call_stack().
+    let display_name = if !has_name && lhs_name.is_none() {
+        generator.pending_display_name.take()
+    } else {
+        generator.pending_display_name.take();
+        None
+    };
     let lhs_name_str: Option<Utf16String> =
         lhs_name.map(|index| generator.identifier_table[index.0 as usize].clone());
+    let display_name_str: Option<Utf16String> =
+        display_name.map(|index| generator.identifier_table[index.0 as usize].clone());
     let name_override = if !has_name {
         lhs_name_str.as_deref()
     } else {
         None
     };
-    let shared_function_data_index = emit_new_function(generator, data, name_override);
+    let shared_function_data_index =
+        emit_new_function(generator, data, name_override, display_name_str.as_deref());
     let home_object = generator.home_objects.last().map(|ho| ho.operand());
     generator.emit(Instruction::NewFunction {
         dst: dst.operand(),
@@ -2782,7 +2793,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 }
                 // b. Instantiate function object.
                 let function_data = generator.function_table.take(fd.function_id);
-                let sfd_index = emit_new_function(generator, function_data, None);
+                let sfd_index = emit_new_function(generator, function_data, None, None);
                 let fo = generator.allocate_register();
                 generator.emit(Instruction::NewFunction {
                     dst: fo.operand(),
@@ -3801,7 +3812,16 @@ fn generate_assignment_expression(
                     } else {
                         None
                     };
+
+                    // Infer a display name for the profiler/debugger from the
+                    // member expression chain (e.g. "Foo.prototype.bar").
+                    // Per spec, member assignment does not affect .name.
+                    if let Some(name) = member_expression_dotted_name(lhs_expression) {
+                        generator.pending_display_name = Some(generator.intern_identifier(&name));
+                    }
+
                     let rhs_val = generate_expression(rhs, generator, None)?;
+                    generator.pending_display_name = None;
                     if let Some(key) = precomputed_key {
                         let base_id = intern_base_identifier(generator, &member_data.object);
                         emit_put_normal_by_value(generator, &base, &key, &rhs_val, base_id);
@@ -5950,7 +5970,7 @@ fn generate_class_expression(
         // Explicit constructor — extract FunctionData from the expression
         if let ExpressionKind::Function(function_id) = &ctor_expression.inner {
             let function_data = generator.function_table.take(*function_id);
-            emit_new_function(generator, function_data, None)
+            emit_new_function(generator, function_data, None, None)
         } else {
             // Fallback: synthesize a default constructor
             emit_default_constructor(generator, has_super)
@@ -5988,6 +6008,7 @@ fn generate_class_expression(
                     super::ffi::FFIOptionalU32::some(emit_new_function(
                         generator,
                         function_data,
+                        None,
                         None,
                     ))
                 } else {
@@ -6111,8 +6132,12 @@ fn generate_class_expression(
                                 ..Default::default()
                             },
                         });
-                        let index =
-                            emit_new_function(generator, function_data, Some(utf16!("field")));
+                        let index = emit_new_function(
+                            generator,
+                            function_data,
+                            Some(utf16!("field")),
+                            None,
+                        );
 
                         // Set class_field_initializer_name on the SFD.
                         let sfd_ptr = generator.shared_function_data[index as usize];
@@ -6190,6 +6215,7 @@ fn generate_class_expression(
                 let sfd_index = super::ffi::FFIOptionalU32::some(emit_new_function(
                     generator,
                     function_data,
+                    None,
                     None,
                 ));
 
@@ -6328,6 +6354,7 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
             generator.vm_ptr,
             generator.source_code_ptr,
             generator.strict,
+            None,
             None,
         )
     };
@@ -7998,6 +8025,7 @@ fn emit_new_function(
     generator: &mut Generator,
     data: Box<FunctionData>,
     name_override: Option<&[u16]>,
+    display_name: Option<&[u16]>,
 ) -> u32 {
     assert!(
         data.source_text_end as usize <= generator.source_len,
@@ -8016,6 +8044,7 @@ fn emit_new_function(
             generator.source_code_ptr,
             generator.strict,
             name_override,
+            display_name,
         )
     };
 
@@ -8434,7 +8463,7 @@ pub fn emit_function_declaration_instantiation(
             let child = &body_scope.children[function_to_init.child_index];
             if let StatementKind::FunctionDeclaration(ref fd) = child.inner {
                 let inner_function_data = generator.function_table.take(fd.function_id);
-                let sfd_index = emit_new_function(generator, inner_function_data, None);
+                let sfd_index = emit_new_function(generator, inner_function_data, None, None);
 
                 // Check if the function name identifier is local.
                 if let Some(name_ident) = &fd.name {
@@ -9433,6 +9462,50 @@ fn intern_base_identifier(
     base: &Expression,
 ) -> Option<IdentifierTableIndex> {
     expression_identifier(base).map(|s| generator.intern_identifier(&s))
+}
+
+/// Build a name from a member expression chain for function name inference.
+/// Handles both dotted (`Foo.prototype.bar`) and bracket (`this.X[y]`) access.
+fn member_expression_dotted_name(expression: &Expression) -> Option<Utf16String> {
+    match &expression.inner {
+        ExpressionKind::Member(data) => {
+            let base = member_expression_dotted_name(&data.object);
+            if data.computed {
+                // Bracket access: build "base[key]"
+                let key_name = match &data.property.inner {
+                    ExpressionKind::Identifier(ident) => Some(ident.name.clone()),
+                    ExpressionKind::StringLiteral(s) => Some((**s).clone()),
+                    ExpressionKind::NumericLiteral(n) => {
+                        let s = format!("{n}");
+                        Some(s.encode_utf16().collect())
+                    }
+                    _ => None,
+                };
+                let key_str =
+                    key_name.unwrap_or_else(|| Utf16String(utf16!("<computed>").to_vec()));
+                let mut result = base.unwrap_or_default();
+                result.0.extend_from_slice(utf16!("["));
+                result.0.extend_from_slice(&key_str);
+                result.0.extend_from_slice(utf16!("]"));
+                Some(result)
+            } else {
+                // Dot access: build "base.prop"
+                let prop = match &data.property.inner {
+                    ExpressionKind::Identifier(ident) => &ident.name,
+                    _ => return base,
+                };
+                let mut result = base.unwrap_or_default();
+                if !result.is_empty() {
+                    result.0.extend_from_slice(utf16!("."));
+                }
+                result.0.extend_from_slice(prop);
+                Some(result)
+            }
+        }
+        ExpressionKind::Identifier(ident) => Some(ident.name.clone()),
+        ExpressionKind::This => Some(Utf16String(utf16!("this").to_vec())),
+        _ => None,
+    }
 }
 
 /// Try to produce a human-readable name for an expression (for error messages).

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -213,6 +213,8 @@ unsafe extern "C" {
         data: *const FFISharedFunctionData,
     ) -> *mut c_void;
 
+    pub fn rust_sfd_set_display_name(sfd_ptr: *mut c_void, name: *const u16, name_len: usize);
+
     pub fn rust_sfd_set_class_field_initializer_name(
         sfd_ptr: *mut c_void,
         name: *const u16,
@@ -309,6 +311,7 @@ pub unsafe fn create_shared_function_data(
     source_code_ptr: *const c_void,
     is_strict: bool,
     name_override: Option<&[u16]>,
+    display_name: Option<&[u16]>,
 ) -> *mut c_void {
     unsafe {
         use crate::ast::FunctionParameterBinding;
@@ -387,6 +390,11 @@ pub unsafe fn create_shared_function_data(
             !sfd_ptr.is_null(),
             "create_shared_function_data: rust_create_sfd returned null"
         );
+
+        if let Some(dn) = display_name {
+            rust_sfd_set_display_name(sfd_ptr, dn.as_ptr(), dn.len());
+        }
+
         sfd_ptr
     }
 }
@@ -409,6 +417,7 @@ pub unsafe fn create_sfd_for_gdi(
             vm_ptr,
             source_code_ptr,
             is_strict,
+            None,
             None,
         )
     }

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -185,6 +185,10 @@ pub struct Generator {
     /// Set by assignment/declaration codegen, consumed by function expression codegen.
     pub pending_lhs_name: Option<IdentifierTableIndex>,
 
+    /// Display name for debugger/profiler, set by member assignment codegen.
+    /// Unlike pending_lhs_name, this does NOT affect .name (spec compliance).
+    pub pending_display_name: Option<IdentifierTableIndex>,
+
     // Source location tracking
     pub current_source_start: u32,
     pub current_source_end: u32,
@@ -323,6 +327,7 @@ impl Generator {
             initialized_locals: Vec::new(),
             initialized_arguments: Vec::new(),
             pending_lhs_name: None,
+            pending_display_name: None,
             current_source_start: 0,
             current_source_end: 0,
             current_completion_register: None,

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -901,6 +901,16 @@ extern "C" void* rust_create_sfd(
     return shared.ptr();
 }
 
+extern "C" void rust_sfd_set_display_name(
+    void* sfd_ptr,
+    uint16_t const* name,
+    size_t name_len)
+{
+    auto& shared = *static_cast<JS::SharedFunctionInstanceData*>(sfd_ptr);
+    if (name_len > 0)
+        shared.m_display_name = Utf16FlyString::from_utf16(Utf16View(reinterpret_cast<char16_t const*>(name), name_len));
+}
+
 extern "C" void rust_sfd_set_metadata(
     void* sfd_ptr,
     bool uses_this,

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,4 +1,5 @@
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
+ladybird_test(test-js-profiler.cpp LibJS LIBS LibJS LibGC)
 
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}")

--- a/Tests/LibJS/test-js-profiler.cpp
+++ b/Tests/LibJS/test-js-profiler.cpp
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonObject.h>
+#include <AK/JsonParser.h>
+#include <AK/Platform.h>
+#include <AK/Utf16String.h>
+#include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/GeckoProfileWriter.h>
+#include <LibJS/Profiler.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibJS/Script.h>
+#include <LibTest/TestCase.h>
+
+static constexpr StringView k_default_filename = "profiler-test.js"sv;
+
+static void run_js(JS::VM& vm, JS::Realm& realm, StringView source, StringView filename = k_default_filename)
+{
+    auto script = JS::Script::parse(source, realm, filename);
+    VERIFY(!script.is_error());
+    auto result = vm.bytecode_interpreter().run(*script.value());
+    VERIFY(!result.is_error());
+}
+
+static void install_request_sample_function(JS::Realm& realm, JS::Profiler& profiler)
+{
+    realm.global_object().define_native_function(
+        realm,
+        Utf16FlyString::from_utf8("requestSample"sv),
+        [&profiler](JS::VM&) -> JS::ThrowCompletionOr<JS::Value> {
+            profiler.request_sample_for_test();
+            return JS::js_undefined();
+        },
+        0,
+        JS::Attribute::Writable | JS::Attribute::Configurable);
+}
+
+static bool string_table_contains(JS::Profiler const& profiler, StringView needle)
+{
+    for (auto const& str : profiler.string_table()) {
+        if (str.contains(needle))
+            return true;
+    }
+    return false;
+}
+
+static Vector<String> sample_frame_locations(JS::Profiler const& profiler, size_t sample_index)
+{
+    Vector<String> locations;
+    Optional<u32> stack_index = profiler.samples()[sample_index].stack_index;
+    while (stack_index.has_value()) {
+        auto const& stack = profiler.stack_table()[*stack_index];
+        auto const& frame = profiler.frame_table()[stack.frame_index];
+        locations.append(profiler.string_table()[frame.string_index]);
+        stack_index = stack.prefix;
+    }
+    return locations;
+}
+
+static Optional<Vector<String>> find_sample_with_leaf(JS::Profiler const& profiler, StringView leaf_name)
+{
+    for (size_t i = 0; i < profiler.samples().size(); ++i) {
+        auto locations = sample_frame_locations(profiler, i);
+        if (!locations.is_empty() && locations[0].contains(leaf_name))
+            return locations;
+    }
+    return {};
+}
+
+// Run JS long enough that timer-driven async samplers capture multiple samples.
+// fib(30) ≈ 1.3 M recursive calls, reliably runs for tens of milliseconds.
+static constexpr StringView k_workload = R"js(
+function fib(n) { return n <= 1 ? n : fib(n - 1) + fib(n - 2); }
+fib(30);
+)js"sv;
+
+TEST_CASE(profiler_collects_samples)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 1000 /* 1 ms */);
+    if (!profiler.supports_timed_sampling())
+        return;
+
+    vm->set_profiler(&profiler);
+    profiler.start();
+    run_js(*vm, realm, k_workload);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT(profiler.samples().size() > 0u);
+    EXPECT(string_table_contains(profiler, "fib"sv));
+}
+
+TEST_CASE(profiler_samples_global_scope_bytecode)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 0);
+    vm->set_profiler(&profiler);
+    install_request_sample_function(realm, profiler);
+    profiler.start();
+    // requestSample() sets the pending flag; the sample is then captured at the
+    // next bytecode dispatch boundary inside the loop, which runs in global scope.
+    run_js(*vm, realm, R"js(
+requestSample();
+let sum = 0;
+for (let i = 0; i < 500000; i++)
+    sum += i;
+)js"sv,
+        "profiler-global.js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT(profiler.samples().size() > 0u);
+    EXPECT(string_table_contains(profiler, "profiler-global.js"sv));
+}
+
+TEST_CASE(profiler_safe_point_sampling_uses_current_frame)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 0);
+    vm->set_profiler(&profiler);
+    install_request_sample_function(realm, profiler);
+    profiler.start();
+    run_js(*vm, realm, R"js(
+function inner() {
+    requestSample();
+    let sum = 0;
+    for (let i = 0; i < 500000; i++)
+        sum += i;
+    return sum;
+}
+function outer() {
+    return inner();
+}
+outer();
+)js"sv,
+        "profiler-safe-point.js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT(profiler.samples().size() > 0u);
+    auto sample_locations = find_sample_with_leaf(profiler, "inner"sv);
+    VERIFY(sample_locations.has_value());
+    EXPECT(sample_locations->size() >= 2u);
+    EXPECT((*sample_locations)[0].contains("inner (profiler-safe-point.js:"sv));
+    EXPECT((*sample_locations)[1].contains("outer (profiler-safe-point.js:"sv));
+}
+
+TEST_CASE(profiler_gecko_json_is_valid)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 0);
+    vm->set_profiler(&profiler);
+    install_request_sample_function(realm, profiler);
+    profiler.start();
+    run_js(*vm, realm, R"js(
+requestSample();
+let sum = 0;
+for (let i = 0; i < 500000; i++)
+    sum += i;
+)js"sv,
+        "profiler-gecko.js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT(profiler.samples().size() > 0u);
+
+    auto json_string = JS::write_gecko_profile(profiler);
+    EXPECT(!json_string.is_empty());
+
+    auto parsed = JsonParser::parse(json_string);
+    EXPECT(!parsed.is_error());
+    EXPECT(parsed.value().is_object());
+
+    auto const& root = parsed.value().as_object();
+    EXPECT(root.has("meta"sv));
+    EXPECT(root.has("threads"sv));
+    EXPECT(root.get("threads"sv)->is_array());
+    EXPECT_EQ(root.get("threads"sv)->as_array().size(), 1u);
+
+    auto const& thread = root.get("threads"sv)->as_array()[0].as_object();
+    EXPECT(thread.has("samples"sv));
+    EXPECT(thread.has("frameTable"sv));
+    EXPECT(thread.has("stackTable"sv));
+    EXPECT(thread.has("stringTable"sv));
+    EXPECT(thread.get("stringTable"sv)->as_array().size() > 0u);
+}
+
+TEST_CASE(profiler_timed_sampling_captures_call_stack)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 1000 /* 1 ms */);
+    if (!profiler.supports_timed_sampling())
+        return;
+
+    vm->set_profiler(&profiler);
+    profiler.start();
+    run_js(*vm, realm, R"js(
+function alpha() {
+    let s = 0;
+    for (let i = 0; i < 5000000; i++) s += i;
+    return s;
+}
+function beta() { return alpha(); }
+beta();
+)js"sv,
+        "profiler-timed-stack.js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    // Verify we captured samples with a multi-frame stack through the async path.
+    auto sample_locations = find_sample_with_leaf(profiler, "alpha"sv);
+    VERIFY(sample_locations.has_value());
+    EXPECT(sample_locations->size() >= 2u);
+    EXPECT((*sample_locations)[0].contains("alpha (profiler-timed-stack.js:"sv));
+    EXPECT((*sample_locations)[1].contains("beta (profiler-timed-stack.js:"sv));
+}
+
+TEST_CASE(profiler_captures_anonymous_functions)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 0);
+    vm->set_profiler(&profiler);
+    install_request_sample_function(realm, profiler);
+    profiler.start();
+    run_js(*vm, realm, R"js(
+(function() {
+    requestSample();
+    let sum = 0;
+    for (let i = 0; i < 500000; i++) sum += i;
+})();
+)js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT(profiler.samples().size() > 0u);
+    EXPECT(string_table_contains(profiler, "(anonymous)"sv));
+}
+
+TEST_CASE(profiler_uses_inferred_member_assignment_name)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 0);
+    vm->set_profiler(&profiler);
+    install_request_sample_function(realm, profiler);
+    profiler.start();
+    run_js(*vm, realm, R"js(
+let object = {};
+object.method = function() {
+    requestSample();
+    let sum = 0;
+    for (let i = 0; i < 500000; i++) sum += i;
+    return sum;
+};
+object.method();
+)js"sv,
+        "profiler-display-name.js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT_EQ(profiler.samples().size(), 1u);
+    EXPECT(string_table_contains(profiler, "object.method (profiler-display-name.js:"sv));
+}
+
+TEST_CASE(profiler_can_be_reused)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    JS::Profiler profiler(*vm, 0);
+    vm->set_profiler(&profiler);
+    install_request_sample_function(realm, profiler);
+
+    profiler.start();
+    run_js(*vm, realm, R"js(
+(function() {
+    requestSample();
+    let sum = 0;
+    for (let i = 0; i < 500000; i++) sum += i;
+})();
+)js"sv,
+        "profiler-reuse-first.js"sv);
+    profiler.stop();
+    EXPECT_EQ(profiler.samples().size(), 1u);
+    EXPECT(string_table_contains(profiler, "profiler-reuse-first.js"sv));
+
+    profiler.start();
+    run_js(*vm, realm, R"js(
+(function() {
+    requestSample();
+    let sum = 0;
+    for (let i = 0; i < 500000; i++) sum += i;
+})();
+)js"sv,
+        "profiler-reuse-second.js"sv);
+    profiler.stop();
+    vm->set_profiler(nullptr);
+
+    EXPECT_EQ(profiler.samples().size(), 1u);
+    EXPECT(string_table_contains(profiler, "profiler-reuse-second.js"sv));
+    EXPECT(!string_table_contains(profiler, "profiler-reuse-first.js"sv));
+}
+
+TEST_CASE(profiler_stop_without_start_is_safe)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+
+    // stop() on a profiler that was never started should not crash.
+    JS::Profiler profiler(*vm);
+    profiler.stop();
+    EXPECT_EQ(profiler.samples().size(), 0u);
+}

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -16,7 +16,9 @@
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Console.h>
 #include <LibJS/Contrib/Test262/GlobalObject.h>
+#include <LibJS/GeckoProfileWriter.h>
 #include <LibJS/Print.h>
+#include <LibJS/Profiler.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
@@ -842,6 +844,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool use_test262_global = false;
     bool parse_only = false;
     StringView evaluate_script;
+    StringView profile_output;
     Vector<StringView> script_paths;
 
     Core::ArgsParser args_parser;
@@ -859,6 +862,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(disable_debug_printing, "Disable debug output", "disable-debug-output", {});
     args_parser.add_option(evaluate_script, "Evaluate argument as a script", "evaluate", 'c', "script");
     args_parser.add_option(use_test262_global, "Use test262 global ($262)", "use-test262-global", {});
+    args_parser.add_option(profile_output, "Write Gecko profile JSON to file", "profile", 0, "output.json");
     args_parser.add_positional_argument(script_paths, "Path to script files", "scripts", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
@@ -946,8 +950,24 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
         // We resolve modules as if it is the first file
 
+        OwnPtr<JS::Profiler> profiler;
+        if (!profile_output.is_empty()) {
+            profiler = make<JS::Profiler>(*g_vm);
+            g_vm->set_profiler(profiler.ptr());
+            profiler->start();
+        }
+
         if (!TRY(parse_and_run(realm, builder.string_view(), source_name, parse_only)))
             return 1;
+
+        if (profiler) {
+            profiler->stop();
+            g_vm->set_profiler(nullptr);
+            auto json = JS::write_gecko_profile(*profiler);
+            auto file = TRY(Core::File::open(profile_output, Core::File::OpenMode::Write));
+            TRY(file->write_until_depleted(json.bytes()));
+            outln("Profile written to {}", profile_output);
+        }
     }
 
     return s_exit_code;


### PR DESCRIPTION
This adds a lightweight JS sampling profiler to LibJS, exports captured samples in Gecko Profile format, and wires js --profile <output> to write profiles that open directly in [Firefox Profiler](https://profiler.firefox.com/). It also improves symbolication by inferring display names for anonymous functions so the resulting call stacks are more readable.

[Before](https://profiler.firefox.com/public/4es8q70p69dtv410asmkf94g2vx9cdm0cy6reqr/calltree/?globalTrackOrder=0&thread=0&timelineType=category&v=15
): 
<img width="498" height="173" alt="image" src="https://github.com/user-attachments/assets/89b8cfaf-3618-4288-a9a5-bd5e14cd5de1" />

[After](https://profiler.firefox.com/public/7v9zqnt9560w22s0w2471095e819tk9rw5j46j8/calltree/?globalTrackOrder=0&thread=0&timelineType=category&v=15):
<img width="565" height="245" alt="image" src="https://github.com/user-attachments/assets/9840849d-7c82-4db3-9992-2fc20790401a" />
