### PR TITLE
LibWeb: Avoid O(n²) behavior in NamedNodeMap::supported_property_names

### DIFF
--- a/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashTable.h>
 #include <LibWeb/Bindings/NamedNodeMapPrototype.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/Document.h>
@@ -55,9 +56,14 @@ Vector<FlyString> NamedNodeMap::supported_property_names() const
     Vector<FlyString> names;
     names.ensure_capacity(m_attributes.size());
 
+    // Use a hash set to track names seen so far, avoiding the O(n²) cost of
+    // contains_slow() on the output vector for elements with many attributes.
+    HashTable<FlyString> seen;
+    seen.ensure_capacity(m_attributes.size());
+
     for (auto const& attribute : m_attributes) {
         auto const attribute_name = attribute->name();
-        if (!names.contains_slow(attribute_name))
+        if (seen.set(attribute_name) == HashSetResult::InsertedNewEntry)
             names.append(attribute_name.to_string());
     }
 


### PR DESCRIPTION
`NamedNodeMap::supported_property_names` deduplicates attribute names while
preserving order. The previous loop called `Vector::contains_slow()` on
`names` at every iteration, which is O(n) in the size of `names`. With n
attributes the deduplication step is therefore O(n²).

Replace the linear scan with a `HashTable<FlyString>` that tracks which
names have already been appended. `HashTable::set()` returns
`HashSetResult::InsertedNewEntry` for first-seen names and
`HashSetResult::KeptExistingEntry` for duplicates, so a single O(1)
amortized call replaces the previous O(n) scan.

The hash table is pre-allocated to the same capacity as the attribute
list to avoid reallocation in the typical case where all attribute names
are unique.

Fixes #7980.