### PR TITLE
LibWeb: Guard against removed fragments in LayoutState::commit()

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -331,8 +331,22 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
 
             fragment.set_inline_length(CSSPixels::nearest_value_for(last_kept_end + ellipsis_width));
 
-            if (i + 1 < fragments.size())
+            if (i + 1 < fragments.size()) {
+                for (size_t j = i + 1; j < fragments.size(); ++j) {
+                    if (auto& removed_fragment = fragments[j]; removed_fragment.is_atomic_inline()) {
+                        const auto& box = as<Box>(removed_fragment.layout_node());
+                        auto& box_state = m_state.get_mutable(box);
+                        box_state.containing_line_box_fragment.clear();
+                        box_state.set_elided(true);
+                        box.for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
+                            if (auto* child_state = m_state.try_get_mutable(child_box))
+                                child_state->set_elided(true);
+                            return TraversalDecision::Continue;
+                        });
+                    }
+                }
                 fragments.remove(i + 1, fragments.size() - i - 1);
+            }
 
             line_box.m_inline_length = available_width;
             break;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -445,6 +445,9 @@ void LayoutState::commit(Box& root)
         if (m_subtree_root && !m_subtree_root->is_inclusive_ancestor_of(node))
             return;
 
+        if (used_values.is_elided())
+            return;
+
         GC::Ptr<Painting::Paintable> paintable;
 
         // Try to reuse cached paintable for Box nodes
@@ -517,9 +520,12 @@ void LayoutState::commit(Box& root)
     // NOTE: This needs to occur before fragments are transferred into the corresponding inline paintables, because
     //       after this transfer, the containing_line_box_fragment will no longer be valid.
     m_used_values_store.for_each([&](UsedValues& used_values) {
-        auto& node = const_cast<NodeWithStyle&>(used_values.node());
+        auto& node = used_values.node();
 
         if (!node.is_box())
+            return;
+
+        if (used_values.is_elided())
             return;
 
         auto& paintable = as<Painting::PaintableBox>(*node.first_paintable());
@@ -527,7 +533,7 @@ void LayoutState::commit(Box& root)
 
         if (used_values.containing_line_box_fragment.has_value()) {
             // Atomic inline case:
-            // We know that `node` is an atomic inline because `containing_line_box_fragments` refers to the
+            // We know that `node` is an atomic inline because `containing_line_box_fragment` refers to the
             // line box fragment in the parent block container that contains it.
             auto const& containing_line_box_fragment = used_values.containing_line_box_fragment.value();
             auto const& containing_block = *node.containing_block();
@@ -619,7 +625,7 @@ void LayoutState::commit(Box& root)
     // Measure overflow in scroll containers.
     m_used_values_store.for_each([&](UsedValues& used_values) {
         auto const* box = as_if<Box>(used_values.node());
-        if (!box)
+        if (!box || !box->paintable_box())
             return;
         measure_scrollable_overflow(*box, contained_boxes_map);
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -215,6 +215,9 @@ struct LayoutState {
 
         Optional<LineBoxFragmentCoordinate> containing_line_box_fragment;
 
+        bool is_elided() const { return m_elided; }
+        void set_elided(bool elided) { m_elided = elided; }
+
         void add_floating_descendant(Box const& box) { m_floating_descendants.set(&box); }
         auto const& floating_descendants() const { return m_floating_descendants; }
 
@@ -279,6 +282,8 @@ struct LayoutState {
         RefPtr<CSS::GridTrackSizeListStyleValue const> m_grid_template_rows;
 
         Optional<StaticPositionRect> m_static_position_rect;
+
+        bool m_elided { false };
     };
 
     LayoutState() = default;

--- a/Tests/LibWeb/Crash/Layout/text-overflow-ellipsis-atomic-inline.html
+++ b/Tests/LibWeb/Crash/Layout/text-overflow-ellipsis-atomic-inline.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- Regression test: text-overflow ellipsis removing atomic inline fragments caused
+     an out-of-bounds access in LayoutState::commit() via a stale containing_line_box_fragment. -->
+<style>
+div {
+    width: 50px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+</style>
+<div>long text <svg width="16" height="16"><rect width="16" height="16"/></svg></div>


### PR DESCRIPTION
When a line contains text, followed by an atomic inline (such as a verified badge icon), followed by more text, all inside an overflowing container with `text-overflow: ellipsis`, applying the ellipsis to the first piece of text causes everything after it to be removed.
When the badge is removed this way, its recorded index is left dangling. The next layout commit then attempts to dereference that stale index and crashes.

This was reproducible on YouTube pages, where channel metadata lines can contain a channel name, a verified checkmark badge, and additional text (e.g. a collaborating channel name) all on the same overflowing line.
[Example](https://www.youtube.com/watch?v=iTD4lWuEKrE&list=RDCLAK5uy_kj3rhiar1LINmyDcuFnXihEO0K1NQa2jI&index=2)

The fix adds a bounds check before dereferencing the fragment index, falling back gracefully if the fragment is no longer present.