### PR TITLE
LibIPC: Dont VERIFY when encoding placeholder TransportHandles

### DIFF
--- a/Libraries/LibIPC/TransportHandle.cpp
+++ b/Libraries/LibIPC/TransportHandle.cpp
@@ -33,8 +33,11 @@ ErrorOr<NonnullOwnPtr<Transport>> TransportHandle::create_transport() const
 template<>
 ErrorOr<void> encode(Encoder& encoder, TransportHandle const& handle)
 {
-    VERIFY(MACH_PORT_VALID(handle.m_receive_right.port()));
-    VERIFY(MACH_PORT_VALID(handle.m_send_right.port()));
+    mach_port_t send_port = handle.m_send_right.port();
+    mach_port_t receive_port = handle.m_receive_right.port();
+    if (send_port == MACH_PORT_NULL || send_port == MACH_PORT_DEAD || receive_port == MACH_PORT_NULL || receive_port == MACH_PORT_DEAD)
+        return Error::from_string_literal("TransportHandle::encode: Invalid Mach port(s)");
+
     TRY(encoder.append_attachment(Attachment::from_mach_port(move(handle.m_receive_right), Core::MachPort::MessageRight::MoveReceive)));
     TRY(encoder.append_attachment(Attachment::from_mach_port(move(handle.m_send_right), Core::MachPort::MessageRight::MoveSend)));
     return {};


### PR DESCRIPTION
Empty transport handles can be generated in a few places in Ladybird sources, notably in WebContentClient::request_worker_agent when view_for_page_id finds nothing.

If those handles reach encode, a VERIFY is triggered in the broker process. A page lookup failure should not be fatal to the browser, so I'll boldly assert it is better to return an error here.

Suggestions are welcome as I did not spend much time chasing for upstream root causes. The failure was observed during large runs of origin and IndexedDB heavy wpt tests in test-web.