### PR TITLE
LibWeb/CSS: Remove some deprecated TokenStream methods

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -93,9 +93,11 @@ RefPtr<StyleValue const> Parser::parse_all_as_single_keyword_value(TokenStream<C
 RefPtr<StyleValueList const> Parser::parse_simple_comma_separated_value_list(PropertyID property_id, TokenStream<ComponentValue>& tokens)
 {
     return parse_comma_separated_value_list(tokens, [this, property_id](auto& tokens) -> RefPtr<StyleValue const> {
-        if (auto value = parse_css_value_for_property(property_id, tokens))
+        auto transaction = tokens.begin_transaction();
+        if (auto value = parse_css_value_for_property(property_id, tokens)) {
+            transaction.commit();
             return value;
-        tokens.reconsume_current_input_token();
+        }
         return nullptr;
     });
 }

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2599,7 +2599,7 @@ RefPtr<StyleValue const> Parser::parse_font_value(TokenStream<ComponentValue>& t
 
         // <font-variant-css2> = normal | small-caps
         // So, we handle that manually instead of trying to parse the font-variant property.
-        if (!font_variant && tokens.peek_token().is_ident("small-caps"sv)) {
+        if (!font_variant && tokens.next_token().is_ident("small-caps"sv)) {
             tokens.discard_a_token(); // small-caps
 
             font_variant = ShorthandStyleValue::create(PropertyID::FontVariant,
@@ -2625,7 +2625,7 @@ RefPtr<StyleValue const> Parser::parse_font_value(TokenStream<ComponentValue>& t
 
         // <font-width-css3> = normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded
         // So again, we do this manually.
-        if (!font_width && tokens.peek_token().is(Token::Type::Ident)) {
+        if (!font_width && tokens.next_token().is(Token::Type::Ident)) {
             auto font_width_transaction = tokens.begin_transaction();
             if (auto keyword = parse_keyword_value(tokens)) {
                 if (keyword_to_font_width(keyword->to_keyword()).has_value()) {

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -477,24 +477,24 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
     auto context_guard = push_temporary_value_parsing_context(property_id);
 
     SubstitutionFunctionsPresence substitution_presence;
+    {
+        // NB: This transaction is intentionally never committed. This loop just examines the tokens and doesn't want
+        //     to permanently consume anything.
+        auto transaction = tokens.begin_transaction();
+        while (tokens.has_next_token()) {
+            auto const& token = tokens.consume_a_token();
 
-    tokens.mark();
-    while (tokens.has_next_token()) {
-        auto const& token = tokens.consume_a_token();
+            if (token.is(Token::Type::Semicolon))
+                return ParseError::SyntaxError;
 
-        if (token.is(Token::Type::Semicolon)) {
-            tokens.reconsume_current_input_token();
-            return ParseError::SyntaxError;
+            // https://drafts.csswg.org/css-values-5/#resolve-property
+            // If a property value contains one or more arbitrary substitution functions, and all of those functions are
+            // themselves syntactically valid according to their argument grammars, the entire value’s grammar must be
+            // assumed to be valid at parse time.
+            if (collect_arbitrary_substitution_function_presence(token, substitution_presence).is_error())
+                return ParseError::SyntaxError;
         }
-
-        // https://drafts.csswg.org/css-values-5/#resolve-property
-        // If a property value contains one or more arbitrary substitution functions, and all of those functions are
-        // themselves syntactically valid according to their argument grammars, the entire value’s grammar must be
-        // assumed to be valid at parse time.
-        if (collect_arbitrary_substitution_function_presence(token, substitution_presence).is_error())
-            return ParseError::SyntaxError;
     }
-    tokens.restore_a_mark();
 
     auto parse_all_as = [](auto& tokens, auto&& callback) -> ParseErrorOr<NonnullRefPtr<StyleValue const>> {
         tokens.discard_whitespace();

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1333,11 +1333,18 @@ RefPtr<StyleValue const> Parser::parse_background_value(TokenStream<ComponentVal
             continue;
         }
 
-        auto value_and_property = parse_css_value_for_properties(remaining_layer_properties, tokens);
-        if (!value_and_property.has_value())
-            return nullptr;
-        auto& value = value_and_property->style_value;
-        auto property = value_and_property->property;
+        Optional<PropertyAndValue> property_and_value;
+        {
+            auto value_transaction = tokens.begin_transaction();
+            property_and_value = parse_css_value_for_properties(remaining_layer_properties, tokens);
+            if (!property_and_value.has_value())
+                return nullptr;
+            // FIXME: background-repeat can't be parsed fully with parse_css_value_for_properties(), so don't commit
+            //        the transaction, and then parse it manually below.
+            if (property_and_value->property != PropertyID::BackgroundRepeat)
+                value_transaction.commit();
+        }
+        auto& [property, value] = *property_and_value;
         remove_property(remaining_layer_properties, property);
 
         switch (property) {
@@ -1399,7 +1406,7 @@ RefPtr<StyleValue const> Parser::parse_background_value(TokenStream<ComponentVal
         }
         case PropertyID::BackgroundRepeat: {
             VERIFY(!background_repeat);
-            tokens.reconsume_current_input_token();
+            // NB: The tokens for this didn't get consumed, see above. So we parse it fully now.
             if (auto maybe_repeat = parse_single_repeat_style_value(property, tokens)) {
                 background_repeat = maybe_repeat.release_nonnull();
                 tokens.discard_whitespace();
@@ -3255,11 +3262,18 @@ RefPtr<StyleValue const> Parser::parse_mask_value(TokenStream<ComponentValue>& t
             continue;
         }
 
-        auto value_and_property = parse_css_value_for_properties(remaining_layer_properties, tokens);
-        if (!value_and_property.has_value())
-            return nullptr;
-        auto& value = value_and_property->style_value;
-        auto property = value_and_property->property;
+        Optional<PropertyAndValue> property_and_value;
+        {
+            auto value_transaction = tokens.begin_transaction();
+            property_and_value = parse_css_value_for_properties(remaining_layer_properties, tokens);
+            if (!property_and_value.has_value())
+                return nullptr;
+            // FIXME: mask-repeat can't be parsed fully with parse_css_value_for_properties(), so don't commit
+            //        the transaction, and then parse it manually below.
+            if (property_and_value->property != PropertyID::MaskRepeat)
+                value_transaction.commit();
+        }
+        auto& [property, value] = *property_and_value;
         remove_property(remaining_layer_properties, property);
 
         switch (property) {
@@ -3293,7 +3307,7 @@ RefPtr<StyleValue const> Parser::parse_mask_value(TokenStream<ComponentValue>& t
         // <repeat-style>
         case PropertyID::MaskRepeat: {
             VERIFY(!mask_repeat);
-            tokens.reconsume_current_input_token();
+            // NB: The tokens for this didn't get consumed, see above. So we parse it fully now.
             if (auto maybe_repeat = parse_single_repeat_style_value(property, tokens)) {
                 mask_repeat = maybe_repeat.release_nonnull();
                 tokens.discard_whitespace();
@@ -4134,13 +4148,21 @@ RefPtr<StyleValue const> Parser::parse_text_decoration_value(TokenStream<Compone
 
     auto transaction = tokens.begin_transaction();
     while (tokens.has_next_token()) {
-        auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.has_value())
-            return nullptr;
-        auto& value = property_and_value->style_value;
-        remove_property(remaining_longhands, property_and_value->property);
+        Optional<PropertyAndValue> property_and_value;
+        {
+            auto value_transaction = tokens.begin_transaction();
+            property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
+            if (!property_and_value.has_value())
+                return nullptr;
+            // FIXME: text-decoration-line can't be parsed fully with parse_css_value_for_properties(), so don't commit
+            //        the transaction, and then parse it manually below.
+            if (property_and_value->property != PropertyID::TextDecorationLine)
+                value_transaction.commit();
+        }
+        auto& [property, value] = *property_and_value;
+        remove_property(remaining_longhands, property);
 
-        switch (property_and_value->property) {
+        switch (property) {
         case PropertyID::TextDecorationColor: {
             VERIFY(!decoration_color);
             decoration_color = value.release_nonnull();
@@ -4148,7 +4170,7 @@ RefPtr<StyleValue const> Parser::parse_text_decoration_value(TokenStream<Compone
         }
         case PropertyID::TextDecorationLine: {
             VERIFY(!decoration_line);
-            tokens.reconsume_current_input_token();
+            // NB: The tokens for this didn't get consumed, see above. So we parse it fully now.
             auto parsed_decoration_line = parse_text_decoration_line_value(tokens);
             if (!parsed_decoration_line)
                 return nullptr;

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -1306,7 +1306,7 @@ Optional<Parser::FunctionPrelude> Parser::parse_function_prelude(TokenStream<Com
 
         // [ : <default-value> ]?
         Optional<Vector<ComponentValue>> default_value;
-        if (parameter_tokens.peek_token().is(Token::Type::Colon)) {
+        if (parameter_tokens.next_token().is(Token::Type::Colon)) {
             parameter_tokens.discard_a_token(); // :
             parameter_tokens.discard_whitespace();
 
@@ -1348,7 +1348,7 @@ Optional<Parser::FunctionPrelude> Parser::parse_function_prelude(TokenStream<Com
     tokens.discard_whitespace();
 
     NonnullOwnPtr<SyntaxNode> return_type = UniversalSyntaxNode::create();
-    if (tokens.peek_token().is_ident("returns"sv)) {
+    if (tokens.next_token().is_ident("returns"sv)) {
         tokens.discard_a_token();
         tokens.discard_whitespace();
 

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -536,45 +536,44 @@ GC::Ptr<CSSKeyframesRule> Parser::convert_to_keyframes_rule(AtRule const& rule)
             }
         }
 
-        auto selectors = Vector<CSS::Percentage> {};
+        auto selectors = Vector<Percentage> {};
         TokenStream child_tokens { qualified_rule.prelude };
         while (child_tokens.has_next_token()) {
             child_tokens.discard_whitespace();
             if (!child_tokens.has_next_token())
                 break;
-            auto tok = child_tokens.consume_a_token();
-            if (!tok.is_token()) {
+            auto& next_token = child_tokens.next_token();
+            if (!next_token.is_token()) {
                 ErrorReporter::the().report(CSS::Parser::InvalidRuleError {
                     .rule_name = "keyframe"_fly_string,
                     .prelude = child_tokens.dump_string(),
                     .description = "Invalid selector."_string,
                 });
-                child_tokens.reconsume_current_input_token();
                 break;
             }
-            auto token = tok.token();
             auto read_a_selector = false;
-            if (token.is(Token::Type::Ident)) {
-                if (token.ident().equals_ignoring_ascii_case("from"sv)) {
-                    selectors.append(CSS::Percentage(0));
-                    read_a_selector = true;
-                }
-                if (token.ident().equals_ignoring_ascii_case("to"sv)) {
-                    selectors.append(CSS::Percentage(100));
-                    read_a_selector = true;
-                }
-            } else if (token.is(Token::Type::Percentage)) {
-                selectors.append(CSS::Percentage(token.percentage()));
+            if (next_token.is_ident("from"sv)) {
+                child_tokens.discard_a_token(); // from
+                selectors.append(Percentage(0));
+                read_a_selector = true;
+            } else if (next_token.is_ident("to"sv)) {
+                child_tokens.discard_a_token(); // to
+                selectors.append(Percentage(100));
+                read_a_selector = true;
+            } else if (next_token.is(Token::Type::Percentage)) {
+                child_tokens.discard_a_token(); // <percentage>
+                selectors.append(Percentage(next_token.token().percentage()));
                 read_a_selector = true;
             }
 
             if (read_a_selector) {
                 child_tokens.discard_whitespace();
-                if (child_tokens.consume_a_token().is(Token::Type::Comma))
+                if (child_tokens.next_token().is(Token::Type::Comma)) {
+                    child_tokens.discard_a_token(); // ,
                     continue;
+                }
             }
 
-            child_tokens.reconsume_current_input_token();
             break;
         }
 

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -1127,6 +1127,13 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
     if (tokens.next_token().is(Token::Type::Colon))
         return TRY(parse_pseudo_class_simple_selector(tokens));
 
+    if (tokens.next_token().is(Token::Type::Delim)
+        && first_is_one_of(static_cast<char>(tokens.next_token().token().delim()), '>', '+', '~', '|')) {
+        // Whitespace is not required between the compound-selector and a combinator.
+        // So, if we see a combinator, return that this compound-selector is done, instead of a syntax error.
+        return Optional<Selector::SimpleSelector> {};
+    }
+
     auto const& first_value = tokens.consume_a_token();
 
     if (first_value.is(Token::Type::Delim)) {
@@ -1156,14 +1163,6 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
                 .value = Selector::SimpleSelector::Name { class_name_value.token().ident() }
             };
         }
-        case '>':
-        case '+':
-        case '~':
-        case '|':
-            // Whitespace is not required between the compound-selector and a combinator.
-            // So, if we see a combinator, return that this compound-selector is done, instead of a syntax error.
-            tokens.reconsume_current_input_token();
-            return Optional<Selector::SimpleSelector> {};
         default:
             ErrorReporter::the().report(InvalidSelectorError {
                 .value_string = tokens.dump_string(),

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -1196,6 +1196,7 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
     return ParseError::SyntaxError;
 }
 
+// https://drafts.csswg.org/css-syntax-3/#anb-microsyntax
 Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_pattern(TokenStream<ComponentValue>& values)
 {
     auto transaction = values.begin_transaction();
@@ -1203,103 +1204,101 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     auto is_sign = [](ComponentValue const& value) -> bool {
         return value.is(Token::Type::Delim) && (value.token().delim() == '+' || value.token().delim() == '-');
     };
+
+    auto is_series_of_1_or_more_digits = [](StringView string) -> bool {
+        if (string.is_empty())
+            return false;
+        for (char c : string) {
+            if (!is_ascii_digit(c))
+                return false;
+        }
+        return true;
+    };
+
+    // <n-dimension> is a <dimension-token> with its type flag set to "integer", and a unit that is an ASCII
+    // case-insensitive match for "n"
     auto is_n_dimension = [](ComponentValue const& value) -> bool {
-        if (!value.is(Token::Type::Dimension))
-            return false;
-        if (!value.token().number().is_integer())
-            return false;
-        if (!value.token().dimension_unit().equals_ignoring_ascii_case("n"sv))
-            return false;
-        return true;
+        return value.is(Token::Type::Dimension)
+            && value.token().number().is_integer()
+            && value.token().dimension_unit().equals_ignoring_ascii_case("n"sv);
     };
+
+    // <ndash-dimension> is a <dimension-token> with its type flag set to "integer", and a unit that is an ASCII
+    // case-insensitive match for "n-"
     auto is_ndash_dimension = [](ComponentValue const& value) -> bool {
-        if (!value.is(Token::Type::Dimension))
-            return false;
-        if (!value.token().number().is_integer())
-            return false;
-        if (!value.token().dimension_unit().equals_ignoring_ascii_case("n-"sv))
-            return false;
-        return true;
+        return value.is(Token::Type::Dimension)
+            && value.token().number().is_integer()
+            && value.token().dimension_unit().equals_ignoring_ascii_case("n-"sv);
     };
-    auto is_ndashdigit_dimension = [](ComponentValue const& value) -> bool {
-        if (!value.is(Token::Type::Dimension))
-            return false;
-        if (!value.token().number().is_integer())
-            return false;
-        auto dimension_unit = value.token().dimension_unit();
-        if (!dimension_unit.starts_with_bytes("n-"sv, CaseSensitivity::CaseInsensitive))
-            return false;
-        for (size_t i = 2; i < dimension_unit.bytes_as_string_view().length(); ++i) {
-            if (!is_ascii_digit(dimension_unit.bytes_as_string_view()[i]))
-                return false;
-        }
-        return true;
+
+    // <ndashdigit-dimension> is a <dimension-token> with its type flag set to "integer", and a unit that is an ASCII
+    // case-insensitive match for "n-*", where "*" is a series of one or more digits
+    auto is_ndashdigit_dimension = [&](ComponentValue const& value) -> bool {
+        return value.is(Token::Type::Dimension)
+            && value.token().number().is_integer()
+            && value.token().dimension_unit().starts_with_bytes("n-"sv, CaseSensitivity::CaseInsensitive)
+            && is_series_of_1_or_more_digits(value.token().dimension_unit().bytes_as_string_view().substring_view(2));
     };
-    auto is_ndashdigit_ident = [](ComponentValue const& value) -> bool {
-        if (!value.is(Token::Type::Ident))
-            return false;
-        auto ident = value.token().ident();
-        if (!ident.starts_with_bytes("n-"sv, CaseSensitivity::CaseInsensitive))
-            return false;
-        for (size_t i = 2; i < ident.bytes_as_string_view().length(); ++i) {
-            if (!is_ascii_digit(ident.bytes_as_string_view()[i]))
-                return false;
-        }
-        return true;
+
+    // <ndashdigit-ident> is an <ident-token> whose value is an ASCII case-insensitive match for "n-*", where "*" is a
+    // series of one or more digits
+    auto is_ndashdigit_ident = [&](ComponentValue const& value) -> bool {
+        return value.is(Token::Type::Ident)
+            && value.token().ident().starts_with_bytes("n-"sv, CaseSensitivity::CaseInsensitive)
+            && is_series_of_1_or_more_digits(value.token().ident().bytes_as_string_view().substring_view(2));
     };
-    auto is_dashndashdigit_ident = [](ComponentValue const& value) -> bool {
-        if (!value.is(Token::Type::Ident))
-            return false;
-        auto ident = value.token().ident();
-        if (!ident.starts_with_bytes("-n-"sv, CaseSensitivity::CaseInsensitive))
-            return false;
-        if (ident.bytes_as_string_view().length() == 3)
-            return false;
-        for (size_t i = 3; i < ident.bytes_as_string_view().length(); ++i) {
-            if (!is_ascii_digit(ident.bytes_as_string_view()[i]))
-                return false;
-        }
-        return true;
+
+    // <dashndashdigit-ident> is an <ident-token> whose value is an ASCII case-insensitive match for "-n-*", where "*"
+    // is a series of one or more digits
+    auto is_dashndashdigit_ident = [&](ComponentValue const& value) -> bool {
+        return value.is(Token::Type::Ident)
+            && value.token().ident().starts_with_bytes("-n-"sv, CaseSensitivity::CaseInsensitive)
+            && is_series_of_1_or_more_digits(value.token().ident().bytes_as_string_view().substring_view(3));
     };
+
+    // <integer> is a <number-token> with its type flag set to "integer"
     auto is_integer = [](ComponentValue const& value) -> bool {
         return value.is(Token::Type::Number) && value.token().number().is_integer();
     };
+
+    // <signed-integer> is a <number-token> with its type flag set to "integer", and a sign character
     auto is_signed_integer = [](ComponentValue const& value) -> bool {
         return value.is(Token::Type::Number) && value.token().number().is_integer_with_explicit_sign();
     };
+
+    // <signless-integer> is a <number-token> with its type flag set to "integer", and no sign character
     auto is_signless_integer = [](ComponentValue const& value) -> bool {
-        return value.is(Token::Type::Number) && !value.token().number().is_integer_with_explicit_sign();
+        return value.is(Token::Type::Number)
+            && value.token().number().is_integer()
+            && !value.token().number().is_integer_with_explicit_sign();
     };
 
-    // https://www.w3.org/TR/css-syntax-3/#the-anb-type
-    // Unfortunately these can't be in the same order as in the spec.
-
     values.discard_whitespace();
-    auto const& first_value = values.consume_a_token();
 
     // odd | even
-    if (first_value.is(Token::Type::Ident)) {
-        auto ident = first_value.token().ident();
-        if (ident.equals_ignoring_ascii_case("odd"sv)) {
-            transaction.commit();
-            return Selector::SimpleSelector::ANPlusBPattern { 2, 1 };
-        }
-        if (ident.equals_ignoring_ascii_case("even"sv)) {
-            transaction.commit();
-            return Selector::SimpleSelector::ANPlusBPattern { 2, 0 };
-        }
+    if (values.next_token().is_ident("odd"sv)) {
+        values.discard_a_token(); // odd
+        transaction.commit();
+        return Selector::SimpleSelector::ANPlusBPattern { 2, 1 };
     }
+    if (values.next_token().is_ident("even"sv)) {
+        values.discard_a_token(); // even
+        transaction.commit();
+        return Selector::SimpleSelector::ANPlusBPattern { 2, 0 };
+    }
+
     // <integer>
-    if (is_integer(first_value)) {
-        int b = first_value.token().to_integer();
+    if (is_integer(values.next_token())) {
+        int b = values.consume_a_token().token().to_integer();
         transaction.commit();
         return Selector::SimpleSelector::ANPlusBPattern { 0, b };
     }
+
     // <n-dimension>
     // <n-dimension> <signed-integer>
     // <n-dimension> ['+' | '-'] <signless-integer>
-    if (is_n_dimension(first_value)) {
-        int a = first_value.token().dimension_value_int();
+    if (is_n_dimension(values.next_token())) {
+        int a = values.consume_a_token().token().dimension_value_int();
         values.discard_whitespace();
 
         // <n-dimension> <signed-integer>
@@ -1327,9 +1326,11 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         transaction.commit();
         return Selector::SimpleSelector::ANPlusBPattern { a, 0 };
     }
+
     // <ndash-dimension> <signless-integer>
-    if (is_ndash_dimension(first_value)) {
+    if (is_ndash_dimension(values.next_token())) {
         values.discard_whitespace();
+        auto const& first_value = values.consume_a_token();
         auto const& second_value = values.consume_a_token();
         if (is_signless_integer(second_value)) {
             int a = first_value.token().dimension_value_int();
@@ -1340,9 +1341,10 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
 
         return {};
     }
+
     // <ndashdigit-dimension>
-    if (is_ndashdigit_dimension(first_value)) {
-        auto const& dimension = first_value.token();
+    if (is_ndashdigit_dimension(values.next_token())) {
+        auto const& dimension = values.consume_a_token().token();
         int a = dimension.dimension_value_int();
         auto maybe_b = dimension.dimension_unit().bytes_as_string_view().substring_view(1).to_number<int>();
         if (maybe_b.has_value()) {
@@ -1352,9 +1354,10 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
 
         return {};
     }
+
     // <dashndashdigit-ident>
-    if (is_dashndashdigit_ident(first_value)) {
-        auto maybe_b = first_value.token().ident().bytes_as_string_view().substring_view(2).to_number<int>();
+    if (is_dashndashdigit_ident(values.next_token())) {
+        auto maybe_b = values.consume_a_token().token().ident().bytes_as_string_view().substring_view(2).to_number<int>();
         if (maybe_b.has_value()) {
             transaction.commit();
             return Selector::SimpleSelector::ANPlusBPattern { -1, maybe_b.value() };
@@ -1362,10 +1365,12 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
 
         return {};
     }
+
     // -n
     // -n <signed-integer>
     // -n ['+' | '-'] <signless-integer>
-    if (first_value.is_ident("-n"sv)) {
+    if (values.next_token().is_ident("-n"sv)) {
+        values.discard_a_token(); // -n
         values.discard_whitespace();
 
         // -n <signed-integer>
@@ -1394,7 +1399,8 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         return Selector::SimpleSelector::ANPlusBPattern { -1, 0 };
     }
     // -n- <signless-integer>
-    if (first_value.is_ident("-n-"sv)) {
+    if (values.next_token().is_ident("-n-"sv)) {
+        values.discard_a_token(); // -n-
         values.discard_whitespace();
         auto const& second_value = values.consume_a_token();
         if (is_signless_integer(second_value)) {
@@ -1413,9 +1419,9 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // '+'?† n- <signless-integer>
     // '+'?† <ndashdigit-ident>
     // In all of these cases, the + is optional, and has no effect.
-    // So, we just skip the +, and carry on.
-    if (!first_value.is_delim('+')) {
-        values.reconsume_current_input_token();
+    // So, we consume the + if it's there.
+    if (values.next_token().is_delim('+')) {
+        values.discard_a_token(); // +
         // We do *not* skip whitespace here.
     }
 

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -437,19 +437,25 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
     if (!attribute_tokens.has_next_token())
         return simple_selector;
 
-    auto const& delim_part = attribute_tokens.consume_a_token();
-    if (!delim_part.is(Token::Type::Delim)) {
-        ErrorReporter::the().report(InvalidSelectorError {
-            .value_string = first_value.to_string(),
-            .description = MUST(String::formatted("Expected delim for attribute comparison, got: '{}'.", delim_part.to_debug_string())),
-        });
-        return ParseError::SyntaxError;
-    }
+    auto parse_attribute_match_type = [&first_value](auto& tokens) -> ParseErrorOr<Selector::SimpleSelector::Attribute::MatchType> {
+        // This is one of: `=`, `~=`, `*=`, `|=`, `^=`, `$=`
+        auto transaction = tokens.begin_transaction();
 
-    if (delim_part.token().delim() == '=') {
-        simple_selector.attribute().match_type = Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch;
-    } else {
-        if (!attribute_tokens.has_next_token()) {
+        auto const& first_delim = tokens.consume_a_token();
+        if (!first_delim.is(Token::Type::Delim)) {
+            ErrorReporter::the().report(InvalidSelectorError {
+                .value_string = first_value.to_string(),
+                .description = MUST(String::formatted("Expected delim for attribute comparison, got: '{}'.", first_delim.to_debug_string())),
+            });
+            return ParseError::SyntaxError;
+        }
+
+        if (first_delim.token().delim() == '=') {
+            transaction.commit();
+            return Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch;
+        }
+
+        if (!tokens.has_next_token()) {
             ErrorReporter::the().report(InvalidSelectorError {
                 .value_string = first_value.to_string(),
                 .description = "Attribute selector ended part way through a match type."_string,
@@ -457,34 +463,40 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
             return ParseError::SyntaxError;
         }
 
-        auto const& delim_second_part = attribute_tokens.consume_a_token();
-        if (!delim_second_part.is_delim('=')) {
+        auto const& second_delim = tokens.consume_a_token();
+        if (!second_delim.is_delim('=')) {
             ErrorReporter::the().report(InvalidSelectorError {
                 .value_string = first_value.to_string(),
-                .description = MUST(String::formatted("Expected a double delim for attribute comparison, got: '{}{}'.", delim_part.to_debug_string(), delim_second_part.to_debug_string())),
+                .description = MUST(String::formatted("Expected a double delim for attribute comparison, got: '{}{}'.", first_delim.to_debug_string(), second_delim.to_debug_string())),
             });
             return ParseError::SyntaxError;
         }
-        switch (delim_part.token().delim()) {
+        switch (first_delim.token().delim()) {
         case '~':
-            simple_selector.attribute().match_type = Selector::SimpleSelector::Attribute::MatchType::ContainsWord;
-            break;
+            transaction.commit();
+            return Selector::SimpleSelector::Attribute::MatchType::ContainsWord;
         case '*':
-            simple_selector.attribute().match_type = Selector::SimpleSelector::Attribute::MatchType::ContainsString;
-            break;
+            transaction.commit();
+            return Selector::SimpleSelector::Attribute::MatchType::ContainsString;
         case '|':
-            simple_selector.attribute().match_type = Selector::SimpleSelector::Attribute::MatchType::StartsWithSegment;
-            break;
+            transaction.commit();
+            return Selector::SimpleSelector::Attribute::MatchType::StartsWithSegment;
         case '^':
-            simple_selector.attribute().match_type = Selector::SimpleSelector::Attribute::MatchType::StartsWithString;
-            break;
+            transaction.commit();
+            return Selector::SimpleSelector::Attribute::MatchType::StartsWithString;
         case '$':
-            simple_selector.attribute().match_type = Selector::SimpleSelector::Attribute::MatchType::EndsWithString;
-            break;
+            transaction.commit();
+            return Selector::SimpleSelector::Attribute::MatchType::EndsWithString;
         default:
-            attribute_tokens.reconsume_current_input_token();
+            ErrorReporter::the().report(InvalidSelectorError {
+                .value_string = first_value.to_string(),
+                .description = MUST(String::formatted("Invalid attribute selector match type `{:c}=`", first_delim.token().delim())),
+            });
+            return ParseError::SyntaxError;
         }
-    }
+    };
+
+    simple_selector.attribute().match_type = TRY(parse_attribute_match_type(attribute_tokens));
 
     attribute_tokens.discard_whitespace();
     if (!attribute_tokens.has_next_token()) {

--- a/Libraries/LibWeb/CSS/Parser/TokenStream.h
+++ b/Libraries/LibWeb/CSS/Parser/TokenStream.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2021-2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -85,6 +85,14 @@ public:
         return m_eof;
     }
 
+    // NB: If offset is 0, this is the same as next_token().
+    [[nodiscard]] T const& peek_token(size_t offset)
+    {
+        if (m_index + offset < m_tokens.size())
+            return m_tokens[m_index + offset];
+        return m_eof;
+    }
+
     // https://drafts.csswg.org/css-syntax/#token-stream-empty
     [[nodiscard]] bool is_empty() const
     {
@@ -141,15 +149,6 @@ public:
     bool has_next_token()
     {
         return !is_empty();
-    }
-
-    // Deprecated
-    T const& peek_token(size_t offset = 0)
-    {
-        if (remaining_token_count() <= offset)
-            return m_eof;
-
-        return m_tokens.at(m_index + offset);
     }
 
     StateTransaction begin_transaction() { return StateTransaction(*this); }

--- a/Libraries/LibWeb/CSS/Parser/TokenStream.h
+++ b/Libraries/LibWeb/CSS/Parser/TokenStream.h
@@ -143,15 +143,6 @@ public:
         return !is_empty();
     }
 
-    // Deprecated, used in older versions of the spec.
-    T const& current_token()
-    {
-        if (m_index < 1 || (m_index - 1) >= m_tokens.size())
-            return m_eof;
-
-        return m_tokens.at(m_index - 1);
-    }
-
     // Deprecated
     T const& peek_token(size_t offset = 0)
     {
@@ -159,13 +150,6 @@ public:
             return m_eof;
 
         return m_tokens.at(m_index + offset);
-    }
-
-    // Deprecated, was used in older versions of the spec.
-    void reconsume_current_input_token()
-    {
-        if (m_index > 0)
-            --m_index;
     }
 
     StateTransaction begin_transaction() { return StateTransaction(*this); }

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2621,7 +2621,7 @@ RefPtr<StyleValue const> Parser::parse_ratio_value(TokenStream<ComponentValue>& 
 
     tokens.discard_whitespace();
 
-    if (tokens.peek_token().is(Token::Type::Delim) && tokens.peek_token().token().delim() == '/') {
+    if (tokens.next_token().is(Token::Type::Delim) && tokens.next_token().token().delim() == '/') {
         tokens.discard_a_token();
         tokens.discard_whitespace();
 
@@ -4649,8 +4649,8 @@ Optional<ExplicitGridTrack> Parser::parse_grid_track_size(TokenStream<ComponentV
     if (!tokens.has_next_token())
         return {};
 
-    if (tokens.peek_token().is_function()) {
-        auto const& token = tokens.peek_token();
+    if (tokens.next_token().is_function()) {
+        auto const& token = tokens.next_token();
         auto const& function_token = token.function();
 
         if (function_token.name.equals_ignoring_ascii_case("minmax"sv)) {
@@ -4691,8 +4691,8 @@ Optional<ExplicitGridTrack> Parser::parse_grid_fixed_size(TokenStream<ComponentV
     if (!tokens.has_next_token())
         return {};
 
-    if (tokens.peek_token().is_function()) {
-        auto const& token = tokens.peek_token();
+    if (tokens.next_token().is_function()) {
+        auto const& token = tokens.next_token();
         auto const& function_token = token.function();
         if (function_token.name.equals_ignoring_ascii_case("minmax"sv)) {
             {


### PR DESCRIPTION
These have been deprecated forever, let's actually tidy them up.