### PR TITLE
CI: Trigger web-benchmarks workflow on push to `master`

### DIFF
--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -1,10 +1,8 @@
 name: 'Web benchmarks'
 
 on:
-  workflow_run:
-    workflows: ['CI']
+  push:
     branches: [master]
-    types: [completed]
 
 env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
@@ -14,7 +12,7 @@ env:
 jobs:
   web-benchmarks:
     runs-on: ${{ fromJSON(matrix.runner_labels) }}
-    if: ${{ github.repository == 'LadybirdBrowser/ladybird' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.repository == 'LadybirdBrowser/ladybird' }}
     name: ${{ matrix.os_name }}, ${{ matrix.arch }}
 
     strategy:
@@ -37,13 +35,13 @@ jobs:
       - name: 'Checkout ladybird'
         uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: 'Determine ladybird commit hash'
         id: ladybird-commit
         shell: bash
         run: |
-          echo "sha=${{ github.event.workflow_run.head_sha }}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${{ github.sha }}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Checkout LadybirdBrowser/web-benchmarks'
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
Previously, the web benchmarks job would only trigger after a successful CI run.