### PR TITLE
LibWeb: Prevent ReplacedBox from locking table row minimum height

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
+#include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/TableFormattingContext.h>
 
 namespace Web::Layout {
@@ -159,6 +160,27 @@ void TableFormattingContext::compute_cell_measures()
         auto max_content_width = calculate_max_content_width(cell.box);
         auto min_content_height = calculate_min_content_height(cell.box, max_content_width);
         auto max_content_height = calculate_max_content_height(cell.box, min_content_width);
+
+        // https://www.w3.org/TR/css-tables-3/#row-layout
+        // The minimum height of a row (without spanning-related height distribution) is defined as the
+        // height of an hypothetical linebox containing the cells originating in the row and where cells
+        // spanning multiple rows are considered having a height of 0px (but their correct baseline). In
+        // this hypothetical linebox, cell heights are considered auto, their width (including borders and
+        // paddings) is forced to the widths and inner spacings of the columns they span, but their other
+        // properties are conserved.
+        // For the purpose of calculating this height, descendants of table cells whose height depends on
+        // percentages of their parent cell' height (see section below) are considered to have an auto
+        // height if they have overflow set to visible, clip, or hidden or if they are replaced elements,
+        // and a 0px height if they have not.
+        // FIXME: For now we're only adjusting replaced elements, but we should probably actually compute
+        // the hypothetical line box here.
+        bool contains_replaced_element = false;
+        cell.box->for_each_in_subtree_of_type<Layout::ReplacedBox>([&](auto const&) {
+            contains_replaced_element = true;
+            return TraversalDecision::Break;
+        });
+        if (contains_replaced_element && computed_values.min_height().is_auto())
+            min_content_height = 0;
 
         // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
         auto min_height = computed_values.min_height().to_px(cell.box, containing_block_height);

--- a/Tests/LibWeb/Layout/expected/table-replaced-box-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/table-replaced-box-min-height.txt
@@ -1,0 +1,36 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 126 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 110 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 110 0+0+674] [0+0+0 110 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 110 0+0+0] [0+0+0 110 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [10,10] table-row-group [0+0+0 106 0+0+0] [0+0+0 106 0+0+0] children: not-inline
+            Box <tr> at [10,10] table-row [0+0+0 106 0+0+0] [0+0+0 106 0+0+0] children: not-inline
+              BlockContainer <td#test-data> at [11,11] table-cell [0+0+1 104 1+0+0] [0+0+1 104 1+0+0] [BFC] children: inline
+                frag 0 from ImageBox start: 0, length: 0, rect: [11,11 104x104] baseline: 104
+                ImageBox <img> at [11,11] [0+0+0 104 0+0+0] [0+0+0 104 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,118] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x110]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 110x110]
+        PaintableBox (Box<TABLE>) [8,8 110x110]
+          PaintableBox (Box<TBODY>) [10,10 106x106]
+            PaintableBox (Box<TR>) [10,10 106x106]
+              PaintableWithLines (BlockContainer<TD>#test-data) [10,10 106x106]
+                ImagePaintable (ImageBox<IMG>) [11,11 104x104]
+      PaintableWithLines (BlockContainer(anonymous)) [8,118 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x126] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table-replaced-box-min-height.html
+++ b/Tests/LibWeb/Layout/input/table-replaced-box-min-height.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Fixed Table Layout: Replaced Element Height</title>
+    <style>
+        table {
+            background-color: fuchsia;
+            table-layout: fixed;
+            width: 110px;
+        }
+        img {
+            width: 100%;
+        }
+    </style>
+</head>
+<body>
+    <table>
+        <td id="test-data"><img src="../../Assets/120.png"/></td>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
Fixes #8884 