### PR TITLE
Rust: Add a config file for rustfmt

### DIFF
--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -124,9 +124,7 @@ pub fn field_type_info(ty: &str) -> FieldType {
         "Label" => ("Label", 4, 4, "label"),
         "Optional<Label>" => ("Option<Label>", 4, 8, "optional_label"),
         "IdentifierTableIndex" => ("IdentifierTableIndex", 4, 4, "u32_newtype"),
-        "Optional<IdentifierTableIndex>" => {
-            ("Option<IdentifierTableIndex>", 4, 4, "optional_u32_newtype")
-        }
+        "Optional<IdentifierTableIndex>" => ("Option<IdentifierTableIndex>", 4, 4, "optional_u32_newtype"),
         "PropertyKeyTableIndex" => ("PropertyKeyTableIndex", 4, 4, "u32_newtype"),
         "StringTableIndex" => ("StringTableIndex", 4, 4, "u32_newtype"),
         "Optional<StringTableIndex>" => ("Option<StringTableIndex>", 4, 4, "optional_u32_newtype"),
@@ -228,13 +226,7 @@ pub fn compute_layouts(ops: &[OpDef]) -> HashMap<String, OpLayout> {
             Some(round_up(offset, STRUCT_ALIGN))
         };
 
-        result.insert(
-            op.name.clone(),
-            OpLayout {
-                field_offsets,
-                size,
-            },
-        );
+        result.insert(op.name.clone(), OpLayout { field_offsets, size });
     }
 
     result

--- a/Libraries/LibJS/Rust/build.rs
+++ b/Libraries/LibJS/Rust/build.rs
@@ -10,9 +10,7 @@
 //! code instead of C++. The generated code lives in $OUT_DIR/instruction_generated.rs
 //! and is included! from src/bytecode/instruction.rs.
 
-use bytecode_def::{
-    Field, OpDef, STRUCT_ALIGN, field_type_info, find_m_length_offset, round_up, user_fields,
-};
+use bytecode_def::{Field, OpDef, STRUCT_ALIGN, field_type_info, find_m_length_offset, round_up, user_fields};
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -27,10 +25,7 @@ fn rust_field_name(name: &str) -> String {
 }
 
 fn generate_rust_code(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
-    writeln!(
-        w,
-        "// @generated from Libraries/LibJS/Bytecode/Bytecode.def"
-    )?;
+    writeln!(w, "// @generated from Libraries/LibJS/Bytecode/Bytecode.def")?;
     writeln!(w, "// Do not edit manually.")?;
     writeln!(w)?;
     writeln!(w, "use super::operand::*;")?;
@@ -43,10 +38,7 @@ fn generate_rust_code(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn st
     Ok(())
 }
 
-fn generate_opcode_enum(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_opcode_enum(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(
         w,
         "/// Bytecode opcode (u8), matching the C++ `Instruction::Type` enum."
@@ -63,16 +55,10 @@ fn generate_opcode_enum(
     Ok(())
 }
 
-fn generate_instruction_enum(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_instruction_enum(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(w, "/// A bytecode instruction with typed fields.")?;
     writeln!(w, "///")?;
-    writeln!(
-        w,
-        "/// Each variant corresponds to one C++ instruction class."
-    )?;
+    writeln!(w, "/// Each variant corresponds to one C++ instruction class.")?;
     writeln!(
         w,
         "/// During codegen, instructions are stored as these typed variants."
@@ -107,10 +93,7 @@ fn generate_instruction_enum(
     Ok(())
 }
 
-fn generate_instruction_impl(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_instruction_impl(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(w, "impl Instruction {{").unwrap();
     generate_opcode_method(&mut w, ops)?;
     generate_is_terminator_method(&mut w, ops)?;
@@ -122,20 +105,13 @@ fn generate_instruction_impl(
     Ok(())
 }
 
-fn generate_opcode_method(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_opcode_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(w, "    pub fn opcode(&self) -> OpCode {{")?;
     writeln!(w, "        match self {{")?;
     for op in ops {
         let fields = user_fields(op);
         if fields.is_empty() {
-            writeln!(
-                w,
-                "            Instruction::{} => OpCode::{},",
-                op.name, op.name
-            )?;
+            writeln!(w, "            Instruction::{} => OpCode::{},", op.name, op.name)?;
         } else {
             writeln!(
                 w,
@@ -151,10 +127,7 @@ fn generate_opcode_method(
     Ok(())
 }
 
-fn generate_is_terminator_method(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_is_terminator_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(w, "    pub fn is_terminator(&self) -> bool {{")?;
     writeln!(w, "        matches!(self, ")?;
     let terminators: Vec<&OpDef> = ops.iter().filter(|op| op.is_terminator).collect();
@@ -174,14 +147,8 @@ fn generate_is_terminator_method(
     Ok(())
 }
 
-fn generate_encoded_size_method(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
-    writeln!(
-        w,
-        "    /// Returns the encoded size of this instruction in bytes."
-    )?;
+fn generate_encoded_size_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
+    writeln!(w, "    /// Returns the encoded size of this instruction in bytes.")?;
     writeln!(w, "    pub fn encoded_size(&self) -> usize {{")?;
     writeln!(w, "        match self {{")?;
 
@@ -266,18 +233,12 @@ fn generate_encoded_size_method(
     Ok(())
 }
 
-fn generate_encode_method(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_encode_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(
         w,
         "    /// Encode this instruction into bytes matching the C++ struct layout."
     )?;
-    writeln!(
-        w,
-        "    pub fn encode(&self, strict: bool, buf: &mut Vec<u8>) {{"
-    )?;
+    writeln!(w, "    pub fn encode(&self, strict: bool, buf: &mut Vec<u8>) {{")?;
     writeln!(w, "        let start = buf.len();")?;
     writeln!(w, "        match self {{")?;
 
@@ -380,10 +341,7 @@ fn generate_encode_method(
             if has_m_length {
                 // Patch m_length: it's the first u32 field after the header
                 let m_length_offset = find_m_length_offset(&op.fields);
-                writeln!(
-                    w,
-                    "                let total_len = (buf.len() - start) as u32;"
-                )?;
+                writeln!(w, "                let total_len = (buf.len() - start) as u32;")?;
                 writeln!(
                     w,
                     "                buf[start + {}..start + {}].copy_from_slice(&total_len.to_ne_bytes());",
@@ -396,10 +354,7 @@ fn generate_encode_method(
             let final_size = round_up(offset, 8);
             let tail_pad = final_size - offset;
             if tail_pad > 0 {
-                writeln!(
-                    w,
-                    "                buf.extend_from_slice(&[0u8; {tail_pad}]);"
-                )?;
+                writeln!(w, "                buf.extend_from_slice(&[0u8; {tail_pad}]);")?;
             }
         }
 
@@ -429,10 +384,7 @@ fn emit_field_write(
         "u8" => writeln!(w, "{prefix}buf.push(*{name});")?,
         "u32" => writeln!(w, "{prefix}buf.extend_from_slice(&{name}.to_ne_bytes());")?,
         "u64" => writeln!(w, "{prefix}buf.extend_from_slice(&{name}.to_ne_bytes());")?,
-        "operand" => writeln!(
-            w,
-            "{prefix}buf.extend_from_slice(&{name}.raw().to_ne_bytes());"
-        )?,
+        "operand" => writeln!(w, "{prefix}buf.extend_from_slice(&{name}.raw().to_ne_bytes());")?,
         "optional_operand" => {
             writeln!(w, "{prefix}match {name} {{")?;
             writeln!(
@@ -450,24 +402,12 @@ fn emit_field_write(
             // C++ Optional<Label> layw: u32 value, bool has_value, 3 bytes padding = 8 bytes total
             writeln!(w, "{prefix}match {name} {{")?;
             writeln!(w, "{prefix}    Some(lbl) => {{")?;
-            writeln!(
-                w,
-                "{prefix}        buf.extend_from_slice(&lbl.0.to_ne_bytes());"
-            )?;
-            writeln!(
-                w,
-                "{prefix}        buf.push(1); buf.push(0); buf.push(0); buf.push(0);"
-            )?;
+            writeln!(w, "{prefix}        buf.extend_from_slice(&lbl.0.to_ne_bytes());")?;
+            writeln!(w, "{prefix}        buf.push(1); buf.push(0); buf.push(0); buf.push(0);")?;
             writeln!(w, "{prefix}    }}")?;
             writeln!(w, "{prefix}    None => {{")?;
-            writeln!(
-                w,
-                "{prefix}        buf.extend_from_slice(&0u32.to_ne_bytes());"
-            )?;
-            writeln!(
-                w,
-                "{prefix}        buf.push(0); buf.push(0); buf.push(0); buf.push(0);"
-            )?;
+            writeln!(w, "{prefix}        buf.extend_from_slice(&0u32.to_ne_bytes());")?;
+            writeln!(w, "{prefix}        buf.push(0); buf.push(0); buf.push(0); buf.push(0);")?;
             writeln!(w, "{prefix}    }}")?;
             writeln!(w, "{prefix}}}")?;
         }
@@ -485,14 +425,8 @@ fn emit_field_write(
             writeln!(w, "{prefix}}}")?;
         }
         "env_coord" => {
-            writeln!(
-                w,
-                "{prefix}buf.extend_from_slice(&{name}.hops.to_ne_bytes());"
-            )?;
-            writeln!(
-                w,
-                "{prefix}buf.extend_from_slice(&{name}.index.to_ne_bytes());"
-            )?;
+            writeln!(w, "{prefix}buf.extend_from_slice(&{name}.hops.to_ne_bytes());")?;
+            writeln!(w, "{prefix}buf.extend_from_slice(&{name}.index.to_ne_bytes());")?;
         }
         other => panic!("Unknown encoding kind: {other}"),
     }
@@ -500,14 +434,8 @@ fn emit_field_write(
     Ok(())
 }
 
-fn generate_visit_operands_method(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
-    writeln!(
-        w,
-        "    /// Visit all `Operand` fields (for operand rewriting)."
-    )?;
+fn generate_visit_operands_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
+    writeln!(w, "    /// Visit all `Operand` fields (for operand rewriting).")?;
     writeln!(
         w,
         "    pub fn visit_operands(&mut self, visitor: &mut dyn FnMut(&mut Operand)) {{"
@@ -559,16 +487,10 @@ fn generate_visit_operands_method(
                         "                for op in {rname}.iter_mut().flatten() {{ visitor(op); }}"
                     )?;
                 } else {
-                    writeln!(
-                        w,
-                        "                for item in {rname}.iter_mut() {{ visitor(item); }}"
-                    )?;
+                    writeln!(w, "                for item in {rname}.iter_mut() {{ visitor(item); }}")?;
                 }
             } else if f.ty == "Optional<Operand>" {
-                writeln!(
-                    w,
-                    "                if let Some(op) = {rname} {{ visitor(op); }}"
-                )?;
+                writeln!(w, "                if let Some(op) = {rname} {{ visitor(op); }}")?;
             } else {
                 writeln!(w, "                visitor({rname});")?;
             }
@@ -584,10 +506,7 @@ fn generate_visit_operands_method(
     Ok(())
 }
 
-fn generate_visit_labels_method(
-    mut w: impl Write,
-    ops: &[OpDef],
-) -> Result<(), Box<dyn std::error::Error>> {
+fn generate_visit_labels_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
     writeln!(w, "    /// Visit all `Label` fields (for label linking).")?;
     writeln!(
         w,
@@ -635,22 +554,13 @@ fn generate_visit_labels_method(
             if f.is_array {
                 if f.ty == "Optional<Label>" {
                     writeln!(w, "                for item in {rname}.iter_mut() {{")?;
-                    writeln!(
-                        w,
-                        "                    if let Some(lbl) = item {{ visitor(lbl); }}"
-                    )?;
+                    writeln!(w, "                    if let Some(lbl) = item {{ visitor(lbl); }}")?;
                     writeln!(w, "                }}")?;
                 } else {
-                    writeln!(
-                        w,
-                        "                for item in {rname}.iter_mut() {{ visitor(item); }}"
-                    )?;
+                    writeln!(w, "                for item in {rname}.iter_mut() {{ visitor(item); }}")?;
                 }
             } else if f.ty == "Optional<Label>" {
-                writeln!(
-                    w,
-                    "                if let Some(lbl) = {rname} {{ visitor(lbl); }}"
-                )?;
+                writeln!(w, "                if let Some(lbl) = {rname} {{ visitor(lbl); }}")?;
             } else {
                 writeln!(w, "                visitor({rname});")?;
             }

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -78,9 +78,7 @@ impl FunctionTable {
     /// # Panics
     /// Panics if the slot was already taken.
     pub fn get(&self, id: FunctionId) -> &FunctionData {
-        self.functions
-            .get(&id)
-            .expect("FunctionTable::get: slot already taken")
+        self.functions.get(&id).expect("FunctionTable::get: slot already taken")
     }
 
     /// Take ownership of the data (for codegen / GDI).
@@ -404,9 +402,7 @@ impl FunctionTable {
                     self.collect_from_expression(key, result);
                     self.collect_from_expression(function, result);
                 }
-                ClassElement::Field {
-                    key, initializer, ..
-                } => {
+                ClassElement::Field { key, initializer, .. } => {
                     self.collect_from_expression(key, result);
                     if let Some(init) = initializer {
                         self.collect_from_expression(init, result);
@@ -441,11 +437,7 @@ impl FunctionTable {
         }
     }
 
-    fn collect_from_target(
-        &mut self,
-        target: &VariableDeclaratorTarget,
-        result: &mut FunctionTable,
-    ) {
+    fn collect_from_target(&mut self, target: &VariableDeclaratorTarget, result: &mut FunctionTable) {
         if let VariableDeclaratorTarget::BindingPattern(pat) = target {
             self.collect_from_pattern(pat, result);
         }
@@ -1461,10 +1453,7 @@ pub enum ExpressionKind {
     // Operators
     Binary(Box<BinaryExprData>),
     Logical(Box<LogicalExprData>),
-    Unary {
-        op: UnaryOp,
-        operand: Box<Expression>,
-    },
+    Unary { op: UnaryOp, operand: Box<Expression> },
     Update(Box<UpdateExprData>),
     Assignment(Box<AssignmentExprData>),
     Conditional(Box<ConditionalExprData>),

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -126,10 +126,7 @@ fn format_position(state: &DumpState, range: &SourceRange) -> String {
         return String::new();
     }
     if state.use_color {
-        format!(
-            " {}@{}:{}{}",
-            DIM, range.start.line, range.start.column, RESET
-        )
+        format!(" {}@{}:{}{}", DIM, range.start.line, range.start.column, RESET)
     } else {
         format!(" @{}:{}", range.start.line, range.start.column)
     }
@@ -356,11 +353,7 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
             let s = scope.borrow();
             // The parser wraps for-loops in a Block for scope. The C++
             // parser does not, so skip the wrapper and dump the child directly.
-            if s.children.len() == 1
-                && matches!(
-                    s.children[0].inner,
-                    StatementKind::For(_) | StatementKind::ForInOf(_)
-                )
+            if s.children.len() == 1 && matches!(s.children[0].inner, StatementKind::For(_) | StatementKind::ForInOf(_))
             {
                 dump_statement(&s.children[0], state);
                 return;
@@ -457,12 +450,7 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
 
         StatementKind::Switch(data) => {
             dump_node!(state, "SwitchStatement", &statement.range);
-            dump_labeled_expression(
-                "discriminant",
-                &data.discriminant,
-                data.cases.is_empty(),
-                state,
-            );
+            dump_labeled_expression("discriminant", &data.discriminant, data.cases.is_empty(), state);
             for (i, case) in data.cases.iter().enumerate() {
                 dump_switch_case(case, &child_state(state, i == data.cases.len() - 1), state);
             }
@@ -538,32 +526,18 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
         StatementKind::UsingDeclaration(declarations) => {
             dump_node!(state, "UsingDeclaration", &statement.range);
             for (i, declaration) in declarations.iter().enumerate() {
-                dump_variable_declarator(
-                    declaration,
-                    &child_state(state, i == declarations.len() - 1),
-                    state,
-                );
+                dump_variable_declarator(declaration, &child_state(state, i == declarations.len() - 1), state);
             }
         }
 
         StatementKind::FunctionDeclaration(data) => {
             let function_data = state.function_table().get(data.function_id);
-            dump_function(
-                function_data,
-                "FunctionDeclaration",
-                &statement.range,
-                state,
-            );
+            dump_function(function_data, "FunctionDeclaration", &statement.range, state);
         }
 
         StatementKind::ClassDeclaration(class_data) => {
             dump_node!(state, "ClassDeclaration", &statement.range);
-            dump_class(
-                class_data,
-                &statement.range,
-                &child_state(state, true),
-                state,
-            );
+            dump_class(class_data, &statement.range, &child_state(state, true), state);
         }
 
         StatementKind::Import(data) => {
@@ -573,11 +547,7 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
                 state,
                 "ImportStatement",
                 &statement.range,
-                format!(
-                    "from {}{}",
-                    color_string(state, &module_spec),
-                    assert_clauses
-                )
+                format!("from {}{}", color_string(state, &module_spec), assert_clauses)
             );
             if !data.entries.is_empty() {
                 for (i, entry) in data.entries.iter().enumerate() {
@@ -601,10 +571,7 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
             let has_entries = !data.entries.is_empty();
 
             if has_entries {
-                print_node(
-                    &child_state(state, !has_statement),
-                    &color_label(state, "entries"),
-                );
+                print_node(&child_state(state, !has_statement), &color_label(state, "entries"));
                 let entries_state = child_state(state, !has_statement);
                 for (i, entry) in data.entries.iter().enumerate() {
                     let export_name = match &entry.export_name {
@@ -629,10 +596,7 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
                             format_assert_clauses(module_request)
                         ));
                     }
-                    print_node(
-                        &child_state(&entries_state, i == data.entries.len() - 1),
-                        &desc,
-                    );
+                    print_node(&child_state(&entries_state, i == data.entries.len() - 1), &desc);
                 }
             }
 
@@ -825,29 +789,16 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
                     OptionalChainReference::Call { arguments, mode } => {
                         print_node(&ref_state, &format!("Call({})", optional_mode_str(*mode)));
                         for (j, argument) in arguments.iter().enumerate() {
-                            dump_expression(
-                                &argument.value,
-                                &child_state(&ref_state, j == arguments.len() - 1),
-                            );
+                            dump_expression(&argument.value, &child_state(&ref_state, j == arguments.len() - 1));
                         }
                     }
                     OptionalChainReference::ComputedReference { expression, mode } => {
-                        print_node(
-                            &ref_state,
-                            &format!("ComputedReference({})", optional_mode_str(*mode)),
-                        );
+                        print_node(&ref_state, &format!("ComputedReference({})", optional_mode_str(*mode)));
                         dump_expression(expression, &child_state(&ref_state, true));
                     }
                     OptionalChainReference::MemberReference { identifier, mode } => {
-                        print_node(
-                            &ref_state,
-                            &format!("MemberReference({})", optional_mode_str(*mode)),
-                        );
-                        dump_identifier(
-                            identifier,
-                            &identifier.range,
-                            &child_state(&ref_state, true),
-                        );
+                        print_node(&ref_state, &format!("MemberReference({})", optional_mode_str(*mode)));
+                        dump_identifier(identifier, &identifier.range, &child_state(&ref_state, true));
                     }
                     OptionalChainReference::PrivateMemberReference {
                         private_identifier,
@@ -875,10 +826,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
             dump_node!(state, "CallExpression", &expression.range);
             dump_expression(&data.callee, &child_state(state, data.arguments.is_empty()));
             for (i, argument) in data.arguments.iter().enumerate() {
-                dump_expression(
-                    &argument.value,
-                    &child_state(state, i == data.arguments.len() - 1),
-                );
+                dump_expression(&argument.value, &child_state(state, i == data.arguments.len() - 1));
             }
         }
 
@@ -886,20 +834,14 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
             dump_node!(state, "NewExpression", &expression.range);
             dump_expression(&data.callee, &child_state(state, data.arguments.is_empty()));
             for (i, argument) in data.arguments.iter().enumerate() {
-                dump_expression(
-                    &argument.value,
-                    &child_state(state, i == data.arguments.len() - 1),
-                );
+                dump_expression(&argument.value, &child_state(state, i == data.arguments.len() - 1));
             }
         }
 
         ExpressionKind::SuperCall(data) => {
             dump_node!(state, "SuperCall", &expression.range);
             for (i, argument) in data.arguments.iter().enumerate() {
-                dump_expression(
-                    &argument.value,
-                    &child_state(state, i == data.arguments.len() - 1),
-                );
+                dump_expression(&argument.value, &child_state(state, i == data.arguments.len() - 1));
             }
         }
 
@@ -918,12 +860,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
 
         ExpressionKind::Function(function_id) => {
             let function_data = state.function_table().get(*function_id);
-            dump_function(
-                function_data,
-                "FunctionExpression",
-                &expression.range,
-                state,
-            );
+            dump_function(function_data, "FunctionExpression", &expression.range, state);
         }
 
         ExpressionKind::Class(class_data) => {
@@ -945,11 +882,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
         ExpressionKind::Object(properties) => {
             dump_node!(state, "ObjectExpression", &expression.range);
             for (i, property) in properties.iter().enumerate() {
-                dump_object_property(
-                    property,
-                    &child_state(state, i == properties.len() - 1),
-                    state,
-                );
+                dump_object_property(property, &child_state(state, i == properties.len() - 1), state);
             }
         }
 
@@ -1018,10 +951,7 @@ fn dump_identifier(ident: &Identifier, range: &SourceRange, state: &DumpState) {
         } else {
             "variable"
         };
-        desc.push_str(&format!(
-            " {}",
-            color_local(state, kind, ident.local_index.get())
-        ));
+        desc.push_str(&format!(" {}", color_local(state, kind, ident.local_index.get())));
     } else if ident.is_global.get() {
         desc.push_str(&format!(" {}", color_global(state)));
     }
@@ -1049,17 +979,11 @@ fn dump_scope_node(class_name: &str, scope: &ScopeData, range: &SourceRange, sta
     }
 }
 
-fn dump_function(
-    function_data: &FunctionData,
-    class_name: &str,
-    range: &SourceRange,
-    state: &DumpState,
-) {
+fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceRange, state: &DumpState) {
     let mut desc = color_node_name(state, class_name);
-    let is_async = function_data.kind == FunctionKind::Async
-        || function_data.kind == FunctionKind::AsyncGenerator;
-    let is_generator = function_data.kind == FunctionKind::Generator
-        || function_data.kind == FunctionKind::AsyncGenerator;
+    let is_async = function_data.kind == FunctionKind::Async || function_data.kind == FunctionKind::AsyncGenerator;
+    let is_generator =
+        function_data.kind == FunctionKind::Generator || function_data.kind == FunctionKind::AsyncGenerator;
     if is_async {
         desc.push_str(" async");
     }
@@ -1084,10 +1008,7 @@ fn dump_function(
         desc.push_str(&format!(" {}", color_flag(state, "uses-this")));
     }
     if function_data.parsing_insights.uses_this_from_environment {
-        desc.push_str(&format!(
-            " {}",
-            color_flag(state, "uses-this-from-environment")
-        ));
+        desc.push_str(&format!(" {}", color_flag(state, "uses-this-from-environment")));
     }
     if function_data.parsing_insights.might_need_arguments_object {
         desc.push_str(&format!(" {}", color_flag(state, "might-need-arguments")));
@@ -1096,31 +1017,19 @@ fn dump_function(
     print_node(state, &desc);
 
     if !function_data.parameters.is_empty() {
-        print_node(
-            &child_state(state, false),
-            &color_label(state, "parameters"),
-        );
+        print_node(&child_state(state, false), &color_label(state, "parameters"));
         let parameters_state = child_state(state, false);
         for (i, parameter) in function_data.parameters.iter().enumerate() {
-            let parameter_state =
-                child_state(&parameters_state, i == function_data.parameters.len() - 1);
+            let parameter_state = child_state(&parameters_state, i == function_data.parameters.len() - 1);
             let has_default = parameter.default_value.is_some();
             if parameter.is_rest {
                 print_node(&parameter_state, &color_label(state, "rest"));
                 match &parameter.binding {
                     FunctionParameterBinding::Identifier(ident) => {
-                        dump_identifier(
-                            ident,
-                            &ident.range,
-                            &child_state(&parameter_state, !has_default),
-                        );
+                        dump_identifier(ident, &ident.range, &child_state(&parameter_state, !has_default));
                     }
                     FunctionParameterBinding::BindingPattern(pattern) => {
-                        dump_binding_pattern(
-                            pattern,
-                            &child_state(&parameter_state, !has_default),
-                            state,
-                        );
+                        dump_binding_pattern(pattern, &child_state(&parameter_state, !has_default), state);
                     }
                 }
             } else {
@@ -1129,34 +1038,22 @@ fn dump_function(
                         dump_identifier(
                             ident,
                             &ident.range,
-                            &child_state(
-                                &parameters_state,
-                                i == function_data.parameters.len() - 1,
-                            ),
+                            &child_state(&parameters_state, i == function_data.parameters.len() - 1),
                         );
                     }
                     FunctionParameterBinding::BindingPattern(pattern) => {
                         dump_binding_pattern(
                             pattern,
-                            &child_state(
-                                &parameters_state,
-                                i == function_data.parameters.len() - 1,
-                            ),
+                            &child_state(&parameters_state, i == function_data.parameters.len() - 1),
                             state,
                         );
                     }
                 }
             }
             if has_default {
-                print_node(
-                    &child_state(&parameter_state, true),
-                    &color_label(state, "default"),
-                );
+                print_node(&child_state(&parameter_state, true), &color_label(state, "default"));
                 dump_expression(
-                    parameter
-                        .default_value
-                        .as_ref()
-                        .expect("guarded by is_some check"),
+                    parameter.default_value.as_ref().expect("guarded by is_some check"),
                     &child_state(&child_state(&parameter_state, true), true),
                 );
             }
@@ -1164,18 +1061,10 @@ fn dump_function(
     }
 
     print_node(&child_state(state, true), &color_label(state, "body"));
-    dump_statement(
-        &function_data.body,
-        &child_state(&child_state(state, true), true),
-    );
+    dump_statement(&function_data.body, &child_state(&child_state(state, true), true));
 }
 
-fn dump_class(
-    class_data: &ClassData,
-    range: &SourceRange,
-    state: &DumpState,
-    root_state: &DumpState,
-) {
+fn dump_class(class_data: &ClassData, range: &SourceRange, state: &DumpState, root_state: &DumpState) {
     let name_str = match &class_data.name {
         Some(ident) => utf16_to_string(&ident.name),
         None => String::new(),
@@ -1193,10 +1082,7 @@ fn dump_class(
     let has_elements = !class_data.elements.is_empty();
 
     if has_super {
-        print_node(
-            &child_state(state, false),
-            &color_label(root_state, "super class"),
-        );
+        print_node(&child_state(state, false), &color_label(root_state, "super class"));
         dump_expression(
             class_data
                 .super_class
@@ -1211,37 +1097,23 @@ fn dump_class(
             &child_state(state, !has_elements),
             &color_label(root_state, "constructor"),
         );
-        dump_expression(
-            constructor,
-            &child_state(&child_state(state, !has_elements), true),
-        );
+        dump_expression(constructor, &child_state(&child_state(state, !has_elements), true));
     }
 
     if has_elements {
-        print_node(
-            &child_state(state, true),
-            &color_label(root_state, "elements"),
-        );
+        print_node(&child_state(state, true), &color_label(root_state, "elements"));
         for (i, element) in class_data.elements.iter().enumerate() {
             dump_class_element(
                 &element.inner,
                 &element.range,
-                &child_state(
-                    &child_state(state, true),
-                    i == class_data.elements.len() - 1,
-                ),
+                &child_state(&child_state(state, true), i == class_data.elements.len() - 1),
                 root_state,
             );
         }
     }
 }
 
-fn dump_class_element(
-    element: &ClassElement,
-    range: &SourceRange,
-    state: &DumpState,
-    root_state: &DumpState,
-) {
+fn dump_class_element(element: &ClassElement, range: &SourceRange, state: &DumpState, root_state: &DumpState) {
     match element {
         ClassElement::Method {
             key,
@@ -1277,10 +1149,7 @@ fn dump_class_element(
             print_node(state, &desc);
             dump_expression(key, &child_state(state, initializer.is_none()));
             if let Some(init) = initializer {
-                print_node(
-                    &child_state(state, true),
-                    &color_label(root_state, "initializer"),
-                );
+                print_node(&child_state(state, true), &color_label(root_state, "initializer"));
                 dump_expression(init, &child_state(&child_state(state, true), true));
             }
         }
@@ -1339,10 +1208,7 @@ fn dump_binding_pattern(pattern: &BindingPattern, state: &DumpState, root_state:
                     dump_identifier(
                         ident,
                         &ident.range,
-                        &child_state(
-                            &child_state(&entry_state, !has_alias && !has_initializer),
-                            true,
-                        ),
+                        &child_state(&child_state(&entry_state, !has_alias && !has_initializer), true),
                     );
                 }
                 Some(BindingEntryName::Expression(expression)) => {
@@ -1352,10 +1218,7 @@ fn dump_binding_pattern(pattern: &BindingPattern, state: &DumpState, root_state:
                     );
                     dump_expression(
                         expression,
-                        &child_state(
-                            &child_state(&entry_state, !has_alias && !has_initializer),
-                            true,
-                        ),
+                        &child_state(&child_state(&entry_state, !has_alias && !has_initializer), true),
                     );
                 }
                 None => {}
@@ -1397,10 +1260,7 @@ fn dump_binding_pattern(pattern: &BindingPattern, state: &DumpState, root_state:
                 &color_label(root_state, "initializer"),
             );
             dump_expression(
-                entry
-                    .initializer
-                    .as_ref()
-                    .expect("guarded by is_some check"),
+                entry.initializer.as_ref().expect("guarded by is_some check"),
                 &child_state(&child_state(&entry_state, true), true),
             );
         }
@@ -1411,11 +1271,7 @@ fn is_elision(entry: &BindingEntry) -> bool {
     entry.name.is_none() && entry.alias.is_none() && entry.initializer.is_none() && !entry.is_rest
 }
 
-fn dump_variable_declarator(
-    declaration: &VariableDeclarator,
-    state: &DumpState,
-    root_state: &DumpState,
-) {
+fn dump_variable_declarator(declaration: &VariableDeclarator, state: &DumpState, root_state: &DumpState) {
     print_node(
         state,
         &format!(
@@ -1480,26 +1336,12 @@ fn dump_catch_clause(clause: &CatchClause, state: &DumpState, root_state: &DumpS
     if let Some(parameter) = &clause.parameter {
         match parameter {
             CatchBinding::Identifier(ident) => {
-                print_node(
-                    &child_state(state, false),
-                    &color_label(root_state, "parameter"),
-                );
-                dump_identifier(
-                    ident,
-                    &ident.range,
-                    &child_state(&child_state(state, false), true),
-                );
+                print_node(&child_state(state, false), &color_label(root_state, "parameter"));
+                dump_identifier(ident, &ident.range, &child_state(&child_state(state, false), true));
             }
             CatchBinding::BindingPattern(pattern) => {
-                print_node(
-                    &child_state(state, false),
-                    &color_label(root_state, "parameter"),
-                );
-                dump_binding_pattern(
-                    pattern,
-                    &child_state(&child_state(state, false), true),
-                    root_state,
-                );
+                print_node(&child_state(state, false), &color_label(root_state, "parameter"));
+                dump_binding_pattern(pattern, &child_state(&child_state(state, false), true), root_state);
             }
         }
     }
@@ -1529,18 +1371,12 @@ fn dump_switch_case(case: &SwitchCase, state: &DumpState, root_state: &DumpState
             ),
         );
     }
-    print_node(
-        &child_state(state, true),
-        &color_label(root_state, "consequent"),
-    );
+    print_node(&child_state(state, true), &color_label(root_state, "consequent"));
     let consequent_state = child_state(&child_state(state, true), true);
     let scope = case.scope.borrow();
     let children = &scope.children;
     for (i, child) in children.iter().enumerate() {
-        dump_statement(
-            child,
-            &child_state(&consequent_state, i == children.len() - 1),
-        );
+        dump_statement(child, &child_state(&consequent_state, i == children.len() - 1));
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -49,8 +49,8 @@ use crate::u32_from_usize;
 
 use super::ffi::{LiteralValueKind, WellKnownSymbolKind};
 use super::generator::{
-    BlockBoundaryType, ConstantValue, FinallyContext, Generator, ScopedOperand, choose_dst,
-    constant_to_boolean, parse_bigint,
+    BlockBoundaryType, ConstantValue, FinallyContext, Generator, ScopedOperand, choose_dst, constant_to_boolean,
+    parse_bigint,
 };
 use super::instruction::Instruction;
 use super::operand::*;
@@ -81,10 +81,7 @@ fn generate_expression_inner(
     // NamedEvaluation: only function/class expressions consume pending_lhs_name.
     // Clear it for all other expression types so it doesn't leak through to
     // nested function expressions (e.g. IIFEs: `let x = (function() { ... })()`).
-    if !matches!(
-        expression.inner,
-        ExpressionKind::Function(_) | ExpressionKind::Class(_)
-    ) {
+    if !matches!(expression.inner, ExpressionKind::Function(_) | ExpressionKind::Class(_)) {
         generator.pending_lhs_name = None;
     }
 
@@ -96,9 +93,7 @@ fn generate_expression_inner(
 
         ExpressionKind::NullLiteral => Some(generator.add_constant_null()),
 
-        ExpressionKind::StringLiteral(value) => {
-            Some(generator.add_constant_string((**value).clone()))
-        }
+        ExpressionKind::StringLiteral(value) => Some(generator.add_constant_string((**value).clone())),
 
         ExpressionKind::BigIntLiteral(value) => {
             // The AST stores the raw value including the 'n' suffix; strip it for codegen.
@@ -122,9 +117,7 @@ fn generate_expression_inner(
         }
 
         // === Identifiers ===
-        ExpressionKind::Identifier(ident) => {
-            Some(generate_identifier(ident, generator, preferred_dst))
-        }
+        ExpressionKind::Identifier(ident) => Some(generate_identifier(ident, generator, preferred_dst)),
 
         // === This ===
         ExpressionKind::This => {
@@ -137,9 +130,7 @@ fn generate_expression_inner(
         }
 
         // === Unary ===
-        ExpressionKind::Unary { op, operand } => {
-            generate_unary_expression(generator, *op, operand, preferred_dst)
-        }
+        ExpressionKind::Unary { op, operand } => generate_unary_expression(generator, *op, operand, preferred_dst),
 
         // === Binary ===
         ExpressionKind::Binary(data) => {
@@ -147,18 +138,12 @@ fn generate_expression_inner(
         }
 
         // === Logical (short-circuit) ===
-        ExpressionKind::Logical(data) => {
-            generate_logical(generator, data.op, &data.lhs, &data.rhs, preferred_dst)
-        }
+        ExpressionKind::Logical(data) => generate_logical(generator, data.op, &data.lhs, &data.rhs, preferred_dst),
 
         // === Conditional (ternary) ===
-        ExpressionKind::Conditional(data) => generate_conditional(
-            generator,
-            &data.test,
-            &data.consequent,
-            &data.alternate,
-            preferred_dst,
-        ),
+        ExpressionKind::Conditional(data) => {
+            generate_conditional(generator, &data.test, &data.consequent, &data.alternate, preferred_dst)
+        }
 
         // === Sequence ===
         ExpressionKind::Sequence(expressions) => {
@@ -173,32 +158,20 @@ fn generate_expression_inner(
         }
 
         // === Function expressions ===
-        ExpressionKind::Function(function_id) => Some(generate_function_expression(
-            generator,
-            *function_id,
-            preferred_dst,
-        )),
+        ExpressionKind::Function(function_id) => {
+            Some(generate_function_expression(generator, *function_id, preferred_dst))
+        }
 
         // === Array ===
-        ExpressionKind::Array(elements) => Some(generate_array_expression(
-            generator,
-            elements,
-            preferred_dst,
-        )),
+        ExpressionKind::Array(elements) => Some(generate_array_expression(generator, elements, preferred_dst)),
 
         // === Member access ===
-        ExpressionKind::Member(data) => generate_member_expression(
-            generator,
-            &data.object,
-            &data.property,
-            data.computed,
-            preferred_dst,
-        ),
+        ExpressionKind::Member(data) => {
+            generate_member_expression(generator, &data.object, &data.property, data.computed, preferred_dst)
+        }
 
         // === Call ===
-        ExpressionKind::Call(data) => {
-            generate_call_expression(generator, data, preferred_dst, false)
-        }
+        ExpressionKind::Call(data) => generate_call_expression(generator, data, preferred_dst, false),
 
         // === New ===
         ExpressionKind::New(data) => generate_call_expression(generator, data, preferred_dst, true),
@@ -206,11 +179,7 @@ fn generate_expression_inner(
         // === Spread ===
         ExpressionKind::Spread(inner) => {
             // Spread is handled by the caller (Call, Array, Object)
-            Some(generate_expression_or_undefined(
-                inner,
-                generator,
-                preferred_dst,
-            ))
+            Some(generate_expression_or_undefined(inner, generator, preferred_dst))
         }
 
         // === Yield ===
@@ -268,9 +237,7 @@ fn generate_expression_inner(
         }
 
         // === Update (++/--) ===
-        ExpressionKind::Update(data) => {
-            generate_update_expression(generator, data.op, &data.argument, data.prefixed)
-        }
+        ExpressionKind::Update(data) => generate_update_expression(generator, data.op, &data.argument, data.prefixed),
 
         // === Assignment ===
         ExpressionKind::Assignment(data) => {
@@ -278,9 +245,7 @@ fn generate_expression_inner(
         }
 
         // === Template literals ===
-        ExpressionKind::TemplateLiteral(data) => {
-            generate_template_literal(generator, data, preferred_dst)
-        }
+        ExpressionKind::TemplateLiteral(data) => generate_template_literal(generator, data, preferred_dst),
 
         // === Tagged template literals ===
         ExpressionKind::TaggedTemplateLiteral(data) => Some(generate_tagged_template_literal(
@@ -291,9 +256,7 @@ fn generate_expression_inner(
         )),
 
         // === Object ===
-        ExpressionKind::Object(data) => {
-            Some(generate_object_expression(generator, data, preferred_dst))
-        }
+        ExpressionKind::Object(data) => Some(generate_object_expression(generator, data, preferred_dst)),
 
         // === OptionalChain ===
         ExpressionKind::OptionalChain(oc_data) => {
@@ -340,9 +303,7 @@ fn generate_expression_inner(
             Some(dst)
         }
 
-        ExpressionKind::Class(data) => {
-            Some(generate_class_expression(generator, data, preferred_dst))
-        }
+        ExpressionKind::Class(data) => Some(generate_class_expression(generator, data, preferred_dst)),
 
         ExpressionKind::PrivateIdentifier(_) => {
             // Private identifiers are handled by member access codegen
@@ -463,12 +424,10 @@ fn might_contain_assignment_expression(expression: &Expression) -> bool {
         | ExpressionKind::Identifier(_) => false,
         ExpressionKind::Unary { op: _, operand } => might_contain_assignment_expression(operand),
         ExpressionKind::Binary(data) => {
-            might_contain_assignment_expression(&data.lhs)
-                || might_contain_assignment_expression(&data.rhs)
+            might_contain_assignment_expression(&data.lhs) || might_contain_assignment_expression(&data.rhs)
         }
         ExpressionKind::Member(data) => {
-            might_contain_assignment_expression(&data.object)
-                || might_contain_assignment_expression(&data.property)
+            might_contain_assignment_expression(&data.object) || might_contain_assignment_expression(&data.property)
         }
         // Conservatively consider everything else, including assignments themselves as potentially
         // assigning.
@@ -578,13 +537,7 @@ fn generate_function_expression(
         });
         generator.lexical_environment_register_stack.push(new_env);
 
-        let id = generator.intern_identifier(
-            &data
-                .name
-                .as_ref()
-                .expect("function declaration must have a name")
-                .name,
-        );
+        let id = generator.intern_identifier(&data.name.as_ref().expect("function declaration must have a name").name);
         generator.emit(Instruction::CreateVariable {
             identifier: id,
             mode: EnvironmentMode::Lexical as u32,
@@ -605,13 +558,8 @@ fn generate_function_expression(
     } else {
         None
     };
-    let lhs_name_str: Option<Utf16String> =
-        lhs_name.map(|index| generator.identifier_table[index.0 as usize].clone());
-    let name_override = if !has_name {
-        lhs_name_str.as_deref()
-    } else {
-        None
-    };
+    let lhs_name_str: Option<Utf16String> = lhs_name.map(|index| generator.identifier_table[index.0 as usize].clone());
+    let name_override = if !has_name { lhs_name_str.as_deref() } else { None };
     let shared_function_data_index = emit_new_function(generator, data, name_override);
     let home_object = generator.home_objects.last().map(|ho| ho.operand());
     generator.emit(Instruction::NewFunction {
@@ -644,9 +592,7 @@ fn generate_array_expression(
             None => true, // holes
             Some(e) => matches!(
                 e.inner,
-                ExpressionKind::NumericLiteral(_)
-                    | ExpressionKind::BooleanLiteral(_)
-                    | ExpressionKind::NullLiteral
+                ExpressionKind::NumericLiteral(_) | ExpressionKind::BooleanLiteral(_) | ExpressionKind::NullLiteral
             ),
         })
     {
@@ -672,9 +618,9 @@ fn generate_array_expression(
     }
 
     // Find the first spread element.
-    let first_spread = elements.iter().position(
-        |e| matches!(e, Some(element) if matches!(element.inner, ExpressionKind::Spread(_))),
-    );
+    let first_spread = elements
+        .iter()
+        .position(|e| matches!(e, Some(element) if matches!(element.inner, ExpressionKind::Spread(_))));
 
     // Collect elements before the first spread into a NewArray.
     let pre_spread_count = first_spread.unwrap_or(elements.len());
@@ -895,8 +841,7 @@ fn generate_expression_or_undefined(
     generator: &mut Generator,
     preferred_dst: Option<&ScopedOperand>,
 ) -> ScopedOperand {
-    generate_expression(expression, generator, preferred_dst)
-        .unwrap_or_else(|| generator.add_constant_undefined())
+    generate_expression(expression, generator, preferred_dst).unwrap_or_else(|| generator.add_constant_undefined())
 }
 
 /// Generate bytecode for a statement.
@@ -918,14 +863,10 @@ pub fn generate_statement(
         StatementKind::Expression(expression) => generate_expression(expression, generator, None),
 
         // === Block ===
-        StatementKind::Block(scope) => {
-            generate_block_statement(generator, &scope.borrow(), preferred_dst)
-        }
+        StatementKind::Block(scope) => generate_block_statement(generator, &scope.borrow(), preferred_dst),
 
         // === FunctionBody ===
-        StatementKind::FunctionBody { scope, .. } => {
-            generate_scope_children(generator, &scope.borrow(), preferred_dst)
-        }
+        StatementKind::FunctionBody { scope, .. } => generate_scope_children(generator, &scope.borrow(), preferred_dst),
 
         // === Program ===
         // Note: GlobalDeclarationInstantiation (GDI) runs before this bytecode
@@ -953,14 +894,10 @@ pub fn generate_statement(
         ),
 
         // === While ===
-        StatementKind::While(data) => {
-            generate_while_statement(generator, &data.test, &data.body, preferred_dst)
-        }
+        StatementKind::While(data) => generate_while_statement(generator, &data.test, &data.body, preferred_dst),
 
         // === DoWhile ===
-        StatementKind::DoWhile(data) => {
-            generate_do_while_statement(generator, &data.test, &data.body, preferred_dst)
-        }
+        StatementKind::DoWhile(data) => generate_do_while_statement(generator, &data.test, &data.body, preferred_dst),
 
         // === For ===
         StatementKind::For(data) => generate_for_statement(
@@ -1027,9 +964,7 @@ pub fn generate_statement(
         }
 
         // === Labelled ===
-        StatementKind::Labelled(data) => {
-            generate_labelled_statement(generator, &data.label, &data.item, preferred_dst)
-        }
+        StatementKind::Labelled(data) => generate_labelled_statement(generator, &data.label, &data.item, preferred_dst),
 
         // === Switch ===
         StatementKind::Switch(data) => generate_switch_statement(generator, data, preferred_dst),
@@ -1068,9 +1003,7 @@ pub fn generate_statement(
                 dst: object_environment.operand(),
                 object: obj.operand(),
             });
-            generator
-                .lexical_environment_register_stack
-                .push(object_environment);
+            generator.lexical_environment_register_stack.push(object_environment);
             generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
 
             let result = generate_statement(&data.body, generator, preferred_dst);
@@ -1082,14 +1015,9 @@ pub fn generate_statement(
         }
 
         // === ForIn / ForOf / ForAwaitOf ===
-        StatementKind::ForInOf(data) => generate_for_in_of_statement(
-            generator,
-            data.kind,
-            &data.lhs,
-            &data.rhs,
-            &data.body,
-            preferred_dst,
-        ),
+        StatementKind::ForInOf(data) => {
+            generate_for_in_of_statement(generator, data.kind, &data.lhs, &data.rhs, &data.body, preferred_dst)
+        }
 
         // === UsingDeclaration ===
         StatementKind::UsingDeclaration(_) => {
@@ -1101,9 +1029,7 @@ pub fn generate_statement(
                 error_string: msg,
             });
             generator.perform_needed_unwinds();
-            generator.emit(Instruction::Throw {
-                src: error.operand(),
-            });
+            generator.emit(Instruction::Throw { src: error.operand() });
             // Switch to a dead block so subsequent codegen doesn't crash.
             let dead = generator.make_block();
             generator.switch_to_basic_block(dead);
@@ -1120,10 +1046,8 @@ pub fn generate_statement(
             // TDZ checks for subsequent uses of the class name.
             if let Some(name_ident) = &data.name {
                 if name_ident.is_local() {
-                    let local = generator.resolve_local(
-                        name_ident.local_index.get(),
-                        name_ident.local_type.get().unwrap(),
-                    );
+                    let local =
+                        generator.resolve_local(name_ident.local_index.get(), name_ident.local_type.get().unwrap());
                     generator.emit_mov(&local, &value);
                 } else {
                     let id = generator.intern_identifier(&name_ident.name);
@@ -1156,8 +1080,7 @@ pub fn generate_statement(
                         // export default <expression>
                         // The child_statement wraps an Expression via StatementKind::Expression.
                         let default_name: Utf16String = Utf16String::from(utf16!("default"));
-                        generator.pending_lhs_name =
-                            Some(generator.intern_identifier(&default_name));
+                        generator.pending_lhs_name = Some(generator.intern_identifier(&default_name));
                         let value = generate_statement(child_statement, generator, None);
                         generator.pending_lhs_name = None;
                         if let Some(value) = value {
@@ -1187,9 +1110,7 @@ pub fn generate_statement(
             }
             let value = generate_expression_or_undefined(&data.expression, generator, None);
             generator.pending_lhs_name = None;
-            generator.emit(Instruction::Return {
-                value: value.operand(),
-            });
+            generator.emit(Instruction::Return { value: value.operand() });
             None
         }
     };
@@ -1392,36 +1313,18 @@ fn generate_yield_from(
     // v. If done is true, then return ? IteratorValue(innerResult).
     let type_is_normal_done_block = generator.make_block();
     let type_is_normal_not_done_block = generator.make_block();
-    generator.emit_jump_if(
-        &done,
-        type_is_normal_done_block,
-        type_is_normal_not_done_block,
-    );
+    generator.emit_jump_if(&done, type_is_normal_done_block, type_is_normal_not_done_block);
 
     generator.switch_to_basic_block(type_is_normal_done_block);
     let return_value = generator.allocate_register();
-    emit_get_by_id(
-        generator,
-        &return_value,
-        &inner_result,
-        utf16!("value"),
-        None,
-    );
-    generator.emit(Instruction::Jump {
-        target: loop_end_block,
-    });
+    emit_get_by_id(generator, &return_value, &inner_result, utf16!("value"), None);
+    generator.emit(Instruction::Jump { target: loop_end_block });
 
     // vi/vii. Yield IteratorValue(innerResult), receive new completion.
     generator.switch_to_basic_block(type_is_normal_not_done_block);
     {
         let current_value = generator.allocate_register();
-        emit_get_by_id(
-            generator,
-            &current_value,
-            &inner_result,
-            utf16!("value"),
-            None,
-        );
+        emit_get_by_id(generator, &current_value, &inner_result, utf16!("value"), None);
 
         generate_yield(
             generator,
@@ -1504,35 +1407,17 @@ fn generate_yield_from(
     // 6. If done is true, return ? IteratorValue(innerResult).
     let type_is_throw_done_block = generator.make_block();
     let type_is_throw_not_done_block = generator.make_block();
-    generator.emit_jump_if(
-        &done,
-        type_is_throw_done_block,
-        type_is_throw_not_done_block,
-    );
+    generator.emit_jump_if(&done, type_is_throw_done_block, type_is_throw_not_done_block);
 
     generator.switch_to_basic_block(type_is_throw_done_block);
-    emit_get_by_id(
-        generator,
-        &return_value,
-        &inner_result,
-        utf16!("value"),
-        None,
-    );
-    generator.emit(Instruction::Jump {
-        target: loop_end_block,
-    });
+    emit_get_by_id(generator, &return_value, &inner_result, utf16!("value"), None);
+    generator.emit(Instruction::Jump { target: loop_end_block });
 
     // 7/8. Yield IteratorValue(innerResult), receive new completion.
     generator.switch_to_basic_block(type_is_throw_not_done_block);
     {
         let yield_value = generator.allocate_register();
-        emit_get_by_id(
-            generator,
-            &yield_value,
-            &inner_result,
-            utf16!("value"),
-            None,
-        );
+        emit_get_by_id(generator, &yield_value, &inner_result, utf16!("value"), None);
         generate_yield(
             generator,
             continuation_block,
@@ -1583,13 +1468,9 @@ fn generate_yield_from(
             received_completion_type,
             received_completion_value,
         );
-        generator.emit(Instruction::ThrowIfNotObject {
-            src: awaited.operand(),
-        });
+        generator.emit(Instruction::ThrowIfNotObject { src: awaited.operand() });
 
-        generator.emit(Instruction::Jump {
-            target: after_close,
-        });
+        generator.emit(Instruction::Jump { target: after_close });
         generator.switch_to_basic_block(after_close);
     } else {
         // Sync: IteratorClose with Normal completion.
@@ -1605,9 +1486,7 @@ fn generate_yield_from(
 
     // Throw a TypeError: iterator does not have a throw method.
     let exception = generator.allocate_register();
-    let error_string = generator.intern_string(utf16!(
-        "yield* protocol violation: iterator must have a throw method"
-    ));
+    let error_string = generator.intern_string(utf16!("yield* protocol violation: iterator must have a throw method"));
     generator.emit(Instruction::NewTypeError {
         dst: exception.operand(),
         error_string,
@@ -1690,11 +1569,7 @@ fn generate_yield_from(
     // viii. If done is true, return IteratorValue(innerReturnResult).
     let type_is_return_done_block = generator.make_block();
     let type_is_return_not_done_block = generator.make_block();
-    generator.emit_jump_if(
-        &done,
-        type_is_return_done_block,
-        type_is_return_not_done_block,
-    );
+    generator.emit_jump_if(&done, type_is_return_done_block, type_is_return_not_done_block);
 
     generator.switch_to_basic_block(type_is_return_done_block);
     let inner_return_result_value = generator.allocate_register();
@@ -1710,13 +1585,7 @@ fn generate_yield_from(
     // ix/x. Yield IteratorValue(innerReturnResult), receive new completion.
     generator.switch_to_basic_block(type_is_return_not_done_block);
     let received = generator.allocate_register();
-    emit_get_by_id(
-        generator,
-        &received,
-        &inner_return_result,
-        utf16!("value"),
-        None,
-    );
+    emit_get_by_id(generator, &received, &inner_return_result, utf16!("value"), None);
     generate_yield(
         generator,
         continuation_block,
@@ -1866,8 +1735,7 @@ fn generate_identifier(
         let needs_tdz_check = if ident.local_type.get() == Some(LocalType::Argument) {
             !generator.is_argument_initialized(local_index)
         } else {
-            generator.is_local_lexically_declared(local_index)
-                && !generator.is_local_initialized(local_index)
+            generator.is_local_lexically_declared(local_index) && !generator.is_local_initialized(local_index)
         };
         if needs_tdz_check {
             if ident.local_type.get() == Some(LocalType::Argument) {
@@ -1877,9 +1745,7 @@ fn generate_identifier(
                 let empty = generator.add_constant_empty();
                 generator.emit_mov(&local, &empty);
             }
-            generator.emit(Instruction::ThrowIfTDZ {
-                src: local.operand(),
-            });
+            generator.emit(Instruction::ThrowIfTDZ { src: local.operand() });
         }
         return local;
     }
@@ -1918,10 +1784,7 @@ fn generate_identifier(
     dst
 }
 
-fn maybe_generate_builtin_constant(
-    generator: &mut Generator,
-    name: &[u16],
-) -> Option<ScopedOperand> {
+fn maybe_generate_builtin_constant(generator: &mut Generator, name: &[u16]) -> Option<ScopedOperand> {
     if name == utf16!("undefined") {
         return Some(generator.add_constant_undefined());
     }
@@ -2554,11 +2417,7 @@ fn generate_for_statement(
     // Body
     generator.switch_to_basic_block(body_block);
     let labels = std::mem::take(&mut generator.pending_labels);
-    let continue_target = if update.is_some() {
-        update_block
-    } else {
-        test_block
-    };
+    let continue_target = if update.is_some() { update_block } else { test_block };
     generator.begin_continuable_scope(continue_target, labels.clone(), completion.clone());
     generator.begin_breakable_scope(end_block, labels, completion.clone());
 
@@ -2570,9 +2429,7 @@ fn generate_for_statement(
         // CreatePerIterationEnvironment at end of each iteration.
         emit_per_iteration_bindings(generator, &per_iteration_binding_names);
         if update.is_some() {
-            generator.emit(Instruction::Jump {
-                target: update_block,
-            });
+            generator.emit(Instruction::Jump { target: update_block });
         } else {
             generator.emit(Instruction::Jump { target: test_block });
         }
@@ -2695,8 +2552,7 @@ fn generate_block_statement(
     // environment and its only child is a for-loop variant, skip
     // generate_scope_children and generate the child directly to avoid
     // emitting a redundant completion Mov.
-    let result = if !did_create_env && scope.children.len() == 1 && is_for_loop(&scope.children[0])
-    {
+    let result = if !did_create_env && scope.children.len() == 1 && is_for_loop(&scope.children[0]) {
         generate_statement(&scope.children[0], generator, preferred_dst)
     } else {
         generate_scope_children(generator, scope, preferred_dst)
@@ -2873,8 +2729,7 @@ fn generate_variable_declaration(
                 let value = init_value.unwrap_or_else(|| generator.add_constant_undefined());
                 if ident.is_local() {
                     let local_index = ident.local_index.get();
-                    let local =
-                        generator.resolve_local(local_index, ident.local_type.get().unwrap());
+                    let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
                     generator.emit_mov(&local, &value);
                     generator.mark_local_initialized(local_index);
                 } else {
@@ -2910,9 +2765,7 @@ fn generate_variable_declaration(
                 if let Some(value) = init_value {
                     let mode = match kind {
                         DeclarationKind::Var => BindingMode::Set,
-                        DeclarationKind::Let | DeclarationKind::Const => {
-                            BindingMode::InitializeLexical
-                        }
+                        DeclarationKind::Let | DeclarationKind::Const => BindingMode::InitializeLexical,
                     };
                     generate_binding_pattern_bytecode(generator, pattern, mode, &value);
                 }
@@ -3030,8 +2883,7 @@ fn try_generate_builtin_abstract_operation(
     }
     if name == utf16!("CreateAsyncFromSyncIterator") {
         let iterator = generate_expression_or_undefined(&data.arguments[0].value, generator, None);
-        let next_method =
-            generate_expression_or_undefined(&data.arguments[1].value, generator, None);
+        let next_method = generate_expression_or_undefined(&data.arguments[1].value, generator, None);
         let done = generate_expression_or_undefined(&data.arguments[2].value, generator, None);
         generator.emit(Instruction::CreateAsyncFromSyncIterator {
             dst: dst.operand(),
@@ -3054,16 +2906,15 @@ fn try_generate_builtin_abstract_operation(
     }
     if name == utf16!("Call") {
         let callee = generate_expression_or_undefined(&data.arguments[0].value, generator, None);
-        let this_value =
-            generate_expression_or_undefined(&data.arguments[1].value, generator, None);
+        let this_value = generate_expression_or_undefined(&data.arguments[1].value, generator, None);
         let extra_args = &data.arguments[2..];
         let mut argument_holders = Vec::with_capacity(extra_args.len());
         for argument in extra_args {
             let val = generate_expression_or_undefined(&argument.value, generator, None);
             argument_holders.push(generator.copy_if_needed_to_preserve_evaluation_order(&val));
         }
-        let callee_name = expression_string_approximation(&data.arguments[0].value)
-            .map(|s| generator.intern_string(&s));
+        let callee_name =
+            expression_string_approximation(&data.arguments[0].value).map(|s| generator.intern_string(&s));
         let arguments: Vec<Operand> = argument_holders.iter().map(|a| a.operand()).collect();
         generator.emit(Instruction::Call {
             dst: dst.operand(),
@@ -3087,11 +2938,7 @@ fn try_generate_builtin_abstract_operation(
     for &op_name in known_operations {
         if *name == op_name {
             let intrinsic_value = unsafe {
-                super::ffi::get_abstract_operation_function(
-                    generator.vm_ptr,
-                    op_name.as_ptr(),
-                    op_name.len(),
-                )
+                super::ffi::get_abstract_operation_function(generator.vm_ptr, op_name.as_ptr(), op_name.len())
             };
             let callee = generator.add_constant_raw_value(intrinsic_value);
             let undefined = generator.add_constant_undefined();
@@ -3119,26 +2966,17 @@ fn try_generate_builtin_abstract_operation(
 
 /// Try to generate a builtin constant (e.g. SYMBOL_ITERATOR).
 /// Returns Some(operand) if the identifier is a known builtin constant.
-fn try_generate_builtin_constant(
-    generator: &mut Generator,
-    name: &Utf16String,
-) -> Option<ScopedOperand> {
+fn try_generate_builtin_constant(generator: &mut Generator, name: &Utf16String) -> Option<ScopedOperand> {
     if !generator.builtin_abstract_operations_enabled {
         return None;
     }
     if *name == utf16!("SYMBOL_ITERATOR") {
-        let value = unsafe {
-            super::ffi::get_well_known_symbol(generator.vm_ptr, WellKnownSymbolKind::SymbolIterator)
-        };
+        let value = unsafe { super::ffi::get_well_known_symbol(generator.vm_ptr, WellKnownSymbolKind::SymbolIterator) };
         return Some(generator.add_constant_raw_value(value));
     }
     if *name == utf16!("SYMBOL_ASYNC_ITERATOR") {
-        let value = unsafe {
-            super::ffi::get_well_known_symbol(
-                generator.vm_ptr,
-                WellKnownSymbolKind::SymbolAsyncIterator,
-            )
-        };
+        let value =
+            unsafe { super::ffi::get_well_known_symbol(generator.vm_ptr, WellKnownSymbolKind::SymbolAsyncIterator) };
         return Some(generator.add_constant_raw_value(value));
     }
     if *name == utf16!("MAX_ARRAY_LIKE_INDEX") {
@@ -3162,10 +3000,7 @@ fn generate_call_expression(
     is_new: bool,
 ) -> Option<ScopedOperand> {
     // Check for builtin abstract operations before anything else.
-    if !is_new
-        && let Some(result) =
-            try_generate_builtin_abstract_operation(generator, data, preferred_dst)
-    {
+    if !is_new && let Some(result) = try_generate_builtin_abstract_operation(generator, data, preferred_dst) {
         return result;
     }
 
@@ -3176,15 +3011,11 @@ fn generate_call_expression(
         expression_string_approximation(&data.callee).map(|s| generator.intern_string(&s));
 
     // Detect direct eval calls: bare identifier "eval" as callee.
-    let is_direct_eval = !is_new
-        && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if ident.name == utf16!("eval"));
+    let is_direct_eval =
+        !is_new && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if ident.name == utf16!("eval"));
 
     // Detect known builtins for member expression callees (e.g. Math.abs).
-    let builtin: Option<u8> = if !is_new {
-        get_builtin(&data.callee)
-    } else {
-        None
-    };
+    let builtin: Option<u8> = if !is_new { get_builtin(&data.callee) } else { None };
 
     // For method calls (obj.method()), we need to use the object as `this`.
     let (callee, this_value) = if !is_new {
@@ -3198,11 +3029,7 @@ fn generate_call_expression(
                 // 4. GetByIdWithThis / GetByValueWithThis
                 let this_value = emit_resolve_this_binding(generator);
                 let computed_key = if data.computed {
-                    Some(generate_expression_or_undefined(
-                        &data.property,
-                        generator,
-                        None,
-                    ))
+                    Some(generate_expression_or_undefined(&data.property, generator, None))
                 } else {
                     None
                 };
@@ -3214,13 +3041,7 @@ fn generate_call_expression(
                 if let Some(key) = computed_key {
                     emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id_with_this(
-                        generator,
-                        &method,
-                        &super_base,
-                        &ident.name,
-                        &this_value,
-                    );
+                    emit_get_by_id_with_this(generator, &method, &super_base, &ident.name, &this_value);
                 }
                 (method, Some(this_value))
             }
@@ -3229,8 +3050,7 @@ fn generate_call_expression(
                 let base_id = intern_base_identifier(generator, &data.object);
                 let method = generator.allocate_register();
                 if data.computed {
-                    let property =
-                        generate_expression_or_undefined(&data.property, generator, None);
+                    let property = generate_expression_or_undefined(&data.property, generator, None);
                     emit_get_by_value(generator, &method, &obj, &property, None);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
                     emit_get_by_id(generator, &method, &obj, &ident.name, base_id);
@@ -3247,8 +3067,7 @@ fn generate_call_expression(
             ExpressionKind::Identifier(ident) if ident.is_local() => {
                 // Local identifier: use the local directly, with ThrowIfTDZ
                 // if not yet initialized.
-                let local = generator
-                    .resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
+                let local = generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
                 let needs_tdz = if ident.local_type.get() == Some(LocalType::Argument) {
                     !generator.is_argument_initialized(ident.local_index.get())
                 } else {
@@ -3256,9 +3075,7 @@ fn generate_call_expression(
                         && !generator.is_local_initialized(ident.local_index.get())
                 };
                 if needs_tdz {
-                    generator.emit(Instruction::ThrowIfTDZ {
-                        src: local.operand(),
-                    });
+                    generator.emit(Instruction::ThrowIfTDZ { src: local.operand() });
                 }
                 (local, None)
             }
@@ -3281,13 +3098,7 @@ fn generate_call_expression(
                 // (current_base) second.
                 let callee = generator.allocate_register();
                 let this_value = generator.allocate_register();
-                generate_optional_chain_inner(
-                    generator,
-                    &oc_data.base,
-                    &oc_data.references,
-                    &callee,
-                    &this_value,
-                )?;
+                generate_optional_chain_inner(generator, &oc_data.base, &oc_data.references, &callee, &this_value)?;
                 (callee, Some(this_value))
             }
             _ => {
@@ -3441,20 +3252,11 @@ fn generate_call_expression(
 
 /// Emit the increment/decrement operation for an update expression.
 /// Returns the result operand: `value` for prefix, a new `dst` for postfix.
-fn emit_update_op(
-    generator: &mut Generator,
-    op: UpdateOp,
-    prefixed: bool,
-    value: &ScopedOperand,
-) -> ScopedOperand {
+fn emit_update_op(generator: &mut Generator, op: UpdateOp, prefixed: bool, value: &ScopedOperand) -> ScopedOperand {
     if prefixed {
         match op {
-            UpdateOp::Increment => generator.emit(Instruction::Increment {
-                dst: value.operand(),
-            }),
-            UpdateOp::Decrement => generator.emit(Instruction::Decrement {
-                dst: value.operand(),
-            }),
+            UpdateOp::Increment => generator.emit(Instruction::Increment { dst: value.operand() }),
+            UpdateOp::Decrement => generator.emit(Instruction::Decrement { dst: value.operand() }),
         }
         value.clone()
     } else {
@@ -3500,18 +3302,12 @@ fn generate_update_expression(
                 // 4. Property lookup with this
                 let this_value = emit_resolve_this_binding(generator);
                 let computed_key = if data.computed {
-                    Some(generate_expression_or_undefined(
-                        &data.property,
-                        generator,
-                        None,
-                    ))
+                    Some(generate_expression_or_undefined(&data.property, generator, None))
                 } else {
                     None
                 };
                 let base = generator.allocate_register();
-                generator.emit(Instruction::ResolveSuperBase {
-                    dst: base.operand(),
-                });
+                generator.emit(Instruction::ResolveSuperBase { dst: base.operand() });
                 let value = generator.allocate_register();
                 if let Some(ref key) = computed_key {
                     emit_get_by_value_with_this(generator, &value, &base, key, &this_value);
@@ -3624,9 +3420,7 @@ fn generate_assignment_expression(
 
                 let is_logical = matches!(
                     op,
-                    AssignmentOp::AndAssignment
-                        | AssignmentOp::OrAssignment
-                        | AssignmentOp::NullishAssignment
+                    AssignmentOp::AndAssignment | AssignmentOp::OrAssignment | AssignmentOp::NullishAssignment
                 );
                 if is_logical {
                     // Logical assignments short-circuit: evaluate RHS only if condition met.
@@ -3696,18 +3490,12 @@ fn generate_assignment_expression(
 
                     if op == AssignmentOp::Assignment {
                         let computed_key = if member_data.computed {
-                            Some(generate_expression_or_undefined(
-                                &member_data.property,
-                                generator,
-                                None,
-                            ))
+                            Some(generate_expression_or_undefined(&member_data.property, generator, None))
                         } else {
                             None
                         };
                         let base = generator.allocate_register();
-                        generator.emit(Instruction::ResolveSuperBase {
-                            dst: base.operand(),
-                        });
+                        generator.emit(Instruction::ResolveSuperBase { dst: base.operand() });
                         let rhs_val = generate_expression(rhs, generator, None)?;
                         emit_super_put(
                             generator,
@@ -3724,35 +3512,21 @@ fn generate_assignment_expression(
                     // Compound/logical assignment: evaluate property, resolve
                     // super base, then get old value.
                     let computed_key = if member_data.computed {
-                        Some(generate_expression_or_undefined(
-                            &member_data.property,
-                            generator,
-                            None,
-                        ))
+                        Some(generate_expression_or_undefined(&member_data.property, generator, None))
                     } else {
                         None
                     };
                     let base = generator.allocate_register();
-                    generator.emit(Instruction::ResolveSuperBase {
-                        dst: base.operand(),
-                    });
+                    generator.emit(Instruction::ResolveSuperBase { dst: base.operand() });
                     let old_val = generator.allocate_register();
                     if let Some(ref key) = computed_key {
                         emit_get_by_value_with_this(generator, &old_val, &base, key, &super_this);
                     } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                        emit_get_by_id_with_this(
-                            generator,
-                            &old_val,
-                            &base,
-                            &ident.name,
-                            &super_this,
-                        );
+                        emit_get_by_id_with_this(generator, &old_val, &base, &ident.name, &super_this);
                     }
                     let is_logical = matches!(
                         op,
-                        AssignmentOp::AndAssignment
-                            | AssignmentOp::OrAssignment
-                            | AssignmentOp::NullishAssignment
+                        AssignmentOp::AndAssignment | AssignmentOp::OrAssignment | AssignmentOp::NullishAssignment
                     );
                     if is_logical {
                         let rhs_block = generator.make_block();
@@ -3800,11 +3574,7 @@ fn generate_assignment_expression(
                 if op == AssignmentOp::Assignment {
                     let base = generator.copy_if_needed_to_preserve_evaluation_order(&base_raw);
                     let precomputed_key = if member_data.computed {
-                        let key_val = generate_expression_or_undefined(
-                            &member_data.property,
-                            generator,
-                            None,
-                        );
+                        let key_val = generate_expression_or_undefined(&member_data.property, generator, None);
                         Some(generator.copy_if_needed_to_preserve_evaluation_order(&key_val))
                     } else {
                         None
@@ -3831,9 +3601,7 @@ fn generate_assignment_expression(
                 let base_id = intern_base_identifier(generator, &member_data.object);
                 let is_logical = matches!(
                     op,
-                    AssignmentOp::AndAssignment
-                        | AssignmentOp::OrAssignment
-                        | AssignmentOp::NullishAssignment
+                    AssignmentOp::AndAssignment | AssignmentOp::OrAssignment | AssignmentOp::NullishAssignment
                 );
 
                 if member_data.computed {
@@ -3910,9 +3678,7 @@ fn generate_assignment_expression(
                         kind: 0,
                     });
                     return Some(dst);
-                } else if let ExpressionKind::PrivateIdentifier(priv_ident) =
-                    &member_data.property.inner
-                {
+                } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
                     let old_val = generator.allocate_register();
                     let id = generator.intern_identifier(&priv_ident.name);
                     generator.emit(Instruction::GetPrivateById {
@@ -4371,8 +4137,7 @@ fn emit_tdz_check_if_needed(generator: &mut Generator, ident: &Identifier) {
     let needs_tdz_check = if ident.local_type.get() == Some(LocalType::Argument) {
         !generator.is_argument_initialized(local_index)
     } else {
-        generator.is_local_lexically_declared(local_index)
-            && !generator.is_local_initialized(local_index)
+        generator.is_local_lexically_declared(local_index) && !generator.is_local_initialized(local_index)
     };
     if needs_tdz_check {
         let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
@@ -4380,9 +4145,7 @@ fn emit_tdz_check_if_needed(generator: &mut Generator, ident: &Identifier) {
             let empty = generator.add_constant_empty();
             generator.emit_mov(&local, &empty);
         }
-        generator.emit(Instruction::ThrowIfTDZ {
-            src: local.operand(),
-        });
+        generator.emit(Instruction::ThrowIfTDZ { src: local.operand() });
     }
 }
 
@@ -4485,11 +4248,7 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                 // Evaluate computed property for side effects before throwing.
                 // Per spec, property key evaluation precedes ResolveSuperBase.
                 let _computed_key = if data.computed {
-                    Some(generate_expression_or_undefined(
-                        &data.property,
-                        generator,
-                        None,
-                    ))
+                    Some(generate_expression_or_undefined(&data.property, generator, None))
                 } else {
                     None
                 };
@@ -4498,8 +4257,7 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                     dst: super_base.operand(),
                 });
                 let exception = generator.allocate_register();
-                let error_string =
-                    generator.intern_string(utf16!("Can't delete a property on 'super'"));
+                let error_string = generator.intern_string(utf16!("Can't delete a property on 'super'"));
                 generator.emit(Instruction::NewReferenceError {
                     dst: exception.operand(),
                     error_string,
@@ -4577,10 +4335,7 @@ enum EvaluatedReference {
 /// Evaluate a member expression target to get pre-computed reference operands
 /// without performing a load. This implements the "Let lref be ? Evaluation of
 /// DestructuringAssignmentTarget" step from the spec.
-fn emit_evaluate_member_reference(
-    generator: &mut Generator,
-    target: &Expression,
-) -> EvaluatedReference {
+fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression) -> EvaluatedReference {
     if let ExpressionKind::Member(member_data) = &target.inner {
         let is_super = matches!(member_data.object.inner, ExpressionKind::Super);
 
@@ -4588,12 +4343,9 @@ fn emit_evaluate_member_reference(
             // ResolveThisBinding first, then ResolveSuperBase.
             let this_value = emit_resolve_this_binding(generator);
             let base = generator.allocate_register();
-            generator.emit(Instruction::ResolveSuperBase {
-                dst: base.operand(),
-            });
+            generator.emit(Instruction::ResolveSuperBase { dst: base.operand() });
             if member_data.computed {
-                let property =
-                    generate_expression_or_undefined(&member_data.property, generator, None);
+                let property = generate_expression_or_undefined(&member_data.property, generator, None);
                 // If the computed property is a constant string (e.g. super["minutes"]),
                 // optimize to SuperMemberId.
                 if let Some(key) = generator.try_constant_string_to_property_key(&property) {
@@ -4628,8 +4380,7 @@ fn emit_evaluate_member_reference(
         } else {
             let base = generate_expression_or_undefined(&member_data.object, generator, None);
             if member_data.computed {
-                let property =
-                    generate_expression_or_undefined(&member_data.property, generator, None);
+                let property = generate_expression_or_undefined(&member_data.property, generator, None);
                 // If the computed property is a constant string (e.g. obj["key"]),
                 // optimize to MemberId.
                 if let Some(key) = generator.try_constant_string_to_property_key(&property) {
@@ -4658,15 +4409,11 @@ fn emit_evaluate_member_reference(
                     cache,
                     base_identifier: None,
                 }
-            } else if let ExpressionKind::PrivateIdentifier(priv_ident) =
-                &member_data.property.inner
-            {
+            } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
                 let id = generator.intern_identifier(&priv_ident.name);
                 EvaluatedReference::PrivateMember { base, property: id }
             } else {
-                unreachable!(
-                    "non-computed member property must be an identifier or private identifier"
-                )
+                unreachable!("non-computed member property must be an identifier or private identifier")
             }
         }
     } else {
@@ -4675,11 +4422,7 @@ fn emit_evaluate_member_reference(
 }
 
 /// Store a value to a pre-evaluated reference.
-fn emit_store_to_evaluated_reference(
-    generator: &mut Generator,
-    reference: &EvaluatedReference,
-    value: &ScopedOperand,
-) {
+fn emit_store_to_evaluated_reference(generator: &mut Generator, reference: &EvaluatedReference, value: &ScopedOperand) {
     match reference {
         EvaluatedReference::Member {
             base,
@@ -4745,9 +4488,7 @@ fn emit_store_to_reference(generator: &mut Generator, target: &Expression, value
                 // ResolveThisBinding first, then ResolveSuperBase.
                 let this_value = emit_resolve_this_binding(generator);
                 let base = generator.allocate_register();
-                generator.emit(Instruction::ResolveSuperBase {
-                    dst: base.operand(),
-                });
+                generator.emit(Instruction::ResolveSuperBase { dst: base.operand() });
                 emit_super_put(
                     generator,
                     &base,
@@ -4869,9 +4610,7 @@ fn emit_compound_assignment(
                 rhs: rhs_op,
             });
         }
-        AssignmentOp::AndAssignment
-        | AssignmentOp::OrAssignment
-        | AssignmentOp::NullishAssignment => {
+        AssignmentOp::AndAssignment | AssignmentOp::OrAssignment | AssignmentOp::NullishAssignment => {
             unreachable!("logical assignment in compound path")
         }
         AssignmentOp::Assignment => unreachable!("plain assignment in compound path"),
@@ -4952,19 +4691,13 @@ fn generate_tagged_template_literal(
 ) -> ScopedOperand {
     // Resolve tag and this_value based on the tag expression type.
     let (tag_reg, this_value) = match &tag.inner {
-        ExpressionKind::Member(member_data)
-            if matches!(member_data.object.inner, ExpressionKind::Super) =>
-        {
+        ExpressionKind::Member(member_data) if matches!(member_data.object.inner, ExpressionKind::Super) => {
             // super.func`` or super["func"]``
             // Per spec, evaluation order: ResolveThisBinding, evaluate
             // computed property, then ResolveSuperBase.
             let this_value = emit_resolve_this_binding(generator);
             let computed_key = if member_data.computed {
-                Some(generate_expression_or_undefined(
-                    &member_data.property,
-                    generator,
-                    None,
-                ))
+                Some(generate_expression_or_undefined(&member_data.property, generator, None))
             } else {
                 None
             };
@@ -4984,15 +4717,12 @@ fn generate_tagged_template_literal(
             let obj = generate_expression_or_undefined(&member_data.object, generator, None);
             let method = generator.allocate_register();
             if member_data.computed {
-                let property =
-                    generate_expression_or_undefined(&member_data.property, generator, None);
+                let property = generate_expression_or_undefined(&member_data.property, generator, None);
                 emit_get_by_value(generator, &method, &obj, &property, None);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
                 emit_get_by_id(generator, &method, &obj, &ident.name, base_id);
-            } else if let ExpressionKind::PrivateIdentifier(priv_ident) =
-                &member_data.property.inner
-            {
+            } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
                 let id = generator.intern_identifier(&priv_ident.name);
                 generator.emit(Instruction::GetPrivateById {
                     dst: method.operand(),
@@ -5174,9 +4904,7 @@ fn generate_switch_statement(
             if did_create_env
                 && let StatementKind::FunctionDeclaration(ref fd) = child.inner
                 && let Some(ref name_ident) = fd.name
-                && generator
-                    .annexb_function_names
-                    .contains(name_ident.name.as_slice())
+                && generator.annexb_function_names.contains(name_ident.name.as_slice())
             {
                 let id = generator.intern_identifier(&name_ident.name);
                 let value = generator.allocate_register();
@@ -5233,16 +4961,10 @@ fn generate_switch_statement(
 /// Create block declaration instantiation for switch statements.
 /// Function declarations and let/const declarations across all cases
 /// share a single lexical environment.
-fn emit_switch_block_declaration_instantiation(
-    generator: &mut Generator,
-    data: &SwitchStatementData,
-) -> bool {
+fn emit_switch_block_declaration_instantiation(generator: &mut Generator, data: &SwitchStatementData) -> bool {
     // Collect all statements across all cases.
     let case_scopes: Vec<_> = data.cases.iter().map(|c| c.scope.borrow()).collect();
-    let all_children: Vec<&Statement> = case_scopes
-        .iter()
-        .flat_map(|scope| scope.children.iter())
-        .collect();
+    let all_children: Vec<&Statement> = case_scopes.iter().flat_map(|scope| scope.children.iter()).collect();
 
     // Check if we need a lexical environment.
     // Only needed if there are non-local lexical declarations.
@@ -5258,9 +4980,7 @@ fn emit_switch_block_declaration_instantiation(
             })
         }
         StatementKind::VariableDeclaration(_) => false,
-        StatementKind::ClassDeclaration(class_data) => {
-            class_data.name.as_ref().is_some_and(|n| !n.is_local())
-        }
+        StatementKind::ClassDeclaration(class_data) => class_data.name.as_ref().is_some_and(|n| !n.is_local()),
         _ => false,
     });
 
@@ -5343,8 +5063,7 @@ fn generate_object_expression(
         //
         // NB: StringLiteral keys are always treated as non-computed (see is_simple comment).
         let is_string_literal_key = matches!(&property.key.inner, ExpressionKind::StringLiteral(_));
-        let is_string_key =
-            is_string_literal_key || matches!(&property.key.inner, ExpressionKind::Identifier(_));
+        let is_string_key = is_string_literal_key || matches!(&property.key.inner, ExpressionKind::Identifier(_));
         let effectively_computed = property.is_computed && !is_string_literal_key;
         let computed_key = if effectively_computed || !is_string_key {
             let key = generate_expression_or_undefined(&property.key, generator, None);
@@ -5425,9 +5144,7 @@ fn generate_object_expression(
                 } else {
                     // Non-simple object: use PutOwnById instead of InitObjectLiteralProperty
                     let property_key = match &property.key.inner {
-                        ExpressionKind::Identifier(ident) => {
-                            generator.intern_property_key(&ident.name)
-                        }
+                        ExpressionKind::Identifier(ident) => generator.intern_property_key(&ident.name),
                         ExpressionKind::StringLiteral(s) => generator.intern_property_key(s),
                         _ => {
                             emit_object_property_set_by_key(
@@ -5457,28 +5174,14 @@ fn generate_object_expression(
                 if let Some(key_val) = &computed_key {
                     emit_put_by_value(generator, &dst, key_val, &value, PutKind::Getter);
                 } else {
-                    emit_object_accessor_by_key(
-                        generator,
-                        &dst,
-                        &property.key,
-                        &value,
-                        true,
-                        false,
-                    );
+                    emit_object_accessor_by_key(generator, &dst, &property.key, &value, true, false);
                 }
             }
             ObjectPropertyType::Setter => {
                 if let Some(key_val) = &computed_key {
                     emit_put_by_value(generator, &dst, key_val, &value, PutKind::Setter);
                 } else {
-                    emit_object_accessor_by_key(
-                        generator,
-                        &dst,
-                        &property.key,
-                        &value,
-                        false,
-                        false,
-                    );
+                    emit_object_accessor_by_key(generator, &dst, &property.key, &value, false, false);
                 }
             }
             ObjectPropertyType::ProtoSetter => {
@@ -5723,9 +5426,7 @@ fn generate_optional_chain_inner(
             OptionalChainReference::Call { mode, .. }
             | OptionalChainReference::ComputedReference { mode, .. }
             | OptionalChainReference::MemberReference { mode, .. }
-            | OptionalChainReference::PrivateMemberReference { mode, .. } => {
-                *mode == OptionalChainMode::Optional
-            }
+            | OptionalChainReference::PrivateMemberReference { mode, .. } => *mode == OptionalChainMode::Optional,
         };
 
         if is_optional {
@@ -5741,13 +5442,7 @@ fn generate_optional_chain_inner(
         match reference {
             OptionalChainReference::MemberReference { identifier, .. } => {
                 generator.emit_mov(current_base, current_value);
-                emit_get_by_id(
-                    generator,
-                    current_value,
-                    current_value,
-                    &identifier.name,
-                    None,
-                );
+                emit_get_by_id(generator, current_value, current_value, &identifier.name, None);
             }
             OptionalChainReference::ComputedReference { expression, .. } => {
                 generator.emit_mov(current_base, current_value);
@@ -5766,9 +5461,7 @@ fn generate_optional_chain_inner(
                 let undef = generator.add_constant_undefined();
                 generator.emit_mov(current_base, &undef);
             }
-            OptionalChainReference::PrivateMemberReference {
-                private_identifier, ..
-            } => {
+            OptionalChainReference::PrivateMemberReference { private_identifier, .. } => {
                 generator.emit_mov(current_base, current_value);
                 let id = generator.intern_identifier(&private_identifier.name);
                 generator.emit(Instruction::GetPrivateById {
@@ -5792,10 +5485,7 @@ fn generate_optional_chain_inner(
 }
 
 /// Convert arguments to an array for CallWithArgumentArray.
-fn generate_arguments_array(
-    generator: &mut Generator,
-    arguments: &[CallArgument],
-) -> ScopedOperand {
+fn generate_arguments_array(generator: &mut Generator, arguments: &[CallArgument]) -> ScopedOperand {
     let dst = generator.allocate_register();
     if arguments.is_empty() {
         generator.emit(Instruction::NewArray {
@@ -5806,10 +5496,7 @@ fn generate_arguments_array(
         return dst;
     }
 
-    let first_spread = arguments
-        .iter()
-        .position(|a| a.is_spread)
-        .unwrap_or(arguments.len());
+    let first_spread = arguments.iter().position(|a| a.is_spread).unwrap_or(arguments.len());
 
     let mut arg_holders = Vec::with_capacity(first_spread);
     for argument in &arguments[..first_spread] {
@@ -5873,9 +5560,7 @@ fn generate_class_expression(
         parent: parent_env.operand(),
         capacity: 0,
     });
-    generator
-        .lexical_environment_register_stack
-        .push(class_env.clone());
+    generator.lexical_environment_register_stack.push(class_env.clone());
 
     // Step 3.a: Create binding for the class name in the class environment.
     // Only emit when the class has a name, or when there's no lhs_name
@@ -5994,11 +5679,7 @@ fn generate_class_expression(
                 // correctly handles computed keys (Symbols, etc).
                 let sfd_index = if let ExpressionKind::Function(function_id) = &function.inner {
                     let function_data = generator.function_table.take(*function_id);
-                    super::ffi::FFIOptionalU32::some(emit_new_function(
-                        generator,
-                        function_data,
-                        None,
-                    ))
+                    super::ffi::FFIOptionalU32::some(emit_new_function(generator, function_data, None))
                 } else {
                     super::ffi::FFIOptionalU32::none()
                 };
@@ -6089,18 +5770,14 @@ fn generate_class_expression(
                         // Wrap the expression in a ClassFieldInitializer statement.
                         let body_statement = Statement::new(
                             init_expression.range,
-                            StatementKind::ClassFieldInitializer(Box::new(
-                                ClassFieldInitializerData {
-                                    expression: Box::new(init_expression.as_ref().clone()),
-                                    field_name,
-                                },
-                            )),
+                            StatementKind::ClassFieldInitializer(Box::new(ClassFieldInitializerData {
+                                expression: Box::new(init_expression.as_ref().clone()),
+                                field_name,
+                            })),
                         );
                         let wrapper_body = Statement::new(
                             init_expression.range,
-                            StatementKind::Block(ScopeData::shared_with_children(vec![
-                                body_statement,
-                            ])),
+                            StatementKind::Block(ScopeData::shared_with_children(vec![body_statement])),
                         );
 
                         // Class bodies are always strict mode.
@@ -6120,8 +5797,7 @@ fn generate_class_expression(
                                 ..Default::default()
                             },
                         });
-                        let index =
-                            emit_new_function(generator, function_data, Some(utf16!("field")));
+                        let index = emit_new_function(generator, function_data, Some(utf16!("field")));
 
                         // Set class_field_initializer_name on the SFD.
                         let sfd_ptr = generator.shared_function_data[index as usize];
@@ -6155,9 +5831,7 @@ fn generate_class_expression(
                 // Keep literal string data alive until FFI call.
                 let (str_ptr, str_len) = if !literal_value_string.is_empty() {
                     literal_string_storage.push(literal_value_string);
-                    let s = literal_string_storage
-                        .last()
-                        .expect("just pushed an element");
+                    let s = literal_string_storage.last().expect("just pushed an element");
                     (s.as_ptr(), s.len())
                 } else {
                     (std::ptr::null(), 0)
@@ -6196,11 +5870,7 @@ fn generate_class_expression(
                         ..Default::default()
                     },
                 });
-                let sfd_index = super::ffi::FFIOptionalU32::some(emit_new_function(
-                    generator,
-                    function_data,
-                    None,
-                ));
+                let sfd_index = super::ffi::FFIOptionalU32::some(emit_new_function(generator, function_data, None));
 
                 ffi_elements.push(super::ffi::FFIClassElement {
                     kind: ClassElementKind::StaticInitializer as u8,
@@ -6246,17 +5916,11 @@ fn generate_class_expression(
             ffi_elements.len(),
         )
     };
-    assert!(
-        !bp_ptr.is_null(),
-        "rust_create_class_blueprint returned null"
-    );
+    assert!(!bp_ptr.is_null(), "rust_create_class_blueprint returned null");
     let blueprint_index = generator.register_class_blueprint(bp_ptr);
 
     // Build element_keys operands for the NewClass instruction
-    let element_key_ops: Vec<Option<Operand>> = element_keys
-        .iter()
-        .map(|k| k.as_ref().map(|s| s.operand()))
-        .collect();
+    let element_key_ops: Vec<Option<Operand>> = element_keys.iter().map(|k| k.as_ref().map(|s| s.operand())).collect();
 
     // Restore parent environment before emitting NewClass.
     generator.emit(Instruction::SetLexicalEnvironment {
@@ -6291,9 +5955,7 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
 
     // Wrap in "function" keyword so it parses as a FunctionDeclaration.
     let source: Utf16String = if has_super {
-        Utf16String::from(utf16!(
-            "function constructor(...arguments) { super(...arguments); }"
-        ))
+        Utf16String::from(utf16!("function constructor(...arguments) { super(...arguments); }"))
     } else {
         Utf16String::from(utf16!("function constructor() {}"))
     };
@@ -6340,10 +6002,7 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
             None,
         )
     };
-    assert!(
-        !sfd_ptr.is_null(),
-        "default constructor creation returned null"
-    );
+    assert!(!sfd_ptr.is_null(), "default constructor creation returned null");
     generator.register_shared_function_data(sfd_ptr)
 }
 
@@ -6504,12 +6163,8 @@ fn generate_for_in_of_statement(
 ) -> Option<ScopedOperand> {
     match kind {
         ForInOfKind::ForIn => generate_for_in_statement(generator, lhs, rhs, body, preferred_dst),
-        ForInOfKind::ForOf => {
-            generate_for_of_statement_inner(generator, lhs, rhs, body, preferred_dst, false)
-        }
-        ForInOfKind::ForAwaitOf => {
-            generate_for_of_statement_inner(generator, lhs, rhs, body, preferred_dst, true)
-        }
+        ForInOfKind::ForOf => generate_for_of_statement_inner(generator, lhs, rhs, body, preferred_dst, false),
+        ForInOfKind::ForAwaitOf => generate_for_of_statement_inner(generator, lhs, rhs, body, preferred_dst, true),
     }
 }
 
@@ -6526,8 +6181,7 @@ fn generate_for_in_statement(
         && let StatementKind::VariableDeclaration(vd) = &statement.inner
         && vd.kind == DeclarationKind::Var
         && let Some(declaration) = vd.declarations.first()
-        && let (VariableDeclaratorTarget::Identifier(ident), Some(init)) =
-            (&declaration.target, &declaration.init)
+        && let (VariableDeclaratorTarget::Identifier(ident), Some(init)) = (&declaration.target, &declaration.init)
     {
         generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
         let value = generate_expression_or_undefined(init, generator, None);
@@ -6584,9 +6238,7 @@ fn generate_for_in_statement(
     // Body evaluation: completion, then jump to update block.
     let completion = generator.allocate_completion_register();
 
-    generator.emit(Instruction::Jump {
-        target: update_block,
-    });
+    generator.emit(Instruction::Jump { target: update_block });
 
     // Update: get next value
     generator.switch_to_basic_block(update_block);
@@ -6630,9 +6282,7 @@ fn generate_for_in_statement(
     generator.end_continuable_scope();
 
     if !generator.is_current_block_terminated() {
-        generator.emit(Instruction::Jump {
-            target: update_block,
-        });
+        generator.emit(Instruction::Jump { target: update_block });
     }
 
     generator.switch_to_basic_block(end_block);
@@ -6778,9 +6428,7 @@ fn generate_for_of_statement_inner(
     generator.begin_breakable_scope(end_block, labels.clone(), completion.clone());
     generator.start_boundary(BlockBoundaryType::ReturnToFinally);
 
-    generator.emit(Instruction::Jump {
-        target: update_block,
-    });
+    generator.emit(Instruction::Jump { target: update_block });
 
     // Update: get next value
     generator.switch_to_basic_block(update_block);
@@ -6879,9 +6527,7 @@ fn generate_for_of_statement_inner(
     generator.end_breakable_scope();
 
     // Pop the FinallyContext.
-    let finally_ctx_index = generator
-        .current_finally_context
-        .expect("no active finally context");
+    let finally_ctx_index = generator.current_finally_context.expect("no active finally context");
     generator.current_finally_context = generator.finally_contexts[finally_ctx_index].parent_index;
 
     // Restore unwind handler
@@ -6896,9 +6542,7 @@ fn generate_for_of_statement_inner(
                 environment: parent.operand(),
             });
         }
-        generator.emit(Instruction::Jump {
-            target: update_block,
-        });
+        generator.emit(Instruction::Jump { target: update_block });
     }
 
     // --- Exception preamble: catch thrown exception, route to iterator close ---
@@ -6970,12 +6614,8 @@ fn generate_for_of_statement_inner(
         let rct = generator.allocate_register();
         let rcv = generator.allocate_register();
         let awaited = generate_await_with_completions(generator, &inner_result, &rc, &rct, &rcv);
-        generator.emit(Instruction::ThrowIfNotObject {
-            src: awaited.operand(),
-        });
-        generator.emit(Instruction::Jump {
-            target: after_close,
-        });
+        generator.emit(Instruction::ThrowIfNotObject { src: awaited.operand() });
+        generator.emit(Instruction::Jump { target: after_close });
         generator.switch_to_basic_block(after_close);
     } else {
         let undef = generator.add_constant_undefined();
@@ -6989,8 +6629,7 @@ fn generate_for_of_statement_inner(
     }
 
     // Dispatch registered jumps (break/continue targets).
-    let registered_jumps =
-        std::mem::take(&mut generator.finally_contexts[finally_ctx_index].registered_jumps);
+    let registered_jumps = std::mem::take(&mut generator.finally_contexts[finally_ctx_index].registered_jumps);
     for jump in &registered_jumps {
         let after_check = generator.make_block();
         let jump_const = generator.add_constant_i32(jump.index);
@@ -7016,12 +6655,8 @@ fn generate_for_of_statement_inner(
 
     generator.switch_to_basic_block(return_block);
     if let Some(outer_index) = generator.current_finally_context {
-        let outer_ct = generator.finally_contexts[outer_index]
-            .completion_type
-            .clone();
-        let outer_cv = generator.finally_contexts[outer_index]
-            .completion_value
-            .clone();
+        let outer_ct = generator.finally_contexts[outer_index].completion_type.clone();
+        let outer_cv = generator.finally_contexts[outer_index].completion_value.clone();
         let outer_fb = generator.finally_contexts[outer_index].finally_body;
         generator.emit_mov(&outer_ct, &close_completion_type);
         generator.emit_mov(&outer_cv, &close_completion_value);
@@ -7097,9 +6732,7 @@ fn generate_for_of_statement_inner(
             generate_await_with_completions(generator, &inner_result, &rc, &rct, &rcv);
 
             // Even if close succeeded, rethrow original (spec step 5).
-            generator.emit(Instruction::Jump {
-                target: rethrow_block,
-            });
+            generator.emit(Instruction::Jump { target: rethrow_block });
         }
 
         // Exception handler: discard close error, rethrow original.
@@ -7109,9 +6742,7 @@ fn generate_for_of_statement_inner(
         generator.emit(Instruction::Catch {
             dst: discarded.operand(),
         });
-        generator.emit(Instruction::Jump {
-            target: rethrow_block,
-        });
+        generator.emit(Instruction::Jump { target: rethrow_block });
 
         generator.switch_to_basic_block(rethrow_block);
         generator.emit(Instruction::Throw {
@@ -7154,8 +6785,7 @@ fn assign_to_for_in_of_lhs(generator: &mut Generator, lhs: &ForInOfLhs, value: &
             if matches!(statement.inner, StatementKind::UsingDeclaration(_)) {
                 generate_statement(statement, generator, None);
                 let exception = generator.allocate_register();
-                let error_string =
-                    generator.intern_string(utf16!("Invalid left-hand side in assignment"));
+                let error_string = generator.intern_string(utf16!("Invalid left-hand side in assignment"));
                 generator.emit(Instruction::NewReferenceError {
                     dst: exception.operand(),
                     error_string,
@@ -7248,8 +6878,7 @@ fn emit_set_variable_with_mode(
     mode: BindingMode,
 ) {
     if ident.is_local() {
-        let local =
-            generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
+        let local = generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
         generator.emit_mov(&local, value);
     } else {
         let id = generator.intern_identifier(&ident.name);
@@ -7331,12 +6960,11 @@ fn generate_array_binding_pattern(
         if entry.is_rest {
             // 13.15.5.3 AssignmentRestElement: ... DestructuringAssignmentTarget
             // Step 1: Evaluate the reference BEFORE iterating remaining elements.
-            let evaluated_ref =
-                if let Some(BindingEntryAlias::MemberExpression(expression)) = &entry.alias {
-                    Some(emit_evaluate_member_reference(generator, expression))
-                } else {
-                    None
-                };
+            let evaluated_ref = if let Some(BindingEntryAlias::MemberExpression(expression)) = &entry.alias {
+                Some(emit_evaluate_member_reference(generator, expression))
+            } else {
+                None
+            };
 
             // Rest element: collect remaining into array.
             // NB: Allocate register unconditionally, then re-allocate in the
@@ -7364,9 +6992,7 @@ fn generate_array_binding_pattern(
                     element_count: 0,
                     elements: Vec::new(),
                 });
-                generator.emit(Instruction::Jump {
-                    target: continuation,
-                });
+                generator.emit(Instruction::Jump { target: continuation });
 
                 generator.switch_to_basic_block(if_not_exhausted);
                 generator.emit(Instruction::IteratorToArray {
@@ -7375,9 +7001,7 @@ fn generate_array_binding_pattern(
                     iterator_next_method: iterator_next.operand(),
                     iterator_done_property: iterator_done.operand(),
                 });
-                generator.emit(Instruction::Jump {
-                    target: continuation,
-                });
+                generator.emit(Instruction::Jump { target: continuation });
 
                 generator.switch_to_basic_block(continuation);
             }
@@ -7392,12 +7016,11 @@ fn generate_array_binding_pattern(
 
         // 13.15.5.5 AssignmentElement: DestructuringAssignmentTarget Initializer(opt)
         // Step 1: Evaluate the reference BEFORE calling IteratorStepValue.
-        let evaluated_ref =
-            if let Some(BindingEntryAlias::MemberExpression(expression)) = &entry.alias {
-                Some(emit_evaluate_member_reference(generator, expression))
-            } else {
-                None
-            };
+        let evaluated_ref = if let Some(BindingEntryAlias::MemberExpression(expression)) = &entry.alias {
+            Some(emit_evaluate_member_reference(generator, expression))
+        } else {
+            None
+        };
 
         // For elisions (name is None), we still advance the iterator
         // but don't bind anything.
@@ -7492,9 +7115,7 @@ fn generate_object_binding_pattern(
     mode: BindingMode,
     object: &ScopedOperand,
 ) {
-    generator.emit(Instruction::ThrowIfNullish {
-        src: object.operand(),
-    });
+    generator.emit(Instruction::ThrowIfNullish { src: object.operand() });
 
     let mut excluded_names: Vec<ScopedOperand> = Vec::new();
     let has_rest = pattern.entries.last().is_some_and(|e| e.is_rest);
@@ -7626,15 +7247,9 @@ fn generate_try_statement(
         //   completion_type = THROW
         //   Jump → finally_body
         generator.switch_to_basic_block(exception_preamble_block);
-        let ctx_index = generator
-            .current_finally_context
-            .expect("no active finally context");
-        let cv = generator.finally_contexts[ctx_index]
-            .completion_value
-            .clone();
-        let ct = generator.finally_contexts[ctx_index]
-            .completion_type
-            .clone();
+        let ctx_index = generator.current_finally_context.expect("no active finally context");
+        let cv = generator.finally_contexts[ctx_index].completion_value.clone();
+        let ct = generator.finally_contexts[ctx_index].completion_type.clone();
         generator.emit(Instruction::Catch { dst: cv.operand() });
         generator.emit(Instruction::SetLexicalEnvironment {
             environment: saved_env.operand(),
@@ -7758,12 +7373,8 @@ fn generate_try_statement(
         if !generator.is_current_block_terminated() {
             if has_finally {
                 // Normal exit from catch → completion_type = NORMAL, jump to finally.
-                let ctx_index = generator
-                    .current_finally_context
-                    .expect("no active finally context");
-                let ct = generator.finally_contexts[ctx_index]
-                    .completion_type
-                    .clone();
+                let ctx_index = generator.current_finally_context.expect("no active finally context");
+                let ct = generator.finally_contexts[ctx_index].completion_type.clone();
                 let fb = generator.finally_contexts[ctx_index].finally_body;
                 let normal_const = generator.add_constant_i32(FinallyContext::NORMAL);
                 generator.emit_mov(&ct, &normal_const);
@@ -7799,9 +7410,7 @@ fn generate_try_statement(
 
     let try_body_block = generator.make_block();
     generator.switch_to_basic_block(saved_block);
-    generator.emit(Instruction::Jump {
-        target: try_body_block,
-    });
+    generator.emit(Instruction::Jump { target: try_body_block });
 
     if has_finally {
         generator.start_boundary(BlockBoundaryType::ReturnToFinally);
@@ -7839,12 +7448,8 @@ fn generate_try_statement(
     if !generator.is_current_block_terminated() {
         if has_finally {
             // Normal exit from try → completion_type = NORMAL, jump to finally.
-            let ctx_index = generator
-                .current_finally_context
-                .expect("no active finally context");
-            let ct = generator.finally_contexts[ctx_index]
-                .completion_type
-                .clone();
+            let ctx_index = generator.current_finally_context.expect("no active finally context");
+            let ct = generator.finally_contexts[ctx_index].completion_type.clone();
             let fb = generator.finally_contexts[ctx_index].finally_body;
             let normal_const = generator.add_constant_i32(FinallyContext::NORMAL);
             generator.emit_mov(&ct, &normal_const);
@@ -7870,18 +7475,12 @@ fn generate_try_statement(
     // --- Generate finally body and after-finally dispatch ---
     if let Some(fb_block) = finally_body_block {
         // Pop FinallyContext.
-        let ctx_index = generator
-            .current_finally_context
-            .expect("no active finally context");
+        let ctx_index = generator.current_finally_context.expect("no active finally context");
         generator.current_finally_context = generator.finally_contexts[ctx_index].parent_index;
 
         // Extract fields needed for dispatch (to avoid borrow conflicts).
-        let ctx_ct = generator.finally_contexts[ctx_index]
-            .completion_type
-            .clone();
-        let ctx_cv = generator.finally_contexts[ctx_index]
-            .completion_value
-            .clone();
+        let ctx_ct = generator.finally_contexts[ctx_index].completion_type.clone();
+        let ctx_cv = generator.finally_contexts[ctx_index].completion_value.clone();
 
         generator.switch_to_basic_block(fb_block);
         generator.start_boundary(BlockBoundaryType::LeaveFinally);
@@ -7922,8 +7521,7 @@ fn generate_try_statement(
             generator.switch_to_basic_block(after_normal_check);
 
             // 2. Registered break/continue jumps
-            let registered_jumps =
-                std::mem::take(&mut generator.finally_contexts[ctx_index].registered_jumps);
+            let registered_jumps = std::mem::take(&mut generator.finally_contexts[ctx_index].registered_jumps);
             for jump in &registered_jumps {
                 let after_jump_check = generator.make_block();
                 let jump_const = generator.add_constant_i32(jump.index);
@@ -7951,12 +7549,8 @@ fn generate_try_statement(
             generator.switch_to_basic_block(return_block);
             if let Some(outer_index) = generator.current_finally_context {
                 // Nested finally: copy completion record to outer and jump to outer finally.
-                let outer_ct = generator.finally_contexts[outer_index]
-                    .completion_type
-                    .clone();
-                let outer_cv = generator.finally_contexts[outer_index]
-                    .completion_value
-                    .clone();
+                let outer_ct = generator.finally_contexts[outer_index].completion_type.clone();
+                let outer_cv = generator.finally_contexts[outer_index].completion_value.clone();
                 let outer_fb = generator.finally_contexts[outer_index].finally_body;
                 generator.emit_mov(&outer_ct, &ctx_ct);
                 generator.emit_mov(&outer_cv, &ctx_cv);
@@ -7974,9 +7568,7 @@ fn generate_try_statement(
 
             // 4. Default → rethrow the exception.
             generator.switch_to_basic_block(rethrow_block);
-            generator.emit(Instruction::Throw {
-                src: ctx_cv.operand(),
-            });
+            generator.emit(Instruction::Throw { src: ctx_cv.operand() });
         }
 
         generator.finally_contexts[ctx_index].lexical_environment_at_entry = None;
@@ -8000,11 +7592,7 @@ fn generate_try_statement(
 /// and register it with the generator.
 ///
 /// Returns the shared_function_data_index for use in NewFunction instructions.
-fn emit_new_function(
-    generator: &mut Generator,
-    data: Box<FunctionData>,
-    name_override: Option<&[u16]>,
-) -> u32 {
+fn emit_new_function(generator: &mut Generator, data: Box<FunctionData>, name_override: Option<&[u16]>) -> u32 {
     assert!(
         data.source_text_end as usize <= generator.source_len,
         "Function source range out of bounds: {}..{} (source len {})",
@@ -8073,22 +7661,13 @@ pub fn emit_function_declaration_instantiation(
                 }
             }
             FunctionParameterBinding::BindingPattern(pattern) => {
-                collect_binding_pattern_names(
-                    pattern,
-                    &mut parameter_names,
-                    &mut seen_names,
-                    &mut has_duplicates,
-                );
+                collect_binding_pattern_names(pattern, &mut parameter_names, &mut seen_names, &mut has_duplicates);
             }
         }
     }
 
     // Determine if arguments object is needed (from parsing insights).
-    let mut arguments_object_needed = if is_arrow
-        || parameter_names
-            .iter()
-            .any(|p| p.name == utf16!("arguments"))
-    {
+    let mut arguments_object_needed = if is_arrow || parameter_names.iter().any(|p| p.name == utf16!("arguments")) {
         false
     } else {
         function_data.parsing_insights.might_need_arguments_object
@@ -8100,10 +7679,7 @@ pub fn emit_function_declaration_instantiation(
         if !has_parameter_expressions && fsd.has_function_named_arguments {
             arguments_object_needed = false;
         }
-        if !has_parameter_expressions
-            && arguments_object_needed
-            && fsd.has_lexically_declared_arguments
-        {
+        if !has_parameter_expressions && arguments_object_needed && fsd.has_lexically_declared_arguments {
             arguments_object_needed = false;
         }
     }
@@ -8153,9 +7729,7 @@ pub fn emit_function_declaration_instantiation(
 
         let kind = if strict
             || !function_data.parameters.iter().all(|p| {
-                !p.is_rest
-                    && p.default_value.is_none()
-                    && matches!(p.binding, FunctionParameterBinding::Identifier(_))
+                !p.is_rest && p.default_value.is_none() && matches!(p.binding, FunctionParameterBinding::Identifier(_))
             }) {
             ArgumentsKind::Unmapped as u32
         } else {
@@ -8267,8 +7841,7 @@ pub fn emit_function_declaration_instantiation(
 
                 if let Some(local_binding) = var.local {
                     let undef = generator.add_constant_undefined();
-                    let local =
-                        var_local_operand(generator, local_binding.local_type, local_binding.index);
+                    let local = var_local_operand(generator, local_binding.local_type, local_binding.index);
                     generator.emit_mov(&local, &undef);
                 } else {
                     let id = generator.intern_identifier(&var.name);
@@ -8301,15 +7874,13 @@ pub fn emit_function_declaration_instantiation(
                 // (e.g. Step 7) use the var environment as their parent, not the
                 // parameter scope.
                 let var_env = generator.allocate_register();
-                generator.emit(Instruction::GetLexicalEnvironment {
-                    dst: var_env.operand(),
-                });
+                generator.emit(Instruction::GetLexicalEnvironment { dst: var_env.operand() });
                 generator.lexical_environment_register_stack.push(var_env);
             }
 
             for var in &fsd.vars_to_initialize {
-                let is_in_parameter_bindings = var.is_parameter
-                    || (arguments_object_needed && var.name == utf16!("arguments"));
+                let is_in_parameter_bindings =
+                    var.is_parameter || (arguments_object_needed && var.name == utf16!("arguments"));
 
                 let initial_value = if !is_in_parameter_bindings || var.is_function_name {
                     let value = generator.allocate_register();
@@ -8317,8 +7888,7 @@ pub fn emit_function_declaration_instantiation(
                     generator.emit_mov(&value, &undef);
                     value
                 } else if let Some(local_binding) = var.local {
-                    let local =
-                        var_local_operand(generator, local_binding.local_type, local_binding.index);
+                    let local = var_local_operand(generator, local_binding.local_type, local_binding.index);
                     let value = generator.allocate_register();
                     generator.emit_mov(&value, &local);
                     value
@@ -8334,8 +7904,7 @@ pub fn emit_function_declaration_instantiation(
                 };
 
                 if let Some(local_binding) = var.local {
-                    let local =
-                        var_local_operand(generator, local_binding.local_type, local_binding.index);
+                    let local = var_local_operand(generator, local_binding.local_type, local_binding.index);
                     generator.emit_mov(&local, &initial_value);
                 } else {
                     let id = generator.intern_identifier(&var.name);
@@ -8477,10 +8046,7 @@ pub fn emit_function_declaration_instantiation(
 
 /// Check if a statement is a for-loop variant (for, for-in, for-of, for-await-of).
 fn is_for_loop(statement: &Statement) -> bool {
-    matches!(
-        statement.inner,
-        StatementKind::For(_) | StatementKind::ForInOf(_)
-    )
+    matches!(statement.inner, StatementKind::For(_) | StatementKind::ForInOf(_))
 }
 
 /// Check if a block needs block declaration instantiation.
@@ -8538,9 +8104,7 @@ fn count_non_local_lexical_bindings(scope: &ScopeData) -> u32 {
                     count += u32_from_usize(names.len());
                 }
             }
-            StatementKind::ClassDeclaration(class_data)
-                if class_data.name.as_ref().is_some_and(|n| !n.is_local()) =>
-            {
+            StatementKind::ClassDeclaration(class_data) if class_data.name.as_ref().is_some_and(|n| !n.is_local()) => {
                 count += 1;
             }
             _ => {}
@@ -8550,11 +8114,7 @@ fn count_non_local_lexical_bindings(scope: &ScopeData) -> u32 {
 }
 
 /// Create a ScopedOperand for a VarToInit's local variable (argument or variable).
-fn var_local_operand(
-    generator: &mut Generator,
-    local_type: LocalType,
-    index: u32,
-) -> ScopedOperand {
+fn var_local_operand(generator: &mut Generator, local_type: LocalType, index: u32) -> ScopedOperand {
     generator.resolve_local(index, local_type)
 }
 
@@ -8578,12 +8138,7 @@ fn collect_binding_pattern_names(
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub_pattern)) => {
-                collect_binding_pattern_names(
-                    sub_pattern,
-                    parameter_names,
-                    seen_names,
-                    has_duplicates,
-                );
+                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates);
             }
             None => {
                 // No alias — the name itself is the binding.
@@ -8670,11 +8225,7 @@ fn get_builtin(callee: &Expression) -> Option<u8> {
         (utf16!("Math"), utf16!("sin"), BUILTIN_MATH_SIN),
         (utf16!("Math"), utf16!("cos"), BUILTIN_MATH_COS),
         (utf16!("Math"), utf16!("tan"), BUILTIN_MATH_TAN),
-        (
-            utf16!("RegExpPrototype"),
-            utf16!("exec"),
-            BUILTIN_REGEXP_PROTOTYPE_EXEC,
-        ),
+        (utf16!("RegExpPrototype"), utf16!("exec"), BUILTIN_REGEXP_PROTOTYPE_EXEC),
         (
             utf16!("RegExpPrototype"),
             utf16!("replace"),
@@ -8710,11 +8261,7 @@ fn get_builtin(callee: &Expression) -> Option<u8> {
             utf16!("next"),
             BUILTIN_STRING_ITERATOR_PROTOTYPE_NEXT,
         ),
-        (
-            utf16!("String"),
-            utf16!("fromCharCode"),
-            BUILTIN_STRING_FROM_CHAR_CODE,
-        ),
+        (utf16!("String"), utf16!("fromCharCode"), BUILTIN_STRING_FROM_CHAR_CODE),
     ];
     for &(base, property, id) in BUILTINS {
         if base_ident.name == base && property_ident.name == property {
@@ -8914,11 +8461,7 @@ fn is_numeric_index_key(key: &[u16]) -> bool {
 // =============================================================================
 
 /// Try to constant-fold a unary operation when the operand is a constant.
-fn try_constant_fold_unary(
-    generator: &mut Generator,
-    op: UnaryOp,
-    operand: &ScopedOperand,
-) -> Option<ScopedOperand> {
+fn try_constant_fold_unary(generator: &mut Generator, op: UnaryOp, operand: &ScopedOperand) -> Option<ScopedOperand> {
     let constant = generator.get_constant(operand)?;
     match op {
         UnaryOp::Minus => {
@@ -8946,10 +8489,7 @@ fn try_constant_fold_unary(
 }
 
 /// Constant-fold !!x when x is a constant, returning Boolean(x).
-fn try_constant_fold_to_boolean(
-    generator: &mut Generator,
-    operand: &ScopedOperand,
-) -> Option<ScopedOperand> {
+fn try_constant_fold_to_boolean(generator: &mut Generator, operand: &ScopedOperand) -> Option<ScopedOperand> {
     let constant = generator.get_constant(operand)?;
     let as_bool = constant_to_boolean(constant)?;
     Some(generator.add_constant_boolean(as_bool))
@@ -8960,12 +8500,12 @@ fn try_constant_fold_to_boolean(
 fn try_constant_loosely_equals(lhs: &ConstantValue, rhs: &ConstantValue) -> Option<bool> {
     // Same type: use strict equality rules.
     match (lhs, rhs) {
-        (
-            ConstantValue::Null | ConstantValue::Undefined,
-            ConstantValue::Null | ConstantValue::Undefined,
-        ) => return Some(true),
-        (ConstantValue::Null | ConstantValue::Undefined, _)
-        | (_, ConstantValue::Null | ConstantValue::Undefined) => return Some(false),
+        (ConstantValue::Null | ConstantValue::Undefined, ConstantValue::Null | ConstantValue::Undefined) => {
+            return Some(true);
+        }
+        (ConstantValue::Null | ConstantValue::Undefined, _) | (_, ConstantValue::Null | ConstantValue::Undefined) => {
+            return Some(false);
+        }
         (ConstantValue::Number(a), ConstantValue::Number(b)) => return Some(a == b),
         (ConstantValue::String(a), ConstantValue::String(b)) => return Some(a == b),
         (ConstantValue::Boolean(a), ConstantValue::Boolean(b)) => return Some(a == b),
@@ -8987,11 +8527,11 @@ fn try_constant_loosely_equals(lhs: &ConstantValue, rhs: &ConstantValue) -> Opti
     // Number == String → compare ToNumber(string) to number.
     // String == Number → compare number to ToNumber(string).
     match (lhs, rhs) {
-        (ConstantValue::Number(n), ConstantValue::String(s))
-        | (ConstantValue::String(s), ConstantValue::Number(n)) => Some(*n == string_to_number(s)),
+        (ConstantValue::Number(n), ConstantValue::String(s)) | (ConstantValue::String(s), ConstantValue::Number(n)) => {
+            Some(*n == string_to_number(s))
+        }
         // BigInt == Number or Number == BigInt: compare mathematical values.
-        (ConstantValue::BigInt(b), ConstantValue::Number(n))
-        | (ConstantValue::Number(n), ConstantValue::BigInt(b)) => {
+        (ConstantValue::BigInt(b), ConstantValue::Number(n)) | (ConstantValue::Number(n), ConstantValue::BigInt(b)) => {
             if n.is_nan() || n.is_infinite() {
                 return Some(false);
             }
@@ -9012,14 +8552,15 @@ fn try_constant_loosely_equals(lhs: &ConstantValue, rhs: &ConstantValue) -> Opti
         }
         // BigInt == String or String == BigInt: parse string as BigInt per StringToBigInt.
         // If the string cannot be parsed, the result is false (not equal).
-        (ConstantValue::BigInt(b), ConstantValue::String(s))
-        | (ConstantValue::String(s), ConstantValue::BigInt(b)) => match string_to_bigint(s) {
-            Some(s_bi) => {
-                let bi = parse_bigint(b)?;
-                Some(bi == s_bi)
+        (ConstantValue::BigInt(b), ConstantValue::String(s)) | (ConstantValue::String(s), ConstantValue::BigInt(b)) => {
+            match string_to_bigint(s) {
+                Some(s_bi) => {
+                    let bi = parse_bigint(b)?;
+                    Some(bi == s_bi)
+                }
+                None => Some(false),
             }
-            None => Some(false),
-        },
+        }
         _ => None,
     }
 }
@@ -9147,12 +8688,8 @@ fn try_constant_fold_bigint_binary(
             Some(generator.add_constant_bigint(num_traits::pow::pow(a, exp as usize).to_string()))
         }
         // Comparison operations: produce a Boolean result.
-        BinaryOp::StrictlyEquals | BinaryOp::LooselyEquals => {
-            Some(generator.add_constant_boolean(a == b))
-        }
-        BinaryOp::StrictlyInequals | BinaryOp::LooselyInequals => {
-            Some(generator.add_constant_boolean(a != b))
-        }
+        BinaryOp::StrictlyEquals | BinaryOp::LooselyEquals => Some(generator.add_constant_boolean(a == b)),
+        BinaryOp::StrictlyInequals | BinaryOp::LooselyInequals => Some(generator.add_constant_boolean(a != b)),
         BinaryOp::LessThan => Some(generator.add_constant_boolean(a < b)),
         BinaryOp::LessThanEquals => Some(generator.add_constant_boolean(a <= b)),
         BinaryOp::GreaterThan => Some(generator.add_constant_boolean(a > b)),
@@ -9239,9 +8776,10 @@ fn string_to_number(s: &Utf16String) -> f64 {
         // Convert validated suffix digits using the parser.
         return bigint_string_to_f64(rest, radix.as_u32());
     }
-    if !trimmed.bytes().all(|b| {
-        b.is_ascii_digit() || b == b'.' || b == b'e' || b == b'E' || b == b'+' || b == b'-'
-    }) {
+    if !trimmed
+        .bytes()
+        .all(|b| b.is_ascii_digit() || b == b'.' || b == b'e' || b == b'E' || b == b'+' || b == b'-')
+    {
         return f64::NAN;
     }
     trimmed.parse::<f64>().unwrap_or(f64::NAN)
@@ -9345,9 +8883,7 @@ fn try_constant_fold_binary(
     match op {
         BinaryOp::Addition => {
             // If either operand is a string, do string concatenation using ToString.
-            if matches!(lhs_const, ConstantValue::String(_))
-                || matches!(rhs_const, ConstantValue::String(_))
-            {
+            if matches!(lhs_const, ConstantValue::String(_)) || matches!(rhs_const, ConstantValue::String(_)) {
                 let a = constant_to_string(lhs_const)?;
                 let b = constant_to_string(rhs_const)?;
                 let mut result = a;
@@ -9401,10 +8937,7 @@ fn try_constant_fold_binary(
             };
             Some(generator.add_constant_boolean(result))
         }
-        BinaryOp::GreaterThan
-        | BinaryOp::GreaterThanEquals
-        | BinaryOp::LessThan
-        | BinaryOp::LessThanEquals => {
+        BinaryOp::GreaterThan | BinaryOp::GreaterThanEquals | BinaryOp::LessThan | BinaryOp::LessThanEquals => {
             // String-string comparison is lexicographic (by UTF-16 code units).
             if let (ConstantValue::String(a), ConstantValue::String(b)) = (lhs_const, rhs_const) {
                 let result = match op {
@@ -9428,9 +8961,7 @@ fn try_constant_fold_binary(
             };
             // BigInt vs Number comparison using Abstract Relational Comparison.
             let bigint_ord = match (lhs_for_cmp, rhs_for_cmp) {
-                (ConstantValue::BigInt(b), ConstantValue::Number(n)) => {
-                    compare_bigint_and_number(b, *n)
-                }
+                (ConstantValue::BigInt(b), ConstantValue::Number(n)) => compare_bigint_and_number(b, *n),
                 (ConstantValue::Number(n), ConstantValue::BigInt(b)) => {
                     compare_bigint_and_number(b, *n).map(|o| o.map(|o| o.reverse()))
                 }
@@ -9457,15 +8988,13 @@ fn try_constant_fold_binary(
             if let Some(ord) = bigint_ord {
                 let result = match op {
                     BinaryOp::GreaterThan => matches!(ord, Some(std::cmp::Ordering::Greater)),
-                    BinaryOp::GreaterThanEquals => matches!(
-                        ord,
-                        Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
-                    ),
+                    BinaryOp::GreaterThanEquals => {
+                        matches!(ord, Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal))
+                    }
                     BinaryOp::LessThan => matches!(ord, Some(std::cmp::Ordering::Less)),
-                    BinaryOp::LessThanEquals => matches!(
-                        ord,
-                        Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
-                    ),
+                    BinaryOp::LessThanEquals => {
+                        matches!(ord, Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal))
+                    }
                     _ => unreachable!("outer match arm only matches comparison operators"),
                 };
                 return Some(generator.add_constant_boolean(result));
@@ -9539,11 +9068,7 @@ const NEGATIVE_ZERO_BITS: u64 = 1u64 << 63;
 
 fn nanboxed_number(value: f64) -> u64 {
     let is_negative_zero = value.to_bits() == NEGATIVE_ZERO_BITS;
-    if value >= i32::MIN as f64
-        && value <= i32::MAX as f64
-        && value.trunc() == value
-        && !is_negative_zero
-    {
+    if value >= i32::MIN as f64 && value <= i32::MAX as f64 && value.trunc() == value && !is_negative_zero {
         (NANBOX_INT32_TAG << NANBOX_TAG_SHIFT) | ((value as i32 as u32) as u64)
     } else if value.is_nan() {
         // Canon NaN
@@ -9571,10 +9096,7 @@ fn nanboxed_empty() -> u64 {
 
 /// Intern the base expression as an identifier for error messages like
 /// "Cannot access property X on null object Y".
-fn intern_base_identifier(
-    generator: &mut Generator,
-    base: &Expression,
-) -> Option<IdentifierTableIndex> {
+fn intern_base_identifier(generator: &mut Generator, base: &Expression) -> Option<IdentifierTableIndex> {
     expression_identifier(base).map(|s| generator.intern_identifier(&s))
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -89,10 +89,7 @@ impl FFIOptionalU32 {
     }
 
     pub fn some(value: u32) -> Self {
-        Self {
-            value,
-            has_value: true,
-        }
+        Self { value, has_value: true }
     }
 }
 
@@ -238,20 +235,10 @@ unsafe extern "C" {
     // Callbacks for populating Script GDI data from Rust.
     pub fn script_gdi_push_lexical_name(ctx: *mut c_void, name: *const u16, len: usize);
     pub fn script_gdi_push_var_name(ctx: *mut c_void, name: *const u16, len: usize);
-    pub fn script_gdi_push_function(
-        ctx: *mut c_void,
-        sfd: *mut c_void,
-        name: *const u16,
-        len: usize,
-    );
+    pub fn script_gdi_push_function(ctx: *mut c_void, sfd: *mut c_void, name: *const u16, len: usize);
     pub fn script_gdi_push_var_scoped_name(ctx: *mut c_void, name: *const u16, len: usize);
     pub fn script_gdi_push_annex_b_name(ctx: *mut c_void, name: *const u16, len: usize);
-    pub fn script_gdi_push_lexical_binding(
-        ctx: *mut c_void,
-        name: *const u16,
-        len: usize,
-        is_constant: bool,
-    );
+    pub fn script_gdi_push_lexical_binding(ctx: *mut c_void, name: *const u16, len: usize, is_constant: bool);
 
     // Callbacks for populating eval EDI data from Rust.
     pub fn eval_gdi_set_strict(ctx: *mut c_void, is_strict: bool);
@@ -259,12 +246,7 @@ unsafe extern "C" {
     pub fn eval_gdi_push_function(ctx: *mut c_void, sfd: *mut c_void, name: *const u16, len: usize);
     pub fn eval_gdi_push_var_scoped_name(ctx: *mut c_void, name: *const u16, len: usize);
     pub fn eval_gdi_push_annex_b_name(ctx: *mut c_void, name: *const u16, len: usize);
-    pub fn eval_gdi_push_lexical_binding(
-        ctx: *mut c_void,
-        name: *const u16,
-        len: usize,
-        is_constant: bool,
-    );
+    pub fn eval_gdi_push_lexical_binding(ctx: *mut c_void, name: *const u16, len: usize, is_constant: bool);
 
     pub fn rust_compile_regex(
         pattern_data: *const u16,
@@ -283,11 +265,7 @@ unsafe extern "C" {
 
     // Get an intrinsic abstract operation function as an opaque Value.
     // name/name_len is the function name (e.g. "GetMethod").
-    pub fn get_abstract_operation_function(
-        vm_ptr: *mut c_void,
-        name: *const u16,
-        name_len: usize,
-    ) -> u64;
+    pub fn get_abstract_operation_function(vm_ptr: *mut c_void, name: *const u16, name_len: usize) -> u64;
 }
 
 /// Create a SharedFunctionInstanceData from a FunctionData.
@@ -327,9 +305,7 @@ pub unsafe fn create_shared_function_data(
         };
 
         let has_simple_parameter_list = function_data.parameters.iter().all(|p| {
-            !p.is_rest
-                && p.default_value.is_none()
-                && matches!(p.binding, FunctionParameterBinding::Identifier(_))
+            !p.is_rest && p.default_value.is_none() && matches!(p.binding, FunctionParameterBinding::Identifier(_))
         });
 
         let parameter_name_slices: Vec<FFIUtf16Slice> = if has_simple_parameter_list {
@@ -340,9 +316,7 @@ pub unsafe fn create_shared_function_data(
                     if let FunctionParameterBinding::Identifier(ref id) = p.binding {
                         FFIUtf16Slice::from(id.name.as_ref())
                     } else {
-                        unreachable!(
-                            "has_simple_parameter_list guarantees all bindings are identifiers"
-                        )
+                        unreachable!("has_simple_parameter_list guarantees all bindings are identifiers")
                     }
                 })
                 .collect()
@@ -403,16 +377,7 @@ pub unsafe fn create_sfd_for_gdi(
     source_code_ptr: *const c_void,
     is_strict: bool,
 ) -> *mut c_void {
-    unsafe {
-        create_shared_function_data(
-            function_data,
-            subtable,
-            vm_ptr,
-            source_code_ptr,
-            is_strict,
-            None,
-        )
-    }
+    unsafe { create_shared_function_data(function_data, subtable, vm_ptr, source_code_ptr, is_strict, None) }
 }
 
 /// Constant tags for the FFI constant buffer (ABI-compatible).
@@ -566,9 +531,7 @@ pub unsafe fn create_executable(
             object_property_iterator_cache_count: generator.next_object_property_iterator_cache,
             number_of_registers: assembled.number_of_registers,
             is_strict: generator.strict,
-            length_identifier: FFIOptionalU32::from(
-                generator.length_identifier.map(|index| index.0),
-            ),
+            length_identifier: FFIOptionalU32::from(generator.length_identifier.map(|index| index.0)),
             shared_function_data: sfd_ptrs.as_ptr(),
             shared_function_data_count: sfd_ptrs.len(),
             class_blueprints: bp_ptrs.as_ptr(),
@@ -606,9 +569,7 @@ pub fn compile_regex(pattern: &[u16], flags: &[u16]) -> Result<*mut c_void, Stri
         if error.is_null() {
             Ok(handle)
         } else {
-            let msg = std::ffi::CStr::from_ptr(error)
-                .to_string_lossy()
-                .into_owned();
+            let msg = std::ffi::CStr::from_ptr(error).to_string_lossy().into_owned();
             rust_free_error_string(error);
             Err(msg)
         }

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -435,10 +435,7 @@ impl Generator {
     /// Copy a local variable into a fresh register to prevent later
     /// side effects from changing its value. Returns the operand unchanged
     /// if it is not a local.
-    pub fn copy_if_needed_to_preserve_evaluation_order(
-        &mut self,
-        operand: &ScopedOperand,
-    ) -> ScopedOperand {
+    pub fn copy_if_needed_to_preserve_evaluation_order(&mut self, operand: &ScopedOperand) -> ScopedOperand {
         match operand.operand().operand_type() {
             OperandType::Register | OperandType::Constant => operand.clone(),
             OperandType::Local | OperandType::Argument => {
@@ -539,12 +536,7 @@ impl Generator {
 
     // --- Table interning ---
 
-    define_intern_method!(
-        intern_string,
-        StringTableIndex,
-        string_table,
-        string_table_index
-    );
+    define_intern_method!(intern_string, StringTableIndex, string_table, string_table_index);
     define_intern_method!(
         intern_identifier,
         IdentifierTableIndex,
@@ -561,10 +553,7 @@ impl Generator {
     /// If `operand` is a constant string that is not an array index, intern it
     /// as a property key and return the index. Uses split borrows to avoid
     /// cloning the string when it is already interned (the common case).
-    pub fn try_constant_string_to_property_key(
-        &mut self,
-        operand: &ScopedOperand,
-    ) -> Option<PropertyKeyTableIndex> {
+    pub fn try_constant_string_to_property_key(&mut self, operand: &ScopedOperand) -> Option<PropertyKeyTableIndex> {
         if !operand.operand().is_constant() {
             return None;
         }
@@ -697,12 +686,7 @@ impl Generator {
     }
 
     /// Emit a conditional jump, with comparison fusion and constant folding.
-    pub fn emit_jump_if(
-        &mut self,
-        condition: &ScopedOperand,
-        true_target: Label,
-        false_target: Label,
-    ) {
+    pub fn emit_jump_if(&mut self, condition: &ScopedOperand, true_target: Label, false_target: Label) {
         // OPTIMIZATION: If condition is a constant, emit an unconditional jump.
         if let Some(constant) = self.get_constant(condition)
             && let Some(is_truthy) = constant_to_boolean(constant)
@@ -727,9 +711,7 @@ impl Generator {
                             false_target,
                         })
                     }
-                    Instruction::LessThanEquals { dst, lhs, rhs }
-                        if *dst == condition.operand() =>
-                    {
+                    Instruction::LessThanEquals { dst, lhs, rhs } if *dst == condition.operand() => {
                         Some(Instruction::JumpLessThanEquals {
                             lhs: *lhs,
                             rhs: *rhs,
@@ -745,9 +727,7 @@ impl Generator {
                             false_target,
                         })
                     }
-                    Instruction::GreaterThanEquals { dst, lhs, rhs }
-                        if *dst == condition.operand() =>
-                    {
+                    Instruction::GreaterThanEquals { dst, lhs, rhs } if *dst == condition.operand() => {
                         Some(Instruction::JumpGreaterThanEquals {
                             lhs: *lhs,
                             rhs: *rhs,
@@ -763,9 +743,7 @@ impl Generator {
                             false_target,
                         })
                     }
-                    Instruction::LooselyInequals { dst, lhs, rhs }
-                        if *dst == condition.operand() =>
-                    {
+                    Instruction::LooselyInequals { dst, lhs, rhs } if *dst == condition.operand() => {
                         Some(Instruction::JumpLooselyInequals {
                             lhs: *lhs,
                             rhs: *rhs,
@@ -773,9 +751,7 @@ impl Generator {
                             false_target,
                         })
                     }
-                    Instruction::StrictlyEquals { dst, lhs, rhs }
-                        if *dst == condition.operand() =>
-                    {
+                    Instruction::StrictlyEquals { dst, lhs, rhs } if *dst == condition.operand() => {
                         Some(Instruction::JumpStrictlyEquals {
                             lhs: *lhs,
                             rhs: *rhs,
@@ -783,9 +759,7 @@ impl Generator {
                             false_target,
                         })
                     }
-                    Instruction::StrictlyInequals { dst, lhs, rhs }
-                        if *dst == condition.operand() =>
-                    {
+                    Instruction::StrictlyInequals { dst, lhs, rhs } if *dst == condition.operand() => {
                         Some(Instruction::JumpStrictlyInequals {
                             lhs: *lhs,
                             rhs: *rhs,
@@ -817,10 +791,7 @@ impl Generator {
     next_cache_method!(next_global_variable_cache, next_global_variable_cache);
     next_cache_method!(next_template_object_cache, next_template_object_cache);
     next_cache_method!(next_object_shape_cache, next_object_shape_cache);
-    next_cache_method!(
-        next_object_property_iterator_cache,
-        next_object_property_iterator_cache
-    );
+    next_cache_method!(next_object_property_iterator_cache, next_object_property_iterator_cache);
 
     // --- Lexical environment helpers ---
 
@@ -828,16 +799,12 @@ impl Generator {
         self.lexical_environment_register_stack
             .last()
             .cloned()
-            .unwrap_or_else(|| {
-                self.scoped_operand(Operand::register(Register::SAVED_LEXICAL_ENVIRONMENT))
-            })
+            .unwrap_or_else(|| self.scoped_operand(Operand::register(Register::SAVED_LEXICAL_ENVIRONMENT)))
     }
 
     pub fn capture_saved_lexical_environment(&mut self) {
         let env_reg = self.scoped_operand(Operand::register(Register::SAVED_LEXICAL_ENVIRONMENT));
-        self.emit(Instruction::GetLexicalEnvironment {
-            dst: env_reg.operand(),
-        });
+        self.emit(Instruction::GetLexicalEnvironment { dst: env_reg.operand() });
         self.lexical_environment_register_stack.push(env_reg);
     }
 
@@ -871,8 +838,7 @@ impl Generator {
             parent: parent.operand(),
             capacity,
         });
-        self.lexical_environment_register_stack
-            .push(new_env.clone());
+        self.lexical_environment_register_stack.push(new_env.clone());
         new_env
     }
 
@@ -972,9 +938,7 @@ impl Generator {
     fn has_outer_finally_before_target(&self, is_break: bool, boundary_index: usize) -> bool {
         for j in (0..boundary_index.saturating_sub(1)).rev() {
             let inner = self.boundaries[j];
-            if (is_break && inner == BlockBoundaryType::Break)
-                || (!is_break && inner == BlockBoundaryType::Continue)
-            {
+            if (is_break && inner == BlockBoundaryType::Break) || (!is_break && inner == BlockBoundaryType::Continue) {
                 return false;
             }
             if inner == BlockBoundaryType::ReturnToFinally {
@@ -987,9 +951,7 @@ impl Generator {
     /// Register a jump target with the current FinallyContext.
     /// Assigns a unique completion_type index and emits code to set it and jump to finally.
     pub fn register_jump_in_finally_context(&mut self, target: Label) {
-        let index = self
-            .current_finally_context
-            .expect("no active finally context");
+        let index = self.current_finally_context.expect("no active finally context");
         let ctx = &mut self.finally_contexts[index];
         let jump_index = ctx.next_jump_index;
         ctx.next_jump_index += 1;
@@ -1001,9 +963,7 @@ impl Generator {
         let finally_body = ctx.finally_body;
         let index_const = self.add_constant_i32(jump_index);
         self.emit_mov(&completion_type, &index_const);
-        self.emit(Instruction::Jump {
-            target: finally_body,
-        });
+        self.emit(Instruction::Jump { target: finally_body });
     }
 
     /// For break/continue through nested finally: create a trampoline block.
@@ -1012,9 +972,7 @@ impl Generator {
         self.register_jump_in_finally_context(trampoline_block);
         self.switch_to_basic_block(trampoline_block);
         // Pop to the parent FinallyContext (simulating the inner finally completing).
-        let index = self
-            .current_finally_context
-            .expect("no active finally context");
+        let index = self.current_finally_context.expect("no active finally context");
         self.current_unwind_handler = self.finally_contexts[index].saved_unwind_handler;
         self.current_finally_context = self.finally_contexts[index].parent_index;
     }
@@ -1049,14 +1007,10 @@ impl Generator {
             let boundary = self.boundaries[i];
             match boundary {
                 BlockBoundaryType::Break if is_break => {
-                    let target_scope = self
-                        .breakable_scopes
-                        .last()
-                        .expect("no active breakable scope");
+                    let target_scope = self.breakable_scopes.last().expect("no active breakable scope");
                     let target = target_scope.bytecode_target;
                     let completion = target_scope.completion_register.clone();
-                    if let (Some(cur), Some(tgt)) =
-                        (self.current_completion_register.clone(), completion)
+                    if let (Some(cur), Some(tgt)) = (self.current_completion_register.clone(), completion)
                         && cur != tgt
                     {
                         self.emit_mov(&tgt, &cur);
@@ -1066,14 +1020,10 @@ impl Generator {
                     return;
                 }
                 BlockBoundaryType::Continue if !is_break => {
-                    let target_scope = self
-                        .continuable_scopes
-                        .last()
-                        .expect("no active continuable scope");
+                    let target_scope = self.continuable_scopes.last().expect("no active continuable scope");
                     let target = target_scope.bytecode_target;
                     let completion = target_scope.completion_register.clone();
-                    if let (Some(cur), Some(tgt)) =
-                        (self.current_completion_register.clone(), completion)
+                    if let (Some(cur), Some(tgt)) = (self.current_completion_register.clone(), completion)
                         && cur != tgt
                     {
                         self.emit_mov(&tgt, &cur);
@@ -1092,18 +1042,13 @@ impl Generator {
                 BlockBoundaryType::ReturnToFinally => {
                     if !self.has_outer_finally_before_target(is_break, i + 1) {
                         let target_scope = if is_break {
-                            self.breakable_scopes
-                                .last()
-                                .expect("no active breakable scope")
+                            self.breakable_scopes.last().expect("no active breakable scope")
                         } else {
-                            self.continuable_scopes
-                                .last()
-                                .expect("no active continuable scope")
+                            self.continuable_scopes.last().expect("no active continuable scope")
                         };
                         let target = target_scope.bytecode_target;
                         let completion = target_scope.completion_register.clone();
-                        if let (Some(cur), Some(tgt)) =
-                            (self.current_completion_register.clone(), completion)
+                        if let (Some(cur), Some(tgt)) = (self.current_completion_register.clone(), completion)
                             && cur != tgt
                         {
                             self.emit_mov(&tgt, &cur);
@@ -1192,8 +1137,7 @@ impl Generator {
             }
 
             if label_set.iter().any(|l| l == label) {
-                if let (Some(cur), Some(tgt)) =
-                    (self.current_completion_register.clone(), completion.clone())
+                if let (Some(cur), Some(tgt)) = (self.current_completion_register.clone(), completion.clone())
                     && cur != tgt
                 {
                     self.emit_mov(&tgt, &cur);
@@ -1216,8 +1160,7 @@ impl Generator {
             match self.boundaries[i] {
                 BlockBoundaryType::LeaveLexicalEnvironment => {
                     env_stack_offset -= 1;
-                    let parent_env =
-                        self.lexical_environment_register_stack[env_stack_offset - 1].clone();
+                    let parent_env = self.lexical_environment_register_stack[env_stack_offset - 1].clone();
                     self.emit(Instruction::SetLexicalEnvironment {
                         environment: parent_env.operand(),
                     });
@@ -1241,18 +1184,14 @@ impl Generator {
             self.emit_mov(&completion_value, value);
             let ret_const = self.add_constant_i32(FinallyContext::RETURN);
             self.emit_mov(&completion_type, &ret_const);
-            self.emit(Instruction::Jump {
-                target: finally_body,
-            });
+            self.emit(Instruction::Jump { target: finally_body });
         } else if self.is_in_generator_or_async_function() {
             self.emit(Instruction::Yield {
                 continuation_label: None,
                 value: value.operand(),
             });
         } else {
-            self.emit(Instruction::Return {
-                value: value.operand(),
-            });
+            self.emit(Instruction::Return { value: value.operand() });
         }
     }
 
@@ -1263,10 +1202,7 @@ impl Generator {
     // --- Local variable initialization tracking ---
 
     pub fn is_local_initialized(&self, index: u32) -> bool {
-        self.initialized_locals
-            .get(index as usize)
-            .copied()
-            .unwrap_or(false)
+        self.initialized_locals.get(index as usize).copied().unwrap_or(false)
     }
 
     pub fn is_local_lexically_declared(&self, index: u32) -> bool {
@@ -1284,10 +1220,7 @@ impl Generator {
     }
 
     pub fn is_argument_initialized(&self, index: u32) -> bool {
-        self.initialized_arguments
-            .get(index as usize)
-            .copied()
-            .unwrap_or(false)
+        self.initialized_arguments.get(index as usize).copied().unwrap_or(false)
     }
 
     pub fn mark_argument_initialized(&mut self, index: u32) {
@@ -1322,27 +1255,25 @@ impl Generator {
         });
 
         if let Some(load_block_index) = synthetic_load_block {
-            let saved_environment_is_used =
-                self.basic_blocks
+            let saved_environment_is_used = self.basic_blocks.iter().enumerate().any(|(block_index, block)| {
+                block
+                    .instructions
                     .iter()
                     .enumerate()
-                    .any(|(block_index, block)| {
-                        block.instructions.iter().enumerate().any(
-                            |(instruction_index, (instruction, _))| {
-                                if block_index == load_block_index && instruction_index == 0 {
-                                    return false;
-                                }
-                                let mut instruction = instruction.clone();
-                                let mut mentions_saved_environment = false;
-                                instruction.visit_operands(&mut |operand: &mut Operand| {
-                                    if *operand == saved_environment {
-                                        mentions_saved_environment = true;
-                                    }
-                                });
-                                mentions_saved_environment
-                            },
-                        )
-                    });
+                    .any(|(instruction_index, (instruction, _))| {
+                        if block_index == load_block_index && instruction_index == 0 {
+                            return false;
+                        }
+                        let mut instruction = instruction.clone();
+                        let mut mentions_saved_environment = false;
+                        instruction.visit_operands(&mut |operand: &mut Operand| {
+                            if *operand == saved_environment {
+                                mentions_saved_environment = true;
+                            }
+                        });
+                        mentions_saved_environment
+                    })
+            });
 
             if !saved_environment_is_used {
                 self.basic_blocks[load_block_index].instructions.remove(0);
@@ -1374,9 +1305,9 @@ impl Generator {
                         OperandType::Constant => {
                             op.offset_index_by(number_of_registers + number_of_locals);
                         }
-                        OperandType::Argument => op.offset_index_by(
-                            number_of_registers + number_of_locals + number_of_constants,
-                        ),
+                        OperandType::Argument => {
+                            op.offset_index_by(number_of_registers + number_of_locals + number_of_constants);
+                        }
                     }
                 });
             }
@@ -1410,8 +1341,7 @@ impl Generator {
                     {
                         let (dst3, src3) = (*dst, *src);
                         let mov2_is_dup = dst2 == dst1 && src2 == src1;
-                        let mov3_is_dup =
-                            (dst3 == dst1 && src3 == src1) || (dst3 == dst2 && src3 == src2);
+                        let mov3_is_dup = (dst3 == dst1 && src3 == src1) || (dst3 == dst2 && src3 == src2);
                         if mov2_is_dup && mov3_is_dup {
                             // All three identical: keep single Mov.
                             block.instructions.remove(i + 2);
@@ -1431,12 +1361,7 @@ impl Generator {
                             continue;
                         } else if mov3_is_dup {
                             // mov3 is dup: Mov2(mov1, mov2).
-                            block.instructions[i].0 = Instruction::Mov2 {
-                                dst1,
-                                src1,
-                                dst2,
-                                src2,
-                            };
+                            block.instructions[i].0 = Instruction::Mov2 { dst1, src1, dst2, src2 };
                             block.instructions.remove(i + 2);
                             block.instructions.remove(i + 1);
                             i += 1;
@@ -1458,12 +1383,7 @@ impl Generator {
                         }
                     }
                     // Only two unique Movs: Mov2.
-                    block.instructions[i].0 = Instruction::Mov2 {
-                        dst1,
-                        src1,
-                        dst2,
-                        src2,
-                    };
+                    block.instructions[i].0 = Instruction::Mov2 { dst1, src1, dst2, src2 };
                     block.instructions.remove(i + 1);
                     i += 1;
                     continue;
@@ -1646,10 +1566,7 @@ impl Generator {
                         let replacement = Instruction::End { value };
                         replacement.encode(self.strict, &mut bytecode);
                     }
-                    InstAction::EmitJumpFalse {
-                        condition,
-                        mut target,
-                    } => {
+                    InstAction::EmitJumpFalse { condition, mut target } => {
                         // Patch label for the target
                         let target_block = target.0 as usize;
                         target.0 = u32_from_usize(block_offsets[target_block]);
@@ -1662,10 +1579,7 @@ impl Generator {
                         let replacement = Instruction::JumpFalse { condition, target };
                         replacement.encode(self.strict, &mut bytecode);
                     }
-                    InstAction::EmitJumpTrue {
-                        condition,
-                        mut target,
-                    } => {
+                    InstAction::EmitJumpTrue { condition, mut target } => {
                         let target_block = target.0 as usize;
                         target.0 = u32_from_usize(block_offsets[target_block]);
                         let instruction_offset = bytecode.len();
@@ -1682,12 +1596,9 @@ impl Generator {
 
             // Unterminated blocks get an implicit End(undefined).
             if !block.terminated {
-                let mut undef_rewritten =
-                    undefined_constant_operand.expect("undefined constant must exist");
+                let mut undef_rewritten = undefined_constant_operand.expect("undefined constant must exist");
                 undef_rewritten.offset_index_by(number_of_registers + number_of_locals);
-                let end_instruction = Instruction::End {
-                    value: undef_rewritten,
-                };
+                let end_instruction = Instruction::End { value: undef_rewritten };
                 let instruction_offset = bytecode.len();
                 source_map.push(SourceMapEntry {
                     bytecode_offset: u32_from_usize(instruction_offset),
@@ -1702,9 +1613,7 @@ impl Generator {
                 exception_handlers.push(ExceptionHandler {
                     start_offset: u32_from_usize(block_start),
                     end_offset: u32_from_usize(bytecode.len()),
-                    handler_offset: u32_from_usize(
-                        block_offsets[handler_label.basic_block_index()],
-                    ),
+                    handler_offset: u32_from_usize(block_offsets[handler_label.basic_block_index()]),
                 });
             }
         }
@@ -1798,10 +1707,7 @@ pub fn parse_bigint(s: &str) -> Option<num_bigint::BigInt> {
 }
 
 /// Use `preferred_dst` if available, otherwise allocate a fresh register.
-pub fn choose_dst(
-    generator: &mut Generator,
-    preferred_dst: Option<&ScopedOperand>,
-) -> ScopedOperand {
+pub fn choose_dst(generator: &mut Generator, preferred_dst: Option<&ScopedOperand>) -> ScopedOperand {
     match preferred_dst {
         Some(dst) => dst.clone(),
         None => generator.allocate_register(),

--- a/Libraries/LibJS/Rust/src/bytecode/operand.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/operand.rs
@@ -78,10 +78,7 @@ impl Operand {
     }
 
     pub fn operand_type(self) -> OperandType {
-        assert!(
-            !self.is_invalid(),
-            "operand_type() called on INVALID operand"
-        );
+        assert!(!self.is_invalid(), "operand_type() called on INVALID operand");
         match (self.0 >> Self::TYPE_SHIFT) & 0x7 {
             0 => OperandType::Register,
             1 => OperandType::Local,

--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -140,10 +140,7 @@ fn decode_code_point(source: &[u16], pos: usize) -> (u32, usize) {
         return (0xFFFD, 1);
     }
     let cu = source[pos];
-    if is_utf16_high_surrogate(cu)
-        && pos + 1 < source.len()
-        && is_utf16_low_surrogate(source[pos + 1])
-    {
+    if is_utf16_high_surrogate(cu) && pos + 1 < source.len() && is_utf16_low_surrogate(source[pos + 1]) {
         let hi = cu as u32;
         let lo = source[pos + 1] as u32;
         let cp = 0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00);
@@ -156,10 +153,7 @@ fn decode_code_point(source: &[u16], pos: usize) -> (u32, usize) {
 // https://tc39.es/ecma262/#sec-line-terminators
 // LineTerminator :: <LF> | <CR> | <LS> | <PS>
 fn is_line_terminator_cp(cp: u32) -> bool {
-    cp == '\n' as u32
-        || cp == '\r' as u32
-        || cp == LINE_SEPARATOR as u32
-        || cp == PARAGRAPH_SEPARATOR as u32
+    cp == '\n' as u32 || cp == '\r' as u32 || cp == LINE_SEPARATOR as u32 || cp == PARAGRAPH_SEPARATOR as u32
 }
 
 // https://tc39.es/ecma262/#sec-white-space
@@ -465,12 +459,7 @@ impl<'a> Lexer<'a> {
         lexer
     }
 
-    pub fn new_at_offset(
-        source: &'a [u16],
-        offset: usize,
-        line_number: u32,
-        line_column: u32,
-    ) -> Self {
+    pub fn new_at_offset(source: &'a [u16], offset: usize, line_number: u32, line_column: u32) -> Self {
         let mut lexer = Lexer {
             source,
             position: offset,
@@ -522,9 +511,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn current_template_state(&self) -> &TemplateState {
-        self.template_states
-            .last()
-            .expect("template_states must not be empty")
+        self.template_states.last().expect("template_states must not be empty")
     }
 
     fn current_template_state_mut(&mut self) -> &mut TemplateState {
@@ -557,9 +544,8 @@ impl<'a> Lexer<'a> {
         }
 
         if self.is_line_terminator() {
-            let second_char_of_crlf = self.position > 1
-                && self.source[self.position - 2] == ch(b'\r')
-                && self.current_code_unit == ch(b'\n');
+            let second_char_of_crlf =
+                self.position > 1 && self.source[self.position - 2] == ch(b'\r') && self.current_code_unit == ch(b'\n');
 
             if !second_char_of_crlf {
                 self.line_number += 1;
@@ -812,9 +798,7 @@ impl<'a> Lexer<'a> {
         if self.position + 1 >= self.source_len() {
             return false;
         }
-        self.current_code_unit == a
-            && self.source[self.position] == b
-            && self.source[self.position + 1] == c
+        self.current_code_unit == a && self.source[self.position] == b && self.source[self.position + 1] == c
     }
 
     fn match4(&self, a: u16, b: u16, c: u16, d: u16) -> bool {
@@ -847,9 +831,7 @@ impl<'a> Lexer<'a> {
     fn is_line_comment_start(&self, line_has_token_yet: bool) -> bool {
         self.match2(ch(b'/'), ch(b'/'))
             || (self.allow_html_comments && self.match4(ch(b'<'), ch(b'!'), ch(b'-'), ch(b'-')))
-            || (self.allow_html_comments
-                && !line_has_token_yet
-                && self.match3(ch(b'-'), ch(b'-'), ch(b'>')))
+            || (self.allow_html_comments && !line_has_token_yet && self.match3(ch(b'-'), ch(b'-'), ch(b'>')))
             || (self.match2(ch(b'#'), ch(b'!')) && self.position == 1)
     }
 
@@ -893,8 +875,7 @@ impl<'a> Lexer<'a> {
         if !is_ascii_digit(self.current_code_unit) {
             return false;
         }
-        while is_ascii_digit(self.current_code_unit)
-            || self.match_numeric_literal_separator_followed_by(is_ascii_digit)
+        while is_ascii_digit(self.current_code_unit) || self.match_numeric_literal_separator_followed_by(is_ascii_digit)
         {
             self.consume();
         }
@@ -917,8 +898,7 @@ impl<'a> Lexer<'a> {
         if !is_octal_digit(self.current_code_unit) {
             return false;
         }
-        while is_octal_digit(self.current_code_unit)
-            || self.match_numeric_literal_separator_followed_by(is_octal_digit)
+        while is_octal_digit(self.current_code_unit) || self.match_numeric_literal_separator_followed_by(is_octal_digit)
         {
             self.consume();
         }
@@ -961,9 +941,7 @@ impl<'a> Lexer<'a> {
     fn consume_regex_literal(&mut self) -> TokenType {
         self.regex_is_in_character_class = false;
         while !self.is_eof() {
-            if self.is_line_terminator()
-                || (!self.regex_is_in_character_class && self.current_code_unit == ch(b'/'))
-            {
+            if self.is_line_terminator() || (!self.regex_is_in_character_class && self.current_code_unit == ch(b'/')) {
                 break;
             }
 
@@ -1062,8 +1040,7 @@ impl<'a> Lexer<'a> {
 
         if self.current_token_type == TokenType::RegexLiteral
             && !self.is_eof()
-            && (self.current_code_unit < 128
-                && (self.current_code_unit as u8 as char).is_ascii_alphabetic())
+            && (self.current_code_unit < 128 && (self.current_code_unit as u8 as char).is_ascii_alphabetic())
             && !did_consume_whitespace_or_comments
         {
             token_type = TokenType::RegexFlags;
@@ -1109,10 +1086,7 @@ impl<'a> Lexer<'a> {
                 self.consume();
                 self.current_template_state_mut().in_expression = true;
             } else {
-                while !self.match2(ch(b'$'), ch(b'{'))
-                    && self.current_code_unit != ch(b'`')
-                    && !self.is_eof()
-                {
+                while !self.match2(ch(b'$'), ch(b'{')) && self.current_code_unit != ch(b'`') && !self.is_eof() {
                     if self.match2(ch(b'\\'), ch(b'$'))
                         || self.match2(ch(b'\\'), ch(b'`'))
                         || self.match2(ch(b'\\'), ch(b'\\'))
@@ -1142,9 +1116,7 @@ impl<'a> Lexer<'a> {
                 token_type = TokenType::PrivateIdentifier;
             } else {
                 token_type = TokenType::Invalid;
-                token_message = Some(
-                    "Start of private name '#' but not followed by valid identifier".to_string(),
-                );
+                token_message = Some("Start of private name '#' but not followed by valid identifier".to_string());
             }
         } else if let Some((_cp, len)) = self.is_identifier_start() {
             let has_escape = self.scan_identifier_body(len);
@@ -1338,10 +1310,8 @@ impl<'a> Lexer<'a> {
             if token_type == TokenType::CurlyOpen {
                 self.current_template_state_mut().open_bracket_count += 1;
             } else if token_type == TokenType::CurlyClose {
-                self.current_template_state_mut().open_bracket_count = self
-                    .current_template_state()
-                    .open_bracket_count
-                    .saturating_sub(1);
+                self.current_template_state_mut().open_bracket_count =
+                    self.current_template_state().open_bracket_count.saturating_sub(1);
             }
         }
 
@@ -1350,12 +1320,7 @@ impl<'a> Lexer<'a> {
         let trivia_has_line_terminator = if trivia_start > 0 && value_start > trivia_start {
             self.source[trivia_start - 1..value_start - 1]
                 .iter()
-                .any(|&cu| {
-                    cu == ch(b'\n')
-                        || cu == ch(b'\r')
-                        || cu == LINE_SEPARATOR
-                        || cu == PARAGRAPH_SEPARATOR
-                })
+                .any(|&cu| cu == ch(b'\n') || cu == ch(b'\r') || cu == LINE_SEPARATOR || cu == PARAGRAPH_SEPARATOR)
         } else {
             false
         };

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -191,13 +191,7 @@ unsafe fn source_from_raw<'a>(source: *const u16, len: usize) -> Option<&'a [u16
 
 /// Callback type for reporting parse errors to C++.
 pub type ParseErrorCallback = Option<
-    unsafe extern "C" fn(
-        ctx: *mut c_void,
-        message: *const u8,
-        message_len: usize,
-        line: u32,
-        column: u32,
-    ) -> (),
+    unsafe extern "C" fn(ctx: *mut c_void, message: *const u8, message_len: usize, line: u32, column: u32) -> (),
 >;
 
 /// Log parser and scope collector errors, returning true if any were found.
@@ -287,9 +281,7 @@ unsafe fn compile_program_body(
         if !generator.is_current_block_terminated()
             && let Some(value) = result
         {
-            generator.emit(bytecode::instruction::Instruction::End {
-                value: value.operand(),
-            });
+            generator.emit(bytecode::instruction::Instruction::End { value: value.operand() });
         }
         // If result is None, the assembler will add End(undefined) as a
         // fallthrough for unterminated blocks, matching C++ compile().
@@ -363,16 +355,9 @@ pub unsafe extern "C" fn rust_compile_program(
                 return std::ptr::null_mut();
             };
 
-            let mut generator =
-                new_program_generator(starts_in_strict_mode, vm_ptr, source_code_ptr, source_len);
+            let mut generator = new_program_generator(starts_in_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
-            compile_program_body(
-                &mut generator,
-                &program,
-                &scope_ref,
-                vm_ptr,
-                source_code_ptr,
-            )
+            compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr)
         })
     }
 }
@@ -437,11 +422,7 @@ pub unsafe extern "C" fn rust_parse_program(
 
             let (scope_ref, is_strict, has_tla) = if errors.is_empty() {
                 if let StatementKind::Program(ref data) = program.inner {
-                    (
-                        data.scope.clone(),
-                        data.is_strict_mode,
-                        data.has_top_level_await,
-                    )
+                    (data.scope.clone(), data.is_strict_mode, data.has_top_level_await)
                 } else {
                     let scope = Rc::new(RefCell::new(ast::ScopeData::default()));
                     (scope, false, false)
@@ -557,8 +538,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
         abort_on_panic(|| {
             let mut parsed = Box::from_raw(parsed);
 
-            let mut generator =
-                new_program_generator(parsed.is_strict_mode, vm_ptr, source_code_ptr, source_len);
+            let mut generator = new_program_generator(parsed.is_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parsed.function_table);
             let exec_ptr = compile_program_body(
                 &mut generator,
@@ -638,12 +618,7 @@ pub unsafe extern "C" fn rust_compile_eval(
 
             parser.scope_collector.analyze(true);
 
-            write_ast_dump_output(
-                &program,
-                &parser.function_table,
-                ast_dump_output,
-                ast_dump_output_len,
-            );
+            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
 
             let (scope_ref, is_strict) = if let StatementKind::Program(ref data) = program.inner {
                 (data.scope.clone(), data.is_strict_mode)
@@ -651,16 +626,9 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             };
 
-            let mut generator =
-                new_program_generator(is_strict, vm_ptr, source_code_ptr, source_len);
+            let mut generator = new_program_generator(is_strict, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
-            let exec_ptr = compile_program_body(
-                &mut generator,
-                &program,
-                &scope_ref,
-                vm_ptr,
-                source_code_ptr,
-            );
+            let exec_ptr = compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr);
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
             }
@@ -727,8 +695,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // Validate parameters standalone.
             // First lex independently to catch lexer errors (e.g. unterminated comments)
             // with correct line/column positions relative to the parameter string.
-            let Some(parameters_slice) = source_from_raw(parameters_source, parameters_source_len)
-            else {
+            let Some(parameters_slice) = source_from_raw(parameters_source, parameters_source_len) else {
                 return std::ptr::null_mut();
             };
             {
@@ -739,9 +706,9 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
                         break;
                     }
                     if token.token_type == token::TokenType::Invalid {
-                        let msg = token.message.unwrap_or_else(|| {
-                            format!("Unexpected token {}", token.token_type.name())
-                        });
+                        let msg = token
+                            .message
+                            .unwrap_or_else(|| format!("Unexpected token {}", token.token_type.name()));
                         if let Some(cb) = error_callback {
                             cb(
                                 error_context,
@@ -836,12 +803,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
                 return std::ptr::null_mut();
             }
 
-            write_ast_dump_output(
-                &program,
-                &parser.function_table,
-                ast_dump_output,
-                ast_dump_output_len,
-            );
+            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
 
             // Extract the FunctionExpression from the program.
             // The program should contain a single ExpressionStatement wrapping a FunctionExpression.
@@ -879,13 +841,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             let is_strict = function_data.is_strict_mode;
             let subtable = parser.function_table.extract_reachable(&function_data);
 
-            bytecode::ffi::create_sfd_for_gdi(
-                function_data,
-                subtable,
-                vm_ptr,
-                source_code_ptr,
-                is_strict,
-            )
+            bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict)
         })
     }
 }
@@ -940,12 +896,7 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
 
             parser.scope_collector.analyze(false);
 
-            write_ast_dump_output(
-                &program,
-                &parser.function_table,
-                ast_dump_output,
-                ast_dump_output_len,
-            );
+            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -968,12 +919,7 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                     if !sfd_ptr.is_null()
                         && let Some(name_ident) = &fd.name
                     {
-                        push_function(
-                            ctx,
-                            sfd_ptr,
-                            name_ident.name.as_ptr(),
-                            name_ident.name.len(),
-                        );
+                        push_function(ctx, sfd_ptr, name_ident.name.as_ptr(), name_ident.name.len());
                     }
                 }
             }
@@ -1052,8 +998,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                 if !tla_executable_out.is_null() {
                     *tla_executable_out = std::ptr::null_mut();
                 }
-                let mut generator =
-                    new_program_generator(true, vm_ptr, source_code_ptr, source_len);
+                let mut generator = new_program_generator(true, vm_ptr, source_code_ptr, source_len);
                 generator.function_table = std::mem::take(&mut parsed.function_table);
                 compile_program_body(
                     &mut generator,
@@ -1110,13 +1055,8 @@ type ModuleRequestedModuleCallback = unsafe extern "C" fn(
 );
 type ModuleFunctionCallback =
     unsafe extern "C" fn(ctx: *mut c_void, sfd_ptr: *mut c_void, name: *const u16, name_len: usize);
-type ModuleLexicalBindingCallback = unsafe extern "C" fn(
-    ctx: *mut c_void,
-    name: *const u16,
-    name_len: usize,
-    is_constant: bool,
-    function_index: i32,
-);
+type ModuleLexicalBindingCallback =
+    unsafe extern "C" fn(ctx: *mut c_void, name: *const u16, name_len: usize, is_constant: bool, function_index: i32);
 
 /// Module callback table passed from C++ to avoid many function pointer parameters.
 #[repr(C)]
@@ -1136,10 +1076,7 @@ pub struct ModuleCallbacks {
 /// Helper to build FFI attribute arrays from a ModuleRequest.
 fn build_attribute_slices(
     attributes: &[ast::ImportAttribute],
-) -> (
-    Vec<bytecode::ffi::FFIUtf16Slice>,
-    Vec<bytecode::ffi::FFIUtf16Slice>,
-) {
+) -> (Vec<bytecode::ffi::FFIUtf16Slice>, Vec<bytecode::ffi::FFIUtf16Slice>) {
     attributes
         .iter()
         .map(|a| {
@@ -1287,11 +1224,8 @@ unsafe fn extract_module_metadata(scope: &ast::ScopeData, ctx: *mut c_void, cb: 
                     let (in_ptr, in_len, is_ns) = entry
                         .import_name
                         .as_ref()
-                        .map_or((std::ptr::null(), 0, true), |n| {
-                            (n.as_ptr(), n.len(), false)
-                        });
-                    let (keys, values) =
-                        build_attribute_slices(&import_data.module_request.attributes);
+                        .map_or((std::ptr::null(), 0, true), |n| (n.as_ptr(), n.len(), false));
+                    let (keys, values) = build_attribute_slices(&import_data.module_request.attributes);
                     (cb.push_import_entry)(
                         ctx,
                         in_ptr,
@@ -1444,18 +1378,12 @@ unsafe fn extract_module_declarations(
 
             match declaration {
                 StatementKind::FunctionDeclaration(fd) => {
-                    let is_default =
-                        is_exported && fd.name.as_ref().is_some_and(|n| n.name == default_name);
+                    let is_default = is_exported && fd.name.as_ref().is_some_and(|n| n.name == default_name);
 
                     let function_data = function_table.take(fd.function_id);
                     let subtable = function_table.extract_reachable(&function_data);
-                    let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
-                        function_data,
-                        subtable,
-                        vm_ptr,
-                        source_code_ptr,
-                        true,
-                    );
+                    let sfd_ptr =
+                        bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, true);
                     if sfd_ptr.is_null() {
                         continue;
                     }
@@ -1470,11 +1398,7 @@ unsafe fn extract_module_declarations(
                     // If default export with *default* name, set the SFD display name to "default".
                     let sfd_name = if is_default {
                         let sfd_display_name = utf16!("default");
-                        module_sfd_set_name(
-                            sfd_ptr,
-                            sfd_display_name.as_ptr(),
-                            sfd_display_name.len(),
-                        );
+                        module_sfd_set_name(sfd_ptr, sfd_display_name.as_ptr(), sfd_display_name.len());
                         let display_name: ast::Utf16String = sfd_display_name.into();
                         display_name
                     } else {
@@ -1486,36 +1410,18 @@ unsafe fn extract_module_declarations(
                     function_count += 1;
 
                     // Lexical binding uses the AST name (e.g., "*default*").
-                    (cb.push_lexical_binding)(
-                        ctx,
-                        binding_name.as_ptr(),
-                        binding_name.len(),
-                        false,
-                        function_index,
-                    );
+                    (cb.push_lexical_binding)(ctx, binding_name.as_ptr(), binding_name.len(), false, function_index);
                 }
                 StatementKind::ClassDeclaration(class_data) => {
                     if let Some(ref name_ident) = class_data.name {
-                        (cb.push_lexical_binding)(
-                            ctx,
-                            name_ident.name.as_ptr(),
-                            name_ident.name.len(),
-                            false,
-                            -1,
-                        );
+                        (cb.push_lexical_binding)(ctx, name_ident.name.as_ptr(), name_ident.name.len(), false, -1);
                     }
                 }
                 StatementKind::VariableDeclaration(vd) if vd.kind != ast::DeclarationKind::Var => {
                     let is_constant = vd.kind == ast::DeclarationKind::Const;
                     for declaration in &vd.declarations {
                         for_each_bound_name(&declaration.target, &mut |name| {
-                            (cb.push_lexical_binding)(
-                                ctx,
-                                name.as_ptr(),
-                                name.len(),
-                                is_constant,
-                                -1,
-                            );
+                            (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), is_constant, -1);
                         });
                     }
                 }
@@ -1562,11 +1468,7 @@ unsafe fn collect_module_var_names(
 }
 
 /// Extract requested modules sorted by source offset.
-unsafe fn extract_requested_modules(
-    scope: &ast::ScopeData,
-    ctx: *mut c_void,
-    cb: &ModuleCallbacks,
-) {
+unsafe fn extract_requested_modules(scope: &ast::ScopeData, ctx: *mut c_void, cb: &ModuleCallbacks) {
     unsafe {
         use ast::StatementKind;
 
@@ -1750,15 +1652,8 @@ fn extract_gdi_common(
     for (function_id, name) in &functions_to_init {
         let function_data = function_table.take(*function_id);
         let subtable = function_table.extract_reachable(&function_data);
-        let sfd_ptr = unsafe {
-            bytecode::ffi::create_sfd_for_gdi(
-                function_data,
-                subtable,
-                vm_ptr,
-                source_code_ptr,
-                is_strict,
-            )
-        };
+        let sfd_ptr =
+            unsafe { bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict) };
         assert!(!sfd_ptr.is_null(), "create_sfd_for_gdi returned null");
         push_function(sfd_ptr, name);
     }
@@ -1811,8 +1706,8 @@ unsafe fn extract_eval_gdi(
 ) {
     unsafe {
         use bytecode::ffi::{
-            eval_gdi_push_annex_b_name, eval_gdi_push_function, eval_gdi_push_lexical_binding,
-            eval_gdi_push_var_name, eval_gdi_push_var_scoped_name, eval_gdi_set_strict,
+            eval_gdi_push_annex_b_name, eval_gdi_push_function, eval_gdi_push_lexical_binding, eval_gdi_push_var_name,
+            eval_gdi_push_var_scoped_name, eval_gdi_set_strict,
         };
 
         eval_gdi_set_strict(ctx, is_strict);
@@ -1847,9 +1742,8 @@ unsafe fn extract_script_gdi(
     unsafe {
         use ast::{DeclarationKind, StatementKind};
         use bytecode::ffi::{
-            script_gdi_push_annex_b_name, script_gdi_push_function,
-            script_gdi_push_lexical_binding, script_gdi_push_lexical_name,
-            script_gdi_push_var_name, script_gdi_push_var_scoped_name,
+            script_gdi_push_annex_b_name, script_gdi_push_function, script_gdi_push_lexical_binding,
+            script_gdi_push_lexical_name, script_gdi_push_var_name, script_gdi_push_var_scoped_name,
         };
 
         // Lexical names (let/const/using/class at top level) — script-only step.
@@ -1897,10 +1791,7 @@ unsafe fn extract_script_gdi(
 
 /// Visit each child statement of a statement, excluding function/class bodies
 /// (which create new var scopes). This enables recursive var-declaration walking.
-fn for_each_child_statement(
-    statement: &ast::StatementKind,
-    f: &mut dyn FnMut(&ast::StatementKind),
-) {
+fn for_each_child_statement(statement: &ast::StatementKind, f: &mut dyn FnMut(&ast::StatementKind)) {
     use ast::StatementKind;
 
     match statement {
@@ -2117,8 +2008,7 @@ pub unsafe extern "C" fn rust_compile_function(
                 generator.switch_to_basic_block(start_block);
             }
 
-            let result =
-                bytecode::codegen::generate_statement(&function_data.body, &mut generator, None);
+            let result = bytecode::codegen::generate_statement(&function_data.body, &mut generator, None);
 
             if !generator.is_current_block_terminated() {
                 if generator.is_in_generator_or_async_function() {
@@ -2129,9 +2019,7 @@ pub unsafe extern "C" fn rust_compile_function(
                         value: undef.operand(),
                     });
                 } else if let Some(value) = result {
-                    generator.emit(bytecode::instruction::Instruction::End {
-                        value: value.operand(),
-                    });
+                    generator.emit(bytecode::instruction::Instruction::End { value: value.operand() });
                 }
                 // If result is None, the assembler will add End(undefined) as a
                 // fallthrough for unterminated blocks, matching C++ compile().
@@ -2202,8 +2090,7 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> SfdMetadata {
                 || function_data.parsing_insights.uses_this_from_environment,
             might_need_arguments: function_data.parsing_insights.might_need_arguments_object,
             has_function_named_arguments: fsd.is_some_and(|f| f.has_function_named_arguments),
-            has_lexically_declared_arguments: fsd
-                .is_some_and(|f| f.has_lexically_declared_arguments),
+            has_lexically_declared_arguments: fsd.is_some_and(|f| f.has_lexically_declared_arguments),
             non_local_var_count: fsd.map_or(0, |f| f.non_local_var_count),
             non_local_var_count_for_parameter_expressions: fsd
                 .map_or(0, |f| f.non_local_var_count_for_parameter_expressions),
@@ -2439,10 +2326,7 @@ fn count_non_local_names_in_binding_pattern(pattern: &ast::BindingPattern, count
     }
 }
 
-fn for_each_binding_pattern_identifier(
-    pattern: &ast::BindingPattern,
-    callback: &mut dyn FnMut(&Rc<ast::Identifier>),
-) {
+fn for_each_binding_pattern_identifier(pattern: &ast::BindingPattern, callback: &mut dyn FnMut(&Rc<ast::Identifier>)) {
     for entry in &pattern.entries {
         match &entry.alias {
             Some(ast::BindingEntryAlias::Identifier(ident)) => callback(ident),

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -37,9 +37,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::ast::{
-    BindingPattern, Expression, ExpressionKind, FunctionParameter, FunctionTable, Identifier,
-    PrivateIdentifier, ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement,
-    StatementKind, Utf16String,
+    BindingPattern, Expression, ExpressionKind, FunctionParameter, FunctionTable, Identifier, PrivateIdentifier,
+    ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement, StatementKind, Utf16String,
 };
 use crate::lexer::{Lexer, ch};
 use crate::scope_collector::{ScopeCollector, ScopeCollectorState};
@@ -151,8 +150,7 @@ impl ForbiddenTokens {
             forbid_logical: self.forbid_logical || other.forbid_logical,
             forbid_coalesce: self.forbid_coalesce || other.forbid_coalesce,
             forbid_paren_open: self.forbid_paren_open || other.forbid_paren_open,
-            forbid_question_mark_period: self.forbid_question_mark_period
-                || other.forbid_question_mark_period,
+            forbid_question_mark_period: self.forbid_question_mark_period || other.forbid_question_mark_period,
             forbid_equals: self.forbid_equals || other.forbid_equals,
         }
     }
@@ -307,11 +305,7 @@ impl<'a> Parser<'a> {
         Self::new_with_line_offset(source, program_type, 1)
     }
 
-    pub fn new_with_line_offset(
-        source: &'a [u16],
-        program_type: ProgramType,
-        initial_line_number: u32,
-    ) -> Self {
+    pub fn new_with_line_offset(source: &'a [u16], program_type: ProgramType, initial_line_number: u32) -> Self {
         let mut lexer = Lexer::new(source, initial_line_number, 0);
         if program_type == ProgramType::Module {
             lexer.disallow_html_comments();
@@ -368,11 +362,7 @@ impl<'a> Parser<'a> {
         Statement::new(self.range_from(start), statement)
     }
 
-    pub(crate) fn make_identifier(
-        &self,
-        start: Position,
-        name: impl Into<SharedUtf16String>,
-    ) -> Rc<Identifier> {
+    pub(crate) fn make_identifier(&self, start: Position, name: impl Into<SharedUtf16String>) -> Rc<Identifier> {
         Rc::new(Identifier::new(self.range_from(start), name.into()))
     }
 
@@ -431,9 +421,7 @@ impl<'a> Parser<'a> {
                         is_first_from_pattern: true,
                     });
                     // Then push bound names from this pattern.
-                    while info_index < parameter_info.len()
-                        && parameter_info[info_index].is_from_pattern
-                    {
+                    while info_index < parameter_info.len() && parameter_info[info_index].is_from_pattern {
                         let pi = &parameter_info[info_index];
                         entries.push(ParameterEntry {
                             name: pi.name.clone(),
@@ -556,11 +544,7 @@ impl<'a> Parser<'a> {
             // https://tc39.es/ecma262/#sec-additional-syntax-numeric-literals
             // In strict mode, legacy octal literals (0-prefixed) are not permitted.
             let value = self.token_value(&token);
-            if value.len() > 1
-                && value[0] == ch(b'0')
-                && value[1] >= ch(b'0')
-                && value[1] <= ch(b'9')
-            {
+            if value.len() > 1 && value[0] == ch(b'0') && value[1] >= ch(b'0') && value[1] <= ch(b'9') {
                 self.syntax_error("Unprefixed octal number not allowed in strict mode");
             }
         }
@@ -583,10 +567,7 @@ impl<'a> Parser<'a> {
             self.consume();
             return;
         }
-        if self.current_token.trivia_has_line_terminator
-            || self.match_token(TokenType::CurlyClose)
-            || self.done()
-        {
+        if self.current_token.trivia_has_line_terminator || self.match_token(TokenType::CurlyClose) || self.done() {
             return;
         }
         self.expected("Semicolon");
@@ -656,9 +637,7 @@ impl<'a> Parser<'a> {
         let value = self.token_value(&self.current_token).to_vec();
         if !self.register_referenced_private_name(&value) {
             let name = String::from_utf16_lossy(&value);
-            self.syntax_error(&format!(
-                "Reference to undeclared private field or method '{name}'"
-            ));
+            self.syntax_error(&format!("Reference to undeclared private field or method '{name}'"));
         }
         let token = self.consume();
         let value = self.token_value(&token).to_vec();
@@ -812,16 +791,10 @@ impl<'a> Parser<'a> {
         value != utf16!("let") && value != utf16!("static")
     }
 
-    pub(crate) fn check_identifier_name_for_assignment_validity(
-        &mut self,
-        name: &[u16],
-        force_strict: bool,
-    ) {
+    pub(crate) fn check_identifier_name_for_assignment_validity(&mut self, name: &[u16], force_strict: bool) {
         if self.flags.strict_mode || force_strict {
             if name == utf16!("arguments") || name == utf16!("eval") {
-                self.syntax_error(
-                    "Binding pattern target may not be called 'arguments' or 'eval' in strict mode",
-                );
+                self.syntax_error("Binding pattern target may not be called 'arguments' or 'eval' in strict mode");
             } else if is_strict_reserved_word(name) {
                 let name_str = String::from_utf16_lossy(name);
                 self.syntax_error(&format!(
@@ -873,9 +846,7 @@ impl<'a> Parser<'a> {
             self.check_identifier_name_for_assignment_validity(name, force_strict);
             if !seen_names.insert(&**name) {
                 let name_str = String::from_utf16_lossy(name);
-                self.syntax_error(&format!(
-                    "Duplicate parameter '{name_str}' not allowed in strict mode"
-                ));
+                self.syntax_error(&format!("Duplicate parameter '{name_str}' not allowed in strict mode"));
             }
         }
     }
@@ -1140,9 +1111,7 @@ impl<'a> Parser<'a> {
             if is_use_strict(raw_value) {
                 found_use_strict = true;
                 if self.flags.string_legacy_octal_escape_sequence_in_scope {
-                    self.syntax_error(
-                        "Octal escape sequence in string literal not allowed in strict mode",
-                    );
+                    self.syntax_error("Octal escape sequence in string literal not allowed in strict mode");
                 }
                 break;
             }
@@ -1151,10 +1120,7 @@ impl<'a> Parser<'a> {
         (found_use_strict, statements)
     }
 
-    pub(crate) fn parse_statement_list(
-        &mut self,
-        allow_labelled_functions: bool,
-    ) -> Vec<Statement> {
+    pub(crate) fn parse_statement_list(&mut self, allow_labelled_functions: bool) -> Vec<Statement> {
         let mut statements = Vec::new();
         while !self.done() {
             if self.match_export_or_import() {
@@ -1253,10 +1219,7 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn operator_precedence(tt: TokenType) -> i32 {
         match tt {
-            TokenType::Period
-            | TokenType::BracketOpen
-            | TokenType::ParenOpen
-            | TokenType::QuestionMarkPeriod => 20,
+            TokenType::Period | TokenType::BracketOpen | TokenType::ParenOpen | TokenType::QuestionMarkPeriod => 20,
             TokenType::New => 19,
             TokenType::PlusPlus | TokenType::MinusMinus => 18,
             TokenType::ExclamationMark
@@ -1355,10 +1318,7 @@ fn is_use_strict(raw: &[u16]) -> bool {
 }
 
 /// Collect all binding names introduced by a variable declarator target.
-fn collect_binding_names(
-    target: &crate::ast::VariableDeclaratorTarget,
-    names: &mut HashSet<Utf16String>,
-) {
+fn collect_binding_names(target: &crate::ast::VariableDeclaratorTarget, names: &mut HashSet<Utf16String>) {
     match target {
         crate::ast::VariableDeclaratorTarget::Identifier(identifier) => {
             names.insert(identifier.name.to_utf16_string());
@@ -1370,10 +1330,7 @@ fn collect_binding_names(
 }
 
 /// Collect all binding names from a binding pattern (object or array destructuring).
-fn collect_binding_pattern_names(
-    pattern: &crate::ast::BindingPattern,
-    names: &mut HashSet<Utf16String>,
-) {
+fn collect_binding_pattern_names(pattern: &crate::ast::BindingPattern, names: &mut HashSet<Utf16String>) {
     for entry in &pattern.entries {
         if let Some(ref alias) = entry.alias {
             match alias {
@@ -1395,10 +1352,7 @@ fn collect_binding_pattern_names(
 /// This includes lexical declarations (let/const), function/class declarations, imports,
 /// and also `var` declarations which hoist to module scope even when nested inside
 /// blocks, loops, if/else, etc.
-fn collect_module_declared_names(
-    statement: &crate::ast::Statement,
-    names: &mut HashSet<Utf16String>,
-) {
+fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut HashSet<Utf16String>) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) => {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -13,8 +13,8 @@ use std::rc::Rc;
 use crate::ast::*;
 use crate::lexer::ch;
 use crate::parser::{
-    Associativity, DeclarationKind, ForbiddenTokens, FunctionKind, MethodKind,
-    PRECEDENCE_ASSIGNMENT, ParamInfo, ParsedParameters, Parser, Position, ProgramType, PropertyKey,
+    Associativity, DeclarationKind, ForbiddenTokens, FunctionKind, MethodKind, PRECEDENCE_ASSIGNMENT, ParamInfo,
+    ParsedParameters, Parser, Position, ProgramType, PropertyKey,
 };
 use crate::token::TokenType;
 
@@ -162,14 +162,11 @@ impl Parser<'_> {
                         declaration_line,
                         declaration_column,
                     );
-                    self.scope_collector
-                        .register_identifier(id.clone(), Some(kind));
+                    self.scope_collector.register_identifier(id.clone(), Some(kind));
                 }
 
                 VariableDeclaratorTarget::Identifier(id)
-            } else if self.match_token(TokenType::CurlyOpen)
-                || self.match_token(TokenType::BracketOpen)
-            {
+            } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 let pat = self.parse_binding_pattern();
                 let bound_names = std::mem::take(&mut self.pattern_bound_names);
 
@@ -197,19 +194,12 @@ impl Parser<'_> {
                         .collect();
                     // NOTE: Binding pattern identifiers don't get declaration_kind,
                     // matching C++ behavior where only simple identifiers do.
-                    self.scope_collector.add_var_declaration(
-                        &entries,
-                        declaration_line,
-                        declaration_column,
-                        None,
-                    );
+                    self.scope_collector
+                        .add_var_declaration(&entries, declaration_line, declaration_column, None);
                 } else {
                     let refs: Vec<&[u16]> = bound_names.iter().map(|(n, _)| n.as_slice()).collect();
-                    self.scope_collector.add_lexical_declaration(
-                        &refs,
-                        declaration_line,
-                        declaration_column,
-                    );
+                    self.scope_collector
+                        .add_lexical_declaration(&refs, declaration_line, declaration_column);
                     // Register each binding pattern identifier for scope analysis
                     // so they get is_local() annotations.
                     // NOTE: C++ does not pass declaration_kind for binding pattern identifiers,
@@ -307,11 +297,8 @@ impl Parser<'_> {
 
             let id = self.make_identifier(declaration_start, name.clone());
 
-            self.scope_collector.add_lexical_declaration(
-                &[name.as_slice()],
-                declaration_line,
-                declaration_column,
-            );
+            self.scope_collector
+                .add_lexical_declaration(&[name.as_slice()], declaration_line, declaration_column);
             // C++ calls parse_lexical_binding() without declaration_kind for using,
             // so we pass None to match.
             self.scope_collector.register_identifier(id.clone(), None);
@@ -319,11 +306,7 @@ impl Parser<'_> {
             let init = if self.match_token(TokenType::Equals) {
                 self.consume();
                 if is_for_loop {
-                    Some(self.parse_expression(
-                        PRECEDENCE_ASSIGNMENT,
-                        Associativity::Right,
-                        ForbiddenTokens::with_in(),
-                    ))
+                    Some(self.parse_expression(PRECEDENCE_ASSIGNMENT, Associativity::Right, ForbiddenTokens::with_in()))
                 } else {
                     Some(self.parse_assignment_expression())
                 }
@@ -358,10 +341,7 @@ impl Parser<'_> {
             self.for_loop_declaration_has_init = any_init;
         }
 
-        self.statement(
-            start,
-            StatementKind::UsingDeclaration(Box::new(declarators)),
-        )
+        self.statement(start, StatementKind::UsingDeclaration(Box::new(declarators)))
     }
 
     // https://tc39.es/ecma262/#sec-function-definitions
@@ -385,10 +365,7 @@ impl Parser<'_> {
         let (name, fn_name) = if self.has_default_export_name && !self.match_identifier() {
             let default_name = Utf16String::from(utf16!("*default*"));
             self.last_function_name = default_name.clone();
-            (
-                Some(self.make_identifier(start, default_name.clone())),
-                default_name,
-            )
+            (Some(self.make_identifier(start, default_name.clone())), default_name)
         } else if self.match_identifier() {
             let token = self.consume();
             let value = Utf16String::from(self.token_value(&token));
@@ -515,9 +492,7 @@ impl Parser<'_> {
     ) -> FunctionData {
         // Validate name against async generator and class static init restrictions.
         if name.is_some() {
-            if kind == FunctionKind::AsyncGenerator
-                && (fn_name == utf16!("await") || fn_name == utf16!("yield"))
-            {
+            if kind == FunctionKind::AsyncGenerator && (fn_name == utf16!("await") || fn_name == utf16!("yield")) {
                 let name_str = String::from_utf16_lossy(fn_name);
                 self.syntax_error(&format!(
                     "async generator function is not allowed to be called '{name_str}'"
@@ -553,8 +528,7 @@ impl Parser<'_> {
         self.flags.in_generator_function_context = in_generator_before;
         self.flags.await_expression_is_valid = await_before;
 
-        let (body, has_use_strict, mut insights) =
-            self.parse_function_body(is_async, is_generator, parsed.is_simple);
+        let (body, has_use_strict, mut insights) = self.parse_function_body(is_async, is_generator, parsed.is_simple);
         self.flags.allow_super_constructor_call = saved_allow_super_call;
         self.flags.allow_super_property_lookup = saved_allow_super_lookup;
 
@@ -629,8 +603,7 @@ impl Parser<'_> {
         } else {
             Some(name_value.as_slice())
         };
-        self.scope_collector
-            .open_class_declaration_scope(class_name_for_scope);
+        self.scope_collector.open_class_declaration_scope(class_name_for_scope);
 
         if name_id.is_some() {
             self.check_identifier_name_for_assignment_validity(&name_value, true);
@@ -649,8 +622,7 @@ impl Parser<'_> {
         self.consume_token(TokenType::CurlyOpen);
         let mut elements: Vec<Node<ClassElement>> = Vec::new();
         let mut constructor: Option<Expression> = None;
-        let mut found_private_names: HashMap<Utf16String, (Option<ClassMethodKind>, bool)> =
-            HashMap::new();
+        let mut found_private_names: HashMap<Utf16String, (Option<ClassMethodKind>, bool)> = HashMap::new();
 
         self.referenced_private_names_stack.push(HashSet::new());
 
@@ -683,10 +655,7 @@ impl Parser<'_> {
         self.class_has_super_class = saved_class_has_super;
 
         // AllPrivateNamesValid: check that all referenced private names were declared.
-        let referenced = self
-            .referenced_private_names_stack
-            .pop()
-            .unwrap_or_default();
+        let referenced = self.referenced_private_names_stack.pop().unwrap_or_default();
         for name in referenced {
             if found_private_names.contains_key(&name) {
                 continue;
@@ -696,9 +665,7 @@ impl Parser<'_> {
                 outer.insert(name);
             } else {
                 let name_str = String::from_utf16_lossy(&name);
-                self.syntax_error(&format!(
-                    "Reference to undeclared private field or method '{name_str}'"
-                ));
+                self.syntax_error(&format!("Reference to undeclared private field or method '{name_str}'"));
             }
         }
         self.flags.strict_mode = strict_before;
@@ -706,11 +673,7 @@ impl Parser<'_> {
         self.scope_collector.close_scope();
 
         if constructor.is_none() {
-            constructor = Some(self.synthesize_default_constructor(
-                start,
-                &name_value,
-                super_class.is_some(),
-            ));
+            constructor = Some(self.synthesize_default_constructor(start, &name_value, super_class.is_some()));
         }
 
         self.last_class_name = saved_class_name;
@@ -744,8 +707,7 @@ impl Parser<'_> {
                         start.line,
                         start.column,
                     );
-                    self.scope_collector
-                        .register_identifier(name_ident.clone(), None);
+                    self.scope_collector.register_identifier(name_ident.clone(), None);
                 }
                 self.statement(start, StatementKind::ClassDeclaration(data))
             }
@@ -757,12 +719,7 @@ impl Parser<'_> {
     // If no constructor is present in the ClassBody:
     //   - Base class: constructor() {}
     //   - Derived class: constructor(...arguments) { super(...arguments); }
-    fn synthesize_default_constructor(
-        &mut self,
-        start: Position,
-        class_name: &[u16],
-        has_super: bool,
-    ) -> Expression {
+    fn synthesize_default_constructor(&mut self, start: Position, class_name: &[u16], has_super: bool) -> Expression {
         let ctor_name = if !class_name.is_empty() {
             Some(self.make_identifier(start, Utf16String::from(class_name)))
         } else {
@@ -775,12 +732,8 @@ impl Parser<'_> {
         if has_super {
             let arguments_name = Utf16String::from(utf16!("args"));
 
-            let arguments_ref = Rc::new(Identifier::new(
-                self.range_from(start),
-                arguments_name.clone().into(),
-            ));
-            let arguments_expression =
-                self.expression(start, ExpressionKind::Identifier(arguments_ref));
+            let arguments_ref = Rc::new(Identifier::new(self.range_from(start), arguments_name.clone().into()));
+            let arguments_expression = self.expression(start, ExpressionKind::Identifier(arguments_ref));
 
             let super_call = self.expression(
                 start,
@@ -792,17 +745,13 @@ impl Parser<'_> {
                     is_synthetic: true,
                 })),
             );
-            let return_statement =
-                self.statement(start, StatementKind::Return(Some(Box::new(super_call))));
+            let return_statement = self.statement(start, StatementKind::Return(Some(Box::new(super_call))));
             let body = self.statement(
                 start,
                 StatementKind::Block(ScopeData::shared_with_children(vec![return_statement])),
             );
 
-            let arguments_binding = Rc::new(Identifier::new(
-                self.range_from(start),
-                arguments_name.into(),
-            ));
+            let arguments_binding = Rc::new(Identifier::new(self.range_from(start), arguments_name.into()));
             let parameters = vec![FunctionParameter {
                 binding: FunctionParameterBinding::Identifier(arguments_binding),
                 default_value: None,
@@ -827,10 +776,7 @@ impl Parser<'_> {
             });
             self.expression(start, ExpressionKind::Function(function_id))
         } else {
-            let body = self.statement(
-                start,
-                StatementKind::Block(ScopeData::shared_with_children(Vec::new())),
-            );
+            let body = self.statement(start, StatementKind::Block(ScopeData::shared_with_children(Vec::new())));
 
             let function_id = self.function_table.insert(FunctionData {
                 name: ctor_name,
@@ -865,56 +811,53 @@ impl Parser<'_> {
         found_private_names: &mut HashMap<Utf16String, (Option<ClassMethodKind>, bool)>,
     ) -> (Option<Node<ClassElement>>, Option<Expression>) {
         // C++ lexes "static" as Identifier and checks original_value() == "static".
-        let mut is_static = if self.match_identifier()
-            && self.token_original_value(&self.current_token) == utf16!("static")
-        {
-            self.consume();
-            // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
-            // ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`
-            if self.match_token(TokenType::CurlyOpen) {
-                // C++ captures static_start (push_start) before consuming '{'.
-                let static_start = self.position();
-                self.consume(); // consume '{'
-                let saved_flags = self.flags;
-                self.flags.in_break_context = false;
-                self.flags.in_continue_context = false;
-                self.flags.in_function_context = false;
-                self.flags.in_generator_function_context = false;
-                self.flags.await_expression_is_valid = false;
-                self.flags.in_class_field_initializer = true;
-                self.flags.in_class_static_init_block = true;
-                self.flags.allow_super_property_lookup = true;
-                self.flags.new_target_is_valid = true;
-                self.scope_collector.open_static_init_scope(None);
-                let children = self.parse_statement_list(false);
-                self.flags = saved_flags;
-                self.consume_token(TokenType::CurlyClose);
-                let scope = ScopeData::shared_with_children(children);
-                self.scope_collector.set_scope_node(scope.clone());
-                self.scope_collector.close_scope();
-                // C++ uses rule_start (class start) for FunctionBody position.
-                let body = self.statement(
-                    class_start,
-                    StatementKind::FunctionBody {
-                        scope,
-                        in_strict_mode: self.flags.strict_mode,
-                    },
-                );
-                // C++ uses static_start (after '{') for StaticInitializer position.
-                return (
-                    Some(Node::new(
-                        self.range_from(static_start),
-                        ClassElement::StaticInitializer {
-                            body: Box::new(body),
+        let mut is_static =
+            if self.match_identifier() && self.token_original_value(&self.current_token) == utf16!("static") {
+                self.consume();
+                // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
+                // ClassStaticBlock : `static` `{` ClassStaticBlockBody `}`
+                if self.match_token(TokenType::CurlyOpen) {
+                    // C++ captures static_start (push_start) before consuming '{'.
+                    let static_start = self.position();
+                    self.consume(); // consume '{'
+                    let saved_flags = self.flags;
+                    self.flags.in_break_context = false;
+                    self.flags.in_continue_context = false;
+                    self.flags.in_function_context = false;
+                    self.flags.in_generator_function_context = false;
+                    self.flags.await_expression_is_valid = false;
+                    self.flags.in_class_field_initializer = true;
+                    self.flags.in_class_static_init_block = true;
+                    self.flags.allow_super_property_lookup = true;
+                    self.flags.new_target_is_valid = true;
+                    self.scope_collector.open_static_init_scope(None);
+                    let children = self.parse_statement_list(false);
+                    self.flags = saved_flags;
+                    self.consume_token(TokenType::CurlyClose);
+                    let scope = ScopeData::shared_with_children(children);
+                    self.scope_collector.set_scope_node(scope.clone());
+                    self.scope_collector.close_scope();
+                    // C++ uses rule_start (class start) for FunctionBody position.
+                    let body = self.statement(
+                        class_start,
+                        StatementKind::FunctionBody {
+                            scope,
+                            in_strict_mode: self.flags.strict_mode,
                         },
-                    )),
-                    None,
-                );
-            }
-            true
-        } else {
-            false
-        };
+                    );
+                    // C++ uses static_start (after '{') for StaticInitializer position.
+                    return (
+                        Some(Node::new(
+                            self.range_from(static_start),
+                            ClassElement::StaticInitializer { body: Box::new(body) },
+                        )),
+                        None,
+                    );
+                }
+                true
+            } else {
+                false
+            };
 
         let mut is_async = false;
         let mut is_generator = false;
@@ -1014,9 +957,7 @@ impl Parser<'_> {
         // It is a Syntax Error if PrivateBoundIdentifiers of ClassElementList contains
         // any duplicate entries, unless the name is used once for a getter and once for
         // a setter and in no other entries, and they are either both static or both non-static.
-        let is_private = key_value
-            .as_ref()
-            .is_some_and(|v| v.first() == Some(&ch(b'#')));
+        let is_private = key_value.as_ref().is_some_and(|v| v.first() == Some(&ch(b'#')));
         if is_private {
             let name = key_value.as_ref().unwrap();
             let current_kind = if is_getter {
@@ -1045,9 +986,7 @@ impl Parser<'_> {
                     };
                     if is_error {
                         let name_str = String::from_utf16_lossy(name);
-                        self.syntax_error(&format!(
-                            "Duplicate private field or method named '{name_str}'"
-                        ));
+                        self.syntax_error(&format!("Duplicate private field or method named '{name_str}'"));
                     }
                 }
                 found_private_names.insert(name.clone(), (current_kind, is_static));
@@ -1056,16 +995,13 @@ impl Parser<'_> {
                 .is_some()
             {
                 let name_str = String::from_utf16_lossy(name);
-                self.syntax_error(&format!(
-                    "Duplicate private field or method named '{name_str}'"
-                ));
+                self.syntax_error(&format!("Duplicate private field or method named '{name_str}'"));
             }
         }
 
         if self.match_token(TokenType::ParenOpen) {
             let ctor_name = utf16!("constructor");
-            let is_constructor =
-                !is_static && !is_getter && !is_setter && key_value.as_deref() == Some(ctor_name);
+            let is_constructor = !is_static && !is_getter && !is_setter && key_value.as_deref() == Some(ctor_name);
 
             // https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
             // It is a Syntax Error if SpecialMethod of MethodDefinition is true
@@ -1098,8 +1034,7 @@ impl Parser<'_> {
             } else {
                 MethodKind::Normal
             };
-            let function =
-                self.parse_method_definition(is_async, is_generator, method_kind, function_start);
+            let function = self.parse_method_definition(is_async, is_generator, method_kind, function_start);
             let class_method_kind = if is_getter {
                 ClassMethodKind::Getter
             } else if is_setter {
@@ -1193,9 +1128,7 @@ impl Parser<'_> {
         if has_use_strict {
             self.flags.strict_mode = true;
             if !is_simple {
-                self.syntax_error(
-                    "Illegal 'use strict' directive in function with non-simple parameter list",
-                );
+                self.syntax_error("Illegal 'use strict' directive in function with non-simple parameter list");
             }
         }
 
@@ -1321,9 +1254,7 @@ impl Parser<'_> {
                     identifier: Some(id.clone()),
                 });
                 (FunctionParameterBinding::Identifier(id), false)
-            } else if self.match_token(TokenType::CurlyOpen)
-                || self.match_token(TokenType::BracketOpen)
-            {
+            } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 let pat = self.parse_binding_pattern();
                 for (n, id) in std::mem::take(&mut self.pattern_bound_names) {
                     parameter_info.push(ParamInfo {
@@ -1349,11 +1280,8 @@ impl Parser<'_> {
                 has_seen_default = true;
                 let saved_in_function = self.flags.in_function_context;
                 self.flags.in_function_context = true;
-                let expr = self.parse_expression(
-                    PRECEDENCE_ASSIGNMENT,
-                    Associativity::Right,
-                    ForbiddenTokens::with_in(),
-                );
+                let expr =
+                    self.parse_expression(PRECEDENCE_ASSIGNMENT, Associativity::Right, ForbiddenTokens::with_in());
                 self.flags.in_function_context = saved_in_function;
                 Some(expr)
             } else {
@@ -1371,11 +1299,7 @@ impl Parser<'_> {
                 is_rest: rest,
             });
             let parameter_info_end = parameter_info.len();
-            parameter_info_ranges.push((
-                parameter_info_start,
-                parameter_info_end,
-                parameter_is_non_simple,
-            ));
+            parameter_info_ranges.push((parameter_info_start, parameter_info_end, parameter_is_non_simple));
 
             if rest || !self.match_token(TokenType::Comma) {
                 break;
@@ -1499,12 +1423,9 @@ impl Parser<'_> {
                         ForbiddenTokens::none().forbid(&[TokenType::Equals]),
                     );
                     if Self::is_member_expression(&expression) {
-                        entry_alias =
-                            Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
+                        entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
                     } else if Self::is_identifier(&expression) {
-                        entry_name = Some(BindingEntryName::Identifier(
-                            expression_into_identifier(expression),
-                        ));
+                        entry_name = Some(BindingEntryName::Identifier(expression_into_identifier(expression)));
                     } else {
                         self.syntax_error("Invalid destructuring assignment target");
                         break;
@@ -1520,18 +1441,14 @@ impl Parser<'_> {
                         || self.match_token(TokenType::BigIntLiteral)
                     {
                         // C++ uses the binding pattern start position for all name identifiers.
-                        let entry_start = self
-                            .binding_pattern_start
-                            .unwrap_or_else(|| self.position());
+                        let entry_start = self.binding_pattern_start.unwrap_or_else(|| self.position());
 
-                        if self.match_token(TokenType::StringLiteral)
-                            || self.match_token(TokenType::NumericLiteral)
-                        {
+                        if self.match_token(TokenType::StringLiteral) || self.match_token(TokenType::NumericLiteral) {
                             needs_alias = true;
                         }
 
-                        entry_is_keyword = self.current_token.token_type.is_identifier_name()
-                            && !self.match_identifier();
+                        entry_is_keyword =
+                            self.current_token.token_type.is_identifier_name() && !self.match_identifier();
 
                         // Suppress eval/arguments check for binding pattern property
                         // keys. C++ uses regular consume() here (no arguments check),
@@ -1587,32 +1504,23 @@ impl Parser<'_> {
                                 Associativity::Right,
                                 ForbiddenTokens::none().forbid(&[TokenType::Equals]),
                             );
-                            if Self::is_object_expression(&expression)
-                                || Self::is_array_expression(&expression)
-                            {
+                            if Self::is_object_expression(&expression) || Self::is_array_expression(&expression) {
                                 let pattern = self.synthesize_binding_pattern(expression_start);
-                                entry_alias =
-                                    Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
+                                entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
                             } else if Self::is_member_expression(&expression) {
-                                entry_alias =
-                                    Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
+                                entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
                             } else if Self::is_identifier(&expression) {
-                                entry_alias = Some(BindingEntryAlias::Identifier(
-                                    expression_into_identifier(expression),
-                                ));
+                                entry_alias =
+                                    Some(BindingEntryAlias::Identifier(expression_into_identifier(expression)));
                             } else {
                                 self.syntax_error("Invalid destructuring assignment target");
                                 break;
                             }
-                        } else if self.match_token(TokenType::CurlyOpen)
-                            || self.match_token(TokenType::BracketOpen)
-                        {
+                        } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                             let nested = self.parse_binding_pattern();
                             entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(nested)));
                         } else if self.match_identifier_name() {
-                            let alias_start = self
-                                .binding_pattern_start
-                                .unwrap_or_else(|| self.position());
+                            let alias_start = self.binding_pattern_start.unwrap_or_else(|| self.position());
                             let token = self.consume();
                             let name = self.token_identifier_name(&token);
                             let id = self.make_identifier(alias_start, name.clone());
@@ -1631,8 +1539,7 @@ impl Parser<'_> {
                             self.syntax_error("Binding pattern target may not be a reserved word");
                         }
                         if let Some(BindingEntryName::Identifier(ref id)) = entry_name {
-                            self.pattern_bound_names
-                                .push((entry_name_value, id.clone()));
+                            self.pattern_bound_names.push((entry_name_value, id.clone()));
                         }
                     }
                 }
@@ -1643,8 +1550,7 @@ impl Parser<'_> {
                     Associativity::Right,
                     ForbiddenTokens::none().forbid(&[TokenType::Equals]),
                 );
-                if Self::is_object_expression(&expression) || Self::is_array_expression(&expression)
-                {
+                if Self::is_object_expression(&expression) || Self::is_array_expression(&expression) {
                     let pattern = self.synthesize_binding_pattern(expression_start);
                     entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
                 } else if Self::is_member_expression(&expression) {
@@ -1657,15 +1563,11 @@ impl Parser<'_> {
                     self.syntax_error("Invalid destructuring assignment target");
                     break;
                 }
-            } else if self.match_token(TokenType::CurlyOpen)
-                || self.match_token(TokenType::BracketOpen)
-            {
+            } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 let nested = self.parse_binding_pattern();
                 entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(nested)));
             } else if self.match_identifier_name() {
-                let alias_start = self
-                    .binding_pattern_start
-                    .unwrap_or_else(|| self.position());
+                let alias_start = self.binding_pattern_start.unwrap_or_else(|| self.position());
                 let token = self.consume();
                 let name = self.token_identifier_name(&token);
                 let id = self.make_identifier(alias_start, name.clone());
@@ -1808,10 +1710,7 @@ impl Parser<'_> {
                             });
                         } else if require_as {
                             self.syntax_error_at_position(
-                                &format!(
-                                    "Unexpected reserved word '{}'",
-                                    String::from_utf16_lossy(&name)
-                                ),
+                                &format!("Unexpected reserved word '{}'", String::from_utf16_lossy(&name)),
                                 name_pos,
                             );
                         } else {
@@ -1921,8 +1820,7 @@ impl Parser<'_> {
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Class) {
                 let next = self.next_token();
-                if next.token_type != TokenType::CurlyOpen && next.token_type != TokenType::Extends
-                {
+                if next.token_type != TokenType::CurlyOpen && next.token_type != TokenType::Extends {
                     let declaration = self.parse_class_declaration();
                     if let StatementKind::ClassDeclaration(ref class) = declaration.inner
                         && let Some(ref name_id) = class.name
@@ -2115,19 +2013,15 @@ impl Parser<'_> {
     }
 
     fn match_imported_binding(&self) -> bool {
-        self.match_identifier()
-            || self.match_token(TokenType::Yield)
-            || self.match_token(TokenType::Await)
+        self.match_identifier() || self.match_token(TokenType::Yield) || self.match_token(TokenType::Await)
     }
 
     fn match_as(&self) -> bool {
-        self.match_token(TokenType::Identifier)
-            && self.token_original_value(&self.current_token) == utf16!("as")
+        self.match_token(TokenType::Identifier) && self.token_original_value(&self.current_token) == utf16!("as")
     }
 
     fn match_from(&self) -> bool {
-        self.match_token(TokenType::Identifier)
-            && self.token_original_value(&self.current_token) == utf16!("from")
+        self.match_token(TokenType::Identifier) && self.token_original_value(&self.current_token) == utf16!("from")
     }
 
     fn consume_module_specifier(&mut self) -> Utf16String {

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -12,9 +12,9 @@ use std::rc::Rc;
 use crate::ast::*;
 use crate::lexer::ch;
 use crate::parser::{
-    Associativity, ForbiddenTokens, FunctionKind, MethodKind, PRECEDENCE_ASSIGNMENT,
-    PRECEDENCE_COMMA, PRECEDENCE_MEMBER, PRECEDENCE_UNARY, ParamInfo, ParsedParameters, Parser,
-    Position, PropertyKey, is_strict_reserved_word,
+    Associativity, ForbiddenTokens, FunctionKind, MethodKind, PRECEDENCE_ASSIGNMENT, PRECEDENCE_COMMA,
+    PRECEDENCE_MEMBER, PRECEDENCE_UNARY, ParamInfo, ParsedParameters, Parser, Position, PropertyKey,
+    is_strict_reserved_word,
 };
 use crate::token::{Token, TokenType};
 
@@ -90,13 +90,8 @@ impl Parser<'_> {
             return false;
         }
         match tt {
-            TokenType::Period
-            | TokenType::BracketOpen
-            | TokenType::ParenOpen
-            | TokenType::QuestionMarkPeriod => true,
-            TokenType::PlusPlus | TokenType::MinusMinus => {
-                !self.current_token.trivia_has_line_terminator
-            }
+            TokenType::Period | TokenType::BracketOpen | TokenType::ParenOpen | TokenType::QuestionMarkPeriod => true,
+            TokenType::PlusPlus | TokenType::MinusMinus => !self.current_token.trivia_has_line_terminator,
             TokenType::DoubleAsterisk
             | TokenType::Asterisk
             | TokenType::Slash
@@ -144,19 +139,11 @@ impl Parser<'_> {
     }
 
     pub(crate) fn parse_expression_any(&mut self) -> Expression {
-        self.parse_expression(
-            PRECEDENCE_COMMA,
-            Associativity::Right,
-            ForbiddenTokens::none(),
-        )
+        self.parse_expression(PRECEDENCE_COMMA, Associativity::Right, ForbiddenTokens::none())
     }
 
     pub(crate) fn parse_assignment_expression(&mut self) -> Expression {
-        self.parse_expression(
-            PRECEDENCE_ASSIGNMENT,
-            Associativity::Right,
-            ForbiddenTokens::none(),
-        )
+        self.parse_expression(PRECEDENCE_ASSIGNMENT, Associativity::Right, ForbiddenTokens::none())
     }
 
     pub(crate) fn parse_expression(
@@ -176,21 +163,11 @@ impl Parser<'_> {
             // NB: UnaryExpression cannot be the base of `**`, only UpdateExpression can.
             // This prevents ambiguity like `-x ** y` (is it `(-x) ** y` or `-(x ** y)`?).
             // ++x ** y and --x ** y are valid (they're UpdateExpressions, not UnaryExpressions).
-            if self.match_token(TokenType::DoubleAsterisk)
-                && !Self::is_update_expression(&expression)
-            {
-                self.syntax_error(
-                    "Unparenthesized unary expression can't appear on the left-hand side of '**'",
-                );
+            if self.match_token(TokenType::DoubleAsterisk) && !Self::is_update_expression(&expression) {
+                self.syntax_error("Unparenthesized unary expression can't appear on the left-hand side of '**'");
             }
 
-            return self.continue_parse_expression(
-                start,
-                expression,
-                min_precedence,
-                associativity,
-                forbidden,
-            );
+            return self.continue_parse_expression(start, expression, min_precedence, associativity, forbidden);
         }
 
         let lhs_start = self.position();
@@ -206,14 +183,8 @@ impl Parser<'_> {
             // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
             // It is a Syntax Error if ContainsArguments of ClassStaticBlockBody is true.
             if self.flags.in_class_static_init_block {
-                self.syntax_error(
-                    "'arguments' is not allowed in class static initialization blocks",
-                );
-            } else if !self.flags.strict_mode
-                && !self
-                    .scope_collector
-                    .has_declaration_in_current_function(&id.name)
-            {
+                self.syntax_error("'arguments' is not allowed in class static initialization blocks");
+            } else if !self.flags.strict_mode && !self.scope_collector.has_declaration_in_current_function(&id.name) {
                 self.scope_collector
                     .set_contains_access_to_arguments_object_in_non_strict_mode();
             }
@@ -223,21 +194,14 @@ impl Parser<'_> {
             // Yield/Await expressions don't participate in secondary expression
             // parsing (e.g. member access), but they DO participate in comma
             // expressions (e.g. `yield 1, yield 2`). Check for comma here.
-            let expression =
-                self.parse_comma_expression(lhs_start, expression, min_precedence, forbidden);
+            let expression = self.parse_comma_expression(lhs_start, expression, min_precedence, forbidden);
             self.report_invalid_private_identifier_usage(&expression);
             return expression;
         }
 
         let expression = self.parse_tagged_template_literals(lhs_start, expression);
 
-        self.continue_parse_expression(
-            lhs_start,
-            expression,
-            min_precedence,
-            associativity,
-            forbidden,
-        )
+        self.continue_parse_expression(lhs_start, expression, min_precedence, associativity, forbidden)
     }
 
     fn continue_parse_expression(
@@ -279,8 +243,7 @@ impl Parser<'_> {
             }
         }
 
-        let expression =
-            self.parse_comma_expression(lhs_start, expression, min_precedence, forbidden);
+        let expression = self.parse_comma_expression(lhs_start, expression, min_precedence, forbidden);
         self.report_invalid_private_identifier_usage(&expression);
         expression
     }
@@ -292,10 +255,7 @@ impl Parser<'_> {
         min_precedence: i32,
         forbidden: ForbiddenTokens,
     ) -> Expression {
-        if min_precedence <= 1
-            && self.match_token(TokenType::Comma)
-            && forbidden.allows(TokenType::Comma)
-        {
+        if min_precedence <= 1 && self.match_token(TokenType::Comma) && forbidden.allows(TokenType::Comma) {
             self.report_invalid_private_identifier_usage(&expression);
             let mut expressions = vec![expression];
             while self.match_token(TokenType::Comma) {
@@ -326,9 +286,7 @@ impl Parser<'_> {
             TokenType::ParenOpen => {
                 let paren_start = self.position();
                 self.consume_token(TokenType::ParenOpen);
-                if let Some(arrow) =
-                    self.try_parse_arrow_function_expression(true, false, Some(paren_start))
-                {
+                if let Some(arrow) = self.try_parse_arrow_function_expression(true, false, Some(paren_start)) {
                     return (arrow, false);
                 }
                 if self.match_token(TokenType::ParenClose) {
@@ -385,9 +343,7 @@ impl Parser<'_> {
                         ),
                         true,
                     )
-                } else if self.match_token(TokenType::Period)
-                    || self.match_token(TokenType::BracketOpen)
-                {
+                } else if self.match_token(TokenType::Period) || self.match_token(TokenType::BracketOpen) {
                     if !self.flags.allow_super_property_lookup {
                         self.syntax_error("'super' keyword unexpected here");
                     }
@@ -402,10 +358,7 @@ impl Parser<'_> {
                 let token = self.consume_and_validate_numeric_literal();
                 let value_str = self.token_value(&token);
                 let value = parse_numeric_value(value_str);
-                (
-                    self.expression(start, ExpressionKind::NumericLiteral(value)),
-                    true,
-                )
+                (self.expression(start, ExpressionKind::NumericLiteral(value)), true)
             }
 
             TokenType::BigIntLiteral => {
@@ -415,10 +368,7 @@ impl Parser<'_> {
                 let value_utf8: String = value
                     .iter()
                     .map(|&c| {
-                        assert!(
-                            c < 128,
-                            "BigIntLiteral should only contain ASCII characters"
-                        );
+                        assert!(c < 128, "BigIntLiteral should only contain ASCII characters");
                         c as u8 as char
                     })
                     .collect();
@@ -432,10 +382,7 @@ impl Parser<'_> {
                 let token = self.consume();
                 let value = self.token_value(&token);
                 let is_true = value == utf16!("true");
-                (
-                    self.expression(start, ExpressionKind::BooleanLiteral(is_true)),
-                    true,
-                )
+                (self.expression(start, ExpressionKind::BooleanLiteral(is_true)), true)
             }
 
             TokenType::StringLiteral => {
@@ -446,9 +393,7 @@ impl Parser<'_> {
                 let (value, has_octal) = self.parse_string_value(&token);
                 if has_octal {
                     if self.flags.strict_mode {
-                        self.syntax_error(
-                            "Octal escape sequence in string literal not allowed in strict mode",
-                        );
+                        self.syntax_error("Octal escape sequence in string literal not allowed in strict mode");
                     } else {
                         self.flags.string_legacy_octal_escape_sequence_in_scope = true;
                     }
@@ -489,15 +434,12 @@ impl Parser<'_> {
                     let expression = self.parse_function_expression();
                     return (expression, true);
                 }
-                if let Some(arrow) = self.try_parse_arrow_function_expression(
-                    next.token_type == TokenType::ParenOpen,
-                    true,
-                    None,
-                ) {
+                if let Some(arrow) =
+                    self.try_parse_arrow_function_expression(next.token_type == TokenType::ParenOpen, true, None)
+                {
                     return (arrow, false);
                 }
-                self.arrow_function_failed_positions
-                    .remove(&(start.offset as usize));
+                self.arrow_function_failed_positions.remove(&(start.offset as usize));
                 // `async => ...` is a regular arrow function with parameter name `async`
                 // (not an async arrow function).
                 if let Some(arrow) = self.try_parse_arrow_function_expression(false, false, None) {
@@ -538,10 +480,7 @@ impl Parser<'_> {
                         self.syntax_error("import.meta is only allowed in modules");
                     }
                     (
-                        self.expression(
-                            start,
-                            ExpressionKind::MetaProperty(MetaPropertyType::ImportMeta),
-                        ),
+                        self.expression(start, ExpressionKind::MetaProperty(MetaPropertyType::ImportMeta)),
                         true,
                     )
                 } else if self.match_token(TokenType::ParenOpen) {
@@ -626,13 +565,8 @@ impl Parser<'_> {
                 // class static init blocks, but we still need to try arrow function
                 // parsing and identifier consumption (with appropriate errors).
                 // This matches C++'s "goto read_as_identifier" pattern.
-                if self.match_identifier()
-                    || self.match_token(TokenType::Await)
-                    || self.match_token(TokenType::Yield)
-                {
-                    if let Some(arrow) =
-                        self.try_parse_arrow_function_expression(false, false, None)
-                    {
+                if self.match_identifier() || self.match_token(TokenType::Await) || self.match_token(TokenType::Yield) {
+                    if let Some(arrow) = self.try_parse_arrow_function_expression(false, false, None) {
                         return (arrow, false);
                     }
                     if self.match_token(TokenType::Await)
@@ -640,16 +574,12 @@ impl Parser<'_> {
                             || self.flags.await_expression_is_valid
                             || self.flags.in_class_static_init_block)
                     {
-                        self.syntax_error(
-                            "'await' is not allowed as an identifier in this context",
-                        );
+                        self.syntax_error("'await' is not allowed as an identifier in this context");
                     }
                     if self.match_token(TokenType::Yield)
                         && (self.flags.strict_mode || self.flags.in_generator_function_context)
                     {
-                        self.syntax_error(
-                            "'yield' is not allowed as an identifier in this context",
-                        );
+                        self.syntax_error("'yield' is not allowed as an identifier in this context");
                     }
                     let token = self.consume_and_check_identifier();
                     let id = self.make_identifier(start, self.token_identifier_name(&token));
@@ -741,11 +671,7 @@ impl Parser<'_> {
             | TokenType::Instanceof => {
                 let op = token_to_binary_op(tt);
                 self.consume();
-                let rhs = self.parse_expression(
-                    min_precedence,
-                    Self::operator_associativity(tt),
-                    forbidden,
-                );
+                let rhs = self.parse_expression(min_precedence, Self::operator_associativity(tt), forbidden);
                 (
                     self.expression(
                         start,
@@ -762,16 +688,14 @@ impl Parser<'_> {
             TokenType::In => {
                 let is_private_in = matches!(&lhs.inner, ExpressionKind::PrivateIdentifier(_));
                 self.consume();
-                let rhs = self.parse_expression(
-                    min_precedence,
-                    Self::operator_associativity(tt),
-                    forbidden,
-                );
+                let rhs = self.parse_expression(min_precedence, Self::operator_associativity(tt), forbidden);
                 if is_private_in
                     && let ExpressionKind::Function(fn_id) = &rhs.inner
                     && self.function_table.get(*fn_id).is_arrow_function
                 {
-                    self.syntax_error("Arrow function is not allowed as the right-hand side of a private 'in' expression");
+                    self.syntax_error(
+                        "Arrow function is not allowed as the right-hand side of a private 'in' expression",
+                    );
                 }
 
                 (
@@ -826,8 +750,7 @@ impl Parser<'_> {
             }
             TokenType::DoubleQuestionMark => {
                 self.consume();
-                let new_forbidden =
-                    forbidden.forbid(&[TokenType::DoubleAmpersand, TokenType::DoublePipe]);
+                let new_forbidden = forbidden.forbid(&[TokenType::DoubleAmpersand, TokenType::DoublePipe]);
                 let rhs = self.parse_expression(min_precedence, Associativity::Left, new_forbidden);
                 (
                     self.expression(
@@ -883,8 +806,7 @@ impl Parser<'_> {
                     }
                     self.pattern_bound_names = saved_bound_names;
                     self.consume();
-                    let rhs =
-                        self.parse_expression(min_precedence, Associativity::Right, forbidden);
+                    let rhs = self.parse_expression(min_precedence, Associativity::Right, forbidden);
                     return (
                         self.expression(
                             start,
@@ -929,8 +851,7 @@ impl Parser<'_> {
                 self.consume();
                 let consequent = self.parse_assignment_expression();
                 self.consume_token(TokenType::Colon);
-                let alternate =
-                    self.parse_expression(PRECEDENCE_ASSIGNMENT, Associativity::Right, forbidden);
+                let alternate = self.parse_expression(PRECEDENCE_ASSIGNMENT, Associativity::Right, forbidden);
                 (
                     self.expression(
                         start,
@@ -956,8 +877,7 @@ impl Parser<'_> {
                     }
                     // C++ uses rule_start (period position) for property identifiers.
                     let id = self.parse_private_identifier(start);
-                    let property =
-                        self.expression(start, ExpressionKind::PrivateIdentifier(Box::new(id)));
+                    let property = self.expression(start, ExpressionKind::PrivateIdentifier(Box::new(id)));
                     (
                         self.expression(
                             start,
@@ -972,10 +892,8 @@ impl Parser<'_> {
                 } else if self.match_identifier_name() {
                     let token = self.consume();
                     // C++ uses rule_start (period position) for property identifiers.
-                    let property_identifier =
-                        self.make_identifier(start, self.token_identifier_name(&token));
-                    let property =
-                        self.expression(start, ExpressionKind::Identifier(property_identifier));
+                    let property_identifier = self.make_identifier(start, self.token_identifier_name(&token));
+                    let property = self.expression(start, ExpressionKind::Identifier(property_identifier));
                     (
                         self.expression(
                             start,
@@ -1098,11 +1016,7 @@ impl Parser<'_> {
         match tt {
             TokenType::PlusPlus => {
                 self.consume();
-                let expression = self.parse_expression(
-                    PRECEDENCE_UNARY,
-                    Associativity::Right,
-                    ForbiddenTokens::none(),
-                );
+                let expression = self.parse_expression(PRECEDENCE_UNARY, Associativity::Right, ForbiddenTokens::none());
                 if !Self::is_simple_assignment_target(&expression, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
@@ -1120,11 +1034,7 @@ impl Parser<'_> {
             }
             TokenType::MinusMinus => {
                 self.consume();
-                let expression = self.parse_expression(
-                    PRECEDENCE_UNARY,
-                    Associativity::Right,
-                    ForbiddenTokens::none(),
-                );
+                let expression = self.parse_expression(PRECEDENCE_UNARY, Associativity::Right, ForbiddenTokens::none());
                 if !Self::is_simple_assignment_target(&expression, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
@@ -1155,11 +1065,7 @@ impl Parser<'_> {
                     _ => UnaryOp::Void,
                 };
                 self.consume();
-                let expression = self.parse_expression(
-                    PRECEDENCE_UNARY,
-                    Associativity::Right,
-                    ForbiddenTokens::none(),
-                );
+                let expression = self.parse_expression(PRECEDENCE_UNARY, Associativity::Right, ForbiddenTokens::none());
                 self.report_invalid_private_identifier_usage(&expression);
                 self.expression(
                     start,
@@ -1175,11 +1081,7 @@ impl Parser<'_> {
             TokenType::Delete => {
                 self.consume();
                 let rhs_start = self.position();
-                let expression = self.parse_expression(
-                    PRECEDENCE_UNARY,
-                    Associativity::Right,
-                    ForbiddenTokens::none(),
-                );
+                let expression = self.parse_expression(PRECEDENCE_UNARY, Associativity::Right, ForbiddenTokens::none());
                 self.report_invalid_private_identifier_usage(&expression);
                 if self.flags.strict_mode && Self::is_identifier(&expression) {
                     self.syntax_error_at(
@@ -1236,17 +1138,13 @@ impl Parser<'_> {
             if self.scope_collector.has_current_scope() {
                 self.scope_collector.set_uses_new_target();
             }
-            return self.expression(
-                start,
-                ExpressionKind::MetaProperty(MetaPropertyType::NewTarget),
-            );
+            return self.expression(start, ExpressionKind::MetaProperty(MetaPropertyType::NewTarget));
         }
 
         let callee = if self.match_token(TokenType::New) {
             self.parse_new_expression()
         } else {
-            let forbidden = ForbiddenTokens::none()
-                .forbid(&[TokenType::ParenOpen, TokenType::QuestionMarkPeriod]);
+            let forbidden = ForbiddenTokens::none().forbid(&[TokenType::ParenOpen, TokenType::QuestionMarkPeriod]);
             self.parse_expression(PRECEDENCE_MEMBER, Associativity::Right, forbidden)
         };
 
@@ -1379,10 +1277,7 @@ impl Parser<'_> {
                             let property_start = self.position();
                             let token = self.consume();
                             references.push(OptionalChainReference::MemberReference {
-                                identifier: self.make_identifier(
-                                    property_start,
-                                    self.token_identifier_name(&token),
-                                ),
+                                identifier: self.make_identifier(property_start, self.token_identifier_name(&token)),
                                 mode: OptionalChainMode::Optional,
                             });
                         } else {
@@ -1410,8 +1305,7 @@ impl Parser<'_> {
                     let property_start = self.position();
                     let token = self.consume();
                     references.push(OptionalChainReference::MemberReference {
-                        identifier: self
-                            .make_identifier(property_start, self.token_identifier_name(&token)),
+                        identifier: self.make_identifier(property_start, self.token_identifier_name(&token)),
                         mode: OptionalChainMode::NotOptional,
                     });
                 } else {
@@ -1458,9 +1352,7 @@ impl Parser<'_> {
         let start = self.position();
 
         if self.flags.in_formal_parameter_context {
-            self.syntax_error(
-                "'Yield' expression is not allowed in formal parameters of generator function",
-            );
+            self.syntax_error("'Yield' expression is not allowed in formal parameters of generator function");
         }
 
         self.consume_token(TokenType::Yield);
@@ -1509,17 +1401,11 @@ impl Parser<'_> {
         let start = self.position();
 
         if self.flags.in_formal_parameter_context {
-            self.syntax_error(
-                "'Await' expression is not allowed in formal parameters of an async function",
-            );
+            self.syntax_error("'Await' expression is not allowed in formal parameters of an async function");
         }
 
         self.consume_token(TokenType::Await);
-        let argument = self.parse_expression(
-            PRECEDENCE_UNARY,
-            Associativity::Right,
-            ForbiddenTokens::none(),
-        );
+        let argument = self.parse_expression(PRECEDENCE_UNARY, Associativity::Right, ForbiddenTokens::none());
         self.scope_collector.set_contains_await_expression();
         self.expression(start, ExpressionKind::Await(Box::new(argument)))
     }
@@ -1552,9 +1438,7 @@ impl Parser<'_> {
                 // PropertyDefinition : PropertyName `:` AssignmentExpression.
                 if property.property_type == ObjectPropertyType::ProtoSetter {
                     if has_proto_setter {
-                        self.syntax_error(
-                            "Duplicate __proto__ fields are not allowed in object expressions",
-                        );
+                        self.syntax_error("Duplicate __proto__ fields are not allowed in object expressions");
                     }
                     has_proto_setter = true;
                 }
@@ -1795,10 +1679,7 @@ impl Parser<'_> {
         ) || next.token_type.is_identifier_name()
     }
 
-    pub(crate) fn parse_property_key(
-        &mut self,
-        ident_pos_override: Option<Position>,
-    ) -> PropertyKey {
+    pub(crate) fn parse_property_key(&mut self, ident_pos_override: Option<Position>) -> PropertyKey {
         // Suppress eval/arguments check for property key tokens (C++ uses
         // regular `consume()` not `consume_and_allow_division()` here).
         let saved_property_key_ctx = self.flags.in_property_key_context;
@@ -1832,18 +1713,13 @@ impl Parser<'_> {
                 let (value, has_octal) = self.parse_string_value(&token);
                 if has_octal {
                     if self.flags.strict_mode {
-                        self.syntax_error(
-                            "Octal escape sequence in string literal not allowed in strict mode",
-                        );
+                        self.syntax_error("Octal escape sequence in string literal not allowed in strict mode");
                     } else {
                         self.flags.string_legacy_octal_escape_sequence_in_scope = true;
                     }
                 }
                 let is_proto = value == proto_name;
-                let expression = self.expression(
-                    after_string,
-                    ExpressionKind::StringLiteral(Box::new(value.clone())),
-                );
+                let expression = self.expression(after_string, ExpressionKind::StringLiteral(Box::new(value.clone())));
                 PropertyKey {
                     expression,
                     name: Some(value),
@@ -1872,15 +1748,11 @@ impl Parser<'_> {
                 let value_utf8: String = value
                     .iter()
                     .map(|&c| {
-                        assert!(
-                            c < 128,
-                            "BigIntLiteral should only contain ASCII characters"
-                        );
+                        assert!(c < 128, "BigIntLiteral should only contain ASCII characters");
                         c as u8 as char
                     })
                     .collect();
-                let expression =
-                    self.expression(start, ExpressionKind::BigIntLiteral(Box::new(value_utf8)));
+                let expression = self.expression(start, ExpressionKind::BigIntLiteral(Box::new(value_utf8)));
                 PropertyKey {
                     expression,
                     name: None,
@@ -1925,10 +1797,7 @@ impl Parser<'_> {
                     let is_proto = value == proto_name;
                     // C++ uses the object expression start position for identifier-name keys.
                     let key_start = ident_pos_override.unwrap_or(start);
-                    let expression = self.expression(
-                        key_start,
-                        ExpressionKind::StringLiteral(Box::new(value.clone())),
-                    );
+                    let expression = self.expression(key_start, ExpressionKind::StringLiteral(Box::new(value.clone())));
                     PropertyKey {
                         expression,
                         name: Some(value),
@@ -1939,10 +1808,8 @@ impl Parser<'_> {
                 } else {
                     self.expected("property key");
                     self.consume();
-                    let expression = self.expression(
-                        start,
-                        ExpressionKind::StringLiteral(Box::new(Utf16String::new())),
-                    );
+                    let expression =
+                        self.expression(start, ExpressionKind::StringLiteral(Box::new(Utf16String::new())));
                     PropertyKey {
                         expression,
                         name: None,
@@ -1996,11 +1863,7 @@ impl Parser<'_> {
     /// Consume any tagged template literals following an expression.
     /// Tagged templates bind tighter than any binary operator, so they
     /// are handled outside the normal precedence loop.
-    fn parse_tagged_template_literals(
-        &mut self,
-        tag_start: Position,
-        mut expression: Expression,
-    ) -> Expression {
+    fn parse_tagged_template_literals(&mut self, tag_start: Position, mut expression: Expression) -> Expression {
         while self.match_token(TokenType::TemplateLiteralStart) {
             let template = self.parse_template_literal(true);
             expression = self.expression(
@@ -2026,10 +1889,7 @@ impl Parser<'_> {
             if is_tagged {
                 raw_strings.push(Utf16String::new());
             }
-            expressions.push(self.expression(
-                start,
-                ExpressionKind::StringLiteral(Box::new(Utf16String::new())),
-            ));
+            expressions.push(self.expression(start, ExpressionKind::StringLiteral(Box::new(Utf16String::new()))));
         }
 
         // For non-tagged templates, we collect parts as expressions (alternating
@@ -2051,10 +1911,8 @@ impl Parser<'_> {
                     let raw_value = raw_template_value(&raw);
                     raw_strings.push(raw_value);
                     match self.process_template_escape_sequences(&raw) {
-                        Some(cooked) => expressions.push(self.expression(
-                            string_pos,
-                            ExpressionKind::StringLiteral(Box::new(cooked)),
-                        )),
+                        Some(cooked) => expressions
+                            .push(self.expression(string_pos, ExpressionKind::StringLiteral(Box::new(cooked)))),
                         // C++ uses rule_start (template literal start) for NullLiteral.
                         None => {
                             expressions.push(self.expression(start, ExpressionKind::NullLiteral));
@@ -2065,9 +1923,7 @@ impl Parser<'_> {
                     if has_octal {
                         self.syntax_error("Octal escape sequence not allowed in template literal");
                     }
-                    expressions.push(
-                        self.expression(string_pos, ExpressionKind::StringLiteral(Box::new(value))),
-                    );
+                    expressions.push(self.expression(string_pos, ExpressionKind::StringLiteral(Box::new(value))));
                 }
             } else if self.match_token(TokenType::TemplateLiteralExprStart) {
                 self.consume();
@@ -2076,10 +1932,8 @@ impl Parser<'_> {
                 self.consume_token(TokenType::TemplateLiteralExprEnd);
                 // After an expression, if no template string follows, insert empty.
                 if !self.match_token(TokenType::TemplateLiteralString) {
-                    expressions.push(self.expression(
-                        start,
-                        ExpressionKind::StringLiteral(Box::new(Utf16String::new())),
-                    ));
+                    expressions
+                        .push(self.expression(start, ExpressionKind::StringLiteral(Box::new(Utf16String::new()))));
                     if is_tagged {
                         raw_strings.push(Utf16String::new());
                     }
@@ -2103,11 +1957,7 @@ impl Parser<'_> {
 
     fn process_template_escape_sequences(&self, raw: &[u16]) -> Option<Utf16String> {
         let result = process_escape_sequences_impl(raw, EscapeMode::TaggedTemplate);
-        if result.failed {
-            None
-        } else {
-            Some(result.value)
-        }
+        if result.failed { None } else { Some(result.value) }
     }
 
     /// Parse a string literal token's value, processing escape sequences.
@@ -2183,9 +2033,7 @@ fn process_escape_sequences_impl(input: &[u16], mode: EscapeMode) -> EscapeResul
                 ZERO => {
                     if mode == EscapeMode::TaggedTemplate {
                         if i + 1 < input.len()
-                            && (is_octal_char(input[i + 1])
-                                || input[i + 1] == EIGHT
-                                || input[i + 1] == NINE)
+                            && (is_octal_char(input[i + 1]) || input[i + 1] == EIGHT || input[i + 1] == NINE)
                         {
                             return EscapeResult {
                                 value: result,
@@ -2201,8 +2049,7 @@ fn process_escape_sequences_impl(input: &[u16], mode: EscapeMode) -> EscapeResul
                         let (val, consumed) = parse_octal_escape(input, i);
                         result.0.push(val);
                         i += consumed;
-                    } else if i + 1 < input.len() && (input[i + 1] == EIGHT || input[i + 1] == NINE)
-                    {
+                    } else if i + 1 < input.len() && (input[i + 1] == EIGHT || input[i + 1] == NINE) {
                         has_legacy_octal = true;
                         result.0.push(0);
                     } else {
@@ -2321,11 +2168,7 @@ impl Parser<'_> {
         if self.arrow_function_failed_positions.contains(&offset) {
             return None;
         }
-        let result = self.try_parse_arrow_function_expression_impl(
-            expect_parens,
-            is_async,
-            source_start_override,
-        );
+        let result = self.try_parse_arrow_function_expression_impl(expect_parens, is_async, source_start_override);
         if result.is_none() {
             self.arrow_function_failed_positions.insert(offset);
         }
@@ -2341,10 +2184,7 @@ impl Parser<'_> {
         let start = source_start_override.unwrap_or_else(|| self.position());
 
         if !expect_parens && !is_async {
-            if !self.match_identifier()
-                && !self.match_token(TokenType::Await)
-                && !self.match_token(TokenType::Yield)
-            {
+            if !self.match_identifier() && !self.match_token(TokenType::Await) && !self.match_token(TokenType::Yield) {
                 return None;
             }
             let next = self.next_token();
@@ -2420,10 +2260,7 @@ impl Parser<'_> {
                 self.syntax_error("'await' is a reserved identifier in async functions");
             }
             // C++ uses rule_start (arrow function start, which is `async` for async arrows).
-            let binding = Rc::new(Identifier::new(
-                self.range_from(start),
-                value.clone().into(),
-            ));
+            let binding = Rc::new(Identifier::new(self.range_from(start), value.clone().into()));
             parsed = ParsedParameters {
                 parameters: vec![FunctionParameter {
                     binding: FunctionParameterBinding::Identifier(binding.clone()),
@@ -2485,18 +2322,13 @@ impl Parser<'_> {
         self.flags.in_class_static_init_block = false;
 
         if self.match_token(TokenType::CurlyOpen) {
-            let (body, has_use_strict, insights) =
-                self.parse_function_body(is_async, false, is_simple);
+            let (body, has_use_strict, insights) = self.parse_function_body(is_async, false, is_simple);
 
             self.scope_collector.close_scope();
             self.pattern_bound_names = saved_pattern_bound_names;
 
             if has_use_strict || fn_kind != FunctionKind::Normal || self.flags.strict_mode {
-                self.check_parameters_post_body(
-                    &parameter_info,
-                    has_use_strict || self.flags.strict_mode,
-                    fn_kind,
-                );
+                self.check_parameters_post_body(&parameter_info, has_use_strict || self.flags.strict_mode, fn_kind);
             }
 
             self.flags.await_expression_is_valid = saved_await_body;
@@ -2594,8 +2426,7 @@ impl Parser<'_> {
         self.flags.await_expression_is_valid = is_async;
         self.flags.in_class_static_init_block = false;
         self.flags.in_class_field_initializer = false;
-        self.flags.allow_super_constructor_call =
-            method_kind == MethodKind::Constructor && self.class_has_super_class;
+        self.flags.allow_super_constructor_call = method_kind == MethodKind::Constructor && self.class_has_super_class;
         self.flags.allow_super_property_lookup = true;
         self.flags.new_target_is_valid = true;
 
@@ -2611,8 +2442,7 @@ impl Parser<'_> {
             self.syntax_error("Getter function must have no arguments");
         }
         if method_kind == MethodKind::Setter
-            && (parsed.parameters.len() != 1
-                || parsed.parameters.first().is_some_and(|p| p.is_rest))
+            && (parsed.parameters.len() != 1 || parsed.parameters.first().is_some_and(|p| p.is_rest))
         {
             self.syntax_error("Setter function must have one argument");
         }
@@ -2620,8 +2450,7 @@ impl Parser<'_> {
         self.flags.in_generator_function_context = in_generator_before;
         self.flags.await_expression_is_valid = await_before;
 
-        let (body, has_use_strict, mut insights) =
-            self.parse_function_body(is_async, is_generator, parsed.is_simple);
+        let (body, has_use_strict, mut insights) = self.parse_function_body(is_async, is_generator, parsed.is_simple);
         self.flags.allow_super_constructor_call = saved_allow_super_call;
         self.flags.allow_super_property_lookup = saved_allow_super_lookup;
 

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -58,8 +58,7 @@ impl Parser<'_> {
                     self.syntax_error("Keyword must not contain escaped characters");
                 }
                 if self.match_identifier_name()
-                    && let Some(labelled) =
-                        self.try_parse_labelled_statement(allow_labelled_function)
+                    && let Some(labelled) = self.try_parse_labelled_statement(allow_labelled_function)
                 {
                     return labelled;
                 }
@@ -102,20 +101,13 @@ impl Parser<'_> {
 
         if self.match_token(TokenType::Async) {
             let lookahead = self.next_token();
-            if lookahead.token_type == TokenType::Function && !lookahead.trivia_has_line_terminator
-            {
-                self.syntax_error(
-                    "Async function declaration not allowed in single-statement context",
-                );
+            if lookahead.token_type == TokenType::Function && !lookahead.trivia_has_line_terminator {
+                self.syntax_error("Async function declaration not allowed in single-statement context");
             }
         } else if self.match_token(TokenType::Function) || self.match_token(TokenType::Class) {
             let name = self.current_token.token_type.name();
-            self.syntax_error(&format!(
-                "{name} declaration not allowed in single-statement context"
-            ));
-        } else if self.match_token(TokenType::Let)
-            && self.next_token().token_type == TokenType::BracketOpen
-        {
+            self.syntax_error(&format!("{name} declaration not allowed in single-statement context"));
+        } else if self.match_token(TokenType::Let) && self.next_token().token_type == TokenType::BracketOpen {
             self.syntax_error("let followed by [ is not allowed in single-statement context");
         }
 
@@ -140,10 +132,7 @@ impl Parser<'_> {
         if self.current_token.trivia_has_line_terminator {
             return self.statement(start, StatementKind::Return(None));
         }
-        if self.match_token(TokenType::Semicolon)
-            || self.match_token(TokenType::CurlyClose)
-            || self.done()
-        {
+        if self.match_token(TokenType::Semicolon) || self.match_token(TokenType::CurlyClose) || self.done() {
             self.consume_or_insert_semicolon();
             return self.statement(start, StatementKind::Return(None));
         }
@@ -200,17 +189,10 @@ impl Parser<'_> {
         };
 
         if label.is_none() && !self.flags.in_break_context {
-            self.syntax_error(
-                "Unlabeled 'break' not allowed outside of a loop or switch statement",
-            );
+            self.syntax_error("Unlabeled 'break' not allowed outside of a loop or switch statement");
         }
 
-        self.statement(
-            start,
-            StatementKind::Break {
-                target_label: label,
-            },
-        )
+        self.statement(start, StatementKind::Break { target_label: label })
     }
 
     // https://tc39.es/ecma262/#sec-continue-statement
@@ -248,12 +230,7 @@ impl Parser<'_> {
 
         self.consume_or_insert_semicolon();
 
-        self.statement(
-            start,
-            StatementKind::Continue {
-                target_label: label,
-            },
-        )
+        self.statement(start, StatementKind::Continue { target_label: label })
     }
 
     fn parse_debugger_statement(&mut self) -> Statement {
@@ -288,9 +265,7 @@ impl Parser<'_> {
                 && self.match_token(TokenType::Function)
                 && self.next_token().token_type != TokenType::Asterisk
             {
-                Some(Box::new(
-                    self.parse_function_declaration_as_block_statement(start),
-                ))
+                Some(Box::new(self.parse_function_declaration_as_block_statement(start)))
             } else {
                 Some(Box::new(self.parse_statement(false)))
             }
@@ -407,21 +382,15 @@ impl Parser<'_> {
         let init_starts_with_async_keyword = self.match_token(TokenType::Async);
         let is_var_init = self.match_token(TokenType::Var);
         let is_using = self.match_for_using_declaration();
-        let is_let = self.match_token(TokenType::Let)
-            && (self.flags.strict_mode || self.try_match_let_declaration());
-        let is_declaration =
-            is_var_init || is_using || is_let || self.match_token(TokenType::Const);
+        let is_let = self.match_token(TokenType::Let) && (self.flags.strict_mode || self.try_match_let_declaration());
+        let is_declaration = is_var_init || is_using || is_let || self.match_token(TokenType::Const);
         let init = if is_using {
             LocalForInit::Declaration(self.parse_using_declaration(true))
         } else if is_declaration {
             LocalForInit::Declaration(self.parse_variable_declaration(true))
         } else {
             let forbidden = ForbiddenTokens::with_in();
-            LocalForInit::Expression(self.parse_expression(
-                PRECEDENCE_COMMA,
-                Associativity::Right,
-                forbidden,
-            ))
+            LocalForInit::Expression(self.parse_expression(PRECEDENCE_COMMA, Associativity::Right, forbidden))
         };
 
         // Check for in
@@ -497,9 +466,7 @@ impl Parser<'_> {
                         && let ExpressionKind::Identifier(ref ident) = expression.inner
                         && ident.name == utf16!("async")
                     {
-                        self.syntax_error(
-                            "for-of statement may not use 'async' as the left-hand side",
-                        );
+                        self.syntax_error("for-of statement may not use 'async' as the left-hand side");
                     }
                     // https://tc39.es/ecma262/#sec-for-in-and-for-of-statements
                     if let LocalForInit::Expression(ref expression) = init
@@ -548,9 +515,7 @@ impl Parser<'_> {
         }
         self.consume_token(TokenType::Semicolon);
         let for_init = match init {
-            LocalForInit::Declaration(declaration) => {
-                Some(ForInit::Declaration(Box::new(declaration)))
-            }
+            LocalForInit::Declaration(declaration) => Some(ForInit::Declaration(Box::new(declaration))),
             LocalForInit::Expression(expression) => Some(ForInit::Expression(Box::new(expression))),
         };
         let result = self.parse_standard_for_loop(start, for_init);
@@ -746,16 +711,11 @@ impl Parser<'_> {
 
         let parameter = if self.match_token(TokenType::ParenOpen) {
             self.consume();
-            let parameter = if self.match_token(TokenType::CurlyOpen)
-                || self.match_token(TokenType::BracketOpen)
-            {
+            let parameter = if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 self.pattern_bound_names.clear();
                 let pattern = self.parse_binding_pattern();
-                let names_to_check: Vec<SharedUtf16String> = self
-                    .pattern_bound_names
-                    .iter()
-                    .map(|(n, _)| n.clone())
-                    .collect();
+                let names_to_check: Vec<SharedUtf16String> =
+                    self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect();
                 // https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors
                 // It is a Syntax Error if BoundNames of CatchParameter
                 // contains any duplicate elements.
@@ -764,22 +724,15 @@ impl Parser<'_> {
                     for name in &names_to_check {
                         if !seen.insert(name.as_slice()) {
                             let name_str = String::from_utf16_lossy(name);
-                            self.syntax_error(&format!(
-                                "Duplicate binding '{name_str}' in catch parameter"
-                            ));
+                            self.syntax_error(&format!("Duplicate binding '{name_str}' in catch parameter"));
                         }
                     }
                 }
                 for name in &names_to_check {
                     self.check_identifier_name_for_assignment_validity(name, false);
                 }
-                let bound_names: Vec<&[u16]> = self
-                    .pattern_bound_names
-                    .iter()
-                    .map(|(n, _)| n.as_slice())
-                    .collect();
-                self.scope_collector
-                    .add_catch_parameter_pattern(&bound_names);
+                let bound_names: Vec<&[u16]> = self.pattern_bound_names.iter().map(|(n, _)| n.as_slice()).collect();
+                self.scope_collector.add_catch_parameter_pattern(&bound_names);
                 // Register each binding pattern identifier for scope analysis
                 // so they get is_local() annotations (matching variable declarations).
                 for (_name, id) in &self.pattern_bound_names {
@@ -796,8 +749,7 @@ impl Parser<'_> {
                     self.token_identifier_name(&token),
                 ));
                 self.scope_collector.register_identifier(id.clone(), None);
-                self.scope_collector
-                    .add_catch_parameter_identifier(&value, id.clone());
+                self.scope_collector.add_catch_parameter_identifier(&value, id.clone());
                 Some(CatchBinding::Identifier(id))
             } else {
                 self.expected("catch parameter");
@@ -812,11 +764,7 @@ impl Parser<'_> {
         // Collect catch parameter names for post-body validation.
         let catch_names: Vec<SharedUtf16String> = match &parameter {
             Some(CatchBinding::Identifier(id)) => vec![id.name.clone()],
-            Some(CatchBinding::BindingPattern(_)) => self
-                .pattern_bound_names
-                .iter()
-                .map(|(n, _)| n.clone())
-                .collect(),
+            Some(CatchBinding::BindingPattern(_)) => self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect(),
             None => Vec::new(),
         };
 
@@ -849,9 +797,7 @@ impl Parser<'_> {
                         for cn in &catch_names {
                             if cn.as_slice() == id.name.as_slice() {
                                 let n = String::from_utf16_lossy(cn);
-                                self.syntax_error(&format!(
-                                    "Identifier '{n}' already declared as catch parameter"
-                                ));
+                                self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                             }
                         }
                     }
@@ -860,9 +806,7 @@ impl Parser<'_> {
                             for cn in &catch_names {
                                 if cn.as_slice() == id.name.as_slice() {
                                     let n = String::from_utf16_lossy(cn);
-                                    self.syntax_error(&format!(
-                                        "Identifier '{n}' already declared as catch parameter"
-                                    ));
+                                    self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                                 }
                             }
                         }
@@ -906,14 +850,11 @@ impl Parser<'_> {
         // https://tc39.es/ecma262/#sec-labelled-statements
         // LabelIdentifier : Identifier (not ReservedWord)
         // `true`, `false`, and `null` are reserved words and cannot be labels.
-        if token.token_type == TokenType::BoolLiteral || token.token_type == TokenType::NullLiteral
-        {
+        if token.token_type == TokenType::BoolLiteral || token.token_type == TokenType::NullLiteral {
             self.syntax_error("Reserved word cannot be used as a label");
         }
 
-        if self.flags.strict_mode
-            && (label == utf16!("let") || crate::parser::is_strict_reserved_word(&label))
-        {
+        if self.flags.strict_mode && (label == utf16!("let") || crate::parser::is_strict_reserved_word(&label)) {
             self.syntax_error("Strict mode reserved word is not allowed in label");
         }
         if self.flags.in_generator_function_context && label == utf16!("yield") {
@@ -932,9 +873,7 @@ impl Parser<'_> {
             self.syntax_error(&format!("Label '{label_str}' has already been declared"));
         }
 
-        if self.match_token(TokenType::Function)
-            && (!allow_labelled_function || self.flags.strict_mode)
-        {
+        if self.match_token(TokenType::Function) && (!allow_labelled_function || self.flags.strict_mode) {
             self.syntax_error("Not allowed to declare a function here");
         }
         if self.match_token(TokenType::Async) {
@@ -956,14 +895,10 @@ impl Parser<'_> {
             if let StatementKind::FunctionDeclaration(ref fd) = fn_decl.inner {
                 match fd.kind {
                     FunctionKind::Generator | FunctionKind::AsyncGenerator => {
-                        self.syntax_error(
-                            "Generator functions cannot be defined in labelled statements",
-                        );
+                        self.syntax_error("Generator functions cannot be defined in labelled statements");
                     }
                     FunctionKind::Async => {
-                        self.syntax_error(
-                            "Async functions cannot be defined in labelled statements",
-                        );
+                        self.syntax_error("Async functions cannot be defined in labelled statements");
                     }
                     _ => {}
                 }
@@ -974,8 +909,7 @@ impl Parser<'_> {
         };
 
         let is_iteration = body_starts_iteration || self.last_inner_label_is_iteration;
-        if !is_iteration && let Some(Some((line, col))) = self.labels_in_scope.get(label.as_slice())
-        {
+        if !is_iteration && let Some(Some((line, col))) = self.labels_in_scope.get(label.as_slice()) {
             self.syntax_error_at(
                 "labelled continue statement cannot use non iterating statement",
                 *line,
@@ -1046,12 +980,9 @@ impl Parser<'_> {
     /// pattern when the LHS is an array or object expression.
     fn synthesize_for_in_of_lhs(&mut self, init: LocalForInit, init_start: Position) -> ForInOfLhs {
         match init {
-            LocalForInit::Declaration(declaration) => {
-                ForInOfLhs::Declaration(Box::new(declaration))
-            }
+            LocalForInit::Declaration(declaration) => ForInOfLhs::Declaration(Box::new(declaration)),
             LocalForInit::Expression(expression) => {
-                if Self::is_array_expression(&expression) || Self::is_object_expression(&expression)
-                {
+                if Self::is_array_expression(&expression) || Self::is_object_expression(&expression) {
                     let pattern = self.synthesize_binding_pattern(init_start);
 
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -54,8 +54,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::ast::{
-    FunctionScopeData, Identifier, LocalBinding, LocalVarKind, LocalVariable, ScopeData,
-    SharedUtf16String, Utf16String, VarToInit,
+    FunctionScopeData, Identifier, LocalBinding, LocalVarKind, LocalVariable, ScopeData, SharedUtf16String,
+    Utf16String, VarToInit,
 };
 use crate::parser::{DeclarationKind, FunctionKind, ParseError, ProgramType};
 use crate::u32_from_usize;
@@ -216,11 +216,7 @@ struct ScopeRecord {
 }
 
 impl ScopeRecord {
-    fn new(
-        scope_type: ScopeType,
-        scope_level: ScopeLevel,
-        scope_data: Option<Rc<RefCell<ScopeData>>>,
-    ) -> Self {
+    fn new(scope_type: ScopeType, scope_level: ScopeLevel, scope_data: Option<Rc<RefCell<ScopeData>>>) -> Self {
         Self {
             scope_type,
             scope_level,
@@ -252,16 +248,13 @@ impl ScopeRecord {
 
     fn variable(&mut self, name: &[u16]) -> &mut ScopeVariable {
         if !self.variables.contains_key(name) {
-            self.variables
-                .insert(Utf16String::from(name), ScopeVariable::default());
+            self.variables.insert(Utf16String::from(name), ScopeVariable::default());
         }
         self.variables.get_mut(name).unwrap()
     }
 
     fn has_flag(&self, name: &[u16], flags: VarFlags) -> bool {
-        self.variables
-            .get(name)
-            .is_some_and(|v| v.flags.intersects(flags))
+        self.variables.get(name).is_some_and(|v| v.flags.intersects(flags))
     }
 
     fn get_parameter_index(&self, name: &[u16]) -> Option<u32> {
@@ -292,10 +285,8 @@ fn ancestor_scopes(start: usize, records: &[ScopeRecord]) -> impl Iterator<Item 
 }
 
 fn last_function_scope(index: usize, records: &[ScopeRecord]) -> Option<usize> {
-    ancestor_scopes(index, records).find(|&i| {
-        records[i].scope_type == ScopeType::Function
-            || records[i].scope_type == ScopeType::ClassStaticInit
-    })
+    ancestor_scopes(index, records)
+        .find(|&i| records[i].scope_type == ScopeType::Function || records[i].scope_type == ScopeType::ClassStaticInit)
 }
 
 // === ScopeCollector ===
@@ -346,10 +337,7 @@ impl ScopeCollector {
 
     fn already_declared_error(&mut self, name: &[u16], line: u32, column: u32) {
         self.errors.push(ParseError {
-            message: format!(
-                "Identifier '{}' already declared",
-                String::from_utf16_lossy(name)
-            ),
+            message: format!("Identifier '{}' already declared", String::from_utf16_lossy(name)),
             line,
             column,
         });
@@ -393,9 +381,7 @@ impl ScopeCollector {
         self.errors.truncate(state.errors_len);
         // Remove any child indices that pointed to now-truncated records.
         if let Some(current_index) = self.current {
-            self.records[current_index]
-                .children
-                .retain(|&c| c < saved_len);
+            self.records[current_index].children.retain(|&c| c < saved_len);
         }
         // Restore flags on ancestor function scopes that may have been
         // modified by set_uses_this() or set_uses_new_target() during
@@ -403,8 +389,7 @@ impl ScopeCollector {
         for saved in &state.saved_flags {
             if saved.index < self.records.len() {
                 self.records[saved.index].uses_this = saved.uses_this;
-                self.records[saved.index].uses_this_from_environment =
-                    saved.uses_this_from_environment;
+                self.records[saved.index].uses_this_from_environment = saved.uses_this_from_environment;
             }
         }
     }
@@ -453,8 +438,7 @@ impl ScopeCollector {
             let arguments = c.contains_access_to_arguments_object_in_non_strict_mode;
             let eval = c.contains_direct_call_to_eval;
             let contains_await = c.contains_await_expression;
-            self.records[parent_index].contains_access_to_arguments_object_in_non_strict_mode |=
-                arguments;
+            self.records[parent_index].contains_access_to_arguments_object_in_non_strict_mode |= arguments;
             self.records[parent_index].contains_direct_call_to_eval |= eval;
             self.records[parent_index].contains_await_expression |= contains_await;
         }
@@ -500,11 +484,7 @@ impl ScopeCollector {
     }
 
     pub fn open_static_init_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
-        self.open_scope(
-            ScopeType::ClassStaticInit,
-            scope_data,
-            ScopeLevel::StaticInitTopLevel,
-        );
+        self.open_scope(ScopeType::ClassStaticInit, scope_data, ScopeLevel::StaticInitTopLevel);
     }
 
     pub fn open_class_field_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
@@ -525,22 +505,12 @@ impl ScopeCollector {
     // https://tc39.es/ecma262/#sec-block-level-function-declarations-web-legacy-compatibility-semantics
     // Lexical declarations (let/const) are block-scoped and must not collide
     // with any existing var, function, or lexical binding in the same scope.
-    pub fn add_lexical_declaration(
-        &mut self,
-        bound_names: &[&[u16]],
-        declaration_line: u32,
-        declaration_column: u32,
-    ) {
+    pub fn add_lexical_declaration(&mut self, bound_names: &[&[u16]], declaration_line: u32, declaration_column: u32) {
         let index = self.current.expect("no current scope");
 
         for name in bound_names {
             let flags = self.records[index].variable(name).flags;
-            if flags.intersects(
-                VarFlags::VAR
-                    | VarFlags::FORBIDDEN_LEXICAL
-                    | VarFlags::FUNCTION
-                    | VarFlags::LEXICAL,
-            ) {
+            if flags.intersects(VarFlags::VAR | VarFlags::FORBIDDEN_LEXICAL | VarFlags::FUNCTION | VarFlags::LEXICAL) {
                 self.already_declared_error(name, declaration_line, declaration_column);
             }
             self.records[index].variable(name).flags |= VarFlags::LEXICAL;
@@ -570,9 +540,7 @@ impl ScopeCollector {
             let mut scope_index = index;
             loop {
                 let existing_flags = self.records[scope_index].variable(name).flags;
-                if existing_flags
-                    .intersects(VarFlags::LEXICAL | VarFlags::FUNCTION | VarFlags::FORBIDDEN_VAR)
-                {
+                if existing_flags.intersects(VarFlags::LEXICAL | VarFlags::FUNCTION | VarFlags::FORBIDDEN_VAR) {
                     self.already_declared_error(name, declaration_line, declaration_column);
                 }
                 let var = self.records[scope_index].variable(name);
@@ -581,9 +549,7 @@ impl ScopeCollector {
                 if self.records[scope_index].is_top_level() {
                     break;
                 }
-                scope_index = self.records[scope_index]
-                    .parent
-                    .expect("scope has no parent");
+                scope_index = self.records[scope_index].parent.expect("scope has no parent");
             }
         }
     }
@@ -638,12 +604,10 @@ impl ScopeCollector {
 
             if !existing_flags.intersects(VarFlags::LEXICAL) {
                 let block_scope = self.records[index].scope_data.clone();
-                self.records[index]
-                    .functions_to_hoist
-                    .push(HoistableFunction {
-                        name: Utf16String::from(name),
-                        block_scope_data: block_scope,
-                    });
+                self.records[index].functions_to_hoist.push(HoistableFunction {
+                    name: Utf16String::from(name),
+                    block_scope_data: block_scope,
+                });
             }
 
             let var = self.records[index].variable(name);
@@ -672,11 +636,7 @@ impl ScopeCollector {
 
     // === Identifier registration ===
 
-    pub fn register_identifier(
-        &mut self,
-        id: Rc<Identifier>,
-        declaration_kind: Option<DeclarationKind>,
-    ) {
+    pub fn register_identifier(&mut self, id: Rc<Identifier>, declaration_kind: Option<DeclarationKind>) {
         let index = self.current.expect("no current scope");
         self.records[index]
             .identifier_groups
@@ -697,11 +657,7 @@ impl ScopeCollector {
 
     // === Function parameters ===
 
-    pub fn set_function_parameters(
-        &mut self,
-        entries: &[ParameterEntry],
-        has_parameter_expressions: bool,
-    ) {
+    pub fn set_function_parameters(&mut self, entries: &[ParameterEntry], has_parameter_expressions: bool) {
         let index = self.current.expect("no current scope");
         self.records[index].has_function_parameters = true;
         self.records[index].has_parameter_expressions = has_parameter_expressions;
@@ -727,10 +683,7 @@ impl ScopeCollector {
             if let Some(ref id) = entry.identifier {
                 self.register_identifier(id.clone(), None);
             }
-            let var = self.records[index]
-                .variables
-                .entry(entry.name.clone())
-                .or_default();
+            let var = self.records[index].variables.entry(entry.name.clone()).or_default();
             var.flags |= VarFlags::PARAMETER_CANDIDATE | VarFlags::FORBIDDEN_LEXICAL;
         }
 
@@ -746,8 +699,7 @@ impl ScopeCollector {
                 .cloned()
                 .collect();
             for name in names_to_mark {
-                self.records[index].variable(&name).flags |=
-                    VarFlags::REFERENCED_IN_FORMAL_PARAMETERS;
+                self.records[index].variable(&name).flags |= VarFlags::REFERENCED_IN_FORMAL_PARAMETERS;
             }
         }
     }
@@ -843,8 +795,7 @@ impl ScopeCollector {
     }
 
     pub fn uses_this(&self) -> bool {
-        self.current
-            .is_some_and(|index| self.records[index].uses_this)
+        self.current.is_some_and(|index| self.records[index].uses_this)
     }
 
     pub fn contains_await_expression(&self) -> bool {
@@ -881,10 +832,7 @@ impl ScopeCollector {
             if Some(si) == stop {
                 break;
             }
-            if self.records[si].has_flag(
-                name,
-                VarFlags::LEXICAL | VarFlags::VAR | VarFlags::PARAMETER_CANDIDATE,
-            ) {
+            if self.records[si].has_flag(name, VarFlags::LEXICAL | VarFlags::VAR | VarFlags::PARAMETER_CANDIDATE) {
                 return true;
             }
             if self.records[si].has_hoistable_function_named(name) {
@@ -932,12 +880,7 @@ impl ScopeCollector {
         // 1. Propagate eval() flags from children to parent.
         Self::propagate_eval_poisoning(&mut self.records, index);
         // 2. Match identifier references to declarations; optimize as locals.
-        Self::resolve_identifiers(
-            &mut self.records,
-            index,
-            initiated_by_eval,
-            suppress_globals,
-        );
+        Self::resolve_identifiers(&mut self.records, index, initiated_by_eval, suppress_globals);
         // 3. Annex B: hoist block-scoped functions to enclosing function scope.
         Self::hoist_functions(&mut self.records, index);
 
@@ -945,8 +888,7 @@ impl ScopeCollector {
         //    the bytecode generator uses to initialize function-scoped variables.
         if self.records[index].scope_data.is_some() {
             let st = self.records[index].scope_type;
-            let needs_fsd = (st == ScopeType::Function
-                && self.records[index].has_function_parameters)
+            let needs_fsd = (st == ScopeType::Function && self.records[index].has_function_parameters)
                 || st == ScopeType::ClassStaticInit
                 || st == ScopeType::ClassField;
             if needs_fsd {
@@ -965,16 +907,12 @@ impl ScopeCollector {
     ///   function (propagates through blocks but stops at function boundaries)
     fn propagate_eval_poisoning(records: &mut [ScopeRecord], index: usize) {
         if let Some(parent_index) = records[index].parent {
-            if records[index].contains_direct_call_to_eval
-                || records[index].poisoned_by_eval_in_scope_chain
-            {
+            if records[index].contains_direct_call_to_eval || records[index].poisoned_by_eval_in_scope_chain {
                 records[parent_index].poisoned_by_eval_in_scope_chain = true;
             }
             // eval_in_current_function propagates upward through blocks but
             // stops at function boundaries (each function is independent).
-            if records[index].eval_in_current_function
-                && records[index].scope_type != ScopeType::Function
-            {
+            if records[index].eval_in_current_function && records[index].scope_type != ScopeType::Function {
                 records[parent_index].eval_in_current_function = true;
             }
         }
@@ -992,12 +930,7 @@ impl ScopeCollector {
     /// - It's NOT captured by a nested function
     /// - It's NOT used inside a `with` statement
     /// - The scope chain is NOT poisoned by `eval()`
-    fn resolve_identifiers(
-        records: &mut [ScopeRecord],
-        index: usize,
-        initiated_by_eval: bool,
-        suppress_globals: bool,
-    ) {
+    fn resolve_identifiers(records: &mut [ScopeRecord], index: usize, initiated_by_eval: bool, suppress_globals: bool) {
         let groups = std::mem::take(&mut records[index].identifier_groups);
         // Sort groups by name for deterministic local variable indices
         // (HashMap iteration order is arbitrary).
@@ -1042,9 +975,7 @@ impl ScopeCollector {
                 local_var_kind = Some(LocalVarKind::ArgumentsObject);
             }
 
-            if records[index].scope_type == ScopeType::Catch
-                && var_flags.intersects(VarFlags::CATCH_PARAMETER)
-            {
+            if records[index].scope_type == ScopeType::Catch && var_flags.intersects(VarFlags::CATCH_PARAMETER) {
                 local_var_kind = Some(LocalVarKind::CatchClauseParameter);
             }
 
@@ -1078,9 +1009,7 @@ impl ScopeCollector {
             let hoistable = records[index].has_hoistable_function_named(&name);
 
             // ClassDeclaration with IsBound: skip entirely.
-            if records[index].scope_type == ScopeType::ClassDeclaration
-                && var_flags.intersects(VarFlags::BOUND)
-            {
+            if records[index].scope_type == ScopeType::ClassDeclaration && var_flags.intersects(VarFlags::BOUND) {
                 continue;
             }
 
@@ -1115,8 +1044,7 @@ impl ScopeCollector {
             }
 
             if records[index].scope_type == ScopeType::Program {
-                let can_use_global =
-                    !(suppress_globals || group.used_inside_with_statement || initiated_by_eval);
+                let can_use_global = !(suppress_globals || group.used_inside_with_statement || initiated_by_eval);
                 if can_use_global {
                     for id in &group.identifiers {
                         if !id.is_inside_scope_with_eval.get() {
@@ -1188,8 +1116,7 @@ impl ScopeCollector {
                                 }
                             }
                         } else {
-                            let kind = local_var_kind
-                                .expect("local_var_kind must be set for local variables");
+                            let kind = local_var_kind.expect("local_var_kind must be set for local variables");
                             let lvi = u32_from_usize(sd.local_variables.len());
                             sd.local_variables.push(LocalVariable {
                                 name: name.to_utf16_string(),
@@ -1293,10 +1220,7 @@ impl ScopeCollector {
             let local_info = if let Some(ref ident) = var.var_identifier {
                 if ident.is_local() {
                     Some(LocalBinding {
-                        local_type: ident
-                            .local_type
-                            .get()
-                            .expect("is_local() implies local_type is Some"),
+                        local_type: ident.local_type.get().expect("is_local() implies local_type is Some"),
                         index: ident.local_index.get(),
                     })
                 } else {
@@ -1358,8 +1282,7 @@ impl ScopeCollector {
             sd.uses_this_from_environment = record.uses_this_from_environment;
             sd.contains_direct_call_to_eval =
                 record.contains_direct_call_to_eval || record.poisoned_by_eval_in_scope_chain;
-            sd.contains_access_to_arguments_object =
-                record.contains_access_to_arguments_object_in_non_strict_mode;
+            sd.contains_access_to_arguments_object = record.contains_access_to_arguments_object_in_non_strict_mode;
         }
     }
 
@@ -1384,8 +1307,7 @@ impl ScopeCollector {
 
         for function in functions {
             // A let/const or forbidden var with the same name blocks hoisting.
-            if records[index].has_flag(&function.name, VarFlags::LEXICAL | VarFlags::FORBIDDEN_VAR)
-            {
+            if records[index].has_flag(&function.name, VarFlags::LEXICAL | VarFlags::FORBIDDEN_VAR) {
                 continue;
             }
 
@@ -1423,9 +1345,7 @@ impl ScopeCollector {
                 }
             } else if let Some(parent_index) = records[index].parent {
                 // Not yet at top level — keep propagating upward unless blocked.
-                if !records[parent_index]
-                    .has_flag(&function.name, VarFlags::LEXICAL | VarFlags::FUNCTION)
-                {
+                if !records[parent_index].has_flag(&function.name, VarFlags::LEXICAL | VarFlags::FUNCTION) {
                     records[parent_index].functions_to_hoist.push(function);
                 }
             }

--- a/Libraries/LibRegex/Rust/src/bytecode.rs
+++ b/Libraries/LibRegex/Rust/src/bytecode.rs
@@ -67,10 +67,7 @@ pub enum Instruction {
     AnyChar { dot_all: bool },
 
     /// Match a character in a set of ranges. `negated` inverts the match.
-    CharClass {
-        ranges: Vec<CharRange>,
-        negated: bool,
-    },
+    CharClass { ranges: Vec<CharRange>, negated: bool },
 
     /// Match a built-in character class (\d, \w, \s and negations).
     BuiltinClass(BuiltinCharacterClass),
@@ -134,11 +131,7 @@ pub enum Instruction {
     /// `forward`: lookahead (true) or lookbehind (false).
     /// `body`: start of the assertion body.
     /// `end`: instruction after the assertion.
-    LookStart {
-        positive: bool,
-        forward: bool,
-        end: u32,
-    },
+    LookStart { positive: bool, forward: bool, end: u32 },
 
     /// End of a lookaround body. Signals success of the assertion sub-match.
     LookEnd,
@@ -245,10 +238,7 @@ pub enum SimpleMatch {
     /// Case-insensitive character.
     CharNoCase(u32, u32),
     /// Character class (set of ranges), negated flag.
-    CharClass {
-        ranges: Vec<CharRange>,
-        negated: bool,
-    },
+    CharClass { ranges: Vec<CharRange>, negated: bool },
     /// Built-in class (\d, \w, \s, etc.)
     BuiltinClass(BuiltinCharacterClass),
     /// Unicode property (\p{...}, \P{...}).

--- a/Libraries/LibRegex/Rust/src/compiler.rs
+++ b/Libraries/LibRegex/Rust/src/compiler.rs
@@ -160,14 +160,12 @@ impl Compiler {
     }
 
     fn emit_unicode_property(&mut self, negated: bool, name: &str, value: Option<&str>) {
-        self.emit(Instruction::UnicodeProperty(Box::new(
-            UnicodePropertyData {
-                negated,
-                name: name.to_string(),
-                value: value.map(|v| v.to_string()),
-                resolved: None,
-            },
-        )));
+        self.emit(Instruction::UnicodeProperty(Box::new(UnicodePropertyData {
+            negated,
+            name: name.to_string(),
+            value: value.map(|v| v.to_string()),
+            resolved: None,
+        })));
     }
 
     fn emit_char_string(&mut self, chars: &[char]) {
@@ -198,14 +196,10 @@ impl Compiler {
 
     fn class_set_expression_lengths(&self, expr: &ClassSetExpression) -> BTreeSet<usize> {
         match expr {
-            ClassSetExpression::Union(operands) => {
-                operands
-                    .iter()
-                    .fold(BTreeSet::new(), |mut lengths, operand| {
-                        lengths.extend(self.class_set_operand_lengths(operand));
-                        lengths
-                    })
-            }
+            ClassSetExpression::Union(operands) => operands.iter().fold(BTreeSet::new(), |mut lengths, operand| {
+                lengths.extend(self.class_set_operand_lengths(operand));
+                lengths
+            }),
             ClassSetExpression::Intersection(operands) => {
                 let Some((first, rest)) = operands.split_first() else {
                     return BTreeSet::new();
@@ -226,9 +220,9 @@ impl Compiler {
 
     fn class_set_operand_lengths(&self, operand: &ClassSetOperand) -> BTreeSet<usize> {
         match operand {
-            ClassSetOperand::Char(_)
-            | ClassSetOperand::Range(_, _)
-            | ClassSetOperand::BuiltinClass(_) => Self::singleton_length_set(),
+            ClassSetOperand::Char(_) | ClassSetOperand::Range(_, _) | ClassSetOperand::BuiltinClass(_) => {
+                Self::singleton_length_set()
+            }
             ClassSetOperand::NestedClass(cc) => {
                 if cc.negated {
                     return Self::singleton_length_set();
@@ -239,10 +233,7 @@ impl Compiler {
                 }
             }
             ClassSetOperand::UnicodeProperty(up) => {
-                if self.program.unicode_sets
-                    && !up.negated
-                    && crate::unicode_ffi::is_string_property(&up.name)
-                {
+                if self.program.unicode_sets && !up.negated && crate::unicode_ffi::is_string_property(&up.name) {
                     let mut lengths = Self::singleton_length_set();
                     for string in Self::get_string_property_strings(&up.name) {
                         lengths.insert(string.len());
@@ -389,10 +380,7 @@ impl Compiler {
     }
 
     fn alternative_can_be_zero_width(&self, alternative: &Alternative) -> bool {
-        alternative
-            .terms
-            .iter()
-            .all(|term| self.term_can_be_zero_width(term))
+        alternative.terms.iter().all(|term| self.term_can_be_zero_width(term))
     }
 
     fn term_can_be_zero_width(&self, term: &Term) -> bool {
@@ -498,10 +486,7 @@ impl Compiler {
                             ranges.push(CharRange { start: *c, end: *c });
                         }
                         CharacterClassRange::Range(lo, hi) => {
-                            ranges.push(CharRange {
-                                start: *lo,
-                                end: *hi,
-                            });
+                            ranges.push(CharRange { start: *lo, end: *hi });
                         }
                         _ => return None, // BuiltinClass or UnicodeProperty in class
                     }
@@ -519,14 +504,12 @@ impl Compiler {
                 if self.program.unicode_sets && crate::unicode_ffi::is_string_property(&up.name) {
                     return None;
                 }
-                Some(SimpleMatch::UnicodeProperty(Box::new(
-                    UnicodePropertyData {
-                        negated: up.negated,
-                        name: up.name.clone(),
-                        value: up.value.clone(),
-                        resolved: None, // Will be populated after compilation.
-                    },
-                )))
+                Some(SimpleMatch::UnicodeProperty(Box::new(UnicodePropertyData {
+                    negated: up.negated,
+                    name: up.name.clone(),
+                    value: up.value.clone(),
+                    resolved: None, // Will be populated after compilation.
+                })))
             }
             _ => None,
         }
@@ -767,12 +750,7 @@ impl Compiler {
         }
     }
 
-    fn compile_counted_optional_repetitions(
-        &mut self,
-        atom: &Atom,
-        optional_count: u32,
-        greedy: bool,
-    ) {
+    fn compile_counted_optional_repetitions(&mut self, atom: &Atom, optional_count: u32, greedy: bool) {
         let counter_reg = self.alloc_register();
         self.emit(Instruction::RepeatStart { counter_reg });
 
@@ -835,10 +813,7 @@ impl Compiler {
             }
 
             Atom::UnicodeProperty(up) => {
-                if self.program.unicode_sets
-                    && !up.negated
-                    && crate::unicode_ffi::is_string_property(&up.name)
-                {
+                if self.program.unicode_sets && !up.negated && crate::unicode_ffi::is_string_property(&up.name) {
                     self.emit_string_property_match(&up.name, up.value.as_deref());
                     return;
                 }
@@ -881,11 +856,7 @@ impl Compiler {
                 self.emit(Instruction::LookEnd);
                 let end = self.current_offset();
                 // Patch the end offset.
-                self.program.instructions[look_start as usize] = Instruction::LookStart {
-                    positive,
-                    forward,
-                    end,
-                };
+                self.program.instructions[look_start as usize] = Instruction::LookStart { positive, forward, end };
             }
 
             Atom::Backreference(br) => match br {
@@ -983,20 +954,13 @@ impl Compiler {
                                 char_ranges.push(CharRange { start: hi, end: hi });
                                 char_ranges.push(CharRange { start: lo, end: lo });
                             } else {
-                                char_ranges.push(CharRange {
-                                    start: *cp,
-                                    end: *cp,
-                                });
+                                char_ranges.push(CharRange { start: *cp, end: *cp });
                             }
                         }
                         CharacterClassRange::Range(lo, hi) => {
-                            char_ranges.push(CharRange {
-                                start: *lo,
-                                end: *hi,
-                            });
+                            char_ranges.push(CharRange { start: *lo, end: *hi });
                         }
-                        CharacterClassRange::BuiltinClass(_)
-                        | CharacterClassRange::UnicodeProperty(_) => {
+                        CharacterClassRange::BuiltinClass(_) | CharacterClassRange::UnicodeProperty(_) => {
                             has_builtin = true;
                         }
                     }
@@ -1065,10 +1029,7 @@ impl Compiler {
             }
             CharacterClassRange::Range(lo, hi) => {
                 self.emit(Instruction::CharClass {
-                    ranges: vec![CharRange {
-                        start: *lo,
-                        end: *hi,
-                    }],
+                    ranges: vec![CharRange { start: *lo, end: *hi }],
                     negated: false,
                 });
             }
@@ -1126,10 +1087,7 @@ impl Compiler {
     fn compile_class_set_expression(&mut self, expr: &ClassSetExpression) {
         // NB: Compile each exact match length separately, longest first, so
         // intersection/subtraction only compare equal-length alternatives.
-        let mut lengths: Vec<_> = self
-            .class_set_expression_lengths(expr)
-            .into_iter()
-            .collect();
+        let mut lengths: Vec<_> = self.class_set_expression_lengths(expr).into_iter().collect();
         lengths.sort_unstable_by(|a, b| b.cmp(a));
 
         if lengths.is_empty() {
@@ -1137,9 +1095,7 @@ impl Compiler {
             return;
         }
 
-        self.emit_split_chain(&lengths, |s, len| {
-            s.compile_class_set_expression_at_length(expr, *len)
-        });
+        self.emit_split_chain(&lengths, |s, len| s.compile_class_set_expression_at_length(expr, *len));
     }
 
     fn compile_class_set_expression_at_length(&mut self, expr: &ClassSetExpression, length: usize) {
@@ -1275,10 +1231,7 @@ impl Compiler {
                 self.emit(Instruction::BuiltinClass(*bc));
             }
             ClassSetOperand::UnicodeProperty(up) => {
-                if self.program.unicode_sets
-                    && !up.negated
-                    && crate::unicode_ffi::is_string_property(&up.name)
-                {
+                if self.program.unicode_sets && !up.negated && crate::unicode_ffi::is_string_property(&up.name) {
                     if length == 1 {
                         self.emit_unicode_property(up.negated, &up.name, up.value.as_deref());
                     } else {
@@ -1287,9 +1240,7 @@ impl Compiler {
                             self.emit(Instruction::Fail);
                             return;
                         }
-                        self.emit_split_chain(&strings, |s, string| {
-                            s.emit_code_point_string(string)
-                        });
+                        self.emit_split_chain(&strings, |s, string| s.emit_code_point_string(string));
                     }
                     return;
                 }

--- a/Libraries/LibRegex/Rust/src/ffi.rs
+++ b/Libraries/LibRegex/Rust/src/ffi.rs
@@ -383,10 +383,7 @@ pub unsafe extern "C" fn rust_regex_get_named_groups(
 /// # Safety
 /// `groups` must be a pointer returned by `rust_regex_get_named_groups`, or null.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_regex_free_named_groups(
-    groups: *mut RustRegexNamedGroup,
-    count: u32,
-) {
+pub unsafe extern "C" fn rust_regex_free_named_groups(groups: *mut RustRegexNamedGroup, count: u32) {
     if !groups.is_null() {
         let len = count as usize;
         drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(groups, len)) });

--- a/Libraries/LibRegex/Rust/src/parser.rs
+++ b/Libraries/LibRegex/Rust/src/parser.rs
@@ -77,10 +77,8 @@ impl std::fmt::Display for Error {
             Self::InvalidQuantifier => write!(f, "invalid quantifier"),
             Self::InvalidCharacterClass => write!(f, "invalid character class"),
             Self::InvalidCharacterRange(lo, hi) => {
-                let lo_str = char::from_u32(*lo)
-                    .map_or_else(|| format!("\\u{{{lo:04X}}}"), |c| format!("{c}"));
-                let hi_str = char::from_u32(*hi)
-                    .map_or_else(|| format!("\\u{{{hi:04X}}}"), |c| format!("{c}"));
+                let lo_str = char::from_u32(*lo).map_or_else(|| format!("\\u{{{lo:04X}}}"), |c| format!("{c}"));
+                let hi_str = char::from_u32(*hi).map_or_else(|| format!("\\u{{{hi:04X}}}"), |c| format!("{c}"));
                 write!(f, "invalid character range '{lo_str}'-'{hi_str}'")
             }
             Self::InvalidUnicodeEscape => write!(f, "invalid Unicode escape"),
@@ -171,8 +169,7 @@ impl Parser {
                     if i + 1 < source.len() && source[i + 1] == '?' {
                         if i + 2 < source.len()
                             && source[i + 2] == '<'
-                            && (i + 3 >= source.len()
-                                || (source[i + 3] != '=' && source[i + 3] != '!'))
+                            && (i + 3 >= source.len() || (source[i + 3] != '=' && source[i + 3] != '!'))
                         {
                             count += 1;
                             has_named = true;
@@ -196,8 +193,7 @@ impl Parser {
 
         // Named backreferences can point forward, so validate them only after
         // the whole pattern has been parsed and every group name is known.
-        let group_names: std::collections::HashSet<&str> =
-            self.named_groups.iter().map(|g| g.name.as_str()).collect();
+        let group_names: std::collections::HashSet<&str> = self.named_groups.iter().map(|g| g.name.as_str()).collect();
         Self::validate_backrefs(&disjunction, &group_names)?;
 
         Ok(Pattern {
@@ -211,16 +207,11 @@ impl Parser {
     /// Apply the named-backreference early error after all group names have
     /// been collected.
     /// <https://tc39.es/ecma262/#sec-patterns-static-semantics-early-errors>
-    fn validate_backrefs(
-        disj: &Disjunction,
-        group_names: &std::collections::HashSet<&str>,
-    ) -> Result<(), Error> {
+    fn validate_backrefs(disj: &Disjunction, group_names: &std::collections::HashSet<&str>) -> Result<(), Error> {
         for alt in &disj.alternatives {
             for term in &alt.terms {
                 match &term.atom {
-                    Atom::Backreference(Backreference::Named(name))
-                        if !group_names.contains(name.as_str()) =>
-                    {
+                    Atom::Backreference(Backreference::Named(name)) if !group_names.contains(name.as_str()) => {
                         return Err(Error::InvalidNamedBackreference(name.clone()));
                     }
                     Atom::Group(g) => Self::validate_backrefs(&g.body, group_names)?,
@@ -288,8 +279,7 @@ impl Parser {
     /// Parse `Disjunction`.
     /// <https://tc39.es/ecma262/#sec-patterns>
     fn parse_disjunction(&mut self) -> Result<Disjunction, Error> {
-        self.alternative_name_stack
-            .push(std::collections::HashSet::new());
+        self.alternative_name_stack.push(std::collections::HashSet::new());
         let mut alternatives = vec![self.parse_alternative()?];
         while self.eat('|') {
             // Reset the current alternative's name set for the next alternative.
@@ -462,11 +452,7 @@ impl Parser {
                 break;
             }
         }
-        if self.pos == start {
-            Ok(None)
-        } else {
-            Ok(Some(value))
-        }
+        if self.pos == start { Ok(None) } else { Ok(Some(value)) }
     }
 
     // ---------------------------------------------------------------
@@ -516,9 +502,7 @@ impl Parser {
 
             '\\' => self.parse_atom_escape().map(Some),
 
-            '[' => self
-                .parse_character_class()
-                .map(|cc| Some(Atom::CharacterClass(cc))),
+            '[' => self.parse_character_class().map(|cc| Some(Atom::CharacterClass(cc))),
 
             '(' => self.parse_group().map(Some),
 
@@ -578,12 +562,8 @@ impl Parser {
             'D' => Ok(Atom::BuiltinCharacterClass(BuiltinCharacterClass::NonDigit)),
             'w' => Ok(Atom::BuiltinCharacterClass(BuiltinCharacterClass::Word)),
             'W' => Ok(Atom::BuiltinCharacterClass(BuiltinCharacterClass::NonWord)),
-            's' => Ok(Atom::BuiltinCharacterClass(
-                BuiltinCharacterClass::Whitespace,
-            )),
-            'S' => Ok(Atom::BuiltinCharacterClass(
-                BuiltinCharacterClass::NonWhitespace,
-            )),
+            's' => Ok(Atom::BuiltinCharacterClass(BuiltinCharacterClass::Whitespace)),
+            'S' => Ok(Atom::BuiltinCharacterClass(BuiltinCharacterClass::NonWhitespace)),
 
             // Assertions.
             'b' => Ok(Atom::Assertion(AssertionKind::WordBoundary)),
@@ -1267,24 +1247,12 @@ impl Parser {
         self.expect('\\')?;
         let ch = self.advance().ok_or(Error::LoneTrailingBackslash)?;
         match ch {
-            'd' => Ok(CharacterClassRange::BuiltinClass(
-                BuiltinCharacterClass::Digit,
-            )),
-            'D' => Ok(CharacterClassRange::BuiltinClass(
-                BuiltinCharacterClass::NonDigit,
-            )),
-            'w' => Ok(CharacterClassRange::BuiltinClass(
-                BuiltinCharacterClass::Word,
-            )),
-            'W' => Ok(CharacterClassRange::BuiltinClass(
-                BuiltinCharacterClass::NonWord,
-            )),
-            's' => Ok(CharacterClassRange::BuiltinClass(
-                BuiltinCharacterClass::Whitespace,
-            )),
-            'S' => Ok(CharacterClassRange::BuiltinClass(
-                BuiltinCharacterClass::NonWhitespace,
-            )),
+            'd' => Ok(CharacterClassRange::BuiltinClass(BuiltinCharacterClass::Digit)),
+            'D' => Ok(CharacterClassRange::BuiltinClass(BuiltinCharacterClass::NonDigit)),
+            'w' => Ok(CharacterClassRange::BuiltinClass(BuiltinCharacterClass::Word)),
+            'W' => Ok(CharacterClassRange::BuiltinClass(BuiltinCharacterClass::NonWord)),
+            's' => Ok(CharacterClassRange::BuiltinClass(BuiltinCharacterClass::Whitespace)),
+            'S' => Ok(CharacterClassRange::BuiltinClass(BuiltinCharacterClass::NonWhitespace)),
             'p' | 'P' if self.unicode_aware() => {
                 let negated = ch == 'P';
                 let prop = self.parse_unicode_property()?;
@@ -1309,9 +1277,7 @@ impl Parser {
             't' => Ok(CharacterClassRange::Single('\t' as u32)),
             'f' => Ok(CharacterClassRange::Single('\u{0C}' as u32)),
             'v' => Ok(CharacterClassRange::Single('\u{0B}' as u32)),
-            '0' if !self.peek().is_some_and(|c| c.is_ascii_digit()) => {
-                Ok(CharacterClassRange::Single(0))
-            }
+            '0' if !self.peek().is_some_and(|c| c.is_ascii_digit()) => Ok(CharacterClassRange::Single(0)),
             'c' => {
                 if let Some(ctrl) = self.advance() {
                     if ctrl.is_ascii_alphabetic() {
@@ -1481,9 +1447,7 @@ impl Parser {
         strings
     }
 
-    fn class_set_expression_strings(
-        expr: &ClassSetExpression,
-    ) -> std::collections::BTreeSet<Vec<u32>> {
+    fn class_set_expression_strings(expr: &ClassSetExpression) -> std::collections::BTreeSet<Vec<u32>> {
         match expr {
             ClassSetExpression::Union(operands) => {
                 operands
@@ -1518,9 +1482,7 @@ impl Parser {
         }
     }
 
-    fn class_set_operand_strings(
-        operand: &ClassSetOperand,
-    ) -> std::collections::BTreeSet<Vec<u32>> {
+    fn class_set_operand_strings(operand: &ClassSetOperand) -> std::collections::BTreeSet<Vec<u32>> {
         match operand {
             ClassSetOperand::NestedClass(class) => {
                 if class.negated {
@@ -1528,31 +1490,24 @@ impl Parser {
                 }
                 match &class.body {
                     CharacterClassBody::Ranges(_) => std::collections::BTreeSet::new(),
-                    CharacterClassBody::UnicodeSet(expr) => {
-                        Self::class_set_expression_strings(expr)
-                    }
+                    CharacterClassBody::UnicodeSet(expr) => Self::class_set_expression_strings(expr),
                 }
             }
             ClassSetOperand::UnicodeProperty(property) => {
-                if !property.negated
-                    && property.value.is_none()
-                    && Self::is_string_property(&property.name)
-                {
+                if !property.negated && property.value.is_none() && Self::is_string_property(&property.name) {
                     return Self::get_string_property_strings(&property.name);
                 }
                 std::collections::BTreeSet::new()
             }
             ClassSetOperand::StringLiteral(chars) => {
                 if chars.len() > 1 {
-                    return [chars.iter().map(|ch| *ch as u32).collect()]
-                        .into_iter()
-                        .collect();
+                    return [chars.iter().map(|ch| *ch as u32).collect()].into_iter().collect();
                 }
                 std::collections::BTreeSet::new()
             }
-            ClassSetOperand::Char(_)
-            | ClassSetOperand::Range(_, _)
-            | ClassSetOperand::BuiltinClass(_) => std::collections::BTreeSet::new(),
+            ClassSetOperand::Char(_) | ClassSetOperand::Range(_, _) | ClassSetOperand::BuiltinClass(_) => {
+                std::collections::BTreeSet::new()
+            }
         }
     }
 
@@ -1603,30 +1558,21 @@ impl Parser {
                                         // Handle surrogate pairs: \uD800\uDC00
                                         if !is_braced && (0xD800..=0xDBFF).contains(&val) {
                                             let saved = self.pos;
-                                            if self.eat('\\')
-                                                && self.eat('u')
-                                                && self.peek() != Some('{')
-                                            {
+                                            if self.eat('\\') && self.eat('u') && self.peek() != Some('{') {
                                                 let low = self.parse_unicode_escape()?;
                                                 if (0xDC00..=0xDFFF).contains(&low) {
-                                                    let combined = 0x10000
-                                                        + ((val - 0xD800) << 10)
-                                                        + (low - 0xDC00);
-                                                    char::from_u32(combined)
-                                                        .ok_or(Error::InvalidUnicodeEscape)?
+                                                    let combined = 0x10000 + ((val - 0xD800) << 10) + (low - 0xDC00);
+                                                    char::from_u32(combined).ok_or(Error::InvalidUnicodeEscape)?
                                                 } else {
                                                     self.pos = saved;
-                                                    char::from_u32(val)
-                                                        .ok_or(Error::InvalidUnicodeEscape)?
+                                                    char::from_u32(val).ok_or(Error::InvalidUnicodeEscape)?
                                                 }
                                             } else {
                                                 self.pos = saved;
-                                                char::from_u32(val)
-                                                    .ok_or(Error::InvalidUnicodeEscape)?
+                                                char::from_u32(val).ok_or(Error::InvalidUnicodeEscape)?
                                             }
                                         } else {
-                                            char::from_u32(val)
-                                                .ok_or(Error::InvalidUnicodeEscape)?
+                                            char::from_u32(val).ok_or(Error::InvalidUnicodeEscape)?
                                         }
                                     }
                                     'c' => {
@@ -1654,22 +1600,16 @@ impl Parser {
                         }
 
                         if alternatives.len() == 1 {
-                            Ok(ClassSetOperand::StringLiteral(
-                                alternatives.into_iter().next().unwrap(),
-                            ))
+                            Ok(ClassSetOperand::StringLiteral(alternatives.into_iter().next().unwrap()))
                         } else {
                             // Multiple alternatives: wrap as a nested class with Union body.
                             // Sort longest-first so greedy matching prefers longer alternatives.
                             alternatives.sort_by_key(|b| std::cmp::Reverse(b.len()));
-                            let operands: Vec<ClassSetOperand> = alternatives
-                                .into_iter()
-                                .map(ClassSetOperand::StringLiteral)
-                                .collect();
+                            let operands: Vec<ClassSetOperand> =
+                                alternatives.into_iter().map(ClassSetOperand::StringLiteral).collect();
                             Ok(ClassSetOperand::NestedClass(CharacterClass {
                                 negated: false,
-                                body: CharacterClassBody::UnicodeSet(ClassSetExpression::Union(
-                                    operands,
-                                )),
+                                body: CharacterClassBody::UnicodeSet(ClassSetExpression::Union(operands)),
                             }))
                         }
                     }
@@ -1679,9 +1619,7 @@ impl Parser {
                     }
                     'D' => {
                         self.advance();
-                        Ok(ClassSetOperand::BuiltinClass(
-                            BuiltinCharacterClass::NonDigit,
-                        ))
+                        Ok(ClassSetOperand::BuiltinClass(BuiltinCharacterClass::NonDigit))
                     }
                     'w' => {
                         self.advance();
@@ -1689,21 +1627,15 @@ impl Parser {
                     }
                     'W' => {
                         self.advance();
-                        Ok(ClassSetOperand::BuiltinClass(
-                            BuiltinCharacterClass::NonWord,
-                        ))
+                        Ok(ClassSetOperand::BuiltinClass(BuiltinCharacterClass::NonWord))
                     }
                     's' => {
                         self.advance();
-                        Ok(ClassSetOperand::BuiltinClass(
-                            BuiltinCharacterClass::Whitespace,
-                        ))
+                        Ok(ClassSetOperand::BuiltinClass(BuiltinCharacterClass::Whitespace))
                     }
                     'S' => {
                         self.advance();
-                        Ok(ClassSetOperand::BuiltinClass(
-                            BuiltinCharacterClass::NonWhitespace,
-                        ))
+                        Ok(ClassSetOperand::BuiltinClass(BuiltinCharacterClass::NonWhitespace))
                     }
                     'p' | 'P' => {
                         let negated = esc == 'P';
@@ -1711,10 +1643,7 @@ impl Parser {
                         let prop = self.parse_unicode_property()?;
                         // In v-mode, string properties cannot be negated (\P)
                         // or used inside a negated character class ([^...]).
-                        if prop.1.is_none()
-                            && Self::is_string_property(&prop.0)
-                            && (negated || self.in_negated_class)
-                        {
+                        if prop.1.is_none() && Self::is_string_property(&prop.0) && (negated || self.in_negated_class) {
                             return Err(Error::InvalidUnicodeProperty(prop.0));
                         }
                         Ok(ClassSetOperand::UnicodeProperty(UnicodeProperty {
@@ -1795,10 +1724,7 @@ impl Parser {
     /// After reading a character in a unicode-sets class, check if it's followed by `-` to form a range.
     fn try_parse_class_set_range(&mut self, first: char) -> Result<ClassSetOperand, Error> {
         if self.eat('-') {
-            if self.peek() == Some(']')
-                || self.peek() == Some('-')
-                || self.peek_pair() == Some(('&', '&'))
-            {
+            if self.peek() == Some(']') || self.peek() == Some('-') || self.peek_pair() == Some(('&', '&')) {
                 // `-]`, `--`, and `-&&` do not start a character range here.
                 // Leave the `-` for the outer class-set parser to reinterpret.
                 self.pos -= 1;
@@ -1848,24 +1774,7 @@ fn is_class_set_syntax_character(ch: char) -> bool {
 fn is_class_set_reserved_double_punctuator_char(ch: char) -> bool {
     matches!(
         ch,
-        '&' | '!'
-            | '#'
-            | '$'
-            | '%'
-            | '*'
-            | '+'
-            | ','
-            | '.'
-            | ':'
-            | ';'
-            | '<'
-            | '='
-            | '>'
-            | '?'
-            | '@'
-            | '^'
-            | '`'
-            | '~'
+        '&' | '!' | '#' | '$' | '%' | '*' | '+' | ',' | '.' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '^' | '`' | '~'
     )
 }
 
@@ -1878,8 +1787,7 @@ fn is_id_start(ch: char) -> bool {
 }
 
 fn is_id_continue(ch: char) -> bool {
-    matches!(ch, '$' | '_' | '\u{200C}' | '\u{200D}')
-        || crate::unicode_ffi::is_id_continue(ch as u32)
+    matches!(ch, '$' | '_' | '\u{200C}' | '\u{200D}') || crate::unicode_ffi::is_id_continue(ch as u32)
 }
 
 /// Extract a single code point from a class atom, for use in ranges.

--- a/Libraries/LibRegex/Rust/src/regex.rs
+++ b/Libraries/LibRegex/Rust/src/regex.rs
@@ -37,11 +37,7 @@ impl Regex {
         let mut program = compiler::compile(&parsed);
         Self::resolve_properties(&mut program);
         let required_literal_hint = extract_required_literal_hint(&parsed, flags);
-        let hints = vm::analyze_pattern(
-            &program,
-            pattern_can_match_empty(&parsed),
-            required_literal_hint,
-        );
+        let hints = vm::analyze_pattern(&program, pattern_can_match_empty(&parsed), required_literal_hint);
 
         let literal_u16 = extract_literal_u16(&parsed, flags);
         let word_boundary_literal_u16 = extract_word_boundary_literal_u16(&parsed, flags);
@@ -70,22 +66,10 @@ impl Regex {
         self.exec_into_input(input, start, out)
     }
 
-    pub(crate) fn exec_into_input<I: vm::Input>(
-        &self,
-        input: I,
-        start: usize,
-        out: &mut [i32],
-    ) -> vm::VmResult {
+    pub(crate) fn exec_into_input<I: vm::Input>(&self, input: I, start: usize, out: &mut [i32]) -> vm::VmResult {
         if self.flags.sticky {
             let scratch = &mut *self.scratch.borrow_mut();
-            return vm::execute_anchored_into_with_scratch(
-                &self.program,
-                input,
-                start,
-                &self.hints,
-                out,
-                scratch,
-            );
+            return vm::execute_anchored_into_with_scratch(&self.program, input, start, &self.hints, out, scratch);
         }
 
         // Fast path for literal patterns: use fast substring search.
@@ -129,14 +113,7 @@ impl Regex {
         if self.flags.sticky {
             let mut out = [-1i32; 2];
             let scratch = &mut *self.scratch.borrow_mut();
-            return vm::execute_anchored_into_with_scratch(
-                &self.program,
-                input,
-                start,
-                &self.hints,
-                &mut out,
-                scratch,
-            );
+            return vm::execute_anchored_into_with_scratch(&self.program, input, start, &self.hints, &mut out, scratch);
         }
 
         if let Some(ref needle) = self.literal_u16 {
@@ -168,13 +145,7 @@ impl Regex {
     }
 
     /// Fast literal substring search for whole-pattern literal fast paths.
-    fn literal_search<I: vm::Input>(
-        input: I,
-        start: usize,
-        needle: &[u16],
-        flags: &Flags,
-        out: &mut [i32],
-    ) -> bool {
+    fn literal_search<I: vm::Input>(input: I, start: usize, needle: &[u16], flags: &Flags, out: &mut [i32]) -> bool {
         if needle.is_empty() {
             // Empty pattern matches at start position.
             if out.len() >= 2 {
@@ -299,12 +270,7 @@ impl Regex {
         false
     }
 
-    fn word_boundary_literal_test<I: vm::Input>(
-        input: I,
-        start: usize,
-        needle: &[u16],
-        flags: &Flags,
-    ) -> bool {
+    fn word_boundary_literal_test<I: vm::Input>(input: I, start: usize, needle: &[u16], flags: &Flags) -> bool {
         let mut out = [0i32; 2];
         Self::word_boundary_literal_search(input, start, needle, flags, &mut out)
     }
@@ -552,24 +518,13 @@ impl Regex {
         self.find_all_into_input(input, start, result_buf)
     }
 
-    pub(crate) fn find_all_into_input<I: vm::Input>(
-        &self,
-        input: I,
-        start: usize,
-        result_buf: &mut [i32],
-    ) -> i32 {
+    pub(crate) fn find_all_into_input<I: vm::Input>(&self, input: I, start: usize, result_buf: &mut [i32]) -> i32 {
         // Fast path for literal patterns.
         if let Some(ref needle) = self.literal_u16 {
             return Self::literal_find_all(input, start, needle, &self.flags, result_buf);
         }
         if let Some(ref needle) = self.word_boundary_literal_u16 {
-            return Self::word_boundary_literal_find_all(
-                input,
-                start,
-                needle,
-                &self.flags,
-                result_buf,
-            );
+            return Self::word_boundary_literal_find_all(input, start, needle, &self.flags, result_buf);
         }
         // Fast path for literal alternation patterns.
         if let Some(ref alts) = self.literal_alt_u16 {
@@ -577,14 +532,7 @@ impl Regex {
         }
         // Use the VM-internal find_all loop which reuses a single VM across matches.
         let scratch = &mut *self.scratch.borrow_mut();
-        vm::find_all_with_scratch(
-            &self.program,
-            input,
-            start,
-            &self.hints,
-            result_buf,
-            scratch,
-        )
+        vm::find_all_with_scratch(&self.program, input, start, &self.hints, result_buf, scratch)
     }
 }
 
@@ -644,11 +592,7 @@ fn find_ascii_case_insensitive_code_unit_in_set<I: vm::Input>(
 }
 
 #[inline(always)]
-fn matches_ascii_case_insensitive_u16_at<I: vm::Input>(
-    input: I,
-    pos: usize,
-    needle: &[u16],
-) -> bool {
+fn matches_ascii_case_insensitive_u16_at<I: vm::Input>(input: I, pos: usize, needle: &[u16]) -> bool {
     if pos + needle.len() > input.len() {
         return false;
     }
@@ -662,14 +606,9 @@ fn matches_ascii_case_insensitive_u16_at<I: vm::Input>(
 }
 
 #[inline(always)]
-fn has_ascii_word_boundaries_at<I: vm::Input>(
-    input: I,
-    match_start: usize,
-    match_end: usize,
-) -> bool {
+fn has_ascii_word_boundaries_at<I: vm::Input>(input: I, match_start: usize, match_end: usize) -> bool {
     let left_is_word = match_start > 0 && is_ascii_word_code_unit(input.code_unit(match_start - 1));
-    let right_is_word =
-        match_end < input.len() && is_ascii_word_code_unit(input.code_unit(match_end));
+    let right_is_word = match_end < input.len() && is_ascii_word_code_unit(input.code_unit(match_end));
     !left_is_word && !right_is_word
 }
 
@@ -682,15 +621,9 @@ struct RequiredLiteralAnalysis {
     guaranteed_runs: Vec<Vec<u16>>,
 }
 
-fn extract_required_literal_hint(
-    pattern: &Pattern,
-    flags: Flags,
-) -> Option<vm::RequiredLiteralHint> {
+fn extract_required_literal_hint(pattern: &Pattern, flags: Flags) -> Option<vm::RequiredLiteralHint> {
     let analysis = analyze_required_literal_disjunction(&pattern.disjunction, flags);
-    let literal = analysis
-        .guaranteed_runs
-        .into_iter()
-        .max_by_key(|run| run.len())?;
+    let literal = analysis.guaranteed_runs.into_iter().max_by_key(|run| run.len())?;
     if literal.is_empty() {
         return None;
     }
@@ -710,10 +643,7 @@ fn extract_required_literal_hint(
     })
 }
 
-fn analyze_required_literal_disjunction(
-    disjunction: &Disjunction,
-    flags: Flags,
-) -> RequiredLiteralAnalysis {
+fn analyze_required_literal_disjunction(disjunction: &Disjunction, flags: Flags) -> RequiredLiteralAnalysis {
     let mut analyses = disjunction
         .alternatives
         .iter()
@@ -732,8 +662,7 @@ fn analyze_required_literal_disjunction(
         if exact_literal.as_deref() != analysis.exact_literal.as_deref() {
             exact_literal = None;
         }
-        guaranteed_runs =
-            intersect_required_literal_runs(&guaranteed_runs, &analysis.guaranteed_runs);
+        guaranteed_runs = intersect_required_literal_runs(&guaranteed_runs, &analysis.guaranteed_runs);
         if guaranteed_runs.is_empty() && exact_literal.is_none() {
             break;
         }
@@ -751,10 +680,7 @@ fn analyze_required_literal_disjunction(
     }
 }
 
-fn analyze_required_literal_alternative(
-    alternative: &Alternative,
-    flags: Flags,
-) -> RequiredLiteralAnalysis {
+fn analyze_required_literal_alternative(alternative: &Alternative, flags: Flags) -> RequiredLiteralAnalysis {
     let mut exact_literal = Some(Vec::new());
     let mut current_run = Vec::new();
     let mut guaranteed_runs = Vec::new();
@@ -878,22 +804,14 @@ fn intersect_required_literal_runs(lhs: &[Vec<u16>], rhs: &[Vec<u16>]) -> Vec<Ve
 }
 
 fn maximal_common_substrings(lhs: &[u16], rhs: &[u16]) -> Vec<Vec<u16>> {
-    let max_len = lhs
-        .len()
-        .min(rhs.len())
-        .min(MAX_REQUIRED_LITERAL_CODE_UNITS);
-    let (shorter, longer) = if lhs.len() <= rhs.len() {
-        (lhs, rhs)
-    } else {
-        (rhs, lhs)
-    };
+    let max_len = lhs.len().min(rhs.len()).min(MAX_REQUIRED_LITERAL_CODE_UNITS);
+    let (shorter, longer) = if lhs.len() <= rhs.len() { (lhs, rhs) } else { (rhs, lhs) };
 
     let mut substrings: Vec<Vec<u16>> = Vec::new();
     for len in (1..=max_len).rev() {
         // Required-literal hints keep at most 64 code units, so intersect
         // fixed-size windows instead of walking every start-position pair.
-        let shorter_windows: HashSet<Vec<u16>> =
-            shorter.windows(len).map(|window| window.to_vec()).collect();
+        let shorter_windows: HashSet<Vec<u16>> = shorter.windows(len).map(|window| window.to_vec()).collect();
         let mut matches = HashSet::new();
         for window in longer.windows(len) {
             if shorter_windows.contains(window) {
@@ -939,9 +857,7 @@ fn repeat_literal_prefix(literal: &[u16], repeat_count: u32) -> Vec<u16> {
         return repeated;
     }
 
-    repeated.reserve(
-        MAX_REQUIRED_LITERAL_CODE_UNITS.min(literal.len().saturating_mul(repeat_count as usize)),
-    );
+    repeated.reserve(MAX_REQUIRED_LITERAL_CODE_UNITS.min(literal.len().saturating_mul(repeat_count as usize)));
     for _ in 0..repeat_count {
         for code_unit in literal {
             if repeated.len() == MAX_REQUIRED_LITERAL_CODE_UNITS {
@@ -959,10 +875,7 @@ fn prune_required_literal_runs(mut runs: Vec<Vec<u16>>) -> Vec<Vec<u16>> {
 
     let mut pruned: Vec<Vec<u16>> = Vec::new();
     'outer: for run in runs {
-        if pruned
-            .iter()
-            .any(|existing| contains_literal_subslice(existing, &run))
-        {
+        if pruned.iter().any(|existing| contains_literal_subslice(existing, &run)) {
             continue;
         }
         pruned.push(run);
@@ -980,9 +893,7 @@ fn contains_literal_subslice(haystack: &[u16], needle: &[u16]) -> bool {
     if needle.len() > haystack.len() {
         return false;
     }
-    haystack
-        .windows(needle.len())
-        .any(|window| window == needle)
+    haystack.windows(needle.len()).any(|window| window == needle)
 }
 
 fn pattern_can_match_empty(pattern: &Pattern) -> bool {
@@ -990,10 +901,7 @@ fn pattern_can_match_empty(pattern: &Pattern) -> bool {
 }
 
 fn disjunction_can_match_empty(disjunction: &Disjunction) -> bool {
-    disjunction
-        .alternatives
-        .iter()
-        .any(alternative_can_match_empty)
+    disjunction.alternatives.iter().any(alternative_can_match_empty)
 }
 
 fn alternative_can_match_empty(alternative: &Alternative) -> bool {
@@ -1113,10 +1021,7 @@ fn extract_word_boundary_literal_u16(pattern: &Pattern, flags: Flags) -> Option<
     ) {
         return None;
     }
-    if !matches!(
-        last_term.atom,
-        Atom::Assertion(crate::ast::AssertionKind::WordBoundary)
-    ) {
+    if !matches!(last_term.atom, Atom::Assertion(crate::ast::AssertionKind::WordBoundary)) {
         return None;
     }
 

--- a/Libraries/LibRegex/Rust/src/unicode_ffi.rs
+++ b/Libraries/LibRegex/Rust/src/unicode_ffi.rs
@@ -18,12 +18,7 @@ unsafe extern "C" {
 
     fn unicode_simple_case_fold(code_point: u32, unicode_mode: i32) -> u32;
 
-    fn unicode_code_point_matches_range_ignoring_case(
-        code_point: u32,
-        from: u32,
-        to: u32,
-        unicode_mode: i32,
-    ) -> i32;
+    fn unicode_code_point_matches_range_ignoring_case(code_point: u32, from: u32, to: u32, unicode_mode: i32) -> i32;
 
     fn unicode_property_matches_case_insensitive(
         code_point: u32,
@@ -34,8 +29,7 @@ unsafe extern "C" {
         has_value: i32,
     ) -> i32;
 
-    fn unicode_get_case_closure(code_point: u32, out_buffer: *mut u32, buffer_capacity: u32)
-    -> u32;
+    fn unicode_get_case_closure(code_point: u32, out_buffer: *mut u32, buffer_capacity: u32) -> u32;
 
     fn unicode_is_string_property(name_ptr: *const u8, name_len: usize) -> i32;
 
@@ -58,12 +52,7 @@ unsafe extern "C" {
         has_value: i32,
     ) -> i32;
 
-    fn unicode_get_string_property_data(
-        name_ptr: *const u8,
-        name_len: usize,
-        out: *mut u32,
-        capacity: u32,
-    ) -> u32;
+    fn unicode_get_string_property_data(name_ptr: *const u8, name_len: usize, out: *mut u32, capacity: u32) -> u32;
 
     fn unicode_resolve_property(
         name_ptr: *const u8,
@@ -91,16 +80,7 @@ pub(crate) fn property_matches(code_point: u32, name: &str, value: Option<&str>)
     let (value_ptr, value_len, has_value) = optional_value_parts(value);
     // SAFETY: `name` and `value` remain valid for the duration of this call,
     // and the C++ helper only reads through those pointers.
-    unsafe {
-        unicode_property_matches(
-            code_point,
-            name.as_ptr(),
-            name.len(),
-            value_ptr,
-            value_len,
-            has_value,
-        )
-    }
+    unsafe { unicode_property_matches(code_point, name.as_ptr(), name.len(), value_ptr, value_len, has_value) }
 }
 
 #[inline(always)]
@@ -110,28 +90,14 @@ pub(crate) fn simple_case_fold(code_point: u32, unicode_mode: bool) -> u32 {
 }
 
 #[inline(always)]
-pub(crate) fn code_point_matches_range_ignoring_case(
-    code_point: u32,
-    from: u32,
-    to: u32,
-    unicode_mode: bool,
-) -> bool {
+pub(crate) fn code_point_matches_range_ignoring_case(code_point: u32, from: u32, to: u32, unicode_mode: bool) -> bool {
     // SAFETY: This forwards only scalar values to the C++ helper.
     unsafe {
-        unicode_code_point_matches_range_ignoring_case(
-            code_point,
-            from,
-            to,
-            if unicode_mode { 1 } else { 0 },
-        ) != 0
+        unicode_code_point_matches_range_ignoring_case(code_point, from, to, if unicode_mode { 1 } else { 0 }) != 0
     }
 }
 
-pub(crate) fn property_matches_case_insensitive(
-    code_point: u32,
-    name: &str,
-    value: Option<&str>,
-) -> bool {
+pub(crate) fn property_matches_case_insensitive(code_point: u32, name: &str, value: Option<&str>) -> bool {
     let (value_ptr, value_len, has_value) = optional_value_parts(value);
     // SAFETY: `name` and `value` remain valid for the duration of this call,
     // and the C++ helper only reads through those pointers.
@@ -160,11 +126,7 @@ pub(crate) fn is_string_property(name: &str) -> bool {
     unsafe { unicode_is_string_property(name.as_ptr(), name.len()) != 0 }
 }
 
-pub(crate) fn property_all_case_equivalents_match(
-    code_point: u32,
-    name: &str,
-    value: Option<&str>,
-) -> bool {
+pub(crate) fn property_all_case_equivalents_match(code_point: u32, name: &str, value: Option<&str>) -> bool {
     let (value_ptr, value_len, has_value) = optional_value_parts(value);
     // SAFETY: `name` and `value` remain valid for the duration of this call,
     // and the C++ helper only reads through those pointers.
@@ -190,23 +152,13 @@ pub(crate) fn is_valid_ecma262_property(name: &str, value: Option<&str>) -> bool
     let (value_ptr, value_len, has_value) = optional_value_parts(value);
     // SAFETY: `name` and `value` remain valid for the duration of this call,
     // and the C++ helper only reads through those pointers.
-    unsafe {
-        unicode_is_valid_ecma262_property(
-            name.as_ptr(),
-            name.len(),
-            value_ptr,
-            value_len,
-            has_value,
-        ) != 0
-    }
+    unsafe { unicode_is_valid_ecma262_property(name.as_ptr(), name.len(), value_ptr, value_len, has_value) != 0 }
 }
 
 pub(crate) fn get_string_property_data(name: &str) -> Vec<u32> {
     // SAFETY: Passing a null output buffer with zero capacity is the API's
     // documented query mode, and `name` remains valid during the call.
-    let needed = unsafe {
-        unicode_get_string_property_data(name.as_ptr(), name.len(), std::ptr::null_mut(), 0)
-    };
+    let needed = unsafe { unicode_get_string_property_data(name.as_ptr(), name.len(), std::ptr::null_mut(), 0) };
     if needed == 0 {
         return Vec::new();
     }
@@ -214,9 +166,7 @@ pub(crate) fn get_string_property_data(name: &str) -> Vec<u32> {
     let mut buffer = vec![0u32; needed as usize];
     // SAFETY: `buffer` has room for `needed` elements and the C++ helper
     // writes at most that many u32 values.
-    let written = unsafe {
-        unicode_get_string_property_data(name.as_ptr(), name.len(), buffer.as_mut_ptr(), needed)
-    };
+    let written = unsafe { unicode_get_string_property_data(name.as_ptr(), name.len(), buffer.as_mut_ptr(), needed) };
     if written == 0 || written > needed {
         return Vec::new();
     }

--- a/Libraries/LibRegex/Rust/src/vm.rs
+++ b/Libraries/LibRegex/Rust/src/vm.rs
@@ -183,10 +183,7 @@ fn next_search_position(match_start: i32, match_end: i32) -> usize {
 
 use crate::bytecode::append_code_point_wtf16;
 
-fn extract_trailing_literal(
-    instructions: &[Instruction],
-    assert_end_pc: usize,
-) -> Option<Vec<u16>> {
+fn extract_trailing_literal(instructions: &[Instruction], assert_end_pc: usize) -> Option<Vec<u16>> {
     let mut trailing_code_points = Vec::new();
     let mut suffix_start = assert_end_pc;
     let mut pc = assert_end_pc;
@@ -200,10 +197,7 @@ fn extract_trailing_literal(
                 pc = prev_pc;
             }
             // Skip zero-width bookkeeping so suffixes after capture boundaries still count.
-            Instruction::Save(_)
-            | Instruction::ClearRegister(_)
-            | Instruction::PopModifiers
-            | Instruction::Nop => {
+            Instruction::Save(_) | Instruction::ClearRegister(_) | Instruction::PopModifiers | Instruction::Nop => {
                 suffix_start = prev_pc;
                 pc = prev_pc;
             }
@@ -251,12 +245,7 @@ fn suffix_has_linear_tail(instructions: &[Instruction], suffix_start: usize) -> 
     true
 }
 
-fn for_each_successor(
-    instruction: &Instruction,
-    pc: usize,
-    instruction_count: usize,
-    mut callback: impl FnMut(usize),
-) {
+fn for_each_successor(instruction: &Instruction, pc: usize, instruction_count: usize, mut callback: impl FnMut(usize)) {
     match instruction {
         Instruction::Jump(target) => callback(*target as usize),
         Instruction::Split { prefer, other } => {
@@ -301,9 +290,7 @@ fn contains_u16_from<I: Input>(input: I, start: usize, needle: &[u16]) -> bool {
     }
 
     if needle.len() == 1 {
-        return input
-            .find_code_unit(start, input.len(), needle[0])
-            .is_some();
+        return input.find_code_unit(start, input.len(), needle[0]).is_some();
     }
 
     if start + needle.len() > input.len() {
@@ -334,11 +321,7 @@ fn fold_ascii_for_compare(ch: u16) -> u16 {
 }
 
 #[inline(always)]
-fn contains_ascii_case_insensitive_u16_from<I: Input>(
-    input: I,
-    start: usize,
-    needle: &[u16],
-) -> bool {
+fn contains_ascii_case_insensitive_u16_from<I: Input>(input: I, start: usize, needle: &[u16]) -> bool {
     if needle.is_empty() {
         return true;
     }
@@ -403,10 +386,9 @@ fn fails_required_literal_hint<I: Input>(input: I, start: usize, hints: &Pattern
 fn leading_start_anchor_at(instructions: &[Instruction], pc: usize) -> Option<bool> {
     match instructions.get(pc)? {
         Instruction::AssertStart { multiline } => Some(*multiline),
-        Instruction::Save(_)
-        | Instruction::Nop
-        | Instruction::ClearRegister(_)
-        | Instruction::PushModifiers { .. } => leading_start_anchor_at(instructions, pc + 1),
+        Instruction::Save(_) | Instruction::Nop | Instruction::ClearRegister(_) | Instruction::PushModifiers { .. } => {
+            leading_start_anchor_at(instructions, pc + 1)
+        }
         Instruction::LookStart {
             positive: true,
             forward: true,
@@ -417,13 +399,7 @@ fn leading_start_anchor_at(instructions: &[Instruction], pc: usize) -> Option<bo
 }
 
 #[inline(always)]
-fn first_char_matches<I: Input>(
-    program: &Program,
-    input: I,
-    pos: usize,
-    ch: u32,
-    case_insensitive: bool,
-) -> bool {
+fn first_char_matches<I: Input>(program: &Program, input: I, pos: usize, ch: u32, case_insensitive: bool) -> bool {
     if pos >= input.len() {
         return false;
     }
@@ -433,9 +409,7 @@ fn first_char_matches<I: Input>(
         && pos + 1 < input.len()
         && is_low_surrogate(input.code_unit(pos + 1))
     {
-        0x10000
-            + ((input.code_unit(pos) as u32 - 0xD800) << 10)
-            + (input.code_unit(pos + 1) as u32 - 0xDC00)
+        0x10000 + ((input.code_unit(pos) as u32 - 0xD800) << 10) + (input.code_unit(pos + 1) as u32 - 0xDC00)
     } else {
         input.code_unit(pos) as u32
     };
@@ -448,40 +422,24 @@ fn first_char_matches<I: Input>(
 }
 
 #[inline(always)]
-fn first_filter_matches<I: Input>(
-    program: &Program,
-    input: I,
-    pos: usize,
-    filter: &SimpleMatch,
-) -> bool {
+fn first_filter_matches<I: Input>(program: &Program, input: I, pos: usize, filter: &SimpleMatch) -> bool {
     let cp = decode_code_point(program.unicode, input, pos);
     match filter {
-        SimpleMatch::BuiltinClass(class) => {
-            match_builtin_class(cp, *class, program.ignore_case && program.unicode)
-        }
+        SimpleMatch::BuiltinClass(class) => match_builtin_class(cp, *class, program.ignore_case && program.unicode),
         SimpleMatch::CharClass { ranges, negated } => char_in_ranges(cp, ranges) != *negated,
         SimpleMatch::AnyChar { dot_all } => *dot_all || !is_line_terminator(cp),
         SimpleMatch::Char(c) => cp == *c,
         SimpleMatch::CharNoCase(lo, _hi) => case_fold_eq(cp, *lo, program.unicode),
         SimpleMatch::UnicodeProperty(data) => {
-            let matched = match_unicode_property_resolved(
-                cp,
-                &data.name,
-                data.value.as_deref(),
-                data.resolved.as_ref(),
-            );
+            let matched =
+                match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
             matched != data.negated
         }
     }
 }
 
 #[inline(always)]
-fn next_candidate_start<I: Input>(
-    program: &Program,
-    input: I,
-    hints: &PatternHints,
-    mut pos: usize,
-) -> Option<usize> {
+fn next_candidate_start<I: Input>(program: &Program, input: I, hints: &PatternHints, mut pos: usize) -> Option<usize> {
     while pos <= input.len() {
         if program.unicode
             && !hints.can_match_empty
@@ -494,10 +452,7 @@ fn next_candidate_start<I: Input>(
             continue;
         }
 
-        if hints.starts_with_anchor
-            && pos != 0
-            && !is_line_terminator(input.code_unit(pos - 1) as u32)
-        {
+        if hints.starts_with_anchor && pos != 0 && !is_line_terminator(input.code_unit(pos - 1) as u32) {
             pos += 1;
             continue;
         }
@@ -893,12 +848,8 @@ fn match_simple_match(matcher: &SimpleMatch, cp: u32) -> bool {
         SimpleMatch::CharClass { ranges, negated } => char_in_ranges(cp, ranges) != *negated,
         SimpleMatch::BuiltinClass(class) => match_builtin_class(cp, *class, false),
         SimpleMatch::UnicodeProperty(data) => {
-            let matched = match_unicode_property_resolved(
-                cp,
-                &data.name,
-                data.value.as_deref(),
-                data.resolved.as_ref(),
-            );
+            let matched =
+                match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
             matched != data.negated
         }
     }
@@ -912,9 +863,7 @@ pub(crate) fn decode_code_point<I: Input>(unicode: bool, input: I, pos: usize) -
         && pos + 1 < input.len()
         && is_low_surrogate(input.code_unit(pos + 1))
     {
-        0x10000
-            + ((input.code_unit(pos) as u32 - 0xD800) << 10)
-            + (input.code_unit(pos + 1) as u32 - 0xDC00)
+        0x10000 + ((input.code_unit(pos) as u32 - 0xD800) << 10) + (input.code_unit(pos + 1) as u32 - 0xDC00)
     } else {
         input.code_unit(pos) as u32
     }
@@ -1017,10 +966,7 @@ struct StartPositionHint {
 /// A simple pattern that can be scanned without the full VM.
 enum SimpleScan {
     /// A single character class.
-    CharClass {
-        ranges: Vec<CharRange>,
-        negated: bool,
-    },
+    CharClass { ranges: Vec<CharRange>, negated: bool },
     /// A single builtin class.
     BuiltinClass(BuiltinCharacterClass),
     /// A single character.
@@ -1083,26 +1029,16 @@ enum LeadingAlternativeStart {
     LiteralCodeUnit(u16),
 }
 
-fn leading_alternative_start_at(
-    instructions: &[Instruction],
-    pc: usize,
-) -> Option<LeadingAlternativeStart> {
+fn leading_alternative_start_at(instructions: &[Instruction], pc: usize) -> Option<LeadingAlternativeStart> {
     match instructions.get(pc)? {
         Instruction::AssertStart { multiline: false } => Some(LeadingAlternativeStart::InputStart),
-        Instruction::Char(c) if *c <= 0xFFFF => {
-            Some(LeadingAlternativeStart::LiteralCodeUnit(*c as u16))
-        }
-        Instruction::Save(_) | Instruction::Nop => {
-            leading_alternative_start_at(instructions, pc + 1)
-        }
+        Instruction::Char(c) if *c <= 0xFFFF => Some(LeadingAlternativeStart::LiteralCodeUnit(*c as u16)),
+        Instruction::Save(_) | Instruction::Nop => leading_alternative_start_at(instructions, pc + 1),
         _ => None,
     }
 }
 
-fn analyze_start_position_hint(
-    instructions: &[Instruction],
-    start: usize,
-) -> Option<StartPositionHint> {
+fn analyze_start_position_hint(instructions: &[Instruction], start: usize) -> Option<StartPositionHint> {
     let Instruction::Split { .. } = instructions.get(start)? else {
         return None;
     };
@@ -1151,11 +1087,7 @@ fn analyze_start_position_hint(
 }
 
 #[inline(always)]
-fn next_literal_start_from_hint<I: Input>(
-    input: I,
-    start: usize,
-    hint: &StartPositionHint,
-) -> Option<usize> {
+fn next_literal_start_from_hint<I: Input>(input: I, start: usize, hint: &StartPositionHint) -> Option<usize> {
     let [literal] = hint.literal_code_units.as_slice() else {
         return None;
     };
@@ -1195,9 +1127,7 @@ pub(crate) fn analyze_pattern(
         Some(Instruction::CharNoCase(c, _)) => Some((*c, true)),
         // For disjunctions (Split chains), find the common first character
         // across all alternatives. E.g., /<script|<style|<link/ all start with '<'.
-        Some(Instruction::Split { .. }) => {
-            find_common_first_char(&program.instructions, filter_offset as u32)
-        }
+        Some(Instruction::Split { .. }) => find_common_first_char(&program.instructions, filter_offset as u32),
         _ => None,
     };
 
@@ -1211,9 +1141,7 @@ pub(crate) fn analyze_pattern(
                 ranges: ranges.clone(),
                 negated: *negated,
             }),
-            Some(Instruction::GreedyLoop { matcher, min, .. }) if *min >= 1 => {
-                Some(matcher.clone())
-            }
+            Some(Instruction::GreedyLoop { matcher, min, .. }) if *min >= 1 => Some(matcher.clone()),
             _ => None,
         }
     } else {
@@ -1226,11 +1154,10 @@ pub(crate) fn analyze_pattern(
         None
     };
 
-    let (starts_with_anchor, anchor_multiline) =
-        match leading_start_anchor_at(&program.instructions, skip) {
-            Some(multiline) => (true, multiline || program.multiline),
-            _ => (false, false),
-        };
+    let (starts_with_anchor, anchor_multiline) = match leading_start_anchor_at(&program.instructions, skip) {
+        Some(multiline) => (true, multiline || program.multiline),
+        _ => (false, false),
+    };
 
     let trailing_literal = match program.instructions.as_slice() {
         [
@@ -1244,32 +1171,33 @@ pub(crate) fn analyze_pattern(
         _ => None,
     };
 
-    let required_literal =
-        pick_more_selective_required_literal(
-            ast_required_literal,
-            match program.instructions.as_slice() {
-                [.., Instruction::Save(1), Instruction::Match] if !program.ignore_case => {
-                    extract_trailing_literal(&program.instructions, program.instructions.len() - 2)
-                        .map(|literal| RequiredLiteralHint {
-                            literal,
-                            ascii_case_insensitive: false,
-                        })
-                }
-                [
-                    ..,
-                    Instruction::AssertEnd { .. },
-                    Instruction::Save(1),
-                    Instruction::Match,
-                ] if !program.ignore_case => {
-                    extract_trailing_literal(&program.instructions, program.instructions.len() - 3)
-                        .map(|literal| RequiredLiteralHint {
-                            literal,
-                            ascii_case_insensitive: false,
-                        })
-                }
-                _ => None,
-            },
-        );
+    let required_literal = pick_more_selective_required_literal(
+        ast_required_literal,
+        match program.instructions.as_slice() {
+            [.., Instruction::Save(1), Instruction::Match] if !program.ignore_case => {
+                extract_trailing_literal(&program.instructions, program.instructions.len() - 2).map(|literal| {
+                    RequiredLiteralHint {
+                        literal,
+                        ascii_case_insensitive: false,
+                    }
+                })
+            }
+            [
+                ..,
+                Instruction::AssertEnd { .. },
+                Instruction::Save(1),
+                Instruction::Match,
+            ] if !program.ignore_case => {
+                extract_trailing_literal(&program.instructions, program.instructions.len() - 3).map(|literal| {
+                    RequiredLiteralHint {
+                        literal,
+                        ascii_case_insensitive: false,
+                    }
+                })
+            }
+            _ => None,
+        },
+    );
 
     // Detect simple patterns: Save(0) + single_matcher + Save(1) + Match
     let simple_scan = if !program.ignore_case
@@ -1287,13 +1215,11 @@ pub(crate) fn analyze_pattern(
             Instruction::Char(c) => Some(SimpleScan::Char(*c)),
             // GreedyLoop of a simple matcher: e.g., \s+, \d+, .+
             // Only when min >= 1 (min=0 means every position matches, complicating the scan).
-            Instruction::GreedyLoop { matcher, min, max } if *min >= 1 => {
-                Some(SimpleScan::GreedyQuantifier {
-                    matcher: matcher.clone(),
-                    min: *min,
-                    max: *max,
-                })
-            }
+            Instruction::GreedyLoop { matcher, min, max } if *min >= 1 => Some(SimpleScan::GreedyQuantifier {
+                matcher: matcher.clone(),
+                min: *min,
+                max: *max,
+            }),
             _ => None,
         }
     } else {
@@ -1320,9 +1246,7 @@ fn pick_more_selective_required_literal(
     match (lhs, rhs) {
         (Some(lhs), Some(rhs)) => {
             if rhs.literal.len() > lhs.literal.len()
-                || (rhs.literal.len() == lhs.literal.len()
-                    && !rhs.ascii_case_insensitive
-                    && lhs.ascii_case_insensitive)
+                || (rhs.literal.len() == lhs.literal.len() && !rhs.ascii_case_insensitive && lhs.ascii_case_insensitive)
             {
                 Some(rhs)
             } else {
@@ -1748,11 +1672,7 @@ impl<'a, I: Input> Vm<'a, I> {
                     self.handle_repeat_check(*counter_reg, *min, *max, *body, *greedy);
                 }
 
-                Instruction::LookStart {
-                    positive,
-                    forward,
-                    end,
-                } => {
+                Instruction::LookStart { positive, forward, end } => {
                     if let Some(result) = self.handle_look_start(*positive, *forward, *end) {
                         return result;
                     }
@@ -1784,10 +1704,7 @@ impl<'a, I: Input> Vm<'a, I> {
                     }
                 }
 
-                Instruction::ProgressCheck {
-                    reg,
-                    clear_captures,
-                } => {
+                Instruction::ProgressCheck { reg, clear_captures } => {
                     let reg = *reg as usize;
                     let last_pos = self.registers[reg];
                     if last_pos == self.pos as i32 {
@@ -1813,13 +1730,7 @@ impl<'a, I: Input> Vm<'a, I> {
                     let max = *max;
                     let start_pos = self.pos;
 
-                    let count = Self::greedy_consume_fast(
-                        input,
-                        &mut self.pos,
-                        matcher,
-                        &self.modifiers,
-                        max,
-                    );
+                    let count = Self::greedy_consume_fast(input, &mut self.pos, matcher, &self.modifiers, max);
 
                     if count < min {
                         self.pos = start_pos;
@@ -1952,11 +1863,8 @@ impl<'a, I: Input> Vm<'a, I> {
                 Instruction::BuiltinClass(class) => {
                     let class = *class;
                     if let Some(cp) = self.current_code_point() {
-                        let matches = match_builtin_class(
-                            cp,
-                            class,
-                            self.modifiers.ignore_case && self.program.unicode,
-                        );
+                        let matches =
+                            match_builtin_class(cp, class, self.modifiers.ignore_case && self.program.unicode);
                         if matches {
                             self.advance_char();
                             self.pc += 1;
@@ -1972,17 +1880,10 @@ impl<'a, I: Input> Vm<'a, I> {
                     if let Some(cp) = self.current_code_point() {
                         let result = if self.modifiers.ignore_case && self.program.unicode {
                             if data.negated && !self.program.unicode_sets {
-                                !match_unicode_property_all_case_equivalents(
-                                    cp,
-                                    &data.name,
-                                    data.value.as_deref(),
-                                )
+                                !match_unicode_property_all_case_equivalents(cp, &data.name, data.value.as_deref())
                             } else {
-                                let matched = match_unicode_property_case_insensitive(
-                                    cp,
-                                    &data.name,
-                                    data.value.as_deref(),
-                                );
+                                let matched =
+                                    match_unicode_property_case_insensitive(cp, &data.name, data.value.as_deref());
                                 if data.negated { !matched } else { matched }
                             }
                         } else {
@@ -2103,11 +2004,7 @@ impl<'a, I: Input> Vm<'a, I> {
                     self.handle_repeat_check(*counter_reg, *min, *max, *body, *greedy);
                 }
 
-                Instruction::LookStart {
-                    positive,
-                    forward,
-                    end,
-                } => {
+                Instruction::LookStart { positive, forward, end } => {
                     if let Some(result) = self.handle_look_start(*positive, *forward, *end) {
                         return result;
                     }
@@ -2139,10 +2036,7 @@ impl<'a, I: Input> Vm<'a, I> {
                     }
                 }
 
-                Instruction::ProgressCheck {
-                    reg,
-                    clear_captures,
-                } => {
+                Instruction::ProgressCheck { reg, clear_captures } => {
                     let reg = *reg as usize;
                     let last_pos = self.registers[reg];
                     if last_pos == self.pos as i32 {
@@ -2168,13 +2062,7 @@ impl<'a, I: Input> Vm<'a, I> {
 
                     // Fast path for common non-unicode matchers.
                     let count = if !self.program.unicode && !self.backward {
-                        Self::greedy_consume_fast(
-                            self.input,
-                            &mut self.pos,
-                            matcher,
-                            &self.modifiers,
-                            max,
-                        )
+                        Self::greedy_consume_fast(self.input, &mut self.pos, matcher, &self.modifiers, max)
                     } else {
                         let mut count: u32 = 0;
                         while max.is_none() || count < max.unwrap() {
@@ -2257,9 +2145,7 @@ impl<'a, I: Input> Vm<'a, I> {
     fn handle_assert_start(&mut self, multiline: bool) -> Option<VmResult> {
         let multiline = multiline || self.modifiers.multiline;
         let at_start = self.pos == 0
-            || (multiline
-                && self.pos > 0
-                && is_line_terminator(self.input_code_unit(self.pos - 1) as u32));
+            || (multiline && self.pos > 0 && is_line_terminator(self.input_code_unit(self.pos - 1) as u32));
         if at_start {
             self.pc += 1;
             None
@@ -2271,8 +2157,7 @@ impl<'a, I: Input> Vm<'a, I> {
     #[inline(always)]
     fn handle_assert_end(&mut self, multiline: bool, input_len: usize) -> Option<VmResult> {
         let multiline = multiline || self.modifiers.multiline;
-        let at_end = self.pos >= input_len
-            || (multiline && is_line_terminator(self.input_code_unit(self.pos) as u32));
+        let at_end = self.pos >= input_len || (multiline && is_line_terminator(self.input_code_unit(self.pos) as u32));
         if at_end {
             self.pc += 1;
             None
@@ -2321,14 +2206,7 @@ impl<'a, I: Input> Vm<'a, I> {
     }
 
     #[inline(always)]
-    fn handle_repeat_check(
-        &mut self,
-        counter_reg: u32,
-        min: u32,
-        max: Option<u32>,
-        body: u32,
-        greedy: bool,
-    ) {
+    fn handle_repeat_check(&mut self, counter_reg: u32, min: u32, max: Option<u32>, body: u32, greedy: bool) {
         let reg = counter_reg as usize;
         let count = self.registers[reg] as u32;
 
@@ -2382,9 +2260,8 @@ impl<'a, I: Input> Vm<'a, I> {
                 self.register_pool.truncate(saved_pool_len);
                 self.pc = end;
             } else {
-                self.registers.copy_from_slice(
-                    &self.register_pool[reg_save_offset..reg_save_offset + reg_count],
-                );
+                self.registers
+                    .copy_from_slice(&self.register_pool[reg_save_offset..reg_save_offset + reg_count]);
                 self.register_pool.truncate(saved_pool_len);
                 return self.fail_current_path();
             }
@@ -2402,12 +2279,7 @@ impl<'a, I: Input> Vm<'a, I> {
     }
 
     #[inline(always)]
-    fn handle_push_modifiers(
-        &mut self,
-        ignore_case: Option<bool>,
-        multiline: Option<bool>,
-        dot_all: Option<bool>,
-    ) {
+    fn handle_push_modifiers(&mut self, ignore_case: Option<bool>, multiline: Option<bool>, dot_all: Option<bool>) {
         self.modifier_stack.push(self.modifiers);
         if let Some(v) = ignore_case {
             self.modifiers.ignore_case = v;
@@ -2429,11 +2301,7 @@ impl<'a, I: Input> Vm<'a, I> {
         self.pc += 1;
     }
 
-    fn handle_string_property_match(
-        &mut self,
-        strings: &[u32],
-        property: &UnicodePropertyData,
-    ) -> Option<VmResult> {
+    fn handle_string_property_match(&mut self, strings: &[u32], property: &UnicodePropertyData) -> Option<VmResult> {
         // Try multi-codepoint strings first (longest match, atomic).
         let mut matched_len = 0usize;
         let mut offset = 0usize;
@@ -2706,9 +2574,8 @@ impl<'a, I: Input> Vm<'a, I> {
     #[inline(always)]
     fn restore_registers(&mut self, reg_snapshot_offset: usize) {
         let reg_count = self.registers.len();
-        self.registers.copy_from_slice(
-            &self.register_pool[reg_snapshot_offset..reg_snapshot_offset + reg_count],
-        );
+        self.registers
+            .copy_from_slice(&self.register_pool[reg_snapshot_offset..reg_snapshot_offset + reg_count]);
     }
 
     // Sum the minimum counts of immediately following loops that match the
@@ -2775,20 +2642,14 @@ impl<'a, I: Input> Vm<'a, I> {
         count
     }
 
-    fn same_matcher_loop_suffix_deficit(
-        &self,
-        pc: usize,
-        current_pos: usize,
-        backward: bool,
-    ) -> Option<u32> {
+    fn same_matcher_loop_suffix_deficit(&self, pc: usize, current_pos: usize, backward: bool) -> Option<u32> {
         let matcher = match self.program.instructions.get(pc) {
             Some(Instruction::GreedyLoop { matcher, .. }) => matcher,
             _ => return None,
         };
 
         let suffix_min = self.same_matcher_loop_suffix_min(pc + 1, matcher)?;
-        let available =
-            self.count_available_same_matcher_chars(current_pos, matcher, suffix_min, backward);
+        let available = self.count_available_same_matcher_chars(current_pos, matcher, suffix_min, backward);
         let deficit = suffix_min.saturating_sub(available);
         (deficit > 0).then_some(deficit)
     }
@@ -2878,10 +2739,8 @@ impl<'a, I: Input> Vm<'a, I> {
                         };
 
                         let next_inst = self.program.instructions.get(pc as usize + 1);
-                        let new_pos = if let Some(suffix_deficit) = same_matcher_loop_suffix_deficit
-                        {
-                            let Some(pos) = self.advance_n_chars(current_pos, suffix_deficit)
-                            else {
+                        let new_pos = if let Some(suffix_deficit) = same_matcher_loop_suffix_deficit {
+                            let Some(pos) = self.advance_n_chars(current_pos, suffix_deficit) else {
                                 return self.backtrack();
                             };
                             if pos > max_pos {
@@ -2890,9 +2749,7 @@ impl<'a, I: Input> Vm<'a, I> {
                             pos
                         } else {
                             match next_inst {
-                                Some(Instruction::Char(target))
-                                    if !self.modifiers.ignore_case && *target <= 0xFFFF =>
-                                {
+                                Some(Instruction::Char(target)) if !self.modifiers.ignore_case && *target <= 0xFFFF => {
                                     let target = *target as u16;
                                     // In backward mode the next Char reads the code
                                     // point immediately to the left of the current
@@ -2903,9 +2760,7 @@ impl<'a, I: Input> Vm<'a, I> {
                                         if scan_pos > max_pos {
                                             return self.backtrack();
                                         }
-                                        if scan_pos > 0
-                                            && self.input_code_unit(scan_pos - 1) == target
-                                        {
+                                        if scan_pos > 0 && self.input_code_unit(scan_pos - 1) == target {
                                             break scan_pos;
                                         }
                                         let next_scan_pos = self.advance_one_char(scan_pos);
@@ -2915,9 +2770,7 @@ impl<'a, I: Input> Vm<'a, I> {
                                         scan_pos = next_scan_pos;
                                     }
                                 }
-                                Some(Instruction::Char(target))
-                                    if !self.modifiers.ignore_case && *target > 0xFFFF =>
-                                {
+                                Some(Instruction::Char(target)) if !self.modifiers.ignore_case && *target > 0xFFFF => {
                                     let hi = ((*target - 0x10000) >> 10) as u16 + 0xD800;
                                     let lo = ((*target - 0x10000) & 0x3FF) as u16 + 0xDC00;
                                     let mut scan_pos = self.advance_one_char(current_pos);
@@ -2988,10 +2841,8 @@ impl<'a, I: Input> Vm<'a, I> {
                         // Char, scan backward for that char to skip positions
                         // that can't match.
                         let next_inst = self.program.instructions.get(pc as usize + 1);
-                        let new_pos = if let Some(suffix_deficit) = same_matcher_loop_suffix_deficit
-                        {
-                            let Some(pos) = self.retreat_n_chars(current_pos, suffix_deficit)
-                            else {
+                        let new_pos = if let Some(suffix_deficit) = same_matcher_loop_suffix_deficit {
+                            let Some(pos) = self.retreat_n_chars(current_pos, suffix_deficit) else {
                                 return self.backtrack();
                             };
                             if pos < min_pos {
@@ -3000,13 +2851,10 @@ impl<'a, I: Input> Vm<'a, I> {
                             pos
                         } else {
                             match next_inst {
-                                Some(Instruction::Char(target))
-                                    if !self.modifiers.ignore_case && *target <= 0xFFFF =>
-                                {
+                                Some(Instruction::Char(target)) if !self.modifiers.ignore_case && *target <= 0xFFFF => {
                                     // BMP char: scan code units directly.
                                     let target = *target as u16;
-                                    let mut scan_pos =
-                                        if current_pos > 0 { current_pos - 1 } else { 0 };
+                                    let mut scan_pos = if current_pos > 0 { current_pos - 1 } else { 0 };
                                     loop {
                                         if scan_pos < min_pos {
                                             return self.backtrack();
@@ -3020,14 +2868,11 @@ impl<'a, I: Input> Vm<'a, I> {
                                         scan_pos -= 1;
                                     }
                                 }
-                                Some(Instruction::Char(target))
-                                    if !self.modifiers.ignore_case && *target > 0xFFFF =>
-                                {
+                                Some(Instruction::Char(target)) if !self.modifiers.ignore_case && *target > 0xFFFF => {
                                     // Supplementary char: scan for the surrogate pair.
                                     let hi = ((*target - 0x10000) >> 10) as u16 + 0xD800;
                                     let lo = ((*target - 0x10000) & 0x3FF) as u16 + 0xDC00;
-                                    let mut scan_pos =
-                                        if current_pos > 1 { current_pos - 2 } else { 0 };
+                                    let mut scan_pos = if current_pos > 1 { current_pos - 2 } else { 0 };
                                     loop {
                                         if scan_pos < min_pos {
                                             return self.backtrack();
@@ -3150,34 +2995,20 @@ impl<'a, I: Input> Vm<'a, I> {
                 );
                 in_class != *negated
             }
-            SimpleMatch::BuiltinClass(class) => match_builtin_class(
-                cp,
-                *class,
-                self.modifiers.ignore_case && self.program.unicode,
-            ),
+            SimpleMatch::BuiltinClass(class) => {
+                match_builtin_class(cp, *class, self.modifiers.ignore_case && self.program.unicode)
+            }
             SimpleMatch::UnicodeProperty(data) => {
                 if self.modifiers.ignore_case && self.program.unicode {
                     if data.negated && !self.program.unicode_sets {
-                        !match_unicode_property_all_case_equivalents(
-                            cp,
-                            &data.name,
-                            data.value.as_deref(),
-                        )
+                        !match_unicode_property_all_case_equivalents(cp, &data.name, data.value.as_deref())
                     } else {
-                        let matched = match_unicode_property_case_insensitive(
-                            cp,
-                            &data.name,
-                            data.value.as_deref(),
-                        );
+                        let matched = match_unicode_property_case_insensitive(cp, &data.name, data.value.as_deref());
                         if data.negated { !matched } else { matched }
                     }
                 } else {
-                    let matched = match_unicode_property_resolved(
-                        cp,
-                        &data.name,
-                        data.value.as_deref(),
-                        data.resolved.as_ref(),
-                    );
+                    let matched =
+                        match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
                     matched != data.negated
                 }
             }
@@ -3284,13 +3115,7 @@ impl<'a, I: Input> Vm<'a, I> {
             SimpleMatch::CharClass { ranges, negated } => {
                 if modifiers.ignore_case {
                     while *pos < len && count < limit {
-                        let in_class = match_char_class(
-                            input.code_unit(*pos) as u32,
-                            ranges,
-                            true,
-                            false,
-                            false,
-                        );
+                        let in_class = match_char_class(input.code_unit(*pos) as u32, ranges, true, false, false);
                         if in_class == *negated {
                             break;
                         }
@@ -3320,12 +3145,8 @@ impl<'a, I: Input> Vm<'a, I> {
             SimpleMatch::UnicodeProperty(data) => {
                 while *pos < len && count < limit {
                     let cp = input.code_unit(*pos) as u32;
-                    let matched = match_unicode_property_resolved(
-                        cp,
-                        &data.name,
-                        data.value.as_deref(),
-                        data.resolved.as_ref(),
-                    );
+                    let matched =
+                        match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
                     if matched == data.negated {
                         break;
                     }
@@ -3359,16 +3180,8 @@ impl<'a, I: Input> Vm<'a, I> {
     /// Implement `BackreferenceMatcher` for a numbered capture.
     /// <https://tc39.es/ecma262/#sec-backreference-matcher>
     fn match_backref(&mut self, index: u32) -> bool {
-        let start = self
-            .registers
-            .get(index as usize * 2)
-            .copied()
-            .unwrap_or(-1);
-        let end = self
-            .registers
-            .get(index as usize * 2 + 1)
-            .copied()
-            .unwrap_or(-1);
+        let start = self.registers.get(index as usize * 2).copied().unwrap_or(-1);
+        let end = self.registers.get(index as usize * 2 + 1).copied().unwrap_or(-1);
         if start < 0 || end < 0 {
             // Unmatched group — backreference succeeds matching empty string (ECMA-262).
             return true;
@@ -3509,16 +3322,8 @@ impl<'a, I: Input> Vm<'a, I> {
         for ng in &self.program.named_groups {
             if ng.name == name {
                 any_group_exists = true;
-                let start = self
-                    .registers
-                    .get(ng.index as usize * 2)
-                    .copied()
-                    .unwrap_or(-1);
-                let end = self
-                    .registers
-                    .get(ng.index as usize * 2 + 1)
-                    .copied()
-                    .unwrap_or(-1);
+                let start = self.registers.get(ng.index as usize * 2).copied().unwrap_or(-1);
+                let end = self.registers.get(ng.index as usize * 2 + 1).copied().unwrap_or(-1);
                 if start >= 0 && end >= 0 {
                     captured_index = Some(ng.index);
                     break;
@@ -3683,25 +3488,16 @@ pub(crate) fn match_char_class(
         // other characters that share the same canonical form as cp.
         // Always use the ICU-based range matcher which correctly handles
         // cross-script case folding (e.g. U+017F ſ folds to ASCII s).
-        ranges.iter().any(|r| {
-            crate::unicode_ffi::code_point_matches_range_ignoring_case(
-                cp,
-                r.start,
-                r.end,
-                unicode_mode,
-            )
-        })
+        ranges
+            .iter()
+            .any(|r| crate::unicode_ffi::code_point_matches_range_ignoring_case(cp, r.start, r.end, unicode_mode))
     } else {
         char_in_ranges(cp, ranges)
     }
 }
 
 #[inline(always)]
-pub(crate) fn match_builtin_class(
-    cp: u32,
-    class: BuiltinCharacterClass,
-    unicode_ignore_case: bool,
-) -> bool {
+pub(crate) fn match_builtin_class(cp: u32, class: BuiltinCharacterClass, unicode_ignore_case: bool) -> bool {
     match class {
         BuiltinCharacterClass::Digit => is_digit(cp),
         BuiltinCharacterClass::NonDigit => !is_digit(cp),
@@ -3714,21 +3510,13 @@ pub(crate) fn match_builtin_class(
 
 /// Match a Unicode property considering case closure for ignore-case matching.
 /// <https://tc39.es/ecma262/#sec-maybesimplecasefolding>
-pub(crate) fn match_unicode_property_case_insensitive(
-    cp: u32,
-    name: &str,
-    value: Option<&str>,
-) -> bool {
+pub(crate) fn match_unicode_property_case_insensitive(cp: u32, name: &str, value: Option<&str>) -> bool {
     crate::unicode_ffi::property_matches_case_insensitive(cp, name, value)
 }
 
 /// Check if all case-equivalents of `cp` have the property.
 /// <https://tc39.es/ecma262/#sec-maybesimplecasefolding>
-pub(crate) fn match_unicode_property_all_case_equivalents(
-    cp: u32,
-    name: &str,
-    value: Option<&str>,
-) -> bool {
+pub(crate) fn match_unicode_property_all_case_equivalents(cp: u32, name: &str, value: Option<&str>) -> bool {
     crate::unicode_ffi::property_all_case_equivalents_match(cp, name, value)
 }
 

--- a/Libraries/LibUnicode/Rust/src/calendar.rs
+++ b/Libraries/LibUnicode/Rust/src/calendar.rs
@@ -120,12 +120,7 @@ fn is_chinese_or_dangi(calendar_name: &str) -> bool {
 ///
 /// Uses `try_from_fields` instead of `try_new` to support the wider year range (+/- 1,040,000) needed by
 /// Chinese and Dangi calendars with extreme years.
-fn try_new_date(
-    extended_year: i32,
-    month: Month,
-    day: u8,
-    calendar: AnyCalendar,
-) -> Option<Date<AnyCalendar>> {
+fn try_new_date(extended_year: i32, month: Month, day: u8, calendar: AnyCalendar) -> Option<Date<AnyCalendar>> {
     let mut fields = DateFields::default();
     fields.extended_year = Some(extended_year);
     fields.month = Some(month);
@@ -166,14 +161,10 @@ fn collect_year_months(
         let month = current_date.month().to_input();
         let days_in_month = current_date.days_in_month();
 
-        result.push(ChineseMonthInfo {
-            month,
-            days_in_month,
-        });
+        result.push(ChineseMonthInfo { month, days_in_month });
 
         // Advance to day 1 of next month via RataDie arithmetic.
-        let rata_die =
-            RataDie::new(current_date.to_rata_die().to_i64_date() + days_in_month as i64);
+        let rata_die = RataDie::new(current_date.to_rata_die().to_i64_date() + days_in_month as i64);
 
         let next_date = Date::from_rata_die(rata_die, calendar.clone());
         if next_date.year().extended_year() != extended_year {
@@ -206,10 +197,7 @@ fn chinese_or_dangi_extended_year(calendar: &AnyCalendar, arithmetic_year: i32) 
 }
 
 /// Build a list of month info for each ordinal month in a Chinese/Dangi year.
-fn chinese_year_months(
-    calendar: &AnyCalendar,
-    arithmetic_year: i32,
-) -> Option<Vec<ChineseMonthInfo>> {
+fn chinese_year_months(calendar: &AnyCalendar, arithmetic_year: i32) -> Option<Vec<ChineseMonthInfo>> {
     let extended_year = chinese_or_dangi_extended_year(calendar, arithmetic_year)?;
 
     let year_start = try_new_date(extended_year, Month::new(1), 1, calendar.clone())?;
@@ -256,12 +244,7 @@ fn make_calendar_date_from_ordinal(
 
         try_new_date(arithmetic_year, month, day, calendar.clone())
     } else {
-        try_new_date(
-            arithmetic_year,
-            Month::new(ordinal_month),
-            day,
-            calendar.clone(),
-        )
+        try_new_date(arithmetic_year, Month::new(ordinal_month), day, calendar.clone())
     }
 }
 
@@ -291,10 +274,7 @@ fn iso_date_to_calendar_date_impl(
 
         (year_start.to_calendar(Iso).year().extended_year(), ordinal)
     } else {
-        (
-            calendar_date.year().extended_year(),
-            calendar_date.month().ordinal,
-        )
+        (calendar_date.year().extended_year(), calendar_date.month().ordinal)
     };
 
     let month = calendar_date.month().to_input();
@@ -329,8 +309,7 @@ pub unsafe extern "C" fn icu_iso_date_to_calendar_date(
     abort_on_panic(|| {
         let calendar_name = ascii_string_from_ffi(calendar, calendar_length);
 
-        iso_date_to_calendar_date_impl(calendar_name, iso_year, iso_month, iso_day)
-            .unwrap_or(EMPTY_CALENDAR_DATE)
+        iso_date_to_calendar_date_impl(calendar_name, iso_year, iso_month, iso_day).unwrap_or(EMPTY_CALENDAR_DATE)
     })
 }
 
@@ -342,13 +321,7 @@ fn calendar_date_to_iso_date_impl(
 ) -> Option<FfiISODate> {
     let calendar = make_calendar(calendar_name)?;
 
-    let calendar_date = make_calendar_date_from_ordinal(
-        calendar_name,
-        &calendar,
-        arithmetic_year,
-        ordinal_month,
-        day,
-    )?;
+    let calendar_date = make_calendar_date_from_ordinal(calendar_name, &calendar, arithmetic_year, ordinal_month, day)?;
 
     let iso_date = calendar_date.to_calendar(Iso);
 
@@ -536,11 +509,7 @@ pub unsafe extern "C" fn icu_calendar_months_in_year(
     })
 }
 
-fn calendar_days_in_month_impl(
-    calendar_name: &str,
-    arithmetic_year: i32,
-    ordinal_month: u8,
-) -> Option<u8> {
+fn calendar_days_in_month_impl(calendar_name: &str, arithmetic_year: i32, ordinal_month: u8) -> Option<u8> {
     let calendar = make_calendar(calendar_name)?;
 
     if is_chinese_or_dangi(calendar_name) {
@@ -550,13 +519,7 @@ fn calendar_days_in_month_impl(
         return months.get(month_index).map(|m| m.days_in_month);
     }
 
-    let date = make_calendar_date_from_ordinal(
-        calendar_name,
-        &calendar,
-        arithmetic_year,
-        ordinal_month,
-        1,
-    )?;
+    let date = make_calendar_date_from_ordinal(calendar_name, &calendar, arithmetic_year, ordinal_month, 1)?;
 
     Some(date.days_in_month())
 }
@@ -577,10 +540,7 @@ pub unsafe extern "C" fn icu_calendar_days_in_month(
     })
 }
 
-fn calendar_max_days_in_month_code_impl(
-    calendar_name: &str,
-    month_code_string: &str,
-) -> Option<u8> {
+fn calendar_max_days_in_month_code_impl(calendar_name: &str, month_code_string: &str) -> Option<u8> {
     let calendar = make_calendar(calendar_name)?;
     let month = Month::try_from_str(month_code_string).ok()?;
 
@@ -625,11 +585,7 @@ pub unsafe extern "C" fn icu_calendar_max_days_in_month_code(
     })
 }
 
-fn year_contains_month_code_impl(
-    calendar_name: &str,
-    arithmetic_year: i32,
-    month_code_string: &str,
-) -> Option<bool> {
+fn year_contains_month_code_impl(calendar_name: &str, arithmetic_year: i32, month_code_string: &str) -> Option<bool> {
     let calendar = make_calendar(calendar_name)?;
     let month = Month::try_from_str(month_code_string).ok()?;
 
@@ -661,7 +617,6 @@ pub unsafe extern "C" fn icu_year_contains_month_code(
         let calendar_name = ascii_string_from_ffi(calendar, calendar_length);
         let month_code_string = ascii_string_from_ffi(month_code, month_code_length);
 
-        year_contains_month_code_impl(calendar_name, arithmetic_year, month_code_string)
-            .unwrap_or(false)
+        year_contains_month_code_impl(calendar_name, arithmetic_year, month_code_string).unwrap_or(false)
     })
 }

--- a/Libraries/RustAllocator.rs
+++ b/Libraries/RustAllocator.rs
@@ -10,12 +10,7 @@ unsafe extern "C" {
     fn ladybird_rust_alloc(size: usize, alignment: usize) -> *mut u8;
     fn ladybird_rust_alloc_zeroed(size: usize, alignment: usize) -> *mut u8;
     fn ladybird_rust_dealloc(ptr: *mut u8, alignment: usize);
-    fn ladybird_rust_realloc(
-        ptr: *mut u8,
-        old_size: usize,
-        new_size: usize,
-        alignment: usize,
-    ) -> *mut u8;
+    fn ladybird_rust_realloc(ptr: *mut u8, old_size: usize, new_size: usize, alignment: usize) -> *mut u8;
 }
 
 struct LadybirdAllocator;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+max_width = 120
+hard_tabs = false
+tab_spaces = 4
+edition = "2024"
+style_edition = "2024"


### PR DESCRIPTION
This sets max_width to 120, which causes a lot of reformatting.

Included toml config:

```toml
max_width = 120
hard_tabs = false
tab_spaces = 4
edition = "2024"
style_edition = "2024"
```

ref: https://rust-lang.github.io/rustfmt/?version=v1.9.0&search=#max_width