### PR TITLE
LibJS+LibUnicode: Update icu4x's calendar module to 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ version = "0.1.0"
 
 [[package]]
 name = "calendrical_calculations"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0b39595c6ee54a8d0900204ba4c401d0ab4eb45adaf07178e8d017541529e7"
+checksum = "5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26"
 dependencies = [
  "core_maths",
  "displaydoc",
@@ -226,9 +226,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_calendar"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
+checksum = "baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
@@ -243,18 +243,19 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d"
+checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -262,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -277,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -291,15 +292,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -344,9 +345,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "ixdtf"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84de9d95a6d2547d9b77ee3f25fa0ee32e3c3a6484d47a55adebc0439c077992"
+checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
 
 [[package]]
 name = "leb128fmt"
@@ -623,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -682,6 +683,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -864,9 +871,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -875,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -908,18 +915,19 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -929,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -1134,7 +1134,7 @@ ThrowCompletionOr<ISODate> non_iso_month_day_to_iso_reference_date(VM& vm, Strin
         //    would return an ISO Date Record isoDate for which ISODateWithinLimits(isoDate) is true, throw a RangeError exception.
         // c. NOTE: The above step exists so as not to require calculating whether the month and day described in fields
         //    exist in user-provided years arbitrarily far in the future or past.
-        if (auto iso_date = MUST(calendar_integers_to_iso(vm, calendar, *fields.year, 1, 1)); !iso_date_within_limits(iso_date))
+        if (auto iso_date = calendar_integers_to_iso(vm, calendar, *fields.year, 1, 1); iso_date.is_error() || !iso_date_within_limits(iso_date.value()))
             return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidISODate);
 
         // d. Let monthsInYear be CalendarMonthsInYear(calendar, fields.[[Year]]).

--- a/Libraries/LibUnicode/Rust/Cargo.toml
+++ b/Libraries/LibUnicode/Rust/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ["staticlib"]
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
-calendrical_calculations = "0.2"
-icu_calendar = { version = "2.1.1", features = ["compiled_data"] }
+calendrical_calculations = "=0.2.4"
+icu_calendar = { version = "=2.2.0", features = ["compiled_data"] }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/Libraries/LibUnicode/Rust/src/calendar.rs
+++ b/Libraries/LibUnicode/Rust/src/calendar.rs
@@ -5,7 +5,10 @@
  */
 
 use calendrical_calculations::rata_die::RataDie;
-use icu_calendar::{AnyCalendar, AnyCalendarKind, Date, types::MonthCode};
+use icu_calendar::{
+    AnyCalendar, AnyCalendarKind, Date, Iso,
+    types::{DateFields, Month},
+};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 #[repr(C)]
@@ -113,23 +116,27 @@ fn is_chinese_or_dangi(calendar_name: &str) -> bool {
     calendar_name == "chinese" || calendar_name == "dangi"
 }
 
-fn parse_month_code(month_code: &str) -> Option<MonthCode> {
-    if month_code.len() < 3 || !month_code.starts_with('M') {
-        return None;
-    }
+/// Construct a date from extended year, month, and day.
+///
+/// Uses `try_from_fields` instead of `try_new` to support the wider year range (+/- 1,040,000) needed by
+/// Chinese and Dangi calendars with extreme years.
+fn try_new_date(
+    extended_year: i32,
+    month: Month,
+    day: u8,
+    calendar: AnyCalendar,
+) -> Option<Date<AnyCalendar>> {
+    let mut fields = DateFields::default();
+    fields.extended_year = Some(extended_year);
+    fields.month = Some(month);
+    fields.day = Some(day);
 
-    let month_number: u8 = month_code[1..3].parse().ok()?;
-    let is_leap_month = month_code.len() == 4 && month_code.as_bytes()[3] == b'L';
-
-    if is_leap_month {
-        MonthCode::new_leap(month_number)
-    } else {
-        MonthCode::new_normal(month_number)
-    }
+    Date::try_from_fields(fields, Default::default(), calendar).ok()
 }
 
-fn encode_month_code(month_code: &MonthCode) -> ([u8; 5], u8) {
-    let serialized = month_code.0.as_str();
+fn encode_month_code(month: Month) -> ([u8; 5], u8) {
+    let code = month.code();
+    let serialized = code.0.as_str();
     let bytes = serialized.as_bytes();
 
     let mut buffer = [0u8; 5];
@@ -140,7 +147,7 @@ fn encode_month_code(month_code: &MonthCode) -> ([u8; 5], u8) {
 }
 
 struct ChineseMonthInfo {
-    month_code: MonthCode,
+    month: Month,
     days_in_month: u8,
 }
 
@@ -156,11 +163,11 @@ fn collect_year_months(
     let mut current_date = year_start.clone();
 
     for _ in 0..months_in_year {
-        let month_code = current_date.month().standard_code;
+        let month = current_date.month().to_input();
         let days_in_month = current_date.days_in_month();
 
         result.push(ChineseMonthInfo {
-            month_code,
+            month,
             days_in_month,
         });
 
@@ -179,11 +186,21 @@ fn collect_year_months(
     result
 }
 
+/// Construct an ISO date using RataDie to bypass the -9999..=9999 year range limit in Date::try_new_iso.
+fn make_iso_date(year: i32, month: u8, day: u8) -> Option<Date<Iso>> {
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+
+    let rd = calendrical_calculations::gregorian::fixed_from_gregorian(year, month, day);
+    Some(Date::from_rata_die(rd, Iso))
+}
+
 /// Look up the ICU4X extended year for a Chinese/Dangi arithmetic year.
 fn chinese_or_dangi_extended_year(calendar: &AnyCalendar, arithmetic_year: i32) -> Option<i32> {
     // Chinese new year falls in Jan/Feb. Use June 15 to land in the right calendar year.
-    let approximate_iso = Date::try_new_iso(arithmetic_year, 6, 15).ok()?;
-    let calendar_date = Date::new_from_iso(approximate_iso, calendar.clone());
+    let approximate_iso = make_iso_date(arithmetic_year, 6, 15)?;
+    let calendar_date = approximate_iso.to_calendar(calendar.clone());
 
     Some(calendar_date.year().extended_year())
 }
@@ -194,10 +211,8 @@ fn chinese_year_months(
     arithmetic_year: i32,
 ) -> Option<Vec<ChineseMonthInfo>> {
     let extended_year = chinese_or_dangi_extended_year(calendar, arithmetic_year)?;
-    let month_one_code = MonthCode::new_normal(1)?;
 
-    let year_start =
-        Date::try_new_from_codes(None, extended_year, month_one_code, 1, calendar.clone()).ok()?;
+    let year_start = try_new_date(extended_year, Month::new(1), 1, calendar.clone())?;
 
     Some(collect_year_months(calendar, &year_start, extended_year))
 }
@@ -218,33 +233,35 @@ fn make_calendar_date_from_ordinal(
             return None;
         }
 
-        let month_code = months[month_index].month_code;
+        let month = months[month_index].month;
         let extended_year = chinese_or_dangi_extended_year(calendar, arithmetic_year)?;
 
-        Date::try_new_from_codes(None, extended_year, month_code, day, calendar.clone()).ok()
+        try_new_date(extended_year, month, day, calendar.clone())
     } else if calendar_name == "hebrew" {
         // Determine if this is a leap year by trying to construct a date with M05L.
-        let adar_i_code = MonthCode::new_leap(5)?;
-        let is_leap_year =
-            Date::try_new_from_codes(None, arithmetic_year, adar_i_code, 1, calendar.clone())
-                .is_ok();
+        let adar_i = Month::leap(5);
+        let is_leap_year = try_new_date(arithmetic_year, adar_i, 1, calendar.clone()).is_some();
 
-        let month_code = if is_leap_year {
+        let month = if is_leap_year {
             if ordinal_month == 6 {
-                MonthCode::new_leap(5)?
+                Month::leap(5)
             } else if ordinal_month > 6 {
-                MonthCode::new_normal(ordinal_month - 1)?
+                Month::new(ordinal_month - 1)
             } else {
-                MonthCode::new_normal(ordinal_month)?
+                Month::new(ordinal_month)
             }
         } else {
-            MonthCode::new_normal(ordinal_month)?
+            Month::new(ordinal_month)
         };
 
-        Date::try_new_from_codes(None, arithmetic_year, month_code, day, calendar.clone()).ok()
+        try_new_date(arithmetic_year, month, day, calendar.clone())
     } else {
-        let month_code = MonthCode::new_normal(ordinal_month)?;
-        Date::try_new_from_codes(None, arithmetic_year, month_code, day, calendar.clone()).ok()
+        try_new_date(
+            arithmetic_year,
+            Month::new(ordinal_month),
+            day,
+            calendar.clone(),
+        )
     }
 }
 
@@ -256,35 +273,32 @@ fn iso_date_to_calendar_date_impl(
 ) -> Option<FfiCalendarDate> {
     let calendar = make_calendar(calendar_name)?;
 
-    let iso_date = Date::try_new_iso(iso_year, iso_month, iso_day).ok()?;
-    let calendar_date = Date::new_from_iso(iso_date, calendar.clone());
+    let iso_date = make_iso_date(iso_year, iso_month, iso_day)?;
+    let calendar_date = iso_date.to_calendar(calendar.clone());
 
     let (arithmetic_year, ordinal_month) = if is_chinese_or_dangi(calendar_name) {
         let extended_year = calendar_date.year().extended_year();
 
-        let month_one_code = MonthCode::new_normal(1)?;
-        let current_month_code = calendar_date.month().standard_code;
+        let current_month = calendar_date.month().to_input();
 
-        let year_start =
-            Date::try_new_from_codes(None, extended_year, month_one_code, 1, calendar.clone())
-                .ok()?;
+        let year_start = try_new_date(extended_year, Month::new(1), 1, calendar.clone())?;
 
         let ordinal = collect_year_months(&calendar, &year_start, extended_year)
             .iter()
-            .position(|m| m.month_code == current_month_code)
+            .position(|m| m.month == current_month)
             .map(|i| (i + 1) as u8)
             .unwrap_or(1);
 
-        (year_start.to_iso().extended_year(), ordinal)
+        (year_start.to_calendar(Iso).year().extended_year(), ordinal)
     } else {
         (
-            calendar_date.extended_year(),
+            calendar_date.year().extended_year(),
             calendar_date.month().ordinal as u8,
         )
     };
 
-    let month_code = calendar_date.month().standard_code;
-    let (month_code_buffer, month_code_length) = encode_month_code(&month_code);
+    let month = calendar_date.month().to_input();
+    let (month_code_buffer, month_code_length) = encode_month_code(month);
 
     Some(FfiCalendarDate {
         year: arithmetic_year,
@@ -292,7 +306,7 @@ fn iso_date_to_calendar_date_impl(
         month_code: month_code_buffer,
         month_code_length,
         day: calendar_date.day_of_month().0,
-        day_of_week: calendar_date.day_of_week() as u8,
+        day_of_week: calendar_date.weekday() as u8,
         day_of_year: calendar_date.day_of_year().0,
         days_in_week: 7,
         days_in_month: calendar_date.days_in_month(),
@@ -336,10 +350,10 @@ fn calendar_date_to_iso_date_impl(
         day,
     )?;
 
-    let iso_date = calendar_date.to_iso();
+    let iso_date = calendar_date.to_calendar(Iso);
 
     Some(FfiISODate {
-        year: iso_date.extended_year(),
+        year: iso_date.year().extended_year(),
         month: iso_date.month().ordinal as u8,
         day: iso_date.day_of_month().0,
     })
@@ -374,37 +388,35 @@ fn iso_year_and_month_code_to_iso_date_impl(
     day: u8,
 ) -> Option<FfiISODate> {
     let calendar = make_calendar(calendar_name)?;
-    let month_code = parse_month_code(month_code_string)?;
+    let month = Month::try_from_str(month_code_string).ok()?;
 
-    let iso_jan1 = Date::try_new_iso(iso_year, 1, 1).ok()?;
-    let iso_dec31 = Date::try_new_iso(iso_year, 12, 31).ok()?;
+    let iso_jan1 = make_iso_date(iso_year, 1, 1)?;
+    let iso_dec31 = make_iso_date(iso_year, 12, 31)?;
 
-    let calendar_jan1 = Date::new_from_iso(iso_jan1, calendar.clone());
-    let calendar_dec31 = Date::new_from_iso(iso_dec31, calendar.clone());
+    let calendar_jan1 = iso_jan1.to_calendar(calendar.clone());
+    let calendar_dec31 = iso_dec31.to_calendar(calendar.clone());
 
-    let start_extended_year = calendar_jan1.extended_year();
-    let end_extended_year = calendar_dec31.extended_year();
+    let start_extended_year = calendar_jan1.year().extended_year();
+    let end_extended_year = calendar_dec31.year().extended_year();
 
     let mut best_iso_date: Option<FfiISODate> = None;
 
     for extended_year in start_extended_year..=end_extended_year {
-        let Ok(candidate) =
-            Date::try_new_from_codes(None, extended_year, month_code, day, calendar.clone())
-        else {
+        let Some(candidate) = try_new_date(extended_year, month, day, calendar.clone()) else {
             continue;
         };
 
-        if candidate.month().standard_code != month_code || candidate.day_of_month().0 != day {
+        if candidate.month().to_input() != month || candidate.day_of_month().0 != day {
             continue;
         }
 
-        let iso_date = candidate.to_iso();
-        if iso_date.extended_year() != iso_year {
+        let iso_date = candidate.to_calendar(Iso);
+        if iso_date.year().extended_year() != iso_year {
             continue;
         }
 
         let candidate_date = FfiISODate {
-            year: iso_date.extended_year(),
+            year: iso_date.year().extended_year(),
             month: iso_date.month().ordinal,
             day: iso_date.day_of_month().0,
         };
@@ -450,7 +462,7 @@ fn calendar_year_and_month_code_to_iso_date_impl(
     day: u8,
 ) -> Option<FfiISODate> {
     let calendar = make_calendar(calendar_name)?;
-    let month_code = parse_month_code(month_code_string)?;
+    let month = Month::try_from_str(month_code_string).ok()?;
 
     let extended_year = if is_chinese_or_dangi(calendar_name) {
         chinese_or_dangi_extended_year(&calendar, arithmetic_year)?
@@ -458,15 +470,15 @@ fn calendar_year_and_month_code_to_iso_date_impl(
         arithmetic_year
     };
 
-    let date = Date::try_new_from_codes(None, extended_year, month_code, day, calendar).ok()?;
-    if date.month().standard_code != month_code || date.day_of_month().0 != day {
+    let date = try_new_date(extended_year, month, day, calendar)?;
+    if date.month().to_input() != month || date.day_of_month().0 != day {
         return None;
     }
 
-    let iso_date = date.to_iso();
+    let iso_date = date.to_calendar(Iso);
 
     Some(FfiISODate {
-        year: iso_date.extended_year(),
+        year: iso_date.year().extended_year(),
         month: iso_date.month().ordinal as u8,
         day: iso_date.day_of_month().0,
     })
@@ -505,9 +517,7 @@ fn calendar_months_in_year_impl(calendar_name: &str, arithmetic_year: i32) -> Op
         return Some(months.len() as u8);
     }
 
-    let month_one_code = MonthCode::new_normal(1)?;
-
-    let date = Date::try_new_from_codes(None, arithmetic_year, month_one_code, 1, calendar).ok()?;
+    let date = try_new_date(arithmetic_year, Month::new(1), 1, calendar)?;
     Some(date.months_in_year())
 }
 
@@ -572,20 +582,19 @@ fn calendar_max_days_in_month_code_impl(
     month_code_string: &str,
 ) -> Option<u8> {
     let calendar = make_calendar(calendar_name)?;
-    let month_code = parse_month_code(month_code_string)?;
+    let month = Month::try_from_str(month_code_string).ok()?;
 
-    let base_iso_date = Date::try_new_iso(1970, 7, 1).ok()?;
-    let base_calendar_date = Date::new_from_iso(base_iso_date, calendar.clone());
-    let base_extended_year = base_calendar_date.extended_year();
+    let base_iso_date = make_iso_date(1970, 7, 1)?;
+    let base_calendar_date = base_iso_date.to_calendar(calendar.clone());
+    let base_extended_year = base_calendar_date.year().extended_year();
 
     let mut max_days_in_month: u8 = 0;
 
     for offset in -2i32..=2 {
         let extended_year = base_extended_year + offset;
 
-        if let Ok(date) =
-            Date::try_new_from_codes(None, extended_year, month_code, 1, calendar.clone())
-            && date.month().standard_code == month_code
+        if let Some(date) = try_new_date(extended_year, month, 1, calendar.clone())
+            && date.month().to_input() == month
         {
             max_days_in_month = max_days_in_month.max(date.days_in_month());
         }
@@ -622,15 +631,15 @@ fn year_contains_month_code_impl(
     month_code_string: &str,
 ) -> Option<bool> {
     let calendar = make_calendar(calendar_name)?;
-    let month_code = parse_month_code(month_code_string)?;
+    let month = Month::try_from_str(month_code_string).ok()?;
 
     let contains_month_code = if is_chinese_or_dangi(calendar_name) {
         let months = chinese_year_months(&calendar, arithmetic_year)?;
-        months.iter().any(|m| m.month_code == month_code)
+        months.iter().any(|m| m.month == month)
     } else {
         matches!(
-            Date::try_new_from_codes(None, arithmetic_year, month_code, 1, calendar),
-            Ok(date) if date.month().standard_code == month_code
+            try_new_date(arithmetic_year, month, 1, calendar),
+            Some(date) if date.month().to_input() == month
         )
     };
 

--- a/Meta/CMake/flatpak/cargo-sources.json
+++ b/Meta/CMake/flatpak/cargo-sources.json
@@ -64,9 +64,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/calendrical_calculations/calendrical_calculations-0.2.3.crate",
-        "sha256": "3a0b39595c6ee54a8d0900204ba4c401d0ab4eb45adaf07178e8d017541529e7",
-        "dest": "cargo/vendor/calendrical_calculations-0.2.3"
+        "url": "https://static.crates.io/crates/calendrical_calculations/calendrical_calculations-0.2.4.crate",
+        "sha256": "5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26",
+        "dest": "cargo/vendor/calendrical_calculations-0.2.4"
     },
     {
         "type": "archive",
@@ -183,51 +183,51 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_calendar/icu_calendar-2.1.1.crate",
-        "sha256": "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e",
-        "dest": "cargo/vendor/icu_calendar-2.1.1"
+        "url": "https://static.crates.io/crates/icu_calendar/icu_calendar-2.2.0.crate",
+        "sha256": "baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf",
+        "dest": "cargo/vendor/icu_calendar-2.2.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_calendar_data/icu_calendar_data-2.1.1.crate",
-        "sha256": "527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d",
-        "dest": "cargo/vendor/icu_calendar_data-2.1.1"
+        "url": "https://static.crates.io/crates/icu_calendar_data/icu_calendar_data-2.2.0.crate",
+        "sha256": "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d",
+        "dest": "cargo/vendor/icu_calendar_data-2.2.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_collections/icu_collections-2.1.1.crate",
-        "sha256": "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43",
-        "dest": "cargo/vendor/icu_collections-2.1.1"
+        "url": "https://static.crates.io/crates/icu_collections/icu_collections-2.2.0.crate",
+        "sha256": "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c",
+        "dest": "cargo/vendor/icu_collections-2.2.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_locale/icu_locale-2.1.1.crate",
-        "sha256": "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60",
-        "dest": "cargo/vendor/icu_locale-2.1.1"
+        "url": "https://static.crates.io/crates/icu_locale/icu_locale-2.2.0.crate",
+        "sha256": "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26",
+        "dest": "cargo/vendor/icu_locale-2.2.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_locale_core/icu_locale_core-2.1.1.crate",
-        "sha256": "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6",
-        "dest": "cargo/vendor/icu_locale_core-2.1.1"
+        "url": "https://static.crates.io/crates/icu_locale_core/icu_locale_core-2.2.0.crate",
+        "sha256": "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29",
+        "dest": "cargo/vendor/icu_locale_core-2.2.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_locale_data/icu_locale_data-2.1.2.crate",
-        "sha256": "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831",
-        "dest": "cargo/vendor/icu_locale_data-2.1.2"
+        "url": "https://static.crates.io/crates/icu_locale_data/icu_locale_data-2.2.0.crate",
+        "sha256": "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993",
+        "dest": "cargo/vendor/icu_locale_data-2.2.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_provider/icu_provider-2.1.1.crate",
-        "sha256": "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614",
-        "dest": "cargo/vendor/icu_provider-2.1.1"
+        "url": "https://static.crates.io/crates/icu_provider/icu_provider-2.2.0.crate",
+        "sha256": "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421",
+        "dest": "cargo/vendor/icu_provider-2.2.0"
     },
     {
         "type": "archive",
@@ -260,9 +260,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ixdtf/ixdtf-0.6.4.crate",
-        "sha256": "84de9d95a6d2547d9b77ee3f25fa0ee32e3c3a6484d47a55adebc0439c077992",
-        "dest": "cargo/vendor/ixdtf-0.6.4"
+        "url": "https://static.crates.io/crates/ixdtf/ixdtf-0.6.5.crate",
+        "sha256": "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1",
+        "dest": "cargo/vendor/ixdtf-0.6.5"
     },
     {
         "type": "archive",
@@ -470,9 +470,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tinystr/tinystr-0.8.2.crate",
-        "sha256": "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869",
-        "dest": "cargo/vendor/tinystr-0.8.2"
+        "url": "https://static.crates.io/crates/tinystr/tinystr-0.8.3.crate",
+        "sha256": "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d",
+        "dest": "cargo/vendor/tinystr-0.8.3"
     },
     {
         "type": "archive",
@@ -515,6 +515,13 @@
         "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
         "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
         "dest": "cargo/vendor/unicode-xid-0.2.6"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8_iter/utf8_iter-1.0.4.crate",
+        "sha256": "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be",
+        "dest": "cargo/vendor/utf8_iter-1.0.4"
     },
     {
         "type": "archive",
@@ -638,16 +645,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/yoke/yoke-0.8.1.crate",
-        "sha256": "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954",
-        "dest": "cargo/vendor/yoke-0.8.1"
+        "url": "https://static.crates.io/crates/yoke/yoke-0.8.2.crate",
+        "sha256": "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca",
+        "dest": "cargo/vendor/yoke-0.8.2"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/yoke-derive/yoke-derive-0.8.1.crate",
-        "sha256": "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d",
-        "dest": "cargo/vendor/yoke-derive-0.8.1"
+        "url": "https://static.crates.io/crates/yoke-derive/yoke-derive-0.8.2.crate",
+        "sha256": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e",
+        "dest": "cargo/vendor/yoke-derive-0.8.2"
     },
     {
         "type": "archive",
@@ -666,23 +673,23 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerotrie/zerotrie-0.2.3.crate",
-        "sha256": "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851",
-        "dest": "cargo/vendor/zerotrie-0.2.3"
+        "url": "https://static.crates.io/crates/zerotrie/zerotrie-0.2.4.crate",
+        "sha256": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf",
+        "dest": "cargo/vendor/zerotrie-0.2.4"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerovec/zerovec-0.11.5.crate",
-        "sha256": "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002",
-        "dest": "cargo/vendor/zerovec-0.11.5"
+        "url": "https://static.crates.io/crates/zerovec/zerovec-0.11.6.crate",
+        "sha256": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239",
+        "dest": "cargo/vendor/zerovec-0.11.6"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerovec-derive/zerovec-derive-0.11.2.crate",
-        "sha256": "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3",
-        "dest": "cargo/vendor/zerovec-derive-0.11.2"
+        "url": "https://static.crates.io/crates/zerovec-derive/zerovec-derive-0.11.3.crate",
+        "sha256": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555",
+        "dest": "cargo/vendor/zerovec-derive-0.11.3"
     },
     {
         "type": "archive",
@@ -702,7 +709,7 @@
             "echo '{\"files\": {}, \"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\"}' > cargo/vendor/anyhow-1.0.102/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8\"}' > cargo/vendor/autocfg-1.5.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af\"}' > cargo/vendor/bitflags-2.11.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"3a0b39595c6ee54a8d0900204ba4c401d0ab4eb45adaf07178e8d017541529e7\"}' > cargo/vendor/calendrical_calculations-0.2.3/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26\"}' > cargo/vendor/calendrical_calculations-0.2.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799\"}' > cargo/vendor/cbindgen-0.29.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801\"}' > cargo/vendor/cfg-if-1.0.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351\"}' > cargo/vendor/clap-4.6.0/.cargo-checksum.json",
@@ -719,18 +726,18 @@
             "echo '{\"files\": {}, \"package\": \"9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1\"}' > cargo/vendor/hashbrown-0.15.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100\"}' > cargo/vendor/hashbrown-0.16.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\"}' > cargo/vendor/heck-0.5.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e\"}' > cargo/vendor/icu_calendar-2.1.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d\"}' > cargo/vendor/icu_calendar_data-2.1.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43\"}' > cargo/vendor/icu_collections-2.1.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60\"}' > cargo/vendor/icu_locale-2.1.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6\"}' > cargo/vendor/icu_locale_core-2.1.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831\"}' > cargo/vendor/icu_locale_data-2.1.2/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614\"}' > cargo/vendor/icu_provider-2.1.1/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf\"}' > cargo/vendor/icu_calendar-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d\"}' > cargo/vendor/icu_calendar_data-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c\"}' > cargo/vendor/icu_collections-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26\"}' > cargo/vendor/icu_locale-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29\"}' > cargo/vendor/icu_locale_core-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993\"}' > cargo/vendor/icu_locale_data-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421\"}' > cargo/vendor/icu_provider-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\"}' > cargo/vendor/id-arena-2.3.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017\"}' > cargo/vendor/indexmap-2.13.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695\"}' > cargo/vendor/is_terminal_polyfill-1.70.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2\"}' > cargo/vendor/itoa-1.0.17/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"84de9d95a6d2547d9b77ee3f25fa0ee32e3c3a6484d47a55adebc0439c077992\"}' > cargo/vendor/ixdtf-0.6.4/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1\"}' > cargo/vendor/ixdtf-0.6.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\"}' > cargo/vendor/leb128fmt-0.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d\"}' > cargo/vendor/libc-0.2.183/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981\"}' > cargo/vendor/libm-0.2.16/.cargo-checksum.json",
@@ -760,13 +767,14 @@
             "echo '{\"files\": {}, \"package\": \"e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99\"}' > cargo/vendor/syn-2.0.117/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2\"}' > cargo/vendor/synstructure-0.13.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\"}' > cargo/vendor/tempfile-3.27.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869\"}' > cargo/vendor/tinystr-0.8.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d\"}' > cargo/vendor/tinystr-0.8.3/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863\"}' > cargo/vendor/toml-0.9.12+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\"}' > cargo/vendor/toml_datetime-0.7.5+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420\"}' > cargo/vendor/toml_parser-1.0.10+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d\"}' > cargo/vendor/toml_writer-1.0.7+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5\"}' > cargo/vendor/unicode-ident-1.0.22/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\"}' > cargo/vendor/unicode-xid-0.2.6/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\"}' > cargo/vendor/utf8_iter-1.0.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\"}' > cargo/vendor/utf8parse-0.2.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5\"}' > cargo/vendor/wasip2-1.0.2+wasi-0.2.9/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5\"}' > cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06/.cargo-checksum.json",
@@ -784,13 +792,13 @@
             "echo '{\"files\": {}, \"package\": \"9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2\"}' > cargo/vendor/wit-component-0.244.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736\"}' > cargo/vendor/wit-parser-0.244.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9\"}' > cargo/vendor/writeable-0.6.2/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954\"}' > cargo/vendor/yoke-0.8.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d\"}' > cargo/vendor/yoke-derive-0.8.1/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca\"}' > cargo/vendor/yoke-0.8.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e\"}' > cargo/vendor/yoke-derive-0.8.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5\"}' > cargo/vendor/zerofrom-0.1.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502\"}' > cargo/vendor/zerofrom-derive-0.1.6/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851\"}' > cargo/vendor/zerotrie-0.2.3/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002\"}' > cargo/vendor/zerovec-0.11.5/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3\"}' > cargo/vendor/zerovec-derive-0.11.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf\"}' > cargo/vendor/zerotrie-0.2.4/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239\"}' > cargo/vendor/zerovec-0.11.6/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555\"}' > cargo/vendor/zerovec-derive-0.11.3/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa\"}' > cargo/vendor/zmij-1.0.21/.cargo-checksum.json",
             "mkdir -p .cargo",
             "printf '[source.crates-io]\\nreplace-with = \"vendored-sources\"\\n\\n[source.vendored-sources]\\ndirectory = \"cargo/vendor\"\\n' > .cargo/config.toml"

--- a/Tests/LibJS/Runtime/builtins/Temporal/PlainDate/PlainDate.from.js
+++ b/Tests/LibJS/Runtime/builtins/Temporal/PlainDate/PlainDate.from.js
@@ -207,4 +207,34 @@ describe("errors", () => {
             Temporal.PlainDate.from("2024-01-01[u-ca=invalid]");
         }).toThrowWithMessage(RangeError, "Invalid calendar identifier 'invalid'");
     });
+
+    test("out-of-range years", () => {
+        const data = [
+            ["buddhist", "M02", 29, "be"],
+            ["chinese", "M06L", 30],
+            ["coptic", "M13", 6, "am"],
+            ["dangi", "M06L", 30],
+            ["ethioaa", "M13", 6, "aa"],
+            ["ethiopic", "M13", 6, "aa"],
+            ["gregory", "M02", 29, "ce", "bce"],
+            ["hebrew", "M05L", 29, "am"],
+            ["indian", "M01", 31, "shaka"],
+            ["islamic-civil", "M12", 30, "ah", "bh"],
+            ["islamic-tbla", "M12", 30, "ah", "bh"],
+            ["islamic-umalqura", "M12", 30, "ah", "bh"],
+            ["japanese", "M02", 29, "reiwa", "bce"],
+            ["persian", "M12", 30, "ap"],
+            ["roc", "M02", 29, "roc", "broc"],
+        ];
+
+        for (const [calendar, monthCode, day, posEra = undefined, negEra = undefined] of data) {
+            expect(() => {
+                Temporal.PlainMonthDay.from({ year: -999999, monthCode, day, calendar });
+            }).toThrowWithMessage(RangeError, "Invalid ISO date");
+
+            expect(() => {
+                Temporal.PlainMonthDay.from({ year: 999999, monthCode, day, calendar });
+            }).toThrowWithMessage(RangeError, "Invalid ISO date");
+        }
+    });
 });


### PR DESCRIPTION
First: We now pin the icu4x version to an exact number. Minor version upgrades can result in noisy deprecation warnings and API changes which cause tests to fail. So let's pin the known-good version exactly.

This patch updates our Rust calendar module to use the new APIs. This initially caused some test failures due to the new `Date::try_new` API (which is the recommended replacement for `Date::try_new_from_codes`) having quite a limited year range of +/-9999. So we must use other APIs (`Date::try_from_fields` and `calendrical_calculations::gregorian`) to avoid these limits.

http://github.com/unicode-org/icu4x/blob/main/CHANGELOG.md#icu4x-22

No test262 diff.