### PR TITLE
Add profiler marker system

### DIFF
--- a/Documentation/Profiler/Markers.md
+++ b/Documentation/Profiler/Markers.md
@@ -1,0 +1,116 @@
+# Profiler markers
+
+Profiler markers are timestamped events emitted by browser and engine code so a profiler UI can show what happened on the timeline: layout, style, script parsing, IPC, network, media decode, GC, and similar phases.
+
+The marker system is designed with the Gecko Profile Format in mind because the first exporter targets profiler.firefox.com. The collected marker stream is format-neutral though — a different exporter can map the same data to Perfetto, Chrome trace-event JSON, or a Ladybird-specific UI.
+
+## Public API
+
+Include `<LibCore/Markers.h>` at marker emit sites. The API is:
+
+| Macro | Use |
+|-------|-----|
+| `MARKER_INSTANT(name, type, category, fields)` | Point-in-time event |
+| `MARKER_START_TIME(var)` | Capture a start timestamp (empty when disabled) |
+| `MARKER_INTERVAL(name, type, category, start, fields)` | Interval from a captured start to now |
+| `MARKER_INTERVAL_START(name, type, category, fields)` | Open-ended interval start |
+| `MARKER_INTERVAL_END(name, type, category, fields)` | Close a paired interval |
+| `MARKER_SCOPE(name, type, category)` | RAII interval for the enclosing scope |
+| `MARKER_SCOPE_FIELDS(name, type, category, fields)` | RAII interval with lazily evaluated fields |
+
+All macros gate on `g_marker_collector_active` before evaluating arguments. When no collector is active, the cost is one relaxed atomic load and a predicted-not-taken branch.
+
+Supporting types in `Markers.h`:
+
+- `MarkerCategory` — broad category enum (Layout, JavaScript, GC, etc.)
+- `MarkerPhase` — instant, interval, interval-start, interval-end
+- `MarkerField` — key-value pair for marker payload data
+- `MarkerFieldValue` — `Variant<StringView, String, double, i64, size_t, bool>`
+- `MarkerString` — `Variant<StringView, String>` for marker names
+- `MarkerScope` — RAII class behind the `MARKER_SCOPE*` macros
+
+All macros route through a single implementation function:
+
+```cpp
+void marker_add(MarkerPhase, MarkerString name, StringView type,
+    MarkerCategory, Optional<MonotonicTime> start, Vector<MarkerField, 4>);
+```
+
+When `start` is empty, `marker_add` uses the current time. For intervals, `start` is the captured beginning and `marker_add` captures the end.
+
+Do not include `<LibCore/MarkerCollector.h>` from instrumentation sites. That header is for code that owns or reads the collector.
+
+## Header boundary
+
+`Markers.h` is included by many libraries. Keep it stable and thin. It does not expose:
+
+- `MarkerCollector` class or `Marker` struct
+- Mutex, `AK::Function`, or thread registry dependencies
+- Gecko exporter details
+
+This lets collector and exporter internals change without recompiling marker call sites.
+
+The active flag (`g_marker_collector_active`) is a relaxed atomic boolean, matching Firefox's `profiler_is_active()` pattern. Firefox reads a relaxed atomic bitfield; we use a single bool since we only need one gate.
+
+## Why macros
+
+C++ evaluates function arguments before entering the function body. Macros put the active check around argument evaluation so disabled instrumentation does not format strings, serialize URLs, build field vectors, or read clocks:
+
+```cpp
+MARKER_INSTANT("Fetch start"sv, "Text"sv, Core::MarkerCategory::Network,
+    { { "name"sv, request.url().to_string() } });
+```
+
+When no collector is active, `url().to_string()` is not called. `MARKER_SCOPE_FIELDS` wraps its fields in a lambda that `MarkerScope` only invokes after the active check:
+
+```cpp
+MARKER_SCOPE_FIELDS("Layout"sv, "Layout"sv, Core::MarkerCategory::Layout,
+    {
+        { "viewportWidth"sv, static_cast<double>(viewport_rect().width().to_double()) },
+    });
+```
+
+For conditional fields, construct the `MarkerScope` directly with a lambda:
+
+```cpp
+Core::MarkerScope marker { "DOMEvent"sv, "DOMEvent"sv, Core::MarkerCategory::DOM,
+    [&]() -> Vector<Core::MarkerField, 4> {
+        Vector<Core::MarkerField, 4> fields;
+        fields.append({ "eventType"sv, event.type().bytes_as_string_view() });
+        if (is<Node>(*target))
+            fields.append({ "target"sv, as<Node>(*target).node_name().to_string() });
+        return fields;
+    } };
+```
+
+## Data flow
+
+`MarkerCollector`'s constructor sets `g_marker_collector_active = true` and `g_marker_collector = this`. The destructor clears both. Macros check the atomic bool; `marker_add` fetches the internal pointer and appends a `Marker` under a mutex.
+
+Readers use `take_markers_snapshot()` for thread-safe copies (e.g., `internals.collectMarkers()`).
+
+## Categories
+
+`MarkerCategory` is a stable enum shared by markers and profiler labels. Keep categories broad — put specificity in marker names and fields, not new categories.
+
+## Disabled-path rules
+
+- Put expensive values inside macro arguments or `MARKER_SCOPE_FIELDS` lambdas.
+- Do not compute marker-only data before the macro gate.
+- Use `MARKER_START_TIME` instead of `MonotonicTime::now()` for marker-only timestamps.
+- Do not call `marker_add` directly from call sites — use the macros.
+
+Good:
+
+```cpp
+MARKER_SCOPE_FIELDS("Parse CSS"sv, "ParseCSS"sv, Core::MarkerCategory::Parser,
+    { { "url"sv, source_url.serialize() } });
+```
+
+Bad — serializes unconditionally:
+
+```cpp
+auto url = source_url.serialize();
+MARKER_SCOPE_FIELDS("Parse CSS"sv, "ParseCSS"sv, Core::MarkerCategory::Parser,
+    { { "url"sv, url } });
+```

--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     EventReceiver.cpp
     File.cpp
     MappedFile.cpp
+    MarkerCollector.cpp
     MimeData.cpp
     Notifier.cpp
     ReportTime.cpp

--- a/Libraries/LibCore/MarkerCategory.h
+++ b/Libraries/LibCore/MarkerCategory.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace Core {
+
+// Strongly-typed category for both markers and labels. Adding a value here
+// will break exhaustive switches in GeckoProfileWriter's build_categories()
+// and category_to_underlying(), forcing the update to ripple out.
+enum class MarkerCategory : u8 {
+    Other = 0,
+    Idle = 1,
+    Layout = 2,
+    JavaScript = 3,
+    GC = 4,
+    Network = 5,
+    Graphics = 6,
+    DOM = 7,
+    IPC = 8,
+    Media = 9,
+    Timer = 10,
+    Profiler = 11,
+    Accessibility = 12,
+    Style = 13,
+    Paint = 14,
+    Parser = 15,
+};
+
+ALWAYS_INLINE StringView marker_category_name(MarkerCategory category)
+{
+    switch (category) {
+    case MarkerCategory::Other:
+        return "Other"sv;
+    case MarkerCategory::Idle:
+        return "Idle"sv;
+    case MarkerCategory::Layout:
+        return "Layout"sv;
+    case MarkerCategory::JavaScript:
+        return "JavaScript"sv;
+    case MarkerCategory::GC:
+        return "GC"sv;
+    case MarkerCategory::Network:
+        return "Network"sv;
+    case MarkerCategory::Graphics:
+        return "Graphics"sv;
+    case MarkerCategory::DOM:
+        return "DOM"sv;
+    case MarkerCategory::IPC:
+        return "IPC"sv;
+    case MarkerCategory::Media:
+        return "Media"sv;
+    case MarkerCategory::Timer:
+        return "Timer"sv;
+    case MarkerCategory::Profiler:
+        return "Profiler"sv;
+    case MarkerCategory::Accessibility:
+        return "Accessibility"sv;
+    case MarkerCategory::Style:
+        return "Style"sv;
+    case MarkerCategory::Paint:
+        return "Paint"sv;
+    case MarkerCategory::Parser:
+        return "Parser"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Libraries/LibCore/MarkerCollector.cpp
+++ b/Libraries/LibCore/MarkerCollector.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+#include <LibCore/MarkerCollector.h>
+
+#if defined(AK_OS_LINUX)
+#    include <sys/syscall.h>
+#    include <unistd.h>
+#elif defined(AK_OS_MACOS)
+#    include <pthread.h>
+#elif defined(AK_OS_WINDOWS)
+#    include <windows.h>
+#endif
+
+namespace Core {
+
+Atomic<bool, AK::MemoryOrder::memory_order_relaxed> g_marker_collector_active { false };
+MarkerCollector* g_marker_collector { nullptr };
+
+MarkerCollector::MarkerCollector()
+{
+    VERIFY(g_marker_collector == nullptr);
+    g_marker_collector = this;
+    g_marker_collector_active = true;
+
+    m_markers.ensure_capacity(4096);
+}
+
+MarkerCollector::~MarkerCollector()
+{
+    g_marker_collector_active = false;
+    g_marker_collector = nullptr;
+}
+
+void MarkerCollector::add_marker(Marker marker)
+{
+    if (marker.tid == 0) {
+#if defined(AK_OS_LINUX)
+        marker.tid = static_cast<u64>(::syscall(SYS_gettid));
+#elif defined(AK_OS_MACOS)
+        uint64_t tid = 0;
+        pthread_threadid_np(nullptr, &tid);
+        marker.tid = tid;
+#elif defined(AK_OS_WINDOWS)
+        marker.tid = static_cast<u64>(::GetCurrentThreadId());
+#endif
+    }
+
+    Threading::MutexLocker locker(m_markers_mutex);
+    m_markers.append(move(marker));
+}
+
+Vector<Marker> MarkerCollector::take_markers_snapshot() const
+{
+    Threading::MutexLocker locker(m_markers_mutex);
+    return m_markers;
+}
+
+void MarkerCollector::clear()
+{
+    Threading::MutexLocker locker(m_markers_mutex);
+    m_markers.clear_with_capacity();
+}
+
+void marker_add(MarkerPhase phase, MarkerString name, StringView type, MarkerCategory category,
+    Optional<MonotonicTime> start, Vector<MarkerField, 4> fields)
+{
+    auto* c = g_marker_collector;
+    if (!c)
+        return;
+    auto now = MonotonicTime::now();
+    auto marker_start = start.value_or(now);
+    auto marker_end = now;
+    c->add_marker({ move(name), type, marker_start, marker_end, phase, category, 0, move(fields) });
+}
+
+void marker_scope_push_label(StringView, MarkerCategory) { }
+void marker_scope_pop_label() { }
+
+MarkerScope::~MarkerScope()
+{
+    if (!m_active)
+        return;
+    marker_scope_pop_label();
+    if (g_marker_collector_active && m_start.has_value()) [[unlikely]]
+        marker_add(MarkerPhase::Interval, m_name, m_schema_type, m_category, m_start, move(m_fields));
+}
+
+}

--- a/Libraries/LibCore/MarkerCollector.h
+++ b/Libraries/LibCore/MarkerCollector.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Implementation header for the marker collector. Only include this if
+// you need to read or manage the collector (e.g., Internals, exporter).
+// The emit-side API lives in <LibCore/Markers.h>.
+
+#include <AK/Vector.h>
+#include <LibCore/Export.h>
+#include <LibCore/Markers.h>
+#include <LibThreading/Mutex.h>
+
+namespace Core {
+
+struct Marker {
+    MarkerString name;
+    StringView type;
+    MonotonicTime start;
+    MonotonicTime end;
+    MarkerPhase phase;
+    MarkerCategory category;
+    u64 tid { 0 };
+    Vector<MarkerField, 4> fields;
+};
+
+class CORE_API MarkerCollector {
+public:
+    MarkerCollector();
+    ~MarkerCollector();
+
+    void add_marker(Marker);
+
+    Vector<Marker> take_markers_snapshot() const;
+
+    MonotonicTime creation_time() const { return m_creation_time; }
+
+    void clear();
+
+private:
+    mutable Threading::Mutex m_markers_mutex;
+    Vector<Marker> m_markers;
+    MonotonicTime m_creation_time { MonotonicTime::now() };
+};
+
+extern CORE_API MarkerCollector* g_marker_collector;
+
+}

--- a/Libraries/LibCore/Markers.h
+++ b/Libraries/LibCore/Markers.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/Optional.h>
+#include <AK/Platform.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Time.h>
+#include <AK/Types.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibCore/Export.h>
+#include <LibCore/MarkerCategory.h>
+
+namespace Core {
+
+using MarkerString = Variant<StringView, String>;
+using MarkerFieldValue = Variant<StringView, String, double, i64, size_t, bool>;
+
+struct MarkerField {
+    StringView key;
+    MarkerFieldValue value;
+};
+
+enum class MarkerPhase : u8 {
+    Instant = 0,
+    Interval = 1,
+    IntervalStart = 2,
+    IntervalEnd = 3,
+};
+
+CORE_API extern Atomic<bool, AK::MemoryOrder::memory_order_relaxed> g_marker_collector_active;
+
+ALWAYS_INLINE MonotonicTime marker_now() { return MonotonicTime::now(); }
+
+CORE_API void marker_add(MarkerPhase phase, MarkerString name, StringView type, MarkerCategory category,
+    Optional<MonotonicTime> start, Vector<MarkerField, 4> fields);
+
+CORE_API void marker_scope_push_label(StringView name, MarkerCategory category);
+CORE_API void marker_scope_pop_label();
+
+class CORE_API MarkerScope {
+public:
+    MarkerScope(StringView name, StringView schema_type, MarkerCategory category)
+    {
+        if (!g_marker_collector_active) [[likely]]
+            return;
+        m_name = name;
+        m_schema_type = schema_type;
+        m_category = category;
+        m_start = marker_now();
+        m_active = true;
+        marker_scope_push_label(name, category);
+    }
+
+    template<typename FieldsCallable>
+    MarkerScope(StringView name, StringView schema_type, MarkerCategory category, FieldsCallable&& fields_callable)
+    {
+        if (!g_marker_collector_active) [[likely]]
+            return;
+        m_name = name;
+        m_schema_type = schema_type;
+        m_category = category;
+        m_start = marker_now();
+        m_fields = fields_callable();
+        m_active = true;
+        marker_scope_push_label(name, category);
+    }
+
+    ~MarkerScope();
+
+    MarkerScope(MarkerScope const&) = delete;
+    MarkerScope& operator=(MarkerScope const&) = delete;
+    MarkerScope(MarkerScope&&) = delete;
+    MarkerScope& operator=(MarkerScope&&) = delete;
+
+private:
+    StringView m_name;
+    StringView m_schema_type;
+    MarkerCategory m_category { MarkerCategory::Other };
+    Optional<MonotonicTime> m_start;
+    Vector<MarkerField, 4> m_fields;
+    bool m_active { false };
+};
+
+}
+
+#define MARKER_START_TIME(VAR) \
+    auto VAR = ::Core::g_marker_collector_active ? ::AK::Optional<::AK::MonotonicTime> { ::Core::marker_now() } : ::AK::Optional<::AK::MonotonicTime> { }
+
+#define MARKER_INSTANT(NAME, TYPE, CATEGORY, ...)                                                    \
+    do {                                                                                             \
+        if (::Core::g_marker_collector_active) [[unlikely]]                                          \
+            ::Core::marker_add(::Core::MarkerPhase::Instant, NAME, TYPE, CATEGORY, {}, __VA_ARGS__); \
+    } while (0)
+
+#define MARKER_INTERVAL(NAME, TYPE, CATEGORY, START, ...)                                                   \
+    do {                                                                                                    \
+        if (::Core::g_marker_collector_active && (START).has_value()) [[unlikely]]                          \
+            ::Core::marker_add(::Core::MarkerPhase::Interval, NAME, TYPE, CATEGORY, *(START), __VA_ARGS__); \
+    } while (0)
+
+#define MARKER_INTERVAL_START(NAME, TYPE, CATEGORY, ...)                                                   \
+    do {                                                                                                   \
+        if (::Core::g_marker_collector_active) [[unlikely]]                                                \
+            ::Core::marker_add(::Core::MarkerPhase::IntervalStart, NAME, TYPE, CATEGORY, {}, __VA_ARGS__); \
+    } while (0)
+
+#define MARKER_INTERVAL_END(NAME, TYPE, CATEGORY, ...)                                                   \
+    do {                                                                                                 \
+        if (::Core::g_marker_collector_active) [[unlikely]]                                              \
+            ::Core::marker_add(::Core::MarkerPhase::IntervalEnd, NAME, TYPE, CATEGORY, {}, __VA_ARGS__); \
+    } while (0)
+
+#define MARKER_SCOPE_IMPL2(NAME, TYPE, CATEGORY, COUNTER) \
+    ::Core::MarkerScope _marker_scope_##COUNTER { NAME, TYPE, CATEGORY }
+#define MARKER_SCOPE_IMPL1(NAME, TYPE, CATEGORY, COUNTER) MARKER_SCOPE_IMPL2(NAME, TYPE, CATEGORY, COUNTER)
+#define MARKER_SCOPE(NAME, TYPE, CATEGORY) MARKER_SCOPE_IMPL1(NAME, TYPE, CATEGORY, __COUNTER__)
+
+#define MARKER_SCOPE_FIELDS_IMPL2(NAME, TYPE, CATEGORY, COUNTER, ...) \
+    ::Core::MarkerScope _marker_scope_##COUNTER                       \
+    {                                                                 \
+        NAME, TYPE, CATEGORY,                                         \
+            [&]() -> ::AK::Vector<::Core::MarkerField, 4> {           \
+                return __VA_ARGS__;                                   \
+            }                                                         \
+    }
+#define MARKER_SCOPE_FIELDS_IMPL1(NAME, TYPE, CATEGORY, COUNTER, ...) MARKER_SCOPE_FIELDS_IMPL2(NAME, TYPE, CATEGORY, COUNTER, __VA_ARGS__)
+#define MARKER_SCOPE_FIELDS(NAME, TYPE, CATEGORY, ...) MARKER_SCOPE_FIELDS_IMPL1(NAME, TYPE, CATEGORY, __COUNTER__, __VA_ARGS__)

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -19,6 +19,7 @@
 #include <AK/TemporaryChange.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/File.h>
+#include <LibCore/Markers.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Heap.h>
@@ -296,6 +297,11 @@ AK::JsonObject Heap::dump_graph()
 void Heap::collect_garbage(CollectionType collection_type, bool print_report)
 {
     VERIFY(!m_collecting_garbage);
+
+    MARKER_SCOPE_FIELDS("GC"sv, "GC"sv, Core::MarkerCategory::GC,
+        {
+            { "kind"sv, collection_type == CollectionType::CollectEverything ? "full"sv : "incremental"sv },
+        });
 
     {
         TemporaryChange change(m_collecting_garbage, true);

--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Vector.h>
+#include <LibCore/Markers.h>
 #include <LibIPC/Connection.h>
 #include <LibIPC/Message.h>
 #include <LibIPC/Stub.h>
@@ -71,6 +72,9 @@ void ConnectionBase::handle_messages()
 
         if (!is_open())
             dbgln("Handling message while connection closed: {}", message->message_name());
+
+        StringView const message_name { message->message_name(), strlen(message->message_name()) };
+        MARKER_SCOPE(message_name, "IPCHandle"sv, Core::MarkerCategory::IPC);
 
         auto handler_result = m_local_stub.handle(move(message));
         if (handler_result.is_error()) {

--- a/Libraries/LibJS/Console.cpp
+++ b/Libraries/LibJS/Console.cpp
@@ -10,6 +10,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
+#include <LibCore/Markers.h>
 #include <LibJS/Console.h>
 #include <LibJS/Print.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -623,6 +624,10 @@ ThrowCompletionOr<Value> Console::time()
 
     // 2. Otherwise, set the value of the entry with key label in the associated timer table to the current time.
     m_timer_table.set(label, Core::ElapsedTimer::start_new());
+
+    MARKER_INTERVAL_START(label, "ConsoleTime"sv, Core::MarkerCategory::JavaScript,
+        { { "name"sv, label } });
+
     return js_undefined();
 }
 
@@ -698,6 +703,9 @@ ThrowCompletionOr<Value> Console::time_end()
         return js_undefined();
     }
     auto start_time = maybe_start_time->value;
+
+    MARKER_INTERVAL_END(label, "ConsoleTime"sv, Core::MarkerCategory::JavaScript,
+        { { "name"sv, label } });
 
     // 3. Remove timerTable[label].
     m_timer_table.remove(label);

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -9,6 +9,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/Stream.h>
 #include <AK/Time.h>
+#include <LibCore/Markers.h>
 #include <LibMedia/FFmpeg/FFmpegDemuxer.h>
 #include <LibMedia/FFmpeg/FFmpegHelpers.h>
 #include <LibMedia/MediaStream.h>
@@ -293,6 +294,9 @@ DecoderErrorOr<ReadonlyBytes> FFmpegDemuxer::get_codec_initialization_data_for_t
 
 DecoderErrorOr<CodedFrame> FFmpegDemuxer::get_next_sample_for_track(Track const& track)
 {
+    MARKER_SCOPE_FIELDS("Demux"sv, "Text"sv, Core::MarkerCategory::Media,
+        { { "name"sv, track.type() == TrackType::Video ? "video"sv : "audio"sv } });
+
     auto& track_context = get_track_context(track);
     auto& format_context = *track_context.format_context;
     auto& packet = *track_context.packet;

--- a/Libraries/LibMedia/Providers/AudioDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Markers.h>
 #include <LibMedia/Audio/SampleSpecification.h>
 #include <LibMedia/Demuxer.h>
 #include <LibMedia/FFmpeg/FFmpegAudioConverter.h>
@@ -506,7 +507,15 @@ void AudioDataProvider::ThreadData::push_data_and_decode_a_block()
         }
     } else {
         auto sample = sample_result.release_value();
+        MARKER_START_TIME(audio_decode_marker_start);
         auto decode_result = m_decoder->receive_coded_data(sample.timestamp(), sample.data());
+        MARKER_INTERVAL("Audio decode"sv, "MediaDecode"sv, Core::MarkerCategory::Media,
+            audio_decode_marker_start,
+            {
+                { "kind"sv, "audio"sv },
+                { "bytes"sv, sample.data().size() },
+                { "pts_us"sv, sample.timestamp().to_microseconds() },
+            });
         if (decode_result.is_error()) {
             set_error_and_wait_for_seek(decode_result.release_error());
             return;

--- a/Libraries/LibMedia/Providers/VideoDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/VideoDataProvider.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/EventLoop.h>
+#include <LibCore/Markers.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibMedia/Demuxer.h>
 #include <LibMedia/FFmpeg/FFmpegVideoDecoder.h>
@@ -511,7 +512,15 @@ void VideoDataProvider::ThreadData::push_data_and_decode_some_frames()
         auto coded_frame = sample_result.release_value();
         dispatch_frame_end_time(coded_frame);
 
+        MARKER_START_TIME(decode_marker_start);
         auto decode_result = m_decoder->receive_coded_data(coded_frame.timestamp(), coded_frame.duration(), coded_frame.data());
+        MARKER_INTERVAL("Video decode"sv, "MediaDecode"sv, Core::MarkerCategory::Media,
+            decode_marker_start,
+            {
+                { "kind"sv, "video"sv },
+                { "bytes"sv, coded_frame.data().size() },
+                { "pts_us"sv, coded_frame.timestamp().to_microseconds() },
+            });
         if (decode_result.is_error()) {
             set_error_and_wait_for_seek(decode_result.release_error());
             return;

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Markers.h>
 #include <LibGC/DeferGC.h>
 #include <LibJS/Module.h>
 #include <LibJS/Runtime/Array.h>
@@ -725,7 +726,11 @@ void queue_mutation_observer_microtask()
                     MUST(wrapped_records->create_data_property(property_index, record.ptr()));
                 }
 
+                MARKER_START_TIME(mutation_observer_marker_start);
                 (void)WebIDL::invoke_callback(callback, mutation_observer, WebIDL::ExceptionBehavior::Report, { { wrapped_records, mutation_observer } });
+                MARKER_INTERVAL("MutationObserver callback"sv, "Text"sv,
+                    Core::MarkerCategory::DOM, mutation_observer_marker_start,
+                    { { "name"sv, MUST(String::formatted("{} records", records.size())) } });
             }
         }
 

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <LibCore/Markers.h>
 #include <LibCore/Promise.h>
 #include <LibGC/Heap.h>
 #include <LibGfx/Font/FontSupport.h>
@@ -709,6 +710,9 @@ void FontFace::set_line_gap_override_impl(NonnullRefPtr<StyleValue const> const&
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-load
 GC::Ref<WebIDL::Promise> FontFace::load()
 {
+    MARKER_INSTANT("FontFace.load"sv, "Text"sv, Core::MarkerCategory::Network,
+        { { "name"sv, m_family } });
+
     //  1. Let font face be the FontFace object on which this method was called.
     auto& font_face = *this;
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <AK/Debug.h>
+#include <LibCore/Markers.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
@@ -185,12 +186,16 @@ GC::RootVector<GC::Ref<CSSRule>> Parser::parse_as_stylesheet_contents()
 // https://drafts.csswg.org/css-syntax/#parse-a-css-stylesheet
 GC::Ref<CSS::CSSStyleSheet> Parser::parse_as_css_stylesheet(Optional<::URL::URL> location, GC::Ptr<MediaList> media_list)
 {
+    MARKER_SCOPE_FIELDS("Parse CSS"sv, "ParseCSS"sv, Core::MarkerCategory::Parser,
+        { { "url"sv, location.has_value() ? location->to_string() : "<inline>"_string } });
+
     // To parse a CSS stylesheet, first parse a stylesheet.
     auto const& style_sheet = parse_a_stylesheet(m_token_stream, location);
 
     auto rule_list = CSSRuleList::create(realm(), convert_rules(style_sheet.rules));
     if (!media_list)
         media_list = MediaList::create(realm(), {});
+
     return CSSStyleSheet::create(realm(), rule_list, *media_list, move(location));
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -21,6 +21,7 @@
 #include <AK/TemporaryChange.h>
 #include <AK/Time.h>
 #include <AK/Utf8View.h>
+#include <LibCore/Markers.h>
 #include <LibCore/Timer.h>
 #include <LibGC/RootVector.h>
 #include <LibHTTP/Cookie/Cookie.h>
@@ -491,6 +492,8 @@ GC::Ref<Document> Document::construct_impl(JS::Realm& realm)
 
 GC::Ref<Document> Document::create(JS::Realm& realm, URL::URL const& url)
 {
+    MARKER_INSTANT("Document::create"sv, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, url.to_string() } });
     return realm.create<Document>(realm, url);
 }
 
@@ -1498,6 +1501,12 @@ void Document::update_layout(UpdateLayoutReason reason)
     ScopeGuard guard = [&] { m_is_running_update_layout = false; };
     m_is_running_update_layout = true;
 
+    MARKER_SCOPE_FIELDS("Layout"sv, "Layout"sv, Core::MarkerCategory::Layout,
+        {
+            { "viewportWidth"sv, static_cast<double>(viewport_rect().width().to_double()) },
+            { "viewportHeight"sv, static_cast<double>(viewport_rect().height().to_double()) },
+        });
+
     update_style();
 
     if (layout_is_up_to_date())
@@ -1784,6 +1793,11 @@ void Document::update_style()
     // style change event. [CSS-Transitions-2]
     m_transition_generation++;
 
+    MARKER_SCOPE_FIELDS("Recalculate Style"sv, "Style"sv, Core::MarkerCategory::Style,
+        {
+            { "kind"sv, needs_full_style_update() ? "full"sv : "incremental"sv },
+        });
+
     if (m_needs_invalidation_of_elements_affected_by_has) {
         m_needs_invalidation_of_elements_affected_by_has = false;
         style_scope().invalidate_style_of_elements_affected_by_has();
@@ -1820,6 +1834,7 @@ void Document::update_style()
 
     if (invalidation.rebuild_stacking_context_tree)
         invalidate_stacking_context_tree();
+
     m_needs_full_style_update = false;
 }
 
@@ -3354,6 +3369,21 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
 
     // 2. Set document's current document readiness to readinessValue.
     m_readiness = readiness_value;
+
+    StringView readiness_marker_name;
+    switch (readiness_value) {
+    case HTML::DocumentReadyState::Loading:
+        readiness_marker_name = "Navigation::DOMLoading"sv;
+        break;
+    case HTML::DocumentReadyState::Interactive:
+        readiness_marker_name = "Navigation::DOMInteractive"sv;
+        break;
+    case HTML::DocumentReadyState::Complete:
+        readiness_marker_name = "Navigation::DOMComplete"sv;
+        break;
+    }
+    MARKER_INSTANT(readiness_marker_name, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, url().to_string() } });
 
     // 3. If document is associated with an HTML parser, then:
     if (m_parser) {
@@ -5263,7 +5293,11 @@ void Document::queue_intersection_observer_task()
 
             // 5. Invoke callback with queue as the first argument, observer as the second argument, and observer as the callback this value. If this throws an exception, report the exception.
             // NOTE: This does not follow the spec as written precisely, but this is the same thing we do elsewhere and there is a WPT test that relies on this.
+            MARKER_START_TIME(intersection_observer_marker_start);
             (void)WebIDL::invoke_callback(callback, observer.ptr(), WebIDL::ExceptionBehavior::Report, { { wrapped_queue, observer.ptr() } });
+            MARKER_INTERVAL("IntersectionObserver callback"sv, "Text"sv,
+                Core::MarkerCategory::DOM, intersection_observer_marker_start,
+                { { "name"sv, MUST(String::formatted("{} entries", queue.size())) } });
         }
     }));
 }
@@ -6601,7 +6635,11 @@ size_t Document::broadcast_active_resize_observations()
         }
 
         // 4. Invoke observer.[[callback]] with entries.
+        MARKER_START_TIME(resize_observer_marker_start);
         observer->invoke_callback(entries);
+        MARKER_INTERVAL("ResizeObserver callback"sv, "Text"sv,
+            Core::MarkerCategory::Layout, resize_observer_marker_start,
+            { { "name"sv, MUST(String::formatted("{} entries", entries.size())) } });
 
         // 5. Clear observer.[[activeTargets]].
         observer->active_targets().clear();
@@ -7445,6 +7483,12 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
 {
     if (m_cached_display_list && m_cached_display_list_paint_config == config)
         return m_cached_display_list;
+
+    MARKER_SCOPE_FIELDS("Paint"sv, "Paint"sv, Core::MarkerCategory::Paint,
+        {
+            { "viewportWidth"sv, static_cast<double>(viewport_rect().width().to_double()) },
+            { "viewportHeight"sv, static_cast<double>(viewport_rect().height().to_double()) },
+        });
 
     update_paint_and_hit_testing_properties_if_needed();
     VERIFY(paintable());

--- a/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/TypeCasts.h>
+#include <LibCore/Markers.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibWeb/DOM/AbortSignal.h>
@@ -362,6 +363,18 @@ bool EventDispatcher::dispatch(GC::Ref<EventTarget> target, Event& event, bool l
         // 12. If activationTarget is non-null and activationTarget has legacy-pre-activation behavior, then run activationTarget’s legacy-pre-activation behavior.
         if (activation_target)
             activation_target->legacy_pre_activation_behavior();
+
+        Core::MarkerScope _dom_event_marker { "DOMEvent"sv, "DOMEvent"sv, Core::MarkerCategory::DOM,
+            [&]() -> Vector<Core::MarkerField, 4> {
+                Vector<Core::MarkerField, 4> fields;
+                fields.append({ "eventType"sv, event.type().to_string() });
+                if (is<Node>(*target))
+                    fields.append({ "target"sv, as<Node>(*target).node_name().to_string() });
+                fields.append({ "bubbles"sv, event.bubbles() });
+                fields.append({ "cancelable"sv, event.cancelable() });
+                fields.append({ "isTrusted"sv, event.is_trusted() });
+                return fields;
+            } };
 
         // 13. For each struct of event’s path, in reverse order:
         for (auto& entry : event.path().in_reverse()) {

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -12,6 +12,7 @@
 #include <AK/Base64.h>
 #include <AK/Debug.h>
 #include <AK/ScopeGuard.h>
+#include <LibCore/Markers.h>
 #include <LibHTTP/Cache/MemoryCache.h>
 #include <LibHTTP/Cache/Utilities.h>
 #include <LibHTTP/Method.h>
@@ -158,6 +159,9 @@ static void store_response_in_cache(HTTP::MemoryCache& http_cache, Infrastructur
 GC::Ref<Infrastructure::FetchController> fetch(JS::Realm& realm, Infrastructure::Request& request, Infrastructure::FetchAlgorithms const& algorithms, UseParallelQueue use_parallel_queue)
 {
     dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'fetch' with: request @ {}", &request);
+
+    MARKER_INSTANT("Fetch start"sv, "Text"sv, Core::MarkerCategory::Network,
+        { { "name"sv, request.url().to_string() } });
 
     auto& vm = realm.vm();
 

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/TemporaryChange.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Markers.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/FontComputer.h>
@@ -31,6 +32,122 @@
 #include <LibWeb/Platform/Timer.h>
 
 namespace Web::HTML {
+
+static StringView task_source_marker_name(Task::Source source)
+{
+    switch (source) {
+    case Task::Source::Unspecified:
+        return "Task: Unspecified"sv;
+    case Task::Source::DOMManipulation:
+        return "Task: DOM Manipulation"sv;
+    case Task::Source::UserInteraction:
+        return "Task: User Interaction"sv;
+    case Task::Source::Networking:
+        return "Task: Networking"sv;
+    case Task::Source::HistoryTraversal:
+        return "Task: History Traversal"sv;
+    case Task::Source::IdleTask:
+        return "Task: Idle"sv;
+    case Task::Source::PostedMessage:
+        return "Task: Posted Message"sv;
+    case Task::Source::Microtask:
+        return "Task: Microtask"sv;
+    case Task::Source::TimerTask:
+        return "Task: Timer"sv;
+    case Task::Source::JavaScriptEngine:
+        return "Task: JS Engine"sv;
+    case Task::Source::Geolocation:
+        return "Task: Geolocation"sv;
+    case Task::Source::BitmapTask:
+        return "Task: Bitmap"sv;
+    case Task::Source::NavigationAndTraversal:
+        return "Task: Navigation"sv;
+    case Task::Source::FileReading:
+        return "Task: File Reading"sv;
+    case Task::Source::IntersectionObserver:
+        return "Task: IntersectionObserver"sv;
+    case Task::Source::PerformanceTimeline:
+        return "Task: Performance Timeline"sv;
+    case Task::Source::CanvasBlobSerializationTask:
+        return "Task: Canvas Blob"sv;
+    case Task::Source::Clipboard:
+        return "Task: Clipboard"sv;
+    case Task::Source::Permissions:
+        return "Task: Permissions"sv;
+    case Task::Source::FontLoading:
+        return "Task: Font Loading"sv;
+    case Task::Source::RemoteEvent:
+        return "Task: Remote Event"sv;
+    case Task::Source::Rendering:
+        return "Task: Rendering"sv;
+    case Task::Source::DatabaseAccess:
+        return "Task: Database"sv;
+    case Task::Source::WebSocket:
+        return "Task: WebSocket"sv;
+    case Task::Source::MediaCapabilities:
+        return "Task: Media Capabilities"sv;
+    case Task::Source::Gamepad:
+        return "Task: Gamepad"sv;
+    case Task::Source::WebGL:
+        return "Task: WebGL"sv;
+    case Task::Source::Crypto:
+        return "Task: Crypto"sv;
+    case Task::Source::UniqueTaskSourceStart:
+    default:
+        // Per-instance unique task sources (HTMLMediaElement etc.) fall
+        // through here. Their values are >= UniqueTaskSourceStart.
+        return "Task: Unique"sv;
+    }
+}
+
+// Map task sources to marker categories so the marker chart picks the
+// right color: Idle tasks render white (transparent), DOM/Network/Timer
+// tasks pick up their category color, etc. Without this all tasks land
+// in the Other (grey) bucket.
+static Core::MarkerCategory task_source_marker_category(Task::Source source)
+{
+    switch (source) {
+    case Task::Source::IdleTask:
+        return Core::MarkerCategory::Idle;
+    case Task::Source::DOMManipulation:
+    case Task::Source::UserInteraction:
+    case Task::Source::HistoryTraversal:
+    case Task::Source::NavigationAndTraversal:
+    case Task::Source::IntersectionObserver:
+    case Task::Source::Clipboard:
+    case Task::Source::Permissions:
+    case Task::Source::Gamepad:
+        return Core::MarkerCategory::DOM;
+    case Task::Source::Networking:
+    case Task::Source::WebSocket:
+    case Task::Source::RemoteEvent:
+        return Core::MarkerCategory::Network;
+    case Task::Source::TimerTask:
+        return Core::MarkerCategory::Timer;
+    case Task::Source::JavaScriptEngine:
+    case Task::Source::Microtask:
+    case Task::Source::Crypto:
+        return Core::MarkerCategory::JavaScript;
+    case Task::Source::BitmapTask:
+    case Task::Source::CanvasBlobSerializationTask:
+    case Task::Source::Rendering:
+    case Task::Source::WebGL:
+        return Core::MarkerCategory::Graphics;
+    case Task::Source::FontLoading:
+        return Core::MarkerCategory::Style;
+    case Task::Source::MediaCapabilities:
+        return Core::MarkerCategory::Media;
+    case Task::Source::DatabaseAccess:
+    case Task::Source::FileReading:
+    case Task::Source::PerformanceTimeline:
+    case Task::Source::Geolocation:
+    case Task::Source::PostedMessage:
+    case Task::Source::Unspecified:
+    case Task::Source::UniqueTaskSourceStart:
+    default:
+        return Core::MarkerCategory::Other;
+    }
+}
 
 GC_DEFINE_ALLOCATOR(EventLoop);
 
@@ -147,6 +264,9 @@ void EventLoop::process()
 
         // 5. Set the event loop's currently running task to oldestTask.
         m_currently_running_task = oldest_task.ptr();
+
+        MARKER_SCOPE(task_source_marker_name(oldest_task->source()),
+            "Task"sv, task_source_marker_category(oldest_task->source()));
 
         // 6. Perform oldestTask's steps.
         oldest_task->execute();

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Markers.h>
 #include <LibJS/Runtime/Promise.h>
 #include <LibMedia/IncrementallyPopulatedStream.h>
 #include <LibMedia/PlaybackManager.h>
@@ -508,6 +509,9 @@ void HTMLMediaElement::set_duration(double duration)
 
 GC::Ref<WebIDL::Promise> HTMLMediaElement::play()
 {
+    MARKER_INSTANT("HTMLMediaElement.play"sv, "Text"sv, Core::MarkerCategory::Media,
+        { { "name"sv, current_src() } });
+
     auto& realm = this->realm();
 
     // FIXME: 1. If the media element is not allowed to play, then return a promise rejected with a "NotAllowedError" DOMException.

--- a/Libraries/LibWeb/HTML/History.cpp
+++ b/Libraries/LibWeb/HTML/History.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Markers.h>
 #include <LibWeb/Bindings/HistoryPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
@@ -172,6 +173,11 @@ bool can_have_its_url_rewritten(DOM::Document const& document, URL::URL const& t
 // https://html.spec.whatwg.org/multipage/history.html#shared-history-push/replace-state-steps
 WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value data, Optional<String> const& url, HistoryHandlingBehavior history_handling)
 {
+    MARKER_INSTANT(
+        history_handling == HistoryHandlingBehavior::Push ? "history.pushState"sv : "history.replaceState"sv,
+        "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, url.value_or(""_string) } });
+
     auto& vm = this->vm();
 
     // 1. Let document be history's relevant global object's associated Document.

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -10,6 +10,7 @@
 #include <AK/Debug.h>
 #include <AK/SourceLocation.h>
 #include <AK/Utf32View.h>
+#include <LibCore/Markers.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -270,7 +271,13 @@ void HTMLParser::run(URL::URL const& url, HTMLTokenizer::StopAtInsertionPoint st
 {
     m_document->set_url(url);
     m_document->set_source(m_tokenizer.source());
-    run(stop_at_insertion_point);
+
+    {
+        MARKER_SCOPE_FIELDS("Parse HTML"sv, "Text"sv, Core::MarkerCategory::DOM,
+            { { "name"sv, url.to_string() } });
+        run(stop_at_insertion_point);
+    }
+
     the_end(*m_document, this);
 }
 
@@ -458,6 +465,8 @@ void HTMLParserEndState::advance_to_asap_scripts_phase()
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
         // 2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
+        MARKER_INSTANT("DOMContentLoaded"sv, "Text"sv, Core::MarkerCategory::DOM,
+            { { "name"sv, document->url().to_string() } });
         auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(content_loaded_event);
@@ -501,6 +510,8 @@ void HTMLParserEndState::complete()
         // 5. Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         //        We should reorganize this so that the flag appears explicitly here instead.
+        MARKER_INSTANT("Load"sv, "Text"sv, Core::MarkerCategory::DOM,
+            { { "name"sv, document->url().to_string() } });
         window.dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load));
 
         // FIXME: 6. Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <LibCore/ElapsedTimer.h>
+#include <LibCore/Markers.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
@@ -131,6 +132,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, GC::Ptr<JS::Envi
     // 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
     else {
         auto timer = Core::ElapsedTimer::start_new();
+        MARKER_SCOPE("Evaluate script"sv, "EvaluateScript"sv, Core::MarkerCategory::JavaScript);
 
         evaluation_status = vm().run(*m_script_record, lexical_environment_override);
 

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/Utf16String.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Markers.h>
 #include <LibGC/Function.h>
 #include <LibGC/Root.h>
 #include <LibJS/Runtime/ModuleRequest.h>
@@ -66,7 +67,14 @@ static void parse_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS
     Threading::ThreadPool::the().submit([utf16_data, length, type, line_number_offset,
                                             callback,
                                             event_loop_weak = move(event_loop_weak)]() {
+        MARKER_START_TIME(parse_start);
         auto* parsed = JS::RustIntegration::parse_program(utf16_data, length, type, line_number_offset);
+        MARKER_INTERVAL(
+            type == JS::RustIntegration::ProgramType::Module ? "Parse module"sv : "Parse script"sv,
+            "ParseScript"sv, Core::MarkerCategory::Parser, parse_start,
+            {
+                { "kind"sv, type == JS::RustIntegration::ProgramType::Module ? "module"sv : "script"sv },
+            });
 
         auto origin = event_loop_weak->take();
         if (!origin)

--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/String.h>
+#include <LibCore/Markers.h>
 #include <LibGC/RootVector.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/StoragePrototype.h>
@@ -90,6 +91,9 @@ Optional<String> Storage::get_item(String const& key) const
 // https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem
 WebIDL::ExceptionOr<void> Storage::set_item(String const& key, String const& value)
 {
+    MARKER_INSTANT("Storage.setItem"sv, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, key } });
+
     // 1. Let oldValue be null.
     // 2. Let reorder be true.
     bool reorder = true;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Utf8View.h>
+#include <LibCore/Markers.h>
 #include <LibGC/WeakHashSet.h>
 #include <LibIPC/File.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -108,6 +109,11 @@ void Window::for_each_active(Function<IterationDecision(Window&)> callback)
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks
 void run_animation_frame_callbacks(DOM::Document& document, double now)
 {
+    MARKER_SCOPE_FIELDS("requestAnimationFrame callbacks"sv, "Text"sv, Core::MarkerCategory::Timer,
+        {
+            { "type"sv, "requestAnimationFrame"sv },
+            { "time"sv, now },
+        });
     // FIXME: Bring this closer to the spec.
     document.window()->animation_frame_callback_driver().run(now);
 }
@@ -1324,6 +1330,8 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options
 WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, WindowPostMessageOptions const& options)
 {
+    MARKER_INSTANT("Window.postMessage"sv, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, options.target_origin } });
     // The Window interface's postMessage(message, options) method steps are to run the window post message steps given
     // this, message, and options.
     return window_post_message_steps(message, options);
@@ -1332,6 +1340,8 @@ WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, WindowPostMess
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage
 WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, String const& target_origin, Vector<GC::Root<JS::Object>> const& transfer)
 {
+    MARKER_INSTANT("Window.postMessage"sv, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, target_origin } });
     // The Window interface's postMessage(message, targetOrigin, transfer) method steps are to run the window post message
     // steps given this, message, and «[ "targetOrigin" → targetOrigin, "transfer" → transfer ]».
     return window_post_message_steps(message, WindowPostMessageOptions { { .transfer = transfer }, target_origin });

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -11,6 +11,7 @@
 #include <AK/String.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
+#include <LibCore/Markers.h>
 #include <LibGC/Function.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
@@ -586,6 +587,10 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
 
         // FIXME: 3. If global's map of setTimeout and setInterval IDs[id] does not equal uniqueHandle, then abort these steps.
         // FIXME: 4. Record timing info for timer handler given handler, global's relevant settings object, and repeat.
+
+        MARKER_SCOPE_FIELDS(repeat == Repeat::Yes ? "setInterval"sv : "setTimeout"sv,
+            "Text"sv, Core::MarkerCategory::Timer,
+            { { "delay"sv, static_cast<double>(timeout) } });
 
         bool continue_ = handler.visit(
             // 5. If handler is a Function, then invoke handler given arguments and "report", and with callback this value set to thisArg.

--- a/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Markers.h>
 #include <LibWeb/Bindings/PerformancePrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
@@ -85,6 +86,9 @@ WebIDL::ExceptionOr<GC::Ref<UserTiming::PerformanceMark>> Performance::mark(Stri
 
     // 1. Run the PerformanceMark constructor and let entry be the newly created object.
     auto entry = TRY(UserTiming::PerformanceMark::construct_impl(realm, mark_name, mark_options));
+
+    MARKER_INSTANT(mark_name, "UserTiming"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, mark_name }, { "entryType"sv, "mark"sv } });
 
     // 2. Queue entry.
     window_or_worker().queue_performance_entry(entry);
@@ -305,6 +309,9 @@ WebIDL::ExceptionOr<GC::Ref<UserTiming::PerformanceMeasure>> Performance::measur
 
     // 4. Create a new PerformanceMeasure object (entry) with this's relevant realm.
     auto entry = realm.create<UserTiming::PerformanceMeasure>(realm, measure_name, start_time, duration, detail);
+
+    MARKER_INSTANT(measure_name, "UserTiming"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, measure_name }, { "entryType"sv, "measure"sv }, { "startTime"sv, start_time }, { "duration"sv, duration } });
 
     // 10. Queue entry.
     window_or_worker().queue_performance_entry(entry);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/JsonObject.h>
+#include <LibCore/MarkerCollector.h>
 #include <LibGfx/Cursor.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/VM.h>
@@ -590,6 +591,76 @@ void Internals::set_environments_top_level_url(StringView url)
 {
     auto& realm = *vm().current_realm();
     HTML::principal_realm_settings_object(realm).top_level_creation_url = URL::Parser::basic_parse(url);
+}
+
+static StringView marker_phase_string(Core::MarkerPhase phase)
+{
+    switch (phase) {
+    case Core::MarkerPhase::Instant:
+        return "Instant"sv;
+    case Core::MarkerPhase::Interval:
+        return "Interval"sv;
+    case Core::MarkerPhase::IntervalStart:
+        return "IntervalStart"sv;
+    case Core::MarkerPhase::IntervalEnd:
+        return "IntervalEnd"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+GC::RootVector<JS::Object*> Internals::collect_markers(Optional<String> const& type_filter)
+{
+    auto& realm = this->realm();
+    GC::RootVector<JS::Object*> result(realm.heap());
+    auto* collector = Core::g_marker_collector;
+    if (!collector)
+        return result;
+
+    auto base_time = collector->creation_time();
+
+    auto markers_snapshot = collector->take_markers_snapshot();
+    for (auto const& marker : markers_snapshot) {
+        if (type_filter.has_value() && marker.type != type_filter->bytes_as_string_view())
+            continue;
+
+        auto obj = JS::Object::create(realm, nullptr);
+
+        auto name_sv = marker.name.visit(
+            [](StringView sv) { return sv; },
+            [](String const& s) { return s.bytes_as_string_view(); });
+        obj->define_direct_property("name"_utf16_fly_string, JS::PrimitiveString::create(vm(), name_sv), JS::default_attributes);
+        obj->define_direct_property("type"_utf16_fly_string, JS::PrimitiveString::create(vm(), marker.type), JS::default_attributes);
+        obj->define_direct_property("phase"_utf16_fly_string, JS::PrimitiveString::create(vm(), marker_phase_string(marker.phase)), JS::default_attributes);
+        obj->define_direct_property("category"_utf16_fly_string, JS::PrimitiveString::create(vm(), Core::marker_category_name(marker.category)), JS::default_attributes);
+
+        auto start_ms = static_cast<double>((marker.start - base_time).to_nanoseconds()) / 1'000'000.0;
+        auto end_ms = static_cast<double>((marker.end - base_time).to_nanoseconds()) / 1'000'000.0;
+        obj->define_direct_property("startTime"_utf16_fly_string, JS::Value(start_ms), JS::default_attributes);
+        obj->define_direct_property("endTime"_utf16_fly_string, JS::Value(end_ms), JS::default_attributes);
+
+        auto fields = JS::Object::create(realm, nullptr);
+        for (auto const& field : marker.fields) {
+            auto value = field.value.visit(
+                [&](StringView sv) -> JS::Value { return JS::PrimitiveString::create(vm(), sv); },
+                [&](String const& s) -> JS::Value { return JS::PrimitiveString::create(vm(), s); },
+                [&](double number) -> JS::Value { return JS::Value(number); },
+                [&](i64 integer) -> JS::Value { return JS::Value(static_cast<double>(integer)); },
+                [&](size_t count) -> JS::Value { return JS::Value(static_cast<double>(count)); },
+                [&](bool flag) -> JS::Value { return JS::Value(flag); });
+            fields->define_direct_property(Utf16FlyString::from_utf8(field.key), value, JS::default_attributes);
+        }
+        obj->define_direct_property("fields"_utf16_fly_string, fields, JS::default_attributes);
+
+        result.append(obj.ptr());
+    }
+
+    return result;
+}
+
+void Internals::clear_markers()
+{
+    if (auto* collector = Core::g_marker_collector)
+        collector->clear();
 }
 
 }

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -109,6 +109,9 @@ public:
     void clear_element(HTML::HTMLElement&);
     void set_environments_top_level_url(StringView url);
 
+    GC::RootVector<JS::Object*> collect_markers(Optional<String> const& type);
+    void clear_markers();
+
 private:
     explicit Internals(JS::Realm&);
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -89,4 +89,7 @@ interface Internals {
 
     undefined clearElement(HTMLElement element);
 
+    sequence<object> collectMarkers(optional DOMString type);
+    undefined clearMarkers();
+
 };

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Markers.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibUnicode/CharacterTypes.h>
@@ -1262,6 +1263,9 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
 
 EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, int click_count)
 {
+    MARKER_INSTANT("Mouse down"sv, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, MUST(String::formatted("button={} count={}", button, click_count)) } });
+
     if (should_ignore_device_input_event())
         return EventResult::Dropped;
 
@@ -1762,6 +1766,9 @@ EventResult EventHandler::input_event(FlyString const& event_name, FlyString con
 
 EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u32 code_point, bool repeat)
 {
+    MARKER_INSTANT("Key down"sv, "Text"sv, Core::MarkerCategory::DOM,
+        { { "name"sv, MUST(String::formatted("key={} repeat={}", static_cast<u32>(key), repeat)) } });
+
     if (!m_navigable->active_document())
         return EventResult::Dropped;
     if (!m_navigable->active_document()->is_fully_active())

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Markers.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/VisualViewport.h>
 #include <LibWeb/DOM/Document.h>

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibCore/Markers.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibRequests/RequestClient.h>
@@ -40,6 +41,9 @@ GC_DEFINE_ALLOCATOR(WebSocket);
 // https://websockets.spec.whatwg.org/#dom-websocket-websocket
 WebIDL::ExceptionOr<GC::Ref<WebSocket>> WebSocket::construct_impl(JS::Realm& realm, String const& url, Optional<Variant<String, Vector<String>>> const& protocols)
 {
+    MARKER_INSTANT("WebSocket.new"sv, "Text"sv, Core::MarkerCategory::Network,
+        { { "name"sv, url } });
+
     auto& vm = realm.vm();
 
     auto web_socket = realm.create<WebSocket>(realm);
@@ -299,6 +303,9 @@ WebIDL::ExceptionOr<void> WebSocket::close(Optional<u16> code, Optional<String> 
 // https://websockets.spec.whatwg.org/#dom-websocket-send
 WebIDL::ExceptionOr<void> WebSocket::send(Variant<GC::Root<WebIDL::BufferSource>, GC::Root<FileAPI::Blob>, String> const& data)
 {
+    MARKER_INSTANT("WebSocket.send"sv, "Text"sv, Core::MarkerCategory::Network,
+        { { "name"sv, url() } });
+
     auto state = ready_state();
     if (state == Requests::WebSocket::ReadyState::Connecting)
         return WebIDL::InvalidStateError::create(realm(), "Websocket is still CONNECTING"_utf16);

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -12,6 +12,7 @@
 #include <AK/Debug.h>
 #include <AK/GenericLexer.h>
 #include <AK/QuickSort.h>
+#include <LibCore/Markers.h>
 #include <LibHTTP/Method.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/Completion.h>
@@ -539,6 +540,9 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
 {
     auto& vm = this->vm();
     auto& realm = *vm.current_realm();
+
+    MARKER_INSTANT("XMLHttpRequest.send"sv, "Text"sv, Core::MarkerCategory::Network,
+        { { "name"sv, MUST(String::formatted("{} {}", m_request_method, m_request_url.to_string())) } });
 
     // 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Opened)

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -162,6 +162,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     bool force_cpu_painting = false;
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
+    bool collect_markers = false;
     bool disable_scrollbar_painting = false;
     bool file_scheme_urls_have_tuple_origins = false;
 
@@ -232,6 +233,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation", 'g');
+    args_parser.add_option(collect_markers, "Collect profiler markers from process start", "collect-markers");
     args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical scrollbars on the main viewport", "disable-scrollbar-painting");
     args_parser.add_option(dns_server_address, "Set the DNS server address", "dns-server", 0, "host|address");
     args_parser.add_option(dns_server_port, "Set the DNS server port", "dns-port", 0, "port (default: 53 or 853 if --dot)");
@@ -348,6 +350,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         .force_fontconfig = force_fontconfig ? ForceFontconfig::Yes : ForceFontconfig::No,
         .enable_autoplay = enable_autoplay ? EnableAutoplay::Yes : EnableAutoplay::No,
         .collect_garbage_on_every_allocation = collect_garbage_on_every_allocation ? CollectGarbageOnEveryAllocation::Yes : CollectGarbageOnEveryAllocation::No,
+        .collect_markers = collect_markers ? CollectMarkers::Yes : CollectMarkers::No,
         .paint_viewport_scrollbars = disable_scrollbar_painting ? PaintViewportScrollbars::No : PaintViewportScrollbars::Yes,
         .file_scheme_urls_have_tuple_origins = file_scheme_urls_have_tuple_origins ? FileSchemeUrlsHaveTupleOrigins::Yes : FileSchemeUrlsHaveTupleOrigins::No,
         .default_time_zone = default_time_zone,
@@ -360,6 +363,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         m_web_content_options.expose_experimental_interfaces = ExposeExperimentalInterfaces::Yes;
         m_web_content_options.expose_internals_object = ExposeInternalsObject::Yes;
         m_web_content_options.force_cpu_painting = ForceCPUPainting::Yes;
+        m_web_content_options.collect_markers = CollectMarkers::Yes;
     }
 
     if (m_web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -121,6 +121,8 @@ static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_proc
         arguments.append("--force-fontconfig"sv);
     if (web_content_options.collect_garbage_on_every_allocation == WebView::CollectGarbageOnEveryAllocation::Yes)
         arguments.append("--collect-garbage-on-every-allocation"sv);
+    if (web_content_options.collect_markers == WebView::CollectMarkers::Yes)
+        arguments.append("--collect-markers"sv);
     if (web_content_options.paint_viewport_scrollbars == PaintViewportScrollbars::No)
         arguments.append("--disable-scrollbar-painting"sv);
     if (web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -162,6 +162,11 @@ enum class PaintViewportScrollbars {
     No,
 };
 
+enum class CollectMarkers {
+    No,
+    Yes,
+};
+
 enum class FileSchemeUrlsHaveTupleOrigins {
     No,
     Yes,
@@ -183,6 +188,7 @@ struct WebContentOptions {
     ForceFontconfig force_fontconfig { ForceFontconfig::No };
     EnableAutoplay enable_autoplay { EnableAutoplay::No };
     CollectGarbageOnEveryAllocation collect_garbage_on_every_allocation { CollectGarbageOnEveryAllocation::No };
+    CollectMarkers collect_markers { CollectMarkers::No };
     Optional<u16> echo_server_port {};
     PaintViewportScrollbars paint_viewport_scrollbars { PaintViewportScrollbars::Yes };
     FileSchemeUrlsHaveTupleOrigins file_scheme_urls_have_tuple_origins { FileSchemeUrlsHaveTupleOrigins::No };

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
+#include <LibCore/MarkerCollector.h>
 #include <LibCore/Process.h>
 #include <LibCore/Resource.h>
 #include <LibCore/System.h>
@@ -147,6 +148,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool force_cpu_painting = false;
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
+    bool collect_markers = false;
     bool is_headless = false;
     bool disable_scrollbar_painting = false;
     StringView echo_server_port_string_view {};
@@ -170,6 +172,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation");
+    args_parser.add_option(collect_markers, "Collect profiler markers from process start", "collect-markers");
     args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical viewport scrollbars", "disable-scrollbar-painting");
     args_parser.add_option(echo_server_port_string_view, "Echo server port used in test internals", "echo-server-port", 0, "echo_server_port");
     args_parser.add_option(is_headless, "Report that the browser is running in headless mode", "headless");
@@ -189,6 +192,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     if (file_origins_are_tuple_origins)
         URL::set_file_scheme_urls_have_tuple_origins();
+
+    static OwnPtr<Core::MarkerCollector> s_marker_collector;
+    if (collect_markers)
+        s_marker_collector = make<Core::MarkerCollector>();
 
     auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
     if (force_fontconfig) {

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SOURCES
     TestLibCorePromise.cpp
     TestLibCoreSharedSingleProducerCircularQueue.cpp
     TestLibCoreStream.cpp
+    TestMarkers.cpp
 )
 
 # FIXME: Change these tests to use a portable tempfile directory

--- a/Tests/LibCore/TestMarkers.cpp
+++ b/Tests/LibCore/TestMarkers.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/MarkerCollector.h>
+#include <LibCore/Markers.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(collector_lifetime_toggles_active_flag_and_pointer)
+{
+    EXPECT(!Core::g_marker_collector_active);
+    EXPECT(Core::g_marker_collector == nullptr);
+    {
+        Core::MarkerCollector collector;
+        EXPECT(Core::g_marker_collector_active);
+        EXPECT(Core::g_marker_collector == &collector);
+    }
+    EXPECT(!Core::g_marker_collector_active);
+    EXPECT(Core::g_marker_collector == nullptr);
+}
+
+TEST_CASE(each_marker_macro_emits_with_its_phase)
+{
+    Core::MarkerCollector collector;
+
+    MARKER_INSTANT("a"sv, "Text"sv, Core::MarkerCategory::Other, {});
+    MARKER_START_TIME(start);
+    MARKER_INTERVAL("b"sv, "Text"sv, Core::MarkerCategory::Other, start, {});
+    MARKER_INTERVAL_START("c"sv, "Text"sv, Core::MarkerCategory::Other, {});
+    MARKER_INTERVAL_END("d"sv, "Text"sv, Core::MarkerCategory::Other, {});
+    {
+        MARKER_SCOPE("e"sv, "Text"sv, Core::MarkerCategory::Other);
+    }
+
+    auto markers = collector.take_markers_snapshot();
+    EXPECT_EQ(markers.size(), 5u);
+    EXPECT_EQ(markers[0].phase, Core::MarkerPhase::Instant);
+    EXPECT_EQ(markers[1].phase, Core::MarkerPhase::Interval);
+    EXPECT_EQ(markers[2].phase, Core::MarkerPhase::IntervalStart);
+    EXPECT_EQ(markers[3].phase, Core::MarkerPhase::IntervalEnd);
+    EXPECT_EQ(markers[4].phase, Core::MarkerPhase::Interval);
+}
+
+TEST_CASE(marker_scope_only_emits_after_destruction)
+{
+    Core::MarkerCollector collector;
+    {
+        MARKER_SCOPE("s"sv, "Text"sv, Core::MarkerCategory::Other);
+        EXPECT_EQ(collector.take_markers_snapshot().size(), 0u);
+    }
+    EXPECT_EQ(collector.take_markers_snapshot().size(), 1u);
+}
+
+TEST_CASE(marker_scope_fields_attaches_fields)
+{
+    Core::MarkerCollector collector;
+    {
+        MARKER_SCOPE_FIELDS("s"sv, "Text"sv, Core::MarkerCategory::Other,
+            { { "n"sv, static_cast<i64>(42) } });
+    }
+    auto markers = collector.take_markers_snapshot();
+    EXPECT_EQ(markers.size(), 1u);
+    EXPECT_EQ(markers[0].fields.size(), 1u);
+    EXPECT_EQ(markers[0].fields[0].value.get<i64>(), 42);
+}
+
+TEST_CASE(marker_tid_is_populated)
+{
+    Core::MarkerCollector collector;
+    MARKER_INSTANT("x"sv, "Text"sv, Core::MarkerCategory::Other, {});
+    EXPECT(collector.take_markers_snapshot()[0].tid != 0);
+}
+
+TEST_CASE(clear_drops_all_markers)
+{
+    Core::MarkerCollector collector;
+    MARKER_INSTANT("a"sv, "Text"sv, Core::MarkerCategory::Other, {});
+    MARKER_INSTANT("b"sv, "Text"sv, Core::MarkerCategory::Other, {});
+    EXPECT_EQ(collector.take_markers_snapshot().size(), 2u);
+    collector.clear();
+    EXPECT_EQ(collector.take_markers_snapshot().size(), 0u);
+}
+
+TEST_CASE(inactive_gated_macros_do_not_evaluate_args)
+{
+    EXPECT(!Core::g_marker_collector_active);
+
+    int calls = 0;
+    auto bomb = [&]() -> StringView {
+        ++calls;
+        return ""sv;
+    };
+
+    MARKER_INSTANT(bomb(), "Text"sv, Core::MarkerCategory::Other, {});
+    MARKER_INTERVAL_START(bomb(), "Text"sv, Core::MarkerCategory::Other, {});
+    MARKER_INTERVAL_END(bomb(), "Text"sv, Core::MarkerCategory::Other, {});
+    MARKER_START_TIME(start);
+    MARKER_INTERVAL(bomb(), "Text"sv, Core::MarkerCategory::Other, start, {});
+
+    EXPECT_EQ(calls, 0);
+}
+
+TEST_CASE(inactive_marker_scope_fields_lambda_is_not_invoked)
+{
+    EXPECT(!Core::g_marker_collector_active);
+
+    int calls = 0;
+    auto bomb = [&]() -> StringView {
+        ++calls;
+        return ""sv;
+    };
+
+    {
+        MARKER_SCOPE_FIELDS("s"sv, "Text"sv, Core::MarkerCategory::Other,
+            { { bomb(), ""sv } });
+    }
+    EXPECT_EQ(calls, 0);
+}

--- a/Tests/LibWeb/Marker/expected/markers-basic.txt
+++ b/Tests/LibWeb/Marker/expected/markers-basic.txt
@@ -1,0 +1,9 @@
+PASS markers collected
+PASS has name
+PASS has type
+PASS has phase
+PASS has category
+PASS has fields
+PASS has startTime
+PASS has endTime
+PASS all phases valid

--- a/Tests/LibWeb/Marker/expected/markers-clear.txt
+++ b/Tests/LibWeb/Marker/expected/markers-clear.txt
@@ -1,0 +1,2 @@
+PASS markers exist before clear
+PASS no markers after clear

--- a/Tests/LibWeb/Marker/expected/markers-console-time.txt
+++ b/Tests/LibWeb/Marker/expected/markers-console-time.txt
@@ -1,1 +1,2 @@
-FAIL no ConsoleTime markers
+PASS console.time start found
+PASS console.timeEnd end found

--- a/Tests/LibWeb/Marker/expected/markers-console-time.txt
+++ b/Tests/LibWeb/Marker/expected/markers-console-time.txt
@@ -1,0 +1,1 @@
+FAIL no ConsoleTime markers

--- a/Tests/LibWeb/Marker/expected/markers-css-parser.txt
+++ b/Tests/LibWeb/Marker/expected/markers-css-parser.txt
@@ -1,1 +1,2 @@
-FAIL no ParseCSS marker
+PASS ParseCSS marker found
+PASS ParseCSS is Interval

--- a/Tests/LibWeb/Marker/expected/markers-css-parser.txt
+++ b/Tests/LibWeb/Marker/expected/markers-css-parser.txt
@@ -1,0 +1,1 @@
+FAIL no ParseCSS marker

--- a/Tests/LibWeb/Marker/expected/markers-dom-event.txt
+++ b/Tests/LibWeb/Marker/expected/markers-dom-event.txt
@@ -1,1 +1,4 @@
-FAIL no DOMEvent click marker
+PASS click event found
+PASS target is BUTTON
+PASS bubbles is boolean
+PASS isTrusted is boolean

--- a/Tests/LibWeb/Marker/expected/markers-dom-event.txt
+++ b/Tests/LibWeb/Marker/expected/markers-dom-event.txt
@@ -1,0 +1,1 @@
+FAIL no DOMEvent click marker

--- a/Tests/LibWeb/Marker/expected/markers-filter.txt
+++ b/Tests/LibWeb/Marker/expected/markers-filter.txt
@@ -1,0 +1,4 @@
+PASS has markers
+PASS filter narrows results
+PASS all filtered are Style
+PASS unknown type returns empty

--- a/Tests/LibWeb/Marker/expected/markers-gc.txt
+++ b/Tests/LibWeb/Marker/expected/markers-gc.txt
@@ -1,0 +1,3 @@
+PASS GC marker found
+PASS phase is Interval
+PASS has kind field

--- a/Tests/LibWeb/Marker/expected/markers-layout.txt
+++ b/Tests/LibWeb/Marker/expected/markers-layout.txt
@@ -1,1 +1,4 @@
-FAIL no Style or Layout markers
+PASS Style marker found
+PASS Layout marker found
+PASS Style is Interval
+PASS Layout is Interval

--- a/Tests/LibWeb/Marker/expected/markers-layout.txt
+++ b/Tests/LibWeb/Marker/expected/markers-layout.txt
@@ -1,0 +1,1 @@
+FAIL no Style or Layout markers

--- a/Tests/LibWeb/Marker/expected/markers-navigation.txt
+++ b/Tests/LibWeb/Marker/expected/markers-navigation.txt
@@ -1,3 +1,3 @@
-FAIL no Document::create
-FAIL no DOMLoading
+PASS Parse HTML found
+PASS Parse HTML is Interval
 PASS DOMInteractive found

--- a/Tests/LibWeb/Marker/expected/markers-navigation.txt
+++ b/Tests/LibWeb/Marker/expected/markers-navigation.txt
@@ -1,1 +1,3 @@
-FAIL no navigation markers
+FAIL no Document::create
+FAIL no DOMLoading
+PASS DOMInteractive found

--- a/Tests/LibWeb/Marker/expected/markers-navigation.txt
+++ b/Tests/LibWeb/Marker/expected/markers-navigation.txt
@@ -1,0 +1,1 @@
+FAIL no navigation markers

--- a/Tests/LibWeb/Marker/expected/markers-paint.txt
+++ b/Tests/LibWeb/Marker/expected/markers-paint.txt
@@ -1,0 +1,1 @@
+FAIL no Paint marker

--- a/Tests/LibWeb/Marker/expected/markers-timer.txt
+++ b/Tests/LibWeb/Marker/expected/markers-timer.txt
@@ -1,0 +1,1 @@
+FAIL no setTimeout marker

--- a/Tests/LibWeb/Marker/expected/markers-timer.txt
+++ b/Tests/LibWeb/Marker/expected/markers-timer.txt
@@ -1,1 +1,3 @@
-FAIL no setTimeout marker
+PASS setTimeout marker found
+PASS timer is Interval
+PASS has delay field

--- a/Tests/LibWeb/Marker/expected/markers-user-timing.txt
+++ b/Tests/LibWeb/Marker/expected/markers-user-timing.txt
@@ -1,1 +1,4 @@
-FAIL no UserTiming markers
+PASS mark found
+PASS mark is Instant
+PASS measure found
+PASS measure is Instant

--- a/Tests/LibWeb/Marker/expected/markers-user-timing.txt
+++ b/Tests/LibWeb/Marker/expected/markers-user-timing.txt
@@ -1,0 +1,1 @@
+FAIL no UserTiming markers

--- a/Tests/LibWeb/Marker/input/markers-basic.html
+++ b/Tests/LibWeb/Marker/input/markers-basic.html
@@ -1,0 +1,20 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    const markers = internals.collectMarkers();
+    println(markers.length > 0 ? "PASS markers collected" : "FAIL no markers");
+
+    const m = markers[0];
+    println("name" in m ? "PASS has name" : "FAIL missing name");
+    println("type" in m ? "PASS has type" : "FAIL missing type");
+    println("phase" in m ? "PASS has phase" : "FAIL missing phase");
+    println("category" in m ? "PASS has category" : "FAIL missing category");
+    println("fields" in m ? "PASS has fields" : "FAIL missing fields");
+    println("startTime" in m ? "PASS has startTime" : "FAIL missing startTime");
+    println("endTime" in m ? "PASS has endTime" : "FAIL missing endTime");
+
+    const validPhases = new Set(["Instant", "Interval", "IntervalStart", "IntervalEnd"]);
+    const allValid = markers.every(m => validPhases.has(m.phase));
+    println(allValid ? "PASS all phases valid" : "FAIL invalid phase found");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-clear.html
+++ b/Tests/LibWeb/Marker/input/markers-clear.html
@@ -1,0 +1,12 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    const before = internals.collectMarkers();
+    println(before.length > 0 ? "PASS markers exist before clear" : "FAIL no markers before clear");
+
+    internals.clearMarkers();
+
+    const after = internals.collectMarkers();
+    println(after.length === 0 ? "PASS no markers after clear" : "FAIL markers remain after clear");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-console-time.html
+++ b/Tests/LibWeb/Marker/input/markers-console-time.html
@@ -1,0 +1,19 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+
+    console.time("test-timer");
+    console.timeEnd("test-timer");
+
+    const markers = internals.collectMarkers("ConsoleTime");
+    const start = markers.find(m => m.fields.name === "test-timer" && m.phase === "IntervalStart");
+    const end = markers.find(m => m.fields.name === "test-timer" && m.phase === "IntervalEnd");
+    if (!start && !end) {
+        println("FAIL no ConsoleTime markers");
+        return;
+    }
+    println(start ? "PASS console.time start found" : "FAIL no start marker");
+    println(end ? "PASS console.timeEnd end found" : "FAIL no end marker");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-css-parser.html
+++ b/Tests/LibWeb/Marker/input/markers-css-parser.html
@@ -1,0 +1,20 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+
+    const style = document.createElement("style");
+    style.textContent = ".test { color: red; font-size: 16px; }";
+    document.head.appendChild(style);
+
+    document.body.offsetHeight;
+
+    const markers = internals.collectMarkers("ParseCSS");
+    if (markers.length === 0) {
+        println("FAIL no ParseCSS marker");
+        return;
+    }
+    println("PASS ParseCSS marker found");
+    println(markers[0].phase === "Interval" ? "PASS ParseCSS is Interval" : "FAIL ParseCSS phase: " + markers[0].phase);
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-dom-event.html
+++ b/Tests/LibWeb/Marker/input/markers-dom-event.html
@@ -1,0 +1,19 @@
+<button id="b">click</button>
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+    document.getElementById("b").click();
+
+    const markers = internals.collectMarkers("DOMEvent");
+    const click = markers.find(m => m.fields.eventType === "click");
+    if (!click) {
+        println("FAIL no DOMEvent click marker");
+        return;
+    }
+    println("PASS click event found");
+    println(click.fields.target === "BUTTON" ? "PASS target is BUTTON" : "FAIL wrong target: " + click.fields.target);
+    println(typeof click.fields.bubbles === "boolean" ? "PASS bubbles is boolean" : "FAIL bubbles type");
+    println(typeof click.fields.isTrusted === "boolean" ? "PASS isTrusted is boolean" : "FAIL isTrusted type");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-filter.html
+++ b/Tests/LibWeb/Marker/input/markers-filter.html
@@ -1,0 +1,14 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    const all = internals.collectMarkers();
+    const style = internals.collectMarkers("Style");
+
+    println(all.length > 0 ? "PASS has markers" : "FAIL no markers");
+    println(all.length >= style.length ? "PASS filter narrows results" : "FAIL filter did not narrow");
+    println(style.every(m => m.type === "Style") ? "PASS all filtered are Style" : "FAIL wrong type in results");
+
+    const nonexistent = internals.collectMarkers("NonExistentType");
+    println(nonexistent.length === 0 ? "PASS unknown type returns empty" : "FAIL unknown type returned results");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-gc.html
+++ b/Tests/LibWeb/Marker/input/markers-gc.html
@@ -1,0 +1,12 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+    internals.gc();
+
+    const markers = internals.collectMarkers("GC");
+    println(markers.length > 0 ? "PASS GC marker found" : "FAIL no GC marker");
+    println(markers[0]?.phase === "Interval" ? "PASS phase is Interval" : "FAIL wrong phase: " + markers[0]?.phase);
+    println(markers[0]?.fields.kind ? "PASS has kind field" : "FAIL missing kind");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-layout.html
+++ b/Tests/LibWeb/Marker/input/markers-layout.html
@@ -1,0 +1,21 @@
+<div id="d" style="width:100px;height:100px;background:red"></div>
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+
+    document.getElementById("d").style.width = "200px";
+    document.getElementById("d").offsetHeight;
+
+    const style = internals.collectMarkers("Style");
+    const layout = internals.collectMarkers("Layout");
+    if (style.length === 0 && layout.length === 0) {
+        println("FAIL no Style or Layout markers");
+        return;
+    }
+    println(style.length > 0 ? "PASS Style marker found" : "FAIL no Style marker");
+    println(layout.length > 0 ? "PASS Layout marker found" : "FAIL no Layout marker");
+    println(style[0]?.phase === "Interval" ? "PASS Style is Interval" : "FAIL Style phase: " + style[0]?.phase);
+    println(layout[0]?.phase === "Interval" ? "PASS Layout is Interval" : "FAIL Layout phase: " + layout[0]?.phase);
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-navigation.html
+++ b/Tests/LibWeb/Marker/input/markers-navigation.html
@@ -1,0 +1,21 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    const markers = internals.collectMarkers("Text");
+    const parseHTML = markers.find(m => {
+        const name = typeof m.name === "string" ? m.name : "";
+        return name === "Parse HTML";
+    });
+    const domInteractive = markers.find(m => {
+        const name = typeof m.name === "string" ? m.name : "";
+        return name === "Navigation::DOMInteractive";
+    });
+    if (!parseHTML && !domInteractive) {
+        println("FAIL no navigation markers");
+        return;
+    }
+    println(parseHTML ? "PASS Parse HTML found" : "FAIL no Parse HTML");
+    println(parseHTML?.phase === "Interval" ? "PASS Parse HTML is Interval" : "FAIL Parse HTML phase: " + parseHTML?.phase);
+    println(domInteractive ? "PASS DOMInteractive found" : "FAIL no DOMInteractive");
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-paint.html
+++ b/Tests/LibWeb/Marker/input/markers-paint.html
@@ -1,0 +1,18 @@
+<div id="d" style="width:100px;height:100px;background:red"></div>
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+
+    document.getElementById("d").style.background = "blue";
+    document.getElementById("d").offsetHeight;
+
+    const markers = internals.collectMarkers("Paint");
+    if (markers.length === 0) {
+        println("FAIL no Paint marker");
+        return;
+    }
+    println("PASS Paint marker found");
+    println(markers[0].phase === "Interval" ? "PASS Paint is Interval" : "FAIL Paint phase: " + markers[0].phase);
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-timer.html
+++ b/Tests/LibWeb/Marker/input/markers-timer.html
@@ -1,0 +1,25 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+asyncTest(done => {
+    internals.clearMarkers();
+
+    setTimeout(() => {
+        setTimeout(() => {
+            const markers = internals.collectMarkers("Text");
+            const timer = markers.find(m => {
+                const name = typeof m.name === "string" ? m.name : "";
+                return name.startsWith("setTimeout");
+            });
+            if (!timer) {
+                println("FAIL no setTimeout marker");
+                done();
+                return;
+            }
+            println("PASS setTimeout marker found");
+            println(timer.phase === "Interval" ? "PASS timer is Interval" : "FAIL timer phase: " + timer.phase);
+            println(typeof timer.fields.delay === "number" ? "PASS has delay field" : "FAIL missing delay");
+            done();
+        }, 0);
+    }, 50);
+});
+</script>

--- a/Tests/LibWeb/Marker/input/markers-user-timing.html
+++ b/Tests/LibWeb/Marker/input/markers-user-timing.html
@@ -1,0 +1,21 @@
+<script src="../../Text/input/include.js"></script>
+<script>
+test(() => {
+    internals.clearMarkers();
+
+    performance.mark("test-mark");
+    performance.measure("test-measure", "test-mark");
+
+    const markers = internals.collectMarkers("UserTiming");
+    const mark = markers.find(m => m.fields.name === "test-mark" && m.fields.entryType === "mark");
+    const measure = markers.find(m => m.fields.name === "test-measure" && m.fields.entryType === "measure");
+    if (!mark && !measure) {
+        println("FAIL no UserTiming markers");
+        return;
+    }
+    println(mark ? "PASS mark found" : "FAIL no mark");
+    println(mark?.phase === "Instant" ? "PASS mark is Instant" : "FAIL mark phase: " + mark?.phase);
+    println(measure ? "PASS measure found" : "FAIL no measure");
+    println(measure?.phase === "Instant" ? "PASS measure is Instant" : "FAIL measure phase: " + measure?.phase);
+});
+</script>

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -26,6 +26,7 @@ enum class TestMode {
     Ref,
     Screenshot,
     Crash,
+    Marker,
 };
 
 enum class TestResult {

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -541,6 +541,8 @@ static ByteString test_mode_to_string(TestMode mode)
         return "Screenshot"sv;
     case TestMode::Crash:
         return "Crash"sv;
+    case TestMode::Marker:
+        return "Marker"sv;
     }
     VERIFY_NOT_REACHED();
 }
@@ -822,7 +824,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
                 });
             });
         };
-    } else if (test.mode == TestMode::Text) {
+    } else if (test.mode == TestMode::Text || test.mode == TestMode::Marker) {
         // Set up variant detection callback.
         view.on_test_variant_metadata = [&view, &context, test_index, on_test_complete](JsonValue metadata) {
             // Verify this IPC response is for the current test on this view (use index to avoid dangling pointer issues)
@@ -1243,6 +1245,7 @@ static void run_test(TestWebView& view, TestRunContext& context, size_t test_ind
         case TestMode::Crash:
         case TestMode::Text:
         case TestMode::Layout:
+        case TestMode::Marker:
             run_dump_test(view, context, test, *url);
             return;
         case TestMode::Ref:
@@ -1355,6 +1358,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
     TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Layout", app.test_root_path), "."sv, TestMode::Layout));
     TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Text", app.test_root_path), "."sv, TestMode::Text));
+    TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Marker", app.test_root_path), "."sv, TestMode::Marker));
     TRY(collect_ref_tests(app, tests, ByteString::formatted("{}/Ref", app.test_root_path), "."sv));
     TRY(collect_crash_tests(app, tests, ByteString::formatted("{}/Crash", app.test_root_path), "."sv));
     TRY(collect_screenshot_tests(app, tests, ByteString::formatted("{}/Screenshot", app.test_root_path), "."sv));


### PR DESCRIPTION
Add a marker collection system for profiler timeline events, inspired by Firefox's marker infrastructure. Markers are timestamped events emitted from engine code that let a profiler UI explain what happened:  layout, style, GC, script parsing, DOM events, timers, network, IPC, and media decode.                                                                                                                              
                                                                  
The public API is a small set of macros in LibCore/Markers.h that gate all argument evaluation behind a relaxed atomic bool check. When no collector is active, cost per call site is one atomic load and a predicted-not-taken branch, no clock reads, no allocations, no string formatting. Design rationale is documented in Documentation/Profiler/Markers.md.
                                                                                                                                                                                                                        
This PR includes 46 markers, they serve as test cases for the reset of the profiling subsystems (profiler, devtools integration, firefox profiling export) and are expected to change over time.

An example of what we are working towards can be seen on this link: https://share.firefox.dev/3Qim8IG

I expect 5-6 PRs before we can get there (marker, profiler, webcontent hookup, devtools, exporter), wip branch of all of the pieces integrated, can be found [here](https://github.com/jdahlin/ladybird/tree/profiler-v2).
                                                                                                                                                                                                                     