### PR TITLE
LibWeb: Handle @font-face within grouping rules like @layer and @media

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -9,7 +9,10 @@
 #include <LibURL/Parser.h>
 #include <LibWeb/Bindings/CSSStyleSheet.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/CSSConditionRule.h>
 #include <LibWeb/CSS/CSSCounterStyleRule.h>
+#include <LibWeb/CSS/CSSFontFaceRule.h>
+#include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
@@ -344,6 +347,50 @@ void CSSStyleSheet::for_each_effective_counter_style_at_rule(Function<void(CSSCo
     for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& rule) {
         if (rule.type() == CSSRule::Type::CounterStyle)
             callback(static_cast<CSSCounterStyleRule const&>(rule));
+    });
+}
+
+// FIXME: This only finds rules within condition rules whose conditions are met at stylesheet load time.
+//        We should re-evaluate when conditions change (e.g., @media after a window resize).
+template<typename Callback>
+static void for_each_effective_font_related_rule(CSSRuleList& rules, Callback&& callback)
+{
+    for (auto& rule : rules) {
+        if (callback(*rule))
+            continue;
+        if (is<CSSConditionRule>(*rule)) {
+            auto& condition_rule = static_cast<CSSConditionRule&>(*rule);
+            if (condition_rule.condition_matches())
+                for_each_effective_font_related_rule(condition_rule.css_rules(), callback);
+        } else if (is<CSSGroupingRule>(*rule)) {
+            for_each_effective_font_related_rule(static_cast<CSSGroupingRule&>(*rule).css_rules(), callback);
+        }
+    }
+}
+
+void CSSStyleSheet::for_each_effective_font_face_rule(Function<void(CSSFontFaceRule&)> const& callback)
+{
+    if (!m_media->matches())
+        return;
+    for_each_effective_font_related_rule(*m_rules, [&](CSSRule& rule) {
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
+            callback(*font_face_rule);
+            return true;
+        }
+        return false;
+    });
+}
+
+void CSSStyleSheet::for_each_effective_font_feature_values_rule(Function<void(CSSFontFeatureValuesRule&)> const& callback)
+{
+    if (!m_media->matches())
+        return;
+    for_each_effective_font_related_rule(*m_rules, [&](CSSRule& rule) {
+        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule)) {
+            callback(*font_feature_values_rule);
+            return true;
+        }
+        return false;
     });
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -89,6 +89,8 @@ public:
     bool evaluate_media_queries(DOM::Document const&);
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
     void for_each_effective_counter_style_at_rule(Function<void(CSSCounterStyleRule const&)> const& callback) const;
+    void for_each_effective_font_face_rule(Function<void(CSSFontFaceRule&)> const& callback);
+    void for_each_effective_font_feature_values_rule(Function<void(CSSFontFeatureValuesRule&)> const& callback);
 
     HashTable<GC::Ptr<DOM::Node>> const& owning_documents_or_shadow_roots() const { return m_owning_documents_or_shadow_roots; }
     void add_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root);

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -792,49 +792,45 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
 
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 {
-    // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
-    for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
-            if (!font_face_rule->is_valid())
-                continue;
+    sheet.for_each_effective_font_face_rule([&](CSSFontFaceRule& font_face_rule) {
+        if (!font_face_rule.is_valid())
+            return;
 
-            auto font_face = FontFace::create_css_connected(document().realm(), *font_face_rule);
-            document().fonts()->add_css_connected_font(font_face);
+        auto font_face = FontFace::create_css_connected(document().realm(), font_face_rule);
+        document().fonts()->add_css_connected_font(font_face);
 
-            if (font_face->has_non_default_unicode_range()) {
-                // Register for matching, but defer loading until a rendered codepoint
-                // actually falls in this face's unicode-range.
-                register_font_face(font_face);
-            } else {
-                // NB: Load via FontFace::load(), to satisfy this requirement:
-                // https://drafts.csswg.org/css-font-loading/#font-face-load
-                // User agents can initiate font loads on their own, whenever they determine that a given font face is
-                // necessary to render something on the page. When this happens, they must act as if they had called the
-                // corresponding FontFace’s load() method described here.
-                font_face->load();
-            }
+        if (font_face->has_non_default_unicode_range()) {
+            // Register for matching, but defer loading until a rendered codepoint
+            // actually falls in this face's unicode-range.
+            register_font_face(font_face);
+        } else {
+            // NB: Load via FontFace::load(), to satisfy this requirement:
+            // https://drafts.csswg.org/css-font-loading/#font-face-load
+            // User agents can initiate font loads on their own, whenever they determine that a given font face is
+            // necessary to render something on the page. When this happens, they must act as if they had called the
+            // corresponding FontFace's load() method described here.
+            font_face->load();
         }
+    });
 
-        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
-            font_feature_values_rule->clear_caches();
-    }
+    sheet.for_each_effective_font_feature_values_rule([&](CSSFontFeatureValuesRule& font_feature_values_rule) {
+        font_feature_values_rule.clear_caches();
+    });
 }
 
 void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
 {
-    // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
-    for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
-            if (auto font_face = font_face_rule->css_connected_font_face())
-                unregister_font_face(*font_face);
-            font_face_rule->disconnect_font_face();
-        }
+    sheet.for_each_effective_font_face_rule([&](CSSFontFaceRule& font_face_rule) {
+        if (auto font_face = font_face_rule.css_connected_font_face())
+            unregister_font_face(*font_face);
+        font_face_rule.disconnect_font_face();
+    });
 
-        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
-            font_feature_values_rule->clear_caches();
-    }
+    sheet.for_each_effective_font_feature_values_rule([&](CSSFontFeatureValuesRule& font_feature_values_rule) {
+        font_feature_values_rule.clear_caches();
+    });
 }
 
 }

--- a/Tests/LibWeb/Text/expected/css/font-face-in-layer.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-in-layer.txt
@@ -1,0 +1,7 @@
+@font-face inside @layer: true
+@font-face inside nested @layer: true
+@font-face in @layer before remove: true
+@font-face in @layer after remove: false
+@font-face inside @supports (true) inside @layer: true
+@font-face inside @supports (false) inside @layer: false
+Top-level @font-face: true

--- a/Tests/LibWeb/Text/input/css/font-face-in-layer.html
+++ b/Tests/LibWeb/Text/input/css/font-face-in-layer.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        // Test 1: @font-face inside @layer should be registered in document.fonts
+        const style1 = document.createElement("style");
+        style1.textContent = `
+            @layer test {
+                @font-face {
+                    font-family: LayerFont;
+                    src: url("does-not-exist.woff");
+                }
+            }
+        `;
+        document.head.appendChild(style1);
+        const layerFont = [...document.fonts].find(f => f.family === "LayerFont");
+        println(`@font-face inside @layer: ${!!layerFont}`);
+        style1.remove();
+
+        // Test 2: @font-face inside nested @layer should be registered
+        const style2 = document.createElement("style");
+        style2.textContent = `
+            @layer outer {
+                @layer inner {
+                    @font-face {
+                        font-family: NestedLayerFont;
+                        src: url("does-not-exist.woff");
+                    }
+                }
+            }
+        `;
+        document.head.appendChild(style2);
+        const nestedFont = [...document.fonts].find(f => f.family === "NestedLayerFont");
+        println(`@font-face inside nested @layer: ${!!nestedFont}`);
+        style2.remove();
+
+        // Test 3: @font-face inside @layer should be removed when stylesheet is removed
+        const style3 = document.createElement("style");
+        style3.textContent = `
+            @layer {
+                @font-face {
+                    font-family: RemovableFont;
+                    src: url("does-not-exist.woff");
+                }
+            }
+        `;
+        document.head.appendChild(style3);
+        const beforeRemove = [...document.fonts].some(f => f.family === "RemovableFont");
+        style3.remove();
+        const afterRemove = [...document.fonts].some(f => f.family === "RemovableFont");
+        println(`@font-face in @layer before remove: ${beforeRemove}`);
+        println(`@font-face in @layer after remove: ${afterRemove}`);
+
+        // Test 4: @font-face inside @supports (true condition) inside @layer
+        const style4 = document.createElement("style");
+        style4.textContent = `
+            @layer {
+                @supports (color: red) {
+                    @font-face {
+                        font-family: SupportsFont;
+                        src: url("does-not-exist.woff");
+                    }
+                }
+            }
+        `;
+        document.head.appendChild(style4);
+        const supportsFont = [...document.fonts].find(f => f.family === "SupportsFont");
+        println(`@font-face inside @supports (true) inside @layer: ${!!supportsFont}`);
+        style4.remove();
+
+        // Test 5: @font-face inside @supports (false condition) should not be registered
+        const style5 = document.createElement("style");
+        style5.textContent = `
+            @layer {
+                @supports (nonexistent-property: value) {
+                    @font-face {
+                        font-family: FalseSupportsFont;
+                        src: url("does-not-exist.woff");
+                    }
+                }
+            }
+        `;
+        document.head.appendChild(style5);
+        const falseSupportsFont = [...document.fonts].find(f => f.family === "FalseSupportsFont");
+        println(`@font-face inside @supports (false) inside @layer: ${!!falseSupportsFont}`);
+        style5.remove();
+
+        // Test 6: Top-level @font-face still works (regression check)
+        const style6 = document.createElement("style");
+        style6.textContent = `
+            @font-face {
+                font-family: TopLevelFont;
+                src: url("does-not-exist.woff");
+            }
+        `;
+        document.head.appendChild(style6);
+        const topLevelFont = [...document.fonts].find(f => f.family === "TopLevelFont");
+        println(`Top-level @font-face: ${!!topLevelFont}`);
+        style6.remove();
+    });
+</script>


### PR DESCRIPTION
FontComputer only iterated top-level rules when loading fonts from stylesheets, so @font-face declarations nested inside grouping rules like @layer were silently ignored. This adds a recursive helper that descends into grouping rules while respecting @media/@supports conditions.

Fixes #8685.