### PR TITLE
test-web: Add --wpt argument for running wpt tests directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Libraries/LibWasm/Tests/Spec
 Tests/LibWeb/WPT/wpt
 Tests/LibWeb/WPT/metadata
 Tests/LibWeb/WPT/MANIFEST.json
+Tests/LibWeb/Fixtures/wpt-server.log
 
 test-dumps
 *.log

--- a/Tests/LibWeb/Fixtures/wpt-resource-overrides.json
+++ b/Tests/LibWeb/Fixtures/wpt-resource-overrides.json
@@ -1,0 +1,19 @@
+{
+  "resources": [
+    {
+      "route": "/resources/testharnessreport.js",
+      "destination": "Text/input/wpt-import/resources/testharnessreport.js",
+      "content_type": "text/javascript;charset=utf8"
+    },
+    {
+      "route": "/resources/testdriver-vendor.js",
+      "destination": "Text/input/wpt-import/resources/testdriver-vendor.js",
+      "content_type": "text/javascript;charset=utf8"
+    },
+    {
+      "route": "/fonts/ahem.css",
+      "destination": "Text/input/wpt-import/fonts/ahem.css",
+      "content_type": "text/css;charset=utf8"
+    }
+  ]
+}

--- a/Tests/LibWeb/Fixtures/wpt-server.py
+++ b/Tests/LibWeb/Fixtures/wpt-server.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import json
+import multiprocessing
+import os
+import sys
+
+TESTS_LIBWEB_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+WPT_ROOT = os.path.join(TESTS_LIBWEB_ROOT, "WPT", "wpt")
+WPT_TOOLS_ROOT = os.path.join(WPT_ROOT, "tools")
+
+
+def main():
+    sys.path[:0] = [
+        os.path.join(WPT_TOOLS_ROOT, "serve"),
+        WPT_TOOLS_ROOT,
+        WPT_ROOT,
+        os.path.join(WPT_TOOLS_ROOT, "third_party", "webencodings"),
+        os.path.join(WPT_TOOLS_ROOT, "third_party", "six"),
+        os.path.join(WPT_TOOLS_ROOT, "third_party", "html5lib"),
+        # WPT/wpt/tools/serve/serve.py imports html5lib eagerly before WPT/wpt/tools/localpaths.py
+        # gets a chance to set up the paths. If launch ever stops working, check serve.py
+    ]
+
+    import serve
+
+    with open(os.path.join(os.path.dirname(__file__), "wpt-resource-overrides.json"), encoding="utf-8") as mapping_file:
+        resource_mappings = json.load(mapping_file)["resources"]
+
+    def route_builder(logger, aliases, config):
+        builder = serve.get_route_builder(logger, aliases, config)
+        for mapping in resource_mappings:
+            file_path = os.path.join(TESTS_LIBWEB_ROOT, mapping["destination"])
+            if os.path.exists(file_path):
+                builder.add_static(file_path, {}, mapping["content_type"], mapping["route"])
+        return builder
+
+    mp_context = serve.MpContext()
+    if os.name != "nt" and "fork" in multiprocessing.get_all_start_methods():
+        mp_context = multiprocessing.get_context("fork")
+
+    return serve.run(
+        route_builder=route_builder,
+        mp_context=mp_context,
+        log_handlers=None,
+        doc_root=WPT_ROOT,
+        verbose=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Environment.h>
 #include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
 
 namespace TestWeb {
 
@@ -18,8 +19,10 @@ Application::Application(Optional<ByteString> ladybird_binary_path)
     , test_concurrency(Core::System::hardware_concurrency())
     , python_executable_path("python3")
 {
-    if (auto ladybird_source_dir = Core::Environment::get("LADYBIRD_SOURCE_DIR"sv); ladybird_source_dir.has_value())
+    if (auto ladybird_source_dir = Core::Environment::get("LADYBIRD_SOURCE_DIR"sv); ladybird_source_dir.has_value()) {
         test_root_path = LexicalPath::join(*ladybird_source_dir, "Tests"sv, "LibWeb"sv).string();
+        wpt_path = LexicalPath::join(test_root_path, "WPT"sv, "wpt"sv).string();
+    }
 
     if (Core::Environment::has("CLAUDECODE"sv) || Core::Environment::has("CODEX_SANDBOX"sv))
         quiet = true;
@@ -36,7 +39,8 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(test_root_path, "Path containing the tests to run", "test-path", 0, "path");
     args_parser.add_option(results_directory, "Directory to store test results", "results-dir", 'R', "path");
     args_parser.add_option(test_concurrency, "Maximum number of tests to run at once", "test-concurrency", 'j', "jobs");
-    args_parser.add_option(test_globs, "Only run tests matching the given glob", "filter", 'f', "glob");
+    args_parser.add_option(test_globs, "Run tests matching the given glob", "filter", 'f', "glob");
+    args_parser.add_option(wpt_filters, "Run matched, unimported WPT tests (no expectations)", "wpt", 'w', "glob");
     args_parser.add_option(python_executable_path, "Path to python3", "python-executable", 'P', "path");
     args_parser.add_option(dump_gc_graph, "Dump GC graph", "dump-gc-graph", 'G');
     args_parser.add_option(fail_fast, "Abort on first failure/timeout/crash (offers debugger attach on timeout)", "fail-fast");
@@ -71,6 +75,12 @@ void Application::create_platform_options(WebView::BrowserOptions& browser_optio
 
     request_server_options.http_disk_cache_mode = WebView::HTTPDiskCacheMode::Testing;
 
+    if (wpt_filters.size() > 0) {
+        auto certificate_path = wpt_certificates_path();
+        if (!certificate_path.is_empty() && FileSystem::exists(certificate_path))
+            request_server_options.certificates.append(move(certificate_path));
+    }
+
     web_content_options.is_test_mode = WebView::IsTestMode::Yes;
 
     // Allow window.open() to succeed for tests.
@@ -103,6 +113,11 @@ ErrorOr<void> Application::launch_test_fixtures()
     }
 
     return {};
+}
+
+ByteString Application::wpt_certificates_path() const
+{
+    return LexicalPath::join(wpt_path, "tools"sv, "certs"sv, "cacert.pem"sv).string();
 }
 
 }

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -36,6 +36,8 @@ public:
     ByteString results_directory { "test-dumps/results"sv };
     size_t test_concurrency { 1 };
     Vector<ByteString> test_globs;
+    ByteString wpt_path;
+    Vector<ByteString> wpt_filters;
 
     ByteString python_executable_path;
     String invocation_command_line;
@@ -51,6 +53,10 @@ public:
 
     u8 verbosity { 0 };
     bool quiet { false };
+
+    bool has_wpt_filters() const { return !wpt_filters.is_empty(); }
+    bool should_collect_regular_tests() const { return !has_wpt_filters() || !test_globs.is_empty(); }
+    ByteString wpt_certificates_path() const;
 };
 
 }

--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     Fuzzy.cpp
     TestRunCapture.cpp
     TestWebView.cpp
+    WebPlatformTest.cpp
     main.cpp
 )
 

--- a/Tests/LibWeb/test-web/Fixture.cpp
+++ b/Tests/LibWeb/test-web/Fixture.cpp
@@ -6,6 +6,7 @@
 
 #include "Fixture.h"
 #include "Application.h"
+#include "WebPlatformTest.h"
 
 #include <AK/ByteBuffer.h>
 #include <AK/LexicalPath.h>
@@ -14,8 +15,6 @@
 #include <LibCore/System.h>
 
 namespace TestWeb {
-
-static ByteString s_fixtures_path;
 
 // Key function for Fixture
 Fixture::~Fixture() = default;
@@ -63,8 +62,8 @@ void HttpEchoServerFixture::teardown_impl()
 
 ErrorOr<void> HttpEchoServerFixture::setup(WebView::WebContentOptions& web_content_options)
 {
-    auto const script_path = LexicalPath::join(s_fixtures_path, m_script_path);
-    auto const arguments = Vector { script_path.string(), "--directory", Application::the().test_root_path };
+    auto const script_path = LexicalPath::join(Application::the().test_root_path, "Fixtures"sv, m_script_path).string();
+    Vector<ByteString> arguments { script_path, "--directory"sv, Application::the().test_root_path };
 
     // FIXME: Pick a more reasonable log path that is more observable
     auto const log_path = LexicalPath::join(Core::StandardPaths::tempfile_directory(), "http-test-server.log"sv).string();
@@ -103,8 +102,6 @@ void HttpEchoServerFixture::teardown_impl()
 {
     VERIFY(m_process.has_value());
 
-    auto script_path = LexicalPath::join(s_fixtures_path, m_script_path);
-
     if (auto kill_or_error = Core::System::kill(m_process->pid(), SIGINT); kill_or_error.is_error()) {
         if (kill_or_error.error().code() != ESRCH) {
             warnln("Failed to kill HTTP echo server, error: {}", kill_or_error.error());
@@ -120,10 +117,12 @@ void HttpEchoServerFixture::teardown_impl()
 
 void Fixture::initialize_fixtures()
 {
-    s_fixtures_path = LexicalPath::join(Application::the().test_root_path, "Fixtures"sv).string();
-
     auto& registry = all();
-    registry.append(make<HttpEchoServerFixture>());
+
+    if (Application::the().should_collect_regular_tests())
+        registry.append(make<HttpEchoServerFixture>());
+    if (Application::the().wpt_filters.size() > 0)
+        registry.append(create_web_platform_test_fixture());
 }
 
 }

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -86,6 +86,7 @@ struct Test {
     ByteString relative_path {};
     ByteString safe_relative_path {};
     Optional<String> variant {};
+    bool is_wpt_test { false };
 
     UnixDateTime start_time {};
     UnixDateTime end_time {};
@@ -100,6 +101,8 @@ struct Test {
     bool did_inject_js { false };
     bool did_check_variants { false };
 
+    Optional<size_t> subtest_count {};
+    size_t subtests_passed { 0 };
     Optional<RefTestExpectationType> ref_test_expectation_type {};
     Optional<URL::URL> ref_test_expectation_url {};
     Vector<FuzzyMatch> fuzzy_matches {};
@@ -129,5 +132,7 @@ Vector<ViewDisplayState>& view_states();
 size_t total_tests();
 
 using TestPromise = Core::Promise<TestCompletion>;
+
+ErrorOr<ByteString> prepare_output_path(Test const& test);
 
 }

--- a/Tests/LibWeb/test-web/WebPlatformTest.cpp
+++ b/Tests/LibWeb/test-web/WebPlatformTest.cpp
@@ -11,6 +11,7 @@
 #include <AK/Array.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Format.h>
+#include <AK/HashTable.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/LexicalPath.h>
@@ -30,6 +31,7 @@
 namespace TestWeb {
 
 static ErrorOr<void> collect_manifest_entries(JsonObject const&, Vector<Test>&, TestMode, StringView prefix = {});
+static ErrorOr<void> collect_test262_source_tests(Vector<Test>& tests, StringView path);
 static ErrorOr<void> write_result(Test const&);
 static TestResult process_test_result(Test&);
 static bool is_valid_test_extension(StringView test_name);
@@ -136,7 +138,14 @@ ErrorOr<void> collect_wpt_tests(Vector<Test>& tests)
         TRY(collect_manifest_entries(*reftest, tests, TestMode::Ref));
     if (Optional<JsonObject const&> crashtest = items.get_object("crashtest"sv); crashtest.has_value())
         TRY(collect_manifest_entries(*crashtest, tests, TestMode::Crash));
-
+    if (Optional<JsonObject const&> test262 = items.get_object("test262"sv); test262.has_value())
+        TRY(collect_manifest_entries(*test262, tests, TestMode::Text));
+    ByteString const test262_source_root = LexicalPath::join(app.wpt_path, "third_party"sv, "test262"sv, "test"sv).string();
+    if (FileSystem::exists(test262_source_root)) {
+        // ADHOC: This filesystem traversal seems necessary because at the moment, the manifest only has
+        // infrastructure/test262
+        TRY(collect_test262_source_tests(tests, test262_source_root));
+    }
     tests.remove_all_matching([&](auto const& test) {
         if (!test.is_wpt_test)
             return false;
@@ -192,9 +201,12 @@ static ErrorOr<void> collect_manifest_entries(
 
         if (!value.is_array())
             return {};
-        auto const input_path = FileSystem::real_path(LexicalPath::join(app.wpt_path, current_path).string());
-        if (input_path.is_error())
+
+        ErrorOr<ByteString> maybe_input_path = FileSystem::real_path(LexicalPath::join(app.wpt_path, current_path).string());
+        if (maybe_input_path.is_error())
             return {};
+
+        ByteString const input_path = maybe_input_path.release_value();
         JsonArray const& generated_tests = value.as_array();
         for (size_t i = 1; i < generated_tests.size(); ++i) {
             JsonValue const& generated_test = generated_tests[i];
@@ -212,7 +224,7 @@ static ErrorOr<void> collect_manifest_entries(
             StringView const sub_path = wpt_path.starts_with('/') ? StringView { wpt_path }.substring_view(1) : StringView { wpt_path };
             ByteString const relative_path = ByteString::formatted("{}{}", WPT_PATH_PREFIX, sub_path);
             ByteString const safe_path = relative_path.replace("?"sv, "@"sv);
-            Test test { mode, input_path.value(), {}, relative_path, safe_path };
+            Test test { mode, input_path, {}, relative_path, safe_path };
             test.is_wpt_test = true;
             tests.append(move(test));
         }
@@ -275,6 +287,126 @@ static bool is_valid_test_extension(StringView test_name)
 {
     static constexpr Array<StringView, 5> VALID { ".htm"sv, ".html"sv, ".svg"sv, ".xhtml"sv, ".xht"sv };
     return AK::any_of(VALID, [&](StringView suffix) { return test_name.ends_with(suffix); });
+}
+
+struct Test262Metadata {
+    bool has_frontmatter { false };
+    bool is_module { false };
+    bool is_only_strict { false };
+};
+
+static void update_test262_flags(StringView flag, Test262Metadata& metadata)
+{
+    StringView const trimmed_flag = flag.trim_whitespace();
+    if (trimmed_flag.equals_ignoring_ascii_case("module"sv))
+        metadata.is_module = true;
+    else if (trimmed_flag.equals_ignoring_ascii_case("onlyStrict"sv))
+        metadata.is_only_strict = true;
+}
+
+static Test262Metadata parse_test262_metadata(StringView file_contents)
+{
+    Test262Metadata metadata;
+
+    Optional<size_t> const frontmatter_start = file_contents.find("/*---"sv);
+    if (!frontmatter_start.has_value())
+        return metadata;
+
+    StringView const frontmatter_and_contents = file_contents.substring_view(*frontmatter_start + 5);
+    Optional<size_t> const frontmatter_end = frontmatter_and_contents.find("---*/"sv);
+    if (!frontmatter_end.has_value())
+        return metadata;
+
+    metadata.has_frontmatter = true;
+    StringView const frontmatter = frontmatter_and_contents.substring_view(0, *frontmatter_end);
+
+    bool parsing_flags_list = false;
+    for (StringView raw_line : frontmatter.lines()) {
+        StringView const line = raw_line.trim_whitespace();
+        if (line.is_empty())
+            continue;
+
+        if (parsing_flags_list) {
+            if (!line.starts_with('-')) {
+                parsing_flags_list = false;
+            } else {
+                update_test262_flags(line.substring_view(1), metadata);
+                continue;
+            }
+        }
+        if (!line.starts_with("flags:"sv))
+            continue;
+
+        StringView const flags = line.substring_view(6).trim_whitespace();
+        if (flags.starts_with('[') && flags.ends_with(']')) {
+            StringView const inline_flags = flags.substring_view(1, flags.length() - 2);
+            for (StringView flag : inline_flags.split_view(','))
+                update_test262_flags(flag, metadata);
+            continue;
+        }
+        parsing_flags_list = true;
+    }
+    return metadata;
+}
+
+static ByteString request_path_for_test262_source(StringView relative_source_path, Test262Metadata const& metadata)
+{
+    VERIFY(relative_source_path.ends_with(".js"sv));
+
+    StringView suffix = ".test262.html"sv;
+    if (metadata.is_module)
+        suffix = ".test262-module.html"sv;
+    else if (metadata.is_only_strict)
+        suffix = ".test262.strict.html"sv;
+
+    return ByteString::formatted("{}{}", relative_source_path.substring_view(0, relative_source_path.length() - 3), suffix);
+}
+
+static ErrorOr<void> collect_test262_source_tests(Vector<Test>& tests, StringView path)
+{
+    HashTable<ByteString> seen_paths;
+    for (auto const& existing_test : tests) {
+        seen_paths.set(existing_test.relative_path);
+    }
+    Function<ErrorOr<void>(StringView)> collect_from_directory = [&](StringView trail) -> ErrorOr<void> {
+        ByteString const directory = trail.is_empty() ? ByteString { path } : ByteString::formatted("{}/{}", path, trail);
+        Core::DirIterator it(directory, Core::DirIterator::Flags::SkipDots);
+
+        while (it.has_next()) {
+            ByteString const name = it.next_path();
+            ByteString const candidate_path = trail.is_empty() ? ByteString::formatted("{}/{}", path, name)
+                                                               : ByteString::formatted("{}/{}/{}", path, trail, name);
+            ByteString const input_path = TRY(FileSystem::real_path(candidate_path));
+
+            if (FileSystem::is_directory(input_path)) {
+                ByteString const next_trail = trail.is_empty() ? name : ByteString::formatted("{}/{}", trail, name);
+                TRY(collect_from_directory(next_trail));
+                continue;
+            }
+
+            if (!name.ends_with(".js"sv) || name.ends_with("_FIXTURE.js"sv))
+                continue;
+
+            NonnullOwnPtr<Core::File> file = TRY(Core::File::open(input_path, Core::File::OpenMode::Read));
+            ByteBuffer const file_contents = TRY(file->read_until_eof());
+            Test262Metadata const metadata = parse_test262_metadata(StringView { file_contents.bytes() });
+            if (!metadata.has_frontmatter)
+                continue;
+
+            ByteString const relative_source_path = LexicalPath::relative_path(input_path, Application::the().wpt_path).release_value();
+            ByteString const relative_path = request_path_for_test262_source(relative_source_path, metadata);
+            ByteString const manifest_relative_path = ByteString::formatted("{}{}", WPT_PATH_PREFIX, relative_path);
+            if (seen_paths.contains(relative_path) || seen_paths.contains(manifest_relative_path))
+                continue;
+
+            seen_paths.set(relative_path);
+            Test test { TestMode::Text, input_path, {}, relative_path, relative_path.replace("?"sv, "@"sv) };
+            test.is_wpt_test = true;
+            tests.append(move(test));
+        }
+        return {};
+    };
+    return collect_from_directory({});
 }
 
 } // namespace TestWeb

--- a/Tests/LibWeb/test-web/WebPlatformTest.cpp
+++ b/Tests/LibWeb/test-web/WebPlatformTest.cpp
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026, The Ladybird developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "WebPlatformTest.h"
+#include "Application.h"
+#include "Fixture.h"
+
+#include <AK/Array.h>
+#include <AK/ByteBuffer.h>
+#include <AK/Format.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <AK/LexicalPath.h>
+#include <LibCore/Directory.h>
+#include <LibCore/File.h>
+#include <LibCore/MappedFile.h>
+#include <LibCore/Process.h>
+#include <LibCore/Socket.h>
+#include <LibCore/System.h>
+#include <LibCore/Timer.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibURL/Parser.h>
+#include <LibURL/URL.h>
+#include <LibWebView/Forward.h>
+#include <LibWebView/Utilities.h>
+
+namespace TestWeb {
+
+static ErrorOr<void> collect_manifest_entries(JsonObject const&, Vector<Test>&, TestMode, StringView prefix = {});
+static ErrorOr<void> write_result(Test const&);
+static TestResult process_test_result(Test&);
+static bool is_valid_test_extension(StringView test_name);
+
+static constexpr StringView WPT_PATH_PREFIX = "WPT/wpt/"sv;
+
+class WebPlatformTestFixture final : public Fixture {
+public:
+    virtual ErrorOr<void> setup(WebView::WebContentOptions&) override;
+    virtual void teardown_impl() override;
+    virtual StringView name() const override { return "WPTHttpTestServer"sv; }
+    virtual bool is_running() const override { return m_process.has_value(); }
+
+private:
+    Optional<Core::Process> m_process;
+};
+
+NonnullOwnPtr<Fixture> create_web_platform_test_fixture() { return make<WebPlatformTestFixture>(); }
+
+ErrorOr<void> WebPlatformTestFixture::setup(WebView::WebContentOptions&)
+{
+#ifndef AK_OS_WINDOWS
+    Application& app = Application::the();
+    ByteString const script_path = LexicalPath::join(app.test_root_path, "Fixtures"sv, "wpt-server.py"sv).string();
+    ByteString const log_path = LexicalPath::join(app.test_root_path, "Fixtures"sv, "wpt-server.log"sv).string();
+    Vector<ByteString> const arguments { script_path };
+
+    auto can_connect = [](u16 port) { return !Core::TCPSocket::connect("127.0.0.1"sv, port).is_error(); };
+
+    if (can_connect(8000) || can_connect(8443) || can_connect(9000)) {
+        warnln("WPT server needs ports 8000, 8443, and 9000 free, but someone's already listening");
+        return Error::from_string_literal("test-web: Could not start WPT server");
+    }
+    (void)Core::System::unlink(log_path);
+
+    Core::ProcessSpawnOptions const process_options {
+        .executable = app.python_executable_path,
+        .search_for_executable_in_path = true,
+        .arguments = arguments,
+        .file_actions = {
+            Core::FileAction::OpenFile { log_path, Core::File::OpenMode::Write | Core::File::OpenMode::Truncate,
+                STDERR_FILENO },
+            Core::FileAction::DupFd { STDERR_FILENO, STDOUT_FILENO },
+        }
+    };
+    m_process = TRY(Core::Process::spawn(process_options));
+
+    for (size_t attempt = 0; attempt < 25; ++attempt) {
+        if (ErrorOr<void> sleep_result = Core::System::sleep_ms(200); sleep_result.is_error()) {
+            if (sleep_result.error().code() != EINTR)
+                return sleep_result.release_error();
+        }
+        if (can_connect(8000) || can_connect(8443))
+            return {};
+    }
+    warnln("Timed out starting WPT server, see {}", log_path);
+#endif
+    return Error::from_string_literal("test-web: Could not start WPT server");
+}
+
+void WebPlatformTestFixture::teardown_impl()
+{
+    if (!m_process.has_value())
+        return;
+
+#ifndef AK_OS_WINDOWS
+    bool should_wait = true;
+    if (ErrorOr<void> maybe_error = Core::System::kill(m_process->pid(), SIGINT); maybe_error.is_error()) {
+        if (maybe_error.error().code() != ESRCH) {
+            warnln("Failed to kill wpt server, error: {}", maybe_error.error());
+            should_wait = false;
+        }
+    }
+    if (should_wait) {
+        if (ErrorOr<int> maybe_code = m_process->wait_for_termination(); maybe_code.is_error())
+            warnln("Failed to kill wpt server, error: {}", maybe_code.error());
+    }
+    m_process = {};
+#endif
+}
+
+ErrorOr<void> collect_wpt_tests(Vector<Test>& tests)
+{
+    Application& app = Application::the();
+    if (app.wpt_filters.is_empty())
+        return {};
+
+    Vector<ByteString> wpt_globs;
+    for (ByteString const& glob : app.wpt_filters) {
+        wpt_globs.append(ByteString::formatted("*{}*", glob));
+    }
+    ByteString const manifest_path = LexicalPath::join(app.wpt_path, "MANIFEST.json"sv).string();
+    NonnullOwnPtr<Core::MappedFile> manifest_file = TRY(Core::MappedFile::map(manifest_path));
+    JsonValue manifest = TRY(JsonValue::from_string(StringView { manifest_file->bytes() }));
+
+    if (!manifest.is_object() || !manifest.as_object().has_object("items"sv))
+        return Error::from_string_literal("Bad WPT manifest");
+
+    JsonObject const& items = manifest.as_object().get_object("items"sv).value();
+
+    if (Optional<JsonObject const&> testharness = items.get_object("testharness"sv); testharness.has_value())
+        TRY(collect_manifest_entries(*testharness, tests, TestMode::Text));
+    if (Optional<JsonObject const&> reftest = items.get_object("reftest"sv); reftest.has_value())
+        TRY(collect_manifest_entries(*reftest, tests, TestMode::Ref));
+    if (Optional<JsonObject const&> crashtest = items.get_object("crashtest"sv); crashtest.has_value())
+        TRY(collect_manifest_entries(*crashtest, tests, TestMode::Crash));
+
+    tests.remove_all_matching([&](auto const& test) {
+        if (!test.is_wpt_test)
+            return false;
+        auto const test_relative_path = test.relative_path.replace("\\"sv, "/"sv);
+        return !any_of(wpt_globs, [&](auto const& glob) { return test_relative_path.matches(glob, CaseSensitivity::CaseSensitive); });
+    });
+    return {};
+}
+
+ErrorOr<TestResult> on_wpt_test_result(Test& test, URL::URL const& url)
+{
+    if (process_test_result(test) == TestResult::Fail) {
+        TRY(write_result(test));
+        if (!Application::the().quiet
+            && Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT
+            && !test.text.is_empty()) {
+            outln("WPT Test failed: {} {}", url, test.text);
+        }
+        return TestResult::Fail;
+    }
+    return TestResult::Pass;
+}
+
+URL::URL wpt_url(StringView relative_path)
+{
+    StringView request_path = relative_path.starts_with(WPT_PATH_PREFIX)
+        ? relative_path.substring_view(WPT_PATH_PREFIX.length())
+        : relative_path;
+    u16 const port = [request_path] {
+        if (request_path.contains(".h2."sv))
+            return 9000;
+        if (request_path.contains(".https."sv))
+            return 8443;
+        return 8000;
+    }();
+    StringView const scheme = port == 8000 ? "http"sv : "https"sv;
+    Optional<URL::URL> url = URL::Parser::basic_parse(ByteString::formatted("{}://web-platform.test:{}/{}", scheme, port, request_path));
+    VERIFY(url.has_value());
+    return url.release_value();
+}
+
+static ErrorOr<void> collect_manifest_entries(
+    JsonObject const& object,
+    Vector<Test>& tests, TestMode mode,
+    StringView prefix)
+{
+    Application& app = Application::the();
+    TRY(object.try_for_each_member([&](String const& key, JsonValue const& value) -> ErrorOr<void> {
+        ByteString const current_path = prefix.is_empty() ? key.to_byte_string() : ByteString::formatted("{}/{}", prefix, key);
+
+        if (value.is_object())
+            return collect_manifest_entries(value.as_object(), tests, mode, current_path);
+
+        if (!value.is_array())
+            return {};
+        auto const input_path = FileSystem::real_path(LexicalPath::join(app.wpt_path, current_path).string());
+        if (input_path.is_error())
+            return {};
+        JsonArray const& generated_tests = value.as_array();
+        for (size_t i = 1; i < generated_tests.size(); ++i) {
+            JsonValue const& generated_test = generated_tests[i];
+            if (!generated_test.is_array())
+                continue;
+
+            JsonArray const& generated_test_parts = generated_test.as_array();
+            ByteString wpt_path = current_path;
+            if (!generated_test_parts.is_empty() && generated_test_parts[0].is_string())
+                wpt_path = generated_test_parts[0].as_string().to_byte_string();
+
+            if (!is_valid_test_extension(wpt_path))
+                continue;
+
+            StringView const sub_path = wpt_path.starts_with('/') ? StringView { wpt_path }.substring_view(1) : StringView { wpt_path };
+            ByteString const relative_path = ByteString::formatted("{}{}", WPT_PATH_PREFIX, sub_path);
+            ByteString const safe_path = relative_path.replace("?"sv, "@"sv);
+            Test test { mode, input_path.value(), {}, relative_path, safe_path };
+            test.is_wpt_test = true;
+            tests.append(move(test));
+        }
+
+        return {};
+    }));
+    return {};
+}
+
+static ErrorOr<void> write_result(Test const& test)
+{
+    ByteString const base_path = TRY(prepare_output_path(test));
+    TRY(Core::Directory::create(LexicalPath { base_path }.dirname(), Core::Directory::CreateDirectories::Yes));
+    ByteString const html_path = ByteString::formatted("{}.wpt.html", base_path);
+    NonnullOwnPtr<Core::File> html_file = TRY(Core::File::open(html_path, Core::File::OpenMode::Write | Core::File::OpenMode::Truncate));
+
+    TRY(html_file->write_until_depleted(R"html(<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+body { margin: 0; background: #0d1117; color: #c9d1d9; }
+pre { margin: 0; padding: 16px; font-family: ui-monospace, monospace; font-size: 12px; line-height: 1.5; white-space: pre-wrap; }
+</style>
+</head>
+<body><pre>)html"sv));
+    TRY(html_file->write_formatted("{}", escape_html_entities(test.text)));
+    TRY(html_file->write_until_depleted("</pre></body></html>"sv));
+
+    return {};
+}
+
+static TestResult process_test_result(Test& test)
+{
+    bool harness_passed = false;
+
+    for (StringView raw_line : test.text.bytes_as_string_view().lines()) {
+        StringView line = raw_line.trim_whitespace();
+        if (line.is_empty())
+            continue;
+
+        if (line.starts_with("Harness status:"sv)) {
+            harness_passed = line.ends_with("OK"sv);
+            continue;
+        }
+        Optional<size_t> tab_index = line.find('\t');
+        if (!tab_index.has_value())
+            continue;
+
+        test.subtest_count = test.subtest_count.value_or(0) + 1;
+        StringView status = line.substring_view(0, *tab_index);
+        if (status == "Pass"sv)
+            test.subtests_passed++;
+    }
+
+    return (!harness_passed || test.subtests_passed < test.subtest_count.value_or(0)) ? TestResult::Fail : TestResult::Pass;
+}
+
+static bool is_valid_test_extension(StringView test_name)
+{
+    static constexpr Array<StringView, 5> VALID { ".htm"sv, ".html"sv, ".svg"sv, ".xhtml"sv, ".xht"sv };
+    return AK::any_of(VALID, [&](StringView suffix) { return test_name.ends_with(suffix); });
+}
+
+} // namespace TestWeb

--- a/Tests/LibWeb/test-web/WebPlatformTest.h
+++ b/Tests/LibWeb/test-web/WebPlatformTest.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, The Ladybird developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "TestWeb.h"
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+#include <LibURL/Forward.h>
+
+namespace TestWeb {
+
+class Fixture;
+
+NonnullOwnPtr<Fixture> create_web_platform_test_fixture();
+ErrorOr<void> collect_wpt_tests(Vector<Test>&);
+ErrorOr<TestResult> on_wpt_test_result(Test&, URL::URL const&);
+URL::URL wpt_url(StringView relative_path);
+
+} // namespace TestWeb

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -14,10 +14,13 @@
 #include "TestRunCapture.h"
 #include "TestWeb.h"
 #include "TestWebView.h"
+#include "WebPlatformTest.h"
 
 #include <AK/ByteBuffer.h>
 #include <AK/Enumerate.h>
 #include <AK/Function.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
@@ -69,7 +72,7 @@ static TestRunContext* s_run_context { nullptr };
 Vector<ViewDisplayState>& view_states() { return s_view_display_states; }
 size_t total_tests() { return s_run_context ? s_run_context->total_tests : 0; }
 
-static ErrorOr<ByteString> prepare_output_path(Test const& test)
+ErrorOr<ByteString> prepare_output_path(Test const& test)
 {
     auto& app = Application::the();
     auto base_path = LexicalPath::join(app.results_directory, test.safe_relative_path);
@@ -292,17 +295,47 @@ static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpa
 
     bool const has_helper_logs = FileSystem::exists(LexicalPath::join(app.results_directory, "helper-process-logs.html"sv).string());
     auto const generated_at = UnixDateTime::now();
+    size_t wpt_total = 0;
+    size_t wpt_subtest_count = 0;
+    size_t wpt_subtests_passed = 0;
 
+    for (auto const& test : tests) {
+        if (!test.is_wpt_test)
+            continue;
+
+        ++wpt_total;
+        if (test.subtest_count.value_or(0) == 0) {
+            ++wpt_subtest_count;
+            continue;
+        }
+        wpt_subtest_count += test.subtest_count.value();
+        wpt_subtests_passed += test.subtests_passed;
+    }
+    for (auto const& result : non_passing_tests) {
+        if (tests[result.test_index].is_wpt_test
+            && tests[result.test_index].subtest_count.value_or(0) == 0
+            && result.result == TestResult::Pass) {
+            ++wpt_subtests_passed;
+        }
+    }
     // Write results.js (as JS to avoid fetch CORS issues with file://)
     StringBuilder js;
     js.append("const RESULTS_DATA = {\n"sv);
-    js.appendff("  \"summary\": {{ \"total\": {}, \"fail\": {}, \"timeout\": {}, \"crashed\": {}, \"skipped\": {} }},\n",
+    js.appendff("  \"summary\": {{ \"total\": {}, \"fail\": {}, \"timeout\": {}, \"crashed\": {}, \"skipped\": {}",
         total_tests(),
         display.fail_count,
         display.timeout_count,
         display.crashed_count,
         display.skipped_count);
-    js.appendff("  \"generatedAt\": {},\n", generated_at.seconds_since_epoch());
+    if (wpt_total > 0) {
+        js.appendff(", \"wptTotal\": {}", wpt_total);
+    }
+    if (wpt_subtest_count > 0) {
+        js.appendff(", \"wptSubtestsPassed\": {}, \"wptSubtestCount\": {}",
+            wpt_subtests_passed,
+            wpt_subtest_count);
+    }
+    js.appendff(" }},\n  \"generatedAt\": {},\n", generated_at.seconds_since_epoch());
     js.appendff("  \"invocationCommandLine\": {},\n", JsonValue(app.invocation_command_line).serialized());
     js.appendff("  \"hasLogs\": {},\n", has_helper_logs ? "true" : "false");
     js.append("  \"tests\": [\n"sv);
@@ -319,12 +352,24 @@ static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpa
         auto const& test = tests[result.test_index];
         auto base_path = TRY(prepare_output_path(test));
         bool has_std_logs = FileSystem::exists(ByteString::formatted("{}.logs.html", base_path));
+        bool has_image_result = (test.mode == TestMode::Ref || test.mode == TestMode::Screenshot)
+            && FileSystem::exists(ByteString::formatted("{}.actual.png", base_path))
+            && FileSystem::exists(ByteString::formatted("{}.expected.png", base_path));
+        bool has_wpt_result = test.is_wpt_test
+            && test.mode == TestMode::Text
+            && test.expectation_path.is_empty()
+            && FileSystem::exists(ByteString::formatted("{}.wpt.html", base_path));
 
-        js.appendff("    {{ \"name\": \"{}\", \"result\": \"{}\", \"mode\": \"{}\", \"hasLogs\": {}",
+        js.appendff("    {{ \"name\": \"{}\", \"result\": \"{}\", \"mode\": \"{}\", \"isWptTest\": {}, \"hasLogs\": {}, \"hasImageResult\": {}, \"hasWptResult\": {}",
             test.safe_relative_path,
             test_result_to_string(result.result),
             test_mode_to_string(test.mode),
-            has_std_logs ? "true" : "false");
+            test.is_wpt_test ? "true" : "false",
+            has_std_logs ? "true" : "false",
+            has_image_result ? "true" : "false",
+            has_wpt_result ? "true" : "false");
+        if (test.is_wpt_test && test.subtest_count.value_or(0) > 0)
+            js.appendff(", \"subtestsPassed\": {}, \"subtestCount\": {}", test.subtests_passed, test.subtest_count.value());
         if ((test.mode == TestMode::Ref || test.mode == TestMode::Screenshot) && test.diff_pixel_error_count > 0)
             js.appendff(", \"pixelErrors\": {}, \"maxChannelDiff\": {}", test.diff_pixel_error_count, test.diff_maximum_error);
         js.append(" }"sv);
@@ -350,6 +395,7 @@ static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpa
 static ErrorOr<void> write_test_diff_to_results(Test const& test, ByteBuffer const& expectation)
 {
     auto base_path = TRY(prepare_output_path(test));
+    TRY(Core::Directory::create(LexicalPath { base_path }.dirname(), Core::Directory::CreateDirectories::Yes));
 
     // Write expected output
     auto expected_path = ByteString::formatted("{}.expected.txt", base_path);
@@ -468,6 +514,9 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
     auto handle_completed_test = [&context, test_index, url]() -> ErrorOr<TestResult> {
         auto& test = context.tests[test_index];
         if (test.expectation_path.is_empty()) {
+            if (test.is_wpt_test && test.mode == TestMode::Text)
+                return on_wpt_test_result(test, url);
+
             if (test.mode != TestMode::Crash)
                 outln("{}", test.text);
             return TestResult::Pass;
@@ -539,7 +588,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
                 });
             });
         };
-    } else if (test.mode == TestMode::Text) {
+    } else if (test.mode == TestMode::Text && !test.is_wpt_test) {
         // Set up variant detection callback.
         view.on_test_variant_metadata = [&view, &context, test_index, on_test_complete](JsonValue metadata) {
             // Verify this IPC response is for the current test on this view (use index to avoid dangling pointer issues)
@@ -604,6 +653,23 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
             if (test.did_finish_loading && test.did_check_variants)
                 on_test_complete();
         };
+    } else if (test.mode == TestMode::Text && test.is_wpt_test) {
+        view.on_load_finish = [on_test_complete, url, &context, test_index](auto const& loaded_url) {
+            if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
+                return;
+
+            auto& test = context.tests[test_index];
+            test.did_finish_loading = true;
+            if (test.did_finish_test)
+                on_test_complete();
+        };
+        view.on_test_finish = [&context, test_index, on_test_complete](auto const& text) {
+            auto& test = context.tests[test_index];
+            test.text = text;
+            test.did_finish_test = true;
+            if (test.did_finish_loading)
+                on_test_complete();
+        };
     } else if (test.mode == TestMode::Crash) {
         view.on_load_finish = [on_test_complete, url, &view, &context, test_index](auto const& loaded_url) {
             // We don't want subframe loads to trigger the test finish.
@@ -632,6 +698,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
 
 static ErrorOr<void> dump_screenshot_to_file(Gfx::Bitmap const& bitmap, StringView path)
 {
+    TRY(Core::Directory::create(LexicalPath { path }.dirname(), Core::Directory::CreateDirectories::Yes));
     auto screenshot_file = TRY(Core::File::open(path, Core::File::OpenMode::Write));
     auto encoded_data = TRY(Gfx::PNGWriter::encode(bitmap));
     TRY(screenshot_file->write_until_depleted(encoded_data));
@@ -937,20 +1004,24 @@ static void run_test(TestWebView& view, TestRunContext& context, size_t test_ind
         auto& test = context.tests[test_index];
         test.did_start_test = true;
 
-        auto real_path = MUST(FileSystem::real_path(test.input_path));
-        auto headers_path = ByteString::formatted("{}.headers", real_path);
-
         Optional<URL::URL> url;
-        if (FileSystem::exists(headers_path) || s_loaded_from_http_server.contains_slow(test.input_path)) {
-            // Some tests need to be served via the echo server so, for example, HTTP headers from .headers files are
-            // sent, or so that the resulting HTML document has a HTTP based origin (e.g for testing cookies).
-            auto echo_server_port = Application::web_content_options().echo_server_port;
-            VERIFY(echo_server_port.has_value());
-            auto relative_path = LexicalPath::relative_path(real_path, app.test_root_path);
-            VERIFY(relative_path.has_value());
-            url = URL::Parser::basic_parse(ByteString::formatted("http://localhost:{}/static/{}", echo_server_port.value(), relative_path.value())).release_value();
+        if (test.is_wpt_test) {
+            url = wpt_url(test.relative_path);
         } else {
-            url = URL::create_with_file_scheme(real_path).release_value();
+            auto real_path = MUST(FileSystem::real_path(test.input_path));
+            auto headers_path = ByteString::formatted("{}.headers", real_path);
+
+            if (FileSystem::exists(headers_path) || s_loaded_from_http_server.contains_slow(test.input_path)) {
+                // Some tests need to be served via the echo server so, for example, HTTP headers from .headers files are
+                // sent, or so that the resulting HTML document has a HTTP based origin (e.g for testing cookies).
+                auto echo_server_port = Application::web_content_options().echo_server_port;
+                VERIFY(echo_server_port.has_value());
+                auto relative_path = LexicalPath::relative_path(real_path, app.test_root_path);
+                VERIFY(relative_path.has_value());
+                url = URL::Parser::basic_parse(ByteString::formatted("http://localhost:{}/static/{}", echo_server_port.value(), relative_path.value())).release_value();
+            } else {
+                url = URL::create_with_file_scheme(real_path).release_value();
+            }
         }
 
         // Append variant query string if present (variant is "?foo=bar", set_query expects "foo=bar")
@@ -1047,60 +1118,70 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
     Vector<Test> tests;
 
-    // Parse explicit variants from filters (e.g., "test.html?variant=foo")
-    HashMap<ByteString, String> explicit_variants;
-    for (auto& glob : app.test_globs) {
-        if (auto query_pos = glob.find('?'); query_pos.has_value()) {
-            auto base_glob = glob.substring(0, query_pos.value());
-            auto variant = MUST(String::from_utf8(glob.substring_view(query_pos.value())));
-            explicit_variants.set(ByteString::formatted("*{}*", base_glob), variant);
-            glob = ByteString::formatted("*{}*", base_glob);
-        } else {
-            glob = ByteString::formatted("*{}*", glob);
+    if (app.should_collect_regular_tests()) {
+        // Parse explicit variants from filters (e.g., "test.html?variant=foo")
+        HashMap<ByteString, String> explicit_variants;
+        for (auto& glob : app.test_globs) {
+            if (auto query_pos = glob.find('?'); query_pos.has_value()) {
+                auto base_glob = glob.substring(0, query_pos.value());
+                auto variant = MUST(String::from_utf8(glob.substring_view(query_pos.value())));
+                explicit_variants.set(ByteString::formatted("*{}*", base_glob), variant);
+                glob = ByteString::formatted("*{}*", base_glob);
+            } else {
+                glob = ByteString::formatted("*{}*", glob);
+            }
         }
-    }
-    if (app.test_globs.is_empty())
-        app.test_globs.append("*"sv);
+        if (app.test_globs.is_empty() && !app.has_wpt_filters())
+            app.test_globs.append("*"sv);
 
-    TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Layout", app.test_root_path), "."sv, TestMode::Layout));
-    TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Text", app.test_root_path), "."sv, TestMode::Text));
-    TRY(collect_ref_tests(app, tests, ByteString::formatted("{}/Ref", app.test_root_path), "."sv));
-    TRY(collect_crash_tests(app, tests, ByteString::formatted("{}/Crash", app.test_root_path), "."sv));
-    TRY(collect_screenshot_tests(app, tests, ByteString::formatted("{}/Screenshot", app.test_root_path), "."sv));
+        TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Layout", app.test_root_path), "."sv, TestMode::Layout));
+        TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Text", app.test_root_path), "."sv, TestMode::Text));
+        TRY(collect_ref_tests(app, tests, ByteString::formatted("{}/Ref", app.test_root_path), "."sv));
+        TRY(collect_crash_tests(app, tests, ByteString::formatted("{}/Crash", app.test_root_path), "."sv));
+        TRY(collect_screenshot_tests(app, tests, ByteString::formatted("{}/Screenshot", app.test_root_path), "."sv));
 
-    tests.remove_all_matching([&](auto const& test) {
-        static constexpr Array support_file_patterns {
-            "*/wpt-import/*/support/*"sv,
-            "*/wpt-import/*/resources/*"sv,
-            "*/wpt-import/common/*"sv,
-            "*/wpt-import/images/*"sv,
-        };
-        auto normalize_path = [](ByteString const& path) { return path.replace("\\"sv, "/"sv); };
-        auto const test_input_path = normalize_path(test.input_path);
-        auto const test_relative_path = normalize_path(test.relative_path);
-        bool is_support_file = any_of(support_file_patterns, [&](auto pattern) { return test_input_path.matches(pattern); });
-        bool match_glob = any_of(app.test_globs, [&](auto const& glob) { return test_relative_path.matches(glob, CaseSensitivity::CaseSensitive); });
-        return is_support_file || !match_glob;
-    });
+        tests.remove_all_matching([&](auto const& test) {
+            if (test.is_wpt_test)
+                return false;
 
-    // Apply explicit variants from filters
-    for (auto& test : tests) {
-        for (auto const& [glob, variant] : explicit_variants) {
-            if (test.relative_path.matches(glob, CaseSensitivity::CaseSensitive)) {
-                test.variant = variant;
-                auto variant_suffix = variant.bytes_as_string_view().substring_view(1);
-                test.relative_path = ByteString::formatted("{}?{}", test.relative_path, variant_suffix);
-                test.safe_relative_path = ByteString::formatted("{}@{}", test.safe_relative_path, variant_suffix);
-                auto dir = LexicalPath::dirname(test.expectation_path);
-                auto title = LexicalPath::title(LexicalPath::basename(test.input_path));
-                if (dir.is_empty())
-                    test.expectation_path = ByteString::formatted("{}@{}.txt", title, variant_suffix);
-                else
-                    test.expectation_path = ByteString::formatted("{}/{}@{}.txt", dir, title, variant_suffix);
-                break;
+            static constexpr Array support_file_patterns {
+                "*/wpt-import/*/support/*"sv,
+                "*/wpt-import/*/resources/*"sv,
+                "*/wpt-import/common/*"sv,
+                "*/wpt-import/images/*"sv,
+            };
+            auto normalize_path = [](ByteString const& path) { return path.replace("\\"sv, "/"sv); };
+            auto const test_input_path = normalize_path(test.input_path);
+            auto const test_relative_path = normalize_path(test.relative_path);
+            bool is_support_file = any_of(support_file_patterns, [&](auto pattern) { return test_input_path.matches(pattern); });
+            bool match_glob = !app.test_globs.is_empty() && any_of(app.test_globs, [&](auto const& glob) { return test_relative_path.matches(glob, CaseSensitivity::CaseSensitive); });
+            return is_support_file || !match_glob;
+        });
+
+        // Apply explicit variants from filters
+        for (auto& test : tests) {
+            if (test.is_wpt_test)
+                continue;
+
+            for (auto const& [glob, variant] : explicit_variants) {
+                if (test.relative_path.matches(glob, CaseSensitivity::CaseSensitive)) {
+                    test.variant = variant;
+                    auto variant_suffix = variant.bytes_as_string_view().substring_view(1);
+                    test.relative_path = ByteString::formatted("{}?{}", test.relative_path, variant_suffix);
+                    test.safe_relative_path = ByteString::formatted("{}@{}", test.safe_relative_path, variant_suffix);
+                    auto dir = LexicalPath::dirname(test.expectation_path);
+                    auto title = LexicalPath::title(LexicalPath::basename(test.input_path));
+                    if (dir.is_empty())
+                        test.expectation_path = ByteString::formatted("{}@{}.txt", title, variant_suffix);
+                    else
+                        test.expectation_path = ByteString::formatted("{}/{}@{}.txt", dir, title, variant_suffix);
+                    break;
+                }
             }
         }
     }
+
+    TRY(collect_wpt_tests(tests));
 
     if (app.shuffle)
         shuffle(tests);
@@ -1115,7 +1196,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     }
 
     if (tests.is_empty()) {
-        if (app.test_globs.is_empty())
+        if (app.test_globs.is_empty() && app.wpt_filters.is_empty())
             return Error::from_string_literal("No tests found");
         return Error::from_string_literal("No tests found matching filter");
     }
@@ -1399,11 +1480,13 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     VERIFY(!app->test_root_path.is_empty());
 
     app->test_root_path = LexicalPath::absolute_path(TRY(FileSystem::current_working_directory()), app->test_root_path);
+    app->wpt_path = LexicalPath::join(app->test_root_path, "WPT"sv, "wpt"sv).string();
 
     app->results_directory = LexicalPath::absolute_path(TRY(FileSystem::current_working_directory()), app->results_directory);
     TRY(Core::Directory::create(app->results_directory, Core::Directory::CreateDirectories::Yes));
 
-    TRY(app->launch_test_fixtures());
+    if (!app->test_dry_run)
+        TRY(app->launch_test_fixtures());
 
     return TestWeb::run_tests(theme, window_size);
 }

--- a/Tests/LibWeb/test-web/results-index.html
+++ b/Tests/LibWeb/test-web/results-index.html
@@ -112,6 +112,9 @@
             margin-bottom: 24px;
         }
 
+        .accent-red { color: var(--accent-red) !important; }
+        .accent-orange { color: var(--accent-orange) !important; }
+
         .stat-card {
             background: var(--bg-secondary);
             border: 1px solid var(--border-primary);
@@ -157,6 +160,10 @@
         .stat-card.timeout .stat-value { color: var(--accent-orange); }
         .stat-card.crashed .stat-value { color: var(--accent-purple); }
         .stat-card.skipped .stat-value { color: var(--text-muted); }
+        .subtests { 
+            color: var(--text-secondary);
+            border-color: var(--text-secondary);
+        }
 
         .stat-label {
             font-size: 12px;
@@ -241,8 +248,8 @@
             font-weight: 600;
             padding: 4px 8px;
             border-radius: 4px;
-            background: var(--bg-tertiary);
             color: var(--text-secondary);
+            background: var(--bg-tertiary);
             border: 1px solid var(--border-primary);
         }
 
@@ -251,6 +258,10 @@
             font-size: 13px;
             color: var(--text-primary);
             word-break: break-all;
+        }
+
+        .wpt {
+            color: var(--text-secondary);
         }
 
         .copy-btn {
@@ -558,6 +569,13 @@
             color: var(--accent-red);
         }
 
+        .fake-wpt-summary {
+            padding: 16px;
+            font-family: var(--font-mono);
+            font-size: 12px;
+            color: var(--text-primary);
+        }
+
         .loading {
             display: flex;
             align-items: center;
@@ -631,6 +649,7 @@
 
         let currentIndex = -1;
         let testElements = [];
+        let resultsByTestId = new Map();
 
         function setCopyButtonContents(btn, icon) {
             if (btn.id !== 'copy-run-command-btn') return btn.innerHTML = icon;
@@ -661,8 +680,9 @@
             const content = document.getElementById('content');
 
             const items = data.hasLogs
-                ? [{ name: 'test-dumps/results/helper-process-logs.html', mode: 'LOGS', inlineFileResult: 'helper-process-logs.html' }, ...data.tests]
+                ? [{ name: 'helper-process-logs.html', mode: 'LOGS', inlineFileResult: 'helper-process-logs.html' }, ...data.tests]
                 : data.tests;
+            resultsByTestId = new Map(items.map(item => [item.name.replace(/[^a-zA-Z0-9]/g, '-'), item]));
 
             let html = `
                 <div class="summary">
@@ -682,10 +702,13 @@
                         <div class="stat-value">${data.summary.crashed}</div>
                         <div class="stat-label">Crashed</div>
                     </div>
-                    <div class="stat-card skipped">
+                    ${data.summary.wptSubtestCount > 0 ? `<div class="stat-card subtests">
+                        <div class="stat-value">${data.summary.wptSubtestsPassed}/${data.summary.wptSubtestCount}</div>
+                        <div class="stat-label">WPT Subtests</div>
+                    </div>` : `<div class="stat-card skipped">
                         <div class="stat-value">${data.summary.skipped}</div>
                         <div class="stat-label">Skipped</div>
-                    </div>
+                    </div>`}
                 </div>
                 <div class="test-list" id="testList">
             `;
@@ -703,13 +726,12 @@
         function renderResultItem(item) {
             const testId = item.name.replace(/[^a-zA-Z0-9]/g, '-');
             const tabs = item.inlineFileResult ? null : buildTabs(item);
-
             let html = `
                 <div class="test-item" data-name="${item.name.toLowerCase()}" id="test-${testId}">
                     <div class="test-header" onclick="toggleTest('${testId}')">
                         ${item.result ? `<span class="result-badge ${item.result}">${item.result}</span>` : ''}
-                        ${item.mode ? `<span class="mode-badge">${item.mode}</span>` : ''}
-                        <span class="test-name">${item.name}</span>
+                        ${modeHtml(item)}
+                        <span class="${item.isWptTest ? 'test-name wpt' : 'test-name'}">${item.name}</span>
                         ${item.result ? `<button class="copy-btn" onclick="copyText(event, this, '${item.name}')" title="Copy test path">${copySvg}</button>` : ''}
                         <span class="expand-icon">&#9654;</span>
                     </div>
@@ -726,17 +748,56 @@
             return html;
         }
 
+        function modeHtml(test) {
+            if (!test.mode) return '';
+            if (test.subtestCount) {
+                const colorClass = test.subtestsPassed === 0 ? 'accent-red' : 'accent-orange';
+                const label = test.isWptTest ? `WPT ${test.subtestsPassed}/${test.subtestCount}` : `${test.subtestsPassed}/${test.subtestCount}`;
+                return `<span class="mode-badge ${colorClass}">${label}</span>`;
+            }
+            if (test.isWptTest && test.mode === 'Ref') {
+                return `<span class="mode-badge accent-red">WPT Ref</span>`;
+            }
+            if (test.isWptTest && test.mode === 'Text') {
+                return `<span class="mode-badge accent-red">WPT Text</span>`;
+            }
+            return `<span class="mode-badge">${test.mode}</span>`;
+        }
+
+        function renderFakeWptSummaryTab(test) {
+            const fields = [
+                ['Test', test.name],
+                ['Result', test.result || 'Unknown'],
+                ['Mode', test.mode || 'Unknown'],
+            ];
+            if (test.subtestCount) {
+                fields.push(['WPT subtests', `${test.subtestsPassed}/${test.subtestCount}`]);
+            }
+            if (test.pixelErrors !== undefined) {
+                fields.push(['Pixel errors', String(test.pixelErrors)]);
+                fields.push(['Max channel diff', String(test.maxChannelDiff)]);
+            }
+            const rows = fields.map(([label, value]) => `<div class="ctx">${label}: ${value}</div>`).join('');
+            return `<div class="fake-wpt-summary">${rows}</div>`;
+        }
+
         function buildTabs(test) {
             let tabs = [];
 
-            if (test.mode === 'Layout' || test.mode === 'Text') {
+            if (test.isWptTest) {
+                if (test.hasWptResult) {
+                    tabs.push({ id: 'summary', label: 'Summary', file: `${test.name}.wpt.html`, type: 'text' });
+                } else {
+                    tabs.push({ id: 'summary', label: 'Summary', type: 'summary' });
+                }
+            } else if (test.mode === 'Layout' || test.mode === 'Text') {
                 tabs.push({ id: 'diff', label: 'Diff', file: `${test.name}.diff.html`, type: 'diff' });
                 tabs.push({ id: 'expected', label: 'Expected', file: `${test.name}.expected.txt`, type: 'text' });
                 tabs.push({ id: 'actual', label: 'Actual', file: `${test.name}.actual.txt`, type: 'text' });
-            } else if (test.mode === 'Ref' || test.mode === 'Screenshot') {
+            }
+            if ((test.mode === 'Ref' || test.mode === 'Screenshot') && test.hasImageResult) {
                 tabs.push({ id: 'compare', label: 'Compare', expected: `${test.name}.expected.png`, actual: `${test.name}.actual.png`, diff: `${test.name}.diff.png`, pixelErrors: test.pixelErrors, maxChannelDiff: test.maxChannelDiff, type: 'imageDiff' });
             }
-
             if (test.hasLogs) tabs.push({ id: 'std-logs', label: 'std logs', file: `${test.name}.logs.html`, type: 'text' });
 
             const bar = tabs.map((t, i) =>
@@ -782,8 +843,11 @@
             btn.classList.add('active');
 
             const container = document.getElementById(`preview-${testId}`);
+            const test = resultsByTestId.get(testId);
 
-            if (tab.type === 'diff' || tab.type === 'text') {
+            if (tab.type === 'summary') {
+                container.innerHTML = renderFakeWptSummaryTab(test);
+            } else if (tab.type === 'diff' || tab.type === 'text') {
                 container.innerHTML = `<iframe class="preview-frame" src="${tab.file}"></iframe>`;
             } else if (tab.type === 'image') {
                 container.innerHTML = `<img class="preview-image" src="${tab.file}" alt="${tab.label}">`;


### PR DESCRIPTION
Similar to `-f`/`--filter`, `-w`/`--wpt` searches and runs tests within the gitignored `WPT/wpt` directory.

We use the upstream `WPT/wpt/serve/serve.py` test server for max compatibility.

There are no expectation files and no need to import. This is for development and debugging, not CI. You run tests and the failures show up in `results/index.html`. That's it.

For example:
```
Build/release/bin/test-web -t 3 -f Element-scrollby -w normal-flow
```
Will get you:

<img width="907" height="565" alt="test-web-wpt" src="https://github.com/user-attachments/assets/74ad21fa-e45a-4b2a-b66c-b30a38dfd3b9" />
