### PR TITLE
Meta: Pin Rust toolchain version and allow dependabot to update it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "CI:"
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "CI:"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
-
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This should prevent CI failures when the clippy version changes in future.

~~I pinned the version to 1.9.4, which is the latest version that passes CI prior to #8948. Should also be a good test of whether dependabot picks up the new version.~~

Version pinned to 1.9.5 now that #8948 is merged.