### PR TITLE
test-web: Remove deferred warnings

### DIFF
--- a/Tests/LibWeb/test-web/Fuzzy.cpp
+++ b/Tests/LibWeb/test-web/Fuzzy.cpp
@@ -38,18 +38,18 @@ bool fuzzy_screenshot_match(
     });
     if (!fuzzy_match.has_value()) {
         if (should_match)
-            add_deferred_warning(ByteString::formatted("{}: Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", test_url, diff.pixel_error_count, diff.maximum_error));
+            warnln(ByteString::formatted("{}: Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", test_url, diff.pixel_error_count, diff.maximum_error));
         return false;
     }
 
     // Apply fuzzy matching.
     auto color_error_matches = fuzzy_match->color_value_error.contains(diff.maximum_error);
     if (!color_error_matches && should_match)
-        add_deferred_warning(ByteString::formatted("{}: Fuzzy mismatch: maximum error {} is outside {}", test_url, diff.maximum_error, fuzzy_match->color_value_error));
+        warnln(ByteString::formatted("{}: Fuzzy mismatch: maximum error {} is outside {}", test_url, diff.maximum_error, fuzzy_match->color_value_error));
 
     auto pixel_error_matches = fuzzy_match->pixel_error_count.contains(diff.pixel_error_count);
     if (!pixel_error_matches && should_match)
-        add_deferred_warning(ByteString::formatted("{}: Fuzzy mismatch: pixel error count {} is outside {}", test_url, diff.pixel_error_count, fuzzy_match->pixel_error_count));
+        warnln(ByteString::formatted("{}: Fuzzy mismatch: pixel error count {} is outside {}", test_url, diff.pixel_error_count, fuzzy_match->pixel_error_count));
 
     return color_error_matches && pixel_error_matches;
 }

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -84,8 +84,4 @@ struct TestCompletion {
 
 using TestPromise = Core::Promise<TestCompletion>;
 
-// Deferred warning system - buffers warnings during live display mode
-void add_deferred_warning(ByteString message);
-void print_deferred_warnings();
-
 }

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -89,24 +89,6 @@ static size_t s_timeout_count = 0;
 static size_t s_crashed_count = 0;
 static size_t s_skipped_count = 0;
 
-// Deferred warning system - buffers warnings during live display mode
-static Vector<ByteString> s_deferred_warnings;
-
-void add_deferred_warning(ByteString message)
-{
-    if (s_live_display_lines > 0)
-        s_deferred_warnings.append(move(message));
-    else
-        warnln("{}", message);
-}
-
-void print_deferred_warnings()
-{
-    for (auto const& warning : s_deferred_warnings)
-        warnln("{}", warning);
-    s_deferred_warnings.clear();
-}
-
 static void render_live_display()
 {
     if (!s_is_tty || s_live_display_lines == 0)
@@ -657,7 +639,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
         auto open_expectation_file = [&](auto mode) {
             auto expectation_file_or_error = Core::File::open(test.expectation_path, mode);
             if (expectation_file_or_error.is_error())
-                add_deferred_warning(ByteString::formatted("Failed opening '{}': {}", test.expectation_path, expectation_file_or_error.error()));
+                warnln(ByteString::formatted("Failed opening '{}': {}", test.expectation_path, expectation_file_or_error.error()));
 
             return expectation_file_or_error;
         };
@@ -1553,7 +1535,6 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                         out("\r"sv);
                         (void)fflush(stdout);
                         s_live_display_lines = 0;
-                        print_deferred_warnings();
                     }
 
                     auto const pid = view->web_content_pid();
@@ -1618,10 +1599,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             out("\033[A\033[2K"sv); // Move up and clear each line
         out("\r"sv);
         (void)fflush(stdout);
-
-        // Print any warnings that were deferred during live display
         s_live_display_lines = 0;
-        print_deferred_warnings();
     }
 
     if (result_or_rejection.is_error())


### PR DESCRIPTION
Deferred warnings were originally intended to suppress output during live display, ostensibly to avoid glitch scrolls.

Then, 1af74d1a7cc0b7cc8b721ed333ecd8c44b27a504 added log capture to the test-web process. Suddenly, deferred warnings became deadly because they're flushed during that tiny window after the capture notifier has stopped draining the tee pipe but before stderr is restored.

This caused a deadlock at exit. The fix is to remove this system and call warnln directly because display integrity is now protected by other means.