### PR TITLE
LibGfx: Remove unused globals

### DIFF
--- a/Libraries/LibGfx/SystemTheme.cpp
+++ b/Libraries/LibGfx/SystemTheme.cpp
@@ -14,8 +14,6 @@
 
 namespace Gfx {
 
-static SystemTheme dummy_theme;
-static SystemTheme const* theme_page = &dummy_theme;
 static Core::AnonymousBuffer theme_buffer;
 
 Core::AnonymousBuffer& current_system_theme_buffer()
@@ -27,7 +25,6 @@ Core::AnonymousBuffer& current_system_theme_buffer()
 void set_system_theme(Core::AnonymousBuffer buffer)
 {
     theme_buffer = move(buffer);
-    theme_page = theme_buffer.data<SystemTheme>();
 }
 
 ErrorOr<Core::AnonymousBuffer> load_system_theme(Core::ConfigFile const& file, Optional<ByteString> const& color_scheme)

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -100,7 +100,7 @@ static RefPtr<Line::Editor> s_editor;
 #endif
 static String s_history_path = String {};
 [[maybe_unused]] static int s_repl_line_level = 0;
-static bool s_keep_running_repl = true;
+[[maybe_unused]] static bool s_keep_running_repl = true;
 static int s_exit_code = 0;
 
 static ErrorOr<void> print_inline(JS::Value value, Stream& stream)


### PR DESCRIPTION
This commit removes an unused but set global found with the new -Wunused-but-set-globals warning on clang main. This warning is a subgroup of -Wunused-but-set-variable so we already have it enabled.