### PR TITLE
LibWebView: Add date_added timestamp to bookmark items

### DIFF
--- a/Libraries/LibWebView/BookmarkStore.cpp
+++ b/Libraries/LibWebView/BookmarkStore.cpp
@@ -26,6 +26,7 @@ static constexpr auto URL_KEY = "url"sv;
 static constexpr auto TITLE_KEY = "title"sv;
 static constexpr auto FAVICON_KEY = "favicon"sv;
 static constexpr auto CHILDREN_KEY = "children"sv;
+static constexpr auto DATE_ADDED_KEY = "dateAdded"sv;
 
 static constexpr auto TYPE_BOOKMARK = "bookmark"sv;
 static constexpr auto TYPE_FOLDER = "folder"sv;
@@ -47,6 +48,10 @@ static Vector<BookmarkItem> parse_bookmark_items(JsonArray const& array)
         auto type = object.get_string(TYPE_KEY);
         auto title = object.get_string(TITLE_KEY);
 
+        auto date_added = UnixDateTime {};
+        if (auto date_added_ms = object.get_integer<i64>(DATE_ADDED_KEY); date_added_ms.has_value())
+            date_added = UnixDateTime::from_milliseconds_since_epoch(*date_added_ms);
+
         if (type == TYPE_BOOKMARK) {
             auto url_string = object.get_string(URL_KEY);
             if (!url_string.has_value())
@@ -60,6 +65,7 @@ static Vector<BookmarkItem> parse_bookmark_items(JsonArray const& array)
 
             items.empend(
                 id.release_value(),
+                date_added,
                 BookmarkItem::Bookmark {
                     .url = url.release_value(),
                     .title = title.map([](auto title) { return title; }),
@@ -72,6 +78,7 @@ static Vector<BookmarkItem> parse_bookmark_items(JsonArray const& array)
 
             items.empend(
                 id.release_value(),
+                date_added,
                 BookmarkItem::Folder {
                     .title = title.map([](auto title) { return title; }),
                     .children = move(children),
@@ -86,6 +93,7 @@ static JsonObject serialize_bookmark_item(BookmarkItem const& item)
 {
     JsonObject object;
     object.set(ID_KEY, item.id);
+    object.set(DATE_ADDED_KEY, item.date_added.milliseconds_since_epoch());
 
     item.data.visit(
         [&](BookmarkItem::Bookmark const& bookmark) {
@@ -118,9 +126,12 @@ static JsonObject serialize_bookmark_item(BookmarkItem const& item)
 
 static Vector<BookmarkItem> create_default_bookmarks()
 {
+    auto now = UnixDateTime::now();
+
     return {
         {
             .id = generate_random_uuid(),
+            .date_added = now,
             .data = BookmarkItem::Bookmark {
                 .url = URL::Parser::basic_parse("https://ladybird.org/"sv).release_value(),
                 .title = "Ladybird"_string,
@@ -129,6 +140,7 @@ static Vector<BookmarkItem> create_default_bookmarks()
         },
         {
             .id = generate_random_uuid(),
+            .date_added = now,
             .data = BookmarkItem::Bookmark {
                 .url = URL::Parser::basic_parse("https://github.com/LadybirdBrowser/ladybird"sv).release_value(),
                 .title = "Ladybird GitHub"_string,
@@ -137,6 +149,7 @@ static Vector<BookmarkItem> create_default_bookmarks()
         },
         {
             .id = generate_random_uuid(),
+            .date_added = now,
             .data = BookmarkItem::Bookmark {
                 .url = URL::Parser::basic_parse("https://discord.com/invite/nvfjVJ4Svh"sv).release_value(),
                 .title = "Ladybird Discord"_string,
@@ -241,6 +254,7 @@ void BookmarkStore::add_bookmark(URL::URL url, Optional<String> title, Optional<
 {
     BookmarkItem item {
         .id = generate_random_uuid(),
+        .date_added = UnixDateTime::now(),
         .data = BookmarkItem::Bookmark {
             .url = move(url),
             .title = move(title),
@@ -258,6 +272,7 @@ void BookmarkStore::add_folder(Optional<String> title, Optional<String const&> t
 {
     BookmarkItem item {
         .id = generate_random_uuid(),
+        .date_added = UnixDateTime::now(),
         .data = BookmarkItem::Folder {
             .title = move(title),
             .children = {},

--- a/Libraries/LibWebView/BookmarkStore.cpp
+++ b/Libraries/LibWebView/BookmarkStore.cpp
@@ -27,6 +27,7 @@ static constexpr auto TITLE_KEY = "title"sv;
 static constexpr auto FAVICON_KEY = "favicon"sv;
 static constexpr auto CHILDREN_KEY = "children"sv;
 static constexpr auto DATE_ADDED_KEY = "dateAdded"sv;
+static constexpr auto LAST_MODIFIED_KEY = "lastModified"sv;
 
 static constexpr auto TYPE_BOOKMARK = "bookmark"sv;
 static constexpr auto TYPE_FOLDER = "folder"sv;
@@ -52,6 +53,10 @@ static Vector<BookmarkItem> parse_bookmark_items(JsonArray const& array)
         if (auto date_added_ms = object.get_integer<i64>(DATE_ADDED_KEY); date_added_ms.has_value())
             date_added = UnixDateTime::from_milliseconds_since_epoch(*date_added_ms);
 
+        auto last_modified = UnixDateTime {};
+        if (auto last_modified_ms = object.get_integer<i64>(LAST_MODIFIED_KEY); last_modified_ms.has_value())
+            last_modified = UnixDateTime::from_milliseconds_since_epoch(*last_modified_ms);
+
         if (type == TYPE_BOOKMARK) {
             auto url_string = object.get_string(URL_KEY);
             if (!url_string.has_value())
@@ -66,6 +71,7 @@ static Vector<BookmarkItem> parse_bookmark_items(JsonArray const& array)
             items.empend(
                 id.release_value(),
                 date_added,
+                last_modified,
                 BookmarkItem::Bookmark {
                     .url = url.release_value(),
                     .title = title.map([](auto title) { return title; }),
@@ -79,6 +85,7 @@ static Vector<BookmarkItem> parse_bookmark_items(JsonArray const& array)
             items.empend(
                 id.release_value(),
                 date_added,
+                last_modified,
                 BookmarkItem::Folder {
                     .title = title.map([](auto title) { return title; }),
                     .children = move(children),
@@ -94,6 +101,7 @@ static JsonObject serialize_bookmark_item(BookmarkItem const& item)
     JsonObject object;
     object.set(ID_KEY, item.id);
     object.set(DATE_ADDED_KEY, item.date_added.milliseconds_since_epoch());
+    object.set(LAST_MODIFIED_KEY, item.last_modified.milliseconds_since_epoch());
 
     item.data.visit(
         [&](BookmarkItem::Bookmark const& bookmark) {
@@ -132,6 +140,7 @@ static Vector<BookmarkItem> create_default_bookmarks()
         {
             .id = generate_random_uuid(),
             .date_added = now,
+            .last_modified = now,
             .data = BookmarkItem::Bookmark {
                 .url = URL::Parser::basic_parse("https://ladybird.org/"sv).release_value(),
                 .title = "Ladybird"_string,
@@ -141,6 +150,7 @@ static Vector<BookmarkItem> create_default_bookmarks()
         {
             .id = generate_random_uuid(),
             .date_added = now,
+            .last_modified = now,
             .data = BookmarkItem::Bookmark {
                 .url = URL::Parser::basic_parse("https://github.com/LadybirdBrowser/ladybird"sv).release_value(),
                 .title = "Ladybird GitHub"_string,
@@ -150,6 +160,7 @@ static Vector<BookmarkItem> create_default_bookmarks()
         {
             .id = generate_random_uuid(),
             .date_added = now,
+            .last_modified = now,
             .data = BookmarkItem::Bookmark {
                 .url = URL::Parser::basic_parse("https://discord.com/invite/nvfjVJ4Svh"sv).release_value(),
                 .title = "Ladybird Discord"_string,
@@ -255,6 +266,7 @@ void BookmarkStore::add_bookmark(URL::URL url, Optional<String> title, Optional<
     BookmarkItem item {
         .id = generate_random_uuid(),
         .date_added = UnixDateTime::now(),
+        .last_modified = UnixDateTime::now(),
         .data = BookmarkItem::Bookmark {
             .url = move(url),
             .title = move(title),
@@ -273,6 +285,7 @@ void BookmarkStore::add_folder(Optional<String> title, Optional<String const&> t
     BookmarkItem item {
         .id = generate_random_uuid(),
         .date_added = UnixDateTime::now(),
+        .last_modified = UnixDateTime::now(),
         .data = BookmarkItem::Folder {
             .title = move(title),
             .children = {},
@@ -294,6 +307,7 @@ void BookmarkStore::edit_bookmark(StringView id, URL::URL url, Optional<String> 
     auto& bookmark = item->bookmark();
     bookmark.url = move(url);
     bookmark.title = move(title);
+    item->last_modified = UnixDateTime::now();
 
     persist_bookmarks();
     notify_observers();
@@ -306,6 +320,7 @@ void BookmarkStore::edit_folder(StringView id, Optional<String> title)
         return;
 
     item->folder().title = move(title);
+    item->last_modified = UnixDateTime::now();
 
     persist_bookmarks();
     notify_observers();
@@ -386,6 +401,7 @@ void BookmarkStore::move_item(StringView id, Optional<String const&> target_fold
     index = min(index, target_list.size());
 
     target_list.insert(index, moved_item.release_value());
+    target_list[index].last_modified = UnixDateTime::now();
 
     persist_bookmarks();
     notify_observers();
@@ -403,6 +419,7 @@ void BookmarkStore::update_favicon(URL::URL const& url, String favicon_base64_pn
         return;
 
     bookmark.favicon_base64_png = move(favicon_base64_png);
+    const_cast<BookmarkItem&>(*item).last_modified = UnixDateTime::now();
 
     persist_bookmarks();
     notify_observers();

--- a/Libraries/LibWebView/BookmarkStore.h
+++ b/Libraries/LibWebView/BookmarkStore.h
@@ -32,6 +32,7 @@ struct WEBVIEW_API BookmarkItem {
 
     String id;
     UnixDateTime date_added;
+    UnixDateTime last_modified;
     Variant<Bookmark, Folder> data;
 
     bool is_bookmark() const { return data.has<Bookmark>(); }

--- a/Libraries/LibWebView/BookmarkStore.h
+++ b/Libraries/LibWebView/BookmarkStore.h
@@ -10,6 +10,7 @@
 #include <AK/JsonValue.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <AK/Time.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibURL/URL.h>
@@ -30,6 +31,7 @@ struct WEBVIEW_API BookmarkItem {
     };
 
     String id;
+    UnixDateTime date_added;
     Variant<Bookmark, Folder> data;
 
     bool is_bookmark() const { return data.has<Bookmark>(); }


### PR DESCRIPTION
Store a creation timestamp on every BookmarkItem, for both bookmarks and folders.

The JSON schema version is bumped from 1 to 2.