### PR TITLE
LibJS: Preserve source positions in bytecode source maps

### DIFF
--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -113,10 +113,13 @@ static void dump_header(StringBuilder& output, Executable const& executable, boo
     // Find the overall source range covered by this executable.
     u32 source_start = NumericLimits<u32>::max();
     u32 source_end = 0;
+    Optional<Position> first_position;
     for (auto const& entry : executable.source_map) {
-        if (entry.source_record.source_start_offset < entry.source_record.source_end_offset) {
-            source_start = min(source_start, entry.source_record.source_start_offset);
-            source_end = max(source_end, entry.source_record.source_end_offset);
+        if (entry.source_record.start.offset < entry.source_record.end.offset) {
+            source_start = min(source_start, entry.source_record.start.offset);
+            source_end = max(source_end, entry.source_record.end.offset);
+            if (!first_position.has_value() || entry.source_record.start.offset < first_position->offset)
+                first_position = entry.source_record.start;
         }
     }
 
@@ -136,17 +139,16 @@ static void dump_header(StringBuilder& output, Executable const& executable, boo
         output.appendff("{}{}${:08x}{}", white_bold, executable.name, hash, reset);
 
     // Show source location if available.
-    if (source_start < source_end) {
-        auto range = executable.source_code->range_from_offsets(source_start, source_end);
+    if (source_start < source_end && first_position.has_value()) {
         auto filename = executable.source_code->filename();
         if (!filename.is_empty()) {
             // Show just the basename to keep output portable across machines.
             auto last_slash = filename.bytes_as_string_view().find_last('/');
             if (last_slash.has_value())
                 filename = MUST(filename.substring_from_byte_offset(last_slash.value() + 1));
-            output.appendff(" {}:{}:{}", filename, range.start.line, range.start.column);
+            output.appendff(" {}:{}:{}", filename, first_position->line, first_position->column);
         } else {
-            output.appendff(" line {}, column {}", range.start.line, range.start.column);
+            output.appendff(" line {}, column {}", first_position->line, first_position->column);
         }
     }
     output.append('\n');
@@ -353,12 +355,10 @@ Optional<Executable::ExceptionHandlers const&> Executable::exception_handlers_fo
     return *entry;
 }
 
-UnrealizedSourceRange Executable::source_range_at(size_t offset) const
+Optional<SourceRange> Executable::source_range_at(size_t offset) const
 {
     if (offset >= bytecode.size())
         return {};
-    auto it = InstructionStreamIterator(bytecode.span().slice(offset), this);
-    VERIFY(!it.at_end());
     auto* entry = binary_search(source_map, offset, nullptr, [](size_t needle, SourceMapEntry const& entry) -> int {
         if (needle < entry.bytecode_offset)
             return -1;
@@ -368,19 +368,18 @@ UnrealizedSourceRange Executable::source_range_at(size_t offset) const
     });
     if (!entry)
         return {};
-    return UnrealizedSourceRange {
-        .source_code = source_code,
-        .start_offset = entry->source_record.source_start_offset,
-        .end_offset = entry->source_record.source_end_offset,
+    return SourceRange {
+        .code = source_code,
+        .start = entry->source_record.start,
+        .end = entry->source_record.end,
     };
 }
 
 SourceRange const& Executable::get_source_range(u32 program_counter)
 {
     return m_source_range_cache.ensure(program_counter, [&] {
-        auto unrealized = source_range_at(program_counter);
-        if (unrealized.source_code)
-            return unrealized.realize();
+        if (auto source_range = source_range_at(program_counter); source_range.has_value())
+            return *source_range;
         static SourceRange dummy { SourceCode::create({}, {}), {}, {} };
         return dummy;
     });

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -137,8 +137,8 @@ struct ObjectPropertyIteratorCache {
 };
 
 struct SourceRecord {
-    u32 source_start_offset {};
-    u32 source_end_offset {};
+    Position start {};
+    Position end {};
 };
 
 struct SourceMapEntry {
@@ -226,7 +226,7 @@ public:
 
     [[nodiscard]] COLD Optional<ExceptionHandlers const&> exception_handlers_for_offset(size_t offset) const;
 
-    [[nodiscard]] UnrealizedSourceRange source_range_at(size_t offset) const;
+    [[nodiscard]] Optional<SourceRange> source_range_at(size_t offset) const;
 
     [[nodiscard]] SourceRange const& get_source_range(u32 program_counter);
 

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -518,8 +518,10 @@ void VM::dump_backtrace() const
 {
     for_each_execution_context_top_to_bottom([&](ExecutionContext const& frame) {
         if (frame.executable) {
-            auto source_range = frame.executable->source_range_at(frame.program_counter).realize();
-            dbgln("-> {} @ {}:{},{}", frame.function ? frame.function->name_for_call_stack() : ""_utf16, source_range.filename(), source_range.start.line, source_range.start.column);
+            if (auto source_range = frame.executable->source_range_at(frame.program_counter); source_range.has_value())
+                dbgln("-> {} @ {}:{},{}", frame.function ? frame.function->name_for_call_stack() : ""_utf16, source_range->filename(), source_range->start.line, source_range->start.column);
+            else
+                dbgln("-> {}", frame.function ? frame.function->name_for_call_stack() : ""_utf16);
         } else {
             dbgln("-> {}", frame.function ? frame.function->name_for_call_stack() : ""_utf16);
         }

--- a/Libraries/LibJS/Rust/src/bytecode/basic_block.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/basic_block.rs
@@ -6,13 +6,14 @@
 
 use super::instruction::Instruction;
 use super::operand::Label;
+use crate::ast::Position;
 
 /// A source map entry mapping a bytecode offset to a source range.
 #[derive(Debug, Clone, Copy)]
 pub struct SourceMapEntry {
     pub bytecode_offset: u32,
-    pub source_start: u32,
-    pub source_end: u32,
+    pub source_start: Position,
+    pub source_end: Position,
 }
 
 /// A basic block in the bytecode generator.

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -63,8 +63,8 @@ pub fn generate_expression(
 ) -> Option<ScopedOperand> {
     let saved_source_start = generator.current_source_start;
     let saved_source_end = generator.current_source_end;
-    generator.current_source_start = expression.range.start.offset;
-    generator.current_source_end = expression.range.end.offset;
+    generator.current_source_start = expression.range.start;
+    generator.current_source_end = expression.range.end;
 
     let result = generate_expression_inner(expression, generator, preferred_dst);
 
@@ -852,8 +852,8 @@ pub fn generate_statement(
 ) -> Option<ScopedOperand> {
     let saved_source_start = generator.current_source_start;
     let saved_source_end = generator.current_source_end;
-    generator.current_source_start = statement.range.start.offset;
-    generator.current_source_end = statement.range.end.offset;
+    generator.current_source_start = statement.range.start;
+    generator.current_source_end = statement.range.end;
 
     let result = match &statement.inner {
         StatementKind::Empty | StatementKind::Error | StatementKind::ErrorDeclaration => None,

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -42,8 +42,12 @@ pub struct FFIExceptionHandler {
 #[repr(C)]
 pub struct FFISourceMapEntry {
     pub bytecode_offset: u32,
-    pub source_start: u32,
-    pub source_end: u32,
+    pub source_start_line: u32,
+    pub source_start_column: u32,
+    pub source_start_offset: u32,
+    pub source_end_line: u32,
+    pub source_end_column: u32,
+    pub source_end_offset: u32,
 }
 
 /// A borrowed UTF-16 string slice for passing across FFI.
@@ -482,8 +486,12 @@ pub unsafe fn create_executable(
             .iter()
             .map(|e| FFISourceMapEntry {
                 bytecode_offset: e.bytecode_offset,
-                source_start: e.source_start,
-                source_end: e.source_end,
+                source_start_line: e.source_start.line,
+                source_start_column: e.source_start.column,
+                source_start_offset: e.source_start.offset,
+                source_end_line: e.source_end.line,
+                source_end_column: e.source_end.column,
+                source_end_offset: e.source_end.offset,
             })
             .collect();
 

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use super::basic_block::{BasicBlock, SourceMapEntry};
 use super::instruction::Instruction;
 use super::operand::*;
-use crate::ast::{LocalType, Utf16String};
+use crate::ast::{LocalType, Position, Utf16String};
 use crate::u32_from_usize;
 
 /// Identifies an operand that auto-frees its register when the last
@@ -187,8 +187,8 @@ pub struct Generator {
     pub pending_lhs_name: Option<IdentifierTableIndex>,
 
     // Source location tracking
-    pub current_source_start: u32,
-    pub current_source_end: u32,
+    pub current_source_start: Position,
+    pub current_source_end: Position,
 
     // --- Completion register ---
     pub current_completion_register: Option<ScopedOperand>,
@@ -325,8 +325,16 @@ impl Generator {
             initialized_locals: Vec::new(),
             initialized_arguments: Vec::new(),
             pending_lhs_name: None,
-            current_source_start: 0,
-            current_source_end: 0,
+            current_source_start: Position {
+                line: 0,
+                column: 0,
+                offset: 0,
+            },
+            current_source_end: Position {
+                line: 0,
+                column: 0,
+                offset: 0,
+            },
             current_completion_register: None,
             must_propagate_completion: false,
             accumulator: ScopedOperand {
@@ -1600,8 +1608,16 @@ impl Generator {
                 let instruction_offset = bytecode.len();
                 source_map.push(SourceMapEntry {
                     bytecode_offset: u32_from_usize(instruction_offset),
-                    source_start: 0,
-                    source_end: 0,
+                    source_start: Position {
+                        line: 0,
+                        column: 0,
+                        offset: 0,
+                    },
+                    source_end: Position {
+                        line: 0,
+                        column: 0,
+                        offset: 0,
+                    },
                 });
                 end_instruction.encode(self.strict, &mut bytecode);
             }

--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -424,7 +424,10 @@ impl<'a> Lexer<'a> {
             current_code_unit: 0,
             eof: false,
             line_number,
-            line_column,
+            // consume() below will bump line_column by one; pre-decrement so
+            // the post-consume state has line_column equal to the column of
+            // the character at `offset`.
+            line_column: line_column.saturating_sub(1),
             current_token_type: TokenType::Eof,
             regex_is_in_character_class: false,
             allow_html_comments: true,

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -786,7 +786,18 @@ extern "C" void* rust_create_executable(
     for (size_t i = 0; i < data->source_map_count; ++i) {
         executable->source_map.append({
             data->source_map[i].bytecode_offset,
-            { data->source_map[i].source_start, data->source_map[i].source_end },
+            {
+                .start = {
+                    .line = data->source_map[i].source_start_line,
+                    .column = data->source_map[i].source_start_column,
+                    .offset = data->source_map[i].source_start_offset,
+                },
+                .end = {
+                    .line = data->source_map[i].source_end_line,
+                    .column = data->source_map[i].source_end_column,
+                    .offset = data->source_map[i].source_end_offset,
+                },
+            },
         });
     }
 

--- a/Libraries/LibJS/SourceRange.h
+++ b/Libraries/LibJS/SourceRange.h
@@ -27,16 +27,4 @@ struct JS_API SourceRange {
     ByteString filename() const { return code->filename().to_byte_string(); }
 };
 
-struct UnrealizedSourceRange {
-    [[nodiscard]] SourceRange realize() const
-    {
-        VERIFY(source_code);
-        return source_code->range_from_offsets(start_offset, end_offset);
-    }
-
-    RefPtr<SourceCode const> source_code;
-    u32 start_offset { 0 };
-    u32 end_offset { 0 };
-};
-
 }

--- a/Tests/LibJS/AST/expected/assignment-targets.txt
+++ b/Tests/LibJS/AST/expected/assignment-targets.txt
@@ -46,10 +46,10 @@ Program (script) @3:1
 │        │     ├─ BindingPattern (array)
 │        │     │  ├─ entry
 │        │     │  │  └─ alias
-│        │     │  │     └─ Identifier "a" [variable:0] (let) @21:7
+│        │     │  │     └─ Identifier "a" [variable:0] (let) @21:6
 │        │     │  └─ entry
 │        │     │     └─ alias
-│        │     │        └─ Identifier "b" [variable:1] (let) @21:10
+│        │     │        └─ Identifier "b" [variable:1] (let) @21:9
 │        │     └─ ArrayExpression @21:14
 │        │        ├─ NumericLiteral 1 @21:15
 │        │        └─ NumericLiteral 2 @21:18

--- a/Tests/LibJS/AST/expected/cover-initialized-name-destructuring.txt
+++ b/Tests/LibJS/AST/expected/cover-initialized-name-destructuring.txt
@@ -10,19 +10,19 @@ Program (script) @5:1
          │     │        └─ BindingPattern (object)
          │     │           └─ entry
          │     │              ├─ name
-         │     │              │  └─ Identifier "a" [global] @6:8
+         │     │              │  └─ Identifier "a" [global] @6:6
          │     │              └─ initializer
-         │     │                 └─ NumericLiteral 0 @6:14
+         │     │                 └─ NumericLiteral 0 @6:12
          │     └─ ArrayExpression @6:19
          └─ ExpressionStatement @7:5
             └─ AssignmentExpression (=) @7:18
                ├─ BindingPattern (array)
                │  └─ entry
                │     └─ alias
-               │        └─ MemberExpression @7:15
-               │           ├─ ObjectExpression @7:7
-               │           │  └─ ObjectProperty @7:7
-               │           │     ├─ StringLiteral "a" @7:7
-               │           │     └─ NumericLiteral 0 @7:12
-               │           └─ Identifier "x" @7:15
+               │        └─ MemberExpression @7:14
+               │           ├─ ObjectExpression @7:6
+               │           │  └─ ObjectProperty @7:6
+               │           │     ├─ StringLiteral "a" @7:6
+               │           │     └─ NumericLiteral 0 @7:11
+               │           └─ Identifier "x" @7:14
                └─ ArrayExpression @7:20

--- a/Tests/LibJS/AST/expected/eval-binding-pattern-no-arguments.txt
+++ b/Tests/LibJS/AST/expected/eval-binding-pattern-no-arguments.txt
@@ -7,7 +7,7 @@ Program (script) @1:1
                ├─ BindingPattern (object)
                │  └─ entry
                │     └─ name
-               │        └─ Identifier "eval" [global] @2:7
+               │        └─ Identifier "eval" [global] @2:6
                └─ ObjectExpression @2:17
                   └─ ObjectProperty @2:17
                      ├─ StringLiteral "eval" @2:17

--- a/Tests/LibJS/AST/expected/for-in-of-lhs-patterns.txt
+++ b/Tests/LibJS/AST/expected/for-in-of-lhs-patterns.txt
@@ -12,10 +12,10 @@ Program (script) @2:1
 │           │  └─ BindingPattern (array)
 │           │     ├─ entry
 │           │     │  └─ alias
-│           │     │     └─ Identifier "a" [variable:0] (var) @4:12
+│           │     │     └─ Identifier "a" [variable:0] (var) @4:11
 │           │     └─ entry
 │           │        └─ alias
-│           │           └─ Identifier "b" [variable:1] (var) @4:15
+│           │           └─ Identifier "b" [variable:1] (var) @4:14
 │           ├─ rhs
 │           │  └─ ObjectExpression @4:20
 │           │     └─ ObjectProperty @4:20
@@ -36,10 +36,10 @@ Program (script) @2:1
 │           │  └─ BindingPattern (object)
 │           │     ├─ entry
 │           │     │  └─ name
-│           │     │     └─ Identifier "x" [variable:0] (var) @10:11
+│           │     │     └─ Identifier "x" [variable:0] (var) @10:10
 │           │     └─ entry
 │           │        └─ name
-│           │           └─ Identifier "y" [variable:1] (var) @10:11
+│           │           └─ Identifier "y" [variable:1] (var) @10:10
 │           ├─ rhs
 │           │  └─ ObjectExpression @10:22
 │           │     └─ ObjectProperty @10:22
@@ -60,10 +60,10 @@ Program (script) @2:1
 │           │  └─ BindingPattern (array)
 │           │     ├─ entry
 │           │     │  └─ alias
-│           │     │     └─ Identifier "a" [variable:0] (var) @16:12
+│           │     │     └─ Identifier "a" [variable:0] (var) @16:11
 │           │     └─ entry
 │           │        └─ alias
-│           │           └─ Identifier "b" [variable:1] (var) @16:15
+│           │           └─ Identifier "b" [variable:1] (var) @16:14
 │           ├─ rhs
 │           │  └─ ArrayExpression @16:20
 │           │     └─ ArrayExpression @16:21
@@ -84,10 +84,10 @@ Program (script) @2:1
 │           │  └─ BindingPattern (object)
 │           │     ├─ entry
 │           │     │  └─ name
-│           │     │     └─ Identifier "x" [variable:0] (var) @22:11
+│           │     │     └─ Identifier "x" [variable:0] (var) @22:10
 │           │     └─ entry
 │           │        └─ name
-│           │           └─ Identifier "y" [variable:1] (var) @22:11
+│           │           └─ Identifier "y" [variable:1] (var) @22:10
 │           ├─ rhs
 │           │  └─ ArrayExpression @22:22
 │           │     └─ ObjectExpression @22:23

--- a/Tests/LibJS/AST/expected/proto-destructuring-assignment.txt
+++ b/Tests/LibJS/AST/expected/proto-destructuring-assignment.txt
@@ -9,12 +9,12 @@ Program (script) @1:1
       ├─ BindingPattern (object)
       │  ├─ entry
       │  │  ├─ name
-      │  │  │  └─ Identifier "__proto__" [global] @2:3
+      │  │  │  └─ Identifier "__proto__" [global] @2:2
       │  │  └─ alias
-      │  │     └─ Identifier "x" [global] (var) @2:16
+      │  │     └─ Identifier "x" [global] (var) @2:15
       │  └─ entry
       │     ├─ name
-      │     │  └─ Identifier "__proto__" [global] @2:3
+      │     │  └─ Identifier "__proto__" [global] @2:2
       │     └─ alias
-      │        └─ Identifier "y" [global] (var) @2:30
+      │        └─ Identifier "y" [global] (var) @2:29
       └─ ObjectExpression @2:35

--- a/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
@@ -1,4 +1,4 @@
-$66877791 bigint-large-constant-folding.js:1:1
+$66877791 bigint-large-constant-folding.js:2:1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
@@ -1,4 +1,4 @@
-$a2397124 bigint-truthiness.js:1:1
+$a2397124 bigint-truthiness.js:2:1
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/chained-member-call.txt
+++ b/Tests/LibJS/Bytecode/expected/chained-member-call.txt
@@ -1,4 +1,4 @@
-$c0e94b43 chained-member-call.js:1:1
+$c0e94b43 chained-member-call.js:12:1
   Registers: 10
   Blocks:    7
   Constants:

--- a/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
@@ -1,4 +1,4 @@
-$5904f18d const-assignment-no-extra-tdz.js:1:1
+$5904f18d const-assignment-no-extra-tdz.js:5:1
   Registers: 9
   Blocks:    4
   Locals:    e~0

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -1,4 +1,4 @@
-$dc4cd9dd const-fold-template-literals.js:1:1
+$dc4cd9dd const-fold-template-literals.js:20:1
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -1,4 +1,4 @@
-$7867793e delete-super-eval-order.js:1:1
+$7867793e delete-super-eval-order.js:4:1
   Registers: 10
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$6f3aad7a for-in-lexical-scope.js:1:1
+$6f3aad7a for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
@@ -1,4 +1,4 @@
-$abb2d42c for-of-iteration-env-capacity.js:1:1
+$abb2d42c for-of-iteration-env-capacity.js:1:14
   Registers: 13
   Blocks:    10
   Locals:    x~0

--- a/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
+++ b/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
@@ -1,4 +1,4 @@
-$01a3b494 indexed-append-guards.js:1:1
+$01a3b494 indexed-append-guards.js:16:1
   Registers: 11
   Blocks:    7
   Constants:

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
@@ -1,4 +1,4 @@
-$b4733eed invalid-lhs-assignment-no-dead-code.js:1:1
+$b4733eed invalid-lhs-assignment-no-dead-code.js:8:1
   Registers: 10
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
@@ -1,4 +1,4 @@
-$fa0f7b9b invalid-lhs-forin-no-dead-code.js:1:1
+$fa0f7b9b invalid-lhs-forin-no-dead-code.js:6:6
   Registers: 11
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
@@ -1,4 +1,4 @@
-$9814d5bc nested-for-loop-completion.js:1:1
+$9814d5bc nested-for-loop-completion.js:4:1
   Registers: 9
   Blocks:    8
   Constants:

--- a/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
@@ -1,4 +1,4 @@
-$87cdcfb6 numeric-property-key.js:1:1
+$87cdcfb6 numeric-property-key.js:4:1
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -1,4 +1,4 @@
-$400d186a tagged-template-if-register-order.js:1:1
+$400d186a tagged-template-if-register-order.js:2:1
   Registers: 10
   Blocks:    3
   Constants:

--- a/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
@@ -1,4 +1,4 @@
-$3a924082 this-base-identifier.js:1:1
+$3a924082 this-base-identifier.js:16:1
   Registers: 10
   Blocks:    4
   Constants:

--- a/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
+++ b/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
@@ -1,5 +1,5 @@
 message = Reporting an Error!
-lineno = 17
+lineno = 19
 colno = 28
 error = Error: Reporting an Error!
 filename URL scheme = file:


### PR DESCRIPTION
Carry full source positions through the Rust bytecode source map so stack traces and other bytecode-backed source lookups can use them directly.

This keeps exception-heavy paths from reconstructing line and column information through `SourceCode::range_from_offsets()`, which can spend a lot of time building `SourceCode`'s position cache on first use.

We're trading some space for time here, but I believe it's worth it at this tag, as this saves ~250ms of main thread time while loading https://x.com/ on my Linux machine. :^)