### PR TITLE
LibWeb: Insert newlines between block-level elements when copying text

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -48,6 +48,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/Layout/BreakNode.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
@@ -2977,8 +2978,21 @@ static String visible_text_in_range(DOM::Range const& range)
         builder.append(static_cast<DOM::Text const&>(*range.start_container()).data().substring_view(range.start_offset()));
 
     range.for_each_contained([&](GC::Ref<DOM::Node> node) {
-        if (is<DOM::Text>(*node) && node->layout_node())
+        if (is<DOM::Text>(*node) && node->layout_node()) {
             builder.append(static_cast<DOM::Text const&>(*node).data());
+        } else if (auto const* layout_node = node->layout_node()) {
+            // Block-level elements (div, p, h1–h6, etc.) and <br> elements
+            // each produce a newline in the plain-text clipboard representation.
+            // We only insert a newline if there is already some text in the
+            // buffer (to avoid a leading blank line) and if the last character
+            // is not already a newline (to avoid consecutive blank lines when
+            // block elements are nested).
+            if ((layout_node->is_block_container() || layout_node->is_break_node())
+                && !builder.is_empty()
+                && !builder.string_view().ends_with('\n')) {
+                builder.append('\n');
+            }
+        }
         return IterationDecision::Continue;
     });
 


### PR DESCRIPTION
When copying text that spans multiple block-level elements (e.g. adjacent
`<div>` nodes), the clipboard received all the text concatenated without
any newlines between the elements.

The root cause was in `visible_text_in_range()`, which iterated the
selection range and only appended data from `Text` nodes. Element nodes
(including block containers and `<br>`) were silently skipped, so no
line separators were ever inserted.

**Fix:** extend the iteration callback to also check element nodes: if
the node's layout representation is a block container (`<div>`, `<p>`,
`<h1>`–`<h6>`, etc.) or a `BreakNode` (`<br>`), and the output buffer
is non-empty, a newline is inserted. The non-empty guard prevents a
spurious leading newline at the start of the copied text.

This matches the plain-text clipboard serialisation behaviour of
Chrome and Firefox for the common case.

Fixes #7315.