### PR TITLE
Tests: Make Navigation-object-properties test deterministic

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
@@ -1,5 +1,5 @@
 entries[length - 1] is current entry: true
 currentEntry is a [object NavigationHistoryEntry]
 transition is null: true
-canGoBack: true
+canGoBack: false
 canGoForward: false

--- a/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
@@ -1,8 +1,19 @@
 <!DOCTYPE html>
+<!-- Run the assertions in an iframe so that the Navigation API object always
+     reflects a freshly-created navigable, independent of any history entries
+     accumulated by earlier tests in the same WebContent process. -->
+<iframe id="testIframe"></iframe>
 <script src="../include.js"></script>
 <script>
-    test(() => {
-        let n = window.navigation;
+    asyncTest(async done => {
+        const iframe = document.getElementById("testIframe");
+
+        await new Promise(resolve => {
+            iframe.addEventListener("load", resolve, { once: true });
+            iframe.src = "about:blank";
+        });
+
+        let n = iframe.contentWindow.navigation;
 
         let len = n.entries().length;
 
@@ -11,6 +22,8 @@
 
         println(`transition is null: ${n.transition == null}`);
         println(`canGoBack: ${n.canGoBack}`);
-        println(`canGoForward: ${n.canGoForward}`);       
+        println(`canGoForward: ${n.canGoForward}`);
+
+        done();
     });
 </script>


### PR DESCRIPTION
The test previously read `window.navigation.canGoBack` directly. Since
multiple tests share the same WebContent process, canGoBack reflected
how many tests had been run before this one: it was `false` when run first,
but `true` when run after any test that generated a navigation entry.

This made the expected output fragile. The file was checked in with
`canGoBack: true` (the value observed in CI, where many tests precede
this one), but running the test in isolation locally would produce a
different result.

As suggested in the linked issue, move the assertions into an iframe.
Each iframe starts with its own fresh Navigation API instance and an
empty history, so `canGoBack` and `canGoForward` are always `false`
regardless of what ran before.

Update the expected output accordingly.

Fixes #7931.