### PR TITLE
UI/Qt: Adjust color of autocomplete title and header rows

### DIFF
--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -268,7 +268,7 @@ public:
         if (kind == RowKind::SectionHeader) {
             auto text = index.data(HeaderTextRole).toString();
             painter->setFont(autocomplete_section_header_font());
-            painter->setPen(option.palette.color(QPalette::Disabled, QPalette::Text));
+            painter->setPen(option.palette.color(QPalette::PlaceholderText));
             auto rect = option.rect.adjusted(
                 SECTION_HEADER_HORIZONTAL_PADDING, SECTION_HEADER_VERTICAL_PADDING,
                 -SECTION_HEADER_HORIZONTAL_PADDING, -SECTION_HEADER_VERTICAL_PADDING);
@@ -327,7 +327,7 @@ public:
                 Qt::AlignLeft | Qt::AlignVCenter, elided_title);
 
             painter->setFont(autocomplete_secondary_font());
-            painter->setPen(option.palette.color(QPalette::Disabled, QPalette::Text));
+            painter->setPen(option.palette.color(QPalette::PlaceholderText));
             auto elided_secondary = secondary_fm.elidedText(secondary_text, Qt::ElideRight, text_width);
             painter->drawText(
                 QRect(text_x, block_y + primary_fm.height() + CELL_LABEL_VERTICAL_SPACING,


### PR DESCRIPTION
The previous color was a bit difficult to read for me.

<table>
<tr><td>Before</td><td>After</td></tr>
<tr>
<td>
<img width="226" height="214" alt="before" src="https://github.com/user-attachments/assets/64b7e68c-93e0-47c2-b1da-22fb34c4680c" />
</td>
<td>
<img width="226" height="214" alt="after" src="https://github.com/user-attachments/assets/8a01e511-6b94-470b-95b8-3b5ed91137c3" />
</td>
</tr>
</table>