### PR TITLE
Documentation+Meta: Remove references to nonexistent Toolchain directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,16 +47,10 @@
                 // Excluding the generated directories keeps your file view clean and speeds up search.
                 "files.exclude": {
                     "**/.git": true,
-                    "Toolchain/Local/**": true,
-                    "Toolchain/Tarballs/**": true,
-                    "Toolchain/Build/**": true,
                     "Build/**": true
                 },
                 "search.exclude": {
                     "**/.git": true,
-                    "Toolchain/Local/**": true,
-                    "Toolchain/Tarballs/**": true,
-                    "Toolchain/Build/**": true,
                     "Build/**": true
                 },
                 // Tab settings

--- a/.devcontainer/features/vcpkg-cache/install.sh
+++ b/.devcontainer/features/vcpkg-cache/install.sh
@@ -27,7 +27,7 @@ mkdir -p ${CACHE_DIR}
 git clone https://github.com/LadybirdBrowser/ladybird.git --depth 1
 cd ladybird
 # Grab and bootstrap the exact commit of vcpkg that trunk is using
-python3 ./Toolchain/BuildVcpkg.py
+python3 ./Meta/build_vcpkg.py
 
 # Install the vcpkg.json in manifest mode from the root of the repo
 # Set the binary cache directory to the one we intend to use at container runtime

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -300,7 +300,7 @@ error: building skia:x64-linux failed with: BUILD_FAILED
 Elapsed time to handle skia:x64-linux: 1.6 s
 
 -- Running vcpkg install - failed
-CMake Error at Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:899 (message):
+CMake Error at Build/vcpkg/scripts/buildsystems/vcpkg.cmake:899 (message):
   vcpkg install failed.  See logs for more information:
   Build/release/vcpkg-manifest-install.log
 Call Stack (most recent call first):

--- a/Documentation/EditorConfiguration/VSCodeConfiguration.md
+++ b/Documentation/EditorConfiguration/VSCodeConfiguration.md
@@ -102,16 +102,10 @@ These belong in the `.vscode/settings.json` of Ladybird.
     // Excluding the generated directories keeps your file view clean and speeds up search.
     "files.exclude": {
         "**/.git": true,
-        "Toolchain/Local/**": true,
-        "Toolchain/Tarballs/**": true,
-        "Toolchain/Build/**": true,
         "Build/**": true,
     },
     "search.exclude": {
         "**/.git": true,
-        "Toolchain/Local/**": true,
-        "Toolchain/Tarballs/**": true,
-        "Toolchain/Build/**": true,
         "Build/**": true,
     },
     // Force clang-format to respect Ladybird's .clang-format style file. This is not necessary if you're not using the Microsoft C++ extension.

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -295,7 +295,6 @@ def configure_build_env(platform: Platform, preset: str) -> tuple[Path, Path]:
         sys.exit(1)
 
     vcpkg_root = str(build_root_dir / "vcpkg")
-    os.environ["PATH"] += os.pathsep + str(ladybird_source_dir.joinpath("Toolchain", "Local", "cmake", "bin"))
     os.environ["PATH"] += os.pathsep + vcpkg_root
     os.environ["VCPKG_ROOT"] = vcpkg_root
     if platform.host_architecture == HostArchitecture.riscv64:

--- a/Meta/refresh-ladybird-qtcreator.sh
+++ b/Meta/refresh-ladybird-qtcreator.sh
@@ -16,7 +16,6 @@ find . \( \
         -o -name Patches \
         -o -name Ports \
         -o -name Root \
-        -o -name Toolchain \
         -o -name Build \
     \) -prune \
     -o \( \


### PR DESCRIPTION
After b1d708dd16a1e648992b34ed8091b242be0d3299, the Toolchain directory was removed from the repository. Some documentation and scripts still referenced it, so this commit removes those references. The only remaining references are in the gitignore file, to prevent bisections from being polluted by the presence of a Toolchain directory in the working copy.

Follow-up to #8996