### PR TITLE
LibGfx/LibMedia: Implement video color conversion for CPU painting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libgfx_rust"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+ "yuv",
+]
+
+[[package]]
 name = "libjs_rust"
 version = "0.1.0"
 dependencies = [
@@ -890,6 +898,15 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "yuv"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d3a7e2cda3061858987ee2fb028f61695f5ee13f9490d75be6c3900df9a4ea"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "Libraries/LibGfx/Rust",
     "Libraries/LibJS/Rust",
     "Libraries/LibRegex/Rust",
     "Libraries/LibUnicode/Rust",

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -118,6 +118,9 @@ find_package(harfbuzz REQUIRED)
 target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
             WebP::webpdemux WebP::libwebpmux skia harfbuzz)
 
+import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libgfx_rust FFI_HEADER RustFFI.h)
+target_link_libraries(LibGfx PRIVATE libgfx_rust)
+
 if (HAS_FONTCONFIG)
     target_link_libraries(LibGfx PRIVATE Fontconfig::Fontconfig)
 endif()

--- a/Libraries/LibGfx/ColorSpace.cpp
+++ b/Libraries/LibGfx/ColorSpace.cpp
@@ -57,8 +57,6 @@ ErrorOr<ColorSpace> ColorSpace::from_cicp(Media::CodingIndependentCodePoints cic
 
         auto primaries = TRY([&] -> ErrorOr<SkColorSpacePrimaries> {
             switch (cicp.color_primaries()) {
-            case Media::ColorPrimaries::Reserved:
-                break;
             case Media::ColorPrimaries::BT709:
             case Media::ColorPrimaries::Unspecified:
                 return SkNamedPrimaries::kRec709;
@@ -92,8 +90,6 @@ ErrorOr<ColorSpace> ColorSpace::from_cicp(Media::CodingIndependentCodePoints cic
 
     auto transfer_function = TRY([&] -> ErrorOr<skcms_TransferFunction> {
         switch (cicp.transfer_characteristics()) {
-        case Media::TransferCharacteristics::Reserved:
-            break;
         case Media::TransferCharacteristics::BT709:
         case Media::TransferCharacteristics::Unspecified:
             return SkNamedTransferFn::kRec709;

--- a/Libraries/LibGfx/ColorSpace.cpp
+++ b/Libraries/LibGfx/ColorSpace.cpp
@@ -51,12 +51,6 @@ ColorSpace::ColorSpace(NonnullOwnPtr<Details::ColorSpaceImpl>&& color_space)
 
 ErrorOr<ColorSpace> ColorSpace::from_cicp(Media::CodingIndependentCodePoints cicp)
 {
-    if (cicp.matrix_coefficients() != Media::MatrixCoefficients::Identity)
-        return Error::from_string_literal("Unsupported matrix coefficients for CICP");
-
-    if (cicp.video_full_range_flag() != Media::VideoFullRangeFlag::Full)
-        return Error::from_string_literal("Unsupported matrix coefficients for CICP");
-
     auto gamut = TRY([&] -> ErrorOr<skcms_Matrix3x3> {
         if (cicp.color_primaries() == Media::ColorPrimaries::XYZ)
             return SkNamedGamut::kXYZ;

--- a/Libraries/LibGfx/ColorSpace.cpp
+++ b/Libraries/LibGfx/ColorSpace.cpp
@@ -92,13 +92,17 @@ ErrorOr<ColorSpace> ColorSpace::from_cicp(Media::CodingIndependentCodePoints cic
         switch (cicp.transfer_characteristics()) {
         case Media::TransferCharacteristics::BT709:
         case Media::TransferCharacteristics::Unspecified:
-            return SkNamedTransferFn::kRec709;
+        case Media::TransferCharacteristics::BT601:
+        case Media::TransferCharacteristics::BT2020BitDepth10:
+        case Media::TransferCharacteristics::BT2020BitDepth12:
+            // This isn't technically correct, but Chromium has set the precedent that these are treated as sRGB as an
+            // optimization. Using the actual transfer characteristics will produce output inconsistent with other
+            // browsers, so we unfortunately have to follow suit.
+            return SkNamedTransferFn::kSRGB;
         case Media::TransferCharacteristics::BT470M:
             return SkNamedTransferFn::kRec470SystemM;
         case Media::TransferCharacteristics::BT470BG:
             return SkNamedTransferFn::kRec470SystemBG;
-        case Media::TransferCharacteristics::BT601:
-            return SkNamedTransferFn::kRec601;
         case Media::TransferCharacteristics::SMPTE240:
             return SkNamedTransferFn::kSMPTE_ST_240;
         case Media::TransferCharacteristics::Linear:
@@ -112,10 +116,6 @@ ErrorOr<ColorSpace> ColorSpace::from_cicp(Media::CodingIndependentCodePoints cic
             return Error::from_string_literal("BT.1361 transfer characteristics are not supported.");
         case Media::TransferCharacteristics::SRGB:
             return SkNamedTransferFn::kSRGB;
-        case Media::TransferCharacteristics::BT2020BitDepth10:
-            return SkNamedTransferFn::kRec2020_10bit;
-        case Media::TransferCharacteristics::BT2020BitDepth12:
-            return SkNamedTransferFn::kRec2020_12bit;
         case Media::TransferCharacteristics::SMPTE2084:
             return SkNamedTransferFn::kPQ;
         case Media::TransferCharacteristics::SMPTE428:

--- a/Libraries/LibGfx/ColorSpace.cpp
+++ b/Libraries/LibGfx/ColorSpace.cpp
@@ -57,41 +57,86 @@ ErrorOr<ColorSpace> ColorSpace::from_cicp(Media::CodingIndependentCodePoints cic
     if (cicp.video_full_range_flag() != Media::VideoFullRangeFlag::Full)
         return Error::from_string_literal("Unsupported matrix coefficients for CICP");
 
-    skcms_Matrix3x3 gamut = SkNamedGamut::kSRGB;
-    switch (cicp.color_primaries()) {
-    case Media::ColorPrimaries::BT709:
-        gamut = SkNamedGamut::kSRGB;
-        break;
-    case Media::ColorPrimaries::BT2020:
-        gamut = SkNamedGamut::kRec2020;
-        break;
-    case Media::ColorPrimaries::XYZ:
-        gamut = SkNamedGamut::kXYZ;
-        break;
-    case Media::ColorPrimaries::SMPTE432:
-        gamut = SkNamedGamut::kDisplayP3;
-        break;
-    default:
-        return Error::from_string_literal("FIXME: Unsupported color primaries");
-    }
+    auto gamut = TRY([&] -> ErrorOr<skcms_Matrix3x3> {
+        if (cicp.color_primaries() == Media::ColorPrimaries::XYZ)
+            return SkNamedGamut::kXYZ;
 
-    skcms_TransferFunction transfer_function = SkNamedTransferFn::kSRGB;
-    switch (cicp.transfer_characteristics()) {
-    case Media::TransferCharacteristics::Linear:
-        transfer_function = SkNamedTransferFn::kLinear;
-        break;
-    case Media::TransferCharacteristics::SRGB:
-        transfer_function = SkNamedTransferFn::kSRGB;
-        break;
-    case Media::TransferCharacteristics::SMPTE2084:
-        transfer_function = SkNamedTransferFn::kPQ;
-        break;
-    case Media::TransferCharacteristics::HLG:
-        transfer_function = SkNamedTransferFn::kHLG;
-        break;
-    default:
-        return Error::from_string_literal("FIXME: Unsupported transfer function");
-    }
+        auto primaries = TRY([&] -> ErrorOr<SkColorSpacePrimaries> {
+            switch (cicp.color_primaries()) {
+            case Media::ColorPrimaries::Reserved:
+                break;
+            case Media::ColorPrimaries::BT709:
+            case Media::ColorPrimaries::Unspecified:
+                return SkNamedPrimaries::kRec709;
+            case Media::ColorPrimaries::BT470M:
+                return SkNamedPrimaries::kRec470SystemM;
+            case Media::ColorPrimaries::BT470BG:
+                return SkNamedPrimaries::kRec470SystemBG;
+            case Media::ColorPrimaries::BT601:
+                return SkNamedPrimaries::kRec601;
+            case Media::ColorPrimaries::SMPTE240:
+                return SkNamedPrimaries::kSMPTE_ST_240;
+            case Media::ColorPrimaries::GenericFilm:
+                return SkNamedPrimaries::kGenericFilm;
+            case Media::ColorPrimaries::BT2020:
+                return SkNamedPrimaries::kRec2020;
+            case Media::ColorPrimaries::XYZ:
+                VERIFY_NOT_REACHED();
+            case Media::ColorPrimaries::SMPTE431:
+                return SkNamedPrimaries::kSMPTE_RP_431_2;
+            case Media::ColorPrimaries::SMPTE432:
+                return SkNamedPrimaries::kSMPTE_EG_432_1;
+            case Media::ColorPrimaries::EBU3213:
+                return SkNamedPrimaries::kITU_T_H273_Value22;
+            }
+            return Error::from_string_literal("Illegal color primaries");
+        }());
+        skcms_Matrix3x3 result;
+        VERIFY(primaries.toXYZD50(&result));
+        return result;
+    }());
+
+    auto transfer_function = TRY([&] -> ErrorOr<skcms_TransferFunction> {
+        switch (cicp.transfer_characteristics()) {
+        case Media::TransferCharacteristics::Reserved:
+            break;
+        case Media::TransferCharacteristics::BT709:
+        case Media::TransferCharacteristics::Unspecified:
+            return SkNamedTransferFn::kRec709;
+        case Media::TransferCharacteristics::BT470M:
+            return SkNamedTransferFn::kRec470SystemM;
+        case Media::TransferCharacteristics::BT470BG:
+            return SkNamedTransferFn::kRec470SystemBG;
+        case Media::TransferCharacteristics::BT601:
+            return SkNamedTransferFn::kRec601;
+        case Media::TransferCharacteristics::SMPTE240:
+            return SkNamedTransferFn::kSMPTE_ST_240;
+        case Media::TransferCharacteristics::Linear:
+            return SkNamedTransferFn::kLinear;
+        case Media::TransferCharacteristics::Log100:
+        case Media::TransferCharacteristics::Log100Sqrt10:
+            return Error::from_string_literal("Logarithmic transfer characteristics are unsupported.");
+        case Media::TransferCharacteristics::IEC61966:
+            return SkNamedTransferFn::kIEC61966_2_4;
+        case Media::TransferCharacteristics::BT1361:
+            return Error::from_string_literal("BT.1361 transfer characteristics are not supported.");
+        case Media::TransferCharacteristics::SRGB:
+            return SkNamedTransferFn::kSRGB;
+        case Media::TransferCharacteristics::BT2020BitDepth10:
+            return SkNamedTransferFn::kRec2020_10bit;
+        case Media::TransferCharacteristics::BT2020BitDepth12:
+            return SkNamedTransferFn::kRec2020_12bit;
+        case Media::TransferCharacteristics::SMPTE2084:
+            return SkNamedTransferFn::kPQ;
+        case Media::TransferCharacteristics::SMPTE428:
+            return SkNamedTransferFn::kSMPTE_ST_428_1;
+        case Media::TransferCharacteristics::HLG:
+            // FIXME: This will need to change to use the HLG transfer function when the surface we're painting to
+            //        supports HDR.
+            return SkNamedTransferFn::kSRGB;
+        }
+        return Error::from_string_literal("Illegal transfer characteristics");
+    }());
 
     return ColorSpace { make<Details::ColorSpaceImpl>(SkColorSpace::MakeRGB(transfer_function, gamut)) };
 }

--- a/Libraries/LibGfx/ColorSpace.cpp
+++ b/Libraries/LibGfx/ColorSpace.cpp
@@ -35,7 +35,8 @@ ColorSpace::ColorSpace(ColorSpace const& other)
 
 ColorSpace& ColorSpace::operator=(ColorSpace const& other)
 {
-    m_color_space = make<Details::ColorSpaceImpl>(other.m_color_space->color_space);
+    if (this != &other)
+        m_color_space = make<Details::ColorSpaceImpl>(other.m_color_space->color_space);
     return *this;
 }
 

--- a/Libraries/LibGfx/ColorSpace.h
+++ b/Libraries/LibGfx/ColorSpace.h
@@ -44,7 +44,7 @@ private:
     template<typename T>
     friend ErrorOr<T> IPC::decode(IPC::Decoder&);
 
-    explicit ColorSpace(NonnullOwnPtr<Details::ColorSpaceImpl>&& color_pace);
+    explicit ColorSpace(NonnullOwnPtr<Details::ColorSpaceImpl>&&);
 
     NonnullOwnPtr<Details::ColorSpaceImpl> m_color_space;
 };

--- a/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
+++ b/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
@@ -50,8 +50,17 @@ static ErrorOr<OwnPtr<ImageDecoderPlugin>> probe_and_sniff_for_appropriate_plugi
 ErrorOr<ColorSpace> ImageDecoder::color_space()
 {
     auto maybe_cicp = TRY(m_plugin->cicp());
-    if (maybe_cicp.has_value())
-        return ColorSpace::from_cicp(*maybe_cicp);
+    if (maybe_cicp.has_value()) {
+        auto cicp = maybe_cicp.release_value();
+
+        if (cicp.matrix_coefficients() != Media::MatrixCoefficients::Identity)
+            return Error::from_string_literal("Unsupported matrix coefficients for CICP");
+
+        if (cicp.video_full_range_flag() != Media::VideoFullRangeFlag::Full)
+            return Error::from_string_literal("Studio range is not supported");
+
+        return ColorSpace::from_cicp(cicp);
+    }
 
     auto maybe_icc_data = TRY(icc_data());
     if (!maybe_icc_data.has_value())

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -151,7 +151,7 @@ ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat 
     if (width > 0 && height > 0) {
         if (format == ExportFormat::RGB888) {
             // 24 bit RGB is not supported by Skia, so we need to handle this format ourselves.
-            auto raw_buffer = buffer.data();
+            auto* raw_buffer = buffer.data();
             for (auto y = 0; y < height; y++) {
                 auto target_y = flags & ExportFlags::FlipY ? height - y - 1 : y;
                 for (auto x = 0; x < width; x++) {
@@ -378,7 +378,7 @@ static SkAlphaType to_skia_alpha_type(Gfx::AlphaType alpha_type)
     }
 }
 
-NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bitmap, ColorSpace color_space)
+NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> const& bitmap, ColorSpace color_space)
 {
     SkBitmap sk_bitmap;
     auto info = SkImageInfo::Make(bitmap->width(), bitmap->height(), to_skia_color_type(bitmap->format()), to_skia_alpha_type(bitmap->alpha_type()), color_space.color_space<sk_sp<SkColorSpace>>());
@@ -390,14 +390,14 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bit
         .context = nullptr,
         .sk_image = move(sk_image),
         .sk_bitmap = move(sk_bitmap),
-        .bitmap = move(bitmap),
+        .bitmap = bitmap,
         .color_space = move(color_space),
         .yuv_data = nullptr,
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
 }
 
-NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bitmap, AlphaType alpha_type, ColorSpace color_space)
+NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> const& bitmap, AlphaType alpha_type, ColorSpace color_space)
 {
     // Convert the source bitmap to the right alpha type on a mismatch. We want to do this when converting from a
     // Bitmap to an ImmutableBitmap, since at that point we usually know the right alpha type to use in context.
@@ -410,7 +410,7 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bit
     return create(source_bitmap, move(color_space));
 }
 
-NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create_snapshot_from_painting_surface(NonnullRefPtr<PaintingSurface> painting_surface)
+NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create_snapshot_from_painting_surface(NonnullRefPtr<PaintingSurface> const& painting_surface)
 {
     painting_surface->lock_context();
     auto sk_image = painting_surface->sk_image_snapshot<sk_sp<SkImage>>();
@@ -427,7 +427,7 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create_snapshot_from_painting_su
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
 }
 
-ImmutableBitmap::ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl> impl)
+ImmutableBitmap::ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl>&& impl)
     : m_impl(move(impl))
 {
 }

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -214,103 +214,16 @@ bool ImmutableBitmap::is_yuv_backed() const
 ErrorOr<NonnullRefPtr<ImmutableBitmap>> ImmutableBitmap::create_from_yuv(NonnullOwnPtr<YUVData> yuv_data)
 {
     // Hold onto the YUVData to lazily create the SkImage later.
+    auto color_space = TRY(ColorSpace::from_cicp(yuv_data->cicp()));
     ImmutableBitmapImpl impl {
         .context = nullptr,
         .sk_image = nullptr,
         .sk_bitmap = {},
         .bitmap = nullptr,
-        .color_space = {},
+        .color_space = move(color_space),
         .yuv_data = move(yuv_data),
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
-}
-
-static sk_sp<SkColorSpace> color_space_from_cicp(Media::CodingIndependentCodePoints const& cicp)
-{
-    auto gamut = [&] {
-        if (cicp.color_primaries() == Media::ColorPrimaries::XYZ)
-            return SkNamedGamut::kXYZ;
-
-        auto primaries = [&] {
-            switch (cicp.color_primaries()) {
-            case Media::ColorPrimaries::Reserved:
-            case Media::ColorPrimaries::Unspecified:
-                return SkNamedPrimaries::kRec709;
-            case Media::ColorPrimaries::XYZ:
-                VERIFY_NOT_REACHED();
-            case Media::ColorPrimaries::BT709:
-                return SkNamedPrimaries::kRec709;
-            case Media::ColorPrimaries::BT470M:
-                return SkNamedPrimaries::kRec470SystemM;
-            case Media::ColorPrimaries::BT470BG:
-                return SkNamedPrimaries::kRec470SystemBG;
-            case Media::ColorPrimaries::BT601:
-                return SkNamedPrimaries::kRec601;
-            case Media::ColorPrimaries::SMPTE240:
-                return SkNamedPrimaries::kSMPTE_ST_240;
-            case Media::ColorPrimaries::GenericFilm:
-                return SkNamedPrimaries::kGenericFilm;
-            case Media::ColorPrimaries::BT2020:
-                return SkNamedPrimaries::kRec2020;
-            case Media::ColorPrimaries::SMPTE431:
-                return SkNamedPrimaries::kSMPTE_RP_431_2;
-            case Media::ColorPrimaries::SMPTE432:
-                return SkNamedPrimaries::kSMPTE_EG_432_1;
-            case Media::ColorPrimaries::EBU3213:
-                return SkNamedPrimaries::kITU_T_H273_Value22;
-            }
-            return SkNamedPrimaries::kRec709;
-        }();
-        skcms_Matrix3x3 result;
-        VERIFY(primaries.toXYZD50(&result));
-        return result;
-    }();
-
-    auto transfer_function = [&] {
-        switch (cicp.transfer_characteristics()) {
-        case Media::TransferCharacteristics::Unspecified:
-        case Media::TransferCharacteristics::Reserved:
-            return SkNamedTransferFn::kRec709;
-        case Media::TransferCharacteristics::BT709:
-            return SkNamedTransferFn::kRec709;
-        case Media::TransferCharacteristics::BT470M:
-            return SkNamedTransferFn::kRec470SystemM;
-        case Media::TransferCharacteristics::BT470BG:
-            return SkNamedTransferFn::kRec470SystemBG;
-        case Media::TransferCharacteristics::BT601:
-            return SkNamedTransferFn::kRec601;
-        case Media::TransferCharacteristics::SMPTE240:
-            return SkNamedTransferFn::kSMPTE_ST_240;
-        case Media::TransferCharacteristics::Linear:
-            return SkNamedTransferFn::kLinear;
-        case Media::TransferCharacteristics::Log100:
-        case Media::TransferCharacteristics::Log100Sqrt10:
-            dbgln("Logarithmic transfer characteristics are not supported, using sRGB.");
-            return SkNamedTransferFn::kSRGB;
-        case Media::TransferCharacteristics::IEC61966:
-            return SkNamedTransferFn::kIEC61966_2_4;
-        case Media::TransferCharacteristics::BT1361:
-            dbgln("BT.1361 transfer characteristics are not supported, using sRGB.");
-            return SkNamedTransferFn::kSRGB;
-        case Media::TransferCharacteristics::SRGB:
-            return SkNamedTransferFn::kSRGB;
-        case Media::TransferCharacteristics::BT2020BitDepth10:
-            return SkNamedTransferFn::kRec2020_10bit;
-        case Media::TransferCharacteristics::BT2020BitDepth12:
-            return SkNamedTransferFn::kRec2020_12bit;
-        case Media::TransferCharacteristics::SMPTE2084:
-            return SkNamedTransferFn::kPQ;
-        case Media::TransferCharacteristics::SMPTE428:
-            return SkNamedTransferFn::kSMPTE_ST_428_1;
-        case Media::TransferCharacteristics::HLG:
-            // FIXME: This will need to change to use the HLG transfer function when the surface we're painting to
-            //        supports HDR.
-            return SkNamedTransferFn::kSRGB;
-        }
-        return SkNamedTransferFn::kRec709;
-    }();
-
-    return SkColorSpace::MakeRGB(transfer_function, gamut);
 }
 
 bool ImmutableBitmap::ensure_sk_image(SkiaBackendContext& context) const
@@ -348,14 +261,13 @@ bool ImmutableBitmap::ensure_sk_image(SkiaBackendContext& context) const
     if (m_impl->yuv_data->bit_depth() > 8)
         m_impl->yuv_data->expand_samples_to_full_16_bit_range();
     auto pixmaps = m_impl->yuv_data->make_pixmaps();
-    auto color_space = color_space_from_cicp(m_impl->yuv_data->cicp());
 
     auto sk_image = SkImages::TextureFromYUVAPixmaps(
         gr_context,
         pixmaps,
         skgpu::Mipmapped::kNo,
         false,
-        color_space);
+        m_impl->color_space.color_space<sk_sp<SkColorSpace>>());
 
     if (!sk_image)
         return false;

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -345,7 +345,9 @@ bool ImmutableBitmap::ensure_sk_image(SkiaBackendContext& context) const
     if (!gr_context)
         return false; // No GPU, cannot create image from YUV data
 
-    auto const& pixmaps = m_impl->yuv_data->skia_yuva_pixmaps();
+    if (m_impl->yuv_data->bit_depth() > 8)
+        m_impl->yuv_data->expand_samples_to_full_16_bit_range();
+    auto pixmaps = m_impl->yuv_data->make_pixmaps();
     auto color_space = color_space_from_cicp(m_impl->yuv_data->cicp());
 
     auto sk_image = SkImages::TextureFromYUVAPixmaps(
@@ -360,6 +362,7 @@ bool ImmutableBitmap::ensure_sk_image(SkiaBackendContext& context) const
 
     m_impl->context = context;
     m_impl->sk_image = move(sk_image);
+    m_impl->yuv_data = nullptr;
     return true;
 }
 

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -208,8 +208,10 @@ ErrorOr<NonnullRefPtr<ImmutableBitmap>> ImmutableBitmap::create_from_yuv(Nonnull
     auto context = SkiaBackendContext::the();
     auto* gr_context = context ? context->sk_context() : nullptr;
 
-    if (!gr_context)
-        return Error::from_string_literal("GPU context is unavailable");
+    if (!gr_context) {
+        auto bitmap = TRY(yuv_data->to_bitmap());
+        return create(move(bitmap), move(color_space));
+    }
 
     if (yuv_data->bit_depth() > 8)
         yuv_data->expand_samples_to_full_16_bit_range();

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -303,7 +303,9 @@ static sk_sp<SkColorSpace> color_space_from_cicp(Media::CodingIndependentCodePoi
         case Media::TransferCharacteristics::SMPTE428:
             return SkNamedTransferFn::kSMPTE_ST_428_1;
         case Media::TransferCharacteristics::HLG:
-            return SkNamedTransferFn::kHLG;
+            // FIXME: This will need to change to use the HLG transfer function when the surface we're painting to
+            //        supports HDR.
+            return SkNamedTransferFn::kSRGB;
         }
         return SkNamedTransferFn::kRec709;
     }();

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -41,20 +41,15 @@ struct ImmutableBitmapImpl {
     SkBitmap sk_bitmap;
     RefPtr<Gfx::Bitmap> bitmap;
     ColorSpace color_space;
-    OwnPtr<YUVData> yuv_data;
 };
 
 int ImmutableBitmap::width() const
 {
-    if (m_impl->yuv_data)
-        return m_impl->yuv_data->size().width();
     return m_impl->sk_image->width();
 }
 
 int ImmutableBitmap::height() const
 {
-    if (m_impl->yuv_data)
-        return m_impl->yuv_data->size().height();
     return m_impl->sk_image->height();
 }
 
@@ -206,22 +201,37 @@ RefPtr<Gfx::Bitmap const> ImmutableBitmap::bitmap() const
     return m_impl->bitmap;
 }
 
-bool ImmutableBitmap::is_yuv_backed() const
-{
-    return m_impl->yuv_data != nullptr;
-}
-
 ErrorOr<NonnullRefPtr<ImmutableBitmap>> ImmutableBitmap::create_from_yuv(NonnullOwnPtr<YUVData> yuv_data)
 {
-    // Hold onto the YUVData to lazily create the SkImage later.
     auto color_space = TRY(ColorSpace::from_cicp(yuv_data->cicp()));
+
+    auto context = SkiaBackendContext::the();
+    auto* gr_context = context ? context->sk_context() : nullptr;
+
+    if (!gr_context)
+        return Error::from_string_literal("GPU context is unavailable");
+
+    if (yuv_data->bit_depth() > 8)
+        yuv_data->expand_samples_to_full_16_bit_range();
+
+    context->lock();
+    auto sk_image = SkImages::TextureFromYUVAPixmaps(
+        gr_context,
+        yuv_data->make_pixmaps(),
+        skgpu::Mipmapped::kNo,
+        false,
+        color_space.color_space<sk_sp<SkColorSpace>>());
+    context->unlock();
+
+    if (!sk_image)
+        return Error::from_string_literal("Failed to upload YUV data");
+
     ImmutableBitmapImpl impl {
-        .context = nullptr,
-        .sk_image = nullptr,
+        .context = context,
+        .sk_image = move(sk_image),
         .sk_bitmap = {},
         .bitmap = nullptr,
-        .color_space = move(color_space),
-        .yuv_data = move(yuv_data),
+        .color_space = {},
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
 }
@@ -240,41 +250,14 @@ bool ImmutableBitmap::ensure_sk_image(SkiaBackendContext& context) const
 
     auto* gr_context = context.sk_context();
 
-    // Bitmap-backed: try to upload raster image to GPU texture
-    if (m_impl->sk_image) {
-        if (!gr_context)
-            return true; // No GPU, but raster image is still usable
-        auto gpu_image = SkImages::TextureFromImage(gr_context, m_impl->sk_image.get(), skgpu::Mipmapped::kNo, skgpu::Budgeted::kYes);
-        if (gpu_image) {
-            m_impl->context = context;
-            m_impl->sk_image = move(gpu_image);
-        }
-        return true;
-    }
-
-    // YUV-backed: GPU is required to decode YUV to RGB
-    VERIFY(m_impl->yuv_data);
-
+    VERIFY(m_impl->sk_image);
     if (!gr_context)
-        return false; // No GPU, cannot create image from YUV data
-
-    if (m_impl->yuv_data->bit_depth() > 8)
-        m_impl->yuv_data->expand_samples_to_full_16_bit_range();
-    auto pixmaps = m_impl->yuv_data->make_pixmaps();
-
-    auto sk_image = SkImages::TextureFromYUVAPixmaps(
-        gr_context,
-        pixmaps,
-        skgpu::Mipmapped::kNo,
-        false,
-        m_impl->color_space.color_space<sk_sp<SkColorSpace>>());
-
-    if (!sk_image)
-        return false;
-
-    m_impl->context = context;
-    m_impl->sk_image = move(sk_image);
-    m_impl->yuv_data = nullptr;
+        return true; // No GPU, but raster image is still usable
+    auto gpu_image = SkImages::TextureFromImage(gr_context, m_impl->sk_image.get(), skgpu::Mipmapped::kNo, skgpu::Budgeted::kYes);
+    if (gpu_image) {
+        m_impl->context = context;
+        m_impl->sk_image = move(gpu_image);
+    }
     return true;
 }
 
@@ -309,7 +292,6 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> con
         .sk_bitmap = move(sk_bitmap),
         .bitmap = bitmap,
         .color_space = move(color_space),
-        .yuv_data = nullptr,
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
 }
@@ -339,7 +321,6 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create_snapshot_from_painting_su
         .sk_bitmap = {},
         .bitmap = nullptr,
         .color_space = {},
-        .yuv_data = nullptr,
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
 }

--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -49,9 +49,9 @@ struct ExportFlags {
 
 class ImmutableBitmap final : public AtomicRefCounted<ImmutableBitmap> {
 public:
-    static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap, ColorSpace color_space = {});
-    static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap, AlphaType, ColorSpace color_space = {});
-    static NonnullRefPtr<ImmutableBitmap> create_snapshot_from_painting_surface(NonnullRefPtr<PaintingSurface>);
+    static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> const& bitmap, ColorSpace color_space = {});
+    static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> const& bitmap, AlphaType, ColorSpace color_space = {});
+    static NonnullRefPtr<ImmutableBitmap> create_snapshot_from_painting_surface(NonnullRefPtr<PaintingSurface> const&);
     static ErrorOr<NonnullRefPtr<ImmutableBitmap>> create_from_yuv(NonnullOwnPtr<YUVData>);
 
     ~ImmutableBitmap();
@@ -79,7 +79,7 @@ private:
 
     mutable NonnullOwnPtr<ImmutableBitmapImpl> m_impl;
 
-    explicit ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl> bitmap);
+    explicit ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl>&&);
 
     void lock_context();
     void unlock_context();

--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -56,7 +56,6 @@ public:
 
     ~ImmutableBitmap();
 
-    bool is_yuv_backed() const;
     bool ensure_sk_image(SkiaBackendContext&) const;
 
     int width() const;
@@ -75,8 +74,6 @@ public:
     RefPtr<Bitmap const> bitmap() const;
 
 private:
-    friend class YUVData;
-
     mutable NonnullOwnPtr<ImmutableBitmapImpl> m_impl;
 
     explicit ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl>&&);

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -91,7 +91,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_from_vkimage(NonnullRefPt
     // Note, we're implicitly giving Skia a reference to vulkan_image. It will eventually be released by the callback function.
     vulkan_image->ref();
     sk_sp<SkSurface> surface = SkSurfaces::WrapBackendRenderTarget(context->sk_context(), rt, origin_to_sk_origin(origin), vk_format_to_sk_color_type(vulkan_image->info.format),
-        nullptr, nullptr, release_vulkan_image, vulkan_image.ptr());
+        SkColorSpace::MakeSRGB(), nullptr, release_vulkan_image, vulkan_image.ptr());
     return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
 }
 #endif
@@ -143,7 +143,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_from_shared_image_buffer(
     GrMtlTextureInfo mtl_info;
     mtl_info.fTexture = sk_ret_cfp(metal_texture->texture());
     auto backend_render_target = GrBackendRenderTargets::MakeMtl(metal_texture->width(), metal_texture->height(), mtl_info);
-    auto surface = SkSurfaces::WrapBackendRenderTarget(context->sk_context(), backend_render_target, origin_to_sk_origin(origin), kBGRA_8888_SkColorType, nullptr, nullptr);
+    auto surface = SkSurfaces::WrapBackendRenderTarget(context->sk_context(), backend_render_target, origin_to_sk_origin(origin), kBGRA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr);
     return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
 }
 #endif

--- a/Libraries/LibGfx/Rust/Cargo.toml
+++ b/Libraries/LibGfx/Rust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "libgfx_rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+yuv = "0.8"
+
+[build-dependencies]
+cbindgen = "0.29"

--- a/Libraries/LibGfx/Rust/build.rs
+++ b/Libraries/LibGfx/Rust/build.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::env;
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
+    println!("cargo:rerun-if-changed=src");
+
+    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| out_dir.clone());
+
+    cbindgen::generate(manifest_dir).map_or_else(
+        |error| match error {
+            cbindgen::Error::ParseSyntaxError { .. } => {}
+            e => panic!("{e:?}"),
+        },
+        |bindings| {
+            let header_path = out_dir.join("RustFFI.h");
+            bindings.write_to_file(&header_path);
+
+            if ffi_out_dir != out_dir {
+                bindings.write_to_file(ffi_out_dir.join("RustFFI.h"));
+            }
+        },
+    );
+
+    Ok(())
+}

--- a/Libraries/LibGfx/Rust/cbindgen.toml
+++ b/Libraries/LibGfx/Rust/cbindgen.toml
@@ -1,0 +1,23 @@
+language = "C++"
+header = """/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */"""
+pragma_once = true
+include_version = true
+line_length = 120
+tab_width = 4
+no_includes = true
+sys_includes = ["stdint.h", "stddef.h"]
+usize_is_size_t = true
+namespaces = ["Gfx", "FFI"]
+
+[parse]
+parse_deps = false
+
+[parse.expand]
+all_features = false
+
+[export.mangle]
+rename_types = "PascalCase"

--- a/Libraries/LibGfx/Rust/src/lib.rs
+++ b/Libraries/LibGfx/Rust/src/lib.rs
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use yuv::{YuvPlanarImage, YuvRange, YuvStandardMatrix};
+
+#[repr(u8)]
+pub enum YUVRange {
+    Limited = 0,
+    Full = 1,
+}
+
+#[repr(u8)]
+pub enum YUVMatrix {
+    Bt709 = 0,
+    Fcc = 1,
+    Bt470BG = 2,
+    Bt601 = 3,
+    Smpte240 = 4,
+    Bt2020 = 5,
+}
+
+impl From<YUVRange> for YuvRange {
+    fn from(range: YUVRange) -> Self {
+        match range {
+            YUVRange::Limited => YuvRange::Limited,
+            YUVRange::Full => YuvRange::Full,
+        }
+    }
+}
+
+impl From<YUVMatrix> for YuvStandardMatrix {
+    fn from(matrix: YUVMatrix) -> Self {
+        match matrix {
+            YUVMatrix::Bt709 => YuvStandardMatrix::Bt709,
+            YUVMatrix::Fcc => YuvStandardMatrix::Fcc,
+            YUVMatrix::Bt470BG => YuvStandardMatrix::Bt470_6,
+            YUVMatrix::Bt601 => YuvStandardMatrix::Bt601,
+            YUVMatrix::Smpte240 => YuvStandardMatrix::Smpte240,
+            YUVMatrix::Bt2020 => YuvStandardMatrix::Bt2020,
+        }
+    }
+}
+
+/// # Safety
+/// All plane pointers must be valid for the specified dimensions and strides.
+/// `dst` must point to a buffer of at least `dst_stride * height` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn yuv_u8_to_rgba(
+    y_plane: *const u8,
+    y_stride: u32,
+    u_plane: *const u8,
+    u_stride: u32,
+    v_plane: *const u8,
+    v_stride: u32,
+    width: u32,
+    height: u32,
+    subsampling_x: bool,
+    subsampling_y: bool,
+    dst: *mut u8,
+    dst_stride: u32,
+    range: YUVRange,
+    matrix: YUVMatrix,
+) -> bool {
+    let y_len = y_stride as usize * height as usize;
+    let uv_height = if subsampling_y {
+        height.div_ceil(2)
+    } else {
+        height
+    } as usize;
+    let uv_len = u_stride as usize * uv_height;
+
+    let planar_image = YuvPlanarImage {
+        y_plane: unsafe { core::slice::from_raw_parts(y_plane, y_len) },
+        y_stride,
+        u_plane: unsafe { core::slice::from_raw_parts(u_plane, uv_len) },
+        u_stride,
+        v_plane: unsafe { core::slice::from_raw_parts(v_plane, uv_len) },
+        v_stride,
+        width,
+        height,
+    };
+
+    let dst_len = dst_stride as usize * height as usize;
+    let dst_slice = unsafe { core::slice::from_raw_parts_mut(dst, dst_len) };
+
+    let result = match (subsampling_x, subsampling_y) {
+        (true, true) => yuv::yuv420_to_rgba(
+            &planar_image,
+            dst_slice,
+            dst_stride,
+            range.into(),
+            matrix.into(),
+        ),
+        (true, false) => yuv::yuv422_to_rgba(
+            &planar_image,
+            dst_slice,
+            dst_stride,
+            range.into(),
+            matrix.into(),
+        ),
+        (false, true) => return false,
+        (false, false) => yuv::yuv444_to_rgba(
+            &planar_image,
+            dst_slice,
+            dst_stride,
+            range.into(),
+            matrix.into(),
+        ),
+    };
+
+    result.is_ok()
+}
+
+/// # Safety
+/// All plane pointers must be valid for the specified dimensions and strides.
+/// `dst` must point to a buffer of at least `dst_stride * height` bytes.
+/// Values in the u16 planes must be in 0-1023 range for 10-bit or 0-4095 for 12-bit.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn yuv_u16_to_rgba(
+    y_plane: *const u16,
+    y_stride: u32,
+    u_plane: *const u16,
+    u_stride: u32,
+    v_plane: *const u16,
+    v_stride: u32,
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    subsampling_x: bool,
+    subsampling_y: bool,
+    dst: *mut u8,
+    dst_stride: u32,
+    range: YUVRange,
+    matrix: YUVMatrix,
+) -> bool {
+    let y_len = y_stride as usize * height as usize;
+    let uv_height = if subsampling_y {
+        height.div_ceil(2)
+    } else {
+        height
+    } as usize;
+    let uv_len = u_stride as usize * uv_height;
+
+    let planar_image = YuvPlanarImage {
+        y_plane: unsafe { core::slice::from_raw_parts(y_plane, y_len) },
+        y_stride,
+        u_plane: unsafe { core::slice::from_raw_parts(u_plane, uv_len) },
+        u_stride,
+        v_plane: unsafe { core::slice::from_raw_parts(v_plane, uv_len) },
+        v_stride,
+        width,
+        height,
+    };
+
+    let dst_len = dst_stride as usize * height as usize;
+    let dst_slice = unsafe { core::slice::from_raw_parts_mut(dst, dst_len) };
+
+    let result = if bit_depth <= 10 {
+        match (subsampling_x, subsampling_y) {
+            (true, true) => yuv::i010_to_rgba(
+                &planar_image,
+                dst_slice,
+                dst_stride,
+                range.into(),
+                matrix.into(),
+            ),
+            (true, false) => yuv::i210_to_rgba(
+                &planar_image,
+                dst_slice,
+                dst_stride,
+                range.into(),
+                matrix.into(),
+            ),
+            (false, true) => return false,
+            (false, false) => yuv::i410_to_rgba(
+                &planar_image,
+                dst_slice,
+                dst_stride,
+                range.into(),
+                matrix.into(),
+            ),
+        }
+    } else {
+        // 12-bit 4:4:4 has no 8-bit RGBA output; shift to 10-bit and use I410.
+        if !subsampling_x && !subsampling_y {
+            let y_10: Vec<u16> = unsafe { core::slice::from_raw_parts(y_plane, y_len) }
+                .iter()
+                .map(|&v| v >> 2)
+                .collect();
+            let u_10: Vec<u16> = unsafe { core::slice::from_raw_parts(u_plane, uv_len) }
+                .iter()
+                .map(|&v| v >> 2)
+                .collect();
+            let v_10: Vec<u16> = unsafe { core::slice::from_raw_parts(v_plane, uv_len) }
+                .iter()
+                .map(|&v| v >> 2)
+                .collect();
+            let planar_10 = YuvPlanarImage {
+                y_plane: &y_10,
+                y_stride,
+                u_plane: &u_10,
+                u_stride,
+                v_plane: &v_10,
+                v_stride,
+                width,
+                height,
+            };
+            return yuv::i410_to_rgba(
+                &planar_10,
+                dst_slice,
+                dst_stride,
+                range.into(),
+                matrix.into(),
+            )
+            .is_ok();
+        }
+        match (subsampling_x, subsampling_y) {
+            (true, true) => yuv::i012_to_rgba(
+                &planar_image,
+                dst_slice,
+                dst_stride,
+                range.into(),
+                matrix.into(),
+            ),
+            (true, false) => yuv::i212_to_rgba(
+                &planar_image,
+                dst_slice,
+                dst_stride,
+                range.into(),
+                matrix.into(),
+            ),
+            (false, true) => return false,
+            (false, false) => unreachable!(),
+        }
+    };
+
+    result.is_ok()
+}

--- a/Libraries/LibGfx/YUVData.cpp
+++ b/Libraries/LibGfx/YUVData.cpp
@@ -12,6 +12,7 @@
 #include <core/SkImage.h>
 #include <core/SkYUVAInfo.h>
 #include <core/SkYUVAPixmaps.h>
+#include <cstddef>
 #include <gpu/ganesh/GrDirectContext.h>
 #include <gpu/ganesh/SkImageGanesh.h>
 
@@ -28,105 +29,6 @@ struct YUVDataImpl {
     FixedArray<u8> y_buffer;
     FixedArray<u8> u_buffer;
     FixedArray<u8> v_buffer;
-
-    // Lazily created when ImmutableBitmap needs it
-    mutable Optional<SkYUVAPixmaps> pixmaps;
-
-    SkYUVColorSpace skia_yuv_color_space() const
-    {
-        bool full_range = cicp.video_full_range_flag() == Media::VideoFullRangeFlag::Full;
-
-        switch (cicp.matrix_coefficients()) {
-        case Media::MatrixCoefficients::BT470BG:
-        case Media::MatrixCoefficients::BT601:
-            return full_range ? kJPEG_Full_SkYUVColorSpace : kRec601_Limited_SkYUVColorSpace;
-        case Media::MatrixCoefficients::BT709:
-            return full_range ? kRec709_Full_SkYUVColorSpace : kRec709_Limited_SkYUVColorSpace;
-        case Media::MatrixCoefficients::BT2020NonConstantLuminance:
-        case Media::MatrixCoefficients::BT2020ConstantLuminance:
-            if (bit_depth <= 8)
-                return kBT2020_8bit_Limited_SkYUVColorSpace;
-            else if (bit_depth <= 10)
-                return kBT2020_10bit_Limited_SkYUVColorSpace;
-            else
-                return kBT2020_12bit_Limited_SkYUVColorSpace;
-        case Media::MatrixCoefficients::Identity:
-            return kIdentity_SkYUVColorSpace;
-        default:
-            // Default to BT.709 for unsupported matrix coefficients
-            return full_range ? kRec709_Full_SkYUVColorSpace : kRec709_Limited_SkYUVColorSpace;
-        }
-    }
-
-    SkYUVAInfo::Subsampling skia_subsampling() const
-    {
-        // Map Media::Subsampling to Skia's subsampling enum
-        // x() = horizontal subsampling, y() = vertical subsampling
-        if (!subsampling.x() && !subsampling.y())
-            return SkYUVAInfo::Subsampling::k444; // 4:4:4 - no subsampling
-        if (subsampling.x() && !subsampling.y())
-            return SkYUVAInfo::Subsampling::k422; // 4:2:2 - horizontal only
-        if (!subsampling.x() && subsampling.y())
-            return SkYUVAInfo::Subsampling::k440; // 4:4:0 - vertical only
-        return SkYUVAInfo::Subsampling::k420;     // 4:2:0 - both
-    }
-
-    SkYUVAPixmaps const& get_or_create_pixmaps() const
-    {
-        if (pixmaps.has_value())
-            return pixmaps.value();
-
-        auto skia_size = SkISize::Make(size.width(), size.height());
-
-        // Use Y_U_V plane configuration (3 separate planes)
-        auto yuva_info = SkYUVAInfo(
-            skia_size,
-            SkYUVAInfo::PlaneConfig::kY_U_V,
-            skia_subsampling(),
-            skia_yuv_color_space());
-
-        // Determine color type based on bit depth
-        SkColorType color_type;
-        if (bit_depth <= 8) {
-            color_type = kAlpha_8_SkColorType;
-        } else {
-            // 10/12/16-bit data stored in 16-bit values
-            color_type = kA16_unorm_SkColorType;
-        }
-
-        // Calculate row bytes for each plane
-        auto component_size = bit_depth <= 8 ? 1 : 2;
-        auto y_row_bytes = static_cast<size_t>(size.width()) * component_size;
-
-        auto uv_size = subsampling.subsampled_size(size);
-        auto uv_row_bytes = static_cast<size_t>(uv_size.width()) * component_size;
-
-        // Create pixmap info for each plane
-        SkYUVAPixmapInfo::DataType data_type = bit_depth <= 8
-            ? SkYUVAPixmapInfo::DataType::kUnorm8
-            : SkYUVAPixmapInfo::DataType::kUnorm16;
-
-        SkYUVAPixmapInfo pixmap_info(yuva_info, data_type, nullptr);
-
-        // Create pixmaps from our buffers
-        SkPixmap y_pixmap(
-            SkImageInfo::Make(size.width(), size.height(), color_type, kOpaque_SkAlphaType),
-            y_buffer.data(),
-            y_row_bytes);
-        SkPixmap u_pixmap(
-            SkImageInfo::Make(uv_size.width(), uv_size.height(), color_type, kOpaque_SkAlphaType),
-            u_buffer.data(),
-            uv_row_bytes);
-        SkPixmap v_pixmap(
-            SkImageInfo::Make(uv_size.width(), uv_size.height(), color_type, kOpaque_SkAlphaType),
-            v_buffer.data(),
-            uv_row_bytes);
-
-        SkPixmap plane_pixmaps[SkYUVAInfo::kMaxPlanes] = { y_pixmap, u_pixmap, v_pixmap, {} };
-
-        pixmaps = SkYUVAPixmaps::FromExternalPixmaps(yuva_info, plane_pixmaps);
-        return pixmaps.value();
-    }
 };
 
 }
@@ -153,7 +55,6 @@ ErrorOr<NonnullOwnPtr<YUVData>> YUVData::create(IntSize size, u8 bit_depth, Medi
         .y_buffer = move(y_buffer),
         .u_buffer = move(u_buffer),
         .v_buffer = move(v_buffer),
-        .pixmaps = {},
     }));
 
     return adopt_nonnull_own_or_enomem(new (nothrow) YUVData(move(impl)));
@@ -201,9 +102,100 @@ Bytes YUVData::v_data()
     return m_impl->v_buffer.span();
 }
 
-SkYUVAPixmaps const& YUVData::skia_yuva_pixmaps() const
+void YUVData::expand_samples_to_full_16_bit_range()
 {
-    return m_impl->get_or_create_pixmaps();
+    auto const shift = 16 - m_impl->bit_depth;
+    auto const inverse_shift = m_impl->bit_depth - shift;
+
+    for (auto buffer : { m_impl->y_buffer.span(), m_impl->u_buffer.span(), m_impl->v_buffer.span() }) {
+        auto* samples = reinterpret_cast<u16*>(buffer.data());
+        auto sample_count = buffer.size() / sizeof(u16);
+        for (size_t i = 0; i < sample_count; i++)
+            samples[i] = static_cast<u16>((samples[i] << shift) | (samples[i] >> inverse_shift));
+    }
+
+    m_impl->bit_depth = 16;
+}
+
+static SkYUVColorSpace skia_yuv_color_space(Media::CodingIndependentCodePoints cicp)
+{
+    bool full_range = cicp.video_full_range_flag() == Media::VideoFullRangeFlag::Full;
+
+    switch (cicp.matrix_coefficients()) {
+    case Media::MatrixCoefficients::BT470BG:
+    case Media::MatrixCoefficients::BT601:
+        return full_range ? kJPEG_Full_SkYUVColorSpace : kRec601_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::BT709:
+        return full_range ? kRec709_Full_SkYUVColorSpace : kRec709_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::BT2020NonConstantLuminance:
+    case Media::MatrixCoefficients::BT2020ConstantLuminance:
+        return full_range ? kBT2020_16bit_Full_SkYUVColorSpace : kBT2020_16bit_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::Identity:
+        return kIdentity_SkYUVColorSpace;
+    default:
+        // Default to BT.709 for unsupported matrix coefficients
+        return full_range ? kRec709_Full_SkYUVColorSpace : kRec709_Limited_SkYUVColorSpace;
+    }
+}
+
+static SkYUVAInfo::Subsampling skia_subsampling(Media::Subsampling subsampling)
+{
+    if (!subsampling.x() && !subsampling.y())
+        return SkYUVAInfo::Subsampling::k444;
+    if (subsampling.x() && !subsampling.y())
+        return SkYUVAInfo::Subsampling::k422;
+    if (!subsampling.x() && subsampling.y())
+        return SkYUVAInfo::Subsampling::k440;
+    return SkYUVAInfo::Subsampling::k420;
+}
+
+SkYUVAPixmaps YUVData::make_pixmaps() const
+{
+    auto skia_size = SkISize::Make(m_impl->size.width(), m_impl->size.height());
+
+    auto yuva_info = SkYUVAInfo(
+        skia_size,
+        SkYUVAInfo::PlaneConfig::kY_U_V,
+        skia_subsampling(m_impl->subsampling),
+        skia_yuv_color_space(m_impl->cicp));
+
+    SkColorType color_type;
+    SkYUVAPixmapInfo::DataType data_type;
+    size_t component_size;
+    if (m_impl->bit_depth <= 8) {
+        color_type = kAlpha_8_SkColorType;
+        data_type = SkYUVAPixmapInfo::DataType::kUnorm8;
+        component_size = 1;
+    } else {
+        color_type = kA16_unorm_SkColorType;
+        data_type = SkYUVAPixmapInfo::DataType::kUnorm16;
+        component_size = 2;
+    }
+
+    auto y_row_bytes = static_cast<size_t>(m_impl->size.width()) * component_size;
+
+    auto uv_size = m_impl->subsampling.subsampled_size(m_impl->size);
+    auto uv_row_bytes = static_cast<size_t>(uv_size.width()) * component_size;
+
+    SkYUVAPixmapInfo pixmap_info(yuva_info, data_type, nullptr);
+
+    // Create pixmaps from our buffers
+    SkPixmap y_pixmap(
+        SkImageInfo::Make(skia_size, color_type, kOpaque_SkAlphaType),
+        m_impl->y_buffer.data(),
+        y_row_bytes);
+    SkPixmap u_pixmap(
+        SkImageInfo::Make(uv_size.width(), uv_size.height(), color_type, kOpaque_SkAlphaType),
+        m_impl->u_buffer.data(),
+        uv_row_bytes);
+    SkPixmap v_pixmap(
+        SkImageInfo::Make(uv_size.width(), uv_size.height(), color_type, kOpaque_SkAlphaType),
+        m_impl->v_buffer.data(),
+        uv_row_bytes);
+
+    SkPixmap plane_pixmaps[SkYUVAInfo::kMaxPlanes] = { y_pixmap, u_pixmap, v_pixmap, {} };
+
+    return SkYUVAPixmaps::FromExternalPixmaps(yuva_info, plane_pixmaps);
 }
 
 }

--- a/Libraries/LibGfx/YUVData.cpp
+++ b/Libraries/LibGfx/YUVData.cpp
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Time.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibGfx/YUVData.h>
+#include <RustFFI.h>
 
 #include <core/SkColorSpace.h>
 #include <core/SkImage.h>
@@ -100,6 +103,126 @@ Bytes YUVData::u_data()
 Bytes YUVData::v_data()
 {
     return m_impl->v_buffer.span();
+}
+
+static FFI::YUVMatrix yuv_matrix_for_cicp(Media::CodingIndependentCodePoints const& cicp)
+{
+    switch (cicp.matrix_coefficients()) {
+    case Media::MatrixCoefficients::Identity:
+        VERIFY_NOT_REACHED();
+    case Media::MatrixCoefficients::FCC:
+        return FFI::YUVMatrix::Fcc;
+    case Media::MatrixCoefficients::BT470BG:
+        return FFI::YUVMatrix::Bt470BG;
+    case Media::MatrixCoefficients::BT601:
+        return FFI::YUVMatrix::Bt601;
+    case Media::MatrixCoefficients::SMPTE240:
+        return FFI::YUVMatrix::Smpte240;
+    case Media::MatrixCoefficients::BT2020NonConstantLuminance:
+    case Media::MatrixCoefficients::BT2020ConstantLuminance:
+        return FFI::YUVMatrix::Bt2020;
+    case Media::MatrixCoefficients::BT709:
+    case Media::MatrixCoefficients::Unspecified:
+    default:
+        return FFI::YUVMatrix::Bt709;
+    }
+}
+
+ErrorOr<NonnullRefPtr<Bitmap>> YUVData::to_bitmap() const
+{
+    auto const& impl = *m_impl;
+    VERIFY(impl.bit_depth <= 12);
+
+    auto bitmap = TRY(Bitmap::create(BitmapFormat::RGBA8888, AlphaType::Premultiplied, impl.size));
+    auto* dst = reinterpret_cast<u8*>(bitmap->scanline(0));
+    auto dst_stride = static_cast<u32>(bitmap->pitch());
+
+    auto width = static_cast<u32>(impl.size.width());
+    auto height = static_cast<u32>(impl.size.height());
+
+    if (impl.cicp.matrix_coefficients() == Media::MatrixCoefficients::Identity) {
+        if (impl.subsampling.x() || impl.subsampling.y())
+            return Error::from_string_literal("Subsampled RGB is unsupported");
+
+        if (impl.bit_depth <= 8) {
+            auto const* y_data = impl.y_buffer.data();
+            auto const* u_data = impl.u_buffer.data();
+            auto const* v_data = impl.v_buffer.data();
+            auto y_stride = static_cast<int>(width);
+
+            for (u32 row = 0; row < height; row++) {
+                auto* dst_row = dst + (static_cast<size_t>(row) * dst_stride);
+                auto const* y_row = y_data + (static_cast<size_t>(row) * y_stride);
+                auto const* u_row = u_data + (static_cast<size_t>(row) * y_stride);
+                auto const* v_row = v_data + (static_cast<size_t>(row) * y_stride);
+                for (u32 col = 0; col < width; col++) {
+                    dst_row[(col * 4) + 0] = v_row[col];
+                    dst_row[(col * 4) + 1] = y_row[col];
+                    dst_row[(col * 4) + 2] = u_row[col];
+                    dst_row[(col * 4) + 3] = 255;
+                }
+            }
+        } else {
+            // Our buffers hold native N-bit values in the low bits of each u16; shift right to reduce
+            // to 8-bit for the output.
+            auto shift = impl.bit_depth - 8;
+            auto const* y_data = reinterpret_cast<u16 const*>(impl.y_buffer.data());
+            auto const* u_data = reinterpret_cast<u16 const*>(impl.u_buffer.data());
+            auto const* v_data = reinterpret_cast<u16 const*>(impl.v_buffer.data());
+            auto y_stride = static_cast<int>(width);
+
+            for (u32 row = 0; row < height; row++) {
+                auto* dst_row = dst + (static_cast<size_t>(row) * dst_stride);
+                auto const* y_row = y_data + (static_cast<size_t>(row) * y_stride);
+                auto const* u_row = u_data + (static_cast<size_t>(row) * y_stride);
+                auto const* v_row = v_data + (static_cast<size_t>(row) * y_stride);
+                for (u32 col = 0; col < width; col++) {
+                    dst_row[(col * 4) + 0] = static_cast<u8>(v_row[col] >> shift);
+                    dst_row[(col * 4) + 1] = static_cast<u8>(y_row[col] >> shift);
+                    dst_row[(col * 4) + 2] = static_cast<u8>(u_row[col] >> shift);
+                    dst_row[(col * 4) + 3] = 255;
+                }
+            }
+        }
+
+        return bitmap;
+    }
+
+    auto uv_size = impl.subsampling.subsampled_size(impl.size).to_type<u32>();
+
+    bool full_range = impl.cicp.video_full_range_flag() == Media::VideoFullRangeFlag::Full;
+    auto range = full_range ? FFI::YUVRange::Full : FFI::YUVRange::Limited;
+    auto matrix = yuv_matrix_for_cicp(impl.cicp);
+
+    auto y_stride = width;
+    auto uv_stride = uv_size.width();
+
+    bool success;
+    if (impl.bit_depth <= 8) {
+        success = FFI::yuv_u8_to_rgba(
+            impl.y_buffer.data(), y_stride,
+            impl.u_buffer.data(), uv_stride,
+            impl.v_buffer.data(), uv_stride,
+            width, height,
+            impl.subsampling.x(), impl.subsampling.y(),
+            dst, dst_stride,
+            range, matrix);
+    } else {
+        success = FFI::yuv_u16_to_rgba(
+            reinterpret_cast<u16 const*>(impl.y_buffer.data()), y_stride,
+            reinterpret_cast<u16 const*>(impl.u_buffer.data()), uv_stride,
+            reinterpret_cast<u16 const*>(impl.v_buffer.data()), uv_stride,
+            width, height,
+            impl.bit_depth,
+            impl.subsampling.x(), impl.subsampling.y(),
+            dst, dst_stride,
+            range, matrix);
+    }
+
+    if (!success)
+        return Error::from_string_literal("YUV-to-RGB conversion failed");
+
+    return bitmap;
 }
 
 void YUVData::expand_samples_to_full_16_bit_range()

--- a/Libraries/LibGfx/YUVData.cpp
+++ b/Libraries/LibGfx/YUVData.cpp
@@ -122,14 +122,22 @@ static SkYUVColorSpace skia_yuv_color_space(Media::CodingIndependentCodePoints c
     bool full_range = cicp.video_full_range_flag() == Media::VideoFullRangeFlag::Full;
 
     switch (cicp.matrix_coefficients()) {
+    case Media::MatrixCoefficients::BT709:
+        return full_range ? kRec709_Full_SkYUVColorSpace : kRec709_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::FCC:
+        return full_range ? kFCC_Full_SkYUVColorSpace : kFCC_Limited_SkYUVColorSpace;
     case Media::MatrixCoefficients::BT470BG:
     case Media::MatrixCoefficients::BT601:
         return full_range ? kJPEG_Full_SkYUVColorSpace : kRec601_Limited_SkYUVColorSpace;
-    case Media::MatrixCoefficients::BT709:
-        return full_range ? kRec709_Full_SkYUVColorSpace : kRec709_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::SMPTE240:
+        return full_range ? kSMPTE240_Full_SkYUVColorSpace : kSMPTE240_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::YCgCo:
+        return full_range ? kYCgCo_16bit_Full_SkYUVColorSpace : kYCgCo_16bit_Limited_SkYUVColorSpace;
     case Media::MatrixCoefficients::BT2020NonConstantLuminance:
     case Media::MatrixCoefficients::BT2020ConstantLuminance:
         return full_range ? kBT2020_16bit_Full_SkYUVColorSpace : kBT2020_16bit_Limited_SkYUVColorSpace;
+    case Media::MatrixCoefficients::SMPTE2085:
+        return full_range ? kYDZDX_Full_SkYUVColorSpace : kYDZDX_Limited_SkYUVColorSpace;
     case Media::MatrixCoefficients::Identity:
         return kIdentity_SkYUVColorSpace;
     default:

--- a/Libraries/LibGfx/YUVData.h
+++ b/Libraries/LibGfx/YUVData.h
@@ -9,6 +9,8 @@
 #include <AK/Error.h>
 #include <AK/FixedArray.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
+#include <LibGfx/Forward.h>
 #include <LibGfx/Size.h>
 #include <LibMedia/Color/CodingIndependentCodePoints.h>
 #include <LibMedia/Subsampling.h>
@@ -41,6 +43,8 @@ public:
     Bytes y_data();
     Bytes u_data();
     Bytes v_data();
+
+    ErrorOr<NonnullRefPtr<Bitmap>> to_bitmap() const;
 
     SkYUVAPixmaps make_pixmaps() const;
 

--- a/Libraries/LibGfx/YUVData.h
+++ b/Libraries/LibGfx/YUVData.h
@@ -42,7 +42,9 @@ public:
     Bytes u_data();
     Bytes v_data();
 
-    SkYUVAPixmaps const& skia_yuva_pixmaps() const;
+    SkYUVAPixmaps make_pixmaps() const;
+
+    void expand_samples_to_full_16_bit_range();
 
 private:
     explicit YUVData(NonnullOwnPtr<Details::YUVDataImpl>);

--- a/Libraries/LibMedia/Color/CodingIndependentCodePoints.h
+++ b/Libraries/LibMedia/Color/CodingIndependentCodePoints.h
@@ -17,9 +17,10 @@ namespace Media {
 // Current edition is from 07/21.
 
 enum class ColorPrimaries : u8 {
-    Reserved = 0,
+    // Reserved
     BT709 = 1,
-    Unspecified = 2, // Used by codecs to indicate that an alternative value may be used
+    Unspecified = 2, // Used by codecs to indicate that an alternative value may be used.
+    // Reserved
     BT470M = 4,
     BT470BG = 5,
     BT601 = 6,
@@ -30,13 +31,13 @@ enum class ColorPrimaries : u8 {
     SMPTE431 = 11,
     SMPTE432 = 12,
     EBU3213 = 22,
-    // All other values are also Reserved for later use.
 };
 
 enum class TransferCharacteristics : u8 {
-    Reserved = 0,
+    // Reserved
     BT709 = 1,
     Unspecified = 2, // Used by codecs to indicate that an alternative value may be used
+    // Reserved
     BT470M = 4,
     BT470BG = 5,
     BT601 = 6, // BT.601 or Rec. 601
@@ -52,13 +53,13 @@ enum class TransferCharacteristics : u8 {
     SMPTE2084 = 16, // Also known as PQ
     SMPTE428 = 17,
     HLG = 18,
-    // All other values are also Reserved for later use.
 };
 
 enum class MatrixCoefficients : u8 {
-    Identity = 0, // Applies no transformation to input values
+    Identity = 0,
     BT709 = 1,
-    Unspecified = 2, // Used by codecs to indicate that an alternative value may be used
+    Unspecified = 2, // Used by codecs to indicate that an alternative value may be used.
+    // Reserved
     FCC = 4,
     BT470BG = 5,
     BT601 = 6,
@@ -70,14 +71,95 @@ enum class MatrixCoefficients : u8 {
     ChromaticityDerivedNonConstantLuminance = 12,
     ChromaticityDerivedConstantLuminance = 13,
     ICtCp = 14,
-    // All other values are Reserved for later use.
 };
 
 enum class VideoFullRangeFlag : u8 {
     Studio = 0,      // Y range 16..235, UV range 16..240
     Full = 1,        // 0..255
-    Unspecified = 2, // Not part of the spec, serenity-specific addition for convenience.
+    Unspecified = 2, // Used by codecs to indicate that an alternative value may be used.
 };
+
+static constexpr bool color_primaries_valid(ColorPrimaries color_primaries)
+{
+    switch (color_primaries) {
+    case ColorPrimaries::Unspecified:
+        return false;
+    case ColorPrimaries::BT709:
+    case ColorPrimaries::BT470M:
+    case ColorPrimaries::BT470BG:
+    case ColorPrimaries::BT601:
+    case ColorPrimaries::SMPTE240:
+    case ColorPrimaries::GenericFilm:
+    case ColorPrimaries::BT2020:
+    case ColorPrimaries::XYZ:
+    case ColorPrimaries::SMPTE431:
+    case ColorPrimaries::SMPTE432:
+    case ColorPrimaries::EBU3213:
+        return true;
+    }
+    return false;
+}
+
+static constexpr bool transfer_characteristics_valid(TransferCharacteristics transfer_characteristics)
+{
+    switch (transfer_characteristics) {
+    case TransferCharacteristics::Unspecified:
+        return false;
+    case TransferCharacteristics::BT709:
+    case TransferCharacteristics::BT470M:
+    case TransferCharacteristics::BT470BG:
+    case TransferCharacteristics::BT601:
+    case TransferCharacteristics::SMPTE240:
+    case TransferCharacteristics::Linear:
+    case TransferCharacteristics::Log100:
+    case TransferCharacteristics::Log100Sqrt10:
+    case TransferCharacteristics::IEC61966:
+    case TransferCharacteristics::BT1361:
+    case TransferCharacteristics::SRGB:
+    case TransferCharacteristics::BT2020BitDepth10:
+    case TransferCharacteristics::BT2020BitDepth12:
+    case TransferCharacteristics::SMPTE2084:
+    case TransferCharacteristics::SMPTE428:
+    case TransferCharacteristics::HLG:
+        return true;
+    }
+    return false;
+}
+
+static constexpr bool matrix_coefficients_valid(MatrixCoefficients matrix_coefficients)
+{
+    switch (matrix_coefficients) {
+    case MatrixCoefficients::Unspecified:
+        return false;
+    case MatrixCoefficients::Identity:
+    case MatrixCoefficients::BT709:
+    case MatrixCoefficients::FCC:
+    case MatrixCoefficients::BT470BG:
+    case MatrixCoefficients::BT601:
+    case MatrixCoefficients::SMPTE240:
+    case MatrixCoefficients::YCgCo:
+    case MatrixCoefficients::BT2020NonConstantLuminance:
+    case MatrixCoefficients::BT2020ConstantLuminance:
+    case MatrixCoefficients::SMPTE2085:
+    case MatrixCoefficients::ChromaticityDerivedNonConstantLuminance:
+    case MatrixCoefficients::ChromaticityDerivedConstantLuminance:
+    case MatrixCoefficients::ICtCp:
+        return true;
+    }
+    return false;
+}
+
+static constexpr bool video_full_range_flag_valid(VideoFullRangeFlag video_full_range_flag)
+{
+    switch (video_full_range_flag) {
+    case VideoFullRangeFlag::Unspecified:
+        return false;
+    case VideoFullRangeFlag::Studio:
+    case VideoFullRangeFlag::Full:
+        return true;
+    }
+    return false;
+}
 
 // https://en.wikipedia.org/wiki/Coding-independent_code_points
 struct CodingIndependentCodePoints {
@@ -103,13 +185,13 @@ public:
 
     constexpr void adopt_specified_values(CodingIndependentCodePoints cicp)
     {
-        if (cicp.color_primaries() != ColorPrimaries::Unspecified && cicp.color_primaries() != ColorPrimaries::Reserved)
+        if (color_primaries_valid(cicp.color_primaries()))
             set_color_primaries(cicp.color_primaries());
-        if (cicp.transfer_characteristics() != TransferCharacteristics::Unspecified && cicp.transfer_characteristics() != TransferCharacteristics::Reserved)
+        if (transfer_characteristics_valid(cicp.transfer_characteristics()))
             set_transfer_characteristics(cicp.transfer_characteristics());
-        if (cicp.matrix_coefficients() != MatrixCoefficients::Unspecified)
+        if (matrix_coefficients_valid(cicp.matrix_coefficients()))
             set_matrix_coefficients(cicp.matrix_coefficients());
-        if (cicp.video_full_range_flag() != VideoFullRangeFlag::Unspecified)
+        if (video_full_range_flag_valid(cicp.video_full_range_flag()))
             set_video_full_range_flag(cicp.video_full_range_flag());
     }
 
@@ -123,8 +205,6 @@ private:
 constexpr StringView color_primaries_to_string(ColorPrimaries color_primaries)
 {
     switch (color_primaries) {
-    case ColorPrimaries::Reserved:
-        return "Reserved"sv;
     case ColorPrimaries::BT709:
         return "BT.709"sv;
     case ColorPrimaries::Unspecified:
@@ -156,8 +236,6 @@ constexpr StringView color_primaries_to_string(ColorPrimaries color_primaries)
 constexpr StringView transfer_characteristics_to_string(TransferCharacteristics transfer_characteristics)
 {
     switch (transfer_characteristics) {
-    case TransferCharacteristics::Reserved:
-        return "Reserved"sv;
     case TransferCharacteristics::BT709:
         return "BT.709"sv;
     case TransferCharacteristics::Unspecified:
@@ -238,7 +316,7 @@ constexpr StringView video_full_range_flag_to_string(VideoFullRangeFlag video_fu
         return "Studio"sv;
     case VideoFullRangeFlag::Full:
         return "Full"sv;
-    case VideoFullRangeFlag::Unspecified: // Not part of the spec, serenity-specific addition for convenience.
+    case VideoFullRangeFlag::Unspecified:
         return "Unspecified"sv;
     }
     return "Unknown"sv;

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
@@ -242,6 +242,8 @@ DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
         Bytes buffers[] = { yuv_data->y_data(), yuv_data->u_data(), yuv_data->v_data() };
         Gfx::Size<size_t> plane_sizes[] = { y_plane_size, uv_plane_size, uv_plane_size };
 
+        auto component_size = bit_depth <= 8 ? 1 : 2;
+
         for (u32 plane = 0; plane < 3; plane++) {
             VERIFY(m_frame->linesize[plane] != 0);
             if (m_frame->linesize[plane] < 0)
@@ -252,30 +254,14 @@ DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
             VERIFY(source != nullptr);
             auto destination = buffers[plane];
 
-            if (bit_depth > 8) {
-                // For 10/12-bit content, normalize values to fill the full 16-bit unorm range.
-                // Use bit replication: (value << shift) | (value >> inverse_shift)
-                auto const shift = 16 - bit_depth;
-                auto const inverse_shift = bit_depth - shift;
-                auto samples_per_row = plane_size.width();
-                auto source_stride = m_frame->linesize[plane];
+            auto output_line_size = plane_size.width() * component_size;
+            VERIFY(output_line_size <= static_cast<size_t>(m_frame->linesize[plane]));
 
-                for (size_t row = 0; row < plane_size.height(); row++) {
-                    auto const* src_row = reinterpret_cast<u16 const*>(source + (row * source_stride));
-                    auto* dest_row = reinterpret_cast<u16*>(destination.data() + (row * samples_per_row * sizeof(u16)));
-                    for (size_t i = 0; i < samples_per_row; i++)
-                        dest_row[i] = static_cast<u16>((src_row[i] << shift) | (src_row[i] >> inverse_shift));
-                }
-            } else {
-                auto output_line_size = plane_size.width();
-                VERIFY(output_line_size <= static_cast<size_t>(m_frame->linesize[plane]));
-
-                auto* dest_ptr = destination.data();
-                for (size_t row = 0; row < plane_size.height(); row++) {
-                    memcpy(dest_ptr, source, output_line_size);
-                    source += m_frame->linesize[plane];
-                    dest_ptr += output_line_size;
-                }
+            auto* dest_ptr = destination.data();
+            for (size_t row = 0; row < plane_size.height(); row++) {
+                memcpy(dest_ptr, source, output_line_size);
+                source += m_frame->linesize[plane];
+                dest_ptr += output_line_size;
             }
         }
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
@@ -164,25 +164,7 @@ DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
             }
         }();
         auto cicp = CodingIndependentCodePoints { color_primaries, transfer_characteristics, matrix_coefficients, color_range };
-
         cicp.adopt_specified_values(container_cicp);
-
-        // BT.470 M, B/G, BT.601, BT.709 and BT.2020 have a similar transfer function to sRGB, so other applications
-        // (Chromium, VLC) forgo transfer characteristics conversion. We will emulate that behavior by
-        // handling those as sRGB instead, which causes no transfer function change in the output,
-        // unless display color management is later implemented.
-        switch (cicp.transfer_characteristics()) {
-        case TransferCharacteristics::BT470BG:
-        case TransferCharacteristics::BT470M:
-        case TransferCharacteristics::BT601:
-        case TransferCharacteristics::BT709:
-        case TransferCharacteristics::BT2020BitDepth10:
-        case TransferCharacteristics::BT2020BitDepth12:
-            cicp.set_transfer_characteristics(TransferCharacteristics::SRGB);
-            break;
-        default:
-            break;
-        }
 
         size_t bit_depth = [&] {
             switch (m_frame->format) {

--- a/Meta/CMake/flatpak/cargo-sources.json
+++ b/Meta/CMake/flatpak/cargo-sources.json
@@ -659,6 +659,13 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/yuv/yuv-0.8.13.crate",
+        "sha256": "47d3a7e2cda3061858987ee2fb028f61695f5ee13f9490d75be6c3900df9a4ea",
+        "dest": "cargo/vendor/yuv-0.8.13"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.6.crate",
         "sha256": "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5",
         "dest": "cargo/vendor/zerofrom-0.1.6"
@@ -794,6 +801,7 @@
             "echo '{\"files\": {}, \"package\": \"9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9\"}' > cargo/vendor/writeable-0.6.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca\"}' > cargo/vendor/yoke-0.8.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e\"}' > cargo/vendor/yoke-derive-0.8.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"47d3a7e2cda3061858987ee2fb028f61695f5ee13f9490d75be6c3900df9a4ea\"}' > cargo/vendor/yuv-0.8.13/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5\"}' > cargo/vendor/zerofrom-0.1.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502\"}' > cargo/vendor/zerofrom-derive-0.1.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf\"}' > cargo/vendor/zerotrie-0.2.4/.cargo-checksum.json",

--- a/Tests/LibMedia/TestCICP.cpp
+++ b/Tests/LibMedia/TestCICP.cpp
@@ -14,7 +14,7 @@ TEST_CASE(adopt_specified_values_ignores_reserved_and_unspecified_values)
         Media::MatrixCoefficients::BT709, Media::VideoFullRangeFlag::Studio
     };
 
-    cicp.adopt_specified_values({ Media::ColorPrimaries::Reserved, Media::TransferCharacteristics::Reserved,
+    cicp.adopt_specified_values({ static_cast<Media::ColorPrimaries>(0), static_cast<Media::TransferCharacteristics>(0),
         Media::MatrixCoefficients::Unspecified, Media::VideoFullRangeFlag::Unspecified });
 
     EXPECT(cicp.color_primaries() == Media::ColorPrimaries::BT709);


### PR DESCRIPTION
The `yuv` crate is used to convert YUV image data into RGB to create a simple bitmap-backed SkImage. This crate seems to perform better at converting 8-bit video than libyuv on ARM, and achieves the same performance on x86. It has the added benefit of some safety checks before it passes off data to the unsafe code, which caught some issues with strides that libyuv happily ignored.

To simplify things a little, the `ImmutableBitmap::create_from_yuv()` function now uploads to the GPU synchronously as well, and the YUV data is not kept alive outside the function. Since that function is only called from decoder threads, that shouldn't block anything real-time.

There were a number of other improvements that came alongside these bigger changes, see the individual commits.