### PR TITLE
LibWeb: Use caption content width for inline layout in table captions

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -58,27 +58,26 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
         // The caption boxes are principal block-level boxes that retain their own content, padding, margin, and border areas,
         // and are rendered as normal block boxes inside the table wrapper box, as described in https://www.w3.org/TR/CSS22/tables.html#model
         if (auto caption_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, child_box)) {
-            caption_context->run(caption_available_space);
-            // FIXME: If caption only has inline children, BlockFormattingContext doesn't resolve the vertical metrics.
-            //        We need to do it manually here.
-            if (auto* block_context = as_if<BlockFormattingContext>(caption_context.ptr())) {
+            auto inner_available_space = caption_available_space;
+            auto* block_context = as_if<BlockFormattingContext>(caption_context.ptr());
+            if (block_context) {
                 auto available_width = caption_available_space.width.to_px_or_zero();
                 block_context->resolve_vertical_box_model_metrics(child_box, available_width);
-                block_context->resolve_horizontal_box_model_metrics(child_box, available_width);
+                block_context->compute_width(child_box, caption_available_space);
+                inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
+            }
 
-                if (child_box.computed_values().width().is_auto()) {
-                    auto& caption_state = m_state.get_mutable(child_box);
-                    caption_state.set_content_width(available_width
-                        - caption_state.margin_left - caption_state.border_left - caption_state.padding_left
-                        - caption_state.padding_right - caption_state.border_right - caption_state.margin_right);
+            caption_context->run(inner_available_space);
 
-                    // Adjust x offset so border-box aligns with the table wrapper.
-                    caption_state.set_content_x(caption_state.offset.x() + caption_state.border_left + caption_state.padding_left);
-                }
+            if (block_context) {
+                auto& caption_state = m_state.get_mutable(child_box);
 
-                if (child_box.computed_values().height().is_auto()) {
+                // Adjust x offset so border-box aligns with the table wrapper.
+                caption_state.set_content_x(caption_state.offset.x() + caption_state.border_left + caption_state.padding_left);
+
+                if (should_treat_height_as_auto(child_box, caption_available_space)) {
                     auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_height();
-                    m_state.get_mutable(child_box).set_content_height(height);
+                    caption_state.set_content_height(height);
                 }
             }
         }

--- a/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
@@ -11,12 +11,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               BlockContainer <(anonymous)> at [50,120] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
                 TextNode <#text> (not painted)
           BlockContainer <figcaption> at [50,16] [0+2+0 102 0+2+0] [0+2+0 50 0+2+0] [BFC] children: not-inline
-            BlockContainer <(anonymous)> at [50,16] [0+0+0 106 0+0+0] [0+0+0 18 0+0+0] children: inline
+            BlockContainer <(anonymous)> at [50,16] [0+0+0 102 0+0+0] [0+0+0 18 0+0+0] children: inline
               frag 0 from TextNode start: 9, length: 12, rect: [50,16 100.609375x18] baseline: 13.796875
                   "Caption text"
               TextNode <#text> (not painted)
-            BlockContainer <div.caption-content> at [51,35] [0+1+0 104 0+1+0] [0+1+0 30 0+1+0] children: not-inline
-            BlockContainer <(anonymous)> at [50,66] [0+0+0 106 0+0+0] [0+0+0 0 0+0+0] children: inline
+            BlockContainer <div.caption-content> at [51,35] [0+1+0 100 0+1+0] [0+1+0 30 0+1+0] children: not-inline
+            BlockContainer <(anonymous)> at [50,66] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
               TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
@@ -34,10 +34,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer<DIV>.table-content) [50,68 102x52]
               PaintableWithLines (BlockContainer(anonymous)) [50,120 102x0]
           PaintableWithLines (BlockContainer<FIGCAPTION>) [48,14 106x54]
-            PaintableWithLines (BlockContainer(anonymous)) [50,16 106x18]
+            PaintableWithLines (BlockContainer(anonymous)) [50,16 102x18]
               TextPaintable (TextNode<#text>)
-            PaintableWithLines (BlockContainer<DIV>.caption-content) [50,34 106x32]
-            PaintableWithLines (BlockContainer(anonymous)) [50,66 106x0]
+            PaintableWithLines (BlockContainer<DIV>.caption-content) [50,34 102x32]
+            PaintableWithLines (BlockContainer(anonymous)) [50,66 102x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,192 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/table-caption-inline-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-caption-inline-width.txt
@@ -1,0 +1,42 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 77 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 61 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 208 0+0+576] [0+0+0 61 0+0+0] [BFC] children: not-inline
+        Box <table> at [9,29] table-box [0+1+0 206 0+1+0] [0+1+0 17 0+1+22] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+            TextNode <#text> (not painted)
+          BlockContainer <caption> at [15,8] [0+1+6 194 6+1+0] [0+1+0 20 0+1+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 10, rect: [62,8 100x10] baseline: 8
+                "AAAAAAAAAA"
+            frag 1 from TextNode start: 11, length: 14, rect: [42,18 140x10] baseline: 8
+                "BBBBBBBBB CCCC"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [11,31] table-row-group [0+0+0 202 0+0+0] [0+0+0 13 0+0+0] children: not-inline
+            Box <tr> at [11,31] table-row [0+0+0 202 0+0+0] [0+0+0 13 0+0+0] children: not-inline
+              BlockContainer <td> at [12,32] table-cell [0+0+1 200 1+0+0] [0+0+1 11 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [12,31 10x10] baseline: 8
+                    "x"
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,69] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x77]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x61]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 208x61]
+        PaintableBox (Box<TABLE>) [8,28 208x19]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,7 208x22]
+            TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TBODY>) [11,31 202x13]
+            PaintableBox (Box<TR>) [11,31 202x13]
+              PaintableWithLines (BlockContainer<TD>) [11,31 202x13]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,69 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x77] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -6,7 +6,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           BlockContainer <caption> at [18,8] [0+0+10 60.46875 10+0+0] [0+0+10 18 10+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 5, length: 7, rect: [28,8 60.46875x18] baseline: 13.796875
+            frag 0 from TextNode start: 5, length: 7, rect: [18,8 60.46875x18] baseline: 13.796875
                 "Caption"
             TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/input/table/table-caption-inline-width.html
+++ b/Tests/LibWeb/Layout/input/table/table-caption-inline-width.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: 'Ahem';
+    src: url('../../../Ref/data/fonts/Ahem.ttf');
+}
+table {
+    border: 1px solid black;
+    font: 10px/1 Ahem;
+}
+caption {
+    padding: 0 6px;
+    border: 1px solid gray;
+}
+</style>
+<table>
+    <!-- The text should not overflow the table border -->
+    <caption>AAAAAAAAAA BBBBBBBBB CCCC</caption>
+    <tr><td style="width: 200px">x</td></tr>
+</table>

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -525,7 +525,7 @@ if (!hasTestWaitClass()) {{
         wait_class));
 }
 
-static auto wait_for_crash_test_completion = generate_wait_for_test_string("test-wait"sv);
+static auto wait_for_test_completion = generate_wait_for_test_string("test-wait"sv);
 static auto wait_for_reftest_completion = generate_wait_for_test_string("reftest-wait"sv);
 
 static ByteString test_mode_to_string(TestMode mode)
@@ -806,11 +806,15 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
     };
 
     if (test.mode == TestMode::Layout) {
-        view.on_load_finish = [&view, &context, test_index, url, on_test_complete = move(on_test_complete)](auto const& loaded_url) {
+        view.on_load_finish = [&view, url](auto const& loaded_url) {
             // We don't want subframe loads to trigger the test finish.
             if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
                 return;
 
+            view.run_javascript(wait_for_test_completion);
+        };
+
+        view.on_test_finish = [&view, &context, test_index, on_test_complete = move(on_test_complete)](auto const&) {
             // NOTE: We take a screenshot here to force the lazy layout of SVG-as-image documents to happen.
             //       It also causes a lot more code to run, which is good for finding bugs. :^)
             view.take_screenshot()->when_resolved([&view, &context, test_index, on_test_complete = move(on_test_complete)](auto const&) {
@@ -895,7 +899,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
 
             auto& test = context.tests[test_index];
             test.did_finish_loading = true;
-            view.run_javascript(wait_for_crash_test_completion);
+            view.run_javascript(wait_for_test_completion);
 
             if (test.did_finish_test)
                 on_test_complete();


### PR DESCRIPTION
Previously, `run_caption_layout()` passed the table's border-box width as the available space to the caption's formatting context. The BFC then used this width directly for inline line breaking, causing text to overflow the caption's content box by the size of the caption's own border and padding.

This fixes an issue where text would occasionally overflow Wikipedia infoboxes.

Here's an example from https://en.wikipedia.org/wiki/Software_bug#Prevention:

Before:

<img width="287" height="275" alt="image" src="https://github.com/user-attachments/assets/343fa694-ac10-4a61-a293-b467726c193f" />


After:

<img width="287" height="275" alt="image" src="https://github.com/user-attachments/assets/fd676181-5860-4c6a-92ca-fdcc98199d04" />
