### PR TITLE
test-web: Dont glitch scroll when concurrency exceeds terminal rows

### DIFF
--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     Application.cpp
     CaptureFile.cpp
     Debug.cpp
+    Display.cpp
     Fixture.cpp
     Fuzzy.cpp
     TestRunCapture.cpp

--- a/Tests/LibWeb/test-web/Display.cpp
+++ b/Tests/LibWeb/test-web/Display.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026, The Ladybird Developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Display.h"
+#include "Application.h"
+
+#include <AK/Enumerate.h>
+#include <AK/Math.h>
+#include <AK/QuickSort.h>
+#include <AK/SaturatingMath.h>
+#include <AK/StringBuilder.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibCore/Timer.h>
+#include <LibDiff/Format.h>
+#include <LibDiff/Generator.h>
+#include <LibGfx/Size.h>
+
+#ifndef AK_OS_WINDOWS
+#    include <sys/ioctl.h>
+#endif
+
+namespace TestWeb {
+
+static constexpr size_t LIVE_DISPLAY_TERMINAL_HEADROOM = 4; // allow for external cruft like tmux panels
+static constexpr size_t LIVE_DISPLAY_STATUS_LINES = 4;      // 2 empty + 1 for status + 1 for progress bar
+static size_t s_display_rows = 80;
+static size_t s_display_columns = 24;
+static size_t count_digits(size_t value);
+
+Display& Display::the()
+{
+    static Display instance;
+    return instance;
+}
+
+void Display::begin_run()
+{
+    auto& app = Application::the();
+    is_tty = Core::System::isatty(STDOUT_FILENO).value_or(false);
+    is_live_display_active = !app.quiet && is_tty && app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT;
+
+    outln("Running {} tests...", total_tests());
+
+    if (!is_live_display_active)
+        return;
+
+#ifndef AK_OS_WINDOWS
+    struct winsize ws;
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0) {
+        s_display_rows = ws.ws_row > 0 ? ws.ws_row : 24;
+        s_display_columns = ws.ws_col > 0 ? ws.ws_col : 80;
+    }
+#endif
+    s_display_rows = AK::clamp(
+        AK::saturating_sub(s_display_rows, LIVE_DISPLAY_TERMINAL_HEADROOM),
+        LIVE_DISPLAY_STATUS_LINES + 1,
+        view_states().size() + LIVE_DISPLAY_STATUS_LINES);
+
+    display_timer = Core::Timer::create_repeating(1000, [this] { render_live_display(); });
+    display_timer->start();
+
+    for (size_t i = 0; i < s_display_rows; i++) {
+        outln();
+    }
+    (void)fflush(stdout);
+}
+
+void Display::on_test_started(size_t view_index, Test const& test, pid_t pid)
+{
+    current_run = test.run_index;
+    if (view_index < view_states().size()) {
+        auto& state = view_states()[view_index];
+        state.pid = pid;
+        state.test_name = test.relative_path;
+        state.start_time = test.start_time;
+        state.active = true;
+    }
+    if (is_live_display_active) {
+        render_live_display();
+        return;
+    }
+    if (Application::the().quiet)
+        return;
+
+    if (Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_DURATION) {
+        outln("[{:{}}] {:{}}/{}:  Start {}", view_index, count_digits(view_states().size()), test.index + 1,
+            count_digits(total_tests()), total_tests(), test.relative_path);
+        return;
+    }
+    outln("{}/{}: {}", test.index + 1, total_tests(), test.relative_path);
+}
+
+void Display::on_test_finished(size_t view_index, Test const& test, TestResult result)
+{
+    switch (result) {
+    case TestResult::Pass:
+        ++pass_count;
+        break;
+    case TestResult::Fail:
+        ++fail_count;
+        break;
+    case TestResult::Timeout:
+        ++timeout_count;
+        break;
+    case TestResult::Crashed:
+        ++crashed_count;
+        break;
+    case TestResult::Skipped:
+        ++skipped_count;
+        break;
+    case TestResult::Expanded:
+        break;
+    }
+    if (result != TestResult::Expanded)
+        ++completed_tests;
+
+    if (view_index >= view_states().size())
+        return;
+
+    auto& app = Application::the();
+    if (app.quiet || app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_DURATION)
+        return;
+
+    auto duration = test.end_time - test.start_time;
+    outln("[{:{}}] {:{}}/{}: Finish {}: {}ms", view_index, count_digits(view_states().size()), test.index + 1,
+        count_digits(total_tests()), total_tests(), test.relative_path, duration.to_milliseconds());
+}
+
+void Display::on_fail_fast(Test const& test, TestResult result, pid_t pid)
+{
+    clear_live_display();
+
+    if (result == TestResult::Timeout)
+        outln("Fail-fast: Timeout: {} (pid {})", test.relative_path, pid);
+    else
+        outln("Fail-fast: {}: {}", test_result_to_string(result), test.relative_path);
+}
+
+void Display::print_run_complete(ReadonlySpan<Test> tests,
+    ReadonlySpan<TestCompletion> non_passing_tests,
+    size_t tests_remaining) const
+{
+    if (tests_remaining > 0)
+        outln("Halted; {} tests not executed.", tests_remaining);
+
+    outln("==========================================================");
+    outln("Pass: {}, Fail: {}, Skipped: {}, Timeout: {}, Crashed: {}", pass_count, fail_count, skipped_count,
+        timeout_count, crashed_count);
+    outln("==========================================================");
+
+    auto& app = Application::the();
+    for (auto const& non_passing_test : non_passing_tests) {
+        if (non_passing_test.result == TestResult::Skipped && app.verbosity < Application::VERBOSITY_LEVEL_LOG_SKIPPED_TESTS)
+            continue;
+
+        auto const& test = tests[non_passing_test.test_index];
+        if (app.repeat_count > 1)
+            outln("{}: (run {}/{}) {}", test_result_to_string(non_passing_test.result), test.run_index,
+                test.total_runs, test.relative_path);
+        else
+            outln("{}: {}", test_result_to_string(non_passing_test.result), test.relative_path);
+    }
+
+    if (!app.quiet && app.verbosity >= Application::VERBOSITY_LEVEL_LOG_SLOWEST_TESTS) {
+        auto tests_to_print = min(10uz, tests.size());
+        outln("\nSlowest {} tests:", tests_to_print);
+
+        Vector<Test const*> sorted_tests;
+        sorted_tests.ensure_capacity(tests.size());
+        for (auto const& test : tests)
+            sorted_tests.unchecked_append(&test);
+
+        quick_sort(sorted_tests, [](Test const* lhs, Test const* rhs) {
+            auto lhs_duration = lhs->end_time - lhs->start_time;
+            auto rhs_duration = rhs->end_time - rhs->start_time;
+            return lhs_duration > rhs_duration;
+        });
+        for (auto const* test : sorted_tests.span().trim(tests_to_print)) {
+            auto duration = test->end_time - test->start_time;
+            outln("{}: {}ms", test->relative_path, duration.to_milliseconds());
+        }
+    }
+}
+
+void Display::print_failure_diff(URL::URL const& url, Test const& test,
+    ByteBuffer const& expectation) const
+{
+    auto& app = Application::the();
+    if (app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT)
+        return;
+
+    auto const color_output = is_tty ? Diff::ColorOutput::Yes : Diff::ColorOutput::No;
+    if (color_output == Diff::ColorOutput::Yes)
+        outln("\n\033[33;1mTest failed\033[0m: {}", url);
+    else
+        outln("\nTest failed: {}", url);
+
+    auto maybe_hunks = Diff::from_text(expectation, test.text, 3);
+    if (maybe_hunks.is_error()) {
+        outln("Failed to generate diff: {}", maybe_hunks.error());
+        return;
+    }
+    auto const& hunks = maybe_hunks.release_value();
+    auto out = MUST(Core::File::standard_output());
+
+    (void)Diff::write_unified_header(test.expectation_path, test.expectation_path, *out);
+    for (auto const& hunk : hunks)
+        (void)Diff::write_unified(hunk, *out, color_output);
+}
+
+void Display::render_live_display() const
+{
+    if (!is_tty || !is_live_display_active)
+        return;
+
+    auto now = UnixDateTime::now();
+    StringBuilder output;
+
+    for (size_t i = 0; i < s_display_rows; ++i)
+        output.append("\033[A"sv);
+    output.append("\r"sv);
+
+    size_t num_view_lines = s_display_rows - LIVE_DISPLAY_STATUS_LINES;
+    if (num_view_lines > 1 && num_view_lines < view_states().size())
+        num_view_lines--; // "Hidden views" line
+
+    for (size_t i = 0; i < num_view_lines; ++i) {
+        output.append("\033[2K"sv);
+
+        if (i < view_states().size()) {
+            auto const& state = view_states()[i];
+            if (state.active && state.pid > 0) {
+                auto duration = (now - state.start_time).to_truncated_seconds();
+                auto prefix = ByteString::formatted("\033[33m⏺\033[0m {} ({}s): ", state.pid, duration);
+                size_t const prefix_visible_length = ByteString::formatted("⏺ {} ({}s): ", state.pid, duration).length();
+                size_t const available_width = s_display_columns > prefix_visible_length
+                    ? s_display_columns - prefix_visible_length
+                    : 10;
+                ByteString name = state.test_name;
+                if (name.length() > available_width && available_width > 3)
+                    name = ByteString::formatted("...{}", name.substring_view(name.length() - available_width + 3));
+
+                output.appendff("{}{}", prefix, name);
+            } else {
+                output.append("\033[90m⏺ (idle)\033[0m"sv);
+            }
+        }
+        output.append("\n"sv);
+    }
+    if (num_view_lines < view_states().size()) {
+        output.append("\033[2K\033[90m... "sv);
+        output.appendff("{} more views hidden\033[0m", view_states().size() - num_view_lines);
+        output.append("\n"sv);
+    }
+    output.append("\033[2K\n\033[2K"sv);
+    output.appendff("\033[1;32mPass:\033[0m {}, ", pass_count);
+    output.appendff("\033[1;31mFail:\033[0m {}, ", fail_count);
+    output.appendff("\033[1;90mSkipped:\033[0m {}, ", skipped_count);
+    output.appendff("\033[1;33mTimeout:\033[0m {}, ", timeout_count);
+    output.appendff("\033[1;35mCrashed:\033[0m {}", crashed_count);
+    output.append("\n\033[2K\n\033[2K"sv);
+
+    if (total_tests() > 0) {
+        auto counter_start = output.length();
+        output.appendff("{}/{} ", completed_tests, total_tests());
+        if (Application::the().repeat_count > 1)
+            output.appendff("run {}/{} ", current_run, Application::the().repeat_count);
+
+        auto const counter_length = output.length() - counter_start;
+        size_t const bar_width = s_display_columns > counter_length + 3 ? s_display_columns - counter_length - 3 : 20;
+        size_t const filled = (completed_tests * bar_width) / total_tests();
+        size_t const empty = bar_width - filled;
+
+        output.append("\033[32m["sv);
+        for (size_t j = 0; j < filled; ++j) {
+            output.append("█"sv);
+        }
+        if (empty > 0 && filled < bar_width) {
+            output.append("\033[33m▓\033[0m\033[90m"sv);
+            for (size_t j = 1; j < empty; ++j) {
+                output.append("░"sv);
+            }
+        }
+        output.append("\033[32m]\033[0m"sv);
+    }
+    output.append("\n"sv);
+
+    out("{}", output.string_view());
+    (void)fflush(stdout);
+}
+
+void Display::clear_live_display()
+{
+    if (!is_live_display_active)
+        return;
+    if (display_timer) {
+        display_timer->stop();
+        display_timer = nullptr;
+    }
+    for (size_t i = 0; i < s_display_rows; ++i) {
+        out("\033[A\033[2K"sv);
+    }
+    out("\r"sv);
+    (void)fflush(stdout);
+
+    is_live_display_active = false;
+}
+
+static size_t count_digits(size_t value)
+{
+    size_t digits = 1;
+    while (value >= 10) {
+        value /= 10;
+        ++digits;
+    }
+    return digits;
+}
+
+} // namespace TestWeb

--- a/Tests/LibWeb/test-web/Display.h
+++ b/Tests/LibWeb/test-web/Display.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, The Ladybird Developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "TestWeb.h"
+
+#include <AK/ByteString.h>
+#include <AK/RefPtr.h>
+#include <AK/Span.h>
+#include <AK/Time.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibCore/Forward.h>
+#include <LibDiff/Format.h>
+
+namespace TestWeb {
+
+struct Display {
+    static Display& the();
+
+    void begin_run();
+    void on_test_started(size_t view_index, Test const&, pid_t);
+    void on_test_finished(size_t view_index, Test const&, TestResult);
+    void on_fail_fast(Test const&, TestResult, pid_t);
+    void print_run_complete(ReadonlySpan<Test>, ReadonlySpan<TestCompletion>, size_t tests_remaining) const;
+    void print_failure_diff(URL::URL const&, Test const&, ByteBuffer const& expectation) const;
+    void render_live_display() const;
+    void clear_live_display();
+
+    RefPtr<Core::Timer> display_timer;
+    Vector<ByteString> deferred_warnings;
+    size_t completed_tests { 0 };
+    size_t pass_count { 0 };
+    size_t fail_count { 0 };
+    size_t timeout_count { 0 };
+    size_t crashed_count { 0 };
+    size_t skipped_count { 0 };
+    size_t current_run { 1 };
+    bool is_tty { false };
+    bool is_live_display_active { false };
+};
+
+}

--- a/Tests/LibWeb/test-web/Fuzzy.cpp
+++ b/Tests/LibWeb/test-web/Fuzzy.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Fuzzy.h"
+#include "Display.h"
 #include "TestWeb.h"
 
 #include <AK/Enumerate.h>

--- a/Tests/LibWeb/test-web/Fuzzy.cpp
+++ b/Tests/LibWeb/test-web/Fuzzy.cpp
@@ -38,18 +38,18 @@ bool fuzzy_screenshot_match(
     });
     if (!fuzzy_match.has_value()) {
         if (should_match)
-            add_deferred_warning(ByteString::formatted("{}: Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", test_url, diff.pixel_error_count, diff.maximum_error));
+            warnln(ByteString::formatted("{}: Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", test_url, diff.pixel_error_count, diff.maximum_error));
         return false;
     }
 
     // Apply fuzzy matching.
     auto color_error_matches = fuzzy_match->color_value_error.contains(diff.maximum_error);
     if (!color_error_matches && should_match)
-        add_deferred_warning(ByteString::formatted("{}: Fuzzy mismatch: maximum error {} is outside {}", test_url, diff.maximum_error, fuzzy_match->color_value_error));
+        warnln(ByteString::formatted("{}: Fuzzy mismatch: maximum error {} is outside {}", test_url, diff.maximum_error, fuzzy_match->color_value_error));
 
     auto pixel_error_matches = fuzzy_match->pixel_error_count.contains(diff.pixel_error_count);
     if (!pixel_error_matches && should_match)
-        add_deferred_warning(ByteString::formatted("{}: Fuzzy mismatch: pixel error count {} is outside {}", test_url, diff.pixel_error_count, fuzzy_match->pixel_error_count));
+        warnln(ByteString::formatted("{}: Fuzzy mismatch: pixel error count {} is outside {}", test_url, diff.pixel_error_count, fuzzy_match->pixel_error_count));
 
     return color_error_matches && pixel_error_matches;
 }

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -84,8 +84,4 @@ struct TestCompletion {
 
 using TestPromise = Core::Promise<TestCompletion>;
 
-// Deferred warning system - buffers warnings during live display mode
-void add_deferred_warning(ByteString message);
-void print_deferred_warnings();
-
 }

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -28,6 +28,23 @@ enum class TestMode {
     Crash,
 };
 
+constexpr StringView test_mode_to_string(TestMode mode)
+{
+    switch (mode) {
+    case TestMode::Layout:
+        return "Layout"sv;
+    case TestMode::Text:
+        return "Text"sv;
+    case TestMode::Ref:
+        return "Ref"sv;
+    case TestMode::Screenshot:
+        return "Screenshot"sv;
+    case TestMode::Crash:
+        return "Crash"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 enum class TestResult {
     Pass,
     Fail,
@@ -36,6 +53,25 @@ enum class TestResult {
     Crashed,
     Expanded,
 };
+
+constexpr StringView test_result_to_string(TestResult result)
+{
+    switch (result) {
+    case TestResult::Pass:
+        return "Pass"sv;
+    case TestResult::Fail:
+        return "Fail"sv;
+    case TestResult::Skipped:
+        return "Skipped"sv;
+    case TestResult::Timeout:
+        return "Timeout"sv;
+    case TestResult::Crashed:
+        return "Crashed"sv;
+    case TestResult::Expanded:
+        return "Expanded"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
 
 enum class RefTestExpectationType {
     Match,
@@ -81,6 +117,16 @@ struct TestCompletion {
     size_t test_index;
     TestResult result;
 };
+
+struct ViewDisplayState {
+    pid_t pid { 0 };
+    ByteString test_name;
+    UnixDateTime start_time;
+    bool active { false };
+};
+
+Vector<ViewDisplayState>& view_states();
+size_t total_tests();
 
 using TestPromise = Core::Promise<TestCompletion>;
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -21,6 +21,7 @@
 #include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
 #include <AK/Random.h>
+#include <AK/SaturatingMath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Span.h>
 #include <LibCore/ConfigFile.h>
@@ -54,6 +55,7 @@ namespace TestWeb {
 
 // Terminal display state
 static size_t s_terminal_width = 80;
+static size_t s_terminal_rows = 24;
 static bool s_is_tty = false;
 
 static size_t s_current_run = 1;
@@ -64,8 +66,10 @@ static void update_terminal_size()
 {
 #ifndef AK_OS_WINDOWS
     struct winsize ws;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0)
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0) {
         s_terminal_width = ws.ws_col > 0 ? ws.ws_col : 80;
+        s_terminal_rows = ws.ws_row > 0 ? ws.ws_row : 24;
+    }
 #endif
 }
 
@@ -1377,7 +1381,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
     // Set up display area for live display
     if (use_live_display) {
-        s_live_display_lines = concurrency + 4; // +1 empty, +1 status counts, +1 empty, +1 progress bar
+        s_live_display_lines = AK::clamp(AK::saturating_sub(s_terminal_rows, 4uz), 5uz, concurrency + 4); // +1 empty, +1 status counts, +1 empty, +1 progress bar
         for (size_t i = 0; i < s_live_display_lines; ++i)
             outln();
         (void)fflush(stdout);

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -89,24 +89,6 @@ static size_t s_timeout_count = 0;
 static size_t s_crashed_count = 0;
 static size_t s_skipped_count = 0;
 
-// Deferred warning system - buffers warnings during live display mode
-static Vector<ByteString> s_deferred_warnings;
-
-void add_deferred_warning(ByteString message)
-{
-    if (s_live_display_lines > 0)
-        s_deferred_warnings.append(move(message));
-    else
-        warnln("{}", message);
-}
-
-void print_deferred_warnings()
-{
-    for (auto const& warning : s_deferred_warnings)
-        warnln("{}", warning);
-    s_deferred_warnings.clear();
-}
-
 static void render_live_display()
 {
     if (!s_is_tty || s_live_display_lines == 0)
@@ -657,7 +639,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
         auto open_expectation_file = [&](auto mode) {
             auto expectation_file_or_error = Core::File::open(test.expectation_path, mode);
             if (expectation_file_or_error.is_error())
-                add_deferred_warning(ByteString::formatted("Failed opening '{}': {}", test.expectation_path, expectation_file_or_error.error()));
+                warnln(ByteString::formatted("Failed opening '{}': {}", test.expectation_path, expectation_file_or_error.error()));
 
             return expectation_file_or_error;
         };
@@ -1553,7 +1535,6 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                         out("\r"sv);
                         (void)fflush(stdout);
                         s_live_display_lines = 0;
-                        print_deferred_warnings();
                     }
 
                     auto const pid = view->web_content_pid();
@@ -1618,10 +1599,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             out("\033[A\033[2K"sv); // Move up and clear each line
         out("\r"sv);
         (void)fflush(stdout);
-
-        // Print any warnings that were deferred during live display
         s_live_display_lines = 0;
-        print_deferred_warnings();
     }
 
     if (result_or_rejection.is_error())

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -10,6 +10,7 @@
 
 #include "Application.h"
 #include "Debug.h"
+#include "Display.h"
 #include "TestRunCapture.h"
 #include "TestWeb.h"
 #include "TestWebView.h"
@@ -21,7 +22,6 @@
 #include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
 #include <AK/Random.h>
-#include <AK/SaturatingMath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Span.h>
 #include <LibCore/ConfigFile.h>
@@ -32,7 +32,6 @@
 #include <LibCore/MappedFile.h>
 #include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
-#include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibDiff/Format.h>
 #include <LibDiff/Generator.h>
@@ -47,142 +46,12 @@
 #include <LibWebView/Process.h>
 #include <LibWebView/Utilities.h>
 
-#ifndef AK_OS_WINDOWS
-#    include <sys/ioctl.h>
-#endif
+#include <signal.h>
 
 namespace TestWeb {
 
-// Terminal display state
-static size_t s_terminal_width = 80;
-static size_t s_terminal_rows = 24;
-static bool s_is_tty = false;
-
-static size_t s_current_run = 1;
-
-static bool s_fail_fast_triggered = false;
-
-static void update_terminal_size()
-{
-#ifndef AK_OS_WINDOWS
-    struct winsize ws;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0) {
-        s_terminal_width = ws.ws_col > 0 ? ws.ws_col : 80;
-        s_terminal_rows = ws.ws_row > 0 ? ws.ws_row : 24;
-    }
-#endif
-}
-
-struct ViewDisplayState {
-    pid_t pid { 0 };
-    ByteString test_name;
-    UnixDateTime start_time;
-    bool active { false };
-};
-
 static Vector<ViewDisplayState> s_view_display_states;
 static Vector<Function<void()>> s_view_run_next_test;
-static RefPtr<Core::Timer> s_display_timer;
-
-static size_t s_live_display_lines = 0;
-static size_t s_total_tests = 0;
-static size_t s_completed_tests = 0;
-static size_t s_pass_count = 0;
-static size_t s_fail_count = 0;
-static size_t s_timeout_count = 0;
-static size_t s_crashed_count = 0;
-static size_t s_skipped_count = 0;
-
-static void render_live_display()
-{
-    if (!s_is_tty || s_live_display_lines == 0)
-        return;
-
-    auto now = UnixDateTime::now();
-
-    // Build everything into one buffer
-    StringBuilder output;
-
-    // Move up N lines using individual commands (more compatible)
-    for (size_t i = 0; i < s_live_display_lines; ++i)
-        output.append("\033[A"sv);
-    output.append("\r"sv);
-
-    // Print test status lines (not counting empty lines, status counts, and progress bar)
-    size_t num_view_lines = s_live_display_lines - 4;
-    for (size_t i = 0; i < num_view_lines; ++i) {
-        output.append("\033[2K"sv); // Clear line
-
-        if (i < s_view_display_states.size()) {
-            auto const& state = s_view_display_states[i];
-            if (state.active && state.pid > 0) {
-                auto duration = (now - state.start_time).to_truncated_seconds();
-                // Format: ⏺ pid (Xs): name
-                auto prefix = ByteString::formatted("\033[33m⏺\033[0m {} ({}s): ", state.pid, duration);
-                // Note: prefix contains ANSI codes, so visible length is different
-                size_t prefix_visible_len = ByteString::formatted("⏺ {} ({}s): ", state.pid, duration).length();
-                size_t avail = s_terminal_width > prefix_visible_len ? s_terminal_width - prefix_visible_len : 10;
-
-                ByteString name = state.test_name;
-                if (name.length() > avail && avail > 3)
-                    name = ByteString::formatted("...{}", name.substring_view(name.length() - avail + 3));
-
-                output.appendff("{}{}", prefix, name);
-            } else {
-                output.append("\033[90m⏺ (idle)\033[0m"sv);
-            }
-        }
-        output.append("\n"sv);
-    }
-
-    // Empty line
-    output.append("\033[2K\n"sv);
-
-    // Status counts line (bold colored labels, plain numbers)
-    output.append("\033[2K"sv);
-    output.appendff("\033[1;32mPass:\033[0m {}, ", s_pass_count);
-    output.appendff("\033[1;31mFail:\033[0m {}, ", s_fail_count);
-    output.appendff("\033[1;90mSkipped:\033[0m {}, ", s_skipped_count);
-    output.appendff("\033[1;33mTimeout:\033[0m {}, ", s_timeout_count);
-    output.appendff("\033[1;35mCrashed:\033[0m {}", s_crashed_count);
-    output.append("\n"sv);
-
-    // Empty line
-    output.append("\033[2K\n"sv);
-
-    // Print progress bar
-    output.append("\033[2K"sv);
-    if (s_total_tests > 0) {
-        size_t completed = s_completed_tests;
-        size_t total = s_total_tests;
-
-        // Calculate progress bar width (leave room for "completed/total []")
-        auto counter_start = output.length();
-        output.appendff("{}/{} ", completed, total);
-        if (Application::the().repeat_count > 1)
-            output.appendff("run {}/{} ", s_current_run, Application::the().repeat_count);
-        auto counter_length = output.length() - counter_start;
-        size_t bar_width = s_terminal_width > counter_length + 3 ? s_terminal_width - counter_length - 3 : 20;
-
-        size_t filled = total > 0 ? (completed * bar_width) / total : 0;
-        size_t empty = bar_width - filled;
-
-        output.append("\033[32m["sv); // Green color
-        for (size_t j = 0; j < filled; ++j)
-            output.append("█"sv);
-        if (empty > 0 && filled < bar_width) {
-            output.append("\033[33m▓\033[0m\033[90m"sv); // Yellow current position, then dim
-            for (size_t j = 1; j < empty; ++j)
-                output.append("░"sv);
-        }
-        output.append("\033[32m]\033[0m"sv);
-    }
-    output.append("\n"sv);
-
-    out("{}", output.string_view());
-    (void)fflush(stdout);
-}
-
 static RefPtr<Core::Promise<Empty>> s_all_tests_complete;
 static Vector<ByteString> s_skipped_tests;
 static Vector<ByteString> s_loaded_from_http_server;
@@ -196,31 +65,15 @@ struct TestRunContext {
 
 static TestRunContext* s_run_context { nullptr };
 
+Vector<ViewDisplayState>& view_states() { return s_view_display_states; }
+size_t total_tests() { return s_run_context ? s_run_context->total_tests : 0; }
+
 static ErrorOr<ByteString> prepare_output_path(Test const& test)
 {
     auto& app = Application::the();
     auto base_path = LexicalPath::join(app.results_directory, test.safe_relative_path);
     TRY(Core::Directory::create(base_path.dirname(), Core::Directory::CreateDirectories::Yes));
     return base_path.string();
-}
-
-static constexpr StringView test_result_to_string(TestResult result)
-{
-    switch (result) {
-    case TestResult::Pass:
-        return "Pass"sv;
-    case TestResult::Fail:
-        return "Fail"sv;
-    case TestResult::Skipped:
-        return "Skipped"sv;
-    case TestResult::Timeout:
-        return "Timeout"sv;
-    case TestResult::Crashed:
-        return "Crashed"sv;
-    case TestResult::Expanded:
-        return "Expanded"sv;
-    }
-    VERIFY_NOT_REACHED();
 }
 
 static bool is_valid_test_name(StringView test_name)
@@ -417,58 +270,23 @@ if (!hasTestWaitClass()) {{
 static auto wait_for_crash_test_completion = generate_wait_for_test_string("test-wait"sv);
 static auto wait_for_reftest_completion = generate_wait_for_test_string("reftest-wait"sv);
 
-static ByteString test_mode_to_string(TestMode mode)
-{
-    switch (mode) {
-    case TestMode::Layout:
-        return "Layout"sv;
-    case TestMode::Text:
-        return "Text"sv;
-    case TestMode::Ref:
-        return "Ref"sv;
-    case TestMode::Screenshot:
-        return "Screenshot"sv;
-    case TestMode::Crash:
-        return "Crash"sv;
-    }
-    VERIFY_NOT_REACHED();
-}
-
 static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpan<TestCompletion> non_passing_tests)
 {
     auto& app = Application::the();
+    auto& display = Display::the();
+
     bool const has_helper_logs = FileSystem::exists(LexicalPath::join(app.results_directory, "helper-process-logs.html"sv).string());
     auto const generated_at = UnixDateTime::now();
-
-    // Count results
-    size_t fail_count = 0;
-    size_t timeout_count = 0;
-    size_t crashed_count = 0;
-    size_t skipped_count = 0;
-    for (auto const& result : non_passing_tests) {
-        switch (result.result) {
-        case TestResult::Fail:
-            ++fail_count;
-            break;
-        case TestResult::Timeout:
-            ++timeout_count;
-            break;
-        case TestResult::Crashed:
-            ++crashed_count;
-            break;
-        case TestResult::Skipped:
-            ++skipped_count;
-            break;
-        default:
-            break;
-        }
-    }
 
     // Write results.js (as JS to avoid fetch CORS issues with file://)
     StringBuilder js;
     js.append("const RESULTS_DATA = {\n"sv);
     js.appendff("  \"summary\": {{ \"total\": {}, \"fail\": {}, \"timeout\": {}, \"crashed\": {}, \"skipped\": {} }},\n",
-        s_total_tests, fail_count, timeout_count, crashed_count, skipped_count);
+        total_tests(),
+        display.fail_count,
+        display.timeout_count,
+        display.crashed_count,
+        display.skipped_count);
     js.appendff("  \"generatedAt\": {},\n", generated_at.seconds_since_epoch());
     js.appendff("  \"invocationCommandLine\": {},\n", JsonValue(app.invocation_command_line).serialized());
     js.appendff("  \"hasLogs\": {},\n", has_helper_logs ? "true" : "false");
@@ -670,23 +488,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
         }
 
         TRY(write_test_diff_to_results(test, expectation));
-
-        if (Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT) {
-            auto const color_output = s_is_tty ? Diff::ColorOutput::Yes : Diff::ColorOutput::No;
-
-            if (color_output == Diff::ColorOutput::Yes)
-                outln("\n\033[33;1mTest failed\033[0m: {}", url);
-            else
-                outln("\nTest failed: {}", url);
-
-            auto hunks = TRY(Diff::from_text(expectation, test.text, 3));
-            auto out = TRY(Core::File::standard_output());
-
-            TRY(Diff::write_unified_header(test.expectation_path, test.expectation_path, *out));
-            for (auto const& hunk : hunks)
-                TRY(Diff::write_unified(hunk, *out, color_output));
-        }
-
+        Display::the().print_failure_diff(url, test, expectation);
         return TestResult::Fail;
     };
 
@@ -1216,6 +1018,8 @@ static void set_ui_callbacks_for_tests(TestWebView& view, TestRunCapture& test_r
 static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePixelSize window_size)
 {
     auto& app = Application::the();
+    auto& display = Display::the();
+
     TRY(load_test_config(app.test_root_path));
 
     Vector<Test> tests;
@@ -1293,8 +1097,6 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         return Error::from_string_literal("No tests found matching filter");
     }
 
-    s_current_run = 1;
-
     if (app.repeat_count > 1) {
         auto base_tests = move(tests);
         tests.ensure_capacity(base_tests.size() * app.repeat_count);
@@ -1309,9 +1111,9 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             }
         }
     }
-    auto concurrency = min(app.test_concurrency, tests.size());
+    size_t total_tests = tests.size();
+    auto concurrency = min(app.test_concurrency, total_tests);
     size_t loaded_web_views = 0;
-
     Vector<NonnullOwnPtr<TestWebView>> views;
     views.ensure_capacity(concurrency);
 
@@ -1339,66 +1141,22 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         s_view_display_states[i].active = false;
     }
 
+    display.begin_run();
+    ScopeGuard clear_live_display = [&] { display.clear_live_display(); };
+
     // Initialize per-view functions (for waking idle views)
     s_view_run_next_test.resize_and_keep_capacity(concurrency);
-
-    // Initialize live terminal display
-    s_is_tty = TRY(Core::System::isatty(STDOUT_FILENO));
-
-    // When on TTY with live display, use the N-line display; otherwise use single-line or verbose
-    bool use_live_display = !app.quiet && s_is_tty && app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT;
-
-    if (use_live_display) {
-        update_terminal_size();
-
-#ifndef AK_OS_WINDOWS
-        // Handle terminal resize
-        Core::EventLoop::register_signal(SIGWINCH, [](int) {
-            Core::EventLoop::current().deferred_invoke([] {
-                update_terminal_size();
-            });
-        });
-#endif
-
-        // Start 1-second timer for display updates
-        s_display_timer = Core::Timer::create_repeating(1000, [] {
-            render_live_display();
-        });
-        s_display_timer->start();
-    }
-
-    // Reset counters for this run
-    s_pass_count = 0;
-    s_fail_count = 0;
-    s_timeout_count = 0;
-    s_crashed_count = 0;
-    s_skipped_count = 0;
-    s_completed_tests = 0;
-    s_fail_fast_triggered = false;
-
-    s_total_tests = tests.size();
-    outln("Running {} tests...", tests.size());
-
-    // Set up display area for live display
-    if (use_live_display) {
-        s_live_display_lines = AK::clamp(AK::saturating_sub(s_terminal_rows, 4uz), 5uz, concurrency + 4); // +1 empty, +1 status counts, +1 empty, +1 progress bar
-        for (size_t i = 0; i < s_live_display_lines; ++i)
-            outln();
-        (void)fflush(stdout);
-    }
 
     s_all_tests_complete = Core::Promise<Empty>::construct();
     auto tests_remaining = tests.size();
     auto current_test = 0uz;
 
-    TestRunContext context { tests, tests_remaining, s_total_tests };
+    TestRunContext context { tests, tests_remaining, total_tests };
     s_run_context = &context;
     ScopeGuard clear_run_context = [&] { s_run_context = nullptr; };
 
     Vector<TestCompletion> non_passing_tests;
-
-    auto digits_for_view_id = static_cast<size_t>(log10(views.size()) + 1);
-    auto digits_for_test_id = static_cast<size_t>(log10(tests.size()) + 1);
+    bool fail_fast_triggered = false;
 
     for (auto [view_id, view] : enumerate(views)) {
         set_ui_callbacks_for_tests(*view, test_run_capture);
@@ -1431,7 +1189,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
         // run_next_test handles: reset promise, attach callback, pick test, run test
         auto run_next_test = [&, view = view.ptr(), cleanup_test, view_id]() {
-            if (app.fail_fast && s_fail_fast_triggered) {
+            if (app.fail_fast && fail_fast_triggered) {
                 if (view_id < s_view_display_states.size())
                     s_view_display_states[view_id].active = false;
                 return;
@@ -1447,34 +1205,15 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             auto index = current_test++;
 
             auto& test = tests[index];
-            s_current_run = test.run_index;
             test.start_time = UnixDateTime::now();
             test.index = index;
 
             // Mark this view as active (for variant wake-up tracking)
-            if (view_id < s_view_display_states.size())
-                s_view_display_states[view_id].active = true;
-
-            if (use_live_display) {
-                // Update view display state for live display (refresh PID in case WebContent respawned)
-                if (view_id < s_view_display_states.size()) {
-                    s_view_display_states[view_id].pid = view->web_content_pid();
-                    s_view_display_states[view_id].test_name = test.relative_path;
-                    s_view_display_states[view_id].start_time = test.start_time;
-                }
-                render_live_display();
-            } else if (!app.quiet) {
-                if (app.verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_DURATION) {
-                    outln("[{:{}}] {:{}}/{}:  Start {}", view_id, digits_for_view_id, test.index + 1, digits_for_test_id, tests.size(), test.relative_path);
-                } else {
-                    // Non-TTY mode: print each test as it starts
-                    outln("{}/{}: {}", test.index + 1, tests.size(), test.relative_path);
-                }
-            }
+            display.on_test_started(view_id, test, view->web_content_pid());
 
             // Reset promise and attach completion callback
             view->reset_test_promise();
-            view->test_promise().when_resolved([&tests, &tests_remaining, &non_passing_tests, &app, view, cleanup_test, view_id, digits_for_view_id, digits_for_test_id, use_live_display, &test_run_capture](auto result) {
+            view->test_promise().when_resolved([&tests, &tests_remaining, &non_passing_tests, &app, view, cleanup_test, view_id, &test_run_capture, &fail_fast_triggered](auto result) {
                 cleanup_test(result.test_index, result.result);
 
                 auto& test = tests[result.test_index];
@@ -1490,62 +1229,18 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                 if (result.result != TestResult::Crashed)
                     test_run_capture.write_test_output(*view);
 
-                if (!app.quiet && app.verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_DURATION) {
-                    auto duration = test.end_time - test.start_time;
-                    outln("[{:{}}] {:{}}/{}: Finish {}: {}ms", view_id, digits_for_view_id, test.index + 1, digits_for_test_id, tests.size(), test.relative_path, duration.to_milliseconds());
-                }
-
-                switch (result.result) {
-                case TestResult::Pass:
-                    ++s_pass_count;
-                    break;
-                case TestResult::Fail:
-                    ++s_fail_count;
-                    break;
-                case TestResult::Timeout:
-                    ++s_timeout_count;
-                    break;
-                case TestResult::Crashed:
-                    ++s_crashed_count;
-                    break;
-                case TestResult::Skipped:
-                    ++s_skipped_count;
-                    break;
-                case TestResult::Expanded:
-                    break;
-                }
-
-                // Don't count Expanded tests in the completed display count
-                if (result.result != TestResult::Expanded)
-                    ++s_completed_tests;
-
                 bool const is_non_passing_result = result.result != TestResult::Pass && result.result != TestResult::Expanded;
                 bool const should_trigger_fail_fast = result.result == TestResult::Fail || result.result == TestResult::Timeout || result.result == TestResult::Crashed;
 
                 if (is_non_passing_result)
                     non_passing_tests.append(result);
 
-                if (app.fail_fast && !s_fail_fast_triggered && should_trigger_fail_fast) {
-                    s_fail_fast_triggered = true;
+                Display::the().on_test_finished(view_id, test, result.result);
 
-                    if (s_display_timer) {
-                        s_display_timer->stop();
-                        s_display_timer = nullptr;
-                    }
-
-                    if (use_live_display) {
-                        for (size_t i = 0; i < s_live_display_lines; ++i)
-                            out("\033[A\033[2K"sv);
-                        out("\r"sv);
-                        (void)fflush(stdout);
-                        s_live_display_lines = 0;
-                    }
-
+                if (app.fail_fast && !fail_fast_triggered && should_trigger_fail_fast) {
+                    fail_fast_triggered = true;
                     auto const pid = view->web_content_pid();
-                    if (result.result == TestResult::Timeout)
-                        outln("Fail-fast: Timeout: {} (pid {})", test.relative_path, pid);
-                    else
-                        outln("Fail-fast: {}: {}", test_result_to_string(result.result), test.relative_path);
+                    Display::the().on_fail_fast(test, result.result, pid);
 
                     if (s_all_tests_complete)
                         s_all_tests_complete->reject(Error::from_string_literal("Fail-fast"));
@@ -1589,57 +1284,10 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         });
     }
 
-    auto result_or_rejection = s_all_tests_complete->await();
-
-    // Stop the live display timer
-    if (s_display_timer) {
-        s_display_timer->stop();
-        s_display_timer = nullptr;
-    }
-
-    // Clear the live display area and move cursor back up
-    if (use_live_display) {
-        for (size_t i = 0; i < s_live_display_lines; ++i)
-            out("\033[A\033[2K"sv); // Move up and clear each line
-        out("\r"sv);
-        (void)fflush(stdout);
-        s_live_display_lines = 0;
-    }
-
-    if (result_or_rejection.is_error())
-        outln("Halted; {} tests not executed.", tests_remaining);
-
-    outln("==========================================================");
-    outln("Pass: {}, Fail: {}, Skipped: {}, Timeout: {}, Crashed: {}", s_pass_count, s_fail_count, s_skipped_count, s_timeout_count, s_crashed_count);
-    outln("==========================================================");
-
-    for (auto const& non_passing_test : non_passing_tests) {
-        if (non_passing_test.result == TestResult::Skipped && app.verbosity < Application::VERBOSITY_LEVEL_LOG_SKIPPED_TESTS)
-            continue;
-
-        auto const& test = tests[non_passing_test.test_index];
-        if (Application::the().repeat_count > 1)
-            outln("{}: (run {}/{}) {}", test_result_to_string(non_passing_test.result), test.run_index, test.total_runs, test.relative_path);
-        else
-            outln("{}: {}", test_result_to_string(non_passing_test.result), test.relative_path);
-    }
-
-    if (!app.quiet && app.verbosity >= Application::VERBOSITY_LEVEL_LOG_SLOWEST_TESTS) {
-        auto tests_to_print = min(10uz, tests.size());
-        outln("\nSlowest {} tests:", tests_to_print);
-
-        quick_sort(tests, [&](auto const& lhs, auto const& rhs) {
-            auto lhs_duration = lhs.end_time - lhs.start_time;
-            auto rhs_duration = rhs.end_time - rhs.start_time;
-            return lhs_duration > rhs_duration;
-        });
-
-        for (auto const& test : tests.span().trim(tests_to_print)) {
-            auto duration = test.end_time - test.start_time;
-
-            outln("{}: {}ms", test.relative_path, duration.to_milliseconds());
-        }
-    }
+    auto result_or_rejection
+        = s_all_tests_complete->await();
+    display.clear_live_display();
+    display.print_run_complete(tests, non_passing_tests, result_or_rejection.is_error() ? tests_remaining : 0);
 
     if (app.dump_gc_graph) {
         for (auto& view : views) {
@@ -1662,7 +1310,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             outln("Results: file://{}/index.html", app.results_directory);
     }
 
-    return s_fail_count + s_timeout_count + s_crashed_count + tests_remaining;
+    return display.fail_count + display.timeout_count + display.crashed_count + tests_remaining;
 }
 
 static void handle_signal(int signal)


### PR DESCRIPTION
Some people run embedded terminals in the bottom panel of their IDEs. This prevents test-web's live display from blowing up their scrollback buffer.

If you don't know what I mean, resize a terminal down to single digit rows and fire up a long-ish test-web batch (prior to this commit).

Reduce main.cpp a bit by moving display stuff into Display.cpp.