### PR TITLE
LibWeb: Keep select button text in sync with the selected option

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -54,7 +54,7 @@ void HTMLOptionElement::update_selection_label()
 {
     if (selected()) {
         if (auto* select_element = first_ancestor_of_type<HTMLSelectElement>()) {
-            select_element->update_inner_text_element({});
+            select_element->clone_selected_option_into_select_button();
         }
     }
 }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -336,7 +336,7 @@ WebIDL::Long HTMLSelectElement::selected_index() const
 WebIDL::ExceptionOr<void> HTMLSelectElement::set_selected_index(WebIDL::Long index)
 {
     // The selectedIndex setter steps are:
-    ScopeGuard guard { [&]() { update_inner_text_element(); } };
+    ScopeGuard guard { [&]() { clone_selected_option_into_select_button(); } };
 
     // 1. Let firstMatchingOption be null.
     GC::Ptr<HTMLOptionElement> first_matching_option;
@@ -457,7 +457,7 @@ Utf16String HTMLSelectElement::value() const
 WebIDL::ExceptionOr<void> HTMLSelectElement::set_value(Utf16String const& value)
 {
     // The value setter steps are:
-    ScopeGuard guard { [&]() { update_inner_text_element(); } };
+    ScopeGuard guard { [&]() { clone_selected_option_into_select_button(); } };
     update_cached_list_of_options();
 
     // 1. Let firstMatchingOption be null.
@@ -499,7 +499,8 @@ void HTMLSelectElement::send_select_update_notifications()
         // 2. Run update a select's selectedcontent given element.
         MUST(update_selectedcontent());
 
-        // FIXME: 3. Run clone selected option into select button given element.
+        // 3. Run clone selected option into select button given element.
+        clone_selected_option_into_select_button();
 
         // 4. Fire an event named input at element, with the bubbles and composed attributes initialized to true.
         auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
@@ -659,7 +660,7 @@ void HTMLSelectElement::did_select_item(Optional<u32> const& id)
         }
     }
 
-    update_inner_text_element();
+    clone_selected_option_into_select_button();
     send_select_update_notifications();
 }
 
@@ -733,28 +734,32 @@ void HTMLSelectElement::create_shadow_tree_if_needed()
 
     MUST(border->append_child(*m_chevron_icon_element));
 
-    update_inner_text_element();
+    clone_selected_option_into_select_button();
 }
 
-void HTMLSelectElement::update_inner_text_element(Badge<HTMLOptionElement>)
+// https://html.spec.whatwg.org/multipage/form-elements.html#clone-selected-option-into-select-button
+void HTMLSelectElement::clone_selected_option_into_select_button()
 {
-    update_cached_list_of_options();
-    update_inner_text_element();
-}
+    // To clone selected option into select button, given a select element select:
 
-// FIXME: This needs to be called any time the selected option's children are modified.
-void HTMLSelectElement::update_inner_text_element()
-{
     if (!m_inner_text_element)
         return;
 
-    // Update inner text element to the label of the selected option
-    for (auto const& option_element : m_cached_list_of_options) {
-        if (option_element->selected()) {
-            m_inner_text_element->string_replace_all(Infra::strip_and_collapse_whitespace(Utf16String::from_utf8(option_element->label())));
-            return;
-        }
-    }
+    update_cached_list_of_options();
+
+    // 1. Let option be the first element of select's option list whose selectedness is set to true,
+    //    if such an element exists; otherwise null.
+    auto option = find_value(m_cached_list_of_options, [](auto option) { return option->selected(); });
+
+    // 2. Let text be the empty string.
+    Utf16String text;
+
+    // 3. If option is not null, then set text to option's label.
+    if (option.has_value())
+        text = Utf16String::from_utf8((*option)->label());
+
+    // 4. Set select's select fallback button text to text.
+    m_inner_text_element->string_replace_all(move(text));
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#selectedness-setting-algorithm
@@ -810,10 +815,13 @@ void HTMLSelectElement::update_selectedness()
     }
 
     // 4. If updateSelectedcontent is true, then run update a select's selectedcontent given element.
-    if (should_update_selectedcontent) {
+    if (should_update_selectedcontent)
         MUST(update_selectedcontent());
-        update_inner_text_element();
-    }
+
+    // AD-HOC: The selectedness setting algorithm does not itself refresh the select's fallback button text, but the
+    //         set of selected options may have changed. Run the spec's "clone selected option into select button"
+    //         algorithm so the button stays in sync.
+    clone_selected_option_into_select_button();
 }
 
 bool HTMLSelectElement::is_focusable() const

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -106,7 +106,7 @@ public:
 
     void update_selectedness();
 
-    void update_inner_text_element(Badge<HTMLOptionElement>);
+    void clone_selected_option_into_select_button();
 
     bool can_skip_selectedness_update_for_inserted_option(HTMLOptionElement const&) const;
 
@@ -148,7 +148,6 @@ private:
     void show_the_picker_if_applicable();
 
     void create_shadow_tree_if_needed();
-    void update_inner_text_element();
     // https://html.spec.whatwg.org/multipage/form-elements.html#send-select-update-notifications
     void send_select_update_notifications();
 

--- a/Tests/LibWeb/Layout/expected/select-innerhtml-optgroup-selected-option.txt
+++ b/Tests/LibWeb/Layout/expected/select-innerhtml-optgroup-selected-option.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 38 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 89.109375x18] baseline: 19
+      BlockContainer <select#s> at [13,10] inline-block [0+1+4 89.109375 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
+        Box <div> at [13,10] flex-container(row) [0+0+0 89.109375 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [13,10] flex-item [0+0+0 69.109375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 8, rect: [13,10 69.109375x18] baseline: 13.796875
+                "Option 2"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [86.109375,11] flex-item [4+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from SVGSVGBox start: 0, length: 0, rect: [86.109375,11 16x16] baseline: 16
+            SVGSVGBox <svg> at [86.109375,11] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <path> at [90.109375,16.71875] [0+0+0 8 0+0+0] [0+0+0 4.953125 0+0+0] children: not-inline
+      TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x38]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x22]
+      PaintableWithLines (BlockContainer<SELECT>#s) [8,8 99.109375x22]
+        PaintableBox (Box<DIV>) [13,10 89.109375x18]
+          PaintableWithLines (BlockContainer<DIV>) [13,10 69.109375x18]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [86.109375,11 16x16]
+            SVGSVGPaintable (SVGSVGBox<svg>) [86.109375,11 16x16]
+              SVGPathPaintable (SVGGeometryBox<path>) [90.109375,16.71875 8x4.953125]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/select-innerhtml-optgroup-selected-option.html
+++ b/Tests/LibWeb/Layout/input/select-innerhtml-optgroup-selected-option.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<select id="s"></select>
+<script>
+    document.getElementById("s").innerHTML =
+        '<optgroup label="G"><option>Option 1</option><option selected>Option 2</option><option>Option 3</option></optgroup>';
+</script>


### PR DESCRIPTION
Previously, the select button's text was only refreshed inside the two non-trivial branches of the selectedness setting algorithm. Paths that left the select with exactly one selected option hit a no-op branch and skipped the refresh.

Fix this by implementing the "clone selected option into select button" algorithm and invoking it whenever the set of selected options may have changed.

This fixes the pronunciation selector on https://wordreference.com.

From https://www.wordreference.com/esen/ejemplo:

Before:

<img width="648" height="108" alt="image" src="https://github.com/user-attachments/assets/99f86250-39c6-433d-bd39-cd5089366b1a" />

After:

<img width="648" height="108" alt="image" src="https://github.com/user-attachments/assets/6cb6847f-d78e-4509-9cd4-e8ea8a3b7059" />
