### PR TITLE
LibWeb: Clamp limited grid item contributions by fixed max tracks

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2461,6 +2461,13 @@ int GridItem::gap_adjusted_column() const
     return column.value() * 2;
 }
 
+bool GridFormattingContext::should_treat_grid_container_maximum_size_as_none(GridDimension dimension) const
+{
+    if (dimension == GridDimension::Column)
+        return should_treat_max_width_as_none(grid_container(), m_available_space->width);
+    return should_treat_max_height_as_none(grid_container(), m_available_space->height);
+}
+
 CSSPixels GridFormattingContext::calculate_grid_container_maximum_size(GridDimension dimension) const
 {
     auto const& computed_values = grid_container().computed_values();
@@ -2569,6 +2576,53 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
     return min(result, maximum_size);
 }
 
+Optional<CSSPixels> GridFormattingContext::calculate_fixed_max_track_size_limit(GridItem const& item, GridDimension dimension) const
+{
+    // https://drafts.csswg.org/css-grid-2/#algo-spanning-items
+    // For an item spanning multiple tracks, the upper limit used to calculate its limited min-/max-content
+    // contribution is the sum of the fixed max track sizing functions of any tracks it spans, and is applied
+    // if it only spans such tracks.
+    //
+    // https://drafts.csswg.org/css-grid-2#algo-terms
+    // In all cases, treat auto and fit-content() as max-content, except where specified otherwise for fit-content().
+    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+
+    CSSPixels result = 0;
+    bool saw_track = false;
+    bool has_limit = true;
+    for_each_spanned_track_by_item(item, dimension, [&](GridTrack const& track) {
+        if (!has_limit)
+            return;
+
+        saw_track = true;
+        auto const& max_track_sizing_function = track.max_track_sizing_function;
+
+        if (max_track_sizing_function.is_fixed(available_size)) {
+            auto const& max_track_size = max_track_sizing_function.css_size();
+            result += max_track_size.to_px(grid_container(), available_size.to_px_or_zero());
+            return;
+        }
+
+        if (max_track_sizing_function.is_fit_content()) {
+            auto const& max_track_size = max_track_sizing_function.css_size();
+            auto const& fit_content_available_space = max_track_size.fit_content_available_space();
+            if (fit_content_available_space.has_value()
+                && (!fit_content_available_space->contains_percentage() || available_size.is_definite())) {
+                result += max_track_size.to_px(grid_container(), available_size.to_px_or_zero());
+                return;
+            }
+        }
+
+        has_limit = false;
+    });
+
+    if (!has_limit)
+        return {};
+    if (!saw_track)
+        return {};
+    return result;
+}
+
 CSSPixels GridFormattingContext::calculate_limited_min_content_contribution(GridItem const& item, GridDimension dimension) const
 {
     // The limited min-content contribution of an item is its min-content contribution,
@@ -2579,19 +2633,10 @@ CSSPixels GridFormattingContext::calculate_limited_min_content_contribution(Grid
     if (min_content_contribution < minimum_contribution)
         return minimum_contribution;
 
-    auto should_treat_max_size_as_none = [&]() {
-        switch (dimension) {
-        case GridDimension::Row:
-            return should_treat_max_height_as_none(grid_container(), m_available_space->height);
-        case GridDimension::Column:
-            return should_treat_max_width_as_none(grid_container(), m_available_space->width);
-        default:
-            VERIFY_NOT_REACHED();
-        }
-    }();
+    if (auto fixed_max_track_size_limit = calculate_fixed_max_track_size_limit(item, dimension); fixed_max_track_size_limit.has_value())
+        return max(min(min_content_contribution, fixed_max_track_size_limit.value()), minimum_contribution);
 
-    // FIXME: limit by max track sizing function instead of grid container maximum size
-    if (!should_treat_max_size_as_none) {
+    if (!should_treat_grid_container_maximum_size_as_none(dimension)) {
         auto max_size = calculate_grid_container_maximum_size(dimension);
         if (min_content_contribution > max_size)
             return max_size;
@@ -2610,12 +2655,13 @@ CSSPixels GridFormattingContext::calculate_limited_max_content_contribution(Grid
     if (max_content_contribution < minimum_contribution)
         return minimum_contribution;
 
-    // FIXME: limit by max track sizing function instead of grid container maximum size
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
-    if (!should_treat_max_width_as_none(grid_container(), available_size)) {
-        auto max_width = calculate_grid_container_maximum_size(dimension);
-        if (max_content_contribution > max_width)
-            return max_width;
+    if (auto fixed_max_track_size_limit = calculate_fixed_max_track_size_limit(item, dimension); fixed_max_track_size_limit.has_value())
+        return max(min(max_content_contribution, fixed_max_track_size_limit.value()), minimum_contribution);
+
+    if (!should_treat_grid_container_maximum_size_as_none(dimension)) {
+        auto max_size = calculate_grid_container_maximum_size(dimension);
+        if (max_content_contribution > max_size)
+            return max_size;
     }
 
     return max_content_contribution;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -362,6 +362,7 @@ private:
     void stretch_auto_tracks(GridDimension);
     void run_track_sizing(GridDimension);
 
+    bool should_treat_grid_container_maximum_size_as_none(GridDimension) const;
     CSSPixels calculate_grid_container_maximum_size(GridDimension) const;
 
     CSSPixels calculate_min_content_size(GridItem const&, GridDimension) const;
@@ -370,6 +371,7 @@ private:
     CSSPixels calculate_min_content_contribution(GridItem const&, GridDimension) const;
     CSSPixels calculate_max_content_contribution(GridItem const&, GridDimension) const;
 
+    Optional<CSSPixels> calculate_fixed_max_track_size_limit(GridItem const&, GridDimension) const;
     CSSPixels calculate_limited_min_content_contribution(GridItem const&, GridDimension) const;
     CSSPixels calculate_limited_max_content_contribution(GridItem const&, GridDimension) const;
 

--- a/Tests/LibWeb/Layout/expected/grid/nested-grid-limited-contribution-fit-content-row.txt
+++ b/Tests/LibWeb/Layout/expected/grid/nested-grid-limited-contribution-fit-content-row.txt
@@ -1,0 +1,41 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 160 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 160 0+0+0] children: not-inline
+      Box <div.outer> at [0,0] [0+0+0 800 0+0+0] [0+0+0 160 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.inner> at [300,0] [0+0+0 200 0+0+0] [0+0+0 160 0+0+0] [GFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.span> at [300,0] [0+0+0 95 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.top> at [405,0] [0+0+0 95 0+0+0] [0+0+0 70 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.middle> at [405,80] [0+0+0 95 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.feed> at [300,110] [0+0+0 200 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+            BlockContainer <div> at [300,110] [0+0+0 200 0+0+0] [0+0+0 300 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,160] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x160]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x160]
+      PaintableBox (Box<DIV>.outer) [0,0 800x160]
+        PaintableBox (Box<DIV>.inner) [300,0 200x160]
+          PaintableWithLines (BlockContainer<DIV>.span) [300,0 95x100]
+          PaintableWithLines (BlockContainer<DIV>.top) [405,0 95x70]
+          PaintableWithLines (BlockContainer<DIV>.middle) [405,80 95x20]
+          PaintableWithLines (BlockContainer<DIV>.feed) [300,110 200x50] overflow: [300,110 200x300]
+            PaintableWithLines (BlockContainer<DIV>) [300,110 200x300]
+      PaintableWithLines (BlockContainer(anonymous)) [0,160 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x160] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/nested-grid-limited-contribution-fit-content-row.html
+++ b/Tests/LibWeb/Layout/input/grid/nested-grid-limited-contribution-fit-content-row.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.outer {
+    display: grid;
+    grid-template-columns: 1fr minmax(auto, 200px) 1fr;
+    background: silver;
+}
+.inner {
+    display: grid;
+    gap: 10px;
+    grid-column: 2;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: min-content 1fr fit-content(0);
+    background: white;
+}
+.span {
+    grid-column: 1;
+    grid-row: 1 / 3;
+    min-height: 100px;
+    background: pink;
+}
+.top {
+    grid-column: 2;
+    grid-row: 1;
+    min-height: 70px;
+    background: orange;
+}
+.middle {
+    grid-column: 2;
+    grid-row: 2;
+    min-height: 20px;
+    background: green;
+}
+.feed {
+    grid-column: 1 / 3;
+    grid-row: 3;
+    min-height: 50px;
+    overflow: hidden;
+    background: red;
+}
+.feed > div {
+    height: 300px;
+    background: blue;
+}
+</style>
+<div class="outer">
+    <div class="inner">
+        <div class="span"></div>
+        <div class="top"></div>
+        <div class="middle"></div>
+        <div class="feed"><div></div></div>
+    </div>
+</div>


### PR DESCRIPTION
When resolving grid track sizes, limited min/max-content contributions should be capped by fixed max track sizing functions, including the argument to fit-content(). We were instead falling back to the grid container maximum size, which allowed a grid item with overflowing contents in a fit-content(0) row to inflate the intrinsic block size of a nested grid.

That bogus intrinsic height could then be used for the grid's second row sizing pass, causing unrelated flexible rows to absorb the extra space.

I am not super sure about the correctness of this change, but it comes from a (very annoying to do) reduction from lichess.org main screen.

Sidenote: We have some sort of bug where the icons for these buttons don't show up on initial page load, but do after the mouse is hovered over them.

Before:

<img width="2034" height="1279" alt="image" src="https://github.com/user-attachments/assets/60023994-f074-4d9a-90fc-8f5f22edf3ef" />

After:

<img width="2034" height="1279" alt="image" src="https://github.com/user-attachments/assets/8890cd66-cede-4a38-8909-a401834e7b58" />
