### PR TITLE
LibWeb: Clear stale layout state for inactive documents

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1171,6 +1171,16 @@ void Document::tear_down_layout_tree()
     m_needs_full_layout_tree_update = true;
 }
 
+void Document::clear_layout_and_paintable_nodes_for_inactive_document()
+{
+    for_each_in_inclusive_subtree([&](auto& node) {
+        node.clear_layout_node_and_paintable({});
+        if (auto* element = as_if<Element>(node))
+            element->clear_pseudo_element_layout_nodes({});
+        return TraversalDecision::Continue;
+    });
+}
+
 Color Document::background_color() const
 {
     // CSS2 says we should use the HTML element's background color unless it's transparent...
@@ -4601,6 +4611,12 @@ void Document::destroy()
     // 6. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
     run_unloading_cleanup_steps();
 
+    // AD-HOC: Destruction does not go through did_stop_being_active_document_in_navigable(),
+    //         but stale per-node and root layout/paintable pointers can still keep the old
+    //         layout tree alive until GC runs.
+    clear_layout_and_paintable_nodes_for_inactive_document();
+    tear_down_layout_tree();
+
     // 7. Remove any tasks whose document is document from any task queue (without running those tasks).
     HTML::main_thread_event_loop().task_queue().remove_tasks_matching([this](auto& task) {
         return task.document() == this;
@@ -4995,6 +5011,7 @@ bool Document::is_allowed_to_use_feature(PolicyControlledFeature feature) const
 
 void Document::did_stop_being_active_document_in_navigable()
 {
+    clear_layout_and_paintable_nodes_for_inactive_document();
     tear_down_layout_tree();
 
     schedule_html_parser_end_check();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1081,6 +1081,7 @@ private:
 
     void invalidate_style_of_elements_affected_by_has();
 
+    void clear_layout_and_paintable_nodes_for_inactive_document();
     void tear_down_layout_tree();
 
     void update_active_element();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1906,6 +1906,15 @@ void Element::clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>)
     }
 }
 
+void Element::clear_pseudo_element_layout_nodes(Badge<Document>)
+{
+    if (m_pseudo_element_data) {
+        for (auto& pseudo_element : *m_pseudo_element_data) {
+            pseudo_element.value->set_layout_node(nullptr);
+        }
+    }
+}
+
 void Element::serialize_children_as_json(JsonObjectSerializer<StringBuilder>& element_object) const
 {
     bool has_pseudo_elements = this->has_pseudo_elements();

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -355,6 +355,7 @@ public:
     bool has_pseudo_element(CSS::PseudoElement) const;
     bool has_pseudo_elements() const;
     void clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>);
+    void clear_pseudo_element_layout_nodes(Badge<Document>);
 
     void serialize_children_as_json(JsonObjectSerializer<StringBuilder>&) const;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1757,6 +1757,12 @@ void Node::set_layout_node(Badge<Layout::Node>, GC::Ref<Layout::Node> layout_nod
     m_layout_node = layout_node;
 }
 
+void Node::clear_layout_node_and_paintable(Badge<Document>)
+{
+    m_layout_node = nullptr;
+    m_paintable = nullptr;
+}
+
 void Node::detach_layout_node(Badge<Layout::TreeBuilder>)
 {
     m_layout_node = nullptr;

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -25,6 +25,8 @@
 
 namespace Web::DOM {
 
+class Document;
+
 enum class NameOrDescription {
     Name,
     Description
@@ -325,6 +327,7 @@ public:
     void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes);
     void set_needs_layout_update(SetNeedsLayoutReason);
 
+    void clear_layout_node_and_paintable(Badge<Document>);
     void set_layout_node(Badge<Layout::Node>, GC::Ref<Layout::Node>);
     void detach_layout_node(Badge<Layout::TreeBuilder>);
 

--- a/Tests/LibWeb/Crash/HTML/intersection-observer-implicit-root-target-in-navigated-iframe.html
+++ b/Tests/LibWeb/Crash/HTML/intersection-observer-implicit-root-target-in-navigated-iframe.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<iframe></iframe>
+<script>
+    const iframe = document.querySelector("iframe");
+
+    iframe.srcdoc = "<div id='target' style='width: 10px; height: 10px'></div>";
+    iframe.onload = () => {
+        const observer = new IntersectionObserver(() => {});
+        observer.observe(iframe.contentDocument.getElementById("target"));
+
+        iframe.onload = () => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    document.documentElement.classList.remove("test-wait");
+                });
+            });
+        };
+        iframe.srcdoc = "<p>replacement document</p>";
+    };
+</script>
+</html>
+</content>
+</invoke>


### PR DESCRIPTION
IntersectionObserver can keep elements from a navigated iframe's old document alive until a later rendering update. Once that document tears down its layout tree, descendant nodes and pseudo-elements can still retain stale layout and paintable pointers, and destruction can bypass the usual inactive-document teardown entirely.

Clear per-node layout and paintable pointers across the inactive document subtree before tearing down the layout tree, and do the same from destroy() for documents that never go through did_stop_being_active_document_in_navigable().

Add a crash test that observes an iframe target, navigates the iframe, and waits for rendering updates without touching stale layout state.