### PR TITLE
Try to solve some WebSocket timeouts

### DIFF
--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/EventLoop.h>
 #include <LibCore/Promise.h>
 #include <LibCore/System.h>
 #include <LibRequests/Request.h>
@@ -28,8 +29,29 @@ void RequestClient::die()
     for (auto& [id, promise] : m_pending_cache_size_estimations)
         promise->reject(Error::from_string_literal("RequestServer process died"));
 
+    auto websockets = move(m_websockets);
+
     m_requests.clear();
     m_pending_cache_size_estimations.clear();
+    m_websockets.clear();
+
+    for (auto& [id, websocket] : websockets) {
+        auto ready_state = websocket->ready_state();
+        websocket->detach_from_client({});
+        websocket->set_ready_state(WebSocket::ReadyState::Closed);
+
+        auto error = ready_state == WebSocket::ReadyState::Connecting
+            ? WebSocket::Error::CouldNotEstablishConnection
+            : WebSocket::Error::ServerClosedSocket;
+        websocket->did_error({}, to_underlying(error));
+        websocket->did_close({}, to_underlying(::WebSocket::CloseStatusCode::AbnormalClosure), {}, false);
+    }
+
+    if (auto request_server_died_callback = move(on_request_server_died)) {
+        Core::deferred_invoke([request_server_died_callback = move(request_server_died_callback)]() mutable {
+            request_server_died_callback();
+        });
+    }
 }
 
 RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL const& url, Optional<HTTP::HeaderList const&> request_headers, ReadonlyBytes request_body, HTTP::CacheMode cache_mode, HTTP::Cookie::IncludeCredentials include_credentials, Core::ProxyData const& proxy_data)

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -154,8 +154,10 @@ void RequestClient::websocket_errored(u64 websocket_id, i32 message)
 
 void RequestClient::websocket_closed(u64 websocket_id, u16 code, ByteString reason, bool clean)
 {
-    if (auto connection = m_websockets.get(websocket_id); connection.has_value())
+    if (auto connection = m_websockets.take(websocket_id); connection.has_value()) {
+        (*connection)->set_ready_state(WebSocket::ReadyState::Closed);
         (*connection)->did_close({}, code, move(reason), clean);
+    }
 }
 
 void RequestClient::websocket_ready_state_changed(u64 websocket_id, u32 ready_state)

--- a/Libraries/LibRequests/WebSocket.cpp
+++ b/Libraries/LibRequests/WebSocket.cpp
@@ -37,6 +37,8 @@ void WebSocket::set_subprotocol_in_use(ByteString subprotocol)
 
 void WebSocket::send(ReadonlyBytes binary_or_text_message, bool is_text)
 {
+    if (!m_client)
+        return;
     m_client->async_websocket_send(m_websocket_id, is_text, binary_or_text_message);
 }
 
@@ -47,6 +49,8 @@ void WebSocket::send(StringView text_message)
 
 void WebSocket::close(u16 code, ByteString reason)
 {
+    if (!m_client)
+        return;
     m_client->async_websocket_close(m_websocket_id, code, move(reason));
 }
 
@@ -78,9 +82,14 @@ void WebSocket::did_request_certificates(Badge<RequestClient>)
 {
     if (on_certificate_requested) {
         auto result = on_certificate_requested();
-        if (!m_client->websocket_set_certificate(m_websocket_id, result.certificate, result.key))
+        if (!m_client || !m_client->websocket_set_certificate(m_websocket_id, result.certificate, result.key))
             dbgln("WebSocket: set_certificate failed");
     }
+}
+
+void WebSocket::detach_from_client(Badge<RequestClient>)
+{
+    m_client = nullptr;
 }
 
 }

--- a/Libraries/LibRequests/WebSocket.h
+++ b/Libraries/LibRequests/WebSocket.h
@@ -70,6 +70,7 @@ public:
     void did_error(Badge<RequestClient>, i32);
     void did_close(Badge<RequestClient>, u16, ByteString, bool);
     void did_request_certificates(Badge<RequestClient>);
+    void detach_from_client(Badge<RequestClient>);
 
 private:
     WebSocket(RequestClient&, u64 websocket_id);

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -106,8 +106,13 @@ WebIDL::ExceptionOr<GC::Ref<WebSocket>> WebSocket::construct_impl(JS::Realm& rea
     Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(vm.heap(), [web_socket, url_record, protocols_sequence = move(protocols_sequence)]() {
         auto& client = HTML::relevant_settings_object(*web_socket);
 
-        //  1. Establish a WebSocket connection given urlRecord, protocols, and client. [FETCH]
-        (void)web_socket->establish_web_socket_connection(*url_record, protocols_sequence, client);
+        // 1. Establish a WebSocket connection given urlRecord, protocols, and client. [FETCH]
+        // AD-HOC: We don't yet implement this method to spec, so it's possible for the connection to fail before we
+        //         make a Requests::WebSocket. If so, we need to manually error and close it.
+        if (web_socket->establish_web_socket_connection(*url_record, protocols_sequence, client).is_error()) {
+            web_socket->on_error();
+            web_socket->on_close(to_underlying(::WebSocket::CloseStatusCode::AbnormalClosure), String {}, false);
+        }
     }));
 
     return web_socket;
@@ -194,6 +199,7 @@ bool WebSocket::must_survive_garbage_collection() const
 ErrorOr<void> WebSocket::establish_web_socket_connection(URL::URL const& url_record, Vector<String> const& protocols, HTML::EnvironmentSettingsObject& client)
 {
     // FIXME: Integrate properly with FETCH as per https://fetch.spec.whatwg.org/#websocket-opening-handshake
+    //        That means following https://websockets.spec.whatwg.org/#concept-websocket-establish
 
     auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(client.global_object());
     auto origin_string = window_or_worker.origin().to_byte_string();

--- a/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Libraries/LibWebSocket/WebSocket.cpp
@@ -8,11 +8,14 @@
 #include <AK/Base64.h>
 #include <AK/Endian.h>
 #include <AK/Random.h>
+#include <LibCore/Timer.h>
 #include <LibCrypto/Hash/HashManager.h>
 #include <LibWebSocket/Impl/WebSocketImplSerenity.h>
 #include <LibWebSocket/WebSocket.h>
 
 namespace WebSocket {
+
+static constexpr int s_closing_handshake_timeout_ms = 30'000;
 
 // Note : The websocket protocol is defined by RFC 6455, found at https://tools.ietf.org/html/rfc6455
 // In this file, section numbers will refer to the RFC 6455
@@ -703,6 +706,21 @@ void WebSocket::set_state(InternalState state)
         return;
     auto old_ready_state = ready_state();
     m_state = state;
+
+    if (state == InternalState::Closing) {
+        if (!m_closing_handshake_timer) {
+            m_closing_handshake_timer = Core::Timer::create_single_shot(s_closing_handshake_timeout_ms, [this] {
+                if (m_state != InternalState::Closing)
+                    return;
+                fail_connection(to_underlying(CloseStatusCode::AbnormalClosure), WebSocket::Error::ServerClosedSocket, "Timed out waiting for the peer's close frame");
+            });
+        } else {
+            m_closing_handshake_timer->restart(s_closing_handshake_timeout_ms);
+        }
+    } else if (m_closing_handshake_timer) {
+        m_closing_handshake_timer->stop();
+    }
+
     auto new_ready_state = ready_state();
     if (old_ready_state != new_ready_state) {
         if (on_ready_state_change)

--- a/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Libraries/LibWebSocket/WebSocket.cpp
@@ -47,8 +47,7 @@ void WebSocket::start()
             discard_connection();
             return;
         }
-        dbgln("WebSocket: Connection error (underlying socket)");
-        fatal_error(WebSocket::Error::CouldNotEstablishConnection);
+        fail_connection(to_underlying(CloseStatusCode::AbnormalClosure), WebSocket::Error::CouldNotEstablishConnection, "Connection error (underlying socket)");
     };
     m_impl->on_connected = [this] {
         if (m_state != WebSocket::InternalState::EstablishingProtocolConnection)
@@ -123,8 +122,8 @@ void WebSocket::close(u16 code, ByteString const& message)
     case InternalState::WaitingForServerHandshake:
         // "If the WebSocket connection is not yet established [WSP]
         // Fail the WebSocket connection and set this’s ready state to CLOSING (2)."
-        // FIXME: Fail the connection.
         set_state(InternalState::Closing);
+        fail_connection(to_underlying(CloseStatusCode::AbnormalClosure), WebSocket::Error::CouldNotEstablishConnection, "Closing connection that's not yet established");
         break;
     case InternalState::Open: {
         // "If the WebSocket closing handshake has not yet been started [WSP]
@@ -174,7 +173,7 @@ void WebSocket::drain_read()
     case InternalState::Closing: {
         auto result = m_impl->read(65536);
         if (result.is_error()) {
-            fatal_error(WebSocket::Error::ServerClosedSocket);
+            fail_connection(to_underlying(CloseStatusCode::AbnormalClosure), WebSocket::Error::ServerClosedSocket, {});
             return;
         }
         auto bytes = result.release_value();
@@ -261,10 +260,12 @@ void WebSocket::send_client_handshake()
 
 void WebSocket::fail_connection(u16 close_status_code, WebSocket::Error error_code, ByteString const& reason)
 {
-    dbgln("WebSocket: {}", reason);
-    set_state(WebSocket::InternalState::Closed);
-    fatal_error(error_code);
+    if (!reason.is_empty())
+        dbgln("WebSocket: {}", reason);
+    set_state(WebSocket::InternalState::Errored);
+    notify_error(error_code);
     notify_close(close_status_code, reason, false);
+    discard_connection();
 }
 
 // The server handshake message is defined in the third list of section 4.1
@@ -653,13 +654,6 @@ void WebSocket::send_frame(WebSocket::OpCode op_code, ReadonlyBytes payload, boo
         offset += payload.size();
     }
     m_impl->send(buf.span().slice(0, offset));
-}
-
-void WebSocket::fatal_error(WebSocket::Error error)
-{
-    set_state(WebSocket::InternalState::Errored);
-    notify_error(error);
-    discard_connection();
 }
 
 void WebSocket::discard_connection()

--- a/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Libraries/LibWebSocket/WebSocket.cpp
@@ -640,9 +640,6 @@ void WebSocket::send_frame(WebSocket::OpCode op_code, ReadonlyBytes payload, boo
         fill_with_random(masking_key);
         buf.overwrite(offset, masking_key, 4);
         offset += 4;
-        // don't try to send empty payload
-        if (payload.size() == 0)
-            return;
         // Mask the payload
         auto masked_payload = buf.span().slice(offset, payload.size());
         for (size_t i = 0; i < payload.size(); ++i) {

--- a/Libraries/LibWebSocket/WebSocket.h
+++ b/Libraries/LibWebSocket/WebSocket.h
@@ -9,6 +9,7 @@
 
 #include <AK/Span.h>
 #include <LibCore/EventReceiver.h>
+#include <LibCore/Forward.h>
 #include <LibWebSocket/ConnectionInfo.h>
 #include <LibWebSocket/Impl/WebSocketImpl.h>
 #include <LibWebSocket/Message.h>
@@ -132,6 +133,7 @@ private:
 
     ConnectionInfo m_connection;
     RefPtr<WebSocketImpl> m_impl;
+    RefPtr<Core::Timer> m_closing_handshake_timer;
 
     Vector<u8> m_buffered_data;
     ByteBuffer m_fragmented_data_buffer;

--- a/Libraries/LibWebSocket/WebSocket.h
+++ b/Libraries/LibWebSocket/WebSocket.h
@@ -98,7 +98,6 @@ private:
     void notify_error(Error);
     void notify_message(Message);
 
-    void fatal_error(Error);
     void discard_connection();
 
     enum class InternalState {

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -63,6 +63,8 @@ ConnectionFromClient::~ConnectionFromClient()
 {
     m_active_requests.clear();
     m_active_revalidation_requests.clear();
+    m_pending_websockets.clear();
+    m_websockets.clear();
 
     curl_multi_cleanup(m_curl_multi);
     m_curl_multi = nullptr;
@@ -303,6 +305,13 @@ void ConnectionFromClient::check_active_requests()
     }
 }
 
+void ConnectionFromClient::fail_websocket(u64 websocket_id, Requests::WebSocket::Error error)
+{
+    async_websocket_ready_state_changed(websocket_id, to_underlying(Requests::WebSocket::ReadyState::Closed));
+    async_websocket_errored(websocket_id, to_underlying(error));
+    async_websocket_closed(websocket_id, to_underlying(WebSocket::CloseStatusCode::AbnormalClosure), {}, false);
+}
+
 Messages::RequestServer::StopRequestResponse ConnectionFromClient::stop_request(u64 request_id)
 {
     auto request = m_active_requests.take(request_id);
@@ -368,21 +377,32 @@ void ConnectionFromClient::websocket_connect(u64 websocket_id, URL::URL url, Byt
 {
     auto host = url.serialized_host().to_byte_string();
     m_pending_websockets.set(websocket_id);
+    auto weak_self = make_weak_ptr<ConnectionFromClient>();
 
     m_resolver->dns.lookup(host, DNS::Messages::Class::IN, { DNS::Messages::ResourceType::A, DNS::Messages::ResourceType::AAAA })
-        ->when_rejected([this, websocket_id](auto const& error) {
+        ->when_rejected([weak_self, websocket_id](auto const& error) {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
             dbgln("WebSocketConnect: DNS lookup failed: {}", error);
-            async_websocket_errored(websocket_id, static_cast<i32>(Requests::WebSocket::Error::CouldNotEstablishConnection));
+            if (!self->m_pending_websockets.remove(websocket_id))
+                return;
+            self->fail_websocket(websocket_id, Requests::WebSocket::Error::CouldNotEstablishConnection);
         })
-        .when_resolved([this, websocket_id, host = move(host), url = move(url), origin = move(origin), protocols = move(protocols), extensions = move(extensions), additional_request_headers = move(additional_request_headers)](auto const& dns_result) mutable {
+        .when_resolved([weak_self, websocket_id, host = move(host), url = move(url), origin = move(origin), protocols = move(protocols), extensions = move(extensions), additional_request_headers = move(additional_request_headers)](auto const& dns_result) mutable {
+            auto self = weak_self.strong_ref();
+            if (!self)
+                return;
             if (dns_result->is_empty() || !dns_result->has_cached_addresses()) {
                 dbgln("WebSocketConnect: DNS lookup failed for '{}'", host);
-                async_websocket_errored(websocket_id, static_cast<i32>(Requests::WebSocket::Error::CouldNotEstablishConnection));
+                if (!self->m_pending_websockets.remove(websocket_id))
+                    return;
+                self->fail_websocket(websocket_id, Requests::WebSocket::Error::CouldNotEstablishConnection);
                 return;
             }
 
             // Don't connect the websocket if we already requested to close it before the DNS lookup completed.
-            if (!m_pending_websockets.remove(websocket_id))
+            if (!self->m_pending_websockets.remove(websocket_id))
                 return;
 
             WebSocket::ConnectionInfo connection_info(move(url));
@@ -395,27 +415,37 @@ void ConnectionFromClient::websocket_connect(u64 websocket_id, URL::URL url, Byt
             if (auto const& path = default_certificate_path(); !path.is_empty())
                 connection_info.set_root_certificates_path(path);
 
-            auto impl = WebSocketImplCurl::create(m_curl_multi);
+            auto impl = WebSocketImplCurl::create(self->m_curl_multi);
             auto connection = WebSocket::WebSocket::create(move(connection_info), move(impl));
 
-            connection->on_open = [this, websocket_id]() {
-                async_websocket_connected(websocket_id);
+            connection->on_open = [self = weak_self, websocket_id]() {
+                if (auto strong_self = self.strong_ref())
+                    strong_self->async_websocket_connected(websocket_id);
             };
-            connection->on_message = [this, websocket_id](auto message) {
-                async_websocket_received(websocket_id, message.is_text(), message.data());
+            connection->on_message = [self = weak_self, websocket_id](auto message) {
+                if (auto strong_self = self.strong_ref())
+                    strong_self->async_websocket_received(websocket_id, message.is_text(), message.data());
             };
-            connection->on_error = [this, websocket_id](auto message) {
-                async_websocket_errored(websocket_id, (i32)message);
+            connection->on_error = [self = weak_self, websocket_id](auto message) {
+                if (auto strong_self = self.strong_ref())
+                    strong_self->async_websocket_errored(websocket_id, (i32)message);
             };
-            connection->on_close = [this, websocket_id](u16 code, ByteString reason, bool was_clean) {
-                async_websocket_closed(websocket_id, code, move(reason), was_clean);
+            connection->on_close = [self = weak_self, websocket_id](u16 code, ByteString reason, bool was_clean) {
+                if (auto strong_self = self.strong_ref()) {
+                    strong_self->async_websocket_closed(websocket_id, code, move(reason), was_clean);
+                    Core::deferred_invoke([self, websocket_id] {
+                        if (auto strong_self = self.strong_ref())
+                            strong_self->m_websockets.remove(websocket_id);
+                    });
+                }
             };
-            connection->on_ready_state_change = [this, websocket_id](auto state) {
-                async_websocket_ready_state_changed(websocket_id, (u32)state);
+            connection->on_ready_state_change = [self = weak_self, websocket_id](auto state) {
+                if (auto strong_self = self.strong_ref())
+                    strong_self->async_websocket_ready_state_changed(websocket_id, (u32)state);
             };
 
             connection->start();
-            m_websockets.set(websocket_id, move(connection));
+            self->m_websockets.set(websocket_id, move(connection));
         });
 }
 
@@ -427,8 +457,12 @@ void ConnectionFromClient::websocket_send(u64 websocket_id, bool is_text, ByteBu
 
 void ConnectionFromClient::websocket_close(u64 websocket_id, u16 code, ByteString reason)
 {
-    m_pending_websockets.remove(websocket_id);
-    if (auto* connection = m_websockets.get(websocket_id).value_or({}); connection && connection->ready_state() == WebSocket::ReadyState::Open)
+    if (m_pending_websockets.remove(websocket_id)) {
+        fail_websocket(websocket_id, Requests::WebSocket::Error::CouldNotEstablishConnection);
+        return;
+    }
+
+    if (auto* connection = m_websockets.get(websocket_id).value_or({}); connection && connection->ready_state() != WebSocket::ReadyState::Closed)
         connection->close(code, reason);
 }
 

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -12,6 +12,7 @@
 #include <LibHTTP/Cache/DiskCacheSettings.h>
 #include <LibHTTP/Forward.h>
 #include <LibIPC/ConnectionFromClient.h>
+#include <LibRequests/WebSocket.h>
 #include <LibWebSocket/WebSocket.h>
 #include <RequestServer/Forward.h>
 #include <RequestServer/RequestClientEndpoint.h>
@@ -70,6 +71,7 @@ private:
     static int on_socket_callback(void*, int sockfd, int what, void* user_data, void*);
     static int on_timeout_callback(void*, long timeout_ms, void* user_data);
     void check_active_requests();
+    void fail_websocket(u64 websocket_id, Requests::WebSocket::Error);
 
     ErrorOr<IPC::TransportHandle> create_client_socket();
 

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Notifier.h>
 #include <RequestServer/CURL.h>
 #include <RequestServer/ConnectionFromClient.h>
 #include <RequestServer/WebSocketImplCurl.h>
 
 namespace RequestServer {
+
+static constexpr long s_connect_timeout_seconds = 90L;
 
 NonnullRefPtr<WebSocketImplCurl> WebSocketImplCurl::create(CURLM* multi_handle)
 {
@@ -24,6 +27,8 @@ WebSocketImplCurl::~WebSocketImplCurl()
 {
     if (m_read_notifier)
         m_read_notifier->close();
+    if (m_write_notifier)
+        m_write_notifier->close();
     if (m_error_notifier)
         m_error_notifier->close();
 
@@ -64,6 +69,7 @@ void WebSocketImplCurl::connect(WebSocket::ConnectionInfo const& info)
     auto const& url = info.url();
     set_option(CURLOPT_URL, url.to_byte_string().characters());
     set_option(CURLOPT_PORT, url.port_or_default());
+    set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
 
     if (auto root_certs = info.root_certificates_path(); root_certs.has_value())
         set_option(CURLOPT_CAINFO, root_certs->characters());
@@ -127,15 +133,17 @@ ErrorOr<ByteString> WebSocketImplCurl::read_line(size_t)
 
 bool WebSocketImplCurl::send(ReadonlyBytes bytes)
 {
-    size_t sent = 0;
-    CURLcode result = CURLE_OK;
-    do {
-        sent = 0;
-        result = curl_easy_send(m_easy_handle, bytes.data(), bytes.size(), &sent);
-        bytes = bytes.slice(sent);
-    } while (bytes.size() > 0 && (result == CURLE_OK || result == CURLE_AGAIN));
+    if (auto const error = m_pending_write_buffer.try_append(bytes); error.is_error()) {
+        dbgln("Failed to queue WebSocket write: {}", error.error());
+        on_connection_error();
+        return false;
+    }
 
-    return result == CURLE_OK;
+    if (flush_pending_write_buffer())
+        return true;
+
+    on_connection_error();
+    return false;
 }
 
 bool WebSocketImplCurl::eof()
@@ -149,6 +157,10 @@ void WebSocketImplCurl::discard_connection()
         m_read_notifier->close();
         m_read_notifier = nullptr;
     }
+    if (m_write_notifier) {
+        m_write_notifier->close();
+        m_write_notifier = nullptr;
+    }
     if (m_error_notifier) {
         m_error_notifier->close();
         m_error_notifier = nullptr;
@@ -158,6 +170,8 @@ void WebSocketImplCurl::discard_connection()
         curl_easy_cleanup(m_easy_handle);
         m_easy_handle = nullptr;
     }
+    m_pending_write_buffer.clear();
+    m_pending_write_buffer_offset = 0;
 }
 
 void WebSocketImplCurl::read_from_socket()
@@ -202,6 +216,39 @@ void WebSocketImplCurl::read_from_socket()
         on_ready_to_read();
 }
 
+bool WebSocketImplCurl::flush_pending_write_buffer()
+{
+    while (m_pending_write_buffer_offset < m_pending_write_buffer.size()) {
+        auto pending_bytes = m_pending_write_buffer.bytes().slice(m_pending_write_buffer_offset);
+
+        size_t sent = 0;
+        auto const result = curl_easy_send(m_easy_handle, pending_bytes.data(), pending_bytes.size(), &sent);
+        if (result != CURLE_OK && result != CURLE_AGAIN) {
+            dbgln("Failed to send to WebSocket: {}", curl_easy_strerror(result));
+            return false;
+        }
+
+        m_pending_write_buffer_offset += sent;
+        if (sent > 0)
+            continue;
+
+        if (result == CURLE_AGAIN) {
+            if (m_write_notifier)
+                m_write_notifier->set_enabled(true);
+            return true;
+        }
+
+        dbgln("Failed to make progress sending to WebSocket");
+        return false;
+    }
+
+    m_pending_write_buffer.clear();
+    m_pending_write_buffer_offset = 0;
+    if (m_write_notifier)
+        m_write_notifier->set_enabled(false);
+    return true;
+}
+
 bool WebSocketImplCurl::did_connect()
 {
     curl_socket_t socket_fd = CURL_SOCKET_BAD;
@@ -213,6 +260,12 @@ bool WebSocketImplCurl::did_connect()
     m_read_notifier->on_activation = [this] {
         read_from_socket();
     };
+    m_write_notifier = Core::Notifier::construct(socket_fd, Core::Notifier::Type::Write);
+    m_write_notifier->on_activation = [this] {
+        if (!flush_pending_write_buffer())
+            on_connection_error();
+    };
+    m_write_notifier->set_enabled(false);
     m_error_notifier = Core::Notifier::construct(socket_fd, Core::Notifier::Type::Error | Core::Notifier::Type::HangUp);
     m_error_notifier->on_activation = [this] {
         on_connection_error();

--- a/Services/RequestServer/WebSocketImplCurl.h
+++ b/Services/RequestServer/WebSocketImplCurl.h
@@ -38,13 +38,17 @@ private:
     explicit WebSocketImplCurl(CURLM*);
 
     void read_from_socket();
+    bool flush_pending_write_buffer();
 
     CURLM* m_multi_handle { nullptr };
     CURL* m_easy_handle { nullptr };
     RefPtr<Core::Notifier> m_read_notifier;
+    RefPtr<Core::Notifier> m_write_notifier;
     RefPtr<Core::Notifier> m_error_notifier;
     Vector<curl_slist*> m_curl_string_lists;
     AllocatingMemoryStream m_read_buffer;
+    ByteBuffer m_pending_write_buffer;
+    size_t m_pending_write_buffer_offset { 0 };
 };
 
 }


### PR DESCRIPTION
Issues found and fixed by Codex, which I've then gone over to make sure it makes some sense. (I am not well-versed in networking and sockets, so I've probably missed things.)

WPT frequently jumps up and down by 80 or 90 subtests in the websockets category because of timeouts, so it'd be nice if that stopped. :^)

It's still not 100% reliable unfortunately, but when testing a few WPTs locally, it's a lot less flaky than it was. As noted, `Web::WebSocket::establish_web_socket_connection()` isn't following the spec at all, and hopefully making that integrate with Fetch would help a lot, but I'm not prepared to dive into that right now.