### PR TITLE
LibWeb: Enable middle mouse autoscroll on middle mouse clicks

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -982,10 +982,14 @@ void EventHandler::stop_updating_selection()
 
 EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
+    auto middle_button_autoscrolled = m_middle_button_scroll_handler && m_middle_button_scroll_handler->mouse_has_moved_beyond_dead_zone();
+
     ScopeGuard clear_mousedown_tracking_and_stop_selection([&] {
         clear_mousedown_tracking();
         stop_updating_selection();
-        m_middle_button_scroll_handler = nullptr;
+
+        if (middle_button_autoscrolled && button == UIEvents::MouseButton::Middle)
+            m_middle_button_scroll_handler = nullptr;
     });
 
     if (should_ignore_device_input_event()) {
@@ -1067,8 +1071,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
     // FIXME: Per spec, the click target should be the nearest common inclusive ancestor of the pointerdown
     //        and pointerup targets. Currently we require an exact match.
     // NB: If the middle button was used to scroll, suppress click and activation behavior.
-    auto middle_button_scrolled = m_middle_button_scroll_handler && m_middle_button_scroll_handler->mouse_has_moved();
-    if (node.ptr() == m_mousedown_target && !middle_button_scrolled) {
+    if (node.ptr() == m_mousedown_target && !middle_button_autoscrolled) {
         if (fire_click_events(*node, coordinates, screen_position, button, buttons, modifiers, click_count)
             && !chrome_widget) {
             // NB: Event dispatches above may have run JS that invalidated layout.
@@ -1185,6 +1188,11 @@ bool EventHandler::initiate_paragraph_selection(DOM::Document& document, Paintin
 
 void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count)
 {
+    if (m_middle_button_scroll_handler) {
+        m_middle_button_scroll_handler = nullptr;
+        return;
+    }
+
     if (button == UIEvents::MouseButton::Middle) {
         if (!m_navigable->page().enable_autoscroll())
             return;
@@ -1794,6 +1802,12 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     // https://html.spec.whatwg.org/multipage/interaction.html#close-requests
     // FIXME: Close requests should queue a global task on the user interaction task source, given `document`'s relevant global object.
     if (key == UIEvents::KeyCode::Key_Escape) {
+        // NB: Exit autoscroll if active before handling other close requests.
+        if (m_middle_button_scroll_handler) {
+            m_middle_button_scroll_handler = nullptr;
+            return EventResult::Handled;
+        }
+
         // 1. If document's fullscreen element is not null, then:
         if (document->fullscreen()) {
             // 1. Fully exit fullscreen given document's node navigable's top-level traversable's active document.

--- a/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
@@ -15,7 +15,7 @@
 
 namespace Web {
 
-static constexpr CSSPixels DEAD_ZONE_RADIUS { 15 };
+static constexpr double DEAD_ZONE_RADIUS { 15 };
 static constexpr double SPEED_FACTOR = 5.0;
 static constexpr double MAX_SPEED_PER_SECOND = 5000.0;
 static constexpr double SCROLL_INTERVAL_MS = 16.0;
@@ -58,21 +58,16 @@ GC::Ptr<DOM::Element> MiddleButtonScrollHandler::find_scrollable_ancestor(DOM::D
     return {};
 }
 
-void MiddleButtonScrollHandler::update_mouse_position(CSSPixelPoint position)
-{
-    m_mouse_position = position;
-    m_mouse_has_moved = true;
-}
-
 void MiddleButtonScrollHandler::perform_tick()
 {
     auto distance_x = (m_mouse_position.x() - m_origin.x()).to_double();
     auto distance_y = (m_mouse_position.y() - m_origin.y()).to_double();
 
-    if (auto distance = AK::hypot(distance_x, distance_y); distance < DEAD_ZONE_RADIUS.to_double())
+    if (auto distance = AK::hypot(distance_x, distance_y); distance < DEAD_ZONE_RADIUS)
         return;
 
     m_container_element->document().update_layout(DOM::UpdateLayoutReason::AutoScrollSelection);
+    m_mouse_has_moved_beyond_dead_zone = true;
 
     auto paintable_box = AutoScrollHandler::auto_scroll_paintable(m_container_element);
     if (!paintable_box)

--- a/Libraries/LibWeb/Page/MiddleButtonScrollHandler.h
+++ b/Libraries/LibWeb/Page/MiddleButtonScrollHandler.h
@@ -22,18 +22,18 @@ public:
 
     static GC::Ptr<DOM::Element> find_scrollable_ancestor(DOM::Document&, Painting::Paintable&);
 
-    void update_mouse_position(CSSPixelPoint);
+    void update_mouse_position(CSSPixelPoint position) { m_mouse_position = position; }
     void perform_tick();
 
     CSSPixelPoint origin() const { return m_origin; }
-    bool mouse_has_moved() const { return m_mouse_has_moved; }
+    bool mouse_has_moved_beyond_dead_zone() const { return m_mouse_has_moved_beyond_dead_zone; }
 
 private:
     GC::Ref<DOM::Element> m_container_element;
     CSSPixelPoint m_origin;
     CSSPixelPoint m_mouse_position;
     CSSPixelPoint m_fractional_delta;
-    bool m_mouse_has_moved { false };
+    bool m_mouse_has_moved_beyond_dead_zone { false };
 };
 
 }


### PR DESCRIPTION
We previously supported autoscroll while the middle mouse button was pressed. We now also support clicking the middle mouse button in-place to begin autoscroll. Pressing any mouse button or the escape key will exit this mode.