### PR TITLE
UI: Focus the web content in "open in new tab" tabs

### DIFF
--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -51,6 +51,10 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     ApplicationDelegate* delegate = [NSApp delegate];
 
     auto* controller = [delegate createNewTab:activate_tab fromTab:[delegate activeTab]];
+    if (activate_tab == Web::HTML::ActivateTab::Yes)
+        [controller focusWebView];
+    else
+        [controller focusWebViewWhenActivated];
     auto* tab = (Tab*)[controller window];
 
     return [[tab web_view] view];

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -88,6 +88,9 @@
 
     if (url.has_value()) {
         [controller loadURL:*url];
+
+        if (*url != WebView::Application::settings().new_tab_page_url())
+            [controller focusWebView];
     }
 
     return controller;
@@ -103,6 +106,8 @@
     if (url.has_value()) {
         [controller loadURL:*url];
     }
+
+    [controller focusWebView];
 
     return controller;
 }

--- a/UI/AppKit/Interface/LadybirdWebViewWindow.h
+++ b/UI/AppKit/Interface/LadybirdWebViewWindow.h
@@ -16,5 +16,6 @@
                      windowRect:(NSRect)window_rect;
 
 @property (nonatomic, strong) LadybirdWebView* web_view;
+@property (nonatomic, weak) NSResponder* preferred_first_responder;
 
 @end

--- a/UI/AppKit/Interface/LadybirdWebViewWindow.mm
+++ b/UI/AppKit/Interface/LadybirdWebViewWindow.mm
@@ -52,4 +52,12 @@
     [super setIsMiniaturized:flag];
 }
 
+- (void)becomeKeyWindow
+{
+    [super becomeKeyWindow];
+
+    if (self.preferred_first_responder && [self firstResponder] != self.preferred_first_responder)
+        [self makeFirstResponder:self.preferred_first_responder];
+}
+
 @end

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -28,6 +28,8 @@
 - (void)onEnterFullscreenWindow;
 - (void)onExitFullscreenWindow;
 
+- (void)focusWebViewWhenActivated;
+- (void)focusWebView;
 - (void)focusLocationToolbarItem;
 
 @end

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -329,9 +329,8 @@ static NSInteger autocomplete_suggestion_index(NSString* suggestion_text, Vector
     [self setLocationFieldText:url.serialize()];
 
     // Don't steal focus from the location bar when loading the new tab page
-    if (url != WebView::Application::settings().new_tab_page_url()) {
-        [self.window makeFirstResponder:[self tab].web_view];
-    }
+    if (url != WebView::Application::settings().new_tab_page_url())
+        [self focusWebView];
 }
 
 - (void)onEnterFullscreenWindow
@@ -353,7 +352,19 @@ static NSInteger autocomplete_suggestion_index(NSString* suggestion_text, Vector
 
 - (void)focusLocationToolbarItem
 {
+    [self tab].preferred_first_responder = self.location_toolbar_item.view;
     [self.window makeFirstResponder:self.location_toolbar_item.view];
+}
+
+- (void)focusWebViewWhenActivated
+{
+    [self tab].preferred_first_responder = [self tab].web_view;
+}
+
+- (void)focusWebView
+{
+    [self tab].preferred_first_responder = [self tab].web_view;
+    [self.window makeFirstResponder:[self tab].web_view];
 }
 
 #pragma mark - Private methods

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -340,6 +340,12 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
             setWindowTitle(QString("%1 - Ladybird").arg(tab->title()));
 
         set_current_tab(tab);
+        if (tab) {
+            if (auto* focus_widget = tab->focusWidget(); focus_widget && tab->isAncestorOf(focus_widget))
+                focus_widget->setFocus();
+            else
+                tab->view().setFocus();
+        }
         fullscreen_mode().exit(FullscreenMode::ExitInitiatedBy::UI);
     });
     QObject::connect(m_tabs_container, &TabWidget::tab_close_requested, this, &BrowserWindow::request_to_close_tab);


### PR DESCRIPTION
Before this change, opening a link in a new tab would open the tab in the background, and when you eventually switch to that tab, the address bar (or nothing) would be focused. This felt weird and wrong.

We now focus the web content in such tabs, so that you can switch to it and immediately start sending keyboard input to the web page. This matches how other browsers behave.