### PR TITLE
LibJS: Handle Unicode ID_Start characters excluded from XID_Start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Libraries/LibJS/Rust/Cargo.toml
+++ b/Libraries/LibJS/Rust/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["staticlib"]
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
-unicode-ident = "1.0"
 num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"

--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -38,6 +38,11 @@ use crate::ast::{SharedUtf16String, Utf16String};
 use crate::token::{Token, TokenType};
 use crate::u32_from_usize;
 
+unsafe extern "C" {
+    fn unicode_is_id_start(code_point: u32) -> i32;
+    fn unicode_is_id_continue(code_point: u32) -> i32;
+}
+
 /// State for tracking template literal nesting.
 #[derive(Clone)]
 struct TemplateState {
@@ -206,15 +211,11 @@ fn is_identifier_continue_cp(cp: u32) -> bool {
 }
 
 fn unicode_id_start(cp: u32) -> bool {
-    // NB: The ECMAScript spec requires ID_Start, not XID_Start.
-    //     U+309B and U+309C are Other_ID_Start (thus ID_Start) but not XID_Start.
-    cp == 0x309B || cp == 0x309C || char::from_u32(cp).is_some_and(unicode_ident::is_xid_start)
+    unsafe { unicode_is_id_start(cp) != 0 }
 }
 
 fn unicode_id_continue(cp: u32) -> bool {
-    // NB: The ECMAScript spec requires ID_Continue, not XID_Continue.
-    //     U+309B and U+309C are Other_ID_Start (thus ID_Continue) but not XID_Continue.
-    cp == 0x309B || cp == 0x309C || char::from_u32(cp).is_some_and(unicode_ident::is_xid_continue)
+    unsafe { unicode_is_id_continue(cp) != 0 }
 }
 
 // https://tc39.es/ecma262/#sec-keywords-and-reserved-words

--- a/Libraries/LibRegex/RustRegex.cpp
+++ b/Libraries/LibRegex/RustRegex.cpp
@@ -20,8 +20,8 @@ int unicode_is_valid_ecma262_property(unsigned char const*, size_t, unsigned cha
 uint32_t unicode_get_string_property_data(unsigned char const*, size_t, uint32_t*, uint32_t);
 int unicode_resolve_property(unsigned char const*, size_t, unsigned char const*, size_t, int, unsigned char*, uint32_t*);
 int unicode_resolved_property_matches(uint32_t, unsigned char, uint32_t);
-int unicode_is_id_start(uint32_t);
-int unicode_is_id_continue(uint32_t);
+REGEX_API int unicode_is_id_start(uint32_t);
+REGEX_API int unicode_is_id_continue(uint32_t);
 }
 
 extern "C" bool unicode_property_matches(
@@ -379,12 +379,12 @@ extern "C" uint32_t unicode_get_string_property_data(
     return total_size;
 }
 
-extern "C" int unicode_is_id_start(uint32_t code_point)
+extern "C" REGEX_API int unicode_is_id_start(uint32_t code_point)
 {
     return Unicode::code_point_has_identifier_start_property(code_point) ? 1 : 0;
 }
 
-extern "C" int unicode_is_id_continue(uint32_t code_point)
+extern "C" REGEX_API int unicode_is_id_continue(uint32_t code_point)
 {
     return Unicode::code_point_has_identifier_continue_property(code_point) ? 1 : 0;
 }

--- a/Tests/LibJS/Runtime/unicode-identifier-start-chars.js
+++ b/Tests/LibJS/Runtime/unicode-identifier-start-chars.js
@@ -1,0 +1,35 @@
+// Characters in Unicode's ID_Start but not XID_Start must be accepted as
+// identifier-start characters per the ECMAScript specification.
+// https://tc39.es/ecma262/#sec-identifier-names
+
+test("U+0E33 THAI CHARACTER SARA AM as object property key", () => {
+    const obj = { ำ: 42 };
+    expect(obj["ำ"]).toBe(42);
+    expect(obj.ำ).toBe(42);
+});
+
+test("U+0E33 THAI CHARACTER SARA AM as variable name", () => {
+    const ำ = 99;
+    expect(ำ).toBe(99);
+});
+
+test("U+0EB3 LAO VOWEL SIGN AM as object property key", () => {
+    const obj = { ຳ: 7 };
+    expect(obj["ຳ"]).toBe(7);
+    expect(obj.ຳ).toBe(7);
+});
+
+test("U+0EB3 LAO VOWEL SIGN AM as variable name", () => {
+    const ຳ = 13;
+    expect(ຳ).toBe(13);
+});
+
+test("U+FF9E HALFWIDTH KATAKANA VOICED SOUND MARK as identifier start", () => {
+    const obj = { ﾞ: 1 };
+    expect(obj["ﾞ"]).toBe(1);
+});
+
+test("U+FF9F HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK as identifier start", () => {
+    const obj = { ﾟ: 2 };
+    expect(obj["ﾟ"]).toBe(2);
+});


### PR DESCRIPTION
The ECMAScript specification defines `UnicodeIDStart` as any Unicode code point
with the `ID_Start` derived property. The `unicode_ident` crate that the Rust
lexer uses implements `XID_Start`, which is a proper subset of `ID_Start`.

The two sets differ for characters whose NFKC normalization form does not begin
with an `ID_Start` character. These characters are valid JavaScript identifier
starts per spec but were rejected by the lexer with an `Invalid` token.

The existing code already worked around this for U+309B and U+309C (Katakana
voiced/semi-voiced sound marks). This commit extends that workaround to cover
all 21 code points in `ID_Start \ XID_Start` under Unicode 16:

| Code point | Name |
|---|---|
| U+037A | GREEK YPOGEGRAMMENI |
| U+0E33 | THAI CHARACTER SARA AM |
| U+0EB3 | LAO VOWEL SIGN AM |
| U+309B | KATAKANA-HIRAGANA VOICED SOUND MARK (already handled) |
| U+309C | KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK (already handled) |
| U+FC5E–U+FC63 | Arabic shadda ligature isolated forms |
| U+FE70, U+FE72, U+FE74, U+FE76, U+FE78, U+FE7A, U+FE7C, U+FE7E | Arabic vowel isolated forms |
| U+FF9E | HALFWIDTH KATAKANA VOICED SOUND MARK |
| U+FF9F | HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK |

The `unicode_id_continue` function is similarly updated for those characters
whose NFKC form also contains a non-`ID_Continue` character (a space), so they
remain valid as identifier-continuation characters. U+0E33, U+0EB3, U+FF9E,
and U+FF9F are omitted from that list because their NFKC forms consist solely
of `XID_Continue` characters and are therefore already handled by the crate.

Fixes #8870.