### PR TITLE
LibWeb: Prevent dragstart after a prevented mousedown or prior dragstart

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -974,11 +974,10 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCo
 
 void EventHandler::clear_mousedown_tracking()
 {
-    m_mousedown_button = {};
-    m_mousedown_modifiers = UIEvents::KeyModifier::Mod_None;
     m_mousedown_target = nullptr;
     m_mousedown_visual_viewport_position = {};
     m_mousedown_click_count = 0;
+    m_mousedown_target_is_drag_candidate = false;
 }
 
 void EventHandler::stop_updating_selection()
@@ -1016,7 +1015,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
     });
 
     if (should_ignore_device_input_event()) {
-        if (is_dragging_element()) {
+        if (m_mousedown_target_is_drag_candidate) {
             auto result = handle_drag_and_drop_event(DragEvent::Type::Drop, visual_viewport_position, screen_position, button, buttons, modifiers, {});
             set_page_cursor(m_navigable->page(), Gfx::StandardCursor::Arrow);
             return result;
@@ -1351,8 +1350,6 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
         return EventResult::Dropped;
 
-    m_mousedown_button = button;
-    m_mousedown_modifiers = modifiers;
     m_mousedown_target = node;
     m_mousedown_visual_viewport_position = visual_viewport_position;
 
@@ -1365,9 +1362,11 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
     if (button == UIEvents::MouseButton::Secondary)
         maybe_show_context_menu(*node, coordinates, screen_position, viewport_position, buttons, modifiers);
 #if defined(AK_OS_MACOS)
-    if (button == UIEvents::MouseButton::Primary && (modifiers & UIEvents::KeyModifier::Mod_Ctrl) != 0)
+    else if (button == UIEvents::MouseButton::Primary && (modifiers & UIEvents::KeyModifier::Mod_Ctrl) != 0)
         maybe_show_context_menu(*node, coordinates, screen_position, viewport_position, buttons, modifiers);
 #endif
+    else
+        m_mousedown_target_is_drag_candidate = button == UIEvents::MouseButton::Primary;
 
     // NB: Dispatching an event may have disturbed the world.
     if (m_navigable->active_document() != document)
@@ -1385,7 +1384,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
 EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 buttons, u32 modifiers)
 {
     if (should_ignore_device_input_event()) {
-        if (is_dragging_element())
+        if (m_mousedown_target_is_drag_candidate)
             return handle_drag_and_drop_event(DragEvent::Type::DragMove, visual_viewport_position, screen_position, UIEvents::MouseButton::Primary, buttons, modifiers, {});
         return EventResult::Dropped;
     }
@@ -1402,7 +1401,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
     if (!paint_root())
         return EventResult::Dropped;
 
-    if (is_dragging_element()) {
+    if (m_mousedown_target_is_drag_candidate) {
         static constexpr CSSPixels DRAG_THRESHOLD = 5;
         auto delta = visual_viewport_position - *m_mousedown_visual_viewport_position;
 
@@ -1415,6 +1414,9 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
 
                 return EventResult::Handled;
             }
+
+            if (result == EventResult::Cancelled)
+                m_mousedown_target_is_drag_candidate = false;
 
             // NB: Dispatching an event may have disturbed the world.
             if (m_navigable->active_document() != document)
@@ -1508,7 +1510,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
 EventResult EventHandler::handle_mouseleave()
 {
     if (should_ignore_device_input_event()) {
-        if (is_dragging_element()) {
+        if (m_mousedown_target_is_drag_candidate) {
             auto result = handle_drag_and_drop_event(DragEvent::Type::DragEnd, {}, {}, UIEvents::MouseButton::Primary, UIEvents::MouseButton::Primary, 0, {});
             set_page_cursor(m_navigable->page(), Gfx::StandardCursor::Arrow);
             return result;
@@ -2140,14 +2142,6 @@ bool EventHandler::should_ignore_device_input_event() const
     // From the moment that the user agent is to initiate the drag-and-drop operation, until the end of the drag-and-drop
     // operation, device input events (e.g. mouse and keyboard events) must be suppressed.
     return m_drag_and_drop_event_handler->has_ongoing_drag_and_drop_operation();
-}
-
-bool EventHandler::is_dragging_element() const
-{
-    return m_mousedown_target
-        && m_mousedown_visual_viewport_position.has_value()
-        && m_mousedown_button == UIEvents::MouseButton::Primary
-        && (m_mousedown_modifiers & UIEvents::KeyModifier::Mod_Ctrl) == 0;
 }
 
 void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -130,7 +130,6 @@ private:
     GC::Ptr<Painting::PaintableBox const> paint_root() const;
 
     bool should_ignore_device_input_event() const;
-    bool is_dragging_element() const;
 
     void handle_gamepad_connected(SDL_JoystickID);
     void handle_gamepad_updated(SDL_JoystickID);
@@ -149,11 +148,10 @@ private:
 
     GC::Weak<DOM::Node> m_effective_legacy_mouse_pointer_position;
 
-    Optional<u32> m_mousedown_button;
-    u32 m_mousedown_modifiers { UIEvents::KeyModifier::Mod_None };
     GC::Weak<DOM::Node> m_mousedown_target;
     Optional<CSSPixelPoint> m_mousedown_visual_viewport_position;
     int m_mousedown_click_count { 0 };
+    bool m_mousedown_target_is_drag_candidate { false };
 
     // https://w3c.github.io/pointerevents/#the-pointerdown-event
     // The PREVENT MOUSE EVENT flag.

--- a/Tests/LibWeb/Text/expected/HTML/drag-and-drop-element.txt
+++ b/Tests/LibWeb/Text/expected/HTML/drag-and-drop-element.txt
@@ -42,3 +42,6 @@ target: drop
 Dragstart cancelled:
 source: dragstart
 dragstart (cancelling)
+
+Mousedown cancelled (prevents dragstart):
+source: mousedown (cancelling)

--- a/Tests/LibWeb/Text/expected/HTML/drag-and-drop-element.txt
+++ b/Tests/LibWeb/Text/expected/HTML/drag-and-drop-element.txt
@@ -1,25 +1,28 @@
 Drag div:
-dragenter
+source: dragstart
+target: dragenter
     types: text/plain
-dragover
+target: dragover
     types: text/plain
-drop
+target: drop
     types: text/plain
     text/plain: 'hello'
     text/uri-list: ''
-    source events: dragstart,dragend:copy
+source: dragend:copy
 
 Drag non-draggable div:
-    drag started: false
+nodrag: mousedown
+nodrag: mousemove
+nodrag: mouseup
 
 Drag link:
 dragstart
     types: text/uri-list
-dragenter
+target: dragenter
     types: text/uri-list
-dragover
+target: dragover
     types: text/uri-list
-drop
+target: drop
     types: text/uri-list
     text/plain: ''
     text/uri-list: 'https://example.com/'
@@ -27,14 +30,15 @@ drop
 Drag image:
 dragstart
     types: text/uri-list
-dragenter
+target: dragenter
     types: text/uri-list
-dragover
+target: dragover
     types: text/uri-list
-drop
+target: drop
     types: text/uri-list
     text/plain: ''
     text/uri-list: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg=='
 
 Dragstart cancelled:
+source: dragstart
 dragstart (cancelling)

--- a/Tests/LibWeb/Text/input/HTML/drag-and-drop-element.html
+++ b/Tests/LibWeb/Text/input/HTML/drag-and-drop-element.html
@@ -31,36 +31,42 @@
         };
 
         target.addEventListener("dragenter", e => {
-            printEvent("dragenter", e);
+            printEvent("target: dragenter", e);
             e.preventDefault();
         });
         target.addEventListener("dragover", e => {
-            printEvent("dragover", e);
+            printEvent("target: dragover", e);
             e.preventDefault();
         });
         target.addEventListener("dragleave", e => {
             printEvent("dragleave", e);
         });
         target.addEventListener("drop", e => {
-            printEvent("drop", e);
+            printEvent("target: drop", e);
             println(`    text/plain: '${e.dataTransfer.getData("text/plain")}'`);
             println(`    text/uri-list: '${e.dataTransfer.getData("text/uri-list")}'`);
             e.preventDefault();
         });
 
-        let sourceEvents = [];
         source.addEventListener("dragstart", e => {
             e.dataTransfer.setData("text/plain", "hello");
-            sourceEvents.push("dragstart");
+            println("source: dragstart");
         });
         source.addEventListener("dragend", e => {
-            sourceEvents.push(`dragend:${e.dataTransfer.dropEffect}`);
+            println(`source: dragend:${e.dataTransfer.dropEffect}`);
         });
 
-        let noDragStarted = false;
+        nodrag.addEventListener("mousedown", () => {
+            println("nodrag: mousedown");
+        });
+        nodrag.addEventListener("mousemove", () => {
+            println("nodrag: mousemove");
+        });
         nodrag.addEventListener("dragstart", () => {
-            console.log("DRAG");
-            noDragStarted = true;
+            println("nodrag: dragstart");
+        });
+        nodrag.addEventListener("mouseup", () => {
+            println("nodrag: mouseup");
         });
 
         link.addEventListener("dragstart", e => {
@@ -78,13 +84,11 @@
         internals.mouseMove(50, 125);
         internals.mouseMove(50, 50);
         internals.mouseUp(50, 50);
-        println(`    source events: ${sourceEvents.join(",")}`);
 
         println("\nDrag non-draggable div:");
         internals.mouseDown(50, 250);
         internals.mouseMove(50, 275);
         internals.mouseUp(50, 275);
-        println(`    drag started: ${noDragStarted}`);
 
         println("\nDrag link:");
         internals.mouseDown(50, 350);

--- a/Tests/LibWeb/Text/input/HTML/drag-and-drop-element.html
+++ b/Tests/LibWeb/Text/input/HTML/drag-and-drop-element.html
@@ -114,6 +114,20 @@
         internals.mouseDown(50, 150);
         internals.mouseMove(50, 125);
         internals.mouseMove(50, 50);
+        internals.mouseMove(55, 50);
+        internals.mouseUp(50, 50);
+
+        println("\nMousedown cancelled (prevents dragstart):");
+        source.addEventListener(
+            "mousedown",
+            e => {
+                println(`source: ${e.type} (cancelling)`);
+                e.preventDefault();
+            },
+            { once: true });
+        internals.mouseDown(50, 150);
+        internals.mouseMove(50, 125);
+        internals.mouseMove(50, 50);
         internals.mouseUp(50, 50);
     });
 </script>


### PR DESCRIPTION
Also, explicitly prevent drag events from firing when the context menu opens. This will only be the case on macOS, since its context menu is opened by Ctrl+mousedown.

The Ctrl modifier no longer prevents drags on other platforms.

Fixes the PDF flipbook drag interactions at https://www.sawatdee.com/minneapolis-menu.