### PR TITLE
LibWeb: Handle null active document in destroy_the_child_navigable

### DIFF
--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -330,8 +330,7 @@ void NavigableContainer::destroy_the_child_navigable()
     // 4. Inform the navigation API about child navigable destruction given navigable.
     navigable->inform_the_navigation_api_about_child_navigable_destruction();
 
-    // 5. Destroy a document and its descendants given navigable's active document.
-    navigable->active_document()->destroy_a_document_and_its_descendants(GC::create_function(heap(), [this, navigable] {
+    auto after_document_destruction = GC::create_function(heap(), [this, navigable] {
         // 3. Set container's content navigable to null.
         m_content_navigable = nullptr;
         document().schedule_html_parser_end_check();
@@ -357,7 +356,19 @@ void NavigableContainer::destroy_the_child_navigable()
                 signal->resolve({});
             }));
         }));
-    }));
+    });
+
+    // 5. Destroy a document and its descendants given navigable's active document.
+    // AD-HOC: The spec assumes the active document is non-null here, but during an ancestor
+    //         unload the child documents are unloaded (and destroyed) before the ancestor's
+    //         pagehide fires. If that pagehide handler then removes a subtree containing this
+    //         container, we reach step 5 with navigable's active document already null. We
+    //         treat the destroy step as a no-op in that case and proceed with the remaining
+    //         post-destruction cleanup.
+    if (auto active_document = navigable->active_document())
+        active_document->destroy_a_document_and_its_descendants(after_document_destruction);
+    else
+        after_document_destruction->function()();
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#potentially-delays-the-load-event

--- a/Tests/LibWeb/Crash/HTML/remove-iframe-in-pagehide-of-navigating-parent.html
+++ b/Tests/LibWeb/Crash/HTML/remove-iframe-in-pagehide-of-navigating-parent.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!-- Test: While an iframe is navigating, its descendants unload first, which
+     clears their navigable's active document. If the parent's pagehide handler
+     then removes a subtree containing one of those descendant iframes,
+     destroy_the_child_navigable ends up calling a method on a null active
+     document. -->
+<html class="test-wait">
+<body>
+<script>
+    const outer = document.createElement("iframe");
+    outer.srcdoc = "<div>outer</div>";
+    let navigated = false;
+    outer.addEventListener("load", () => {
+        if (navigated) {
+            document.documentElement.classList.remove("test-wait");
+            return;
+        }
+        navigated = true;
+
+        const outerDoc = outer.contentDocument;
+        const outerWin = outer.contentWindow;
+
+        // Place an inner iframe inside a wrapper so that the removal target
+        // is an ancestor of the iframe (the crash needs the shadow-including
+        // descendant walk in Node::remove to reach the iframe).
+        const wrapper = outerDoc.createElement("div");
+        const inner = outerDoc.createElement("iframe");
+        inner.srcdoc = "<div>inner</div>";
+        wrapper.appendChild(inner);
+        outerDoc.body.appendChild(wrapper);
+
+        inner.addEventListener("load", () => {
+            // When we navigate outer, its descendants unload first. That
+            // destroys inner's document and sets inner's navigable's active
+            // document to null. Then outer's pagehide fires here.
+            outerWin.addEventListener("pagehide", () => {
+                wrapper.remove();
+            });
+
+            outer.srcdoc = "<div>outer after</div>";
+        });
+    });
+    document.body.appendChild(outer);
+</script>
+</body>
+</html>


### PR DESCRIPTION
When an ancestor document is unloaded, its child documents are unloaded (and destroyed) first, which leaves their navigable's active document null. If the ancestor's pagehide handler then removes a subtree containing one of those iframe containers, destroy_the_child_navigable crashed dereferencing the null active document.

Treat the "destroy a document and its descendants" step as a no-op when there is no document left to destroy, and still run the remaining post-destruction cleanup.

This fixes a crash when closing a GMail tab.