### PR TITLE
Build: Use one rust runtime per executable or shared library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bytecode_def"
@@ -111,9 +111,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -321,12 +321,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -339,9 +339,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixdtf"
@@ -357,12 +357,12 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libgfx_rust"
+name = "libgfx_rust_core"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
@@ -370,14 +370,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libjs_rust"
+name = "libjs_rust_core"
 version = "0.1.0"
 dependencies = [
  "bytecode_def",
  "cbindgen",
  "foldhash",
  "indexmap",
- "libunicode_rust",
+ "libunicode_rust_core",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -390,15 +390,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libregex_rust"
+name = "libregex_rust_core"
 version = "0.1.0"
 dependencies = [
  "cbindgen",
- "libunicode_rust",
+ "libunicode_rust_core",
 ]
 
 [[package]]
-name = "libunicode_rust"
+name = "libunicode_rust_core"
 version = "0.1.0"
 dependencies = [
  "calendrical_calculations",
@@ -421,9 +421,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -479,9 +479,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "serde_core",
  "writeable",
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -677,24 +677,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -716,11 +716,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -789,9 +789,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -801,6 +801,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -883,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
@@ -921,18 +927,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -106,8 +106,7 @@ endif()
 target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
             WebP::webpdemux WebP::libwebpmux skia harfbuzz)
 
-import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libgfx_rust FFI_HEADER RustFFI.h)
-target_link_libraries(LibGfx PRIVATE libgfx_rust)
+import_rust_ffi_crate(LibGfx MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libgfx_rust_core FFI_HEADER RustFFI.h)
 
 if (HAS_FONTCONFIG)
     target_link_libraries(LibGfx PRIVATE Fontconfig::Fontconfig)

--- a/Libraries/LibGfx/Rust/Cargo.toml
+++ b/Libraries/LibGfx/Rust/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "libgfx_rust"
+name = "libgfx_rust_core"
 version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 yuv = "0.8"

--- a/Libraries/LibGfx/Rust/build.rs
+++ b/Libraries/LibGfx/Rust/build.rs
@@ -14,12 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
-    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
     println!("cargo:rerun-if-changed=src");
-
-    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| out_dir.clone());
 
     cbindgen::generate(manifest_dir).map_or_else(
         |error| match error {
@@ -27,12 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             e => panic!("{e:?}"),
         },
         |bindings| {
-            let header_path = out_dir.join("RustFFI.h");
-            bindings.write_to_file(&header_path);
-
-            if ffi_out_dir != out_dir {
-                bindings.write_to_file(ffi_out_dir.join("RustFFI.h"));
-            }
+            bindings.write_to_file(out_dir.join("RustFFI.h"));
         },
     );
 

--- a/Libraries/LibGfx/Rust/src/lib.rs
+++ b/Libraries/LibGfx/Rust/src/lib.rs
@@ -4,7 +4,4 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[path = "../../../RustAllocator.rs"]
-mod rust_allocator;
-
 pub mod yuv;

--- a/Libraries/LibGfx/YUVData.cpp
+++ b/Libraries/LibGfx/YUVData.cpp
@@ -7,9 +7,9 @@
 #include <AK/Time.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
+#include <LibGfx/RustFFI.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibGfx/YUVData.h>
-#include <RustFFI.h>
 
 #include <core/SkColorSpace.h>
 #include <core/SkImage.h>

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -289,37 +289,7 @@ endif()
 
 target_link_libraries(LibJS PUBLIC JSClangPlugin)
 
-import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libjs_rust FFI_HEADER RustFFI.h)
-target_link_libraries(LibJS PRIVATE libjs_rust)
-if ((LINUX OR BSD) AND NOT BUILD_SHARED_LIBS)
-    # Rust staticlibs each carry the same allocator shim symbols. LibJS can
-    # pull in multiple crates' copies in static ELF links, but they all
-    # forward to the same ladybird_rust_* entry points in AK/kmalloc.cpp.
-    target_link_options(LibJS INTERFACE LINKER:--allow-multiple-definition)
-endif()
-
-# The Rust library and LibJS have a circular dependency (C++ calls Rust
-# entry points, Rust calls C++ callbacks). For static builds, merge the
-# Rust archive into the LibJS archive so all symbols are in one place.
-if(NOT BUILD_SHARED_LIBS)
-    add_custom_command(TARGET LibJS POST_BUILD
-        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libjs_rust>
-        COMMAND ${CMAKE_AR} -qS $<TARGET_FILE:LibJS> *.o
-        COMMAND ${CMAKE_RANLIB} $<TARGET_FILE:LibJS>
-        COMMAND ${CMAKE_COMMAND} -E remove -f *.o
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp
-        COMMENT "Merging Rust archive into LibJS"
-    )
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
-
-    # POST_BUILD steps don't track inputs, so when libjs_rust.a changes ninja
-    # leaves liblagom-js.a alone and the merged archive ends up with stale
-    # Rust objects. Force the C++ FFI bridge file to depend on the Rust
-    # archive: when it changes, RustIntegration.cpp recompiles, LibJS gets
-    # re-archived, and POST_BUILD re-merges the fresh Rust objects.
-    get_target_property(_libjs_rust_lib libjs_rust IMPORTED_LOCATION)
-    set_property(SOURCE RustIntegration.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libjs_rust_lib})
-endif()
+import_rust_ffi_crate(LibJS MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libjs_rust_core FFI_HEADER RustFFI.h)
 
 # AsmInterpreter: generate platform-specific assembly from DSL
 # NB: Win64 uses a different ABI (shadow space, different arg registers)

--- a/Libraries/LibJS/Rust/Cargo.toml
+++ b/Libraries/LibJS/Rust/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "libjs_rust"
+name = "libjs_rust_core"
 version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["rlib"]
 
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
-libunicode_rust = { path = "../../LibUnicode/Rust", default-features = false }
+libunicode_rust = { package = "libunicode_rust_core", path = "../../LibUnicode/Rust", default-features = false }
 num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"

--- a/Libraries/LibJS/Rust/build.rs
+++ b/Libraries/LibJS/Rust/build.rs
@@ -919,14 +919,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed={}", def_path.display());
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
-    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
     println!("cargo:rerun-if-changed=src");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-
-    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| out_dir.clone());
 
     cbindgen::generate(manifest_dir).map_or_else(
         |error| match error {
@@ -934,12 +929,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             e => panic!("{e:?}"),
         },
         |bindings| {
-            let header_path = out_dir.join("RustFFI.h");
-            bindings.write_to_file(&header_path);
-
-            if ffi_out_dir != out_dir {
-                bindings.write_to_file(ffi_out_dir.join("RustFFI.h"));
-            }
+            bindings.write_to_file(out_dir.join("RustFFI.h"));
         },
     );
 

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -52,9 +52,6 @@
 //! - `bytecode/` — Bytecode generator, instruction types, and FFI
 //! - `scope_collector.rs` — Scope analysis
 
-#[path = "../../../RustAllocator.rs"]
-mod rust_allocator;
-
 /// Compile-time conversion of an ASCII string literal to `&'static [u16]`.
 ///
 /// Produces a static `[u16; N]` array, so comparisons like

--- a/Libraries/LibRegex/CMakeLists.txt
+++ b/Libraries/LibRegex/CMakeLists.txt
@@ -6,8 +6,4 @@ set(SOURCES
 ladybird_lib(LibRegex regex EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibRegex PRIVATE LibUnicode)
 
-import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libregex_rust FFI_HEADER RustFFI.h)
-target_link_libraries(LibRegex PRIVATE libregex_rust)
-if ((LINUX OR BSD) AND NOT BUILD_SHARED_LIBS)
-    target_link_options(LibRegex INTERFACE LINKER:--allow-multiple-definition)
-endif()
+import_rust_ffi_crate(LibRegex MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libregex_rust_core FFI_HEADER RustFFI.h)

--- a/Libraries/LibRegex/Rust/Cargo.toml
+++ b/Libraries/LibRegex/Rust/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "libregex_rust"
+name = "libregex_rust_core"
 version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["rlib"]
 
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
-libunicode_rust = { path = "../../LibUnicode/Rust", default-features = false }
+libunicode_rust = { package = "libunicode_rust_core", path = "../../LibUnicode/Rust", default-features = false }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/Libraries/LibRegex/Rust/build.rs
+++ b/Libraries/LibRegex/Rust/build.rs
@@ -14,12 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
-    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
     println!("cargo:rerun-if-changed=src");
-
-    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| out_dir.clone());
 
     cbindgen::generate(manifest_dir).map_or_else(
         |error| match error {
@@ -27,12 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             e => panic!("{e:?}"),
         },
         |bindings| {
-            let header_path = out_dir.join("RustFFI.h");
-            bindings.write_to_file(&header_path);
-
-            if ffi_out_dir != out_dir {
-                bindings.write_to_file(ffi_out_dir.join("RustFFI.h"));
-            }
+            bindings.write_to_file(out_dir.join("RustFFI.h"));
         },
     );
 

--- a/Libraries/LibRegex/Rust/src/lib.rs
+++ b/Libraries/LibRegex/Rust/src/lib.rs
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[path = "../../../RustAllocator.rs"]
-mod rust_allocator;
-
 pub mod ast;
 pub mod bytecode;
 pub mod compiler;

--- a/Libraries/LibRegex/RustRegex.h
+++ b/Libraries/LibRegex/RustRegex.h
@@ -12,7 +12,7 @@
 #include <AK/Utf16View.h>
 #include <AK/Vector.h>
 #include <LibRegex/Export.h>
-#include <RustFFI.h>
+#include <LibRegex/RustFFI.h>
 
 namespace regex {
 

--- a/Libraries/LibRustRuntime/src/allocator.rs
+++ b/Libraries/LibRustRuntime/src/allocator.rs
@@ -19,6 +19,8 @@ unsafe extern "C" {
 
 struct LadybirdAllocator;
 
+// Generated runtimes include this once so static links do not get one global
+// allocator shim per Rust crate.
 #[global_allocator]
 static LADYBIRD_ALLOCATOR: LadybirdAllocator = LadybirdAllocator;
 

--- a/Libraries/LibUnicode/CMakeLists.txt
+++ b/Libraries/LibUnicode/CMakeLists.txt
@@ -29,8 +29,7 @@ ladybird_lib(LibUnicode unicode)
 
 target_link_libraries(LibUnicode PRIVATE ICU::i18n ICU::uc ICU::data)
 
-import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libunicode_rust FEATURES allocator FFI_HEADER RustFFI.h)
-target_link_libraries(LibUnicode PRIVATE libunicode_rust)
+import_rust_ffi_crate(LibUnicode MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libunicode_rust_core FFI_HEADER RustFFI.h)
 
 # FIXME: Add support for building LibGfx in sanitize
 #   lld-link: error: /failifmismatch: mismatch detected for 'annotate_string':

--- a/Libraries/LibUnicode/Rust/Cargo.toml
+++ b/Libraries/LibUnicode/Rust/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
-name = "libunicode_rust"
+name = "libunicode_rust_core"
 version = "0.1.0"
 edition = "2024"
 
-[features]
-default = []
-allocator = []
-
 [lib]
-crate-type = ["staticlib", "rlib"]
+crate-type = ["rlib"]
 
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py

--- a/Libraries/LibUnicode/Rust/build.rs
+++ b/Libraries/LibUnicode/Rust/build.rs
@@ -14,12 +14,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
-    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
     println!("cargo:rerun-if-changed=src");
-
-    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| out_dir.clone());
 
     cbindgen::generate(manifest_dir).map_or_else(
         |error| match error {
@@ -27,12 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             e => panic!("{e:?}"),
         },
         |bindings| {
-            let header_path = out_dir.join("RustFFI.h");
-            bindings.write_to_file(&header_path);
-
-            if ffi_out_dir != out_dir {
-                bindings.write_to_file(ffi_out_dir.join("RustFFI.h"));
-            }
+            bindings.write_to_file(out_dir.join("RustFFI.h"));
         },
     );
 

--- a/Libraries/LibUnicode/Rust/src/lib.rs
+++ b/Libraries/LibUnicode/Rust/src/lib.rs
@@ -4,9 +4,5 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[cfg(feature = "allocator")]
-#[path = "../../../RustAllocator.rs"]
-mod rust_allocator;
-
 pub mod calendar;
 pub mod character_types;

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1251,30 +1251,9 @@ ladybird_lib(LibWeb web EXPLICIT_SYMBOL_EXPORT)
 
 target_link_libraries(LibWeb PRIVATE LibCore LibCompress LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests LibGC LibThreading skia ${ANGLE_TARGETS} SDL3::SDL3 LibXml2::LibXml2)
 
-import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libweb_rust FFI_HEADER RustFFI.h)
-target_link_libraries(LibWeb PRIVATE libweb_rust)
+import_rust_ffi_crate(LibWeb MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libweb_rust FFI_HEADER RustFFI.h)
 if ((LINUX OR BSD) AND NOT BUILD_SHARED_LIBS)
     target_link_options(LibWeb INTERFACE LINKER:--allow-multiple-definition)
-endif()
-
-if(NOT BUILD_SHARED_LIBS)
-    add_custom_command(TARGET LibWeb POST_BUILD
-        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_rust>
-        COMMAND ${CMAKE_AR} -qS $<TARGET_FILE:LibWeb> *.o
-        COMMAND ${CMAKE_RANLIB} $<TARGET_FILE:LibWeb>
-        COMMAND ${CMAKE_COMMAND} -E remove -f *.o
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp
-        COMMENT "Merging Rust archive into LibWeb"
-    )
-    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
-
-    # POST_BUILD steps don't track inputs, so when libweb_rust.a changes
-    # ninja leaves liblagom-web.a alone and the merged archive ends up with
-    # stale Rust objects. Force the C++ FFI bridge file to depend on the
-    # Rust archive: when it changes, RustTokenizer.cpp recompiles, LibWeb
-    # re-archives, and POST_BUILD re-merges the fresh Rust objects.
-    get_target_property(_libweb_rust_lib libweb_rust IMPORTED_LOCATION)
-    set_property(SOURCE CSS/Parser/RustTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
 endif()
 
 if (HAS_FONTCONFIG)

--- a/Libraries/LibWeb/Rust/Cargo.toml
+++ b/Libraries/LibWeb/Rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["rlib"]
 
 # After changing dependencies, regenerate the Flatpak sources:
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py

--- a/Libraries/LibWeb/Rust/src/lib.rs
+++ b/Libraries/LibWeb/Rust/src/lib.rs
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[path = "../../../RustAllocator.rs"]
-mod rust_allocator;
-
 mod css_tokenizer;
 
 use std::ffi::c_void;

--- a/Meta/CMake/flatpak/cargo-sources.json
+++ b/Meta/CMake/flatpak/cargo-sources.json
@@ -57,9 +57,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bitflags/bitflags-2.11.0.crate",
-        "sha256": "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af",
-        "dest": "cargo/vendor/bitflags-2.11.0"
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.11.1.crate",
+        "sha256": "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3",
+        "dest": "cargo/vendor/bitflags-2.11.1"
     },
     {
         "type": "archive",
@@ -85,9 +85,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/clap/clap-4.6.0.crate",
-        "sha256": "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351",
-        "dest": "cargo/vendor/clap-4.6.0"
+        "url": "https://static.crates.io/crates/clap/clap-4.6.1.crate",
+        "sha256": "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51",
+        "dest": "cargo/vendor/clap-4.6.1"
     },
     {
         "type": "archive",
@@ -141,9 +141,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/fastrand/fastrand-2.3.0.crate",
-        "sha256": "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be",
-        "dest": "cargo/vendor/fastrand-2.3.0"
+        "url": "https://static.crates.io/crates/fastrand/fastrand-2.4.1.crate",
+        "sha256": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6",
+        "dest": "cargo/vendor/fastrand-2.4.1"
     },
     {
         "type": "archive",
@@ -169,9 +169,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.16.1.crate",
-        "sha256": "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100",
-        "dest": "cargo/vendor/hashbrown-0.16.1"
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.0.crate",
+        "sha256": "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51",
+        "dest": "cargo/vendor/hashbrown-0.17.0"
     },
     {
         "type": "archive",
@@ -239,9 +239,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indexmap/indexmap-2.13.0.crate",
-        "sha256": "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017",
-        "dest": "cargo/vendor/indexmap-2.13.0"
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.14.0.crate",
+        "sha256": "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9",
+        "dest": "cargo/vendor/indexmap-2.14.0"
     },
     {
         "type": "archive",
@@ -253,9 +253,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/itoa/itoa-1.0.17.crate",
-        "sha256": "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2",
-        "dest": "cargo/vendor/itoa-1.0.17"
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.18.crate",
+        "sha256": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682",
+        "dest": "cargo/vendor/itoa-1.0.18"
     },
     {
         "type": "archive",
@@ -274,9 +274,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libc/libc-0.2.183.crate",
-        "sha256": "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d",
-        "dest": "cargo/vendor/libc-0.2.183"
+        "url": "https://static.crates.io/crates/libc/libc-0.2.186.crate",
+        "sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
+        "dest": "cargo/vendor/libc-0.2.186"
     },
     {
         "type": "archive",
@@ -295,9 +295,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/litemap/litemap-0.8.1.crate",
-        "sha256": "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77",
-        "dest": "cargo/vendor/litemap-0.8.1"
+        "url": "https://static.crates.io/crates/litemap/litemap-0.8.2.crate",
+        "sha256": "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0",
+        "dest": "cargo/vendor/litemap-0.8.2"
     },
     {
         "type": "archive",
@@ -351,9 +351,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.4.crate",
-        "sha256": "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77",
-        "dest": "cargo/vendor/potential_utf-0.1.4"
+        "url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.5.crate",
+        "sha256": "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564",
+        "dest": "cargo/vendor/potential_utf-0.1.5"
     },
     {
         "type": "archive",
@@ -393,9 +393,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/semver/semver-1.0.27.crate",
-        "sha256": "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2",
-        "dest": "cargo/vendor/semver-1.0.27"
+        "url": "https://static.crates.io/crates/semver/semver-1.0.28.crate",
+        "sha256": "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd",
+        "dest": "cargo/vendor/semver-1.0.28"
     },
     {
         "type": "archive",
@@ -428,9 +428,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.0.4.crate",
-        "sha256": "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776",
-        "dest": "cargo/vendor/serde_spanned-1.0.4"
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.1.1.crate",
+        "sha256": "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26",
+        "dest": "cargo/vendor/serde_spanned-1.1.1"
     },
     {
         "type": "archive",
@@ -491,23 +491,23 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.0.10+spec-1.1.0.crate",
-        "sha256": "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420",
-        "dest": "cargo/vendor/toml_parser-1.0.10+spec-1.1.0"
+        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.1.2+spec-1.1.0.crate",
+        "sha256": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526",
+        "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.0.7+spec-1.1.0.crate",
-        "sha256": "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d",
-        "dest": "cargo/vendor/toml_writer-1.0.7+spec-1.1.0"
+        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.1.1+spec-1.1.0.crate",
+        "sha256": "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db",
+        "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.22.crate",
-        "sha256": "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5",
-        "dest": "cargo/vendor/unicode-ident-1.0.22"
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.24.crate",
+        "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
+        "dest": "cargo/vendor/unicode-ident-1.0.24"
     },
     {
         "type": "archive",
@@ -533,9 +533,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/wasip2/wasip2-1.0.2+wasi-0.2.9.crate",
-        "sha256": "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5",
-        "dest": "cargo/vendor/wasip2-1.0.2+wasi-0.2.9"
+        "url": "https://static.crates.io/crates/wasip2/wasip2-1.0.3+wasi-0.2.9.crate",
+        "sha256": "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6",
+        "dest": "cargo/vendor/wasip2-1.0.3+wasi-0.2.9"
     },
     {
         "type": "archive",
@@ -589,9 +589,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-1.0.0.crate",
-        "sha256": "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8",
-        "dest": "cargo/vendor/winnow-1.0.0"
+        "url": "https://static.crates.io/crates/winnow/winnow-1.0.2.crate",
+        "sha256": "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0",
+        "dest": "cargo/vendor/winnow-1.0.2"
     },
     {
         "type": "archive",
@@ -599,6 +599,13 @@
         "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.51.0.crate",
         "sha256": "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5",
         "dest": "cargo/vendor/wit-bindgen-0.51.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.57.1.crate",
+        "sha256": "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e",
+        "dest": "cargo/vendor/wit-bindgen-0.57.1"
     },
     {
         "type": "archive",
@@ -638,9 +645,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/writeable/writeable-0.6.2.crate",
-        "sha256": "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9",
-        "dest": "cargo/vendor/writeable-0.6.2"
+        "url": "https://static.crates.io/crates/writeable/writeable-0.6.3.crate",
+        "sha256": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4",
+        "dest": "cargo/vendor/writeable-0.6.3"
     },
     {
         "type": "archive",
@@ -666,16 +673,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.6.crate",
-        "sha256": "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5",
-        "dest": "cargo/vendor/zerofrom-0.1.6"
+        "url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.7.crate",
+        "sha256": "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df",
+        "dest": "cargo/vendor/zerofrom-0.1.7"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zerofrom-derive/zerofrom-derive-0.1.6.crate",
-        "sha256": "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502",
-        "dest": "cargo/vendor/zerofrom-derive-0.1.6"
+        "url": "https://static.crates.io/crates/zerofrom-derive/zerofrom-derive-0.1.7.crate",
+        "sha256": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1",
+        "dest": "cargo/vendor/zerofrom-derive-0.1.7"
     },
     {
         "type": "archive",
@@ -715,11 +722,11 @@
             "echo '{\"files\": {}, \"package\": \"291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d\"}' > cargo/vendor/anstyle-wincon-3.0.11/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\"}' > cargo/vendor/anyhow-1.0.102/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8\"}' > cargo/vendor/autocfg-1.5.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af\"}' > cargo/vendor/bitflags-2.11.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3\"}' > cargo/vendor/bitflags-2.11.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26\"}' > cargo/vendor/calendrical_calculations-0.2.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799\"}' > cargo/vendor/cbindgen-0.29.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801\"}' > cargo/vendor/cfg-if-1.0.4/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351\"}' > cargo/vendor/clap-4.6.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51\"}' > cargo/vendor/clap-4.6.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f\"}' > cargo/vendor/clap_builder-4.6.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9\"}' > cargo/vendor/clap_lex-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570\"}' > cargo/vendor/colorchoice-1.0.5/.cargo-checksum.json",
@@ -727,11 +734,11 @@
             "echo '{\"files\": {}, \"package\": \"97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0\"}' > cargo/vendor/displaydoc-0.2.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\"}' > cargo/vendor/equivalent-1.0.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\"}' > cargo/vendor/errno-0.3.14/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be\"}' > cargo/vendor/fastrand-2.3.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6\"}' > cargo/vendor/fastrand-2.4.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2\"}' > cargo/vendor/foldhash-0.1.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555\"}' > cargo/vendor/getrandom-0.4.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1\"}' > cargo/vendor/hashbrown-0.15.5/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100\"}' > cargo/vendor/hashbrown-0.16.1/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51\"}' > cargo/vendor/hashbrown-0.17.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\"}' > cargo/vendor/heck-0.5.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf\"}' > cargo/vendor/icu_calendar-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d\"}' > cargo/vendor/icu_calendar_data-2.2.0/.cargo-checksum.json",
@@ -741,15 +748,15 @@
             "echo '{\"files\": {}, \"package\": \"d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993\"}' > cargo/vendor/icu_locale_data-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421\"}' > cargo/vendor/icu_provider-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\"}' > cargo/vendor/id-arena-2.3.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017\"}' > cargo/vendor/indexmap-2.13.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9\"}' > cargo/vendor/indexmap-2.14.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695\"}' > cargo/vendor/is_terminal_polyfill-1.70.2/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2\"}' > cargo/vendor/itoa-1.0.17/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\"}' > cargo/vendor/itoa-1.0.18/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1\"}' > cargo/vendor/ixdtf-0.6.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\"}' > cargo/vendor/leb128fmt-0.1.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d\"}' > cargo/vendor/libc-0.2.183/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66\"}' > cargo/vendor/libc-0.2.186/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981\"}' > cargo/vendor/libm-0.2.16/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53\"}' > cargo/vendor/linux-raw-sys-0.12.1/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77\"}' > cargo/vendor/litemap-0.8.1/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0\"}' > cargo/vendor/litemap-0.8.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897\"}' > cargo/vendor/log-0.4.29/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79\"}' > cargo/vendor/memchr-2.8.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9\"}' > cargo/vendor/num-bigint-0.4.6/.cargo-checksum.json",
@@ -757,18 +764,18 @@
             "echo '{\"files\": {}, \"package\": \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\"}' > cargo/vendor/num-traits-0.2.19/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50\"}' > cargo/vendor/once_cell-1.21.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe\"}' > cargo/vendor/once_cell_polyfill-1.70.2/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77\"}' > cargo/vendor/potential_utf-0.1.4/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564\"}' > cargo/vendor/potential_utf-0.1.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b\"}' > cargo/vendor/prettyplease-0.2.37/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\"}' > cargo/vendor/proc-macro2-1.0.106/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924\"}' > cargo/vendor/quote-1.0.45/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf\"}' > cargo/vendor/r-efi-6.0.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190\"}' > cargo/vendor/rustix-1.1.4/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2\"}' > cargo/vendor/semver-1.0.27/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd\"}' > cargo/vendor/semver-1.0.28/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e\"}' > cargo/vendor/serde-1.0.228/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad\"}' > cargo/vendor/serde_core-1.0.228/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79\"}' > cargo/vendor/serde_derive-1.0.228/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86\"}' > cargo/vendor/serde_json-1.0.149/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776\"}' > cargo/vendor/serde_spanned-1.0.4/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26\"}' > cargo/vendor/serde_spanned-1.1.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596\"}' > cargo/vendor/stable_deref_trait-1.2.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f\"}' > cargo/vendor/strsim-0.11.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99\"}' > cargo/vendor/syn-2.0.117/.cargo-checksum.json",
@@ -777,13 +784,13 @@
             "echo '{\"files\": {}, \"package\": \"c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d\"}' > cargo/vendor/tinystr-0.8.3/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863\"}' > cargo/vendor/toml-0.9.12+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\"}' > cargo/vendor/toml_datetime-0.7.5+spec-1.1.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420\"}' > cargo/vendor/toml_parser-1.0.10+spec-1.1.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d\"}' > cargo/vendor/toml_writer-1.0.7+spec-1.1.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5\"}' > cargo/vendor/unicode-ident-1.0.22/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526\"}' > cargo/vendor/toml_parser-1.1.2+spec-1.1.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db\"}' > cargo/vendor/toml_writer-1.1.1+spec-1.1.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\"}' > cargo/vendor/unicode-ident-1.0.24/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\"}' > cargo/vendor/unicode-xid-0.2.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\"}' > cargo/vendor/utf8_iter-1.0.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\"}' > cargo/vendor/utf8parse-0.2.2/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5\"}' > cargo/vendor/wasip2-1.0.2+wasi-0.2.9/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6\"}' > cargo/vendor/wasip2-1.0.3+wasi-0.2.9/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5\"}' > cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319\"}' > cargo/vendor/wasm-encoder-0.244.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909\"}' > cargo/vendor/wasm-metadata-0.244.0/.cargo-checksum.json",
@@ -791,19 +798,20 @@
             "echo '{\"files\": {}, \"package\": \"f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5\"}' > cargo/vendor/windows-link-0.2.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc\"}' > cargo/vendor/windows-sys-0.61.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945\"}' > cargo/vendor/winnow-0.7.15/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8\"}' > cargo/vendor/winnow-1.0.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0\"}' > cargo/vendor/winnow-1.0.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5\"}' > cargo/vendor/wit-bindgen-0.51.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e\"}' > cargo/vendor/wit-bindgen-0.57.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc\"}' > cargo/vendor/wit-bindgen-core-0.51.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21\"}' > cargo/vendor/wit-bindgen-rust-0.51.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a\"}' > cargo/vendor/wit-bindgen-rust-macro-0.51.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2\"}' > cargo/vendor/wit-component-0.244.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736\"}' > cargo/vendor/wit-parser-0.244.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9\"}' > cargo/vendor/writeable-0.6.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4\"}' > cargo/vendor/writeable-0.6.3/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca\"}' > cargo/vendor/yoke-0.8.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e\"}' > cargo/vendor/yoke-derive-0.8.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"47d3a7e2cda3061858987ee2fb028f61695f5ee13f9490d75be6c3900df9a4ea\"}' > cargo/vendor/yuv-0.8.13/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5\"}' > cargo/vendor/zerofrom-0.1.6/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502\"}' > cargo/vendor/zerofrom-derive-0.1.6/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df\"}' > cargo/vendor/zerofrom-0.1.7/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1\"}' > cargo/vendor/zerofrom-derive-0.1.7/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf\"}' > cargo/vendor/zerotrie-0.2.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239\"}' > cargo/vendor/zerovec-0.11.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555\"}' > cargo/vendor/zerovec-derive-0.11.3/.cargo-checksum.json",

--- a/Meta/CMake/rust_crate.cmake
+++ b/Meta/CMake/rust_crate.cmake
@@ -1,15 +1,170 @@
+## Store the rust crates attached to a cmake target as crate-name|manifest-path strings.
+## This travels with the target through the link graph.
+define_property(TARGET PROPERTY TARGET_CRATE_ENTRIES
+    BRIEF_DOCS "Rust crates exposed by this target"
+    FULL_DOCS "A list of crate-name|manifest-path entries that should be linked into a rust runtime for this target."
+)
+
+# Register this crate in TARGET_CRATE_ENTRIES. target_name uses crate_name from manifest_path
+function(register_crate target_name crate_name manifest_path)
+    if (NOT TARGET "${target_name}")
+        message(FATAL_ERROR "Cannot register crate ${crate_name} for unknown target ${target_name}")
+    endif()
+    if (NOT IS_ABSOLUTE "${manifest_path}")
+        set(manifest_path "${CMAKE_CURRENT_SOURCE_DIR}/${manifest_path}")
+    endif()
+
+    # Normalize the name-NOTFOUND string for missing targets to an empty list before appending to it.
+    get_target_property(target_crates "${target_name}" TARGET_CRATE_ENTRIES)
+    if ("${target_crates}" MATCHES "-NOTFOUND$")
+        set(target_crates "")
+    endif()
+
+    # Dedup here so repeated imports or repeated walks do not grow the list.
+    list(APPEND target_crates "${crate_name}|${manifest_path}")
+    list(REMOVE_DUPLICATES target_crates)
+    set_target_properties("${target_name}" PROPERTIES TARGET_CRATE_ENTRIES "${target_crates}")
+endfunction()
+
+# Helper that walks the link graph to collect crates registered to the target and its dependencies.
+function(_collect_crates_impl target_name output_var visited_var)
+    if (NOT TARGET "${target_name}")
+        return()
+    endif()
+    list(FIND ${visited_var} "${target_name}" target_index)
+    if (NOT target_index EQUAL -1)
+        return()
+    endif()
+    list(APPEND ${visited_var} "${target_name}")
+    get_target_property(target_crates "${target_name}" TARGET_CRATE_ENTRIES)
+    if (NOT "${target_crates}" MATCHES "-NOTFOUND$")
+        list(APPEND ${output_var} ${target_crates})
+    endif()
+
+    foreach(link_property IN ITEMS LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+        get_target_property(target_libraries "${target_name}" ${link_property})
+        if ("${target_libraries}" MATCHES "-NOTFOUND$")
+            continue()
+        endif()
+        foreach(target_library IN LISTS target_libraries)
+            if (TARGET "${target_library}")
+                _collect_crates_impl("${target_library}" ${output_var} ${visited_var})
+            endif()
+        endforeach()
+    endforeach()
+    set(${output_var} "${${output_var}}" PARENT_SCOPE)
+    set(${visited_var} "${${visited_var}}" PARENT_SCOPE)
+endfunction()
+
+# Gather crates registered on the target and linked dependencies.
+function(collect_crates target_name output_var)
+    set(collected_crates "")
+    set(visited_targets "")
+    _collect_crates_impl("${target_name}" collected_crates visited_targets)
+    list(REMOVE_DUPLICATES collected_crates)
+    list(SORT collected_crates)
+    set(${output_var} "${collected_crates}" PARENT_SCOPE)
+endfunction()
+
+# Get crates attached directly to this target. Shared-library builds link each library separately,
+# so they only need a local runtime instead of the full transitive closure.
+function(collect_local_crates target_name output_var)
+    get_target_property(target_crates "${target_name}" TARGET_CRATE_ENTRIES)
+    if ("${target_crates}" MATCHES "-NOTFOUND$")
+        set(target_crates "")
+    endif()
+    list(REMOVE_DUPLICATES target_crates)
+    list(SORT target_crates)
+    set(${output_var} "${target_crates}" PARENT_SCOPE)
+endfunction()
+
+# Generate a staticlib crate for a native link target using the passed in crate list (shared lib
+# builds) or the collected transitive closure (static builds).
+function(link_rust_runtime target_name)
+    # Shared library builds pass a direct crate list here so each library gets a private runtime
+    # and allocator shim for its own crates.
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "RUST_CRATE_ENTRIES")
+
+    if (ARG_RUST_CRATE_ENTRIES)
+        set(target_crates ${ARG_RUST_CRATE_ENTRIES})
+    else()
+        # Static and final-target callers fall back to the full transitive closure for target_name.
+        collect_crates("${target_name}" target_crates)
+    endif()
+    if (NOT target_crates)
+        return()
+    endif()
+
+    string(TOLOWER "${target_name}" runtime_name_suffix)
+    string(REGEX REPLACE "[^a-z0-9_]" "_" runtime_name_suffix "${runtime_name_suffix}")
+    set(runtime_crate_name "ladybird_runtime_${runtime_name_suffix}")
+    set(runtime_dir "${CMAKE_BINARY_DIR}/rust-runtime/${target_name}")
+    set(runtime_src_dir "${runtime_dir}/src")
+    file(MAKE_DIRECTORY "${runtime_src_dir}")
+    set(runtime_dependencies "")
+    set(runtime_reexports "")
+    set(runtime_depends "")
+    file(RELATIVE_PATH allocator_path "${runtime_src_dir}" "${LADYBIRD_SOURCE_DIR}/Libraries/LibRustRuntime/src/allocator.rs")
+
+    # Each entry is stored as crate-name|manifest-path. Split it back apart and
+    # write the matching cargo dependency line for the generated crate.
+    foreach(target_crate IN LISTS target_crates)
+        string(REPLACE "|" ";" crate_parts "${target_crate}")
+        list(GET crate_parts 0 crate_name)
+        list(GET crate_parts 1 crate_manifest_path)
+        get_filename_component(crate_dir "${crate_manifest_path}" DIRECTORY)
+        file(RELATIVE_PATH crate_path "${runtime_dir}" "${crate_dir}")
+        string(APPEND runtime_dependencies "${crate_name} = { path = \"${crate_path}\" }\n")
+        string(APPEND runtime_reexports "pub use ${crate_name} as ${crate_name}_runtime_export;\n")
+        list(APPEND runtime_depends "${crate_manifest_path}")
+    endforeach()
+
+    # Generate the manifest and a lib.rs with the allocator in the build directory.
+    file(CONFIGURE OUTPUT "${runtime_dir}/Cargo.toml" CONTENT [=[
+[package]
+name = "@runtime_crate_name@"
+version = "0.1.0"
+edition = "2024"
+[lib]
+crate-type = ["staticlib"]
+[workspace]
+[dependencies]
+@runtime_dependencies@]=] @ONLY)
+
+    file(CONFIGURE OUTPUT "${runtime_src_dir}/lib.rs" CONTENT [=[
+#[path = "@allocator_path@"]
+mod allocator;
+@runtime_reexports@]=] @ONLY)
+
+    # Build the generated crate like any other rust crate, but track the source
+    # manifests of the crates it depends on so config changes rebuild it too.
+    import_rust_crate(
+        MANIFEST_PATH "${runtime_dir}/Cargo.toml"
+        CRATE_NAME "${runtime_crate_name}"
+        WORKSPACE_DIR "${LADYBIRD_SOURCE_DIR}"
+        DEPENDS ${runtime_depends}
+    )
+    set_property(TARGET "${target_name}" APPEND PROPERTY LINK_LIBRARIES "${runtime_crate_name}")
+endfunction()
+
 # import_rust_crate(MANIFEST_PATH path/to/Cargo.toml CRATE_NAME name)
 #
-# Builds a Rust static library crate using cargo and creates an IMPORTED target.
-# MANIFEST_PATH is relative to CMAKE_CURRENT_SOURCE_DIR.
+# Builds a Rust crate using cargo and creates an IMPORTED target.
+# MANIFEST_PATH is relative to CMAKE_CURRENT_SOURCE_DIR unless already absolute.
 #
 # When corrosion supports dependency tracking, we can use corrosion_import_crate() instead of this function. See:
 # https://github.com/corrosion-rs/corrosion/issues/206
 # https://github.com/corrosion-rs/corrosion/issues/624
 function(import_rust_crate)
-    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "MANIFEST_PATH;CRATE_NAME;FFI_OUTPUT_DIR;FFI_HEADER" "FEATURES")
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "MANIFEST_PATH;CRATE_NAME;CRATE_KIND;FFI_OUTPUT_DIR;FFI_HEADER" "FEATURES")
 
-    set(ARG_MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_MANIFEST_PATH}")
+    if (NOT ARG_CRATE_KIND)
+        set(ARG_CRATE_KIND "STATICLIB")
+    endif()
+
+    if (NOT IS_ABSOLUTE "${ARG_MANIFEST_PATH}")
+        set(ARG_MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_MANIFEST_PATH}")
+    endif()
     if (NOT ARG_FFI_OUTPUT_DIR)
         set(ARG_FFI_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
@@ -18,10 +173,14 @@ function(import_rust_crate)
     endif()
 
     # Find the workspace Cargo.lock to track as a dependency.
-    get_filename_component(workspace_dir "${ARG_MANIFEST_PATH}" DIRECTORY)
-    while(NOT EXISTS "${workspace_dir}/Cargo.lock")
-        get_filename_component(workspace_dir "${workspace_dir}" DIRECTORY)
-    endwhile()
+    if (ARG_WORKSPACE_DIR)
+        set(workspace_dir "${ARG_WORKSPACE_DIR}")
+    else()
+        get_filename_component(workspace_dir "${ARG_MANIFEST_PATH}" DIRECTORY)
+        while(NOT EXISTS "${workspace_dir}/Cargo.lock")
+            get_filename_component(workspace_dir "${workspace_dir}" DIRECTORY)
+        endwhile()
+    endif()
 
     # Detect the Rust toolchain.
     find_program(RUST_CARGO cargo REQUIRED)
@@ -56,7 +215,10 @@ function(import_rust_crate)
     set(cargo_target_dir "${CMAKE_BINARY_DIR}/cargo/build")
     set(cargo_output_dir "${cargo_target_dir}/${RUST_TARGET_TRIPLE}/${cargo_profile_dir}")
 
-    if (WIN32)
+    if (ARG_CRATE_KIND STREQUAL "RLIB")
+        set(output_lib "${cargo_output_dir}/lib${ARG_CRATE_NAME}.rlib")
+        set(depfile "${cargo_output_dir}/lib${ARG_CRATE_NAME}.d")
+    elseif (WIN32)
         set(output_lib "${cargo_output_dir}/${ARG_CRATE_NAME}.lib")
         set(depfile "${cargo_output_dir}/${ARG_CRATE_NAME}.d")
     else()
@@ -69,7 +231,6 @@ function(import_rust_crate)
         "CC_${target_underscore}=${CMAKE_C_COMPILER}"
         "CXX_${target_underscore}=${CMAKE_CXX_COMPILER}"
         "CARGO_BUILD_RUSTC=${RUST_RUSTC}"
-        "FFI_OUTPUT_DIR=${ARG_FFI_OUTPUT_DIR}"
     )
 
     # On Windows, rustc invokes the linker directly with MSVC-style flags, so we must not override it with a
@@ -108,7 +269,7 @@ function(import_rust_crate)
                 -DFFI_HEADER=${ARG_FFI_HEADER}
                 -DFFI_OUTPUT_DIR=${ARG_FFI_OUTPUT_DIR}
                 -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/sync_rust_ffi_header.cmake"
-        DEPENDS "${ARG_MANIFEST_PATH}"
+        DEPENDS "${ARG_MANIFEST_PATH}" ${ARG_DEPENDS}
             "${workspace_dir}/Cargo.lock" "${workspace_dir}/Cargo.toml"
         DEPFILE "${depfile}"
         COMMENT "Building Rust crate ${ARG_CRATE_NAME}"
@@ -117,6 +278,16 @@ function(import_rust_crate)
     )
 
     add_custom_target(${ARG_CRATE_NAME}-build DEPENDS "${output_lib}" ${ffi_output})
+
+    if (ARG_CRATE_KIND STREQUAL "RLIB")
+        # The rlib is only an internal rust dependency. c++ uses it for the generated header, not for linking.
+        add_library(${ARG_CRATE_NAME} INTERFACE IMPORTED GLOBAL)
+        set_target_properties(${ARG_CRATE_NAME} PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${ARG_FFI_OUTPUT_DIR}"
+        )
+        add_dependencies(${ARG_CRATE_NAME} ${ARG_CRATE_NAME}-build)
+        return()
+    endif()
 
     add_library(${ARG_CRATE_NAME} STATIC IMPORTED GLOBAL)
     set_target_properties(${ARG_CRATE_NAME} PROPERTIES
@@ -130,5 +301,28 @@ function(import_rust_crate)
         set_target_properties(${ARG_CRATE_NAME} PROPERTIES
             INTERFACE_LINK_LIBRARIES "kernel32;ntdll;Ws2_32;userenv"
         )
+    endif()
+endfunction()
+
+function(import_rust_ffi_crate target_name)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "MANIFEST_PATH;CRATE_NAME;FFI_OUTPUT_DIR;FFI_HEADER" "FEATURES")
+
+    import_rust_crate(
+        MANIFEST_PATH "${ARG_MANIFEST_PATH}"
+        CRATE_NAME "${ARG_CRATE_NAME}"
+        CRATE_KIND RLIB
+        FFI_OUTPUT_DIR "${ARG_FFI_OUTPUT_DIR}"
+        FFI_HEADER "${ARG_FFI_HEADER}"
+        FEATURES ${ARG_FEATURES}
+    )
+
+    register_crate("${target_name}" "${ARG_CRATE_NAME}" "${ARG_MANIFEST_PATH}")
+
+    target_link_libraries(${target_name} PRIVATE ${ARG_CRATE_NAME})
+
+    # Shared-library builds want one runtime per library target.
+    if (BUILD_SHARED_LIBS)
+        collect_local_crates("${target_name}" local_crates)
+        link_rust_runtime("${target_name}" RUST_CRATE_ENTRIES ${local_crates})
     endif()
 endfunction()

--- a/Meta/CMake/targets.cmake
+++ b/Meta/CMake/targets.cmake
@@ -139,6 +139,10 @@ function(lagom_test source)
         target_link_libraries(${LAGOM_TEST_NAME} PRIVATE ${MMAN_LIBRARY})
     endif()
 
+    if (NOT BUILD_SHARED_LIBS)
+        link_rust_runtime(${LAGOM_TEST_NAME})
+    endif()
+
     add_test(
             NAME ${LAGOM_TEST_NAME}
             COMMAND ${LAGOM_TEST_NAME}
@@ -151,6 +155,9 @@ function(lagom_utility name)
 
     add_executable("${name}" ${LAGOM_UTILITY_SOURCES})
     target_link_libraries("${name}" PRIVATE AK LibCore ${LAGOM_UTILITY_LIBS})
+    if (NOT BUILD_SHARED_LIBS)
+        link_rust_runtime(${name})
+    endif()
     lagom_generate_dsym(${name})
 endfunction()
 

--- a/Services/ImageDecoder/CMakeLists.txt
+++ b/Services/ImageDecoder/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories(imagedecoderservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Se
 target_link_libraries(ImageDecoder PRIVATE imagedecoderservice LibCore LibMain LibThreading)
 target_link_libraries(imagedecoderservice PRIVATE LibCore LibGfx LibIPC LibImageDecoderClient LibMain LibThreading)
 
+if (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(ImageDecoder)
+endif()
+
 if (WIN32)
     lagom_windows_bin(ImageDecoder CONSOLE)
 endif()

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -38,6 +38,12 @@ add_executable(WebContent main.cpp)
 
 target_link_libraries(WebContent PRIVATE webcontentservice LibURL)
 
+if (ANDROID)
+    link_rust_runtime(webcontentservice)
+elseif (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(WebContent)
+endif()
+
 if(WIN32)
     lagom_windows_bin(WebContent CONSOLE)
 endif()

--- a/Services/WebDriver/CMakeLists.txt
+++ b/Services/WebDriver/CMakeLists.txt
@@ -15,6 +15,10 @@ target_include_directories(WebDriver PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)
 target_link_libraries(WebDriver PRIVATE LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibWebView)
 target_link_libraries(WebDriver PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
+if (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(WebDriver)
+endif()
+
 if (WIN32)
     lagom_windows_bin(WebDriver)
 endif()

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -21,6 +21,10 @@ add_executable(WebWorker main.cpp)
 target_include_directories(WebWorker PRIVATE ${LADYBIRD_SOURCE_DIR})
 target_link_libraries(WebWorker PRIVATE webworkerservice OpenSSL::Crypto OpenSSL::SSL)
 
+if (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(WebWorker)
+endif()
+
 if(WIN32)
     target_include_directories(WebWorker PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)
     lagom_windows_bin(WebWorker CONSOLE)

--- a/Tests/LibWasm/CMakeLists.txt
+++ b/Tests/LibWasm/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_executable(test-wasm test-wasm.cpp)
 target_link_libraries(test-wasm AK LibCore LibFileSystem JavaScriptTestRunnerMain LibTest LibWasm LibJS LibCrypto LibGC)
+
+if (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(test-wasm)
+endif()
+
 set(wasm_test_root "${LADYBIRD_SOURCE_DIR}")
 if (INCLUDE_WASM_SPEC_TESTS)
     set(wasm_test_root "${CMAKE_BINARY_DIR}")

--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -14,6 +14,10 @@ add_executable(test-web ${SOURCES})
 add_dependencies(test-web ladybird_build_resource_files ImageDecoder RequestServer WebContent WebWorker)
 target_link_libraries(test-web PRIVATE AK LibCore LibDiff LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibRequests LibURL LibWeb LibWebView)
 
+if (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(test-web)
+endif()
+
 if (APPLE)
     target_compile_definitions(test-web PRIVATE LADYBIRD_BINARY_PATH="$<TARGET_FILE_DIR:ladybird>")
 elseif (WIN32)

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -67,6 +67,10 @@ target_include_directories(${LADYBIRD_TARGET} ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${LADYBIRD_TARGET} ${LADYBIRD_SOURCE_DIR})
 target_include_directories(${LADYBIRD_TARGET} ${LADYBIRD_SOURCE_DIR}/Services/)
 
+if (NOT BUILD_SHARED_LIBS)
+    link_rust_runtime(ladybird)
+endif()
+
 if(WIN32)
     target_link_libraries(${LADYBIRD_TARGET} LibDevTools)
 endif()


### PR DESCRIPTION
Stop building LibJS, LibGfx, LibUnicode, and LibRegex as separate staticlibs exporting their own bundled rust runtime and allocator. Build them as rlibs instead, and generate a per-target runtime staticlib that pulls in LibRustRuntime's allocator shim.

This keeps one copy of the rust runtime per dso or executable and avoids duplicate allocator and std symbols. It also fixes a debug-link mess from pulling multiple rust staticlibs into the same process, causing elf debug builds of WebContent with mimalloc to insta-die on any regex.

Build details:

A library imports its rust crate as an rlib rather than staticlib, and Meta/rust_crate.cmake's import_rust_ffi_crate function registers that crate on the cmake target as metadata. Later, link_rust_runtime turns the collected crate list into a generated per-target staticlib crate in the build_dir which pulls in allocator.rs from LibRustRuntime, reexports the component crates, and links exactly one rust runtime bundle into the native link target.

To hook in a new rust-backed library, make the crate an rlib in Cargo.toml, then call the import_rust_ffi_crate function from the library's CMakeLists.txt. Example from LibRegex:
```
import_rust_ffi_crate(LibRegex MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libregex_rust_core FFI_HEADER RustFFI.h)
```
This gives the c++ side its generated ffi header, registers the crate metadata for later codegen, and, in shared builds, gives that shared library its own local allocator shim and runtime.

An executable uses it at the final native link boundary. In static builds, executables call link_rust_runtime which walks the linked libraries, finds registered rust crates transitively, and builds one runtime. Shared libraries get private rust runtimes when they import their crates, so an executable just links those normally.