### PR TITLE
Tests: Remove the timeout between steps in media source tests

### DIFF
--- a/Tests/LibWeb/Text/input/HTML/media-source-buffered.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-buffered.html
@@ -3,25 +3,12 @@
 <script src="../include.js"></script>
 <script>
     asyncTest(done => {
-        const TIMEOUT_MS = 1000;
-        let timer;
-        function restartTimeout() {
-            clearTimeout(timer);
-            timer = setTimeout(() => {
-                println("FAIL: timeout");
-                done();
-            }, TIMEOUT_MS);
-        }
-        restartTimeout();
-
         function step(text) {
             println(text);
-            restartTimeout();
         }
 
         function fail(name, error) {
             println(`FAIL: ${name}: ${error}`);
-            clearTimeout(timer);
             done();
         }
 
@@ -83,8 +70,6 @@
                     // Append Clusters 1 and 2 again to fill in the gap properly.
                     await appendSlice(INIT_END, CLUSTER2_START, "cluster 1 again");
                     await appendSlice(CLUSTER2_START, CLUSTER3_START, "cluster 2 again");
-
-                    clearTimeout(timer);
                     done();
                 } catch (e) {
                     fail("sourceopen handler", e);

--- a/Tests/LibWeb/Text/input/HTML/media-source-setup.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-setup.html
@@ -3,25 +3,12 @@
 <script src="../include.js"></script>
 <script>
     asyncTest(done => {
-        const TIMEOUT_MS = 1000;
-        let timer;
-        function restartTimeout() {
-            clearTimeout(timer);
-            timer = setTimeout(() => {
-                println("FAIL: timeout");
-                done();
-            }, TIMEOUT_MS);
-        }
-        restartTimeout();
-
         function step(name) {
             println(`PASS: ${name}`);
-            restartTimeout();
         }
 
         function fail(name, error) {
             println(`FAIL: ${name}: ${error}`);
-            clearTimeout(timer);
             done();
         }
 
@@ -127,8 +114,6 @@
                             video.addEventListener("playing", resolve);
                     });
                     step("playing");
-
-                    clearTimeout(timer);
                     done();
                 } catch (e) {
                     fail("sourceopen handler", e);


### PR DESCRIPTION
The goal with these timeouts was to eagerly fail the test and not spend an excessive amount of time waiting for the full test-web timeout. However, since CI uses sanitizers, it's plausible that the time it takes between steps, especially the fetch, could exceed that. Instead, let's just let test-web time these out.

Hopefully this will make the test green on CI.