### PR TITLE
LibWeb/CSS: Use resolved serialization for typed custom property values

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
@@ -85,6 +85,15 @@ bool contains_guaranteed_invalid_value(Vector<ComponentValue> const& values)
     return false;
 }
 
+static Vector<ComponentValue> substitution_component_values_equivalent_to_computed_value(DOM::Document const& document, StyleValue const& value)
+{
+    if (value.is_unresolved())
+        return value.as_unresolved().values();
+
+    auto serialized = value.to_string(SerializationMode::ResolvedValue);
+    return Parser::create(ParsingParams { document }, serialized).parse_as_list_of_component_values();
+}
+
 // https://drafts.csswg.org/css-values-5/#replace-an-attr-function
 static Vector<ComponentValue> replace_an_attr_function(DOM::AbstractElement& element, GuardedSubstitutionContexts& guarded_contexts, ArbitrarySubstitutionFunctionArguments const& arguments)
 {
@@ -242,7 +251,7 @@ static Vector<ComponentValue> replace_an_attr_function(DOM::AbstractElement& ele
     auto parsed_value = parse_with_a_syntax(ParsingParams { element.document() }, substituted_values, *syntax.get<NonnullOwnPtr<SyntaxNode>>());
     if (parsed_value->is_guaranteed_invalid())
         return failure();
-    return parsed_value->tokenize();
+    return substitution_component_values_equivalent_to_computed_value(element.document(), *parsed_value);
 
     // 7. FAILURE:
     // NB: Step 7 is a lambda defined at the top of the function.
@@ -369,7 +378,7 @@ static Vector<ComponentValue> replace_an_inherit_function(DOM::AbstractElement& 
     if (name_token.is(Token::Type::Ident) && is_a_custom_property_name_string(name_token.token().ident()) && first_argument_tokens.is_empty()) {
         if (auto element_to_inherit_style_from = element.element_to_inherit_style_from(); element_to_inherit_style_from.has_value()) {
             if (auto const& inherited_value = element_to_inherit_style_from->get_custom_property(name_token.token().ident())) {
-                auto inherited_value_tokens = inherited_value->tokenize();
+                auto inherited_value_tokens = substitution_component_values_equivalent_to_computed_value(element.document(), *inherited_value);
                 if (!contains_guaranteed_invalid_value(inherited_value_tokens))
                     return inherited_value_tokens;
             }
@@ -414,11 +423,8 @@ static Vector<ComponentValue> replace_a_var_function(DOM::AbstractElement& eleme
         auto custom_property_value = StyleComputer::compute_value_of_custom_property(element, custom_property_name, guarded_contexts);
         if (custom_property_value->is_guaranteed_invalid()) {
             result = { ComponentValue { GuaranteedInvalidValue {} } };
-        } else if (custom_property_value->is_unresolved()) {
-            result = custom_property_value->as_unresolved().values();
         } else {
-            dbgln_if(CSS_PARSER_DEBUG, "Custom property `{}` is an unsupported type: {}", custom_property_name, to_underlying(custom_property_value->type()));
-            result = { ComponentValue { GuaranteedInvalidValue {} } };
+            result = substitution_component_values_equivalent_to_computed_value(element.document(), *custom_property_value);
         }
     }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/registered-property-initial.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-properties-values-api/registered-property-initial.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 29 tests
 
-13 Pass
-16 Fail
+27 Pass
+2 Fail
 Pass	Initial value for <length> correctly computed [calc(10px + 15px)]
 Pass	Initial value for <length> correctly computed [1in]
 Pass	Initial value for <length> correctly computed [2.54cm]
@@ -19,17 +19,17 @@ Pass	Initial value for <transform-list> correctly computed [scale(calc(2 + 2))]
 Pass	Initial value for <transform-list> correctly computed [scale(calc(2 + 1)) translateX(calc(3px + 1px))]
 Fail	Initial value for <url> correctly computed [url(a)]
 Fail	Initial value for <url>+ correctly computed [url(a) url(a)]
-Fail	Initial inherited value can be substituted [purple, color]
-Fail	Initial non-inherited value can be substituted [pink, background-color]
-Fail	Initial non-inherited value can be substituted [	foo	, --x]
-Fail	Initial non-inherited value can be substituted [	1turn, --x]
-Fail	Initial non-inherited value can be substituted [ pink , --x]
-Fail	Initial non-inherited value can be substituted [	test, --x]
-Fail	Initial non-inherited value can be substituted [calc(20 + 20 + 10), --x]
-Fail	Initial non-inherited value can be substituted [	calc(13% + 37px), --x]
-Fail	Initial non-inherited value can be substituted [calc(10px + 15px), --x]
-Fail	Initial non-inherited value can be substituted [calc(13 + 37), --x]
-Fail	Initial non-inherited value can be substituted [calc(13% + 37%), --x]
-Fail	Initial non-inherited value can be substituted [2000ms, --x]
-Fail	Initial non-inherited value can be substituted [scale(calc(2 + 2)), --x]
-Fail	Initial non-inherited value can be substituted [scale(calc(2 + 2)) translateX(calc(3px + 1px)), --x]
+Pass	Initial inherited value can be substituted [purple, color]
+Pass	Initial non-inherited value can be substituted [pink, background-color]
+Pass	Initial non-inherited value can be substituted [	foo	, --x]
+Pass	Initial non-inherited value can be substituted [	1turn, --x]
+Pass	Initial non-inherited value can be substituted [ pink , --x]
+Pass	Initial non-inherited value can be substituted [	test, --x]
+Pass	Initial non-inherited value can be substituted [calc(20 + 20 + 10), --x]
+Pass	Initial non-inherited value can be substituted [	calc(13% + 37px), --x]
+Pass	Initial non-inherited value can be substituted [calc(10px + 15px), --x]
+Pass	Initial non-inherited value can be substituted [calc(13 + 37), --x]
+Pass	Initial non-inherited value can be substituted [calc(13% + 37%), --x]
+Pass	Initial non-inherited value can be substituted [2000ms, --x]
+Pass	Initial non-inherited value can be substituted [scale(calc(2 + 2)), --x]
+Pass	Initial non-inherited value can be substituted [scale(calc(2 + 2)) translateX(calc(3px + 1px)), --x]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/attr-all-types.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/attr-all-types.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 172 tests
 
-160 Pass
-12 Fail
+164 Pass
+8 Fail
 Pass	Invariant behaviour for var
 Pass	CSS Values and Units Test: attr
 Pass	CSS Values and Units Test: attr 1
@@ -46,7 +46,7 @@ Pass	CSS Values and Units Test: attr 37
 Pass	CSS Values and Units Test: attr 38
 Pass	CSS Values and Units Test: attr 39
 Pass	CSS Values and Units Test: attr 40
-Fail	CSS Values and Units Test: attr 41
+Pass	CSS Values and Units Test: attr 41
 Pass	CSS Values and Units Test: attr 42
 Pass	CSS Values and Units Test: attr 43
 Pass	CSS Values and Units Test: attr 44
@@ -67,7 +67,7 @@ Pass	CSS Values and Units Test: attr 58
 Fail	CSS Values and Units Test: attr 59
 Pass	CSS Values and Units Test: attr 60
 Pass	CSS Values and Units Test: attr 61
-Fail	CSS Values and Units Test: attr 62
+Pass	CSS Values and Units Test: attr 62
 Pass	CSS Values and Units Test: attr 63
 Pass	CSS Values and Units Test: attr 64
 Pass	CSS Values and Units Test: attr 65
@@ -79,12 +79,12 @@ Pass	CSS Values and Units Test: attr 70
 Pass	CSS Values and Units Test: attr 71
 Pass	CSS Values and Units Test: attr 72
 Pass	CSS Values and Units Test: attr 73
-Fail	CSS Values and Units Test: attr 74
+Pass	CSS Values and Units Test: attr 74
 Pass	CSS Values and Units Test: attr 75
 Pass	CSS Values and Units Test: attr 76
 Pass	CSS Values and Units Test: attr 77
 Pass	CSS Values and Units Test: attr 78
-Fail	CSS Values and Units Test: attr 79
+Pass	CSS Values and Units Test: attr 79
 Pass	CSS Values and Units Test: attr 80
 Fail	CSS Values and Units Test: attr 81
 Pass	CSS Values and Units Test: attr 82

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/attr-security.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/attr-security.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 43 tests
 
-28 Pass
-15 Fail
+29 Pass
+14 Fail
 Pass	'--x: image-set(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"
 Pass	'background-image: image-set(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"
 Fail	'background-image: image-set("https://does-not-exist.test/404.png")' with data-foo="https://does-not-exist.test/404.png"
@@ -27,7 +27,7 @@ Pass	'background-image: image-set(var(--some-string))' with data-foo="https://do
 Pass	'--x: image-set(var(--some-string-list))' with data-foo="https://does-not-exist.test/404.png"
 Pass	'background-image: image-set(var(--some-string-list))' with data-foo="https://does-not-exist.test/404.png"
 Fail	'--registered-url: attr(data-foo type(<url>))' with data-foo="https://does-not-exist.test/404.png"
-Fail	'--registered-color: attr(data-foo type(<color>))' with data-foo="blue"
+Pass	'--registered-color: attr(data-foo type(<color>))' with data-foo="blue"
 Pass	'--x: image-set(var(--some-other-url))' with data-foo="https://does-not-exist.test/404.png"
 Pass	'background-image: image-set(var(--some-other-url))' with data-foo="https://does-not-exist.test/404.png"
 Fail	'background-image: attr(data-foo type(*))' with data-foo="url(https://does-not-exist.test/404.png), linear-gradient(black, white)"

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-css-wide-keywords.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-css-wide-keywords.txt
@@ -2,15 +2,15 @@ Harness status: OK
 
 Found 30 tests
 
-9 Pass
-21 Fail
+11 Pass
+19 Fail
 Pass	`initial` as a value for an unregistered custom property
 Pass	`inherit` as a value for an unregistered custom property
 Pass	`unset` as a value for an unregistered custom property
 Fail	`revert` as a value for an unregistered custom property
 Pass	`revert-layer` as a value for an unregistered custom property
-Fail	`initial` as a value for a non-inheriting registered custom property
-Fail	`initial` as a value for an inheriting registered custom property
+Pass	`initial` as a value for a non-inheriting registered custom property
+Pass	`initial` as a value for an inheriting registered custom property
 Pass	`inherit` as a value for a non-inheriting registered custom property
 Pass	`inherit` as a value for an inheriting registered custom property
 Fail	`unset` as a value for a non-inheriting registered custom property


### PR DESCRIPTION
Substitute typed custom-property values using component values equivalent to their computed value.

This fixes the header bar on https://www.semrush.com appearing as white.

Very unsure if this is the correct approach.


Original reduction I made was:

```html
<!doctype html>
<style>
@property --x {
    syntax: "<percentage>";
    inherits: true;
    initial-value: 0%;
}

div {
    height: 80px;
    background: color-mix(in oklab, white var(--x), #dceeeb);
}
</style>
<div></div>
```

Before:

<img width="1947" height="736" alt="image" src="https://github.com/user-attachments/assets/6bb15ddc-233d-4e5c-8862-d1ea16b0ad04" />

After:

<img width="1947" height="736" alt="image" src="https://github.com/user-attachments/assets/5d49b727-6a66-448c-a38a-7473f1ac9047" />
