### PR TITLE
LibJS: Preserve outer parameter bindings for arrow arguments access

### DIFF
--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -447,7 +447,8 @@ impl ScopeCollector {
         let index = self.current.expect("close_scope with no current scope");
 
         if let Some(parent_index) = self.records[index].parent
-            && !self.records[index].has_function_parameters
+            && (self.records[index].scope_type != ScopeType::Function
+                || self.records[index].is_arrow_function)
         {
             let c = &self.records[index];
             let arguments = c.contains_access_to_arguments_object_in_non_strict_mode;

--- a/Tests/LibJS/Runtime/arguments-object.js
+++ b/Tests/LibJS/Runtime/arguments-object.js
@@ -13,3 +13,11 @@ test("basic arguments object", () => {
     expect(bar("hello", "friends", ":^)")).toBe("friends");
     expect(bar("hello")).toBe(undefined);
 });
+
+test("arrow function access keeps mapped parameter bindings in the environment", () => {
+    function outer(value) {
+        return (() => arguments[0])();
+    }
+
+    expect(outer(42)).toBe(42);
+});


### PR DESCRIPTION
When an arrow function accesses the enclosing function's arguments object,
LibJS must keep mapped parameter bindings in the outer environment.

This fixes a case where `(() => arguments[0])()` caused the outer
parameter binding to be optimized away, which then broke mapped
arguments access.

Added a regression test for that case.

Closes #8805 