### PR TITLE
LibWeb: Respect image response MIME type over .svg URL suffix

### DIFF
--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -148,7 +148,8 @@ void SharedResourceRequest::handle_successful_fetch(URL::URL const& url_string, 
     // AD-HOC: At this point, things gets very ad-hoc.
     // FIXME: Bring this closer to spec.
 
-    bool const is_svg_image = mime_type == "image/svg+xml"sv || url_string.basename().ends_with(".svg"sv);
+    bool const is_svg_image = mime_type == "image/svg+xml"sv
+        || (mime_type.is_empty() && url_string.basename().ends_with(".svg"sv));
 
     if (is_svg_image) {
         auto result = SVG::SVGDecodedImageData::create(m_document->realm(), m_page, url_string, data);

--- a/Tests/LibWeb/Text/expected/HTML/image-webp-served-from-svg-url.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-webp-served-from-svg-url.txt
@@ -1,0 +1,2 @@
+naturalWidth: 1
+naturalHeight: 1

--- a/Tests/LibWeb/Text/input/HTML/image-webp-served-from-svg-url.html
+++ b/Tests/LibWeb/Text/input/HTML/image-webp-served-from-svg-url.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const server = httpTestServer();
+        const imageUrl = await server.createEcho("GET", "/image-webp-served-from-svg-url.svg", {
+            status: 200,
+            headers: {
+                "Content-Type": "image/webp",
+                "X-Content-Type-Options": "nosniff",
+            },
+            body_encoding: "base64",
+            // 1x1 webp
+            body: "UklGRhwAAABXRUJQVlA4TA8AAAAvAAAAAAcQ/Y/+ByKi/wEA",
+        });
+
+        const image = new Image();
+        image.onload = () => {
+            println(`naturalWidth: ${image.naturalWidth}`);
+            println(`naturalHeight: ${image.naturalHeight}`);
+            done();
+        };
+        image.onerror = () => {
+            println("FAIL: image failed to load");
+            done();
+        };
+        image.src = imageUrl;
+    });
+</script>


### PR DESCRIPTION
SharedResourceRequest was treating any URL ending in .svg as SVG, even when the response Content-Type was some other format (like image/webp). This could result in transformed CDN image URLs to fail decoding.

Only use the .svg URL suffix fallback when no MIME type was provided.

I saw this on a live site where some image icons were not rendering, reduced it to this, but unfortunately we seem to have another issue causing it to still not load so I don't have a nice before and after.