### PR TITLE
AK: Avoid some overflow conditions in Duration's rational conversions

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -231,11 +231,17 @@ i64 Duration::to_time_units(u32 numerator, u32 denominator) const
 
     auto seconds_product = saturating_mul(m_seconds, static_cast<i64>(denominator));
     auto time_units = seconds_product / numerator;
-    auto remainder = seconds_product % numerator;
+    auto seconds_remainder_dividend = seconds_product % numerator;
 
-    auto remainder_in_nanoseconds = remainder * 1'000'000'000;
-    auto rounding_half = static_cast<i64>(numerator) * 500'000'000;
-    time_units = saturating_add(time_units, ((static_cast<i64>(m_nanoseconds) * denominator + remainder_in_nanoseconds + rounding_half) / numerator) / 1'000'000'000);
+    auto seconds_remainder_nanosecond_dividend = seconds_remainder_dividend * 1'000'000'000;
+    auto rounding_half_nanosecond_dividend = static_cast<i64>(numerator) * 500'000'000;
+    auto sub_seconds_nanosecond_dividend = (static_cast<i64>(m_nanoseconds) * denominator) + seconds_remainder_nanosecond_dividend;
+
+    auto sub_seconds_nanosecond_units = sub_seconds_nanosecond_dividend / numerator;
+    auto sub_seconds_units_remainder_nanosecond_dividend = sub_seconds_nanosecond_dividend % numerator;
+    auto rounding_adjustment_nanosecond_units = (rounding_half_nanosecond_dividend + sub_seconds_units_remainder_nanosecond_dividend) / numerator;
+
+    time_units = saturating_add(time_units, (sub_seconds_nanosecond_units + rounding_adjustment_nanosecond_units) / 1'000'000'000);
 
     return time_units;
 }

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -73,18 +73,19 @@ Duration Duration::from_time_units(i64 time_units, u32 numerator, u32 denominato
     VERIFY(numerator != 0);
     VERIFY(denominator != 0);
 
-    auto seconds_checked = Checked<i64>(time_units);
-    seconds_checked.mul(numerator);
-    seconds_checked.div(denominator);
-    if (time_units < 0)
-        seconds_checked.sub(1);
-
-    if (seconds_checked.has_overflow())
+    if (Checked<i64>::multiplication_would_overflow(time_units, numerator))
         return Duration(time_units >= 0 ? NumericLimits<i64>::max() : NumericLimits<i64>::min(), 0);
-    auto seconds = seconds_checked.value_unchecked();
-    auto seconds_in_time_units = seconds * denominator / numerator;
-    auto remainder_in_time_units = time_units - seconds_in_time_units;
-    auto nanoseconds = ((remainder_in_time_units * 1'000'000'000 * numerator) + (denominator / 2)) / denominator;
+    auto time_units_product = time_units * numerator;
+    auto seconds = time_units_product / denominator;
+    auto time_units_remainder = time_units_product % denominator;
+    if (time_units_remainder < 0) {
+        if (seconds == NumericLimits<i64>::min())
+            return Duration(NumericLimits<i64>::min(), 0);
+        seconds--;
+        time_units_remainder += denominator;
+    }
+
+    auto nanoseconds = ((time_units_remainder * 1'000'000'000) + (denominator / 2)) / denominator;
     if (nanoseconds == 1'000'000'000) {
         seconds++;
         nanoseconds = 0;

--- a/Tests/AK/TestTime.cpp
+++ b/Tests/AK/TestTime.cpp
@@ -986,6 +986,8 @@ TEST_CASE(time_units)
     EXPECT_EQ(Duration::from_seconds(2'147'483'649).to_time_units(1, NumericLimits<u32>::max()), NumericLimits<i64>::max());
     EXPECT_EQ(Duration::from_seconds(2'147'483'648).to_time_units(1, NumericLimits<u32>::max()), NumericLimits<i64>::max() - (NumericLimits<u32>::max() / 2));
 
+    EXPECT_EQ((Duration::from_seconds(1) + Duration::from_nanoseconds(999'999'999)).to_time_units(NumericLimits<u32>::max(), NumericLimits<u32>::max() - 1), 2);
+
     EXPECT_DEATH("From time units with zero numerator", (void)Duration::from_time_units(1, 0, 1));
     EXPECT_DEATH("From time units with zero denominator", (void)Duration::from_time_units(1, 1, 0));
 }

--- a/Tests/AK/TestTime.cpp
+++ b/Tests/AK/TestTime.cpp
@@ -961,6 +961,13 @@ TEST_CASE(time_units)
 
     EXPECT_EQ(Duration::from_time_units(-43776, 1, 14592), Duration::from_seconds(-3));
 
+    EXPECT_EQ(Duration::from_time_units(NumericLimits<i64>::min(), 1, 2), Duration::from_seconds(NumericLimits<i64>::min() / 2));
+    EXPECT_EQ(Duration::from_time_units(NumericLimits<i64>::min() + 1, 1, 2), Duration::from_seconds(NumericLimits<i64>::min() / 2) + Duration::from_milliseconds(500));
+    EXPECT_EQ(Duration::from_time_units(NumericLimits<i64>::min(), 1, 3), Duration::from_seconds(NumericLimits<i64>::min() / 3) - Duration::from_nanoseconds(666'666'667));
+
+    EXPECT_EQ(Duration::from_time_units(-1, 1, 2'000'000'000), Duration::zero());
+    EXPECT_EQ(Duration::from_time_units(-2, 1, 2'000'000'000), Duration::from_nanoseconds(-1));
+
     EXPECT_EQ(Duration::from_milliseconds(999).to_time_units(1, 48'000), 47'952);
     EXPECT_EQ(Duration::from_milliseconds(-12'500).to_time_units(1, 1'000), -12'500);
     EXPECT_EQ(Duration::from_milliseconds(-12'500).to_time_units(1, 1'000), -12'500);


### PR DESCRIPTION
There were a few situations where these could allow unchecked overflows. I've fixed those cases and added some tests for them.