### PR TITLE
Tests: Remove insecure location.hash evaluation in Range-test-iframe.html

### DIFF
--- a/Tests/LibWeb/Text/input/wpt-import/dom/ranges/resources/Range-test-iframe.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/ranges/resources/Range-test-iframe.html
@@ -22,19 +22,13 @@ function run() {
       window.testNode = eval(window.testNodeInput);
     }
 
-    var rangeEndpoints;
     if (typeof window.testRangeInput == "undefined") {
-      // Use the hash (old way of doing things, bad because it requires
-      // navigation)
-      if (location.hash == "") {
-        return;
-      }
-      rangeEndpoints = eval(location.hash.substr(1));
-    } else {
-      // Get the variable directly off the window, faster and can be done
-      // synchronously
-      rangeEndpoints = eval(window.testRangeInput);
+      return;
     }
+
+    // Get the variable directly off the window, faster and can be done
+    // synchronously
+    var rangeEndpoints = eval(window.testRangeInput);
 
     var range;
     if (rangeEndpoints == "detached") {


### PR DESCRIPTION
This resolves CVE-2024-26466 by removing the old, unused location.hash injection vector in the Range test iframe. Modern WPT tests use window.testRangeInput instead.