### PR TITLE
LibJS: Make bytecode register allocator O(1)

### DIFF
--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -386,18 +386,16 @@ impl Generator {
     // --- Register management ---
 
     /// Allocate a new register (or reuse a freed one).
-    /// Always picks the lowest-numbered free register to ensure deterministic
-    /// allocation regardless of operand drop order.
     pub fn allocate_register(&mut self) -> ScopedOperand {
         let reg = {
             let mut pool = self.free_register_pool.borrow_mut();
-            if pool.is_empty() {
-                let r = Register(self.next_register);
-                self.next_register += 1;
-                r
-            } else {
-                let min_index = pool.iter().enumerate().min_by_key(|(_, r)| r.0).unwrap().0;
-                pool.remove(min_index)
+            match pool.pop() {
+                Some(r) => r,
+                None => {
+                    let r = Register(self.next_register);
+                    self.next_register += 1;
+                    r
+                }
             }
         };
         self.scoped_operand(Operand::register(reg))

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -12,12 +12,12 @@ block0:
   [  38] GetGlobal dst:reg9, `annexBFunctionInIf`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(true)]
   [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg7, `console`
-  [  b8] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  a0] GetGlobal dst:reg6, `console`
+  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d8] GetGlobal dst:reg10, `annexBFunctionInIf`
   [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(false)]
-  [ 118] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 140] End value:reg6
+  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 140] End value:reg7
 
 
 annexBFunctionInIf$cf6b2161 annex-b-function-in-if.js:2:5

--- a/Tests/LibJS/Bytecode/expected/async-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await.txt
@@ -25,13 +25,13 @@ block1:
   [  10] GetGlobal dst:reg6, `Promise`
   [  28] GetById dst:reg7, base:reg6, `resolve` (Promise.resolve)
   [  48] Call dst:reg5, callee:reg7, this_value:reg6, Promise.resolve, arguments:[Int32(42)]
-  [  70] Mov dst:reg6, src:reg0
+  [  70] Mov dst:reg7, src:reg0
   [  80] Await continuation_label:block2, argument:reg5
 
 block2:
-  [  90] Mov dst:reg6, src:reg0
-  [  a0] GetCompletionFields type_dst:reg7, value_dst:reg8, completion:reg6
-  [  b0] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block3, false_target:block4
+  [  90] Mov dst:reg7, src:reg0
+  [  a0] GetCompletionFields type_dst:reg6, value_dst:reg8, completion:reg7
+  [  b0] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block3, false_target:block4
 
 block3:
   [  c8] Await continuation_label:block5, argument:reg8
@@ -41,11 +41,11 @@ block4:
 
 block5:
   [  e0] Mov dst:reg5, src:reg0
-  [  f0] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [ 100] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block6, false_target:block7
+  [  f0] GetCompletionFields type_dst:reg7, value_dst:reg6, completion:reg5
+  [ 100] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block6, false_target:block7
 
 block6:
-  [ 118] Yield value:reg7
+  [ 118] Yield value:reg6
 
 block7:
-  [ 128] Throw src:reg7
+  [ 128] Throw src:reg6

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -10,12 +10,12 @@ block0:
   [  38] GetGlobal dst:reg9, `closureOverBlockScope`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, closureOverBlockScope
   [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg7, `console`
-  [  b0] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  98] GetGlobal dst:reg6, `console`
+  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d0] GetGlobal dst:reg10, `breakThroughBlockScopes`
   [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughBlockScopes
-  [ 108] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 130] End value:reg6
+  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 130] End value:reg7
 
 
 closureOverBlockScope$4f0633f8 block-scoping.js:2:15

--- a/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
+++ b/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
@@ -10,12 +10,12 @@ block0:
   [  38] GetGlobal dst:reg9, `throwInCatch`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, throwInCatch
   [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg7, `console`
-  [  b0] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  98] GetGlobal dst:reg6, `console`
+  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d0] GetGlobal dst:reg10, `throwInCatchWithLocals`
   [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, throwInCatchWithLocals
-  [ 108] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 130] End value:reg6
+  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 130] End value:reg7
 
 
 throwInCatch$ff1cead7 catch-scope-boundary.js:2:5

--- a/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
@@ -13,9 +13,9 @@ block0:
   [  18] SetLexicalEnvironment environment:reg4
   [  20] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (C), element_keys:[element_keys:Int32(3)]
   [  48] SetGlobal `C`, src:reg6
-  [  60] GetGlobal dst:reg6, `C`
-  [  78] CallConstruct dst:reg5, callee:reg6, C
-  [  90] End value:reg5
+  [  60] GetGlobal dst:reg5, `C`
+  [  78] CallConstruct dst:reg6, callee:reg5, C
+  [  90] End value:reg6
 
 
 C$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/class-environment.txt
+++ b/Tests/LibJS/Bytecode/expected/class-environment.txt
@@ -30,8 +30,8 @@ block0:
   [  58] CallConstruct dst:reg6, callee:C~0, C
   [  70] GetById dst:reg7, base:reg6, `method`
   [  90] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
-  [  b0] StrictlyEquals dst:reg6, lhs:reg5, rhs:C~0
-  [  c0] Return value:reg6
+  [  b0] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
+  [  c0] Return value:reg7
 
 
 Foo$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
+++ b/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
@@ -47,8 +47,8 @@ block0:
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("x"), element_keys:String("y"), element_keys:String("z"), element_keys:String("w"), element_keys:String("s"), element_keys:String("computed")]
   [  68] Mov dst:A~0, src:reg6
   [  78] ThrowIfTDZ src:A~0
-  [  80] CallConstruct dst:reg5, callee:A~0, A
-  [  98] Return value:reg5
+  [  80] CallConstruct dst:reg6, callee:A~0, A
+  [  98] Return value:reg6
 
 
 A$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
@@ -26,9 +26,9 @@ block0:
   [  30] GetByValue dst:reg8, base:reg7, property:Int32(0) (v[Int32(0)])
   [  48] Sub dst:reg7, lhs:reg5, rhs:reg8
   [  58] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
-  [  70] GetByValue dst:reg5, base:arg0, property:Int32(1) (self[Int32(1)])
-  [  88] Mov2 dst1:reg6, src1:Int32(1), dst2:reg7, src2:arg1
-  [  a0] GetByValue dst:reg8, base:reg7, property:Int32(1) (v[Int32(1)])
-  [  b8] Sub dst:reg7, lhs:reg5, rhs:reg8
-  [  c8] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
+  [  70] GetByValue dst:reg7, base:arg0, property:Int32(1) (self[Int32(1)])
+  [  88] Mov2 dst1:reg5, src1:Int32(1), dst2:reg6, src2:arg1
+  [  a0] GetByValue dst:reg8, base:reg6, property:Int32(1) (v[Int32(1)])
+  [  b8] Sub dst:reg6, lhs:reg7, rhs:reg8
+  [  c8] PutByValue base:arg0, property:reg5, src:reg6, kind:Normal
   [  e0] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
@@ -45,6 +45,6 @@ block0:
   [  18] Mov dst:reg6, src:arg1
   [  28] Add dst:reg7, lhs:reg5, rhs:Int32(0)
   [  38] PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
-  [  50] Mov2 dst1:reg5, src1:arg0, dst2:reg6, src2:arg1
-  [  68] PutByValue base:reg5, property:reg6, src:arg1, kind:Normal (imag[reg6])
+  [  50] Mov2 dst1:reg7, src1:arg0, dst2:reg5, src2:arg1
+  [  68] PutByValue base:reg7, property:reg5, src:arg1, kind:Normal (imag[reg5])
   [  80] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
@@ -22,9 +22,9 @@ block0:
   [   0] GetByValue dst:reg5, base:arg0, property:Int32(3) (c[Int32(3)])
   [  18] PostfixIncrement dst:reg6, src:reg5
   [  28] PutByValue base:arg0, property:Int32(3), src:reg5, kind:Normal
-  [  40] GetGlobal dst:reg6, `foo`
+  [  40] GetGlobal dst:reg5, `foo`
   [  58] Mov dst:reg7, src:arg0
-  [  68] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
+  [  68] Call dst:reg6, callee:reg5, this_value:Undefined, foo, arguments:[reg7]
   [  90] End value:Undefined
 
 

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -16,21 +16,21 @@ block0:
   [  70] Jump target:block3
 
 block1:
-  [  78] Catch dst:reg5
+  [  78] Catch dst:reg6
   [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov2 dst1:reg6, src1:Undefined, dst2:reg7, src2:reg6
+  [  88] Mov2 dst1:reg5, src1:Undefined, dst2:reg7, src2:reg5
 
 block2:
-  [  a0] End value:reg6
+  [  a0] End value:reg5
 
 block3:
-  [  a8] Mov dst:reg5, src:Undefined
+  [  a8] Mov dst:reg6, src:Undefined
   [  b8] GetGlobal dst:reg9, `A`
   [  d0] CallConstruct dst:reg8, callee:reg9, A
   [  e8] GetById dst:reg9, base:reg8, `m`
-  [ 108] Call dst:reg6, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
-  [ 130] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
-  [ 148] End value:reg6
+  [ 108] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
+  [ 130] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 148] End value:reg5
 
 Exception handlers:
   [  a8 ..  150] => handler block1

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -17,37 +17,37 @@ block0:
   [  70] Jump target:block3
 
 block1:
-  [  78] Catch dst:reg5
+  [  78] Catch dst:reg6
   [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov3 dst1:e~0, src1:reg5, dst2:reg6, src2:Undefined, dst3:reg7, src3:reg6
+  [  88] Mov3 dst1:e~0, src1:reg6, dst2:reg5, src2:Undefined, dst3:reg7, src3:reg5
 
 block2:
   [  a8] Jump target:block6
 
 block3:
-  [  b0] Mov dst:reg5, src:Undefined
+  [  b0] Mov dst:reg6, src:Undefined
   [  c0] GetGlobal dst:reg9, `A`
   [  d8] CallConstruct dst:reg8, callee:reg9, A
   [  f0] GetById dst:reg9, base:reg8, `foo`
-  [ 110] Call dst:reg6, callee:reg9, this_value:reg8, <object>.foo
-  [ 130] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+  [ 110] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
+  [ 130] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
   [ 148] Jump target:block2
 
 block4:
-  [ 150] Catch dst:reg5
+  [ 150] Catch dst:reg6
   [ 158] SetLexicalEnvironment environment:reg4
-  [ 160] Mov3 dst1:e~1, src1:reg5, dst2:reg7, src2:Undefined, dst3:reg8, src3:reg7
+  [ 160] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
 
 block5:
   [ 180] End value:reg7
 
 block6:
-  [ 188] Mov dst:reg5, src:Undefined
+  [ 188] Mov dst:reg6, src:Undefined
   [ 198] GetGlobal dst:reg10, `A`
-  [ 1b0] CallConstruct dst:reg9, callee:reg10, A
-  [ 1c8] GetById dst:reg10, base:reg9, `baz`
-  [ 1e8] Call dst:reg7, callee:reg10, this_value:reg9, <object>.baz
-  [ 208] Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
+  [ 1b0] CallConstruct dst:reg8, callee:reg10, A
+  [ 1c8] GetById dst:reg10, base:reg8, `baz`
+  [ 1e8] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
+  [ 208] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
   [ 220] End value:reg7
 
 Exception handlers:

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -46,9 +46,9 @@ block1:
   [ 160] InitializeLexicalBinding `i`, src:reg6
 
 block2:
-  [ 178] GetBinding dst:reg6, `i`
-  [ 190] PostfixIncrement dst:reg7, src:reg6
-  [ 1a0] SetLexicalBinding `i`, src:reg6
+  [ 178] GetBinding dst:reg7, `i`
+  [ 190] PostfixIncrement dst:reg6, src:reg7
+  [ 1a0] SetLexicalBinding `i`, src:reg7
 
 block3:
   [ 1b8] GetBinding dst:reg6, `i`

--- a/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
@@ -29,7 +29,7 @@ block1:
   [  18] End value:Undefined
 
 block2:
-  [  20] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg7, iterator_done:reg8
+  [  20] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg8, iterator_done:reg6
   [  38] JumpIf condition:reg11, true_target:block1, false_target:block8
 
 block3:
@@ -42,20 +42,20 @@ block4:
   [  90] Mov dst:reg5, src:arg1
 
 block5:
-  [  a0] GetGlobal dst:reg7, `Object`
-  [  b8] GetById dst:reg8, base:reg7, `entries` (Object.entries)
+  [  a0] GetGlobal dst:reg6, `Object`
+  [  b8] GetById dst:reg8, base:reg6, `entries` (Object.entries)
   [  d8] NewObject dst:reg9
-  [  e8] Call dst:reg6, callee:reg8, this_value:reg7, Object.entries, arguments:[reg9]
-  [ 110] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg7, dst_iterator_done:reg8, iterable:reg6
+  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, Object.entries, arguments:[reg9]
+  [ 110] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg8, dst_iterator_done:reg6, iterable:reg7
   [ 128] Jump target:block2
 
 block6:
   [ 130] Catch dst:reg9
   [ 138] SetLexicalEnvironment environment:reg4
-  [ 140] Mov dst:reg6, src:Int32(1)
+  [ 140] Mov dst:reg7, src:Int32(1)
 
 block7:
-  [ 150] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block16, false_target:block17
+  [ 150] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block16, false_target:block17
 
 block8:
   [ 168] Mov dst:reg12, src:Bool(false)
@@ -92,12 +92,12 @@ block15:
   [ 278] Jump target:block14
 
 block16:
-  [ 280] IteratorClose iterator_object:reg5, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
+  [ 280] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:reg9
   [ 298] Throw src:reg9
 
 block17:
-  [ 2a0] IteratorClose iterator_object:reg5, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-  [ 2b8] JumpStrictlyEquals lhs:reg6, rhs:Int32(2), true_target:block18, false_target:block19
+  [ 2a0] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:Undefined
+  [ 2b8] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block18, false_target:block19
 
 block18:
   [ 2d0] Return value:reg9

--- a/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
@@ -21,19 +21,19 @@ block1:
   [  38] Jump target:block8
 
 block2:
-  [  40] GetGlobal dst:reg6, `i`
-  [  58] PostfixIncrement dst:reg7, src:reg6
-  [  68] SetGlobal `i`, src:reg6
+  [  40] GetGlobal dst:reg7, `i`
+  [  58] PostfixIncrement dst:reg6, src:reg7
+  [  68] SetGlobal `i`, src:reg7
 
 block3:
   [  80] GetGlobal dst:reg6, `i`
   [  98] JumpLessThan lhs:reg6, rhs:Int32(5), true_target:block1, false_target:block4
 
 block4:
-  [  b0] GetGlobal dst:reg6, `i`
-  [  c8] StrictlyInequals dst:reg7, lhs:reg6, rhs:Int32(5)
-  [  d8] Mov dst:reg6, src:Undefined
-  [  e8] JumpIf condition:reg7, true_target:block14, false_target:block15
+  [  b0] GetGlobal dst:reg10, `i`
+  [  c8] StrictlyInequals dst:reg8, lhs:reg10, rhs:Int32(5)
+  [  d8] Mov dst:reg10, src:Undefined
+  [  e8] JumpIf condition:reg8, true_target:block14, false_target:block15
 
 block5:
   [  f8] Catch dst:reg7
@@ -75,7 +75,7 @@ block14:
   [ 208] Throw src:String("bad")
 
 block15:
-  [ 210] End value:reg6
+  [ 210] End value:reg10
 
 Exception handlers:
   [ 140 ..  188] => handler block5

--- a/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
@@ -40,9 +40,9 @@ block2:
   [  70] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block3, false_target:block4
 
 block3:
-  [  88] Mov dst:reg8, src:arg1
-  [  98] GetById dst:reg9, base:reg8, `y` (b.y)
-  [  b8] Yield continuation_label:block7, value:reg9
+  [  88] Mov dst:reg9, src:arg1
+  [  98] GetById dst:reg8, base:reg9, `y` (b.y)
+  [  b8] Yield continuation_label:block7, value:reg8
 
 block4:
   [  c8] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block5, false_target:block6
@@ -54,18 +54,18 @@ block6:
   [  e8] Yield value:reg7
 
 block7:
-  [  f8] Mov dst:reg5, src:reg0
-  [ 108] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [ 118] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block8, false_target:block9
+  [  f8] Mov dst:reg7, src:reg0
+  [ 108] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
+  [ 118] JumpStrictlyEquals lhs:reg5, rhs:Int32(1), true_target:block8, false_target:block9
 
 block8:
   [ 130] Yield value:Undefined
 
 block9:
-  [ 140] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block10, false_target:block11
+  [ 140] JumpStrictlyEquals lhs:reg5, rhs:Int32(5), true_target:block10, false_target:block11
 
 block10:
-  [ 158] Throw src:reg7
+  [ 158] Throw src:reg6
 
 block11:
-  [ 160] Yield value:reg7
+  [ 160] Yield value:reg6

--- a/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
@@ -59,40 +59,40 @@ block9:
   [  f0] Jump target:block3
 
 block10:
-  [  f8] Mov dst:reg7, src:reg0
-  [ 108] GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
-  [ 118] JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:block11, false_target:block12
+  [  f8] Mov dst:reg9, src:reg0
+  [ 108] GetCompletionFields type_dst:reg7, value_dst:reg8, completion:reg9
+  [ 118] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block11, false_target:block12
 
 block11:
   [ 130] Mov dst:reg5, src:Int32(0)
   [ 140] Jump target:block3
 
 block12:
-  [ 148] JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:block13, false_target:block14
+  [ 148] JumpStrictlyEquals lhs:reg7, rhs:Int32(5), true_target:block13, false_target:block14
 
 block13:
-  [ 160] Throw src:reg9
+  [ 160] Throw src:reg8
 
 block14:
-  [ 168] Mov2 dst1:reg6, src1:reg9, dst2:reg5, src2:Int32(2)
+  [ 168] Mov2 dst1:reg6, src1:reg8, dst2:reg5, src2:Int32(2)
   [ 180] Jump target:block3
 
 block15:
-  [ 188] Mov2 dst1:reg1, src1:reg10, dst2:reg7, src2:reg0
-  [ 1a0] GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
-  [ 1b0] JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:block16, false_target:block17
+  [ 188] Mov2 dst1:reg1, src1:reg10, dst2:reg8, src2:reg0
+  [ 1a0] GetCompletionFields type_dst:reg9, value_dst:reg7, completion:reg8
+  [ 1b0] JumpStrictlyEquals lhs:reg9, rhs:Int32(1), true_target:block16, false_target:block17
 
 block16:
   [ 1c8] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block20, false_target:block21
 
 block17:
-  [ 1e0] JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:block18, false_target:block19
+  [ 1e0] JumpStrictlyEquals lhs:reg9, rhs:Int32(5), true_target:block18, false_target:block19
 
 block18:
-  [ 1f8] Throw src:reg9
+  [ 1f8] Throw src:reg7
 
 block19:
-  [ 200] Yield value:reg9
+  [ 200] Yield value:reg7
 
 block20:
   [ 210] Yield value:Undefined

--- a/Tests/LibJS/Bytecode/expected/generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield.txt
@@ -11,10 +11,10 @@ block0:
   [  50] GetGlobal dst:reg6, `g`
   [  68] GetById dst:reg7, base:reg6, `next` (g.next)
   [  88] Call dst:reg5, callee:reg7, this_value:reg6, g.next
-  [  a8] GetGlobal dst:reg7, `g`
-  [  c0] GetById dst:reg8, base:reg7, `next` (g.next)
-  [  e0] Call dst:reg6, callee:reg8, this_value:reg7, g.next
-  [ 100] End value:reg6
+  [  a8] GetGlobal dst:reg6, `g`
+  [  c0] GetById dst:reg8, base:reg6, `next` (g.next)
+  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, g.next
+  [ 100] End value:reg7
 
 
 multi_yield$617e06b7 generator-yield.js:7:5
@@ -50,18 +50,18 @@ block6:
   [  88] Yield value:reg7
 
 block7:
-  [  98] Mov dst:reg5, src:reg0
-  [  a8] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  b8] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block8, false_target:block9
+  [  98] Mov dst:reg7, src:reg0
+  [  a8] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
+  [  b8] JumpStrictlyEquals lhs:reg5, rhs:Int32(1), true_target:block8, false_target:block9
 
 block8:
   [  d0] Yield value:Undefined
 
 block9:
-  [  e0] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block10, false_target:block11
+  [  e0] JumpStrictlyEquals lhs:reg5, rhs:Int32(5), true_target:block10, false_target:block11
 
 block10:
-  [  f8] Throw src:reg7
+  [  f8] Throw src:reg6
 
 block11:
-  [ 100] Yield value:reg7
+  [ 100] Yield value:reg6

--- a/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
@@ -39,9 +39,9 @@ block3:
   [  68] JumpLessThan lhs:i~1, rhs:Int32(10), true_target:block1, false_target:block4
 
 block4:
-  [  80] GetGlobal dst:reg6, `parseInt`
-  [  98] Mov dst:reg7, src:a~0
-  [  a8] Call dst:reg5, callee:reg6, this_value:Undefined, parseInt, arguments:[reg7]
+  [  80] GetGlobal dst:reg7, `parseInt`
+  [  98] Mov dst:reg10, src:a~0
+  [  a8] Call dst:reg5, callee:reg7, this_value:Undefined, parseInt, arguments:[reg10]
   [  d0] Return value:reg5
 
 block5:
@@ -64,13 +64,13 @@ block9:
   [ 180] Jump target:block11
 
 block10:
-  [ 188] Mov2 dst1:reg6, src1:arg0, dst2:reg7, src2:j~2
-  [ 1a0] GetGlobal dst:reg9, `parseInt`
-  [ 1b8] Mov dst:reg10, src:arg0
+  [ 188] Mov2 dst1:reg10, src1:arg0, dst2:reg6, src2:j~2
+  [ 1a0] GetGlobal dst:reg8, `parseInt`
+  [ 1b8] Mov dst:reg9, src:arg0
   [ 1c8] Sub dst:reg11, lhs:j~2, rhs:Int32(3)
-  [ 1d8] GetByValue dst:reg12, base:reg10, property:reg11 (x[reg11])
-  [ 1f0] Call dst:reg8, callee:reg9, this_value:Undefined, parseInt, arguments:[reg12, Int32(1)]
-  [ 218] PutByValue base:reg6, property:reg7, src:reg8, kind:Normal (x[reg7])
+  [ 1d8] GetByValue dst:reg12, base:reg9, property:reg11 (x[reg11])
+  [ 1f0] Call dst:reg7, callee:reg8, this_value:Undefined, parseInt, arguments:[reg12, Int32(1)]
+  [ 218] PutByValue base:reg10, property:reg6, src:reg7, kind:Normal (x[reg6])
 
 block11:
   [ 230] Jump target:block6

--- a/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
+++ b/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
@@ -21,14 +21,14 @@ block0:
   [  58] PutByValue base:reg8, property:Int32(0), src:Int32(1), kind:Own
   [  70] Call dst:reg5, callee:reg7, this_value:reg6, Object.preventExtensions, arguments:[reg8]
   [  98] InitializeLexicalBinding `object`, src:reg5
-  [  b0] GetGlobal dst:reg6, `expect_type_error`
-  [  c8] NewFunction dst:reg7, shared_function_data_index:0
-  [  e0] Call dst:reg5, callee:reg6, this_value:Undefined, expect_type_error, arguments:[reg7]
-  [ 108] GetGlobal dst:reg6, `object`
-  [ 120] GetByValue dst:reg7, base:reg6, property:Int32(1) (object[Int32(1)])
-  [ 138] StrictlyInequals dst:reg6, lhs:reg7, rhs:Undefined
-  [ 148] Mov dst:reg7, src:Undefined
-  [ 158] JumpFalse condition:reg6, target:block2
+  [  b0] GetGlobal dst:reg7, `expect_type_error`
+  [  c8] NewFunction dst:reg6, shared_function_data_index:0
+  [  e0] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
+  [ 108] GetGlobal dst:reg7, `object`
+  [ 120] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
+  [ 138] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
+  [ 148] Mov dst:reg6, src:Undefined
+  [ 158] JumpFalse condition:reg7, target:block2
 
 block1:
   [ 168] GetGlobal dst:reg9, `Error`
@@ -38,41 +38,41 @@ block1:
 block2:
   [ 1a8] NewPrimitiveArray dst:reg5, elements:[1, 2]
   [ 1c8] InitializeLexicalBinding `array`, src:reg5
-  [ 1e0] GetGlobal dst:reg6, `Object`
-  [ 1f8] GetById dst:reg8, base:reg6, `defineProperty` (Object.defineProperty)
+  [ 1e0] GetGlobal dst:reg7, `Object`
+  [ 1f8] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
   [ 218] GetGlobal dst:reg9, `array`
   [ 230] NewObject dst:reg10
   [ 240] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
   [ 258] CacheObjectShape object:reg10
-  [ 268] Call dst:reg5, callee:reg8, this_value:reg6, Object.defineProperty, arguments:[reg9, String("length"), reg10]
-  [ 298] GetGlobal dst:reg7, `expect_type_error`
-  [ 2b0] NewFunction dst:reg8, shared_function_data_index:1
-  [ 2c8] Call dst:reg6, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg8]
+  [ 268] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
+  [ 298] GetGlobal dst:reg8, `expect_type_error`
+  [ 2b0] NewFunction dst:reg7, shared_function_data_index:1
+  [ 2c8] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
   [ 2f0] GetGlobal dst:reg5, `array`
-  [ 308] GetLength dst:reg7, base:reg5 (array.length)
-  [ 320] StrictlyInequals dst:reg5, lhs:reg7, rhs:Int32(2)
-  [ 330] Mov dst:reg7, src:Undefined
+  [ 308] GetLength dst:reg8, base:reg5 (array.length)
+  [ 320] StrictlyInequals dst:reg5, lhs:reg8, rhs:Int32(2)
+  [ 330] Mov dst:reg8, src:Undefined
   [ 340] JumpFalse condition:reg5, target:block4
 
 block3:
-  [ 350] GetGlobal dst:reg9, `Error`
-  [ 368] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Array length changed")]
-  [ 388] Throw src:reg8
+  [ 350] GetGlobal dst:reg10, `Error`
+  [ 368] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
+  [ 388] Throw src:reg7
 
 block4:
-  [ 390] GetGlobal dst:reg5, `array`
-  [ 3a8] GetByValue dst:reg6, base:reg5, property:Int32(2) (array[Int32(2)])
-  [ 3c0] StrictlyInequals dst:reg5, lhs:reg6, rhs:Undefined
-  [ 3d0] Mov dst:reg6, src:Undefined
-  [ 3e0] JumpFalse condition:reg5, target:block6
+  [ 390] GetGlobal dst:reg6, `array`
+  [ 3a8] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
+  [ 3c0] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
+  [ 3d0] Mov dst:reg5, src:Undefined
+  [ 3e0] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 3f0] GetGlobal dst:reg9, `Error`
-  [ 408] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Array append mutated")]
-  [ 428] Throw src:reg8
+  [ 3f0] GetGlobal dst:reg10, `Error`
+  [ 408] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
+  [ 428] Throw src:reg7
 
 block6:
-  [ 430] End value:reg6
+  [ 430] End value:reg5
 
 
 expect_type_error$f42c6af9 indexed-append-guards.js:4:5
@@ -114,8 +114,8 @@ block5:
   [  e0] Jump target:block4
 
 block6:
-  [  e8] GetGlobal dst:reg7, `Error`
-  [ 100] CallConstruct dst:reg6, callee:reg7, Error, arguments:[String("Expected TypeError")]
+  [  e8] GetGlobal dst:reg8, `Error`
+  [ 100] CallConstruct dst:reg6, callee:reg8, Error, arguments:[String("Expected TypeError")]
   [ 120] Throw src:reg6
 
 block7:

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -11,32 +11,32 @@ block0:
   [  40] GetGlobal dst:reg9, `withTeardown`
   [  58] Call dst:reg8, callee:reg9, this_value:Undefined, withTeardown
   [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg7, `console`
-  [  b8] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  a0] GetGlobal dst:reg6, `console`
+  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d8] GetGlobal dst:reg10, `blockTeardown`
   [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, blockTeardown
-  [ 110] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 138] GetGlobal dst:reg7, `console`
-  [ 150] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 110] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 138] GetGlobal dst:reg8, `console`
+  [ 150] GetById dst:reg6, base:reg8, `log` (console.log)
   [ 170] GetGlobal dst:reg10, `forInTeardown`
   [ 188] Call dst:reg9, callee:reg10, this_value:Undefined, forInTeardown
-  [ 1a8] Call dst:reg5, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 1d0] GetGlobal dst:reg7, `console`
-  [ 1e8] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 1a8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 1d0] GetGlobal dst:reg6, `console`
+  [ 1e8] GetById dst:reg8, base:reg6, `log` (console.log)
   [ 208] GetGlobal dst:reg10, `forOfTeardown`
   [ 220] Call dst:reg9, callee:reg10, this_value:Undefined, forOfTeardown
-  [ 240] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 268] GetGlobal dst:reg7, `console`
-  [ 280] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 240] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 268] GetGlobal dst:reg8, `console`
+  [ 280] GetById dst:reg6, base:reg8, `log` (console.log)
   [ 2a0] GetGlobal dst:reg10, `catchTeardown`
   [ 2b8] Call dst:reg9, callee:reg10, this_value:Undefined, catchTeardown
-  [ 2d8] Call dst:reg5, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 300] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
+  [ 2d8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 300] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0
   [ 310] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
-  [ 320] NewFunction dst:reg7, shared_function_data_index:0
-  [ 338] InitializeLexicalBinding `myName`, src:reg7
+  [ 320] NewFunction dst:reg6, shared_function_data_index:0
+  [ 338] InitializeLexicalBinding `myName`, src:reg6
   [ 350] SetLexicalEnvironment environment:reg4
-  [ 358] SetGlobal `namedFn`, src:reg7
+  [ 358] SetGlobal `namedFn`, src:reg6
   [ 370] GetGlobal dst:reg7, `console`
   [ 388] GetById dst:reg8, base:reg7, `log` (console.log)
   [ 3a8] GetGlobal dst:reg10, `namedFn`

--- a/Tests/LibJS/Bytecode/expected/mov-merging.txt
+++ b/Tests/LibJS/Bytecode/expected/mov-merging.txt
@@ -10,12 +10,12 @@ block0:
   [  38] GetGlobal dst:reg9, `twoLocals`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, twoLocals
   [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg7, `console`
-  [  b0] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  98] GetGlobal dst:reg6, `console`
+  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d0] GetGlobal dst:reg10, `threeLocals`
   [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, threeLocals
-  [ 108] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 130] End value:reg6
+  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 130] End value:reg7
 
 
 twoLocals$37fee39e mov-merging.js:2:5

--- a/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
@@ -20,9 +20,9 @@ block1:
   [  58] Jump target:block6
 
 block2:
-  [  60] GetGlobal dst:reg6, `n`
-  [  78] Add dst:reg7, lhs:reg6, rhs:Int32(1)
-  [  88] SetGlobal `n`, src:reg7
+  [  60] GetGlobal dst:reg7, `n`
+  [  78] Add dst:reg6, lhs:reg7, rhs:Int32(1)
+  [  88] SetGlobal `n`, src:reg6
 
 block3:
   [  a0] GetGlobal dst:reg6, `n`
@@ -32,9 +32,9 @@ block4:
   [  d0] End value:reg5
 
 block5:
-  [  d8] GetGlobal dst:reg7, `depth`
-  [  f0] Add dst:reg8, lhs:reg7, rhs:Int32(2)
-  [ 100] SetGlobal `depth`, src:reg8
+  [  d8] GetGlobal dst:reg8, `depth`
+  [  f0] Add dst:reg7, lhs:reg8, rhs:Int32(2)
+  [ 100] SetGlobal `depth`, src:reg7
 
 block6:
   [ 118] GetGlobal dst:reg7, `depth`

--- a/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
@@ -48,8 +48,8 @@ block5:
 block6:
   [  78] GetGlobal dst:reg8, `console`
   [  90] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  b0] Mov dst:reg10, src:i~0
-  [  c0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg10]
+  [  b0] Mov dst:reg11, src:i~0
+  [  c0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg11]
   [  e8] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block19, false_target:block20
 
 block7:

--- a/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
@@ -12,11 +12,11 @@ block0:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
   [  58] InitializeLexicalBinding `C`, src:reg6
-  [  70] GetGlobal dst:reg6, `C`
-  [  88] CallConstruct dst:reg5, callee:reg6, C
-  [  a0] GetByValue dst:reg6, base:reg5, property:Int32(42)
-  [  b8] GetById dst:reg5, base:reg6, `name` ([42].name)
-  [  d8] End value:reg5
+  [  70] GetGlobal dst:reg5, `C`
+  [  88] CallConstruct dst:reg6, callee:reg5, C
+  [  a0] GetByValue dst:reg5, base:reg6, property:Int32(42)
+  [  b8] GetById dst:reg6, base:reg5, `name` ([42].name)
+  [  d8] End value:reg6
 
 
 C$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
@@ -16,10 +16,10 @@ block0:
   [  68] LeavePrivateEnvironment
   [  70] InitializeLexicalBinding `C`, src:reg6
   [  88] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg6, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg6, `nextId`
-  [  d8] Call dst:reg5, callee:reg7, this_value:reg6, <object>.nextId
-  [  f8] End value:reg5
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `nextId`
+  [  d8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
+  [  f8] End value:reg6
 
 
 C$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
@@ -16,10 +16,10 @@ block0:
   [  68] LeavePrivateEnvironment
   [  70] InitializeLexicalBinding `C`, src:reg6
   [  88] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg6, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg6, `f`
-  [  d8] Call dst:reg5, callee:reg7, this_value:reg6, <object>.f
-  [  f8] End value:reg5
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `f`
+  [  d8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
+  [  f8] End value:reg6
 
 
 C$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
+++ b/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
@@ -16,10 +16,10 @@ block0:
   [  68] LeavePrivateEnvironment
   [  70] InitializeLexicalBinding `C`, src:reg6
   [  88] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg6, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg6, `call`
-  [  d8] Call dst:reg5, callee:reg7, this_value:reg6, <object>.call
-  [  f8] End value:reg5
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `call`
+  [  d8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
+  [  f8] End value:reg6
 
 
 C$811c9dc5

--- a/Tests/LibJS/Bytecode/expected/regex-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/regex-literals.txt
@@ -14,9 +14,9 @@ block0:
   [  60] NewRegExp dst:reg5, baz, i
   [  78] Add dst:reg6, lhs:Int32(1), rhs:reg5
   [  88] InitializeLexicalBinding `c`, src:reg6
-  [  a0] GetGlobal dst:reg6, `matchDigits`
-  [  b8] Call dst:reg5, callee:reg6, this_value:Undefined, matchDigits, arguments:[String("abc123")]
-  [  e0] End value:reg5
+  [  a0] GetGlobal dst:reg5, `matchDigits`
+  [  b8] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
+  [  e0] End value:reg6
 
 
 matchDigits$4cca49e8 regex-literals.js:8:5

--- a/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
+++ b/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
@@ -43,23 +43,23 @@ block2:
 
 block3:
   [  70] Mov dst:reg5, src:result~2
-  [  80] Add dst:reg6, lhs:reg5, rhs:String("a")
-  [  90] Mov dst:result~2, src:reg6
+  [  80] Add dst:reg7, lhs:reg5, rhs:String("a")
+  [  90] Mov dst:result~2, src:reg7
   [  a0] Throw src:Int32(1)
 
 block4:
-  [  a8] Catch dst:reg5
+  [  a8] Catch dst:reg7
   [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] Mov2 dst1:e~1, src1:reg5, dst2:reg6, src2:result~2
-  [  d0] Add dst:reg7, lhs:reg6, rhs:String("d")
-  [  e0] Mov dst:result~2, src:reg7
+  [  b8] Mov2 dst1:e~1, src1:reg7, dst2:reg5, src2:result~2
+  [  d0] Add dst:reg6, lhs:reg5, rhs:String("d")
+  [  e0] Mov dst:result~2, src:reg6
 
 block5:
   [  f0] Return value:result~2
 
 block6:
-  [  f8] Mov dst:reg5, src:result~2
-  [ 108] Add dst:reg6, lhs:reg5, rhs:String("c")
+  [  f8] Mov dst:reg7, src:result~2
+  [ 108] Add dst:reg6, lhs:reg7, rhs:String("c")
   [ 118] Mov dst:result~2, src:reg6
   [ 128] Throw src:Int32(2)
 

--- a/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
@@ -9,7 +9,7 @@ block0:
   [   0] GetGlobal dst:reg6, `String`
   [  18] GetById dst:reg7, base:reg6, `fromCharCode` (String.fromCharCode)
   [  38] CallBuiltinStringFromCharCode dst:reg5, callee:reg7, this_value:reg6, argument:Int32(65), String.fromCharCode
-  [  50] GetGlobal dst:reg7, `String`
-  [  68] GetById dst:reg8, base:reg7, `fromCharCode` (String.fromCharCode)
-  [  88] Call dst:reg6, callee:reg8, this_value:reg7, String.fromCharCode, arguments:[Int32(65), Int32(66)]
-  [  b0] End value:reg6
+  [  50] GetGlobal dst:reg6, `String`
+  [  68] GetById dst:reg8, base:reg6, `fromCharCode` (String.fromCharCode)
+  [  88] Call dst:reg7, callee:reg8, this_value:reg6, String.fromCharCode, arguments:[Int32(65), Int32(66)]
+  [  b0] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
@@ -12,9 +12,9 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
   [  68] InitializeLexicalBinding `C`, src:reg7
-  [  80] GetGlobal dst:reg6, `C`
-  [  98] CallConstruct dst:reg5, callee:reg6, C
-  [  b0] End value:reg5
+  [  80] GetGlobal dst:reg5, `C`
+  [  98] CallConstruct dst:reg7, callee:reg5, C
+  [  b0] End value:reg7
 
 
 C$0ec9c92d super-call-spread-register-order.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
@@ -12,17 +12,17 @@ block0:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
   [  50] InitializeLexicalBinding `Base`, src:reg6
-  [  68] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
+  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
   [  78] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
-  [  88] GetGlobal dst:reg6, `Base`
+  [  88] GetGlobal dst:reg5, `Base`
   [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:1, element_keys:[element_keys:String("test")]
+  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
   [  d0] InitializeLexicalBinding `Derived`, src:reg7
-  [  e8] GetGlobal dst:reg7, `Derived`
-  [ 100] CallConstruct dst:reg6, callee:reg7, Derived
-  [ 118] GetById dst:reg7, base:reg6, `test`
-  [ 138] Call dst:reg5, callee:reg7, this_value:reg6, <object>.test
-  [ 158] End value:reg5
+  [  e8] GetGlobal dst:reg5, `Derived`
+  [ 100] CallConstruct dst:reg6, callee:reg5, Derived
+  [ 118] GetById dst:reg5, base:reg6, `test`
+  [ 138] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
+  [ 158] End value:reg7
 
 
 Derived$1c41db7c super-computed-eval-order.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
@@ -12,9 +12,9 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
   [  68] InitializeLexicalBinding `C`, src:reg7
-  [  80] GetGlobal dst:reg6, `C`
-  [  98] CallConstruct dst:reg5, callee:reg6, C
-  [  b0] End value:reg5
+  [  80] GetGlobal dst:reg5, `C`
+  [  98] CallConstruct dst:reg7, callee:reg5, C
+  [  b0] End value:reg7
 
 
 C$851d2148 super-computed-string-to-id.js:3:14
@@ -29,6 +29,6 @@ block0:
   [   0] NewArray dst:reg5
   [  10] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:false
   [  20] ResolveThisBinding
-  [  28] ResolveSuperBase dst:reg5
-  [  30] PutByIdWithThis base:reg5, this_value:this, `foo`, src:Int32(1), kind:Normal
+  [  28] ResolveSuperBase dst:reg6
+  [  30] PutByIdWithThis base:reg6, this_value:this, `foo`, src:Int32(1), kind:Normal
   [  50] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
+++ b/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
@@ -12,15 +12,15 @@ block0:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
   [  50] InitializeLexicalBinding `Base`, src:reg6
-  [  68] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
+  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
   [  78] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
-  [  88] GetGlobal dst:reg6, `Base`
+  [  88] GetGlobal dst:reg5, `Base`
   [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:1
+  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
   [  c8] InitializeLexicalBinding `Derived`, src:reg7
   [  e0] GetGlobal dst:reg6, `Derived`
-  [  f8] CallConstruct dst:reg5, callee:reg6, Derived, arguments:[Int32(1)]
-  [ 118] End value:reg5
+  [  f8] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
+  [ 118] End value:reg7
 
 
 Derived$3808ea25 super-constructor-call.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -15,19 +15,19 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
   [  78] InitializeLexicalBinding `A`, src:reg7
-  [  90] GetGlobal dst:reg7, `A`
-  [  a8] CallConstruct dst:reg6, callee:reg7, A
-  [  c0] GetById dst:reg7, base:reg6, `read`
-  [  e0] Call dst:reg5, callee:reg7, this_value:reg6, <object>.read
+  [  90] GetGlobal dst:reg6, `A`
+  [  a8] CallConstruct dst:reg5, callee:reg6, A
+  [  c0] GetById dst:reg6, base:reg5, `read`
+  [  e0] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
   [ 100] GetGlobal dst:reg8, `A`
-  [ 118] CallConstruct dst:reg7, callee:reg8, A
-  [ 130] GetById dst:reg8, base:reg7, `write`
-  [ 150] Call dst:reg6, callee:reg8, this_value:reg7, <object>.write
-  [ 170] GetGlobal dst:reg8, `A`
-  [ 188] CallConstruct dst:reg7, callee:reg8, A
-  [ 1a0] GetById dst:reg8, base:reg7, `update`
-  [ 1c0] Call dst:reg5, callee:reg8, this_value:reg7, <object>.update
-  [ 1e0] End value:reg5
+  [ 118] CallConstruct dst:reg5, callee:reg8, A
+  [ 130] GetById dst:reg8, base:reg5, `write`
+  [ 150] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
+  [ 170] GetGlobal dst:reg5, `A`
+  [ 188] CallConstruct dst:reg8, callee:reg5, A
+  [ 1a0] GetById dst:reg5, base:reg8, `update`
+  [ 1c0] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
+  [ 1e0] End value:reg7
 
 
 A$3f156142 super-evaluation-order.js:1:1

--- a/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
@@ -11,9 +11,9 @@ block0:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
   [  50] InitializeLexicalBinding `C`, src:reg6
-  [  68] GetGlobal dst:reg6, `C`
-  [  80] CallConstruct dst:reg5, callee:reg6, C
-  [  98] End value:reg5
+  [  68] GetGlobal dst:reg5, `C`
+  [  80] CallConstruct dst:reg6, callee:reg5, C
+  [  98] End value:reg6
 
 
 C$f4d17d48 super-for-of-resolve-order.js:3:28

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -13,17 +13,17 @@ block0:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("length")]
   [  58] InitializeLexicalBinding `A`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
   [  80] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:false
-  [  90] GetGlobal dst:reg6, `A`
+  [  90] GetGlobal dst:reg5, `A`
   [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:1, element_keys:[element_keys:String("m")]
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
   [  d8] InitializeLexicalBinding `B`, src:reg7
-  [  f0] GetGlobal dst:reg7, `B`
-  [ 108] CallConstruct dst:reg6, callee:reg7, B
-  [ 120] GetById dst:reg7, base:reg6, `m`
-  [ 140] Call dst:reg5, callee:reg7, this_value:reg6, <object>.m
-  [ 160] End value:reg5
+  [  f0] GetGlobal dst:reg5, `B`
+  [ 108] CallConstruct dst:reg6, callee:reg5, B
+  [ 120] GetById dst:reg5, base:reg6, `m`
+  [ 140] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
+  [ 160] End value:reg7
 
 
 B$ea587383 super-length-access.js:7:1

--- a/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
@@ -21,11 +21,11 @@ block0:
   [ 190] GetGlobal dst:reg6, `obj`
   [ 1a8] GetById dst:reg7, base:reg6, `test` (obj.test)
   [ 1c8] Call dst:reg5, callee:reg7, this_value:reg6, obj.test
-  [ 1e8] GetGlobal dst:reg6, `obj`
-  [ 200] GetById dst:reg7, base:reg6, `x` (obj.x)
-  [ 220] GetGlobal dst:reg6, `obj`
-  [ 238] GetById dst:reg8, base:reg6, `test2` (obj.test2)
-  [ 258] Call dst:reg5, callee:reg8, this_value:reg6, obj.test2
+  [ 1e8] GetGlobal dst:reg7, `obj`
+  [ 200] GetById dst:reg6, base:reg7, `x` (obj.x)
+  [ 220] GetGlobal dst:reg7, `obj`
+  [ 238] GetById dst:reg8, base:reg7, `test2` (obj.test2)
+  [ 258] Call dst:reg5, callee:reg8, this_value:reg7, obj.test2
   [ 278] End value:reg5
 
 

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -12,17 +12,17 @@ block0:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
   [  58] InitializeLexicalBinding `Base`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
   [  80] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
-  [  90] GetGlobal dst:reg6, `Base`
+  [  90] GetGlobal dst:reg5, `Base`
   [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:1, element_keys:[element_keys:String("method")]
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
   [  d8] InitializeLexicalBinding `Foo`, src:reg7
-  [  f0] GetGlobal dst:reg7, `Foo`
-  [ 108] CallConstruct dst:reg6, callee:reg7, Foo
-  [ 120] GetById dst:reg7, base:reg6, `method`
-  [ 140] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
-  [ 160] End value:reg5
+  [  f0] GetGlobal dst:reg5, `Foo`
+  [ 108] CallConstruct dst:reg6, callee:reg5, Foo
+  [ 120] GetById dst:reg5, base:reg6, `method`
+  [ 140] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
+  [ 160] End value:reg7
 
 
 Foo$4b66ae80 super-optional-call-this.js:4:1

--- a/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
@@ -13,16 +13,16 @@ block0:
   [  38] GetGlobal dst:reg9, `eval`
   [  50] CallDirectEval dst:reg8, callee:reg9, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'hello'; let x = 1; }")]
   [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg7, `console`
-  [  b8] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  a0] GetGlobal dst:reg6, `console`
+  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d8] GetGlobal dst:reg10, `eval`
   [  f0] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'first'; 'second'; }")]
-  [ 118] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 140] GetGlobal dst:reg7, `console`
-  [ 158] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 140] GetGlobal dst:reg8, `console`
+  [ 158] GetById dst:reg6, base:reg8, `log` (console.log)
   [ 178] GetGlobal dst:reg10, `eval`
   [ 190] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'matched'; break; default: 'default'; }")]
-  [ 1b8] Call dst:reg5, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 1b8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
   [ 1e0] End value:reg5
 
 

--- a/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
@@ -13,16 +13,16 @@ block0:
   [  38] GetGlobal dst:reg9, `switchLocalOnly`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, switchLocalOnly, arguments:[Int32(1)]
   [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg7, `console`
-  [  b8] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  a0] GetGlobal dst:reg6, `console`
+  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d8] GetGlobal dst:reg10, `switchLocalOnly`
   [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(2)]
-  [ 118] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 140] GetGlobal dst:reg7, `console`
-  [ 158] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 140] GetGlobal dst:reg8, `console`
+  [ 158] GetById dst:reg6, base:reg8, `log` (console.log)
   [ 178] GetGlobal dst:reg10, `switchLocalOnly`
   [ 190] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(3)]
-  [ 1b8] Call dst:reg5, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 1b8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
   [ 1e0] End value:reg5
 
 

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -12,12 +12,12 @@ block0:
   [  38] GetGlobal dst:reg9, `switchWithBlockDecl`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(1)]
   [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg7, `console`
-  [  b8] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  a0] GetGlobal dst:reg6, `console`
+  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d8] GetGlobal dst:reg10, `switchWithBlockDecl`
   [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(2)]
-  [ 118] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 140] End value:reg6
+  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 140] End value:reg7
 
 
 switchWithBlockDecl$2b5ecfcd switch-scoping.js:2:5

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -14,17 +14,17 @@ block0:
   [  58] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
   [  80] InitializeLexicalBinding `x`, src:reg8
   [  98] InitializeLexicalBinding `y`, src:Null
-  [  b0] GetGlobal dst:reg5, `x`
-  [  c8] StrictlyEquals dst:reg6, lhs:reg5, rhs:String("hello")
-  [  d8] Mov dst:reg5, src:Undefined
+  [  b0] GetGlobal dst:reg8, `x`
+  [  c8] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
+  [  d8] Mov dst:reg8, src:Undefined
   [  e8] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  f8] GetGlobal dst:reg8, `x`
-  [ 110] GetById dst:reg9, base:reg8, `toUpperCase` (x.toUpperCase)
-  [ 130] Call dst:reg7, callee:reg9, this_value:reg8, x.toUpperCase
+  [  f8] GetGlobal dst:reg5, `x`
+  [ 110] GetById dst:reg9, base:reg5, `toUpperCase` (x.toUpperCase)
+  [ 130] Call dst:reg7, callee:reg9, this_value:reg5, x.toUpperCase
   [ 150] SetGlobal `y`, src:reg7
-  [ 168] Mov dst:reg5, src:reg7
+  [ 168] Mov dst:reg8, src:reg7
 
 block2:
-  [ 178] End value:reg5
+  [ 178] End value:reg8

--- a/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
@@ -72,9 +72,9 @@ block1:
 block2:
   [  40] Mov dst:z~2, src:Int32(3)
   [  50] GetGlobal dst:reg8, `console`
-  [  68] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  88] Mov dst:reg10, src:z~2
-  [  98] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[reg10]
+  [  68] GetById dst:reg10, base:reg8, `log` (console.log)
+  [  88] Mov dst:reg9, src:z~2
+  [  98] Call dst:reg7, callee:reg10, this_value:reg8, console.log, arguments:[reg9]
   [  c0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block5, false_target:block6
 
 block3:

--- a/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
@@ -10,12 +10,12 @@ block0:
   [  38] GetGlobal dst:reg9, `continueThroughFinally`
   [  50] Call dst:reg8, callee:reg9, this_value:Undefined, continueThroughFinally
   [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg7, `console`
-  [  b0] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  98] GetGlobal dst:reg6, `console`
+  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
   [  d0] GetGlobal dst:reg10, `breakThroughFinally`
   [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughFinally
-  [ 108] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 130] End value:reg6
+  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 130] End value:reg7
 
 
 continueThroughFinally$8372c35a try-finally-continue.js:2:5
@@ -53,9 +53,9 @@ block5:
   [  70] Mov dst:reg5, src:Int32(1)
 
 block6:
-  [  80] Mov dst:reg7, src:result~1
-  [  90] Add dst:reg8, lhs:reg7, rhs:Int32(10)
-  [  a0] Mov dst:result~1, src:reg8
+  [  80] Mov dst:reg8, src:result~1
+  [  90] Add dst:reg7, lhs:reg8, rhs:Int32(10)
+  [  a0] Mov dst:result~1, src:reg7
   [  b0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block10, false_target:block11
 
 block7:
@@ -126,9 +126,9 @@ block5:
   [  70] Mov dst:reg5, src:Int32(1)
 
 block6:
-  [  80] Mov dst:reg7, src:result~1
-  [  90] Add dst:reg8, lhs:reg7, rhs:Int32(100)
-  [  a0] Mov dst:result~1, src:reg8
+  [  80] Mov dst:reg8, src:result~1
+  [  90] Add dst:reg7, lhs:reg8, rhs:Int32(100)
+  [  a0] Mov dst:result~1, src:reg7
   [  b0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block10, false_target:block11
 
 block7:


### PR DESCRIPTION
`Generator::allocate_register` used to scan the free pool to find the lowest-numbered register and then `Vec::remove` it, making every allocation **O(n)** in the size of the pool. When loading https://x.com/ on my Linux machine, we spent ~800ms in this function alone!

This logic only existed to match the C++ register allocation ordering while transitioning from C++ to Rust in the LibJS compiler, so now we can simply get rid of it and make it instant. :^)

So drop the "always hand out the lowest-numbered free register" policy and use the pool as a plain LIFO stack. Pushing and popping the back of the `Vec` are both **O(1)**, and peak register usage is unchanged since the policy only affects which specific register gets reused, not how aggressively.

Benchmarks swing around a bit as expected from changes to register allocation, but looks neutral/good on the whole:

```
Suite           Test                                            Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  ----------------------------------------------  ---------  ---------------------------------  ---------------------------------  -----------------
LongSpider      3d-cube.js                                      0.988      4.557 ± 4.504 … 4.610              4.611 ± 4.508 … 4.713              +0.0% (+0.0 MB)
LongSpider      3d-morph.js                                     1.001      1.575 ± 1.546 … 1.604              1.573 ± 1.557 … 1.590              -1.1% (-0.3 MB)
LongSpider      3d-raytrace.js                                  1.042      2.960 ± 2.952 … 2.969              2.841 ± 2.830 … 2.853              +0.3% (+0.1 MB)
LongSpider      access-binary-trees.js                          1.010      7.961 ± 7.878 … 8.043              7.884 ± 7.861 … 7.907              +35.0% (+33.3 MB)
LongSpider      access-fannkuch.js                              1.102      1.780 ± 1.665 … 1.894              1.615 ± 1.547 … 1.682              -1.1% (-0.3 MB)
LongSpider      access-nbody.js                                 1.069      3.923 ± 3.824 … 4.023              3.669 ± 3.629 … 3.709              -1.1% (-0.3 MB)
LongSpider      access-nsieve.js                                1.008      0.920 ± 0.897 … 0.943              0.912 ± 0.909 … 0.916              +0.0% (+0.1 MB)
LongSpider      bitops-3bit-bits-in-byte.js                     1.007      0.437 ± 0.437 … 0.438              0.434 ± 0.434 … 0.435              -1.1% (-0.3 MB)
LongSpider      bitops-bits-in-byte.js                          1.216      0.696 ± 0.693 … 0.699              0.572 ± 0.572 … 0.573              -1.1% (-0.3 MB)
LongSpider      bitops-nsieve-bits.js                           1.084      1.954 ± 1.898 … 2.010              1.802 ± 1.801 … 1.803              +0.3% (+0.1 MB)
LongSpider      controlflow-recursive.js                        1.018      1.803 ± 1.788 … 1.818              1.770 ± 1.768 … 1.772              -1.1% (-0.3 MB)
LongSpider      crypto-aes.js                                   1.049      4.508 ± 4.397 … 4.618              4.295 ± 4.269 … 4.321              +0.4% (+0.1 MB)
LongSpider      crypto-md5.js                                   1.003      4.444 ± 4.414 … 4.473              4.431 ± 4.426 … 4.436              -0.1% (-0.1 MB)
LongSpider      crypto-sha1.js                                  0.957      8.366 ± 8.282 … 8.450              8.742 ± 8.410 … 9.074              -0.4% (-0.4 MB)
LongSpider      date-format-tofte.js                            0.992      3.570 ± 3.559 … 3.582              3.599 ± 3.596 … 3.603              -0.4% (-0.1 MB)
LongSpider      date-format-xparb.js                            1.002      4.229 ± 4.227 … 4.232              4.220 ± 4.171 … 4.269              +0.2% (+0.1 MB)
LongSpider      hash-map.js                                     1.000      1.030 ± 1.017 … 1.043              1.029 ± 1.013 … 1.045              -0.1% (-0.2 MB)
LongSpider      math-cordic.js                                  0.993      5.249 ± 5.234 … 5.263              5.283 ± 5.257 … 5.309              -1.1% (-0.3 MB)
LongSpider      math-partial-sums.js                            1.029      0.825 ± 0.789 … 0.862              0.803 ± 0.800 … 0.805              -1.1% (-0.3 MB)
LongSpider      math-spectral-norm.js                           0.998      4.750 ± 4.739 … 4.761              4.760 ± 4.759 … 4.761              -1.1% (-0.3 MB)
LongSpider      string-base64.js                                1.026      1.444 ± 1.437 … 1.452              1.408 ± 1.405 … 1.410              +0.0% (+0.1 MB)
LongSpider      string-fasta.js                                 1.014      1.573 ± 1.570 … 1.576              1.550 ± 1.536 … 1.565              +0.2% (+0.1 MB)
LongSpider      string-tagcloud.js                              0.998      0.738 ± 0.736 … 0.739              0.739 ± 0.737 … 0.742              +0.2% (+0.1 MB)
Kraken          ai-astar.js                                     0.941      0.618 ± 0.617 … 0.619              0.657 ± 0.652 … 0.662              +0.1% (+0.0 MB)
Kraken          audio-beat-detection.js                         1.071      0.535 ± 0.534 … 0.536              0.499 ± 0.495 … 0.503              -0.0% (-0.0 MB)
Kraken          audio-dft.js                                    1.039      0.364 ± 0.347 … 0.380              0.350 ± 0.345 … 0.355              +0.1% (+0.1 MB)
Kraken          audio-fft.js                                    1.101      0.462 ± 0.455 … 0.470              0.420 ± 0.416 … 0.424              -0.1% (-0.0 MB)
Kraken          audio-oscillator.js                             0.961      0.349 ± 0.349 … 0.349              0.363 ± 0.357 … 0.369              -0.2% (-0.2 MB)
Kraken          imaging-darkroom.js                             1.010      0.553 ± 0.551 … 0.555              0.548 ± 0.534 … 0.561              -0.2% (-0.1 MB)
Kraken          imaging-desaturate.js                           1.114      0.630 ± 0.627 … 0.632              0.565 ± 0.564 … 0.566              -0.0% (-0.0 MB)
Kraken          imaging-gaussian-blur.js                        1.003      2.658 ± 2.616 … 2.701              2.649 ± 2.572 … 2.727              -0.1% (-0.1 MB)
Kraken          json-parse-financial.js                         1.177      0.064 ± 0.054 … 0.073              0.054 ± 0.054 … 0.054              +0.0% (+0.0 MB)
Kraken          json-stringify-tinderbox.js                     1.073      0.052 ± 0.052 … 0.052              0.049 ± 0.048 … 0.049              -2.4% (-0.9 MB)
Kraken          stanford-crypto-aes.js                          0.986      0.211 ± 0.211 … 0.211              0.214 ± 0.212 … 0.215              -0.0% (-0.0 MB)
Kraken          stanford-crypto-ccm.js                          1.027      0.164 ± 0.161 … 0.166              0.159 ± 0.157 … 0.161              +0.3% (+0.2 MB)
Kraken          stanford-crypto-pbkdf2.js                       1.023      0.365 ± 0.350 … 0.379              0.357 ± 0.342 … 0.371              -0.5% (-0.2 MB)
Kraken          stanford-crypto-sha256-iterative.js             1.045      0.139 ± 0.137 … 0.140              0.133 ± 0.132 … 0.134              +0.0% (+0.0 MB)
Octane          box2d.js                                        1.002      8709.500 ± 8615.000 … 8804.000     8729.500 ± 8713.000 … 8746.000     +0.1% (+0.1 MB)
Octane          code-load.js                                    0.998      19167.000 ± 19133.000 … 19201.000  19138.000 ± 19115.000 … 19161.000  -0.3% (-2.7 MB)
Octane          crypto.js                                       1.093      2789.500 ± 2716.000 … 2863.000     3049.500 ± 2983.000 … 3116.000     -3.2% (-1.0 MB)
Octane          deltablue.js                                    0.986      2302.000 ± 2288.000 … 2316.000     2270.500 ± 2200.000 … 2341.000     +1.1% (+0.3 MB)
Octane          earley-boyer.js                                 1.002      4824.000 ± 4799.000 … 4849.000     4833.000 ± 4832.000 … 4834.000     -0.9% (-0.5 MB)
Octane          gbemu.js                                        1.014      16805.500 ± 16759.000 … 16852.000  17047.000 ± 17039.000 … 17055.000  +0.0% (+0.0 MB)
Octane          mandreel.js                                     1.027      16320.000 ± 16133.000 … 16507.000  16758.000 ± 16617.000 … 16899.000  -2.5% (-8.1 MB)
Octane          navier-stokes.js                                0.995      5178.000 ± 5072.000 … 5284.000     5154.500 ± 5092.000 … 5217.000     -1.1% (-0.3 MB)
Octane          pdfjs.js                                        1.006      7333.500 ± 7317.000 … 7350.000     7380.500 ± 7377.000 … 7384.000     -0.2% (-0.2 MB)
Octane          raytrace.js                                     1.014      3515.500 ± 3479.000 … 3552.000     3563.500 ± 3562.000 … 3565.000     +0.1% (+0.0 MB)
Octane          regexp.js                                       0.986      2060.000 ± 2058.000 … 2062.000     2032.000 ± 2032.000 … 2032.000     +0.8% (+0.4 MB)
Octane          richards.js                                     0.991      2496.500 ± 2475.000 … 2518.000     2475.000 ± 2475.000 … 2475.000     +1.3% (+0.3 MB)
Octane          splay.js                                        0.977      5507.500 ± 5495.000 … 5520.000     5382.000 ± 5257.000 … 5507.000     -0.1% (-0.2 MB)
Octane          typescript.js                                   0.989      21220.500 ± 21058.000 … 21383.000  20996.000 ± 20899.000 … 21093.000  +0.0% (+0.1 MB)
Octane          zlib.js                                         1.039      5510.000 ± 5475.000 … 5545.000     5722.500 ± 5644.000 … 5801.000     -0.0% (-0.0 MB)
JetStream       bigfib.cpp.js                                   0.998      4.795 ± 4.662 … 4.929              4.806 ± 4.658 … 4.954              +0.1% (+0.2 MB)
JetStream       cdjs.js                                         1.008      1.945 ± 1.945 … 1.946              1.931 ± 1.917 … 1.945              +1.2% (+0.4 MB)
JetStream       container.cpp.js                                1.030      21.137 ± 21.070 … 21.203           20.529 ± 20.461 … 20.598           +0.0% (+0.1 MB)
JetStream       dry.c.js                                        0.958      10.870 ± 10.354 … 11.386           11.342 ± 10.572 … 12.111           +0.1% (+0.1 MB)
JetStream       float-mm.c.js                                   0.960      12.361 ± 12.258 … 12.464           12.872 ± 12.372 … 13.372           -0.0% (-0.0 MB)
JetStream       gcc-loops.cpp.js                                1.102      77.825 ± 77.444 … 78.206           70.639 ± 68.817 … 72.460           +0.1% (+0.1 MB)
JetStream       hash-map.js                                     0.927      1.019 ± 1.014 … 1.025              1.099 ± 1.012 … 1.187              +0.1% (+0.1 MB)
JetStream       n-body.c.js                                     1.004      17.450 ± 16.897 … 18.003           17.376 ± 17.152 … 17.600           -0.1% (-0.0 MB)
JetStream       quicksort.c.js                                  1.133      3.096 ± 2.874 … 3.318              2.733 ± 2.680 … 2.786              +0.2% (+0.1 MB)
JetStream       towers.c.js                                     1.054      3.180 ± 3.012 … 3.349              3.018 ± 3.002 … 3.035              -0.1% (-0.1 MB)
JetStream3      js-tokens.js                                    1.021      0.277 ± 0.275 … 0.280              0.272 ± 0.270 … 0.273              -0.9% (-0.2 MB)
JetStream3      lazy-collections.js                             1.019      0.842 ± 0.841 … 0.842              0.826 ± 0.820 … 0.831              +0.6% (+0.2 MB)
JetStream3      raytrace-private-class-fields.js                0.999      3.566 ± 3.556 … 3.575              3.568 ± 3.552 … 3.584              +0.0% (+0.0 MB)
JetStream3      raytrace-public-class-fields.js                 1.005      2.661 ± 2.643 … 2.678              2.648 ± 2.646 … 2.650              -0.4% (-0.1 MB)
JetStream3      sync-file-system.js                             0.997      1.784 ± 1.781 … 1.788              1.790 ± 1.786 … 1.794              +0.3% (+0.1 MB)
AsyncBench      async-call-return.js                            1.013      0.181 ± 0.179 … 0.184              0.179 ± 0.176 … 0.182              -0.0% (-0.0 MB)
AsyncBench      async-class-method.js                           1.008      0.208 ± 0.205 … 0.211              0.206 ± 0.205 … 0.207              +0.1% (+0.0 MB)
AsyncBench      async-fan-out.js                                1.026      0.179 ± 0.178 … 0.179              0.174 ± 0.173 … 0.175              +0.8% (+0.2 MB)
AsyncBench      async-generator.js                              1.036      0.271 ± 0.268 … 0.274              0.262 ± 0.261 … 0.262              +0.8% (+0.2 MB)
AsyncBench      async-iife.js                                   1.012      0.281 ± 0.279 … 0.283              0.277 ± 0.277 … 0.278              +0.4% (+0.1 MB)
AsyncBench      async-nested-calls.js                           1.003      0.295 ± 0.295 … 0.295              0.294 ± 0.294 … 0.294              -1.2% (-0.4 MB)
AsyncBench      async-pipeline.js                               0.998      0.354 ± 0.351 … 0.357              0.354 ± 0.354 … 0.355              +0.3% (+0.1 MB)
AsyncBench      async-sequential-awaits.js                      1.084      0.100 ± 0.099 … 0.101              0.092 ± 0.092 … 0.093              -0.5% (-0.1 MB)
AsyncBench      async-try-catch-reject.js                       1.008      0.506 ± 0.500 … 0.512              0.503 ± 0.499 … 0.506              -0.5% (-0.2 MB)
AsyncBench      await-primitive.js                              1.045      0.054 ± 0.052 … 0.056              0.052 ± 0.050 … 0.053              -0.6% (-0.3 MB)
AsyncBench      await-resolved-promise.js                       1.032      0.431 ± 0.422 … 0.441              0.418 ± 0.417 … 0.419              -0.6% (-0.3 MB)
AsyncBench      await-thenable.js                               1.034      0.053 ± 0.051 … 0.055              0.051 ± 0.051 … 0.051              -0.2% (-0.1 MB)
AsyncBench      promise-all.js                                  1.001      0.498 ± 0.498 … 0.498              0.498 ± 0.495 … 0.500              -0.6% (-0.3 MB)
AsyncBench      promise-allSettled.js                           1.000      0.570 ± 0.567 … 0.572              0.570 ± 0.568 … 0.571              -0.6% (-0.3 MB)
AsyncBench      promise-chain.js                                1.010      0.264 ± 0.263 … 0.264              0.261 ± 0.260 … 0.262              +0.1% (+0.3 MB)
AsyncBench      promise-new-resolve.js                          1.012      0.274 ± 0.272 … 0.276              0.271 ± 0.270 … 0.271              -0.6% (-0.3 MB)
AsyncBench      promise-race.js                                 0.996      0.510 ± 0.509 … 0.512              0.512 ± 0.510 … 0.515              -0.6% (-0.3 MB)
ARES-6          Air.js                                          1.006      1.717 ± 1.710 … 1.725              1.708 ± 1.696 … 1.719              -0.0% (-0.0 MB)
ARES-6          Babylon.js                                      0.993      1.038 ± 1.030 … 1.046              1.046 ± 1.044 … 1.047              -0.6% (-0.3 MB)
ARES-6          Basic.js                                        1.007      1.352 ± 1.348 … 1.356              1.343 ± 1.341 … 1.345              -0.6% (-0.3 MB)
ARES-6          ML.js                                           0.978      1.508 ± 1.490 … 1.526              1.542 ± 1.539 … 1.544              -0.6% (-0.3 MB)
JetStreamExtra  FlightPlanner.js                                0.911      1.128 ± 1.127 … 1.129              1.238 ± 1.069 … 1.407              +0.0% (+0.2 MB)
JetStreamExtra  OfflineAssembler.js                             1.015      1.106 ± 1.096 … 1.117              1.090 ± 1.087 … 1.093              +0.5% (+0.3 MB)
JetStreamExtra  UniPoker.js                                     1.022      1.257 ± 1.251 … 1.263              1.229 ± 1.228 … 1.231              -0.6% (-0.3 MB)
JetStreamExtra  async-fs.js                                     1.004      1.721 ± 1.720 … 1.721              1.713 ± 1.698 … 1.729              -0.6% (-0.3 MB)
JetStreamExtra  babylonjs-startup-es5.js                        1.002      1.165 ± 1.159 … 1.170              1.162 ± 1.159 … 1.166              -0.0% (-0.2 MB)
JetStreamExtra  babylonjs-startup-es6.js                        1.001      1.413 ± 1.405 … 1.421              1.411 ± 1.407 … 1.416              +0.0% (+0.3 MB)
JetStreamExtra  bigint-bigdenary.js                             1.000      1.674 ± 1.660 … 1.687              1.674 ± 1.669 … 1.679              -0.6% (-0.3 MB)
JetStreamExtra  bigint-noble-bls12-381.js                       0.993      1.780 ± 1.777 … 1.784              1.794 ± 1.791 … 1.797              -0.6% (-0.3 MB)
JetStreamExtra  bigint-noble-ed25519.js                         0.981      1.841 ± 1.832 … 1.850              1.877 ± 1.854 … 1.900              -0.2% (-0.1 MB)
JetStreamExtra  bigint-noble-secp256k1.js                       0.996      1.702 ± 1.698 … 1.706              1.709 ± 1.708 … 1.710              -0.2% (-0.1 MB)
JetStreamExtra  bigint-paillier.js                              0.999      1.826 ± 1.816 … 1.836              1.828 ± 1.824 … 1.831              -0.5% (-0.3 MB)
JetStreamExtra  doxbee-async.js                                 0.991      1.634 ± 1.630 … 1.639              1.649 ± 1.642 … 1.657              +0.5% (+0.2 MB)
JetStreamExtra  doxbee-promise.js                               1.006      1.622 ± 1.615 … 1.630              1.613 ± 1.611 … 1.616              +0.7% (+0.3 MB)
JetStreamExtra  first-inspector-code-load.js                    1.004      2.016 ± 2.012 … 2.021              2.009 ± 2.008 … 2.010              -0.2% (-3.2 MB)
JetStreamExtra  jsdom-d3-startup.js                             1.002      1.544 ± 1.543 … 1.545              1.541 ± 1.534 … 1.549              +0.0% (+0.1 MB)
JetStreamExtra  json-parse-inspector.js                         0.951      1.086 ± 1.082 … 1.090              1.142 ± 1.076 … 1.208              +0.0% (+0.0 MB)
JetStreamExtra  json-stringify-inspector.js                     1.035      0.968 ± 0.943 … 0.994              0.935 ± 0.935 … 0.936              -0.6% (-1.7 MB)
JetStreamExtra  mobx-startup.js                                 1.006      1.392 ± 1.384 … 1.399              1.384 ± 1.377 … 1.390              +0.6% (+0.3 MB)
JetStreamExtra  multi-inspector-code-load.js                    1.001      2.019 ± 2.018 … 2.020              2.017 ± 2.016 … 2.018              -0.1% (-1.9 MB)
JetStreamExtra  prismjs-startup-es5.js                          0.993      1.637 ± 1.634 … 1.640              1.649 ± 1.646 … 1.651              -0.6% (-0.3 MB)
JetStreamExtra  prismjs-startup-es6.js                          1.024      1.679 ± 1.673 … 1.684              1.640 ± 1.639 … 1.640              -0.6% (-0.3 MB)
JetStreamExtra  proxy-mobx.js                                   1.003      1.234 ± 1.233 … 1.234              1.230 ± 1.229 … 1.231              -0.6% (-0.3 MB)
JetStreamExtra  proxy-vue.js                                    0.841      1.161 ± 1.124 … 1.197              1.379 ± 1.283 … 1.476              +4.8% (+2.6 MB)
JetStreamExtra  threejs.js                                      1.001      1.653 ± 1.653 … 1.653              1.651 ± 1.641 … 1.661              -0.0% (-0.2 MB)
JetStreamExtra  typescript-lib.js                               1.006      0.693 ± 0.690 … 0.696              0.689 ± 0.688 … 0.690              +0.7% (+2.0 MB)
JetStreamExtra  validatorjs.js                                  0.994      1.485 ± 1.478 … 1.491              1.493 ± 1.486 … 1.501              +1.2% (+0.7 MB)
JetStreamExtra  web-ssr.js                                      0.999      1.788 ± 1.787 … 1.789              1.789 ± 1.785 … 1.793              -0.3% (-0.5 MB)
GarBench        array-of-objects.js                             1.010      0.857 ± 0.853 … 0.861              0.849 ± 0.848 … 0.851              -0.0% (-0.0 MB)
GarBench        closures.js                                     1.004      1.194 ± 1.190 … 1.197              1.189 ± 1.186 … 1.193              -0.0% (-0.1 MB)
GarBench        cyclic-graph.js                                 1.003      1.237 ± 1.202 … 1.271              1.233 ± 1.204 … 1.261              +0.0% (+0.0 MB)
GarBench        deep-linked-list.js                             1.021      0.800 ± 0.792 … 0.808              0.784 ± 0.783 … 0.784              -0.0% (-0.1 MB)
GarBench        finalization.js                                 1.013      0.964 ± 0.961 … 0.967              0.951 ± 0.951 … 0.952              +0.0% (+0.0 MB)
GarBench        many-properties.js                              0.988      2.676 ± 2.675 … 2.676              2.708 ± 2.685 … 2.731              +0.0% (+0.0 MB)
GarBench        marking-stress.js                               1.016      1.380 ± 1.187 … 1.573              1.358 ± 1.175 … 1.540              -0.0% (-0.2 MB)
GarBench        mixed-sizes.js                                  0.995      1.051 ± 1.043 … 1.058              1.056 ± 1.055 … 1.056              -0.0% (-0.1 MB)
GarBench        sparse-arrays.js                                1.022      2.282 ± 2.272 … 2.291              2.233 ± 2.225 … 2.240              -0.0% (-0.0 MB)
GarBench        string-heavy.js                                 1.008      1.579 ± 1.568 … 1.589              1.566 ± 1.562 … 1.569              +0.0% (+0.1 MB)
GarBench        wide-tree.js                                    0.995      1.473 ± 1.471 … 1.475              1.481 ± 1.477 … 1.485              +0.0% (+0.5 MB)
MicroBench      array-destructuring-assignment-rest.js          1.070      0.328 ± 0.320 … 0.336              0.306 ± 0.306 … 0.307              -0.6% (-0.3 MB)
MicroBench      array-destructuring-assignment.js               0.983      2.954 ± 2.948 … 2.959              3.004 ± 2.859 … 3.149              -0.0% (-0.1 MB)
MicroBench      array-prototype-map.js                          0.937      1.207 ± 1.204 … 1.210              1.288 ± 1.214 … 1.363              +0.0% (+0.1 MB)
MicroBench      array-prototype-shift.js                        1.577      0.026 ± 0.017 … 0.035              0.017 ± 0.016 … 0.017              -0.6% (-0.3 MB)
MicroBench      bound-call-00-args.js                           0.982      1.427 ± 1.424 … 1.431              1.454 ± 1.434 … 1.474              -0.6% (-0.3 MB)
MicroBench      bound-call-04-args.js                           0.994      1.544 ± 1.543 … 1.544              1.554 ± 1.551 … 1.556              -0.6% (-0.3 MB)
MicroBench      bound-call-16-args.js                           1.122      1.990 ± 1.848 … 2.132              1.773 ± 1.772 … 1.774              -0.6% (-0.3 MB)
MicroBench      call-00-args.js                                 1.031      0.448 ± 0.445 … 0.451              0.435 ± 0.432 … 0.438              -0.6% (-0.3 MB)
MicroBench      call-01-args.js                                 1.018      0.471 ± 0.471 … 0.472              0.463 ± 0.462 … 0.464              -0.6% (-0.3 MB)
MicroBench      call-02-args.js                                 1.011      0.488 ± 0.477 … 0.498              0.482 ± 0.470 … 0.495              -0.6% (-0.3 MB)
MicroBench      call-03-args.js                                 1.048      0.521 ± 0.520 … 0.522              0.497 ± 0.488 … 0.506              -0.6% (-0.3 MB)
MicroBench      call-04-args.js                                 0.998      0.507 ± 0.506 … 0.507              0.508 ± 0.507 … 0.508              -0.6% (-0.3 MB)
MicroBench      call-16-args.js                                 1.002      0.676 ± 0.675 … 0.676              0.675 ± 0.670 … 0.679              -0.6% (-0.3 MB)
MicroBench      call-32-args.js                                 0.989      0.925 ± 0.910 … 0.939              0.935 ± 0.935 … 0.935              -0.6% (-0.3 MB)
MicroBench      call-with-function-environment-2.js             1.007      0.905 ± 0.905 … 0.906              0.899 ± 0.897 … 0.902              -0.6% (-0.3 MB)
MicroBench      call-with-function-environment-captured-var.js  0.989      0.933 ± 0.929 … 0.938              0.944 ± 0.938 … 0.950              -0.6% (-0.3 MB)
MicroBench      call-with-function-environment.js               1.011      0.469 ± 0.468 … 0.470              0.464 ± 0.464 … 0.465              -0.6% (-0.3 MB)
MicroBench      for-in-indexed-properties.js                    1.012      0.228 ± 0.227 … 0.229              0.226 ± 0.225 … 0.226              +0.1% (+0.1 MB)
MicroBench      for-in-named-properties.js                      1.002      0.172 ± 0.170 … 0.173              0.171 ± 0.171 … 0.171              -0.6% (-0.3 MB)
MicroBench      for-of.js                                       1.099      0.558 ± 0.528 … 0.588              0.508 ± 0.507 … 0.508              -0.6% (-0.3 MB)
MicroBench      function-prototype-call.js                      1.011      0.386 ± 0.371 … 0.401              0.382 ± 0.380 … 0.384              -0.6% (-0.3 MB)
MicroBench      object-keys.js                                  0.991      1.260 ± 1.257 … 1.263              1.271 ± 1.271 … 1.271              +0.0% (+0.0 MB)
MicroBench      object-set-with-rope-strings.js                 1.009      0.688 ± 0.682 … 0.694              0.682 ± 0.678 … 0.687              -0.6% (-0.3 MB)
MicroBench      pic-add-own.js                                  1.019      0.428 ± 0.424 … 0.433              0.420 ± 0.420 … 0.420              -0.6% (-0.3 MB)
MicroBench      pic-get-own.js                                  1.006      0.498 ± 0.496 … 0.500              0.495 ± 0.495 … 0.496              -0.6% (-0.3 MB)
MicroBench      pic-get-pchain.js                               1.007      0.499 ± 0.499 … 0.499              0.496 ± 0.495 … 0.497              -0.6% (-0.3 MB)
MicroBench      pic-put-own.js                                  0.962      0.510 ± 0.509 … 0.511              0.530 ± 0.512 … 0.548              -0.6% (-0.3 MB)
MicroBench      pic-put-pchain.js                               0.992      1.886 ± 1.879 … 1.893              1.902 ± 1.882 … 1.921              -0.6% (-0.3 MB)
MicroBench      setter-in-prototype-chain.js                    0.819      2.018 ± 1.962 … 2.074              2.464 ± 2.144 … 2.784              -0.6% (-0.3 MB)
MicroBench      strictly-equals-object.js                       1.010      0.731 ± 0.731 … 0.732              0.724 ± 0.723 … 0.725              -0.6% (-0.3 MB)
LongSpider      Total                                           1.011      69.291                             68.544                             +1.8% (+30.9 MB)
Kraken          Total                                           1.021      7.163                              7.016                              -0.2% (-1.2 MB)
Octane          Total                                           1.006      123739.000                         124531.500                         -0.4% (-11.7 MB)
JetStream       Total                                           1.050      153.679                            146.345                            +0.1% (+1.0 MB)
JetStream3      Total                                           1.003      9.130                              9.104                              -0.0% (-0.0 MB)
AsyncBench      Total                                           1.011      5.029                              4.974                              -0.2% (-1.7 MB)
ARES-6          Total                                           0.996      5.616                              5.638                              -0.5% (-0.9 MB)
JetStreamExtra  Total                                           0.992      40.225                             40.536                             -0.0% (-3.2 MB)
GarBench        Total                                           1.005      15.491                             15.407                             +0.0% (+0.1 MB)
MicroBench      Total                                           0.989      25.682                             25.970                             -0.2% (-7.8 MB)
All Suites      Total                                           1.023      396.587                            387.629                            +0.0% (+5.4 MB)
```