### PR TITLE
LibWeb/CSS: Simplify parse_as_pseudo_element_selector()

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -54,29 +54,16 @@ Optional<SelectorList> Parser::parse_as_relative_selector(SelectorParsingMode pa
 
 Optional<Selector::PseudoElementSelector> Parser::parse_as_pseudo_element_selector()
 {
-    // FIXME: This is quite janky. Selector parsing is not at all designed to allow parsing just a single part of a selector.
-    //        So, this code parses a whole selector, then rejects it if it's not a single pseudo-element simple selector.
-    //        Come back and fix this, future Sam!
-    auto maybe_selector_list = parse_a_selector_list(m_token_stream, SelectorType::Standalone, SelectorParsingMode::Standard);
-    if (maybe_selector_list.is_error())
+    auto component_values = consume_a_list_of_component_values(m_token_stream);
+    TokenStream tokens { component_values };
+    auto maybe_simple_selector = parse_pseudo_element_simple_selector(tokens);
+    if (maybe_simple_selector.is_error())
         return {};
-    auto& selector_list = maybe_selector_list.value();
-
-    if (selector_list.size() != 1)
+    if (tokens.has_next_token())
         return {};
-    auto& selector = selector_list.first();
-
-    if (selector->compound_selectors().size() != 1)
-        return {};
-    auto& first_compound_selector = selector->compound_selectors().first();
-
-    if (first_compound_selector.simple_selectors.size() != 1)
-        return {};
-    auto& simple_selector = first_compound_selector.simple_selectors.first();
-
+    auto simple_selector = maybe_simple_selector.release_value();
     if (simple_selector.type != Selector::SimpleSelector::Type::PseudoElement)
         return {};
-
     return simple_selector.pseudo_element();
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-pseudo.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-pseudo.txt
@@ -2,11 +2,11 @@ Harness status: OK
 
 Found 28 tests
 
-23 Pass
-2 Fail
+24 Pass
+1 Fail
 3 Optional Feature Unsupported
 Pass	Resolution of width is correct when pseudo-element argument is ignored (due to no colon)
-Fail	Resolution of width is correct when pseudo-element argument is invalid (due to a trailing token)
+Pass	Resolution of width is correct when pseudo-element argument is invalid (due to a trailing token)
 Pass	Resolution of width is correct for ::before and ::after pseudo-elements (single-colon)
 Pass	Resolution of width is correct for ::before and ::after pseudo-elements (double-colon)
 Pass	Pseudo-elements can use the full range of CSS syntax


### PR DESCRIPTION
Now that we have a method that parses a single pseudo-element selector, use that. This actually fixes a bug too.