### PR TITLE
LibWeb: Handle uninitialized Navigation API in same-document navigation

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2755,7 +2755,11 @@ void perform_url_and_history_update_steps(DOM::Document& document, URL::URL new_
     // 11. Update the navigation API entries for a same-document navigation given document's relevant global object's navigation API, newEntry, and historyHandling.
     auto& relevant_global_object = as<Window>(HTML::relevant_global_object(document));
     auto navigation_type = history_handling == HistoryHandlingBehavior::Push ? Bindings::NavigationType::Push : Bindings::NavigationType::Replace;
-    relevant_global_object.navigation()->update_the_navigation_api_entries_for_a_same_document_navigation(new_entry, navigation_type);
+    
+    // Only update Navigation API entries if it has been properly initialized
+    if (relevant_global_object.navigation()->is_navigation_api_initialized()) {
+        relevant_global_object.navigation()->update_the_navigation_api_entries_for_a_same_document_navigation(new_entry, navigation_type);
+    }
 
     // 12. Let traversable be navigable's traversable navigable.
     auto traversable = navigable->traversable_navigable();

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -1466,13 +1466,6 @@ void Navigation::update_the_navigation_api_entries_for_a_same_document_navigatio
     if (has_entries_and_events_disabled())
         return;
 
-    // If the Navigation API has not been initialized yet (m_current_entry_index == -1),
-    // there is nothing to update. This can occur during document creation or reactivation
-    // before the navigation entries are properly set up.
-    if (m_current_entry_index == -1) {
-        return;
-    }
-
     // 2. Let oldCurrentNHE be the current entry of navigation.
     auto old_current_nhe = current_entry();
 

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -1466,6 +1466,13 @@ void Navigation::update_the_navigation_api_entries_for_a_same_document_navigatio
     if (has_entries_and_events_disabled())
         return;
 
+    // If the Navigation API has not been initialized yet (m_current_entry_index == -1),
+    // there is nothing to update. This can occur during document creation or reactivation
+    // before the navigation entries are properly set up.
+    if (m_current_entry_index == -1) {
+        return;
+    }
+
     // 2. Let oldCurrentNHE be the current entry of navigation.
     auto old_current_nhe = current_entry();
 

--- a/Libraries/LibWeb/HTML/Navigation.h
+++ b/Libraries/LibWeb/HTML/Navigation.h
@@ -136,6 +136,8 @@ public:
 
     void set_was_initial_about_blank_opened(bool b) { m_was_initial_about_blank_opened = b; }
 
+    bool is_navigation_api_initialized() const { return m_current_entry_index != -1; }
+
 private:
     explicit Navigation(JS::Realm&);
 

--- a/Tests/LibWeb/HTML/navigation-refresh-crash.html
+++ b/Tests/LibWeb/HTML/navigation-refresh-crash.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Navigation API Refresh Test</title>
+</head>
+<body>
+    <h1>Navigation API Refresh Test</h1>
+    <p>This page tests the Navigation API refresh crash issue.</p>
+    
+    <script>
+        // Test accessing navigation API
+        console.log('Navigation API available:', !!window.navigation);
+        
+        if (window.navigation) {
+            console.log('Current entry:', window.navigation.currentEntry);
+            console.log('Can go back:', window.navigation.canGoBack);
+            console.log('Can go forward:', window.navigation.canGoForward);
+            
+            // Test navigation events
+            window.navigation.addEventListener('navigate', (event) => {
+                console.log('Navigate event:', event);
+            });
+            
+            // Simulate refresh with history API
+            setTimeout(() => {
+                console.log('Testing history replaceState...');
+                try {
+                    history.replaceState({test: true}, 'Test Title', location.href);
+                    console.log('History replaceState succeeded');
+                } catch (e) {
+                    console.error('History replaceState failed:', e);
+                }
+            }, 100);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
The update_the_navigation_api_entries_for_a_same_document_navigation() function can be called before the Navigation API is initialized (m_current_entry_index == -1), particularly during document creation or reactivation scenarios.

Add a guard clause to return early when the Navigation API is not yet initialized, as there are no entries to update in this state. This prevents verification failures that cause browser crashes.

Fixes #8495 