### PR TITLE
LibGfx: Re-enable tech(variations) font support

### DIFF
--- a/Libraries/LibGfx/Font/FontSupport.cpp
+++ b/Libraries/LibGfx/Font/FontSupport.cpp
@@ -53,8 +53,7 @@ bool font_tech_is_supported(FontTech const font_tech)
 #endif
     case FontTech::Variations:
         // avar, cvar, fvar, gvar, HVAR, MVAR, STAT, and VVAR, supported by HarfBuzz
-        // FIXME: This does not actually seem to work and causes issues with the font weight on https://ladybird.org
-        return false;
+        return true;
     case FontTech::ColorColrv0:
     case FontTech::ColorColrv1:
         // COLR, supported by HarfBuzz

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-tech.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-tech.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 39 tests
 
-36 Pass
-3 Fail
+39 Pass
 Pass	Check that src: url("foo.ttf") is valid
 Pass	Check that src: url("foo.ttf") tech() is invalid
 Pass	Check that src: url("foo.ttf") tech(features-opentype) is valid
@@ -12,12 +11,12 @@ Pass	Check that src: url("foo.ttf") tech(color-COLRv0) is valid
 Pass	Check that src: url("foo.ttf") tech(color-COLRv1) is valid
 Pass	Check that src: url("foo.ttf") tech(color-sbix) is valid
 Pass	Check that src: url("foo.ttf") tech(color-CBDT) is valid
-Fail	Check that src: url("foo.ttf") tech(variations) is valid
+Pass	Check that src: url("foo.ttf") tech(variations) is valid
 Pass	Check that src: url("foo.ttf") tech(palettes) is valid
 Pass	Check that src: url("foo.ttf") tech("features-opentype") is invalid
 Pass	Check that src: url("foo.ttf") tech("color-COLRv0") is invalid
 Pass	Check that src: url("foo.ttf") tech("variations") is invalid
-Fail	Check that src: url("foo.ttf") tech(features-opentype, color-COLRv0, variations, palettes) is valid
+Pass	Check that src: url("foo.ttf") tech(features-opentype, color-COLRv0, variations, palettes) is valid
 Pass	Check that src: url("foo.ttf") tech(features-opentype color-COLRv0 variations palettes) is invalid
 Pass	Check that src: url("foo.ttf") tech(feature-opentype) is invalid
 Pass	Check that src: url("foo.ttf") tech(feature-aat) is invalid
@@ -41,5 +40,5 @@ Pass	Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is 
 Pass	Check that src: url("foo.ttf") dummy("opentype") tech(variations) is invalid
 Pass	Check that src: url("foo.ttf") dummy("opentype") dummy(variations) is invalid
 Pass	Check that src: url("foo.ttf") format(opentype) tech(features-opentype) dummy(something) is invalid
-Fail	Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid
+Pass	Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid
 Pass	Check that src: url("foo.ttf") tech(color), url("bar.html") is valid


### PR DESCRIPTION
`tech(variations)` was disabled in #5062 because it caused the wrong font weight to display on https://ladybird.org.

Since then we've made several improvements to variable font support that address the underlying issues:

- [Introduce FontVariationSettings](https://github.com/LadybirdBrowser/ladybird/commit/489381698f101666d97d24cd1923025e84e18adf)
- [Pass font variation settings to HarfBuzz](https://github.com/LadybirdBrowser/ladybird/commit/aa5b3ff95a46cb76d6b5a2f536585a71f81bfba9) (also fixed visual artifacts)
- [Always respect `font-variation-settings`](https://github.com/LadybirdBrowser/ladybird/commit/2f7848913bba1373055ec53b89dabfa96f1ce636) (previously ignored for fonts matched via `font_matching_algorithm`)
- [Parse `@font-face { font-weight }` with two values](https://github.com/LadybirdBrowser/ladybird/commit/f657a4b71b8544b26cb675a952ddd2b56aaeb65b)
- [Make FontFaceKey weights a range of values](https://github.com/LadybirdBrowser/ladybird/commit/2660db3f5208bd1434456eeff1ea3db0e26353eb)

Re-enabling `tech(variations)` restores the 3 WPT tests that were broken by #5062 and allows https://ladybird.org to load its custom variable font (General Sans) correctly.