### PR TITLE
LibJS: Cache missing GetById lookups

### DIFF
--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -920,23 +920,13 @@ i64 asm_try_get_by_id_cache(Interpreter* interp, u32 pc)
     auto& shape = object.shape();
     auto& cache = *bit_cast<PropertyLookupCache*>(insn.cache());
 
-    for (auto& entry : cache.entries) {
-        auto cached_prototype = entry.prototype.ptr();
-        if (cached_prototype) {
-            if (&shape != entry.shape) [[unlikely]]
+    for (size_t i = 0; i < cache.entries.size(); ++i) {
+        auto& entry = cache.entries[i];
+        auto type = cache.types[i];
+        if (type == PropertyLookupCache::Entry::Type::GetOwnProperty) {
+            auto cached_shape = entry.shape.ptr();
+            if (&shape != cached_shape) [[unlikely]]
                 continue;
-            if (shape.is_dictionary()
-                && shape.dictionary_generation() != entry.shape_dictionary_generation)
-                continue;
-            auto pcv = entry.prototype_chain_validity.ptr();
-            if (!pcv || !pcv->is_valid()) [[unlikely]]
-                continue;
-            auto value = cached_prototype->get_direct(entry.property_offset);
-            if (value.is_accessor()) [[unlikely]]
-                return 1;
-            interp->set(insn.dst(), value);
-            return 0;
-        } else if (&shape == entry.shape) {
             if (shape.is_dictionary()
                 && shape.dictionary_generation() != entry.shape_dictionary_generation)
                 continue;
@@ -944,6 +934,47 @@ i64 asm_try_get_by_id_cache(Interpreter* interp, u32 pc)
             if (value.is_accessor()) [[unlikely]]
                 return 1;
             interp->set(insn.dst(), value);
+            return 0;
+        }
+
+        if (type == PropertyLookupCache::Entry::Type::GetPropertyInPrototypeChain) {
+            auto cached_shape = entry.shape.ptr();
+            if (&shape != cached_shape) [[unlikely]]
+                continue;
+            if (shape.is_dictionary()
+                && shape.dictionary_generation() != entry.shape_dictionary_generation)
+                continue;
+            auto pcv = entry.prototype_chain_validity.ptr();
+            if (!pcv || !pcv->is_valid()) [[unlikely]]
+                continue;
+            auto cached_prototype = entry.prototype.ptr();
+            if (!cached_prototype) [[unlikely]]
+                continue;
+            auto value = cached_prototype->get_direct(entry.property_offset);
+            if (value.is_accessor()) [[unlikely]]
+                return 1;
+            interp->set(insn.dst(), value);
+            return 0;
+        }
+
+        if (type == PropertyLookupCache::Entry::Type::GetMissingProperty) {
+            if (!object.may_cache_get_by_id_missing_property())
+                continue;
+            auto cached_shape = entry.shape.ptr();
+            if (&shape != cached_shape) [[unlikely]]
+                continue;
+            if (shape.is_dictionary()
+                && shape.dictionary_generation() != entry.shape_dictionary_generation)
+                continue;
+            auto cached_prototype = entry.prototype.ptr();
+            auto pcv = entry.prototype_chain_validity.ptr();
+            if (cached_prototype) {
+                if (!pcv || !pcv->is_valid()) [[unlikely]]
+                    continue;
+            } else if (pcv && !pcv->is_valid()) [[unlikely]] {
+                continue;
+            }
+            interp->set(insn.dst(), js_undefined());
             return 0;
         }
     }

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1366,7 +1366,7 @@ handler PutByValue
     branch_bits_set t0, OBJECT_FLAG_MAY_INTERFERE, .slow
     # Packed is the hot path: existing elements can be overwritten directly.
     load8 t0, [t3, OBJECT_INDEXED_STORAGE_KIND]
-    branch_ne t0, INDEXED_STORAGE_KIND_PACKED, .not_packed
+    branch_ne t0, OBJECT_INDEXED_STORAGE_KIND_PACKED, .not_packed
     # Check index vs array_like_size
     load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
     branch_ge_unsigned t4, t5, .slow
@@ -1375,7 +1375,7 @@ handler PutByValue
     store64 [t5, t4, 8], t1
     dispatch_next
 .not_packed:
-    branch_ne t0, INDEXED_STORAGE_KIND_HOLEY, .slow
+    branch_ne t0, OBJECT_INDEXED_STORAGE_KIND_HOLEY, .slow
     # Holey arrays need a slot load to distinguish existing elements from holes.
     load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
     branch_ge_unsigned t4, t5, .slow
@@ -1492,8 +1492,12 @@ handler GetById
     # Check entry[0].shape matches Object's shape (direct pointer compare)
     load64 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE]
     branch_ne t0, t4, .try_cache
-    # Check entry[0].prototype (null = own property, non-null = prototype chain)
+    # Load entry[0].prototype. For missing-property cache entries this stores
+    # whether the original lookup had a prototype chain to validate.
     load64 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
+    # Distinguish own-property hits from negative-cache hits.
+    load8 t1, [t5, PROPERTY_LOOKUP_CACHE_TYPE0]
+    branch_eq t1, PROPERTY_LOOKUP_CACHE_TYPE_GET_MISSING_PROPERTY, .missing
     branch_nonzero t0, .proto
     # Check dictionary generation matches
     load32 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
@@ -1526,6 +1530,24 @@ handler GetById
     # Check value is not an accessor
     extract_tag t2, t0
     branch_eq t2, ACCESSOR_TAG, .try_cache
+    store_operand m_dst, t0
+    dispatch_next
+.missing:
+    load8 t1, [t3, OBJECT_FLAGS]
+    branch_bits_clear t1, OBJECT_FLAG_MAY_CACHE_GET_BY_ID_MISSING_PROPERTY, .try_cache
+    # Entry[0] caches a missing property. The receiver shape already matched
+    # before branching here. If the original lookup had a prototype chain,
+    # we need a live validity token before returning undefined.
+    branch_zero t0, .missing_check_dict
+    load64 t1, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE_CHAIN_VALIDITY]
+    branch_zero t1, .try_cache
+    load8 t2, [t1, PROTOTYPE_CHAIN_VALIDITY_VALID]
+    branch_zero t2, .try_cache
+.missing_check_dict:
+    load32 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    load32 t2, [t4, SHAPE_DICTIONARY_GENERATION]
+    branch_ne t0, t2, .try_cache
+    mov t0, UNDEFINED_SHIFTED
     store_operand m_dst, t0
     dispatch_next
 .try_cache:
@@ -1606,7 +1628,7 @@ handler GetByValue
     branch_bits_set t0, OBJECT_FLAG_MAY_INTERFERE, .slow
     # Packed is the hot path: in-bounds elements are always present.
     load8 t0, [t3, OBJECT_INDEXED_STORAGE_KIND]
-    branch_ne t0, INDEXED_STORAGE_KIND_PACKED, .not_packed
+    branch_ne t0, OBJECT_INDEXED_STORAGE_KIND_PACKED, .not_packed
     # Check index < array_like_size
     load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
     branch_ge_unsigned t4, t5, .slow
@@ -1617,7 +1639,7 @@ handler GetByValue
     store_operand m_dst, t0
     dispatch_next
 .not_packed:
-    branch_ne t0, INDEXED_STORAGE_KIND_HOLEY, .slow
+    branch_ne t0, OBJECT_INDEXED_STORAGE_KIND_HOLEY, .slow
     # Holey arrays need a slot load to distinguish present elements from holes.
     load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
     branch_ge_unsigned t4, t5, .slow
@@ -1742,8 +1764,12 @@ handler GetLength
     # Check entry[0].shape matches (direct pointer compare)
     load64 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE]
     branch_ne t0, t4, .slow
-    # Check entry[0].prototype is null (own-property only)
+    # Load entry[0].prototype. For missing-property cache entries this stores
+    # whether the original lookup had a prototype chain to validate.
     load64 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
+    # Distinguish own-property hits from negative-cache hits.
+    load8 t1, [t5, PROPERTY_LOOKUP_CACHE_TYPE0]
+    branch_eq t1, PROPERTY_LOOKUP_CACHE_TYPE_GET_MISSING_PROPERTY, .missing
     branch_nonzero t0, .slow
     # Check dictionary generation
     load32 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
@@ -1755,6 +1781,24 @@ handler GetLength
     load64 t0, [t5, t0, 8]
     extract_tag t2, t0
     branch_eq t2, ACCESSOR_TAG, .slow
+    store_operand m_dst, t0
+    dispatch_next
+.missing:
+    load8 t1, [t3, OBJECT_FLAGS]
+    branch_bits_clear t1, OBJECT_FLAG_MAY_CACHE_GET_BY_ID_MISSING_PROPERTY, .slow
+    # Entry[0] caches a missing property. The receiver shape already matched
+    # above. If the original lookup had a prototype chain, we need a live
+    # validity token before returning undefined.
+    branch_zero t0, .missing_check_dict
+    load64 t1, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE_CHAIN_VALIDITY]
+    branch_zero t1, .slow
+    load8 t2, [t1, PROTOTYPE_CHAIN_VALIDITY_VALID]
+    branch_zero t2, .slow
+.missing_check_dict:
+    load32 t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    load32 t2, [t4, SHAPE_DICTIONARY_GENERATION]
+    branch_ne t0, t2, .slow
+    mov t0, UNDEFINED_SHIFTED
     store_operand m_dst, t0
     dispatch_next
 .magical_length:

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -44,13 +44,16 @@ int main()
     EMIT_OFFSET(OBJECT_INDEXED_ARRAY_LIKE_SIZE, Object, m_indexed_array_like_size);
     EMIT_SIZEOF(OBJECT_SIZE, Object);
 
-    // Object flags byte
+    // Object flags
     outln("\n# Object flags");
     EMIT_OFFSET(OBJECT_FLAGS, Object, m_flags);
     outln("const OBJECT_FLAG_HAS_MAGICAL_LENGTH = {}", Object::Flag::HasMagicalLengthProperty);
     outln("const OBJECT_FLAG_MAY_INTERFERE = {}", Object::Flag::MayInterfereWithIndexedPropertyAccess);
     outln("const OBJECT_FLAG_IS_TYPED_ARRAY = {}", Object::Flag::IsTypedArray);
     outln("const OBJECT_FLAG_IS_FUNCTION = {}", Object::Flag::IsFunction);
+    outln("const OBJECT_FLAG_MAY_CACHE_GET_BY_ID_MISSING_PROPERTY = {}", Object::Flag::MayCacheGetByIdMissingProperty);
+    outln("const OBJECT_INDEXED_STORAGE_KIND_PACKED = {}", static_cast<u8>(IndexedStorageKind::Packed));
+    outln("const OBJECT_INDEXED_STORAGE_KIND_HOLEY = {}", static_cast<u8>(IndexedStorageKind::Holey));
 
     // Shape layout
     outln("\n# Shape layout");
@@ -60,8 +63,10 @@ int main()
 
     // PropertyLookupCache layout
     outln("\n# PropertyLookupCache layout");
+    EMIT_OFFSET(PROPERTY_LOOKUP_CACHE_TYPES, PropertyLookupCache, types);
     EMIT_OFFSET(PROPERTY_LOOKUP_CACHE_ENTRIES, PropertyLookupCache, entries);
     EMIT_SIZEOF(PROPERTY_LOOKUP_CACHE_SIZE, PropertyLookupCache);
+    outln("const PROPERTY_LOOKUP_CACHE_TYPE_GET_MISSING_PROPERTY = {}", to_underlying(PropertyLookupCache::Entry::Type::GetMissingProperty));
 
     // PropertyLookupCache::Entry layout
     outln("\n# PropertyLookupCache::Entry layout");
@@ -75,7 +80,9 @@ int main()
 
     // Composite offsets for entry[0] within a PropertyLookupCache
     outln("\n# Entry[0] offsets within PropertyLookupCache");
+    auto plc_types = offsetof(PropertyLookupCache, types);
     auto plc_entries = offsetof(PropertyLookupCache, entries);
+    outln("const PROPERTY_LOOKUP_CACHE_TYPE0 = {}", plc_types + 0 * sizeof(PropertyLookupCache::Entry::Type));
     outln("const PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET = {}", plc_entries + offsetof(PropertyLookupCache::Entry, property_offset));
     outln("const PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION = {}", plc_entries + offsetof(PropertyLookupCache::Entry, shape_dictionary_generation));
     outln("const PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE = {}", plc_entries + offsetof(PropertyLookupCache::Entry, shape));

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -32,13 +32,14 @@ namespace JS::Bytecode {
 struct PropertyLookupCache {
     static constexpr size_t max_number_of_shapes_to_remember = 4;
     struct Entry {
-        enum class Type {
+        enum class Type : u8 {
             Empty,
             AddOwnProperty,
             ChangeOwnProperty,
             GetOwnProperty,
             ChangePropertyInPrototypeChain,
             GetPropertyInPrototypeChain,
+            GetMissingProperty,
         };
         u32 property_offset { 0 };
         u32 shape_dictionary_generation { 0 };

--- a/Libraries/LibJS/Bytecode/PropertyAccess.h
+++ b/Libraries/LibJS/Bytecode/PropertyAccess.h
@@ -89,9 +89,34 @@ ALWAYS_INLINE ThrowCompletionOr<Value> get_by_id(VM& vm, GetBaseIdentifier get_b
 
     auto& shape = base_obj->shape();
 
-    for (auto& cache_entry : cache.entries) {
-        auto cached_prototype = cache_entry.prototype.ptr();
-        if (cached_prototype) {
+    for (size_t i = 0; i < cache.entries.size(); ++i) {
+        auto type = cache.types[i];
+        auto& cache_entry = cache.entries[i];
+        if (type == PropertyLookupCache::Entry::Type::GetOwnProperty) {
+            if (&shape != cache_entry.shape)
+                continue;
+
+            // OPTIMIZATION: If the shape of the object hasn't changed, we can use the cached property offset.
+            bool can_use_cache = true;
+            if (shape.is_dictionary()) {
+                if (shape.dictionary_generation() != cache_entry.shape_dictionary_generation) [[unlikely]]
+                    can_use_cache = false;
+            }
+
+            if (can_use_cache) [[likely]] {
+                auto value = base_obj->get_direct(cache_entry.property_offset);
+                if (value.is_accessor())
+                    return TRY(call(vm, value.as_accessor().getter(), this_value));
+                return value;
+            }
+            continue;
+        }
+
+        if (type == PropertyLookupCache::Entry::Type::GetPropertyInPrototypeChain) {
+            auto cached_prototype = cache_entry.prototype.ptr();
+            if (!cached_prototype)
+                continue;
+
             // OPTIMIZATION: If the prototype chain hasn't been mutated in a way that would invalidate the cache, we can use it.
             bool can_use_cache = [&]() -> bool {
                 if (&shape != cache_entry.shape) [[unlikely]]
@@ -110,28 +135,39 @@ ALWAYS_INLINE ThrowCompletionOr<Value> get_by_id(VM& vm, GetBaseIdentifier get_b
                     return false;
                 return true;
             }();
+
             if (can_use_cache) [[likely]] {
                 auto value = cached_prototype->get_direct(cache_entry.property_offset);
                 if (value.is_accessor())
                     return TRY(call(vm, value.as_accessor().getter(), this_value));
                 return value;
             }
-        } else if (&shape == cache_entry.shape) {
-            // OPTIMIZATION: If the shape of the object hasn't changed, we can use the cached property offset.
-            bool can_use_cache = true;
-            if (shape.is_dictionary()) {
-                if (shape.dictionary_generation() != cache_entry.shape_dictionary_generation) [[unlikely]] {
-                    can_use_cache = false;
-                }
-            }
+            continue;
+        }
 
-            if (can_use_cache) [[likely]] {
-                auto value = base_obj->get_direct(cache_entry.property_offset);
-                if (value.is_accessor()) {
-                    return TRY(call(vm, value.as_accessor().getter(), this_value));
-                }
-                return value;
+        if (type == PropertyLookupCache::Entry::Type::GetMissingProperty) {
+            if (!base_obj->may_cache_get_by_id_missing_property())
+                continue;
+            if (&shape != cache_entry.shape)
+                continue;
+            if (shape.is_dictionary()) {
+                if (shape.dictionary_generation() != cache_entry.shape_dictionary_generation) [[unlikely]]
+                    continue;
             }
+            auto cached_prototype = cache_entry.prototype.ptr();
+            auto cached_prototype_chain_validity = cache_entry.prototype_chain_validity.ptr();
+            if (cached_prototype) {
+                // Misses cached on objects with a prototype chain must keep their
+                // invalidation token alive; a cleared weak pointer means we need
+                // to re-check through the slow path.
+                if (!cached_prototype_chain_validity) [[unlikely]]
+                    continue;
+                if (!cached_prototype_chain_validity->is_valid()) [[unlikely]]
+                    continue;
+            } else if (cached_prototype_chain_validity && !cached_prototype_chain_validity->is_valid()) [[unlikely]] {
+                continue;
+            }
+            return js_undefined();
         }
     }
     GC::Ptr<PrototypeChainValidity> prototype_chain_validity;
@@ -145,30 +181,34 @@ ALWAYS_INLINE ThrowCompletionOr<Value> get_by_id(VM& vm, GetBaseIdentifier get_b
     // that collected metadata is valid, e.g. if getter in prototype chain added
     // property with the same name into the object itself.
     if (&shape == &base_obj->shape()) {
-        auto get_cache_slot = [&] -> PropertyLookupCache::Entry& {
-            for (size_t i = cache.entries.size() - 1; i >= 1; --i) {
-                cache.entries[i] = cache.entries[i - 1];
-            }
-            cache.entries[0] = {};
-            return cache.entries[0];
-        };
         if (cacheable_metadata.type == CacheableGetPropertyMetadata::Type::GetOwnProperty) {
-            auto& entry = get_cache_slot();
-            entry.shape = shape;
-            entry.property_offset = cacheable_metadata.property_offset.value();
+            cache.update(PropertyLookupCache::Entry::Type::GetOwnProperty, [&](auto& entry) {
+                entry.shape = shape;
+                entry.property_offset = cacheable_metadata.property_offset.value();
 
-            if (shape.is_dictionary()) {
-                entry.shape_dictionary_generation = shape.dictionary_generation();
-            }
+                if (shape.is_dictionary())
+                    entry.shape_dictionary_generation = shape.dictionary_generation();
+            });
         } else if (cacheable_metadata.type == CacheableGetPropertyMetadata::Type::GetPropertyInPrototypeChain) {
-            auto& entry = get_cache_slot();
-            entry.shape = &base_obj->shape();
-            entry.property_offset = cacheable_metadata.property_offset.value();
-            entry.prototype = const_cast<Object*>(cacheable_metadata.prototype.ptr());
-            entry.prototype_chain_validity = prototype_chain_validity;
+            cache.update(PropertyLookupCache::Entry::Type::GetPropertyInPrototypeChain, [&](auto& entry) {
+                entry.shape = &base_obj->shape();
+                entry.property_offset = cacheable_metadata.property_offset.value();
+                entry.prototype = const_cast<Object*>(cacheable_metadata.prototype.ptr());
+                entry.prototype_chain_validity = prototype_chain_validity;
 
-            if (shape.is_dictionary()) {
-                entry.shape_dictionary_generation = shape.dictionary_generation();
+                if (shape.is_dictionary())
+                    entry.shape_dictionary_generation = shape.dictionary_generation();
+            });
+        } else if (cacheable_metadata.type == CacheableGetPropertyMetadata::Type::GetMissingProperty) {
+            if (base_obj->may_cache_get_by_id_missing_property()) {
+                cache.update(PropertyLookupCache::Entry::Type::GetMissingProperty, [&](auto& entry) {
+                    entry.shape = &base_obj->shape();
+                    entry.prototype = shape.prototype();
+                    entry.prototype_chain_validity = prototype_chain_validity;
+
+                    if (shape.is_dictionary())
+                        entry.shape_dictionary_generation = shape.dictionary_generation();
+                });
             }
         }
     }

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1073,7 +1073,6 @@ Object* create_unmapped_arguments_object(VM& vm, ReadonlySpan<Value> arguments)
     // 2. Let obj be OrdinaryObjectCreate(%Object.prototype%, « [[ParameterMap]] »).
     // 3. Set obj.[[ParameterMap]] to undefined.
     auto object = Object::create_with_premade_shape(realm.intrinsics().unmapped_arguments_object_shape());
-    object->set_has_parameter_map();
 
     // 4. Perform ! DefinePropertyOrThrow(obj, "length", PropertyDescriptor { [[Value]]: 𝔽(len), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
     object->put_direct(realm.intrinsics().unmapped_arguments_object_length_offset(), Value(length));

--- a/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -21,7 +21,6 @@ ArgumentsObject::ArgumentsObject(Realm& realm, Environment& environment, bool pa
 void ArgumentsObject::initialize(Realm& realm)
 {
     Base::initialize(realm);
-    set_has_parameter_map();
 }
 
 void ArgumentsObject::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -255,6 +255,7 @@ void Intrinsics::initialize_intrinsics(Realm& realm)
 
     m_unmapped_arguments_object_shape = heap().allocate<Shape>(realm);
     m_unmapped_arguments_object_shape->set_prototype_without_transition(m_object_prototype);
+    m_unmapped_arguments_object_shape->set_has_parameter_map();
     m_unmapped_arguments_object_shape->add_property_without_transition(vm.names.length, Attribute::Writable | Attribute::Configurable);
     m_unmapped_arguments_object_shape->add_property_without_transition(vm.well_known_symbol_iterator(), Attribute::Writable | Attribute::Configurable);
     m_unmapped_arguments_object_shape->add_property_without_transition(vm.names.callee, 0);
@@ -264,6 +265,7 @@ void Intrinsics::initialize_intrinsics(Realm& realm)
 
     m_mapped_arguments_object_shape = heap().allocate<Shape>(realm);
     m_mapped_arguments_object_shape->set_prototype_without_transition(m_object_prototype);
+    m_mapped_arguments_object_shape->set_has_parameter_map();
     m_mapped_arguments_object_shape->add_property_without_transition(vm.names.length, Attribute::Writable | Attribute::Configurable);
     m_mapped_arguments_object_shape->add_property_without_transition(vm.well_known_symbol_iterator(), Attribute::Writable | Attribute::Configurable);
     m_mapped_arguments_object_shape->add_property_without_transition(vm.names.callee, Attribute::Writable | Attribute::Configurable);

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -14,7 +14,7 @@ namespace JS {
 GC_DEFINE_ALLOCATOR(ModuleNamespaceObject);
 
 ModuleNamespaceObject::ModuleNamespaceObject(Realm& realm, Module* module, Vector<Utf16FlyString> exports)
-    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes)
+    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes, MayCacheGetByIdMissingProperty::No)
     , m_module(module)
     , m_exports(move(exports))
 {

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -110,45 +110,55 @@ GC::Ref<Object> Object::create_with_premade_shape(Shape& shape)
     return shape.realm().create<Object>(shape);
 }
 
-Object::Object(GlobalObjectTag, Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+Object::Object(GlobalObjectTag, Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty may_cache_get_by_id_missing_property)
 {
     if (may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
         set_may_interfere_with_indexed_property_access();
+    if (may_cache_get_by_id_missing_property == MayCacheGetByIdMissingProperty::No)
+        clear_may_cache_get_by_id_missing_property();
     // This is the global object
     m_shape = heap().allocate<Shape>(realm);
 }
 
-Object::Object(ConstructWithoutPrototypeTag, Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+Object::Object(ConstructWithoutPrototypeTag, Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty may_cache_get_by_id_missing_property)
 {
     if (may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
         set_may_interfere_with_indexed_property_access();
+    if (may_cache_get_by_id_missing_property == MayCacheGetByIdMissingProperty::No)
+        clear_may_cache_get_by_id_missing_property();
     m_shape = heap().allocate<Shape>(realm);
 }
 
-Object::Object(Realm& realm, Object* prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+Object::Object(Realm& realm, Object* prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty may_cache_get_by_id_missing_property)
 {
     if (may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
         set_may_interfere_with_indexed_property_access();
+    if (may_cache_get_by_id_missing_property == MayCacheGetByIdMissingProperty::No)
+        clear_may_cache_get_by_id_missing_property();
     m_shape = realm.intrinsics().empty_object_shape();
     VERIFY(m_shape);
     if (prototype != nullptr)
         set_prototype(prototype);
 }
 
-Object::Object(ConstructWithPrototypeTag, Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+Object::Object(ConstructWithPrototypeTag, Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty may_cache_get_by_id_missing_property)
 {
     if (may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
         set_may_interfere_with_indexed_property_access();
+    if (may_cache_get_by_id_missing_property == MayCacheGetByIdMissingProperty::No)
+        clear_may_cache_get_by_id_missing_property();
     m_shape = prototype.shape().realm().intrinsics().empty_object_shape();
     VERIFY(m_shape);
     set_prototype(&prototype);
 }
 
-Object::Object(Shape& shape, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+Object::Object(Shape& shape, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty may_cache_get_by_id_missing_property)
     : m_shape(&shape)
 {
     if (may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
         set_may_interfere_with_indexed_property_access();
+    if (may_cache_get_by_id_missing_property == MayCacheGetByIdMissingProperty::No)
+        clear_may_cache_get_by_id_missing_property();
     if (shape.property_count() > 0)
         ensure_named_storage_capacity(shape.property_count());
 }
@@ -996,8 +1006,16 @@ ThrowCompletionOr<Value> Object::internal_get(PropertyKey const& property_key, V
         auto* parent = TRY(internal_get_prototype_of());
 
         // b. If parent is null, return undefined.
-        if (!parent)
+        if (!parent) {
+            if (cacheable_metadata) {
+                *cacheable_metadata = CacheableGetPropertyMetadata {
+                    .type = CacheableGetPropertyMetadata::Type::GetMissingProperty,
+                    .property_offset = {},
+                    .prototype = nullptr,
+                };
+            }
             return js_undefined();
+        }
 
         // c. Return ? parent.[[Get]](P, Receiver).
         return parent->internal_get(property_key, receiver, cacheable_metadata, PropertyLookupPhase::PrototypeChain);
@@ -1456,7 +1474,7 @@ ThrowCompletionOr<void> Object::for_each_own_property_with_enumerability(Functio
             auto indices = indexed_indices();
             for (auto index : indices) {
                 bool enumerable = true;
-                if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+                if (indexed_storage_kind() == IndexedStorageKind::Dictionary) {
                     auto result = indexed_dictionary()->get(index);
                     if (result.has_value())
                         enumerable = result->attributes.is_enumerable();
@@ -1616,7 +1634,7 @@ void Object::visit_edges(Cell::Visitor& visitor)
     if (auto count = shape().property_count())
         visitor.visit(Span<Value> { m_named_properties, count });
 
-    switch (m_indexed_storage_kind) {
+    switch (indexed_storage_kind()) {
     case IndexedStorageKind::None:
         break;
     case IndexedStorageKind::Packed:
@@ -1690,7 +1708,7 @@ static constexpr size_t LENGTH_SETTER_GENERIC_STORAGE_THRESHOLD = 4 * MiB;
 
 GenericIndexedPropertyStorage* Object::indexed_dictionary() const
 {
-    VERIFY(m_indexed_storage_kind == IndexedStorageKind::Dictionary);
+    VERIFY(indexed_storage_kind() == IndexedStorageKind::Dictionary);
     return reinterpret_cast<GenericIndexedPropertyStorage*>(m_indexed_elements);
 }
 
@@ -1698,7 +1716,8 @@ u32 Object::indexed_elements_capacity() const
 {
     if (!m_indexed_elements)
         return 0;
-    VERIFY(m_indexed_storage_kind == IndexedStorageKind::Packed || m_indexed_storage_kind == IndexedStorageKind::Holey);
+    auto storage_kind = indexed_storage_kind();
+    VERIFY(storage_kind == IndexedStorageKind::Packed || storage_kind == IndexedStorageKind::Holey);
     // Capacity is stored as a u32 at (m_indexed_elements - sizeof(u64))
     return *reinterpret_cast<u32 const*>(reinterpret_cast<u8 const*>(m_indexed_elements) - sizeof(u64));
 }
@@ -1727,13 +1746,13 @@ static void deallocate_indexed_elements(Value* elements)
 
 void Object::free_indexed_elements()
 {
-    if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+    if (indexed_storage_kind() == IndexedStorageKind::Dictionary) {
         delete indexed_dictionary();
     } else {
         deallocate_indexed_elements(m_indexed_elements);
     }
     m_indexed_elements = nullptr;
-    m_indexed_storage_kind = IndexedStorageKind::None;
+    set_indexed_storage_kind(IndexedStorageKind::None);
     m_indexed_array_like_size = 0;
 }
 
@@ -1767,7 +1786,8 @@ void Object::transition_to_dictionary()
 {
     auto* dict = new GenericIndexedPropertyStorage();
 
-    if (m_indexed_storage_kind == IndexedStorageKind::Packed || m_indexed_storage_kind == IndexedStorageKind::Holey) {
+    auto storage_kind = indexed_storage_kind();
+    if (storage_kind == IndexedStorageKind::Packed || storage_kind == IndexedStorageKind::Holey) {
         // Transfer existing elements
         u32 count = m_indexed_array_like_size;
         for (u32 i = 0; i < count; ++i) {
@@ -1782,12 +1802,12 @@ void Object::transition_to_dictionary()
     dict->set_array_like_size(m_indexed_array_like_size);
 
     m_indexed_elements = reinterpret_cast<Value*>(dict);
-    m_indexed_storage_kind = IndexedStorageKind::Dictionary;
+    set_indexed_storage_kind(IndexedStorageKind::Dictionary);
 }
 
 Optional<ValueAndAttributes> Object::indexed_get(u32 index) const
 {
-    switch (m_indexed_storage_kind) {
+    switch (indexed_storage_kind()) {
     case IndexedStorageKind::None:
         return {};
     case IndexedStorageKind::Packed:
@@ -1810,7 +1830,7 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
 {
     bool const storing_hole = value.is_special_empty_value();
 
-    if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+    if (indexed_storage_kind() == IndexedStorageKind::Dictionary) {
         indexed_dictionary()->put(index, value, attributes);
         m_indexed_array_like_size = indexed_dictionary()->array_like_size();
         return;
@@ -1818,7 +1838,7 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
 
     // Non-default attributes require Dictionary mode
     if (attributes != default_attributes) {
-        if (m_indexed_storage_kind != IndexedStorageKind::Dictionary)
+        if (indexed_storage_kind() != IndexedStorageKind::Dictionary)
             transition_to_dictionary();
         indexed_dictionary()->put(index, value, attributes);
         m_indexed_array_like_size = indexed_dictionary()->array_like_size();
@@ -1827,15 +1847,15 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
 
     // Check for sparse threshold
     if (index > m_indexed_array_like_size + SPARSE_ARRAY_HOLE_THRESHOLD) {
-        if (m_indexed_storage_kind != IndexedStorageKind::Dictionary)
+        if (indexed_storage_kind() != IndexedStorageKind::Dictionary)
             transition_to_dictionary();
         indexed_dictionary()->put(index, value, attributes);
         m_indexed_array_like_size = indexed_dictionary()->array_like_size();
         return;
     }
 
-    if (m_indexed_storage_kind == IndexedStorageKind::None) {
-        m_indexed_storage_kind = storing_hole || index > 0 ? IndexedStorageKind::Holey : IndexedStorageKind::Packed;
+    if (indexed_storage_kind() == IndexedStorageKind::None) {
+        set_indexed_storage_kind(storing_hole || index > 0 ? IndexedStorageKind::Holey : IndexedStorageKind::Packed);
         u32 needed = index + 1;
         ensure_indexed_elements(needed);
         m_indexed_elements[index] = value;
@@ -1849,23 +1869,23 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
         u32 new_size = index + 1;
         ensure_indexed_elements(new_size);
 
-        if (m_indexed_storage_kind == IndexedStorageKind::Packed
+        if (indexed_storage_kind() == IndexedStorageKind::Packed
             && (index > m_indexed_array_like_size || storing_hole)) {
             // Gap created
-            m_indexed_storage_kind = IndexedStorageKind::Holey;
+            set_indexed_storage_kind(IndexedStorageKind::Holey);
         }
 
         m_indexed_array_like_size = new_size;
     }
 
-    if (m_indexed_storage_kind == IndexedStorageKind::Packed && storing_hole)
-        m_indexed_storage_kind = IndexedStorageKind::Holey;
+    if (indexed_storage_kind() == IndexedStorageKind::Packed && storing_hole)
+        set_indexed_storage_kind(IndexedStorageKind::Holey);
 
     m_indexed_elements[index] = value;
 
     // Promote Holey -> Packed when filling the last hole.
     // Only check when writing to the last index to avoid O(N^2) scanning.
-    if (m_indexed_storage_kind == IndexedStorageKind::Holey && index == m_indexed_array_like_size - 1) {
+    if (indexed_storage_kind() == IndexedStorageKind::Holey && index == m_indexed_array_like_size - 1) {
         bool has_holes = false;
         for (u32 i = 0; i < m_indexed_array_like_size; ++i) {
             if (m_indexed_elements[i].is_special_empty_value()) {
@@ -1874,13 +1894,13 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
             }
         }
         if (!has_holes)
-            m_indexed_storage_kind = IndexedStorageKind::Packed;
+            set_indexed_storage_kind(IndexedStorageKind::Packed);
     }
 }
 
 bool Object::indexed_has(u32 index) const
 {
-    switch (m_indexed_storage_kind) {
+    switch (indexed_storage_kind()) {
     case IndexedStorageKind::None:
         return false;
     case IndexedStorageKind::Packed:
@@ -1895,14 +1915,14 @@ bool Object::indexed_has(u32 index) const
 
 void Object::indexed_delete(u32 index)
 {
-    switch (m_indexed_storage_kind) {
+    switch (indexed_storage_kind()) {
     case IndexedStorageKind::None:
         VERIFY_NOT_REACHED();
         break;
     case IndexedStorageKind::Packed:
         VERIFY(index < m_indexed_array_like_size);
         m_indexed_elements[index] = js_special_empty_value();
-        m_indexed_storage_kind = IndexedStorageKind::Holey;
+        set_indexed_storage_kind(IndexedStorageKind::Holey);
         break;
     case IndexedStorageKind::Holey:
         VERIFY(index < m_indexed_array_like_size);
@@ -1916,10 +1936,10 @@ void Object::indexed_delete(u32 index)
 
 bool Object::set_indexed_array_like_size(size_t new_size)
 {
-    if (new_size == m_indexed_array_like_size && m_indexed_storage_kind != IndexedStorageKind::None)
+    if (new_size == m_indexed_array_like_size && indexed_storage_kind() != IndexedStorageKind::None)
         return true;
 
-    if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+    if (indexed_storage_kind() == IndexedStorageKind::Dictionary) {
         bool result = indexed_dictionary()->set_array_like_size(new_size);
         m_indexed_array_like_size = indexed_dictionary()->array_like_size();
         return result;
@@ -1937,10 +1957,10 @@ bool Object::set_indexed_array_like_size(size_t new_size)
     u32 old_size = m_indexed_array_like_size;
     auto new_size_u32 = static_cast<u32>(new_size);
 
-    if (m_indexed_storage_kind == IndexedStorageKind::None) {
+    if (indexed_storage_kind() == IndexedStorageKind::None) {
         if (new_size_u32 == 0)
             return true;
-        m_indexed_storage_kind = IndexedStorageKind::Holey;
+        set_indexed_storage_kind(IndexedStorageKind::Holey);
         ensure_indexed_elements(new_size_u32);
         m_indexed_array_like_size = new_size_u32;
         return true;
@@ -1948,8 +1968,8 @@ bool Object::set_indexed_array_like_size(size_t new_size)
 
     if (new_size_u32 > old_size) {
         ensure_indexed_elements(new_size_u32);
-        if (m_indexed_storage_kind == IndexedStorageKind::Packed)
-            m_indexed_storage_kind = IndexedStorageKind::Holey;
+        if (indexed_storage_kind() == IndexedStorageKind::Packed)
+            set_indexed_storage_kind(IndexedStorageKind::Holey);
         m_indexed_array_like_size = new_size_u32;
         return true;
     }
@@ -1972,7 +1992,7 @@ void Object::indexed_append(Value value, PropertyAttributes attributes)
 
 ValueAndAttributes Object::indexed_take_first()
 {
-    if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+    if (indexed_storage_kind() == IndexedStorageKind::Dictionary) {
         auto result = indexed_dictionary()->take_first();
         m_indexed_array_like_size = indexed_dictionary()->array_like_size();
         return result;
@@ -1994,7 +2014,7 @@ ValueAndAttributes Object::indexed_take_first()
 
 ValueAndAttributes Object::indexed_take_last()
 {
-    if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+    if (indexed_storage_kind() == IndexedStorageKind::Dictionary) {
         auto result = indexed_dictionary()->take_last();
         m_indexed_array_like_size = indexed_dictionary()->array_like_size();
         return result;
@@ -2012,7 +2032,7 @@ ValueAndAttributes Object::indexed_take_last()
 
 size_t Object::indexed_real_size() const
 {
-    switch (m_indexed_storage_kind) {
+    switch (indexed_storage_kind()) {
     case IndexedStorageKind::None:
         return 0;
     case IndexedStorageKind::Packed:
@@ -2033,7 +2053,7 @@ size_t Object::indexed_real_size() const
 
 Vector<u32> Object::indexed_indices() const
 {
-    switch (m_indexed_storage_kind) {
+    switch (indexed_storage_kind()) {
     case IndexedStorageKind::None:
         return {};
     case IndexedStorageKind::Packed: {
@@ -2069,7 +2089,7 @@ void Object::set_indexed_property_elements(Vector<Value>&& values)
         return;
 
     u32 size = values.size();
-    m_indexed_storage_kind = IndexedStorageKind::Packed;
+    set_indexed_storage_kind(IndexedStorageKind::Packed);
     m_indexed_array_like_size = size;
     m_indexed_elements = allocate_indexed_elements(size);
     for (u32 i = 0; i < size; ++i)
@@ -2078,7 +2098,7 @@ void Object::set_indexed_property_elements(Vector<Value>&& values)
 
 ReadonlySpan<Value> Object::indexed_packed_elements_span() const
 {
-    VERIFY(m_indexed_storage_kind == IndexedStorageKind::Packed);
+    VERIFY(indexed_storage_kind() == IndexedStorageKind::Packed);
     return { m_indexed_elements, m_indexed_array_like_size };
 }
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -47,10 +47,11 @@ struct PrivateElement {
 // Non-standard: This is information optionally returned by object property access functions.
 //               It can be used to implement inline caches for property lookup.
 struct CacheableGetPropertyMetadata {
-    enum class Type {
+    enum class Type : u8 {
         NotCacheable,
         GetOwnProperty,
         GetPropertyInPrototypeChain,
+        GetMissingProperty,
     };
     Type type { Type::NotCacheable };
     Optional<u32> property_offset;
@@ -105,6 +106,11 @@ public:
     };
 
     enum class MayInterfereWithIndexedPropertyAccess {
+        No,
+        Yes,
+    };
+
+    enum class MayCacheGetByIdMissingProperty {
         No,
         Yes,
     };
@@ -190,6 +196,10 @@ public:
 
     [[nodiscard]] bool may_interfere_with_indexed_property_access() const { return m_flags & Flag::MayInterfereWithIndexedPropertyAccess; }
     void set_may_interfere_with_indexed_property_access() { m_flags |= Flag::MayInterfereWithIndexedPropertyAccess; }
+
+    [[nodiscard]] bool may_cache_get_by_id_missing_property() const { return m_flags & Flag::MayCacheGetByIdMissingProperty; }
+    void set_may_cache_get_by_id_missing_property() { m_flags |= Flag::MayCacheGetByIdMissingProperty; }
+    void clear_may_cache_get_by_id_missing_property() { m_flags &= ~Flag::MayCacheGetByIdMissingProperty; }
 
     ThrowCompletionOr<bool> ordinary_set_with_own_descriptor(PropertyKey const&, Value, Value, Optional<PropertyDescriptor>, CacheableSetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty);
 
@@ -310,7 +320,7 @@ public:
     template<typename Callback>
     void indexed_for_each_value(Callback callback)
     {
-        switch (m_indexed_storage_kind) {
+        switch (indexed_storage_kind()) {
         case IndexedStorageKind::None:
             break;
         case IndexedStorageKind::Packed:
@@ -360,16 +370,16 @@ protected:
     enum class ConstructWithoutPrototypeTag { Tag };
     enum class ConstructWithPrototypeTag { Tag };
 
-    Object(GlobalObjectTag, Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
-    Object(ConstructWithoutPrototypeTag, Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
-    Object(Realm&, Object* prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
-    Object(ConstructWithPrototypeTag, Object& prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
-    explicit Object(Shape&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    Object(GlobalObjectTag, Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No, MayCacheGetByIdMissingProperty = MayCacheGetByIdMissingProperty::Yes);
+    Object(ConstructWithoutPrototypeTag, Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No, MayCacheGetByIdMissingProperty = MayCacheGetByIdMissingProperty::Yes);
+    Object(Realm&, Object* prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No, MayCacheGetByIdMissingProperty = MayCacheGetByIdMissingProperty::Yes);
+    Object(ConstructWithPrototypeTag, Object& prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No, MayCacheGetByIdMissingProperty = MayCacheGetByIdMissingProperty::Yes);
+    explicit Object(Shape&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No, MayCacheGetByIdMissingProperty = MayCacheGetByIdMissingProperty::Yes);
 
 private:
     struct Flag {
         static constexpr u8 IsExtensible = 1 << 0;
-        static constexpr u8 HasParameterMap = 1 << 1;
+        static constexpr u8 MayCacheGetByIdMissingProperty = 1 << 1;
         static constexpr u8 HasMagicalLengthProperty = 1 << 2;
         static constexpr u8 IsTypedArray = 1 << 3;
         static constexpr u8 MayInterfereWithIndexedPropertyAccess = 1 << 4;
@@ -378,7 +388,12 @@ private:
         static constexpr u8 IsFunction = 1 << 7;
     };
 
-    u8 m_flags { Flag::IsExtensible };
+    void set_indexed_storage_kind(IndexedStorageKind indexed_storage_kind)
+    {
+        m_indexed_storage_kind = indexed_storage_kind;
+    }
+
+    u8 m_flags { Flag::IsExtensible | Flag::MayCacheGetByIdMissingProperty };
     IndexedStorageKind m_indexed_storage_kind { IndexedStorageKind::None };
     // 2 bytes padding
     u32 m_indexed_array_like_size { 0 };

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -285,8 +285,7 @@ public:
     // B.3.7 The [[IsHTMLDDA]] Internal Slot, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
     virtual bool is_htmldda() const { return false; }
 
-    bool has_parameter_map() const { return m_flags & Flag::HasParameterMap; }
-    void set_has_parameter_map() { m_flags |= Flag::HasParameterMap; }
+    bool has_parameter_map() const { return shape().has_parameter_map(); }
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -46,6 +46,8 @@ ProxyObject::ProxyObject(Object& target, Object& handler, Object& prototype)
     , m_target(target)
     , m_handler(handler)
 {
+    clear_may_cache_get_by_id_missing_property();
+
     // A Proxy is callable iff its target is callable.
     if (!target.is_function())
         clear_is_function();

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -28,6 +28,7 @@ GC::Ref<Shape> Shape::create_dictionary_transition()
 {
     auto new_shape = heap().allocate<Shape>(m_realm);
     new_shape->m_dictionary = true;
+    new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     ensure_property_table();
@@ -142,6 +143,7 @@ Shape::Shape(Realm& realm)
 Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAttributes attributes, TransitionType transition_type)
     : m_attributes(attributes)
     , m_transition_type(transition_type)
+    , m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
     , m_previous(&previous_shape)
     , m_property_key(property_key)
@@ -152,6 +154,7 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAtt
 
 Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionType transition_type)
     : m_transition_type(transition_type)
+    , m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
     , m_previous(&previous_shape)
     , m_property_key(property_key)
@@ -163,6 +166,7 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionT
 
 Shape::Shape(Shape& previous_shape, Object* new_prototype)
     : m_transition_type(TransitionType::Prototype)
+    , m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
     , m_previous(&previous_shape)
     , m_prototype(new_prototype)
@@ -321,6 +325,7 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     auto new_shape = heap().allocate<Shape>(m_realm);
     m_realm->all_prototype_shapes().set(new_shape);
     new_shape->m_is_prototype_shape = true;
+    new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     ensure_property_table();
     new_shape->ensure_property_table();

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -87,6 +87,8 @@ public:
     void set_property_attributes_without_transition(PropertyKey const&, PropertyAttributes);
 
     [[nodiscard]] bool is_dictionary() const { return m_dictionary; }
+    [[nodiscard]] bool has_parameter_map() const { return m_has_parameter_map; }
+    void set_has_parameter_map() { m_has_parameter_map = true; }
 
     [[nodiscard]] u32 dictionary_generation() const { return m_dictionary_generation; }
 
@@ -130,6 +132,7 @@ private:
 
     bool m_dictionary : 1 { false };
     bool m_is_prototype_shape : 1 { false };
+    bool m_has_parameter_map : 1 { false };
 
     GC::Ref<Realm> m_realm;
 

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -14,12 +14,12 @@
 namespace Web::Bindings {
 
 PlatformObject::PlatformObject(JS::Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
-    : JS::Object(realm, nullptr, may_interfere_with_indexed_property_access)
+    : JS::Object(realm, nullptr, may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty::No)
 {
 }
 
 PlatformObject::PlatformObject(JS::Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
-    : JS::Object(ConstructWithPrototypeTag::Tag, prototype, may_interfere_with_indexed_property_access)
+    : JS::Object(ConstructWithPrototypeTag::Tag, prototype, may_interfere_with_indexed_property_access, MayCacheGetByIdMissingProperty::No)
 {
 }
 

--- a/Tests/LibJS/Runtime/modules/basic-modules.js
+++ b/Tests/LibJS/Runtime/modules/basic-modules.js
@@ -185,6 +185,19 @@ describe("in- and exports", () => {
         expectModulePassed("./namespace-order.mjs");
     });
 
+    test("missing property inline cache does not cross module namespace objects", () => {
+        const first = expectModulePassed("./namespace-missing-property-a.mjs");
+        const second = expectModulePassed("./namespace-missing-property-b.mjs");
+
+        function get_value(namespace) {
+            return namespace.value;
+        }
+
+        expect(get_value(first)).toBeUndefined();
+        expect(get_value(first)).toBeUndefined();
+        expect(get_value(second)).toBe(1);
+    });
+
     test("can have multiple star imports even from the same file", () => {
         expectModulePassed("./multiple-star-imports.mjs");
     });

--- a/Tests/LibJS/Runtime/modules/namespace-missing-property-a.mjs
+++ b/Tests/LibJS/Runtime/modules/namespace-missing-property-a.mjs
@@ -1,0 +1,1 @@
+export const passed = true;

--- a/Tests/LibJS/Runtime/modules/namespace-missing-property-b.mjs
+++ b/Tests/LibJS/Runtime/modules/namespace-missing-property-b.mjs
@@ -1,0 +1,2 @@
+export const passed = true;
+export const value = 1;

--- a/Tests/LibJS/Runtime/regress/inline-caching.js
+++ b/Tests/LibJS/Runtime/regress/inline-caching.js
@@ -91,3 +91,101 @@ test("Modifying prototype in dictionary mode should cause prototype-chain validi
     });
     f(obj, 123);
 });
+
+test("Repeated missing property access stays undefined after caching", () => {
+    function getMissing(obj) {
+        return obj.hm;
+    }
+
+    // This guards against treating a missing-property cache entry like an own-property hit.
+    const obj = { x: 1 };
+
+    expect(getMissing(obj)).toBeUndefined();
+    expect(getMissing(obj)).toBeUndefined();
+});
+
+test("Adding property on direct prototype invalidates missing-property cache", () => {
+    function getMissing(obj) {
+        return obj.hm;
+    }
+
+    const proto = {};
+    const obj = Object.create(proto);
+
+    expect(getMissing(obj)).toBeUndefined();
+
+    proto.hm = 123;
+
+    expect(getMissing(obj)).toBe(123);
+    expect(getMissing(obj)).toBe(123);
+});
+
+test("Adding property on direct prototype invalidates missing-property cache after GC", () => {
+    function getMissing(obj) {
+        return obj.hm;
+    }
+
+    const proto = {};
+    const obj = Object.create(proto);
+
+    expect(getMissing(obj)).toBeUndefined();
+
+    proto.hm = 123;
+    gc();
+
+    expect(getMissing(obj)).toBe(123);
+    expect(getMissing(obj)).toBe(123);
+});
+
+test("Adding property on dictionary-mode prototype invalidates missing-property cache", () => {
+    function getMissing(obj) {
+        return obj.hm;
+    }
+
+    const proto = {};
+    for (let i = 0; i < 1000; i++) {
+        proto["i" + i] = i;
+    }
+
+    const obj = Object.create(proto);
+
+    expect(getMissing(obj)).toBeUndefined();
+
+    proto.hm = 123;
+
+    expect(getMissing(obj)).toBe(123);
+    expect(getMissing(obj)).toBe(123);
+});
+
+test("Repeated missing .length access stays undefined after caching", () => {
+    function getLength(obj) {
+        return obj.length;
+    }
+
+    // The broken asm fast path would incorrectly read the first named slot here.
+    const obj = { x: 1 };
+
+    expect(getLength(obj)).toBeUndefined();
+    expect(getLength(obj)).toBeUndefined();
+});
+
+test("Missing property cache does not bypass Proxy get trap", () => {
+    function getMissing(obj) {
+        return obj.hm;
+    }
+
+    const proxy = new Proxy(
+        {},
+        {
+            get(target, property, receiver) {
+                if (property === "hm") return 123;
+                return Reflect.get(target, property, receiver);
+            },
+        }
+    );
+
+    expect(getMissing({})).toBeUndefined();
+    expect(getMissing({})).toBeUndefined();
+    expect(getMissing(proxy)).toBe(123);
+    expect(getMissing(proxy)).toBe(123);
+});

--- a/Tests/LibWeb/Text/expected/DOM/dataset-missing-property-inline-cache.txt
+++ b/Tests/LibWeb/Text/expected/DOM/dataset-missing-property-inline-cache.txt
@@ -1,0 +1,3 @@
+undefined
+undefined
+value

--- a/Tests/LibWeb/Text/input/DOM/dataset-missing-property-inline-cache.html
+++ b/Tests/LibWeb/Text/input/DOM/dataset-missing-property-inline-cache.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<div id="first"></div>
+<div id="second" data-expected="value"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function get_expected(element) {
+            return element.dataset.expected;
+        }
+
+        let first = document.getElementById("first");
+        let second = document.getElementById("second");
+
+        println(get_expected(first));
+        println(get_expected(first));
+        println(get_expected(second));
+    });
+</script>


### PR DESCRIPTION
Cache ordinary `GetById` misses so repeated property probes that keep returning `undefined` can avoid the full lookup machinery. Record a missing-lookup cache entry keyed by the receiver shape and prototype-chain state, and teach the C++ and asm fast paths to return `undefined` directly when that entry still applies.

For misses discovered through a prototype chain, keep the fast paths conservative across GC: if the weak prototype-chain validity token has been cleared, fall back to the slow path instead of returning stale `undefined`.

Add test coverage for repeated misses plus prototype invalidation in normal, dictionary-mode, and post-GC cases, and cover the `GetLength` asm fast path too.

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ----------------
LongSpider      3d-cube.js                              1.032      4.769 ± 4.700 … 4.838              4.622 ± 4.587 … 4.657              +0.3% (+0.1 MB)
LongSpider      3d-morph.js                             0.968      2.531 ± 2.519 … 2.542              2.614 ± 2.503 … 2.725              +0.5% (+0.1 MB)
LongSpider      3d-raytrace.js                          0.970      2.929 ± 2.919 … 2.938              3.018 ± 3.009 … 3.027              -0.3% (-0.1 MB)
LongSpider      access-binary-trees.js                  0.999      8.978 ± 8.956 … 9.001              8.990 ± 8.962 … 9.019              +3.1% (+2.9 MB)
LongSpider      access-fannkuch.js                      0.980      1.612 ± 1.576 … 1.648              1.644 ± 1.628 … 1.661              +0.5% (+0.1 MB)
LongSpider      access-nbody.js                         0.933      3.902 ± 3.889 … 3.914              4.180 ± 4.015 … 4.346              +0.5% (+0.1 MB)
LongSpider      access-nsieve.js                        0.980      13.789 ± 13.766 … 13.811           14.073 ± 14.031 … 14.114           -0.0% (-0.3 MB)
LongSpider      bitops-3bit-bits-in-byte.js             1.023      0.530 ± 0.525 … 0.536              0.518 ± 0.515 … 0.522              +0.5% (+0.1 MB)
LongSpider      bitops-bits-in-byte.js                  0.993      0.649 ± 0.636 … 0.662              0.654 ± 0.653 … 0.654              +0.5% (+0.1 MB)
LongSpider      bitops-nsieve-bits.js                   0.892      1.914 ± 1.906 … 1.922              2.145 ± 2.127 … 2.163              -0.9% (-0.3 MB)
LongSpider      controlflow-recursive.js                0.986      2.959 ± 2.935 … 2.982              3.001 ± 2.961 … 3.041              +0.5% (+0.1 MB)
LongSpider      crypto-aes.js                           0.994      5.372 ± 5.368 … 5.376              5.407 ± 5.363 … 5.451              +0.2% (+0.1 MB)
LongSpider      crypto-md5.js                           1.007      6.572 ± 6.467 … 6.678              6.530 ± 6.458 … 6.602              +0.2% (+0.2 MB)
LongSpider      crypto-sha1.js                          0.994      12.123 ± 12.067 … 12.178           12.199 ± 11.984 … 12.413           -0.1% (-0.1 MB)
LongSpider      date-format-tofte.js                    0.990      3.522 ± 3.487 … 3.556              3.556 ± 3.549 … 3.562              +0.3% (+0.1 MB)
LongSpider      date-format-xparb.js                    1.051      4.466 ± 4.465 … 4.467              4.248 ± 4.242 … 4.253              -0.3% (-0.1 MB)
LongSpider      hash-map.js                             1.014      1.222 ± 1.213 … 1.231              1.205 ± 1.204 … 1.207              +0.1% (+0.1 MB)
LongSpider      math-cordic.js                          0.990      5.861 ± 5.833 … 5.888              5.917 ± 5.914 … 5.921              +0.5% (+0.1 MB)
LongSpider      math-partial-sums.js                    1.067      0.874 ± 0.817 … 0.931              0.819 ± 0.815 … 0.823              +0.5% (+0.1 MB)
LongSpider      math-spectral-norm.js                   1.003      6.026 ± 5.957 … 6.095              6.006 ± 5.921 … 6.091              +0.5% (+0.1 MB)
LongSpider      string-base64.js                        0.995      2.189 ± 2.169 … 2.209              2.201 ± 2.192 … 2.210              +3.1% (+12.5 MB)
LongSpider      string-fasta.js                         1.000      4.287 ± 4.280 … 4.293              4.287 ± 4.270 … 4.304              -0.0% (-0.0 MB)
LongSpider      string-tagcloud.js                      1.002      0.838 ± 0.834 … 0.843              0.837 ± 0.834 … 0.839              +1.6% (+0.9 MB)
Kraken          ai-astar.js                             0.982      0.642 ± 0.631 … 0.652              0.653 ± 0.639 … 0.668              +0.5% (+0.2 MB)
Kraken          audio-beat-detection.js                 1.073      0.541 ± 0.540 … 0.542              0.504 ± 0.498 … 0.510              +0.0% (+0.0 MB)
Kraken          audio-dft.js                            1.002      0.375 ± 0.368 … 0.381              0.374 ± 0.368 … 0.380              -0.4% (-0.2 MB)
Kraken          audio-fft.js                            0.995      0.444 ± 0.438 … 0.449              0.446 ± 0.445 … 0.447              +0.3% (+0.1 MB)
Kraken          audio-oscillator.js                     0.987      0.456 ± 0.455 … 0.457              0.462 ± 0.453 … 0.471              -0.0% (-0.0 MB)
Kraken          imaging-darkroom.js                     0.980      0.606 ± 0.603 … 0.609              0.618 ± 0.615 … 0.622              -0.3% (-0.2 MB)
Kraken          imaging-desaturate.js                   0.999      0.575 ± 0.566 … 0.584              0.576 ± 0.575 … 0.576              +0.2% (+0.2 MB)
Kraken          imaging-gaussian-blur.js                1.019      2.611 ± 2.537 … 2.684              2.562 ± 2.533 … 2.592              -0.3% (-0.2 MB)
Kraken          json-parse-financial.js                 0.975      0.055 ± 0.054 … 0.056              0.057 ± 0.056 … 0.057              -0.9% (-0.3 MB)
Kraken          json-stringify-tinderbox.js             1.049      0.052 ± 0.052 … 0.053              0.050 ± 0.050 … 0.051              +0.3% (+0.1 MB)
Kraken          stanford-crypto-aes.js                  0.998      0.219 ± 0.219 … 0.219              0.219 ± 0.211 … 0.228              -0.5% (-0.2 MB)
Kraken          stanford-crypto-ccm.js                  1.003      0.180 ± 0.178 … 0.182              0.180 ± 0.178 … 0.181              +0.0% (+0.0 MB)
Kraken          stanford-crypto-pbkdf2.js               1.040      0.383 ± 0.381 … 0.385              0.369 ± 0.367 … 0.371              +0.1% (+0.0 MB)
Kraken          stanford-crypto-sha256-iterative.js     1.027      0.154 ± 0.153 … 0.156              0.150 ± 0.150 … 0.151              -0.9% (-0.3 MB)
Octane          box2d.js                                0.970      8013.500 ± 7966.000 … 8061.000     7772.000 ± 7746.000 … 7798.000     -0.1% (-0.0 MB)
Octane          code-load.js                            1.006      19168.000 ± 19121.000 … 19215.000  19284.500 ± 19223.000 … 19346.000  +0.4% (+4.4 MB)
Octane          crypto.js                               0.983      2858.000 ± 2839.000 … 2877.000     2810.000 ± 2751.000 … 2869.000     +2.6% (+0.8 MB)
Octane          deltablue.js                            1.036      1484.500 ± 1463.000 … 1506.000     1538.500 ± 1536.000 … 1541.000     -0.7% (-0.2 MB)
Octane          earley-boyer.js                         0.979      4447.500 ± 4445.000 … 4450.000     4352.000 ± 4303.000 … 4401.000     +0.5% (+0.3 MB)
Octane          gbemu.js                                1.009      15065.000 ± 15065.000 … 15065.000  15195.500 ± 15166.000 … 15225.000  -3.9% (-3.1 MB)
Octane          mandreel.js                             1.000      16509.000 ± 16345.000 … 16673.000  16507.500 ± 16453.000 … 16562.000  -0.9% (-3.0 MB)
Octane          navier-stokes.js                        1.066      5120.000 ± 5072.000 … 5168.000     5455.500 ± 5305.000 … 5606.000     +1.1% (+0.3 MB)
Octane          pdfjs.js                                0.996      6449.500 ± 6426.000 … 6473.000     6423.000 ± 6368.000 … 6478.000     -0.4% (-0.3 MB)
Octane          raytrace.js                             0.990      3392.000 ± 3374.000 … 3410.000     3357.000 ± 3354.000 … 3360.000     -0.1% (-0.0 MB)
Octane          regexp.js                               0.994      1796.000 ± 1795.000 … 1797.000     1786.000 ± 1786.000 … 1786.000     -0.2% (-0.1 MB)
Octane          richards.js                             0.925      1867.000 ± 1859.000 … 1875.000     1727.000 ± 1661.000 … 1793.000     -1.7% (-0.4 MB)
Octane          splay.js                                0.993      5530.500 ± 5477.000 … 5584.000     5493.000 ± 5482.000 … 5504.000     -0.2% (-0.7 MB)
Octane          typescript.js                           1.007      17549.000 ± 17270.000 … 17828.000  17666.500 ± 17498.000 … 17835.000  +0.1% (+0.2 MB)
Octane          zlib.js                                 1.016      5446.000 ± 5249.000 … 5643.000     5531.000 ± 5452.000 … 5610.000     -0.1% (-0.2 MB)
JetStream       bigfib.cpp.js                           1.143      5.168 ± 5.092 … 5.245              4.522 ± 4.371 … 4.673              +0.0% (+0.0 MB)
JetStream       cdjs.js                                 0.992      2.448 ± 2.420 … 2.477              2.469 ± 2.465 … 2.473              +0.7% (+0.2 MB)
JetStream       container.cpp.js                        0.986      20.940 ± 20.860 … 21.021           21.228 ± 20.956 … 21.499           +0.1% (+0.1 MB)
JetStream       dry.c.js                                1.103      12.317 ± 12.242 … 12.393           11.163 ± 10.267 … 12.058           +0.1% (+0.1 MB)
JetStream       float-mm.c.js                           1.010      13.238 ± 12.896 … 13.580           13.104 ± 12.682 … 13.527           +0.4% (+0.2 MB)
JetStream       gcc-loops.cpp.js                        1.053      76.364 ± 74.442 … 78.287           72.514 ± 71.380 … 73.647           -0.1% (-0.2 MB)
JetStream       hash-map.js                             1.019      1.231 ± 1.227 … 1.236              1.208 ± 1.203 … 1.214              -0.1% (-0.1 MB)
JetStream       n-body.c.js                             1.037      18.080 ± 17.954 … 18.207           17.436 ± 17.255 … 17.616           +0.3% (+0.1 MB)
JetStream       quicksort.c.js                          0.952      3.030 ± 2.973 … 3.087              3.181 ± 3.140 … 3.223              +0.1% (+0.1 MB)
JetStream       towers.c.js                             1.015      3.375 ± 3.225 … 3.525              3.326 ± 3.245 … 3.407              +0.2% (+0.1 MB)
JetStream3      js-tokens.js                            0.992      0.303 ± 0.303 … 0.304              0.306 ± 0.305 … 0.306              -0.9% (-0.3 MB)
JetStream3      lazy-collections.js                     0.982      0.882 ± 0.880 … 0.885              0.898 ± 0.898 … 0.898              -6.3% (-2.1 MB)
JetStream3      raytrace-private-class-fields.js        0.988      3.688 ± 3.682 … 3.693              3.734 ± 3.732 … 3.736              -0.6% (-0.2 MB)
JetStream3      raytrace-public-class-fields.js         0.988      2.766 ± 2.757 … 2.775              2.799 ± 2.774 … 2.823              +0.5% (+0.1 MB)
JetStream3      sync-file-system.js                     1.006      1.936 ± 1.923 … 1.948              1.923 ± 1.913 … 1.933              -0.3% (-0.1 MB)
AsyncBench      async-call-return.js                    0.994      0.174 ± 0.173 … 0.174              0.175 ± 0.173 … 0.177              -0.1% (-0.0 MB)
AsyncBench      async-class-method.js                   0.994      0.204 ± 0.204 … 0.205              0.206 ± 0.204 … 0.207              -0.1% (-0.0 MB)
AsyncBench      async-fan-out.js                        1.006      0.182 ± 0.182 … 0.183              0.181 ± 0.181 … 0.181              +0.6% (+0.1 MB)
AsyncBench      async-generator.js                      1.017      0.270 ± 0.264 … 0.275              0.265 ± 0.262 … 0.268              +0.7% (+0.2 MB)
AsyncBench      async-iife.js                           0.944      0.274 ± 0.274 … 0.274              0.291 ± 0.274 … 0.307              -0.0% (-0.0 MB)
AsyncBench      async-nested-calls.js                   1.007      0.291 ± 0.291 … 0.291              0.289 ± 0.287 … 0.291              -0.2% (-0.1 MB)
AsyncBench      async-pipeline.js                       1.000      0.350 ± 0.348 … 0.353              0.350 ± 0.346 … 0.355              -0.1% (-0.0 MB)
AsyncBench      async-sequential-awaits.js              1.027      0.094 ± 0.093 … 0.094              0.091 ± 0.091 … 0.091              +0.5% (+0.1 MB)
AsyncBench      async-try-catch-reject.js               0.996      0.494 ± 0.494 … 0.494              0.496 ± 0.496 … 0.496              +0.4% (+0.1 MB)
AsyncBench      await-primitive.js                      0.996      0.051 ± 0.049 … 0.053              0.051 ± 0.051 … 0.052              +0.4% (+0.2 MB)
AsyncBench      await-resolved-promise.js               1.006      0.436 ± 0.432 … 0.441              0.434 ± 0.433 … 0.434              +0.4% (+0.2 MB)
AsyncBench      await-thenable.js                       0.985      0.053 ± 0.053 … 0.053              0.054 ± 0.054 … 0.054              -0.0% (-0.0 MB)
AsyncBench      promise-all.js                          0.995      0.516 ± 0.515 … 0.517              0.519 ± 0.516 … 0.522              +0.4% (+0.2 MB)
AsyncBench      promise-allSettled.js                   1.007      0.588 ± 0.586 … 0.590              0.583 ± 0.582 … 0.585              +0.4% (+0.2 MB)
AsyncBench      promise-chain.js                        1.011      0.292 ± 0.290 … 0.295              0.289 ± 0.289 … 0.290              +0.0% (+0.1 MB)
AsyncBench      promise-new-resolve.js                  1.018      0.276 ± 0.274 … 0.278              0.271 ± 0.269 … 0.273              +0.4% (+0.2 MB)
AsyncBench      promise-race.js                         1.008      0.528 ± 0.528 … 0.529              0.524 ± 0.521 … 0.528              +0.4% (+0.2 MB)
ARES-6          Air.js                                  1.000      1.790 ± 1.784 … 1.795              1.789 ± 1.779 … 1.799              -0.4% (-0.3 MB)
ARES-6          Babylon.js                              1.013      1.242 ± 1.241 … 1.243              1.226 ± 1.223 … 1.229              +0.4% (+0.2 MB)
ARES-6          Basic.js                                0.977      1.781 ± 1.694 … 1.868              1.822 ± 1.755 … 1.889              +0.4% (+0.2 MB)
ARES-6          ML.js                                   0.986      2.031 ± 2.003 … 2.060              2.059 ± 2.053 … 2.065              +0.4% (+0.2 MB)
JetStreamExtra  FlightPlanner.js                        1.002      1.151 ± 1.139 … 1.163              1.149 ± 1.117 … 1.181              -0.0% (-0.0 MB)
JetStreamExtra  OfflineAssembler.js                     1.004      1.436 ± 1.431 … 1.442              1.431 ± 1.426 … 1.435              +0.1% (+0.4 MB)
JetStreamExtra  UniPoker.js                             1.006      1.391 ± 1.390 … 1.392              1.383 ± 1.371 … 1.394              +0.4% (+0.2 MB)
JetStreamExtra  async-fs.js                             0.994      1.759 ± 1.752 … 1.766              1.769 ± 1.764 … 1.774              +0.4% (+0.2 MB)
JetStreamExtra  babylonjs-startup-es5.js                1.010      1.178 ± 1.176 … 1.181              1.167 ± 1.165 … 1.170              +0.0% (+0.3 MB)
JetStreamExtra  babylonjs-startup-es6.js                1.013      1.423 ± 1.417 … 1.430              1.405 ± 1.404 … 1.405              -0.2% (-1.2 MB)
JetStreamExtra  bigint-bigdenary.js                     0.970      1.753 ± 1.746 … 1.759              1.807 ± 1.796 … 1.819              +0.4% (+0.2 MB)
JetStreamExtra  bigint-noble-bls12-381.js               0.992      1.865 ± 1.859 … 1.871              1.880 ± 1.879 … 1.881              +0.4% (+0.2 MB)
JetStreamExtra  bigint-noble-ed25519.js                 0.989      1.903 ± 1.900 … 1.906              1.925 ± 1.924 … 1.925              -0.3% (-0.2 MB)
JetStreamExtra  bigint-noble-secp256k1.js               1.001      1.764 ± 1.760 … 1.768              1.763 ± 1.757 … 1.769              +0.1% (+0.0 MB)
JetStreamExtra  bigint-paillier.js                      0.982      1.819 ± 1.816 … 1.822              1.852 ± 1.847 … 1.856              -0.7% (-0.4 MB)
JetStreamExtra  doxbee-async.js                         1.000      1.797 ± 1.793 … 1.801              1.797 ± 1.795 … 1.799              -0.4% (-0.2 MB)
JetStreamExtra  doxbee-promise.js                       0.989      1.735 ± 1.725 … 1.745              1.755 ± 1.746 … 1.765              -0.3% (-0.2 MB)
JetStreamExtra  first-inspector-code-load.js            1.001      2.001 ± 2.000 … 2.002              2.000 ± 1.997 … 2.002              +0.1% (+2.0 MB)
JetStreamExtra  jsdom-d3-startup.js                     0.998      1.623 ± 1.620 … 1.626              1.626 ± 1.621 … 1.632              -0.1% (-0.4 MB)
JetStreamExtra  json-parse-inspector.js                 0.996      1.103 ± 1.103 … 1.103              1.107 ± 1.105 … 1.109              -0.2% (-0.5 MB)
JetStreamExtra  json-stringify-inspector.js             1.027      0.978 ± 0.960 … 0.996              0.952 ± 0.949 … 0.955              -4.8% (-14.7 MB)
JetStreamExtra  mobx-startup.js                         0.994      1.582 ± 1.582 … 1.582              1.592 ± 1.580 … 1.603              -2.3% (-1.2 MB)
JetStreamExtra  multi-inspector-code-load.js            1.000      2.002 ± 2.000 … 2.005              2.002 ± 1.995 … 2.009              +0.1% (+1.2 MB)
JetStreamExtra  prismjs-startup-es5.js                  1.003      1.906 ± 1.899 … 1.914              1.900 ± 1.897 … 1.903              +0.4% (+0.2 MB)
JetStreamExtra  prismjs-startup-es6.js                  1.000      1.912 ± 1.911 … 1.912              1.911 ± 1.904 … 1.919              +0.4% (+0.2 MB)
JetStreamExtra  proxy-mobx.js                           1.037      1.459 ± 1.447 … 1.471              1.407 ± 1.394 … 1.420              +0.4% (+0.2 MB)
JetStreamExtra  proxy-vue.js                            1.031      1.422 ± 1.405 … 1.438              1.379 ± 1.344 … 1.414              +1.6% (+0.9 MB)
JetStreamExtra  threejs.js                              1.073      2.084 ± 2.030 … 2.138              1.943 ± 1.935 … 1.951              -0.1% (-0.3 MB)
JetStreamExtra  typescript-lib.js                       1.012      0.755 ± 0.754 … 0.756              0.746 ± 0.742 … 0.750              -0.9% (-2.4 MB)
JetStreamExtra  validatorjs.js                          1.003      1.716 ± 1.716 … 1.717              1.711 ± 1.708 … 1.714              +0.4% (+0.2 MB)
JetStreamExtra  web-ssr.js                              1.013      1.973 ± 1.962 … 1.985              1.947 ± 1.946 … 1.948              +0.0% (+0.0 MB)
GarBench        array-of-objects.js                     1.008      0.974 ± 0.966 … 0.983              0.967 ± 0.962 … 0.971              +0.0% (+0.1 MB)
GarBench        closures.js                             1.001      1.257 ± 1.257 … 1.257              1.256 ± 1.254 … 1.257              +0.0% (+0.1 MB)
GarBench        cyclic-graph.js                         1.009      1.399 ± 1.370 … 1.428              1.387 ± 1.359 … 1.415              -0.1% (-0.2 MB)
GarBench        deep-linked-list.js                     0.984      0.818 ± 0.813 … 0.823              0.832 ± 0.828 … 0.836              +0.0% (+0.0 MB)
GarBench        finalization.js                         0.961      0.986 ± 0.983 … 0.989              1.027 ± 0.986 … 1.067              +0.0% (+0.0 MB)
GarBench        many-properties.js                      1.019      2.950 ± 2.949 … 2.952              2.895 ± 2.887 … 2.903              -0.0% (-0.6 MB)
GarBench        marking-stress.js                       1.133      1.581 ± 1.401 … 1.761              1.395 ± 1.389 … 1.402              +1.2% (+8.4 MB)
GarBench        mixed-sizes.js                          1.144      1.135 ± 1.100 … 1.170              0.992 ± 0.953 … 1.031              -0.0% (-0.0 MB)
GarBench        sparse-arrays.js                        0.989      2.380 ± 2.248 … 2.513              2.407 ± 2.258 … 2.556              +0.0% (+0.1 MB)
GarBench        string-heavy.js                         0.985      2.013 ± 2.011 … 2.016              2.045 ± 2.034 … 2.055              -0.0% (-0.2 MB)
GarBench        wide-tree.js                            0.993      1.614 ± 1.611 … 1.617              1.625 ± 1.616 … 1.634              -0.0% (-0.2 MB)
MicroBench      array-destructuring-assignment-rest.js  1.021      0.318 ± 0.317 … 0.319              0.311 ± 0.310 … 0.312              +0.4% (+0.2 MB)
MicroBench      array-destructuring-assignment.js       1.012      3.168 ± 3.107 … 3.229              3.130 ± 3.121 … 3.139              +0.0% (+0.0 MB)
MicroBench      array-prototype-map.js                  1.000      1.157 ± 1.148 … 1.166              1.157 ± 1.143 … 1.171              +0.0% (+0.1 MB)
MicroBench      array-prototype-shift.js                0.999      0.019 ± 0.019 … 0.020              0.019 ± 0.019 … 0.020              +0.4% (+0.2 MB)
MicroBench      bound-call-00-args.js                   1.038      1.624 ± 1.548 … 1.699              1.564 ± 1.561 … 1.566              +0.4% (+0.2 MB)
MicroBench      bound-call-04-args.js                   0.993      1.689 ± 1.689 … 1.689              1.700 ± 1.699 … 1.702              +0.4% (+0.2 MB)
MicroBench      bound-call-16-args.js                   0.993      1.903 ± 1.899 … 1.906              1.916 ± 1.905 … 1.926              +0.4% (+0.2 MB)
MicroBench      call-00-args.js                         1.000      0.756 ± 0.751 … 0.760              0.756 ± 0.754 … 0.757              +0.4% (+0.2 MB)
MicroBench      call-01-args.js                         1.010      0.786 ± 0.773 … 0.798              0.778 ± 0.776 … 0.780              +0.4% (+0.2 MB)
MicroBench      call-02-args.js                         0.976      0.809 ± 0.796 … 0.823              0.829 ± 0.794 … 0.865              +0.4% (+0.2 MB)
MicroBench      call-03-args.js                         0.991      0.829 ± 0.826 … 0.832              0.837 ± 0.835 … 0.838              +0.4% (+0.2 MB)
MicroBench      call-04-args.js                         0.820      0.827 ± 0.826 … 0.827              1.008 ± 0.827 … 1.189              +0.4% (+0.2 MB)
MicroBench      call-16-args.js                         0.985      1.028 ± 1.028 … 1.028              1.044 ± 1.044 … 1.044              +0.4% (+0.2 MB)
MicroBench      call-32-args.js                         0.986      1.252 ± 1.247 … 1.257              1.270 ± 1.249 … 1.291              +0.4% (+0.2 MB)
MicroBench      deep-call-stack.js                      1.023      0.281 ± 0.279 … 0.283              0.275 ± 0.274 … 0.275              +0.4% (+0.2 MB)
MicroBench      for-in-indexed-properties.js            0.989      0.962 ± 0.960 … 0.964              0.972 ± 0.968 … 0.977              +0.1% (+0.1 MB)
MicroBench      for-in-named-properties.js              0.997      1.268 ± 1.266 … 1.270              1.272 ± 1.272 … 1.273              +0.2% (+0.2 MB)
MicroBench      for-of.js                               0.896      0.540 ± 0.538 … 0.542              0.603 ± 0.602 … 0.604              +0.4% (+0.2 MB)
MicroBench      object-keys.js                          0.996      1.303 ± 1.303 … 1.304              1.309 ± 1.301 … 1.317              -0.2% (-0.2 MB)
MicroBench      object-set-with-rope-strings.js         1.004      0.702 ± 0.702 … 0.702              0.699 ± 0.697 … 0.701              +0.4% (+0.2 MB)
MicroBench      pic-add-own.js                          1.004      0.423 ± 0.415 … 0.431              0.421 ± 0.419 … 0.423              +0.4% (+0.2 MB)
MicroBench      pic-get-missing-pchain.js               2.133      2.884 ± 2.871 … 2.896              1.352 ± 1.351 … 1.353              +0.4% (+0.2 MB)
MicroBench      pic-get-own.js                          0.806      0.766 ± 0.751 … 0.782              0.951 ± 0.746 … 1.155              +0.4% (+0.2 MB)
MicroBench      pic-get-pchain.js                       1.020      0.782 ± 0.778 … 0.786              0.767 ± 0.760 … 0.773              +0.4% (+0.2 MB)
MicroBench      pic-put-own.js                          1.000      0.792 ± 0.781 … 0.803              0.792 ± 0.784 … 0.800              +0.4% (+0.2 MB)
MicroBench      pic-put-pchain.js                       1.032      2.251 ± 2.237 … 2.264              2.182 ± 2.176 … 2.188              +0.4% (+0.2 MB)
MicroBench      setter-in-prototype-chain.js            1.097      2.066 ± 1.941 … 2.190              1.883 ± 1.878 … 1.888              +0.4% (+0.2 MB)
MicroBench      strictly-equals-object.js               1.010      0.724 ± 0.723 … 0.726              0.717 ± 0.716 … 0.718              +0.4% (+0.2 MB)
LongSpider      Total                                   0.992      97.913                             98.671                             +0.6% (+17.1 MB)
Kraken          Total                                   1.010      7.294                              7.221                              -0.1% (-0.7 MB)          Octane          Total                                   1.002      114695.500                         114899.000                         -0.1% (-2.1 MB)
JetStream       Total                                   1.040      156.193                            150.151                            +0.1% (+0.7 MB)
JetStream3      Total                                   0.991      9.575                              9.660                              -1.6% (-2.5 MB)
AsyncBench      Total                                   1.001      5.075                              5.070                              +0.2% (+1.8 MB)
ARES-6          Total                                   0.992      6.844                              6.896                              +0.2% (+0.4 MB)
JetStreamExtra  Total                                   1.004      43.491                             43.305                             -0.2% (-15.3 MB)
GarBench        Total                                   1.017      17.108                             16.827                             +0.1% (+7.5 MB)
MicroBench      Total                                   1.046      31.908                             30.513                             +0.1% (+5.2 MB)
All Suites      Total                                   1.018      442.643                            434.877                            +0.0% (+12.1 MB)
```