### PR TITLE
LibWeb: Use float edges for formatting context avoidance

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1624,12 +1624,12 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats
 
     CSSPixels left_intrusion = 0;
     if (space_and_containing_margin.matching_left_float_box) {
-        left_intrusion = space_and_containing_margin.left_used_space;
+        left_intrusion = max(CSSPixels(0), space_and_containing_margin.left_float_margin_edge_right_in_root - box_in_root_rect.x());
     }
 
     CSSPixels right_intrusion = 0;
     if (space_and_containing_margin.matching_right_float_box) {
-        right_intrusion = space_and_containing_margin.right_used_space;
+        right_intrusion = max(CSSPixels(0), box_in_root_rect.right() - space_and_containing_margin.right_float_margin_edge_left_in_root);
     }
 
     return { left_intrusion, right_intrusion };

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -186,13 +186,6 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 {
     auto remaining_available_space = available_space;
 
-    // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
-    if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
-        auto intrusion = intrusion_by_floats_into_box(box, 0);
-        auto remaining_width = available_space.width.to_px_or_zero() - intrusion.left - intrusion.right;
-        remaining_available_space.width = AvailableSize::make_definite(remaining_width);
-    }
-
     if (box_is_sized_as_replaced_element(box, available_space)) {
         compute_width_for_block_level_replaced_element_in_normal_flow(box, available_space);
         if (box.is_floating()) {
@@ -229,6 +222,13 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //       as the preferred width and min/max constraints are irrelevant for intrinsic sizing.
     if (box_state.width_constraint != SizeConstraint::None)
         return;
+
+    // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
+    if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
+        auto intrusion = intrusion_by_floats_into_box(box, -box_state.border_box_top());
+        auto remaining_width = available_space.width.to_px_or_zero() - intrusion.left - intrusion.right;
+        remaining_available_space.width = AvailableSize::make_definite(remaining_width);
+    }
 
     auto const remaining_width_px = remaining_available_space.width.to_px_or_zero();
     auto const zero_value = CSS::Length::make_px(0);
@@ -347,8 +347,6 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
 void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space)
 {
-    if (box.computed_values().width().is_auto())
-        return;
     if (!available_space.width.is_definite())
         return;
     if (!box_should_avoid_floats_because_it_establishes_fc(box))
@@ -359,9 +357,22 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
     // place it adjacent to such floats if there is sufficient space.
     auto& box_state = m_state.get_mutable(box);
     while (true) {
-        auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
-        auto space_used_by_floats = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
-        auto remaining_space = available_space.width.to_px_or_zero() - space_used_by_floats.left_used_space - space_used_by_floats.right_used_space;
+        auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
+        CSSPixels y_in_root = box_in_root_rect.y() - box_state.border_box_top();
+        auto space_used_by_floats = space_used_and_containing_margin_for_floats(y_in_root);
+        auto const* containing_block = box_state.containing_block_used_values();
+        VERIFY(containing_block);
+        auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
+
+        CSSPixels left_intrusion = 0;
+        if (space_used_by_floats.matching_left_float_box)
+            left_intrusion = max(CSSPixels(0), space_used_by_floats.left_float_margin_edge_right_in_root - containing_block_rect_in_root.x());
+
+        CSSPixels right_intrusion = 0;
+        if (space_used_by_floats.matching_right_float_box)
+            right_intrusion = max(CSSPixels(0), containing_block_rect_in_root.right() - space_used_by_floats.right_float_margin_edge_left_in_root);
+
+        auto remaining_space = available_space.width.to_px_or_zero() - left_intrusion - right_intrusion;
         if (box_state.border_box_width() <= remaining_space)
             break;
 
@@ -380,7 +391,7 @@ void BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpa
         if (!topmost_float_bottom.has_value())
             break;
 
-        box_state.set_content_y(box_state.offset.y() + topmost_float_bottom.value() - box_in_root_rect.y());
+        box_state.set_content_y(box_state.offset.y() + topmost_float_bottom.value() - y_in_root);
     }
 }
 
@@ -1194,25 +1205,25 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
         && box_should_avoid_floats_because_it_establishes_fc(child_box)) {
         auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
         auto space_and_containing_margin = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
-        available_width_within_containing_block -= space_and_containing_margin.left_used_space + space_and_containing_margin.right_used_space;
+        auto const* containing_block = box_state.containing_block_used_values();
+        VERIFY(containing_block);
+        auto current_containing_block_in_root_rect = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
+
+        auto left_overlap = space_and_containing_margin.matching_left_float_box
+            ? max(CSSPixels(0), space_and_containing_margin.left_float_margin_edge_right_in_root - current_containing_block_in_root_rect.x())
+            : CSSPixels(0);
+        auto right_overlap = space_and_containing_margin.matching_right_float_box
+            ? max(CSSPixels(0), current_containing_block_in_root_rect.right() - space_and_containing_margin.right_float_margin_edge_left_in_root)
+            : CSSPixels(0);
+
+        available_width_within_containing_block -= left_overlap + right_overlap;
 
         // Since this box has a FC, it should avoid floats which means we cannot have its border box overlap with any
-        // float's margin box. We start off at the right-most border of the floats, and if this box' margin-left is not
-        // auto, we must overlap that margin with the floats as far as possible.
-        x = space_and_containing_margin.left_used_space;
+        // float's margin box. Start at the amount the float actually overlaps the current containing block.
         if (!child_box.computed_values().margin().left().is_auto())
-            x = max(x - max(box_state.margin_left, 0), 0);
-
-        // All non-anonymous containing blocks that are ancestors of the child box, but are not ancestors of the left
-        // float box, might have left margins set that overlap with the used float space.
-        if (space_and_containing_margin.matching_left_float_box) {
-            Box const* current_ancestor = child_box.non_anonymous_containing_block();
-            while (!current_ancestor->is_ancestor_of(*space_and_containing_margin.matching_left_float_box)) {
-                x -= m_state.get(*current_ancestor).margin_left;
-                current_ancestor = current_ancestor->non_anonymous_containing_block();
-            }
-            x = max(x, 0);
-        }
+            x = max(left_overlap - max(box_state.margin_left, 0), 0);
+        else
+            x = left_overlap;
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {
@@ -1433,8 +1444,8 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
                     ? offset_from_edge + box_state.content_width() + box_state.margin_box_right()
                     : offset_from_edge + box_state.margin_box_left();
                 auto used_by_opposite_side = (side == FloatSide::Left)
-                    ? max<CSSPixels>(0, space_used_by_floats.right_used_space + space_used_by_floats.right_total_containing_margin - (m_state.get(root()).content_width() - current_containing_block_in_root_rect.right()))
-                    : max<CSSPixels>(0, space_used_by_floats.left_total_containing_margin + space_used_by_floats.left_used_space - current_containing_block_in_root_rect.x());
+                    ? max<CSSPixels>(0, current_containing_block_in_root_rect.right() - space_used_by_floats.right_float_margin_edge_left_in_root)
+                    : max<CSSPixels>(0, space_used_by_floats.left_float_margin_edge_right_in_root - current_containing_block_in_root_rect.x());
                 if (used_by_this_side + used_by_opposite_side <= available_space.width.to_px_or_zero())
                     break;
 
@@ -1568,14 +1579,13 @@ BlockFormattingContext::SpaceUsedAndContainingMarginForFloats BlockFormattingCon
         // NOTE: The floating box is *not* in the final horizontal position yet, but the size and vertical position is valid.
         auto rect = floating_box.margin_box_rect_in_root_coordinate_space;
         if (rect.contains_vertically(y)) {
-            CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-            for (auto const* containing_block = floating_box.used_values.containing_block_used_values(); containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
-                offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_left();
-            }
+            auto const* containing_block = floating_box.used_values.containing_block_used_values();
+            VERIFY(containing_block);
+            auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
             space_and_containing_margin.left_used_space = floating_box.offset_from_edge
                 + floating_box.used_values.content_width()
                 + floating_box.used_values.margin_box_right();
-            space_and_containing_margin.left_total_containing_margin = offset_from_containing_block_chain_margins_between_here_and_root;
+            space_and_containing_margin.left_float_margin_edge_right_in_root = containing_block_rect_in_root.x() + space_and_containing_margin.left_used_space;
             space_and_containing_margin.matching_left_float_box = floating_box.box;
             break;
         }
@@ -1586,13 +1596,12 @@ BlockFormattingContext::SpaceUsedAndContainingMarginForFloats BlockFormattingCon
         // NOTE: The floating box is *not* in the final horizontal position yet, but the size and vertical position is valid.
         auto rect = floating_box.margin_box_rect_in_root_coordinate_space;
         if (rect.contains_vertically(y)) {
-            CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-            for (auto const* containing_block = floating_box.used_values.containing_block_used_values(); containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
-                offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_right();
-            }
+            auto const* containing_block = floating_box.used_values.containing_block_used_values();
+            VERIFY(containing_block);
+            auto containing_block_rect_in_root = content_box_rect_in_ancestor_coordinate_space(*containing_block, root());
             space_and_containing_margin.right_used_space = floating_box.offset_from_edge
                 + floating_box.used_values.margin_box_left();
-            space_and_containing_margin.right_total_containing_margin = offset_from_containing_block_chain_margins_between_here_and_root;
+            space_and_containing_margin.right_float_margin_edge_left_in_root = containing_block_rect_in_root.right() - space_and_containing_margin.right_used_space;
             space_and_containing_margin.matching_right_float_box = floating_box.box;
             break;
         }
@@ -1615,21 +1624,12 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats
 
     CSSPixels left_intrusion = 0;
     if (space_and_containing_margin.matching_left_float_box) {
-        auto left_side_floats_limit_to_right = space_and_containing_margin.left_total_containing_margin + space_and_containing_margin.left_used_space;
-        left_intrusion = max(CSSPixels(0), left_side_floats_limit_to_right - box_in_root_rect.x());
+        left_intrusion = space_and_containing_margin.left_used_space;
     }
 
-    // If we did not match a right float, the right_total_containing_margin will be 0 (as its never set). Since no floats means
-    // no intrusion we would instead want it to be exactly equal to offset_from_containing_block_chain_margins_between_here_and_root.
-    // Since this is not the case we have to explicitly handle this case.
     CSSPixels right_intrusion = 0;
     if (space_and_containing_margin.matching_right_float_box) {
-        auto right_side_floats_limit_to_right = space_and_containing_margin.right_used_space + space_and_containing_margin.right_total_containing_margin;
-        CSSPixels offset_from_containing_block_chain_margins_between_here_and_root = 0;
-        for (auto const* containing_block = &box_used_values; containing_block && &containing_block->node() != &root(); containing_block = containing_block->containing_block_used_values()) {
-            offset_from_containing_block_chain_margins_between_here_and_root += containing_block->margin_box_right();
-        }
-        right_intrusion = max(CSSPixels(0), right_side_floats_limit_to_right - offset_from_containing_block_chain_margins_between_here_and_root);
+        right_intrusion = space_and_containing_margin.right_used_space;
     }
 
     return { left_intrusion, right_intrusion };

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -181,10 +181,10 @@ protected:
         // Width for left / right floats, including their own margins.
         CSSPixels left_used_space;
         CSSPixels right_used_space;
-        // Left / right total margins from the outermost containing block to the floating element.
-        // Each block in the containing chain adds its own margin and we store the total here.
-        CSSPixels left_total_containing_margin;
-        CSSPixels right_total_containing_margin;
+        // Root-space margin-box edges of the matched floats, used to compute actual overlap against nested
+        // containing blocks without reconstructing positions from containing-chain margins.
+        CSSPixels left_float_margin_edge_right_in_root;
+        CSSPixels right_float_margin_edge_left_in_root;
         GC::Ptr<Box const> matching_left_float_box;
         GC::Ptr<Box const> matching_right_float_box;
     };

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -52,7 +52,7 @@ CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels y) const
 
     // If the left edge of the containing block is to the right of the rightmost left-side float, start placing inline
     // content at the left edge of the containing block.
-    auto left_side_floats_limit_to_right = space_and_containing_margin.left_total_containing_margin + space_and_containing_margin.left_used_space;
+    auto left_side_floats_limit_to_right = space_and_containing_margin.left_float_margin_edge_right_in_root;
     if (box_in_root_rect.x() >= left_side_floats_limit_to_right)
         return 0;
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/overflow-hidden-bfc-after-float-with-border-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/overflow-hidden-bfc-after-float-with-border-left.txt
@@ -1,0 +1,37 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        BlockContainer <div.left> at [8,8] floating [0+0+0 92 0+0+0] [0+0+0 92 0+0+0] [BFC] children: inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [9,9 90x90] baseline: 92
+          TextNode <#text> (not painted)
+          ImageBox <img> at [9,9] [0+1+0 90 0+1+0] [0+1+0 90 0+1+0] children: not-inline
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <div.right> at [264,8] [0+256+0 528 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [264,8] [0+0+0 528 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [264,8] [0+0+0 528 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 51, rect: [264,8 430.53125x18] baseline: 13.796875
+              "This line should not be pushed down past the image."
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [264,26] [0+0+0 528 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>.left) [8,8 92x92]
+          ImagePaintable (ImageBox<IMG>) [8,8 92x92]
+      PaintableWithLines (BlockContainer<DIV>.right) [8,8 784x18]
+        PaintableWithLines (BlockContainer(anonymous)) [264,8 528x0]
+        PaintableWithLines (BlockContainer<DIV>) [264,8 528x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [264,26 528x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/overflow-hidden-bfc-after-float-with-border-left.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/overflow-hidden-bfc-after-float-with-border-left.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+img {
+    border: 1px solid black;
+}
+
+.left {
+    float: left;
+}
+
+.right {
+    border-left: 16em solid gray;
+}
+
+.right > div {
+    width: 100%;
+    overflow: hidden;
+}
+</style>
+<div class="left">
+    <img width="90" height="90" />
+</div>
+<div class="right">
+    <div>This line should not be pushed down past the image.</div>
+</div>


### PR DESCRIPTION
  Fixes #8764 

  ## Summary

  Compute float intrusions and float-avoidance placement from root-space
  float margin-box edges instead of reconstructing overlap from
  containing-block margins.

  This fixes nested formatting contexts that are offset by border or
  padding, such as `overflow:hidden` content inside a block with
  `border-left` beside a float.

  ## Details

  The previous float-avoidance logic inferred overlap from accumulated
  containing-block margins. That breaks when a nested containing block is
  shifted by border or padding instead of margin.

  Update the float bookkeeping to store the matched float's root-space
  edges and use those values when:
  - computing float intrusion into nested boxes
  - deciding whether a formatting-context-establishing block must clear
  - placing formatting-context-establishing blocks horizontally
  - computing inline offsets from floats
  - checking opposite-side float fit during float placement

  ## Testing

  - Add a regression test for a floated image followed by a block with
    `border-left`, containing an `overflow:hidden` child that should stay
    beside the float
  - Run the `hidden-overflow` test subset
  - Run the `float-` test sweep
  
  