### PR TITLE
Tests/AK: Check json_array_ensure_capacity precondition

### DIFF
--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -536,8 +536,12 @@ TEST_CASE(json_array_ensure_capacity)
 {
     auto array = setup_json_array();
     size_t new_capacity { 16 };
+    EXPECT(array.values().capacity() < new_capacity);
     array.ensure_capacity(new_capacity);
-    EXPECT_EQ(array.values().capacity(), new_capacity);
+    // The allocator may round up the capacity to a larger value that is
+    // efficient for its internal bookkeeping (e.g. mimalloc's mi_good_size),
+    // so we only require that the resulting capacity is at least new_capacity.
+    EXPECT(array.values().capacity() >= new_capacity);
 }
 
 TEST_CASE(json_array_for_each)


### PR DESCRIPTION
The `ensure_capacity` contract only guarantees a minimum capacity, so the
postcondition remains an at-least check. Add the precondition requested in
review so the test also verifies that ensure_capacity grows the array.

Fixes #8876.