### PR TITLE
LibWeb: Make range input respect step attribute during mouse drag

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1417,8 +1417,22 @@ void HTMLInputElement::create_range_input_shadow_tree()
         double maximum = *max();
         if (minimum > maximum)
             return;
-        // FIXME: Snap new value to input steps
-        MUST(set_value_as_number(clamp(round(((client_x - rect.left().to_double()) / rect.width().to_double()) * (maximum - minimum) + minimum), minimum, maximum)));
+
+        double fraction = (client_x - rect.left().to_double()) / rect.width().to_double();
+        double value = fraction * (maximum - minimum) + minimum;
+
+        // Snap to allowed value step per the HTML spec for <input type=range>.
+        // https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)
+        if (auto maybe_allowed_value_step = allowed_value_step(); maybe_allowed_value_step.has_value()) {
+            double allowed_value_step = *maybe_allowed_value_step;
+            double base = step_base();
+
+            // Round to the nearest allowed step. If two numbers are equally close,
+            // choose the one nearest to positive infinity.
+            value = base + floor((value - base) / allowed_value_step + 0.5) * allowed_value_step;
+        }
+
+        MUST(set_value_as_number(clamp(value, minimum, maximum)));
         user_interaction_did_change_input_value();
     };
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -13,7 +13,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StdLibExtras.h>
 #include <LibGfx/DecodedImageFrame.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/RegExpObject.h>
@@ -1419,7 +1421,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
             return;
 
         double fraction = (client_x - rect.left().to_double()) / rect.width().to_double();
-        double value = fraction * (maximum - minimum) + minimum;
+        double value = mix(minimum, maximum, fraction);
 
         // Snap to allowed value step per the HTML spec for <input type=range>.
         // https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)


### PR DESCRIPTION
This PR fixes the issue where dragging the slider handle on range inputs with a set `step` attribute only snapped to integer values.

Fixes #8777