### PR TITLE
Meta: Don't use `enum.StrEnum` for GUI framework

### DIFF
--- a/Meta/host_platform.py
+++ b/Meta/host_platform.py
@@ -22,12 +22,22 @@ class HostSystem(enum.IntEnum):
     BSD = enum.auto()
 
 
-class GUIFramework(enum.StrEnum):
-    # enum.auto() will tolower the values
-    Qt = "Qt"
-    AppKit = "AppKit"
-    Gtk = "Gtk"
-    Android = "Android"
+class GUIFramework(enum.IntEnum):
+    Qt = enum.auto()
+    AppKit = enum.auto()
+    Gtk = enum.auto()
+    Android = enum.auto()
+
+    @classmethod
+    def from_string(cls, gui: str) -> "GUIFramework":
+        try:
+            return cls[gui]
+        except KeyError:
+            # argparse does not catch KeyError, so we return a ValueError for better command line errors.
+            raise ValueError(f"Unknown GUIFramework: {gui!r}") from None
+
+    def __str__(self):
+        return self.name
 
 
 class Platform:

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -44,7 +44,9 @@ def main():
     compiler_parser.add_argument("--cc", required=False, default=default_cc)
     compiler_parser.add_argument("--cxx", required=False, default=default_cxx)
     compiler_parser.add_argument("--jobs", "-j", required=False)
-    compiler_parser.add_argument("--gui", required=False, choices=platform.valid_gui_frameworks())
+    compiler_parser.add_argument(
+        "--gui", required=False, type=GUIFramework.from_string, choices=platform.valid_gui_frameworks()
+    )
 
     target_parser = argparse.ArgumentParser(add_help=False)
     target_parser.add_argument("target", nargs=argparse.OPTIONAL)
@@ -235,7 +237,7 @@ def gui_for_build_dir(build_preset_dir: Path) -> Optional[GUIFramework]:
         for line in f:
             if line.startswith("LADYBIRD_GUI_FRAMEWORK:STRING="):
                 try:
-                    return GUIFramework(line.strip().split("=", 1)[1])
+                    return GUIFramework.from_string(line.strip().split("=", 1)[1])
                 except ValueError:
                     return None
     return None


### PR DESCRIPTION
This was added in Python 3.11, whereas the default macOS version is still 3.9.