### PR TITLE
LibGC: Implement incremental garbage collection

### DIFF
--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -38,6 +38,12 @@ public:                                            \
     }                                              \
     friend class GC::Heap;
 
+enum class Color : u8 {
+    White, // Not yet reached — will be reclaimed if still white at sweep time.
+    Gray,  // Reached but outgoing edges not yet traced (on marking worklist).
+    Black, // Reached and fully traced.
+};
+
 class GC_API Cell {
     AK_MAKE_NONCOPYABLE(Cell);
     AK_MAKE_NONMOVABLE(Cell);
@@ -48,8 +54,11 @@ public:
 
     virtual ~Cell() = default;
 
-    bool is_marked() const { return m_mark; }
-    void set_marked(bool b) { m_mark = b; }
+    bool is_marked() const { return m_color != Color::White; }
+    void set_marked(bool b) { m_color = b ? Color::Black : Color::White; }
+
+    Color gc_color() const { return m_color; }
+    void set_gc_color(Color color) { m_color = color; }
 
     enum class State : bool {
         Live,
@@ -140,6 +149,13 @@ public:
         }
 
         template<typename T>
+        void visit(ValueVector<T> const& vector)
+        requires(IsBaseOf<NanBoxedValue, T>)
+        {
+            visit_impl(ReadonlySpan<NanBoxedValue>(vector.span().data(), vector.size()));
+        }
+
+        template<typename T>
         void visit(HashTable<T> const& table)
         {
             for (auto& value : table)
@@ -215,7 +231,7 @@ protected:
     Cell() = default;
 
 private:
-    bool m_mark { false };
+    Color m_color { Color::White };
     State m_state { State::Live };
 };
 

--- a/Libraries/LibGC/DeferGC.h
+++ b/Libraries/LibGC/DeferGC.h
@@ -10,6 +10,8 @@
 
 namespace GC {
 
+// note: write barriers remain active during deferral to ensure the tri-color
+// invariant is preserved.
 class GC_API DeferGC {
 public:
     explicit DeferGC(Heap& heap)

--- a/Libraries/LibGC/Forward.h
+++ b/Libraries/LibGC/Forward.h
@@ -28,6 +28,12 @@ template<typename T>
 class HeapHashTable;
 
 template<class T>
+class RawPtr;
+
+template<class T>
+class RawRef;
+
+template<class T>
 class Root;
 
 template<class T, size_t inline_capacity = 0>
@@ -35,6 +41,9 @@ class ConservativeVector;
 
 template<class T>
 class HeapVector;
+
+template<class T>
+class ValueVector;
 
 template<class T, size_t inline_capacity = 0>
 class RootVector;

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -17,6 +17,7 @@
 #include <AK/StackInfo.h>
 #include <AK/StackUnwinder.h>
 #include <AK/TemporaryChange.h>
+#include <LibCore/ConfigFile.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
@@ -26,6 +27,7 @@
 #include <LibGC/NanBoxedValue.h>
 #include <LibGC/Root.h>
 #include <LibGC/Weak.h>
+#include <LibGC/WriteBarrier.h>
 #include <setjmp.h>
 
 #ifdef HAS_ADDRESS_SANITIZER
@@ -39,6 +41,34 @@
 namespace GC {
 
 static Heap* s_the;
+
+bool s_incremental_marking_active = false;
+
+void shade_gray_slow(Cell* old_target)
+{
+    if (old_target->gc_color() == GC::Color::White) {
+        old_target->set_gc_color(GC::Color::Gray);
+        Heap::the().enqueue_barrier_gray(*old_target);
+    }
+}
+
+void value_write_barrier(NanBoxedValue const& old_value)
+{
+    if (!s_incremental_marking_active) [[likely]]
+        return;
+    if (old_value.is_cell())
+        shade_gray_slow(const_cast<Cell*>(&old_value.as_cell()));
+}
+
+void value_write_barrier(NanBoxedValue const& old_value, NanBoxedValue const& new_value)
+{
+    if (!s_incremental_marking_active) [[likely]]
+        return;
+    if (old_value.is_cell())
+        shade_gray_slow(const_cast<Cell*>(&old_value.as_cell()));
+    if (new_value.is_cell())
+        shade_gray_slow(const_cast<Cell*>(&new_value.as_cell()));
+}
 
 Heap& Heap::the()
 {
@@ -57,6 +87,15 @@ Heap::Heap(AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roo
     m_size_based_cell_allocators.append(make<CellAllocator>(512));
     m_size_based_cell_allocators.append(make<CellAllocator>(1024));
     m_size_based_cell_allocators.append(make<CellAllocator>(3072));
+
+    // Tunable via ~/.config/lib/GC.ini under the [Incremental] group:
+    //   MarkBudget  - cells traced per incremental mark step
+    //   SweepBudget - blocks swept per incremental sweep step
+    if (auto config_or_error = Core::ConfigFile::open_for_lib("GC"); !config_or_error.is_error()) {
+        auto config = config_or_error.release_value();
+        m_incremental_marking_budget = config->read_num_entry<size_t>("Incremental", "MarkBudget", m_incremental_marking_budget);
+        m_incremental_sweep_budget = config->read_num_entry<size_t>("Incremental", "SweepBudget", m_incremental_sweep_budget);
+    }
 }
 
 Heap::~Heap()
@@ -66,15 +105,108 @@ Heap::~Heap()
 
 void Heap::will_allocate(size_t size)
 {
+    if (m_gc_deferrals || m_collecting_garbage)
+        goto count;
+
+    if (m_incremental_sweep_in_progress) {
+        TemporaryChange change(m_collecting_garbage, true);
+        if (continue_incremental_sweep(m_incremental_sweep_budget)) {
+            finalize_incremental_sweep();
+            m_allocated_bytes_since_last_gc = 0;
+            run_post_gc_tasks();
+        }
+        goto count;
+    }
+
+    if (m_incremental_marking_in_progress) {
+        TemporaryChange change(m_collecting_garbage, true);
+        // Continue in-progress marking increment.
+        if (continue_incremental_marking(m_incremental_marking_budget)) {
+            // Marking complete — run finalize, then begin incremental sweep.
+            finish_incremental_marking();
+            finalize_unmarked_cells();
+            sweep_weak_blocks();
+            // Weak containers and sweep callbacks must run before sweep
+            // begins so interleaved JS execution never observes dangling
+            // pointers into freed cells.
+            for (auto& weak_container : m_weak_containers)
+                weak_container.remove_dead_cells({});
+            for (auto& callback : m_sweep_callbacks)
+                callback();
+            begin_incremental_sweep();
+            if (continue_incremental_sweep(m_incremental_sweep_budget)) {
+                finalize_incremental_sweep();
+                m_allocated_bytes_since_last_gc = 0;
+                run_post_gc_tasks();
+            }
+        }
+        goto count;
+    }
+
     if (should_collect_on_every_allocation()) {
+        // Stress-test mode: full stop-the-world collection every allocation.
         m_allocated_bytes_since_last_gc = 0;
         collect_garbage();
     } else if (m_allocated_bytes_since_last_gc + size > m_gc_bytes_threshold) {
-        m_allocated_bytes_since_last_gc = 0;
-        collect_garbage();
+        TemporaryChange change(m_collecting_garbage, true);
+        // Start a new incremental marking cycle.
+        start_incremental_marking();
+        // Run an initial budget immediately.
+        if (continue_incremental_marking(m_incremental_marking_budget)) {
+            // Small heap — marking completed in one step; begin sweep.
+            finish_incremental_marking();
+            finalize_unmarked_cells();
+            sweep_weak_blocks();
+            for (auto& weak_container : m_weak_containers)
+                weak_container.remove_dead_cells({});
+            for (auto& callback : m_sweep_callbacks)
+                callback();
+            begin_incremental_sweep();
+            if (continue_incremental_sweep(m_incremental_sweep_budget)) {
+                finalize_incremental_sweep();
+                m_allocated_bytes_since_last_gc = 0;
+                run_post_gc_tasks();
+            }
+        }
     }
 
+count:
     m_allocated_bytes_since_last_gc += size;
+}
+
+void Heap::incremental_idle_step()
+{
+    if (m_gc_deferrals || m_collecting_garbage)
+        return;
+
+    if (m_incremental_sweep_in_progress) {
+        TemporaryChange change(m_collecting_garbage, true);
+        if (continue_incremental_sweep(m_incremental_sweep_budget)) {
+            finalize_incremental_sweep();
+            m_allocated_bytes_since_last_gc = 0;
+            run_post_gc_tasks();
+        }
+        return;
+    }
+
+    if (m_incremental_marking_in_progress) {
+        TemporaryChange change(m_collecting_garbage, true);
+        if (continue_incremental_marking(m_incremental_marking_budget)) {
+            finish_incremental_marking();
+            finalize_unmarked_cells();
+            sweep_weak_blocks();
+            for (auto& weak_container : m_weak_containers)
+                weak_container.remove_dead_cells({});
+            for (auto& callback : m_sweep_callbacks)
+                callback();
+            begin_incremental_sweep();
+            if (continue_incremental_sweep(m_incremental_sweep_budget)) {
+                finalize_incremental_sweep();
+                m_allocated_bytes_since_last_gc = 0;
+                run_post_gc_tasks();
+            }
+        }
+    }
 }
 
 static void add_possible_value(HashMap<FlatPtr, HeapRoot>& possible_pointers, FlatPtr data, HeapRoot origin, FlatPtr min_block_address, FlatPtr max_block_address)
@@ -304,11 +436,38 @@ void Heap::collect_garbage(CollectionType collection_type, bool print_report)
         if (print_report)
             collection_measurement_timer.start();
 
+        // If an incremental sweep is in progress, finish it synchronously
+        // before starting a new collection cycle.
+        if (m_incremental_sweep_in_progress)
+            force_sweep_to_completion();
+
+        // If incremental marking is in progress, clean it up.
+        if (m_incremental_marking_in_progress) {
+            m_marking_visitor.clear();
+            m_marking_heap_blocks.clear();
+            m_incremental_marking_in_progress = false;
+            s_incremental_marking_active = false;
+
+            // Reset all cell colors to white so that a fresh mark or
+            // CollectEverything sweep sees a clean slate.
+            for_each_block([&](auto& block) {
+                block.template for_each_cell_in_state<Cell::State::Live>([](Cell* cell) {
+                    cell->set_gc_color(GC::Color::White);
+                });
+                return IterationDecision::Continue;
+            });
+
+            for (auto& inverse_root : m_uprooted_cells)
+                inverse_root->set_gc_color(GC::Color::White);
+            m_uprooted_cells.clear();
+        }
+
         if (collection_type == CollectionType::CollectGarbage) {
             if (m_gc_deferrals) {
                 m_should_gc_when_deferral_ends = true;
                 return;
             }
+            // Full stop-the-world mark.
             HashMap<Cell*, HeapRoot> roots;
             HashTable<HeapBlock*> all_live_heap_blocks;
             gather_roots(roots, all_live_heap_blocks);
@@ -322,6 +481,7 @@ void Heap::collect_garbage(CollectionType collection_type, bool print_report)
             dump_allocators();
     }
 
+    m_allocated_bytes_since_last_gc = 0;
     run_post_gc_tasks();
 }
 
@@ -615,11 +775,11 @@ public:
 
     virtual void visit_impl(Cell& cell) override
     {
-        if (cell.is_marked())
+        if (cell.gc_color() != GC::Color::White)
             return;
         dbgln_if(HEAP_DEBUG, "  ! {}", &cell);
 
-        cell.set_marked(true);
+        cell.set_gc_color(GC::Color::Gray);
         m_work_queue.append(cell);
     }
 
@@ -631,11 +791,11 @@ public:
             if (!value.is_cell())
                 continue;
             auto& cell = value.as_cell();
-            if (cell.is_marked())
+            if (cell.gc_color() != GC::Color::White)
                 continue;
             dbgln_if(HEAP_DEBUG, "  ! {}", &cell);
 
-            cell.set_marked(true);
+            cell.set_gc_color(GC::Color::Gray);
             m_work_queue.unchecked_append(cell);
         }
     }
@@ -649,11 +809,11 @@ public:
             add_possible_value(possible_pointers, raw_pointer_sized_values[i], HeapRoot { .type = HeapRoot::Type::HeapFunctionCapturedPointer }, m_min_block_address, m_max_block_address);
 
         for_each_cell_among_possible_pointers(m_all_live_heap_blocks, possible_pointers, [&](Cell* cell, FlatPtr) {
-            if (cell->is_marked())
+            if (cell->gc_color() != GC::Color::White)
                 return;
             if (cell->state() != Cell::State::Live)
                 return;
-            cell->set_marked(true);
+            cell->set_gc_color(GC::Color::Gray);
             m_work_queue.append(*cell);
         });
     }
@@ -661,8 +821,26 @@ public:
     void mark_all_live_cells()
     {
         while (!m_work_queue.is_empty()) {
-            m_work_queue.take_last()->visit_edges(*this);
+            auto& cell = *m_work_queue.take_last();
+            cell.visit_edges(*this);
+            cell.set_gc_color(GC::Color::Black);
         }
+    }
+
+    // Process up to `budget` cells from the worklist.
+    bool mark_live_cells_budgeted(size_t budget)
+    {
+        for (size_t i = 0; i < budget && !m_work_queue.is_empty(); ++i) {
+            auto& cell = *m_work_queue.take_last();
+            cell.visit_edges(*this);
+            cell.set_gc_color(GC::Color::Black);
+        }
+        return m_work_queue.is_empty();
+    }
+
+    void enqueue_barrier_gray(Cell& cell)
+    {
+        m_work_queue.append(cell);
     }
 
 private:
@@ -681,9 +859,76 @@ void Heap::mark_live_cells(HashMap<Cell*, HeapRoot> const& roots, HashTable<Heap
     visitor.mark_all_live_cells();
 
     for (auto& inverse_root : m_uprooted_cells)
-        inverse_root->set_marked(false);
+        inverse_root->set_gc_color(GC::Color::White);
 
     m_uprooted_cells.clear();
+}
+
+void Heap::start_incremental_marking()
+{
+    VERIFY(!m_incremental_marking_in_progress);
+
+    m_incremental_marking_in_progress = true;
+
+    // Gather roots and create the marking visitor with initial gray set.
+    // Root scanning is stop-the-world: the stack is a snapshot at this point.
+    HashMap<Cell*, HeapRoot> roots;
+    m_marking_heap_blocks.clear();
+    gather_roots(roots, m_marking_heap_blocks);
+
+    m_marking_visitor = make<MarkingVisitor>(*this, roots, m_marking_heap_blocks);
+
+    // Enable write barriers only once the visitor exists, so that
+    // enqueue_barrier_gray has a valid target.
+    s_incremental_marking_active = true;
+}
+
+bool Heap::continue_incremental_marking(size_t cell_budget)
+{
+    VERIFY(m_incremental_marking_in_progress);
+    VERIFY(m_marking_visitor);
+
+    return m_marking_visitor->mark_live_cells_budgeted(cell_budget);
+}
+
+void Heap::enqueue_barrier_gray(Cell& cell)
+{
+    if (m_marking_visitor)
+        m_marking_visitor->enqueue_barrier_gray(cell);
+}
+
+void Heap::finish_incremental_marking()
+{
+    VERIFY(m_incremental_marking_in_progress);
+
+    if (m_marking_visitor) {
+        // First process any remaining worklist items to completion.
+        // This includes cells added by allocate-gray during mutator execution.
+        m_marking_visitor->mark_all_live_cells();
+
+        // Re-mark phase: re-scan roots to catch any new references the
+        // mutator created on the stack or in root containers since
+        // start_incremental_marking. Heap writes are covered by the
+        // hybrid SATB + Dijkstra write barriers, so a full black-cell
+        // re-visit is not needed.
+        HashMap<Cell*, HeapRoot> roots;
+        m_marking_heap_blocks.clear();
+        gather_roots(roots, m_marking_heap_blocks);
+        for (auto* root : roots.keys())
+            m_marking_visitor->visit(root);
+
+        // Drain newly discovered cells.
+        m_marking_visitor->mark_all_live_cells();
+    }
+
+    for (auto& inverse_root : m_uprooted_cells)
+        inverse_root->set_gc_color(GC::Color::White);
+    m_uprooted_cells.clear();
+
+    m_marking_visitor.clear();
+    m_marking_heap_blocks.clear();
+    m_incremental_marking_in_progress = false;
+    s_incremental_marking_active = false;
 }
 
 void Heap::finalize_unmarked_cells()
@@ -692,7 +937,7 @@ void Heap::finalize_unmarked_cells()
         if (!block.overrides_finalize())
             return IterationDecision::Continue;
         block.template for_each_cell_in_state<Cell::State::Live>([](Cell* cell) {
-            if (!cell->is_marked())
+            if (cell->gc_color() == GC::Color::White)
                 cell->finalize();
         });
         return IterationDecision::Continue;
@@ -715,55 +960,68 @@ void Heap::sweep_weak_blocks()
     }
 }
 
-void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measurement_timer)
+void Heap::sweep_one_block(HeapBlock& block)
 {
-    dbgln_if(HEAP_DEBUG, "sweep_dead_cells:");
-    Vector<HeapBlock*, 32> empty_blocks;
-    Vector<HeapBlock*, 32> full_blocks_that_became_usable;
+    bool block_has_live_cells = false;
+    bool block_was_full = block.is_full();
+    block.for_each_cell_in_state<Cell::State::Live>([&](Cell* cell) {
+        if (cell->gc_color() == GC::Color::White) {
+            dbgln_if(HEAP_DEBUG, "  ~ {}", cell);
+            block.deallocate(cell);
+            ++m_sweep_collected_cells;
+            m_sweep_collected_cell_bytes += block.cell_size();
+        } else {
+            cell->set_gc_color(GC::Color::White);
+            block_has_live_cells = true;
+            ++m_sweep_live_cells;
+            m_sweep_live_cell_bytes += block.cell_size();
+        }
+    });
+    if (!block_has_live_cells) {
+        dbgln_if(HEAP_DEBUG, " - HeapBlock empty @ {}: cell_size={}", &block, block.cell_size());
+        ++m_sweep_empty_block_count;
+        block.cell_allocator().block_did_become_empty({}, block);
+    } else if (block_was_full != block.is_full()) {
+        dbgln_if(HEAP_DEBUG, " - HeapBlock usable again @ {}: cell_size={}", &block, block.cell_size());
+        block.cell_allocator().block_did_become_usable({}, block);
+    }
+}
 
-    size_t collected_cells = 0;
-    size_t live_cells = 0;
-    size_t collected_cell_bytes = 0;
-    size_t live_cell_bytes = 0;
+void Heap::begin_incremental_sweep()
+{
+    VERIFY(!m_incremental_sweep_in_progress);
+    m_incremental_sweep_in_progress = true;
 
+    m_sweep_collected_cells = 0;
+    m_sweep_live_cells = 0;
+    m_sweep_collected_cell_bytes = 0;
+    m_sweep_live_cell_bytes = 0;
+    m_sweep_empty_block_count = 0;
+
+    m_sweep_blocks_remaining.clear();
     for_each_block([&](auto& block) {
-        bool block_has_live_cells = false;
-        bool block_was_full = block.is_full();
-        block.template for_each_cell_in_state<Cell::State::Live>([&](Cell* cell) {
-            if (!cell->is_marked()) {
-                dbgln_if(HEAP_DEBUG, "  ~ {}", cell);
-                block.deallocate(cell);
-                ++collected_cells;
-                collected_cell_bytes += block.cell_size();
-            } else {
-                cell->set_marked(false);
-                block_has_live_cells = true;
-                ++live_cells;
-                live_cell_bytes += block.cell_size();
-            }
-        });
-        if (!block_has_live_cells)
-            empty_blocks.append(&block);
-        else if (block_was_full != block.is_full())
-            full_blocks_that_became_usable.append(&block);
+        m_sweep_blocks_remaining.append(&block);
         return IterationDecision::Continue;
     });
+}
 
-    for (auto& weak_container : m_weak_containers)
-        weak_container.remove_dead_cells({});
-
-    for (auto& callback : m_sweep_callbacks)
-        callback();
-
-    for (auto* block : empty_blocks) {
-        dbgln_if(HEAP_DEBUG, " - HeapBlock empty @ {}: cell_size={}", block, block->cell_size());
-        block->cell_allocator().block_did_become_empty({}, *block);
+bool Heap::continue_incremental_sweep(size_t block_budget)
+{
+    VERIFY(m_incremental_sweep_in_progress);
+    for (size_t i = 0; i < block_budget && !m_sweep_blocks_remaining.is_empty(); ++i) {
+        auto* block = m_sweep_blocks_remaining.take_last();
+        sweep_one_block(*block);
     }
+    return m_sweep_blocks_remaining.is_empty();
+}
 
-    for (auto* block : full_blocks_that_became_usable) {
-        dbgln_if(HEAP_DEBUG, " - HeapBlock usable again @ {}: cell_size={}", block, block->cell_size());
-        block->cell_allocator().block_did_become_usable({}, *block);
-    }
+void Heap::finalize_incremental_sweep()
+{
+    VERIFY(m_incremental_sweep_in_progress);
+    VERIFY(m_sweep_blocks_remaining.is_empty());
+
+    // NOTE: m_sweep_callbacks were already invoked before begin_incremental_sweep,
+    //       so doomed cells they referenced have already been cleared.
 
     if constexpr (HEAP_DEBUG) {
         for_each_block([&](auto& block) {
@@ -772,7 +1030,40 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
         });
     }
 
-    m_gc_bytes_threshold = live_cell_bytes > GC_MIN_BYTES_THRESHOLD ? live_cell_bytes : GC_MIN_BYTES_THRESHOLD;
+    // Cells allocated into already-swept blocks (or into new blocks
+    // created during sweep) were colored black by the allocator so the
+    // sweep would not reclaim them.  Reset any remaining non-white
+    // cells back to white so the next mark cycle starts from a clean
+    // slate.  sweep_one_block already handles this for blocks it
+    // visited, so this loop only catches cells sweep did not touch.
+    for_each_block([&](auto& block) {
+        block.template for_each_cell_in_state<Cell::State::Live>([](Cell* cell) {
+            if (cell->gc_color() != GC::Color::White)
+                cell->set_gc_color(GC::Color::White);
+        });
+        return IterationDecision::Continue;
+    });
+
+    m_gc_bytes_threshold = m_sweep_live_cell_bytes > GC_MIN_BYTES_THRESHOLD ? m_sweep_live_cell_bytes : GC_MIN_BYTES_THRESHOLD;
+    m_incremental_sweep_in_progress = false;
+}
+
+void Heap::force_sweep_to_completion()
+{
+    while (!continue_incremental_sweep(SIZE_MAX)) { }
+    finalize_incremental_sweep();
+}
+
+void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measurement_timer)
+{
+    dbgln_if(HEAP_DEBUG, "sweep_dead_cells:");
+    for (auto& weak_container : m_weak_containers)
+        weak_container.remove_dead_cells({});
+    for (auto& callback : m_sweep_callbacks)
+        callback();
+
+    begin_incremental_sweep();
+    force_sweep_to_completion();
 
     if (print_report) {
         AK::Duration const time_spent = measurement_timer.elapsed_time();
@@ -785,10 +1076,10 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
         dbgln("Garbage collection report");
         dbgln("=============================================");
         dbgln("     Time spent: {} ms", time_spent.to_milliseconds());
-        dbgln("     Live cells: {} ({} bytes)", live_cells, live_cell_bytes);
-        dbgln("Collected cells: {} ({} bytes)", collected_cells, collected_cell_bytes);
+        dbgln("     Live cells: {} ({} bytes)", m_sweep_live_cells, m_sweep_live_cell_bytes);
+        dbgln("Collected cells: {} ({} bytes)", m_sweep_collected_cells, m_sweep_collected_cell_bytes);
         dbgln("    Live blocks: {} ({} bytes)", live_block_count, live_block_count * HeapBlock::BLOCK_SIZE);
-        dbgln("   Freed blocks: {} ({} bytes)", empty_blocks.size(), empty_blocks.size() * HeapBlock::BLOCK_SIZE);
+        dbgln("   Freed blocks: {} ({} bytes)", m_sweep_empty_block_count, m_sweep_empty_block_count * HeapBlock::BLOCK_SIZE);
         dbgln("=============================================");
     }
 }

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -10,6 +10,7 @@
 #include <AK/Function.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/StackInfo.h>
 #include <AK/String.h>
 #include <AK/Types.h>
@@ -33,6 +34,8 @@ struct StackFrameInfo {
     size_t size_bytes { 0 };
 };
 
+class MarkingVisitor;
+
 class GC_API Heap {
     AK_MAKE_NONCOPYABLE(Heap);
     AK_MAKE_NONMOVABLE(Heap);
@@ -49,6 +52,17 @@ public:
         auto* memory = allocate_cell<T>();
         defer_gc();
         new (memory) T(forward<Args>(args)...);
+        // Allocate-gray: cells created during incremental marking are
+        // added to the marking worklist so their edges get traced.
+        if (m_incremental_marking_in_progress) {
+            memory->set_gc_color(GC::Color::Gray);
+            enqueue_barrier_gray(*memory);
+        } else if (m_incremental_sweep_in_progress) {
+            // Allocate-black: cells created during incremental sweep
+            // must not be swept.  finalize_incremental_sweep resets
+            // their color to white before the next cycle starts.
+            memory->set_gc_color(GC::Color::Black);
+        }
         undefer_gc();
         return *static_cast<T*>(memory);
     }
@@ -84,8 +98,14 @@ public:
     void register_cell_allocator(Badge<CellAllocator>, CellAllocator&);
 
     void uproot_cell(Cell* cell);
+    void enqueue_barrier_gray(Cell& cell);
 
     bool is_gc_deferred() const { return m_gc_deferrals > 0; }
+
+    // Advance any in-progress incremental mark or sweep by one budget step.
+    // Intended to be called from an event-loop idle hook so cycles continue
+    // to make progress even when the mutator stops allocating.
+    void incremental_idle_step();
 
     void enqueue_post_gc_task(AK::Function<void()>);
 
@@ -130,9 +150,17 @@ private:
     void gather_conservative_roots(HashMap<Cell*, HeapRoot>&, HashTable<HeapBlock*> const& all_live_heap_blocks, Vector<StackFrameInfo>* out_stack_frames = nullptr);
     void gather_asan_fake_stack_roots(HashMap<FlatPtr, HeapRoot>&, FlatPtr, FlatPtr min_block_address, FlatPtr max_block_address);
     void mark_live_cells(HashMap<Cell*, HeapRoot> const& live_cells, HashTable<HeapBlock*> const& all_live_heap_blocks);
+    void start_incremental_marking();
+    bool continue_incremental_marking(size_t cell_budget);
+    void finish_incremental_marking();
     void finalize_unmarked_cells();
     void sweep_dead_cells(bool print_report, Core::ElapsedTimer const&);
     void sweep_weak_blocks();
+    void begin_incremental_sweep();
+    bool continue_incremental_sweep(size_t block_budget);
+    void finalize_incremental_sweep();
+    void force_sweep_to_completion();
+    void sweep_one_block(HeapBlock& block);
     void run_post_gc_tasks();
 
     ALWAYS_INLINE CellAllocator& allocator_for_size(size_t cell_size)
@@ -159,6 +187,9 @@ private:
     size_t m_gc_bytes_threshold { GC_MIN_BYTES_THRESHOLD };
     size_t m_allocated_bytes_since_last_gc { 0 };
 
+    size_t m_incremental_marking_budget { 1000 };
+    size_t m_incremental_sweep_budget { 4 };
+
     bool m_should_collect_on_every_allocation { false };
 
     Vector<NonnullOwnPtr<CellAllocator>> m_size_based_cell_allocators;
@@ -176,6 +207,20 @@ private:
     bool m_should_gc_when_deferral_ends { false };
 
     bool m_collecting_garbage { false };
+
+    // Incremental marking state.
+    bool m_incremental_marking_in_progress { false };
+    OwnPtr<MarkingVisitor> m_marking_visitor;
+    HashTable<HeapBlock*> m_marking_heap_blocks;
+
+    // Incremental sweep state.
+    bool m_incremental_sweep_in_progress { false };
+    Vector<HeapBlock*> m_sweep_blocks_remaining;
+    size_t m_sweep_collected_cells { 0 };
+    size_t m_sweep_live_cells { 0 };
+    size_t m_sweep_collected_cell_bytes { 0 };
+    size_t m_sweep_live_cell_bytes { 0 };
+    size_t m_sweep_empty_block_count { 0 };
     StackInfo m_stack_info;
     AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> m_gather_embedder_roots;
 

--- a/Libraries/LibGC/HeapBlock.cpp
+++ b/Libraries/LibGC/HeapBlock.cpp
@@ -41,7 +41,7 @@ void HeapBlock::deallocate(Cell* cell)
     VERIFY(is_valid_cell_pointer(cell));
     VERIFY(!m_freelist || is_valid_cell_pointer(m_freelist));
     VERIFY(cell->state() == Cell::State::Live);
-    VERIFY(!cell->is_marked());
+    VERIFY(cell->gc_color() == GC::Color::White);
 
     cell->~Cell();
     auto* freelist_entry = new (cell) FreelistEntry();

--- a/Libraries/LibGC/Ptr.h
+++ b/Libraries/LibGC/Ptr.h
@@ -9,11 +9,18 @@
 #include <AK/Format.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
+#include <LibGC/WriteBarrier.h>
 
 namespace GC {
 
 template<typename T>
 class Ptr;
+
+template<typename T>
+class RawPtr;
+
+template<typename T>
+class RawRef;
 
 template<typename T>
 class Ref {
@@ -23,6 +30,7 @@ public:
     Ref(T& ptr)
         : m_ptr(&ptr)
     {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     template<typename U>
@@ -30,6 +38,7 @@ public:
     requires(IsConvertible<U*, T*>)
         : m_ptr(&static_cast<T&>(ptr))
     {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     template<typename U>
@@ -37,18 +46,51 @@ public:
     requires(IsConvertible<U*, T*>)
         : m_ptr(other.ptr())
     {
+        write_barrier<T>(nullptr, m_ptr);
+    }
+
+    Ref(RawRef<T> const& other)
+        : m_ptr(other.ptr())
+    {
+        write_barrier<T>(nullptr, m_ptr);
+    }
+
+    template<typename U>
+    Ref(RawRef<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     template<typename U>
     Ref& operator=(Ref<U> const& other)
     requires(IsConvertible<U*, T*>)
     {
+        write_barrier(m_ptr, static_cast<T*>(other.ptr()));
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    Ref& operator=(RawRef<T> const& other)
+    {
+        write_barrier(m_ptr, other.ptr());
+        m_ptr = other.ptr();
+        return *this;
+    }
+
+    template<typename U>
+    Ref& operator=(RawRef<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        write_barrier(m_ptr, static_cast<T*>(other.ptr()));
         m_ptr = static_cast<T*>(other.ptr());
         return *this;
     }
 
     Ref& operator=(T& other)
     {
+        write_barrier(m_ptr, &other);
         m_ptr = &other;
         return *this;
     }
@@ -57,6 +99,7 @@ public:
     Ref& operator=(U& other)
     requires(IsConvertible<U*, T*>)
     {
+        write_barrier(m_ptr, &static_cast<T&>(other));
         m_ptr = &static_cast<T&>(other);
         return *this;
     }
@@ -86,11 +129,13 @@ public:
     Ptr(T& ptr)
         : m_ptr(&ptr)
     {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     Ptr(T* ptr)
         : m_ptr(ptr)
     {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     template<typename U>
@@ -98,11 +143,13 @@ public:
     requires(IsConvertible<U*, T*>)
         : m_ptr(other.ptr())
     {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     Ptr(Ref<T> const& other)
         : m_ptr(other.ptr())
     {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     template<typename U>
@@ -110,6 +157,35 @@ public:
     requires(IsConvertible<U*, T*>)
         : m_ptr(other.ptr())
     {
+        write_barrier<T>(nullptr, m_ptr);
+    }
+
+    Ptr(RawPtr<T> const& other)
+        : m_ptr(other.ptr())
+    {
+        write_barrier<T>(nullptr, m_ptr);
+    }
+
+    template<typename U>
+    Ptr(RawPtr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+        write_barrier<T>(nullptr, m_ptr);
+    }
+
+    Ptr(RawRef<T> const& other)
+        : m_ptr(other.ptr())
+    {
+        write_barrier<T>(nullptr, m_ptr);
+    }
+
+    template<typename U>
+    Ptr(RawRef<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+        write_barrier<T>(nullptr, m_ptr);
     }
 
     Ptr(nullptr_t)
@@ -121,12 +197,14 @@ public:
     Ptr& operator=(Ptr<U> const& other)
     requires(IsConvertible<U*, T*>)
     {
+        write_barrier(m_ptr, static_cast<T*>(other.ptr()));
         m_ptr = static_cast<T*>(other.ptr());
         return *this;
     }
 
     Ptr& operator=(Ref<T> const& other)
     {
+        write_barrier(m_ptr, other.ptr());
         m_ptr = other.ptr();
         return *this;
     }
@@ -135,12 +213,46 @@ public:
     Ptr& operator=(Ref<U> const& other)
     requires(IsConvertible<U*, T*>)
     {
+        write_barrier(m_ptr, static_cast<T*>(other.ptr()));
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    Ptr& operator=(RawRef<T> const& other)
+    {
+        write_barrier(m_ptr, other.ptr());
+        m_ptr = other.ptr();
+        return *this;
+    }
+
+    template<typename U>
+    Ptr& operator=(RawRef<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        write_barrier(m_ptr, static_cast<T*>(other.ptr()));
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    Ptr& operator=(RawPtr<T> const& other)
+    {
+        write_barrier(m_ptr, other.ptr());
+        m_ptr = other.ptr();
+        return *this;
+    }
+
+    template<typename U>
+    Ptr& operator=(RawPtr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        write_barrier(m_ptr, static_cast<T*>(other.ptr()));
         m_ptr = static_cast<T*>(other.ptr());
         return *this;
     }
 
     Ptr& operator=(T& other)
     {
+        write_barrier(m_ptr, &other);
         m_ptr = &other;
         return *this;
     }
@@ -149,12 +261,14 @@ public:
     Ptr& operator=(U& other)
     requires(IsConvertible<U*, T*>)
     {
+        write_barrier(m_ptr, &static_cast<T&>(other));
         m_ptr = &static_cast<T&>(other);
         return *this;
     }
 
     Ptr& operator=(T* other)
     {
+        write_barrier(m_ptr, other);
         m_ptr = other;
         return *this;
     }
@@ -163,6 +277,7 @@ public:
     Ptr& operator=(U* other)
     requires(IsConvertible<U*, T*>)
     {
+        write_barrier(m_ptr, static_cast<T*>(other));
         m_ptr = static_cast<T*>(other);
         return *this;
     }
@@ -196,13 +311,223 @@ private:
     T* m_ptr { nullptr };
 };
 
-// Non-Owning GC::Ptr
+// Non-owning, untraced GC pointer. Not visited by visit_edges.
+// Used for inline caches, weak bookkeeping, and other non-owning references.
+// Unlike Ptr<T>, RawPtr<T> will not receive a write barrier when one is added.
 template<typename T>
-using RawPtr = Ptr<T>;
+class RawPtr {
+public:
+    constexpr RawPtr() = default;
 
-// Non-Owning Ref
+    RawPtr(T& ptr)
+        : m_ptr(&ptr)
+    {
+    }
+
+    RawPtr(T* ptr)
+        : m_ptr(ptr)
+    {
+    }
+
+    template<typename U>
+    RawPtr(RawPtr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    RawPtr(Ptr<T> const& other)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    template<typename U>
+    RawPtr(Ptr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    RawPtr(Ref<T> const& other)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    template<typename U>
+    RawPtr(Ref<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    RawPtr(nullptr_t)
+        : m_ptr(nullptr)
+    {
+    }
+
+    template<typename U>
+    RawPtr& operator=(RawPtr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    RawPtr& operator=(Ptr<T> const& other)
+    {
+        m_ptr = other.ptr();
+        return *this;
+    }
+
+    template<typename U>
+    RawPtr& operator=(Ptr<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    RawPtr& operator=(Ref<T> const& other)
+    {
+        m_ptr = other.ptr();
+        return *this;
+    }
+
+    template<typename U>
+    RawPtr& operator=(Ref<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    RawPtr& operator=(T& other)
+    {
+        m_ptr = &other;
+        return *this;
+    }
+
+    template<typename U>
+    RawPtr& operator=(U& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = &static_cast<T&>(other);
+        return *this;
+    }
+
+    RawPtr& operator=(T* other)
+    {
+        m_ptr = other;
+        return *this;
+    }
+
+    template<typename U>
+    RawPtr& operator=(U* other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = static_cast<T*>(other);
+        return *this;
+    }
+
+    T* operator->() const
+    {
+        ASSERT(m_ptr);
+        return m_ptr;
+    }
+
+    [[nodiscard]] T& operator*() const
+    {
+        ASSERT(m_ptr);
+        return *m_ptr;
+    }
+
+    T* ptr() const { return m_ptr; }
+
+    explicit operator bool() const { return !!m_ptr; }
+    bool operator!() const { return !m_ptr; }
+
+    operator T*() const { return m_ptr; }
+
+private:
+    T* m_ptr { nullptr };
+};
+
+// Non-owning, untraced GC reference. Not visited by visit_edges.
+// Unlike Ref<T>, RawRef<T> will not receive a write barrier when one is added.
 template<typename T>
-using RawRef = Ref<T>;
+class RawRef {
+public:
+    RawRef() = delete;
+
+    RawRef(T& ptr)
+        : m_ptr(&ptr)
+    {
+    }
+
+    template<typename U>
+    RawRef(U& ptr)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(&static_cast<T&>(ptr))
+    {
+    }
+
+    template<typename U>
+    RawRef(RawRef<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    RawRef(Ref<T> const& other)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    template<typename U>
+    RawRef(Ref<U> const& other)
+    requires(IsConvertible<U*, T*>)
+        : m_ptr(other.ptr())
+    {
+    }
+
+    template<typename U>
+    RawRef& operator=(RawRef<U> const& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = static_cast<T*>(other.ptr());
+        return *this;
+    }
+
+    RawRef& operator=(T& other)
+    {
+        m_ptr = &other;
+        return *this;
+    }
+
+    template<typename U>
+    RawRef& operator=(U& other)
+    requires(IsConvertible<U*, T*>)
+    {
+        m_ptr = &static_cast<T&>(other);
+        return *this;
+    }
+
+    RETURNS_NONNULL T* operator->() const { return m_ptr; }
+
+    [[nodiscard]] T& operator*() const { return *m_ptr; }
+
+    RETURNS_NONNULL T* ptr() const { return m_ptr; }
+
+    RETURNS_NONNULL operator T*() const { return m_ptr; }
+
+    operator T&() const { return *m_ptr; }
+
+    operator bool() const = delete;
+    bool operator!() const = delete;
+
+private:
+    T* m_ptr { nullptr };
+};
 
 template<typename T, typename U>
 inline bool operator==(Ptr<T> const& a, Ptr<U> const& b)
@@ -228,9 +553,75 @@ inline bool operator==(Ref<T> const& a, Ptr<U> const& b)
     return a.ptr() == b.ptr();
 }
 
+template<typename T, typename U>
+inline bool operator==(RawPtr<T> const& a, RawPtr<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+template<typename T, typename U>
+inline bool operator==(RawPtr<T> const& a, RawRef<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+template<typename T, typename U>
+inline bool operator==(RawRef<T> const& a, RawRef<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+template<typename T, typename U>
+inline bool operator==(RawRef<T> const& a, RawPtr<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+// Cross-type comparisons between owning and non-owning pointers
+template<typename T, typename U>
+inline bool operator==(Ptr<T> const& a, RawPtr<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+template<typename T, typename U>
+inline bool operator==(RawPtr<T> const& a, Ptr<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+template<typename T, typename U>
+inline bool operator==(Ref<T> const& a, RawRef<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
+template<typename T, typename U>
+inline bool operator==(RawRef<T> const& a, Ref<U> const& b)
+{
+    return a.ptr() == b.ptr();
+}
+
 }
 
 namespace AK {
+
+template<typename T>
+struct Traits<GC::RawPtr<T>> : public DefaultTraits<GC::RawPtr<T>> {
+    static unsigned hash(GC::RawPtr<T> const& value)
+    {
+        return Traits<T*>::hash(value.ptr());
+    }
+    static constexpr bool may_have_slow_equality_check() { return false; }
+};
+
+template<typename T>
+struct Traits<GC::RawRef<T>> : public DefaultTraits<GC::RawRef<T>> {
+    static unsigned hash(GC::RawRef<T> const& value)
+    {
+        return Traits<T*>::hash(value.ptr());
+    }
+};
 
 template<typename T>
 struct Traits<GC::Ptr<T>> : public DefaultTraits<GC::Ptr<T>> {
@@ -269,6 +660,31 @@ template<typename T>
 requires(!HasFormatter<T>)
 struct Formatter<GC::Ref<T>> : Formatter<T const*> {
     ErrorOr<void> format(FormatBuilder& builder, GC::Ref<T> const& value)
+    {
+        return Formatter<T const*>::format(builder, value.ptr());
+    }
+};
+
+template<typename T>
+struct Formatter<GC::RawPtr<T>> : Formatter<T const*> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::RawPtr<T> const& value)
+    {
+        return Formatter<T const*>::format(builder, value.ptr());
+    }
+};
+
+template<Formattable T>
+struct Formatter<GC::RawRef<T>> : Formatter<T> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::RawRef<T> const& value)
+    {
+        return Formatter<T>::format(builder, *value);
+    }
+};
+
+template<typename T>
+requires(!HasFormatter<T>)
+struct Formatter<GC::RawRef<T>> : Formatter<T const*> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::RawRef<T> const& value)
     {
         return Formatter<T const*>::format(builder, value.ptr());
     }

--- a/Libraries/LibGC/Root.h
+++ b/Libraries/LibGC/Root.h
@@ -73,6 +73,16 @@ public:
     {
     }
 
+    Root(RawRef<T> cell, SourceLocation location = SourceLocation::current())
+        : Root(*cell, location)
+    {
+    }
+
+    Root(RawPtr<T> cell, SourceLocation location = SourceLocation::current())
+        : Root(cell.ptr(), location)
+    {
+    }
+
     T* cell() const
     {
         if (!m_impl)

--- a/Libraries/LibGC/ValueVector.h
+++ b/Libraries/LibGC/ValueVector.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Marc Butler <marc@mailworks.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibGC/NanBoxedValue.h>
+#include <LibGC/WriteBarrier.h>
+
+namespace GC {
+
+// A Vector<Value> wrapper that calls the Yuasa write barrier before
+// overwriting any element that might contain a cell pointer.
+// Read access is unrestricted; mutation goes through set() or
+// explicit barrier-aware methods.
+template<typename V>
+class ValueVector {
+    static_assert(IsBaseOf<NanBoxedValue, V>);
+
+public:
+    ValueVector() = default;
+
+    ValueVector(Vector<V>&& vec)
+        : m_vector(move(vec))
+    {
+    }
+
+    // --- Read-only element access ---
+
+    V const& operator[](size_t i) const { return m_vector[i]; }
+    V const& at(size_t i) const { return m_vector.at(i); }
+    V const* data() const { return m_vector.data(); }
+
+    size_t size() const { return m_vector.size(); }
+    bool is_empty() const { return m_vector.is_empty(); }
+
+    auto begin() const { return m_vector.begin(); }
+    auto end() const { return m_vector.end(); }
+    ReadonlySpan<V> span() const { return m_vector.span(); }
+    operator ReadonlySpan<V>() const { return m_vector.span(); }
+
+    // --- Barriered mutation ---
+
+    void set(size_t i, V value)
+    {
+        value_write_barrier(m_vector[i], value);
+        m_vector[i] = value;
+    }
+
+    // Append: no old value, but barrier the new value for Dijkstra insertion.
+    void append(V value)
+    {
+        value_write_barrier(V(), value);
+        m_vector.append(value);
+    }
+
+    void ensure_capacity(size_t c) { m_vector.ensure_capacity(c); }
+
+    void resize(size_t new_size)
+    {
+        // Barrier elements being truncated.
+        for (size_t i = new_size; i < m_vector.size(); ++i)
+            value_write_barrier(m_vector[i]);
+        m_vector.resize(new_size);
+    }
+
+    void clear()
+    {
+        for (auto& v : m_vector)
+            value_write_barrier(v);
+        m_vector.clear();
+    }
+
+    void resize_and_keep_capacity(size_t new_size)
+    {
+        for (size_t i = new_size; i < m_vector.size(); ++i)
+            value_write_barrier(m_vector[i]);
+        m_vector.resize_and_keep_capacity(new_size);
+    }
+
+    // --- Visitor support ---
+    // Expose underlying vector so visit_edges can use visitor.visit(vec.underlying()).
+    Vector<V> const& underlying() const { return m_vector; }
+
+private:
+    Vector<V> m_vector;
+};
+
+}

--- a/Libraries/LibGC/WeakBlock.cpp
+++ b/Libraries/LibGC/WeakBlock.cpp
@@ -67,7 +67,7 @@ void WeakBlock::sweep()
         if (impl.state() == WeakImpl::State::Freelist)
             continue;
         auto* cell = static_cast<Cell*>(impl.ptr());
-        if (!cell || !cell->is_marked())
+        if (!cell || cell->gc_color() == GC::Color::White)
             impl.set_ptr({}, nullptr);
         if (impl.ref_count() == 0)
             deallocate(&impl);

--- a/Libraries/LibGC/WriteBarrier.h
+++ b/Libraries/LibGC/WriteBarrier.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Marc Butler <marc@mailworks.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
+#include <LibGC/Forward.h>
+
+namespace GC {
+
+// Hybrid SATB + Dijkstra write barrier for incremental marking.
+//
+// SATB (deletion barrier): shades the OLD target gray to preserve the
+// snapshot-at-the-beginning invariant.
+//
+// Dijkstra (insertion barrier): shades the NEW target gray so that edges
+// created after a cell is traced are still discovered.
+//
+// The fast path (checking s_incremental_marking_active) is inlined.
+// The slow path (shade_gray_slow) is out-of-line in Heap.cpp.
+
+GC_API extern bool s_incremental_marking_active;
+
+GC_API void shade_gray_slow(Cell* old_target);
+
+template<typename T>
+ALWAYS_INLINE void write_barrier(T* old_target, T* new_target)
+{
+    if (!s_incremental_marking_active) [[likely]]
+        return;
+    if (old_target)
+        shade_gray_slow(reinterpret_cast<Cell*>(const_cast<RemoveConst<T>*>(old_target)));
+    if (new_target)
+        shade_gray_slow(reinterpret_cast<Cell*>(const_cast<RemoveConst<T>*>(new_target)));
+}
+
+// Write barrier for NanBoxedValue stores.
+// Extracts the cell pointer (if any) from old and new values and shades gray.
+GC_API void value_write_barrier(NanBoxedValue const& old_value);
+GC_API void value_write_barrier(NanBoxedValue const& old_value, NanBoxedValue const& new_value);
+
+}

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -58,7 +58,7 @@ Executable::Executable(
     NonnullOwnPtr<PropertyKeyTable> property_key_table,
     NonnullOwnPtr<StringTable> string_table,
     NonnullOwnPtr<RegexTable> regex_table,
-    Vector<Value> constants,
+    GC::ValueVector<Value> constants,
     NonnullRefPtr<SourceCode const> source_code,
     size_t number_of_property_lookup_caches,
     size_t number_of_global_variable_caches,
@@ -304,13 +304,14 @@ StaticPropertyLookupCache::StaticPropertyLookupCache()
 
 static void clear_cache_entry_if_dead(PropertyLookupCache::Entry& entry)
 {
-    if (entry.from_shape && entry.from_shape->state() != Cell::State::Live)
+    // NOTE: Called between mark and sweep — doomed cells are still Live but White.
+    if (entry.from_shape && entry.from_shape->gc_color() == GC::Color::White)
         entry.from_shape = nullptr;
-    if (entry.shape && entry.shape->state() != Cell::State::Live)
+    if (entry.shape && entry.shape->gc_color() == GC::Color::White)
         entry.shape = nullptr;
-    if (entry.prototype && entry.prototype->state() != Cell::State::Live)
+    if (entry.prototype && entry.prototype->gc_color() == GC::Color::White)
         entry.prototype = nullptr;
-    if (entry.prototype_chain_validity && entry.prototype_chain_validity->state() != Cell::State::Live)
+    if (entry.prototype_chain_validity && entry.prototype_chain_validity->gc_color() == GC::Color::White)
         entry.prototype_chain_validity = nullptr;
 }
 
@@ -333,8 +334,14 @@ void Executable::remove_dead_cells(Badge<GC::Heap>)
             clear_cache_entry_if_dead(entry);
     }
     for (auto& cache : object_shape_caches) {
-        if (cache.shape && cache.shape->state() != Cell::State::Live)
+        if (cache.shape && cache.shape->gc_color() == GC::Color::White)
             cache.shape = nullptr;
+    }
+    for (auto& cache : object_property_iterator_caches) {
+        if (cache.data && cache.data->gc_color() == GC::Color::White)
+            cache.data = nullptr;
+        if (cache.reusable_property_name_iterator && cache.reusable_property_name_iterator->gc_color() == GC::Color::White)
+            cache.reusable_property_name_iterator = nullptr;
     }
 }
 

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -12,6 +12,7 @@
 #include <AK/Utf16FlyString.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Ptr.h>
+#include <LibGC/ValueVector.h>
 #include <LibGC/WeakContainer.h>
 #include <LibJS/Bytecode/ClassBlueprint.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
@@ -159,7 +160,7 @@ public:
         NonnullOwnPtr<PropertyKeyTable>,
         NonnullOwnPtr<StringTable>,
         NonnullOwnPtr<RegexTable>,
-        Vector<Value> constants,
+        GC::ValueVector<Value> constants,
         NonnullRefPtr<SourceCode const>,
         size_t number_of_property_lookup_caches,
         size_t number_of_global_variable_caches,
@@ -182,7 +183,7 @@ public:
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<PropertyKeyTable> property_key_table;
     NonnullOwnPtr<RegexTable> regex_table;
-    Vector<Value> constants;
+    GC::ValueVector<Value> constants;
 
     Vector<GC::Ptr<SharedFunctionInstanceData>> shared_function_data;
     Vector<ClassBlueprint> class_blueprints;

--- a/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -14,7 +14,7 @@ namespace JS {
 GC_DEFINE_ALLOCATOR(BoundFunction);
 
 // 10.4.1.3 BoundFunctionCreate ( targetFunction, boundThis, boundArgs ), https://tc39.es/ecma262/#sec-boundfunctioncreate
-ThrowCompletionOr<GC::Ref<BoundFunction>> BoundFunction::create(Realm& realm, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments)
+ThrowCompletionOr<GC::Ref<BoundFunction>> BoundFunction::create(Realm& realm, FunctionObject& target_function, Value bound_this, GC::ValueVector<Value> bound_arguments)
 {
     // 1. Let proto be ? targetFunction.[[GetPrototypeOf]]().
     auto* prototype = TRY(target_function.internal_get_prototype_of());
@@ -34,7 +34,7 @@ ThrowCompletionOr<GC::Ref<BoundFunction>> BoundFunction::create(Realm& realm, Fu
     return object;
 }
 
-BoundFunction::BoundFunction(Realm& realm, FunctionObject& bound_target_function, Value bound_this, Vector<Value> bound_arguments, Object* prototype)
+BoundFunction::BoundFunction(Realm& realm, FunctionObject& bound_target_function, Value bound_this, GC::ValueVector<Value> bound_arguments, Object* prototype)
     : FunctionObject(realm, prototype)
     , m_bound_target_function(&bound_target_function)
     , m_bound_this(bound_this)

--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGC/ValueVector.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/FunctionObject.h>
 
@@ -16,7 +17,7 @@ class BoundFunction final : public FunctionObject {
     GC_DECLARE_ALLOCATOR(BoundFunction);
 
 public:
-    static ThrowCompletionOr<GC::Ref<BoundFunction>> create(Realm&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments);
+    static ThrowCompletionOr<GC::Ref<BoundFunction>> create(Realm&, FunctionObject& target_function, Value bound_this, GC::ValueVector<Value> bound_arguments);
 
     virtual ~BoundFunction() override = default;
 
@@ -28,12 +29,12 @@ public:
 
     FunctionObject& bound_target_function() const { return *m_bound_target_function; }
     Value bound_this() const { return m_bound_this; }
-    Vector<Value> const& bound_arguments() const { return m_bound_arguments; }
+    GC::ValueVector<Value> const& bound_arguments() const { return m_bound_arguments; }
 
     virtual Utf16String name_for_call_stack() const override;
 
 private:
-    BoundFunction(Realm&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments, Object* prototype);
+    BoundFunction(Realm&, FunctionObject& target_function, Value bound_this, GC::ValueVector<Value> bound_arguments, Object* prototype);
 
     void get_stack_frame_info(size_t& registers_and_locals_count, ReadonlySpan<Value>& constants, size_t& argument_count) override;
     virtual void visit_edges(Visitor&) override;
@@ -42,7 +43,7 @@ private:
 
     GC::Ptr<FunctionObject> m_bound_target_function; // [[BoundTargetFunction]]
     Value m_bound_this;                              // [[BoundThis]]
-    Vector<Value> m_bound_arguments;                 // [[BoundArguments]]
+    GC::ValueVector<Value> m_bound_arguments;        // [[BoundArguments]]
 };
 
 template<>

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/WriteBarrier.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
 #include <LibJS/Runtime/Error.h>
@@ -119,6 +120,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding_direct(VM& vm
         TRY(add_disposable_resource(vm, m_dispose_capability, value, hint));
 
     // 3. Set the bound value for N in envRec to V.
+    GC::value_write_barrier(binding.value, value);
     binding.value = value;
 
     // 4. Record that the binding for N in envRec has been initialized.
@@ -169,6 +171,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding_direct(VM& v
         return vm.throw_completion<ReferenceError>(ErrorType::BindingNotInitialized, binding.name);
 
     if (binding.mutable_) {
+        GC::value_write_barrier(binding.value, value);
         binding.value = value;
     } else {
         if (strict)

--- a/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -52,19 +52,21 @@ bool FinalizationRegistry::remove_by_token(Cell& unregister_token)
 
 void FinalizationRegistry::remove_dead_cells(Badge<GC::Heap>)
 {
-    auto any_cells_were_removed = false;
-    for (auto& record : m_records) {
-        if (!record.target || record.target->state() == Cell::State::Live)
-            continue;
-        record.target = nullptr;
-        any_cells_were_removed = true;
-        break;
-    }
+    // If the registry itself will be swept this cycle, so will its records.
+    if (gc_color() == GC::Color::White)
+        return;
+
+    auto removed = [](FinalizationRecord const& rec) -> bool {
+        return rec.target || rec.target->gc_color() == GC::Color::White;
+    };
+
+    auto any_cells_were_removed = m_records.find_if(removed) != m_records.end();
+
     if (any_cells_were_removed) {
-        // NOTE: We make a GC::Root here to ensure that the FinalizationRegistry stays alive
-        //       even if a subsequent GC is triggered before the callback has a chance to run.
-        heap().enqueue_post_gc_task([that = GC::make_root(this)]() {
-            that->vm().host_enqueue_finalization_registry_cleanup_job(*that);
+        // This registry will survive until the next cycle (checked above),
+        // so `this` pointer is guaranteed to be valid post collection.
+        heap().enqueue_post_gc_task([this]() {
+            vm().host_enqueue_finalization_registry_cleanup_job(*this);
         });
     }
 }

--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibGC/WriteBarrier.h>
 #include <LibJS/Runtime/Accessor.h>
 #include <LibJS/Runtime/IndexedProperties.h>
 
@@ -26,12 +27,18 @@ void GenericIndexedPropertyStorage::put(u32 index, Value value, PropertyAttribut
 {
     if (index >= m_array_size)
         m_array_size = index + 1;
+    if (auto it = m_sparse_elements.find(index); it != m_sparse_elements.end())
+        GC::value_write_barrier(it->value.value, value);
+    else
+        GC::value_write_barrier(Value(), value);
     m_sparse_elements.set(index, { value, attributes });
 }
 
 void GenericIndexedPropertyStorage::remove(u32 index)
 {
     VERIFY(index < m_array_size);
+    if (auto it = m_sparse_elements.find(index); it != m_sparse_elements.end())
+        GC::value_write_barrier(it->value.value);
     m_sparse_elements.remove(index);
 }
 
@@ -77,10 +84,12 @@ bool GenericIndexedPropertyStorage::set_array_like_size(size_t new_size)
     HashMap<u32, ValueAndAttributes> new_sparse_elements;
     for (auto& entry : m_sparse_elements) {
         if (entry.key >= new_size) {
-            if (entry.value.attributes.is_configurable())
+            if (entry.value.attributes.is_configurable()) {
+                GC::value_write_barrier(entry.value.value);
                 continue;
-            else
+            } else {
                 any_failed = true;
+            }
         }
         new_sparse_elements.set(entry.key, entry.value);
         highest_index = max(highest_index, entry.key);

--- a/Libraries/LibJS/Runtime/IteratorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/IteratorConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Enumerate.h>
+#include <LibGC/ValueVector.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Intrinsics.h>
@@ -449,7 +450,7 @@ private:
 
     Vector<PropertyKey> m_keys;
 
-    Vector<Value> m_padding;
+    GC::ValueVector<Value> m_padding;
 
     GC::Ptr<FinishResults> m_finish_results;
 };

--- a/Libraries/LibJS/Runtime/Map.cpp
+++ b/Libraries/LibJS/Runtime/Map.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/WriteBarrier.h>
 #include <LibJS/Runtime/Map.h>
 
 namespace JS {
@@ -66,8 +67,11 @@ void Map::map_set(Value const& key, Value value)
 {
     auto it = m_entries.find(key);
     if (it != m_entries.end()) {
+        GC::value_write_barrier(it->value, value);
         it->value = value;
     } else {
+        GC::value_write_barrier(JS::js_undefined(), key);
+        GC::value_write_barrier(JS::js_undefined(), value);
         auto index = m_next_insertion_id++;
         m_keys.insert(index, key);
         m_entries.set(key, value);

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1306,8 +1306,11 @@ Optional<ValueAndAttributes> Object::storage_get(PropertyKey const& property_key
             return {};
 
         if (has_intrinsic_accessors()) {
-            if (auto accessor = find_intrinsic_accessor(this, property_key); accessor.has_value())
-                const_cast<Object&>(*this).m_named_properties[metadata->offset] = (*accessor)(shape().realm());
+            if (auto accessor = find_intrinsic_accessor(this, property_key); accessor.has_value()) {
+                auto new_value = (*accessor)(shape().realm());
+                GC::value_write_barrier(m_named_properties[metadata->offset], new_value);
+                const_cast<Object&>(*this).m_named_properties[metadata->offset] = new_value;
+            }
         }
 
         value = m_named_properties[metadata->offset];
@@ -1356,6 +1359,7 @@ Optional<u32> Object::storage_set(PropertyKey const& property_key, ValueAndAttri
             set_shape(*m_shape->create_put_transition(property_key, attributes));
         u32 new_offset = shape().property_count() - 1;
         ensure_named_storage_capacity(shape().property_count());
+        GC::value_write_barrier(m_named_properties[new_offset], value);
         m_named_properties[new_offset] = value;
         return new_offset;
     }
@@ -1367,6 +1371,7 @@ Optional<u32> Object::storage_set(PropertyKey const& property_key, ValueAndAttri
             set_shape(*m_shape->create_configure_transition(property_key, attributes));
     }
 
+    GC::value_write_barrier(m_named_properties[metadata->offset], value);
     m_named_properties[metadata->offset] = value;
     return metadata->offset;
 }
@@ -1391,6 +1396,8 @@ void Object::storage_delete(PropertyKey const& property_key)
     } else {
         m_shape = m_shape->create_delete_transition(property_key);
     }
+    // Barrier the deleted property's value before shifting.
+    GC::value_write_barrier(m_named_properties[metadata->offset]);
     // Shift remaining properties down to fill the gap.
     u32 remaining = shape().property_count() - metadata->offset;
     if (remaining > 0)
@@ -1862,6 +1869,7 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
         m_indexed_storage_kind = storing_hole || index > 0 ? IndexedStorageKind::Holey : IndexedStorageKind::Packed;
         u32 needed = index + 1;
         ensure_indexed_elements(needed);
+        GC::value_write_barrier(Value(), value);
         m_indexed_elements[index] = value;
         m_indexed_array_like_size = max(m_indexed_array_like_size, index + 1);
         return;
@@ -1887,6 +1895,7 @@ void Object::indexed_put(u32 index, Value value, PropertyAttributes attributes)
     if (m_indexed_storage_kind == IndexedStorageKind::Packed && storing_hole)
         m_indexed_storage_kind = IndexedStorageKind::Holey;
 
+    GC::value_write_barrier(m_indexed_elements[index], value);
     m_indexed_elements[index] = value;
 
     // Promote Holey -> Packed when filling the last hole.
@@ -1928,6 +1937,7 @@ void Object::indexed_delete(u32 index)
         return;
     case IndexedStorageKind::Packed:
         VERIFY(index < m_indexed_array_like_size);
+        GC::value_write_barrier(m_indexed_elements[index]);
         m_indexed_elements[index] = js_special_empty_value();
         m_indexed_storage_kind = IndexedStorageKind::Holey;
         break;
@@ -1935,6 +1945,7 @@ void Object::indexed_delete(u32 index)
         VERIFY(index < m_indexed_array_like_size);
         if (index >= indexed_elements_capacity())
             return;
+        GC::value_write_barrier(m_indexed_elements[index]);
         m_indexed_elements[index] = js_special_empty_value();
         break;
     case IndexedStorageKind::Dictionary:
@@ -1977,8 +1988,10 @@ bool Object::set_indexed_array_like_size(size_t new_size)
     // Shrinking
     if (new_size_u32 < old_size) {
         u32 capacity = indexed_elements_capacity();
-        for (u32 i = new_size_u32; i < min(old_size, capacity); ++i)
+        for (u32 i = new_size_u32; i < min(old_size, capacity); ++i) {
+            GC::value_write_barrier(m_indexed_elements[i]);
             m_indexed_elements[i] = js_special_empty_value();
+        }
         m_indexed_array_like_size = new_size_u32;
     }
 
@@ -2007,9 +2020,11 @@ ValueAndAttributes Object::indexed_take_first()
     auto available_elements = min(m_indexed_array_like_size, indexed_elements_capacity());
     auto first = available_elements > 0 ? m_indexed_elements[0] : js_special_empty_value();
 
-    // Shift all elements left
-    for (u32 i = 0; i + 1 < available_elements; ++i)
+    // Shift all elements left with write barriers for each overwrite.
+    for (u32 i = 0; i + 1 < available_elements; ++i) {
+        GC::value_write_barrier(m_indexed_elements[i], m_indexed_elements[i + 1]);
         m_indexed_elements[i] = m_indexed_elements[i + 1];
+    }
 
     m_indexed_array_like_size--;
     if (available_elements > 0)
@@ -2034,6 +2049,7 @@ ValueAndAttributes Object::indexed_take_last()
         return {};
 
     auto last = m_indexed_elements[m_indexed_array_like_size];
+    GC::value_write_barrier(last);
     m_indexed_elements[m_indexed_array_like_size] = js_special_empty_value();
 
     if (last.is_special_empty_value())
@@ -2095,6 +2111,15 @@ Vector<u32> Object::indexed_indices() const
 
 void Object::set_indexed_property_elements(Vector<Value>&& values)
 {
+    // Barrier old indexed values before freeing the storage.
+    if (m_indexed_storage_kind == IndexedStorageKind::Packed || m_indexed_storage_kind == IndexedStorageKind::Holey) {
+        u32 available = min(m_indexed_array_like_size, indexed_elements_capacity());
+        for (u32 i = 0; i < available; ++i)
+            GC::value_write_barrier(m_indexed_elements[i]);
+    } else if (m_indexed_storage_kind == IndexedStorageKind::Dictionary) {
+        for (auto& entry : indexed_dictionary()->sparse_elements())
+            GC::value_write_barrier(entry.value.value);
+    }
     free_indexed_elements();
 
     if (values.is_empty())
@@ -2104,8 +2129,10 @@ void Object::set_indexed_property_elements(Vector<Value>&& values)
     m_indexed_storage_kind = IndexedStorageKind::Packed;
     m_indexed_array_like_size = size;
     m_indexed_elements = allocate_indexed_elements(size);
-    for (u32 i = 0; i < size; ++i)
+    for (u32 i = 0; i < size; ++i) {
+        GC::value_write_barrier(Value(), values[i]);
         m_indexed_elements[i] = values[i];
+    }
 }
 
 ReadonlySpan<Value> Object::indexed_packed_elements_span() const

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -294,7 +294,11 @@ public:
     virtual void visit_edges(Cell::Visitor&) override;
 
     Value get_direct(size_t index) const { return m_named_properties[index]; }
-    void put_direct(size_t index, Value value) { m_named_properties[index] = value; }
+    void put_direct(size_t index, Value value)
+    {
+        GC::value_write_barrier(m_named_properties[index], value);
+        m_named_properties[index] = value;
+    }
 
     // Indexed property storage
     Optional<ValueAndAttributes> indexed_get(u32 index) const;

--- a/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Libraries/LibJS/Runtime/Promise.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <LibGC/WriteBarrier.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
 #include <AK/TypeCasts.h>
@@ -209,6 +210,7 @@ void Promise::fulfill(Value value)
     // NOTE: This is a noop, we do these steps in a slightly different order.
 
     // 3. Set promise.[[PromiseResult]] to value.
+    GC::value_write_barrier(m_result, value);
     m_result = value;
 
     // 4. Set promise.[[PromiseFulfillReactions]] to undefined.
@@ -239,6 +241,7 @@ void Promise::reject(Value reason)
     // NOTE: This is a noop, we do these steps in a slightly different order.
 
     // 3. Set promise.[[PromiseResult]] to reason.
+    GC::value_write_barrier(m_result, reason);
     m_result = reason;
 
     // 4. Set promise.[[PromiseFulfillReactions]] to undefined.

--- a/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -76,7 +76,7 @@ ThrowCompletionOr<Value> PromiseAllResolveElementFunction::resolve_element()
     auto& realm = *vm.current_realm();
 
     // 8. Set values[index] to x.
-    m_values->values()[m_index] = vm.argument(0);
+    m_values->values().set(m_index, vm.argument(0));
 
     // 9. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 10. If remainingElementsCount.[[Value]] is 0, then
@@ -117,7 +117,7 @@ ThrowCompletionOr<Value> PromiseAllSettledResolveElementFunction::resolve_elemen
     MUST(object->create_data_property_or_throw(vm.names.value, vm.argument(0)));
 
     // 12. Set values[index] to obj.
-    m_values->values()[m_index] = object;
+    m_values->values().set(m_index, object);
 
     // 13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 14. If remainingElementsCount.[[Value]] is 0, then
@@ -158,7 +158,7 @@ ThrowCompletionOr<Value> PromiseAllSettledRejectElementFunction::resolve_element
     MUST(object->create_data_property_or_throw(vm.names.reason, vm.argument(0)));
 
     // 12. Set values[index] to obj.
-    m_values->values()[m_index] = object;
+    m_values->values().set(m_index, object);
 
     // 13. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 14. If remainingElementsCount.[[Value]] is 0, then
@@ -190,7 +190,7 @@ ThrowCompletionOr<Value> PromiseAnyRejectElementFunction::resolve_element()
     auto& realm = *vm.current_realm();
 
     // 8. Set errors[index] to x.
-    m_values->values()[m_index] = vm.argument(0);
+    m_values->values().set(m_index, vm.argument(0));
 
     // 9. Set remainingElementsCount.[[Value]] to remainingElementsCount.[[Value]] - 1.
     // 10. If remainingElementsCount.[[Value]] is 0, then

--- a/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StringView.h>
+#include <LibGC/ValueVector.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/PromiseCapability.h>
 
@@ -32,15 +33,15 @@ class PromiseValueList final : public Cell {
     GC_DECLARE_ALLOCATOR(PromiseValueList);
 
 public:
-    Vector<Value>& values() { return m_values; }
-    Vector<Value> const& values() const { return m_values; }
+    GC::ValueVector<Value>& values() { return m_values; }
+    GC::ValueVector<Value> const& values() const { return m_values; }
 
 private:
     PromiseValueList() = default;
 
     virtual void visit_edges(Visitor&) override;
 
-    Vector<Value> m_values;
+    GC::ValueVector<Value> m_values;
 };
 
 class PromiseResolvingElementFunction : public NativeFunction {

--- a/Libraries/LibJS/Runtime/WeakMap.cpp
+++ b/Libraries/LibJS/Runtime/WeakMap.cpp
@@ -24,7 +24,7 @@ WeakMap::WeakMap(Object& prototype)
 void WeakMap::remove_dead_cells(Badge<GC::Heap>)
 {
     m_values.remove_all_matching([](Cell* key, Value) {
-        return key->state() != Cell::State::Live;
+        return key->gc_color() == GC::Color::White;
     });
 }
 

--- a/Libraries/LibJS/Runtime/WeakRef.cpp
+++ b/Libraries/LibJS/Runtime/WeakRef.cpp
@@ -38,7 +38,7 @@ WeakRef::WeakRef(Symbol& value, Object& prototype)
 
 void WeakRef::remove_dead_cells(Badge<GC::Heap>)
 {
-    if (m_value.visit([](Cell* cell) -> bool { return cell->state() == Cell::State::Live; }, [](Empty) -> bool { return true; }))
+    if (m_value.visit([](Cell* cell) -> bool { return cell->gc_color() != GC::Color::White; }, [](Empty) -> bool { return true; }))
         return;
 
     m_value = Empty {};

--- a/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -24,7 +24,7 @@ WeakSet::WeakSet(Object& prototype)
 void WeakSet::remove_dead_cells(Badge<GC::Heap>)
 {
     m_values.remove_all_matching([](Cell* cell) {
-        return cell->state() != Cell::State::Live;
+        return cell->gc_color() == GC::Color::White;
     });
 }
 

--- a/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Libraries/LibJS/Runtime/WeakSet.h
@@ -25,8 +25,8 @@ public:
 
     virtual ~WeakSet() override = default;
 
-    HashTable<GC::Ptr<Cell>> const& values() const { return m_values; }
-    HashTable<GC::Ptr<Cell>>& values() { return m_values; }
+    HashTable<GC::RawPtr<Cell>> const& values() const { return m_values; }
+    HashTable<GC::RawPtr<Cell>>& values() { return m_values; }
 
     virtual void remove_dead_cells(Badge<GC::Heap>) override;
 

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -176,6 +176,10 @@ void EventLoop::process()
 
     // 5. If this is a window event loop that has no runnable task in this event loop's task queues, then:
     if (m_type == Type::Window && !m_task_queue->has_runnable_tasks()) {
+        // Advance any in-progress incremental GC cycle during idle time so
+        // mark/sweep can complete even if the mutator stops allocating.
+        vm().heap().incremental_idle_step();
+
         // 1. Set this event loop's last idle period start time to the unsafe shared current time.
         m_last_idle_period_start_time = HighResolutionTime::unsafe_shared_current_time();
 

--- a/Libraries/LibWeb/Painting/BackingStoreManager.cpp
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.cpp
@@ -23,8 +23,11 @@ GC_DEFINE_ALLOCATOR(BackingStoreManager);
 
 BackingStoreManager::BackingStoreManager(HTML::Navigable& navigable)
     : m_navigable(navigable)
+    , m_liveness_token(make_ref_counted<LivenessToken>())
 {
-    m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this] {
+    m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this, liveness = m_liveness_token] {
+        if (!liveness->alive)
+            return;
         resize_backing_stores_if_needed(WindowResizingInProgress::No);
     });
 }
@@ -33,6 +36,16 @@ void BackingStoreManager::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_navigable);
+}
+
+void BackingStoreManager::finalize()
+{
+    Base::finalize();
+    // Mark this cell dead so any already-queued timer callback skips
+    // dereferencing swept memory when the event loop drains it.
+    m_liveness_token->alive = false;
+    if (m_backing_store_shrink_timer)
+        m_backing_store_shrink_timer->stop();
 }
 
 void BackingStoreManager::restart_resize_timer()

--- a/Libraries/LibWeb/Painting/BackingStoreManager.h
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.h
@@ -15,6 +15,8 @@ class WEB_API BackingStoreManager : public JS::Cell {
     GC_DECLARE_ALLOCATOR(BackingStoreManager);
 
 public:
+    static constexpr bool OVERRIDES_FINALIZE = true;
+
     enum class WindowResizingInProgress {
         No,
         Yes
@@ -24,6 +26,7 @@ public:
     void restart_resize_timer();
 
     virtual void visit_edges(Cell::Visitor& visitor) override;
+    virtual void finalize() override;
 
     BackingStoreManager(HTML::Navigable&);
 
@@ -38,6 +41,14 @@ private:
     Gfx::IntSize m_allocated_size;
 
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
+
+    // Flipped to false by finalize(). The timer callback captures a
+    // ref-counted copy and checks it before dereferencing `this`, so a
+    // callback already queued in the event loop cannot touch swept memory.
+    struct LivenessToken : public RefCounted<LivenessToken> {
+        bool alive { true };
+    };
+    NonnullRefPtr<LivenessToken> m_liveness_token;
 };
 
 }


### PR DESCRIPTION
Convert collector to run incrementally, using standard tricolor marking and a hybrid of Yuasa (SATB, deletion) and Dijkstra (insertion) write barriers that shade both old and new targets gray.

Marking and sweeping budgets specified in cells, and blocks respectively, and there has been no attempt to tune either.

This code is more than a proof-of-concept, but lacks refinement.