### PR TITLE
LibWeb: Prevent crash when Gfx::Bitmap rejects oversized ImageData dimensions

### DIFF
--- a/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Libraries/LibWeb/HTML/ImageData.cpp
@@ -19,9 +19,16 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(ImageData);
 
-[[nodiscard]] static auto create_bitmap_backed_by_uint8_clamped_array(u32 const width, u32 const height, JS::Uint8ClampedArray& data)
+[[nodiscard]] static ErrorOr<NonnullRefPtr<Gfx::Bitmap>> create_bitmap_backed_by_uint8_clamped_array(u32 const width, u32 const height, JS::Uint8ClampedArray& data)
 {
-    return Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::AlphaType::Unpremultiplied, Gfx::IntSize(width, height), width * sizeof(u32), data.data().data());
+    // Gfx::Bitmap::create_wrapper rejects dimensions that would overflow its internal
+    // size calculations (e.g. width >= INT16_MAX). Map any such failure to ENOMEM so
+    // TRY_OR_THROW_OOM can propagate it as a JavaScript out-of-memory error without
+    // triggering an internal VERIFY abort.
+    auto result = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::AlphaType::Unpremultiplied, Gfx::IntSize(width, height), width * sizeof(u32), data.data().data());
+    if (result.is_error())
+        return Error::from_errno(ENOMEM);
+    return result.release_value();
 }
 
 GC::Ref<ImageData> ImageData::create(JS::Realm& realm)

--- a/Tests/LibWeb/Crash/HTML/imagedata-oversized-getImageData.html
+++ b/Tests/LibWeb/Crash/HTML/imagedata-oversized-getImageData.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<!-- Regression test for https://github.com/LadybirdBrowser/ladybird/issues/8496 -->
+<!-- Calling getImageData() with a very large region must not crash with a VERIFY -->
+<!-- failure when Gfx::Bitmap rejects the dimensions. -->
+<script>
+var c = document.createElement("canvas");
+c.width = 100;
+c.height = 100;
+var ctx = c.getContext("2d");
+try {
+    ctx.getImageData(0, 0, 32767, 32767);
+} catch (e) {
+    // Any thrown exception (RangeError, InternalError, ...) is acceptable.
+}
+</script>


### PR DESCRIPTION
`Gfx::Bitmap::create_wrapper` rejects image dimensions that are >= `INT16_MAX`
(32767) with a string-based `Error`, not `ENOMEM`. The
`create_bitmap_backed_by_uint8_clamped_array` helper returned this error
directly to the `TRY_OR_THROW_OOM` macro, which asserts that any failure
must carry `ENOMEM`. When that assertion fails the process aborts.

The crash is reproducible with:
```js
var ctx = document.createElement('canvas').getContext('2d');
ctx.getImageData(0, 0, 32767, 32767);
```

Map all failures from `create_bitmap_backed_by_uint8_clamped_array` to
`ENOMEM`. The `TRY_OR_THROW_OOM` macro then converts the error into a
JavaScript `InternalError` ("out of memory") without crashing, which is a
reasonable outcome for an allocation/size-limit failure.

A crash regression test is included.

Fixes #8496.