### PR TITLE
LibWeb: Left-align the video progress bar

### DIFF
--- a/Libraries/LibWeb/HTML/MediaControls.css
+++ b/Libraries/LibWeb/HTML/MediaControls.css
@@ -55,6 +55,7 @@
     background-clip: content-box;
     cursor: pointer;
     flex-shrink: 0;
+    text-align: left;
 }
 
 .timeline-fill {


### PR DESCRIPTION
Prevents ancestors of the `<video>` element from moving the bar around. For example, `<center><video></center>` would cause the progress bar to start in the center and expand outwards.

---

Fixes the video on https://apod.nasa.gov/apod/ap260409.html

Before:
<img width="1367" height="1210" alt="image" src="https://github.com/user-attachments/assets/739edb67-1ad8-436f-b825-aa6386a7ffa1" />

After:
<img width="1367" height="1210" alt="Screenshot_20260410_122801" src="https://github.com/user-attachments/assets/63cc2fa0-28ab-469c-9a11-e7a0615fb919" />

Not 100% sure if this is the right thing to do, so feel free to correct me ruthlessly!