### PR TITLE
test-web: Cleanup state and report open fds in live-display

### DIFF
--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     Display.cpp
     Fixture.cpp
     Fuzzy.cpp
+    ResourceStats.cpp
     TestRunCapture.cpp
     TestWebView.cpp
     main.cpp

--- a/Tests/LibWeb/test-web/Display.cpp
+++ b/Tests/LibWeb/test-web/Display.cpp
@@ -6,11 +6,10 @@
 
 #include "Display.h"
 #include "Application.h"
+#include "ResourceStats.h"
 
-#include <AK/Enumerate.h>
 #include <AK/QuickSort.h>
 #include <AK/SaturatingMath.h>
-#include <AK/StringBuilder.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/Timer.h>
@@ -27,11 +26,10 @@
 namespace TestWeb {
 
 static constexpr size_t LIVE_DISPLAY_TERMINAL_HEADROOM = 4; // allow for external cruft like tmux panels
-static constexpr size_t LIVE_DISPLAY_STATUS_LINES = 4;      // 2 empty + 1 for status + 1 for progress bar
+static constexpr size_t LIVE_DISPLAY_STATUS_LINES = 5;      // 2 empty + 2 for status + 1 for progress bar
 static size_t s_display_rows = 24;
 
 static ::Test::LiveDisplay s_live_display;
-
 static size_t count_digits(size_t value);
 
 Display& Display::the()
@@ -127,6 +125,8 @@ void Display::print_run_complete(ReadonlySpan<Test> tests,
     outln("Pass: {}, Fail: {}, Skipped: {}, Timeout: {}, Crashed: {}",
         test_stats().pass_count, test_stats().fail_count, test_stats().skipped_count,
         test_stats().timeout_count, test_stats().crashed_count);
+    auto resources = resource_stats(true);
+    outln("fd: {}, pipe: {}, sock: {}, file: {}, shm: {}, other: {}", resources.open_fds, resources.pipes, resources.sockets, resources.files, resources.shared_memory, resources.other);
     outln("==========================================================");
 
     auto& app = Application::the();
@@ -217,12 +217,14 @@ void Display::render_live_display() const
                 }
             });
         }
+
         if (need_hidden_line) {
             t.line([&] {
                 auto label = ByteString::formatted("... {} more views hidden", view_states().size() - num_view_lines);
                 t.label(label, {}, { .prefix = ::Test::LiveDisplay::Gray, .text = ::Test::LiveDisplay::None });
             });
         }
+
         t.lines(
             [] {},
             [&] {
@@ -232,6 +234,16 @@ void Display::render_live_display() const
                     { .label = "Skipped"sv, .color = ::Test::LiveDisplay::Gray, .value = test_stats().skipped_count },
                     { .label = "Timeout"sv, .color = ::Test::LiveDisplay::Yellow, .value = test_stats().timeout_count },
                     { .label = "Crashed"sv, .color = ::Test::LiveDisplay::Magenta, .value = test_stats().crashed_count },
+                });
+            },
+            [&] {
+                t.counter({
+                    { .label = "FD"sv, .color = ::Test::LiveDisplay::Gray, .value = resource_stats().open_fds },
+                    { .label = "Pipe"sv, .color = ::Test::LiveDisplay::Gray, .value = resource_stats().pipes },
+                    { .label = "Sock"sv, .color = ::Test::LiveDisplay::Gray, .value = resource_stats().sockets },
+                    { .label = "File"sv, .color = ::Test::LiveDisplay::Gray, .value = resource_stats().files },
+                    { .label = "SHM"sv, .color = ::Test::LiveDisplay::Gray, .value = resource_stats().shared_memory },
+                    { .label = "Other"sv, .color = ::Test::LiveDisplay::Gray, .value = resource_stats().other },
                 });
             },
             [] {},

--- a/Tests/LibWeb/test-web/Display.cpp
+++ b/Tests/LibWeb/test-web/Display.cpp
@@ -46,7 +46,7 @@ void Display::begin_run()
     is_tty = ::Test::stdout_is_tty();
     bool const want_live_display = !app.quiet && is_tty && app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT;
 
-    outln("Running {} tests...", total_tests());
+    outln("Running {} tests...", test_stats().total_tests);
 
     if (!want_live_display)
         return;
@@ -80,7 +80,6 @@ void Display::begin_run()
 
 void Display::on_test_started(size_t view_index, Test const& test, pid_t pid)
 {
-    current_run = test.run_index;
     if (view_index < view_states().size()) {
         auto& state = view_states()[view_index];
         state.pid = pid;
@@ -97,36 +96,14 @@ void Display::on_test_started(size_t view_index, Test const& test, pid_t pid)
 
     if (Application::the().verbosity >= Application::VERBOSITY_LEVEL_LOG_TEST_DURATION) {
         outln("[{:{}}] {:{}}/{}:  Start {}", view_index, count_digits(view_states().size()), test.index + 1,
-            count_digits(total_tests()), total_tests(), test.relative_path);
+            count_digits(test_stats().total_tests), test_stats().total_tests, test.relative_path);
         return;
     }
-    outln("{}/{}: {}", test.index + 1, total_tests(), test.relative_path);
+    outln("{}/{}: {}", test.index + 1, test_stats().total_tests, test.relative_path);
 }
 
-void Display::on_test_finished(size_t view_index, Test const& test, TestResult result)
+void Display::on_test_finished(size_t view_index, Test const& test)
 {
-    switch (result) {
-    case TestResult::Pass:
-        ++pass_count;
-        break;
-    case TestResult::Fail:
-        ++fail_count;
-        break;
-    case TestResult::Timeout:
-        ++timeout_count;
-        break;
-    case TestResult::Crashed:
-        ++crashed_count;
-        break;
-    case TestResult::Skipped:
-        ++skipped_count;
-        break;
-    case TestResult::Expanded:
-        break;
-    }
-    if (result != TestResult::Expanded)
-        ++completed_tests;
-
     if (view_index >= view_states().size())
         return;
 
@@ -136,17 +113,7 @@ void Display::on_test_finished(size_t view_index, Test const& test, TestResult r
 
     auto duration = test.end_time - test.start_time;
     outln("[{:{}}] {:{}}/{}: Finish {}: {}ms", view_index, count_digits(view_states().size()), test.index + 1,
-        count_digits(total_tests()), total_tests(), test.relative_path, duration.to_milliseconds());
-}
-
-void Display::on_fail_fast(Test const& test, TestResult result, pid_t pid)
-{
-    clear_live_display();
-
-    if (result == TestResult::Timeout)
-        outln("Fail-fast: Timeout: {} (pid {})", test.relative_path, pid);
-    else
-        outln("Fail-fast: {}: {}", test_result_to_string(result), test.relative_path);
+        count_digits(test_stats().total_tests), test_stats().total_tests, test.relative_path, duration.to_milliseconds());
 }
 
 void Display::print_run_complete(ReadonlySpan<Test> tests,
@@ -157,8 +124,9 @@ void Display::print_run_complete(ReadonlySpan<Test> tests,
         outln("Halted; {} tests not executed.", tests_remaining);
 
     outln("==========================================================");
-    outln("Pass: {}, Fail: {}, Skipped: {}, Timeout: {}, Crashed: {}", pass_count, fail_count, skipped_count,
-        timeout_count, crashed_count);
+    outln("Pass: {}, Fail: {}, Skipped: {}, Timeout: {}, Crashed: {}",
+        test_stats().pass_count, test_stats().fail_count, test_stats().skipped_count,
+        test_stats().timeout_count, test_stats().crashed_count);
     outln("==========================================================");
 
     auto& app = Application::the();
@@ -255,26 +223,25 @@ void Display::render_live_display() const
                 t.label(label, {}, { .prefix = ::Test::LiveDisplay::Gray, .text = ::Test::LiveDisplay::None });
             });
         }
-
         t.lines(
             [] {},
             [&] {
                 t.counter({
-                    { .label = "Pass"sv, .color = ::Test::LiveDisplay::Green, .value = pass_count },
-                    { .label = "Fail"sv, .color = ::Test::LiveDisplay::Red, .value = fail_count },
-                    { .label = "Skipped"sv, .color = ::Test::LiveDisplay::Gray, .value = skipped_count },
-                    { .label = "Timeout"sv, .color = ::Test::LiveDisplay::Yellow, .value = timeout_count },
-                    { .label = "Crashed"sv, .color = ::Test::LiveDisplay::Magenta, .value = crashed_count },
+                    { .label = "Pass"sv, .color = ::Test::LiveDisplay::Green, .value = test_stats().pass_count },
+                    { .label = "Fail"sv, .color = ::Test::LiveDisplay::Red, .value = test_stats().fail_count },
+                    { .label = "Skipped"sv, .color = ::Test::LiveDisplay::Gray, .value = test_stats().skipped_count },
+                    { .label = "Timeout"sv, .color = ::Test::LiveDisplay::Yellow, .value = test_stats().timeout_count },
+                    { .label = "Crashed"sv, .color = ::Test::LiveDisplay::Magenta, .value = test_stats().crashed_count },
                 });
             },
             [] {},
             [&] {
-                if (total_tests() == 0)
+                if (test_stats().total_tests == 0)
                     return;
                 ByteString suffix;
                 if (Application::the().repeat_count > 1)
-                    suffix = ByteString::formatted("run {}/{}", current_run, Application::the().repeat_count);
-                t.progress_bar(completed_tests, total_tests(), suffix);
+                    suffix = ByteString::formatted("run {}/{}", test_stats().current_run, Application::the().repeat_count);
+                t.progress_bar(test_stats().completed_tests, test_stats().total_tests, suffix);
             });
     });
 }

--- a/Tests/LibWeb/test-web/Display.h
+++ b/Tests/LibWeb/test-web/Display.h
@@ -11,6 +11,7 @@
 #include <AK/ByteString.h>
 #include <AK/RefPtr.h>
 #include <AK/Span.h>
+#include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -24,22 +25,13 @@ struct Display {
 
     void begin_run();
     void on_test_started(size_t view_index, Test const&, pid_t);
-    void on_test_finished(size_t view_index, Test const&, TestResult);
-    void on_fail_fast(Test const&, TestResult, pid_t);
+    void on_test_finished(size_t view_index, Test const&);
     void print_run_complete(ReadonlySpan<Test>, ReadonlySpan<TestCompletion>, size_t tests_remaining) const;
     void print_failure_diff(URL::URL const&, Test const&, ByteBuffer const& expectation) const;
     void render_live_display() const;
     void clear_live_display();
 
     RefPtr<Core::Timer> display_timer;
-    Vector<ByteString> deferred_warnings;
-    size_t completed_tests { 0 };
-    size_t pass_count { 0 };
-    size_t fail_count { 0 };
-    size_t timeout_count { 0 };
-    size_t crashed_count { 0 };
-    size_t skipped_count { 0 };
-    size_t current_run { 1 };
     bool is_tty { false };
     bool is_live_display_active { false };
 };

--- a/Tests/LibWeb/test-web/ResourceStats.cpp
+++ b/Tests/LibWeb/test-web/ResourceStats.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, The Ladybird Developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ResourceStats.h"
+
+#include <AK/Optional.h>
+#include <AK/StringBuilder.h>
+#include <AK/Time.h>
+#include <AK/Vector.h>
+#include <LibCore/DirIterator.h>
+#include <LibCore/System.h>
+
+#if defined(AK_OS_MACOS)
+#    include <libproc.h>
+#    include <sys/proc_info.h>
+#endif
+
+#if !defined(AK_OS_WINDOWS)
+#    include <sys/resource.h>
+#    include <sys/stat.h>
+#    include <unistd.h>
+#endif
+
+namespace TestWeb {
+
+static ResourceStats query_resource_stats();
+
+ResourceStats resource_stats(bool force_update)
+{
+    static ResourceStats stats = query_resource_stats();
+    static UnixDateTime last_update = UnixDateTime::now();
+
+    if (force_update || (UnixDateTime::now() - last_update).to_truncated_milliseconds() >= 200) {
+        stats = query_resource_stats();
+        last_update = UnixDateTime::now();
+    }
+
+    return stats;
+}
+
+#if defined(AK_OS_MACOS)
+ResourceStats query_resource_stats()
+{
+    ResourceStats stats;
+    struct rlimit limits;
+    if (getrlimit(RLIMIT_NOFILE, &limits) == 0)
+        stats.fd_limit = limits.rlim_cur;
+
+    pid_t const pid = Core::System::getpid();
+    Vector<proc_fdinfo> fd_infos;
+
+    for (size_t capacity = 256;; capacity *= 2) {
+        fd_infos.resize(capacity);
+        int const buffer_size = static_cast<int>(capacity * sizeof(proc_fdinfo));
+        int const bytes_filled = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fd_infos.data(), buffer_size);
+        if (bytes_filled <= 0) {
+            fd_infos.clear();
+            break;
+        }
+
+        if (bytes_filled < buffer_size) {
+            fd_infos.resize(static_cast<size_t>(bytes_filled) / sizeof(proc_fdinfo));
+            break;
+        }
+    }
+
+    stats.open_fds = fd_infos.size();
+    for (auto const& fd_info : fd_infos) {
+        switch (fd_info.proc_fdtype) {
+        case PROX_FDTYPE_VNODE:
+            ++stats.files;
+            break;
+        case PROX_FDTYPE_SOCKET:
+            ++stats.sockets;
+            break;
+        case PROX_FDTYPE_PIPE:
+            ++stats.pipes;
+            break;
+        case PROX_FDTYPE_PSHM:
+            ++stats.shared_memory;
+            break;
+        default:
+            ++stats.other;
+            break;
+        }
+    }
+    return stats;
+}
+
+#elif defined(AK_OS_LINUX)
+
+static bool is_shmem(StringView target)
+{
+    return target.starts_with("/dev/shm/"sv)
+        || target.starts_with("/memfd:"sv)
+        || target.starts_with("memfd:"sv);
+}
+
+static void classify_linux_fd(ResourceStats& stats, int fd, StringView target)
+{
+    struct stat stat_buffer;
+    if (fstat(fd, &stat_buffer) == 0) {
+        if (S_ISSOCK(stat_buffer.st_mode)) {
+            ++stats.sockets;
+            return;
+        }
+        if (S_ISFIFO(stat_buffer.st_mode)) {
+            ++stats.pipes;
+            return;
+        }
+        if (S_ISREG(stat_buffer.st_mode) || S_ISDIR(stat_buffer.st_mode) || S_ISCHR(stat_buffer.st_mode) || S_ISBLK(stat_buffer.st_mode)) {
+            if (is_shmem(target)) {
+                ++stats.shared_memory;
+                return;
+            }
+            ++stats.files;
+            return;
+        }
+    }
+    if (target.starts_with("socket:"sv))
+        ++stats.sockets;
+    else if (target.starts_with("pipe:"sv))
+        ++stats.pipes;
+    else if (is_shmem(target))
+        ++stats.shared_memory;
+    else if (!target.is_empty())
+        ++stats.files;
+    else
+        ++stats.other;
+}
+static ByteString get_link_target(ByteString const& path)
+{
+    Vector<char> buffer;
+    buffer.resize(PATH_MAX);
+    for (;;) {
+        ssize_t const bytes_read = ::readlink(path.characters(), buffer.data(), buffer.size());
+        if (bytes_read < 0)
+            return {};
+        if (static_cast<size_t>(bytes_read) < buffer.size())
+            return ByteString(buffer.data(), static_cast<size_t>(bytes_read));
+
+        buffer.resize(buffer.size() * 2);
+    }
+}
+
+ResourceStats query_resource_stats()
+{
+    ResourceStats stats;
+    struct rlimit limits;
+    if (getrlimit(RLIMIT_NOFILE, &limits) == 0)
+        stats.fd_limit = limits.rlim_cur;
+
+    Core::DirIterator fd_iterator("/proc/self/fd"sv, Core::DirIterator::Flags::SkipDots);
+    if (fd_iterator.has_error())
+        return stats;
+
+    int const iterator_fd = fd_iterator.fd();
+    while (fd_iterator.has_next()) {
+        Optional<Core::DirectoryEntry> entry = fd_iterator.next();
+        if (!entry.has_value())
+            break;
+
+        Optional<int> maybe_fd = entry->name.to_number<int>();
+        if (!maybe_fd.has_value())
+            continue;
+
+        int const fd = maybe_fd.value();
+        if (fd == iterator_fd)
+            continue;
+
+        ++stats.open_fds;
+        ByteString target = get_link_target(ByteString::formatted("/proc/self/fd/{}", fd));
+        classify_linux_fd(stats, fd, target);
+    }
+
+    return stats;
+}
+
+#else
+
+ResourceStats query_resource_stats()
+{
+    ResourceStats stats;
+    return stats;
+}
+#endif
+
+}

--- a/Tests/LibWeb/test-web/ResourceStats.h
+++ b/Tests/LibWeb/test-web/ResourceStats.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, The Ladybird Developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+
+#if !defined(AK_OS_WINDOWS)
+#    include <sys/resource.h>
+#endif
+
+namespace TestWeb {
+
+struct ResourceStats {
+    size_t open_fds { 0 };
+    size_t files { 0 };
+    size_t sockets { 0 };
+    size_t pipes { 0 };
+    size_t shared_memory { 0 };
+    size_t other { 0 };
+#if !defined(AK_OS_WINDOWS)
+    Optional<rlim_t> fd_limit;
+#endif
+};
+
+ResourceStats resource_stats(bool force_update = false);
+
+}

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -125,8 +125,19 @@ struct ViewDisplayState {
     bool active { false };
 };
 
+struct TestStats {
+    size_t total_tests { 0 };
+    size_t completed_tests { 0 };
+    size_t pass_count { 0 };
+    size_t fail_count { 0 };
+    size_t timeout_count { 0 };
+    size_t crashed_count { 0 };
+    size_t skipped_count { 0 };
+    size_t current_run { 1 };
+};
+
 Vector<ViewDisplayState>& view_states();
-size_t total_tests();
+TestStats const& test_stats();
 
 using TestPromise = Core::Promise<TestCompletion>;
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -61,13 +61,16 @@ static HashMap<WebView::ViewImplementation const*, size_t> s_current_test_index_
 struct TestRunContext {
     Vector<Test>& tests;
     size_t& tests_remaining;
-    size_t& total_tests;
 };
 
 static TestRunContext* s_run_context { nullptr };
+static TestStats s_stats;
+
+static void update_stats(TestResult result);
 
 Vector<ViewDisplayState>& view_states() { return s_view_display_states; }
-size_t total_tests() { return s_run_context ? s_run_context->total_tests : 0; }
+
+TestStats const& test_stats() { return s_stats; }
 
 static ErrorOr<ByteString> prepare_output_path(Test const& test)
 {
@@ -288,7 +291,6 @@ window.PDFViewerApplication.initializedPromise.then(() => {
 static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpan<TestCompletion> non_passing_tests)
 {
     auto& app = Application::the();
-    auto& display = Display::the();
 
     bool const has_helper_logs = FileSystem::exists(LexicalPath::join(app.results_directory, "helper-process-logs.html"sv).string());
     auto const generated_at = UnixDateTime::now();
@@ -297,11 +299,11 @@ static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpa
     StringBuilder js;
     js.append("const RESULTS_DATA = {\n"sv);
     js.appendff("  \"summary\": {{ \"total\": {}, \"fail\": {}, \"timeout\": {}, \"crashed\": {}, \"skipped\": {} }},\n",
-        total_tests(),
-        display.fail_count,
-        display.timeout_count,
-        display.crashed_count,
-        display.skipped_count);
+        s_stats.total_tests,
+        s_stats.fail_count,
+        s_stats.timeout_count,
+        s_stats.crashed_count,
+        s_stats.skipped_count);
     js.appendff("  \"generatedAt\": {},\n", generated_at.seconds_since_epoch());
     js.appendff("  \"invocationCommandLine\": {},\n", JsonValue(app.invocation_command_line).serialized());
     js.appendff("  \"hasLogs\": {},\n", has_helper_logs ? "true" : "false");
@@ -458,7 +460,7 @@ static void expand_test_with_variants(TestRunContext& context, size_t base_test_
     context.tests_remaining += variants.size();
 
     // For display, add (variants.size() - 1) since Expanded tests don't count in s_completed_tests
-    context.total_tests += variants.size() - 1;
+    s_stats.total_tests += variants.size() - 1;
 }
 
 static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test, URL::URL const& url)
@@ -1134,8 +1136,8 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             }
         }
     }
-    size_t total_tests = tests.size();
-    auto concurrency = min(app.test_concurrency, total_tests);
+    s_stats.total_tests = tests.size();
+    auto concurrency = min(app.test_concurrency, s_stats.total_tests);
     size_t loaded_web_views = 0;
     Vector<NonnullOwnPtr<TestWebView>> views;
     views.ensure_capacity(concurrency);
@@ -1174,7 +1176,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     auto tests_remaining = tests.size();
     auto current_test = 0uz;
 
-    TestRunContext context { tests, tests_remaining, total_tests };
+    TestRunContext context { tests, tests_remaining };
     s_run_context = &context;
     ScopeGuard clear_run_context = [&] { s_run_context = nullptr; };
 
@@ -1232,6 +1234,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             test.index = index;
 
             // Mark this view as active (for variant wake-up tracking)
+            s_stats.current_run = test.run_index;
             display.on_test_started(view_id, test, view->web_content_pid());
 
             // Reset promise and attach completion callback
@@ -1258,12 +1261,18 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                 if (is_non_passing_result)
                     non_passing_tests.append(result);
 
-                Display::the().on_test_finished(view_id, test, result.result);
+                update_stats(result.result);
+                Display::the().on_test_finished(view_id, test);
 
                 if (app.fail_fast && !fail_fast_triggered && should_trigger_fail_fast) {
                     fail_fast_triggered = true;
                     auto const pid = view->web_content_pid();
-                    Display::the().on_fail_fast(test, result.result, pid);
+                    Display::the().clear_live_display();
+
+                    if (result.result == TestResult::Timeout)
+                        outln("Fail-fast: Timeout: {} (pid {})", test.relative_path, pid);
+                    else
+                        outln("Fail-fast: {}: {}", test_result_to_string(result.result), test.relative_path);
 
                     if (s_all_tests_complete)
                         s_all_tests_complete->reject(Error::from_string_literal("Fail-fast"));
@@ -1333,7 +1342,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             outln("Results: file://{}/index.html", app.results_directory);
     }
 
-    return display.fail_count + display.timeout_count + display.crashed_count + tests_remaining;
+    return s_stats.fail_count + s_stats.timeout_count + s_stats.crashed_count + tests_remaining;
 }
 
 static void handle_signal(int signal)
@@ -1369,6 +1378,33 @@ static void handle_signal(int signal)
     s_all_tests_complete->reject(signal == SIGINT
             ? Error::from_string_view("SIGINT received"sv)
             : Error::from_string_view("SIGTERM received"sv));
+}
+
+static void update_stats(TestResult result)
+{
+    auto& stats = s_stats;
+    switch (result) {
+    case TestResult::Pass:
+        ++stats.pass_count;
+        break;
+    case TestResult::Fail:
+        ++stats.fail_count;
+        break;
+    case TestResult::Timeout:
+        ++stats.timeout_count;
+        break;
+    case TestResult::Crashed:
+        ++stats.crashed_count;
+        break;
+    case TestResult::Skipped:
+        ++stats.skipped_count;
+        break;
+    case TestResult::Expanded:
+        // Don't count Expanded as a separate result in stats, it's just a UI state for certain tests.
+        break;
+    }
+    if (result != TestResult::Expanded)
+        stats.completed_tests++;
 }
 
 }


### PR DESCRIPTION
Define the run counts in a TestWeb.h struct with static storage in main.cpp.

Add ResourceStats class to provide running totals of fd usage.

<img width="844" height="211" alt="image" src="https://github.com/user-attachments/assets/6aef2a64-e6b7-40c8-b50c-ab221f40f540" />
