### PR TITLE
LibWebView: Do not diddle ProcessManager state from MachBootstrapListener thread

### DIFF
--- a/Libraries/LibMain/CMakeLists.txt
+++ b/Libraries/LibMain/CMakeLists.txt
@@ -4,3 +4,4 @@ set(SOURCES
 
 ladybird_lib(LibMain main TYPE STATIC)
 target_link_libraries(LibMain PRIVATE LibThreading)
+target_link_libraries(LibMain INTERFACE "$<LINK_ONLY:LibThreading>")

--- a/Libraries/LibMain/CMakeLists.txt
+++ b/Libraries/LibMain/CMakeLists.txt
@@ -3,3 +3,4 @@ set(SOURCES
 )
 
 ladybird_lib(LibMain main TYPE STATIC)
+target_link_libraries(LibMain PRIVATE LibThreading)

--- a/Libraries/LibMain/Main.cpp
+++ b/Libraries/LibMain/Main.cpp
@@ -8,6 +8,7 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibMain/Main.h>
+#include <LibThreading/Thread.h>
 #include <string.h>
 #include <time.h>
 #if defined(AK_OS_WINDOWS)
@@ -33,6 +34,7 @@ void set_return_code_for_errors(int code)
 int main(int argc, char** argv)
 {
     tzset();
+    Threading::set_main_thread();
 
 #if defined(AK_OS_WINDOWS)
     windows_init();

--- a/Libraries/LibThreading/Thread.cpp
+++ b/Libraries/LibThreading/Thread.cpp
@@ -8,6 +8,8 @@
 
 namespace Threading {
 
+static Optional<pthread_t> s_main_thread_tid;
+
 Thread::Thread(Function<intptr_t()> action, StringView thread_name)
     : m_action(move(action))
     , m_thread_name(thread_name)
@@ -140,6 +142,21 @@ void Thread::detach()
 
     int rc = pthread_detach(m_tid);
     VERIFY(rc == 0);
+}
+
+bool is_main_thread()
+{
+    if (!s_main_thread_tid.has_value()) {
+        dbgln("Thread::set_main_thread() must be called before Thread::is_main_thread()");
+        VERIFY_NOT_REACHED();
+    }
+    return pthread_equal(pthread_self(), *s_main_thread_tid);
+}
+
+void set_main_thread()
+{
+    VERIFY(!s_main_thread_tid.has_value());
+    s_main_thread_tid = pthread_self();
 }
 
 }

--- a/Libraries/LibThreading/Thread.h
+++ b/Libraries/LibThreading/Thread.h
@@ -20,6 +20,9 @@ namespace Threading {
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(intptr_t, ThreadError);
 
+bool is_main_thread();
+void set_main_thread();
+
 // States of userspace threads are simplified over actual kernel states (and possibly POSIX states).
 // There are only a couple of well-defined transitions between these states, and any attempt to call a function in a state where this is not allowed will crash the program.
 enum class ThreadState : u8 {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -105,12 +105,14 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         warnln("Unable to increase open file limit: {}", result.error());
 #endif
 
+    m_event_loop = create_platform_event_loop();
+
 #if defined(AK_OS_MACOS)
     m_mach_port_server = make<IPC::MachBootstrapListener>(mach_server_name_for_process("Ladybird"sv, Core::System::getpid()));
     set_mach_server_name(m_mach_port_server->server_port_name());
 
     m_mach_port_server->on_bootstrap_request = [this](IPC::MachBootstrapListener::BootstrapRequest request) {
-        set_process_mach_port(request.pid, move(request.task_port));
+        m_event_loop->deferred_invoke([this, pid = request.pid, task_port = move(request.task_port)]() mutable { set_process_mach_port(pid, move(task_port)); });
         auto result = MUST(m_transport_bootstrap_server.handle_bootstrap_request(request.pid, move(request.reply_port)));
         result.visit(
             [](IPC::TransportBootstrapMachServer::ChildTransportHandled) {
@@ -382,7 +384,6 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 
     initialize_actions();
 
-    m_event_loop = create_platform_event_loop();
     TRY(launch_services());
 
     return {};

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -77,7 +77,7 @@ compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIClient.ipc ${CMAKE_B
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebUIServerEndpoint.h)
 
 ladybird_lib(LibWebView webview EXPLICIT_SYMBOL_EXPORT)
-target_link_libraries(LibWebView PRIVATE LibCore LibDatabase LibDevTools LibFileSystem LibGfx LibHTTP LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSyntax LibTextCodec)
+target_link_libraries(LibWebView PRIVATE LibCore LibDatabase LibDevTools LibFileSystem LibGfx LibHTTP LibImageDecoderClient LibIPC LibRequests LibJS LibThreading LibWeb LibUnicode LibURL LibSyntax LibTextCodec)
 
 # Third-party
 if (HAS_FONTCONFIG)

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
+#include <LibThreading/Thread.h>
 #include <LibWebView/ProcessManager.h>
 
 namespace WebView {
@@ -67,13 +68,13 @@ ProcessManager::ProcessManager()
 
 Optional<Process&> ProcessManager::find_process(pid_t pid)
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     return m_processes.get(pid);
 }
 
 void ProcessManager::add_process(WebView::Process&& process)
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     auto pid = process.pid();
     on_process_added(process);
     auto result = m_processes.set(pid, move(process));
@@ -84,7 +85,7 @@ void ProcessManager::add_process(WebView::Process&& process)
 
 void ProcessManager::for_each_process(Function<void(Process&)> callback)
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     for (auto& entry : m_processes)
         callback(entry.value);
 }
@@ -92,7 +93,7 @@ void ProcessManager::for_each_process(Function<void(Process&)> callback)
 #if defined(AK_OS_MACH)
 void ProcessManager::set_process_mach_port(pid_t pid, Core::MachPort&& port)
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     for (auto const& info : m_statistics.processes) {
         if (info->pid == pid) {
             info->child_task_port = move(port);
@@ -104,7 +105,7 @@ void ProcessManager::set_process_mach_port(pid_t pid, Core::MachPort&& port)
 
 Optional<Process> ProcessManager::remove_process(pid_t pid)
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     m_statistics.processes.remove_first_matching([&](auto const& info) {
         return (info->pid == pid);
     });
@@ -113,13 +114,13 @@ Optional<Process> ProcessManager::remove_process(pid_t pid)
 
 void ProcessManager::update_all_process_statistics()
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     (void)update_process_statistics(m_statistics);
 }
 
 JsonValue ProcessManager::serialize_json()
 {
-    verify_event_loop();
+    VERIFY(Threading::is_main_thread());
     JsonArray serialized;
 
     m_statistics.for_each_process([&](auto const& process) {
@@ -141,12 +142,6 @@ JsonValue ProcessManager::serialize_json()
     });
 
     return serialized;
-}
-
-void ProcessManager::verify_event_loop() const
-{
-    if (Core::EventLoop::is_running())
-        VERIFY(&Core::EventLoop::current() == m_creation_event_loop);
 }
 
 }

--- a/Libraries/LibWebView/ProcessManager.h
+++ b/Libraries/LibWebView/ProcessManager.h
@@ -9,7 +9,7 @@
 #include <AK/Function.h>
 #include <AK/JsonValue.h>
 #include <AK/Types.h>
-#include <LibCore/EventLoop.h>
+#include <LibCore/Forward.h>
 #include <LibCore/Platform/ProcessStatistics.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Process.h>
@@ -43,12 +43,9 @@ public:
     Function<void(Process&&)> on_process_exited;
 
 private:
-    void verify_event_loop() const;
-
     Core::Platform::ProcessStatistics m_statistics;
     HashMap<pid_t, Process> m_processes;
     ProcessMonitor m_process_monitor;
-    Core::EventLoop* m_creation_event_loop { &Core::EventLoop::current() };
 };
 
 }


### PR DESCRIPTION
The MachBootstrapListener thread was sneaking through the verify_event_loop guard in ProcessManager by virtue of having no event loop.

- First, in Application::initialize we move event loop creation above the bootstrap lambda (which calls ProcessManager::set_process_mach_port)
- Then, we issue that port assignment using deferred_invoke so it actually happens on the main thread.
- Finally, we strengthen the guard using VERIFY(Threading::is_main_thread()) to protect ProcessManager's internal state.

I saw evidence of this race condition in set_process_mach_port during a wpt run. It culminated in Ladybird attempting to access a previously moved NonnullOwnPtr<ProcessInfo>