### PR TITLE
LibJS: Make substrings lazy

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
@@ -65,7 +65,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentIteratorPrototype::next)
     // NOTE: This is already handled by LibUnicode.
 
     // 10. Let segmentData be CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
-    auto segment_data = TRY(create_segment_data_object(vm, segmenter, string, start_index, end_index));
+    auto segment_data = TRY(create_segment_data_object(vm, segmenter, iterator->segments().segments_primitive_string(), string, start_index, end_index));
 
     // 11. Return CreateIterResultObject(segmentData, false).
     return create_iterator_result_object(vm, segment_data, false);

--- a/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
@@ -34,7 +34,7 @@ ReadonlySpan<ResolutionOptionDescriptor> Segmenter::resolution_option_descriptor
 }
 
 // 19.7.1 CreateSegmentDataObject ( segmenter, string, startIndex, endIndex ), https://tc39.es/ecma402/#sec-createsegmentdataobject
-ThrowCompletionOr<GC::Ref<Object>> create_segment_data_object(VM& vm, Unicode::Segmenter const& segmenter, Utf16View const& string, size_t start_index, size_t end_index)
+ThrowCompletionOr<GC::Ref<Object>> create_segment_data_object(VM& vm, Unicode::Segmenter const& segmenter, PrimitiveString const& string_value, Utf16View const& string, size_t start_index, size_t end_index)
 {
     auto& realm = *vm.current_realm();
 
@@ -54,16 +54,15 @@ ThrowCompletionOr<GC::Ref<Object>> create_segment_data_object(VM& vm, Unicode::S
     auto result = Object::create(realm, realm.intrinsics().object_prototype());
 
     // 6. Let segment be the substring of string from startIndex to endIndex.
-    auto segment = string.substring_view(start_index, end_index - start_index);
 
     // 7. Perform ! CreateDataPropertyOrThrow(result, "segment", segment).
-    MUST(result->create_data_property_or_throw(vm.names.segment, PrimitiveString::create(vm, segment)));
+    MUST(result->create_data_property_or_throw(vm.names.segment, PrimitiveString::create(vm, string_value, start_index, end_index - start_index)));
 
     // 8. Perform ! CreateDataPropertyOrThrow(result, "index", 𝔽(startIndex)).
     MUST(result->create_data_property_or_throw(vm.names.index, Value(start_index)));
 
     // 9. Perform ! CreateDataPropertyOrThrow(result, "input", string).
-    MUST(result->create_data_property_or_throw(vm.names.input, PrimitiveString::create(vm, string)));
+    MUST(result->create_data_property_or_throw(vm.names.input, &string_value));
 
     // 10. Let granularity be segmenter.[[SegmenterGranularity]].
     auto granularity = segmenter.segmenter_granularity();

--- a/Libraries/LibJS/Runtime/Intl/Segmenter.h
+++ b/Libraries/LibJS/Runtime/Intl/Segmenter.h
@@ -43,7 +43,7 @@ private:
     OwnPtr<Unicode::Segmenter> m_segmenter;
 };
 
-ThrowCompletionOr<GC::Ref<Object>> create_segment_data_object(VM&, Unicode::Segmenter const&, Utf16View const&, size_t start_index, size_t end_index);
+ThrowCompletionOr<GC::Ref<Object>> create_segment_data_object(VM&, Unicode::Segmenter const&, PrimitiveString const&, Utf16View const&, size_t start_index, size_t end_index);
 
 enum class Direction {
     Before,

--- a/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
@@ -67,10 +67,10 @@ JS_DEFINE_NATIVE_FUNCTION(SegmenterPrototype::segment)
     auto segmenter = TRY(typed_this_object(vm));
 
     // 3. Let string be ? ToString(string).
-    auto string = TRY(vm.argument(0).to_utf16_string(vm));
+    auto string = TRY(vm.argument(0).to_primitive_string(vm));
 
     // 4. Return ! CreateSegmentsObject(segmenter, string).
-    return Segments::create(realm, segmenter->segmenter(), move(string));
+    return Segments::create(realm, segmenter->segmenter(), string);
 }
 
 }

--- a/Libraries/LibJS/Runtime/Intl/Segments.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Segments.cpp
@@ -13,7 +13,7 @@ namespace JS::Intl {
 GC_DEFINE_ALLOCATOR(Segments);
 
 // 19.5.1 CreateSegmentsObject ( segmenter, string ), https://tc39.es/ecma402/#sec-createsegmentsobject
-GC::Ref<Segments> Segments::create(Realm& realm, Unicode::Segmenter const& segmenter, Utf16String string)
+GC::Ref<Segments> Segments::create(Realm& realm, Unicode::Segmenter const& segmenter, GC::Ref<PrimitiveString> string)
 {
     // 1. Let internalSlotsList be « [[SegmentsSegmenter]], [[SegmentsString]] ».
     // 2. Let segments be OrdinaryObjectCreate(%IntlSegmentsPrototype%, internalSlotsList).
@@ -24,12 +24,19 @@ GC::Ref<Segments> Segments::create(Realm& realm, Unicode::Segmenter const& segme
 }
 
 // 19.5 Segments Objects, https://tc39.es/ecma402/#sec-segments-objects
-Segments::Segments(Realm& realm, Unicode::Segmenter const& segmenter, Utf16String string)
+Segments::Segments(Realm& realm, Unicode::Segmenter const& segmenter, GC::Ref<PrimitiveString> string)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().intl_segments_prototype())
     , m_segments_segmenter(segmenter.clone())
-    , m_segments_string(move(string))
+    , m_segments_string_value(string)
+    , m_segments_string(string->utf16_string())
 {
     m_segments_segmenter->set_segmented_text(m_segments_string);
+}
+
+void Segments::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_segments_string_value);
 }
 
 }

--- a/Libraries/LibJS/Runtime/Intl/Segments.h
+++ b/Libraries/LibJS/Runtime/Intl/Segments.h
@@ -18,18 +18,22 @@ class Segments final : public Object {
     GC_DECLARE_ALLOCATOR(Segments);
 
 public:
-    static GC::Ref<Segments> create(Realm&, Unicode::Segmenter const&, Utf16String);
+    static GC::Ref<Segments> create(Realm&, Unicode::Segmenter const&, GC::Ref<PrimitiveString>);
 
     virtual ~Segments() override = default;
 
     Unicode::Segmenter& segments_segmenter() const { return *m_segments_segmenter; }
 
+    PrimitiveString const& segments_primitive_string() const { return m_segments_string_value; }
     Utf16String const& segments_string() const { return m_segments_string; }
 
 private:
-    Segments(Realm&, Unicode::Segmenter const&, Utf16String);
+    Segments(Realm&, Unicode::Segmenter const&, GC::Ref<PrimitiveString>);
+
+    virtual void visit_edges(Visitor&) override;
 
     NonnullOwnPtr<Unicode::Segmenter> m_segments_segmenter; // [[SegmentsSegmenter]]
+    GC::Ref<PrimitiveString> m_segments_string_value;       // [[SegmentsStringValue]]
     Utf16String m_segments_string;                          // [[SegmentsString]]
 };
 

--- a/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
@@ -60,7 +60,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmentsPrototype::containing)
     auto end_index = find_boundary(segmenter, string, static_cast<size_t>(n), Direction::After);
 
     // 10. Return CreateSegmentDataObject(segmenter, string, startIndex, endIndex).
-    return TRY(create_segment_data_object(vm, segmenter, string, start_index, end_index));
+    return TRY(create_segment_data_object(vm, segmenter, segments->segments_primitive_string(), string, start_index, end_index));
 }
 
 // 19.5.2.2 %IntlSegmentsPrototype% [ %Symbol.iterator% ] ( ), https://tc39.es/ecma402/#sec-%intlsegmentsprototype%-%symbol.iterator%

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -133,7 +133,7 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, P
     return vm.heap().allocate<RopeString>(lhs, rhs);
 }
 
-GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& string, size_t code_unit_offset, size_t code_unit_length)
+GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString const& string, size_t code_unit_offset, size_t code_unit_length)
 {
     auto string_length = string.length_in_utf16_code_units();
     VERIFY(code_unit_offset <= string_length);
@@ -143,14 +143,14 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& string
         return vm.empty_string();
 
     if (code_unit_offset == 0 && code_unit_length == string_length)
-        return string;
+        return const_cast<PrimitiveString&>(string);
 
     if (string.m_deferred_kind == DeferredKind::Substring) {
         auto const& substring = static_cast<Substring const&>(string);
         return create(vm, *substring.m_source_string, substring.m_code_unit_offset + code_unit_offset, code_unit_length);
     }
 
-    return vm.heap().allocate<Substring>(string, code_unit_offset, code_unit_length);
+    return vm.heap().allocate<Substring>(const_cast<PrimitiveString&>(string), code_unit_offset, code_unit_length);
 }
 
 PrimitiveString::PrimitiveString(Utf16String string)
@@ -283,7 +283,7 @@ ThrowCompletionOr<Optional<Value>> PrimitiveString::get(VM& vm, PropertyKey cons
     if (string.length_in_code_units() <= index.as_index())
         return Optional<Value> {};
 
-    return create(vm, string.substring_view(index.as_index(), 1));
+    return create(vm, *this, index.as_index(), 1);
 }
 
 void PrimitiveString::resolve_if_needed(EncodingPreference preference) const

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -27,6 +27,7 @@ static constexpr size_t MAX_LENGTH_FOR_STRING_CACHE = 256;
 
 GC_DEFINE_ALLOCATOR(PrimitiveString);
 GC_DEFINE_ALLOCATOR(RopeString);
+GC_DEFINE_ALLOCATOR(Substring);
 
 GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16String const& string)
 {
@@ -49,6 +50,7 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16String const& stri
         return *it->value;
 
     auto new_string = vm.heap().allocate<PrimitiveString>(string);
+    new_string->m_utf16_string_is_in_cache = true;
     string_cache.set(move(string), new_string);
     return *new_string;
 }
@@ -85,6 +87,7 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, String const& string)
         return *it->value;
 
     auto new_string = vm.heap().allocate<PrimitiveString>(string);
+    new_string->m_utf8_string_is_in_cache = true;
     string_cache.set(move(string), new_string);
     return *new_string;
 }
@@ -130,6 +133,26 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, P
     return vm.heap().allocate<RopeString>(lhs, rhs);
 }
 
+GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& string, size_t code_unit_offset, size_t code_unit_length)
+{
+    auto string_length = string.length_in_utf16_code_units();
+    VERIFY(code_unit_offset <= string_length);
+    VERIFY(code_unit_length <= string_length - code_unit_offset);
+
+    if (code_unit_length == 0)
+        return vm.empty_string();
+
+    if (code_unit_offset == 0 && code_unit_length == string_length)
+        return string;
+
+    if (string.m_deferred_kind == DeferredKind::Substring) {
+        auto const& substring = static_cast<Substring const&>(string);
+        return create(vm, *substring.m_source_string, substring.m_code_unit_offset + code_unit_offset, code_unit_length);
+    }
+
+    return vm.heap().allocate<Substring>(string, code_unit_offset, code_unit_length);
+}
+
 PrimitiveString::PrimitiveString(Utf16String string)
     : m_utf16_string(move(string))
 {
@@ -145,24 +168,26 @@ PrimitiveString::~PrimitiveString() = default;
 void PrimitiveString::finalize()
 {
     Base::finalize();
-    if (has_utf16_string()) {
+    if (m_utf16_string_is_in_cache) {
         auto const& string = *m_utf16_string;
         if (string.length_in_code_units() <= MAX_LENGTH_FOR_STRING_CACHE)
             vm().utf16_string_cache().remove(string);
     }
-    if (has_utf8_string()) {
+    if (m_utf8_string_is_in_cache) {
         auto const& string = *m_utf8_string;
         if (string.length_in_code_units() <= MAX_LENGTH_FOR_STRING_CACHE)
-            vm().string_cache().remove(*m_utf8_string);
+            vm().string_cache().remove(string);
     }
 }
 
 bool PrimitiveString::is_empty() const
 {
-    if (m_is_rope) {
+    if (m_deferred_kind == DeferredKind::Rope) {
         // NOTE: We never make an empty rope string.
         return false;
     }
+    if (m_deferred_kind == DeferredKind::Substring)
+        return static_cast<Substring const&>(*this).m_code_unit_length == 0;
 
     if (has_utf16_string())
         return m_utf16_string->is_empty();
@@ -173,7 +198,7 @@ bool PrimitiveString::is_empty() const
 
 String PrimitiveString::utf8_string() const
 {
-    resolve_rope_if_needed(EncodingPreference::UTF8);
+    resolve_if_needed(EncodingPreference::UTF8);
 
     if (!has_utf8_string()) {
         VERIFY(has_utf16_string());
@@ -197,7 +222,7 @@ StringView PrimitiveString::utf8_string_view() const
 
 Utf16String PrimitiveString::utf16_string() const
 {
-    resolve_rope_if_needed(EncodingPreference::UTF16);
+    resolve_if_needed(EncodingPreference::UTF16);
 
     if (!has_utf16_string()) {
         VERIFY(has_utf8_string());
@@ -209,13 +234,20 @@ Utf16String PrimitiveString::utf16_string() const
 
 Utf16View PrimitiveString::utf16_string_view() const
 {
-    if (!has_utf16_string())
+    if (!has_utf16_string()) {
+        if (m_deferred_kind == DeferredKind::Substring) {
+            auto const& substring = static_cast<Substring const&>(*this);
+            return substring.m_source_string->utf16_string_view().substring_view(substring.m_code_unit_offset, substring.m_code_unit_length);
+        }
         (void)utf16_string();
+    }
     return *m_utf16_string;
 }
 
 size_t PrimitiveString::length_in_utf16_code_units() const
 {
+    if (m_deferred_kind == DeferredKind::Substring)
+        return static_cast<Substring const&>(*this).m_code_unit_length;
     return utf16_string_view().length_in_code_units();
 }
 
@@ -252,13 +284,20 @@ ThrowCompletionOr<Optional<Value>> PrimitiveString::get(VM& vm, PropertyKey cons
     return create(vm, string.substring_view(index.as_index(), 1));
 }
 
-void PrimitiveString::resolve_rope_if_needed(EncodingPreference preference) const
+void PrimitiveString::resolve_if_needed(EncodingPreference preference) const
 {
-    if (!m_is_rope)
+    switch (m_deferred_kind) {
+    case DeferredKind::None:
         return;
+    case DeferredKind::Rope:
+        static_cast<RopeString const&>(*this).resolve(preference);
+        return;
+    case DeferredKind::Substring:
+        static_cast<Substring const&>(*this).resolve(preference);
+        return;
+    }
 
-    auto const& rope_string = static_cast<RopeString const&>(*this);
-    rope_string.resolve(preference);
+    VERIFY_NOT_REACHED();
 }
 
 void RopeString::resolve(EncodingPreference preference) const
@@ -277,7 +316,7 @@ void RopeString::resolve(EncodingPreference preference) const
     stack.append(m_lhs);
     while (!stack.is_empty()) {
         auto const* current = stack.take_last();
-        if (current->m_is_rope) {
+        if (current->m_deferred_kind == DeferredKind::Rope) {
             auto& current_rope_string = static_cast<RopeString const&>(*current);
             stack.append(current_rope_string.m_rhs);
             stack.append(current_rope_string.m_lhs);
@@ -304,7 +343,7 @@ void RopeString::resolve(EncodingPreference preference) const
         }
 
         m_utf16_string = builder.to_utf16_string();
-        m_is_rope = false;
+        m_deferred_kind = DeferredKind::None;
         m_lhs = nullptr;
         m_rhs = nullptr;
         return;
@@ -373,13 +412,13 @@ void RopeString::resolve(EncodingPreference preference) const
 
     // NOTE: We've already produced valid UTF-8 above, so there's no need for additional validation.
     m_utf8_string = builder.to_string_without_validation();
-    m_is_rope = false;
+    m_deferred_kind = DeferredKind::None;
     m_lhs = nullptr;
     m_rhs = nullptr;
 }
 
 RopeString::RopeString(GC::Ref<PrimitiveString> lhs, GC::Ref<PrimitiveString> rhs)
-    : PrimitiveString(RopeTag::Rope)
+    : PrimitiveString(DeferredKind::Rope)
     , m_lhs(lhs)
     , m_rhs(rhs)
 {
@@ -392,6 +431,37 @@ void RopeString::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_lhs);
     visitor.visit(m_rhs);
+}
+
+void Substring::resolve(EncodingPreference preference) const
+{
+    auto source_view = m_source_string->utf16_string_view().substring_view(m_code_unit_offset, m_code_unit_length);
+
+    if (preference == EncodingPreference::UTF16) {
+        m_utf16_string = Utf16String::from_utf16(source_view);
+    } else {
+        auto substring = Utf16String::from_utf16(source_view);
+        m_utf8_string = substring.to_utf8();
+    }
+
+    m_deferred_kind = DeferredKind::None;
+    m_source_string = nullptr;
+}
+
+Substring::Substring(GC::Ref<PrimitiveString> source_string, size_t code_unit_offset, size_t code_unit_length)
+    : PrimitiveString(DeferredKind::Substring)
+    , m_source_string(source_string)
+    , m_code_unit_offset(code_unit_offset)
+    , m_code_unit_length(code_unit_length)
+{
+}
+
+Substring::~Substring() = default;
+
+void Substring::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_source_string);
 }
 
 }

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -255,11 +255,13 @@ bool PrimitiveString::operator==(PrimitiveString const& other) const
 {
     if (this == &other)
         return true;
+    if (length_in_utf16_code_units() != other.length_in_utf16_code_units())
+        return false;
     if (m_utf8_string.has_value() && other.m_utf8_string.has_value())
         return m_utf8_string->bytes_as_string_view() == other.m_utf8_string->bytes_as_string_view();
     if (m_utf16_string.has_value() && other.m_utf16_string.has_value())
         return *m_utf16_string == *other.m_utf16_string;
-    return utf8_string_view() == other.utf8_string_view();
+    return utf16_string_view() == other.utf16_string_view();
 }
 
 ThrowCompletionOr<Optional<Value>> PrimitiveString::get(VM& vm, PropertyKey const& property_key) const

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -36,7 +36,7 @@ public:
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, FlyString const&);
 
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString&, PrimitiveString&);
-    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString&, size_t code_unit_offset, size_t code_unit_length);
+    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString const&, size_t code_unit_offset, size_t code_unit_length);
 
     [[nodiscard]] static GC::Ref<PrimitiveString> create_from_unsigned_integer(VM&, u64);
 

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -36,6 +36,7 @@ public:
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, FlyString const&);
 
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString&, PrimitiveString&);
+    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString&, size_t code_unit_offset, size_t code_unit_length);
 
     [[nodiscard]] static GC::Ref<PrimitiveString> create_from_unsigned_integer(VM&, u64);
 
@@ -61,16 +62,24 @@ public:
     [[nodiscard]] bool operator==(PrimitiveString const&) const;
 
 protected:
-    enum class RopeTag { Rope };
-    explicit PrimitiveString(RopeTag)
-        : m_is_rope(true)
+    enum class DeferredKind : u8 {
+        None,
+        Rope,
+        Substring,
+    };
+
+    explicit PrimitiveString(DeferredKind deferred_kind)
+        : m_deferred_kind(deferred_kind)
     {
     }
 
-    mutable bool m_is_rope { false };
+    mutable DeferredKind m_deferred_kind { DeferredKind::None };
 
     mutable Optional<String> m_utf8_string;
     mutable Optional<Utf16String> m_utf16_string;
+
+    bool m_utf8_string_is_in_cache { false };
+    bool m_utf16_string_is_in_cache { false };
 
     enum class EncodingPreference {
         UTF8,
@@ -79,13 +88,14 @@ protected:
 
 private:
     friend class RopeString;
+    friend class Substring;
 
     virtual void finalize() override;
 
     explicit PrimitiveString(Utf16String);
     explicit PrimitiveString(String);
 
-    void resolve_rope_if_needed(EncodingPreference) const;
+    void resolve_if_needed(EncodingPreference) const;
 };
 
 class RopeString final : public PrimitiveString {
@@ -106,6 +116,27 @@ private:
 
     mutable GC::Ptr<PrimitiveString> m_lhs;
     mutable GC::Ptr<PrimitiveString> m_rhs;
+};
+
+class Substring final : public PrimitiveString {
+    GC_CELL(Substring, PrimitiveString);
+    GC_DECLARE_ALLOCATOR(Substring);
+
+public:
+    virtual ~Substring() override;
+
+private:
+    friend class PrimitiveString;
+
+    explicit Substring(GC::Ref<PrimitiveString>, size_t code_unit_offset, size_t code_unit_length);
+
+    virtual void visit_edges(Visitor&) override;
+
+    void resolve(EncodingPreference) const;
+
+    mutable GC::Ptr<PrimitiveString> m_source_string;
+    size_t m_code_unit_offset { 0 };
+    size_t m_code_unit_length { 0 };
 };
 
 }

--- a/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -42,6 +42,12 @@ RegExpConstructor::RegExpConstructor(Realm& realm)
 {
 }
 
+void RegExpConstructor::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    m_legacy_static_properties.visit_edges(visitor);
+}
+
 void RegExpConstructor::initialize(Realm& realm)
 {
     auto& vm = this->vm();

--- a/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -21,6 +21,7 @@ public:
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<GC::Ref<Object>> construct(FunctionObject& new_target) override;
+    virtual void visit_edges(Cell::Visitor&) override;
     ThrowCompletionOr<GC::Ref<Object>> construct_impl(FunctionObject& new_target, bool pattern_is_regexp);
 
     RegExpLegacyStaticProperties& legacy_static_properties() { return m_legacy_static_properties; }

--- a/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.cpp
+++ b/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.cpp
@@ -13,16 +13,22 @@ namespace JS {
 
 void RegExpLegacyStaticProperties::invalidate()
 {
-    m_input = {};
-    m_last_match = {};
-    m_last_match_string = {};
-    m_last_paren = {};
-    m_left_context = {};
-    m_left_context_string = {};
-    m_right_context = {};
-    m_right_context_string = {};
+    m_input = nullptr;
+    m_match_source = nullptr;
+    m_last_match_start = 0;
+    m_last_match_length = 0;
+    m_last_match_string = nullptr;
+    m_last_paren = nullptr;
+    m_last_paren_start = -1;
+    m_last_paren_end = -1;
+    m_left_context_start = 0;
+    m_left_context_length = 0;
+    m_left_context_string = nullptr;
+    m_right_context_start = 0;
+    m_right_context_length = 0;
+    m_right_context_string = nullptr;
     for (auto& p : m_$)
-        p = {};
+        p = nullptr;
     for (auto& s : m_paren_starts)
         s = -1;
     for (auto& e : m_paren_ends)
@@ -30,18 +36,121 @@ void RegExpLegacyStaticProperties::invalidate()
     m_parens_materialized = true;
 }
 
-Optional<Utf16String> const& RegExpLegacyStaticProperties::lazy_paren(size_t index) const
+void RegExpLegacyStaticProperties::visit_edges(Cell::Visitor& visitor)
+{
+    visitor.visit(m_input);
+    visitor.visit(m_match_source);
+    visitor.visit(m_last_paren);
+    for (auto& paren : m_$)
+        visitor.visit(paren);
+    visitor.visit(m_last_match_string);
+    visitor.visit(m_left_context_string);
+    visitor.visit(m_right_context_string);
+}
+
+void RegExpLegacyStaticProperties::set_match_source(GC::Ref<PrimitiveString> match_source)
+{
+    m_match_source = match_source;
+    m_last_match_string = nullptr;
+    m_last_paren = nullptr;
+    m_left_context_string = nullptr;
+    m_right_context_string = nullptr;
+    for (auto& paren : m_$)
+        paren = nullptr;
+}
+
+void RegExpLegacyStaticProperties::set_last_match(size_t start, size_t length)
+{
+    m_last_match_start = start;
+    m_last_match_length = length;
+    m_last_match_string = nullptr;
+}
+
+void RegExpLegacyStaticProperties::set_last_paren(GC::Ref<PrimitiveString> last_paren)
+{
+    m_last_paren = last_paren;
+    m_last_paren_start = -1;
+    m_last_paren_end = -1;
+}
+
+void RegExpLegacyStaticProperties::set_left_context(size_t start, size_t length)
+{
+    m_left_context_start = start;
+    m_left_context_length = length;
+    m_left_context_string = nullptr;
+}
+
+void RegExpLegacyStaticProperties::set_right_context(size_t start, size_t length)
+{
+    m_right_context_start = start;
+    m_right_context_length = length;
+    m_right_context_string = nullptr;
+}
+
+GC::Ref<PrimitiveString> RegExpLegacyStaticProperties::empty_string() const
+{
+    VERIFY(m_match_source);
+    return m_match_source->vm().empty_string();
+}
+
+GC::Ref<PrimitiveString> RegExpLegacyStaticProperties::substring_of_match_source(size_t start, size_t length) const
+{
+    VERIFY(m_match_source);
+    return PrimitiveString::create(m_match_source->vm(), *m_match_source, start, length);
+}
+
+GC::Ptr<PrimitiveString> RegExpLegacyStaticProperties::last_match() const
+{
+    if (!m_match_source)
+        return nullptr;
+    if (!m_last_match_string)
+        m_last_match_string = substring_of_match_source(m_last_match_start, m_last_match_length);
+    return m_last_match_string;
+}
+
+GC::Ptr<PrimitiveString> RegExpLegacyStaticProperties::last_paren() const
+{
+    if (!m_match_source)
+        return nullptr;
+    if (!m_last_paren) {
+        if (m_last_paren_start >= 0 && m_last_paren_end >= 0)
+            m_last_paren = substring_of_match_source(m_last_paren_start, m_last_paren_end - m_last_paren_start);
+        else
+            m_last_paren = empty_string();
+    }
+    return m_last_paren;
+}
+
+GC::Ptr<PrimitiveString> RegExpLegacyStaticProperties::left_context() const
+{
+    if (!m_match_source)
+        return nullptr;
+    if (!m_left_context_string)
+        m_left_context_string = substring_of_match_source(m_left_context_start, m_left_context_length);
+    return m_left_context_string;
+}
+
+GC::Ptr<PrimitiveString> RegExpLegacyStaticProperties::right_context() const
+{
+    if (!m_match_source)
+        return nullptr;
+    if (!m_right_context_string)
+        m_right_context_string = substring_of_match_source(m_right_context_start, m_right_context_length);
+    return m_right_context_string;
+}
+
+GC::Ptr<PrimitiveString> RegExpLegacyStaticProperties::lazy_paren(size_t index) const
 {
     VERIFY(index < 9);
+    if (!m_match_source)
+        return nullptr;
     if (!m_parens_materialized) {
         // Materialize all lazy parens from stored indices.
         for (size_t i = 0; i < 9; i++) {
-            if (m_paren_starts[i] >= 0 && m_paren_ends[i] >= 0 && m_input.has_value()) {
-                auto view = m_input->substring_view(m_paren_starts[i], m_paren_ends[i] - m_paren_starts[i]);
-                m_$[i] = Utf16String::from_utf16(view);
-            } else {
-                m_$[i] = Utf16String {};
-            }
+            if (m_paren_starts[i] >= 0 && m_paren_ends[i] >= 0)
+                m_$[i] = substring_of_match_source(m_paren_starts[i], m_paren_ends[i] - m_paren_starts[i]);
+            else
+                m_$[i] = empty_string();
         }
         m_parens_materialized = true;
     }
@@ -61,20 +170,23 @@ void RegExpLegacyStaticProperties::set_captures_lazy(size_t num_captures, int co
     }
     // Clear any previously materialized strings.
     for (auto& p : m_$)
-        p = {};
+        p = nullptr;
     m_parens_materialized = false;
 
     // Set last_paren to the last captured value.
-    if (num_captures > 0 && capture_starts[num_captures - 1] >= 0 && capture_ends[num_captures - 1] >= 0 && m_input.has_value()) {
-        auto view = m_input->substring_view(capture_starts[num_captures - 1], capture_ends[num_captures - 1] - capture_starts[num_captures - 1]);
-        m_last_paren = Utf16String::from_utf16(view);
+    if (num_captures > 0 && capture_starts[num_captures - 1] >= 0 && capture_ends[num_captures - 1] >= 0) {
+        m_last_paren = nullptr;
+        m_last_paren_start = capture_starts[num_captures - 1];
+        m_last_paren_end = capture_ends[num_captures - 1];
     } else {
-        m_last_paren = Utf16String {};
+        m_last_paren = empty_string();
+        m_last_paren_start = -1;
+        m_last_paren_end = -1;
     }
 }
 
 // GetLegacyRegExpStaticProperty( C, thisValue, internalSlotName ), https://github.com/tc39/proposal-regexp-legacy-features#getlegacyregexpstaticproperty-c-thisvalue-internalslotname-
-ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, Optional<Utf16String> const& (RegExpLegacyStaticProperties::*property_getter)() const)
+ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, GC::Ptr<PrimitiveString> (RegExpLegacyStaticProperties::*property_getter)() const)
 {
     // 1. Assert C is an object that has an internal slot named internalSlotName.
 
@@ -86,15 +198,15 @@ ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstru
     auto val = (constructor.legacy_static_properties().*property_getter)();
 
     // 4. If val is empty, throw a TypeError exception.
-    if (!val.has_value())
+    if (!val)
         return vm.throw_completion<TypeError>(ErrorType::GetLegacyRegExpStaticPropertyValueEmpty);
 
     // 5. Return val.
-    return PrimitiveString::create(vm, val.release_value());
+    return val;
 }
 
 // SetLegacyRegExpStaticProperty( C, thisValue, internalSlotName, val ), https://github.com/tc39/proposal-regexp-legacy-features#setlegacyregexpstaticproperty-c-thisvalue-internalslotname-val-
-ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(Utf16String), Value value)
+ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(GC::Ref<PrimitiveString>), Value value)
 {
     // 1. Assert C is an object that has an internal slot named internalSlotName.
 
@@ -103,7 +215,7 @@ ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstruc
         return vm.throw_completion<TypeError>(ErrorType::SetLegacyRegExpStaticPropertyThisValueMismatch);
 
     // 3. Let strVal be ? ToString(val).
-    auto str_value = TRY(value.to_utf16_string(vm));
+    auto str_value = TRY(value.to_primitive_string(vm));
 
     // 4. Set the value of the internal slot of C named internalSlotName to strVal.
     (constructor.legacy_static_properties().*property_setter)(str_value);
@@ -112,7 +224,7 @@ ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstruc
 }
 
 // UpdateLegacyRegExpStaticProperties ( C, S, startIndex, endIndex, capturedValues ), https://github.com/tc39/proposal-regexp-legacy-features#updatelegacyregexpstaticproperties--c-s-startindex-endindex-capturedvalues-
-void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values)
+void update_legacy_regexp_static_properties(RegExpConstructor& constructor, GC::Ref<PrimitiveString> string, size_t start_index, size_t end_index, Vector<GC::Ref<PrimitiveString>> const& captured_values)
 {
     auto& legacy_static_properties = constructor.legacy_static_properties();
 
@@ -120,7 +232,7 @@ void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf1
     // 2. Assert: Type(S) is String.
 
     // 3. Let len be the number of code units in S.
-    auto len = string.length_in_code_units();
+    auto len = string->length_in_utf16_code_units();
 
     // 4. Assert: startIndex and endIndex are integers such that 0 ≤ startIndex ≤ endIndex ≤ len.
     VERIFY(start_index <= end_index);
@@ -133,10 +245,10 @@ void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf1
 
     // 7. Set the value of C’s [[RegExpInput]] internal slot to S.
     legacy_static_properties.set_input(string);
+    legacy_static_properties.set_match_source(string);
 
     // 8. Set the value of C’s [[RegExpLastMatch]] internal slot to a String whose length is endIndex - startIndex and containing the code units from S with indices startIndex through endIndex - 1, in ascending order.
-    auto last_match = legacy_static_properties.input()->substring_view(start_index, end_index - start_index);
-    legacy_static_properties.set_last_match(last_match);
+    legacy_static_properties.set_last_match(start_index, end_index - start_index);
 
     // 9. If n > 0, set the value of C’s [[RegExpLastParen]] internal slot to the last element of capturedValues.
     if (group_count > 0) {
@@ -145,22 +257,22 @@ void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf1
     }
     // 10. Else, set the value of C’s [[RegExpLastParen]] internal slot to the empty String.
     else {
-        legacy_static_properties.set_last_paren({});
+        legacy_static_properties.set_last_paren(string->vm().empty_string());
     }
 
     // 11. Set the value of C’s [[RegExpLeftContext]] internal slot to a String whose length is startIndex and containing the code units from S with indices 0 through startIndex - 1, in ascending order.
-    auto left_context = legacy_static_properties.input()->substring_view(0, start_index);
-    legacy_static_properties.set_left_context(left_context);
+    legacy_static_properties.set_left_context(0, start_index);
 
     // 12. Set the value of C’s [[RegExpRightContext]] internal slot to a String whose length is len - endIndex and containing the code units from S with indices endIndex through len - 1, in ascending order.
-    auto right_context = legacy_static_properties.input()->substring_view(end_index, len - end_index);
-    legacy_static_properties.set_right_context(right_context);
+    legacy_static_properties.set_right_context(end_index, len - end_index);
 
     // 13. For each integer i such that 1 ≤ i ≤ 9
     for (size_t i = 1; i <= 9; i++) {
         // i. If i ≤ n, set the value of C’s [[RegExpPareni]] internal slot to the ith element of capturedValues.
         // ii. Else, set the value of C’s [[RegExpPareni]] internal slot to the empty String.
-        auto value = (i <= group_count) ? captured_values[i - 1] : Utf16String {};
+        GC::Ref<PrimitiveString> value = string->vm().empty_string();
+        if (i <= group_count)
+            value = captured_values[i - 1];
 
         if (i == 1) {
             legacy_static_properties.set_$1(move(value));
@@ -186,24 +298,22 @@ void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf1
 
 // Like update_legacy_regexp_static_properties, but defers $1-$9 string creation.
 // Captures are stored as index pairs into the input string and materialized on access.
-void update_legacy_regexp_static_properties_lazy(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, size_t num_captures, int const* capture_starts, int const* capture_ends)
+void update_legacy_regexp_static_properties_lazy(RegExpConstructor& constructor, GC::Ref<PrimitiveString> string, size_t start_index, size_t end_index, size_t num_captures, int const* capture_starts, int const* capture_ends)
 {
     auto& legacy_static_properties = constructor.legacy_static_properties();
 
-    auto len = string.length_in_code_units();
+    auto len = string->length_in_utf16_code_units();
     VERIFY(start_index <= end_index);
     VERIFY(end_index <= len);
 
     legacy_static_properties.set_input(string);
+    legacy_static_properties.set_match_source(string);
 
-    auto last_match = legacy_static_properties.input()->substring_view(start_index, end_index - start_index);
-    legacy_static_properties.set_last_match(last_match);
+    legacy_static_properties.set_last_match(start_index, end_index - start_index);
 
-    auto left_context = legacy_static_properties.input()->substring_view(0, start_index);
-    legacy_static_properties.set_left_context(left_context);
+    legacy_static_properties.set_left_context(0, start_index);
 
-    auto right_context = legacy_static_properties.input()->substring_view(end_index, len - end_index);
-    legacy_static_properties.set_right_context(right_context);
+    legacy_static_properties.set_right_context(end_index, len - end_index);
 
     legacy_static_properties.set_captures_lazy(num_captures, capture_starts, capture_ends);
 }

--- a/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
+++ b/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.h
@@ -22,96 +22,70 @@ namespace JS {
 // [[RegExpParen1]] ... [[RegExpParen9]]
 class RegExpLegacyStaticProperties {
 public:
-    Optional<Utf16String> const& input() const { return m_input; }
-    Optional<Utf16String> const& last_match() const
-    {
-        if (!m_last_match_string.has_value())
-            m_last_match_string = Utf16String::from_utf16(m_last_match);
-        return m_last_match_string;
-    }
-    Optional<Utf16String> const& last_paren() const { return m_last_paren; }
-    Optional<Utf16String> const& left_context() const
-    {
-        if (!m_left_context_string.has_value())
-            m_left_context_string = Utf16String::from_utf16(m_left_context);
-        return m_left_context_string;
-    }
-    Optional<Utf16String> const& right_context() const
-    {
-        if (!m_right_context_string.has_value())
-            m_right_context_string = Utf16String::from_utf16(m_right_context);
-        return m_right_context_string;
-    }
-    Optional<Utf16String> const& $1() const { return lazy_paren(0); }
-    Optional<Utf16String> const& $2() const { return lazy_paren(1); }
-    Optional<Utf16String> const& $3() const { return lazy_paren(2); }
-    Optional<Utf16String> const& $4() const { return lazy_paren(3); }
-    Optional<Utf16String> const& $5() const { return lazy_paren(4); }
-    Optional<Utf16String> const& $6() const { return lazy_paren(5); }
-    Optional<Utf16String> const& $7() const { return lazy_paren(6); }
-    Optional<Utf16String> const& $8() const { return lazy_paren(7); }
-    Optional<Utf16String> const& $9() const { return lazy_paren(8); }
+    GC::Ptr<PrimitiveString> input() const { return m_input; }
+    GC::Ptr<PrimitiveString> last_match() const;
+    GC::Ptr<PrimitiveString> last_paren() const;
+    GC::Ptr<PrimitiveString> left_context() const;
+    GC::Ptr<PrimitiveString> right_context() const;
+    GC::Ptr<PrimitiveString> $1() const { return lazy_paren(0); }
+    GC::Ptr<PrimitiveString> $2() const { return lazy_paren(1); }
+    GC::Ptr<PrimitiveString> $3() const { return lazy_paren(2); }
+    GC::Ptr<PrimitiveString> $4() const { return lazy_paren(3); }
+    GC::Ptr<PrimitiveString> $5() const { return lazy_paren(4); }
+    GC::Ptr<PrimitiveString> $6() const { return lazy_paren(5); }
+    GC::Ptr<PrimitiveString> $7() const { return lazy_paren(6); }
+    GC::Ptr<PrimitiveString> $8() const { return lazy_paren(7); }
+    GC::Ptr<PrimitiveString> $9() const { return lazy_paren(8); }
 
-    void set_input(Utf16String input) { m_input = move(input); }
-    void set_last_match(Utf16View last_match)
+    void set_input(GC::Ref<PrimitiveString> input) { m_input = input; }
+    void set_match_source(GC::Ref<PrimitiveString>);
+    void set_last_match(size_t start, size_t length);
+    void set_last_paren(GC::Ref<PrimitiveString>);
+    void set_left_context(size_t start, size_t length);
+    void set_right_context(size_t start, size_t length);
+    void set_$1(GC::Ref<PrimitiveString> value)
     {
-        m_last_match = last_match;
-        m_last_match_string = {};
-    }
-    void set_last_paren(Utf16String last_paren) { m_last_paren = move(last_paren); }
-    void set_left_context(Utf16View left_context)
-    {
-        m_left_context = left_context;
-        m_left_context_string = {};
-    }
-    void set_right_context(Utf16View right_context)
-    {
-        m_right_context = right_context;
-        m_right_context_string = {};
-    }
-    void set_$1(Utf16String value)
-    {
-        m_$[0] = move(value);
+        m_$[0] = value;
         m_parens_materialized = true;
     }
-    void set_$2(Utf16String value)
+    void set_$2(GC::Ref<PrimitiveString> value)
     {
-        m_$[1] = move(value);
+        m_$[1] = value;
         m_parens_materialized = true;
     }
-    void set_$3(Utf16String value)
+    void set_$3(GC::Ref<PrimitiveString> value)
     {
-        m_$[2] = move(value);
+        m_$[2] = value;
         m_parens_materialized = true;
     }
-    void set_$4(Utf16String value)
+    void set_$4(GC::Ref<PrimitiveString> value)
     {
-        m_$[3] = move(value);
+        m_$[3] = value;
         m_parens_materialized = true;
     }
-    void set_$5(Utf16String value)
+    void set_$5(GC::Ref<PrimitiveString> value)
     {
-        m_$[4] = move(value);
+        m_$[4] = value;
         m_parens_materialized = true;
     }
-    void set_$6(Utf16String value)
+    void set_$6(GC::Ref<PrimitiveString> value)
     {
-        m_$[5] = move(value);
+        m_$[5] = value;
         m_parens_materialized = true;
     }
-    void set_$7(Utf16String value)
+    void set_$7(GC::Ref<PrimitiveString> value)
     {
-        m_$[6] = move(value);
+        m_$[6] = value;
         m_parens_materialized = true;
     }
-    void set_$8(Utf16String value)
+    void set_$8(GC::Ref<PrimitiveString> value)
     {
-        m_$[7] = move(value);
+        m_$[7] = value;
         m_parens_materialized = true;
     }
-    void set_$9(Utf16String value)
+    void set_$9(GC::Ref<PrimitiveString> value)
     {
-        m_$[8] = move(value);
+        m_$[8] = value;
         m_parens_materialized = true;
     }
 
@@ -120,33 +94,41 @@ public:
     void set_captures_lazy(size_t num_captures, int const* capture_starts, int const* capture_ends);
 
     void invalidate();
+    void visit_edges(Cell::Visitor&);
 
 private:
-    Optional<Utf16String> const& lazy_paren(size_t index) const;
+    GC::Ptr<PrimitiveString> lazy_paren(size_t index) const;
+    GC::Ref<PrimitiveString> empty_string() const;
+    GC::Ref<PrimitiveString> substring_of_match_source(size_t start, size_t length) const;
 
-    Optional<Utf16String> m_input;
-    Optional<Utf16String> m_last_paren;
-    mutable Optional<Utf16String> m_$[9];
+    GC::Ptr<PrimitiveString> m_input;
+    GC::Ptr<PrimitiveString> m_match_source;
+    mutable GC::Ptr<PrimitiveString> m_last_paren;
+    mutable GC::Ptr<PrimitiveString> m_$[9];
 
-    // NOTE: These are views into m_input and we only turn them into full strings if/when needed.
-    Utf16View m_last_match;
-    Utf16View m_left_context;
-    Utf16View m_right_context;
-    mutable Optional<Utf16String> m_last_match_string;
-    mutable Optional<Utf16String> m_left_context_string;
-    mutable Optional<Utf16String> m_right_context_string;
+    size_t m_last_match_start { 0 };
+    size_t m_last_match_length { 0 };
+    size_t m_left_context_start { 0 };
+    size_t m_left_context_length { 0 };
+    size_t m_right_context_start { 0 };
+    size_t m_right_context_length { 0 };
+    mutable GC::Ptr<PrimitiveString> m_last_match_string;
+    mutable GC::Ptr<PrimitiveString> m_left_context_string;
+    mutable GC::Ptr<PrimitiveString> m_right_context_string;
+    int m_last_paren_start { -1 };
+    int m_last_paren_end { -1 };
 
-    // Lazy capture storage: indices into m_input.
+    // Lazy capture storage: indices into m_match_source.
     // -1 means not captured. Strings materialized on access.
     int m_paren_starts[9] = { -1, -1, -1, -1, -1, -1, -1, -1, -1 };
     int m_paren_ends[9] = { -1, -1, -1, -1, -1, -1, -1, -1, -1 };
     mutable bool m_parens_materialized = true;
 };
 
-ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(Utf16String), Value value);
-ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, Optional<Utf16String> const& (RegExpLegacyStaticProperties::*property_getter)() const);
-void update_legacy_regexp_static_properties(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, Vector<Utf16String> const& captured_values);
-void update_legacy_regexp_static_properties_lazy(RegExpConstructor& constructor, Utf16String const& string, size_t start_index, size_t end_index, size_t num_captures, int const* capture_starts, int const* capture_ends);
+ThrowCompletionOr<void> set_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, void (RegExpLegacyStaticProperties::*property_setter)(GC::Ref<PrimitiveString>), Value value);
+ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstructor& constructor, Value this_value, GC::Ptr<PrimitiveString> (RegExpLegacyStaticProperties::*property_getter)() const);
+void update_legacy_regexp_static_properties(RegExpConstructor& constructor, GC::Ref<PrimitiveString> string, size_t start_index, size_t end_index, Vector<GC::Ref<PrimitiveString>> const& captured_values);
+void update_legacy_regexp_static_properties_lazy(RegExpConstructor& constructor, GC::Ref<PrimitiveString> string, size_t start_index, size_t end_index, size_t num_captures, int const* capture_starts, int const* capture_ends);
 void invalidate_legacy_regexp_static_properties(RegExpConstructor& constructor);
 
 }

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -261,8 +261,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
     array->put_direct(realm.intrinsics().regexp_builtin_exec_array_input_offset(), string);
 
     // Element 0: the full match substring.
-    auto match_str = Utf16String::from_utf16(utf16_view.substring_view(match_index, end_index - match_index));
-    array->indexed_put(0, PrimitiveString::create(vm, match_str));
+    array->indexed_put(0, PrimitiveString::create(vm, *string, match_index, end_index - match_index));
 
     bool has_groups = !named_groups.is_empty();
     auto groups = has_groups ? Object::create(realm, nullptr) : js_undefined();
@@ -282,9 +281,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
         int cap_end = (i < total_groups) ? compiled_regex->capture_slot(i * 2 + 1) : -1;
 
         if (cap_start >= 0 && cap_end >= 0) {
-            auto cap_view = utf16_view.substring_view(cap_start, cap_end - cap_start);
-            auto cap_str = Utf16String::from_utf16(cap_view);
-            captured_value = PrimitiveString::create(vm, cap_str);
+            captured_value = PrimitiveString::create(vm, *string, static_cast<size_t>(cap_start), static_cast<size_t>(cap_end - cap_start));
         } else {
             captured_value = js_undefined();
         }
@@ -1237,8 +1234,7 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_split_impl(VM& vm, Object& rege
                     }
 
                     // Add substring before this match.
-                    auto substring = utf16_view.substring_view(last_match_end, next_search_from - last_match_end);
-                    array->indexed_put(array_length, PrimitiveString::create(vm, substring));
+                    array->indexed_put(array_length, PrimitiveString::create(vm, *string, last_match_end, next_search_from - last_match_end));
                     ++array_length;
                     if (array_length == limit)
                         return array;
@@ -1265,8 +1261,7 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_split_impl(VM& vm, Object& rege
                         int cap_end = (i < total_groups) ? compiled_regex->capture_slot(i * 2 + 1) : -1;
 
                         if (cap_start >= 0 && cap_end >= 0) {
-                            auto cap_view = utf16_view.substring_view(cap_start, cap_end - cap_start);
-                            array->indexed_put(array_length, PrimitiveString::create(vm, cap_view));
+                            array->indexed_put(array_length, PrimitiveString::create(vm, *string, static_cast<size_t>(cap_start), static_cast<size_t>(cap_end - cap_start)));
                         } else {
                             array->indexed_put(array_length, js_undefined());
                         }
@@ -1279,8 +1274,7 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_split_impl(VM& vm, Object& rege
                 }
 
                 // Add trailing substring.
-                auto trailing = utf16_view.substring_view(last_match_end);
-                array->indexed_put(array_length, PrimitiveString::create(vm, trailing));
+                array->indexed_put(array_length, PrimitiveString::create(vm, *string, last_match_end, size - last_match_end));
 
                 return array;
             }
@@ -1379,10 +1373,8 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_split_impl(VM& vm, Object& rege
         // iv. Else,
 
         // 1. Let T be the substring of S from p to q.
-        auto substring = string->utf16_string_view().substring_view(last_match_end, next_search_from - last_match_end);
-
         // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-        array->indexed_put(array_length, PrimitiveString::create(vm, substring));
+        array->indexed_put(array_length, PrimitiveString::create(vm, *string, last_match_end, next_search_from - last_match_end));
 
         // 3. Set lengthA to lengthA + 1.
         ++array_length;
@@ -1425,10 +1417,8 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_split_impl(VM& vm, Object& rege
     }
 
     // 20. Let T be the substring of S from p to size.
-    auto substring = string->utf16_string_view().substring_view(last_match_end);
-
     // 21. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-    array->indexed_put(array_length, PrimitiveString::create(vm, substring));
+    array->indexed_put(array_length, PrimitiveString::create(vm, *string, last_match_end, string->length_in_utf16_code_units() - last_match_end));
 
     // 22. Return A.
     return array;

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -330,7 +330,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
             cap_starts[g] = (gi < total_groups) ? compiled_regex->capture_slot(gi * 2) : -1;
             cap_ends[g] = (gi < total_groups) ? compiled_regex->capture_slot(gi * 2 + 1) : -1;
         }
-        update_legacy_regexp_static_properties_lazy(realm.intrinsics().regexp_constructor(), string->utf16_string(), match_index, end_index, cap_count, cap_starts, cap_ends);
+        update_legacy_regexp_static_properties_lazy(realm.intrinsics().regexp_constructor(), string, match_index, end_index, cap_count, cap_starts, cap_ends);
     } else if (&realm == &regexp_object.realm()) {
         invalidate_legacy_regexp_static_properties(realm.intrinsics().regexp_constructor());
     }
@@ -860,7 +860,7 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_replace_impl(VM& vm, Object& re
                             cap_starts[g] = (gi < total_groups) ? compiled_regex->capture_slot(gi * 2) : -1;
                             cap_ends[g] = (gi < total_groups) ? compiled_regex->capture_slot(gi * 2 + 1) : -1;
                         }
-                        update_legacy_regexp_static_properties_lazy(realm.intrinsics().regexp_constructor(), string->utf16_string(), last_match_start, last_match_end, cap_count, cap_starts, cap_ends);
+                        update_legacy_regexp_static_properties_lazy(realm.intrinsics().regexp_constructor(), string, last_match_start, last_match_end, cap_count, cap_starts, cap_ends);
                     }
 
                     // Fast path: if no matches were found, return the original string.
@@ -1252,7 +1252,7 @@ ThrowCompletionOr<Value> RegExpPrototype::symbol_split_impl(VM& vm, Object& rege
                             cap_ends[g] = (gi < total_groups) ? compiled_regex->capture_slot(gi * 2 + 1) : -1;
                         }
                         update_legacy_regexp_static_properties_lazy(realm.intrinsics().regexp_constructor(),
-                            string->utf16_string(), match_start, match_end, cap_count, cap_starts, cap_ends);
+                            string, match_start, match_end, cap_count, cap_starts, cap_ends);
                     }
 
                     // Add captures.
@@ -1488,7 +1488,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::test)
                             cap_ends[g] = (gi < total_groups) ? compiled_regex->capture_slot(gi * 2 + 1) : -1;
                         }
                         update_legacy_regexp_static_properties_lazy(realm.intrinsics().regexp_constructor(),
-                            string->utf16_string(), match_start, match_end, cap_count, cap_starts, cap_ends);
+                            string, match_start, match_end, cap_count, cap_starts, cap_ends);
                     } else {
                         invalidate_legacy_regexp_static_properties(realm.intrinsics().regexp_constructor());
                     }

--- a/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Libraries/LibJS/Runtime/StringObject.cpp
@@ -73,7 +73,8 @@ static ThrowCompletionOr<Optional<PropertyDescriptor>> string_get_own_property(S
 
     // 6. Let str be S.[[StringData]].
     // 7. Assert: Type(str) is String.
-    auto str = string.primitive_string().utf16_string_view();
+    auto& primitive_string = string.primitive_string();
+    auto str = primitive_string.utf16_string_view();
 
     // 8. Let len be the length of str.
     auto length = str.length_in_code_units();
@@ -83,7 +84,7 @@ static ThrowCompletionOr<Optional<PropertyDescriptor>> string_get_own_property(S
         return Optional<PropertyDescriptor> {};
 
     // 10. Let resultStr be the substring of str from ℝ(index) to ℝ(index) + 1.
-    auto result_str = PrimitiveString::create(vm, str.substring_view(index.as_index(), 1));
+    auto result_str = PrimitiveString::create(vm, primitive_string, index.as_index(), 1);
 
     // 11. Return the PropertyDescriptor { [[Value]]: resultStr, [[Writable]]: false, [[Enumerable]]: true, [[Configurable]]: false }.
     return PropertyDescriptor {

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -285,7 +285,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::at)
         return js_undefined();
 
     // 7. Return ? Get(O, ! ToString(𝔽(k))).
-    return PrimitiveString::create(vm, string->utf16_string_view().substring_view(index.value(), 1));
+    return PrimitiveString::create(vm, *string, index.value(), 1);
 }
 
 // 22.1.3.2 String.prototype.charAt ( pos ), https://tc39.es/ecma262/#sec-string.prototype.charat
@@ -304,7 +304,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::char_at)
         return PrimitiveString::create(vm, String {});
 
     // 6. Return the substring of S from position to position + 1.
-    return PrimitiveString::create(vm, string->utf16_string_view().substring_view(position, 1));
+    return PrimitiveString::create(vm, *string, position, 1);
 }
 
 // 22.1.3.3 String.prototype.charCodeAt ( pos ), https://tc39.es/ecma262/#sec-string.prototype.charcodeat
@@ -1147,7 +1147,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::slice)
         return PrimitiveString::create(vm, String {});
 
     // 13. Return the substring of S from from to to.
-    return PrimitiveString::create(vm, string->utf16_string_view().substring_view(int_start, int_end - int_start));
+    return PrimitiveString::create(vm, *string, int_start, int_end - int_start);
 }
 
 // 22.1.3.23 String.prototype.split ( separator, limit ), https://tc39.es/ecma262/#sec-string.prototype.split
@@ -1232,10 +1232,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::split)
             ++position;
             continue;
         }
-        auto segment = string->utf16_string_view().substring_view(start, position - start);
-
         // b. Append T to substrings.
-        MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, segment)));
+        MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, *string, start, position - start)));
         ++array_length;
 
         // c. If the number of elements in substrings is lim, return CreateArrayFromList(substrings).
@@ -1250,10 +1248,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::split)
     }
 
     // 15. Let T be the substring of S from i.
-    auto rest = string->utf16_string_view().substring_view(start);
-
     // 16. Append T to substrings.
-    MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, rest)));
+    MUST(array->create_data_property_or_throw(array_length, PrimitiveString::create(vm, *string, start, string_length - start)));
 
     // 17. Return CreateArrayFromList(substrings).
     return array;
@@ -1345,7 +1341,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::substring)
     size_t to = max(final_start, final_end);
 
     // 10. Return the substring of S from from to to.
-    return PrimitiveString::create(vm, string->utf16_string_view().substring_view(from, to - from));
+    return PrimitiveString::create(vm, *string, from, to - from);
 }
 
 enum class TargetCase {
@@ -1588,7 +1584,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::substr)
         return PrimitiveString::create(vm, String {});
 
     // 11. Return the substring of S from intStart to intEnd.
-    return PrimitiveString::create(vm, string->utf16_string_view().substring_view(int_start, int_end - int_start));
+    return PrimitiveString::create(vm, *string, int_start, int_end - int_start);
 }
 
 // B.2.2.2.1 CreateHTML ( string, tag, attribute, value ), https://tc39.es/ecma262/#sec-createhtml

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,4 +1,5 @@
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
+ladybird_test(test-primitive-string.cpp LibJS LIBS LibJS LibGC)
 
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}")

--- a/Tests/LibJS/Runtime/builtins/Intl/Segmenter/Segmenter.prototype.segment.js
+++ b/Tests/LibJS/Runtime/builtins/Intl/Segmenter/Segmenter.prototype.segment.js
@@ -103,6 +103,19 @@ describe("correct behavior", () => {
         expect(index).toBe(1);
     });
 
+    test("segment data preserves rope-backed UTF-16 strings", () => {
+        const string = "😀" + "x";
+        const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+        const segments = segmenter.segment(string);
+
+        const first = segments.containing(0);
+        expect(first.segment).toBe("😀");
+        expect(first.index).toBe(0);
+        expect(first.input).toBe(string);
+
+        expect(Array.from(segments, segment => segment.segment)).toEqual(["😀", "x"]);
+    });
+
     test("word segmentation of string with mid-word punctuation", () => {
         const string = "The quick (“brown”) fox can’t jump 32.3 feet, right?";
 

--- a/Tests/LibJS/Runtime/builtins/RegExp/RegExp.legacy.js
+++ b/Tests/LibJS/Runtime/builtins/RegExp/RegExp.legacy.js
@@ -36,6 +36,21 @@ test("They should be read only", () => {
     expect(typeof RegExp.input).toBe(typeof String());
 });
 
+test("setting RegExp.input does not change the last match state", () => {
+    /((\d+)\.(\d+))/.exec("abc123.456def");
+
+    RegExp.input = "overridden";
+
+    expect(RegExp.input).toBe("overridden");
+    expect(RegExp.lastMatch).toBe("123.456");
+    expect(RegExp.lastParen).toBe("456");
+    expect(RegExp.leftContext).toBe("abc");
+    expect(RegExp.rightContext).toBe("def");
+    expect(RegExp.$1).toBe("123.456");
+    expect(RegExp.$2).toBe("123");
+    expect(RegExp.$3).toBe("456");
+});
+
 test("They should be read only (strict mode)", () => {
     "use strict";
 
@@ -205,6 +220,17 @@ test("legacy static properties with a temporary string", () => {
         expect(RegExp.rightContext).toBe("1");
         expect(RegExp.$1).toBe("a");
     }
+});
+
+test("legacy static properties preserve rope-backed UTF-16 strings", () => {
+    /(x)/.exec("😀" + "x1y");
+
+    expect(RegExp.input).toBe("😀x1y");
+    expect(RegExp.lastMatch).toBe("x");
+    expect(RegExp.lastParen).toBe("x");
+    expect(RegExp.leftContext).toBe("😀");
+    expect(RegExp.rightContext).toBe("1y");
+    expect(RegExp.$1).toBe("x");
 });
 
 test("legacy octal escapes", () => {

--- a/Tests/LibJS/Runtime/builtins/RegExp/RegExp.prototype.exec.js
+++ b/Tests/LibJS/Runtime/builtins/RegExp/RegExp.prototype.exec.js
@@ -245,6 +245,16 @@ test("cached UTF-16 code point length", () => {
     expect(match.codePointAt(0)).toBe(0x1f600);
 });
 
+test("UTF-16 captures", () => {
+    let result = /(\ud83d\ude00)(\ud83d)(\ude00)/.exec("😀😀");
+
+    expect(result).not.toBe(null);
+    expect(result[0]).toBe("😀😀");
+    expect(result[1]).toBe("😀");
+    expect(result[2]).toBe("\ud83d");
+    expect(result[3]).toBe("\ude00");
+});
+
 test("named groups source order", () => {
     // Test that named groups appear in source order, not match order
     let re = /(?<y>a)(?<x>a)|(?<x>b)(?<y>b)/;

--- a/Tests/LibJS/Runtime/builtins/String/String.prototype.split.js
+++ b/Tests/LibJS/Runtime/builtins/String/String.prototype.split.js
@@ -50,6 +50,8 @@ test("regex split", () => {
         "CODE",
         "",
     ]);
+
+    expect(/(\ud83d\ude00)(\ud83d)(\ude00)/[Symbol.split]("x😀😀y")).toEqual(["x", "😀", "\ud83d", "\ude00", "y"]);
 });
 
 test("UTF-16", () => {

--- a/Tests/LibJS/Runtime/string-rope-substrings.js
+++ b/Tests/LibJS/Runtime/string-rope-substrings.js
@@ -1,0 +1,25 @@
+test("string substring-producing operations work on ropes", () => {
+    let rope = "ab" + "cd";
+
+    expect(rope.at(1)).toBe("b");
+    expect(rope.charAt(2)).toBe("c");
+    expect(rope.slice(1, 3)).toBe("bc");
+    expect(rope.substring(1, 3)).toBe("bc");
+    expect(rope.substr(1, 2)).toBe("bc");
+    expect(rope.split("b")).toEqual(["a", "cd"]);
+    expect(rope[2]).toBe("c");
+    expect(new String(rope)[2]).toBe("c");
+});
+
+test("string substring-producing operations preserve UTF-16 code units on ropes", () => {
+    let rope = "😀" + "x";
+
+    expect(rope.at(0)).toBe("\ud83d");
+    expect(rope.charAt(1)).toBe("\ude00");
+    expect(rope.slice(1, 3)).toBe("\ude00x");
+    expect(rope.substring(1, 3)).toBe("\ude00x");
+    expect(rope.substr(1, 2)).toBe("\ude00x");
+    expect(rope.split("x")).toEqual(["😀", ""]);
+    expect(rope[1]).toBe("\ude00");
+    expect(new String(rope)[1]).toBe("\ude00");
+});

--- a/Tests/LibJS/test-primitive-string.cpp
+++ b/Tests/LibJS/test-primitive-string.cpp
@@ -117,6 +117,20 @@ TEST_CASE(primitive_string_substring_utf16_views_stay_deferred)
     EXPECT(!substring->has_utf16_string());
 }
 
+TEST_CASE(primitive_string_substring_equality_uses_utf16_code_units)
+{
+    TestVM test_vm;
+
+    char16_t const source_code_units[] = { u'x', u'x', u'x', 0xd800, 0xdc00, 0xdc00, u'x', u'x' };
+    char16_t const substring_code_units[] = { 0xd800, 0xdc00, 0xdc00 };
+
+    auto source = PrimitiveString::create(*test_vm.vm, Utf16View { source_code_units, 8 });
+    auto substring = PrimitiveString::create(*test_vm.vm, *source, 3, 3);
+    auto expected = PrimitiveString::create(*test_vm.vm, Utf16View { substring_code_units, 3 });
+
+    EXPECT(*substring == *expected);
+}
+
 TEST_CASE(deferred_primitive_strings_do_not_evict_cached_strings)
 {
     TestVM test_vm;

--- a/Tests/LibJS/test-primitive-string.cpp
+++ b/Tests/LibJS/test-primitive-string.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringView.h>
+#include <AK/Try.h>
+#include <LibGC/Root.h>
+#include <LibJS/Runtime/PrimitiveString.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibTest/TestCase.h>
+
+using namespace JS;
+
+namespace {
+
+struct TestVM {
+    TestVM()
+        : vm(VM::create())
+        , execution_context(MUST(Realm::initialize_host_defined_realm(*vm, nullptr, nullptr)))
+    {
+    }
+
+    ~TestVM()
+    {
+        vm->pop_execution_context();
+    }
+
+    NonnullRefPtr<VM> vm;
+    NonnullOwnPtr<ExecutionContext> execution_context;
+};
+
+NEVER_INLINE static void materialize_temporary_rope(VM& vm)
+{
+    auto rope = PrimitiveString::create(vm,
+        *PrimitiveString::create(vm, "f"_string),
+        *PrimitiveString::create(vm, "oo"_string));
+    EXPECT(rope->utf8_string_view() == "foo"sv);
+}
+
+NEVER_INLINE static void materialize_temporary_substring(VM& vm)
+{
+    auto source = PrimitiveString::create(vm, "foobar"_string);
+    auto substring = PrimitiveString::create(vm, *source, 0, 3);
+    EXPECT(substring->utf8_string_view() == "foo"sv);
+}
+
+NEVER_INLINE static void clobber_stack()
+{
+    char volatile stack_bytes[4096] {};
+    for (size_t i = 0; i < sizeof(stack_bytes); ++i)
+        stack_bytes[i] = static_cast<char>(i);
+}
+
+}
+
+TEST_CASE(primitive_string_substring_supports_nested_ranges)
+{
+    TestVM test_vm;
+
+    auto string = PrimitiveString::create(*test_vm.vm, "abcdef"_string);
+    auto substring = PrimitiveString::create(*test_vm.vm, *string, 1, 4);
+    auto nested_substring = PrimitiveString::create(*test_vm.vm, *substring, 1, 2);
+
+    EXPECT_EQ(substring->length_in_utf16_code_units(), 4u);
+    EXPECT(substring->utf8_string_view() == "bcde"sv);
+    EXPECT_EQ(nested_substring->length_in_utf16_code_units(), 2u);
+    EXPECT(nested_substring->utf8_string_view() == "cd"sv);
+}
+
+TEST_CASE(primitive_string_substring_materializes_rope_ranges)
+{
+    TestVM test_vm;
+
+    auto rope = PrimitiveString::create(*test_vm.vm,
+        *PrimitiveString::create(*test_vm.vm, "ab"_string),
+        *PrimitiveString::create(*test_vm.vm, "cd"_string));
+    auto substring = PrimitiveString::create(*test_vm.vm, *rope, 1, 2);
+
+    EXPECT_EQ(substring->length_in_utf16_code_units(), 2u);
+    EXPECT(substring->utf8_string_view() == "bc"sv);
+}
+
+TEST_CASE(primitive_string_substring_handles_surrogate_boundaries)
+{
+    TestVM test_vm;
+
+    auto string = PrimitiveString::create(*test_vm.vm, "😀x"_string);
+    auto leading_surrogate = PrimitiveString::create(*test_vm.vm, *string, 0, 1);
+    auto trailing_surrogate = PrimitiveString::create(*test_vm.vm, *string, 1, 1);
+    auto full_code_point = PrimitiveString::create(*test_vm.vm, *string, 0, 2);
+
+    EXPECT_EQ(leading_surrogate->length_in_utf16_code_units(), 1u);
+    EXPECT_EQ(leading_surrogate->utf16_string_view().code_unit_at(0), static_cast<u16>(0xd83d));
+    EXPECT_EQ(trailing_surrogate->length_in_utf16_code_units(), 1u);
+    EXPECT_EQ(trailing_surrogate->utf16_string_view().code_unit_at(0), static_cast<u16>(0xde00));
+    EXPECT(full_code_point->utf8_string_view() == "😀"sv);
+}
+
+TEST_CASE(primitive_string_substring_utf16_views_stay_deferred)
+{
+    TestVM test_vm;
+
+    auto string = PrimitiveString::create(*test_vm.vm, Utf16View { u"abcd", 4 });
+    auto substring = PrimitiveString::create(*test_vm.vm, *string, 1, 2);
+
+    EXPECT(string->has_utf16_string());
+    EXPECT(!substring->has_utf16_string());
+
+    auto view = substring->utf16_string_view();
+
+    EXPECT_EQ(view.length_in_code_units(), 2u);
+    EXPECT_EQ(view.code_unit_at(0), 'b');
+    EXPECT_EQ(view.code_unit_at(1), 'c');
+    EXPECT(!substring->has_utf16_string());
+}
+
+TEST_CASE(deferred_primitive_strings_do_not_evict_cached_strings)
+{
+    TestVM test_vm;
+
+    GC::Root<PrimitiveString> cached_foo = PrimitiveString::create(*test_vm.vm, "foo"_string);
+
+    materialize_temporary_rope(*test_vm.vm);
+    clobber_stack();
+
+    test_vm.vm->heap().collect_garbage();
+    EXPECT_EQ(PrimitiveString::create(*test_vm.vm, "foo"_string).ptr(), cached_foo.ptr());
+
+    materialize_temporary_substring(*test_vm.vm);
+    clobber_stack();
+
+    test_vm.vm->heap().collect_garbage();
+    EXPECT_EQ(PrimitiveString::create(*test_vm.vm, "foo"_string).ptr(), cached_foo.ptr());
+}


### PR DESCRIPTION
This adds `JS::Substring`, a new `PrimitiveString` subclass that represents a substring as a source string plus start/length and only materializes when owned string storage is actually needed.

With that in place, LibJS now uses lazy substrings for regexp match results, captures, split results, and legacy regexp statics, as well as for string builtins like `at`, `charAt`, `slice`, `substring`, `substr`, `split`, and indexed string access. `Intl.Segmenter` segment data now also reuses the original primitive string and returns lazy substrings for segments.

Benchmark totals stayed effectively neutral overall while improving regexp-heavy workloads, including a `1.066x` speedup on `Octane/regexp.js`.

Full benchmarks (macOS):

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ------------------
LongSpider      3d-cube.js                              0.995      3.767 ± 3.739 … 3.795              3.784 ± 3.751 … 3.818              -0.2% (-0.0 MB)
LongSpider      3d-morph.js                             0.986      2.181 ± 2.179 … 2.182              2.211 ± 2.186 … 2.236              -0.2% (-0.0 MB)
LongSpider      3d-raytrace.js                          0.985      2.664 ± 2.650 … 2.678              2.705 ± 2.702 … 2.709              -0.5% (-0.1 MB)
LongSpider      access-binary-trees.js                  1.009      6.937 ± 6.889 … 6.985              6.875 ± 6.798 … 6.953              +3.5% (+2.6 MB)
LongSpider      access-fannkuch.js                      0.998      1.467 ± 1.456 … 1.478              1.470 ± 1.460 … 1.480              -0.5% (-0.1 MB)
LongSpider      access-nbody.js                         1.001      3.991 ± 3.980 … 4.001              3.985 ± 3.984 … 3.986              -0.3% (-0.0 MB)
LongSpider      access-nsieve.js                        0.995      1.086 ± 1.074 … 1.099              1.092 ± 1.084 … 1.101              -0.0% (-0.0 MB)
LongSpider      bitops-3bit-bits-in-byte.js             0.988      0.426 ± 0.424 … 0.427              0.431 ± 0.423 … 0.439              -0.8% (-0.1 MB)
LongSpider      bitops-bits-in-byte.js                  0.986      0.851 ± 0.848 … 0.854              0.863 ± 0.860 … 0.866              -0.5% (-0.1 MB)
LongSpider      bitops-nsieve-bits.js                   1.003      1.628 ± 1.625 … 1.631              1.623 ± 1.612 … 1.634              -0.2% (-0.0 MB)
LongSpider      controlflow-recursive.js                1.025      2.809 ± 2.759 … 2.859              2.741 ± 2.736 … 2.745              -0.5% (-0.1 MB)
LongSpider      crypto-aes.js                           1.001      3.766 ± 3.765 … 3.767              3.762 ± 3.759 … 3.766              -1.9% (-0.4 MB)
LongSpider      crypto-md5.js                           1.010      5.275 ± 5.271 … 5.279              5.222 ± 5.190 … 5.254              +0.1% (+0.1 MB)
LongSpider      crypto-sha1.js                          0.995      10.145 ± 10.132 … 10.158           10.198 ± 10.113 … 10.284           -0.0% (-0.0 MB)
LongSpider      date-format-tofte.js                    0.962      3.020 ± 3.017 … 3.023              3.139 ± 3.131 … 3.146              -0.1% (-0.0 MB)
LongSpider      date-format-xparb.js                    1.002      3.738 ± 3.732 … 3.744              3.732 ± 3.718 … 3.746              +0.1% (+0.0 MB)
LongSpider      hash-map.js                             0.999      0.954 ± 0.952 … 0.956              0.955 ± 0.955 … 0.955              -0.1% (-0.0 MB)
LongSpider      math-cordic.js                          1.004      4.588 ± 4.584 … 4.593              4.569 ± 4.564 … 4.573              -0.4% (-0.0 MB)
LongSpider      math-partial-sums.js                    0.996      0.751 ± 0.749 … 0.754              0.755 ± 0.754 … 0.755              -0.3% (-0.0 MB)
LongSpider      math-spectral-norm.js                   1.002      5.612 ± 5.536 … 5.687              5.603 ± 5.575 … 5.630              -0.4% (-0.0 MB)
LongSpider      string-base64.js                        0.869      1.475 ± 1.461 … 1.488              1.697 ± 1.667 … 1.728              +89.4% (+268.1 MB)
LongSpider      string-fasta.js                         1.180      1.597 ± 1.595 … 1.600              1.354 ± 1.351 … 1.357              -19.4% (-5.8 MB)
LongSpider      string-tagcloud.js                      1.009      0.778 ± 0.776 … 0.781              0.771 ± 0.769 … 0.774              +2.2% (+1.0 MB)
Kraken          ai-astar.js                             1.002      0.527 ± 0.527 … 0.527              0.526 ± 0.525 … 0.527              -0.2% (-0.1 MB)
Kraken          audio-beat-detection.js                 0.998      0.457 ± 0.457 … 0.457              0.458 ± 0.456 … 0.459              -0.0% (-0.0 MB)
Kraken          audio-dft.js                            1.004      0.331 ± 0.328 … 0.334              0.329 ± 0.329 … 0.330              -0.1% (-0.0 MB)
Kraken          audio-fft.js                            1.004      0.393 ± 0.390 … 0.395              0.391 ± 0.389 … 0.393              -0.1% (-0.0 MB)
Kraken          audio-oscillator.js                     1.033      0.349 ± 0.346 … 0.352              0.338 ± 0.334 … 0.342              -0.1% (-0.1 MB)
Kraken          imaging-darkroom.js                     1.000      0.567 ± 0.567 … 0.568              0.567 ± 0.566 … 0.569              -0.0% (-0.0 MB)
Kraken          imaging-desaturate.js                   0.986      0.567 ± 0.564 … 0.570              0.575 ± 0.569 … 0.582              -0.1% (-0.0 MB)
Kraken          imaging-gaussian-blur.js                0.993      2.409 ± 2.392 … 2.427              2.427 ± 2.425 … 2.428              -0.1% (-0.0 MB)
Kraken          json-parse-financial.js                 0.984      0.052 ± 0.051 … 0.052              0.052 ± 0.052 … 0.053              -0.5% (-0.1 MB)
Kraken          json-stringify-tinderbox.js             1.000      0.054 ± 0.053 … 0.054              0.054 ± 0.053 … 0.055              +0.8% (+0.3 MB)
Kraken          stanford-crypto-aes.js                  0.997      0.183 ± 0.183 … 0.184              0.184 ± 0.183 … 0.184              -1.6% (-0.5 MB)
Kraken          stanford-crypto-ccm.js                  1.056      0.148 ± 0.146 … 0.149              0.140 ± 0.140 … 0.140              -0.7% (-0.3 MB)
Kraken          stanford-crypto-pbkdf2.js               1.006      0.339 ± 0.338 … 0.340              0.337 ± 0.337 … 0.337              +0.8% (+0.2 MB)
Kraken          stanford-crypto-sha256-iterative.js     0.999      0.137 ± 0.137 … 0.137              0.137 ± 0.137 … 0.137              -0.3% (-0.1 MB)
Octane          box2d.js                                1.001      8906.000 ± 8889.000 … 8923.000     8911.000 ± 8855.000 … 8967.000     -0.1% (-0.0 MB)
Octane          code-load.js                            1.008      24800.500 ± 24788.000 … 24813.000  24993.500 ± 24986.000 … 25001.000  -2.4% (-25.0 MB)
Octane          crypto.js                               1.005      3338.500 ± 3321.000 … 3356.000     3355.000 ± 3349.000 … 3361.000     +1.1% (+0.3 MB)
Octane          deltablue.js                            1.012      2147.000 ± 2094.000 … 2200.000     2173.500 ± 2158.000 … 2189.000     -0.5% (-0.1 MB)
Octane          earley-boyer.js                         0.990      5203.000 ± 5192.000 … 5214.000     5153.000 ± 5139.000 … 5167.000     +0.0% (+0.0 MB)
Octane          gbemu.js                                0.991      19224.000 ± 19224.000 … 19224.000  19058.500 ± 19050.000 … 19067.000  +12.4% (+8.3 MB)
Octane          mandreel.js                             0.984      17964.500 ± 17932.000 … 17997.000  17680.000 ± 17492.000 … 17868.000  +0.2% (+0.7 MB)
Octane          navier-stokes.js                        1.005      4853.500 ± 4839.000 … 4868.000     4878.000 ± 4873.000 … 4883.000     -0.3% (-0.0 MB)
Octane          pdfjs.js                                0.959      8473.000 ± 8461.000 … 8485.000     8128.500 ± 8114.000 … 8143.000     +4.1% (+3.2 MB)
Octane          raytrace.js                             1.008      3935.000 ± 3929.000 … 3941.000     3966.500 ± 3949.000 … 3984.000     +0.3% (+0.1 MB)
Octane          regexp.js                               1.066      2075.500 ± 2070.000 … 2081.000     2212.000 ± 2200.000 … 2224.000     -20.1% (-9.7 MB)
Octane          richards.js                             0.960      2369.000 ± 2355.000 … 2383.000     2273.500 ± 2217.000 … 2330.000     -1.2% (-0.2 MB)
Octane          splay.js                                0.986      7929.500 ± 7851.000 … 8008.000     7819.000 ± 7794.000 … 7844.000     +3.6% (+8.4 MB)
Octane          typescript.js                           0.994      22953.500 ± 22945.000 … 22962.000  22824.500 ± 22753.000 … 22896.000  +0.1% (+0.1 MB)
Octane          zlib.js                                 1.000      7034.500 ± 7033.000 … 7036.000     7036.500 ± 7033.000 … 7040.000     +0.0% (+0.0 MB)
JetStream       bigfib.cpp.js                           1.002      3.913 ± 3.911 … 3.915              3.907 ± 3.898 … 3.915              +0.2% (+0.4 MB)
JetStream       cdjs.js                                 1.002      1.997 ± 1.996 … 1.997              1.992 ± 1.989 … 1.994              -0.4% (-0.1 MB)
JetStream       container.cpp.js                        0.996      19.149 ± 19.140 … 19.158           19.224 ± 19.211 … 19.237           +0.1% (+0.1 MB)
JetStream       dry.c.js                                0.999      8.910 ± 8.903 … 8.917              8.920 ± 8.911 … 8.929              -0.0% (-0.0 MB)
JetStream       float-mm.c.js                           0.980      13.683 ± 13.600 … 13.766           13.967 ± 13.859 … 14.075           -0.0% (-0.0 MB)
JetStream       gcc-loops.cpp.js                        1.003      54.893 ± 54.776 … 55.010           54.730 ± 54.690 … 54.770           -0.0% (-0.0 MB)
JetStream       hash-map.js                             0.993      0.949 ± 0.940 … 0.958              0.956 ± 0.955 … 0.957              -0.2% (-0.2 MB)
JetStream       n-body.c.js                             0.997      15.786 ± 15.731 … 15.841           15.839 ± 15.633 … 16.045           -0.2% (-0.1 MB)
JetStream       quicksort.c.js                          1.012      2.742 ± 2.719 … 2.765              2.711 ± 2.663 … 2.759              +0.2% (+0.1 MB)
JetStream       towers.c.js                             0.988      2.893 ± 2.883 … 2.903              2.928 ± 2.867 … 2.990              -0.1% (-0.0 MB)
JetStream3      js-tokens.js                            0.973      0.288 ± 0.286 … 0.291              0.296 ± 0.296 … 0.297              -3.3% (-0.7 MB)
JetStream3      lazy-collections.js                     1.009      0.712 ± 0.708 … 0.715              0.705 ± 0.704 … 0.706              +0.2% (+0.0 MB)
JetStream3      raytrace-private-class-fields.js        0.998      3.197 ± 3.193 … 3.200              3.202 ± 3.195 … 3.210              -0.1% (-0.0 MB)
JetStream3      raytrace-public-class-fields.js         1.009      2.355 ± 2.346 … 2.364              2.334 ± 2.323 … 2.346              +0.5% (+0.1 MB)
JetStream3      sync-file-system.js                     0.998      1.376 ± 1.372 … 1.380              1.379 ± 1.373 … 1.386              -0.9% (-0.3 MB)
AsyncBench      async-call-return.js                    1.000      0.145 ± 0.144 … 0.145              0.145 ± 0.144 … 0.145              -0.4% (-0.1 MB)
AsyncBench      async-class-method.js                   1.001      0.166 ± 0.165 … 0.166              0.166 ± 0.165 … 0.166              -0.4% (-0.1 MB)
AsyncBench      async-fan-out.js                        1.002      0.153 ± 0.153 … 0.154              0.153 ± 0.153 … 0.154              -0.4% (-0.1 MB)
AsyncBench      async-generator.js                      0.997      0.213 ± 0.211 … 0.215              0.214 ± 0.214 … 0.214              -0.5% (-0.1 MB)
AsyncBench      async-iife.js                           0.996      0.230 ± 0.230 … 0.230              0.231 ± 0.230 … 0.232              -0.4% (-0.1 MB)
AsyncBench      async-nested-calls.js                   1.003      0.249 ± 0.247 … 0.252              0.249 ± 0.248 … 0.249              -0.3% (-0.1 MB)
AsyncBench      async-pipeline.js                       0.993      0.276 ± 0.275 … 0.276              0.278 ± 0.274 … 0.281              -0.4% (-0.1 MB)
AsyncBench      async-sequential-awaits.js              0.965      0.069 ± 0.069 … 0.070              0.072 ± 0.071 … 0.073              -0.4% (-0.1 MB)
AsyncBench      async-try-catch-reject.js               0.996      1.233 ± 1.232 … 1.234              1.239 ± 1.233 … 1.244              -0.4% (-0.1 MB)
AsyncBench      await-primitive.js                      0.975      0.036 ± 0.035 … 0.036              0.036 ± 0.036 … 0.037              -0.6% (-0.1 MB)
AsyncBench      await-resolved-promise.js               1.005      0.363 ± 0.361 … 0.366              0.362 ± 0.361 … 0.362              -0.7% (-0.1 MB)
AsyncBench      await-thenable.js                       0.986      0.034 ± 0.034 … 0.034              0.035 ± 0.035 … 0.035              -0.0% (-0.0 MB)
AsyncBench      promise-all.js                          0.999      0.417 ± 0.414 … 0.419              0.417 ± 0.417 … 0.417              -0.6% (-0.1 MB)
AsyncBench      promise-allSettled.js                   0.991      0.478 ± 0.477 … 0.478              0.482 ± 0.481 … 0.483              -0.1% (-0.0 MB)
AsyncBench      promise-chain.js                        0.991      0.148 ± 0.147 … 0.149              0.149 ± 0.149 … 0.150              -0.0% (-0.0 MB)
AsyncBench      promise-new-resolve.js                  0.995      0.230 ± 0.229 … 0.231              0.232 ± 0.231 … 0.233              -0.2% (-0.0 MB)
AsyncBench      promise-race.js                         0.993      0.417 ± 0.417 … 0.418              0.420 ± 0.420 … 0.421              +0.1% (+0.0 MB)
ARES-6          Air.js                                  0.999      1.426 ± 1.421 … 1.431              1.427 ± 1.423 … 1.431              -0.7% (-0.3 MB)
ARES-6          Babylon.js                              1.009      1.097 ± 1.091 … 1.103              1.087 ± 1.087 … 1.087              -4.2% (-1.4 MB)
ARES-6          Basic.js                                1.005      1.291 ± 1.289 … 1.293              1.285 ± 1.284 … 1.286              +1.5% (+0.4 MB)
ARES-6          ML.js                                   0.995      1.579 ± 1.577 … 1.581              1.587 ± 1.582 … 1.592              +0.0% (+0.0 MB)
JetStreamExtra  FlightPlanner.js                        1.028      0.904 ± 0.887 … 0.922              0.880 ± 0.878 … 0.882              +0.3% (+1.3 MB)
JetStreamExtra  OfflineAssembler.js                     1.088      1.303 ± 1.302 … 1.304              1.198 ± 1.197 … 1.199              -90.5% (-413.3 MB)
JetStreamExtra  UniPoker.js                             1.006      1.298 ± 1.289 … 1.307              1.291 ± 1.288 … 1.294              -1.2% (-0.3 MB)
JetStreamExtra  async-fs.js                             1.012      1.394 ± 1.391 … 1.397              1.377 ± 1.374 … 1.380              +0.6% (+0.2 MB)
JetStreamExtra  babylonjs-startup-es5.js                1.010      0.819 ± 0.816 … 0.822              0.811 ± 0.809 … 0.814              +0.3% (+1.6 MB)
JetStreamExtra  babylonjs-startup-es6.js                0.997      0.995 ± 0.993 … 0.997              0.998 ± 0.996 … 1.000              +0.2% (+1.4 MB)
JetStreamExtra  bigint-bigdenary.js                     1.013      1.484 ± 1.482 … 1.486              1.465 ± 1.458 … 1.471              -0.1% (-0.0 MB)
JetStreamExtra  bigint-noble-bls12-381.js               1.006      1.515 ± 1.512 … 1.518              1.506 ± 1.505 … 1.507              -0.4% (-0.2 MB)
JetStreamExtra  bigint-noble-ed25519.js                 1.000      1.493 ± 1.493 … 1.494              1.494 ± 1.494 … 1.494              -0.2% (-0.1 MB)
JetStreamExtra  bigint-noble-secp256k1.js               1.007      1.442 ± 1.440 … 1.444              1.432 ± 1.428 … 1.436              -0.4% (-0.2 MB)
JetStreamExtra  bigint-paillier.js                      0.997      1.550 ± 1.549 … 1.550              1.554 ± 1.550 … 1.557              -0.1% (-0.1 MB)
JetStreamExtra  doxbee-async.js                         1.011      1.322 ± 1.316 … 1.328              1.308 ± 1.292 … 1.323              -0.6% (-0.3 MB)
JetStreamExtra  doxbee-promise.js                       0.987      1.383 ± 1.381 … 1.386              1.401 ± 1.394 … 1.408              -0.4% (-0.2 MB)
JetStreamExtra  first-inspector-code-load.js            1.003      1.499 ± 1.498 … 1.499              1.494 ± 1.493 … 1.495              +0.0% (+0.0 MB)
JetStreamExtra  jsdom-d3-startup.js                     0.984      1.213 ± 1.211 … 1.215              1.233 ± 1.229 … 1.237              +1.3% (+4.1 MB)
JetStreamExtra  json-parse-inspector.js                 0.993      0.956 ± 0.956 … 0.956              0.962 ± 0.962 … 0.963              +2.0% (+5.4 MB)
JetStreamExtra  json-stringify-inspector.js             1.015      0.943 ± 0.942 … 0.944              0.929 ± 0.918 … 0.939              -1.5% (-3.8 MB)
JetStreamExtra  mobx-startup.js                         0.995      1.347 ± 1.344 … 1.349              1.353 ± 1.352 … 1.354              +0.5% (+0.2 MB)
JetStreamExtra  multi-inspector-code-load.js            0.998      1.497 ± 1.497 … 1.497              1.499 ± 1.497 … 1.502              -0.0% (-0.0 MB)
JetStreamExtra  prismjs-startup-es5.js                  0.993      1.453 ± 1.449 … 1.456              1.462 ± 1.460 … 1.465              -1.4% (-0.5 MB)
JetStreamExtra  prismjs-startup-es6.js                  0.991      1.450 ± 1.449 … 1.450              1.462 ± 1.458 … 1.467              -1.6% (-0.6 MB)
JetStreamExtra  proxy-mobx.js                           0.999      1.135 ± 1.128 … 1.142              1.136 ± 1.134 … 1.138              -0.8% (-0.2 MB)
JetStreamExtra  proxy-vue.js                            1.009      1.080 ± 1.075 … 1.085              1.071 ± 1.001 … 1.140              -0.3% (-0.1 MB)
JetStreamExtra  threejs.js                              1.002      1.397 ± 1.391 … 1.403              1.394 ± 1.393 … 1.394              +1.2% (+4.6 MB)
JetStreamExtra  typescript-lib.js                       0.988      0.557 ± 0.556 … 0.557              0.563 ± 0.563 … 0.564              +0.4% (+1.2 MB)
JetStreamExtra  validatorjs.js                          1.012      1.260 ± 1.258 … 1.261              1.245 ± 1.243 … 1.247              +0.6% (+0.3 MB)
JetStreamExtra  web-ssr.js                              1.005      1.420 ± 1.413 … 1.427              1.413 ± 1.410 … 1.415              -5.2% (-5.8 MB)
GarBench        array-of-objects.js                     1.015      0.488 ± 0.478 … 0.498              0.481 ± 0.480 … 0.483              -0.0% (-0.0 MB)
GarBench        closures.js                             1.008      0.728 ± 0.725 … 0.731              0.722 ± 0.720 … 0.725              -0.0% (-0.0 MB)
GarBench        cyclic-graph.js                         0.835      1.326 ± 1.325 … 1.327              1.589 ± 1.587 … 1.591              -0.9% (-1.8 MB)
GarBench        deep-linked-list.js                     1.003      0.415 ± 0.414 … 0.416              0.414 ± 0.413 … 0.415              -0.0% (-0.0 MB)
GarBench        finalization.js                         0.998      0.733 ± 0.732 … 0.734              0.734 ± 0.733 … 0.735              +0.3% (+1.0 MB)
GarBench        many-properties.js                      1.017      1.795 ± 1.793 … 1.796              1.764 ± 1.764 … 1.765              +1.9% (+19.9 MB)
GarBench        marking-stress.js                       1.407      1.490 ± 1.489 … 1.490              1.058 ± 0.942 … 1.175              +4.0% (+20.6 MB)
GarBench        mixed-sizes.js                          0.975      0.815 ± 0.812 … 0.817              0.835 ± 0.830 … 0.841              +1.3% (+7.4 MB)
GarBench        sparse-arrays.js                        0.996      1.755 ± 1.752 … 1.758              1.762 ± 1.760 … 1.764              -0.0% (-0.1 MB)
GarBench        string-heavy.js                         0.994      1.199 ± 1.195 … 1.202              1.205 ± 1.202 … 1.208              +15.9% (+118.8 MB)
GarBench        wide-tree.js                            0.997      0.882 ± 0.875 … 0.889              0.884 ± 0.877 … 0.891              -0.0% (-0.0 MB)
MicroBench      array-destructuring-assignment-rest.js  1.000      0.262 ± 0.260 … 0.263              0.262 ± 0.262 … 0.262              -0.4% (-0.1 MB)
MicroBench      array-destructuring-assignment.js       1.009      1.673 ± 1.669 … 1.677              1.658 ± 1.658 … 1.659              -0.0% (-0.1 MB)
MicroBench      array-prototype-map.js                  1.004      0.959 ± 0.957 … 0.960              0.955 ± 0.953 … 0.957              -0.0% (-0.1 MB)
MicroBench      array-prototype-shift.js                1.003      0.017 ± 0.016 … 0.017              0.017 ± 0.017 … 0.017              -0.3% (-0.0 MB)
MicroBench      base64-from.js                          1.001      0.164 ± 0.164 … 0.164              0.164 ± 0.163 … 0.164              -0.0% (-0.1 MB)
MicroBench      base64-to.js                            0.998      0.203 ± 0.202 … 0.204              0.203 ± 0.203 … 0.204              +0.0% (+0.8 MB)
MicroBench      bound-call-00-args.js                   1.041      1.084 ± 1.060 … 1.109              1.042 ± 1.033 … 1.050              -0.5% (-0.1 MB)
MicroBench      bound-call-04-args.js                   1.019      1.153 ± 1.128 … 1.177              1.131 ± 1.118 … 1.145              -0.5% (-0.1 MB)
MicroBench      bound-call-16-args.js                   0.956      1.452 ± 1.440 … 1.464              1.519 ± 1.483 … 1.555              -0.5% (-0.1 MB)
MicroBench      call-00-args.js                         0.990      0.638 ± 0.625 … 0.651              0.644 ± 0.626 … 0.662              -0.7% (-0.1 MB)
MicroBench      call-01-args.js                         1.029      0.641 ± 0.633 … 0.649              0.623 ± 0.618 … 0.629              -0.7% (-0.1 MB)
MicroBench      call-02-args.js                         0.974      0.644 ± 0.626 … 0.662              0.661 ± 0.651 … 0.672              -0.7% (-0.1 MB)
MicroBench      call-03-args.js                         1.027      0.689 ± 0.670 … 0.708              0.671 ± 0.670 … 0.672              -0.5% (-0.1 MB)
MicroBench      call-04-args.js                         0.996      0.674 ± 0.666 … 0.682              0.677 ± 0.660 … 0.693              -0.8% (-0.1 MB)
MicroBench      call-16-args.js                         1.018      0.873 ± 0.871 … 0.874              0.857 ± 0.856 … 0.859              -0.7% (-0.1 MB)
MicroBench      call-32-args.js                         1.015      1.151 ± 1.147 … 1.156              1.135 ± 1.120 … 1.149              -0.5% (-0.1 MB)
MicroBench      call-native.js                          1.003      0.667 ± 0.663 … 0.672              0.666 ± 0.662 … 0.669              -0.3% (-0.0 MB)
MicroBench      construct-00-args.js                    1.021      0.761 ± 0.755 … 0.768              0.745 ± 0.745 … 0.746              -0.4% (-0.1 MB)
MicroBench      construct-04-args.js                    1.002      0.783 ± 0.777 … 0.788              0.781 ± 0.777 … 0.785              -0.5% (-0.1 MB)
MicroBench      deep-call-stack.js                      0.987      0.258 ± 0.257 … 0.260              0.262 ± 0.260 … 0.263              -0.9% (-0.1 MB)
MicroBench      env-binding-oneshot-eval.js             1.002      0.482 ± 0.482 … 0.483              0.481 ± 0.480 … 0.483              -0.7% (-0.1 MB)
MicroBench      for-in-indexed-properties.js            0.999      0.153 ± 0.152 … 0.153              0.153 ± 0.153 … 0.153              +5.0% (+8.0 MB)
MicroBench      for-in-named-properties.js              0.995      0.152 ± 0.152 … 0.152              0.153 ± 0.150 … 0.155              -0.3% (-0.0 MB)
MicroBench      for-of.js                               0.991      0.424 ± 0.424 … 0.425              0.428 ± 0.423 … 0.432              -0.6% (-0.1 MB)
MicroBench      json-parse-edge-cases.js                1.062      0.007 ± 0.006 … 0.008              0.006 ± 0.006 … 0.007              -0.4% (-0.0 MB)
MicroBench      json-parse-massive.js                   1.000      0.813 ± 0.813 … 0.813              0.814 ± 0.813 … 0.814              +3.4% (+2.4 MB)
MicroBench      json-stringify-edge-cases.js            1.006      0.007 ± 0.006 … 0.008              0.007 ± 0.006 … 0.007              -0.9% (-0.1 MB)
MicroBench      json-stringify-massive.js               1.011      0.925 ± 0.924 … 0.927              0.915 ± 0.911 … 0.919              -0.1% (-0.4 MB)
MicroBench      lots-alloc.js                           1.000      1.924 ± 1.922 … 1.926              1.923 ± 1.921 … 1.926              -0.0% (-0.1 MB)
MicroBench      object-keys.js                          1.001      1.324 ± 1.317 … 1.331              1.323 ± 1.322 … 1.325              -12.4% (-14.0 MB)
MicroBench      object-literal.js                       1.007      1.078 ± 1.075 … 1.080              1.070 ± 1.062 … 1.078              -0.1% (-0.0 MB)
MicroBench      object-set-with-rope-strings.js         1.029      0.553 ± 0.551 … 0.556              0.537 ± 0.530 … 0.545              -0.2% (-0.0 MB)
MicroBench      pic-add-own.js                          0.960      0.345 ± 0.345 … 0.345              0.359 ± 0.359 … 0.360              +0.1% (+0.0 MB)
MicroBench      pic-get-own.js                          0.991      0.639 ± 0.635 … 0.643              0.645 ± 0.645 … 0.645              -0.3% (-0.0 MB)
MicroBench      pic-get-pchain.js                       0.983      0.641 ± 0.639 … 0.642              0.651 ± 0.649 … 0.654              -0.4% (-0.0 MB)
MicroBench      pic-put-own.js                          0.945      0.625 ± 0.621 … 0.629              0.661 ± 0.650 … 0.672              -0.2% (-0.0 MB)
MicroBench      pic-put-pchain.js                       0.971      1.598 ± 1.590 … 1.606              1.646 ± 1.574 … 1.718              -0.5% (-0.1 MB)
MicroBench      setter-in-prototype-chain.js            1.008      1.511 ± 1.492 … 1.529              1.499 ± 1.484 … 1.514              -0.5% (-0.1 MB)
MicroBench      strictly-equals-object.js               0.941      0.671 ± 0.670 … 0.672              0.712 ± 0.698 … 0.727              -0.7% (-0.1 MB)
LongSpider      Total                                   1.000      69.506                             69.537                             +20.3% (+264.8 MB)
Kraken          Total                                   0.999      6.513                              6.516                              -0.1% (-0.9 MB)
Octane          Total                                   0.995      141207.000                         140463.000                         -0.6% (-13.9 MB)
JetStream       Total                                   0.998      124.915                            125.174                            +0.0% (+0.1 MB)
JetStream3      Total                                   1.001      7.928                              7.918                              -0.8% (-0.9 MB)
AsyncBench      Total                                   0.996      4.858                              4.878                              -0.2% (-1.2 MB)
ARES-6          Total                                   1.001      5.393                              5.386                              -0.9% (-1.3 MB)
JetStreamExtra  Total                                   1.005      34.106                             33.929                             -5.1% (-405.5 MB)
GarBench        Total                                   1.015      11.624                             11.450                             +2.2% (+165.6 MB)
MicroBench      Total                                   0.999      28.617                             28.657                             -0.1% (-5.5 MB)
All Suites      Total                                   1.000      351.775                            351.817                            +0.0% (+1.3 MB)
```