### PR TITLE
LibWebView+Base: Add reset to defaults for browser settings

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -18,6 +18,47 @@
                 }
             }
 
+            body.settings header {
+                justify-content: space-between;
+                gap: 16px;
+            }
+
+            body.settings .header-brand {
+                display: flex;
+                align-items: center;
+            }
+
+            /* Closed <dialog> must stay hidden; display:flex on dialog overrides UA :not([open]). */
+            dialog.reset-settings-dialog:not([open]) {
+                display: none;
+            }
+
+            dialog.reset-settings-dialog[open] {
+                display: flex;
+                flex-direction: column;
+
+                width: min(560px, 94vw);
+                max-width: min(560px, 94vw);
+            }
+
+            dialog.reset-settings-dialog .dialog-body {
+                flex: 0 1 auto;
+                height: auto;
+                min-height: min-content;
+                max-height: none;
+
+                overflow: visible;
+                overflow-wrap: break-word;
+                word-wrap: break-word;
+            }
+
+            dialog.reset-settings-dialog .reset-settings-dialog-text {
+                margin: 0;
+
+                font-size: 14px;
+                line-height: 1.5;
+            }
+
             hr {
                 height: 1px;
                 background-color: var(--border-color);
@@ -324,14 +365,34 @@
             }
         </style>
     </head>
-    <body>
+    <body class="settings">
         <header>
-            <picture>
-                <source srcset="resource://icons/128x128/app-browser.png" media="(prefers-color-scheme: dark)" />
-                <img src="resource://icons/128x128/app-browser-dark.png" />
-            </picture>
-            <h1>Ladybird Settings</h1>
+            <div class="header-brand">
+                <picture>
+                    <source srcset="resource://icons/128x128/app-browser.png" media="(prefers-color-scheme: dark)" />
+                    <img src="resource://icons/128x128/app-browser-dark.png" />
+                </picture>
+                <h1>Ladybird Settings</h1>
+            </div>
+            <button type="button" id="reset-settings-open" class="secondary-button">Reset to defaults</button>
         </header>
+
+        <dialog id="reset-settings-dialog" class="reset-settings-dialog">
+            <div class="dialog-header">
+                <h3 class="dialog-title">Reset settings</h3>
+                <button type="button" class="dialog-button" id="reset-settings-dialog-close" aria-label="Close">&times;</button>
+            </div>
+            <div class="dialog-body">
+                <p class="reset-settings-dialog-text">
+                    This restores all Ladybird settings stored in Settings.json to their default values. Custom search engines
+                    will be removed. This does not delete browsing data.
+                </p>
+            </div>
+            <div class="dialog-footer">
+                <button type="button" class="secondary-button" id="reset-settings-cancel">Cancel</button>
+                <button type="button" class="primary-button" id="reset-settings-confirm">Reset to defaults</button>
+            </div>
+        </dialog>
 
         <div class="tab-bar">
             <button class="tab-button active" data-tab="general">General</button>
@@ -662,6 +723,21 @@
                         dialog.close();
                     }
                 });
+            });
+
+            const resetSettingsDialog = document.querySelector("#reset-settings-dialog");
+            document.querySelector("#reset-settings-open").addEventListener("click", () => {
+                resetSettingsDialog.showModal();
+            });
+            document.querySelector("#reset-settings-dialog-close").addEventListener("click", () => {
+                resetSettingsDialog.close();
+            });
+            document.querySelector("#reset-settings-cancel").addEventListener("click", () => {
+                resetSettingsDialog.close();
+            });
+            document.querySelector("#reset-settings-confirm").addEventListener("click", () => {
+                ladybird.sendMessage("resetToDefaults");
+                resetSettingsDialog.close();
             });
 
             document.addEventListener("WebUILoaded", () => {

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -487,6 +487,46 @@ void Settings::set_dns_settings(DNSSettings const& dns_settings, bool override_b
         observer.dns_settings_changed();
 }
 
+void Settings::reset_to_defaults()
+{
+    auto preserved_dns_settings = m_dns_settings;
+    auto preserved_dns_override = m_dns_override_by_command_line;
+
+    m_new_tab_page_url = URL::about_newtab();
+    m_show_bookmarks_bar = default_show_bookmarks_bar;
+    m_default_zoom_level_factor = initial_zoom_level_factor;
+    m_languages = { default_language };
+    m_search_engine.clear();
+    m_custom_search_engines.clear();
+    m_autocomplete_engine.clear();
+    m_autoplay = SiteSetting {};
+    m_browsing_data_settings = {};
+    m_global_privacy_control = GlobalPrivacyControl::No;
+
+    if (preserved_dns_override) {
+        m_dns_settings = preserved_dns_settings;
+        m_dns_override_by_command_line = true;
+    } else {
+        m_dns_settings = SystemDNS {};
+        m_dns_override_by_command_line = false;
+    }
+
+    persist_settings();
+
+    for (auto& observer : m_observers) {
+        observer.new_tab_page_url_changed();
+        observer.show_bookmarks_bar_changed();
+        observer.default_zoom_level_factor_changed();
+        observer.languages_changed();
+        observer.search_engine_changed();
+        observer.autocomplete_engine_changed();
+        observer.autoplay_settings_changed();
+        observer.browsing_data_settings_changed();
+        observer.global_privacy_control_changed();
+        observer.dns_settings_changed();
+    }
+}
+
 void Settings::persist_settings()
 {
     auto settings = serialize_json();

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -58,6 +58,8 @@ public:
 
     JsonValue serialize_json() const;
 
+    void reset_to_defaults();
+
     URL::URL const& new_tab_page_url() const { return m_new_tab_page_url; }
     void set_new_tab_page_url(URL::URL);
 

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -17,6 +17,10 @@ void SettingsUI::register_interfaces()
     register_interface("loadCurrentSettings"sv, [this](auto const&) {
         load_current_settings();
     });
+    register_interface("resetToDefaults"sv, [this](auto const&) {
+        Application::settings().reset_to_defaults();
+        load_current_settings();
+    });
 
     register_interface("setNewTabPageURL"sv, [this](auto const& data) {
         set_new_tab_page_url(data);


### PR DESCRIPTION
## Summary

Adds **Reset to defaults** for Ladybird’s main browser settings. The about:settings page gets a header action and a confirmation dialog before applying changes.

## Implementation

- Restores all persisted fields to the same defaults as a fresh `Settings` instance (new tab URL, bookmarks bar, zoom, languages, search/autocomplete, autoplay site settings, browsing data / disk cache preferences, global privacy control, DNS when not forced by the shell).
- If DNS was applied with the command-line override flag, that DNS configuration is **not** cleared on reset so launch behavior stays consistent with how the browser was started.
- After persisting, all `SettingsObserver` hooks are invoked so chrome, request server (disk cache / DNS), and views stay aligned.
- New `resetToDefaults` WebUI message runs reset then `loadCurrentSettings` so the page refreshes.
- Header button, modal dialog (copy explains that custom search engines are removed and browsing data is **not** deleted).

## What it doesn't do

- Does not clear cookies, history, site data, or cache contents (only resets **settings** such as cache size limits).
- Does not reset Qt shell `QSettings` (window geometry / menubar), if applicable to the build.

## How to test

1. Change several settings (for example new tab URL, zoom, search engine, DNS in the UI).
2. Open about:settings → **Reset to defaults** → confirm.
3. Confirm UI and behavior match defaults and `Settings.json` reflects defaults (with DNS unchanged when started with CLI DNS override).
4. Confirm observers behave (for example bookmarks bar visibility, network/DNS after reset).

## EDIT: Image
<img width="875" height="733" alt="{456661E5-B45A-49B6-94A8-0414F44D4123}" src="https://github.com/user-attachments/assets/9b0ce3a6-6773-4600-964a-9d613a8dd58a" />
