### PR TITLE
LibWeb: Skip unstyled descendants in animation updates

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -822,6 +822,8 @@ AnimationUpdateContext::~AnimationUpdateContext()
 
         // Traversal of the subtree is necessary to update the animated properties inherited from the target element.
         target->for_each_in_subtree_of_type<DOM::Element>([&](auto& element) {
+            if (!element.cascaded_properties({}))
+                return TraversalDecision::SkipChildrenAndContinue;
             auto element_invalidation = element.recompute_inherited_style();
             if (element_invalidation.is_none())
                 return TraversalDecision::SkipChildrenAndContinue;

--- a/Tests/LibWeb/Crash/CSS/animation-subtree-append-unstyled-child.html
+++ b/Tests/LibWeb/Crash/CSS/animation-subtree-append-unstyled-child.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<style>
+    @keyframes anim { from { opacity: 1 } to { opacity: 0.5 } }
+    #target { animation: anim 10s infinite; }
+</style>
+<div id="target"></div>
+<script>
+    const animation = target.getAnimations()[0];
+
+    function waitForAnimationTick() {
+        if (animation.currentTime === null || animation.currentTime === 0) {
+            requestAnimationFrame(waitForAnimationTick);
+            return;
+        }
+
+        target.appendChild(document.createElement("div"));
+        requestAnimationFrame(() => {
+            document.documentElement.classList.remove("test-wait");
+        });
+    }
+
+    requestAnimationFrame(waitForAnimationTick);
+</script>
+</html>


### PR DESCRIPTION
Animation updates propagate inherited animated values by walking the animated target's subtree and calling `recompute_inherited_style()` on each element. Elements inserted during the same rendering update may not have computed properties yet, which violates an existing assertion, causing a crash.

Fix this by skipping unstyled descendants during this walk. The subsequent recursive style update computes their style from scratch.

This fixes an intermittent crash I encountered when logging in to https://sainsburys.co.uk.

NB: The assertion this crash hits was added as part of #9014 (merged yesterday - 2026-04-21). An alternative fix would be to revert 06a7723ee39b484a2588f12ea0d34eebb953ba56.