### PR TITLE
UI/Qt: Open new tab page when New Window is created with no URLs

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -325,7 +325,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         tab.focus_location_editor();
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [] {
-        (void)Application::the().new_window({});
+        (void)Application::the().new_window({ WebView::Application::settings().new_tab_page_url() });
     });
     QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
 


### PR DESCRIPTION
## Problem

Clicking the **Hamburger/Menu icon**, and then clicking **New Window** calls `Application::new_window` with an empty URL list. `BrowserWindow` only creates tabs by iterating `initial_urls`, so with no URLs and no parent tab it added zero tabs. The window appeared empty (no real browser content).

Second-instance launches already behave correctly because `BrowserProcess` uses `sanitize_urls()`, which appends the new tab URL when the list is empty.

<img width="750" height="505" alt="image" src="https://github.com/user-attachments/assets/6c8b6644-6407-42a5-ab45-5536be54858c" />

_When I had orignally been testing this issue it did not even have the plus icon. Having that does make it better, but I still think this is a worthwhile improvement_
## Solution

When there is no parent tab and the URL list is empty, append `settings().new_tab_page_url()` before constructing `BrowserWindow`, matching the `sanitize_urls()` behavior.

<img width="1065" height="502" alt="image" src="https://github.com/user-attachments/assets/60c78b74-01ea-4bd2-988f-0d00a1b29558" />
