### PR TITLE
LibWeb: Update DOM Node moving and removing steps

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1657,9 +1657,9 @@ void Element::inserted()
     play_or_cancel_animations_after_display_property_change();
 }
 
-void Element::removed_from(Node* old_parent, Node& old_root)
+void Element::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
     if (m_id.has_value() && is<ShadowRoot>(old_root))
         static_cast<ShadowRoot&>(old_root).element_by_id().remove(*m_id, *this);
@@ -1683,9 +1683,9 @@ void Element::removed_from(Node* old_parent, Node& old_root)
     exit_fullscreen_on_element_removal();
 }
 
-void Element::moved_from(GC::Ptr<Node> old_parent)
+void Element::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<Node> old_ancestor)
 {
-    Base::moved_from(old_parent);
+    Base::moved_from(is_subtree_root, old_ancestor);
 }
 
 void Element::children_changed(ChildrenChangedMetadata const& metadata)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -603,8 +603,8 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
-    virtual void moved_from(GC::Ptr<Node> old_parent) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
+    virtual void moved_from(IsSubtreeRoot, GC::Ptr<Node> old_ancestor) override;
 
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual i32 default_tab_index_value() const;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1044,8 +1044,8 @@ void Node::remove(bool suppress_observers)
         assign_slottables_for_a_tree(*this);
     }
 
-    // 11. Run the removing steps with node and parent.
-    removed_from(parent, parent_root);
+    // 11. Run the removing steps with node, true, and parent.
+    removed_from(IsSubtreeRoot::Yes, parent, parent_root);
 
     // 12. Let isParentConnected be parent’s connected.
     bool is_parent_connected = parent->is_connected();
@@ -1063,8 +1063,8 @@ void Node::remove(bool suppress_observers)
 
     // 14. For each shadow-including descendant descendant of node, in shadow-including tree order:
     for_each_shadow_including_descendant([&](Node& descendant) {
-        // 1. Run the removing steps with descendant and null.
-        descendant.removed_from(nullptr, parent_root);
+        // 1. Run the removing steps with descendant, false, and parent.
+        descendant.removed_from(IsSubtreeRoot::No, parent, parent_root);
 
         // 2. If descendant is custom and isParentConnected is true, then enqueue a custom element callback reaction
         //    with descendant, callback name "disconnectedCallback", and « ».
@@ -1438,18 +1438,17 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
 
     // 24. For each shadow-including inclusive descendant inclusiveDescendant of node, in shadow-including tree order:
     for_each_shadow_including_inclusive_descendant([this, &new_parent, old_parent](Node& inclusive_descendant) {
-        // 1. If inclusiveDescendant is node, then run the moving steps with inclusiveDescendant and oldParent. Otherwise, run the moving
-        //    steps with inclusiveDescendant and null.
-        if (&inclusive_descendant == this)
-            inclusive_descendant.moved_from(*old_parent);
-        else
-            inclusive_descendant.moved_from(nullptr);
+        // 1. Let isSubtreeRoot be true if inclusiveDescendant is node; otherwise false.
+        auto is_subtree_root = (&inclusive_descendant == this) ? IsSubtreeRoot::Yes : IsSubtreeRoot::No;
 
-        // NOTE: Because the move algorithm is a separate primitive from insert and remove, it does not invoke the traditional insertion steps or
-        //       removing steps for inclusiveDescendant.
+        // 2. Run the moving steps with inclusiveDescendant, isSubtreeRoot, and oldParent.
+        inclusive_descendant.moved_from(is_subtree_root, old_parent);
 
-        // 2. If inclusiveDescendant is custom and newParent is connected, then enqueue a custom element callback reaction with inclusiveDescendant,
-        //    callback name "connectedMoveCallback", and « ».
+        // NOTE: Because the move algorithm is a separate primitive from insert and remove, it does not invoke the
+        //       insertion steps or removing steps for inclusiveDescendant.
+
+        // 3. If inclusiveDescendant is custom and newParent is connected, then enqueue a custom element callback
+        //    reaction with inclusiveDescendant, callback name "connectedMoveCallback", and « ».
         if (auto* element = as_if<DOM::Element>(inclusive_descendant)) {
             if (element->is_custom() && new_parent.is_connected()) {
                 GC::RootVector<JS::Value> empty_arguments { vm().heap() };
@@ -1883,7 +1882,7 @@ void Node::inserted()
     set_needs_style_update(true);
 }
 
-void Node::removed_from(Node*, Node&)
+void Node::removed_from(IsSubtreeRoot, Node*, Node&)
 {
     m_is_connected = false;
     m_in_editable_subtree = false;
@@ -1892,7 +1891,7 @@ void Node::removed_from(Node*, Node&)
 }
 
 // https://dom.spec.whatwg.org/#concept-node-move-ext
-void Node::moved_from(GC::Ptr<Node>)
+void Node::moved_from(IsSubtreeRoot, GC::Ptr<Node>)
 {
     recompute_editable_subtree_flag();
 }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -289,8 +289,12 @@ public:
 
     MUST_UPCALL virtual void inserted();
     virtual void post_connection();
-    MUST_UPCALL virtual void removed_from(Node* old_parent, Node& old_root);
-    MUST_UPCALL virtual void moved_from(GC::Ptr<Node> old_parent);
+    enum class IsSubtreeRoot : u8 {
+        No,
+        Yes,
+    };
+    MUST_UPCALL virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root);
+    MUST_UPCALL virtual void moved_from(IsSubtreeRoot, GC::Ptr<Node> old_ancestor);
 
     struct ChildrenChangedMetadata {
         enum class Type {

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -41,9 +41,9 @@ void HTMLBaseElement::inserted()
         set_the_frozen_base_url();
 }
 
-void HTMLBaseElement::removed_from(Node* old_parent, Node& old_root)
+void HTMLBaseElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    HTMLElement::removed_from(old_parent, old_root);
+    HTMLElement::removed_from(is_subtree_root, old_ancestor, old_root);
     auto old_first_base_element_with_href_in_tree_order = document().first_base_element_with_href_in_tree_order();
     document().update_base_element({});
 

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -23,7 +23,7 @@ public:
     URL::URL const& frozen_base_url() const { return m_frozen_base_url; }
 
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -47,9 +47,9 @@ void HTMLDialogElement::visit_edges(JS::Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element:html-element-removing-steps
-void HTMLDialogElement::removed_from(Node* old_parent, Node& old_root)
+void HTMLDialogElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    HTMLElement::removed_from(old_parent, old_root);
+    HTMLElement::removed_from(is_subtree_root, old_ancestor, old_root);
 
     // 1. If removedNode has an open attribute, then run the dialog cleanup steps given removedNode.
     if (has_attribute(AttributeNames::open))

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -21,7 +21,7 @@ class HTMLDialogElement final : public HTMLElement {
 public:
     virtual ~HTMLDialogElement() override;
 
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
 
     // ^EventTarget
     virtual bool is_focusable() const override { return true; }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -2039,36 +2039,59 @@ void HTMLElement::did_lose_focus()
     document().editing_host_manager()->set_active_contenteditable_element(nullptr);
 }
 
-void HTMLElement::removed_from(Node* old_parent, Node& old_root)
+// https://html.spec.whatwg.org/multipage/infrastructure.html#dom-trees:concept-node-remove-ext
+void HTMLElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Element::removed_from(old_parent, old_root);
+    Element::removed_from(is_subtree_root, old_ancestor, old_root);
 
-    // https://html.spec.whatwg.org/multipage/infrastructure.html#dom-trees:concept-node-remove-ext
-    // If removedNode's popover attribute is not in the No Popover state, then run the hide popover algorithm given removedNode, false, false, false, true, and null.
+    // FIXME: 1. Let document be removedNode's node document.
+    // FIXME: 2. If document's focused area is removedNode, then set document's focused area to document's viewport,
+    //   and set document's relevant global object's navigation API's focus changed during ongoing navigation to false.
+
+    // 3. If removedNode is an element whose namespace is the HTML namespace, and this standard defines HTML element
+    //    removing steps for removedNode's local name, then run the corresponding HTML element removing steps given
+    //    removedNode, isSubtreeRoot, and oldAncestor.
+    // NB: This is done by overriding removed_from() in subclasses.
+
+    // 4. If removedNode is a form-associated element with a non-null form owner and removedNode and its form owner are
+    //    no longer in the same tree, then reset the form owner of removedNode.
+    // FIXME: Follow the spec here.
+    if (is_form_associated_element()) {
+        form_node_was_removed();
+        form_associated_element_was_removed(old_ancestor);
+    }
+
+    // 5. If removedNode's popover attribute is not in the No Popover state, then run the hide popover algorithm given
+    //    removedNode, false, false, false, true, and null.
     if (popover().has_value())
         MUST(hide_popover(FocusPreviousElement::No, FireEvents::No, ThrowExceptions::No, IgnoreDomState::Yes, nullptr));
 
-    if (old_parent) {
-        auto* parent_html_element = as_if<HTMLElement>(old_parent);
+    // AD-HOC: Update inertness
+    if (old_ancestor) {
+        auto* parent_html_element = as_if<HTMLElement>(old_ancestor);
         if (!parent_html_element)
-            parent_html_element = old_parent->first_ancestor_of_type<HTMLElement>();
+            parent_html_element = old_ancestor->first_ancestor_of_type<HTMLElement>();
         if (parent_html_element && parent_html_element->is_inert() && !has_attribute(HTML::AttributeNames::inert))
             set_subtree_inertness(false);
     }
-
-    if (is_form_associated_element()) {
-        form_node_was_removed();
-        form_associated_element_was_removed(old_parent);
-    }
 }
 
-void HTMLElement::moved_from(GC::Ptr<DOM::Node> old_parent)
+// https://html.spec.whatwg.org/multipage/infrastructure.html#dom-trees:concept-node-move-ext
+void HTMLElement::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<DOM::Node> old_ancestor)
 {
-    Element::moved_from(old_parent);
+    Element::moved_from(is_subtree_root, old_ancestor);
 
+    // 1. If movedNode is an element whose namespace is the HTML namespace, and this standard defines HTML element
+    //    moving steps for movedNode's local name, then run the corresponding HTML element moving steps given
+    //    movedNode, isSubtreeRoot, and oldAncestor.
+    // NB: This is done by overriding moved_from() in subclasses.
+
+    // 2. If movedNode is a form-associated element with a non-null form owner and movedNode and its form owner are no
+    //    longer in the same tree, then reset the form owner of movedNode.
+    // FIXME: Follow the spec here.
     if (is_form_associated_element()) {
         form_node_was_moved();
-        form_associated_element_was_moved(old_parent);
+        form_associated_element_was_moved(old_ancestor);
     }
 }
 

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -159,8 +159,8 @@ public:
     Optional<String> popover() const;
     Optional<String> opened_in_popover_mode() const { return m_opened_in_popover_mode; }
 
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
-    virtual void moved_from(GC::Ptr<DOM::Node> old_parent) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
+    virtual void moved_from(IsSubtreeRoot, GC::Ptr<DOM::Node> old_ancestor) override;
 
     enum class PopoverVisibilityState : u8 {
         Hidden,

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -56,9 +56,9 @@ void HTMLFrameElement::inserted()
 }
 
 // https://html.spec.whatwg.org/multipage/obsolete.html#frames:html-element-removing-steps
-void HTMLFrameElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
+void HTMLFrameElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* old_ancestor, DOM::Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
     // The frame HTML element removing steps, given removedNode, are to destroy a child navigable given removedNode.
     destroy_the_child_navigable();

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.h
@@ -26,7 +26,7 @@ private:
 
     // ^DOM::Element
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -206,9 +206,9 @@ void HTMLIFrameElement::process_the_iframe_attributes(InitialInsertion initial_i
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:the-iframe-element-7
-void HTMLIFrameElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
+void HTMLIFrameElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* old_ancestor, DOM::Node& old_root)
 {
-    HTMLElement::removed_from(old_parent, old_root);
+    HTMLElement::removed_from(is_subtree_root, old_ancestor, old_root);
 
     // When an iframe element is removed from a document, the user agent must destroy the nested navigable of the element.
     destroy_the_child_navigable();

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -56,7 +56,7 @@ private:
 
     // ^DOM::Element
     virtual void post_connection() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
     virtual bool is_presentational_hint(FlyString const&) const override;

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -80,9 +80,9 @@ void HTMLLinkElement::inserted()
     }
 }
 
-void HTMLLinkElement::removed_from(Node* old_parent, Node& old_root)
+void HTMLLinkElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
     if (m_loaded_style_sheet) {
         auto& style_sheet_list = [&old_root] -> CSS::StyleSheetList& {

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -26,7 +26,7 @@ public:
     virtual ~HTMLLinkElement() override;
 
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
 
     String rel() const { return get_attribute_value(HTML::AttributeNames::rel); }
     String type() const { return get_attribute_value(HTML::AttributeNames::type); }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -241,9 +241,9 @@ void HTMLMediaElement::set_assigned_media_provider_object(MediaProviderObject co
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#playing-the-media-resource:media-element-83
-void HTMLMediaElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
+void HTMLMediaElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* old_ancestor, DOM::Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
     // When a media element is removed from a Document, the user agent must run the following steps:
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -182,7 +182,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
-    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, DOM::Node* old_ancestor, DOM::Node& old_root) override;
     virtual void children_changed(ChildrenChangedMetadata const& metadata) override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -227,9 +227,9 @@ void HTMLMetaElement::inserted()
     }
 }
 
-void HTMLMetaElement::removed_from(Node* old_parent, Node& old_root)
+void HTMLMetaElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
     update_metadata();
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.h
@@ -46,7 +46,7 @@ private:
 
     // ^DOM::Element
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
@@ -36,14 +36,14 @@ void HTMLOptGroupElement::inserted()
         static_cast<HTMLSelectElement&>(*parent()).update_selectedness();
 }
 
-void HTMLOptGroupElement::removed_from(Node* old_parent, Node& old_root)
+void HTMLOptGroupElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
     // The optgroup HTML element removing steps, given removedNode and oldParent, are:
     // 1. If oldParent is a select element and removedNode has an option child, then run oldParent's selectedness setting algorithm.
-    if (old_parent && is<HTMLSelectElement>(*old_parent) && first_child_of_type<HTMLOptionElement>())
-        static_cast<HTMLSelectElement&>(*old_parent).update_selectedness();
+    if (old_ancestor && is<HTMLSelectElement>(*old_ancestor) && first_child_of_type<HTMLOptionElement>())
+        static_cast<HTMLSelectElement&>(*old_ancestor).update_selectedness();
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
@@ -28,7 +28,7 @@ private:
     virtual bool is_html_optgroup_element() const final { return true; }
 
     virtual void initialize(JS::Realm&) override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void inserted() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -350,7 +350,15 @@ void HTMLOptionElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_an
     update_nearest_select_element();
 }
 
-// FIXME: Moving steps. https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element:html-element-moving-steps
+// https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element:html-element-moving-steps
+void HTMLOptionElement::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<Node> old_ancestor)
+{
+    Base::moved_from(is_subtree_root, old_ancestor);
+
+    // The option HTML element moving steps, given movedNode, isSubtreeRoot, and oldAncestor are to run update an
+    // option's nearest ancestor select given movedNode.
+    update_nearest_select_element();
+}
 
 void HTMLOptionElement::children_changed(ChildrenChangedMetadata const& metadata)
 {

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -340,14 +340,17 @@ void HTMLOptionElement::inserted()
     update_nearest_select_element();
 }
 
-void HTMLOptionElement::removed_from(Node* old_parent, Node& old_root)
+// https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element:html-element-removing-steps
+void HTMLOptionElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
-    // The option HTML element removing steps, given removedOption and oldParent,
-    // are to run update an option's nearest ancestor select given removedOption.
+    // The option HTML element removing steps, given removedNode, isSubtreeRoot, and oldAncestor are to run update an
+    // option's nearest ancestor select given removedNode.
     update_nearest_select_element();
 }
+
+// FIXME: Moving steps. https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element:html-element-moving-steps
 
 void HTMLOptionElement::children_changed(ChildrenChangedMetadata const& metadata)
 {

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -65,6 +65,7 @@ private:
 
     virtual void inserted() override;
     virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
+    virtual void moved_from(IsSubtreeRoot, GC::Ptr<Node> old_ancestor) override;
     virtual void children_changed(ChildrenChangedMetadata const&) override;
 
     void ask_for_a_reset();

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -64,7 +64,7 @@ private:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void children_changed(ChildrenChangedMetadata const&) override;
 
     void ask_for_a_reset();

--- a/Libraries/LibWeb/HTML/HTMLSelectedContentElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectedContentElement.cpp
@@ -82,12 +82,16 @@ void HTMLSelectedContentElement::post_connection()
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#the-selectedcontent-element:html-element-removing-steps
-void HTMLSelectedContentElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
+void HTMLSelectedContentElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* old_ancestor, DOM::Node& old_root)
 {
-    // The selectedcontent HTML element removing steps, given selectedcontent and oldParent, are:
-    Base::removed_from(old_parent, old_root);
+    // The selectedcontent HTML element removing steps, given removedNode, isSubtreeRoot, and oldAncestor are:
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
-    // 1. For each ancestor of selectedcontent's ancestors, in reverse tree order:
+    // 1. If removedNode's disabled is true, then return.
+    if (m_disabled)
+        return;
+
+    // 2. For each ancestor of removedNode's ancestors, in reverse tree order:
     for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         // 1. If ancestor is a select element, then return.
         if (is<HTMLSelectElement>(*ancestor)) {
@@ -95,8 +99,8 @@ void HTMLSelectedContentElement::removed_from(DOM::Node* old_parent, DOM::Node& 
         }
     }
 
-    // 2. For each ancestor of oldParent's inclusive ancestors, in reverse tree order:
-    for (auto* ancestor = old_parent; ancestor; ancestor = ancestor->parent()) {
+    // 3. For each ancestor of oldAncestor's inclusive ancestors, in reverse tree order:
+    for (auto* ancestor = old_ancestor; ancestor; ancestor = ancestor->parent()) {
         // 1. If ancestor is a select element, then run update a select's selectedcontent given ancestor and return.
         if (auto* select_element = as_if<HTMLSelectElement>(*ancestor)) {
             MUST(select_element->update_selectedcontent());

--- a/Libraries/LibWeb/HTML/HTMLSelectedContentElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectedContentElement.h
@@ -34,7 +34,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     virtual void post_connection() override;
-    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, DOM::Node* old_ancestor, DOM::Node& old_root) override;
 
     // https://html.spec.whatwg.org/multipage/form-elements.html#selectedcontent-disabled
     bool m_disabled { false };

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -49,22 +49,23 @@ void HTMLSourceElement::inserted()
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-17
-void HTMLSourceElement::moved_from(GC::Ptr<DOM::Node> old_parent)
+void HTMLSourceElement::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<DOM::Node> old_ancestor)
 {
-    Base::moved_from(old_parent);
+    // The source HTML element moving steps, given movedNode, isSubtreeRoot, and oldAncestor are:
+    Base::moved_from(is_subtree_root, old_ancestor);
 
-    // FIXME: 1. If oldParent is a picture element, then for each child of oldParent's children, if child is an img
-    //        element, then count this as a relevant mutation for child.
+    // FIXME: 1. If isSubtreeRoot is true and oldAncestor is a picture element, then for each child of oldAncestor's
+    //        children: if child is an img element, then count this as a relevant mutation for child.
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-18
-void HTMLSourceElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
+void HTMLSourceElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* old_ancestor, DOM::Node& old_root)
 {
-    // The source HTML element removing steps, given removedNode and oldParent, are:
-    Base::removed_from(old_parent, old_root);
+    // The source HTML element removing steps, given removedNode, isSubtreeRoot, and oldAncestor are:
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
-    // FIXME: 1. If oldParent is a picture element, then for each child of oldParent's children, if child is an img
-    //           element, then count this as a relevant mutation for child.
+    // FIXME: 1. If isSubtreeRoot is true and oldAncestor is a picture element, then for each child of oldAncestor's
+    //        children: if child is an img element, then count this as a relevant mutation for child.
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.h
@@ -23,8 +23,8 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
-    virtual void moved_from(GC::Ptr<Node> old_parent) override;
+    virtual void removed_from(IsSubtreeRoot, DOM::Node* old_ancestor, DOM::Node& old_root) override;
+    virtual void moved_from(IsSubtreeRoot, GC::Ptr<Node> old_ancestor) override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -46,9 +46,9 @@ void HTMLStyleElement::inserted()
     update_a_style_block();
 }
 
-void HTMLStyleElement::removed_from(Node* old_parent, Node& old_root)
+void HTMLStyleElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
     update_a_style_block();
 }
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -23,7 +23,7 @@ public:
 
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     bool disabled();

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -253,9 +253,9 @@ void SVGElement::update_use_elements_that_reference_this()
     });
 }
 
-void SVGElement::removed_from(Node* old_parent, Node& old_root)
+void SVGElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
     auto is_use_element_shadow_root = [](Node& node) {
         auto* shadow_root = as_if<DOM::ShadowRoot>(node);

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -47,7 +47,7 @@ protected:
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     MUST_UPCALL virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     void update_use_elements_that_reference_this();

--- a/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -42,9 +42,9 @@ void SVGStyleElement::inserted()
     update_a_style_block();
 }
 
-void SVGStyleElement::removed_from(Node* old_parent, Node& old_root)
+void SVGStyleElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
-    Base::removed_from(old_parent, old_root);
+    Base::removed_from(is_subtree_root, old_ancestor, old_root);
     update_a_style_block();
 }
 

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -22,7 +22,7 @@ public:
 
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
 
 private:
     SVGStyleElement(DOM::Document&, DOM::QualifiedName);


### PR DESCRIPTION
A couple of spec changes modified what's passed to the moving and removing steps. I then also noticed we were missing the moving steps for `<option>`, so added that.