### PR TITLE
LibJS: Make JS-to-JS calls faster (2/N)

### DIFF
--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1939,15 +1939,18 @@ fn emit_instruction(
         "branch_bits_set" | "branch_bits_clear" => {
             if insn.operands.len() == 3 {
                 let a = resolve_op(&insn.operands[0], handler, program);
-                let mask = resolve_op(&insn.operands[1], handler, program);
                 let label = resolve_label(&insn.operands[2], handler);
-                let cc = match m.as_str() {
-                    "branch_bits_set" => "b.ne",
-                    "branch_bits_clear" => "b.eq",
-                    _ => unreachable!(),
-                };
                 if let Some(val) = get_immediate_value(&insn.operands[1], program) {
                     let uval = val as u64;
+                    if uval != 0 && uval.is_power_of_two() {
+                        let cc = match m.as_str() {
+                            "branch_bits_set" => "tbnz",
+                            "branch_bits_clear" => "tbz",
+                            _ => unreachable!(),
+                        };
+                        w!(out, "    {cc} {a}, #{}, {label}", uval.trailing_zeros());
+                        return;
+                    }
                     if is_logical_immediate(uval) {
                         w!(out, "    tst {a}, #0x{uval:x}");
                     } else {
@@ -1955,8 +1958,14 @@ fn emit_instruction(
                         w!(out, "    tst {a}, x9");
                     }
                 } else {
+                    let mask = resolve_op(&insn.operands[1], handler, program);
                     w!(out, "    tst {a}, {mask}");
                 }
+                let cc = match m.as_str() {
+                    "branch_bits_set" => "b.ne",
+                    "branch_bits_clear" => "b.eq",
+                    _ => unreachable!(),
+                };
                 w!(out, "    {cc} {label}");
             }
         }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -931,6 +931,24 @@ fn emit_instruction(
             emit_ldr64(out, "x28", "x20", interp_ctx);
         }
 
+        // load_vm dst: copy the hidden VM* from the pinned x20 register.
+        "load_vm" => {
+            if let Some(op) = insn.operands.first() {
+                let dst = resolve_op(op, handler, program);
+                w!(out, "    mov {dst}, x20");
+            }
+        }
+
+        // inc32_mem [base, offset]: increment a 32-bit memory slot by 1.
+        "inc32_mem" => {
+            if let Some(op) = insn.operands.first() {
+                let mem_str = resolve_op(op, handler, program);
+                if let Some(mem) = parse_mem(&mem_str) {
+                    emit_inc32_mem(out, &mem);
+                }
+            }
+        }
+
         // dispatch_variable: advance ip by value in register and dispatch
         "dispatch_variable" => {
             if let Some(op) = insn.operands.first() {
@@ -1317,7 +1335,7 @@ fn emit_instruction(
                 let src = resolve_op(&insn.operands[1], handler, program);
                 if let Some(val) = get_immediate_value(&insn.operands[1], program) {
                     emit_mov_imm(out, &dst, val);
-                } else {
+                } else if dst != src {
                     w!(out, "    mov {dst}, {src}");
                 }
             }
@@ -2206,6 +2224,135 @@ fn emit_mem_store(out: &mut String, src: &str, mem: &MemOp, size: u32) {
                     2 => emit_strh(out, src, "x9", *offset),
                     1 => emit_strb(out, src, "x9", *offset),
                     _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn choose_scratch_register<'a>(forbidden: &[&str], candidates: &'a [&'a str]) -> &'a str {
+    candidates
+        .iter()
+        .copied()
+        .find(|reg| !forbidden.iter().any(|forbidden_reg| forbidden_reg == reg))
+        .expect("no scratch register available")
+}
+
+fn emit_inc32_mem(out: &mut String, mem: &MemOp) {
+    let candidates = ["x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17"];
+    let mut forbidden = vec![mem.base.as_str()];
+    match &mem.index {
+        MemIndex::Reg(idx) | MemIndex::RegScale(idx, _) | MemIndex::RegImm(idx, _) => {
+            forbidden.push(idx.as_str());
+        }
+        MemIndex::None | MemIndex::Imm(_) => {}
+    }
+
+    let value_reg = choose_scratch_register(&forbidden, &candidates);
+    forbidden.push(value_reg);
+    let addr_reg = choose_scratch_register(&forbidden, &candidates);
+    let value_wreg = to_w_reg(value_reg);
+
+    match &mem.index {
+        MemIndex::None => {
+            w!(out, "    ldr {value_wreg}, [{}]", mem.base);
+            w!(out, "    add {value_wreg}, {value_wreg}, #1");
+            w!(out, "    str {value_wreg}, [{}]", mem.base);
+        }
+        MemIndex::Imm(offset) => {
+            if *offset == 0 {
+                w!(out, "    ldr {value_wreg}, [{}]", mem.base);
+                w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                w!(out, "    str {value_wreg}, [{}]", mem.base);
+            } else if (0..16380).contains(offset) && offset % 4 == 0 {
+                w!(out, "    ldr {value_wreg}, [{}, #{offset}]", mem.base);
+                w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                w!(out, "    str {value_wreg}, [{}, #{offset}]", mem.base);
+            } else if (-256..=255).contains(offset) {
+                w!(out, "    ldur {value_wreg}, [{}, #{offset}]", mem.base);
+                w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                w!(out, "    stur {value_wreg}, [{}, #{offset}]", mem.base);
+            } else {
+                emit_mov_imm(out, addr_reg, *offset);
+                w!(out, "    ldr {value_wreg}, [{}, {addr_reg}]", mem.base);
+                w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                w!(out, "    str {value_wreg}, [{}, {addr_reg}]", mem.base);
+            }
+        }
+        MemIndex::Reg(idx) => {
+            w!(out, "    ldr {value_wreg}, [{}, {idx}]", mem.base);
+            w!(out, "    add {value_wreg}, {value_wreg}, #1");
+            w!(out, "    str {value_wreg}, [{}, {idx}]", mem.base);
+        }
+        MemIndex::RegScale(idx, scale) => {
+            let shift = match scale {
+                1 => None,
+                2 => Some(1),
+                4 => Some(2),
+                8 => Some(3),
+                _ => None,
+            };
+            if let Some(shift_amt) = shift {
+                w!(
+                    out,
+                    "    ldr {value_wreg}, [{}, {idx}, lsl #{shift_amt}]",
+                    mem.base
+                );
+                w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                w!(
+                    out,
+                    "    str {value_wreg}, [{}, {idx}, lsl #{shift_amt}]",
+                    mem.base
+                );
+            } else {
+                emit_mov_imm(out, addr_reg, *scale);
+                w!(out, "    madd {addr_reg}, {idx}, {addr_reg}, {}", mem.base);
+                w!(out, "    ldr {value_wreg}, [{addr_reg}]");
+                w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                w!(out, "    str {value_wreg}, [{addr_reg}]");
+            }
+        }
+        MemIndex::RegImm(idx, offset) => {
+            if mem.base == "x26" && idx == "x25" {
+                if *offset == 0 {
+                    w!(out, "    ldr {value_wreg}, [x21]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    str {value_wreg}, [x21]");
+                } else if (0..16380).contains(offset) && offset % 4 == 0 {
+                    w!(out, "    ldr {value_wreg}, [x21, #{offset}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    str {value_wreg}, [x21, #{offset}]");
+                } else if (-256..=255).contains(offset) {
+                    w!(out, "    ldur {value_wreg}, [x21, #{offset}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    stur {value_wreg}, [x21, #{offset}]");
+                } else {
+                    emit_mov_imm(out, addr_reg, *offset);
+                    w!(out, "    add {addr_reg}, x21, {addr_reg}");
+                    w!(out, "    ldr {value_wreg}, [{addr_reg}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    str {value_wreg}, [{addr_reg}]");
+                }
+            } else {
+                w!(out, "    add {addr_reg}, {}, {idx}", mem.base);
+                if *offset == 0 {
+                    w!(out, "    ldr {value_wreg}, [{addr_reg}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    str {value_wreg}, [{addr_reg}]");
+                } else if (0..16380).contains(offset) && offset % 4 == 0 {
+                    w!(out, "    ldr {value_wreg}, [{addr_reg}, #{offset}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    str {value_wreg}, [{addr_reg}, #{offset}]");
+                } else if (-256..=255).contains(offset) {
+                    w!(out, "    ldur {value_wreg}, [{addr_reg}, #{offset}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    stur {value_wreg}, [{addr_reg}, #{offset}]");
+                } else {
+                    emit_mov_imm(out, value_reg, *offset);
+                    w!(out, "    add {addr_reg}, {addr_reg}, {value_reg}");
+                    w!(out, "    ldr {value_wreg}, [{addr_reg}]");
+                    w!(out, "    add {value_wreg}, {value_wreg}, #1");
+                    w!(out, "    str {value_wreg}, [{addr_reg}]");
                 }
             }
         }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -657,6 +657,13 @@ fn emit_str64(out: &mut String, src: &str, base: &str, offset: i64) {
 fn emit_mov_imm(out: &mut String, dst: &str, val: i64) {
     let uval = val as u64;
 
+    // Writing a w-register zero-extends into the corresponding x-register.
+    // Prefer the 32-bit materialization when the upper half is known zero.
+    if dst.starts_with('x') && uval <= 0xFFFF_FFFF {
+        emit_mov_imm32(out, &to_w_reg(dst), val);
+        return;
+    }
+
     // Check if it fits in a single movz (16-bit value at any position)
     if uval == 0 {
         w!(out, "    mov {dst}, #0");

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1235,10 +1235,19 @@ fn emit_instruction(
         "store8" => {
             if insn.operands.len() >= 2 {
                 let mem_str = resolve_op(&insn.operands[0], handler, program);
-                let src = resolve_op(&insn.operands[1], handler, program);
                 if let Some(mem) = parse_mem(&mem_str) {
-                    let wsrc = to_w_reg(&src);
-                    emit_mem_store(out, &wsrc, &mem, 1);
+                    if let Some(val) = get_immediate_value(&insn.operands[1], program) {
+                        if val == 0 {
+                            emit_mem_store(out, "wzr", &mem, 1);
+                        } else {
+                            emit_mov_imm32(out, "w9", val);
+                            emit_mem_store(out, "w9", &mem, 1);
+                        }
+                    } else {
+                        let src = resolve_op(&insn.operands[1], handler, program);
+                        let wsrc = to_w_reg(&src);
+                        emit_mem_store(out, &wsrc, &mem, 1);
+                    }
                 }
             }
         }
@@ -1247,10 +1256,19 @@ fn emit_instruction(
         "store16" => {
             if insn.operands.len() >= 2 {
                 let mem_str = resolve_op(&insn.operands[0], handler, program);
-                let src = resolve_op(&insn.operands[1], handler, program);
                 if let Some(mem) = parse_mem(&mem_str) {
-                    let wsrc = to_w_reg(&src);
-                    emit_mem_store(out, &wsrc, &mem, 2);
+                    if let Some(val) = get_immediate_value(&insn.operands[1], program) {
+                        if val == 0 {
+                            emit_mem_store(out, "wzr", &mem, 2);
+                        } else {
+                            emit_mov_imm32(out, "w9", val);
+                            emit_mem_store(out, "w9", &mem, 2);
+                        }
+                    } else {
+                        let src = resolve_op(&insn.operands[1], handler, program);
+                        let wsrc = to_w_reg(&src);
+                        emit_mem_store(out, &wsrc, &mem, 2);
+                    }
                 }
             }
         }
@@ -1259,10 +1277,19 @@ fn emit_instruction(
         "store32" => {
             if insn.operands.len() >= 2 {
                 let mem_str = resolve_op(&insn.operands[0], handler, program);
-                let src = resolve_op(&insn.operands[1], handler, program);
                 if let Some(mem) = parse_mem(&mem_str) {
-                    let wsrc = to_w_reg(&src);
-                    emit_mem_store(out, &wsrc, &mem, 4);
+                    if let Some(val) = get_immediate_value(&insn.operands[1], program) {
+                        if val == 0 {
+                            emit_mem_store(out, "wzr", &mem, 4);
+                        } else {
+                            emit_mov_imm32(out, "w9", val);
+                            emit_mem_store(out, "w9", &mem, 4);
+                        }
+                    } else {
+                        let src = resolve_op(&insn.operands[1], handler, program);
+                        let wsrc = to_w_reg(&src);
+                        emit_mem_store(out, &wsrc, &mem, 4);
+                    }
                 }
             }
         }
@@ -1271,9 +1298,18 @@ fn emit_instruction(
         "store64" => {
             if insn.operands.len() >= 2 {
                 let mem_str = resolve_op(&insn.operands[0], handler, program);
-                let src = resolve_op(&insn.operands[1], handler, program);
                 if let Some(mem) = parse_mem(&mem_str) {
-                    emit_mem_store(out, &src, &mem, 8);
+                    if let Some(val) = get_immediate_value(&insn.operands[1], program) {
+                        if val == 0 {
+                            emit_mem_store(out, "xzr", &mem, 8);
+                        } else {
+                            emit_mov_imm(out, "x9", val);
+                            emit_mem_store(out, "x9", &mem, 8);
+                        }
+                    } else {
+                        let src = resolve_op(&insn.operands[1], handler, program);
+                        emit_mem_store(out, &src, &mem, 8);
+                    }
                 }
             }
         }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -412,6 +412,22 @@ fn emit_instruction(out: &mut String, insn: &AsmInstruction, handler: &Handler, 
             w!(out, "    mov rbx, QWORD PTR [rcx + {interp_ctx}]");
         }
 
+        // load_vm dst: load the hidden VM* from the stack frame.
+        "load_vm" => {
+            if let Some(op) = insn.operands.first() {
+                let dst = resolve_op(op, handler, program);
+                w!(out, "    mov {dst}, QWORD PTR [rbp - 48]");
+            }
+        }
+
+        // inc32_mem [base, offset]: increment a 32-bit memory slot by 1.
+        "inc32_mem" => {
+            if let Some(op) = insn.operands.first() {
+                let mem = resolve_op(op, handler, program);
+                w!(out, "    add DWORD PTR {mem}, 1");
+            }
+        }
+
         // dispatch_variable pseudo-instruction: advance pc by value in register and dispatch
         "dispatch_variable" => {
             if let Some(op) = insn.operands.first() {
@@ -889,6 +905,7 @@ fn emit_instruction(out: &mut String, insn: &AsmInstruction, handler: &Handler, 
         "mov" => {
             if insn.operands.len() == 2 {
                 let dst = resolve_op(&insn.operands[0], handler, program);
+                let src = resolve_op(&insn.operands[1], handler, program);
                 if let Some(val) = get_immediate_value(&insn.operands[1], program) {
                     let uval = val as u64;
                     if uval <= 0x7FFFFFFF || val < 0 && val >= -0x80000000 {
@@ -901,8 +918,7 @@ fn emit_instruction(out: &mut String, insn: &AsmInstruction, handler: &Handler, 
                     } else {
                         w!(out, "    movabs {dst}, {val}");
                     }
-                } else {
-                    let src = resolve_op(&insn.operands[1], handler, program);
+                } else if dst != src {
                     w!(out, "    mov {dst}, {src}");
                 }
             }

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -73,6 +73,8 @@
 //!   Result lands in `t0`. The handler continues. Does NOT reload pinned state.
 //! - `reload_exec_ctx` -- Reload the exec_ctx register from the VM*.
 //!   Used after non-terminal calls that may modify the running execution context.
+//! - `load_vm dst` -- Load the hidden VM* into `dst`.
+//!   Used when a handler needs to update VM-owned bookkeeping directly.
 //!
 //! ### Bytecode operand access
 //!
@@ -100,6 +102,7 @@
 //! - `store32 [base, offset], src` -- Store low 32 bits.
 //! - `store16 [base, offset], src` -- Store low 16 bits.
 //! - `store8 [base, offset], src` -- Store low 8 bits.
+//! - `inc32_mem [base, offset]` -- Increment a 32-bit memory slot by 1.
 //!
 //! ### Integer ALU
 //!

--- a/Libraries/LibJS/AsmIntGen/src/shared.rs
+++ b/Libraries/LibJS/AsmIntGen/src/shared.rs
@@ -30,6 +30,13 @@ pub fn substitute_macro(
     insn: &AsmInstruction,
     param_map: &HashMap<String, String>,
 ) -> AsmInstruction {
+    let substitute_name = |name: &String| {
+        param_map
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| name.clone())
+    };
+
     let operands = insn
         .operands
         .iter()
@@ -48,6 +55,11 @@ pub fn substitute_macro(
                     op.clone()
                 }
             }
+            Operand::Memory { base, index, scale } => Operand::Memory {
+                base: substitute_name(base),
+                index: index.as_ref().map(substitute_name),
+                scale: scale.as_ref().map(substitute_name),
+            },
             _ => op.clone(),
         })
         .collect();

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -271,8 +271,6 @@ u64 asm_helper_empty_string(u64);
 u64 asm_helper_single_ascii_character_string(u64 encoded_value);
 u64 asm_helper_single_utf16_code_unit_string(u64 encoded_value);
 i64 asm_try_inline_call(VM*, u32 pc);
-i64 asm_pop_inline_frame(VM*, u32 pc);
-i64 asm_pop_inline_frame_end(VM*, u32 pc);
 i64 asm_try_put_by_id_cache(VM*, u32 pc);
 i64 asm_try_get_by_id_cache(VM*, u32 pc);
 i64 asm_slow_path_initialize_lexical_binding(VM*, u32 pc);
@@ -882,30 +880,6 @@ i64 asm_try_inline_call(VM* vm, u32 pc)
     if (!callee_context) [[unlikely]]
         return 1;
 
-    return 0;
-}
-
-// Pop an inline frame after Return. Returns 0 on success.
-i64 asm_pop_inline_frame(VM* vm, u32 pc)
-{
-    auto* bytecode = vm->current_executable().bytecode.data();
-    auto& insn = *reinterpret_cast<Op::Return const*>(&bytecode[pc]);
-    auto value = vm->get(insn.value());
-    if (value.is_special_empty_value())
-        value = js_undefined();
-    vm->pop_inline_frame(value);
-    return 0;
-}
-
-// Pop an inline frame after End. Returns 0 on success.
-i64 asm_pop_inline_frame_end(VM* vm, u32 pc)
-{
-    auto* bytecode = vm->current_executable().bytecode.data();
-    auto& insn = *reinterpret_cast<Op::End const*>(&bytecode[pc]);
-    auto value = vm->get(insn.value());
-    if (value.is_special_empty_value())
-        value = js_undefined();
-    vm->pop_inline_frame(value);
     return 0;
 }
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -867,15 +867,15 @@ i64 asm_try_inline_call(VM* vm, u32 pc)
     if (!is<ECMAScriptFunctionObject>(callee_object))
         return 1;
     auto& callee_function = static_cast<ECMAScriptFunctionObject&>(callee_object);
-    if (callee_function.kind() != FunctionKind::Normal
-        || callee_function.is_class_constructor()
-        || !callee_function.bytecode_executable())
+    if (!callee_function.can_inline_call())
         return 1;
+
+    auto& callee_executable = callee_function.inline_call_executable();
 
     u32 return_pc = pc + insn.length();
 
     auto* callee_context = vm->push_inline_frame(
-        callee_function, *callee_function.bytecode_executable(),
+        callee_function, callee_executable,
         insn.arguments(), return_pc, insn.dst().raw(),
         vm->get(insn.this_value()), nullptr, false);
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -852,35 +852,37 @@ i64 asm_try_put_by_value_holey_array(VM* vm, u32 pc)
     return 0;
 }
 
-// Try to inline a JS-to-JS call. Returns 0 on success (callee frame pushed),
-// 1 on failure (caller should fall through to slow path).
+// Try to inline a JS-to-JS call by building the callee frame through the
+// shared VM::push_inline_frame() helper. Returns 0 on success (callee frame
+// pushed) and 1 on failure (caller should keep handling the Call itself).
 i64 asm_try_inline_call(VM* vm, u32 pc)
 {
     auto* bytecode = vm->current_executable().bytecode.data();
     auto& insn = *reinterpret_cast<Op::Call const*>(&bytecode[pc]);
+
     auto callee = vm->get(insn.callee());
-    if (!callee.is_object())
+    if (!callee.is_object()) [[unlikely]]
         return 1;
+
     auto& callee_object = callee.as_object();
-    if (!is<ECMAScriptFunctionObject>(callee_object))
+    if (!is<ECMAScriptFunctionObject>(callee_object)) [[unlikely]]
         return 1;
+
     auto& callee_function = static_cast<ECMAScriptFunctionObject&>(callee_object);
-    if (!callee_function.can_inline_call())
+    if (!callee_function.can_inline_call()) [[unlikely]]
         return 1;
-
-    auto& callee_executable = callee_function.inline_call_executable();
-
-    u32 return_pc = pc + insn.length();
 
     auto* callee_context = vm->push_inline_frame(
-        callee_function, callee_executable,
-        insn.arguments(), return_pc, insn.dst().raw(),
-        vm->get(insn.this_value()), nullptr, false);
+        callee_function,
+        callee_function.inline_call_executable(),
+        insn.arguments(),
+        pc + insn.length(),
+        insn.dst().raw(),
+        vm->get(insn.this_value()),
+        nullptr,
+        false);
 
-    if (!callee_context) [[unlikely]]
-        return 1;
-
-    return 0;
+    return callee_context ? 0 : 1;
 }
 
 // Fast cache-only PutById. Tries all cache entries for ChangeOwnProperty and

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -458,6 +458,45 @@ macro reload_state_from_exec_ctx()
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
 end
 
+# Pop an inline frame and resume the caller without bouncing through C++.
+# The asm-managed JS-to-JS call fast path currently only inlines Call, never
+# CallConstruct, so caller_is_construct is always false for asm-managed inline
+# frames.
+#
+# This mirrors VM::pop_inline_frame():
+#   1. Read the caller's destination register from the callee frame.
+#   2. Publish the caller's resume pc and returned value.
+#   3. Deallocate the callee by rewinding InterpreterStack::top to exec_ctx.
+#   4. Make the caller the running execution context again.
+#   5. Advance execution_generation so WeakRef and similar observers still see
+#      the same boundary they would have seen through the C++ helper.
+#
+# The macro expects exec_ctx/pb/values/pc to still describe the callee frame.
+# Input:
+#   caller_frame = ExecutionContext* of the caller
+#   return_pc = caller program counter to resume at
+#   value_reg = NaN-boxed return value
+# Clobbers:
+#   t2, t4
+macro pop_inline_frame_and_resume(caller_frame, return_pc, value_reg)
+    load32 t2, [exec_ctx, EXECUTION_CONTEXT_CALLER_DST_RAW]
+    store32 [caller_frame, EXECUTION_CONTEXT_PROGRAM_COUNTER], return_pc
+    lea t4, [caller_frame, SIZEOF_EXECUTION_CONTEXT]
+    store64 [t4, t2, 8], value_reg
+
+    load_vm t4
+    store64 [t4, VM_RUNNING_EXECUTION_CONTEXT], caller_frame
+    store64 [t4, VM_INTERPRETER_STACK_TOP], exec_ctx
+    inc32_mem [t4, VM_EXECUTION_GENERATION]
+
+    mov exec_ctx, caller_frame
+    load64 t4, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [t4, EXECUTABLE_BYTECODE_DATA]
+    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    mov pc, return_pc
+    dispatch_current
+end
+
 # ============================================================================
 # Simple data movement
 # ============================================================================
@@ -838,48 +877,46 @@ end
 # ============================================================================
 
 handler Return
-    # Check if this is an inline frame (caller_frame != nullptr)
+    # Empty is the internal "no explicit value" marker. Returning it from
+    # bytecode means "return undefined" at the JS level.
+    load_operand t0, m_value
+    mov t2, EMPTY_TAG_SHIFTED
+    branch_ne t0, t2, .value_ready
+    mov t0, UNDEFINED_SHIFTED
+.value_ready:
+    # Inline JS-to-JS calls resume the caller directly from asm. Top-level
+    # returns instead exit back to the outer interpreter entry point.
     load64 t1, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
     branch_zero t1, .top_level
-    # Inline return: pop the frame via C++ helper, then reload state
-    call_interp asm_pop_inline_frame
-    reload_state_from_exec_ctx
-    # Load the restored caller's program_counter
-    load32 pc, [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER]
-    dispatch_current
+    load32 t3, [exec_ctx, EXECUTION_CONTEXT_CALLER_RETURN_PC]
+    pop_inline_frame_and_resume t1, t3, t0
 .top_level:
-    # Top-level return: load value, empty->undefined, store to return_value
-    load_operand t0, m_value
-    mov t1, EMPTY_TAG_SHIFTED
-    branch_ne t0, t1, .store_return
-    mov t0, UNDEFINED_SHIFTED
-.store_return:
+    # Top-level return matches VM::run_executable(): write return_value,
+    # clear the exception slot, and leave the asm interpreter entirely.
     # values[3] = return_value, values[1] = empty (clear exception)
     store64 [values, 24], t0
-    mov t1, EMPTY_TAG_SHIFTED
-    store64 [values, 8], t1
+    store64 [values, 8], t2
     exit
 end
 
 # Like Return, but does not clear the exception register (values[1]).
 # Used at the end of a function body (after all user code).
 handler End
-    # Check if this is an inline frame (caller_frame != nullptr)
+    # End shares the same inline-frame unwind logic as Return. The only
+    # top-level difference is that End preserves the current exception slot.
+    load_operand t0, m_value
+    mov t2, EMPTY_TAG_SHIFTED
+    branch_ne t0, t2, .value_ready
+    mov t0, UNDEFINED_SHIFTED
+.value_ready:
+    # Inline frame: resume the caller immediately.
     load64 t1, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
     branch_zero t1, .top_level
-    # Inline return: pop the frame via C++ helper, then reload state
-    call_interp asm_pop_inline_frame_end
-    reload_state_from_exec_ctx
-    # Load the restored caller's program_counter
-    load32 pc, [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER]
-    dispatch_current
+    load32 t3, [exec_ctx, EXECUTION_CONTEXT_CALLER_RETURN_PC]
+    pop_inline_frame_and_resume t1, t3, t0
 .top_level:
-    # Top-level end: load value, empty->undefined, store to return_value
-    load_operand t0, m_value
-    mov t1, EMPTY_TAG_SHIFTED
-    branch_ne t0, t1, .store_end
-    mov t0, UNDEFINED_SHIFTED
-.store_end:
+    # Top-level end: publish the return value and exit without touching
+    # values[1], since End does not model a user-visible `return` opcode.
     store64 [values, 24], t0
     exit
 end

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -12,7 +12,7 @@
 #   dispatch = dispatch table base pointer (256 entries, 8 bytes each)
 #
 # Temporary registers (caller-saved, clobbered by C++ calls):
-#   t0-t9    = general-purpose scratch
+#   t0-t8    = general-purpose scratch
 #   ft0-ft3  = floating-point scratch (scalar double)
 #
 # NaN-boxing encoding:
@@ -446,16 +446,6 @@ macro walk_env_chain(m_cache_field, fail_label)
 .walk_done:
     load8 t0, [t3, ENVIRONMENT_SCREWED_BY_EVAL]
     branch_nonzero t0, fail_label
-end
-
-# Reload pb and values from the current running execution context.
-# Used after inline call/return to switch to the new frame's bytecode.
-# Clobbers t0, t1.
-macro reload_state_from_exec_ctx()
-    reload_exec_ctx
-    load64 t1, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
-    load64 pb, [t1, EXECUTABLE_BYTECODE_DATA]
-    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
 end
 
 # Pop an inline frame and resume the caller without bouncing through C++.
@@ -2008,11 +1998,233 @@ handler SetGlobal
 end
 
 handler Call
-    # Try to inline the call
+    # Inline JS-to-JS Call in asm when the callee is an ECMAScriptFunctionObject
+    # with bytecode ready. Cases that need function-environment allocation or
+    # sloppy primitive this boxing bounce through a C++ helper that still
+    # prepares an inline frame instead of taking the full slow path.
+    #
+    # High-level flow:
+    #   1. Validate the callee and load its shared function metadata.
+    #   2. Bind `this` inline when we can do so without allocations.
+    #   3. Reserve an InterpreterStack frame and populate ExecutionContext.
+    #   4. Materialize [registers | locals | constants | arguments].
+    #   5. Swap VM state over to the callee frame and dispatch at pc = 0.
+    #
+    # Register usage within this handler:
+    #   t3 = callee ECMAScriptFunctionObject*
+    #   t2 = SharedFunctionInstanceData* / later callee ExecutionContext*
+    #   t8 = boxed `this` value carried into the callee
+    load_operand t0, m_callee
+    extract_tag t1, t0
+    branch_ne t1, OBJECT_TAG, .call_slow
+    unbox_object t0, t0
+    mov t3, t0
+
+    # Reject everything except ordinary ECMAScript function objects with
+    # already-prepared bytecode and cached inline-call eligibility.
+    load8 t1, [t3, OBJECT_FLAGS]
+    branch_bits_clear t1, OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT, .call_slow
+
+    load64 t2, [t3, ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA]
+    load8 t1, [t2, SHARED_FUNCTION_INSTANCE_DATA_CAN_INLINE_CALL]
+    branch_zero t1, .call_slow
+    # NewFunctionEnvironment() allocates and has to stay out of the pure asm
+    # path, but we still preserve inline-call semantics via .call_interp_inline.
+    load8 t1, [t2, SHARED_FUNCTION_INSTANCE_DATA_FUNCTION_ENVIRONMENT_NEEDED]
+    branch_nonzero t1, .call_interp_inline
+
+    # Bind this without allocations. Sloppy primitive this-values still need
+    # ToObject(), so they use the C++ inline-frame helper.
+    #
+    # t8 starts as "empty" to match the normal interpreter behavior for
+    # callees that never observe `this`.
+    mov t8, EMPTY_TAG_SHIFTED
+    load8 t1, [t2, SHARED_FUNCTION_INSTANCE_DATA_USES_THIS]
+    branch_zero t1, .this_ready
+    load_operand t8, m_this_value
+    load8 t1, [t2, SHARED_FUNCTION_INSTANCE_DATA_STRICT]
+    branch_nonzero t1, .this_ready
+
+    # Sloppy null/undefined binds the callee realm's global object.
+    # Sloppy primitive receivers need ToObject(), which may allocate wrappers,
+    # so they go through the helper instead of the full Call slow path.
+    extract_tag t1, t8
+    mov t0, t1
+    and t0, 0xFFFE
+    branch_eq t0, UNDEFINED_TAG, .sloppy_global_this
+    branch_eq t1, OBJECT_TAG, .this_ready
+    jmp .call_interp_inline
+
+.sloppy_global_this:
+    load64 t1, [t3, OBJECT_SHAPE]
+    load64 t1, [t1, SHAPE_REALM]
+    load64 t1, [t1, REALM_GLOBAL_ENVIRONMENT]
+    load64 t1, [t1, GLOBAL_ENVIRONMENT_GLOBAL_THIS_VALUE]
+    # Match Value(Object*): keep only the low 48 pointer bits before boxing.
+    shl t1, 16
+    shr t1, 16
+    mov t8, OBJECT_TAG_SHIFTED
+    or t8, t1
+
+.this_ready:
+    # The pure asm path only runs once bytecode is already compiled.
+    load64 t0, [t2, SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE]
+    branch_zero t0, .call_slow
+
+    load32 t7, [pb, pc, m_argument_count]
+    load32 t4, [t2, SHARED_FUNCTION_INSTANCE_DATA_FORMAL_PARAMETER_COUNT]
+    branch_ge_unsigned t4, t7, .arg_count_ready
+    mov t4, t7
+.arg_count_ready:
+    load32 t5, [t0, EXECUTABLE_REGISTERS_AND_LOCALS_COUNT]
+    load64 t6, [t0, EXECUTABLE_CONSTANTS_SIZE]
+
+    # Inline InterpreterStack::allocate().
+    # t1 = total Value slots, t2 = new stack top, t6 = current frame base.
+    mov t1, t5
+    add t1, t6
+    add t1, t4
+    mov t2, t1
+    shl t2, 3
+    add t2, SIZEOF_EXECUTION_CONTEXT
+
+    load_vm t0
+    lea t0, [t0, VM_INTERPRETER_STACK]
+    load64 t6, [t0, INTERPRETER_STACK_TOP]
+    add t2, t6
+    load64 t0, [t0, INTERPRETER_STACK_LIMIT]
+    branch_ge_unsigned t0, t2, .stack_ok
+    jmp .call_slow
+
+.stack_ok:
+    load_vm t0
+    store64 [t0, VM_INTERPRETER_STACK_TOP], t2
+
+    # Set up the callee ExecutionContext header exactly the way
+    # VM::push_inline_frame() / run_executable() would see it.
+    store64 [t6, EXECUTION_CONTEXT_FUNCTION], t3
+    load64 t0, [t3, OBJECT_SHAPE]
+    load64 t0, [t0, SHAPE_REALM]
+    store64 [t6, EXECUTION_CONTEXT_REALM], t0
+
+    load64 t0, [t3, ECMASCRIPT_FUNCTION_OBJECT_ENVIRONMENT]
+    store64 [t6, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], t0
+    store64 [t6, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT], t0
+    load64 t0, [t3, ECMASCRIPT_FUNCTION_OBJECT_PRIVATE_ENVIRONMENT]
+    store64 [t6, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT], t0
+    load64 t0, [t3, ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA]
+    load64 t0, [t0, SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE]
+    store64 [t6, EXECUTION_CONTEXT_EXECUTABLE], t0
+
+    # ScriptOrModule is a two-word Variant in ExecutionContext, so copy both
+    # machine words explicitly.
+    lea t0, [t6, EXECUTION_CONTEXT_SCRIPT_OR_MODULE]
+    lea t2, [t3, ECMASCRIPT_FUNCTION_OBJECT_SCRIPT_OR_MODULE]
+    load64 t3, [t2, 0]
+    store64 [t0, 0], t3
+    load64 t3, [t2, 8]
+    store64 [t0, 8], t3
+
+    store32 [t6, EXECUTION_CONTEXT_PROGRAM_COUNTER], 0
+    store32 [t6, EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER], 0
+    mov t0, EXECUTION_CONTEXT_NO_YIELD_CONTINUATION
+    store32 [t6, EXECUTION_CONTEXT_YIELD_CONTINUATION], t0
+    store8 [t6, EXECUTION_CONTEXT_YIELD_IS_AWAIT], 0
+    store8 [t6, EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT], 0
+    store64 [t6, EXECUTION_CONTEXT_THIS_VALUE], t8
+    store64 [t6, EXECUTION_CONTEXT_CALLER_FRAME], exec_ctx
+    store32 [t6, EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT], t1
+    store32 [t6, EXECUTION_CONTEXT_ARGUMENT_COUNT], t4
+    store32 [t6, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT], t7
+    load32 t0, [pb, pc, m_length]
+    lea t2, [pb, pc]
+    sub t2, pb
+    add t0, t2
+    store32 [t6, EXECUTION_CONTEXT_CALLER_RETURN_PC], t0
+    load32 t0, [pb, pc, m_dst]
+    store32 [t6, EXECUTION_CONTEXT_CALLER_DST_RAW], t0
+
+    # values = [registers | locals | constants | arguments]
+    # Keep t2 at the ExecutionContext base while t6 walks the Value tail.
+    mov t2, t6
+    lea t6, [t6, SIZEOF_EXECUTION_CONTEXT]
+    mov t0, EMPTY_TAG_SHIFTED
+    xor t3, t3
+.clear_registers_and_locals:
+    branch_ge_unsigned t3, t5, .copy_constants
+    store64 [t6, t3, 8], t0
+    add t3, 1
+    jmp .clear_registers_and_locals
+
+.copy_constants:
+    load64 t0, [t2, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 t3, [t0, EXECUTABLE_CONSTANTS_SIZE]
+    load64 t0, [t0, EXECUTABLE_CONSTANTS_DATA]
+    mov t1, t5
+    xor t8, t8
+.copy_constants_loop:
+    branch_ge_unsigned t8, t3, .copy_arguments
+    load64 t7, [t0, t8, 8]
+    store64 [t6, t1, 8], t7
+    add t8, 1
+    add t1, 1
+    jmp .copy_constants_loop
+
+.copy_arguments:
+    load32 t7, [t2, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT]
+    mov t1, t5
+    add t1, t3
+    lea t0, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    lea t8, [pb, pc]
+    add t8, m_expression_string
+    add t8, 4
+    xor t3, t3
+.copy_arguments_loop:
+    # The operand array in the bytecode stores caller register indices.
+    branch_ge_unsigned t3, t7, .fill_missing_arguments
+    load32 t5, [t8, t3, 4]
+    load64 t5, [t0, t5, 8]
+    store64 [t6, t1, 8], t5
+    add t3, 1
+    add t1, 1
+    jmp .copy_arguments_loop
+
+.fill_missing_arguments:
+    mov t3, t1
+    add t3, t4
+    sub t3, t7
+    mov t0, UNDEFINED_SHIFTED
+.fill_missing_arguments_loop:
+    branch_ge_unsigned t1, t3, .enter_callee
+    store64 [t6, t1, 8], t0
+    add t1, 1
+    jmp .fill_missing_arguments_loop
+
+.enter_callee:
+    # Mirror the normal interpreter entry sequence: cache `this` in the
+    # dedicated register slot, then reload pb/values/exec_ctx for the callee.
+    load64 t0, [t2, EXECUTION_CONTEXT_THIS_VALUE]
+    store64 [t6, THIS_VALUE_REG_OFFSET], t0
+
+    load64 t0, [t2, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [t0, EXECUTABLE_BYTECODE_DATA]
+    load_vm t0
+    store64 [t0, VM_RUNNING_EXECUTION_CONTEXT], t2
+    mov exec_ctx, t2
+    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    xor pc, pc
+    dispatch_current
+.call_interp_inline:
+    # Shared escape hatch for the cases that need C++ help to build the inline
+    # frame correctly but must not take the full Call slow path, since that
+    # would insert a run_executable() boundary and observable microtask drain.
     call_interp asm_try_inline_call
     branch_nonzero t0, .call_slow
-    # Success: reload pb/values from new execution context, pc=0
-    reload_state_from_exec_ctx
+    load_vm t0
+    load64 exec_ctx, [t0, VM_RUNNING_EXECUTION_CONTEXT]
+    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    load64 t0, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [t0, EXECUTABLE_BYTECODE_DATA]
     xor pc, pc
     dispatch_current
 .call_slow:

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -131,8 +131,14 @@ int main()
     EMIT_OFFSET(EXECUTION_CONTEXT_REALM, ExecutionContext, realm);
     EMIT_OFFSET(EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT, ExecutionContext, lexical_environment);
     EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_FRAME, ExecutionContext, caller_frame);
+    EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_RETURN_PC, ExecutionContext, caller_return_pc);
+    EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_DST_RAW, ExecutionContext, caller_dst_raw);
     EMIT_OFFSET(EXECUTION_CONTEXT_PROGRAM_COUNTER, ExecutionContext, program_counter);
     EMIT_SIZEOF(SIZEOF_EXECUTION_CONTEXT, ExecutionContext);
+
+    // InterpreterStack layout
+    outln("\n# InterpreterStack layout");
+    EMIT_OFFSET(INTERPRETER_STACK_TOP, InterpreterStack, m_top);
 
     // Realm layout
     outln("\n# Realm layout");
@@ -142,6 +148,9 @@ int main()
     // VM layout
     outln("\n# VM layout");
     EMIT_OFFSET(VM_RUNNING_EXECUTION_CONTEXT, VM, m_running_execution_context);
+    EMIT_OFFSET(VM_INTERPRETER_STACK, VM, m_interpreter_stack);
+    EMIT_OFFSET(VM_EXECUTION_GENERATION, VM, m_execution_generation);
+    outln("const VM_INTERPRETER_STACK_TOP = {}", offsetof(VM, m_interpreter_stack) + offsetof(InterpreterStack, m_top));
 
     // IndexedStorageKind enum values
     outln("\n# IndexedStorageKind enum values");

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -16,13 +16,16 @@
 #include <LibJS/Bytecode/PutKind.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
+#include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/FunctionObject.h>
+#include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/IndexedProperties.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/Shape.h>
+#include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/VM.h>
 
@@ -61,9 +64,11 @@ int main()
     outln("const OBJECT_FLAG_MAY_INTERFERE = {}", Object::Flag::MayInterfereWithIndexedPropertyAccess);
     outln("const OBJECT_FLAG_IS_TYPED_ARRAY = {}", Object::Flag::IsTypedArray);
     outln("const OBJECT_FLAG_IS_FUNCTION = {}", Object::Flag::IsFunction);
+    outln("const OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT = {}", Object::Flag::IsECMAScriptFunctionObject);
 
     // Shape layout
     outln("\n# Shape layout");
+    EMIT_OFFSET(SHAPE_REALM, Shape, m_realm);
     EMIT_OFFSET(SHAPE_PROTOTYPE, Shape, m_prototype);
     EMIT_OFFSET(SHAPE_DICTIONARY_GENERATION, Shape, m_dictionary_generation);
     EMIT_SIZEOF(SHAPE_SIZE, Shape);
@@ -123,25 +128,43 @@ int main()
 
     // Executable layout
     outln("\n# Executable layout");
+    EMIT_OFFSET(EXECUTABLE_CONSTANTS, Executable, constants);
     EMIT_OFFSET(EXECUTABLE_PROPERTY_LOOKUP_CACHES, Executable, property_lookup_caches);
+    EMIT_OFFSET(EXECUTABLE_REGISTERS_AND_LOCALS_COUNT, Executable, registers_and_locals_count);
 
     // ExecutionContext layout
     outln("\n# ExecutionContext layout");
     EMIT_OFFSET(EXECUTION_CONTEXT_EXECUTABLE, ExecutionContext, executable);
+    EMIT_OFFSET(EXECUTION_CONTEXT_FUNCTION, ExecutionContext, function);
     EMIT_OFFSET(EXECUTION_CONTEXT_REALM, ExecutionContext, realm);
+    EMIT_OFFSET(EXECUTION_CONTEXT_SCRIPT_OR_MODULE, ExecutionContext, script_or_module);
     EMIT_OFFSET(EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT, ExecutionContext, lexical_environment);
+    EMIT_OFFSET(EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT, ExecutionContext, variable_environment);
+    EMIT_OFFSET(EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT, ExecutionContext, private_environment);
+    EMIT_OFFSET(EXECUTION_CONTEXT_YIELD_CONTINUATION, ExecutionContext, yield_continuation);
+    EMIT_OFFSET(EXECUTION_CONTEXT_YIELD_IS_AWAIT, ExecutionContext, yield_is_await);
+    EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT, ExecutionContext, caller_is_construct);
+    EMIT_OFFSET(EXECUTION_CONTEXT_THIS_VALUE, ExecutionContext, this_value);
     EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_FRAME, ExecutionContext, caller_frame);
+    EMIT_OFFSET(EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT, ExecutionContext, passed_argument_count);
     EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_RETURN_PC, ExecutionContext, caller_return_pc);
     EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_DST_RAW, ExecutionContext, caller_dst_raw);
     EMIT_OFFSET(EXECUTION_CONTEXT_PROGRAM_COUNTER, ExecutionContext, program_counter);
+    EMIT_OFFSET(EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT, ExecutionContext, registers_and_constants_and_locals_and_arguments_count);
+    EMIT_OFFSET(EXECUTION_CONTEXT_ARGUMENT_COUNT, ExecutionContext, argument_count);
     EMIT_SIZEOF(SIZEOF_EXECUTION_CONTEXT, ExecutionContext);
+    outln("const ALIGNOF_EXECUTION_CONTEXT = {}", alignof(ExecutionContext));
+    outln("const EXECUTION_CONTEXT_NO_YIELD_CONTINUATION = {}", ExecutionContext::no_yield_continuation);
+    outln("const SIZEOF_SCRIPT_OR_MODULE = {}", sizeof(ScriptOrModule));
 
     // InterpreterStack layout
     outln("\n# InterpreterStack layout");
+    EMIT_OFFSET(INTERPRETER_STACK_LIMIT, InterpreterStack, m_limit);
     EMIT_OFFSET(INTERPRETER_STACK_TOP, InterpreterStack, m_top);
 
     // Realm layout
     outln("\n# Realm layout");
+    EMIT_OFFSET(REALM_GLOBAL_ENVIRONMENT, Realm, m_global_environment);
     EMIT_OFFSET(REALM_GLOBAL_OBJECT, Realm, m_global_object);
     EMIT_OFFSET(REALM_GLOBAL_DECLARATIVE_ENVIRONMENT, Realm, m_global_declarative_environment);
 
@@ -177,6 +200,8 @@ int main()
 
         // Composite offset for Executable.bytecode data pointer
         outln("const EXECUTABLE_BYTECODE_DATA = {}", offsetof(Executable, bytecode) + vec_data);
+        outln("const EXECUTABLE_CONSTANTS_DATA = {}", offsetof(Executable, constants) + vec_data);
+        outln("const EXECUTABLE_CONSTANTS_SIZE = {}", offsetof(Executable, constants) + vec_size);
         outln("const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA = {}", offsetof(ObjectPropertyIteratorCacheData, m_property_values) + vec_data);
         outln("const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE = {}", offsetof(ObjectPropertyIteratorCacheData, m_property_values) + vec_size);
     }
@@ -228,6 +253,26 @@ int main()
         outln("const FUNCTION_OBJECT_BUILTIN_VALUE = {}", base);
         outln("const FUNCTION_OBJECT_BUILTIN_HAS_VALUE = {}", base + 1);
     }
+
+    // ECMAScriptFunctionObject layout
+    outln("\n# ECMAScriptFunctionObject layout");
+    EMIT_OFFSET(ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA, ECMAScriptFunctionObject, m_shared_data);
+    EMIT_OFFSET(ECMASCRIPT_FUNCTION_OBJECT_ENVIRONMENT, ECMAScriptFunctionObject, m_environment);
+    EMIT_OFFSET(ECMASCRIPT_FUNCTION_OBJECT_PRIVATE_ENVIRONMENT, ECMAScriptFunctionObject, m_private_environment);
+    EMIT_OFFSET(ECMASCRIPT_FUNCTION_OBJECT_SCRIPT_OR_MODULE, ECMAScriptFunctionObject, m_script_or_module);
+
+    // SharedFunctionInstanceData layout
+    outln("\n# SharedFunctionInstanceData layout");
+    EMIT_OFFSET(SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE, SharedFunctionInstanceData, m_executable);
+    EMIT_OFFSET(SHARED_FUNCTION_INSTANCE_DATA_FORMAL_PARAMETER_COUNT, SharedFunctionInstanceData, m_formal_parameter_count);
+    EMIT_OFFSET(SHARED_FUNCTION_INSTANCE_DATA_STRICT, SharedFunctionInstanceData, m_strict);
+    EMIT_OFFSET(SHARED_FUNCTION_INSTANCE_DATA_FUNCTION_ENVIRONMENT_NEEDED, SharedFunctionInstanceData, m_function_environment_needed);
+    EMIT_OFFSET(SHARED_FUNCTION_INSTANCE_DATA_USES_THIS, SharedFunctionInstanceData, m_uses_this);
+    EMIT_OFFSET(SHARED_FUNCTION_INSTANCE_DATA_CAN_INLINE_CALL, SharedFunctionInstanceData, m_can_inline_call);
+
+    // GlobalEnvironment layout
+    outln("\n# GlobalEnvironment layout");
+    EMIT_OFFSET(GLOBAL_ENVIRONMENT_GLOBAL_THIS_VALUE, GlobalEnvironment, m_global_this_value);
 
     // PrimitiveString layout
     outln("\n# PrimitiveString layout");
@@ -319,6 +364,7 @@ int main()
 
     // Shifted value constants
     outln("\n# Shifted value constants");
+    outln("const OBJECT_TAG_SHIFTED = 0x{:X}", static_cast<u64>(OBJECT_TAG << GC::TAG_SHIFT));
     outln("const EMPTY_VALUE = 0x{:X}", static_cast<u64>(EMPTY_TAG << GC::TAG_SHIFT));
     outln("const INT32_TAG_SHIFTED = 0x{:X}", static_cast<u64>(INT32_TAG << GC::TAG_SHIFT));
     outln("const BOOLEAN_TRUE = 0x{:X}", static_cast<u64>((BOOLEAN_TAG << GC::TAG_SHIFT) | 1));

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -134,6 +134,7 @@ int main()
 
     // ExecutionContext layout
     outln("\n# ExecutionContext layout");
+    VERIFY(alignof(ExecutionContext) == sizeof(Value));
     EMIT_OFFSET(EXECUTION_CONTEXT_EXECUTABLE, ExecutionContext, executable);
     EMIT_OFFSET(EXECUTION_CONTEXT_FUNCTION, ExecutionContext, function);
     EMIT_OFFSET(EXECUTION_CONTEXT_REALM, ExecutionContext, realm);
@@ -141,6 +142,7 @@ int main()
     EMIT_OFFSET(EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT, ExecutionContext, lexical_environment);
     EMIT_OFFSET(EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT, ExecutionContext, variable_environment);
     EMIT_OFFSET(EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT, ExecutionContext, private_environment);
+    EMIT_OFFSET(EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER, ExecutionContext, skip_when_determining_incumbent_counter);
     EMIT_OFFSET(EXECUTION_CONTEXT_YIELD_CONTINUATION, ExecutionContext, yield_continuation);
     EMIT_OFFSET(EXECUTION_CONTEXT_YIELD_IS_AWAIT, ExecutionContext, yield_is_await);
     EMIT_OFFSET(EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT, ExecutionContext, caller_is_construct);

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -323,15 +323,15 @@ NEVER_INLINE bool VM::try_inline_call(Instruction const& insn, u32 current_pc)
     if (!is<ECMAScriptFunctionObject>(callee_object))
         return false;
     auto& callee_function = static_cast<ECMAScriptFunctionObject&>(callee_object);
-    if (callee_function.kind() != FunctionKind::Normal
-        || callee_function.is_class_constructor()
-        || !callee_function.bytecode_executable())
+    if (!callee_function.can_inline_call())
         return false;
+
+    auto& callee_executable = callee_function.inline_call_executable();
 
     u32 return_pc = current_pc + instruction.length();
 
     auto* callee_context = push_inline_frame(
-        callee_function, *callee_function.bytecode_executable(),
+        callee_function, callee_executable,
         instruction.arguments(), return_pc, instruction.dst().raw(),
         get(instruction.this_value()), nullptr, false);
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -139,10 +139,11 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
 
 void ECMAScriptFunctionObject::get_stack_frame_info(size_t& registers_and_locals_count, ReadonlySpan<Value>& constants, size_t& argument_count)
 {
-    auto& executable = shared_data().m_executable;
+    auto executable = shared_data().m_executable;
     if (!executable) {
         auto rust_executable = RustIntegration::compile_function(vm(), *m_shared_data, false);
         VERIFY(rust_executable);
+        m_shared_data->set_executable(rust_executable);
         executable = rust_executable;
         executable->name = m_shared_data->m_name;
         if (Bytecode::g_dump_bytecode)

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -62,9 +62,15 @@ public:
     Utf16FlyString const& name() const { return shared_data().m_name; }
     void set_name(Utf16FlyString const& name);
 
-    void set_is_class_constructor() { const_cast<SharedFunctionInstanceData&>(shared_data()).m_is_class_constructor = true; }
+    void set_is_class_constructor() { const_cast<SharedFunctionInstanceData&>(shared_data()).set_is_class_constructor(); }
 
     auto& bytecode_executable() const { return shared_data().m_executable; }
+    [[nodiscard]] bool can_inline_call() const { return shared_data().can_inline_call(); }
+    [[nodiscard]] Bytecode::Executable& inline_call_executable() const
+    {
+        VERIFY(can_inline_call());
+        return *shared_data().m_executable;
+    }
 
     Environment* environment() { return m_environment; }
     virtual Realm* realm() const override { return &shape().realm(); }

--- a/Libraries/LibJS/Runtime/NativeJavaScriptBackedFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeJavaScriptBackedFunction.cpp
@@ -95,10 +95,11 @@ ThrowCompletionOr<Value> NativeJavaScriptBackedFunction::call()
 
 Bytecode::Executable& NativeJavaScriptBackedFunction::bytecode_executable()
 {
-    auto& executable = m_shared_function_instance_data->m_executable;
+    auto executable = m_shared_function_instance_data->m_executable;
     if (!executable) {
         auto rust_executable = RustIntegration::compile_function(vm(), *m_shared_function_instance_data, true);
         VERIFY(rust_executable);
+        m_shared_function_instance_data->set_executable(rust_executable);
         executable = rust_executable;
         executable->name = m_shared_function_instance_data->m_name;
         if (Bytecode::g_dump_bytecode)

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
@@ -39,6 +39,8 @@ SharedFunctionInstanceData::SharedFunctionInstanceData(
         m_this_mode = ThisMode::Strict;
     else
         m_this_mode = ThisMode::Global;
+
+    update_can_inline_call();
 }
 
 void SharedFunctionInstanceData::visit_edges(Visitor& visitor)
@@ -51,6 +53,18 @@ void SharedFunctionInstanceData::visit_edges(Visitor& visitor)
 }
 
 SharedFunctionInstanceData::~SharedFunctionInstanceData() = default;
+
+void SharedFunctionInstanceData::set_executable(GC::Ptr<Bytecode::Executable> executable)
+{
+    m_executable = executable;
+    update_can_inline_call();
+}
+
+void SharedFunctionInstanceData::set_is_class_constructor()
+{
+    m_is_class_constructor = true;
+    update_can_inline_call();
+}
 
 void SharedFunctionInstanceData::finalize()
 {
@@ -67,6 +81,11 @@ void SharedFunctionInstanceData::clear_compile_inputs()
     m_lexical_bindings.clear();
     RustIntegration::free_function_ast(m_rust_function_ast);
     m_rust_function_ast = nullptr;
+}
+
+void SharedFunctionInstanceData::update_can_inline_call()
+{
+    m_can_inline_call = m_executable && m_kind == FunctionKind::Normal && !m_is_class_constructor;
 }
 
 }

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
@@ -63,6 +63,10 @@ public:
         Vector<Utf16FlyString> parameter_names_for_mapped_arguments,
         void* rust_function_ast);
 
+    void set_executable(GC::Ptr<Bytecode::Executable>);
+    void set_is_class_constructor();
+    [[nodiscard]] bool can_inline_call() const { return m_can_inline_call; }
+
     mutable GC::Ptr<Bytecode::Executable> m_executable;
 
     Utf16FlyString m_name;
@@ -141,6 +145,9 @@ public:
 
 private:
     virtual void visit_edges(Visitor&) override;
+    void update_can_inline_call();
+
+    bool m_can_inline_call { false };
 };
 
 }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -493,7 +493,7 @@ Optional<Result<ModuleResult, Vector<ParserError>>> compile_parsed_module(Parsed
         builder.result.tla_shared_data->m_is_module_wrapper = true;
         builder.result.tla_shared_data->m_uses_this = true;
         builder.result.tla_shared_data->m_function_environment_needed = true;
-        builder.result.tla_shared_data->m_executable = tla_exec;
+        builder.result.tla_shared_data->set_executable(tla_exec);
     } else {
         builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
     }

--- a/Tests/LibJS/Runtime/builtins/WeakRef/WeakRef.prototype.deref.js
+++ b/Tests/LibJS/Runtime/builtins/WeakRef/WeakRef.prototype.deref.js
@@ -35,3 +35,27 @@ test("symbol kept alive for current synchronous execution sequence", () => {
     // This is fine 🔥
     expect(weakRef.deref()).not.toBe(undefined);
 });
+
+test("returned WeakRef target is no longer kept alive after an inline return", () => {
+    function createWeakRef() {
+        return new WeakRef({});
+    }
+
+    var weakRef = createWeakRef();
+    gc();
+
+    expect(weakRef.deref()).toBe(undefined);
+});
+
+test("assigned WeakRef target is no longer kept alive after an inline end", () => {
+    var weakRef;
+
+    function createWeakRef() {
+        weakRef = new WeakRef({});
+    }
+
+    createWeakRef();
+    gc();
+
+    expect(weakRef.deref()).toBe(undefined);
+});

--- a/Tests/LibJS/Runtime/regress/asm-inline-call-microtask-order.js
+++ b/Tests/LibJS/Runtime/regress/asm-inline-call-microtask-order.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+test("closure-capturing callees do not drain promise jobs before the caller resumes", () => {
+    let order = [];
+
+    function inner() {
+        let x = 1;
+        order.push("inner");
+        return () => x;
+    }
+
+    inner();
+    order.length = 0;
+
+    function outer() {
+        inner();
+        order.push("outer");
+    }
+
+    Promise.resolve().then(() => order.push("micro"));
+
+    outer();
+    expect(order).toEqual(["inner", "outer", "micro"]);
+});
+
+test("sloppy primitive receivers do not drain promise jobs before the caller resumes", () => {
+    let order = [];
+
+    Number.prototype.__asmInlineCallMicrotaskOrder = function () {
+        this;
+        order.push("inner");
+    };
+
+    (1).__asmInlineCallMicrotaskOrder();
+    order.length = 0;
+
+    function outer() {
+        (1).__asmInlineCallMicrotaskOrder();
+        order.push("outer");
+    }
+
+    Promise.resolve().then(() => order.push("micro"));
+
+    outer();
+    expect(order).toEqual(["inner", "outer", "micro"]);
+});
+
+test("sloppy undefined receivers still bind the global object in inline calls", () => {
+    function inner() {
+        return this;
+    }
+
+    inner();
+
+    function outer() {
+        return inner();
+    }
+
+    expect(outer()).toBe(globalThis);
+});


### PR DESCRIPTION
More work towards faster calls. This time we move the `Call`, `Return` and `End` instructions into AsmInt. They stay in pure assembly in the common cases, but we still bounce out for C++ if we have to do GC allocation or other complex things.

See individual commits for details.

Benchmarks happy (Linux):

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ----------------
LongSpider      3d-cube.js                              1.111      5.199 ± 5.023 … 5.374              4.679 ± 4.490 … 4.868              -0.2% (-0.1 MB)
LongSpider      3d-morph.js                             1.024      2.436 ± 2.397 … 2.475              2.378 ± 2.376 … 2.379              +0.5% (+0.1 MB)
LongSpider      3d-raytrace.js                          0.927      3.033 ± 3.032 … 3.034              3.270 ± 3.015 … 3.525              -0.3% (-0.1 MB)
LongSpider      access-binary-trees.js                  1.141      9.146 ± 9.072 … 9.220              8.016 ± 7.985 … 8.046              +8.0% (+7.7 MB)
LongSpider      access-fannkuch.js                      0.982      1.769 ± 1.751 … 1.787              1.802 ± 1.791 … 1.813              +0.5% (+0.1 MB)
LongSpider      access-nbody.js                         1.051      4.135 ± 3.974 … 4.295              3.934 ± 3.934 … 3.934              +0.5% (+0.1 MB)
LongSpider      access-nsieve.js                        1.036      0.992 ± 0.941 … 1.042              0.957 ± 0.946 … 0.968              -0.0% (-0.1 MB)
LongSpider      bitops-3bit-bits-in-byte.js             1.107      0.524 ± 0.524 … 0.525              0.473 ± 0.473 … 0.474              +0.5% (+0.1 MB)
LongSpider      bitops-bits-in-byte.js                  0.954      0.664 ± 0.651 … 0.678              0.696 ± 0.685 … 0.706              +0.5% (+0.1 MB)
LongSpider      bitops-nsieve-bits.js                   0.931      1.956 ± 1.951 … 1.961              2.102 ± 2.093 … 2.110              +0.5% (+0.2 MB)
LongSpider      controlflow-recursive.js                1.345      2.709 ± 2.698 … 2.719              2.015 ± 2.013 … 2.017              +0.5% (+0.1 MB)
LongSpider      crypto-aes.js                           1.072      4.842 ± 4.626 … 5.057              4.517 ± 4.479 … 4.554              -0.3% (-0.1 MB)
LongSpider      crypto-md5.js                           1.198      5.587 ± 5.522 … 5.652              4.664 ± 4.649 … 4.680              +0.1% (+0.0 MB)
LongSpider      crypto-sha1.js                          1.220      10.913 ± 10.891 … 10.935           8.949 ± 8.914 … 8.983              +0.2% (+0.2 MB)
LongSpider      date-format-tofte.js                    1.004      3.646 ± 3.635 … 3.658              3.631 ± 3.620 … 3.642              -1.3% (-0.4 MB)
LongSpider      date-format-xparb.js                    0.978      4.538 ± 4.532 … 4.544              4.641 ± 4.588 … 4.694              +0.0% (+0.0 MB)
LongSpider      hash-map.js                             1.130      1.198 ± 1.157 … 1.240              1.061 ± 1.045 … 1.076              +0.0% (+0.0 MB)
LongSpider      math-cordic.js                          1.079      5.718 ± 5.714 … 5.722              5.300 ± 5.292 … 5.308              +0.5% (+0.1 MB)
LongSpider      math-partial-sums.js                    1.006      0.800 ± 0.796 … 0.804              0.796 ± 0.795 … 0.796              +0.5% (+0.1 MB)
LongSpider      math-spectral-norm.js                   1.174      5.766 ± 5.763 … 5.770              4.913 ± 4.906 … 4.920              +0.5% (+0.1 MB)
LongSpider      string-base64.js                        0.981      1.405 ± 1.404 … 1.406              1.432 ± 1.430 … 1.434              -0.0% (-0.0 MB)
LongSpider      string-fasta.js                         1.000      1.628 ± 1.623 … 1.633              1.629 ± 1.607 … 1.651              -0.6% (-0.2 MB)
LongSpider      string-tagcloud.js                      1.002      0.763 ± 0.757 … 0.770              0.762 ± 0.750 … 0.773              -0.2% (-0.1 MB)
Kraken          ai-astar.js                             1.018      0.673 ± 0.662 … 0.685              0.662 ± 0.652 … 0.671              -0.2% (-0.1 MB)
Kraken          audio-beat-detection.js                 0.963      0.526 ± 0.519 … 0.533              0.546 ± 0.542 … 0.550              -0.2% (-0.2 MB)
Kraken          audio-dft.js                            1.082      0.386 ± 0.382 … 0.389              0.356 ± 0.352 … 0.360              -0.3% (-0.1 MB)
Kraken          audio-fft.js                            1.052      0.447 ± 0.443 … 0.451              0.425 ± 0.423 … 0.427              -0.2% (-0.1 MB)
Kraken          audio-oscillator.js                     0.932      0.360 ± 0.357 … 0.363              0.386 ± 0.370 … 0.403              +0.0% (+0.0 MB)
Kraken          imaging-darkroom.js                     1.052      0.593 ± 0.591 … 0.595              0.564 ± 0.563 … 0.564              +0.3% (+0.2 MB)
Kraken          imaging-desaturate.js                   1.036      0.621 ± 0.614 … 0.628              0.600 ± 0.594 … 0.605              -0.2% (-0.1 MB)
Kraken          imaging-gaussian-blur.js                0.982      2.648 ± 2.584 … 2.712              2.697 ± 2.656 … 2.738              +0.1% (+0.1 MB)
Kraken          json-parse-financial.js                 0.929      0.055 ± 0.055 … 0.055              0.059 ± 0.056 … 0.062              -0.2% (-0.1 MB)
Kraken          json-stringify-tinderbox.js             0.996      0.050 ± 0.050 … 0.051              0.051 ± 0.050 … 0.051              -2.8% (-1.1 MB)
Kraken          stanford-crypto-aes.js                  1.043      0.227 ± 0.222 … 0.233              0.218 ± 0.213 … 0.222              -0.2% (-0.1 MB)
Kraken          stanford-crypto-ccm.js                  1.021      0.178 ± 0.176 … 0.179              0.174 ± 0.171 … 0.176              -0.2% (-0.1 MB)
Kraken          stanford-crypto-pbkdf2.js               1.011      0.382 ± 0.381 … 0.384              0.378 ± 0.377 … 0.379              -0.9% (-0.3 MB)
Kraken          stanford-crypto-sha256-iterative.js     0.970      0.140 ± 0.140 … 0.141              0.145 ± 0.144 … 0.145              -0.1% (-0.1 MB)
Octane          box2d.js                                1.037      7900.500 ± 7874.000 … 7927.000     8193.000 ± 8193.000 … 8193.000     +0.0% (+0.0 MB)
Octane          code-load.js                            0.992      18907.500 ± 18907.000 … 18908.000  18765.500 ± 18764.000 … 18767.000  -1.6% (-16.8 MB)
Octane          crypto.js                               0.985      2853.500 ± 2807.000 … 2900.000     2811.000 ± 2788.000 … 2834.000     +0.2% (+0.1 MB)
Octane          deltablue.js                            1.327      1603.500 ± 1516.000 … 1691.000     2128.000 ± 2094.000 … 2162.000     +1.9% (+0.6 MB)
Octane          earley-boyer.js                         1.023      4558.000 ± 4549.000 … 4567.000     4662.000 ± 4636.000 … 4688.000     -0.3% (-0.1 MB)
Octane          gbemu.js                                1.077      15226.000 ± 15094.000 … 15358.000  16402.000 ± 16285.000 … 16519.000  -0.1% (-0.1 MB)
Octane          mandreel.js                             0.998      15776.500 ± 15677.000 … 15876.000  15751.000 ± 15726.000 … 15776.000  -0.8% (-2.6 MB)
Octane          navier-stokes.js                        1.081      4933.000 ± 4830.000 … 5036.000     5334.000 ± 5011.000 … 5657.000     +0.0% (+0.0 MB)
Octane          pdfjs.js                                1.028      7059.000 ± 7031.000 … 7087.000     7255.000 ± 7245.000 … 7265.000     +0.3% (+0.2 MB)
Octane          raytrace.js                             0.996      3358.500 ± 3340.000 … 3377.000     3343.500 ± 3337.000 … 3350.000     -0.3% (-0.1 MB)
Octane          regexp.js                               1.007      1894.000 ± 1879.000 … 1909.000     1908.000 ± 1905.000 … 1911.000     +0.3% (+0.2 MB)
Octane          richards.js                             1.264      1871.000 ± 1871.000 … 1871.000     2365.500 ± 2358.000 … 2373.000     +4.3% (+1.1 MB)
Octane          splay.js                                1.016      5407.000 ± 5320.000 … 5494.000     5494.500 ± 5464.000 … 5525.000     +0.1% (+0.2 MB)
Octane          typescript.js                           1.072      19116.500 ± 19025.000 … 19208.000  20491.000 ± 20440.000 … 20542.000  -0.0% (-0.1 MB)
Octane          zlib.js                                 1.024      5409.500 ± 5394.000 … 5425.000     5539.000 ± 5485.000 … 5593.000     -0.0% (-0.1 MB)
JetStream       bigfib.cpp.js                           1.006      4.973 ± 4.917 … 5.030              4.944 ± 4.831 … 5.058              +0.5% (+1.1 MB)
JetStream       cdjs.js                                 1.151      2.391 ± 2.385 … 2.398              2.077 ± 2.076 … 2.079              -0.4% (-0.2 MB)
JetStream       container.cpp.js                        1.001      21.101 ± 20.968 … 21.233           21.075 ± 21.000 … 21.150           +0.2% (+0.2 MB)
JetStream       dry.c.js                                1.027      10.857 ± 10.852 … 10.861           10.575 ± 10.443 … 10.708           +0.3% (+0.1 MB)
JetStream       float-mm.c.js                           1.053      13.536 ± 13.325 … 13.747           12.850 ± 12.562 … 13.138           +0.6% (+0.3 MB)
JetStream       gcc-loops.cpp.js                        1.054      77.510 ± 73.760 … 81.259           73.535 ± 71.624 … 75.446           -0.0% (-0.1 MB)
JetStream       hash-map.js                             1.163      1.183 ± 1.178 … 1.188              1.017 ± 1.010 … 1.023              -0.9% (-1.0 MB)
JetStream       n-body.c.js                             1.006      17.308 ± 17.189 … 17.427           17.203 ± 17.092 … 17.313           -0.1% (-0.1 MB)
JetStream       quicksort.c.js                          0.932      2.997 ± 2.921 … 3.073              3.215 ± 2.891 … 3.539              -0.0% (-0.0 MB)
JetStream       towers.c.js                             1.111      3.519 ± 3.483 … 3.556              3.167 ± 3.001 … 3.332              -0.4% (-0.2 MB)
JetStream3      js-tokens.js                            0.977      0.295 ± 0.295 … 0.295              0.302 ± 0.298 … 0.306              +0.3% (+0.1 MB)
JetStream3      lazy-collections.js                     1.053      0.899 ± 0.886 … 0.912              0.853 ± 0.850 … 0.856              -0.1% (-0.0 MB)
JetStream3      raytrace-private-class-fields.js        1.026      3.704 ± 3.682 … 3.725              3.611 ± 3.580 … 3.643              -0.6% (-0.2 MB)
JetStream3      raytrace-public-class-fields.js         1.030      2.760 ± 2.748 … 2.772              2.679 ± 2.644 … 2.714              -0.6% (-0.2 MB)
JetStream3      sync-file-system.js                     1.003      1.874 ± 1.866 … 1.882              1.869 ± 1.862 … 1.876              +2.7% (+0.9 MB)
AsyncBench      async-call-return.js                    1.007      0.176 ± 0.176 … 0.176              0.175 ± 0.175 … 0.175              -0.1% (-0.0 MB)
AsyncBench      async-class-method.js                   0.995      0.207 ± 0.206 … 0.208              0.208 ± 0.206 … 0.210              -0.4% (-0.1 MB)
AsyncBench      async-fan-out.js                        1.018      0.186 ± 0.185 … 0.186              0.183 ± 0.181 … 0.184              +0.2% (+0.1 MB)
AsyncBench      async-generator.js                      0.979      0.267 ± 0.267 … 0.268              0.273 ± 0.269 … 0.277              -0.4% (-0.1 MB)
AsyncBench      async-iife.js                           0.970      0.275 ± 0.273 … 0.277              0.284 ± 0.278 … 0.290              +0.1% (+0.0 MB)
AsyncBench      async-nested-calls.js                   1.046      0.307 ± 0.297 … 0.317              0.294 ± 0.291 … 0.297              -0.2% (-0.1 MB)
AsyncBench      async-pipeline.js                       0.982      0.354 ± 0.353 … 0.355              0.361 ± 0.357 … 0.365              +0.1% (+0.0 MB)
AsyncBench      async-sequential-awaits.js              0.992      0.095 ± 0.094 … 0.095              0.095 ± 0.094 … 0.096              -0.4% (-0.1 MB)
AsyncBench      async-try-catch-reject.js               0.995      0.504 ± 0.504 … 0.504              0.507 ± 0.503 … 0.510              +0.2% (+0.1 MB)
AsyncBench      await-primitive.js                      1.038      0.053 ± 0.053 … 0.054              0.051 ± 0.051 … 0.052              -0.0% (-0.0 MB)
AsyncBench      await-resolved-promise.js               0.958      0.444 ± 0.443 … 0.445              0.464 ± 0.462 … 0.467              -0.0% (-0.0 MB)
AsyncBench      await-thenable.js                       1.003      0.051 ± 0.050 … 0.052              0.051 ± 0.051 … 0.051              +0.0% (+0.0 MB)
AsyncBench      promise-all.js                          0.968      0.519 ± 0.519 … 0.519              0.536 ± 0.514 … 0.558              -0.0% (-0.0 MB)
AsyncBench      promise-allSettled.js                   1.031      0.596 ± 0.585 … 0.607              0.578 ± 0.576 … 0.579              -0.0% (-0.0 MB)
AsyncBench      promise-chain.js                        1.003      0.290 ± 0.289 … 0.291              0.289 ± 0.288 … 0.290              +0.1% (+0.3 MB)
AsyncBench      promise-new-resolve.js                  0.971      0.277 ± 0.275 … 0.278              0.285 ± 0.278 … 0.291              -0.0% (-0.0 MB)
AsyncBench      promise-race.js                         0.975      0.531 ± 0.530 … 0.533              0.545 ± 0.531 … 0.559              -0.0% (-0.0 MB)
ARES-6          Air.js                                  1.021      1.772 ± 1.766 … 1.777              1.735 ± 1.731 … 1.739              -0.0% (-0.0 MB)
ARES-6          Babylon.js                              1.064      1.165 ± 1.157 … 1.173              1.094 ± 1.092 … 1.096              -0.0% (-0.0 MB)
ARES-6          Basic.js                                1.017      1.644 ± 1.641 … 1.647              1.616 ± 1.615 … 1.617              -0.0% (-0.0 MB)
ARES-6          ML.js                                   1.271      1.995 ± 1.980 … 2.011              1.570 ± 1.561 … 1.580              -0.0% (-0.0 MB)
JetStreamExtra  FlightPlanner.js                        1.033      1.164 ± 1.153 … 1.175              1.127 ± 1.086 … 1.168              +0.0% (+0.1 MB)
JetStreamExtra  OfflineAssembler.js                     1.011      1.149 ± 1.146 … 1.151              1.136 ± 1.132 … 1.140              -0.0% (-0.0 MB)
JetStreamExtra  UniPoker.js                             1.019      1.383 ± 1.383 … 1.383              1.357 ± 1.344 … 1.369              -0.0% (-0.0 MB)
JetStreamExtra  async-fs.js                             0.980      1.779 ± 1.778 … 1.780              1.815 ± 1.781 … 1.849              -0.0% (-0.0 MB)
JetStreamExtra  babylonjs-startup-es5.js                1.002      1.189 ± 1.187 … 1.192              1.187 ± 1.184 … 1.190              -0.0% (-0.1 MB)
JetStreamExtra  babylonjs-startup-es6.js                0.998      1.433 ± 1.430 … 1.436              1.436 ± 1.431 … 1.442              +0.1% (+0.8 MB)
JetStreamExtra  bigint-bigdenary.js                     1.030      1.750 ± 1.745 … 1.754              1.699 ± 1.695 … 1.704              -0.0% (-0.0 MB)
JetStreamExtra  bigint-noble-bls12-381.js               1.011      1.829 ± 1.824 … 1.834              1.810 ± 1.804 … 1.815              -0.0% (-0.0 MB)
JetStreamExtra  bigint-noble-ed25519.js                 1.022      1.904 ± 1.900 … 1.909              1.863 ± 1.862 … 1.863              +0.3% (+0.2 MB)
JetStreamExtra  bigint-noble-secp256k1.js               1.021      1.773 ± 1.769 … 1.777              1.737 ± 1.736 … 1.737              -0.2% (-0.1 MB)
JetStreamExtra  bigint-paillier.js                      0.993      1.831 ± 1.827 … 1.835              1.844 ± 1.836 … 1.851              -0.4% (-0.2 MB)
JetStreamExtra  doxbee-async.js                         1.002      1.729 ± 1.729 … 1.730              1.726 ± 1.719 … 1.733              +0.2% (+0.2 MB)
JetStreamExtra  doxbee-promise.js                       1.010      1.771 ± 1.749 … 1.794              1.754 ± 1.742 … 1.765              +0.6% (+0.3 MB)
JetStreamExtra  first-inspector-code-load.js            0.998      2.009 ± 2.006 … 2.011              2.012 ± 2.010 … 2.014              +0.0% (+0.0 MB)
JetStreamExtra  jsdom-d3-startup.js                     1.009      1.603 ± 1.603 … 1.603              1.588 ± 1.585 … 1.592              -0.1% (-0.3 MB)
JetStreamExtra  json-parse-inspector.js                 0.949      1.097 ± 1.095 … 1.100              1.156 ± 1.096 … 1.217              +1.4% (+3.7 MB)
JetStreamExtra  json-stringify-inspector.js             0.986      0.958 ± 0.955 … 0.962              0.972 ± 0.971 … 0.973              -1.7% (-4.9 MB)
JetStreamExtra  mobx-startup.js                         1.066      1.566 ± 1.560 … 1.571              1.469 ± 1.467 … 1.471              +0.1% (+0.0 MB)
JetStreamExtra  multi-inspector-code-load.js            1.003      2.013 ± 2.012 … 2.013              2.007 ± 2.000 … 2.015              +0.1% (+1.0 MB)
JetStreamExtra  prismjs-startup-es5.js                  1.019      1.751 ± 1.742 … 1.759              1.718 ± 1.717 … 1.718              -0.0% (-0.0 MB)
JetStreamExtra  prismjs-startup-es6.js                  1.019      1.756 ± 1.742 … 1.771              1.723 ± 1.723 … 1.724              -0.0% (-0.0 MB)
JetStreamExtra  proxy-mobx.js                           1.061      1.409 ± 1.401 … 1.418              1.328 ± 1.325 … 1.332              -0.0% (-0.0 MB)
JetStreamExtra  proxy-vue.js                            1.012      1.411 ± 1.360 … 1.462              1.395 ± 1.214 … 1.576              +2.1% (+1.2 MB)
JetStreamExtra  threejs.js                              1.033      1.819 ± 1.813 … 1.825              1.762 ± 1.745 … 1.778              +0.0% (+0.2 MB)
JetStreamExtra  typescript-lib.js                       1.029      0.745 ± 0.742 … 0.748              0.724 ± 0.722 … 0.726              -0.1% (-0.2 MB)
JetStreamExtra  validatorjs.js                          1.003      1.584 ± 1.577 … 1.590              1.578 ± 1.576 … 1.580              +1.4% (+0.8 MB)
JetStreamExtra  web-ssr.js                              1.015      1.902 ± 1.888 … 1.915              1.874 ± 1.866 … 1.882              -0.3% (-0.5 MB)
GarBench        array-of-objects.js                     1.009      0.875 ± 0.868 … 0.881              0.867 ± 0.864 … 0.870              +0.1% (+1.2 MB)
GarBench        closures.js                             1.017      1.234 ± 1.225 … 1.243              1.213 ± 1.206 … 1.220              -0.1% (-0.9 MB)
GarBench        cyclic-graph.js                         0.977      1.378 ± 1.334 … 1.421              1.411 ± 1.409 … 1.412              +0.1% (+0.2 MB)
GarBench        deep-linked-list.js                     1.000      0.809 ± 0.808 … 0.811              0.809 ± 0.807 … 0.811              +0.0% (+0.1 MB)
GarBench        finalization.js                         1.030      1.062 ± 1.023 … 1.101              1.031 ± 1.022 … 1.039              +0.0% (+0.1 MB)
GarBench        many-properties.js                      0.998      2.685 ± 2.683 … 2.688              2.692 ± 2.690 … 2.694              -0.0% (-0.2 MB)
GarBench        marking-stress.js                       0.818      1.574 ± 1.535 … 1.614              1.924 ± 1.871 … 1.976              -1.4% (-9.3 MB)
GarBench        mixed-sizes.js                          1.070      1.164 ± 1.117 … 1.210              1.088 ± 1.086 … 1.089              -0.0% (-0.0 MB)
GarBench        sparse-arrays.js                        0.947      2.358 ± 2.272 … 2.444              2.491 ± 2.426 … 2.556              +0.0% (+0.1 MB)
GarBench        string-heavy.js                         0.994      1.570 ± 1.570 … 1.571              1.580 ± 1.579 … 1.580              +0.0% (+0.0 MB)
GarBench        wide-tree.js                            1.029      1.578 ± 1.576 … 1.580              1.533 ± 1.530 … 1.537              +0.0% (+0.1 MB)
MicroBench      array-destructuring-assignment-rest.js  0.980      0.310 ± 0.308 … 0.312              0.316 ± 0.310 … 0.323              -0.0% (-0.0 MB)
MicroBench      array-destructuring-assignment.js       1.061      3.192 ± 3.067 … 3.318              3.009 ± 3.000 … 3.019              -0.0% (-0.2 MB)
MicroBench      array-prototype-map.js                  1.010      1.203 ± 1.201 … 1.204              1.191 ± 1.190 … 1.192              +0.0% (+0.1 MB)
MicroBench      array-prototype-shift.js                0.953      0.016 ± 0.016 … 0.017              0.017 ± 0.017 … 0.017              -0.0% (-0.0 MB)
MicroBench      bound-call-00-args.js                   1.004      1.431 ± 1.423 … 1.439              1.425 ± 1.425 … 1.426              -0.0% (-0.0 MB)
MicroBench      bound-call-04-args.js                   0.996      1.539 ± 1.538 … 1.539              1.544 ± 1.535 … 1.553              -0.0% (-0.0 MB)
MicroBench      bound-call-16-args.js                   0.996      1.768 ± 1.767 … 1.769              1.774 ± 1.755 … 1.793              -0.0% (-0.0 MB)
MicroBench      call-00-args.js                         2.160      0.992 ± 0.664 … 1.321              0.459 ± 0.458 … 0.461              -0.0% (-0.0 MB)
MicroBench      call-01-args.js                         1.411      0.714 ± 0.704 … 0.724              0.506 ± 0.498 … 0.515              -0.0% (-0.0 MB)
MicroBench      call-02-args.js                         1.272      0.749 ± 0.732 … 0.765              0.589 ± 0.538 … 0.639              -0.0% (-0.0 MB)
MicroBench      call-03-args.js                         1.357      0.742 ± 0.742 … 0.742              0.547 ± 0.545 … 0.549              -0.0% (-0.0 MB)
MicroBench      call-04-args.js                         1.325      0.775 ± 0.774 … 0.776              0.585 ± 0.584 … 0.585              -0.0% (-0.0 MB)
MicroBench      call-16-args.js                         1.326      0.981 ± 0.980 … 0.982              0.740 ± 0.738 … 0.741              -0.0% (-0.0 MB)
MicroBench      call-32-args.js                         1.261      1.235 ± 1.234 … 1.236              0.980 ± 0.977 … 0.982              -0.0% (-0.0 MB)
MicroBench      for-in-indexed-properties.js            0.999      0.232 ± 0.228 … 0.237              0.233 ± 0.232 … 0.234              +0.0% (+0.0 MB)
MicroBench      for-in-named-properties.js              1.005      0.180 ± 0.180 … 0.180              0.179 ± 0.179 … 0.180              -0.0% (-0.0 MB)
MicroBench      for-of.js                               1.031      0.547 ± 0.533 … 0.561              0.530 ± 0.497 … 0.563              -0.0% (-0.0 MB)
MicroBench      object-keys.js                          0.989      1.263 ± 1.260 … 1.266              1.278 ± 1.272 … 1.283              +0.3% (+0.4 MB)
MicroBench      object-set-with-rope-strings.js         0.988      0.680 ± 0.680 … 0.681              0.689 ± 0.683 … 0.694              -0.0% (-0.0 MB)
MicroBench      pic-add-own.js                          1.002      0.415 ± 0.413 … 0.417              0.414 ± 0.413 … 0.415              -0.0% (-0.0 MB)
MicroBench      pic-get-own.js                          1.229      0.681 ± 0.678 … 0.684              0.554 ± 0.542 … 0.567              -0.0% (-0.0 MB)
MicroBench      pic-get-pchain.js                       1.254      0.703 ± 0.690 … 0.715              0.560 ± 0.556 … 0.564              -0.0% (-0.0 MB)
MicroBench      pic-put-own.js                          1.292      0.716 ± 0.716 … 0.716              0.554 ± 0.544 … 0.564              -0.0% (-0.0 MB)
MicroBench      pic-put-pchain.js                       1.110      2.112 ± 2.105 … 2.118              1.903 ± 1.881 … 1.925              -0.0% (-0.0 MB)
MicroBench      setter-in-prototype-chain.js            0.834      1.964 ± 1.942 … 1.986              2.354 ± 1.942 … 2.767              -0.0% (-0.0 MB)
MicroBench      strictly-equals-object.js               1.028      0.762 ± 0.757 … 0.767              0.741 ± 0.714 … 0.768              -0.0% (-0.0 MB)
LongSpider      Total                                   1.093      79.368                             72.616                             +0.5% (+8.3 MB)
Kraken          Total                                   1.004      7.287                              7.259                              -0.3% (-1.9 MB)
Octane          Total                                   1.039      115874.000                         120443.000                         -0.7% (-17.7 MB)
JetStream       Total                                   1.038      155.375                            149.659                            +0.0% (+0.3 MB)
JetStream3      Total                                   1.023      9.532                              9.315                              +0.4% (+0.6 MB)
AsyncBench      Total                                   0.991      5.133                              5.178                              +0.0% (+0.1 MB)
ARES-6          Total                                   1.093      6.575                              6.015                              -0.0% (-0.0 MB)
JetStreamExtra  Total                                   1.012      42.306                             41.796                             +0.0% (+2.2 MB)
GarBench        Total                                   0.979      16.287                             16.638                             -0.1% (-8.7 MB)
MicroBench      Total                                   1.094      25.904                             23.673                             +0.0% (+0.3 MB)
All Suites      Total                                   1.042      414.339                            397.635                            -0.1% (-16.6 MB)
```