### PR TITLE
LibWeb: Serialize external content surface clears

### DIFF
--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -209,7 +209,9 @@ public:
                     if (should_clear_back_store) {
                         // Embedded navigables leave their PaintConfig canvas unfilled, so double-buffered back stores
                         // must be cleared before repainting.
+                        m_backing_stores.back_store->lock_context();
                         m_backing_stores.back_store->canvas().clear(SK_ColorTRANSPARENT);
+                        m_backing_stores.back_store->unlock_context();
                     }
                     m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *m_backing_stores.back_store);
                     i32 rendered_bitmap_id = m_backing_stores.back_bitmap_id;


### PR DESCRIPTION
Lock the shared Skia backend context before clearing an external content back store.

Nested navigables render through PublishToExternalContent, and that clear ran outside the locking used by normal display list playback. This allowed multiple renderer threads to enter the same Ganesh context concurrently and trip Skia's SingleOwner checks during painting.

Fixes a crash when tracking packages on https://dhl.com/