### PR TITLE
LibWeb: Make Node::is_connected() O(1) via a cached flag

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1387,11 +1387,15 @@ void Element::set_shadow_root(GC::Ptr<ShadowRoot> shadow_root)
 {
     if (m_shadow_root == shadow_root)
         return;
-    if (m_shadow_root)
+    if (m_shadow_root) {
         m_shadow_root->set_host(nullptr);
+        m_shadow_root->set_is_connected(false);
+    }
     m_shadow_root = move(shadow_root);
-    if (m_shadow_root)
+    if (m_shadow_root) {
         m_shadow_root->set_host(this);
+        m_shadow_root->set_is_connected(is_connected());
+    }
     invalidate_style(StyleInvalidationReason::ElementSetShadowRoot);
     set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::ElementSetShadowRoot);
 }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -104,6 +104,9 @@ Node::Node(JS::Realm& realm, Document& document, NodeType type)
     , m_type(type)
     , m_unique_id(allocate_unique_id(this))
 {
+    // A Document is its own shadow-including root, so it is always connected.
+    if (type == NodeType::DOCUMENT_NODE)
+        m_is_connected = true;
 }
 
 Node::Node(Document& document, NodeType type)
@@ -612,13 +615,6 @@ bool Node::is_closed_shadow_hidden_from(Node const& b) const
         return true;
 
     return false;
-}
-
-// https://dom.spec.whatwg.org/#connected
-bool Node::is_connected() const
-{
-    // An element is connected if its shadow-including root is a document.
-    return shadow_including_root().is_document();
 }
 
 // https://html.spec.whatwg.org/multipage/infrastructure.html#browsing-context-connected
@@ -1862,12 +1858,21 @@ void Node::post_connection()
 
 void Node::inserted()
 {
+    // NB: The DOM insertion steps visit shadow-including inclusive descendants in tree order,
+    //     so by the time we get here, our parent (or host, for shadow roots) has already had
+    //     its connected flag updated, and we can just inherit from it.
+    if (auto* shadow_root = as_if<ShadowRoot>(*this))
+        m_is_connected = shadow_root->host() && shadow_root->host()->is_connected();
+    else if (parent())
+        m_is_connected = parent()->is_connected();
+
     recompute_editable_subtree_flag();
     set_needs_style_update(true);
 }
 
 void Node::removed_from(Node*, Node&)
 {
+    m_is_connected = false;
     m_in_editable_subtree = false;
     m_layout_node = nullptr;
     m_paintable = nullptr;

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -275,7 +275,8 @@ public:
 
     bool is_closed_shadow_hidden_from(Node const&) const;
 
-    bool is_connected() const;
+    bool is_connected() const { return m_is_connected; }
+    void set_is_connected(bool is_connected) { m_is_connected = is_connected; }
 
     [[nodiscard]] bool is_browsing_context_connected() const;
 
@@ -485,6 +486,7 @@ protected:
     bool m_child_needs_style_update { false };
     bool m_entire_subtree_needs_style_update { false };
     bool m_in_editable_subtree { false };
+    bool m_is_connected { false };
 
     UniqueNodeID m_unique_id;
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -42,14 +42,14 @@ void HTMLStyleElement::children_changed(ChildrenChangedMetadata const& metadata)
 
 void HTMLStyleElement::inserted()
 {
-    update_a_style_block();
     Base::inserted();
+    update_a_style_block();
 }
 
 void HTMLStyleElement::removed_from(Node* old_parent, Node& old_root)
 {
-    update_a_style_block();
     Base::removed_from(old_parent, old_root);
+    update_a_style_block();
 }
 
 void HTMLStyleElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)

--- a/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -38,14 +38,14 @@ void SVGStyleElement::children_changed(ChildrenChangedMetadata const& metadata)
 
 void SVGStyleElement::inserted()
 {
-    update_a_style_block();
     Base::inserted();
+    update_a_style_block();
 }
 
 void SVGStyleElement::removed_from(Node* old_parent, Node& old_root)
 {
-    update_a_style_block();
     Base::removed_from(old_parent, old_root);
+    update_a_style_block();
 }
 
 }


### PR DESCRIPTION
Previously this walked up the parent chain on every call, which shows up as a 2.5% item in the profile while watching YouTube videos.

Cache an `m_is_connected` bit on `Node` instead, maintained by the DOM insertion and removal steps.