### PR TITLE
LibWeb: Clean-up more input state after running each test

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -574,8 +574,8 @@ void Internals::perform_per_test_cleanup()
         gamepad->disconnect();
     m_gamepads.clear();
 
-    // Clear any mouse-down state
-    page().top_level_traversable()->event_handler().clear_mousedown_tracking();
+    // Clear any input state
+    page().top_level_traversable()->event_handler().clear_per_test_input_state({});
 }
 
 void Internals::set_highlighted_node(GC::Ptr<DOM::Node> node)

--- a/Libraries/LibWeb/Page/DragAndDropEventHandler.h
+++ b/Libraries/LibWeb/Page/DragAndDropEventHandler.h
@@ -27,6 +27,8 @@ public:
     EventResult handle_drag_leave(JS::Realm&, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers);
     EventResult handle_drop(JS::Realm&, CSSPixelPoint screen_position, CSSPixelPoint page_offset, CSSPixelPoint client_offset, CSSPixelPoint offset, unsigned button, unsigned buttons, unsigned modifiers);
 
+    void reset();
+
 private:
     enum class Cancelled {
         No,
@@ -48,8 +50,6 @@ private:
         GC::Ptr<DOM::EventTarget> related_target = nullptr);
 
     bool allow_text_drop(GC::Ref<DOM::Node>) const;
-
-    void reset();
 
     RefPtr<HTML::DragDataStore> m_drag_data_store;
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -980,6 +980,19 @@ void EventHandler::stop_updating_selection()
     m_auto_scroll_handler = nullptr;
 }
 
+void EventHandler::clear_per_test_input_state(Badge<Internals::Internals>)
+{
+    clear_mousedown_tracking();
+    stop_updating_selection();
+    m_middle_button_scroll_handler = nullptr;
+    m_prevent_mouse_event = false;
+    m_hovered_chrome_widget = nullptr;
+    m_captured_chrome_widget = nullptr;
+    m_effective_legacy_mouse_pointer_position = nullptr;
+    m_drag_and_drop_event_handler->reset();
+    m_mousemove_previous_screen_position.clear();
+}
+
 EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     auto middle_button_autoscrolled = m_middle_button_scroll_handler && m_middle_button_scroll_handler->mouse_has_moved_beyond_dead_zone();

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -77,6 +77,8 @@ public:
         return {};
     }
 
+    void clear_per_test_input_state(Badge<Internals::Internals>);
+
 private:
     EventResult focus_next_element();
     EventResult focus_previous_element();


### PR DESCRIPTION
The clean-up in 71c457c36e33c68ce3ef24d49ab8ae56e731bef7 turns out to not be enough for all cases. So be more thorough and clear up anything that could affect the next test.

In particular this fixes flakiness in `Text/input/select-text.html` but hopefully it solves the issue for good!