### PR TITLE
LibWeb: Distribute content into dynamic height multicol containers

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -768,6 +768,7 @@ set(SOURCES
     Layout/FieldSetBox.cpp
     Layout/FlexFormattingContext.cpp
     Layout/FormattingContext.cpp
+    Layout/Fragmentation.cpp
     Layout/GridFormattingContext.cpp
     Layout/ImageBox.cpp
     Layout/ImageProvider.cpp

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1126,6 +1126,12 @@ ColumnSpan ComputedProperties::column_span() const
     return keyword_to_column_span(value.to_keyword()).release_value();
 }
 
+ColumnFill ComputedProperties::column_fill() const
+{
+    auto const& value = property(PropertyID::ColumnFill);
+    return keyword_to_column_fill(value.to_keyword()).release_value();
+}
+
 ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level) const
 {
     auto const& value = property(PropertyID::Content);

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -115,6 +115,7 @@ public:
     Color caret_color(Layout::NodeWithStyle const&) const;
     Clear clear() const;
     ColumnSpan column_span() const;
+    ColumnFill column_fill() const;
     struct ContentDataAndQuoteNestingLevel {
         ContentData content_data;
         u32 final_quote_nesting_level { 0 };

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -261,6 +261,7 @@ public:
     static ColumnCount column_count() { return ColumnCount::make_auto(); }
     static Variant<LengthPercentage, NormalGap> column_gap() { return NormalGap {}; }
     static ColumnSpan column_span() { return ColumnSpan::None; }
+    static ColumnFill column_fill() { return ColumnFill::Balance; }
     static Size column_width() { return Size::make_auto(); }
     static Size column_height() { return Size::make_auto(); }
     static Variant<LengthPercentage, NormalGap> row_gap() { return NormalGap {}; }
@@ -630,6 +631,7 @@ public:
     ColumnCount column_count() const { return m_noninherited.column_count; }
     Variant<LengthPercentage, NormalGap> const& column_gap() const { return m_noninherited.column_gap; }
     ColumnSpan const& column_span() const { return m_noninherited.column_span; }
+    ColumnFill const& column_fill() const { return m_noninherited.column_fill; }
     Size const& column_width() const { return m_noninherited.column_width; }
     Size const& column_height() const { return m_noninherited.column_height; }
     Variant<LengthPercentage, NormalGap> const& row_gap() const { return m_noninherited.row_gap; }
@@ -895,6 +897,7 @@ protected:
         Vector<BackgroundLayerData> background_layers;
         FlexDirection flex_direction { InitialValues::flex_direction() };
         ColumnSpan column_span { InitialValues::column_span() };
+        ColumnFill column_fill { InitialValues::column_fill() };
         BackgroundBox background_color_clip { InitialValues::background_color_clip() };
 
         Color flood_color { InitialValues::flood_color() };
@@ -1146,6 +1149,7 @@ public:
     void set_column_count(ColumnCount value) { m_noninherited.column_count = value; }
     void set_column_gap(Variant<LengthPercentage, NormalGap> const& column_gap) { m_noninherited.column_gap = column_gap; }
     void set_column_span(ColumnSpan const column_span) { m_noninherited.column_span = column_span; }
+    void set_column_fill(ColumnFill const column_fill) { m_noninherited.column_fill = column_fill; }
     void set_column_width(Size const& column_width) { m_noninherited.column_width = column_width; }
     void set_column_height(Size const& column_height) { m_noninherited.column_height = column_height; }
     void set_row_gap(Variant<LengthPercentage, NormalGap> const& row_gap) { m_noninherited.row_gap = row_gap; }

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -168,6 +168,11 @@
     "linearrgb",
     "srgb"
   ],
+  "column-fill": [
+    "auto",
+    "balance",
+    "balance-all"
+  ],
   "column-span": [
     "none",
     "all"

--- a/Libraries/LibWeb/CSS/Keywords.json
+++ b/Libraries/LibWeb/CSS/Keywords.json
@@ -108,6 +108,7 @@
   "background",
   "backwards",
   "balance",
+  "balance-all",
   "balinese",
   "bamum",
   "bangla",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1441,6 +1441,18 @@
       "auto"
     ]
   },
+  "column-fill": {
+    "initial": "balance",
+    "inherited": false,
+    "affects-layout": true,
+    "animation-type": "discrete",
+    "requires-computation": "never",
+    "valid-identifiers": [
+      "auto",
+      "balance",
+      "balance-all"
+    ]
+  },
   "column-gap": {
     "animation-type": "by-computed-value",
     "inherited": false,

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1564,7 +1564,7 @@ static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
     auto content_height = svg_state.content_height();
 
     Layout::SVGFormattingContext svg_context(layout_state, Layout::LayoutMode::Normal, svg_root, nullptr);
-    svg_context.run(Layout::AvailableSpace(Layout::AvailableSize::make_definite(content_width), Layout::AvailableSize::make_definite(content_height)));
+    svg_context.run(Layout::AvailableSpace(Layout::AvailableSize::make_definite(content_width), Layout::AvailableSize::make_definite(content_height)), {});
     layout_state.commit(svg_root);
 
     svg_root.for_each_in_inclusive_subtree([](auto& node) {
@@ -1783,10 +1783,10 @@ void Document::update_layout(UpdateLayoutReason reason)
                 auto content_height = layout_state.get(*svg_root.containing_block()).content_height();
                 layout_state.get_mutable(svg_root).set_content_height(content_height);
                 Layout::SVGFormattingContext svg_formatting_context(layout_state, Layout::LayoutMode::Normal, svg_root, nullptr);
-                svg_formatting_context.run(available_space);
+                svg_formatting_context.run(available_space, {});
             } else {
                 Layout::BlockFormattingContext root_formatting_context(layout_state, Layout::LayoutMode::Normal, *m_layout_root, nullptr);
-                root_formatting_context.run(available_space);
+                root_formatting_context.run(available_space, {});
             }
         }
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -942,6 +942,8 @@ class CheckBox;
 class FieldSetBox;
 class FlexFormattingContext;
 class FormattingContext;
+class FragmentationContext;
+class ColumnFragmentationContext;
 class ImageBox;
 class InlineFormattingContext;
 class InlineNode;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/FieldSetBox.h>
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/LegendBox.h>
 #include <LibWeb/Layout/LineBuilder.h>
@@ -97,27 +98,37 @@ static bool margins_collapse_through(Box const& box, LayoutState& state)
     return true;
 }
 
-void BlockFormattingContext::run(AvailableSpace const& available_space)
+void BlockFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     FORMATTING_CONTEXT_TRACE();
     // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
     auto const& root_state = m_state.get(root());
     auto column_count = determine_used_value_for_column_count(root_state.content_width());
-    if (column_count.has_value()) {
+    // FIXME: Figure out how to implement multicol layout with unconstrained (indefinite) height.
+    // FIXME: Support nested fragmentation contexts.
+    if (column_count.has_value() && available_space.height.is_definite() && !fragmentation_context.has_value()) {
         auto column_width = determine_used_value_for_column_width(root_state.content_width(), column_count.value());
-        // FIXME: Do multi-column layout.
-        (void)column_width;
+        auto multicol_fragmentation_context = ColumnFragmentationContext(root(), column_width, available_space.height.to_px_or_zero(), get_column_gap_used_value_for_multicol(root_state.content_width()));
+        auto multicol_available_space = AvailableSpace(AvailableSize::make_definite(column_width), AvailableSize::make_indefinite());
+
+        layout_children(multicol_available_space, multicol_fragmentation_context);
+        return;
     }
 
+    layout_children(available_space, fragmentation_context);
+}
+
+void BlockFormattingContext::layout_children(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
+{
     if (auto const* fieldset_box = as_if<FieldSetBox>(root()); fieldset_box && fieldset_box->rendered_legend()) {
-        layout_fieldset_with_rendered_legend(*fieldset_box, available_space);
+        layout_fieldset_with_rendered_legend(*fieldset_box, available_space, fragmentation_context);
         return;
     }
 
     if (root().children_are_inline())
-        layout_inline_children(root(), available_space);
+        layout_inline_children(root(), available_space, fragmentation_context);
     else
-        layout_block_level_children(root(), available_space);
+        layout_block_level_children(root(), available_space, fragmentation_context);
 
     // Fieldsets without a rendered legend skip collapsed margin assignment.
     if (is<FieldSetBox>(root()))
@@ -596,14 +607,14 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
     box_state.set_content_height(height);
 }
 
-void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     VERIFY(block_container.children_are_inline());
 
     auto& block_container_state = m_state.get_mutable(block_container);
 
     InlineFormattingContext context(m_state, m_layout_mode, block_container, block_container_state, *this);
-    context.run(available_space);
+    context.run(available_space, fragmentation_context);
 
     if (!block_container_state.has_definite_width()) {
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
@@ -764,7 +775,7 @@ static CSSPixels containing_block_height_to_resolve_percentage_in_quirks_mode(Bo
     VERIFY_NOT_REACHED();
 }
 
-void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     if (box.is_absolutely_positioned()) {
         if (m_layout_mode == LayoutMode::Normal) {
@@ -896,6 +907,14 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         inline_space_used_before_children_formatted = intrusion_by_floats_into_box(list_item_state, offset_y);
     }
 
+    auto unfragmented_box_y = box_state.offset.y();
+    if (fragmentation_context.has_value()) {
+        FragmentationContext const* context = &fragmentation_context.value();
+        auto fragmented_flow_block_offset = content_box_rect_in_ancestor_coordinate_space(box_state, context->root()).y();
+        box_state.set_content_y(box_state.offset.y() + context->fragmentainer_y_offset_at(fragmented_flow_block_offset));
+        box_state.set_content_x(box_state.offset.x() + context->fragmentainer_x_offset_at(fragmented_flow_block_offset));
+    }
+
     if (independent_formatting_context) {
         // Margins of elements that establish new formatting contexts do not collapse with their in-flow children
         m_margin_state.reset();
@@ -917,7 +936,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             }
 
             auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
-            measuring_context->run(inner_available_space);
+            measuring_context->run(inner_available_space, {});
             auto content_height = measuring_context->automatic_content_height();
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height());
             if (content_height < min_height) {
@@ -925,12 +944,12 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             }
         }
 
-        independent_formatting_context->run(inner_available_space);
+        independent_formatting_context->run(inner_available_space, fragmentation_context);
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
         if (box.children_are_inline()) {
-            layout_inline_children(as<BlockContainer>(box), space_available_for_children);
+            layout_inline_children(as<BlockContainer>(box), space_available_for_children, fragmentation_context);
         } else {
             auto registered_block_container_y_position_update_callback = false;
             if (box_state.border_top > 0 || box_state.padding_top > 0) {
@@ -938,15 +957,18 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 m_margin_state.reset();
             } else if (!m_margin_state.has_block_container_waiting_for_final_y_position()) {
                 // margin-top of block container can be updated during children layout hence it's final y position yet to be determined
-                m_margin_state.register_block_container_y_position_update_callback([this, &box, y, introduce_clearance](CSSPixels margin_top) {
+                m_margin_state.register_block_container_y_position_update_callback([this, &box, &box_state, y, introduce_clearance, &unfragmented_box_y](CSSPixels margin_top) {
                     if (introduce_clearance == DidIntroduceClearance::No) {
                         place_block_level_element_in_normal_flow_vertically(box, margin_top + y);
+                        unfragmented_box_y = box_state.offset.y();
+                        // FIXME: This might've bumped the box down into a subsequent fragmentainer, so we need to
+                        //        translate it if that is the case.
                     }
                 });
                 registered_block_container_y_position_update_callback = true;
             }
 
-            layout_block_level_children(as<BlockContainer>(box), space_available_for_children);
+            layout_block_level_children(as<BlockContainer>(box), space_available_for_children, fragmentation_context);
 
             if (registered_block_container_y_position_update_callback) {
                 m_margin_state.unregister_block_container_y_position_update_callback();
@@ -970,7 +992,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_y_offset_of_current_block_container = box_state.offset.y() + box_state.content_height() + box_state.border_box_bottom();
+        m_y_offset_of_current_block_container = unfragmented_box_y + box_state.content_height() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -980,13 +1002,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto const& block_container_state = m_state.get(block_container);
     compute_inset(box, content_box_rect(block_container_state).size());
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
+    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, unfragmented_box_y + box_state.content_height() + box_state.margin_box_bottom());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     VERIFY(!block_container.children_are_inline());
 
@@ -994,7 +1016,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 
     TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
     block_container.for_each_child_of_type<Box>([&](Box& box) {
-        layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, available_space);
+        layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, available_space, fragmentation_context);
         return IterationDecision::Continue;
     });
 
@@ -1027,7 +1049,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 }
 
 // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox const& fieldset_box, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox const& fieldset_box, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     auto& fieldset_state = m_state.get_mutable(fieldset_box);
 
@@ -1038,7 +1060,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     {
         TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
         CSSPixels dummy_bottom = 0;
-        layout_block_level_box(*legend, fieldset_box, dummy_bottom, available_space);
+        layout_block_level_box(*legend, fieldset_box, dummy_bottom, available_space, fragmentation_context);
     }
 
     // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
@@ -1063,7 +1085,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         fieldset_box.for_each_child_of_type<Box>([&](Box& child) {
             if (&child == legend)
                 return IterationDecision::Continue;
-            layout_block_level_box(child, fieldset_box, bottom_of_lowest_margin_box, available_space);
+            layout_block_level_box(child, fieldset_box, bottom_of_lowest_margin_box, available_space, fragmentation_context);
             return IterationDecision::Continue;
         });
     }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -104,13 +104,47 @@ void BlockFormattingContext::run(AvailableSpace const& available_space, Optional
     // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
     auto const& root_state = m_state.get(root());
     auto column_count = determine_used_value_for_column_count(root_state.content_width());
-    // FIXME: Figure out how to implement multicol layout with unconstrained (indefinite) height.
     // FIXME: Support nested fragmentation contexts.
-    if (column_count.has_value() && available_space.height.is_definite() && !fragmentation_context.has_value()) {
+    if (column_count.has_value() && !fragmentation_context.has_value()) {
         auto column_width = determine_used_value_for_column_width(root_state.content_width(), column_count.value());
-        auto multicol_fragmentation_context = ColumnFragmentationContext(root(), column_width, available_space.height.to_px_or_zero(), get_column_gap_used_value_for_multicol(root_state.content_width()));
-        auto multicol_available_space = AvailableSpace(AvailableSize::make_definite(column_width), AvailableSize::make_indefinite());
 
+        LayoutState throwaway_state {};
+        BlockFormattingContext measuring_context(throwaway_state, m_layout_mode, root(), this->parent());
+        measuring_context.layout_children(AvailableSpace(AvailableSize::make_definite(column_width), AvailableSize::make_indefinite()), {});
+
+        CSSPixels ideal_column_height;
+        auto is_height_limited = available_space.height.is_definite();
+        // https://drafts.csswg.org/css-multicol-2/#cf
+        // This property specifies whether content in a multi-column line that does not immediately precede a spanner
+        // is balanced across columns or not.
+        switch (root().computed_values().column_fill()) {
+        case CSS::ColumnFill::Balance:
+            // Balance content equally between columns, as far as possible. In fragmented contexts, only the last
+            // fragment is balanced.
+            // FIXME: Until we have nested fragmentation contexts, this is exactly the same as balance-all
+        case CSS::ColumnFill::BalanceAll:
+            // Balance content equally between columns, as far as possible. In fragmented contexts, all fragments are
+            // balanced.
+            ideal_column_height = measuring_context.automatic_content_height() / column_count.value();
+            break;
+        case CSS::ColumnFill::Auto:
+            // fill columns sequentially
+            // NB: This is achieved by setting the preferred height to the maximum height we can get, which will make
+            //     impossible to over-fill a column. Thus, the only 'balancing' that takes place is content getting
+            //     shunted into the next column if it would not fit into the current one.
+            ideal_column_height = is_height_limited ? available_space.height.to_px_or_zero() : measuring_context.automatic_content_height();
+            break;
+        }
+
+        auto multicol_fragmentation_context = ColumnFragmentationContext(
+            root(),
+            column_count.value(),
+            column_width,
+            get_column_gap_used_value_for_multicol(root_state.content_width()),
+            ideal_column_height,
+            is_height_limited ? available_space.height.to_px_or_zero() : Optional<CSSPixels>());
+
+        auto multicol_available_space = AvailableSpace(AvailableSize::make_definite(column_width), AvailableSize::make_indefinite());
         layout_children(multicol_available_space, multicol_fragmentation_context);
         return;
     }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -22,7 +22,7 @@ public:
     explicit BlockFormattingContext(LayoutState&, LayoutMode layout_mode, BlockContainer const&, FormattingContext* parent);
     ~BlockFormattingContext();
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 
@@ -62,7 +62,7 @@ public:
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, AvailableSpace const&, CSSPixels y, LineBuilder* = nullptr);
 
-    void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&);
+    void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&, Optional<FragmentationContext&>);
 
     void resolve_vertical_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
     void resolve_horizontal_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
@@ -102,9 +102,10 @@ private:
 
     void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&);
 
-    void layout_block_level_children(BlockContainer const&, AvailableSpace const&);
-    void layout_inline_children(BlockContainer const&, AvailableSpace const&);
-    void layout_fieldset_with_rendered_legend(FieldSetBox const&, AvailableSpace const&);
+    void layout_children(AvailableSpace const&, Optional<FragmentationContext&>);
+    void layout_block_level_children(BlockContainer const&, AvailableSpace const&, Optional<FragmentationContext&>);
+    void layout_inline_children(BlockContainer const&, AvailableSpace const&, Optional<FragmentationContext&>);
+    void layout_fieldset_with_rendered_legend(FieldSetBox const&, AvailableSpace const&, Optional<FragmentationContext&>);
 
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
@@ -163,7 +164,7 @@ private:
             }
         }
 
-        void register_block_container_y_position_update_callback(ESCAPING Function<void(CSSPixels)> callback)
+        void register_block_container_y_position_update_callback(Function<void(CSSPixels)> callback)
         {
             m_block_container_y_position_update_callback = move(callback);
         }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -54,8 +54,11 @@ CSSPixels FlexFormattingContext::automatic_content_height() const
     return m_flex_container_state.content_height();
 }
 
-void FlexFormattingContext::run(AvailableSpace const& available_space)
+void FlexFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
+    // FIXME: Actually deal with fragmentation
+    (void)fragmentation_context;
+
     // This implements https://www.w3.org/TR/css-flexbox-1/#layout-algorithm
 
     // OPTIMIZATION: If we're in intrinsic sizing layout, but the flex container is not the

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -18,7 +18,7 @@ public:
 
     virtual bool inhibits_floating() const override { return true; }
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -344,7 +344,7 @@ struct ReplacedFormattingContext : public FormattingContext {
     }
     virtual CSSPixels automatic_content_width() const override { return 0; }
     virtual CSSPixels automatic_content_height() const override { return 0; }
-    virtual void run(AvailableSpace const&) override { }
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override { }
 };
 
 // FIXME: This is a hack. Get rid of it.
@@ -355,7 +355,7 @@ struct DummyFormattingContext : public FormattingContext {
     }
     virtual CSSPixels automatic_content_width() const override { return 0; }
     virtual CSSPixels automatic_content_height() const override { return 0; }
-    virtual void run(AvailableSpace const&) override { }
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override { }
 };
 
 OwnPtr<FormattingContext> FormattingContext::create_independent_formatting_context_if_needed(LayoutState& state, LayoutMode layout_mode, Box const& child_box)
@@ -424,9 +424,9 @@ OwnPtr<FormattingContext> FormattingContext::layout_inside(Box const& child_box,
 
     auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, layout_mode, child_box);
     if (independent_formatting_context)
-        independent_formatting_context->run(available_space);
+        independent_formatting_context->run(available_space, {});
     else
-        run(available_space);
+        run(available_space, {});
 
     return independent_formatting_context;
 }
@@ -676,7 +676,7 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
 
     auto context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     VERIFY(context);
-    context->run(m_state.get(box).available_inner_space_or_constraints_from(available_space));
+    context->run(m_state.get(box).available_inner_space_or_constraints_from(available_space), {});
 
     Optional<Box const&> table_box;
     box.for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
@@ -2102,7 +2102,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
         ? AvailableSize::make_definite(box_state.content_height())
         : AvailableSize::make_indefinite();
 
-    context->run(AvailableSpace(available_width, available_height));
+    context->run(AvailableSpace(available_width, available_height), {});
 
     auto min_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     cache.emplace(min_content_width);
@@ -2170,7 +2170,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
         ? AvailableSize::make_definite(box_state.content_height())
         : AvailableSize::make_indefinite();
 
-    context->run(AvailableSpace(available_width, available_height));
+    context->run(AvailableSpace(available_width, available_height), {});
 
     auto max_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     cache.emplace(max_content_width);
@@ -2208,7 +2208,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box);
 
-    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content()));
+    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content()), {});
 
     auto min_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     cache.emplace(min_content_height);
@@ -2243,7 +2243,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box);
 
-    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content()));
+    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content()), {});
 
     auto max_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     cache_slot.emplace(max_content_height);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -105,7 +105,7 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    virtual void run(AvailableSpace const&) = 0;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) = 0;
 
     // These functions return the automatic content dimensions of the context's root box.
     virtual CSSPixels automatic_content_width() const = 0;

--- a/Libraries/LibWeb/Layout/Fragmentation.cpp
+++ b/Libraries/LibWeb/Layout/Fragmentation.cpp
@@ -20,8 +20,11 @@ ColumnFragmentationContext::ColumnFragmentationContext(GC::Ref<Box const> root_b
     , m_column_count(column_count)
     , m_column_width(column_width)
     , m_column_gap(column_gap)
-    , m_ideal_column_height(ideal_column_height)
-    , m_max_column_height(max_column_height)
+    // https://drafts.csswg.org/css-break/#breaking-rules
+    // To guarantee progress, fragmentainers are assumed to have a minimum block size of 1px regardless of
+    // their used size.
+    , m_ideal_column_height(max(ideal_column_height, 1))
+    , m_max_column_height(max_column_height.has_value() ? max(max_column_height.value(), 1) : max_column_height)
 {
 }
 

--- a/Libraries/LibWeb/Layout/Fragmentation.cpp
+++ b/Libraries/LibWeb/Layout/Fragmentation.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present, Psychpsyo <psychpsyo@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/Fragmentation.h>
+
+namespace Web::Layout {
+
+FragmentationContext::FragmentationContext(GC::Ref<Box const> root_box)
+    : m_root_box(root_box)
+{
+}
+
+FragmentationContext::~FragmentationContext() = default;
+
+ColumnFragmentationContext::ColumnFragmentationContext(GC::Ref<Box const> root_box, CSSPixels column_width, CSSPixels column_height, CSSPixels column_gap)
+    : FragmentationContext(root_box)
+    , m_column_width(column_width)
+    , m_column_height(column_height)
+    , m_column_gap(column_gap)
+{
+}
+
+ColumnFragmentationContext::~ColumnFragmentationContext() = default;
+
+CSSPixels ColumnFragmentationContext::fragmentainer_x_offset_at(CSSPixels progress) const
+{
+    auto current_fragmentainer = floor(progress / m_column_height);
+    return (m_column_width + m_column_gap) * current_fragmentainer;
+}
+
+CSSPixels ColumnFragmentationContext::fragmentainer_y_offset_at(CSSPixels progress) const
+{
+    auto current_fragmentainer = floor(progress / m_column_height);
+    return -m_column_height * current_fragmentainer;
+}
+
+// https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
+CSSPixels ColumnFragmentationContext::remaining_fragmentainer_extent_at(CSSPixels progress) const
+{
+    return m_column_height - (progress % m_column_height);
+}
+
+}

--- a/Libraries/LibWeb/Layout/Fragmentation.cpp
+++ b/Libraries/LibWeb/Layout/Fragmentation.cpp
@@ -15,11 +15,13 @@ FragmentationContext::FragmentationContext(GC::Ref<Box const> root_box)
 
 FragmentationContext::~FragmentationContext() = default;
 
-ColumnFragmentationContext::ColumnFragmentationContext(GC::Ref<Box const> root_box, CSSPixels column_width, CSSPixels column_height, CSSPixels column_gap)
+ColumnFragmentationContext::ColumnFragmentationContext(GC::Ref<Box const> root_box, int column_count, CSSPixels column_width, CSSPixels column_gap, CSSPixels ideal_column_height, Optional<CSSPixels> max_column_height)
     : FragmentationContext(root_box)
+    , m_column_count(column_count)
     , m_column_width(column_width)
-    , m_column_height(column_height)
     , m_column_gap(column_gap)
+    , m_ideal_column_height(ideal_column_height)
+    , m_max_column_height(max_column_height)
 {
 }
 
@@ -27,20 +29,96 @@ ColumnFragmentationContext::~ColumnFragmentationContext() = default;
 
 CSSPixels ColumnFragmentationContext::fragmentainer_x_offset_at(CSSPixels progress) const
 {
-    auto current_fragmentainer = floor(progress / m_column_height);
+    auto current_fragmentainer = floor(progress / m_ideal_column_height);
     return (m_column_width + m_column_gap) * current_fragmentainer;
 }
 
 CSSPixels ColumnFragmentationContext::fragmentainer_y_offset_at(CSSPixels progress) const
 {
-    auto current_fragmentainer = floor(progress / m_column_height);
-    return -m_column_height * current_fragmentainer;
+    auto current_fragmentainer = floor(progress / m_ideal_column_height);
+    return -m_ideal_column_height * current_fragmentainer;
 }
 
 // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
 CSSPixels ColumnFragmentationContext::remaining_fragmentainer_extent_at(CSSPixels progress) const
 {
-    return m_column_height - (progress % m_column_height);
+    return m_ideal_column_height - (progress % m_ideal_column_height);
+}
+
+FragmentationDecision ColumnFragmentationContext::make_fragmentation_decision_at(CSSPixels progress, CSSPixels item_height)
+{
+    // This function decides whether a piece of monolithic content is placed as-is, shunted down into the next
+    // fragmentainer, or placed as-is and then sliced into fragments.
+    auto remaining_fragmentainer_extent = remaining_fragmentainer_extent_at(progress);
+
+    // If this item would exceed our height limit, try to shunt it into the next column if it can fit there.
+    if (m_max_column_height.has_value() && item_height > m_max_column_height.value() - m_ideal_column_height + remaining_fragmentainer_extent) {
+        // If the next column is not tall enough to fit the item, it must be fragmented across multiple columns instead.
+        if (item_height > m_max_column_height.value())
+            return FragmentationDecision::Fragment;
+
+        // If the item is larger than our ideal height, but still fits within the height limit, shunting it to
+        // the start of the next column will still incur a content deficit as it exceeds the ideal height of
+        // that column.
+        if (item_height > m_ideal_column_height)
+            m_content_deficit += item_height - m_ideal_column_height;
+        return FragmentationDecision::Shunt;
+    }
+
+    // If we are not height-limited and are in the last column, we cannot shunt or fragment anymore. We must place.
+    if (floor(progress / m_ideal_column_height) >= m_column_count)
+        return FragmentationDecision::Place;
+
+    // If there is no content in the current column yet, we must place and take any potential content deficit to avoid
+    // generating infinite empty columns.
+    if (remaining_fragmentainer_extent == m_ideal_column_height) {
+        if (item_height > m_ideal_column_height)
+            m_content_deficit += item_height - m_ideal_column_height;
+        return FragmentationDecision::Place;
+    }
+
+    // If we are not yet in the last column, calculate the deficit or surplus we would incur by placing the item as-is
+    // or shunting it into the next column.
+
+    // Note: The following calculations make it possible to shunt items which should fit entirely within the current
+    //       column. The spec does not allow this if the column balancing is set to fill the columns sequentially.
+    //       However, this will never be a problem, since these contexts either have their ideal height set to the max
+    //       height (and so never allow taking a deficit that would need to be balanced out with surplus from an
+    //       overzealous shunt) or their ideal height is equal to the total content height, in which case we never hit
+    //       the end of the column and thus never get the chance to take such a deficit either.
+
+    // Potential FIXME: This algorithm is somewhat short-sighted in nature and leads to situations where columns
+    // alternate between having n and n+1 lines of text in them, since m_content_deficit likes to bounce between being
+    // positive and negative, leading to alternating place and shunt decisions when the ideal content height cuts the
+    // usual last line box in half. While the spec has no opinion on this, one could argue that it is more
+    // aesthetically pleasing to first put only columns with n+1 lines in them, followed by only columns with n lines
+    // in them. It would be nice if we could somehow anticipate this situation up-front and adjust our ideal height
+    // both going in and when reaching the column where it needs to decrease by 1 line.
+
+    auto deficit_if_placed = max(item_height - remaining_fragmentainer_extent, 0);
+    auto surplus_if_shunted = remaining_fragmentainer_extent;
+
+    // Calculate the improvement scores that placing and shunting would incur, both in the current column and at the
+    // projected end of the last column. A lower score is better, because the score is simply the overall deviation
+    // from our ideal column height.
+    auto current_column_place_score = deficit_if_placed;
+    auto current_column_shunt_score = surplus_if_shunted;
+    auto last_column_place_score = abs(m_content_deficit + deficit_if_placed);
+    auto last_column_shunt_score = abs(m_content_deficit - surplus_if_shunted);
+    auto total_place_score = current_column_place_score + last_column_place_score;
+    auto total_shunt_score = current_column_shunt_score + last_column_shunt_score;
+
+    // Depending on the scores, we either take the surplus and shunt, or we take the deficit and place.
+    // In case of a tie, we prioritize the shunt/place scores of the current column. The idea behind this is that,
+    // while the decision does not matter in theory, the current column can only be improved now, whereas the final
+    // column might still get more opportunities for improvement.
+    if (total_shunt_score == total_place_score ? current_column_shunt_score < current_column_place_score : total_shunt_score < total_place_score) {
+        m_content_deficit -= surplus_if_shunted;
+        return FragmentationDecision::Shunt;
+    }
+
+    m_content_deficit += deficit_if_placed;
+    return FragmentationDecision::Place;
 }
 
 }

--- a/Libraries/LibWeb/Layout/Fragmentation.h
+++ b/Libraries/LibWeb/Layout/Fragmentation.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present, Psychpsyo <psychpsyo@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/Ptr.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::Layout {
+
+// https://drafts.csswg.org/css-break/#fragmentation-context
+// FIXME: Some of this will need to be merged with AvailableSpace in some form once we get to fragmentation contexts
+//        with variable-width fragmentainers.
+//        (print mode under the influence of @page rules that turn only some pages sideways comes to mind)
+class FragmentationContext {
+public:
+    virtual ~FragmentationContext();
+
+    virtual CSSPixels fragmentainer_x_offset_at(CSSPixels) const { return 0; }
+    virtual CSSPixels fragmentainer_y_offset_at(CSSPixels) const { return 0; }
+
+    // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
+    virtual CSSPixels remaining_fragmentainer_extent_at(CSSPixels) const { return 0; }
+
+    GC::Ref<Box const> root() const { return m_root_box; }
+
+protected:
+    FragmentationContext(GC::Ref<Box const> root_box);
+
+private:
+    CSSPixels m_used_fragmentainer_extent;
+    // This is the box that hosts the fragmented flow. It is used to determine the fragmentation-relative position of
+    // elements in said flow. A containing block for fragmentation-related positioning, if you will.
+    GC::Ref<Box const> m_root_box;
+};
+
+// https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
+class ColumnFragmentationContext : public FragmentationContext {
+public:
+    ColumnFragmentationContext(GC::Ref<Box const> root_box, CSSPixels column_width, CSSPixels column_height, CSSPixels column_gap);
+    virtual ~ColumnFragmentationContext();
+
+    CSSPixels fragmentainer_x_offset_at(CSSPixels progress) const override;
+    CSSPixels fragmentainer_y_offset_at(CSSPixels progress) const override;
+
+    // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
+    CSSPixels remaining_fragmentainer_extent_at(CSSPixels progress) const override;
+
+private:
+    CSSPixels m_column_width;
+    CSSPixels m_column_height;
+    CSSPixels m_column_gap;
+};
+
+}

--- a/Libraries/LibWeb/Layout/Fragmentation.h
+++ b/Libraries/LibWeb/Layout/Fragmentation.h
@@ -12,6 +12,12 @@
 
 namespace Web::Layout {
 
+enum class FragmentationDecision {
+    Fragment,
+    Place,
+    Shunt
+};
+
 // https://drafts.csswg.org/css-break/#fragmentation-context
 // FIXME: Some of this will need to be merged with AvailableSpace in some form once we get to fragmentation contexts
 //        with variable-width fragmentainers.
@@ -25,6 +31,14 @@ public:
 
     // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
     virtual CSSPixels remaining_fragmentainer_extent_at(CSSPixels) const { return 0; }
+
+    virtual FragmentationDecision make_fragmentation_decision_at(CSSPixels progress, CSSPixels item_height)
+    {
+        if (remaining_fragmentainer_extent_at(progress) >= item_height)
+            return FragmentationDecision::Place;
+
+        return FragmentationDecision::Fragment;
+    }
 
     GC::Ref<Box const> root() const { return m_root_box; }
 
@@ -41,7 +55,7 @@ private:
 // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
 class ColumnFragmentationContext : public FragmentationContext {
 public:
-    ColumnFragmentationContext(GC::Ref<Box const> root_box, CSSPixels column_width, CSSPixels column_height, CSSPixels column_gap);
+    ColumnFragmentationContext(GC::Ref<Box const> root_box, int column_count, CSSPixels column_width, CSSPixels column_gap, CSSPixels ideal_column_height, Optional<CSSPixels> max_column_height);
     virtual ~ColumnFragmentationContext();
 
     CSSPixels fragmentainer_x_offset_at(CSSPixels progress) const override;
@@ -50,10 +64,29 @@ public:
     // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
     CSSPixels remaining_fragmentainer_extent_at(CSSPixels progress) const override;
 
+    virtual FragmentationDecision make_fragmentation_decision_at(CSSPixels progress, CSSPixels item_height) override;
+
 private:
+    int m_column_count;
     CSSPixels m_column_width;
-    CSSPixels m_column_height;
     CSSPixels m_column_gap;
+    // m_ideal_column_height represents our preferred height for a column which is calculated from the height that the
+    // content would have if flowed into a single, long column. Fragmentation breaks are assumed to sit at this
+    // preferred height.
+    CSSPixels m_ideal_column_height;
+    Optional<CSSPixels> m_max_column_height;
+
+    // When monolithic content would be placed across a fragmentation break, it becomes impossible to honor the
+    // ideal height for every column. In those cases, we either introduce a gap to shunt the monolithic content across
+    // the break, into the next column, or we increase the actual column height to fit that content. If we increased
+    // the actual height, we still want to fill all subsequent columns up to the ideal height, but we no longer have
+    // enough content to do so. We call this a content deficit, and it is represented by this variable being positive.
+    // If we introduce a gap, we now have too much content left. This amount is indicated by negative values and we
+    // refer to it as a content surplus.
+    // All fragmentation decisions are made to minimize deficit and surplus on both the current column and overall,
+    // since the overall deficit and surplus are just the projected deviation we expect to be forced into on the
+    // last column.
+    CSSPixels m_content_deficit = 0;
 };
 
 }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2122,8 +2122,11 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
     return area_rect;
 }
 
-void GridFormattingContext::run(AvailableSpace const& available_space)
+void GridFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
+    // FIXME: Actually deal with fragmentation
+    (void)fragmentation_context;
+
     // OPTIMIZATION: If we're in intrinsic sizing layout, but the grid container is not the
     //               box being measured, we can skip everything here.
     //               The parent formatting context has already figured out our size anyway.

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -170,7 +170,7 @@ public:
 
     virtual bool inhibits_floating() const override { return true; }
 
-    virtual void run(AvailableSpace const& available_space) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
     StaticPositionRect calculate_static_position_rect(Box const&) const;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -80,12 +80,12 @@ CSSPixels InlineFormattingContext::automatic_content_height() const
     return m_automatic_content_height;
 }
 
-void InlineFormattingContext::run(AvailableSpace const& available_space)
+void InlineFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     FORMATTING_CONTEXT_TRACE();
     VERIFY(containing_block().children_are_inline());
     m_available_space = available_space;
-    generate_line_boxes();
+    generate_line_boxes(fragmentation_context);
 
     CSSPixels content_height = 0;
 
@@ -340,7 +340,7 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
     }
 }
 
-void InlineFormattingContext::generate_line_boxes()
+void InlineFormattingContext::generate_line_boxes(Optional<FragmentationContext&> fragmentation_context)
 {
     auto& line_boxes = m_containing_block_used_values.line_boxes;
     line_boxes.clear_with_capacity();
@@ -371,7 +371,7 @@ void InlineFormattingContext::generate_line_boxes()
             if (item.node->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 auto next_width = iterator.next_non_whitespace_sequence_width();
                 if (next_width > 0)
-                    line_builder.break_if_needed(next_width);
+                    line_builder.break_if_needed(next_width, fragmentation_context);
             }
             leading_margin_from_collapsible_whitespace += item.margin_start;
             leading_border_from_collapsible_whitespace += item.border_start;
@@ -388,7 +388,7 @@ void InlineFormattingContext::generate_line_boxes()
 
         switch (item.type) {
         case InlineLevelIterator::Item::Type::ForcedBreak: {
-            line_builder.break_line(LineBuilder::ForcedBreak::Yes);
+            line_builder.break_line(LineBuilder::ForcedBreak::Yes, fragmentation_context);
             if (item.node) {
                 auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this);
                 if (introduce_clearance == BlockFormattingContext::DidIntroduceClearance::Yes) {
@@ -407,7 +407,7 @@ void InlineFormattingContext::generate_line_boxes()
                     minimum_space_needed_on_line += item.margin_start;
                 if (item.margin_end < 0)
                     minimum_space_needed_on_line += item.margin_end;
-                line_builder.break_if_needed(minimum_space_needed_on_line);
+                line_builder.break_if_needed(minimum_space_needed_on_line, fragmentation_context);
             }
             line_builder.append_box(box, item.border_start + item.padding_start, item.padding_end + item.border_end, item.margin_start, item.margin_end);
             break;
@@ -447,7 +447,7 @@ void InlineFormattingContext::generate_line_boxes()
                 }
 
                 // If whitespace caused us to break, don't put it on the next line.
-                if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width)) {
+                if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width, fragmentation_context)) {
                     // Record that the previous line has trailing whitespace for text selection.
                     line_builder.set_trailing_whitespace_on_previous_line();
                     break;
@@ -457,7 +457,7 @@ void InlineFormattingContext::generate_line_boxes()
                 // If a shortened line box is too small to contain any content, then the line box is shifted downward
                 // (and its width recomputed) until either some content fits or there are no more floats present.
                 if (!is_whitespace && (item.can_break_before || line_boxes.last().is_empty()))
-                    line_builder.break_if_needed(item.border_box_width());
+                    line_builder.break_if_needed(item.border_box_width(), fragmentation_context);
             }
             line_builder.append_text_chunk(
                 text_node,
@@ -503,7 +503,7 @@ void InlineFormattingContext::generate_line_boxes()
         }
     }
 
-    line_builder.update_last_line();
+    line_builder.update_last_line(fragmentation_context);
     m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 
     if (m_layout_mode == LayoutMode::Normal) {

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -23,7 +23,7 @@ public:
 
     BlockContainer const& containing_block() const { return static_cast<BlockContainer const&>(context_box()); }
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_height() const override;
     virtual CSSPixels automatic_content_width() const override;
     StaticPositionRect calculate_static_position_rect(Box const&) const;
@@ -39,7 +39,7 @@ public:
     void set_vertical_float_clearance(CSSPixels);
 
 private:
-    void generate_line_boxes();
+    void generate_line_boxes(Optional<FragmentationContext&>);
     void apply_text_overflow_ellipsis(Vector<LineBox>&);
     void apply_justification_to_fragments(CSS::TextJustify, LineBox&, bool is_last_line);
     StaticPositionRect calculate_inline_end_static_position_rect() const;

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -359,10 +359,11 @@ void LineBuilder::update_last_line(Optional<FragmentationContext&> fragmentation
 
     // Start with the "strut", an imaginary zero-width box at the start of each line box.
     auto const strut_line_height = m_context.containing_block().computed_values().line_height();
-    auto strut_top = m_current_block_offset;
-    auto strut_bottom = should_align_strut_to_line_box_baseline
-        ? m_current_block_offset + line_box_baseline + (strut_line_height - strut_baseline)
-        : m_current_block_offset + strut_line_height;
+    auto strut_top = m_current_block_offset + block_fragmentainer_offset;
+    auto strut_bottom = m_current_block_offset + block_fragmentainer_offset;
+    strut_bottom += should_align_strut_to_line_box_baseline
+        ? line_box_baseline + (strut_line_height - strut_baseline)
+        : strut_line_height;
 
     CSSPixels uppermost_box_top = strut_top;
     CSSPixels lowermost_box_bottom = strut_bottom;

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -272,17 +272,30 @@ void LineBuilder::update_last_line(Optional<FragmentationContext&> fragmentation
 
     CSSPixels inline_fragmentainer_offset = 0;
     CSSPixels block_fragmentainer_offset = 0;
+    CSSPixels distance_to_backtrack_after_placing_line = 0;
     if (fragmentation_context.has_value()) {
-        FragmentationContext const* context = &fragmentation_context.value();
+        FragmentationContext* context = &fragmentation_context.value();
 
         // FIXME: Block doesn't always mean Y-axis and inline doesn't always mean X-axis, so account for writing mode.
         auto fragmented_flow_block_offset = m_context.content_box_rect_in_ancestor_coordinate_space(
                                                          m_layout_state.get(m_context.containing_block()), context->root())
                                                 .y();
 
-        auto remaining_fragmentainer_extent = context->remaining_fragmentainer_extent_at(fragmented_flow_block_offset + m_current_block_offset);
-        if (remaining_fragmentainer_extent < line_height) {
-            m_current_block_offset += remaining_fragmentainer_extent;
+        switch (context->make_fragmentation_decision_at(fragmented_flow_block_offset + m_current_block_offset, line_height)) {
+        case FragmentationDecision::Fragment:
+            // FIXME: Implement fragmenting of an entire line box across multiple fragmentainers.
+            break;
+        case FragmentationDecision::Place: {
+            // If we place past the end of a fragmentainer, we need to pull subsequent content up to the start of its
+            // fragmentainer. Otherwise there would be gaps at the top of subsequent columns in multicol contexts.
+            auto remaining_fragmentainer_extent = context->remaining_fragmentainer_extent_at(fragmented_flow_block_offset + m_current_block_offset);
+            if (remaining_fragmentainer_extent < line_height)
+                distance_to_backtrack_after_placing_line = line_height - remaining_fragmentainer_extent;
+            break;
+        }
+        case FragmentationDecision::Shunt:
+            m_current_block_offset += context->remaining_fragmentainer_extent_at(fragmented_flow_block_offset + m_current_block_offset);
+            break;
         }
 
         inline_fragmentainer_offset = context->fragmentainer_x_offset_at(fragmented_flow_block_offset + m_current_block_offset);
@@ -445,6 +458,8 @@ void LineBuilder::update_last_line(Optional<FragmentationContext&> fragmentation
 
     line_box.m_bottom = m_current_block_offset + block_fragmentainer_offset + line_box.m_block_length;
     line_box.m_baseline = line_box_baseline;
+
+    m_current_block_offset -= distance_to_backtrack_after_placing_line;
 }
 
 void LineBuilder::remove_last_line_if_empty()

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -24,7 +24,7 @@ LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_s
     begin_new_line(false);
 }
 
-void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_item_width)
+void LineBuilder::break_line(ForcedBreak forced_break, Optional<FragmentationContext&> fragmentation_context, Optional<CSSPixels> next_item_width)
 {
     // FIXME: Respect inline direction.
 
@@ -33,7 +33,7 @@ void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_
     last_line_box.m_has_forced_break = forced_break == ForcedBreak::Yes;
 
     m_last_line_needs_update = true;
-    update_last_line();
+    update_last_line(fragmentation_context);
 
     size_t break_count = 0;
     bool floats_intrude_at_current_y = false;
@@ -208,7 +208,7 @@ bool LineBuilder::should_break(CSSPixels next_item_width)
     return (current_line_width + next_item_width) > m_available_width_for_current_line;
 }
 
-void LineBuilder::update_last_line()
+void LineBuilder::update_last_line(Optional<FragmentationContext&> fragmentation_context)
 {
     if (!m_last_line_needs_update)
         return;
@@ -266,6 +266,27 @@ void LineBuilder::update_last_line()
         default:
             break;
         }
+    }
+
+    auto line_height = m_context.containing_block().computed_values().line_height();
+
+    CSSPixels inline_fragmentainer_offset = 0;
+    CSSPixels block_fragmentainer_offset = 0;
+    if (fragmentation_context.has_value()) {
+        FragmentationContext const* context = &fragmentation_context.value();
+
+        // FIXME: Block doesn't always mean Y-axis and inline doesn't always mean X-axis, so account for writing mode.
+        auto fragmented_flow_block_offset = m_context.content_box_rect_in_ancestor_coordinate_space(
+                                                         m_layout_state.get(m_context.containing_block()), context->root())
+                                                .y();
+
+        auto remaining_fragmentainer_extent = context->remaining_fragmentainer_extent_at(fragmented_flow_block_offset + m_current_block_offset);
+        if (remaining_fragmentainer_extent < line_height) {
+            m_current_block_offset += remaining_fragmentainer_extent;
+        }
+
+        inline_fragmentainer_offset = context->fragmentainer_x_offset_at(fragmented_flow_block_offset + m_current_block_offset);
+        block_fragmentainer_offset = context->fragmentainer_y_offset_at(fragmented_flow_block_offset + m_current_block_offset);
     }
 
     auto strut_baseline = [&] {
@@ -334,7 +355,7 @@ void LineBuilder::update_last_line()
     CSSPixels lowermost_box_bottom = strut_bottom;
 
     for (auto& fragment : line_box.fragments()) {
-        CSSPixels new_fragment_inline_offset = inline_offset + fragment.inline_offset();
+        CSSPixels new_fragment_inline_offset = inline_offset + inline_fragmentainer_offset + fragment.inline_offset();
         CSSPixels new_fragment_block_offset = 0;
 
         auto block_offset_value_for_alignment = [&](CSS::VerticalAlign vertical_align) {
@@ -391,7 +412,7 @@ void LineBuilder::update_last_line()
         }
 
         fragment.set_inline_offset(new_fragment_inline_offset);
-        fragment.set_block_offset(floor(new_fragment_block_offset) + block_offset);
+        fragment.set_block_offset(floor(new_fragment_block_offset) + block_offset + block_fragmentainer_offset);
 
         CSSPixels top_of_inline_box = 0;
         CSSPixels bottom_of_inline_box = 0;
@@ -422,7 +443,7 @@ void LineBuilder::update_last_line()
     line_box.m_block_length = lowermost_box_bottom - uppermost_box_top;
     m_should_advance_to_last_line_box_bottom = should_align_strut_to_line_box_baseline;
 
-    line_box.m_bottom = m_current_block_offset + line_box.m_block_length;
+    line_box.m_bottom = m_current_block_offset + block_fragmentainer_offset + line_box.m_block_length;
     line_box.m_baseline = line_box_baseline;
 }
 

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 
 namespace Web::Layout {
@@ -22,21 +23,21 @@ public:
         Yes,
     };
 
-    void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
+    void break_line(ForcedBreak, Optional<FragmentationContext&> fragmentation_context, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
 
     // Returns whether a line break occurred.
-    bool break_if_needed(CSSPixels next_item_width)
+    bool break_if_needed(CSSPixels next_item_width, Optional<FragmentationContext&> fragmentation_context)
     {
         if (should_break(next_item_width)) {
-            break_line(LineBuilder::ForcedBreak::No, next_item_width);
+            break_line(LineBuilder::ForcedBreak::No, fragmentation_context, next_item_width);
             return true;
         }
         return false;
     }
 
-    void update_last_line();
+    void update_last_line(Optional<FragmentationContext&>);
 
     void remove_last_line_if_empty();
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1012,6 +1012,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_column_count(CSS::ColumnCount::make_integer(column_count.as_integer().integer()));
 
     computed_values.set_column_span(computed_style.column_span());
+    computed_values.set_column_fill(computed_style.column_fill());
 
     computed_values.set_column_width(computed_style.size_value(CSS::PropertyID::ColumnWidth));
     computed_values.set_column_height(computed_style.size_value(CSS::PropertyID::ColumnHeight));

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -14,8 +14,11 @@ ReplacedWithChildrenFormattingContext::ReplacedWithChildrenFormattingContext(Lay
 {
 }
 
-void ReplacedWithChildrenFormattingContext::run(AvailableSpace const& available_space)
+void ReplacedWithChildrenFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
+    // FIXME: Actually deal with fragmentation
+    (void)fragmentation_context;
+
     auto& root_state = m_state.get_mutable(context_box());
     auto content_width = root_state.content_width();
 
@@ -48,7 +51,7 @@ void ReplacedWithChildrenFormattingContext::run(AvailableSpace const& available_
     wrapper_state.set_content_offset({ 0, 0 });
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
-    bfc->run(child_available_space);
+    bfc->run(child_available_space, {});
 
     m_automatic_content_width = content_width;
     m_automatic_content_height = bfc->automatic_content_height();

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.h
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.h
@@ -14,7 +14,7 @@ class ReplacedWithChildrenFormattingContext final : public FormattingContext {
 public:
     explicit ReplacedWithChildrenFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent);
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
     virtual void parent_context_did_dimension_child_root_box() override;

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -176,7 +176,7 @@ static bool is_container_element(Node const& node)
     return false;
 }
 
-void SVGFormattingContext::run(AvailableSpace const& available_space)
+void SVGFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&>)
 {
     FORMATTING_CONTEXT_TRACE();
     // NOTE: SVG doesn't have a "formatting context" in the spec, but this is the most
@@ -315,7 +315,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
         child_state.set_content_width(transformed_rect.width());
         child_state.set_content_height(transformed_rect.height());
 
-        bfc.run(AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height())));
+        bfc.run(AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height())), {});
 
         if (auto* mask_box = child.first_child_of_type<SVGMaskBox>())
             layout_mask_or_clip(*mask_box);
@@ -370,7 +370,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform);
-    nested_context.run(*m_available_space);
+    nested_context.run(*m_available_space, {});
 }
 
 Gfx::Path SVGFormattingContext::compute_path_for_text(SVGTextBox const& text_box) const
@@ -581,7 +581,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform);
     layout_state.set_has_definite_width(true);
     layout_state.set_has_definite_height(true);
-    nested_context.run(*m_available_space);
+    nested_context.run(*m_available_space, {});
 }
 
 void SVGFormattingContext::layout_container_element(SVGBox const& container)

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -20,7 +20,7 @@ public:
     explicit SVGFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform = {});
     ~SVGFormattingContext();
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/TableFormattingContext.h>
 
@@ -56,7 +57,7 @@ static inline bool is_table_column(Box const& box)
     return box.display().is_table_column();
 }
 
-CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, AvailableSpace const& caption_available_space)
+CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, AvailableSpace const& caption_available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     CSSPixels caption_height = 0;
     for (auto* child = table_box().first_child(); child; child = child->next_sibling()) {
@@ -76,7 +77,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
             }
 
-            caption_context->run(inner_available_space);
+            caption_context->run(inner_available_space, fragmentation_context);
 
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
@@ -1788,7 +1789,7 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
     layout_absolutely_positioned_children();
 }
 
-void TableFormattingContext::run(AvailableSpace const& available_space)
+void TableFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     FORMATTING_CONTEXT_TRACE();
     m_available_space = available_space;
@@ -1804,7 +1805,7 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
         AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_width())),
         available_space.height);
 
-    auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
+    auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space, fragmentation_context);
 
     // Distribute the width of the table among columns.
     distribute_width_to_columns();
@@ -1818,7 +1819,7 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
 
     m_state.get_mutable(table_box()).set_content_height(m_table_height);
 
-    total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space);
+    total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space, fragmentation_context);
 
     // Table captions are positioned between the table margins and its borders (outside the grid box borders) as described in
     // https://www.w3.org/TR/css-tables-3/#bounding-box-assignment

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -25,7 +25,7 @@ public:
 
     void run_until_width_calculation(AvailableSpace const& available_space);
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
     StaticPositionRect calculate_static_position_rect(Box const&) const;
@@ -41,7 +41,7 @@ public:
     virtual void parent_context_did_dimension_child_root_box() override;
 
 private:
-    CSSPixels run_caption_layout(CSS::CaptionSide, AvailableSpace const&);
+    CSSPixels run_caption_layout(CSS::CaptionSide, AvailableSpace const&, Optional<FragmentationContext&>);
     CSSPixels compute_capmin();
     void compute_constrainedness();
     void compute_cell_measures();

--- a/Libraries/LibWeb/PixelUnits.h
+++ b/Libraries/LibWeb/PixelUnits.h
@@ -219,6 +219,11 @@ public:
     constexpr CSSPixelFraction operator/(CSSPixels const& other) const;
     constexpr CSSPixels operator/(CSSPixelFraction const& other) const;
 
+    constexpr CSSPixels operator%(CSSPixels const& other) const
+    {
+        return from_raw(raw_value() % other.raw_value());
+    }
+
     constexpr CSSPixels& operator+=(CSSPixels const& other)
     {
         *this = *this + other;

--- a/Tests/LibWeb/Crash/CSS/multicol-0-height.html
+++ b/Tests/LibWeb/Crash/CSS/multicol-0-height.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+	body {
+		height: 0;
+		column-count: 2;
+		column-fill: auto;
+	}
+</style>
+Line 1<br>
+Line 2

--- a/Tests/LibWeb/Ref/expected/css/css-multicol/block-positioning-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/css-multicol/block-positioning-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+  body {
+    display: flex;
+  }
+  div {
+    width: 20em;
+    background-color: lightgray;
+    border: 2px solid;
+    box-sizing: border-box;
+  }
+</style>
+<div>VeryLongUnbrokenWord1</div>
+<div>VeryLongUnbrokenWord2</div>

--- a/Tests/LibWeb/Ref/expected/css/css-multicol/text-basic-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/css-multicol/text-basic-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+  div {
+    display: flex;
+  }
+  span {
+    width: 20em;
+  }
+</style>
+<div>
+  <span>VeryLongUnbrokenWord1</span>
+  <span>VeryLongUnbrokenWord2</span>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-001-ref.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-001-ref.xht
@@ -1,0 +1,40 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Opera Software ASA" href="http://www.opera.com/" />
+  <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-07-30 -->
+  <meta name="flags" content="ahem" />
+  <link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  color: black;
+  font: 1.25em/1 Ahem;
+  float: left;
+  width: 10em;
+  margin-right: 1em;
+  }
+  ]]></style>
+ </head>
+ <body>
+
+  <div>1 22 333
+  4444 55555
+  666666
+  7777777
+  999999999
+  1 22 333
+  4444 55555
+  666666
+  7777777
+  999999999</div>
+
+  <div>1 22 333
+  4444 55555
+  666666
+  7777777
+  999999999</div>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-002-ref.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-002-ref.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>multicolumn | column-fill-auto</title>
+<link rel="author" title="howcome@opera.com" href="http://www.opera.com/"/>
+<meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+<style type="text/css"><![CDATA[
+body>div {
+	font-family: Ahem;
+	font-size: 1.25em;
+	line-height: 1em;
+	color: green;
+	height: 3em;
+	width: 2em;
+	orphans: 1;
+	widows: 1;
+	position: relative;
+	margin: 1em;
+}
+div.col {
+	column-count: 2;
+	column-fill: auto;
+	column-gap: 0;
+}
+div.red {
+	background: red; position: absolute; z-index: -1;
+}
+]]></style>
+</head>
+
+<body>
+
+<div class='ref'>
+oo<br/>t<br/>o
+</div>
+
+<div class='ref'>
+oo<br/>t<br/>o
+</div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-balance-001-ref.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-balance-001-ref.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>multicolumn | column-fill</title>
+<link rel="author" title="howcome@opera.com" href="http://www.opera.com/"/>
+<meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+<style type="text/css"><![CDATA[
+body>div {
+	font-family: Ahem;
+	font-size: 1.25em;
+	line-height: 1em;
+	color: green;
+	height: 3em;
+	width: 2em;
+	orphans: 1;
+	widows: 1;
+	position: relative;
+	margin: 1em;
+}
+div.col {
+	column-count: 2;
+	column-fill: balance;
+	column-gap: 0;
+}
+div.red {
+	background: red; position: absolute; z-index: -1;
+}
+]]></style>
+</head>
+
+<body>
+
+<div class='ref'>
+oo<br/>tt
+</div>
+
+<div class='ref'>
+oo<br/>tt
+</div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/reference/multicol-basic-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/reference/multicol-basic-ref.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<!-- Submitted from TestTWF Paris -->
+<head>
+	<title>CSS Test reference</title>
+	<link rel="author" title="Anselm Hannemann" href="mailto:info@anselm-hannemann.com"/>
+	<link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact">
+	<meta name="flags" content="ahem"/>
+
+	<link rel="stylesheet" type="text/css" href="../../../../../data/fonts/ahem.css" />
+	<style type="text/css">
+		.multicol-wrapper>*{
+			font: 20px/1 Ahem;
+		}
+
+		div.multicol-wrapper{
+			border: thin solid black;
+			display: inline-block;
+			margin: 1em auto;
+			width: 360px;
+		}
+
+		.multicol-basic-ref{
+			background: yellow;
+			width: 360px;
+			border-spacing: 0;
+			border-collapse: collapse;
+			padding: 0;
+		}
+
+		.multicol-basic-ref td{
+			padding: 0;
+		}
+		.multicol-basic-ref-item{
+			padding: 0;
+			width: 120px;
+			background: #000;
+			border-spacing: 0;
+			border-collapse: collapse;
+			display: inline;
+			border: none;
+		}
+
+		.item-1{
+			background: purple;
+			color: purple;
+		}
+
+		.item-2{
+			background: orange;
+			color: orange;
+		}
+
+		.item-3{
+			background: blue;
+			color: blue;
+		}
+	</style>
+</head>
+<body>
+<p>Test passes if there are three vertical stripes in the yellow box below: 1st purple, 2nd orange, 3rd blue.</p>
+<div class="multicol-wrapper">
+	<table class="multicol-basic-ref">
+		<tr>
+			<td><div class="multicol-basic-ref-item item-1">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</div></td>
+			<td><div class="multicol-basic-ref-item item-2">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</div></td>
+			<td><div class="multicol-basic-ref-item item-3">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</div></td>
+		</tr>
+	</table>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/css/css-multicol/block-positioning.html
+++ b/Tests/LibWeb/Ref/input/css/css-multicol/block-positioning.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/css-multicol/block-positioning-ref.html" />
+<style>
+  body {
+    columns: 2;
+    height: calc(1lh + 4px);
+	  column-width: 1em;
+    max-width: 40em;
+    column-gap: 0;
+  }
+  div {
+    background-color: lightgray;
+    border: 2px solid;
+  }
+</style>
+<div>VeryLongUnbrokenWord1</div>
+<div>VeryLongUnbrokenWord2</div>

--- a/Tests/LibWeb/Ref/input/css/css-multicol/text-basic.html
+++ b/Tests/LibWeb/Ref/input/css/css-multicol/text-basic.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/css-multicol/text-basic-ref.html" />
+<style>
+  div {
+    columns: 2;
+    height: 1lh;
+	  column-width: 1em;
+    max-width: 40em;
+    column-gap: 0;
+  }
+</style>
+<div>
+	VeryLongUnbrokenWord1
+	VeryLongUnbrokenWord2
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-001.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<!-- Submitted from TestTWF Paris -->
+<head>
+	<meta charset="utf-8">
+	<title>CSS Test: Multi-column element via columns: [integer]</title>
+	<link rel="author" title="Anselm Hannemann" href="mailto:info@anselm-hannemann.com"/>
+	<link rel="author" title="Håkon Wium Lie" href="mailto:howcome@opera.com"/>
+	<link rel="help" href="http://www.w3.org/TR/css3-multicol/#columns"/>
+	<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/reference/multicol-basic-ref.html"/>
+	<meta name="flags" content="ahem"/>
+	<link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact">
+
+	<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+	<style type="text/css">
+		.multicol-wrapper>*{
+			font: 20px/1 Ahem;
+		}
+
+		div.multicol-wrapper{
+			border: thin solid black;
+			display: inline-block;
+			margin: 1em auto;
+			width: 360px;
+		}
+
+		.multicol-basic-ref{
+			background: yellow;
+			width: 360px;
+			columns: 3;
+			column-gap: 0;
+			column-rule: none;
+		}
+
+		.multicol-basic-ref-item{
+			background: #000;
+		}
+
+		.item-1{
+			background: purple;
+			color: purple;
+		}
+
+		.item-2{
+			background: orange;
+			color: orange;
+		}
+
+		.item-3{
+			background: blue;
+			color: blue;
+		}
+	</style>
+</head>
+<body>
+<p>Test passes if there are three vertical stripes in the yellow box below: 1st purple, 2nd orange, 3rd blue.</p>
+<div class="multicol-wrapper">
+	<div class="multicol-basic-ref">
+		<span class="multicol-basic-ref-item item-1">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-2">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-3">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+	</div>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-002.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<!-- Submitted from TestTWF Paris -->
+<head>
+	<meta charset="utf-8">
+	<title>CSS Test: Multi-column element via column-count: [integer]</title>
+	<link rel="author" title="Anselm Hannemann" href="mailto:info@anselm-hannemann.com"/>
+	<link rel="author" title="Håkon Wium Lie" href="mailto:howcome@opera.com"/>
+	<link rel="help" href="http://www.w3.org/TR/css3-multicol/#columns"/>
+	<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/reference/multicol-basic-ref.html"/>
+	<meta name="flags" content="ahem"/>
+	<link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact">
+
+	<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+	<style type="text/css">
+		.multicol-wrapper>*{
+			font: 20px/1 Ahem;
+		}
+
+		div.multicol-wrapper{
+			border: thin solid black;
+			display: inline-block;
+			margin: 1em auto;
+			width: 360px;
+		}
+
+		.multicol-basic-ref{
+			background: yellow;
+			width: 360px;
+			column-count: 3;
+			column-gap: 0;
+			column-rule: none;
+		}
+
+		.multicol-basic-ref-item{
+			background: #000;
+		}
+
+		.item-1{
+			background: purple;
+			color: purple;
+		}
+
+		.item-2{
+			background: orange;
+			color: orange;
+		}
+
+		.item-3{
+			background: blue;
+			color: blue;
+		}
+	</style>
+</head>
+<body>
+<p>Test passes if there are three vertical stripes in the yellow box below: 1st purple, 2nd orange, 3rd blue.</p>
+<div class="multicol-wrapper">
+	<div class="multicol-basic-ref">
+		<span class="multicol-basic-ref-item item-1">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-2">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-3">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+	</div>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-003.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<!-- Submitted from TestTWF Paris -->
+<head>
+	<meta charset="utf-8">
+	<title>CSS Test: Multi-column element via columns: [width]</title>
+	<link rel="author" title="Anselm Hannemann" href="mailto:info@anselm-hannemann.com"/>
+	<link rel="author" title="Håkon Wium Lie" href="mailto:howcome@opera.com"/>
+	<link rel="help" href="http://www.w3.org/TR/css3-multicol/#columns"/>
+	<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/reference/multicol-basic-ref.html"/>
+	<meta name="flags" content="ahem"/>
+	<link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact">
+
+	<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+	<style type="text/css">
+		.multicol-wrapper>*{
+			font: 20px/1 Ahem;
+		}
+
+		div.multicol-wrapper{
+			border: thin solid black;
+			display: inline-block;
+			margin: 1em auto;
+			width: 360px;
+		}
+
+		.multicol-basic-ref{
+			background: yellow;
+			width: 360px;
+			columns: 120px;
+			column-gap: 0;
+			column-rule: none;
+		}
+
+		.multicol-basic-ref-item{
+			background: #000;
+		}
+
+		.item-1{
+			background: purple;
+			color: purple;
+		}
+
+		.item-2{
+			background: orange;
+			color: orange;
+		}
+
+		.item-3{
+			background: blue;
+			color: blue;
+		}
+	</style>
+</head>
+<body>
+<p>Test passes if there are three vertical stripes in the yellow box below: 1st purple, 2nd orange, 3rd blue.</p>
+<div class="multicol-wrapper">
+	<div class="multicol-basic-ref">
+		<span class="multicol-basic-ref-item item-1">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-2">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-3">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+	</div>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-basic-004.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<!-- Submitted from TestTWF Paris -->
+<head>
+	<meta charset="utf-8">
+	<title>CSS Test: Multi-column element via column-width: [width]</title>
+	<link rel="author" title="Anselm Hannemann" href="mailto:info@anselm-hannemann.com"/>
+	<link rel="author" title="Håkon Wium Lie" href="mailto:howcome@opera.com"/>
+	<link rel="help" href="http://www.w3.org/TR/css3-multicol/#columns"/>
+	<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/reference/multicol-basic-ref.html"/>
+	<meta name="flags" content="ahem"/>
+	<link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact">
+
+	<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+	<style type="text/css">
+		.multicol-wrapper>*{
+			font: 20px/1 Ahem;
+		}
+
+		div.multicol-wrapper{
+			border: thin solid black;
+			display: inline-block;
+			margin: 1em auto;
+			width: 360px;
+		}
+
+		.multicol-basic-ref{
+			background: yellow;
+			width: 360px;
+			column-width: 120px;
+			column-gap: 0;
+			column-rule: none;
+		}
+
+		.multicol-basic-ref-item{
+			background: #000;
+		}
+
+		.item-1{
+			background: purple;
+			color: purple;
+		}
+
+		.item-2{
+			background: orange;
+			color: orange;
+		}
+
+		.item-3{
+			background: blue;
+			color: blue;
+		}
+	</style>
+</head>
+<body>
+<p>Test passes if there are three vertical stripes in the yellow box below: 1st purple, 2nd orange, 3rd blue.</p>
+<div class="multicol-wrapper">
+	<div class="multicol-basic-ref">
+		<span class="multicol-basic-ref-item item-1">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-2">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+		<span class="multicol-basic-ref-item item-3">XXXX XXXX XXXX XXXX XXXX XXXX XXXX</span>
+	</div>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-001.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-001.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Multi-column Layout Test: 'column-fill: auto' (basic)</title>
+  <link rel="author" title="Opera Software ASA" href="http://www.opera.com/" />
+  <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-07-30 -->
+  <link rel="help" href="http://www.w3.org/TR/css3-multicol/#cf" title="7.1 'column-fill'" />
+  <link rel="match" href="../../../../expected/wpt-import/css/css-multicol/multicol-fill-auto-001-ref.xht" />
+  <meta name="flags" content="ahem" />
+  <meta name="assert" content="This test checks that 'column-fill: auto' fills the column boxes of a multi-colum element sequentially with inline content and does not bother about balancing content of column boxes." />
+  <link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  color: black;
+  font: 1.25em/1 Ahem;
+  height: 10em;
+  orphans: 1;
+  widows: 1;
+  width: 32em;
+
+  column-count: 3;
+  column-fill: auto;
+  column-gap: 1em;
+  }
+  ]]></style>
+ </head>
+
+ <body>
+
+  <div>1 22 333 4444 55555 666666 7777777 999999999 1 22 333 4444 55555 666666 7777777 999999999 1 22 333 4444 55555 666666 7777777 999999999</div>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-002.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-002.xht
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>multicolumn | column-fill-auto</title>
+<meta name="assert" content="This test checks that columns are not balanced when 'column-fill: auto' is set"/>
+<link rel="author" title="howcome@opera.com" href="http://www.opera.com/"/>
+<link rel="help" href="http://www.w3.org/TR/css3-multicol/#filling-columns"/>
+<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/multicol-fill-auto-002-ref.xht"/>
+<meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+<style type="text/css"><![CDATA[
+body>div {
+	font-family: Ahem;
+	font-size: 1.25em;
+	line-height: 1em;
+	color: green;
+	height: 3em;
+	width: 2em;
+	orphans: 1;
+	widows: 1;
+	position: relative;
+	margin: 1em;
+}
+div.col {
+	column-count: 2;
+	column-fill: auto;
+	column-gap: 0;
+}
+div.red {
+	background: red; position: absolute; z-index: -1;
+}
+]]></style>
+</head>
+
+<body>
+
+<div class='col'>
+<div class='red' style="top: 0; left: 0; height: 3em; width: 1em;"></div>
+<div class='red' style="top: 0; left: 0; height: 1em; width: 2em;"></div>
+o<br/>t<br/>
+o<br/>t<br/>
+</div>
+
+<div class='ref'>
+oo<br/>t<br/>o
+</div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-balance-001.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-balance-001.xht
@@ -1,0 +1,49 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>multicolumn | column-fill</title>
+<meta name="assert" content="This test checks that columns are properly balanced when 'column-fill: balance' is set"/>
+<link rel="author" title="howcome@opera.com" href="http://www.opera.com/"/>
+<link rel="help" href="http://www.w3.org/TR/css3-multicol/#filling-columns"/>
+<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/multicol-fill-balance-001-ref.xht"/>
+<meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+<style type="text/css"><![CDATA[
+body>div {
+	font-family: Ahem;
+	font-size: 1.25em;
+	line-height: 1em;
+	color: green;
+	height: 3em;
+	width: 2em;
+	orphans: 1;
+	widows: 1;
+	position: relative;
+	margin: 1em;
+}
+div.col {
+	column-count: 2;
+	column-fill: balance;
+	column-gap: 0;
+}
+div.red {
+	background: red; position: absolute; z-index: -1;
+}
+]]></style>
+</head>
+
+<body>
+
+<div class='col'>
+<div class='red' style="top: 0; left: 0; height: 2em; width: 2em;"></div>
+o<br/>t<br/>
+o<br/>t<br/>
+</div>
+
+<div class='ref'>
+oo<br/>tt
+</div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-balance-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-balance-002.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Multi-column Layout Test: Balancing with more forced breaks than columns</title>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<link rel="help" href="https://www.w3.org/TR/css-multicol-1/#cf" title="7.1. column-fill">
+<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="This multicol container will create overflowing columns, no matter what, due to forced break. Don't overstretch.">
+<p>Test passes if there is a filled green square.</p>
+<div style="columns:2; column-gap:0; width:100px; background:green;">
+  <div style="height:100px;"></div>
+  <div style="break-before:column; height:90px;"></div>
+  <div style="break-before:column; height:10px;"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-balance-024.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-balance-024.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
+  <link rel="help" href="https://www.w3.org/TR/css-multicol-1/#cf">
+  <link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1336291">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-multicol/../reference/ref-filled-green-100px-square.xht">
+  <style>
+    .hidden { display:none; }
+    #mc > div { height:25px; contain:size; background:green;}
+  </style>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div id="mc" style="columns:2; gap:0; width:100px; background:red;">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+    <div class="hidden"></div>
+    <div class="hidden"></div>
+    <div class="hidden"></div>
+    <div class="hidden"></div>
+  </div>
+  <script>
+    requestAnimationFrame(()=> {
+      requestAnimationFrame(()=> {
+        for (let e of document.getElementsByClassName('hidden'))
+          e.style.display = "block";
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  </script>
+</html>

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
@@ -151,6 +151,7 @@ All properties associated with getComputedStyle(document.body):
     "clip",
     "clip-path",
     "column-count",
+    "column-fill",
     "column-gap",
     "column-height",
     "column-span",

--- a/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
@@ -383,6 +383,8 @@ All supported properties and their default values exposed from CSSStylePropertie
 'color-scheme': 'normal'
 'columnCount': 'auto'
 'column-count': 'auto'
+'columnFill': 'balance'
+'column-fill': 'balance'
 'columnGap': 'normal'
 'column-gap': 'normal'
 'columnHeight': 'auto'

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -149,6 +149,7 @@ clear: none
 clip: auto
 clip-path: none
 column-count: auto
+column-fill: balance
 column-gap: normal
 column-height: auto
 column-span: none
@@ -191,7 +192,7 @@ grid-row-start: auto
 grid-template-areas: none
 grid-template-columns: none
 grid-template-rows: none
-height: 2895px
+height: 2910px
 inline-size: 784px
 inset-block-end: auto
 inset-block-start: auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 305 tests
+Found 306 tests
 
-301 Pass
+302 Pass
 4 Fail
 Pass	accent-color
 Pass	border-collapse
@@ -148,6 +148,7 @@ Pass	clear
 Pass	clip
 Pass	clip-path
 Pass	column-count
+Pass	column-fill
 Pass	column-gap
 Pass	column-span
 Pass	column-width

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-multicol/multicol-fill-balance-027.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-multicol/multicol-fill-balance-027.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Make room for the float in the first column

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-multicol/multicol-fill-balance-027.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-multicol/multicol-fill-balance-027.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
+<link rel="help" href="https://www.w3.org/TR/css-multicol-1/#cf">
+<div id="multicol" style="columns:2;">
+  <div style="height:60px;"></div>
+  <div style="float:left; width:100%; contain:size; height:40px;"></div>
+  <div style="clear:left; height:90px;"></div>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  test(()=> {
+    assert_equals(multicol.offsetHeight, 100);
+  }, "Make room for the float in the first column");
+</script>


### PR DESCRIPTION
Builds upon #8557 to implement multicol containers with dynamic height, where such height is expected to be derived via balancing the content equally between all columns as far as possible. (unless `column-fill` is set to `auto`)

`column-fill` had to be implemented in the same go, or else one of the existing tests would've been broken by the new balancing behavior. (Before this patch, our behavior was always `column-fill: auto`)

Some newly passing multicol tests have also been imported.