### PR TITLE
LibJS: Dispatch native function calls directly from asm interpreter

### DIFF
--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1139,6 +1139,18 @@ fn emit_instruction(
             }
         }
 
+        // call_raw_native: NON-TERMINAL indirect call to
+        // ThrowCompletionOr<Value> (*)(VM&). Passes VM* in x0 and keeps the
+        // aggregate return in x0/x1 (= t0/t1).
+        "call_raw_native" => {
+            if let Some(op) = insn.operands.first() {
+                let func = resolve_op(op, handler, program);
+                w!(out, "    mov x9, {func}");
+                w!(out, "    mov x0, x20");
+                w!(out, "    blr x9");
+            }
+        }
+
         // double_to_int32 dst, src_fpr, fail_label
         // Truncate double to int32 with strict round-trip check.
         // Fails (branches to fail_label) if the value is fractional,

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -518,6 +518,20 @@ fn emit_instruction(
             }
         }
 
+        // call_raw_native pseudo-instruction
+        // Indirectly calls ThrowCompletionOr<Value> (*)(VM&) from a register.
+        // Passes the hidden VM* as the sole argument. Result payload lands in
+        // rax (t0) and the Variant index is normalized into rcx (t1).
+        "call_raw_native" => {
+            if let Some(op) = insn.operands.first() {
+                let func = resolve_op(op, handler, program);
+                w!(out, "    mov r11, {func}");
+                w!(out, "    mov rdi, QWORD PTR [rbp - 48]");
+                w!(out, "    call r11");
+                w!(out, "    mov rcx, rdx");
+            }
+        }
+
         // double_to_int32 dst, src_fpr, fail_label
         // Truncate double to int32 with strict round-trip check.
         // Fails if fractional, out of i32 range, or NaN.

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -43,7 +43,8 @@
 //! | `ft0`-`ft3` | Floating-point scratch (caller-saved)            |
 //!
 //! Temporaries are **not preserved across C++ calls** (`call_slow_path`,
-//! `call_helper`, `call_interp`). The DSL also provides `sp` and `fp`.
+//! `call_helper`, `call_interp`, `call_raw_native`). The DSL also provides
+//! `sp` and `fp`.
 //!
 //! ## DSL instruction reference
 //!
@@ -71,6 +72,10 @@
 //!   after the call. Does NOT reload pinned state.
 //! - `call_interp func` -- **Non-terminal.** Calls `i64 func(VM*, u32 pc)`.
 //!   Result lands in `t0`. The handler continues. Does NOT reload pinned state.
+//! - `call_raw_native reg` -- **Non-terminal.** Indirectly calls a
+//!   `ThrowCompletionOr<Value> (*)(VM&)` function pointer stored in `reg`.
+//!   Passes the hidden VM* as the sole argument. On return, `t0` holds the
+//!   payload and `t1` holds the variant index on both supported architectures.
 //! - `reload_exec_ctx` -- Reload the exec_ctx register from the VM*.
 //!   Used after non-terminal calls that may modify the running execution context.
 //! - `load_vm dst` -- Load the hidden VM* into `dst`.

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -270,6 +270,7 @@ u64 asm_helper_math_exp(u64 encoded_value);
 u64 asm_helper_empty_string(u64);
 u64 asm_helper_single_ascii_character_string(u64 encoded_value);
 u64 asm_helper_single_utf16_code_unit_string(u64 encoded_value);
+i64 asm_helper_handle_raw_native_exception(u64 encoded_exception);
 i64 asm_try_inline_call(VM*, u32 pc);
 i64 asm_try_put_by_id_cache(VM*, u32 pc);
 i64 asm_try_get_by_id_cache(VM*, u32 pc);
@@ -1273,6 +1274,21 @@ u64 asm_helper_math_exp(u64 encoded_value)
 u64 asm_helper_empty_string(u64)
 {
     return bit_cast<u64>(Value(&VM::the().empty_string()));
+}
+
+i64 asm_helper_handle_raw_native_exception(u64 encoded_exception)
+{
+    auto& vm = VM::the();
+    auto& callee_frame = vm.running_execution_context();
+    VERIFY(callee_frame.caller_frame);
+
+    // Raw-native asm calls keep their callee frame off the VM execution
+    // context stack, so we have to unwind it manually before exception
+    // dispatch. Match VM::handle_exception()'s inline-frame semantics by
+    // probing the caller with a PC inside the Call instruction.
+    auto caller_pc = callee_frame.caller_return_pc;
+    vm.unwind_inline_frame_for_exception();
+    return handle_asm_exception(vm, caller_pc - 1, bit_cast<Value>(encoded_exception));
 }
 
 u64 asm_helper_single_ascii_character_string(u64 encoded_value)

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1980,12 +1980,28 @@ handler SetGlobal
 end
 
 handler Call
-    # Inline JS-to-JS Call in asm when the callee is an ECMAScriptFunctionObject
-    # with bytecode ready. Cases that need function-environment allocation or
-    # sloppy primitive this boxing bounce through a C++ helper that still
-    # prepares an inline frame instead of taking the full slow path.
+    # Inline Call in asm for the two callee kinds that can stay in the
+    # dispatch loop without taking the full Call slow path:
     #
-    # High-level flow:
+    #  - ECMAScriptFunctionObject with inline-ready bytecode: build the
+    #    callee frame here and dispatch at pc = 0 of the callee bytecode.
+    #    Cases that need function-environment allocation or sloppy primitive
+    #    this-boxing can't stay in pure asm but also don't want the full
+    #    slow path (which would insert a run_executable() boundary and an
+    #    observable microtask drain), so they detour through the
+    #    asm_try_inline_call helper at .call_interp_inline.
+    #
+    #  - RawNativeFunction: build a callee ExecutionContext here, call the
+    #    stored C++ function pointer directly via call_raw_native, and then
+    #    tear the frame down on return. Exceptions go through a dedicated
+    #    helper that unwinds the callee frame before dispatching to a JS
+    #    handler (see .call_raw_native_exception).
+    #
+    # Everything else — non-functions, NativeJavaScriptBackedFunction,
+    # ECMAScript functions that can't inline, Proxies, ... — falls through
+    # to .call_slow, i.e. asm_slow_path_call.
+    #
+    # High-level flow of the ECMAScript fast path:
     #   1. Validate the callee and load its shared function metadata.
     #   2. Bind `this` inline when we can do so without allocations.
     #   3. Reserve an InterpreterStack frame and populate ExecutionContext.
@@ -2003,10 +2019,12 @@ handler Call
     unbox_object t0, t0
     mov t3, t0
 
-    # Reject everything except ordinary ECMAScript function objects with
-    # already-prepared bytecode and cached inline-call eligibility.
+    # Non-functions still go through the normal Call slow path for proper error
+    # reporting. Non-ECMAScript function objects get a RawNativeFunction fast
+    # path attempt before we fully give up.
     load8 t1, [t3, OBJECT_FLAGS]
-    branch_bits_clear t1, OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT, .call_slow
+    branch_bits_clear t1, OBJECT_FLAG_IS_FUNCTION, .call_slow
+    branch_bits_clear t1, OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT, .call_try_native
 
     load64 t2, [t3, ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA]
     load_pair64 t7, t2, [t2, SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE], [t2, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA]
@@ -2186,7 +2204,7 @@ handler Call
     mov exec_ctx, t2
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
     xor pc, pc
-    dispatch_current
+    goto_handler pc
 .call_interp_inline:
     # Shared escape hatch for the cases that need C++ help to build the inline
     # frame correctly but must not take the full Call slow path, since that
@@ -2199,7 +2217,189 @@ handler Call
     load64 t0, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
     load64 pb, [t0, EXECUTABLE_BYTECODE_DATA]
     xor pc, pc
-    dispatch_current
+    goto_handler pc
+.call_try_native:
+    # Fast path for RawNativeFunction: the callee is a plain C++ function
+    # pointer with no JS-visible prologue, so we can build the callee frame
+    # ourselves and jump straight at the entry point. NativeFunction objects
+    # that still carry a callback (NativeJavaScriptBackedFunction) do not have
+    # this flag set and fall through to .call_slow.
+    load8 t0, [t3, OBJECT_FLAGS]
+    branch_bits_clear t0, OBJECT_FLAG_IS_RAW_NATIVE_FUNCTION, .call_slow
+
+    # Unlike the ECMAScript path we don't pad to the formal parameter count:
+    # native functions read their arguments via the passed-count API, so we
+    # only need space for the call-site arguments plus the ExecutionContext
+    # header. t4 = argument count, t5 = total bytes needed for this frame.
+    load32 t4, [pb, pc, m_argument_count]
+    mov t5, t4
+    shl t5, 3
+    add t5, SIZEOF_EXECUTION_CONTEXT
+
+    # Inline InterpreterStack::allocate(): bail to C++ if the interpreter
+    # stack doesn't have room for the new frame. t6 = new frame base (old
+    # top), t5 becomes the new top after the add below.
+    load_vm t0
+    lea t0, [t0, VM_INTERPRETER_STACK]
+    load_pair64 t6, t7, [t0, INTERPRETER_STACK_TOP], [t0, INTERPRETER_STACK_LIMIT]
+    add t5, t6
+    branch_ge_unsigned t7, t5, .native_interpreter_stack_ok
+    jmp .call_slow
+
+.native_interpreter_stack_ok:
+    # RawNativeFunctions run real C++ code on the host stack, so we also have
+    # to check that we're not about to blow past the VM's reserved stack
+    # limit. The ECMAScript path can skip this because it never leaves asm.
+    load_vm t0
+    lea t0, [t0, VM_STACK_INFO]
+    load64 t7, [t0, STACK_INFO_BASE]
+    add t7, VM_STACK_SPACE_LIMIT
+    branch_ge_unsigned fp, t7, .native_stack_space_ok
+    jmp .call_slow
+
+.native_stack_space_ok:
+    # Commit the new interpreter stack top. From here on we own [t6, t5).
+    load_vm t0
+    store64 [t0, VM_INTERPRETER_STACK_TOP], t5
+
+    # Populate the callee ExecutionContext to match what VM::push_execution_context
+    # plus NativeFunction::internal_call would produce. t2 tracks the EC
+    # header, t6 advances to the argument Value array that follows it.
+    mov t2, t6
+    lea t6, [t6, SIZEOF_EXECUTION_CONTEXT]
+    # For natives, argument_count and "registers+..." total are both just the
+    # call-site argument count: there are no registers, locals, or constants.
+    store_pair32 [t2, EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT], [t2, EXECUTION_CONTEXT_ARGUMENT_COUNT], t4, t4
+    store32 [t2, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT], t4
+
+    # Shape stores a Realm pointer; use it as the callee EC realm.
+    load64 t0, [t3, OBJECT_SHAPE]
+    load64 t0, [t0, SHAPE_REALM]
+    store_pair64 [t2, EXECUTION_CONTEXT_FUNCTION], [t2, EXECUTION_CONTEXT_REALM], t3, t0
+
+    # Mirror NativeFunction::internal_call: a raw native has no environment of
+    # its own, so lexical/variable/private environments are copied straight
+    # from the caller frame.
+    load_pair64 t0, t7, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [exec_ctx, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT]
+    store_pair64 [t2, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [t2, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT], t0, t7
+    load64 t0, [exec_ctx, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT]
+    store64 [t2, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT], t0
+    # |this| is forwarded unchanged. Native builtins do their own type checks
+    # on the receiver where they need to.
+    load_operand t0, m_this_value
+    store64 [t2, EXECUTION_CONTEXT_THIS_VALUE], t0
+
+    # Zero out the ScriptOrModule variant (two words) and Executable pointer.
+    # Native frames don't belong to any script/module and have no bytecode.
+    xor t0, t0
+    lea t7, [t2, EXECUTION_CONTEXT_SCRIPT_OR_MODULE]
+    store_pair64 [t7, 0], [t7, 8], t0, t0
+    store64 [t2, EXECUTION_CONTEXT_EXECUTABLE], t0
+    store32 [t2, EXECUTION_CONTEXT_PROGRAM_COUNTER], 0
+    store32 [t2, EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER], 0
+    mov t0, EXECUTION_CONTEXT_NO_YIELD_CONTINUATION
+    store32 [t2, EXECUTION_CONTEXT_YIELD_CONTINUATION], t0
+    store8 [t2, EXECUTION_CONTEXT_YIELD_IS_AWAIT], 0
+    store8 [t2, EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT], 0
+
+    # While asm runs, the authoritative program counter lives in the `pc`
+    # register and the caller EC's stored program_counter is stale. Before we
+    # leave asm to run native C++ that may throw, sync `pc` into the caller
+    # EC as a bytecode offset (pc - pb). asm_helper_handle_raw_native_exception
+    # and VM::handle_exception both read from the caller EC after unwind.
+    lea t7, [pb, pc]
+    sub t7, pb
+    store32 [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER], t7
+    store64 [t2, EXECUTION_CONTEXT_CALLER_FRAME], exec_ctx
+    # CALLER_RETURN_PC is the bytecode offset of the instruction after the
+    # Call (Call offset + Call length). CALLER_DST_RAW records where the
+    # return value should be written in the caller's value array.
+    load32 t0, [pb, pc, m_length]
+    add t0, t7
+    store32 [t2, EXECUTION_CONTEXT_CALLER_RETURN_PC], t0
+    load32 t0, [pb, pc, m_dst]
+    store32 [t2, EXECUTION_CONTEXT_CALLER_DST_RAW], t0
+
+    # Copy the call-site arguments from the caller's value array into the
+    # callee frame's argument tail. t0 points at the caller's value array,
+    # t8 at the Operand[] that trails the fixed Call instruction fields.
+    # The Call layout ends with `m_expression_string: Optional<StringTableIndex>`
+    # (4 bytes via the sentinel specialization) followed by `m_arguments`, so
+    # base + offsetof(m_expression_string) + 4 is the operand array.
+    lea t0, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    lea t8, [pb, pc]
+    add t8, m_expression_string
+    add t8, 4
+    xor t7, t7
+.copy_native_arguments_loop:
+    branch_ge_unsigned t7, t4, .enter_raw_native
+    load32 t5, [t8, t7, 4]
+    load64 t5, [t0, t5, 8]
+    store64 [t6, t7, 8], t5
+    add t7, 1
+    jmp .copy_native_arguments_loop
+
+.enter_raw_native:
+    # Swap the running ExecutionContext over to the callee and point the
+    # asm `values` register at its argument array. After this, we look like
+    # a normal inline frame from the VM's perspective.
+    load_vm t0
+    store64 [t0, VM_RUNNING_EXECUTION_CONTEXT], t2
+    mov exec_ctx, t2
+    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+
+    # Invoke the raw C++ function pointer. call_raw_native lowers to a native
+    # call through the platform ABI and surfaces the returned
+    # ThrowCompletionOr<Value> via (t0, t1): t0 is the Value payload and t1
+    # holds the Variant discriminator in its low byte (0 = Value, 1 =
+    # ErrorValue). Anything non-zero in that byte means the native threw and
+    # t0 is the thrown Value, not a return value.
+    load64 t3, [t3, RAW_NATIVE_FUNCTION_NATIVE_FUNCTION]
+    call_raw_native t3
+    and t1, 0xFF
+    branch_nonzero t1, .call_raw_native_exception
+
+    # Normal return path: tear the callee frame off the interpreter stack,
+    # restore the caller as the running ExecutionContext, write the return
+    # value into the caller's m_dst operand, and dispatch the next insn.
+    load64 t2, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
+    load_vm t3
+    store64 [t3, VM_RUNNING_EXECUTION_CONTEXT], t2
+    store64 [t3, VM_INTERPRETER_STACK_TOP], exec_ctx
+    mov exec_ctx, t2
+    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    store_operand m_dst, t0
+    load32 t0, [pb, pc, m_length]
+    dispatch_variable t0
+
+.call_raw_native_exception:
+    # The native threw. Hand the thrown Value off to a C++ helper, which
+    # unwinds the callee frame off the interpreter stack and calls through
+    # to VM::handle_exception. Return value (t0) follows the standard asm
+    # slow-path convention (see AsmInterpreter.cpp:127):
+    #   >= 0 : an enclosing handler was found; t0 is the new program counter
+    #          to resume at inside the (post-unwind) running execution context.
+    #    < 0 : no handler; bail out of the asm dispatch loop entirely.
+    mov t1, t0
+    call_helper asm_helper_handle_raw_native_exception
+    branch_negative t0, .call_exit_asm
+    jmp .call_exception_handled
+.call_exception_handled:
+    # Reload exec_ctx/values/pb/pc from the caller frame the helper left us
+    # on, and resume dispatching at its program_counter (which the helper
+    # already updated to the handler entry).
+    load_vm t0
+    load64 exec_ctx, [t0, VM_RUNNING_EXECUTION_CONTEXT]
+    lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    load64 t0, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [t0, EXECUTABLE_BYTECODE_DATA]
+    load32 t2, [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER]
+    mov pc, t2
+    goto_handler pc
+.call_exit_asm:
+    # No JS handler caught the native exception; bail out of the asm
+    # dispatch loop and let the C++ caller of run_asm() see the throw.
+    exit
 .call_slow:
     call_slow_path asm_slow_path_call
 end

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -21,6 +21,7 @@
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/IndexedProperties.h>
+#include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/Realm.h>
@@ -65,6 +66,7 @@ int main()
     outln("const OBJECT_FLAG_IS_TYPED_ARRAY = {}", Object::Flag::IsTypedArray);
     outln("const OBJECT_FLAG_IS_FUNCTION = {}", Object::Flag::IsFunction);
     outln("const OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT = {}", Object::Flag::IsECMAScriptFunctionObject);
+    outln("const OBJECT_FLAG_IS_RAW_NATIVE_FUNCTION = {}", Object::Flag::IsRawNativeFunction);
 
     // Shape layout
     outln("\n# Shape layout");
@@ -177,8 +179,18 @@ int main()
     outln("\n# VM layout");
     EMIT_OFFSET(VM_RUNNING_EXECUTION_CONTEXT, VM, m_running_execution_context);
     EMIT_OFFSET(VM_INTERPRETER_STACK, VM, m_interpreter_stack);
+    EMIT_OFFSET(VM_STACK_INFO, VM, m_stack_info);
     EMIT_OFFSET(VM_EXECUTION_GENERATION, VM, m_execution_generation);
     outln("const VM_INTERPRETER_STACK_TOP = {}", offsetof(VM, m_interpreter_stack) + offsetof(InterpreterStack, m_top));
+#if defined(HAS_ADDRESS_SANITIZER)
+    outln("const VM_STACK_SPACE_LIMIT = {}", 96 * KiB);
+#else
+    outln("const VM_STACK_SPACE_LIMIT = {}", 32 * KiB);
+#endif
+
+    // StackInfo layout
+    outln("\n# StackInfo layout");
+    EMIT_OFFSET(STACK_INFO_BASE, StackInfo, m_base);
 
     // IndexedStorageKind enum values
     outln("\n# IndexedStorageKind enum values");
@@ -258,6 +270,10 @@ int main()
         outln("const FUNCTION_OBJECT_BUILTIN_VALUE = {}", base);
         outln("const FUNCTION_OBJECT_BUILTIN_HAS_VALUE = {}", base + 1);
     }
+
+    // RawNativeFunction layout
+    outln("\n# RawNativeFunction layout");
+    EMIT_OFFSET(RAW_NATIVE_FUNCTION_NATIVE_FUNCTION, RawNativeFunction, m_native_function);
 
     // ECMAScriptFunctionObject layout
     outln("\n# ECMAScriptFunctionObject layout");

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -407,6 +407,17 @@ NEVER_INLINE void VM::pop_inline_frame(Value return_value)
     vm().finish_execution_generation();
 }
 
+NEVER_INLINE void VM::unwind_inline_frame_for_exception()
+{
+    auto* callee_frame = m_running_execution_context;
+    VERIFY(callee_frame);
+    VERIFY(callee_frame->caller_frame);
+
+    auto* caller_frame = callee_frame->caller_frame;
+    vm().interpreter_stack().deallocate(callee_frame);
+    m_running_execution_context = caller_frame;
+}
+
 void VM::run_bytecode(size_t entry_point)
 {
     if (vm().interpreter_stack().is_exhausted() || vm().did_reach_stack_space_limit()) [[unlikely]] {

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -195,6 +195,7 @@ class ModuleEnvironment;
 class Module;
 struct ModuleRequest;
 class NativeFunction;
+class RawNativeFunction;
 class NativeJavaScriptBackedFunction;
 class ObjectEnvironment;
 struct ParserError;
@@ -311,6 +312,7 @@ struct TimeZoneOffset;
 template<typename T>
 requires(!IsLvalueReference<T>)
 class ThrowCompletionOr;
+using NativeFunctionPointer = ThrowCompletionOr<Value> (*)(VM&);
 
 namespace Bytecode {
 

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1074,7 +1074,6 @@ Object* create_unmapped_arguments_object(VM& vm, ReadonlySpan<Value> arguments)
     // 2. Let obj be OrdinaryObjectCreate(%Object.prototype%, « [[ParameterMap]] »).
     // 3. Set obj.[[ParameterMap]] to undefined.
     auto object = Object::create_with_premade_shape(realm.intrinsics().unmapped_arguments_object_shape());
-    object->set_has_parameter_map();
 
     // 4. Perform ! DefinePropertyOrThrow(obj, "length", PropertyDescriptor { [[Value]]: 𝔽(len), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
     object->put_direct(realm.intrinsics().unmapped_arguments_object_length_offset(), Value(length));

--- a/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -21,7 +21,6 @@ ArgumentsObject::ArgumentsObject(Realm& realm, Environment& environment, bool pa
 void ArgumentsObject::initialize(Realm& realm)
 {
     Base::initialize(realm);
-    set_has_parameter_map();
 }
 
 void ArgumentsObject::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -255,6 +255,7 @@ void Intrinsics::initialize_intrinsics(Realm& realm)
 
     m_unmapped_arguments_object_shape = heap().allocate<Shape>(realm);
     m_unmapped_arguments_object_shape->set_prototype_without_transition(m_object_prototype);
+    m_unmapped_arguments_object_shape->set_has_parameter_map();
     m_unmapped_arguments_object_shape->add_property_without_transition(vm.names.length, Attribute::Writable | Attribute::Configurable);
     m_unmapped_arguments_object_shape->add_property_without_transition(vm.well_known_symbol_iterator(), Attribute::Writable | Attribute::Configurable);
     m_unmapped_arguments_object_shape->add_property_without_transition(vm.names.callee, 0);
@@ -264,6 +265,7 @@ void Intrinsics::initialize_intrinsics(Realm& realm)
 
     m_mapped_arguments_object_shape = heap().allocate<Shape>(realm);
     m_mapped_arguments_object_shape->set_prototype_without_transition(m_object_prototype);
+    m_mapped_arguments_object_shape->set_has_parameter_map();
     m_mapped_arguments_object_shape->add_property_without_transition(vm.names.length, Attribute::Writable | Attribute::Configurable);
     m_mapped_arguments_object_shape->add_property_without_transition(vm.well_known_symbol_iterator(), Attribute::Writable | Attribute::Configurable);
     m_mapped_arguments_object_shape->add_property_without_transition(vm.names.callee, Attribute::Writable | Attribute::Configurable);

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -163,12 +163,14 @@ RawNativeFunction::RawNativeFunction(NativeFunctionPointer native_function, Obje
     : NativeFunction(prototype, realm, builtin)
     , m_native_function(native_function)
 {
+    set_is_raw_native_function();
 }
 
 RawNativeFunction::RawNativeFunction(Utf16FlyString name, NativeFunctionPointer native_function, Object& prototype)
     : NativeFunction(move(name), prototype)
     , m_native_function(native_function)
 {
+    set_is_raw_native_function();
 }
 
 // NOTE: Do not attempt to DRY these, it's not worth it. The difference in return types (Value vs Object*),

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -15,11 +15,50 @@
 namespace JS {
 
 GC_DEFINE_ALLOCATOR(NativeFunction);
+GC_DEFINE_ALLOCATOR(RawNativeFunction);
+
+namespace {
+
+class CapturingNativeFunction final : public NativeFunction {
+    JS_OBJECT(CapturingNativeFunction, NativeFunction);
+    GC_DECLARE_ALLOCATOR(CapturingNativeFunction);
+
+public:
+    CapturingNativeFunction(Function<ThrowCompletionOr<Value>(VM&)> native_function, Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin)
+        : NativeFunction(prototype, realm, builtin)
+        , m_native_function(move(native_function))
+    {
+    }
+
+    CapturingNativeFunction(Utf16FlyString name, Function<ThrowCompletionOr<Value>(VM&)> native_function, Object& prototype)
+        : NativeFunction(move(name), prototype)
+        , m_native_function(move(native_function))
+    {
+    }
+
+    virtual ThrowCompletionOr<Value> call() override
+    {
+        VERIFY(m_native_function);
+        return m_native_function(vm());
+    }
+
+private:
+    virtual void visit_edges(Cell::Visitor& visitor) override
+    {
+        NativeFunction::visit_edges(visitor);
+        visitor.visit_possible_values(m_native_function.raw_capture_range());
+    }
+
+    AK::Function<ThrowCompletionOr<Value>(VM&)> m_native_function;
+};
+
+GC_DEFINE_ALLOCATOR(CapturingNativeFunction);
+
+}
 
 void NativeFunction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit_possible_values(m_native_function.raw_capture_range());
     visitor.visit(m_realm);
 }
 
@@ -44,7 +83,7 @@ GC::Ref<NativeFunction> NativeFunction::create(Realm& allocating_realm, Function
     // 7. Set func.[[Extensible]] to true.
     // 8. Set func.[[Realm]] to realm.
     // 9. Set func.[[InitialName]] to null.
-    auto function = allocating_realm.create<NativeFunction>(move(behaviour), prototype, *realm.value(), builtin);
+    auto function = allocating_realm.create<CapturingNativeFunction>(move(behaviour), prototype, *realm.value(), builtin);
 
     function->unsafe_set_shape(realm.value()->intrinsics().native_function_shape());
 
@@ -61,14 +100,43 @@ GC::Ref<NativeFunction> NativeFunction::create(Realm& allocating_realm, Function
     return function;
 }
 
-GC::Ref<NativeFunction> NativeFunction::create(Realm& realm, Utf16FlyString const& name, Function<ThrowCompletionOr<Value>(VM&)> function)
+GC::Ref<NativeFunction> NativeFunction::create(Realm& allocating_realm, NativeFunctionPointer behaviour, i32 length, PropertyKey const& name, Optional<Realm*> realm, Optional<StringView> const& prefix, Optional<Bytecode::Builtin> builtin)
 {
-    return realm.create<NativeFunction>(name, move(function), realm.intrinsics().function_prototype());
+    return RawNativeFunction::create(allocating_realm, behaviour, length, name, realm, prefix, builtin);
 }
 
-NativeFunction::NativeFunction(AK::Function<ThrowCompletionOr<Value>(VM&)> native_function, Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin)
+GC::Ref<NativeFunction> NativeFunction::create(Realm& realm, Utf16FlyString const& name, Function<ThrowCompletionOr<Value>(VM&)> function)
+{
+    return realm.create<CapturingNativeFunction>(name, move(function), realm.intrinsics().function_prototype());
+}
+
+GC::Ref<NativeFunction> NativeFunction::create(Realm& realm, Utf16FlyString const& name, NativeFunctionPointer function)
+{
+    return RawNativeFunction::create(realm, name, function);
+}
+
+GC::Ref<RawNativeFunction> RawNativeFunction::create(Realm& allocating_realm, NativeFunctionPointer behaviour, i32 length, PropertyKey const& name, Optional<Realm*> realm, Optional<StringView> const& prefix, Optional<Bytecode::Builtin> builtin)
+{
+    auto& vm = allocating_realm.vm();
+
+    if (!realm.has_value())
+        realm = vm.current_realm();
+
+    auto prototype = realm.value()->intrinsics().function_prototype();
+    auto function = allocating_realm.create<RawNativeFunction>(behaviour, prototype, *realm.value(), builtin);
+    function->unsafe_set_shape(realm.value()->intrinsics().native_function_shape());
+    function->put_direct(realm.value()->intrinsics().native_function_length_offset(), Value { length });
+    function->put_direct(realm.value()->intrinsics().native_function_name_offset(), function->make_function_name(name, prefix));
+    return function;
+}
+
+GC::Ref<RawNativeFunction> RawNativeFunction::create(Realm& realm, Utf16FlyString const& name, NativeFunctionPointer function)
+{
+    return realm.create<RawNativeFunction>(name, function, realm.intrinsics().function_prototype());
+}
+
+NativeFunction::NativeFunction(Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin)
     : FunctionObject(realm, prototype)
-    , m_native_function(move(native_function))
     , m_realm(realm)
 {
     m_builtin = builtin;
@@ -84,18 +152,22 @@ NativeFunction::NativeFunction(Object& prototype)
 {
 }
 
-NativeFunction::NativeFunction(Utf16FlyString name, AK::Function<ThrowCompletionOr<Value>(VM&)> native_function, Object& prototype)
-    : FunctionObject(prototype)
-    , m_name(move(name))
-    , m_native_function(move(native_function))
-    , m_realm(prototype.shape().realm())
-{
-}
-
 NativeFunction::NativeFunction(Utf16FlyString name, Object& prototype)
     : FunctionObject(prototype)
     , m_name(move(name))
     , m_realm(prototype.shape().realm())
+{
+}
+
+RawNativeFunction::RawNativeFunction(NativeFunctionPointer native_function, Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin)
+    : NativeFunction(prototype, realm, builtin)
+    , m_native_function(native_function)
+{
+}
+
+RawNativeFunction::RawNativeFunction(Utf16FlyString name, NativeFunctionPointer native_function, Object& prototype)
+    : NativeFunction(move(name), prototype)
+    , m_native_function(native_function)
 {
 }
 
@@ -213,6 +285,11 @@ ThrowCompletionOr<GC::Ref<Object>> NativeFunction::internal_construct(ExecutionC
 }
 
 ThrowCompletionOr<Value> NativeFunction::call()
+{
+    VERIFY_NOT_REACHED();
+}
+
+ThrowCompletionOr<Value> RawNativeFunction::call()
 {
     VERIFY(m_native_function);
     return m_native_function(vm());

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -22,7 +22,9 @@ class JS_API NativeFunction : public FunctionObject {
 
 public:
     static GC::Ref<NativeFunction> create(Realm&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name = Utf16FlyString {}, Optional<Realm*> = {}, Optional<StringView> const& prefix = {}, Optional<Bytecode::Builtin> builtin = {});
+    static GC::Ref<NativeFunction> create(Realm&, NativeFunctionPointer behaviour, i32 length, PropertyKey const& name = Utf16FlyString {}, Optional<Realm*> = {}, Optional<StringView> const& prefix = {}, Optional<Bytecode::Builtin> builtin = {});
     static GC::Ref<NativeFunction> create(Realm&, Utf16FlyString const& name, ESCAPING Function<ThrowCompletionOr<Value>(VM&)>);
+    static GC::Ref<NativeFunction> create(Realm&, Utf16FlyString const& name, NativeFunctionPointer);
 
     virtual ~NativeFunction() override = default;
 
@@ -30,7 +32,6 @@ public:
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ExecutionContext&, FunctionObject& new_target) override;
 
     // Used for [[Call]] / [[Construct]]'s "...result of evaluating F in a manner that conforms to the specification of F".
-    // Needs to be overridden by all NativeFunctions without an m_native_function.
     virtual ThrowCompletionOr<Value> call();
     virtual ThrowCompletionOr<GC::Ref<Object>> construct(FunctionObject& new_target);
 
@@ -48,9 +49,8 @@ public:
     virtual size_t function_environment_bindings_count() const { return 0; }
 
 protected:
+    NativeFunction(Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin);
     NativeFunction(Utf16FlyString name, Object& prototype);
-    NativeFunction(AK::Function<ThrowCompletionOr<Value>(VM&)>, Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin);
-    NativeFunction(Utf16FlyString name, AK::Function<ThrowCompletionOr<Value>(VM&)>, Object& prototype);
     explicit NativeFunction(Object& prototype);
 
     virtual void visit_edges(Cell::Visitor& visitor) override;
@@ -60,11 +60,36 @@ private:
 
     Utf16FlyString m_name;
     Optional<Utf16FlyString> m_initial_name; // [[InitialName]]
-    AK::Function<ThrowCompletionOr<Value>(VM&)> m_native_function;
     GC::Ref<Realm> m_realm;
 };
 
 template<>
 inline bool Object::fast_is<NativeFunction>() const { return is_native_function(); }
+
+class JS_API RawNativeFunction final : public NativeFunction {
+    JS_OBJECT(RawNativeFunction, NativeFunction);
+    GC_DECLARE_ALLOCATOR(RawNativeFunction);
+
+public:
+    static GC::Ref<RawNativeFunction> create(Realm&, NativeFunctionPointer behaviour, i32 length, PropertyKey const& name = Utf16FlyString {}, Optional<Realm*> = {}, Optional<StringView> const& prefix = {}, Optional<Bytecode::Builtin> builtin = {});
+    static GC::Ref<RawNativeFunction> create(Realm&, Utf16FlyString const& name, NativeFunctionPointer);
+
+    virtual ~RawNativeFunction() override = default;
+
+    virtual ThrowCompletionOr<Value> call() override;
+
+    NativeFunctionPointer native_function() const { return m_native_function; }
+
+private:
+    RawNativeFunction(NativeFunctionPointer, Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin);
+    RawNativeFunction(Utf16FlyString name, NativeFunctionPointer, Object& prototype);
+
+    virtual bool is_raw_native_function() const final { return true; }
+
+    NativeFunctionPointer m_native_function { nullptr };
+};
+
+template<>
+inline bool Object::fast_is<RawNativeFunction>() const { return is_raw_native_function(); }
 
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -84,8 +84,6 @@ private:
     RawNativeFunction(NativeFunctionPointer, Object* prototype, Realm& realm, Optional<Bytecode::Builtin> builtin);
     RawNativeFunction(Utf16FlyString name, NativeFunctionPointer, Object& prototype);
 
-    virtual bool is_raw_native_function() const final { return true; }
-
     NativeFunctionPointer m_native_function { nullptr };
 };
 

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1404,6 +1404,17 @@ void Object::set_prototype(Object* new_prototype)
     m_shape = shape().create_prototype_transition(new_prototype);
 }
 
+void Object::define_native_accessor(Realm& realm, PropertyKey const& property_key, NativeFunctionPointer getter, NativeFunctionPointer setter, PropertyAttributes attribute)
+{
+    FunctionObject* getter_function = nullptr;
+    if (getter)
+        getter_function = NativeFunction::create(realm, move(getter), 0, property_key, &realm, "get"sv);
+    FunctionObject* setter_function = nullptr;
+    if (setter)
+        setter_function = NativeFunction::create(realm, move(setter), 1, property_key, &realm, "set"sv);
+    define_direct_accessor(property_key, getter_function, setter_function, attribute);
+}
+
 void Object::define_native_accessor(Realm& realm, PropertyKey const& property_key, Function<ThrowCompletionOr<Value>(VM&)> getter, Function<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attribute)
 {
     FunctionObject* getter_function = nullptr;
@@ -1508,6 +1519,12 @@ Value Object::get_without_side_effects(PropertyKey const& property_key) const
         object = object->prototype();
     }
     return {};
+}
+
+void Object::define_native_function(Realm& realm, PropertyKey const& property_key, NativeFunctionPointer native_function, i32 length, PropertyAttributes attribute, Optional<Bytecode::Builtin> builtin)
+{
+    auto function = NativeFunction::create(realm, move(native_function), length, property_key, &realm, {}, builtin);
+    define_direct_property(property_key, function, attribute);
 }
 
 void Object::define_native_function(Realm& realm, PropertyKey const& property_key, Function<ThrowCompletionOr<Value>(VM&)> native_function, i32 length, PropertyAttributes attribute, Optional<Bytecode::Builtin> builtin)

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -225,7 +225,9 @@ public:
     using IntrinsicAccessor = Value (*)(Realm&);
     void define_intrinsic_accessor(PropertyKey const&, PropertyAttributes attributes, IntrinsicAccessor accessor);
 
+    void define_native_function(Realm&, PropertyKey const&, NativeFunctionPointer, i32 length, PropertyAttributes attributes, Optional<Bytecode::Builtin> builtin = {});
     void define_native_function(Realm&, PropertyKey const&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)>, i32 length, PropertyAttributes attributes, Optional<Bytecode::Builtin> builtin = {});
+    void define_native_accessor(Realm&, PropertyKey const&, NativeFunctionPointer getter, NativeFunctionPointer setter, PropertyAttributes attributes);
     void define_native_accessor(Realm&, PropertyKey const&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> getter, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attributes);
     void define_native_javascript_backed_function(PropertyKey const&, GC::Ref<NativeJavaScriptBackedFunction> function, i32 length, PropertyAttributes attributes);
 
@@ -254,6 +256,7 @@ public:
     virtual bool is_global_object() const { return false; }
     virtual bool is_proxy_object() const { return false; }
     virtual bool is_native_function() const { return false; }
+    virtual bool is_raw_native_function() const { return false; }
     [[nodiscard]] bool is_ecmascript_function_object() const { return m_flags & Flag::IsECMAScriptFunctionObject; }
     void set_is_ecmascript_function_object() { m_flags |= Flag::IsECMAScriptFunctionObject; }
     void set_is_function() { m_flags |= Flag::IsFunction; }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -256,10 +256,11 @@ public:
     virtual bool is_global_object() const { return false; }
     virtual bool is_proxy_object() const { return false; }
     virtual bool is_native_function() const { return false; }
-    virtual bool is_raw_native_function() const { return false; }
+    [[nodiscard]] bool is_raw_native_function() const { return m_flags & Flag::IsRawNativeFunction; }
     [[nodiscard]] bool is_ecmascript_function_object() const { return m_flags & Flag::IsECMAScriptFunctionObject; }
     void set_is_ecmascript_function_object() { m_flags |= Flag::IsECMAScriptFunctionObject; }
     void set_is_function() { m_flags |= Flag::IsFunction; }
+    void set_is_raw_native_function() { m_flags |= Flag::IsRawNativeFunction; }
     void clear_is_function() { m_flags &= ~Flag::IsFunction; }
     virtual bool is_array_iterator() const { return false; }
     virtual bool is_raw_json_object() const { return false; }
@@ -372,6 +373,7 @@ protected:
 private:
     struct Flag {
         static constexpr u8 IsExtensible = 1 << 0;
+        static constexpr u8 IsRawNativeFunction = 1 << 1;
         static constexpr u8 HasMagicalLengthProperty = 1 << 2;
         static constexpr u8 IsTypedArray = 1 << 3;
         static constexpr u8 MayInterfereWithIndexedPropertyAccess = 1 << 4;

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -288,8 +288,7 @@ public:
     // B.3.7 The [[IsHTMLDDA]] Internal Slot, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
     virtual bool is_htmldda() const { return false; }
 
-    bool has_parameter_map() const { return m_flags & Flag::HasParameterMap; }
-    void set_has_parameter_map() { m_flags |= Flag::HasParameterMap; }
+    bool has_parameter_map() const { return shape().has_parameter_map(); }
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -373,7 +372,6 @@ protected:
 private:
     struct Flag {
         static constexpr u8 IsExtensible = 1 << 0;
-        static constexpr u8 HasParameterMap = 1 << 1;
         static constexpr u8 HasMagicalLengthProperty = 1 << 2;
         static constexpr u8 IsTypedArray = 1 << 3;
         static constexpr u8 MayInterfereWithIndexedPropertyAccess = 1 << 4;

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -28,6 +28,7 @@ GC::Ref<Shape> Shape::create_dictionary_transition()
 {
     auto new_shape = heap().allocate<Shape>(m_realm);
     new_shape->m_dictionary = true;
+    new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     ensure_property_table();
@@ -142,6 +143,7 @@ Shape::Shape(Realm& realm)
 Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAttributes attributes, TransitionType transition_type)
     : m_attributes(attributes)
     , m_transition_type(transition_type)
+    , m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
     , m_previous(&previous_shape)
     , m_property_key(property_key)
@@ -152,6 +154,7 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAtt
 
 Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionType transition_type)
     : m_transition_type(transition_type)
+    , m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
     , m_previous(&previous_shape)
     , m_property_key(property_key)
@@ -163,6 +166,7 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionT
 
 Shape::Shape(Shape& previous_shape, Object* new_prototype)
     : m_transition_type(TransitionType::Prototype)
+    , m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
     , m_previous(&previous_shape)
     , m_prototype(new_prototype)
@@ -321,6 +325,7 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     auto new_shape = heap().allocate<Shape>(m_realm);
     m_realm->all_prototype_shapes().set(new_shape);
     new_shape->m_is_prototype_shape = true;
+    new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     ensure_property_table();
     new_shape->ensure_property_table();

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -87,6 +87,8 @@ public:
     void set_property_attributes_without_transition(PropertyKey const&, PropertyAttributes);
 
     [[nodiscard]] bool is_dictionary() const { return m_dictionary; }
+    [[nodiscard]] bool has_parameter_map() const { return m_has_parameter_map; }
+    void set_has_parameter_map() { m_has_parameter_map = true; }
 
     [[nodiscard]] u32 dictionary_generation() const { return m_dictionary_generation; }
 
@@ -130,6 +132,7 @@ private:
 
     bool m_dictionary : 1 { false };
     bool m_is_prototype_shape : 1 { false };
+    bool m_has_parameter_map : 1 { false };
 
     GC::Ref<Realm> m_realm;
 

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -134,6 +134,7 @@ public:
     [[nodiscard]] COLD HandleExceptionResponse handle_exception(u32 program_counter, Value exception);
 
     NEVER_INLINE void pop_inline_frame(Value return_value);
+    NEVER_INLINE void unwind_inline_frame_for_exception();
 
     ExecutionContext* push_inline_frame(
         ECMAScriptFunctionObject& callee_function,

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -144,7 +144,7 @@ GC::Ref<WebIDL::CallbackType> UniversalGlobalScopeMixin::byte_length_queuing_str
         };
 
         // 2. Let F be ! CreateBuiltinFunction(steps, 1, "size", « », globalObject’s relevant Realm).
-        auto function = JS::NativeFunction::create(realm, move(steps), 1, "size"_utf16_fly_string, &realm);
+        auto function = JS::NativeFunction::create(realm, Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)> { move(steps) }, 1, "size"_utf16_fly_string, &realm);
 
         // 3. Set globalObject’s byte length queuing strategy size function to a Function that represents a reference to F, with callback context equal to globalObject’s relevant settings object.
         // FIXME: Update spec comment to pass globalObject's relevant realm once Streams spec is updated for ShadowRealm spec

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -575,9 +575,22 @@ GC::Ref<ExportedWasmFunction> ExportedWasmFunction::create(JS::Realm& realm, Utf
 }
 
 ExportedWasmFunction::ExportedWasmFunction(Utf16FlyString name, AK::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)> behavior, Wasm::FunctionAddress exported_address, JS::Object& prototype)
-    : NativeFunction(move(name), move(behavior), prototype)
+    : NativeFunction(move(name), prototype)
+    , m_behavior(move(behavior))
     , m_exported_address(exported_address)
 {
+}
+
+void ExportedWasmFunction::visit_edges(Cell::Visitor& visitor)
+{
+    NativeFunction::visit_edges(visitor);
+    visitor.visit_possible_values(m_behavior.raw_capture_range());
+}
+
+JS::ThrowCompletionOr<JS::Value> ExportedWasmFunction::call()
+{
+    VERIFY(m_behavior);
+    return m_behavior(vm());
 }
 
 JS::NativeFunction* create_native_function(JS::VM& vm, Wasm::FunctionAddress address, Utf16FlyString name, Instance* instance)

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -94,10 +94,15 @@ public:
 
     Wasm::FunctionAddress exported_address() const { return m_exported_address; }
 
+    virtual JS::ThrowCompletionOr<JS::Value> call() override;
+
 protected:
     ExportedWasmFunction(Utf16FlyString name, AK::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>, Wasm::FunctionAddress, Object& prototype);
 
 private:
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    AK::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)> m_behavior;
     Wasm::FunctionAddress m_exported_address;
 };
 

--- a/Tests/LibJS/Runtime/asm-call-this-binding.js
+++ b/Tests/LibJS/Runtime/asm-call-this-binding.js
@@ -23,3 +23,45 @@ test("non-strict asm Call keeps global this binding metadata alive", () => {
     if (old_value === undefined) delete globalThis.__asm_call_answer;
     else globalThis.__asm_call_answer = old_value;
 });
+
+test("asm Call fast-paths native method calls", () => {
+    let map = new Map();
+    let returned;
+
+    for (let i = 0; i < 100; i++) returned = map.set(i, i + 1);
+
+    expect(returned).toBe(map);
+    expect(map.size).toBe(100);
+    expect(map.get(41)).toBe(42);
+});
+
+test("asm Call unwinds raw native exceptions", () => {
+    let getter = Map.prototype.get;
+
+    for (let i = 0; i < 10; i++) expect(() => getter(1)).toThrow(TypeError);
+});
+
+test("asm Call lets JS try/catch observe direct raw native throws", () => {
+    let caught = false;
+
+    try {
+        Object.defineProperty(null, "x", {});
+    } catch (error) {
+        caught = error instanceof TypeError;
+    }
+
+    expect(caught).toBeTrue();
+});
+
+test("asm Call lets JS try/catch observe Reflect.construct throws", () => {
+    function isConstructor(value) {
+        try {
+            Reflect.construct(function () {}, [], value);
+        } catch {
+            return false;
+        }
+        return true;
+    }
+
+    expect(isConstructor(Object.defineProperty)).toBeFalse();
+});

--- a/Tests/LibJS/Runtime/functions/function-TypeError.js
+++ b/Tests/LibJS/Runtime/functions/function-TypeError.js
@@ -34,5 +34,5 @@ test("constructing object", () => {
 test("constructing native function", () => {
     expect(() => {
         new isNaN();
-    }).toThrowWithMessage(TypeError, "[object NativeFunction] is not a constructor (evaluated from 'isNaN')");
+    }).toThrowWithMessage(TypeError, "[object RawNativeFunction] is not a constructor (evaluated from 'isNaN')");
 });


### PR DESCRIPTION
Native functions in LibJS are backed by `AK::Function`, which reserves storage for possible captures. That's fine when a built-in actually needs captured state, but most don't, and for those we're paying for storage we never use. Worse, every call has to bounce out of the asm interpreter into C++, go through virtual dispatch, and walk the full `internal_call` path before reaching the built-in.

This PR introduces `RawNativeFunction`: a variant that holds a plain function pointer with a fixed calling convention instead of an `AK::Function`. The existing `NativeFunction` hierarchy is split so the raw and `AK::Function`-backed flavors are separate types, and the asm interpreter's `Call` opcode now recognizes the raw case and performs the bare minimum call frame setup before dispatching to the function pointer, entirely from within asm. :^)

Some highlights:
```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  -----------------
LongSpider      3d-morph.js                             1.624      2.376 ± 2.366 … 2.385              1.463 ± 1.456 … 1.470              +1.1% (+0.3 MB)
ARES-6          Basic.js                                1.179      1.581 ± 1.580 … 1.582              1.341 ± 1.337 … 1.346              +0.2% (+0.1 MB)
JetStream3      sync-file-system.js                     1.123      1.967 ± 1.881 … 2.053              1.752 ± 1.742 … 1.763              -1.8% (-0.6 MB)
Kraken          audio-oscillator.js                     1.104      0.386 ± 0.366 … 0.406              0.350 ± 0.349 … 0.351              +0.1% (+0.1 MB)
Octane          raytrace.js                             1.077      3433.000 ± 3416.000 … 3450.000     3698.500 ± 3649.000 … 3748.000     -0.3% (-0.1 MB)
```

Full benchmarks (Linux):

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  -----------------
LongSpider      3d-cube.js                              1.006      4.705 ± 4.577 … 4.833              4.675 ± 4.648 … 4.703              -1.3% (-0.4 MB)
LongSpider      3d-morph.js                             1.624      2.376 ± 2.366 … 2.385              1.463 ± 1.456 … 1.470              +1.1% (+0.3 MB)
LongSpider      3d-raytrace.js                          0.947      2.800 ± 2.793 … 2.808              2.957 ± 2.887 … 3.027              +0.1% (+0.0 MB)
LongSpider      access-binary-trees.js                  1.028      8.051 ± 7.997 … 8.105              7.835 ± 7.815 … 7.854              -10.5% (-11.2 MB)
LongSpider      access-fannkuch.js                      0.960      1.664 ± 1.611 … 1.717              1.733 ± 1.703 … 1.762              +1.1% (+0.3 MB)
LongSpider      access-nbody.js                         0.980      3.689 ± 3.681 … 3.697              3.766 ± 3.760 … 3.773              +1.1% (+0.3 MB)
LongSpider      access-nsieve.js                        0.973      0.928 ± 0.928 … 0.928              0.953 ± 0.932 … 0.975              -0.0% (-0.1 MB)
LongSpider      bitops-3bit-bits-in-byte.js             1.005      0.439 ± 0.437 … 0.440              0.437 ± 0.435 … 0.438              +1.1% (+0.3 MB)
LongSpider      bitops-bits-in-byte.js                  0.798      0.554 ± 0.553 … 0.554              0.694 ± 0.689 … 0.699              +1.1% (+0.3 MB)
LongSpider      bitops-nsieve-bits.js                   0.921      1.852 ± 1.825 … 1.878              2.010 ± 1.950 … 2.071              +0.3% (+0.1 MB)
LongSpider      controlflow-recursive.js                1.003      1.787 ± 1.780 … 1.794              1.781 ± 1.779 … 1.784              +1.1% (+0.3 MB)
LongSpider      crypto-aes.js                           0.989      4.508 ± 4.285 … 4.730              4.559 ± 4.480 … 4.639              -1.0% (-0.3 MB)
LongSpider      crypto-md5.js                           0.967      4.364 ± 4.348 … 4.380              4.511 ± 4.483 … 4.540              -0.0% (-0.0 MB)
LongSpider      crypto-sha1.js                          0.988      8.554 ± 8.551 … 8.557              8.662 ± 8.598 … 8.725              -0.1% (-0.1 MB)
LongSpider      date-format-tofte.js                    0.993      3.621 ± 3.598 … 3.644              3.647 ± 3.633 … 3.660              -0.2% (-0.1 MB)
LongSpider      date-format-xparb.js                    1.052      4.436 ± 4.429 … 4.443              4.217 ± 4.209 … 4.225              -0.6% (-0.2 MB)
LongSpider      hash-map.js                             1.035      1.075 ± 1.075 … 1.076              1.039 ± 1.018 … 1.061              -0.2% (-0.2 MB)
LongSpider      math-cordic.js                          0.997      5.260 ± 5.221 … 5.298              5.273 ± 5.268 … 5.278              +1.1% (+0.3 MB)
LongSpider      math-partial-sums.js                    1.009      0.792 ± 0.789 … 0.795              0.785 ± 0.780 … 0.790              +1.1% (+0.3 MB)
LongSpider      math-spectral-norm.js                   1.003      4.746 ± 4.744 … 4.748              4.730 ± 4.726 … 4.733              +1.1% (+0.3 MB)
LongSpider      string-base64.js                        1.008      1.471 ± 1.413 … 1.529              1.460 ± 1.428 … 1.492              +21.7% (+88.5 MB)
LongSpider      string-fasta.js                         0.995      1.562 ± 1.558 … 1.566              1.570 ± 1.562 … 1.577              -0.7% (-0.2 MB)
LongSpider      string-tagcloud.js                      1.038      0.767 ± 0.765 … 0.769              0.739 ± 0.739 … 0.739              -0.2% (-0.1 MB)
Kraken          ai-astar.js                             1.009      0.659 ± 0.648 … 0.670              0.653 ± 0.636 … 0.670              +0.1% (+0.1 MB)
Kraken          audio-beat-detection.js                 0.986      0.511 ± 0.499 … 0.524              0.518 ± 0.518 … 0.518              +0.2% (+0.1 MB)
Kraken          audio-dft.js                            0.998      0.348 ± 0.340 … 0.355              0.348 ± 0.338 … 0.358              -0.6% (-0.3 MB)
Kraken          audio-fft.js                            0.979      0.435 ± 0.429 … 0.441              0.444 ± 0.441 … 0.448              -0.3% (-0.2 MB)
Kraken          audio-oscillator.js                     1.104      0.386 ± 0.366 … 0.406              0.350 ± 0.349 … 0.351              +0.1% (+0.1 MB)
Kraken          imaging-darkroom.js                     0.992      0.539 ± 0.537 … 0.541              0.544 ± 0.541 … 0.546              -0.3% (-0.2 MB)
Kraken          imaging-desaturate.js                   1.082      0.623 ± 0.622 … 0.624              0.576 ± 0.568 … 0.584              -0.0% (-0.0 MB)
Kraken          imaging-gaussian-blur.js                1.042      2.562 ± 2.517 … 2.607              2.458 ± 2.450 … 2.466              -0.3% (-0.3 MB)
Kraken          json-parse-financial.js                 0.995      0.056 ± 0.055 … 0.056              0.056 ± 0.056 … 0.056              +0.6% (+0.2 MB)
Kraken          json-stringify-tinderbox.js             1.014      0.053 ± 0.052 … 0.053              0.052 ± 0.051 … 0.053              -0.1% (-0.0 MB)
Kraken          stanford-crypto-aes.js                  0.974      0.217 ± 0.217 … 0.217              0.223 ± 0.222 … 0.223              -0.6% (-0.3 MB)
Kraken          stanford-crypto-ccm.js                  1.018      0.170 ± 0.169 … 0.170              0.167 ± 0.165 … 0.168              -0.4% (-0.2 MB)
Kraken          stanford-crypto-pbkdf2.js               1.006      0.366 ± 0.363 … 0.369              0.364 ± 0.360 … 0.368              -0.2% (-0.1 MB)
Kraken          stanford-crypto-sha256-iterative.js     1.001      0.136 ± 0.136 … 0.137              0.136 ± 0.136 … 0.137              -0.1% (-0.0 MB)
Octane          box2d.js                                1.040      8419.000 ± 8407.000 … 8431.000     8754.000 ± 8729.000 … 8779.000     -0.3% (-0.1 MB)
Octane          code-load.js                            1.017      18694.000 ± 18560.000 … 18828.000  19005.000 ± 18982.000 … 19028.000  +2.4% (+24.8 MB)
Octane          crypto.js                               1.021      2937.500 ± 2906.000 … 2969.000     2998.500 ± 2933.000 … 3064.000     +0.4% (+0.1 MB)
Octane          deltablue.js                            1.010      2253.500 ± 2246.000 … 2261.000     2275.500 ± 2250.000 … 2301.000     -1.3% (-0.4 MB)
Octane          earley-boyer.js                         1.008      4819.500 ± 4816.000 … 4823.000     4860.000 ± 4853.000 … 4867.000     -1.9% (-1.0 MB)
Octane          gbemu.js                                0.983      16767.000 ± 16759.000 … 16775.000  16484.000 ± 16285.000 … 16683.000  -0.1% (-0.1 MB)
Octane          mandreel.js                             1.015      16081.500 ± 16030.000 … 16133.000  16318.500 ± 16238.000 … 16399.000  -1.7% (-5.7 MB)
Octane          navier-stokes.js                        0.978      5109.500 ± 5102.000 … 5117.000     4998.500 ± 4961.000 … 5036.000     +1.1% (+0.3 MB)
Octane          pdfjs.js                                1.012      7327.000 ± 7317.000 … 7337.000     7414.500 ± 7411.000 … 7418.000     -0.6% (-0.6 MB)
Octane          raytrace.js                             1.077      3433.000 ± 3416.000 … 3450.000     3698.500 ± 3649.000 … 3748.000     -0.3% (-0.1 MB)
Octane          regexp.js                               1.051      1951.500 ± 1950.000 … 1953.000     2051.000 ± 2050.000 … 2052.000     -0.5% (-0.2 MB)
Octane          richards.js                             0.996      2485.000 ± 2471.000 … 2499.000     2475.000 ± 2472.000 … 2478.000     -2.2% (-0.6 MB)
Octane          splay.js                                1.028      5408.000 ± 5396.000 … 5420.000     5562.000 ± 5542.000 … 5582.000     +0.0% (+0.0 MB)
Octane          typescript.js                           1.019      20909.500 ± 20906.000 … 20913.000  21306.000 ± 21286.000 … 21326.000  -0.8% (-2.0 MB)
Octane          zlib.js                                 0.983      5534.000 ± 5434.000 … 5634.000     5441.500 ± 5403.000 … 5480.000     -0.1% (-0.1 MB)
JetStream       bigfib.cpp.js                           0.909      4.821 ± 4.521 … 5.120              5.302 ± 5.154 … 5.449              -0.1% (-0.1 MB)
JetStream       cdjs.js                                 1.065      2.038 ± 2.035 … 2.041              1.913 ± 1.911 … 1.915              +0.1% (+0.0 MB)
JetStream       container.cpp.js                        0.987      21.632 ± 21.411 … 21.853           21.912 ± 21.178 … 22.646           +0.1% (+0.2 MB)
JetStream       dry.c.js                                1.048      11.098 ± 10.901 … 11.294           10.585 ± 10.554 … 10.615           -0.1% (-0.0 MB)
JetStream       float-mm.c.js                           0.947      13.264 ± 13.160 … 13.368           14.013 ± 13.086 … 14.939           -0.1% (-0.0 MB)
JetStream       gcc-loops.cpp.js                        1.021      75.255 ± 72.552 … 77.958           73.700 ± 72.446 … 74.954           +0.0% (+0.0 MB)
JetStream       hash-map.js                             1.007      1.040 ± 1.039 … 1.041              1.033 ± 1.007 … 1.059              -0.0% (-0.0 MB)
JetStream       n-body.c.js                             1.020      18.224 ± 17.959 … 18.489           17.873 ± 17.843 … 17.903           -0.4% (-0.2 MB)
JetStream       quicksort.c.js                          0.974      2.956 ± 2.939 … 2.973              3.036 ± 2.846 … 3.225              -0.2% (-0.1 MB)
JetStream       towers.c.js                             1.042      3.451 ± 3.341 … 3.562              3.312 ± 3.073 … 3.551              -0.0% (-0.0 MB)
JetStream3      js-tokens.js                            1.060      0.297 ± 0.296 … 0.298              0.280 ± 0.278 … 0.283              +0.4% (+0.1 MB)
JetStream3      lazy-collections.js                     1.003      0.832 ± 0.829 … 0.835              0.829 ± 0.828 … 0.830              +0.1% (+0.0 MB)
JetStream3      raytrace-private-class-fields.js        0.996      3.522 ± 3.515 … 3.529              3.536 ± 3.527 … 3.546              -0.6% (-0.2 MB)
JetStream3      raytrace-public-class-fields.js         0.989      2.612 ± 2.605 … 2.618              2.642 ± 2.620 … 2.664              +0.8% (+0.2 MB)
JetStream3      sync-file-system.js                     1.123      1.967 ± 1.881 … 2.053              1.752 ± 1.742 … 1.763              -1.8% (-0.6 MB)
AsyncBench      async-call-return.js                    1.065      0.188 ± 0.182 … 0.195              0.177 ± 0.175 … 0.179              -0.0% (-0.0 MB)
AsyncBench      async-class-method.js                   0.995      0.206 ± 0.205 … 0.206              0.207 ± 0.206 … 0.207              -0.4% (-0.1 MB)
AsyncBench      async-fan-out.js                        1.045      0.183 ± 0.182 … 0.184              0.175 ± 0.173 … 0.178              +8.2% (+2.2 MB)
AsyncBench      async-generator.js                      1.038      0.270 ± 0.268 … 0.272              0.260 ± 0.260 … 0.260              -1.1% (-0.3 MB)
AsyncBench      async-iife.js                           0.995      0.280 ± 0.277 … 0.283              0.281 ± 0.280 … 0.283              +0.1% (+0.0 MB)
AsyncBench      async-nested-calls.js                   1.009      0.297 ± 0.294 … 0.300              0.295 ± 0.288 … 0.301              -0.3% (-0.1 MB)
AsyncBench      async-pipeline.js                       1.017      0.358 ± 0.352 … 0.363              0.352 ± 0.346 … 0.357              -0.4% (-0.1 MB)
AsyncBench      async-sequential-awaits.js              1.051      0.097 ± 0.095 … 0.099              0.092 ± 0.092 … 0.093              -1.3% (-0.4 MB)
AsyncBench      async-try-catch-reject.js               1.004      0.499 ± 0.497 … 0.501              0.497 ± 0.497 … 0.497              -0.2% (-0.1 MB)
AsyncBench      await-primitive.js                      0.994      0.052 ± 0.051 … 0.053              0.052 ± 0.051 … 0.053              +0.2% (+0.1 MB)
AsyncBench      await-resolved-promise.js               1.084      0.443 ± 0.441 … 0.445              0.409 ± 0.408 … 0.410              +0.2% (+0.1 MB)
AsyncBench      await-thenable.js                       0.964      0.050 ± 0.050 … 0.050              0.052 ± 0.052 … 0.052              -4.5% (-3.0 MB)
AsyncBench      promise-all.js                          1.030      0.521 ± 0.520 … 0.522              0.506 ± 0.495 … 0.517              +0.2% (+0.1 MB)
AsyncBench      promise-allSettled.js                   1.032      0.585 ± 0.581 … 0.590              0.567 ± 0.565 … 0.569              +0.2% (+0.1 MB)
AsyncBench      promise-chain.js                        1.098      0.286 ± 0.285 … 0.287              0.261 ± 0.257 … 0.264              -8.6% (-29.1 MB)
AsyncBench      promise-new-resolve.js                  1.024      0.282 ± 0.282 … 0.282              0.276 ± 0.275 … 0.276              +0.2% (+0.1 MB)
AsyncBench      promise-race.js                         1.063      0.539 ± 0.536 … 0.542              0.507 ± 0.506 … 0.509              +0.2% (+0.1 MB)
ARES-6          Air.js                                  1.016      1.718 ± 1.717 … 1.720              1.692 ± 1.688 … 1.697              -0.2% (-0.1 MB)
ARES-6          Babylon.js                              1.032      1.064 ± 1.054 … 1.075              1.031 ± 1.022 … 1.040              +0.2% (+0.1 MB)
ARES-6          Basic.js                                1.179      1.581 ± 1.580 … 1.582              1.341 ± 1.337 … 1.346              +0.2% (+0.1 MB)
ARES-6          ML.js                                   1.053      1.566 ± 1.538 … 1.593              1.486 ± 1.463 … 1.510              +0.2% (+0.1 MB)
JetStreamExtra  FlightPlanner.js                        1.003      1.149 ± 1.148 … 1.149              1.145 ± 1.139 … 1.151              +0.0% (+0.1 MB)
JetStreamExtra  OfflineAssembler.js                     1.041      1.133 ± 1.133 … 1.133              1.089 ± 1.088 … 1.089              -0.2% (-0.1 MB)
JetStreamExtra  UniPoker.js                             1.088      1.351 ± 1.349 … 1.353              1.241 ± 1.240 … 1.242              +0.2% (+0.1 MB)
JetStreamExtra  async-fs.js                             1.032      1.776 ± 1.772 … 1.780              1.720 ± 1.718 … 1.722              +0.2% (+0.1 MB)
JetStreamExtra  babylonjs-startup-es5.js                1.008      1.187 ± 1.183 … 1.191              1.177 ± 1.176 … 1.178              -0.1% (-0.4 MB)
JetStreamExtra  babylonjs-startup-es6.js                1.027      1.453 ± 1.429 … 1.477              1.415 ± 1.412 … 1.417              +0.1% (+0.7 MB)
JetStreamExtra  bigint-bigdenary.js                     1.023      1.714 ± 1.699 … 1.730              1.675 ± 1.671 … 1.680              +0.2% (+0.1 MB)
JetStreamExtra  bigint-noble-bls12-381.js               1.015      1.820 ± 1.815 … 1.825              1.793 ± 1.788 … 1.797              +0.2% (+0.1 MB)
JetStreamExtra  bigint-noble-ed25519.js                 1.003      1.856 ± 1.848 … 1.864              1.850 ± 1.848 … 1.852              -1.3% (-0.8 MB)
JetStreamExtra  bigint-noble-secp256k1.js               1.008      1.727 ± 1.713 … 1.742              1.713 ± 1.713 … 1.714              -0.2% (-0.1 MB)
JetStreamExtra  bigint-paillier.js                      1.003      1.846 ± 1.840 … 1.852              1.840 ± 1.837 … 1.843              -0.8% (-0.4 MB)
JetStreamExtra  doxbee-async.js                         1.042      1.717 ± 1.709 … 1.724              1.647 ± 1.625 … 1.670              -11.0% (-6.8 MB)
JetStreamExtra  doxbee-promise.js                       1.093      1.754 ± 1.746 … 1.761              1.605 ± 1.604 … 1.605              -9.1% (-5.2 MB)
JetStreamExtra  first-inspector-code-load.js            0.999      2.012 ± 2.006 … 2.018              2.014 ± 2.007 … 2.021              +0.0% (+0.1 MB)
JetStreamExtra  jsdom-d3-startup.js                     1.018      1.573 ± 1.566 … 1.579              1.545 ± 1.541 … 1.550              +0.0% (+0.1 MB)
JetStreamExtra  json-parse-inspector.js                 1.040      1.149 ± 1.100 … 1.198              1.105 ± 1.103 … 1.106              -0.1% (-0.1 MB)
JetStreamExtra  json-stringify-inspector.js             0.986      0.970 ± 0.970 … 0.971              0.984 ± 0.979 … 0.989              -4.1% (-12.3 MB)
JetStreamExtra  mobx-startup.js                         1.051      1.456 ± 1.442 … 1.470              1.385 ± 1.385 … 1.386              -0.4% (-0.2 MB)
JetStreamExtra  multi-inspector-code-load.js            1.031      2.073 ± 2.018 … 2.129              2.012 ± 2.009 … 2.015              -0.1% (-2.3 MB)
JetStreamExtra  prismjs-startup-es5.js                  1.038      1.723 ± 1.719 … 1.728              1.660 ± 1.659 … 1.662              +0.2% (+0.1 MB)
JetStreamExtra  prismjs-startup-es6.js                  1.035      1.723 ± 1.721 … 1.724              1.664 ± 1.663 … 1.665              +0.2% (+0.1 MB)
JetStreamExtra  proxy-mobx.js                           1.055      1.304 ± 1.299 … 1.308              1.236 ± 1.229 … 1.243              +0.2% (+0.1 MB)
JetStreamExtra  proxy-vue.js                            0.916      1.189 ± 1.168 … 1.209              1.297 ± 1.185 … 1.410              +3.5% (+1.9 MB)
JetStreamExtra  threejs.js                              1.064      1.759 ± 1.753 … 1.765              1.653 ± 1.650 … 1.657              +0.4% (+1.6 MB)
JetStreamExtra  typescript-lib.js                       1.011      0.710 ± 0.708 … 0.712              0.702 ± 0.700 … 0.704              -0.1% (-0.2 MB)
JetStreamExtra  validatorjs.js                          1.033      1.565 ± 1.563 … 1.568              1.515 ± 1.510 … 1.519              -0.3% (-0.2 MB)
JetStreamExtra  web-ssr.js                              1.032      1.848 ± 1.847 … 1.850              1.791 ± 1.787 … 1.794              +0.2% (+0.3 MB)
GarBench        array-of-objects.js                     1.010      0.862 ± 0.852 … 0.873              0.853 ± 0.853 … 0.854              -0.0% (-0.0 MB)
GarBench        closures.js                             1.028      1.217 ± 1.211 … 1.224              1.184 ± 1.175 … 1.193              -0.2% (-2.3 MB)
GarBench        cyclic-graph.js                         1.088      1.410 ± 1.409 … 1.411              1.296 ± 1.275 … 1.317              +0.0% (+0.1 MB)
GarBench        deep-linked-list.js                     0.997      0.782 ± 0.782 … 0.783              0.785 ± 0.785 … 0.785              -0.0% (-0.1 MB)
GarBench        finalization.js                         1.028      1.022 ± 1.016 … 1.027              0.994 ± 0.969 … 1.018              -0.0% (-0.1 MB)
GarBench        many-properties.js                      0.995      2.669 ± 2.657 … 2.680              2.683 ± 2.679 … 2.688              -0.0% (-0.1 MB)
GarBench        marking-stress.js                       0.900      1.383 ± 1.213 … 1.553              1.536 ± 1.534 … 1.538              -1.4% (-9.1 MB)
GarBench        mixed-sizes.js                          1.052      1.099 ± 1.091 … 1.107              1.045 ± 1.044 … 1.046              -0.0% (-0.1 MB)
GarBench        sparse-arrays.js                        1.020      2.259 ± 2.259 … 2.260              2.216 ± 2.213 … 2.219              +0.1% (+1.0 MB)
GarBench        string-heavy.js                         1.005      1.562 ± 1.552 … 1.571              1.554 ± 1.550 … 1.558              +0.0% (+0.1 MB)
GarBench        wide-tree.js                            1.026      1.504 ± 1.501 … 1.507              1.466 ± 1.450 … 1.481              +0.0% (+0.1 MB)
MicroBench      array-destructuring-assignment-rest.js  0.990      0.317 ± 0.310 … 0.324              0.320 ± 0.319 … 0.322              +0.2% (+0.1 MB)
MicroBench      array-destructuring-assignment.js       1.062      3.022 ± 3.020 … 3.023              2.844 ± 2.838 … 2.851              -0.0% (-0.1 MB)
MicroBench      array-prototype-map.js                  0.981      1.210 ± 1.210 … 1.211              1.234 ± 1.205 … 1.263              +0.0% (+0.1 MB)
MicroBench      array-prototype-shift.js                1.048      0.018 ± 0.017 … 0.018              0.017 ± 0.016 … 0.017              +0.2% (+0.1 MB)
MicroBench      bound-call-00-args.js                   1.041      1.494 ± 1.434 … 1.554              1.435 ± 1.434 … 1.437              +0.2% (+0.1 MB)
MicroBench      bound-call-04-args.js                   0.997      1.546 ± 1.543 … 1.549              1.551 ± 1.549 … 1.554              +0.2% (+0.1 MB)
MicroBench      bound-call-16-args.js                   0.875      1.765 ± 1.761 … 1.768              2.016 ± 1.850 … 2.182              +0.2% (+0.1 MB)
MicroBench      call-00-args.js                         1.033      0.452 ± 0.443 … 0.461              0.437 ± 0.437 … 0.438              +0.2% (+0.1 MB)
MicroBench      call-01-args.js                         0.958      0.464 ± 0.463 … 0.464              0.484 ± 0.484 … 0.485              +0.2% (+0.1 MB)
MicroBench      call-02-args.js                         0.995      0.526 ± 0.521 … 0.531              0.529 ± 0.524 … 0.534              +0.2% (+0.1 MB)
MicroBench      call-03-args.js                         1.006      0.525 ± 0.525 … 0.526              0.522 ± 0.521 … 0.523              +0.2% (+0.1 MB)
MicroBench      call-04-args.js                         1.047      0.526 ± 0.523 … 0.528              0.502 ± 0.501 … 0.503              +0.2% (+0.1 MB)
MicroBench      call-16-args.js                         1.389      0.942 ± 0.703 … 1.181              0.678 ± 0.678 … 0.678              +0.2% (+0.1 MB)
MicroBench      call-32-args.js                         1.000      0.936 ± 0.932 … 0.940              0.936 ± 0.933 … 0.940              +0.2% (+0.1 MB)
MicroBench      for-in-indexed-properties.js            1.000      0.230 ± 0.229 … 0.232              0.230 ± 0.230 … 0.231              -0.1% (-0.1 MB)
MicroBench      for-in-named-properties.js              0.995      0.172 ± 0.171 … 0.172              0.173 ± 0.172 … 0.173              +0.2% (+0.1 MB)
MicroBench      for-of.js                               1.099      0.553 ± 0.539 … 0.567              0.503 ± 0.498 … 0.509              +0.2% (+0.1 MB)
MicroBench      object-keys.js                          0.980      1.278 ± 1.273 … 1.282              1.304 ± 1.269 … 1.338              +0.0% (+0.0 MB)
MicroBench      object-set-with-rope-strings.js         0.991      0.688 ± 0.682 … 0.695              0.695 ± 0.687 … 0.703              +0.2% (+0.1 MB)
MicroBench      pic-add-own.js                          0.996      0.429 ± 0.421 … 0.437              0.431 ± 0.424 … 0.437              +0.2% (+0.1 MB)
MicroBench      pic-get-own.js                          0.985      0.490 ± 0.486 … 0.494              0.497 ± 0.495 … 0.499              +0.2% (+0.1 MB)
MicroBench      pic-get-pchain.js                       1.358      0.729 ± 0.511 … 0.946              0.537 ± 0.537 … 0.537              +0.2% (+0.1 MB)
MicroBench      pic-put-own.js                          1.000      0.512 ± 0.511 … 0.514              0.512 ± 0.510 … 0.515              +0.2% (+0.1 MB)
MicroBench      pic-put-pchain.js                       1.054      1.963 ± 1.929 … 1.997              1.862 ± 1.860 … 1.864              +0.2% (+0.1 MB)
MicroBench      setter-in-prototype-chain.js            1.039      2.105 ± 2.076 … 2.133              2.026 ± 1.999 … 2.052              +0.2% (+0.1 MB)
MicroBench      strictly-equals-object.js               1.003      0.724 ± 0.720 … 0.729              0.722 ± 0.721 … 0.723              +0.2% (+0.1 MB)
LongSpider      Total                                   1.007      70.000                             69.495                             +4.7% (+78.0 MB)
Kraken          Total                                   1.025      7.061                              6.889                              -0.1% (-1.1 MB)
Octane          Total                                   1.012      122129.500                         123642.500                         +0.6% (+14.4 MB)
JetStream       Total                                   1.007      153.779                            152.678                            -0.0% (-0.3 MB)
JetStream3      Total                                   1.021      9.230                              9.040                              -0.3% (-0.4 MB)
AsyncBench      Total                                   1.034      5.137                              4.965                              -3.2% (-30.3 MB)
ARES-6          Total                                   1.068      5.929                              5.550                              +0.1% (+0.2 MB)
JetStreamExtra  Total                                   1.026      41.536                             40.472                             -0.3% (-23.7 MB)
GarBench        Total                                   1.010      15.769                             15.613                             -0.1% (-10.7 MB)
MicroBench      Total                                   1.027      23.615                             22.998                             +0.0% (+2.4 MB)
All Suites      Total                                   1.010      397.212                            393.297                            +0.1% (+28.6 MB)
```