### PR TITLE
UI/Qt: Reset zoom button shows three digit numbers.

### DIFF
--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -146,7 +146,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
     // This is a little awkward, but without this Qt shrinks the button to the size of the icon.
     // Note: toolButtonStyle="0" -> ToolButtonIconOnly.
-    m_toolbar->setStyleSheet("QToolButton[toolButtonStyle=\"0\"]{width:24px;height:24px}");
+    m_toolbar->setStyleSheet("QToolButton[toolButtonStyle=\"0\"]{padding:0px 4px 0px 4px;height:24px}");
 
     m_hamburger_button_action->setVisible(!Settings::the()->show_menubar());
 


### PR DESCRIPTION
## Issue

Zooming in or out makes a new "Reset zoom" button appear on the toolbar right between the Bookmark toggle and hamburger menu buttons. It shows the current zoom scale, `90%` or `110%`. The button was wide enough to show two digit percentages but not wide enough for three digit numbers, failing back to `...`.

## Root cause

All the other buttons on this toolbar are square icons of size `16px x 16px`. To make the bar look nicer and not have the icons too close to each other, a general style was applied to the toolbar to fix the size of those buttons to `24px x 24px`. The text `XX%` happens to fit in this box, but `XYZ%` does not. It probably depends on the system font too.

## Solution

I left the height of the toolbar buttons fixed to `24px` but replaced the width with a horizontal padding of `4px` on both sides. This has the same effect on the icon buttons and allows buttons with text to stretch to fit the text.