### PR TITLE
LibWeb+LibGfx: Decompress WOFF2 fonts off the main thread

### DIFF
--- a/Libraries/LibGfx/Font/WOFF2/Loader.cpp
+++ b/Libraries/LibGfx/Font/WOFF2/Loader.cpp
@@ -53,7 +53,7 @@ private:
     ByteBuffer& m_buffer;
 };
 
-ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes bytes)
+ErrorOr<ByteBuffer> convert_to_ttf(ReadonlyBytes bytes)
 {
     auto ttf_buffer = TRY(ByteBuffer::create_uninitialized(0));
     auto output = WOFF2ByteBufferOut { ttf_buffer };
@@ -62,6 +62,12 @@ ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes bytes)
         return Error::from_string_literal("Failed to convert the WOFF2 font to TTF");
     }
 
+    return ttf_buffer;
+}
+
+ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes bytes)
+{
+    auto ttf_buffer = TRY(convert_to_ttf(bytes));
     auto font_data = Gfx::FontData::create_from_byte_buffer(move(ttf_buffer));
     auto input_font = TRY(Gfx::Typeface::try_load_from_font_data(move(font_data)));
     return input_font;

--- a/Libraries/LibGfx/Font/WOFF2/Loader.h
+++ b/Libraries/LibGfx/Font/WOFF2/Loader.h
@@ -7,12 +7,14 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <LibGfx/Font/Typeface.h>
 
 namespace WOFF2 {
 
+ErrorOr<ByteBuffer> convert_to_ttf(ReadonlyBytes);
 ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes);
 
 }

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -177,6 +177,7 @@ set(SOURCES
     CSS/Flex.cpp
     CSS/FontComputer.cpp
     CSS/FontFace.cpp
+    CSS/FontLoading.cpp
     CSS/FontFaceSet.cpp
     CSS/FontFaceSetLoadEvent.cpp
     CSS/FontFeatureData.cpp

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -10,8 +10,6 @@
 
 #include "FontComputer.h"
 #include <LibGfx/Font/FontDatabase.h>
-#include <LibGfx/Font/WOFF/Loader.h>
-#include <LibGfx/Font/WOFF2/Loader.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
@@ -19,6 +17,7 @@
 #include <LibWeb/CSS/Fetch.h>
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/FontFaceSet.h>
+#include <LibWeb/CSS/FontLoading.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
@@ -130,24 +129,60 @@ void FontLoader::start_loading_next_url()
             // 1. If stream is null, return.
             // 2. Load a font from stream according to its type.
 
-            // NB: We need to fetch the next source if this one fails to fetch OR decode. So, first try to decode it.
-            RefPtr<Gfx::Typeface const> typeface;
-            if (auto* bytes = stream.template get_pointer<ByteBuffer>()) {
-                if (auto maybe_typeface = loader->try_load_font(response, *bytes); !maybe_typeface.is_error())
-                    typeface = maybe_typeface.release_value();
-            }
-
-            if (!typeface) {
-                // NB: If we have other sources available, try the next one.
+            auto* bytes = stream.template get_pointer<ByteBuffer>();
+            if (!bytes) {
                 if (loader->m_urls.is_empty()) {
                     loader->font_did_load_or_fail(nullptr);
                 } else {
                     loader->m_fetch_controller = nullptr;
                     loader->start_loading_next_url();
                 }
-            } else {
-                loader->font_did_load_or_fail(move(typeface));
+                return;
             }
+
+            auto mime_type_essence = loader->try_load_font_mime_type_essence(response, *bytes);
+            if (!requires_off_thread_vector_font_preparation(*bytes, mime_type_essence)) {
+                auto maybe_typeface = try_load_vector_font(*bytes, mime_type_essence);
+                if (maybe_typeface.is_error()) {
+                    if (loader->m_urls.is_empty()) {
+                        loader->font_did_load_or_fail(nullptr);
+                    } else {
+                        loader->m_fetch_controller = nullptr;
+                        loader->start_loading_next_url();
+                    }
+                    return;
+                }
+
+                loader->font_did_load_or_fail(maybe_typeface.release_value());
+                return;
+            }
+
+            auto loader_handle = GC::make_root(GC::Ref(*loader));
+            prepare_vector_font_data_off_thread(move(*bytes), [loader = move(loader_handle)](auto prepared_font_data) mutable {
+                if (prepared_font_data.is_error()) {
+                    // NB: If we have other sources available, try the next one.
+                    if (loader->m_urls.is_empty()) {
+                        loader->font_did_load_or_fail(nullptr);
+                    } else {
+                        loader->m_fetch_controller = nullptr;
+                        loader->start_loading_next_url();
+                    }
+                    return;
+                }
+
+                auto prepared = prepared_font_data.release_value();
+                auto maybe_typeface = try_load_vector_font(prepared.data, prepared.mime_type_essence);
+                if (maybe_typeface.is_error()) {
+                    if (loader->m_urls.is_empty()) {
+                        loader->font_did_load_or_fail(nullptr);
+                    } else {
+                        loader->m_fetch_controller = nullptr;
+                        loader->start_loading_next_url();
+                    }
+                    return;
+                }
+
+                loader->font_did_load_or_fail(maybe_typeface.release_value()); }, move(mime_type_essence));
         });
 
     if (!m_fetch_controller)
@@ -168,32 +203,16 @@ void FontLoader::font_did_load_or_fail(RefPtr<Gfx::Typeface const> typeface)
     m_fetch_controller = nullptr;
 }
 
-ErrorOr<NonnullRefPtr<Gfx::Typeface const>> FontLoader::try_load_font(Fetch::Infrastructure::Response const& response, ByteBuffer const& bytes)
+Optional<ByteString> FontLoader::try_load_font_mime_type_essence(Fetch::Infrastructure::Response const& response, ByteBuffer const& bytes)
 {
     // FIXME: This could maybe use the format() provided in @font-face as well, since often the mime type is just application/octet-stream and we have to try every format
     auto mime_type = Fetch::Infrastructure::extract_mime_type(response.header_list());
     if (!mime_type.has_value() || !mime_type->is_font()) {
         mime_type = MimeSniff::Resource::sniff(bytes, MimeSniff::SniffingConfiguration { .sniffing_context = MimeSniff::SniffingContext::Font });
     }
-    if (mime_type.has_value()) {
-        if (mime_type->essence() == "font/ttf"sv || mime_type->essence() == "application/x-font-ttf"sv || mime_type->essence() == "font/otf"sv) {
-            if (auto result = Gfx::Typeface::try_load_from_temporary_memory(bytes); !result.is_error()) {
-                return result;
-            }
-        }
-        if (mime_type->essence() == "font/woff"sv || mime_type->essence() == "application/font-woff"sv) {
-            if (auto result = WOFF::try_load_from_bytes(bytes); !result.is_error()) {
-                return result;
-            }
-        }
-        if (mime_type->essence() == "font/woff2"sv || mime_type->essence() == "application/font-woff2"sv) {
-            if (auto result = WOFF2::try_load_from_bytes(bytes); !result.is_error()) {
-                return result;
-            }
-        }
-    }
-
-    return Error::from_string_literal("Automatic format detection failed");
+    if (!mime_type.has_value())
+        return {};
+    return mime_type->essence().to_byte_string();
 }
 
 struct FontComputer::MatchingFontCandidate {

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGfx/FontCascadeList.h>
 #include <LibWeb/CSS/Fetch.h>
@@ -77,7 +78,7 @@ public:
 private:
     virtual void visit_edges(Visitor&) override;
 
-    ErrorOr<NonnullRefPtr<Gfx::Typeface const>> try_load_font(Fetch::Infrastructure::Response const&, ByteBuffer const&);
+    Optional<ByteString> try_load_font_mime_type_essence(Fetch::Infrastructure::Response const&, ByteBuffer const&);
 
     void font_did_load_or_fail(RefPtr<Gfx::Typeface const>);
 

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -10,8 +10,6 @@
 #include <LibGC/Heap.h>
 #include <LibGfx/Font/FontSupport.h>
 #include <LibGfx/Font/Typeface.h>
-#include <LibGfx/Font/WOFF/Loader.h>
-#include <LibGfx/Font/WOFF2/Loader.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/FontFacePrototype.h>
@@ -21,6 +19,7 @@
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/FontFaceSet.h>
+#include <LibWeb/CSS/FontLoading.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/ComputationContext.h>
@@ -78,32 +77,36 @@ static int compute_slope(StyleValue const& value)
     return StyleComputer::compute_font_style(value)->as_font_style().to_font_slope();
 }
 
-static NonnullRefPtr<Core::Promise<NonnullRefPtr<Gfx::Typeface const>>> load_vector_font(JS::Realm& realm, ByteBuffer const& data)
+static NonnullRefPtr<Core::Promise<NonnullRefPtr<Gfx::Typeface const>>> load_vector_font([[maybe_unused]] JS::Realm& realm, ByteBuffer data)
 {
     auto promise = Core::Promise<NonnullRefPtr<Gfx::Typeface const>>::construct();
 
-    // FIXME: 'Asynchronously' shouldn't mean 'later on the main thread'.
-    //        Can we defer this to a background thread?
-    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(realm.heap(), [&data, promise] {
-        // FIXME: This should be de-duplicated with StyleComputer::FontLoader::try_load_font
-        // We don't have the luxury of knowing the MIME type, so we have to try all formats.
-        auto ttf = Gfx::Typeface::try_load_from_externally_owned_memory(data);
-        if (!ttf.is_error()) {
-            promise->resolve(ttf.release_value());
+    if (!requires_off_thread_vector_font_preparation(data)) {
+        auto result = try_load_vector_font(data);
+        if (result.is_error()) {
+            promise->reject(result.release_error());
+            return promise;
+        }
+
+        promise->resolve(result.release_value());
+        return promise;
+    }
+
+    prepare_vector_font_data_off_thread(move(data), [promise](auto prepared_font_data) {
+        if (prepared_font_data.is_error()) {
+            promise->reject(prepared_font_data.release_error());
             return;
         }
-        auto woff = WOFF::try_load_from_bytes(data);
-        if (!woff.is_error()) {
-            promise->resolve(woff.release_value());
+
+        auto prepared = prepared_font_data.release_value();
+        auto result = try_load_vector_font(prepared.data, prepared.mime_type_essence);
+        if (result.is_error()) {
+            promise->reject(result.release_error());
             return;
         }
-        auto woff2 = WOFF2::try_load_from_bytes(data);
-        if (!woff2.is_error()) {
-            promise->resolve(woff2.release_value());
-            return;
-        }
-        promise->reject(Error::from_string_literal("Automatic format detection failed"));
-    }));
+
+        promise->resolve(result.release_value());
+    });
 
     return promise;
 }
@@ -200,7 +203,7 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
 
         // 3. Asynchronously, attempt to parse the data in it as a font.
         //    When this is completed, successfully or not, queue a task to run the following steps synchronously:
-        font_face->m_font_load_promise = load_vector_font(realm, font_face->m_binary_data);
+        font_face->m_font_load_promise = load_vector_font(realm, move(font_face->m_binary_data));
 
         font_face->m_font_load_promise->when_resolved([font = GC::make_root(font_face)](auto const& vector_font) -> ErrorOr<void> {
             HTML::queue_global_task(HTML::Task::Source::FontLoading, HTML::relevant_global_object(*font), GC::create_function(font->heap(), [font = GC::Ref(*font), vector_font] {

--- a/Libraries/LibWeb/CSS/FontLoading.cpp
+++ b/Libraries/LibWeb/CSS/FontLoading.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Endian.h>
+#include <LibCore/EventLoop.h>
+#include <LibGfx/Font/WOFF/Loader.h>
+#include <LibGfx/Font/WOFF2/Loader.h>
+#include <LibThreading/ThreadPool.h>
+#include <LibWeb/CSS/FontLoading.h>
+
+namespace Web::CSS {
+
+static constexpr u32 woff2_signature = 0x774F4632;
+
+bool requires_off_thread_vector_font_preparation(ByteBuffer const& data, Optional<ByteString> const& mime_type_essence)
+{
+    if (mime_type_essence == "font/woff2"sv || mime_type_essence == "application/font-woff2"sv)
+        return true;
+    if (data.size() < sizeof(u32))
+        return false;
+    auto signature = *bit_cast<BigEndian<u32> const*>(data.data());
+    return signature == woff2_signature;
+}
+
+static ErrorOr<PreparedVectorFontData> prepare_vector_font_data(ByteBuffer data, Optional<ByteString> mime_type_essence)
+{
+    if (!requires_off_thread_vector_font_preparation(data, mime_type_essence))
+        return PreparedVectorFontData { .data = move(data), .mime_type_essence = move(mime_type_essence) };
+
+    return PreparedVectorFontData {
+        .data = TRY(WOFF2::convert_to_ttf(data)),
+        .mime_type_essence = ByteString { "font/ttf"sv }
+    };
+}
+
+ErrorOr<NonnullRefPtr<Gfx::Typeface const>> try_load_vector_font(ByteBuffer const& data, Optional<ByteString> const& mime_type_essence)
+{
+    auto try_ttf = [&]() -> ErrorOr<NonnullRefPtr<Gfx::Typeface const>> {
+        return Gfx::Typeface::try_load_from_temporary_memory(data);
+    };
+    auto try_woff = [&]() -> ErrorOr<NonnullRefPtr<Gfx::Typeface const>> {
+        return WOFF::try_load_from_bytes(data);
+    };
+    auto try_woff2 = [&]() -> ErrorOr<NonnullRefPtr<Gfx::Typeface const>> {
+        return WOFF2::try_load_from_bytes(data);
+    };
+
+    if (mime_type_essence.has_value()) {
+        if (*mime_type_essence == "font/ttf"sv || *mime_type_essence == "application/x-font-ttf"sv || *mime_type_essence == "font/otf"sv)
+            return try_ttf();
+        if (*mime_type_essence == "font/woff"sv || *mime_type_essence == "application/font-woff"sv)
+            return try_woff();
+        if (*mime_type_essence == "font/woff2"sv || *mime_type_essence == "application/font-woff2"sv)
+            return try_woff2();
+    } else {
+        if (auto result = try_ttf(); !result.is_error())
+            return result.release_value();
+        if (auto result = try_woff(); !result.is_error())
+            return result.release_value();
+        if (auto result = try_woff2(); !result.is_error())
+            return result.release_value();
+    }
+
+    return Error::from_string_literal("Automatic format detection failed");
+}
+
+void prepare_vector_font_data_off_thread(ByteBuffer data, Function<void(ErrorOr<PreparedVectorFontData>)>&& on_complete, Optional<ByteString> mime_type_essence)
+{
+    // Keep the callback on the origin thread so any GC roots it captures are
+    // also destroyed there.
+    auto* callback = new Function<void(ErrorOr<PreparedVectorFontData>)>(move(on_complete));
+    auto event_loop_weak = Core::EventLoop::current_weak();
+
+    Threading::ThreadPool::the().submit(
+        [data = move(data), callback, event_loop_weak = move(event_loop_weak), mime_type_essence = move(mime_type_essence)]() mutable {
+            auto result = prepare_vector_font_data(move(data), move(mime_type_essence));
+
+            auto origin = event_loop_weak->take();
+            if (!origin)
+                return;
+
+            origin->deferred_invoke([callback, result = move(result)]() mutable {
+                (*callback)(move(result));
+                delete callback;
+            });
+        });
+}
+
+}

--- a/Libraries/LibWeb/CSS/FontLoading.h
+++ b/Libraries/LibWeb/CSS/FontLoading.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <LibGfx/Font/Typeface.h>
+
+namespace Web::CSS {
+
+struct PreparedVectorFontData {
+    ByteBuffer data;
+    Optional<ByteString> mime_type_essence;
+};
+
+bool requires_off_thread_vector_font_preparation(ByteBuffer const&, Optional<ByteString> const& mime_type_essence = {});
+ErrorOr<NonnullRefPtr<Gfx::Typeface const>> try_load_vector_font(ByteBuffer const&, Optional<ByteString> const& mime_type_essence = {});
+void prepare_vector_font_data_off_thread(ByteBuffer, Function<void(ErrorOr<PreparedVectorFontData>)>&&, Optional<ByteString> mime_type_essence = {});
+
+}


### PR DESCRIPTION
Add an off-thread preparation step for downloaded vector fonts so WOFF2 resources can be decompressed before LibWeb tries to create a typeface from them. This avoids doing the conversion work on the main thread during @font-face loading.

Expose raw WOFF2-to-TTF conversion from LibGfx's WOFF2 loader and use that from the new preparation path. Keeping the libwoff2 integration in LibGfx preserves the layering between LibWeb and the third-party decoder while still letting LibWeb schedule the work off-thread.

This avoids blocking the main thread for ~170ms when opening GMail on my Linux machine. :^)