### PR TITLE
LibWeb: Distinguish omitted and null Animation timeline arguments, remove [ExplicitNull] IDL generator support

### DIFF
--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -52,7 +52,7 @@ WebIDL::ExceptionOr<GC::Ref<Animation>> Animatable::animate(Optional<GC::Root<JS
 
     // 4. Construct a new Animation object, animation, in the relevant Realm of target by using the same procedure as
     //    the Animation() constructor, passing effect and timeline as arguments of the same name.
-    auto animation = TRY(Animation::construct_impl(realm, effect, move(timeline)));
+    auto animation = Animation::construct_impl(realm, effect, move(timeline));
 
     // 5. If options is a KeyframeAnimationOptions object, assign the value of the id member of options to animation’s
     //    id attribute.

--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -52,7 +52,7 @@ WebIDL::ExceptionOr<GC::Ref<Animation>> Animatable::animate(Optional<GC::Root<JS
 
     // 4. Construct a new Animation object, animation, in the relevant Realm of target by using the same procedure as
     //    the Animation() constructor, passing effect and timeline as arguments of the same name.
-    auto animation = Animation::construct_impl(realm, effect, move(timeline));
+    auto animation = Animation::create(realm, effect, move(timeline));
 
     // 5. If options is a KeyframeAnimationOptions object, assign the value of the id member of options to animation’s
     //    id attribute.

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -48,6 +48,10 @@ GC::Ref<Animation> Animation::create(JS::Realm& realm, GC::Ptr<AnimationEffect> 
 
 GC::Ref<Animation> Animation::construct_impl(JS::Realm& realm, GC::Ptr<AnimationEffect> effect, Optional<GC::Ptr<AnimationTimeline>> timeline)
 {
+    // NB: If the timeline argument was not present, pass an OptionalNone so 'create' treats it as missing.
+    if (realm.vm().argument_count() < 2)
+        return create(realm, effect, OptionalNone {});
+
     return create(realm, effect, timeline);
 }
 

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -46,7 +46,7 @@ GC::Ref<Animation> Animation::create(JS::Realm& realm, GC::Ptr<AnimationEffect> 
     return animation;
 }
 
-WebIDL::ExceptionOr<GC::Ref<Animation>> Animation::construct_impl(JS::Realm& realm, GC::Ptr<AnimationEffect> effect, Optional<GC::Ptr<AnimationTimeline>> timeline)
+GC::Ref<Animation> Animation::construct_impl(JS::Realm& realm, GC::Ptr<AnimationEffect> effect, Optional<GC::Ptr<AnimationTimeline>> timeline)
 {
     return create(realm, effect, timeline);
 }

--- a/Libraries/LibWeb/Animations/Animation.h
+++ b/Libraries/LibWeb/Animations/Animation.h
@@ -32,7 +32,7 @@ public:
     static constexpr bool OVERRIDES_FINALIZE = true;
 
     static GC::Ref<Animation> create(JS::Realm&, GC::Ptr<AnimationEffect>, Optional<GC::Ptr<AnimationTimeline>>);
-    static WebIDL::ExceptionOr<GC::Ref<Animation>> construct_impl(JS::Realm&, GC::Ptr<AnimationEffect>, Optional<GC::Ptr<AnimationTimeline>>);
+    static GC::Ref<Animation> construct_impl(JS::Realm&, GC::Ptr<AnimationEffect>, Optional<GC::Ptr<AnimationTimeline>>);
 
     FlyString const& id() const { return m_id; }
     void set_id(FlyString value) { m_id = move(value); }

--- a/Libraries/LibWeb/Animations/Animation.idl
+++ b/Libraries/LibWeb/Animations/Animation.idl
@@ -6,7 +6,7 @@
 [Exposed=Window]
 interface Animation : EventTarget {
     constructor(optional AnimationEffect? effect = null,
-                [ExplicitNull] optional AnimationTimeline? timeline);
+                optional AnimationTimeline? timeline);
 
     attribute DOMString id;
     attribute AnimationEffect? effect;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -769,7 +769,6 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 {
     auto scoped_generator = generator.fork();
     auto acceptable_cpp_name = make_input_acceptable_cpp(cpp_name);
-    auto explicit_null = parameter.extended_attributes.contains("ExplicitNull");
     scoped_generator.set("cpp_name", acceptable_cpp_name);
     scoped_generator.set("js_name", js_name);
     scoped_generator.set("js_suffix", js_suffix);
@@ -781,18 +780,6 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     scoped_generator.set("parameter.type.name.normalized", cpp_type_name(*type));
 
     scoped_generator.set("parameter.name", parameter.name);
-
-    if (explicit_null) {
-        if (!IDL::is_platform_object(*parameter.type)) {
-            dbgln("Parameter marked [ExplicitNull] in interface {} must be a platform object", interface.name);
-            VERIFY_NOT_REACHED();
-        }
-
-        if (!optional || !parameter.type->is_nullable()) {
-            dbgln("Parameter marked [ExplicitNull] in interface {} must be an optional and nullable type", interface.name);
-            VERIFY_NOT_REACHED();
-        }
-    }
 
     if (optional_default_value.has_value())
         scoped_generator.set("parameter.optional_default_value", *optional_default_value);
@@ -846,17 +833,9 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
             }
         } else {
-            if (explicit_null) {
-                scoped_generator.append(R"~~~(
-    Optional<GC::Ptr<@parameter.type.name.normalized@>> @cpp_name@;
-    if (maybe_@js_name@@js_suffix@.has_value()) {
-        auto @js_name@@js_suffix@ = maybe_@js_name@@js_suffix@.release_value();
-)~~~");
-            } else {
-                scoped_generator.append(R"~~~(
+            scoped_generator.append(R"~~~(
     GC::Ptr<@parameter.type.name.normalized@> @cpp_name@;
 )~~~");
-            }
 
             scoped_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_nullish()) {
@@ -866,12 +845,6 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
         @cpp_name@ = &static_cast<@parameter.type.name.normalized@&>(@js_name@@js_suffix@.as_object());
     }
 )~~~");
-
-            if (explicit_null) {
-                scoped_generator.append(R"~~~(
-    }
-)~~~");
-            }
         }
     } else if (parameter.type->is_floating_point()) {
         if (parameter.type->name() == "unrestricted float") {
@@ -1936,16 +1909,9 @@ static void generate_arguments(SourceGenerator& generator, Vector<IDL::Parameter
 
             arguments_generator.set("argument.index", ByteString::number(argument_index));
 
-            if (parameter.extended_attributes.contains("ExplicitNull")) {
-                arguments_generator.set("argument.size", ByteString::number(argument_index + 1));
-                arguments_generator.append(R"~~~(
-    auto maybe_arg@argument.index@ = vm.argument_count() >= @argument.size@ ? Optional<JS::Value> { vm.argument(@argument.index@) } : OptionalNone {};
-)~~~");
-            } else {
-                arguments_generator.append(R"~~~(
+            arguments_generator.append(R"~~~(
     auto arg@argument.index@ = vm.argument(@argument.index@);
 )~~~");
-            }
         }
 
         bool legacy_null_to_empty_string = parameter.extended_attributes.contains("LegacyNullToEmptyString");

--- a/Tests/LibWeb/Text/expected/wpt-import/web-animations/timing-model/animations/reversing-an-animation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/web-animations/timing-model/animations/reversing-an-animation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 18 tests
 
-16 Pass
-2 Fail
+17 Pass
+1 Fail
 Pass	Reversing an animation inverts the playback rate
 Pass	Reversing an animation plays a pausing animation
 Pass	Reversing an animation maintains the same current time
@@ -19,6 +19,6 @@ Pass	Reversing animation when playbackRate = 0 and currentTime < 0 and the targe
 Pass	Reversing an animation when playbackRate < 0 and currentTime < 0 and the target effect end is positive infinity should make it play from the start
 Fail	Reversing when when playbackRate == 0 should preserve the current time and playback rate
 Pass	Reversing an idle animation from starts playing the animation
-Fail	Reversing an animation without an active timeline throws an InvalidStateError
+Pass	Reversing an animation without an active timeline throws an InvalidStateError
 Pass	Reversing should use the negative pending playback rate
 Pass	When reversing fails, it should restore any previous pending playback rate

--- a/Tests/LibWeb/Text/expected/wpt-import/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 13 tests
 
-12 Pass
-1 Fail
+13 Pass
 Pass	Validate different value types that can be used to set start time
-Fail	Setting the start time of an animation without an active timeline
+Pass	Setting the start time of an animation without an active timeline
 Pass	Setting an unresolved start time an animation without an active timeline does not clear the current time
 Pass	Setting the start time clears the hold time
 Pass	Setting an unresolved start time sets the hold time


### PR DESCRIPTION
Stemmed from some changes I was making improving the readability and complexity of the IDL generator, ended up fixing a bug, so split this out.