### PR TITLE
LibWeb: Allow non-solid borders to share corners with adjacent borders

### DIFF
--- a/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -261,6 +261,89 @@ void paint_border(DisplayListRecorder& painter, BorderEdge edge, DevicePixelRect
             painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
             return;
         }
+
+        // FIXME: Border-radius is not yet handled here; falls through to solid path-based rendering below.
+        bool has_no_radius = radius.horizontal_radius == 0 && radius.vertical_radius == 0
+            && opposite_radius.horizontal_radius == 0 && opposite_radius.vertical_radius == 0;
+        if (has_no_radius) {
+            auto fill_corner_triangle = [&](DevicePixelPoint outer_corner, DevicePixelPoint outer_cut, DevicePixelPoint inner_cut) {
+                Gfx::Path corner_path;
+                corner_path.move_to(Gfx::FloatPoint(outer_corner.to_type<int>()));
+                corner_path.line_to(Gfx::FloatPoint(outer_cut.to_type<int>()));
+                corner_path.line_to(Gfx::FloatPoint(inner_cut.to_type<int>()));
+                corner_path.close();
+                painter.fill_path({ .path = corner_path, .paint_style_or_color = color, .winding_rule = Gfx::WindingRule::Nonzero });
+            };
+
+            DevicePixels half_width = border_data.width / 2;
+            switch (edge) {
+            case BorderEdge::Top: {
+                auto left_width = borders_data.left.width;
+                auto right_width = borders_data.right.width;
+                fill_corner_triangle(rect.top_left(),
+                    rect.top_left().translated(left_width, 0),
+                    rect.bottom_left().translated(left_width, 0));
+                fill_corner_triangle(rect.top_right(),
+                    rect.top_right().translated(-right_width, 0),
+                    rect.bottom_right().translated(-right_width, 0));
+                if (rect.width() > left_width + right_width) {
+                    DevicePixelPoint p1(rect.left() + left_width + half_width, rect.top() + half_width);
+                    DevicePixelPoint p2(rect.right() - 1 - right_width - half_width, rect.top() + half_width);
+                    painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
+                }
+                break;
+            }
+            case BorderEdge::Right: {
+                auto top_width = borders_data.top.width;
+                auto bottom_width = borders_data.bottom.width;
+                fill_corner_triangle(rect.top_right(),
+                    rect.top_right().translated(0, top_width),
+                    rect.top_left().translated(0, top_width));
+                fill_corner_triangle(rect.bottom_right(),
+                    rect.bottom_right().translated(0, -bottom_width),
+                    rect.bottom_left().translated(0, -bottom_width));
+                if (rect.height() > top_width + bottom_width) {
+                    DevicePixelPoint p1(rect.right() - 1 - half_width, rect.top() + top_width + half_width);
+                    DevicePixelPoint p2(rect.right() - 1 - half_width, rect.bottom() - 1 - bottom_width - half_width);
+                    painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
+                }
+                break;
+            }
+            case BorderEdge::Bottom: {
+                auto left_width = borders_data.left.width;
+                auto right_width = borders_data.right.width;
+                fill_corner_triangle(rect.bottom_left(),
+                    rect.bottom_left().translated(left_width, 0),
+                    rect.top_left().translated(left_width, 0));
+                fill_corner_triangle(rect.bottom_right(),
+                    rect.bottom_right().translated(-right_width, 0),
+                    rect.top_right().translated(-right_width, 0));
+                if (rect.width() > left_width + right_width) {
+                    DevicePixelPoint p1(rect.left() + left_width + half_width, rect.bottom() - 1 - half_width);
+                    DevicePixelPoint p2(rect.right() - 1 - right_width - half_width, rect.bottom() - 1 - half_width);
+                    painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
+                }
+                break;
+            }
+            case BorderEdge::Left: {
+                auto top_width = borders_data.top.width;
+                auto bottom_width = borders_data.bottom.width;
+                fill_corner_triangle(rect.top_left(),
+                    rect.top_left().translated(0, top_width),
+                    rect.top_right().translated(0, top_width));
+                fill_corner_triangle(rect.bottom_left(),
+                    rect.bottom_left().translated(0, -bottom_width),
+                    rect.bottom_right().translated(0, -bottom_width));
+                if (rect.height() > top_width + bottom_width) {
+                    DevicePixelPoint p1(rect.left() + half_width, rect.top() + top_width + half_width);
+                    DevicePixelPoint p2(rect.left() + half_width, rect.bottom() - 1 - bottom_width - half_width);
+                    painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
+                }
+                break;
+            }
+            }
+            return;
+        }
     }
 
     auto draw_border = [&](Vector<Gfx::FloatPoint> const& points, bool joined_corner_has_inner_corner, bool opposite_joined_corner_has_inner_corner, Gfx::FloatSize joined_inner_corner_offset, Gfx::FloatSize opposite_joined_inner_corner_offset, bool ready_to_draw) {

--- a/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -221,31 +221,46 @@ void paint_border(DisplayListRecorder& painter, BorderEdge edge, DevicePixelRect
     };
 
     if (gfx_line_style != Gfx::LineStyle::Solid) {
-        auto [p1, p2] = points_for_edge(edge, rect);
+        auto adjacent_differs = [&](BorderEdge adjacent_edge, DevicePixels adjacent_width) {
+            return adjacent_width > 0 && border_color(adjacent_edge, borders_data) != color;
+        };
+        bool needs_corner_sharing = false;
         switch (edge) {
         case BorderEdge::Top:
-            p1.translate_by(border_data.width / 2, border_data.width / 2);
-            p2.translate_by(-border_data.width / 2, border_data.width / 2);
+        case BorderEdge::Bottom:
+            needs_corner_sharing = adjacent_differs(BorderEdge::Left, borders_data.left.width)
+                || adjacent_differs(BorderEdge::Right, borders_data.right.width);
             break;
         case BorderEdge::Right:
-            p1.translate_by(-border_data.width / 2, border_data.width / 2);
-            p2.translate_by(-border_data.width / 2, -border_data.width / 2);
-            break;
-        case BorderEdge::Bottom:
-            p1.translate_by(border_data.width / 2, -border_data.width / 2);
-            p2.translate_by(-border_data.width / 2, -border_data.width / 2);
-            break;
         case BorderEdge::Left:
-            p1.translate_by(border_data.width / 2, border_data.width / 2);
-            p2.translate_by(border_data.width / 2, -border_data.width / 2);
+            needs_corner_sharing = adjacent_differs(BorderEdge::Top, borders_data.top.width)
+                || adjacent_differs(BorderEdge::Bottom, borders_data.bottom.width);
             break;
         }
-        if (border_style == CSS::LineStyle::Dotted) {
+
+        if (!needs_corner_sharing) {
+            auto [p1, p2] = points_for_edge(edge, rect);
+            switch (edge) {
+            case BorderEdge::Top:
+                p1.translate_by(border_data.width / 2, border_data.width / 2);
+                p2.translate_by(-border_data.width / 2, border_data.width / 2);
+                break;
+            case BorderEdge::Right:
+                p1.translate_by(-border_data.width / 2, border_data.width / 2);
+                p2.translate_by(-border_data.width / 2, -border_data.width / 2);
+                break;
+            case BorderEdge::Bottom:
+                p1.translate_by(border_data.width / 2, -border_data.width / 2);
+                p2.translate_by(-border_data.width / 2, -border_data.width / 2);
+                break;
+            case BorderEdge::Left:
+                p1.translate_by(border_data.width / 2, border_data.width / 2);
+                p2.translate_by(border_data.width / 2, -border_data.width / 2);
+                break;
+            }
             painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
             return;
         }
-        painter.draw_line(p1.to_type<int>(), p2.to_type<int>(), color, border_data.width.value(), gfx_line_style);
-        return;
     }
 
     auto draw_border = [&](Vector<Gfx::FloatPoint> const& points, bool joined_corner_has_inner_corner, bool opposite_joined_corner_has_inner_corner, Gfx::FloatSize joined_inner_corner_offset, Gfx::FloatSize opposite_joined_inner_corner_offset, bool ready_to_draw) {

--- a/Tests/LibWeb/Ref/expected/css/borders/dashed-corner-sharing-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/borders/dashed-corner-sharing-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+  div {
+    width: 0;
+    height: 0;
+    border-top: 40px solid red;
+    border-left: 40px solid transparent;
+    border-right: 40px solid transparent;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/css/borders/dashed-corner-sharing.html
+++ b/Tests/LibWeb/Ref/input/css/borders/dashed-corner-sharing.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/borders/dashed-corner-sharing-ref.html" />
+<style>
+  div {
+    width: 0;
+    height: 0;
+    border-top: 40px dashed red;
+    border-left: 40px solid transparent;
+    border-right: 40px solid transparent;
+  }
+</style>
+<div></div>


### PR DESCRIPTION
This change resolves issue #8740.

Previously, only solid borders could use path-based corner-sharing
geometry. Dashed and dotted borders would claim the entire corner
when adjacent to transparent borders (e.g. the common CSS triangle/
caret trick using `border-top: 4px dashed` with transparent left/right
borders).

Now, non-solid borders fall through to the corner-sharing path when
adjacent borders have non-zero width, producing the same triangle
shape as solid borders.