### PR TITLE
LibJS: Cache stable for-in iteration at bytecode sites

### DIFF
--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -849,11 +849,16 @@ fn emit_instruction(out: &mut String, insn: &AsmInstruction, handler: &Handler, 
             if insn.operands.len() >= 2 {
                 let offset = resolve_op(&insn.operands[0], handler, program);
                 let src = resolve_op(&insn.operands[1], handler, program);
-                // Load the u32 operand raw value from bytecode.
-                // Use r11 as scratch to avoid clobbering src if it's rax.
-                w!(out, "    mov r11d, DWORD PTR [r14 + r13 + {offset}]");
-                // Store value into values array
-                w!(out, "    mov QWORD PTR [r15 + r11 * 8], {src}");
+                // Load the u32 operand raw value from bytecode without
+                // clobbering the source value register.
+                if src == "r11" {
+                    w!(out, "    mov eax, DWORD PTR [r14 + r13 + {offset}]");
+                    w!(out, "    mov QWORD PTR [r15 + rax * 8], {src}");
+                } else {
+                    w!(out, "    mov r11d, DWORD PTR [r14 + r13 + {offset}]");
+                    // Store value into values array
+                    w!(out, "    mov QWORD PTR [r15 + r11 * 8], {src}");
+                }
             }
         }
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -239,6 +239,8 @@ i64 asm_slow_path_get_global(Interpreter*, u32 pc);
 i64 asm_slow_path_set_global(Interpreter*, u32 pc);
 i64 asm_slow_path_call(Interpreter*, u32 pc);
 i64 asm_slow_path_call_builtin(Interpreter*, u32 pc);
+i64 asm_slow_path_get_object_property_iterator(Interpreter*, u32 pc);
+i64 asm_slow_path_object_property_iterator_next(Interpreter*, u32 pc);
 i64 asm_slow_path_call_construct(Interpreter*, u32 pc);
 i64 asm_slow_path_new_object(Interpreter*, u32 pc);
 i64 asm_slow_path_cache_object_shape(Interpreter*, u32 pc);
@@ -414,6 +416,8 @@ i64 asm_fallback_handler(Interpreter* interp, u32 pc)
         return execute_throwing<Op::GetMethod>(*interp, pc);
     case Instruction::Type::GetObjectPropertyIterator:
         return execute_throwing<Op::GetObjectPropertyIterator>(*interp, pc);
+    case Instruction::Type::ObjectPropertyIteratorNext:
+        return execute_throwing<Op::ObjectPropertyIteratorNext>(*interp, pc);
     case Instruction::Type::HasPrivateId:
         return execute_throwing<Op::HasPrivateId>(*interp, pc);
     case Instruction::Type::ImportCall:
@@ -695,6 +699,16 @@ i64 asm_slow_path_set_global(Interpreter* interp, u32 pc)
 i64 asm_slow_path_call(Interpreter* interp, u32 pc)
 {
     return slow_path_throwing<Op::Call>(*interp, pc);
+}
+
+i64 asm_slow_path_get_object_property_iterator(Interpreter* interp, u32 pc)
+{
+    return slow_path_throwing<Op::GetObjectPropertyIterator>(*interp, pc);
+}
+
+i64 asm_slow_path_object_property_iterator_next(Interpreter* interp, u32 pc)
+{
+    return slow_path_throwing<Op::ObjectPropertyIteratorNext>(*interp, pc);
 }
 
 i64 asm_slow_path_call_builtin(Interpreter* interp, u32 pc)

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -2022,6 +2022,102 @@ end
 # chain walks, etc). Having them here avoids the generic fallback handler's
 # overhead of saving/restoring all temporaries.
 
+handler GetObjectPropertyIterator
+    call_slow_path asm_slow_path_get_object_property_iterator
+end
+
+handler ObjectPropertyIteratorNext
+    load_operand t1, m_iterator_object
+    extract_tag t2, t1
+    branch_ne t2, OBJECT_TAG, .slow
+    unbox_object t3, t1
+
+    load8 t4, [t3, PROPERTY_NAME_ITERATOR_FAST_PATH]
+    mov t0, OBJECT_PROPERTY_ITERATOR_FAST_PATH_NONE
+    branch_eq t4, t0, .slow
+
+    # These guards mirror PropertyNameIterator::fast_path_still_valid(). If the
+    # receiver or prototype chain no longer matches the cached snapshot, we drop
+    # to C++ and continue in deoptimized mode for the rest of the enumeration.
+    load64 t5, [t3, PROPERTY_NAME_ITERATOR_PROPERTY_CACHE]
+    load64 t6, [t3, PROPERTY_NAME_ITERATOR_OBJECT]
+    load64 t7, [t3, PROPERTY_NAME_ITERATOR_SHAPE]
+    load64 t8, [t6, OBJECT_SHAPE]
+    branch_ne t8, t7, .slow
+
+    load8 t2, [t3, PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY]
+    branch_zero t2, .check_receiver
+    load32 t0, [t8, SHAPE_DICTIONARY_GENERATION]
+    load32 t2, [t3, PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION]
+    branch_ne t0, t2, .slow
+
+.check_receiver:
+    mov t0, OBJECT_PROPERTY_ITERATOR_FAST_PATH_PACKED_INDEXED
+    branch_ne t4, t0, .check_proto
+    load8 t0, [t6, OBJECT_INDEXED_STORAGE_KIND]
+    mov t2, INDEXED_STORAGE_KIND_PACKED
+    branch_ne t0, t2, .slow
+    load32 t0, [t6, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    load32 t2, [t3, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT]
+    branch_ne t0, t2, .slow
+
+.check_proto:
+    load64 t0, [t3, PROPERTY_NAME_ITERATOR_PROTOTYPE_CHAIN_VALIDITY]
+    branch_zero t0, .next_key
+    load8 t2, [t0, PROTOTYPE_CHAIN_VALIDITY_VALID]
+    branch_zero t2, .slow
+
+.next_key:
+    # property_values is laid out as:
+    #   [receiver packed index keys..., flattened named keys...]
+    load32 t0, [t3, PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY]
+    load32 t2, [t3, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT]
+    branch_ge_unsigned t0, t2, .named
+    load64 t8, [t5, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA]
+    load64 t8, [t8, t0, 8]
+    add t0, 1
+    store32 [t3, PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY], t0
+    store_operand m_dst_value, t8
+    mov t0, BOOLEAN_FALSE
+    store_operand m_dst_done, t0
+    dispatch_next
+
+.named:
+    load64 t0, [t3, PROPERTY_NAME_ITERATOR_NEXT_PROPERTY]
+    load64 t8, [t5, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE]
+    load32 t2, [t3, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT]
+    sub t8, t2
+    branch_ge_unsigned t0, t8, .done
+    mov t8, t0
+    add t8, t2
+    load64 t5, [t5, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA]
+    load64 t8, [t5, t8, 8]
+    add t0, 1
+    store64 [t3, PROPERTY_NAME_ITERATOR_NEXT_PROPERTY], t0
+    store_operand m_dst_value, t8
+    mov t0, BOOLEAN_FALSE
+    store_operand m_dst_done, t0
+    dispatch_next
+
+.done:
+    load64 t5, [t3, PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT]
+    branch_zero t5, .store_done
+    # Return the exhausted iterator object to the bytecode-site cache so the
+    # next execution of this loop can reset and reuse it.
+    mov t0, 0
+    store64 [t3, PROPERTY_NAME_ITERATOR_OBJECT], t0
+    store64 [t5, OBJECT_PROPERTY_ITERATOR_CACHE_REUSABLE_PROPERTY_NAME_ITERATOR], t3
+    store64 [t3, PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT], t0
+
+.store_done:
+    mov t0, BOOLEAN_TRUE
+    store_operand m_dst_done, t0
+    dispatch_next
+
+.slow:
+    call_slow_path asm_slow_path_object_property_iterator_next
+end
+
 handler CallConstruct
     call_slow_path asm_slow_path_call_construct
 end

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Bytecode/Builtins.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Bytecode/PropertyNameIterator.h>
 #include <LibJS/Bytecode/PutKind.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
@@ -82,6 +83,35 @@ int main()
     outln("const PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE = {}", plc_entries + offsetof(PropertyLookupCache::Entry, prototype));
     outln("const PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE_CHAIN_VALIDITY = {}", plc_entries + offsetof(PropertyLookupCache::Entry, prototype_chain_validity));
 
+    // ObjectPropertyIteratorCacheData layout
+    outln("\n# ObjectPropertyIteratorCacheData layout");
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTIES, ObjectPropertyIteratorCacheData, m_properties);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES, ObjectPropertyIteratorCacheData, m_property_values);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_SHAPE, ObjectPropertyIteratorCacheData, m_shape);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROTOTYPE_CHAIN_VALIDITY, ObjectPropertyIteratorCacheData, m_prototype_chain_validity);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_INDEXED_PROPERTY_COUNT, ObjectPropertyIteratorCacheData, m_indexed_property_count);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_SHAPE_DICTIONARY_GENERATION, ObjectPropertyIteratorCacheData, m_shape_dictionary_generation);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_FAST_PATH, ObjectPropertyIteratorCacheData, m_fast_path);
+
+    // ObjectPropertyIteratorCache layout
+    outln("\n# ObjectPropertyIteratorCache layout");
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PTR, ObjectPropertyIteratorCache, data);
+    EMIT_OFFSET(OBJECT_PROPERTY_ITERATOR_CACHE_REUSABLE_PROPERTY_NAME_ITERATOR, ObjectPropertyIteratorCache, reusable_property_name_iterator);
+
+    // PropertyNameIterator layout
+    outln("\n# PropertyNameIterator layout");
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_OBJECT, PropertyNameIterator, m_object);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_PROPERTY_CACHE, PropertyNameIterator, m_property_cache);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_SHAPE, PropertyNameIterator, m_shape);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_PROTOTYPE_CHAIN_VALIDITY, PropertyNameIterator, m_prototype_chain_validity);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT, PropertyNameIterator, m_iterator_cache_slot);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT, PropertyNameIterator, m_indexed_property_count);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY, PropertyNameIterator, m_next_indexed_property);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_NEXT_PROPERTY, PropertyNameIterator, m_next_property);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY, PropertyNameIterator, m_shape_is_dictionary);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION, PropertyNameIterator, m_shape_dictionary_generation);
+    EMIT_OFFSET(PROPERTY_NAME_ITERATOR_FAST_PATH, PropertyNameIterator, m_fast_path);
+
     // Executable layout
     outln("\n# Executable layout");
     EMIT_OFFSET(EXECUTABLE_PROPERTY_LOOKUP_CACHES, Executable, property_lookup_caches);
@@ -111,6 +141,12 @@ int main()
     outln("const INDEXED_STORAGE_KIND_HOLEY = {}", static_cast<u8>(IndexedStorageKind::Holey));
     outln("const INDEXED_STORAGE_KIND_DICTIONARY = {}", static_cast<u8>(IndexedStorageKind::Dictionary));
 
+    // ObjectPropertyIteratorFastPath enum values
+    outln("\n# ObjectPropertyIteratorFastPath enum values");
+    outln("const OBJECT_PROPERTY_ITERATOR_FAST_PATH_NONE = {}", static_cast<u8>(ObjectPropertyIteratorFastPath::None));
+    outln("const OBJECT_PROPERTY_ITERATOR_FAST_PATH_PLAIN_NAMED = {}", static_cast<u8>(ObjectPropertyIteratorFastPath::PlainNamed));
+    outln("const OBJECT_PROPERTY_ITERATOR_FAST_PATH_PACKED_INDEXED = {}", static_cast<u8>(ObjectPropertyIteratorFastPath::PackedIndexed));
+
     // Vector<Value> layout (used for bytecode)
     outln("\n# Vector<Value> layout");
     {
@@ -123,6 +159,8 @@ int main()
 
         // Composite offset for Executable.bytecode data pointer
         outln("const EXECUTABLE_BYTECODE_DATA = {}", offsetof(Executable, bytecode) + vec_data);
+        outln("const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA = {}", offsetof(ObjectPropertyIteratorCacheData, m_property_values) + vec_data);
+        outln("const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE = {}", offsetof(ObjectPropertyIteratorCacheData, m_property_values) + vec_size);
     }
 
     // PutKind enum

--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -348,10 +348,9 @@ op GetNewTarget < Instruction
 endop
 
 op GetObjectPropertyIterator < Instruction
-    m_dst_iterator_object: Operand
-    m_dst_iterator_next: Operand
-    m_dst_iterator_done: Operand
+    m_dst_iterator: Operand
     m_object: Operand
+    m_cache: ObjectPropertyIteratorCache*
 endop
 
 op GetPrivateById < Instruction
@@ -466,6 +465,12 @@ op IteratorNextUnpack < Instruction
     m_iterator_object: Operand
     m_iterator_next: Operand
     m_iterator_done: Operand
+endop
+
+op ObjectPropertyIteratorNext < Instruction
+    m_dst_value: Operand
+    m_dst_done: Operand
+    m_iterator_object: Operand
 endop
 
 op IteratorToArray < Instruction
@@ -950,4 +955,3 @@ op InitObjectLiteralProperty < Instruction
     m_shape_cache_index: u32
     m_property_slot: u32
 endop
-

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -19,6 +19,38 @@
 namespace JS::Bytecode {
 
 GC_DEFINE_ALLOCATOR(Executable);
+GC_DEFINE_ALLOCATOR(ObjectPropertyIteratorCacheData);
+
+ObjectPropertyIteratorCacheData::ObjectPropertyIteratorCacheData(VM& vm, Vector<PropertyKey> properties, ObjectPropertyIteratorFastPath fast_path, u32 indexed_property_count, bool receiver_has_magical_length_property, GC::Ref<Shape> shape, GC::Ptr<PrototypeChainValidity> prototype_chain_validity)
+    : m_properties(move(properties))
+    , m_shape(shape)
+    , m_prototype_chain_validity(prototype_chain_validity)
+    , m_indexed_property_count(indexed_property_count)
+    , m_receiver_has_magical_length_property(receiver_has_magical_length_property)
+    , m_fast_path(fast_path)
+{
+    // The iterator fast path returns JS Values directly, so materialize the
+    // cached key list once up front instead of converting PropertyKeys during
+    // every ObjectPropertyIteratorNext.
+    m_property_values.ensure_capacity(indexed_property_count + m_properties.size());
+    for (u32 i = 0; i < indexed_property_count; ++i)
+        m_property_values.append(PropertyKey { i }.to_value(vm));
+    for (auto const& key : m_properties)
+        m_property_values.append(key.to_value(vm));
+
+    if (m_shape->is_dictionary())
+        m_shape_dictionary_generation = m_shape->dictionary_generation();
+}
+
+void ObjectPropertyIteratorCacheData::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_shape);
+    visitor.visit(m_prototype_chain_validity);
+    visitor.visit(m_property_values.span());
+    for (auto& key : m_properties)
+        key.visit_edges(visitor);
+}
 
 Executable::Executable(
     Vector<u8> bytecode,
@@ -32,6 +64,7 @@ Executable::Executable(
     size_t number_of_global_variable_caches,
     size_t number_of_template_object_caches,
     size_t number_of_object_shape_caches,
+    size_t number_of_object_property_iterator_caches,
     size_t number_of_registers,
     Strict strict)
     : GC::WeakContainer(heap())
@@ -49,6 +82,7 @@ Executable::Executable(
     global_variable_caches.resize(number_of_global_variable_caches);
     template_object_caches.resize(number_of_template_object_caches);
     object_shape_caches.resize(number_of_object_shape_caches);
+    object_property_iterator_caches.resize(number_of_object_property_iterator_caches);
 }
 
 Executable::~Executable() = default;
@@ -61,7 +95,8 @@ void Executable::fixup_cache_pointers()
             property_lookup_caches.span(),
             global_variable_caches.span(),
             template_object_caches.span(),
-            object_shape_caches.span());
+            object_shape_caches.span(),
+            object_property_iterator_caches.span());
     }
 }
 
@@ -239,6 +274,10 @@ void Executable::visit_edges(Visitor& visitor)
     visitor.visit(constants);
     for (auto& cache : template_object_caches)
         visitor.visit(cache.cached_template_object);
+    for (auto& cache : object_property_iterator_caches)
+        visitor.visit(cache.data);
+    for (auto& cache : object_property_iterator_caches)
+        visitor.visit(cache.reusable_property_name_iterator);
     for (auto& data : shared_function_data)
         visitor.visit(data);
     for (auto& blueprint : class_blueprints) {

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -95,6 +95,47 @@ struct ObjectShapeCache {
     Vector<u32> property_offsets;
 };
 
+enum class ObjectPropertyIteratorFastPath : u8 {
+    None,
+    PlainNamed,
+    PackedIndexed,
+};
+
+class JS_API ObjectPropertyIteratorCacheData final : public Cell {
+    GC_CELL(ObjectPropertyIteratorCacheData, Cell);
+    GC_DECLARE_ALLOCATOR(ObjectPropertyIteratorCacheData);
+
+public:
+    ObjectPropertyIteratorCacheData(VM&, Vector<PropertyKey>, ObjectPropertyIteratorFastPath, u32 indexed_property_count, bool receiver_has_magical_length_property, GC::Ref<Shape>, GC::Ptr<PrototypeChainValidity> = nullptr);
+    virtual ~ObjectPropertyIteratorCacheData() override = default;
+
+    [[nodiscard]] ReadonlySpan<PropertyKey> properties() const { return m_properties.span(); }
+    [[nodiscard]] ReadonlySpan<Value> property_values() const { return m_property_values.span(); }
+    [[nodiscard]] ObjectPropertyIteratorFastPath fast_path() const { return m_fast_path; }
+    [[nodiscard]] u32 indexed_property_count() const { return m_indexed_property_count; }
+    [[nodiscard]] bool receiver_has_magical_length_property() const { return m_receiver_has_magical_length_property; }
+    [[nodiscard]] GC::Ptr<Shape> shape() const { return m_shape; }
+    [[nodiscard]] GC::Ptr<PrototypeChainValidity> prototype_chain_validity() const { return m_prototype_chain_validity; }
+    [[nodiscard]] u32 shape_dictionary_generation() const { return m_shape_dictionary_generation; }
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    Vector<PropertyKey> m_properties;
+    Vector<Value> m_property_values;
+    GC::Ptr<Shape> m_shape;
+    GC::Ptr<PrototypeChainValidity> m_prototype_chain_validity;
+    u32 m_indexed_property_count { 0 };
+    u32 m_shape_dictionary_generation { 0 };
+    bool m_receiver_has_magical_length_property { false };
+    ObjectPropertyIteratorFastPath m_fast_path { ObjectPropertyIteratorFastPath::None };
+};
+
+struct ObjectPropertyIteratorCache {
+    GC::Ptr<ObjectPropertyIteratorCacheData> data;
+    GC::Ptr<Object> reusable_property_name_iterator;
+};
+
 struct SourceRecord {
     u32 source_start_offset {};
     u32 source_end_offset {};
@@ -124,6 +165,7 @@ public:
         size_t number_of_global_variable_caches,
         size_t number_of_template_object_caches,
         size_t number_of_object_shape_caches,
+        size_t number_of_object_property_iterator_caches,
         size_t number_of_registers,
         Strict);
 
@@ -135,6 +177,7 @@ public:
     Vector<GlobalVariableCache> global_variable_caches;
     Vector<TemplateObjectCache> template_object_caches;
     Vector<ObjectShapeCache> object_shape_caches;
+    Vector<ObjectPropertyIteratorCache> object_property_iterator_caches;
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<PropertyKeyTable> property_key_table;

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -17,6 +17,7 @@
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/PropertyAccess.h>
+#include <LibJS/Bytecode/PropertyNameIterator.h>
 #include <LibJS/Export.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Accessor.h>
@@ -707,6 +708,7 @@ void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(IteratorClose);
             HANDLE_INSTRUCTION(IteratorNext);
             HANDLE_INSTRUCTION(IteratorNextUnpack);
+            HANDLE_INSTRUCTION(ObjectPropertyIteratorNext);
             HANDLE_INSTRUCTION(IteratorToArray);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(LeavePrivateEnvironment);
             HANDLE_INSTRUCTION(LeftShift);
@@ -1428,65 +1430,180 @@ inline ThrowCompletionOr<void> append(VM& vm, Value lhs, Value rhs, bool is_spre
     return {};
 }
 
-class JS_API PropertyNameIterator final
-    : public Object
-    , public BuiltinIterator {
-    JS_OBJECT(PropertyNameIterator, Object);
-    GC_DECLARE_ALLOCATOR(PropertyNameIterator);
-
-public:
-    virtual ~PropertyNameIterator() override = default;
-
-    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value) override { return this; }
-    ThrowCompletionOr<void> next(VM& vm, bool& done, Value& value) override
-    {
-        while (true) {
-            if (m_iterator == m_properties.end()) {
-                done = true;
-                return {};
-            }
-
-            auto const& entry = *m_iterator;
-            ScopeGuard remove_first = [&] { ++m_iterator; };
-
-            // If the property is deleted, don't include it (invariant no. 2)
-            if (!TRY(m_object->has_property(entry)))
-                continue;
-
-            done = false;
-            value = entry.to_value(vm);
-            return {};
-        }
-    }
-
-private:
-    PropertyNameIterator(JS::Realm& realm, GC::Ref<Object> object, Vector<PropertyKey> properties)
-        : Object(realm, nullptr)
-        , m_object(object)
-        , m_properties(move(properties))
-        , m_iterator(m_properties.begin())
-    {
-    }
-
-    virtual void visit_edges(Visitor& visitor) override
-    {
-        Base::visit_edges(visitor);
-        visitor.visit(m_object);
-        for (auto& key : m_properties)
-            key.visit_edges(visitor);
-        if (!m_iterator.is_end())
-            m_iterator->visit_edges(visitor);
-    }
-
-    GC::Ref<Object> m_object;
-    Vector<PropertyKey> m_properties;
-    decltype(m_properties.begin()) m_iterator;
+struct FastPropertyNameIteratorData {
+    Vector<PropertyKey> properties;
+    PropertyNameIterator::FastPath fast_path { PropertyNameIterator::FastPath::None };
+    u32 indexed_property_count { 0 };
+    bool receiver_has_magical_length_property { false };
+    GC::Ptr<Shape> shape;
+    GC::Ptr<PrototypeChainValidity> prototype_chain_validity;
 };
 
-GC_DEFINE_ALLOCATOR(PropertyNameIterator);
+static bool shape_has_enumerable_string_property(Shape const& shape)
+{
+    for (auto const& [property_key, metadata] : shape.property_table()) {
+        if (property_key.is_string() && metadata.attributes.is_enumerable())
+            return true;
+    }
+    return false;
+}
+
+static bool property_name_iterator_fast_path_is_still_eligible(Object& object, PropertyNameIterator::FastPath fast_path, u32 indexed_property_count)
+{
+    Object const* object_to_check = &object;
+    bool is_receiver = true;
+
+    while (object_to_check) {
+        if (!object_to_check->eligible_for_own_property_enumeration_fast_path())
+            return false;
+
+        if (is_receiver) {
+            if (fast_path == PropertyNameIterator::FastPath::PackedIndexed) {
+                if (object_to_check->indexed_storage_kind() != IndexedStorageKind::Packed)
+                    return false;
+                if (object_to_check->indexed_array_like_size() != indexed_property_count)
+                    return false;
+            } else if (object_to_check->indexed_array_like_size() != 0) {
+                return false;
+            }
+        } else if (object_to_check->indexed_array_like_size() != 0) {
+            return false;
+        }
+
+        object_to_check = object_to_check->prototype();
+        is_receiver = false;
+    }
+
+    return true;
+}
+
+static bool object_property_iterator_cache_matches(Object& object, ObjectPropertyIteratorCacheData const& cache)
+{
+    // A cache entry represents the fully flattened key snapshot for one bytecode
+    // site. Reusing it is only valid while the receiver still has the same local
+    // state and the prototype chain validity token says nothing above it changed.
+    if (object.has_magical_length_property() != cache.receiver_has_magical_length_property())
+        return false;
+
+    auto& shape = object.shape();
+    if (&shape != cache.shape())
+        return false;
+
+    if (shape.is_dictionary() && shape.dictionary_generation() != cache.shape_dictionary_generation())
+        return false;
+
+    if (cache.prototype_chain_validity() && !cache.prototype_chain_validity()->is_valid())
+        return false;
+
+    return property_name_iterator_fast_path_is_still_eligible(object, cache.fast_path(), cache.indexed_property_count());
+}
+
+static ThrowCompletionOr<Optional<FastPropertyNameIteratorData>> try_get_fast_property_name_iterator_data(Object& object)
+{
+    auto& vm = object.vm();
+    FastPropertyNameIteratorData result {};
+    result.fast_path = PropertyNameIterator::FastPath::PlainNamed;
+    result.receiver_has_magical_length_property = object.has_magical_length_property();
+    result.shape = &object.shape();
+
+    HashTable<GC::Ref<Object>> seen_objects;
+    size_t estimated_properties_count = 0;
+    bool prototype_chain_has_enumerable_named_properties = false;
+    for (auto object_to_check = GC::Ptr { &object }; object_to_check && !seen_objects.contains(*object_to_check); object_to_check = TRY(object_to_check->internal_get_prototype_of())) {
+        seen_objects.set(*object_to_check);
+        if (!object_to_check->eligible_for_own_property_enumeration_fast_path())
+            return Optional<FastPropertyNameIteratorData> {};
+        if (&object == object_to_check.ptr()) {
+            if (object_to_check->indexed_array_like_size() != 0) {
+                if (object_to_check->indexed_storage_kind() != IndexedStorageKind::Packed)
+                    return Optional<FastPropertyNameIteratorData> {};
+                result.fast_path = PropertyNameIterator::FastPath::PackedIndexed;
+                result.indexed_property_count = object_to_check->indexed_array_like_size();
+            } else {
+                result.fast_path = PropertyNameIterator::FastPath::PlainNamed;
+            }
+        } else if (object_to_check->indexed_array_like_size() != 0) {
+            // The fast path only knows how to synthesize a packed indexed prefix
+            // for the receiver itself. As soon as indexed properties appear in
+            // the prototype chain, we fall back to the generic enumeration path.
+            return Optional<FastPropertyNameIteratorData> {};
+        } else if (!prototype_chain_has_enumerable_named_properties) {
+            prototype_chain_has_enumerable_named_properties = shape_has_enumerable_string_property(object_to_check->shape());
+        }
+        estimated_properties_count += object_to_check->shape().property_count();
+    }
+    seen_objects.clear_with_capacity();
+
+    if (auto* prototype = object.shape().prototype()) {
+        result.prototype_chain_validity = prototype->shape().prototype_chain_validity();
+        if (!result.prototype_chain_validity)
+            return Optional<FastPropertyNameIteratorData> {};
+    }
+
+    if (!prototype_chain_has_enumerable_named_properties) {
+        // Common case: only the receiver contributes enumerable string keys, so
+        // we can copy them straight from the shape without any shadowing work.
+        result.properties.ensure_capacity(object.shape().property_count());
+        for (auto const& [property_key, metadata] : object.shape().property_table()) {
+            if (property_key.is_string() && metadata.attributes.is_enumerable())
+                result.properties.append(property_key);
+        }
+        return result;
+    }
+
+    result.properties.ensure_capacity(estimated_properties_count);
+
+    HashTable<PropertyKey> seen_non_enumerable_properties;
+    Optional<HashTable<PropertyKey>> seen_properties;
+    auto ensure_seen_properties = [&] {
+        if (seen_properties.has_value())
+            return;
+        // Prototype shadowing ignores enumerability, so once we start looking
+        // above the receiver we need an explicit visited set for names we have
+        // already decided to expose from lower objects.
+        seen_properties = HashTable<PropertyKey> {};
+        seen_properties->ensure_capacity(result.properties.size());
+        for (auto const& property : result.properties)
+            seen_properties->set(property);
+    };
+
+    bool in_prototype_chain = false;
+    for (auto object_to_check = GC::Ptr { &object }; object_to_check && !seen_objects.contains(*object_to_check); object_to_check = TRY(object_to_check->internal_get_prototype_of())) {
+        seen_objects.set(*object_to_check);
+
+        // Arrays keep a non-enumerable magical `length` property outside the shape
+        // table, but it still shadows enumerable `length` properties higher up the
+        // prototype chain during for-in.
+        if (object_to_check->has_magical_length_property())
+            seen_non_enumerable_properties.set(vm.names.length);
+
+        for (auto const& [property_key, metadata] : object_to_check->shape().property_table()) {
+            if (!property_key.is_string())
+                continue;
+
+            bool enumerable = metadata.attributes.is_enumerable();
+            if (!enumerable)
+                seen_non_enumerable_properties.set(property_key);
+            if (in_prototype_chain && enumerable) {
+                if (seen_non_enumerable_properties.contains(property_key))
+                    continue;
+                ensure_seen_properties();
+                if (seen_properties->contains(property_key))
+                    continue;
+            }
+            if (enumerable)
+                result.properties.append(property_key);
+            if (seen_properties.has_value())
+                seen_properties->set(property_key);
+        }
+        in_prototype_chain = true;
+    }
+
+    return result;
+}
 
 // 14.7.5.9 EnumerateObjectProperties ( O ), https://tc39.es/ecma262/#sec-enumerate-object-properties
-inline ThrowCompletionOr<IteratorRecordImpl> get_object_property_iterator(Interpreter& interpreter, Value value)
+inline ThrowCompletionOr<GC::Ref<PropertyNameIterator>> get_object_property_iterator(Interpreter& interpreter, Value value, ObjectPropertyIteratorCache* cache = nullptr)
 {
     // While the spec does provide an algorithm, it allows us to implement it ourselves so long as we meet the following invariants:
     //    1- Returned property keys do not include keys that are Symbols
@@ -1506,6 +1623,43 @@ inline ThrowCompletionOr<IteratorRecordImpl> get_object_property_iterator(Interp
     auto object = TRY(value.to_object(vm));
     // Note: While the spec doesn't explicitly require these to be ordered, it says that the values should be retrieved via OwnPropertyKeys,
     //       so we just keep the order consistent anyway.
+
+    if (cache && cache->data) {
+        if (object_property_iterator_cache_matches(*object, *cache->data)) {
+            if (cache->reusable_property_name_iterator) {
+                // We keep one iterator object per bytecode site alive so hot
+                // loops can recycle it without allocating a new cell each time.
+                auto& iterator = static_cast<PropertyNameIterator&>(*cache->reusable_property_name_iterator);
+                cache->reusable_property_name_iterator = nullptr;
+                iterator.reset_with_cache_data(object, *cache->data, cache);
+                return iterator;
+            }
+
+            return PropertyNameIterator::create(interpreter.realm(), object, *cache->data, cache);
+        }
+    }
+
+    if (auto fast_iterator_data = TRY(try_get_fast_property_name_iterator_data(*object)); fast_iterator_data.has_value()) {
+        VERIFY(fast_iterator_data->shape);
+        auto cache_data = vm.heap().allocate<ObjectPropertyIteratorCacheData>(
+            vm,
+            move(fast_iterator_data->properties),
+            fast_iterator_data->fast_path,
+            fast_iterator_data->indexed_property_count,
+            fast_iterator_data->receiver_has_magical_length_property,
+            *fast_iterator_data->shape,
+            fast_iterator_data->prototype_chain_validity);
+        if (cache)
+            cache->data = cache_data;
+        if (cache && cache->reusable_property_name_iterator) {
+            auto& iterator = static_cast<PropertyNameIterator&>(*cache->reusable_property_name_iterator);
+            cache->reusable_property_name_iterator = nullptr;
+            iterator.reset_with_cache_data(object, cache_data, cache);
+            return iterator;
+        }
+
+        return PropertyNameIterator::create(interpreter.realm(), object, cache_data, cache);
+    }
 
     size_t estimated_properties_count = 0;
     HashTable<GC::Ref<Object>> seen_objects;
@@ -1552,8 +1706,7 @@ inline ThrowCompletionOr<IteratorRecordImpl> get_object_property_iterator(Interp
         in_prototype_chain = true;
     }
 
-    auto iterator = interpreter.realm().create<PropertyNameIterator>(interpreter.realm(), object, move(properties));
-    return IteratorRecordImpl { .done = false, .iterator = iterator, .next_method = js_undefined() };
+    return PropertyNameIterator::create(interpreter.realm(), object, move(properties));
 }
 
 ByteString Instruction::to_byte_string(Bytecode::Executable const& executable) const
@@ -3152,10 +3305,8 @@ ThrowCompletionOr<void> GetMethod::execute_impl(Bytecode::Interpreter& interpret
 
 NEVER_INLINE ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    auto iterator_record = TRY(get_object_property_iterator(interpreter, interpreter.get(m_object)));
-    interpreter.set(m_dst_iterator_object, iterator_record.iterator);
-    interpreter.set(m_dst_iterator_next, iterator_record.next_method);
-    interpreter.set(m_dst_iterator_done, Value(iterator_record.done));
+    auto* cache = bit_cast<ObjectPropertyIteratorCache*>(m_cache);
+    interpreter.set(m_dst_iterator, TRY(get_object_property_iterator(interpreter, interpreter.get(m_object), cache)));
     return {};
 }
 
@@ -3202,6 +3353,18 @@ ThrowCompletionOr<void> IteratorNextUnpack::execute_impl(Bytecode::Interpreter& 
     auto& iteration_result = iteration_result_or_done.get<IterationResult>();
     interpreter.set(m_dst_done, TRY(iteration_result.done));
     interpreter.set(m_dst_value, TRY(iteration_result.value));
+    return {};
+}
+
+ThrowCompletionOr<void> ObjectPropertyIteratorNext::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& iterator = static_cast<PropertyNameIterator&>(interpreter.get(m_iterator_object).as_object());
+    Value value;
+    bool done = false;
+    TRY(iterator.next(interpreter.vm(), done, value));
+    interpreter.set(m_dst_done, Value(done));
+    if (!done)
+        interpreter.set(m_dst_value, value);
     return {};
 }
 

--- a/Libraries/LibJS/Bytecode/PropertyNameIterator.cpp
+++ b/Libraries/LibJS/Bytecode/PropertyNameIterator.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Bytecode/PropertyNameIterator.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/Shape.h>
+
+namespace JS::Bytecode {
+
+GC_DEFINE_ALLOCATOR(PropertyNameIterator);
+
+GC::Ref<PropertyNameIterator> PropertyNameIterator::create(Realm& realm, GC::Ref<Object> object, Vector<PropertyKey> properties, FastPath fast_path, u32 indexed_property_count, GC::Ptr<Shape> shape, GC::Ptr<PrototypeChainValidity> prototype_chain_validity)
+{
+    return realm.create<PropertyNameIterator>(realm, object, move(properties), fast_path, indexed_property_count, shape, prototype_chain_validity);
+}
+
+GC::Ref<PropertyNameIterator> PropertyNameIterator::create(Realm& realm, GC::Ref<Object> object, ObjectPropertyIteratorCacheData& property_cache, ObjectPropertyIteratorCache* iterator_cache_slot)
+{
+    VERIFY(property_cache.fast_path() != FastPath::None);
+    return realm.create<PropertyNameIterator>(realm, object, property_cache, iterator_cache_slot);
+}
+
+ThrowCompletionOr<void> PropertyNameIterator::next(VM& vm, bool& done, Value& value)
+{
+    VERIFY(m_object);
+
+    while (true) {
+        if (m_next_indexed_property < m_indexed_property_count) {
+            auto current_index = m_next_indexed_property++;
+            auto entry = PropertyKey { current_index };
+
+            if (m_fast_path != FastPath::None && !fast_path_still_valid())
+                disable_fast_path();
+
+            if (m_fast_path == FastPath::None && !TRY(m_object->has_property(entry)))
+                continue;
+
+            done = false;
+            if (m_fast_path != FastPath::None && m_property_cache)
+                // Cache-backed iterators keep the return values pre-materialized
+                // so the asm fast path can hand back keys without converting a
+                // PropertyKey on every iteration.
+                value = property_value_list()[current_index];
+            else
+                value = entry.to_value(vm);
+            return {};
+        }
+
+        auto properties = property_list();
+        if (m_next_property >= properties.size()) {
+            if (m_iterator_cache_slot) {
+                // Once exhausted, hand the iterator object back to the bytecode
+                // site cache so the next execution of the same loop can reuse it.
+                m_object = nullptr;
+                m_iterator_cache_slot->reusable_property_name_iterator = this;
+                m_iterator_cache_slot = nullptr;
+            }
+            done = true;
+            return {};
+        }
+
+        auto current_index = m_next_property++;
+        auto const& entry = properties[current_index];
+
+        if (m_fast_path != FastPath::None && !fast_path_still_valid())
+            disable_fast_path();
+
+        // If the property is deleted, don't include it (invariant no. 2)
+        if (m_fast_path == FastPath::None && !TRY(m_object->has_property(entry)))
+            continue;
+
+        done = false;
+        if (m_fast_path != FastPath::None && m_property_cache)
+            value = property_value_list()[m_indexed_property_count + current_index];
+        else
+            value = entry.to_value(vm);
+        return {};
+    }
+}
+
+void PropertyNameIterator::reset_with_cache_data(GC::Ref<Object> object, ObjectPropertyIteratorCacheData& property_cache, ObjectPropertyIteratorCache* iterator_cache_slot)
+{
+    VERIFY(property_cache.fast_path() != FastPath::None);
+    m_object = object;
+    m_owned_properties.clear();
+    m_property_cache = &property_cache;
+    m_shape = property_cache.shape();
+    m_prototype_chain_validity = property_cache.prototype_chain_validity();
+    m_indexed_property_count = property_cache.indexed_property_count();
+    m_next_indexed_property = 0;
+    m_next_property = 0;
+    m_shape_is_dictionary = property_cache.shape()->is_dictionary();
+    m_shape_dictionary_generation = property_cache.shape_dictionary_generation();
+    m_fast_path = property_cache.fast_path();
+    m_iterator_cache_slot = iterator_cache_slot;
+    VERIFY(m_property_cache);
+    VERIFY(m_shape);
+}
+
+PropertyNameIterator::PropertyNameIterator(Realm& realm, GC::Ref<Object> object, Vector<PropertyKey> properties, FastPath fast_path, u32 indexed_property_count, GC::Ptr<Shape> shape, GC::Ptr<PrototypeChainValidity> prototype_chain_validity)
+    : Object(realm, nullptr)
+    , m_object(object)
+    , m_owned_properties(move(properties))
+    , m_shape(shape)
+    , m_prototype_chain_validity(prototype_chain_validity)
+    , m_indexed_property_count(indexed_property_count)
+    , m_fast_path(fast_path)
+{
+    if (m_shape)
+        m_shape_is_dictionary = m_shape->is_dictionary();
+    if (m_shape_is_dictionary)
+        m_shape_dictionary_generation = m_shape->dictionary_generation();
+}
+
+PropertyNameIterator::PropertyNameIterator(Realm& realm, GC::Ref<Object> object, ObjectPropertyIteratorCacheData& property_cache, ObjectPropertyIteratorCache* iterator_cache_slot)
+    : Object(realm, nullptr)
+    , m_object(object)
+    , m_property_cache(&property_cache)
+    , m_shape(property_cache.shape())
+    , m_prototype_chain_validity(property_cache.prototype_chain_validity())
+    , m_iterator_cache_slot(iterator_cache_slot)
+    , m_indexed_property_count(property_cache.indexed_property_count())
+    , m_shape_is_dictionary(property_cache.shape()->is_dictionary())
+    , m_shape_dictionary_generation(property_cache.shape_dictionary_generation())
+    , m_fast_path(property_cache.fast_path())
+{
+    VERIFY(m_fast_path != FastPath::None);
+    VERIFY(m_property_cache);
+    VERIFY(m_shape);
+}
+
+ReadonlySpan<PropertyKey> PropertyNameIterator::property_list() const
+{
+    if (m_property_cache)
+        return m_property_cache->properties();
+    return m_owned_properties.span();
+}
+
+ReadonlySpan<Value> PropertyNameIterator::property_value_list() const
+{
+    VERIFY(m_property_cache);
+    return m_property_cache->property_values();
+}
+
+bool PropertyNameIterator::fast_path_still_valid() const
+{
+    VERIFY(m_object);
+    VERIFY(m_shape);
+
+    // We revalidate on every next() call so active enumeration can deopt if the
+    // receiver or prototype chain changes underneath us. After deopting, the
+    // iterator resumes with has_property() checks for the remaining snapshot.
+    auto& shape = m_object->shape();
+    if (&shape != m_shape)
+        return false;
+
+    if (m_shape_is_dictionary && shape.dictionary_generation() != m_shape_dictionary_generation)
+        return false;
+
+    if (m_fast_path == FastPath::PackedIndexed) {
+        if (m_object->indexed_storage_kind() != IndexedStorageKind::Packed)
+            return false;
+        if (m_object->indexed_array_like_size() != m_indexed_property_count)
+            return false;
+    }
+
+    if (m_prototype_chain_validity && !m_prototype_chain_validity->is_valid())
+        return false;
+
+    return true;
+}
+
+void PropertyNameIterator::disable_fast_path()
+{
+    m_fast_path = FastPath::None;
+    m_shape = nullptr;
+    m_prototype_chain_validity = nullptr;
+    m_shape_is_dictionary = false;
+    m_shape_dictionary_generation = 0;
+}
+
+void PropertyNameIterator::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_object);
+    visitor.visit(m_property_cache);
+    visitor.visit(m_shape);
+    visitor.visit(m_prototype_chain_validity);
+    for (auto& key : m_owned_properties)
+        key.visit_edges(visitor);
+}
+
+}

--- a/Libraries/LibJS/Bytecode/PropertyNameIterator.h
+++ b/Libraries/LibJS/Bytecode/PropertyNameIterator.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Bytecode/Executable.h>
+#include <LibJS/Export.h>
+#include <LibJS/Runtime/Iterator.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace JS::Bytecode {
+
+class JS_API PropertyNameIterator final
+    : public Object
+    , public BuiltinIterator {
+    JS_OBJECT(PropertyNameIterator, Object);
+    GC_DECLARE_ALLOCATOR(PropertyNameIterator);
+
+public:
+    using FastPath = ObjectPropertyIteratorFastPath;
+
+    static GC::Ref<PropertyNameIterator> create(Realm&, GC::Ref<Object>, Vector<PropertyKey>, FastPath = FastPath::None, u32 indexed_property_count = 0, GC::Ptr<Shape> = nullptr, GC::Ptr<PrototypeChainValidity> = nullptr);
+    static GC::Ref<PropertyNameIterator> create(Realm&, GC::Ref<Object>, ObjectPropertyIteratorCacheData&, ObjectPropertyIteratorCache* = nullptr);
+
+    virtual ~PropertyNameIterator() override = default;
+
+    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value) override { return this; }
+    ThrowCompletionOr<void> next(VM&, bool& done, Value& value) override;
+
+    void reset_with_cache_data(GC::Ref<Object>, ObjectPropertyIteratorCacheData&, ObjectPropertyIteratorCache*);
+
+private:
+    PropertyNameIterator(Realm&, GC::Ref<Object>, Vector<PropertyKey>, FastPath, u32 indexed_property_count, GC::Ptr<Shape>, GC::Ptr<PrototypeChainValidity>);
+    PropertyNameIterator(Realm&, GC::Ref<Object>, ObjectPropertyIteratorCacheData&, ObjectPropertyIteratorCache*);
+
+    ReadonlySpan<PropertyKey> property_list() const;
+    ReadonlySpan<Value> property_value_list() const;
+
+    bool fast_path_still_valid() const;
+    void disable_fast_path();
+
+    virtual void visit_edges(Visitor&) override;
+
+    GC::Ptr<Object> m_object;
+    Vector<PropertyKey> m_owned_properties;
+    GC::Ptr<ObjectPropertyIteratorCacheData> m_property_cache;
+    GC::Ptr<Shape> m_shape;
+    GC::Ptr<PrototypeChainValidity> m_prototype_chain_validity;
+    ObjectPropertyIteratorCache* m_iterator_cache_slot { nullptr };
+    u32 m_indexed_property_count { 0 };
+    u32 m_next_indexed_property { 0 };
+    size_t m_next_property { 0 };
+    bool m_shape_is_dictionary { false };
+    u32 m_shape_dictionary_generation { 0 };
+    FastPath m_fast_path { FastPath::None };
+};
+
+}

--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -143,7 +143,8 @@ pub fn field_type_info(ty: &str) -> FieldType {
         "PropertyLookupCache*"
         | "GlobalVariableCache*"
         | "TemplateObjectCache*"
-        | "ObjectShapeCache*" => ("u64", 8, 8, "u64"),
+        | "ObjectShapeCache*"
+        | "ObjectPropertyIteratorCache*" => ("u64", 8, 8, "u64"),
         _ => unreachable!("Unknown field type: {ty}"),
     }
     .into()

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     Bytecode/Instruction.cpp
     Bytecode/Interpreter.cpp
     Bytecode/Label.cpp
+    Bytecode/PropertyNameIterator.cpp
     Bytecode/PropertyKeyTable.cpp
     Bytecode/RegexTable.cpp
     Bytecode/StringTable.cpp

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1450,7 +1450,7 @@ ThrowCompletionOr<void> Object::for_each_own_property_with_enumerability(Functio
             bool enumerable;
         };
         GC::ConservativeVector<OwnKey> keys { heap() };
-        keys.ensure_capacity(indexed_real_size() + shape().property_count());
+        keys.ensure_capacity(indexed_real_size() + shape().property_count() + (has_magical_length_property() ? 1 : 0));
 
         {
             auto indices = indexed_indices();
@@ -1464,6 +1464,9 @@ ThrowCompletionOr<void> Object::for_each_own_property_with_enumerability(Functio
                 keys.unchecked_append({ PropertyKey(index), enumerable });
             }
         }
+
+        if (has_magical_length_property())
+            keys.unchecked_append({ PropertyKey(vm.names.length), false });
 
         for (auto const& [property_key, metadata] : shape().property_table()) {
             if (!property_key.is_string())
@@ -1491,7 +1494,7 @@ ThrowCompletionOr<void> Object::for_each_own_property_with_enumerability(Functio
 
 size_t Object::own_properties_count() const
 {
-    return indexed_real_size() + shape().property_table().size();
+    return indexed_real_size() + shape().property_table().size() + (has_magical_length_property() ? 1 : 0);
 }
 
 // Simple side-effect free property lookup, following the prototype chain. Non-standard.

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -6538,18 +6538,17 @@ fn generate_for_in_statement(
     // Create TDZ for lexical declarations before evaluating the RHS expression.
     let entered_tdz = enter_for_in_of_head_tdz(generator, lhs);
 
-    // Evaluate RHS into `object`, allocate iterator registers, emit the
-    // null/undefined check + GetObjectPropertyIterator, then let `object`
-    // go out of scope so its register is freed before the loop body.
-    let (iterator_object, iterator_next_method, iterator_done) = {
+    // Evaluate RHS into `object`, allocate the internal property iterator
+    // register, emit the null/undefined check + GetObjectPropertyIterator,
+    // then let `object` go out of scope so its register is freed before the
+    // loop body.
+    let iterator_object = {
         let object = generate_expression_or_undefined(rhs, generator, None);
         if entered_tdz {
             leave_for_in_of_head_tdz(generator);
         }
 
         let iterator_object = generator.allocate_register();
-        let iterator_next_method = generator.allocate_register();
-        let iterator_done = generator.allocate_register();
 
         // Check for null/undefined
         let nullish_block = generator.make_block();
@@ -6566,14 +6565,14 @@ fn generate_for_in_statement(
         generator.switch_to_basic_block(continue_block);
 
         // Get property iterator
+        let cache = generator.next_object_property_iterator_cache();
         generator.emit(Instruction::GetObjectPropertyIterator {
-            dst_iterator_object: iterator_object.operand(),
-            dst_iterator_next: iterator_next_method.operand(),
-            dst_iterator_done: iterator_done.operand(),
+            dst_iterator: iterator_object.operand(),
             object: object.operand(),
+            cache: cache as u64,
         });
 
-        (iterator_object, iterator_next_method, iterator_done)
+        iterator_object
     };
     // Body evaluation: completion, then jump to update block.
     let completion = generator.allocate_completion_register();
@@ -6586,12 +6585,10 @@ fn generate_for_in_statement(
     generator.switch_to_basic_block(update_block);
     let next_value = generator.allocate_register();
     let done = generator.allocate_register();
-    generator.emit(Instruction::IteratorNextUnpack {
+    generator.emit(Instruction::ObjectPropertyIteratorNext {
         dst_value: next_value.operand(),
         dst_done: done.operand(),
         iterator_object: iterator_object.operand(),
-        iterator_next: iterator_next_method.operand(),
-        iterator_done: iterator_done.operand(),
     });
 
     let loop_continue_block = generator.make_block();

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -189,6 +189,7 @@ pub struct FFIExecutableData {
     pub global_variable_cache_count: u32,
     pub template_object_cache_count: u32,
     pub object_shape_cache_count: u32,
+    pub object_property_iterator_cache_count: u32,
     pub number_of_registers: u32,
     pub is_strict: bool,
     pub length_identifier: FFIOptionalU32,
@@ -562,6 +563,7 @@ pub unsafe fn create_executable(
             global_variable_cache_count: generator.next_global_variable_cache,
             template_object_cache_count: generator.next_template_object_cache,
             object_shape_cache_count: generator.next_object_shape_cache,
+            object_property_iterator_cache_count: generator.next_object_property_iterator_cache,
             number_of_registers: assembled.number_of_registers,
             is_strict: generator.strict,
             length_identifier: FFIOptionalU32::from(

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -172,6 +172,7 @@ pub struct Generator {
     pub next_global_variable_cache: u32,
     pub next_template_object_cache: u32,
     pub next_object_shape_cache: u32,
+    pub next_object_property_iterator_cache: u32,
 
     // --- Codegen state ---
     pub strict: bool,
@@ -316,6 +317,7 @@ impl Generator {
             next_global_variable_cache: 0,
             next_template_object_cache: 0,
             next_object_shape_cache: 0,
+            next_object_property_iterator_cache: 0,
             strict: false,
             function_environment_needed: true,
             enclosing_function_kind: FunctionKind::Normal,
@@ -815,6 +817,10 @@ impl Generator {
     next_cache_method!(next_global_variable_cache, next_global_variable_cache);
     next_cache_method!(next_template_object_cache, next_template_object_cache);
     next_cache_method!(next_object_shape_cache, next_object_shape_cache);
+    next_cache_method!(
+        next_object_property_iterator_cache,
+        next_object_property_iterator_cache
+    );
 
     // --- Lexical environment helpers ---
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -768,6 +768,7 @@ extern "C" void* rust_create_executable(
         data->global_variable_cache_count,
         data->template_object_cache_count,
         data->object_shape_cache_count,
+        data->object_property_iterator_cache_count,
         data->number_of_registers,
         data->is_strict ? JS::Strict::Yes : JS::Strict::No);
 

--- a/Meta/generate-libjs-bytecode-def-derived.py
+++ b/Meta/generate-libjs-bytecode-def-derived.py
@@ -361,6 +361,7 @@ CACHE_POINTER_TYPES = {
     "GlobalVariableCache*": "global_variable_caches",
     "TemplateObjectCache*": "template_object_caches",
     "ObjectShapeCache*": "object_shape_caches",
+    "ObjectPropertyIteratorCache*": "object_property_iterator_caches",
 }
 
 
@@ -608,7 +609,8 @@ def generate_fixup_cache_function(ops: List[OpDef]) -> str:
     lines.append("    Span<PropertyLookupCache> property_lookup_caches,")
     lines.append("    Span<GlobalVariableCache> global_variable_caches,")
     lines.append("    Span<TemplateObjectCache> template_object_caches,")
-    lines.append("    Span<ObjectShapeCache> object_shape_caches)")
+    lines.append("    Span<ObjectShapeCache> object_shape_caches,")
+    lines.append("    Span<ObjectPropertyIteratorCache> object_property_iterator_caches)")
     lines.append("{")
     lines.append('    // Sentinel value used to indicate "no cache" (originally u32::MAX).')
     lines.append("    static constexpr u64 NO_CACHE = NumericLimits<u32>::max();")
@@ -704,7 +706,8 @@ void fixup_instruction_cache(
     Span<PropertyLookupCache> property_lookup_caches,
     Span<GlobalVariableCache> global_variable_caches,
     Span<TemplateObjectCache> template_object_caches,
-    Span<ObjectShapeCache> object_shape_caches);
+    Span<ObjectShapeCache> object_shape_caches,
+    Span<ObjectPropertyIteratorCache> object_property_iterator_caches);
 
 } // namespace JS::Bytecode
 """

--- a/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
@@ -13,7 +13,7 @@ block0:
 
 
 foo$ad9db83a for-in-block-order.js:2:16
-  Registers: 10
+  Registers: 8
   Blocks:    6
   Locals:    k~0
   Constants:
@@ -28,16 +28,16 @@ block1:
   [  28] End value:Undefined
 
 block2:
-  [  30] IteratorNextUnpack dst_value:reg8, dst_done:reg9, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
-  [  48] JumpIf condition:reg9, true_target:block1, false_target:block5
+  [  30] ObjectPropertyIteratorNext dst_value:reg6, dst_done:reg7, iterator_object:reg5
+  [  40] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  58] Jump target:block1
+  [  50] Jump target:block1
 
 block4:
-  [  60] GetObjectPropertyIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, object:arg0
-  [  78] Jump target:block2
+  [  58] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
+  [  70] Jump target:block2
 
 block5:
-  [  80] Mov dst:k~0, src:reg8
-  [  90] Jump target:block2
+  [  78] Mov dst:k~0, src:reg6
+  [  88] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,5 +1,5 @@
 $6f3aad7a for-in-lexical-scope.js:1:1
-  Registers: 14
+  Registers: 12
   Blocks:    6
   Constants:
     [0] = Int32(0)
@@ -19,27 +19,27 @@ block1:
   [  78] End value:reg6
 
 block2:
-  [  80] IteratorNextUnpack dst_value:reg9, dst_done:reg10, iterator_object:reg5, iterator_next:reg7, iterator_done:reg8
-  [  98] JumpIf condition:reg10, true_target:block1, false_target:block5
+  [  80] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg5
+  [  90] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  a8] End value:reg6
+  [  a0] End value:reg6
 
 block4:
-  [  b0] GetObjectPropertyIterator dst_iterator_object:reg5, dst_iterator_next:reg7, dst_iterator_done:reg8, object:reg6
-  [  c8] Mov dst:reg6, src:Undefined
-  [  d8] Jump target:block2
+  [  a8] GetObjectPropertyIterator dst_iterator:reg5, object:reg6
+  [  c0] Mov dst:reg6, src:Undefined
+  [  d0] Jump target:block2
 
 block5:
-  [  e0] CreateLexicalEnvironment dst:reg11, parent:reg4, capacity:0
-  [  f0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [ 100] InitializeLexicalBinding `x`, src:reg9
-  [ 118] CreateLexicalEnvironment dst:reg12, parent:reg11, capacity:0
-  [ 128] CreateMutableBinding environment:reg12, `probeDecl`, can_be_deleted:false
-  [ 138] NewFunction dst:reg13, shared_function_data_index:0
-  [ 150] InitializeLexicalBinding `probeDecl`, src:reg13
-  [ 168] GetBinding dst:reg13, `probeDecl`
-  [ 180] SetVariableBinding `probeDecl`, src:reg13
-  [ 198] SetLexicalEnvironment environment:reg11
-  [ 1a0] SetLexicalEnvironment environment:reg4
-  [ 1a8] Jump target:block2
+  [  d8] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0
+  [  e8] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  f8] InitializeLexicalBinding `x`, src:reg7
+  [ 110] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0
+  [ 120] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
+  [ 130] NewFunction dst:reg11, shared_function_data_index:0
+  [ 148] InitializeLexicalBinding `probeDecl`, src:reg11
+  [ 160] GetBinding dst:reg11, `probeDecl`
+  [ 178] SetVariableBinding `probeDecl`, src:reg11
+  [ 190] SetLexicalEnvironment environment:reg9
+  [ 198] SetLexicalEnvironment environment:reg4
+  [ 1a0] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
@@ -1,0 +1,56 @@
+$5af00ff4 for-in-object-property-iterator-next.js:8:1
+  Registers: 8
+  Blocks:    1
+  Constants:
+    [0] = Undefined
+    [1] = Int32(2)
+    [2] = String("two")
+    [3] = String("foo")
+    [4] = Int32(7)
+    [5] = String("seven")
+
+block0:
+  [   0] GetLexicalEnvironment dst:reg4
+  [   8] GetGlobal dst:reg6, `collect`
+  [  20] NewObject dst:reg7
+  [  30] ToPrimitiveWithStringHint dst:Int32(2), value:Int32(2)
+  [  40] PutByValue base:reg7, property:Int32(2), src:String("two"), kind:Own
+  [  58] PutById base:reg7, `foo`, src:String("foo"), kind:Own
+  [  80] ToPrimitiveWithStringHint dst:Int32(7), value:Int32(7)
+  [  90] PutByValue base:reg7, property:Int32(7), src:String("seven"), kind:Own
+  [  a8] Call dst:reg5, callee:reg6, this_value:Undefined, collect, arguments:[reg7]
+  [  d0] End value:reg5
+
+
+collect$4195dbe6 for-in-object-property-iterator-next.js:2:18
+  Registers: 12
+  Blocks:    6
+  Locals:    key~0, keys~1
+
+block0:
+  [   0] GetLexicalEnvironment dst:reg4
+  [   8] NewArray dst:keys~1
+  [  18] JumpNullish condition:arg0, true_target:block3, false_target:block4
+
+block1:
+  [  28] Return value:keys~1
+
+block2:
+  [  30] ObjectPropertyIteratorNext dst_value:reg6, dst_done:reg7, iterator_object:reg5
+  [  40] JumpIf condition:reg7, true_target:block1, false_target:block5
+
+block3:
+  [  50] Return value:keys~1
+
+block4:
+  [  58] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
+  [  70] Jump target:block2
+
+block5:
+  [  78] Mov dst:key~0, src:reg6
+  [  88] GetById dst:reg9, base:keys~1, `push` (keys.push)
+  [  a8] Mov dst:reg10, src:keys~1
+  [  b8] ThrowIfTDZ src:key~0
+  [  c0] Mov dst:reg11, src:key~0
+  [  d0] Call dst:reg8, callee:reg9, this_value:reg10, keys.push, arguments:[reg11]
+  [  f8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
@@ -1,5 +1,5 @@
 $0d42cfa1 for-in-register-lifetime.js:1:1
-  Registers: 16
+  Registers: 14
   Blocks:    6
   Constants:
     [0] = String("")
@@ -24,26 +24,26 @@ block1:
   [  c8] End value:reg5
 
 block2:
-  [  d0] IteratorNextUnpack dst_value:reg9, dst_done:reg10, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  e8] JumpIf condition:reg10, true_target:block1, false_target:block5
+  [  d0] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
+  [  e0] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  f8] End value:reg5
+  [  f0] End value:reg5
 
 block4:
-  [ 100] GetObjectPropertyIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, object:reg5
-  [ 118] Mov dst:reg5, src:Undefined
-  [ 128] Jump target:block2
+  [  f8] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [ 110] Mov dst:reg5, src:Undefined
+  [ 120] Jump target:block2
 
 block5:
-  [ 130] SetGlobal `k`, src:reg9
-  [ 148] GetGlobal dst:reg11, `result`
-  [ 160] GetGlobal dst:reg12, `k`
-  [ 178] GetGlobal dst:reg13, `obj`
-  [ 190] GetGlobal dst:reg14, `k`
-  [ 1a8] GetByValue dst:reg15, base:reg13, property:reg14 (obj[reg14])
-  [ 1c0] Add dst:reg13, lhs:reg12, rhs:reg15
-  [ 1d0] Add dst:reg12, lhs:reg11, rhs:reg13
-  [ 1e0] SetGlobal `result`, src:reg12
-  [ 1f8] Mov dst:reg5, src:reg12
-  [ 208] Jump target:block2
+  [ 128] SetGlobal `k`, src:reg7
+  [ 140] GetGlobal dst:reg9, `result`
+  [ 158] GetGlobal dst:reg10, `k`
+  [ 170] GetGlobal dst:reg11, `obj`
+  [ 188] GetGlobal dst:reg12, `k`
+  [ 1a0] GetByValue dst:reg13, base:reg11, property:reg12 (obj[reg12])
+  [ 1b8] Add dst:reg11, lhs:reg10, rhs:reg13
+  [ 1c8] Add dst:reg10, lhs:reg9, rhs:reg11
+  [ 1d8] SetGlobal `result`, src:reg10
+  [ 1f0] Mov dst:reg5, src:reg10
+  [ 200] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
@@ -12,7 +12,7 @@ block0:
 
 
 fn$a115675f for-in-var-function-lhs-name.js:4:19
-  Registers: 10
+  Registers: 8
   Blocks:    6
   Locals:    f~0
   Constants:
@@ -30,16 +30,16 @@ block1:
   [  60] End value:Undefined
 
 block2:
-  [  68] IteratorNextUnpack dst_value:reg5, dst_done:reg9, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  80] JumpIf condition:reg9, true_target:block1, false_target:block5
+  [  68] ObjectPropertyIteratorNext dst_value:reg5, dst_done:reg7, iterator_object:reg6
+  [  78] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  90] Jump target:block1
+  [  88] Jump target:block1
 
 block4:
-  [  98] GetObjectPropertyIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, object:reg5
-  [  b0] Jump target:block2
+  [  90] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  a8] Jump target:block2
 
 block5:
-  [  b8] Mov dst:f~0, src:reg5
-  [  c8] Jump target:block2
+  [  b0] Mov dst:f~0, src:reg5
+  [  c0] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
@@ -1,5 +1,5 @@
 $fa0f7b9b invalid-lhs-forin-no-dead-code.js:1:1
-  Registers: 13
+  Registers: 11
   Blocks:    6
   Constants:
     [0] = Undefined
@@ -13,19 +13,19 @@ block1:
   [  28] End value:reg5
 
 block2:
-  [  30] IteratorNextUnpack dst_value:reg9, dst_done:reg10, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  48] JumpIf condition:reg10, true_target:block1, false_target:block5
+  [  30] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
+  [  40] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  58] End value:reg5
+  [  50] End value:reg5
 
 block4:
-  [  60] GetObjectPropertyIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, object:reg5
-  [  78] Mov dst:reg5, src:Undefined
-  [  88] Jump target:block2
+  [  58] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  70] Mov dst:reg5, src:Undefined
+  [  80] Jump target:block2
 
 block5:
-  [  90] GetGlobal dst:reg12, `f`
-  [  a8] Call dst:reg11, callee:reg12, this_value:Undefined, f
-  [  c8] NewReferenceError dst:reg11, Invalid left-hand side in assignment
-  [  d8] Throw src:reg11
+  [  88] GetGlobal dst:reg10, `f`
+  [  a0] Call dst:reg9, callee:reg10, this_value:Undefined, f
+  [  c0] NewReferenceError dst:reg9, Invalid left-hand side in assignment
+  [  d0] Throw src:reg9

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -86,7 +86,7 @@ block0:
 
 
 forInTeardown$e8d7ea8e lexical-env-teardown.js:28:5
-  Registers: 10
+  Registers: 8
   Blocks:    6
   Locals:    k~0, outer~1
   Constants:
@@ -107,20 +107,20 @@ block1:
   [  78] Return value:outer~1
 
 block2:
-  [  80] IteratorNextUnpack dst_value:reg5, dst_done:reg9, iterator_object:reg6, iterator_next:reg7, iterator_done:reg8
-  [  98] JumpIf condition:reg9, true_target:block1, false_target:block5
+  [  80] ObjectPropertyIteratorNext dst_value:reg5, dst_done:reg7, iterator_object:reg6
+  [  90] JumpIf condition:reg7, true_target:block1, false_target:block5
 
 block3:
-  [  a8] Return value:outer~1
+  [  a0] Return value:outer~1
 
 block4:
-  [  b0] GetObjectPropertyIterator dst_iterator_object:reg6, dst_iterator_next:reg7, dst_iterator_done:reg8, object:reg5
-  [  c8] Jump target:block2
+  [  a8] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  c0] Jump target:block2
 
 block5:
-  [  d0] Mov dst:k~0, src:reg5
-  [  e0] ThrowIfTDZ src:k~0
-  [  e8] Jump target:block2
+  [  c8] Mov dst:k~0, src:reg5
+  [  d8] ThrowIfTDZ src:k~0
+  [  e0] Jump target:block2
 
 
 forOfTeardown$b603f5d2 lexical-env-teardown.js:38:5

--- a/Tests/LibJS/Bytecode/input/for-in-object-property-iterator-next.js
+++ b/Tests/LibJS/Bytecode/input/for-in-object-property-iterator-next.js
@@ -1,0 +1,8 @@
+function collect(object) {
+    const keys = [];
+    for (const key in object)
+        keys.push(key);
+    return keys;
+}
+
+collect({ 2: "two", foo: "foo", 7: "seven" });

--- a/Tests/LibJS/Runtime/loops/for-in-basic.js
+++ b/Tests/LibJS/Runtime/loops/for-in-basic.js
@@ -30,12 +30,123 @@ test("iterate through string", () => {
     expect(a).toEqual(["0", "1", "2", "3", "4"]);
 });
 
+test("iterate through typed array", () => {
+    const a = [];
+    for (const property in new Uint8Array([1, 2])) {
+        a.push(property);
+    }
+    expect(a).toEqual(["0", "1"]);
+});
+
+test("array magical length shadows enumerable length higher in prototype chain", () => {
+    const tail = { length: 1 };
+    const array_prototype = [];
+    Object.setPrototypeOf(array_prototype, tail);
+
+    const array = [1, 2];
+    Object.setPrototypeOf(array, array_prototype);
+
+    const keys = [];
+    for (const key in array) {
+        keys.push(key);
+    }
+
+    expect(keys).toEqual(["0", "1"]);
+});
+
+test("array in prototype chain shadows enumerable length higher up", () => {
+    const tail = { length: 1 };
+    const array_prototype = [];
+    Object.setPrototypeOf(array_prototype, tail);
+
+    const object = Object.create(array_prototype);
+    object.foo = 1;
+
+    const keys = [];
+    for (const key in object) {
+        keys.push(key);
+    }
+
+    expect(keys).toEqual(["foo"]);
+});
+
+test("array magical length still shadows enumerable length on slow path", () => {
+    const tail = { length: 1 };
+    const proxy = new Proxy(Object.create(tail), {});
+
+    const array = [1, 2];
+    Object.setPrototypeOf(array, proxy);
+
+    const keys = [];
+    for (const key in array) {
+        keys.push(key);
+    }
+
+    expect(keys).toEqual(["0", "1"]);
+});
+
+test("same for-in site distinguishes arrays from plain objects with same prototype", () => {
+    function collect(object) {
+        const keys = [];
+        for (const key in object) keys.push(key);
+        return keys;
+    }
+
+    const proto = Object.create({ length: 1, z: 2 });
+
+    const array = [];
+    Object.setPrototypeOf(array, proto);
+
+    const object = {};
+    Object.setPrototypeOf(object, proto);
+
+    expect(collect(array)).toEqual(["z"]);
+    expect(collect(object)).toEqual(["length", "z"]);
+    expect(collect(array)).toEqual(["z"]);
+});
+
+test("same for-in site distinguishes plain objects from arrays with same prototype", () => {
+    function collect(object) {
+        const keys = [];
+        for (const key in object) keys.push(key);
+        return keys;
+    }
+
+    const proto = Object.create({ length: 1, z: 2 });
+
+    const array = [];
+    Object.setPrototypeOf(array, proto);
+
+    const object = {};
+    Object.setPrototypeOf(object, proto);
+
+    expect(collect(object)).toEqual(["length", "z"]);
+    expect(collect(array)).toEqual(["z"]);
+    expect(collect(object)).toEqual(["length", "z"]);
+});
+
 test("iterate through object", () => {
     const a = [];
     for (const property in { a: 1, b: 2, c: 2 }) {
         a.push(property);
     }
     expect(a).toEqual(["a", "b", "c"]);
+});
+
+test("iterate through object with numeric-looking and named properties", () => {
+    const object = {};
+    object[7] = "seven";
+    object.foo = "foo";
+    object[2] = "two";
+    object.bar = "bar";
+    object[9] = "nine";
+
+    const keys = [];
+    for (const key in object) {
+        keys.push(key);
+    }
+
+    expect(keys).toEqual(["2", "7", "9", "foo", "bar"]);
 });
 
 test("iterate through undefined", () => {
@@ -118,6 +229,44 @@ test("remove properties while iterating", () => {
     expect(to).toEqual(["0", "1"]);
 });
 
+test("delete future packed index while iterating", () => {
+    const from = [1, 2, 3];
+    const to = [];
+
+    for (const prop in from) {
+        to.push(prop);
+        if (prop === "0") delete from[1];
+    }
+
+    expect(to).toEqual(["0", "2"]);
+});
+
+test("iterate through holey array", () => {
+    const from = [1, 2, 3];
+    delete from[1];
+
+    const to = [];
+    for (const prop in from) {
+        to.push(prop);
+    }
+
+    expect(to).toEqual(["0", "2"]);
+});
+
+test("iterate through sparse array", () => {
+    const from = [];
+    from[1] = 2;
+    from[100] = 3;
+    from.foo = 4;
+
+    const to = [];
+    for (const prop in from) {
+        to.push(prop);
+    }
+
+    expect(to).toEqual(["1", "100", "foo"]);
+});
+
 test("duplicated properties in prototype", () => {
     const object = { a: 1 };
     const proto = { a: 2 };
@@ -127,4 +276,409 @@ test("duplicated properties in prototype", () => {
         a.push(prop);
     }
     expect(a).toEqual(["a"]);
+});
+
+test("delete future own named property while iterating", () => {
+    const object = { a: 1, b: 2, c: 3 };
+    const keys = [];
+
+    for (const key in object) {
+        keys.push(key);
+        if (key === "a") delete object.b;
+    }
+
+    expect(keys).toEqual(["a", "c"]);
+});
+
+test("delete future prototype named property while iterating", () => {
+    const proto = { a: 1, b: 2 };
+    const object = Object.create(proto);
+    const keys = [];
+
+    for (const key in object) {
+        keys.push(key);
+        if (key === "a") delete proto.b;
+    }
+
+    expect(keys).toEqual(["a"]);
+});
+
+test("delete future own dictionary property while iterating", () => {
+    const object = {};
+    for (let i = 0; i < 70; i++) object["p" + i] = i;
+
+    const keys = [];
+    for (const key in object) {
+        keys.push(key);
+        if (key === "p0") delete object.p1;
+        if (key === "p2") delete object.p10;
+    }
+
+    expect(keys).not.toContain("p1");
+    expect(keys).not.toContain("p10");
+    expect(keys).toHaveLength(68);
+});
+
+test("delete future prototype dictionary property while iterating", () => {
+    const proto = {};
+    for (let i = 0; i < 70; i++) proto["p" + i] = i;
+
+    const object = Object.create(proto);
+    const keys = [];
+    for (const key in object) {
+        keys.push(key);
+        if (key === "p0") delete proto.p1;
+        if (key === "p2") delete proto.p10;
+    }
+
+    expect(keys).not.toContain("p1");
+    expect(keys).not.toContain("p10");
+    expect(keys).toHaveLength(68);
+});
+
+test("packed indices stay ahead of named properties", () => {
+    const array = [1, 2];
+    array.foo = 3;
+    array.bar = 4;
+
+    const keys = [];
+    for (const key in array) keys.push(key);
+
+    expect(keys).toEqual(["0", "1", "foo", "bar"]);
+});
+
+test("delete future own named property while iterating packed indices", () => {
+    const array = [1, 2];
+    array.foo = 3;
+    array.bar = 4;
+
+    const keys = [];
+    for (const key in array) {
+        keys.push(key);
+        if (key === "0") delete array.foo;
+    }
+
+    expect(keys).toEqual(["0", "1", "bar"]);
+});
+
+test("delete future prototype named property while iterating packed indices", () => {
+    const proto = Object.create(Array.prototype);
+    proto.foo = 1;
+    proto.bar = 2;
+
+    const array = [1, 2];
+    Object.setPrototypeOf(array, proto);
+
+    const keys = [];
+    for (const key in array) {
+        keys.push(key);
+        if (key === "0") delete proto.foo;
+    }
+
+    expect(keys).toEqual(["0", "1", "bar"]);
+});
+
+test("repeated for-in sees own named properties added between runs", () => {
+    function collect_twice(object, between_runs) {
+        const runs = [];
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+            if (pass === 0) between_runs();
+        }
+        return runs;
+    }
+
+    const object = { a: 1 };
+    const runs = collect_twice(object, () => {
+        object.b = 2;
+    });
+
+    expect(runs).toEqual([["a"], ["a", "b"]]);
+});
+
+test("repeated for-in sees prototype named properties added between runs", () => {
+    function collect_twice(object, between_runs) {
+        const runs = [];
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+            if (pass === 0) between_runs();
+        }
+        return runs;
+    }
+
+    const proto = {};
+    const object = Object.create(proto);
+    const runs = collect_twice(object, () => {
+        proto.foo = 1;
+    });
+
+    expect(runs).toEqual([[], ["foo"]]);
+});
+
+test("repeated for-in sees indexed receiver properties added between runs", () => {
+    function collect_twice(object, between_runs) {
+        const runs = [];
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+            if (pass === 0) between_runs();
+        }
+        return runs;
+    }
+
+    const object = { foo: 1 };
+    const runs = collect_twice(object, () => {
+        object[0] = 2;
+    });
+
+    expect(runs).toEqual([["foo"], ["0", "foo"]]);
+});
+
+test("repeated for-in sees indexed prototype properties added between runs", () => {
+    function collect_twice(object, between_runs) {
+        const runs = [];
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+            if (pass === 0) between_runs();
+        }
+        return runs;
+    }
+
+    const proto = {};
+    const object = Object.create(proto);
+    const runs = collect_twice(object, () => {
+        proto[0] = 1;
+    });
+
+    expect(runs).toEqual([[], ["0"]]);
+});
+
+test("repeated for-in sees packed receivers grow between runs", () => {
+    function collect_twice(object, between_runs) {
+        const runs = [];
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+            if (pass === 0) between_runs();
+        }
+        return runs;
+    }
+
+    const array = [1, 2];
+    const runs = collect_twice(array, () => {
+        array[2] = 3;
+    });
+
+    expect(runs).toEqual([
+        ["0", "1"],
+        ["0", "1", "2"],
+    ]);
+});
+
+test("repeated for-in sees packed receivers become holey between runs", () => {
+    function collect_twice(object, between_runs) {
+        const runs = [];
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+            if (pass === 0) between_runs();
+        }
+        return runs;
+    }
+
+    const array = [1, 2, 3];
+    const runs = collect_twice(array, () => {
+        delete array[1];
+    });
+
+    expect(runs).toEqual([
+        ["0", "1", "2"],
+        ["0", "2"],
+    ]);
+});
+
+test("recursive for-in re-entry keeps the active enumeration stable", () => {
+    function collect(object, nested_object) {
+        const keys = [];
+
+        for (const key in object) {
+            keys.push(key);
+            if (nested_object && key === "a") keys.push(...collect(nested_object));
+        }
+
+        return keys;
+    }
+
+    const outer = { a: 1, b: 2, c: 3 };
+    const inner = [1, 2];
+
+    expect(collect(outer, inner)).toEqual(["a", "0", "1", "b", "c"]);
+});
+
+test("repeated for-in after break still sees the full next enumeration", () => {
+    function collect_twice(object) {
+        const runs = [];
+
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) {
+                keys.push(key);
+                if (pass === 0) break;
+            }
+            runs.push(keys);
+        }
+
+        return runs;
+    }
+
+    expect(collect_twice({ a: 1, b: 2, c: 3 })).toEqual([["a"], ["a", "b", "c"]]);
+});
+
+test("repeated for-in after full named completion still sees the full next enumeration", () => {
+    function collect_twice(object) {
+        const runs = [];
+
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+        }
+
+        return runs;
+    }
+
+    expect(collect_twice({ a: 1, b: 2, c: 3 })).toEqual([
+        ["a", "b", "c"],
+        ["a", "b", "c"],
+    ]);
+});
+
+test("completed cached for-in does not keep the last receiver alive", () => {
+    function exhaust(object) {
+        for (const key in object) {
+        }
+    }
+
+    function exhaust_and_drop_receiver() {
+        let receiver = { a: 1, b: 2, c: 3 };
+        let weak_ref = new WeakRef(receiver);
+        exhaust(receiver);
+        return weak_ref;
+    }
+
+    let weak_ref = exhaust_and_drop_receiver();
+    gc();
+    expect(weak_ref.deref()).toBeUndefined();
+});
+
+test("repeated for-in after full packed completion still sees the full next enumeration", () => {
+    function collect_twice(object) {
+        const runs = [];
+
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+        }
+
+        return runs;
+    }
+
+    const array = [1, 2];
+    array.foo = 3;
+    array.bar = 4;
+
+    expect(collect_twice(array)).toEqual([
+        ["0", "1", "foo", "bar"],
+        ["0", "1", "foo", "bar"],
+    ]);
+});
+
+test("repeated for-in after full mixed numeric-looking and named completion stays stable", () => {
+    function collect_twice(object) {
+        const runs = [];
+
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+        }
+
+        return runs;
+    }
+
+    const object = {};
+    object[7] = "seven";
+    object.foo = "foo";
+    object[2] = "two";
+    object.bar = "bar";
+    object[9] = "nine";
+
+    expect(collect_twice(object)).toEqual([
+        ["2", "7", "9", "foo", "bar"],
+        ["2", "7", "9", "foo", "bar"],
+    ]);
+});
+
+test("repeated empty for-in stays empty", () => {
+    function collect_twice(object) {
+        const runs = [];
+
+        for (let pass = 0; pass < 2; ++pass) {
+            const keys = [];
+            for (const key in object) keys.push(key);
+            runs.push(keys);
+        }
+
+        return runs;
+    }
+
+    expect(collect_twice({})).toEqual([[], []]);
+});
+
+test("shrink packed length while iterating", () => {
+    const array = [1, 2, 3];
+    const keys = [];
+
+    for (const key in array) {
+        keys.push(key);
+        if (key === "0") array.length = 1;
+    }
+
+    expect(keys).toEqual(["0"]);
+});
+
+test("indexed properties on prototype are still enumerated", () => {
+    const proto = [1, 2];
+    proto.foo = 3;
+
+    const object = Object.create(proto);
+    const keys = [];
+    for (const key in object) {
+        keys.push(key);
+    }
+
+    expect(keys).toEqual(["0", "1", "foo"]);
+});
+
+test("proxy in prototype chain is still enumerated", () => {
+    const proxy = new Proxy({ a: 1, b: 2 }, {});
+    const object = Object.create(proxy);
+    const keys = [];
+
+    for (const key in object) {
+        keys.push(key);
+        if (key === "a") delete proxy.b;
+    }
+
+    expect(keys).toEqual(["a"]);
 });

--- a/Tests/LibJS/Runtime/modules/basic-modules.js
+++ b/Tests/LibJS/Runtime/modules/basic-modules.js
@@ -148,6 +148,16 @@ describe("in- and exports", () => {
         expect(result).toHaveProperty("namedVarValue", 3 + 3);
     });
 
+    test("for-in can enumerate module namespace objects", () => {
+        const result = expectModulePassed("./basic-export-types.mjs");
+        const keys = [];
+        for (const key in result) {
+            keys.push(key);
+        }
+
+        expect(keys).toEqual(Object.keys(result));
+    });
+
     test("default exports", () => {
         const result = expectModulePassed("./module-with-default.mjs");
         expect(result).toHaveProperty("defaultValue");


### PR DESCRIPTION
Cache the flattened enumerable key snapshot for each `for..in` site and reuse a `PropertyNameIterator` when the receiver shape, dictionary generation, indexed storage kind and length, prototype chain validity, and magical-length state still match.

Handle packed indexed receivers as well as plain named-property objects. Teach `ObjectPropertyIteratorNext` in `asmint.asm` to return cached property values directly and to fall back to the slow iterator logic when any guard fails.

Treat arrays' hidden non-enumerable `length` property as a visited name for for-in shadowing, and include the receiver's magical-length state in the cache key so arrays and plain objects do not share snapshots.

Add `test-js` and `test-js-bytecode` coverage for mixed numeric and named keys, packed receiver transitions, re-entry, iterator reuse, GC retention, array length shadowing, and same-site cache reuse.

Speedometer 2 & 3 are both very happy:
```
Benchmark     Old Score     New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  67.70 ± 2.40  73.61 ± 1.65                1.087  7443.57 ± 87.43        6779.70 ± 105.36           1.098
Speedometer3  4.11 ± 0.08   4.22 ± 0.05                 1.028  6137.80 ± 45.29        6022.27 ± 64.58            1.019
```

js-benchmarks neutral or happy as well.

Some real winners where `for..in` iteration is actually used:

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ------------------
JetStreamExtra  web-ssr.js                              1.070      1.963 ± 1.961 … 1.965              1.835 ± 1.830 … 1.840              +0.2% (+0.2 MB)
JetStreamExtra  threejs.js                              1.090      2.022 ± 2.017 … 2.027              1.855 ± 1.852 … 1.857              -13.6% (-67.3 MB)
JetStreamExtra  prismjs-startup-es5.js                  1.098      1.904 ± 1.902 … 1.905              1.734 ± 1.732 … 1.736              -0.8% (-0.4 MB)
JetStreamExtra  prismjs-startup-es6.js                  1.100      1.906 ± 1.900 … 1.912              1.733 ± 1.729 … 1.736              -0.8% (-0.4 MB)
LongSpider      string-tagcloud.js                      1.111      0.856 ± 0.854 … 0.858              0.770 ± 0.770 … 0.771              -0.7% (-0.4 MB)
LongSpider      string-fasta.js                         2.397      4.286 ± 4.270 … 4.303              1.788 ± 1.780 … 1.796              -1.0% (-0.4 MB)
MicroBench      for-in-indexed-properties.js            4.405      0.991 ± 0.987 … 0.995              0.225 ± 0.224 … 0.226              +110.4% (+90.6 MB)
MicroBench      for-in-named-properties.js              7.167      1.272 ± 1.271 … 1.273              0.177 ± 0.176 … 0.179              -44.0% (-37.9 MB)
```

Full result (Linux/x86_64):
```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ------------------
LongSpider      3d-cube.js                              0.996      4.641 ± 4.566 … 4.716              4.658 ± 4.642 … 4.674              -0.0% (-0.0 MB)
LongSpider      3d-morph.js                             0.966      2.520 ± 2.514 … 2.527              2.610 ± 2.488 … 2.731              -1.6% (-0.4 MB)
LongSpider      3d-raytrace.js                          1.025      3.041 ± 3.040 … 3.042              2.967 ± 2.954 … 2.980              +0.6% (+0.2 MB)
LongSpider      access-binary-trees.js                  0.998      9.054 ± 8.977 … 9.130              9.073 ± 8.954 … 9.193              -3.4% (-3.4 MB)
LongSpider      access-fannkuch.js                      1.006      1.652 ± 1.649 … 1.655              1.642 ± 1.637 … 1.647              -1.6% (-0.4 MB)
LongSpider      access-nbody.js                         0.975      3.881 ± 3.873 … 3.888              3.979 ± 3.922 … 4.036              -1.6% (-0.4 MB)
LongSpider      access-nsieve.js                        1.014      0.939 ± 0.922 … 0.955              0.926 ± 0.921 … 0.932              -0.1% (-0.5 MB)
LongSpider      bitops-3bit-bits-in-byte.js             0.989      0.530 ± 0.530 … 0.530              0.536 ± 0.526 … 0.545              -1.6% (-0.4 MB)
LongSpider      bitops-bits-in-byte.js                  1.060      0.680 ± 0.680 … 0.681              0.642 ± 0.638 … 0.646              -1.6% (-0.4 MB)
LongSpider      bitops-nsieve-bits.js                   0.964      1.793 ± 1.746 … 1.839              1.860 ± 1.822 … 1.898              -0.2% (-0.1 MB)
LongSpider      controlflow-recursive.js                1.012      3.006 ± 2.951 … 3.061              2.970 ± 2.914 … 3.025              -1.6% (-0.4 MB)
LongSpider      crypto-aes.js                           0.953      4.488 ± 4.483 … 4.493              4.710 ± 4.498 … 4.923              -0.7% (-0.2 MB)
LongSpider      crypto-md5.js                           0.987      6.459 ± 6.416 … 6.503              6.542 ± 6.482 … 6.602              -0.4% (-0.3 MB)
LongSpider      crypto-sha1.js                          0.993      11.901 ± 11.886 … 11.916           11.986 ± 11.959 … 12.013           +0.0% (+0.0 MB)
LongSpider      date-format-tofte.js                    0.982      3.533 ± 3.533 … 3.534              3.598 ± 3.583 … 3.614              -3.7% (-1.1 MB)
LongSpider      date-format-xparb.js                    0.998      4.462 ± 4.439 … 4.485              4.472 ± 4.450 … 4.495              -0.3% (-0.1 MB)
LongSpider      hash-map.js                             0.975      1.207 ± 1.205 … 1.208              1.238 ± 1.189 … 1.287              +0.7% (+0.7 MB)
LongSpider      math-cordic.js                          0.997      5.858 ± 5.858 … 5.859              5.875 ± 5.858 … 5.892              -1.6% (-0.4 MB)
LongSpider      math-partial-sums.js                    1.040      0.847 ± 0.824 … 0.870              0.815 ± 0.812 … 0.818              -1.6% (-0.4 MB)
LongSpider      math-spectral-norm.js                   0.984      5.936 ± 5.934 … 5.939              6.034 ± 5.936 … 6.131              -1.6% (-0.4 MB)
LongSpider      string-base64.js                        1.007      2.184 ± 2.182 … 2.186              2.170 ± 2.162 … 2.178              +3.3% (+12.6 MB)
LongSpider      string-fasta.js                         2.397      4.286 ± 4.270 … 4.303              1.788 ± 1.780 … 1.796              -1.0% (-0.4 MB)
LongSpider      string-tagcloud.js                      1.111      0.856 ± 0.854 … 0.858              0.770 ± 0.770 … 0.771              -0.7% (-0.4 MB)
Kraken          ai-astar.js                             0.991      0.633 ± 0.618 … 0.647              0.638 ± 0.632 … 0.645              -0.3% (-0.2 MB)
Kraken          audio-beat-detection.js                 1.037      0.535 ± 0.528 … 0.542              0.516 ± 0.506 … 0.526              -4.8% (-3.2 MB)
Kraken          audio-dft.js                            0.958      0.353 ± 0.351 … 0.355              0.369 ± 0.354 … 0.384              -0.2% (-0.1 MB)
Kraken          audio-fft.js                            1.030      0.440 ± 0.422 … 0.458              0.427 ± 0.424 … 0.430              -0.5% (-0.3 MB)
Kraken          audio-oscillator.js                     0.940      0.366 ± 0.365 … 0.366              0.389 ± 0.367 … 0.412              +0.1% (+0.1 MB)
Kraken          imaging-darkroom.js                     0.996      0.606 ± 0.604 … 0.608              0.609 ± 0.607 … 0.611              -0.2% (-0.2 MB)
Kraken          imaging-desaturate.js                   0.979      0.584 ± 0.584 … 0.585              0.597 ± 0.579 … 0.615              +0.1% (+0.0 MB)
Kraken          imaging-gaussian-blur.js                0.903      2.581 ± 2.566 … 2.596              2.858 ± 2.627 … 3.089              -0.0% (-0.0 MB)
Kraken          json-parse-financial.js                 0.961      0.055 ± 0.054 … 0.055              0.057 ± 0.057 … 0.057              +1.8% (+0.6 MB)
Kraken          json-stringify-tinderbox.js             0.988      0.049 ± 0.049 … 0.050              0.050 ± 0.050 … 0.050              -2.7% (-1.1 MB)
Kraken          stanford-crypto-aes.js                  0.991      0.222 ± 0.222 … 0.223              0.224 ± 0.220 … 0.229              +0.0% (+0.0 MB)
Kraken          stanford-crypto-ccm.js                  0.974      0.174 ± 0.170 … 0.179              0.179 ± 0.177 … 0.181              -1.8% (-0.8 MB)
Kraken          stanford-crypto-pbkdf2.js               1.025      0.386 ± 0.384 … 0.389              0.377 ± 0.372 … 0.382              +0.6% (+0.2 MB)
Kraken          stanford-crypto-sha256-iterative.js     0.974      0.154 ± 0.153 … 0.154              0.158 ± 0.157 … 0.159              -0.6% (-0.2 MB)
Octane          box2d.js                                0.983      7946.500 ± 7927.000 … 7966.000     7813.000 ± 7783.000 … 7843.000     -0.0% (-0.0 MB)
Octane          code-load.js                            1.008      19224.000 ± 19215.000 … 19233.000  19386.000 ± 19376.000 … 19396.000  +0.5% (+5.2 MB)
Octane          crypto.js                               0.950      2873.500 ± 2868.000 … 2879.000     2730.500 ± 2727.000 … 2734.000     +0.2% (+0.1 MB)
Octane          deltablue.js                            0.980      1517.000 ± 1507.000 … 1527.000     1487.000 ± 1475.000 … 1499.000     -0.1% (-0.0 MB)
Octane          earley-boyer.js                         1.008      4445.000 ± 4438.000 … 4452.000     4479.500 ± 4450.000 … 4509.000     -0.5% (-0.3 MB)
Octane          gbemu.js                                1.005      15152.000 ± 15152.000 … 15152.000  15232.500 ± 15225.000 … 15240.000  +0.1% (+0.1 MB)
Octane          mandreel.js                             0.977      16537.000 ± 16345.000 … 16729.000  16161.000 ± 16030.000 … 16292.000  -0.2% (-0.7 MB)
Octane          navier-stokes.js                        0.998      5369.500 ± 5082.000 … 5657.000     5359.000 ± 5016.000 … 5702.000     -1.6% (-0.4 MB)
Octane          pdfjs.js                                0.991      6466.500 ± 6443.000 … 6490.000     6405.500 ± 6397.000 … 6414.000     -0.9% (-0.7 MB)
Octane          raytrace.js                             0.977      3375.500 ± 3357.000 … 3394.000     3296.500 ± 3249.000 … 3344.000     -0.3% (-0.1 MB)
Octane          regexp.js                               0.992      1789.500 ± 1779.000 … 1800.000     1776.000 ± 1776.000 … 1776.000     -0.0% (-0.0 MB)
Octane          richards.js                             0.992      1833.000 ± 1800.000 … 1866.000     1819.000 ± 1776.000 … 1862.000     -0.1% (-0.0 MB)
Octane          splay.js                                0.991      5578.500 ± 5575.000 … 5582.000     5526.500 ± 5514.000 … 5539.000     +0.0% (+0.1 MB)
Octane          typescript.js                           1.016      17906.500 ± 17860.000 … 17953.000  18193.000 ± 18168.000 … 18218.000  +1.8% (+4.3 MB)
Octane          zlib.js                                 0.977      5734.000 ± 5664.000 … 5804.000     5600.500 ± 5536.000 … 5665.000     +0.1% (+0.1 MB)
JetStream       bigfib.cpp.js                           0.926      4.455 ± 4.412 … 4.498              4.812 ± 4.719 … 4.906              +0.5% (+1.1 MB)
JetStream       cdjs.js                                 1.013      2.480 ± 2.471 … 2.490              2.448 ± 2.443 … 2.453              +0.6% (+0.2 MB)
JetStream       container.cpp.js                        1.045      21.247 ± 21.020 … 21.474           20.338 ± 20.127 … 20.550           +0.1% (+0.2 MB)
JetStream       dry.c.js                                0.943      11.460 ± 11.248 … 11.673           12.157 ± 12.123 … 12.192           -0.0% (-0.0 MB)
JetStream       float-mm.c.js                           1.028      12.967 ± 12.795 … 13.140           12.611 ± 12.281 … 12.941           -0.2% (-0.1 MB)
JetStream       gcc-loops.cpp.js                        1.035      76.012 ± 74.496 … 77.528           73.448 ± 71.891 … 75.004           +0.0% (+0.1 MB)
JetStream       hash-map.js                             0.999      1.198 ± 1.188 … 1.207              1.198 ± 1.197 … 1.200              +0.3% (+0.3 MB)
JetStream       n-body.c.js                             0.995      18.140 ± 17.589 … 18.690           18.239 ± 18.192 … 18.285           +0.4% (+0.2 MB)
JetStream       quicksort.c.js                          0.917      2.906 ± 2.869 … 2.944              3.168 ± 3.141 … 3.194              -0.1% (-0.0 MB)
JetStream       towers.c.js                             0.940      3.301 ± 3.209 … 3.393              3.511 ± 3.473 … 3.550              -0.5% (-0.2 MB)
JetStream3      js-tokens.js                            1.022      0.309 ± 0.307 … 0.311              0.302 ± 0.300 … 0.305              -0.2% (-0.1 MB)
JetStream3      lazy-collections.js                     0.979      0.902 ± 0.892 … 0.912              0.921 ± 0.897 … 0.946              +0.0% (+0.0 MB)
JetStream3      raytrace-private-class-fields.js        1.053      3.878 ± 3.805 … 3.950              3.682 ± 3.672 … 3.692              -0.7% (-0.2 MB)
JetStream3      raytrace-public-class-fields.js         1.022      2.812 ± 2.768 … 2.857              2.752 ± 2.749 … 2.755              -0.9% (-0.2 MB)
JetStream3      sync-file-system.js                     0.952      1.904 ± 1.892 … 1.916              1.999 ± 1.995 … 2.003              +2.0% (+0.7 MB)
AsyncBench      async-call-return.js                    1.043      0.179 ± 0.174 … 0.185              0.172 ± 0.172 … 0.172              +0.4% (+0.1 MB)
AsyncBench      async-class-method.js                   1.004      0.205 ± 0.204 … 0.206              0.204 ± 0.202 … 0.205              +0.8% (+0.2 MB)
AsyncBench      async-fan-out.js                        0.997      0.182 ± 0.179 … 0.185              0.183 ± 0.182 … 0.183              -0.5% (-0.1 MB)
AsyncBench      async-generator.js                      0.991      0.262 ± 0.261 … 0.263              0.265 ± 0.263 … 0.267              -0.7% (-0.2 MB)
AsyncBench      async-iife.js                           1.028      0.287 ± 0.287 … 0.287              0.279 ± 0.275 … 0.282              +0.7% (+0.2 MB)
AsyncBench      async-nested-calls.js                   0.969      0.291 ± 0.289 … 0.292              0.300 ± 0.289 … 0.311              -0.1% (-0.0 MB)
AsyncBench      async-pipeline.js                       0.993      0.346 ± 0.346 … 0.347              0.349 ± 0.344 … 0.354              +0.3% (+0.1 MB)
AsyncBench      async-sequential-awaits.js              0.951      0.089 ± 0.089 … 0.090              0.094 ± 0.091 … 0.097              -0.4% (-0.1 MB)
AsyncBench      async-try-catch-reject.js               1.005      0.495 ± 0.495 … 0.495              0.493 ± 0.492 … 0.494              -0.1% (-0.0 MB)
AsyncBench      await-primitive.js                      0.986      0.050 ± 0.049 … 0.051              0.051 ± 0.050 … 0.051              -0.8% (-0.4 MB)
AsyncBench      await-resolved-promise.js               0.985      0.430 ± 0.429 … 0.432              0.437 ± 0.437 … 0.437              -0.8% (-0.4 MB)
AsyncBench      await-thenable.js                       0.994      0.054 ± 0.053 … 0.054              0.054 ± 0.053 … 0.056              +0.0% (+0.0 MB)
AsyncBench      promise-all.js                          0.985      0.508 ± 0.505 … 0.511              0.516 ± 0.513 … 0.519              -0.8% (-0.4 MB)
AsyncBench      promise-allSettled.js                   1.011      0.591 ± 0.584 … 0.598              0.584 ± 0.583 … 0.585              -0.8% (-0.4 MB)
AsyncBench      promise-chain.js                        1.000      0.291 ± 0.290 … 0.292              0.291 ± 0.288 … 0.293              -0.0% (-0.0 MB)
AsyncBench      promise-new-resolve.js                  1.015      0.279 ± 0.278 … 0.279              0.274 ± 0.273 … 0.276              -0.8% (-0.4 MB)
AsyncBench      promise-race.js                         1.000      0.534 ± 0.533 … 0.534              0.534 ± 0.528 … 0.539              -0.8% (-0.4 MB)
ARES-6          Air.js                                  1.006      1.792 ± 1.790 … 1.794              1.781 ± 1.771 … 1.790              +0.6% (+0.4 MB)
ARES-6          Babylon.js                              0.995      1.244 ± 1.244 … 1.245              1.251 ± 1.240 … 1.262              -0.8% (-0.4 MB)
ARES-6          Basic.js                                0.999      1.682 ± 1.678 … 1.685              1.683 ± 1.669 … 1.697              -0.8% (-0.4 MB)
ARES-6          ML.js                                   0.985      1.960 ± 1.954 … 1.966              1.990 ± 1.966 … 2.014              -0.8% (-0.4 MB)
JetStreamExtra  FlightPlanner.js                        0.935      1.175 ± 1.171 … 1.180              1.258 ± 1.128 … 1.387              +0.0% (+0.2 MB)
JetStreamExtra  OfflineAssembler.js                     1.011      1.430 ± 1.424 … 1.435              1.414 ± 1.411 … 1.417              +0.1% (+0.4 MB)
JetStreamExtra  UniPoker.js                             0.985      1.401 ± 1.399 … 1.403              1.423 ± 1.393 … 1.454              -0.8% (-0.4 MB)
JetStreamExtra  async-fs.js                             0.995      1.754 ± 1.751 … 1.758              1.763 ± 1.751 … 1.775              -0.8% (-0.4 MB)
JetStreamExtra  babylonjs-startup-es5.js                0.986      1.167 ± 1.165 … 1.169              1.183 ± 1.171 … 1.195              +0.2% (+1.2 MB)
JetStreamExtra  babylonjs-startup-es6.js                0.988      1.412 ± 1.412 … 1.412              1.430 ± 1.407 … 1.452              -0.1% (-1.1 MB)
JetStreamExtra  bigint-bigdenary.js                     0.980      1.754 ± 1.745 … 1.763              1.789 ± 1.753 … 1.825              -0.8% (-0.4 MB)
JetStreamExtra  bigint-noble-bls12-381.js               0.991      1.860 ± 1.854 … 1.867              1.877 ± 1.852 … 1.902              -0.8% (-0.4 MB)
JetStreamExtra  bigint-noble-ed25519.js                 1.004      1.910 ± 1.897 … 1.924              1.903 ± 1.895 … 1.911              -0.0% (-0.0 MB)
JetStreamExtra  bigint-noble-secp256k1.js               0.988      1.753 ± 1.748 … 1.758              1.774 ± 1.774 … 1.774              +0.6% (+0.3 MB)
JetStreamExtra  bigint-paillier.js                      1.008      1.825 ± 1.819 … 1.830              1.810 ± 1.808 … 1.812              +0.2% (+0.1 MB)
JetStreamExtra  doxbee-async.js                         0.983      1.723 ± 1.719 … 1.728              1.752 ± 1.750 … 1.754              +0.5% (+0.3 MB)
JetStreamExtra  doxbee-promise.js                       0.972      1.741 ± 1.729 … 1.752              1.791 ± 1.775 … 1.806              -0.5% (-0.3 MB)
JetStreamExtra  first-inspector-code-load.js            0.983      1.988 ± 1.983 … 1.992              2.021 ± 2.019 … 2.024              +0.0% (+0.1 MB)
JetStreamExtra  jsdom-d3-startup.js                     0.999      1.621 ± 1.619 … 1.622              1.622 ± 1.615 … 1.629              -0.2% (-0.6 MB)
JetStreamExtra  json-parse-inspector.js                 0.998      1.097 ± 1.094 … 1.099              1.099 ± 1.098 … 1.100              -2.7% (-7.7 MB)
JetStreamExtra  json-stringify-inspector.js             1.020      0.971 ± 0.955 … 0.988              0.952 ± 0.950 … 0.954              -0.7% (-1.9 MB)
JetStreamExtra  mobx-startup.js                         0.992      1.584 ± 1.583 … 1.586              1.598 ± 1.591 … 1.605              -1.3% (-0.7 MB)
JetStreamExtra  multi-inspector-code-load.js            0.986      1.990 ± 1.989 … 1.991              2.018 ± 2.004 … 2.031              -0.1% (-0.9 MB)
JetStreamExtra  prismjs-startup-es5.js                  1.098      1.904 ± 1.902 … 1.905              1.734 ± 1.732 … 1.736              -0.8% (-0.4 MB)
JetStreamExtra  prismjs-startup-es6.js                  1.100      1.906 ± 1.900 … 1.912              1.733 ± 1.729 … 1.736              -0.8% (-0.4 MB)
JetStreamExtra  proxy-mobx.js                           0.998      1.420 ± 1.410 … 1.430              1.423 ± 1.418 … 1.428              -0.8% (-0.4 MB)
JetStreamExtra  proxy-vue.js                            1.001      1.478 ± 1.360 … 1.595              1.476 ± 1.403 … 1.550              -1.3% (-0.8 MB)
JetStreamExtra  threejs.js                              1.090      2.022 ± 2.017 … 2.027              1.855 ± 1.852 … 1.857              -13.6% (-67.3 MB)
JetStreamExtra  typescript-lib.js                       1.007      0.760 ± 0.754 … 0.766              0.755 ± 0.746 … 0.764              -1.4% (-3.8 MB)
JetStreamExtra  validatorjs.js                          1.058      1.720 ± 1.720 … 1.720              1.625 ± 1.608 … 1.643              -0.7% (-0.4 MB)
JetStreamExtra  web-ssr.js                              1.070      1.963 ± 1.961 … 1.965              1.835 ± 1.830 … 1.840              +0.2% (+0.2 MB)
GarBench        array-of-objects.js                     1.016      0.903 ± 0.875 … 0.931              0.889 ± 0.873 … 0.905              +0.0% (+0.1 MB)
GarBench        closures.js                             1.001      1.261 ± 1.251 … 1.271              1.259 ± 1.258 … 1.261              -0.2% (-2.1 MB)
GarBench        cyclic-graph.js                         1.002      1.393 ± 1.367 … 1.418              1.390 ± 1.360 … 1.419              -0.0% (-0.0 MB)
GarBench        deep-linked-list.js                     0.998      0.826 ± 0.826 … 0.827              0.827 ± 0.827 … 0.827              +0.0% (+0.2 MB)
GarBench        finalization.js                         1.011      1.071 ± 1.041 … 1.101              1.060 ± 1.023 … 1.096              -0.0% (-0.1 MB)
GarBench        many-properties.js                      1.033      2.976 ± 2.976 … 2.976              2.882 ± 2.881 … 2.883              +2.1% (+27.8 MB)
GarBench        marking-stress.js                       1.068      1.615 ± 1.546 … 1.684              1.513 ± 1.479 … 1.546              +0.1% (+0.8 MB)
GarBench        mixed-sizes.js                          1.039      1.176 ± 1.125 … 1.227              1.132 ± 1.119 … 1.145              +0.0% (+0.1 MB)
GarBench        sparse-arrays.js                        0.961      2.330 ± 2.279 … 2.380              2.425 ± 2.268 … 2.583              +0.0% (+0.0 MB)
GarBench        string-heavy.js                         0.968      2.035 ± 2.035 … 2.035              2.101 ± 2.047 … 2.156              +0.0% (+0.2 MB)
GarBench        wide-tree.js                            1.001      1.617 ± 1.615 … 1.619              1.615 ± 1.615 … 1.615              +0.0% (+0.3 MB)
MicroBench      array-destructuring-assignment-rest.js  1.000      0.317 ± 0.310 … 0.323              0.316 ± 0.310 … 0.323              -0.8% (-0.4 MB)
MicroBench      array-destructuring-assignment.js       0.994      3.105 ± 3.100 … 3.110              3.126 ± 3.109 … 3.142              +0.0% (+0.0 MB)
MicroBench      array-prototype-map.js                  1.003      1.170 ± 1.166 … 1.174              1.166 ± 1.165 … 1.167              +0.1% (+0.3 MB)
MicroBench      array-prototype-shift.js                0.973      0.017 ± 0.017 … 0.017              0.017 ± 0.017 … 0.018              -0.8% (-0.4 MB)
MicroBench      bound-call-00-args.js                   1.000      1.552 ± 1.550 … 1.554              1.551 ± 1.547 … 1.556              -0.8% (-0.4 MB)
MicroBench      bound-call-04-args.js                   1.000      1.700 ± 1.697 … 1.704              1.700 ± 1.698 … 1.702              -0.8% (-0.4 MB)
MicroBench      bound-call-16-args.js                   1.025      1.953 ± 1.905 … 2.001              1.906 ± 1.905 … 1.907              -0.8% (-0.4 MB)
MicroBench      call-00-args.js                         0.997      0.757 ± 0.754 … 0.760              0.759 ± 0.759 … 0.760              -0.8% (-0.4 MB)
MicroBench      call-01-args.js                         1.015      0.797 ± 0.786 … 0.809              0.786 ± 0.785 … 0.787              -0.8% (-0.4 MB)
MicroBench      call-02-args.js                         0.976      0.805 ± 0.803 … 0.808              0.825 ± 0.800 … 0.850              -0.8% (-0.4 MB)
MicroBench      call-03-args.js                         1.014      0.829 ± 0.828 … 0.830              0.817 ± 0.816 … 0.819              -0.8% (-0.4 MB)
MicroBench      call-04-args.js                         0.986      0.840 ± 0.839 … 0.840              0.852 ± 0.842 … 0.861              -0.8% (-0.4 MB)
MicroBench      call-16-args.js                         1.003      1.034 ± 1.028 … 1.041              1.031 ± 1.029 … 1.033              -0.8% (-0.4 MB)
MicroBench      call-32-args.js                         1.003      1.258 ± 1.255 … 1.260              1.254 ± 1.243 … 1.265              -0.8% (-0.4 MB)
MicroBench      for-in-indexed-properties.js            4.405      0.991 ± 0.987 … 0.995              0.225 ± 0.224 … 0.226              +110.4% (+90.6 MB)
MicroBench      for-in-named-properties.js              7.167      1.272 ± 1.271 … 1.273              0.177 ± 0.176 … 0.179              -44.0% (-37.9 MB)
MicroBench      for-of.js                               1.027      0.575 ± 0.519 … 0.631              0.560 ± 0.513 … 0.607              -0.8% (-0.4 MB)
MicroBench      object-keys.js                          1.014      1.286 ± 1.282 … 1.289              1.268 ± 1.267 … 1.269              -0.2% (-0.2 MB)
MicroBench      object-set-with-rope-strings.js         0.968      0.696 ± 0.696 … 0.696              0.719 ± 0.702 … 0.737              -0.8% (-0.4 MB)
MicroBench      pic-add-own.js                          0.992      0.419 ± 0.418 … 0.420              0.422 ± 0.421 … 0.424              -0.8% (-0.4 MB)
MicroBench      pic-get-own.js                          1.009      0.755 ± 0.751 … 0.760              0.749 ± 0.746 … 0.751              -0.8% (-0.4 MB)
MicroBench      pic-get-pchain.js                       1.019      0.770 ± 0.765 … 0.774              0.755 ± 0.754 … 0.756              -0.8% (-0.4 MB)
MicroBench      pic-put-own.js                          1.108      0.889 ± 0.778 … 1.000              0.802 ± 0.784 … 0.820              -0.8% (-0.4 MB)
MicroBench      pic-put-pchain.js                       0.955      2.200 ± 2.163 … 2.237              2.304 ± 2.165 … 2.443              -0.8% (-0.4 MB)
MicroBench      setter-in-prototype-chain.js            1.125      2.311 ± 1.889 … 2.734              2.055 ± 1.956 … 2.154              -0.8% (-0.4 MB)
MicroBench      strictly-equals-object.js               1.015      0.732 ± 0.730 … 0.734              0.721 ± 0.720 … 0.722              -0.8% (-0.4 MB)
LongSpider      Total                                   1.023      83.755                             81.862                             +0.2% (+3.5 MB)
Kraken          Total                                   0.958      7.139                              7.449                              -0.7% (-5.2 MB)
Octane          Total                                   0.996      115748.000                         115265.500                         +0.3% (+7.5 MB)
JetStream       Total                                   1.015      154.166                            151.931                            +0.2% (+1.6 MB)
JetStream3      Total                                   1.015      9.805                              9.657                              +0.1% (+0.1 MB)
AsyncBench      Total                                   0.999      5.073                              5.079                              -0.2% (-2.2 MB)
ARES-6          Total                                   0.996      6.678                              6.704                              -0.4% (-0.8 MB)
JetStreamExtra  Total                                   1.010      43.329                             42.912                             -1.0% (-85.3 MB)
GarBench        Total                                   1.006      17.202                             17.093                             +0.3% (+27.1 MB)
MicroBench      Total                                   1.069      29.031                             27.146                             +0.9% (+44.6 MB)
All Suites      Total                                   1.014      421.688                            415.883                            -0.0% (-9.0 MB)
```