### PR TITLE
LibWeb: Apply calculated vertical-align offsets in LineBuilder

### DIFF
--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -290,13 +290,10 @@ void LineBuilder::update_last_line()
             // Remember the baseline used for this fragment. This will be used when painting the fragment.
             fragment.set_baseline(fragment_baseline);
 
-            // NOTE: For fragments with a <length> vertical-align, shift the line box baseline down by the length.
+            // NOTE: For fragments with a <length-percentage> vertical-align, shift the line box baseline down by the resolved amount.
             //       This ensures that we make enough vertical space on the line for any manually-aligned fragments.
             if (auto const* length_percentage = fragment.layout_node().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-                if (length_percentage->is_length())
-                    fragment_baseline += length_percentage->length().to_px(fragment.layout_node());
-                else if (length_percentage->is_percentage())
-                    fragment_baseline += line_height.scaled(length_percentage->percentage().as_fraction());
+                fragment_baseline += length_percentage->to_px(fragment.layout_node(), line_height);
             }
 
             line_box_baseline = max(line_box_baseline, fragment_baseline);
@@ -363,13 +360,8 @@ void LineBuilder::update_last_line()
             new_fragment_block_offset = block_offset_value_for_alignment(vertical_align.get<CSS::VerticalAlign>());
         } else {
             if (auto const* length_percentage = vertical_align.get_pointer<CSS::LengthPercentage>()) {
-                if (length_percentage->is_length()) {
-                    auto vertical_align_amount = length_percentage->length().to_px(fragment.layout_node());
-                    new_fragment_block_offset = block_offset_value_for_alignment(CSS::VerticalAlign::Baseline) - vertical_align_amount;
-                } else if (length_percentage->is_percentage()) {
-                    auto vertical_align_amount = m_context.containing_block().computed_values().line_height().scaled(length_percentage->percentage().as_fraction());
-                    new_fragment_block_offset = block_offset_value_for_alignment(CSS::VerticalAlign::Baseline) - vertical_align_amount;
-                }
+                auto vertical_align_amount = length_percentage->to_px(fragment.layout_node(), fragment.layout_node().computed_values().line_height());
+                new_fragment_block_offset = block_offset_value_for_alignment(CSS::VerticalAlign::Baseline) - vertical_align_amount;
             }
         }
 
@@ -393,10 +385,7 @@ void LineBuilder::update_last_line()
                 bottom_of_inline_box = (fragment.block_offset() + fragment.baseline() + CSSPixels::nearest_value_for(font_metrics.descent) + half_leading);
             }
             if (auto const* length_percentage = fragment.layout_node().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-                if (length_percentage->is_length())
-                    bottom_of_inline_box += length_percentage->length().to_px(fragment.layout_node());
-                else if (length_percentage->is_percentage())
-                    bottom_of_inline_box += m_context.containing_block().computed_values().line_height().scaled(length_percentage->percentage().as_fraction());
+                bottom_of_inline_box += length_percentage->to_px(fragment.layout_node(), fragment.layout_node().computed_values().line_height());
             }
         }
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-calculated-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-calculated-vertical-align.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 80 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 80 0+0+0] children: inline
+      frag 0 from TextNode start: 0, length: 12, rect: [0,0 104.15625x80] baseline: 44.796875
+          "Get in touch"
+      frag 1 from BlockContainer start: 0, length: 0, rect: [104.15625,30 16x16] baseline: 16
+      TextNode <#text> (not painted)
+      BlockContainer <span.icon> at [104.15625,30] inline-block [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x80]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x80]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<SPAN>.icon) [104.15625,30 16x16]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x80] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/atomic-inline-with-calculated-vertical-align.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/atomic-inline-with-calculated-vertical-align.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html><html><head><style>
+* {
+    margin: 0;
+    padding: 0;
+    font: 16px SerenitySans;
+}
+body {
+    line-height: 5rem;
+}
+.icon {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background: red;
+    vertical-align: calc(0.5px + 0.3465em - 0.5rem);
+}
+</style></head><body>Get in touch<span class="icon"></span></body>


### PR DESCRIPTION
Fixes the alignment of the arrow for "Get in touch" on canonical.com

Before:

<img width="1511" height="803" alt="image" src="https://github.com/user-attachments/assets/2d8f791d-3af5-4668-81d8-78d48b362ef9" />

After:

<img width="1511" height="803" alt="image" src="https://github.com/user-attachments/assets/6e2e9e7b-223c-4e74-bee7-c9d5131c344e" />
