### PR TITLE
LibWeb: Load @font-face rules inside CSS grouping rules such as @layer

### DIFF
--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -714,11 +714,16 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
 
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 {
-    // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
-    for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
+    sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& const_rule) {
+        // for_each_effective_rule delivers const references; the underlying objects are
+        // non-const, so we cast here to call the mutating methods below.
+        auto& rule = const_cast<CSSRule&>(const_rule);
+
+        // FIXME: Revisit this for conditional group rules that become effective
+        // after the initial stylesheet traversal, such as @media on resize.
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
             if (!font_face_rule->is_valid())
-                continue;
+                return;
 
             auto font_face = FontFace::create_css_connected(document().realm(), *font_face_rule);
             document().fonts()->add_css_connected_font(font_face);
@@ -731,26 +736,29 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
             font_face->load();
         }
 
-        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
+        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
             font_feature_values_rule->clear_caches();
-    }
+    });
 }
 
 void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
 {
-    // FIXME: Handle @font-face and @font-feature-values within grouping rules (@media, @supports, etc)
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
-    for (auto const& rule : sheet.rules()) {
-        if (auto* font_face_rule = as_if<CSSFontFaceRule>(*rule)) {
+    sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& const_rule) {
+        // for_each_effective_rule delivers const references; the underlying objects are
+        // non-const, so we cast here to call the mutating methods below.
+        auto& rule = const_cast<CSSRule&>(const_rule);
+
+        if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
             if (auto font_face = font_face_rule->css_connected_font_face())
                 unregister_font_face(*font_face);
             font_face_rule->disconnect_font_face();
         }
 
-        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))
+        if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))
             font_feature_values_rule->clear_caches();
-    }
+    });
 }
 
 }

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -715,8 +715,6 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
 {
     sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& const_rule) {
-        // for_each_effective_rule delivers const references; the underlying objects are
-        // non-const, so we cast here to call the mutating methods below.
         auto& rule = const_cast<CSSRule&>(const_rule);
 
         // FIXME: Revisit this for conditional group rules that become effective
@@ -746,10 +744,11 @@ void FontComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
     // https://drafts.csswg.org/css-font-loading/#font-face-css-connection
     // If a @font-face rule is removed from the document, its connected FontFace object is no longer CSS-connected.
     sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& const_rule) {
-        // for_each_effective_rule delivers const references; the underlying objects are
-        // non-const, so we cast here to call the mutating methods below.
         auto& rule = const_cast<CSSRule&>(const_rule);
 
+        // FIXME: This only visits currently-effective conditional group rules. If a
+        // conditional group rule stops matching, we still need to disconnect any
+        // @font-face rules that were loaded while it matched.
         if (auto* font_face_rule = as_if<CSSFontFaceRule>(rule)) {
             if (auto font_face = font_face_rule->css_connected_font_face())
                 unregister_font_face(*font_face);

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,6 +20,7 @@ Text/input/navigation/history-replace-push-then-back.html
 
 ; CSS @font-face url() requires HTTP(s) scheme.
 Text/input/selection-rect-consistency-with-kerning.html
+Text/input/css/font-face-in-layer.html
 
 ; Form submission to /common/blank.html requires HTTP(s) scheme.
 Text/input/wpt-import/custom-elements/form-associated/form-disabled-callback.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,7 +20,6 @@ Text/input/navigation/history-replace-push-then-back.html
 
 ; CSS @font-face url() requires HTTP(s) scheme.
 Text/input/selection-rect-consistency-with-kerning.html
-Text/input/css/font-face-in-layer.html
 
 ; Form submission to /common/blank.html requires HTTP(s) scheme.
 Text/input/wpt-import/custom-elements/form-associated/form-disabled-callback.html

--- a/Tests/LibWeb/Text/expected/css/font-face-in-layer.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-in-layer.txt
@@ -1,0 +1,5 @@
+layered font connected: true
+layered font loaded: true
+layered font check: true
+layered font disconnected: true
+layered font check after removal: true

--- a/Tests/LibWeb/Text/input/css/font-face-in-layer.html
+++ b/Tests/LibWeb/Text/input/css/font-face-in-layer.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style id="font-style">
+    @layer {
+        @font-face {
+            font-family: LayeredHashSans;
+            src: url("../../../Assets/HashSans.woff");
+        }
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const fontFamily = "LayeredHashSans";
+        const fontSize = "32px";
+        const fontQuery = `${fontSize} ${fontFamily}`;
+        const hasLayeredFontFace = () =>
+            [...document.fonts].some(face => face.family === fontFamily);
+
+        await document.fonts.ready;
+
+        println(`layered font connected: ${hasLayeredFontFace()}`);
+
+        const loadedFaces = await document.fonts.load(fontQuery);
+        println(`layered font loaded: ${loadedFaces.length === 1}`);
+        println(`layered font check: ${document.fonts.check(fontQuery)}`);
+
+        document.getElementById("font-style").remove();
+        println(`layered font disconnected: ${!hasLayeredFontFace()}`);
+        const fontUnloaded = !document.fonts.check(fontQuery);
+        println(`layered font check after removal: ${fontUnloaded}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
The font-loading code in `FontComputer` previously iterated only the
top-level rules of a stylesheet, so `@font-face` declarations nested
inside grouping rules (`@layer`, `@media`, `@supports`, ...) were
silently ignored. This caused fonts declared inside `@layer` blocks to
never be loaded, breaking sites that rely on this pattern.

The fix replaces the flat `sheet.rules()` loop with
`sheet.for_each_effective_rule()`, which already has the correct
recursive semantics and is used for `@keyframes` and `@counter-style`
collection. It respects `@media` / `@supports` conditions (fonts inside
non-matching conditions are not loaded) and descends into `@layer`
blocks (which are unconditional).

The same change is applied to `unload_fonts_from_sheet()` for
symmetry: fonts that were loaded from nested rules are now also
properly disconnected when the stylesheet is removed from the document.

Resolves the FIXME comments that previously marked both functions.

Fixes #8685.