### PR TITLE
LibWeb: Clean up mouse-down state after running each test

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -573,6 +573,9 @@ void Internals::perform_per_test_cleanup()
     for (auto gamepad : m_gamepads)
         gamepad->disconnect();
     m_gamepads.clear();
+
+    // Clear any mouse-down state
+    page().top_level_traversable()->event_handler().clear_mousedown_tracking();
 }
 
 void Internals::set_highlighted_node(GC::Ptr<DOM::Node> node)


### PR DESCRIPTION
If a test calls internals.mouseDown() without also calling mouseUp(), the following test can start with the EventHandler thinking a mouse button is still held, and this confuses drag events. This led to our drag-and-drop.html test being flaky.

Usually the GC collects the EventHandler::m_mousedown_target, but sometimes that is kept alive, probably because of the conservative GC stack/register scan.

Manually clear this state at the end of each test so it can't interfere.

Verified with this command, which fails ~40% of the time without this change, and fails 0% of the time with it. :^)

```sh
Meta/ladybird.py run test-web -j1
    -f 'Text/input/click-behind-user-select-none-fragment.html'
    -f 'Text/input/HTML/drag-and-drop.html' --repeat 50
```