### PR TITLE
LibGfx+LibWeb: Ensure sk_image is available in ::export_to_byte_buffer()

### DIFF
--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -125,6 +125,9 @@ static SkColorType export_format_to_skia_color_type(ExportFormat format)
 
 ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat format, int flags, Optional<int> target_width, Optional<int> target_height) const
 {
+    if (SkiaBackendContext::the() && !ensure_sk_image(*SkiaBackendContext::the()))
+        return Error::from_string_literal("Failed to create a Skia image for this ImmutableBitmap");
+
     int width = target_width.value_or(this->width());
     int height = target_height.value_or(this->height());
 

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -23,7 +23,6 @@
 #include <core/SkCanvas.h>
 #include <core/SkImage.h>
 #include <core/SkPath.h>
-#include <core/SkPathEffect.h>
 #include <effects/SkBlurMaskFilter.h>
 #include <effects/SkDashPathEffect.h>
 #include <effects/SkGradientShader.h>


### PR DESCRIPTION
When an ImmutableBitmap is constructed from video data, there's a probability that we're dealing with YUV data and we do not yet have an sk_image to work with.

No regression test since we require a GPU to end up in this situation.

Fixes the background scenery on https://screen.toys/roadtrip/.

CC @Zaggy1024 

| Before | After |
|--|--|
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/d711a104-702f-45be-9700-da1b8eea85d5" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/4b09ce3b-c792-4957-84cc-5b840ac6707f" /> |
