### PR TITLE
LibWeb: Invalidate XPath iterator results on DOM mutation

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -212,6 +212,7 @@
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/ObservableArray.h>
 #include <LibWeb/XPath/XPath.h>
+#include <LibWeb/XPath/XPathResult.h>
 
 namespace Web::DOM {
 
@@ -4156,6 +4157,23 @@ void Document::unregister_node_iterator(Badge<NodeIterator>, NodeIterator& node_
 {
     bool was_removed = m_node_iterators.remove(&node_iterator);
     VERIFY(was_removed);
+}
+
+void Document::register_xpath_result(Badge<XPath::XPathResult>, XPath::XPathResult& xpath_result)
+{
+    auto result = m_xpath_iterators.set(xpath_result);
+    VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+}
+
+void Document::unregister_xpath_result(Badge<XPath::XPathResult>, XPath::XPathResult& xpath_result)
+{
+    m_xpath_iterators.remove(xpath_result);
+}
+
+void Document::invalidate_xpath_iterators()
+{
+    for (auto& xpath_result : m_xpath_iterators)
+        xpath_result->invalidate();
 }
 
 void Document::register_document_observer(Badge<DocumentObserver>, DocumentObserver& document_observer)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -643,6 +643,11 @@ public:
     void register_node_iterator(Badge<NodeIterator>, NodeIterator&);
     void unregister_node_iterator(Badge<NodeIterator>, NodeIterator&);
 
+    void register_xpath_result(Badge<XPath::XPathResult>, XPath::XPathResult&);
+    void unregister_xpath_result(Badge<XPath::XPathResult>, XPath::XPathResult&);
+
+    void invalidate_xpath_iterators();
+
     void register_document_observer(Badge<DocumentObserver>, DocumentObserver&);
     void unregister_document_observer(Badge<DocumentObserver>, DocumentObserver&);
 
@@ -1320,6 +1325,7 @@ private:
     bool m_needs_animated_style_update { false };
 
     HashTable<GC::Ptr<NodeIterator>> m_node_iterators;
+    HashTable<GC::RawRef<XPath::XPathResult>> m_xpath_iterators;
 
     // Document should not visit DocumentObserver to avoid leaks.
     // It's responsibility of object that requires DocumentObserver to keep it alive.

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -709,6 +709,8 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
         queue_tree_mutation_record(nodes, {}, previous_sibling.ptr(), child.ptr());
     }
 
+    document().invalidate_xpath_iterators();
+
     // 9. Run the children changed steps for parent.
     ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, node };
     children_changed(metadata);
@@ -860,6 +862,8 @@ void Node::remove(bool suppress_observers)
     document().for_each_node_iterator([&](NodeIterator& node_iterator) {
         node_iterator.run_pre_removing_steps(*this);
     });
+
+    document().invalidate_xpath_iterators();
 
     // 5. Let oldPreviousSibling be node’s previous sibling.
     GC::Ptr<Node> old_previous_sibling = previous_sibling();
@@ -1197,6 +1201,8 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
     document().for_each_node_iterator([&](NodeIterator& node_iterator) {
         node_iterator.run_pre_removing_steps(*this);
     });
+
+    document().invalidate_xpath_iterators();
 
     // 11. Let oldPreviousSibling be node’s previous sibling.
     auto* old_previous_sibling = previous_sibling();

--- a/Libraries/LibWeb/XPath/XPath.cpp
+++ b/Libraries/LibWeb/XPath/XPath.cpp
@@ -115,7 +115,7 @@ static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node)
     return nullptr;
 }
 
-static void convert_xpath_result(xmlXPathObjectPtr xpath_result, XPath::XPathResult* result, unsigned short type)
+static void convert_xpath_result(xmlXPathObjectPtr xpath_result, XPath::XPathResult* result, unsigned short type, GC::Ptr<DOM::Document> document)
 {
     if (!xpath_result) {
         return;
@@ -137,7 +137,7 @@ static void convert_xpath_result(xmlXPathObjectPtr xpath_result, XPath::XPathRes
             }
         }
 
-        result->set_node_set(move(node_list), type);
+        result->set_node_set(move(node_list), type, document);
         break;
     }
     case XPATH_BOOLEAN: {
@@ -203,7 +203,7 @@ WebIDL::ExceptionOr<GC::Ref<XPathResult>> evaluate(JS::Realm& realm, String cons
         result = realm.create<XPathResult>(realm);
     }
 
-    convert_xpath_result(xpath_result, result, type);
+    convert_xpath_result(xpath_result, result, type, const_cast<DOM::Document*>(&context_node.document()));
 
     return GC::Ref<XPathResult>(*result);
 }

--- a/Libraries/LibWeb/XPath/XPathResult.cpp
+++ b/Libraries/LibWeb/XPath/XPathResult.cpp
@@ -8,7 +8,10 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Bindings/XPathResult.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/WebIDL/DOMException.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 #include "XPathResult.h"
 
@@ -32,8 +35,16 @@ void XPathResult::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_node_set);
+    visitor.visit(m_document);
     if (!m_node_set_iter.is_end())
         visitor.visit(*m_node_set_iter);
+}
+
+void XPathResult::finalize()
+{
+    Base::finalize();
+    if (m_document)
+        m_document->unregister_xpath_result({}, *this);
 }
 
 XPathResult::~XPathResult() = default;
@@ -55,21 +66,44 @@ void XPathResult::set_boolean(bool boolean_value)
     m_boolean_value = boolean_value;
 }
 
-void XPathResult::set_node_set(Vector<GC::Ptr<DOM::Node>> node_set, unsigned short type)
+void XPathResult::set_node_set(Vector<GC::Ptr<DOM::Node>> node_set, unsigned short type, GC::Ptr<DOM::Document> document)
 {
+    if (m_document)
+        m_document->unregister_xpath_result({}, *this);
+    m_document = nullptr;
+    m_invalid_iterator_state = false;
+
     if (type >= XPathResult::UNORDERED_NODE_ITERATOR_TYPE && type <= XPathResult::FIRST_ORDERED_NODE_TYPE)
         m_result_type = type;
+    else if (type == ANY_TYPE)
+        m_result_type = UNORDERED_NODE_ITERATOR_TYPE;
+    else if (type == NUMBER_TYPE || type == STRING_TYPE || type == BOOLEAN_TYPE)
+        m_result_type = type;
     else
-        m_result_type = UNORDERED_NODE_ITERATOR_TYPE; // Default if the caller does not explicity ask for anything else
+        m_result_type = UNORDERED_NODE_ITERATOR_TYPE; // Default for unrecognized resultType values
 
     m_node_set = move(node_set);
     m_node_set_iter = m_node_set.begin();
+
+    // https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult
+    if (m_result_type == UNORDERED_NODE_ITERATOR_TYPE || m_result_type == ORDERED_NODE_ITERATOR_TYPE) {
+        m_document = document;
+        if (m_document)
+            m_document->register_xpath_result({}, *this);
+    }
 }
 
-GC::Ptr<DOM::Node> XPathResult::iterate_next()
+// https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-iterateNext
+WebIDL::ExceptionOr<GC::Ptr<DOM::Node>> XPathResult::iterate_next()
 {
+    if (m_result_type != UNORDERED_NODE_ITERATOR_TYPE && m_result_type != ORDERED_NODE_ITERATOR_TYPE)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "XPathResult is not an iterator type"_string };
+
+    if (m_invalid_iterator_state)
+        return WebIDL::InvalidStateError::create(realm(), "The document has been mutated since the XPathResult was returned"_utf16);
+
     if (m_node_set_iter == m_node_set.end())
-        return nullptr;
+        return GC::Ptr<DOM::Node> {};
 
     return *m_node_set_iter++;
 }

--- a/Libraries/LibWeb/XPath/XPathResult.h
+++ b/Libraries/LibWeb/XPath/XPathResult.h
@@ -10,6 +10,7 @@
 #include <AK/Vector.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::XPath {
@@ -19,6 +20,8 @@ class XPathResult : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(XPathResult);
 
 public:
+    static constexpr bool OVERRIDES_FINALIZE = true;
+
     static WebIDL::UnsignedShort const ANY_TYPE = 0;
     static WebIDL::UnsignedShort const NUMBER_TYPE = 1;
     static WebIDL::UnsignedShort const STRING_TYPE = 2;
@@ -34,6 +37,7 @@ public:
     virtual ~XPathResult() override;
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
 
     WebIDL::UnsignedShort result_type() const { return m_result_type; }
     WebIDL::Double number_value() const { return m_number_value; }
@@ -43,13 +47,15 @@ public:
     WebIDL::Boolean invalid_iterator_state() const { return m_invalid_iterator_state; }
     WebIDL::UnsignedLong snapshot_length() const { return m_node_set.size(); }
 
-    GC::Ptr<DOM::Node> iterate_next();
+    WebIDL::ExceptionOr<GC::Ptr<DOM::Node>> iterate_next();
     GC::Ptr<DOM::Node> snapshot_item(int index);
 
     void set_number(WebIDL::Double number_value);
     void set_string(String string_value);
     void set_boolean(bool boolean_value);
-    void set_node_set(Vector<GC::Ptr<DOM::Node>> node_set, unsigned short type);
+    void set_node_set(Vector<GC::Ptr<DOM::Node>> node_set, unsigned short type, GC::Ptr<DOM::Document> document);
+
+    void invalidate() { m_invalid_iterator_state = true; }
 
 private:
     WebIDL::UnsignedShort m_result_type { 0 };
@@ -58,6 +64,8 @@ private:
     WebIDL::Boolean m_boolean_value { false };
     WebIDL::Boolean m_invalid_iterator_state { false };
     WebIDL::UnsignedLong m_snapshot_length { 0 };
+
+    GC::Ptr<DOM::Document> m_document;
 
     Vector<GC::Ptr<DOM::Node>> m_node_set;
     Vector<GC::Ptr<DOM::Node>>::Iterator m_node_set_iter;

--- a/Tests/LibWeb/Text/expected/wpt-import/domxpath/result-iterateNext.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domxpath/result-iterateNext.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 7 tests
 
-3 Pass
-4 Fail
+7 Pass
 Pass	Using an ordered iterator without modifying the dom should yield the expected elements in correct order without errors.
 Pass	Using an unordered iterator without modifying the dom should yield the correct number of elements without errors.
 Pass	invalidIteratorState should be false for non-iterable results.
-Fail	Calling iterateNext on a non-iterable XPathResult should throw a TypeError.
-Fail	Calling iterateNext on a non-iterable XPathResult after modifying the DOM should throw a TypeError.
-Fail	Calling iterateNext after having modified the DOM should throw an exception.
-Fail	Calling iterateNext after having modified the DOM should throw an exception even if the iterator is exhausted.
+Pass	Calling iterateNext on a non-iterable XPathResult should throw a TypeError.
+Pass	Calling iterateNext on a non-iterable XPathResult after modifying the DOM should throw a TypeError.
+Pass	Calling iterateNext after having modified the DOM should throw an exception.
+Pass	Calling iterateNext after having modified the DOM should throw an exception even if the iterator is exhausted.


### PR DESCRIPTION
## Summary

`XPathResult` iterator types weren't being invalidated when the DOM tree changed. So `iterateNext()` could keep returning nodes from a stale result instead of throwing `InvalidStateError` as required by the spec. Also, `iterateNext()` wasn't throwing `TypeError` when called on a non-iterator result type.

This tracks iterator-type `XPathResult` objects on `Document` and invalidates them whenever nodes are inserted, removed, or moved. `iterateNext()` now raises `TypeError` or `InvalidStateError` as appropriate.

## Testing

Fixes the following subtests in `Tests/LibWeb/Text/input/wpt-import/domxpath/result-iterateNext.html`:

- `invalidIteratorState should be false for non-iterable results`
- `Calling iterateNext on a non-iterable XPathResult should throw a TypeError`
- `Calling iterateNext on a non-iterable XPathResult after modifying the DOM should throw a TypeError`
- `Calling iterateNext after having modified the DOM should throw an exception`
- `Calling iterateNext after having modified the DOM should throw an exception even if the iterator is exhausted`

All 7 tests in this file now pass.
