### PR TITLE
RequestServer: Use correct request map for stale-while-revalidate cookie

### DIFF
--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -109,14 +109,14 @@ void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header
         warnln("Received headers for non-existent request {}", request_id);
 }
 
-void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, URL::URL url)
+void RequestClient::retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url)
 {
     String cookie;
 
     if (on_retrieve_http_cookie)
         cookie = on_retrieve_http_cookie(url);
 
-    async_retrieved_http_cookie(client_id, request_id, cookie);
+    async_retrieved_http_cookie(client_id, request_id, request_type, cookie);
 }
 
 void RequestClient::certificate_requested(u64 request_id)

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -53,7 +53,7 @@ private:
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
     virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>) override;
 
-    virtual void retrieve_http_cookie(int client_id, u64 request_id, URL::URL url) override;
+    virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url) override;
 
     virtual void certificate_requested(u64 request_id) override;
 

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -328,10 +328,22 @@ void ConnectionFromClient::ensure_connection(u64 request_id, URL::URL url, ::Req
     m_active_requests.set(request_id, move(request));
 }
 
-void ConnectionFromClient::retrieved_http_cookie(int client_id, u64 request_id, String cookie)
+void ConnectionFromClient::retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, String cookie)
 {
     if (auto connection = m_connections.get(client_id); connection.has_value()) {
-        if (auto request = (*connection)->m_active_requests.get(request_id); request.has_value())
+        auto request = [&]() {
+            switch (request_type) {
+            case RequestType::Fetch:
+                return (*connection)->m_active_requests.get(request_id);
+            case RequestType::BackgroundRevalidation:
+                return (*connection)->m_active_revalidation_requests.get(request_id);
+            case RequestType::Connect:
+                break;
+            }
+            VERIFY_NOT_REACHED();
+        }();
+
+        if (request.has_value())
             (*request)->notify_retrieved_http_cookie({}, cookie);
     }
 }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -79,7 +79,7 @@ void ConnectionFromClient::request_complete(Badge<Request>, Request const& reque
 {
     Core::deferred_invoke([weak_self = make_weak_ptr<ConnectionFromClient>(), request_id = request.request_id(), type = request.type()] {
         if (auto self = weak_self.strong_ref()) {
-            if (type == Request::Type::BackgroundRevalidation)
+            if (type == RequestType::BackgroundRevalidation)
                 self->m_active_revalidation_requests.remove(request_id);
             else
                 self->m_active_requests.remove(request_id);

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -57,7 +57,7 @@ private:
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(u64 request_id, ByteString, ByteString) override;
     virtual void ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level) override;
 
-    virtual void retrieved_http_cookie(int client_id, u64 request_id, String cookie) override;
+    virtual void retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, String cookie) override;
 
     virtual void estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) override;
     virtual void remove_cache_entries_accessed_since(UnixDateTime since) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -463,7 +463,7 @@ void Request::handle_retrieve_cookie_state()
     }
 
     if (auto connection = ConnectionFromClient::primary_connection(); connection.has_value()) {
-        connection->async_retrieve_http_cookie(m_client.client_id(), m_request_id, m_url);
+        connection->async_retrieve_http_cookie(m_client.client_id(), m_request_id, m_type, m_url);
     } else {
         m_network_error = Requests::NetworkError::RequestServerDied;
         transition_to_state(State::Error);

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -40,7 +40,7 @@ NonnullOwnPtr<Request> Request::fetch(
     ByteString alt_svc_cache_path,
     Core::ProxyData proxy_data)
 {
-    auto request = adopt_own(*new Request { request_id, Type::Fetch, disk_cache, cache_mode, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data });
+    auto request = adopt_own(*new Request { request_id, RequestType::Fetch, disk_cache, cache_mode, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data });
     request->process();
 
     return request;
@@ -82,7 +82,7 @@ NonnullOwnPtr<Request> Request::revalidate(
     ByteString alt_svc_cache_path,
     Core::ProxyData proxy_data)
 {
-    auto request = adopt_own(*new Request { request_id, Type::BackgroundRevalidation, disk_cache, HTTP::CacheMode::Default, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data });
+    auto request = adopt_own(*new Request { request_id, RequestType::BackgroundRevalidation, disk_cache, HTTP::CacheMode::Default, client, curl_multi, resolver, move(url), move(method), move(request_headers), move(request_body), include_credentials, move(alt_svc_cache_path), proxy_data });
     request->process();
 
     return request;
@@ -90,7 +90,7 @@ NonnullOwnPtr<Request> Request::revalidate(
 
 Request::Request(
     u64 request_id,
-    Type type,
+    RequestType type,
     Optional<HTTP::DiskCache&> disk_cache,
     HTTP::CacheMode cache_mode,
     ConnectionFromClient& client,
@@ -128,7 +128,7 @@ Request::Request(
     Resolver& resolver,
     URL::URL url)
     : m_request_id(request_id)
-    , m_type(Type::Connect)
+    , m_type(RequestType::Connect)
     , m_client(client)
     , m_curl_multi_handle(curl_multi)
     , m_resolver(resolver)
@@ -182,11 +182,11 @@ void Request::notify_fetch_complete(Badge<ConnectionFromClient>, int result_code
 {
     if (is_revalidation_request()) {
         if (acquire_status_code() == 304) {
-            if (m_type == Type::BackgroundRevalidation && m_disk_cache->mode() == HTTP::DiskCache::Mode::Testing)
+            if (m_type == RequestType::BackgroundRevalidation && m_disk_cache->mode() == HTTP::DiskCache::Mode::Testing)
                 m_response_headers->set({ HTTP::TEST_CACHE_REVALIDATION_STATUS_HEADER, "fresh"sv });
 
             m_cache_entry_reader->revalidation_succeeded(m_response_headers);
-            transition_to_state(m_type == Type::Fetch ? State::ReadCache : State::Complete);
+            transition_to_state(m_type == RequestType::Fetch ? State::ReadCache : State::Complete);
             return;
         }
 
@@ -261,7 +261,7 @@ void Request::handle_initial_state()
     if (m_cache_mode == HTTP::CacheMode::NoStore) {
         m_cache_status = HTTP::CacheRequest::CacheStatus::NotCached;
     } else if (m_disk_cache.has_value()) {
-        auto open_mode = m_type == Type::BackgroundRevalidation
+        auto open_mode = m_type == RequestType::BackgroundRevalidation
             ? HTTP::DiskCache::OpenMode::Revalidate
             : HTTP::DiskCache::OpenMode::Read;
 
@@ -278,7 +278,7 @@ void Request::handle_initial_state()
                             transition_to_state(State::DNSLookup);
                         else
                             transition_to_state(State::ReadCache);
-                    } else if (m_type == Type::BackgroundRevalidation) {
+                    } else if (m_type == RequestType::BackgroundRevalidation) {
                         // If we were not able to open a cache entry reader for revalidation requests, there's no point
                         // in issuing a request over the network.
                         transition_to_state(State::Complete);
@@ -446,7 +446,7 @@ void Request::handle_dns_lookup_state()
                 dbgln("Request::handle_dns_lookup_state: DNS lookup failed for '{}'", host);
                 self.m_network_error = Requests::NetworkError::UnableToResolveHost;
                 self.transition_to_state(State::Error);
-            } else if (first_is_one_of(self.m_type, Type::Fetch, Type::BackgroundRevalidation)) {
+            } else if (first_is_one_of(self.m_type, RequestType::Fetch, RequestType::BackgroundRevalidation)) {
                 self.m_dns_result = move(dns_result);
                 self.transition_to_state(State::RetrieveCookie);
             } else {
@@ -617,7 +617,7 @@ void Request::handle_fetch_state()
 
 void Request::handle_complete_state()
 {
-    if (m_type == Type::Fetch) {
+    if (m_type == RequestType::Fetch) {
         VERIFY(m_curl_result_code.has_value());
 
         // HTTPS servers might terminate their connection without proper notice of shutdown - i.e. they do not send
@@ -650,7 +650,7 @@ void Request::handle_complete_state()
 
 void Request::handle_error_state()
 {
-    if (m_type == Type::Fetch) {
+    if (m_type == RequestType::Fetch) {
         // FIXME: Implement timing info for failed requests.
         m_client.async_request_finished(m_request_id, m_bytes_transferred_to_client, {}, m_network_error.value_or(Requests::NetworkError::Unknown));
     }
@@ -733,7 +733,7 @@ size_t Request::on_data_received(void* buffer, size_t size, size_t nmemb, void* 
 
 ErrorOr<void> Request::inform_client_request_started()
 {
-    if (m_type == Type::BackgroundRevalidation)
+    if (m_type == RequestType::BackgroundRevalidation)
         return {};
 
     auto request_pipe = RequestPipe::create();
@@ -767,7 +767,7 @@ void Request::transfer_headers_to_client_if_needed()
         }
     }
 
-    if (m_type == Type::BackgroundRevalidation)
+    if (m_type == RequestType::BackgroundRevalidation)
         return;
 
     if (m_disk_cache.has_value() && m_disk_cache->mode() == HTTP::DiskCache::Mode::Testing) {
@@ -805,7 +805,7 @@ ErrorOr<void> Request::write_queued_bytes_without_blocking()
             m_cache_entry_writer.clear();
     };
 
-    if (m_type == Type::BackgroundRevalidation) {
+    if (m_type == RequestType::BackgroundRevalidation) {
         write_bytes_to_disk_cache(bytes_to_send.size());
         MUST(m_response_buffer.discard(bytes_to_send.size()));
 
@@ -849,11 +849,11 @@ ErrorOr<void> Request::write_queued_bytes_without_blocking()
 bool Request::is_revalidation_request() const
 {
     switch (m_type) {
-    case Type::Fetch:
+    case RequestType::Fetch:
         return m_cache_entry_reader.has_value() && m_cache_entry_reader->revalidation_type() == HTTP::CacheEntryReader::RevalidationType::MustRevalidate;
-    case Type::Connect:
+    case RequestType::Connect:
         return false;
-    case Type::BackgroundRevalidation:
+    case RequestType::BackgroundRevalidation:
         return m_cache_entry_reader.has_value();
     }
     VERIFY_NOT_REACHED();
@@ -861,7 +861,7 @@ bool Request::is_revalidation_request() const
 
 ErrorOr<void> Request::revalidation_failed()
 {
-    if (m_type == Type::BackgroundRevalidation && m_disk_cache->mode() == HTTP::DiskCache::Mode::Testing)
+    if (m_type == RequestType::BackgroundRevalidation && m_disk_cache->mode() == HTTP::DiskCache::Mode::Testing)
         m_response_headers->set({ HTTP::TEST_CACHE_REVALIDATION_STATUS_HEADER, "expired"sv });
 
     m_cache_entry_reader->revalidation_failed();

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -23,6 +23,7 @@
 #include <RequestServer/CacheLevel.h>
 #include <RequestServer/Forward.h>
 #include <RequestServer/RequestPipe.h>
+#include <RequestServer/RequestType.h>
 
 struct curl_slist;
 
@@ -69,14 +70,8 @@ public:
 
     virtual ~Request() override;
 
-    enum class Type : u8 {
-        Fetch,
-        Connect,
-        BackgroundRevalidation,
-    };
-
     u64 request_id() const { return m_request_id; }
-    Type type() const { return m_type; }
+    RequestType type() const { return m_type; }
     URL::URL const& url() const { return m_url; }
 
     virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override;
@@ -129,7 +124,7 @@ private:
 
     Request(
         u64 request_id,
-        Type type,
+        RequestType type,
         Optional<HTTP::DiskCache&> disk_cache,
         HTTP::CacheMode cache_mode,
         ConnectionFromClient& client,
@@ -180,7 +175,7 @@ private:
     Requests::RequestTimingInfo acquire_timing_info() const;
 
     u64 m_request_id { 0 };
-    Type m_type { Type::Fetch };
+    RequestType m_type { RequestType::Fetch };
     State m_state { State::Init };
 
     Optional<HTTP::DiskCache&> m_disk_cache;

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -3,6 +3,7 @@
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
+#include <RequestServer/RequestType.h>
 
 endpoint RequestClient
 {
@@ -10,7 +11,7 @@ endpoint RequestClient
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
     headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase) =|
 
-    retrieve_http_cookie(int client_id, u64 request_id, URL::URL url) =|
+    retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url) =|
 
     // Websocket API
     // FIXME: See if this can be merged with the regular APIs

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -6,6 +6,7 @@
 #include <LibIPC/TransportHandle.h>
 #include <LibURL/URL.h>
 #include <RequestServer/CacheLevel.h>
+#include <RequestServer/RequestType.h>
 
 endpoint RequestServer
 {
@@ -28,7 +29,7 @@ endpoint RequestServer
 
     ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level) =|
 
-    retrieved_http_cookie(int client_id, u64 request_id, String cookie) =|
+    retrieved_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, String cookie) =|
 
     estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) =|
     remove_cache_entries_accessed_since(UnixDateTime since) =|

--- a/Services/RequestServer/RequestType.h
+++ b/Services/RequestServer/RequestType.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace RequestServer {
+
+enum class RequestType : u8 {
+    Fetch,
+    Connect,
+    BackgroundRevalidation,
+};
+
+}

--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -111,6 +111,13 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
     def do_OPTIONS(self):
         if self.path.startswith("/echo"):
+            # Requests with "credentials=include" cannot have "Access-Control-Allow-Origin=*". If the test registered
+            # an OPTIONS echo, return the headers that it specified.
+            key = f"OPTIONS {self.path}"
+            if key in echo_store:
+                self.handle_echo()
+                return
+
             self.send_response(204)
             self.send_header("Access-Control-Allow-Origin", "*")
             self.send_header("Access-Control-Allow-Methods", "*")

--- a/Tests/LibWeb/Text/input/Cache/http-disk-cache.html
+++ b/Tests/LibWeb/Text/input/Cache/http-disk-cache.html
@@ -47,12 +47,14 @@
         await server.createEcho("OPTIONS", path, {
             status: 200,
             headers: {
+                "Access-Control-Allow-Credentials": "true",
                 "Access-Control-Allow-Headers": ACCESS_CONTROL_ALLOW_HEADERS,
                 "Access-Control-Allow-Methods": options.method,
                 "Access-Control-Allow-Origin": location.origin,
             },
         });
 
+        options.headers["Access-Control-Allow-Credentials"] = "true";
         options.headers["Access-Control-Allow-Origin"] = location.origin;
         options.headers["Access-Control-Expose-Headers"] = ACCESS_CONTROL_EXPOSE_HEADERS;
 
@@ -76,6 +78,9 @@
         if (!options.cache) {
             options.cache = "default";
         }
+        if (!options.credentials) {
+            options.credentials = "same-origin";
+        }
 
         options.headers[TEST_CACHE_ENABLED_HEADER] = "1";
 
@@ -83,6 +88,7 @@
             method: options.method,
             headers: options.headers,
             cache: options.cache,
+            credentials: options.credentials,
             mode: "cors",
         });
 
@@ -854,6 +860,54 @@
             expectRevalidationStatus(url, response, "expired");
 
             response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 60,
+                },
+            });
+            expectCacheStatus(url, response, "written-to-cache");
+        })();
+
+        // Expired responses are cached until their max-age and stale-while-revalidate directives are reached. The
+        // response is successfully revalidated in the background. The request includes credentials, thus cookie
+        // retrieval occurs asynchronously via IPC during the background revalidation.
+        await (async () => {
+            url = await createRequest("/cache-test/stale-while-revalidate-with-credentials", {
+                headers: {
+                    "Cache-Control": "max-age=10,stale-while-revalidate=10",
+                    "Last-Modified": new Date().toUTCString(),
+                },
+            });
+
+            response = await cacheFetch(url, { credentials: "include" });
+            expectCacheStatus(url, response, "written-to-cache");
+
+            response = await cacheFetch(url, { credentials: "include" });
+            expectCacheStatus(url, response, "read-from-cache");
+
+            response = await cacheFetch(url, {
+                credentials: "include",
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 12,
+                    [TEST_CACHE_RESPOND_WITH_NOT_MODIFIED]: "1",
+                },
+            });
+            expectCacheStatus(url, response, "read-from-cache");
+            expectRevalidationStatus(url, response, null);
+
+            // We must issue another request to inspect the status of the background revalidation request triggered by
+            // the previous request.
+            response = await cacheFetch(url, {
+                credentials: "include",
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 15,
+                    [TEST_CACHE_RESPOND_WITH_NOT_MODIFIED]: "1",
+                },
+            });
+            expectCacheStatus(url, response, "read-from-cache");
+            expectRevalidationStatus(url, response, "fresh");
+
+            response = await cacheFetch(url, {
+                credentials: "include",
                 headers: {
                     [TEST_CACHE_REQUEST_TIME_OFFSET]: 60,
                 },


### PR DESCRIPTION
When we request the HTTP cookie for a SWR request, we were providing the cookie to the standard request corresponding to the SWR request's ID. This had two effects:

1. The SWR request would never finish.
2. If the corresponding standard request happened to be a connect-only request, this would result in a crash as we were expecting it to have gone through the normal fetch process.

This was seen on some articles on news.google.com.