### PR TITLE
LibWeb: Implement SVGTransform mutation methods

### DIFF
--- a/Libraries/LibWeb/SVG/SVGTransform.cpp
+++ b/Libraries/LibWeb/SVG/SVGTransform.cpp
@@ -1,10 +1,13 @@
 /*
  * Copyright (c) 2024, MacDue <macdue@dueutil.tech>
  * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright (c) 2026, Sawyer Ramsey <sawyereramsey@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
+#include <LibGfx/AffineTransform.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGTransformPrototype.h>
 #include <LibWeb/SVG/SVGTransform.h>
@@ -34,54 +37,56 @@ void SVGTransform::initialize(JS::Realm& realm)
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__type
 SVGTransform::Type SVGTransform::type()
 {
-    dbgln("FIXME: Implement SVGTransform::type()");
-    return SVGTransform::Type::Unknown;
+    return m_type;
 }
 
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__angle
 float SVGTransform::angle()
 {
-    dbgln("FIXME: Implement SVGTransform::angle()");
-    return 0;
+    return m_angle;
 }
 
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__setTranslate
 void SVGTransform::set_translate(float tx, float ty)
 {
-    (void)tx;
-    (void)ty;
-    dbgln("FIXME: Implement SVGTransform::set_translate(float tx, float ty)");
+    m_matrix = Gfx::AffineTransform {}.translate(tx, ty);
+    m_angle = 0;
+    m_type = Type::Translate;
 }
 
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__setScale
 void SVGTransform::set_scale(float sx, float sy)
 {
-    (void)sx;
-    (void)sy;
-    dbgln("FIXME: Implement SVGTransform::set_scale(float sx, float sy)");
+    m_matrix = Gfx::AffineTransform {}.scale(sx, sy);
+    m_angle = 0;
+    m_type = Type::Scale;
 }
 
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__setRotate
 void SVGTransform::set_rotate(float angle, float cx, float cy)
 {
-    (void)angle;
-    (void)cx;
-    (void)cy;
-    dbgln("FIXME: Implement SVGTransform::set_rotate(float angle, float cx, float cy)");
+    m_matrix = Gfx::AffineTransform {}
+                   .translate(cx, cy)
+                   .rotate_radians(AK::to_radians(angle))
+                   .translate(-cx, -cy);
+    m_angle = angle;
+    m_type = Type::Rotate;
 }
 
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__setSkewX
 void SVGTransform::set_skew_x(float angle)
 {
-    (void)angle;
-    dbgln("FIXME: Implement SVGTransform::set_skew_x(float angle)");
+    m_matrix = Gfx::AffineTransform {}.skew_radians(AK::to_radians(angle), 0);
+    m_angle = angle;
+    m_type = Type::SkewX;
 }
 
 // https://svgwg.org/svg2-draft/single-page.html#coords-__svg__SVGTransform__setSkewY
 void SVGTransform::set_skew_y(float angle)
 {
-    (void)angle;
-    dbgln("FIXME: Implement SVGTransform::set_skew_y(float angle)");
+    m_matrix = Gfx::AffineTransform {}.skew_radians(0, AK::to_radians(angle));
+    m_angle = angle;
+    m_type = Type::SkewY;
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGTransform.h
+++ b/Libraries/LibWeb/SVG/SVGTransform.h
@@ -7,11 +7,11 @@
 
 #pragma once
 
+#include <LibGfx/AffineTransform.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::SVG {
 
-// FIXME: This class is just a stub.
 // https://svgwg.org/svg2-draft/single-page.html#coords-InterfaceSVGTransform
 class SVGTransform final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SVGTransform, Bindings::PlatformObject);
@@ -42,6 +42,10 @@ public:
 
 private:
     SVGTransform(JS::Realm& realm);
+
+    Type m_type { Type::Unknown };
+    Gfx::AffineTransform m_matrix;
+    float m_angle { 0 };
 
     virtual void initialize(JS::Realm& realm) override;
 };


### PR DESCRIPTION
Implements the mutation methods for SVGTransform:
  - setTranslate
  - setScale
  - setRotate
  - setSkewX
  - setSkewY

Spec: https://svgwg.org/svg2-draft/single-page.html#coords-InterfaceSVGTransform