### PR TITLE
LibWeb: Make srcdoc iframe test wait for nested document

### DIFF
--- a/Tests/LibWeb/Text/input/HTML/set-innerHTML-inside-iframe-srcdoc-document.html
+++ b/Tests/LibWeb/Text/input/HTML/set-innerHTML-inside-iframe-srcdoc-document.html
@@ -2,14 +2,23 @@
 <iframe id="ifr" srcdoc=""></iframe>
 <script src="../include.js"></script>
 <script>
-    test(() => {
-        ifr.contentDocument.body.innerHTML = "<a href='foo.html'>foo</a>";
-        let href = ifr.contentDocument.body.querySelector("a").href;
-        if (href.endsWith("foo.html")) {
-            println("PASS (Didn't crash)");
+    asyncTest(done => {
+        const runTest = () => {
+            ifr.contentDocument.body.innerHTML = "<a href='foo.html'>foo</a>";
+            let href = ifr.contentDocument.body.querySelector("a").href;
+            if (href.endsWith("foo.html")) {
+                println("PASS (Didn't crash)");
+            } else {
+                println("FAIL");
+            }
+            ifr.remove();
+            done();
+        };
+
+        if (ifr.contentDocument?.body) {
+            runTest();
         } else {
-            println("FAIL");
+            ifr.addEventListener("load", runTest, { once: true });
         }
-        ifr.remove();
     });
 </script>


### PR DESCRIPTION
The test assumed the parent document's DOMContentLoaded implied the iframe srcdoc document already had a body. That is not guaranteed, and the test could intermittently hit a null contentDocument.body on slower runs.

(I've seen this test flaking on CI a couple times.)