### PR TITLE
Meta: Update license copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018-2025, the Ladybird developers.
+Copyright (c) 2018-2026, the Ladybird developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The end year in the copyright range was still 2025.