### PR TITLE
LibWeb: Cache parsed selectors in Element.matches() and .closest()

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8110,20 +8110,48 @@ void Document::exit_pointer_lock()
     dbgln("FIXME: exit_pointer_lock()");
 }
 
-Optional<CSS::SelectorList> const* Document::cached_query_selector_result(String const& selector_text) const
+static bool contains_named_namespace(CSS::SelectorList const& selectors)
 {
-    auto it = m_selector_query_cache.find(selector_text);
-    if (it == m_selector_query_cache.end())
-        return nullptr;
-    return &it->value;
+    for (auto const& selector : selectors) {
+        for (auto const& compound_selector : selector->compound_selectors()) {
+            for (auto const& simple_selector : compound_selector.simple_selectors) {
+                if (simple_selector.value.has<CSS::Selector::SimpleSelector::QualifiedName>()) {
+                    if (simple_selector.qualified_name().namespace_type == CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Named)
+                        return true;
+                }
+
+                if (simple_selector.value.has<CSS::Selector::SimpleSelector::PseudoClassSelector>()) {
+                    if (contains_named_namespace(simple_selector.pseudo_class().argument_selector_list))
+                        return true;
+                }
+            }
+        }
+    }
+    return false;
 }
 
-void Document::cache_query_selector_result(String selector_text, Optional<CSS::SelectorList> result)
+Optional<CSS::SelectorList> const& Document::parse_or_cache_selector_list(StringView selector_text) const
 {
-    if (m_selector_query_cache.size() >= max_selector_query_cache_size)
+    static constexpr size_t MAX_SELECTOR_QUERY_CACHE_SIZE = 512;
+
+    auto selector_text_string = MUST(String::from_utf8(selector_text));
+
+    if (auto it = m_selector_query_cache.find(selector_text_string); it != m_selector_query_cache.end())
+        return it->value;
+
+    auto maybe_selectors = parse_selector(CSS::Parser::ParsingParams { *this }, selector_text);
+
+    // "Note: Support for namespaces within selectors is not planned and will not be added."
+    if (maybe_selectors.has_value() && contains_named_namespace(maybe_selectors.value()))
+        maybe_selectors.clear();
+
+    if (m_selector_query_cache.size() >= MAX_SELECTOR_QUERY_CACHE_SIZE)
         m_selector_query_cache.remove(m_selector_query_cache.begin());
 
-    m_selector_query_cache.set(move(selector_text), move(result));
+    m_selector_query_cache.set(selector_text_string, move(maybe_selectors));
+    auto it = m_selector_query_cache.find(selector_text_string);
+    VERIFY(it != m_selector_query_cache.end());
+    return it->value;
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1049,8 +1049,7 @@ public:
 
     void exit_pointer_lock();
 
-    Optional<CSS::SelectorList> const* cached_query_selector_result(String const& selector_text) const;
-    void cache_query_selector_result(String selector_text, Optional<CSS::SelectorList>);
+    Optional<CSS::SelectorList> const& parse_or_cache_selector_list(StringView) const;
 
     GC::Ptr<HTML::CustomElementRegistry> custom_element_registry() const;
     void set_custom_element_registry(GC::Ptr<HTML::CustomElementRegistry> custom_element_registry) { m_custom_element_registry = custom_element_registry; }
@@ -1491,9 +1490,8 @@ private:
     // https://drafts.csswg.org/css-values-5/#random-caching
     HashMap<CSS::RandomCachingKey, double> m_element_shared_css_random_base_value_cache;
 
-    // Cache of parsed selector lists for querySelectorAll/querySelector.
-    static constexpr size_t max_selector_query_cache_size = 256;
-    HashMap<String, Optional<CSS::SelectorList>> m_selector_query_cache;
+    // Cache of parsed selector lists for querySelectorAll/querySelector/matches/closest.
+    mutable HashMap<String, Optional<CSS::SelectorList>> m_selector_query_cache;
 
     // https://fullscreen.spec.whatwg.org/#list-of-pending-fullscreen-events
     Vector<PendingFullscreenEvent> m_pending_fullscreen_events;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1246,15 +1246,14 @@ GC::Ptr<ShadowRoot> Element::shadow_root_for_bindings() const
 WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 {
     // 1. Let s be the result of parse a selector from selectors.
-    auto maybe_selectors = parse_selector(CSS::Parser::ParsingParams(document()), selectors);
+    auto const& maybe_selectors = document().parse_or_cache_selector_list(selectors);
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
         return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_utf16);
 
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
-    auto sel = maybe_selectors.value();
-    for (auto& s : sel) {
+    for (auto const& s : maybe_selectors.value()) {
         SelectorEngine::MatchContext context;
         if (SelectorEngine::matches(s, *this, nullptr, context, static_cast<ParentNode const*>(this)))
             return true;
@@ -1266,7 +1265,7 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) const
 {
     // 1. Let s be the result of parse a selector from selectors.
-    auto maybe_selectors = parse_selector(CSS::Parser::ParsingParams(document()), selectors);
+    auto const& maybe_selectors = document().parse_or_cache_selector_list(selectors);
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
@@ -1282,7 +1281,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
         return false;
     };
 
-    auto const selector_list = maybe_selectors.release_value();
+    auto const& selector_list = maybe_selectors.value();
 
     // 3. Let elements be this’s inclusive ancestors that are elements, in reverse tree order.
     for (auto* element = this; element; element = element->parent_element()) {

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -23,26 +23,6 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(ParentNode);
 
-static bool contains_named_namespace(CSS::SelectorList const& selectors)
-{
-    for (auto const& selector : selectors) {
-        for (auto const& compound_selector : selector->compound_selectors()) {
-            for (auto const& simple_selector : compound_selector.simple_selectors) {
-                if (simple_selector.value.has<CSS::Selector::SimpleSelector::QualifiedName>()) {
-                    if (simple_selector.qualified_name().namespace_type == CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Named)
-                        return true;
-                }
-
-                if (simple_selector.value.has<CSS::Selector::SimpleSelector::PseudoClassSelector>()) {
-                    if (contains_named_namespace(simple_selector.pseudo_class().argument_selector_list))
-                        return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
 enum class ReturnMatches {
     First,
     All,
@@ -52,37 +32,15 @@ static WebIDL::ExceptionOr<Variant<GC::Ptr<Element>, GC::Ref<NodeList>>> scope_m
 {
     // To scope-match a selectors string selectors against a node, run these steps:
     auto& document = node.document();
-    auto selector_text_string = MUST(String::from_utf8(selector_text));
 
-    CSS::SelectorList const* selectors_ptr = nullptr;
+    // 1. Let s be the result of parse a selector selectors.
+    auto const& maybe_selectors = document.parse_or_cache_selector_list(selector_text);
 
-    // Check the document’s parsed selector cache first.
-    if (auto const* cached = document.cached_query_selector_result(selector_text_string)) {
-        // 2. If s is failure, then throw a "SyntaxError" DOMException.
-        if (!cached->has_value())
-            return WebIDL::SyntaxError::create(node.realm(), "Failed to parse selector"_utf16);
-        selectors_ptr = &cached->value();
-    } else {
-        // 1. Let s be the result of parse a selector selectors.
-        auto maybe_selectors = parse_selector(CSS::Parser::ParsingParams { document }, selector_text);
+    // 2. If s is failure, then throw a "SyntaxError" DOMException.
+    if (!maybe_selectors.has_value())
+        return WebIDL::SyntaxError::create(node.realm(), "Failed to parse selector"_utf16);
 
-        // "Note: Support for namespaces within selectors is not planned and will not be added."
-        if (maybe_selectors.has_value() && contains_named_namespace(maybe_selectors.value()))
-            maybe_selectors.clear();
-
-        document.cache_query_selector_result(selector_text_string, move(maybe_selectors));
-
-        auto const* cached_after_insert = document.cached_query_selector_result(selector_text_string);
-        VERIFY(cached_after_insert);
-
-        // 2. If s is failure, then throw a "SyntaxError" DOMException.
-        if (!cached_after_insert->has_value())
-            return WebIDL::SyntaxError::create(node.realm(), "Failed to parse selector"_utf16);
-
-        selectors_ptr = &cached_after_insert->value();
-    }
-
-    auto const& selectors = *selectors_ptr;
+    auto const& selectors = maybe_selectors.value();
 
     // 3. Return the result of match a selector against a tree with s and node’s root using scoping root node.
     GC::Ptr<Element> single_result;


### PR DESCRIPTION
`Element::matches()` and `Element::closest()` were re-parsing the selector string on every call. The document already maintains a parsed-selector cache for `querySelector`/`querySelectorAll`.

This patch folds that cache's lookup, parse, namespace filtering and insertion behind a `Document::parse_or_cache_selector_list(string)` and calls it from all four entry points. We also bump the cache's limit to get more hits.

Saves 100ms of main thread time when loading the "insights" view on our GitHub repo on my Linux machine. :^)