### PR TITLE
LibMedia+LibWeb: Handle media with unknown duration or size

### DIFF
--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
@@ -149,10 +149,9 @@ DecoderErrorOr<CodedFrame> MatroskaDemuxer::get_next_sample_for_track(Track cons
     return CodedFrame(timestamp, duration, flags, move(status.frames[status.frame_index++]), aux_data);
 }
 
-DecoderErrorOr<AK::Duration> MatroskaDemuxer::total_duration()
+DecoderErrorOr<Optional<AK::Duration>> MatroskaDemuxer::total_duration()
 {
-    auto duration = m_reader.duration();
-    return duration.value_or(AK::Duration::zero());
+    return m_reader.duration();
 }
 
 TimeRanges MatroskaDemuxer::buffered_time_ranges() const
@@ -165,7 +164,7 @@ TimeRanges MatroskaDemuxer::buffered_time_ranges() const
     return ranges;
 }
 
-DecoderErrorOr<AK::Duration> MatroskaDemuxer::duration_of_track(Track const&)
+DecoderErrorOr<Optional<AK::Duration>> MatroskaDemuxer::duration_of_track(Track const&)
 {
     return total_duration();
 }

--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
@@ -31,8 +31,8 @@ public:
 
     virtual DecoderErrorOr<DemuxerSeekResult> seek_to_most_recent_keyframe(Track const&, AK::Duration timestamp, DemuxerSeekOptions) override;
 
-    virtual DecoderErrorOr<AK::Duration> duration_of_track(Track const&) override;
-    virtual DecoderErrorOr<AK::Duration> total_duration() override;
+    virtual DecoderErrorOr<Optional<AK::Duration>> duration_of_track(Track const&) override;
+    virtual DecoderErrorOr<Optional<AK::Duration>> total_duration() override;
 
     virtual TimeRanges buffered_time_ranges() const override;
 

--- a/Libraries/LibMedia/Demuxer.h
+++ b/Libraries/LibMedia/Demuxer.h
@@ -54,8 +54,8 @@ public:
     // in the case that the timestamp is closer to the current time than the nearest keyframe.
     virtual DecoderErrorOr<DemuxerSeekResult> seek_to_most_recent_keyframe(Track const&, AK::Duration timestamp, DemuxerSeekOptions = DemuxerSeekOptions::None) = 0;
 
-    virtual DecoderErrorOr<AK::Duration> duration_of_track(Track const&) = 0;
-    virtual DecoderErrorOr<AK::Duration> total_duration() = 0;
+    virtual DecoderErrorOr<Optional<AK::Duration>> duration_of_track(Track const&) = 0;
+    virtual DecoderErrorOr<Optional<AK::Duration>> total_duration() = 0;
 
     virtual TimeRanges buffered_time_ranges() const = 0;
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -127,7 +127,8 @@ DecoderErrorOr<NonnullRefPtr<FFmpegDemuxer>> FFmpegDemuxer::from_stream(NonnullR
     TRY(initialize_format_context(format_context, *io_context->avio_context()));
 
     auto demuxer = DECODER_TRY_ALLOC(adopt_nonnull_ref_or_enomem(new (nothrow) FFmpegDemuxer(stream)));
-    demuxer->m_total_duration = AK::Duration::from_time_units(format_context->duration, 1, AV_TIME_BASE);
+    if (format_context->duration != AV_NOPTS_VALUE)
+        demuxer->m_total_duration = AK::Duration::from_time_units(format_context->duration, 1, AV_TIME_BASE);
 
     auto format_name = StringView(format_context->iformat->name, strlen(format_context->iformat->name));
     auto seen_types = HashTable<TrackType>();
@@ -139,7 +140,7 @@ DecoderErrorOr<NonnullRefPtr<FFmpegDemuxer>> FFmpegDemuxer::from_stream(NonnullR
         auto codec_id = media_codec_id_from_ffmpeg_codec_id(stream.codecpar->codec_id);
         auto codec_initialization_data = DECODER_TRY_ALLOC(ByteBuffer::copy(stream.codecpar->extradata, stream.codecpar->extradata_size));
 
-        AK::Duration duration;
+        Optional<AK::Duration> duration;
         if (stream.duration >= 0)
             duration = AK::Duration::from_time_units(stream.duration, stream.time_base.num, stream.time_base.den);
         else
@@ -212,7 +213,7 @@ static inline i64 duration_to_time_units(AK::Duration duration, AVRational const
     return duration.to_time_units(time_base.num, time_base.den);
 }
 
-DecoderErrorOr<AK::Duration> FFmpegDemuxer::total_duration()
+DecoderErrorOr<Optional<AK::Duration>> FFmpegDemuxer::total_duration()
 {
     return m_total_duration;
 }
@@ -221,12 +222,12 @@ TimeRanges FFmpegDemuxer::buffered_time_ranges() const
 {
     // FIXME: Use the format context's index to determine the buffered ranges from the underlying stream.
     TimeRanges ranges;
-    if (!m_total_duration.is_zero())
-        ranges.add_range(AK::Duration::zero(), m_total_duration);
+    if (m_total_duration.has_value() && !m_total_duration->is_zero())
+        ranges.add_range(AK::Duration::zero(), *m_total_duration);
     return ranges;
 }
 
-DecoderErrorOr<AK::Duration> FFmpegDemuxer::duration_of_track(Track const& track)
+DecoderErrorOr<Optional<AK::Duration>> FFmpegDemuxer::duration_of_track(Track const& track)
 {
     auto const& track_info = get_track_info(track);
     return track_info.duration;

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
@@ -32,8 +32,8 @@ public:
 
     virtual DecoderErrorOr<DemuxerSeekResult> seek_to_most_recent_keyframe(Track const&, AK::Duration timestamp, DemuxerSeekOptions) override;
 
-    virtual DecoderErrorOr<AK::Duration> duration_of_track(Track const&) override;
-    virtual DecoderErrorOr<AK::Duration> total_duration() override;
+    virtual DecoderErrorOr<Optional<AK::Duration>> duration_of_track(Track const&) override;
+    virtual DecoderErrorOr<Optional<AK::Duration>> total_duration() override;
 
     virtual TimeRanges buffered_time_ranges() const override;
 
@@ -52,7 +52,7 @@ private:
         Track track;
         CodecID codec_id;
         ByteBuffer codec_initialization_data;
-        AK::Duration duration;
+        Optional<AK::Duration> duration;
         i32 time_base_numerator;
         i32 time_base_denominator;
     };
@@ -80,7 +80,7 @@ private:
     TrackContext& get_track_context(Track const&);
 
     NonnullRefPtr<MediaStream> m_stream;
-    AK::Duration m_total_duration;
+    Optional<AK::Duration> m_total_duration;
     Vector<StreamInfo> m_stream_info;
     Array<int, to_underlying(TrackType::Unknown)> m_preferred_track_for_type;
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegIOContext.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegIOContext.cpp
@@ -56,8 +56,10 @@ ErrorOr<NonnullOwnPtr<FFmpegIOContext>> FFmpegIOContext::create(NonnullRefPtr<Me
             whence &= ~AVSEEK_FORCE;
 
             auto& stream_cursor = *static_cast<MediaStreamCursor*>(opaque);
-            if (whence == AVSEEK_SIZE)
-                return stream_cursor.size();
+            if (whence == AVSEEK_SIZE) {
+                auto size = stream_cursor.expected_size();
+                return size.has_value() ? static_cast<int64_t>(size.value()) : -1;
+            }
 
             auto seek_mode_from_whence = [](int origin) -> AK::SeekMode {
                 if (origin == SEEK_CUR)

--- a/Libraries/LibMedia/IncrementallyPopulatedStream.cpp
+++ b/Libraries/LibMedia/IncrementallyPopulatedStream.cpp
@@ -265,15 +265,27 @@ DecoderErrorOr<void> IncrementallyPopulatedStream::Cursor::seek(i64 offset, Seek
     case SeekMode::FromCurrentPosition:
         m_position += offset;
         break;
-    case SeekMode::FromEndPosition:
-        m_position = this->size() + offset;
+    case SeekMode::FromEndPosition: {
+        auto size = m_stream->expected_size();
+        if (!size.has_value())
+            return DecoderError::with_description(DecoderErrorCategory::EndOfStream, "Stream size is unknown, cannot seek from end"sv);
+        m_position = size.value() + offset;
         break;
+    }
     default:
         VERIFY_NOT_REACHED();
     }
 
     m_active_timeout = MonotonicTime::now_coarse() + CURSOR_ACTIVE_TIME;
     return {};
+}
+
+Optional<size_t> IncrementallyPopulatedStream::Cursor::expected_size() const
+{
+    auto size = m_stream->expected_size();
+    if (!size.has_value())
+        return {};
+    return size.value();
 }
 
 DecoderErrorOr<size_t> IncrementallyPopulatedStream::Cursor::read_into(Bytes bytes)

--- a/Libraries/LibMedia/IncrementallyPopulatedStream.h
+++ b/Libraries/LibMedia/IncrementallyPopulatedStream.h
@@ -56,6 +56,7 @@ public:
 
         virtual size_t position() const override { return m_position; }
         virtual size_t size() const override { return m_stream->size(); }
+        virtual Optional<size_t> expected_size() const override;
 
         virtual void abort() override;
         virtual void reset_abort() override { m_aborted = false; }

--- a/Libraries/LibMedia/MediaStream.h
+++ b/Libraries/LibMedia/MediaStream.h
@@ -21,6 +21,7 @@ public:
     virtual DecoderErrorOr<size_t> read_into(Bytes) = 0;
     virtual size_t position() const = 0;
     virtual size_t size() const = 0;
+    virtual Optional<size_t> expected_size() const { return size(); }
 
     virtual void abort() { }
     virtual void reset_abort() { }

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -76,7 +76,7 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
     if (preferred_audio_track.has_value() && !supported_audio_tracks.contains_slow(*preferred_audio_track))
         preferred_audio_track = {};
 
-    auto duration = demuxer->total_duration().value_or(AK::Duration::zero());
+    auto duration = TRY(demuxer->total_duration());
 
     auto main_thread_event_loop = main_thread_event_loop_reference->take();
     main_thread_event_loop->deferred_invoke([self, video_tracks = move(supported_video_tracks), video_track_datas = move(supported_video_track_datas), preferred_video_track, audio_tracks = move(supported_audio_tracks), audio_track_datas = move(supported_audio_track_datas), preferred_audio_track, duration] mutable {
@@ -109,7 +109,8 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
         if (!self->m_preferred_audio_track.has_value())
             self->m_preferred_audio_track = preferred_audio_track;
 
-        self->check_for_duration_change(duration);
+        if (duration.has_value())
+            self->check_for_duration_change(duration.value());
 
         self->set_up_data_providers();
 
@@ -277,11 +278,11 @@ void PlaybackManager::track_stopped_buffering(Track const& track)
 
 void PlaybackManager::check_for_duration_change(AK::Duration duration)
 {
-    if (m_duration >= duration)
+    if (m_duration.has_value() && m_duration.value() >= duration)
         return;
     m_duration = duration;
     if (on_duration_change)
-        on_duration_change(m_duration);
+        on_duration_change(duration);
 }
 
 void PlaybackManager::dispatch_error(DecoderError&& error)

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -55,9 +55,13 @@ public:
 
     void set_audio_output_disabled(bool disabled) { m_audio_output_disabled = disabled; }
 
-    AK::Duration duration() const { return m_duration; }
+    Optional<AK::Duration> duration() const { return m_duration; }
     void set_duration(AK::Duration duration) { m_duration = duration; }
-    AK::Duration current_time() const { return min(m_time_provider->current_time(), duration()); }
+    AK::Duration current_time() const
+    {
+        auto time = m_time_provider->current_time();
+        return m_duration.has_value() ? min(time, m_duration.value()) : time;
+    }
 
     auto const& video_tracks() const { return m_video_tracks; }
     auto const& audio_tracks() const { return m_audio_tracks; }
@@ -172,7 +176,7 @@ private:
     Optional<Track> m_preferred_video_track;
     Optional<Track> m_preferred_audio_track;
 
-    AK::Duration m_duration;
+    Optional<AK::Duration> m_duration;
 
     HashTable<Track> m_tracks_still_buffering;
 

--- a/Libraries/LibMedia/Providers/AudioDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.cpp
@@ -120,7 +120,7 @@ i64 AudioDataProvider::ThreadData::queue_end_sample() const
     return m_queue_end_sample;
 }
 
-AudioDataProvider::ThreadData::ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, AK::Duration duration, NonnullOwnPtr<Audio::AudioConverter>&& converter)
+AudioDataProvider::ThreadData::ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, Optional<AK::Duration> duration, NonnullOwnPtr<Audio::AudioConverter>&& converter)
     : m_main_thread_event_loop(main_thread_event_loop)
     , m_demuxer(demuxer)
     , m_track(track)
@@ -290,7 +290,7 @@ void AudioDataProvider::ThreadData::invoke_on_main_thread(Invokee invokee)
 void AudioDataProvider::ThreadData::dispatch_block_end_time(AudioBlock const& block)
 {
     auto end_time = block.end_timestamp();
-    if (end_time < m_duration)
+    if (m_duration.has_value() && end_time < m_duration.value())
         return;
     m_duration = end_time;
     invoke_on_main_thread_while_locked([end_time](auto const& self) {
@@ -557,7 +557,10 @@ void AudioDataProvider::ThreadData::push_data_and_decode_a_block()
 
 TimeRanges AudioDataProvider::ThreadData::buffered_time_ranges() const
 {
-    return m_demuxer->buffered_time_ranges();
+    auto ranges = m_demuxer->buffered_time_ranges();
+    if (ranges.is_empty() && m_duration.has_value())
+        ranges.add_range(AK::Duration::zero(), m_duration.value());
+    return ranges;
 }
 
 }

--- a/Libraries/LibMedia/Providers/AudioDataProvider.h
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.h
@@ -64,7 +64,7 @@ public:
 private:
     class ThreadData final : public AtomicRefCounted<ThreadData> {
     public:
-        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration, NonnullOwnPtr<Audio::AudioConverter>&&);
+        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, Optional<AK::Duration>, NonnullOwnPtr<Audio::AudioConverter>&&);
         ~ThreadData();
 
         void set_error_handler(ErrorHandler&&);
@@ -126,7 +126,7 @@ private:
 
         NonnullRefPtr<Demuxer> m_demuxer;
         Track m_track;
-        AK::Duration m_duration;
+        Optional<AK::Duration> m_duration;
         OwnPtr<AudioDecoder> m_decoder;
         bool m_decoder_needs_keyframe_next_seek { false };
         NonnullOwnPtr<Audio::AudioConverter> m_converter;

--- a/Libraries/LibMedia/Providers/VideoDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/VideoDataProvider.cpp
@@ -97,7 +97,7 @@ void VideoDataProvider::seek(AK::Duration timestamp, SeekMode seek_mode, SeekCom
     m_thread_data->seek(timestamp, seek_mode, move(completion_handler));
 }
 
-VideoDataProvider::ThreadData::ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, AK::Duration duration, RefPtr<MediaTimeProvider> const& time_provider)
+VideoDataProvider::ThreadData::ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const& demuxer, Track const& track, Optional<AK::Duration> duration, RefPtr<MediaTimeProvider> const& time_provider)
     : m_main_thread_event_loop(main_thread_event_loop)
     , m_demuxer(demuxer)
     , m_track(track)
@@ -272,7 +272,7 @@ void VideoDataProvider::ThreadData::invoke_on_main_thread(Invokee invokee)
 void VideoDataProvider::ThreadData::dispatch_frame_end_time(CodedFrame const& frame)
 {
     auto end_time = frame.timestamp() + frame.duration();
-    if (end_time < m_duration)
+    if (m_duration.has_value() && end_time < m_duration.value())
         return;
     m_duration = end_time;
     invoke_on_main_thread([end_time](auto const& self) {
@@ -570,7 +570,10 @@ bool VideoDataProvider::ThreadData::is_blocked() const
 
 TimeRanges VideoDataProvider::ThreadData::buffered_time_ranges() const
 {
-    return m_demuxer->buffered_time_ranges();
+    auto ranges = m_demuxer->buffered_time_ranges();
+    if (ranges.is_empty() && m_duration.has_value())
+        ranges.add_range(AK::Duration::zero(), m_duration.value());
+    return ranges;
 }
 
 }

--- a/Libraries/LibMedia/Providers/VideoDataProvider.h
+++ b/Libraries/LibMedia/Providers/VideoDataProvider.h
@@ -63,7 +63,7 @@ public:
 private:
     class ThreadData final : public AtomicRefCounted<ThreadData> {
     public:
-        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration, RefPtr<MediaTimeProvider> const&);
+        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, Optional<AK::Duration>, RefPtr<MediaTimeProvider> const&);
         ~ThreadData();
 
         void set_error_handler(ErrorHandler&&);
@@ -120,7 +120,7 @@ private:
 
         NonnullRefPtr<Demuxer> m_demuxer;
         Track m_track;
-        AK::Duration m_duration;
+        Optional<AK::Duration> m_duration;
         OwnPtr<VideoDecoder> m_decoder;
         bool m_decoder_needs_keyframe_next_seek { false };
 

--- a/Libraries/LibMedia/ReadonlyBytesCursor.h
+++ b/Libraries/LibMedia/ReadonlyBytesCursor.h
@@ -57,6 +57,7 @@ public:
 
     virtual size_t position() const override { return m_position; }
     virtual size_t size() const override { return m_data.size(); }
+    virtual Optional<size_t> expected_size() const override { return m_data.size(); }
 
     void set_data(ReadonlyBytes data) { m_data = data; }
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1687,14 +1687,18 @@ void HTMLMediaElement::on_metadata_parsed()
 
     // 4. Update the duration attribute with the time of the last frame of the resource, if known, on the media timeline established above. If it is
     //    not known (e.g. a stream that is in principle infinite), update the duration attribute to the value positive Infinity.
-    // FIXME: Handle unbounded media resources.
-    set_duration(m_playback_manager->duration().to_seconds_f64());
+    auto initial_duration = m_playback_manager->duration();
+    if (initial_duration.has_value()) {
+        set_duration(initial_duration->to_seconds_f64());
 
-    // NB: Register the duration change handler here so that we don't set the duration when the
-    //     playback manager updates the duration after parsing.
-    m_playback_manager->on_duration_change = GC::weak_callback(*this, [](auto& self, AK::Duration duration) {
-        self.set_duration(duration.to_seconds_f64());
-    });
+        // NB: Register the duration change handler here so that we don't set the duration when the
+        //     playback manager updates the duration after parsing.
+        m_playback_manager->on_duration_change = GC::weak_callback(*this, [](auto& self, AK::Duration duration) {
+            self.set_duration(duration.to_seconds_f64());
+        });
+    } else {
+        set_duration(INFINITY);
+    }
 
     // 5. For video elements, set the videoWidth and videoHeight attributes, and queue a media element task given the media element to fire an event
     //    named resize at the media element.
@@ -2137,7 +2141,6 @@ void HTMLMediaElement::update_ready_state()
     //        the buffered head.
     constexpr auto have_enough_data_duration = AK::Duration::from_seconds(5);
 
-    auto duration = m_playback_manager->duration();
     auto current_range_end = AK::Duration::zero();
     if (current_range.has_value())
         current_range_end = current_range->end;
@@ -2145,7 +2148,8 @@ void HTMLMediaElement::update_ready_state()
 
     // -> If HTMLMediaElement's buffered contains a TimeRanges that includes the current playback position and
     //    enough data to ensure uninterrupted playback:
-    if (has_future_data && (playable_duration >= have_enough_data_duration || current_range_end >= duration)) {
+    auto duration = m_playback_manager->duration();
+    if (has_future_data && (playable_duration >= have_enough_data_duration || (duration.has_value() && current_range_end >= duration.value()))) {
         // 1. Set the HTMLMediaElement's readyState attribute to HAVE_ENOUGH_DATA.
         set_ready_state(ReadyState::HaveEnoughData);
 
@@ -2401,8 +2405,9 @@ void HTMLMediaElement::seek_element(double playback_position, MediaSeekMode seek
     //     available, and, if it is, until it has decoded enough data to play back that position.
     if (m_playback_manager) {
         AK::Duration new_playback_position_as_duration;
-        if (playback_position == m_duration)
-            new_playback_position_as_duration = m_playback_manager->duration();
+        auto duration = m_playback_manager->duration();
+        if (duration.has_value() && playback_position == m_duration)
+            new_playback_position_as_duration = duration.value();
         else
             new_playback_position_as_duration = AK::Duration::from_seconds_f64(playback_position);
         m_playback_manager->seek(new_playback_position_as_duration, manager_seek_mode);

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/MediaControls.h>
+#include <LibWeb/HTML/TimeRanges.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/KeyboardEvent.h>
@@ -227,7 +228,7 @@ void MediaControls::set_up_event_listeners()
         VERIFY(m_media_element);
         VERIFY(m_dom->timeline_element);
 
-        auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
+        auto position = compute_timeline_position(event, *m_dom->timeline_element, effective_duration());
         if (!position.has_value())
             return false;
 
@@ -246,7 +247,7 @@ void MediaControls::set_up_event_listeners()
             VERIFY(m_media_element);
             VERIFY(m_dom->timeline_element);
 
-            auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
+            auto position = compute_timeline_position(event, *m_dom->timeline_element, effective_duration());
             if (!position.has_value())
                 return false;
 
@@ -261,7 +262,7 @@ void MediaControls::set_up_event_listeners()
             auto was_playing = m_scrubbing_timeline == Scrubbing::WhilePlaying;
             m_scrubbing_timeline = Scrubbing::No;
 
-            auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
+            auto position = compute_timeline_position(event, *m_dom->timeline_element, effective_duration());
             if (position.has_value())
                 set_current_time(*position);
 
@@ -482,12 +483,24 @@ void MediaControls::update_play_pause_icon()
     MUST(m_dom->play_pause_icon->class_list()->toggle(s_playing_class, !paused));
 }
 
+double MediaControls::effective_duration() const
+{
+    VERIFY(m_media_element);
+    auto duration = m_media_element->duration();
+    if (!isinf(duration))
+        return duration;
+    auto buffered = m_media_element->buffered();
+    if (buffered->length() > 0)
+        return MUST(buffered->end(buffered->length() - 1));
+    return 0.0;
+}
+
 void MediaControls::update_timeline()
 {
     VERIFY(m_media_element);
     VERIFY(m_dom->timeline_fill);
 
-    auto duration = m_media_element->duration();
+    auto duration = effective_duration();
     double percentage = 0.0;
     if (!isnan(duration) && duration > 0.0)
         percentage = (m_media_element->current_time() / duration) * 100.0;
@@ -505,9 +518,8 @@ void MediaControls::update_timestamp()
     VERIFY(m_dom->timestamp_element);
 
     auto current = human_readable_digital_time(round_to<i64>(m_media_element->current_time()));
-    auto duration = m_media_element->duration();
+    auto duration = effective_duration();
     auto total = human_readable_digital_time(isnan(duration) ? 0 : round_to<i64>(duration));
-
     MUST(m_dom->timestamp_element->set_text_content(Utf16String::formatted("{} / {}", current, total)));
 }
 

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -51,6 +51,7 @@ private:
     void toggle_mute();
     void toggle_fullscreen();
 
+    double effective_duration() const;
     void update_play_pause_icon();
     void update_timeline();
     void update_timestamp();

--- a/Libraries/LibWeb/MediaSourceExtensions/TrackBufferDemuxer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/TrackBufferDemuxer.cpp
@@ -236,12 +236,12 @@ Media::DecoderErrorOr<Media::DemuxerSeekResult> TrackBufferDemuxer::seek_to_most
     return Media::DemuxerSeekResult::MovedPosition;
 }
 
-Media::DecoderErrorOr<AK::Duration> TrackBufferDemuxer::duration_of_track(Media::Track const&)
+Media::DecoderErrorOr<Optional<AK::Duration>> TrackBufferDemuxer::duration_of_track(Media::Track const&)
 {
     return AK::Duration::zero();
 }
 
-Media::DecoderErrorOr<AK::Duration> TrackBufferDemuxer::total_duration()
+Media::DecoderErrorOr<Optional<AK::Duration>> TrackBufferDemuxer::total_duration()
 {
     return AK::Duration::zero();
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/TrackBufferDemuxer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/TrackBufferDemuxer.h
@@ -43,8 +43,8 @@ public:
     virtual Media::DecoderErrorOr<Media::CodecID> get_codec_id_for_track(Media::Track const&) override;
     virtual Media::DecoderErrorOr<ReadonlyBytes> get_codec_initialization_data_for_track(Media::Track const&) override;
     virtual Media::DecoderErrorOr<Media::DemuxerSeekResult> seek_to_most_recent_keyframe(Media::Track const&, AK::Duration, Media::DemuxerSeekOptions) override;
-    virtual Media::DecoderErrorOr<AK::Duration> duration_of_track(Media::Track const&) override;
-    virtual Media::DecoderErrorOr<AK::Duration> total_duration() override;
+    virtual Media::DecoderErrorOr<Optional<AK::Duration>> duration_of_track(Media::Track const&) override;
+    virtual Media::DecoderErrorOr<Optional<AK::Duration>> total_duration() override;
 
     virtual Media::TimeRanges buffered_time_ranges() const override;
 

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -240,6 +240,8 @@ int ConnectionFromClient::on_socket_callback(CURL*, int sockfd, int what, void* 
             notifier->set_enabled(true);
             return notifier;
         });
+    } else {
+        client->m_read_notifiers.remove(sockfd);
     }
 
     if (what & CURL_POLL_OUT) {
@@ -255,6 +257,8 @@ int ConnectionFromClient::on_socket_callback(CURL*, int sockfd, int what, void* 
             notifier->set_enabled(true);
             return notifier;
         });
+    } else {
+        client->m_write_notifiers.remove(sockfd);
     }
 
     return 0;


### PR DESCRIPTION
In this case, we report +Infinity duration for the media per the spec.
This can occur for media with no definitive duration, such as MP3s
streamed from radio servers (e.g. via Icecast)

Plus a drive-by RequestServer fix to not burn CPU when receiving infinite responses.