### PR TITLE
AK: Use system allocator in debug builds

### DIFF
--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -73,9 +73,12 @@ nothrow_t const nothrow;
 #    include <cstddef>
 #    include <cstring>
 
-#    if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#    if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__) || !defined(NDEBUG)
 // LeakSanitizer does not reliably trace references stored in mimalloc-managed
 // AK containers, so sanitizer builds fall back to the system allocator.
+// We disable it in debug builds because mimalloc's vcpkg debug profile causes
+// severe multi-minute hangs during GenerateWindowOrWorkerInterface and locks up
+// entirely on some pages (like news.google.com)
 #        define AK_USE_SYSTEM_ALLOCATOR_INSTRUMENTED 1
 #    else
 #        include <mimalloc.h>


### PR DESCRIPTION
Rolling back mimalloc resolves a curious regression where Text/input/canvas/export-offscreencanvas.html exports a jpeg that is 8 pixels smaller than expected.

It also prevents a multi-minute hang during the GenerateWindowOrWorkerInterface codegen stage which runs quite frequently in ordinary work.