### PR TITLE
AK: Uninitialized struct tm reported by cppcheck

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -16,11 +16,22 @@
 
 #ifdef AK_OS_WINDOWS
 #    include <AK/Windows.h>
-#    define localtime_r(time, tm) localtime_s(tm, time)
-#    define gmtime_r(time, tm) gmtime_s(tm, time)
 #    define tzname _tzname
 #    define timegm _mkgmtime
 #endif
+
+static bool fill_tm(time_t& timestamp, struct tm& tm, UnixDateTime::LocalTime& local_time)
+{
+#ifdef AK_OS_WINDOWS
+    if (local_time == UnixDateTime::LocalTime::Yes)
+        return localtime_s(&tm, &timestamp) == 0;
+    return gmtime_s(&tm, &timestamp) == 0;
+#else
+    if (local_time == UnixDateTime::LocalTime::Yes)
+        return localtime_r(&timestamp, &tm) != nullptr;
+    return gmtime_r(&timestamp, &tm) != nullptr;
+#endif
+}
 
 namespace AK {
 
@@ -527,13 +538,11 @@ UnixDateTime UnixDateTime::now_coarse()
 
 ErrorOr<void> UnixDateTime::to_string_impl(StringBuilder& builder, StringView format, LocalTime local_time) const
 {
-    struct tm tm;
-
+    struct tm tm {};
     auto timestamp = m_offset.to_timespec().tv_sec;
-    if (local_time == LocalTime::Yes)
-        (void)localtime_r(&timestamp, &tm);
-    else
-        (void)gmtime_r(&timestamp, &tm);
+
+    if (!fill_tm(timestamp, tm, local_time))
+        VERIFY_NOT_REACHED();
 
     size_t const format_len = format.length();
 

--- a/Tests/AK/TestTime.cpp
+++ b/Tests/AK/TestTime.cpp
@@ -11,7 +11,6 @@
 
 #ifdef AK_OS_WINDOWS
 #    include <time.h>
-#    define gmtime_r(time, tm) gmtime_s(tm, time)
 #endif
 
 using AK::Duration;
@@ -771,9 +770,9 @@ TEST_CASE(parse_time)
         VERIFY(result.has_value());
 
         auto result_time = result.value().to_timespec();
-        struct tm tm;
+        struct tm tm {};
 #ifdef AK_OS_WINDOWS
-        VERIFY(gmtime_r(&result_time.tv_sec, &tm) == 0);
+        VERIFY(gmtime_s(&tm, &result_time.tv_sec) == 0);
 #else
         VERIFY(gmtime_r(&result_time.tv_sec, &tm) != nullptr);
 #endif
@@ -833,9 +832,9 @@ TEST_CASE(parse_wildcard_characters)
         VERIFY(result.has_value());
 
         auto result_time = result.value().to_timespec();
-        struct tm tm;
+        struct tm tm {};
 #ifdef AK_OS_WINDOWS
-        VERIFY(gmtime_r(&result_time.tv_sec, &tm) == 0);
+        VERIFY(gmtime_s(&tm, &result_time.tv_sec) == 0);
 #else
         VERIFY(gmtime_r(&result_time.tv_sec, &tm) != nullptr);
 #endif
@@ -877,9 +876,9 @@ TEST_CASE(parse_time_from_gmt)
 
     // Verify the parsed time by converting back to tm structure
     auto result_time = test_gmt3.value().to_timespec();
-    struct tm tm;
+    struct tm tm {};
 #ifdef AK_OS_WINDOWS
-    VERIFY(gmtime_r(&result_time.tv_sec, &tm) == 0);
+    VERIFY(gmtime_s(&tm, &result_time.tv_sec) == 0);
 #else
     VERIFY(gmtime_r(&result_time.tv_sec, &tm) != nullptr);
 #endif


### PR DESCRIPTION
Cppcheck reports that the struct tm variable should be initialized, at least to properly support Windows.

Checked using cppcheck 2.17 (Ubuntu 25.10) and 2.19 (Ubuntu 26.04 Beta)

```
Checking AK/Time.cpp ...
Checking AK/Time.cpp: AK_OS_WINDOWS...
AK/Time.cpp:488:15: error: Uninitialized variable: &tm [uninitvar]
        (void)localtime_r(&timestamp, &tm);
              ^
32/39 files checked 87% done
```

When using cppcheck 2.17, using the following command line

`cppcheck --check-level=exhaustive AK`