### PR TITLE
LibWeb: Recompute inherited style even if there is no layout node 

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1025,9 +1025,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
 CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
 {
     auto computed_properties = this->computed_properties();
-    // NB: We use unsafe_layout_node() because we're in the middle of style recalculation
-    //     and layout is inherently stale while recomputing inherited styles.
-    if (!m_cascaded_properties || !computed_properties || !unsafe_layout_node())
+    if (!m_cascaded_properties || !computed_properties)
         return {};
 
     CSS::RequiredInvalidationAfterStyleChange invalidation;
@@ -1090,7 +1088,8 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
 
     // NB: unsafe_layout_node() because we're applying recomputed inherited styles during
     //     style recalculation, before layout has been updated.
-    unsafe_layout_node()->apply_style(*computed_properties);
+    if (unsafe_layout_node())
+        unsafe_layout_node()->apply_style(*computed_properties);
     if (invalidation.repaint)
         set_needs_repaint();
     return invalidation;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1025,8 +1025,8 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
 CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
 {
     auto computed_properties = this->computed_properties();
-    if (!m_cascaded_properties || !computed_properties)
-        return {};
+    VERIFY(m_cascaded_properties);
+    VERIFY(computed_properties);
 
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 

--- a/Tests/LibWeb/Text/expected/recompute-inherited-style-of-display-none-descendant.txt
+++ b/Tests/LibWeb/Text/expected/recompute-inherited-style-of-display-none-descendant.txt
@@ -1,0 +1,4 @@
+Visibility before: hidden
+Color      before: rgb(255, 0, 0)
+Visibility after: hidden
+Color      after: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/recompute-inherited-style-of-display-none-descendant.txt
+++ b/Tests/LibWeb/Text/expected/recompute-inherited-style-of-display-none-descendant.txt
@@ -1,4 +1,4 @@
 Visibility before: hidden
 Color      before: rgb(255, 0, 0)
-Visibility after: hidden
-Color      after: rgb(255, 0, 0)
+Visibility after: visible
+Color      after: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/recompute-inherited-style-of-display-none-descendant.html
+++ b/Tests/LibWeb/Text/input/recompute-inherited-style-of-display-none-descendant.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+.one {
+  visibility: hidden;
+  color: red;
+  display: none;
+}
+.active.one {
+  visibility: visible;
+  color: green;
+}
+</style>
+<div class="one"><div class="two"><div class="three"><div class="four"></div></div></div></div>
+<script>
+function printStyles(when, element) {
+  const computedStyle = getComputedStyle(element);
+  println(`Visibility ${when}: ${computedStyle["visibility"]}`);
+  println(`Color      ${when}: ${computedStyle["color"]}`);
+}
+
+test(() => {
+  const ancestor = document.querySelector(".one");
+  const descendant = document.querySelector(".four");
+  printStyles("before", descendant);
+  ancestor.classList.add("active");
+  printStyles("after", descendant);
+});
+</script>


### PR DESCRIPTION
`recompute_inherited_style()` assumed that there is no work to do if the element has no layout node. This however is not necessarily true.

In particular, the following can happen:
1. The element in question is a descendant at least two layers below an element that has `display: none`, i.e. with at least one other element between them. (If it is a direct child, a full style recomputation will be forced for unrelated reasons).
2. TreeBuilder decides to skip creating layout nodes for the `display: none` element and all its descendants.
3. Due to some change on the ancestor (e.g. class added, id changed), the value of a property that can be inherited changes on the ancestor.
4. The property value of the descendant now also needs to change.

In that scenario, we won't compute the entire style of the descendant, since that already happened. But we do need to update its inherited properties because the old ones are now stale. At that point we still don't have a layout node for the element since it will only be created after this style update.

Instead of skipping the update for inherited properties, simply allow `recompute_inherited_style()` to run even in absence of a layout node. And then apply the style to the layout node only if one exists. If none exists, the style will be applied later if and when a corresponding layout node is created.

This partially fixes the blank main navigation menus on https://bleepingcomputer.com/.

| Before | After |
|--------|--------|
| <img width="1190" height="312" alt="tmp2" src="https://github.com/user-attachments/assets/3f14a4bf-f2bb-4389-b56a-b72cededfeec" /> | <img width="1189" height="308" alt="tmp" src="https://github.com/user-attachments/assets/f8117ea7-f9c3-4dea-b761-9c8be2d2f8d4" /> | 

Images are still missing until you click into the menu or hover over them. That also seems like a bug with some stale data. However, the same problem appears for many other images on the page as well for me, none of which are ever hidden due to `display: none`. So I suspect that to be a separate, but maybe related bug. Also, that one is a bit annoying to debug since the problem goes away when saving a static page. So, taking the partial win for now ;)