### PR TITLE
Reduce redundant @font-face fetches

### DIFF
--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -34,13 +34,45 @@ void FontCascadeList::add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> u
         } });
 }
 
+void FontCascadeList::add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<void()> start_load)
+{
+    if (unicode_ranges.is_empty())
+        return;
+
+    u32 lowest_code_point = 0xFFFFFFFF;
+    u32 highest_code_point = 0;
+    for (auto const& range : unicode_ranges) {
+        lowest_code_point = min(lowest_code_point, range.min_code_point());
+        highest_code_point = max(highest_code_point, range.max_code_point());
+    }
+
+    m_pending_faces.append(adopt_ref(*new PendingFace(
+        UnicodeRange { lowest_code_point, highest_code_point },
+        move(unicode_ranges),
+        move(start_load))));
+}
+
 void FontCascadeList::extend(FontCascadeList const& other)
 {
     m_fonts.extend(other.m_fonts);
+    m_pending_faces.extend(other.m_pending_faces);
 }
 
 Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point) const
 {
+    // Walk pending entries first: if this codepoint falls in an unloaded face's
+    // unicode-range we kick off the fetch and drop the entry — a fallback font that
+    // happens to cover the codepoint shouldn't prevent the real face from loading.
+    // FontComputer::clear_computed_font_cache() rebuilds the cascade once the fetch
+    // completes, so later shapes pick up the loaded face. Run before the ASCII cache
+    // lookup so a previously-cached codepoint still triggers a newly-added face.
+    m_pending_faces.remove_all_matching([code_point](auto const& pending) {
+        if (!pending->covers(code_point))
+            return false;
+        pending->start_load();
+        return true;
+    });
+
     if (code_point < m_ascii_cache.size()) {
         if (auto const* cached = m_ascii_cache[code_point])
             return *cached;

--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -58,20 +58,27 @@ void FontCascadeList::extend(FontCascadeList const& other)
     m_pending_faces.extend(other.m_pending_faces);
 }
 
-Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point) const
+Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point, TriggerPendingLoads trigger_pending_loads) const
 {
-    // Walk pending entries first: if this codepoint falls in an unloaded face's
-    // unicode-range we kick off the fetch and drop the entry — a fallback font that
-    // happens to cover the codepoint shouldn't prevent the real face from loading.
-    // FontComputer::clear_computed_font_cache() rebuilds the cascade once the fetch
-    // completes, so later shapes pick up the loaded face. Run before the ASCII cache
-    // lookup so a previously-cached codepoint still triggers a newly-added face.
-    m_pending_faces.remove_all_matching([code_point](auto const& pending) {
-        if (!pending->covers(code_point))
-            return false;
-        pending->start_load();
-        return true;
-    });
+    // Only the text-shaping paths pass TriggerPendingLoads::Yes. Probes that don't
+    // lead to a glyph being drawn (the U+0020 check used to compute first-available-
+    // font metrics, for instance) skip this block so they can't initiate a download
+    // for a subset face that happens to cover the probe codepoint.
+    if (trigger_pending_loads == TriggerPendingLoads::Yes) {
+        // Walk pending entries first: if this codepoint falls in an unloaded face's
+        // unicode-range we kick off the fetch and drop the entry — a fallback font
+        // that happens to cover the codepoint shouldn't prevent the real face from
+        // loading. FontComputer::clear_computed_font_cache() rebuilds the cascade
+        // once the fetch completes, so later shapes pick up the loaded face. Run
+        // before the ASCII cache lookup so a previously-cached codepoint still
+        // triggers a newly-added face.
+        m_pending_faces.remove_all_matching([code_point](auto const& pending) {
+            if (!pending->covers(code_point))
+                return false;
+            pending->start_load();
+            return true;
+        });
+    }
 
     if (code_point < m_ascii_cache.size()) {
         if (auto const* cached = m_ascii_cache[code_point])

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/Function.h>
+#include <AK/RefCounted.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/UnicodeRange.h>
 
@@ -23,7 +24,7 @@ public:
     }
 
     size_t size() const { return m_fonts.size(); }
-    bool is_empty() const { return m_fonts.is_empty() && !m_last_resort_font; }
+    bool is_empty() const { return m_fonts.is_empty() && m_pending_faces.is_empty() && !m_last_resort_font; }
     Font const& first() const { return !m_fonts.is_empty() ? *m_fonts.first().font : *m_last_resort_font; }
 
     template<typename Callback>
@@ -35,6 +36,10 @@ public:
 
     void add(NonnullRefPtr<Font const> font);
     void add(NonnullRefPtr<Font const> font, Vector<UnicodeRange> unicode_ranges);
+
+    // Register an unloaded face covering `unicode_ranges`. The cascade invokes
+    // `start_load` the first time a rendered codepoint falls within one of the ranges.
+    void add_pending_face(Vector<UnicodeRange> unicode_ranges, Function<void()> start_load);
 
     void extend(FontCascadeList const& other);
 
@@ -53,6 +58,34 @@ public:
         Optional<RangeData> range_data;
     };
 
+    class PendingFace : public RefCounted<PendingFace> {
+    public:
+        PendingFace(UnicodeRange enclosing, Vector<UnicodeRange> ranges, Function<void()> start_load)
+            : m_enclosing_range(enclosing)
+            , m_unicode_ranges(move(ranges))
+            , m_start_load(move(start_load))
+        {
+        }
+
+        bool covers(u32 code_point) const
+        {
+            if (!m_enclosing_range.contains(code_point))
+                return false;
+            for (auto const& range : m_unicode_ranges) {
+                if (range.contains(code_point))
+                    return true;
+            }
+            return false;
+        }
+
+        void start_load() { m_start_load(); }
+
+    private:
+        UnicodeRange m_enclosing_range;
+        Vector<UnicodeRange> m_unicode_ranges;
+        Function<void()> m_start_load;
+    };
+
     void set_last_resort_font(NonnullRefPtr<Font> font) { m_last_resort_font = move(font); }
     void set_system_font_fallback_callback(SystemFontFallbackCallback callback) { m_system_font_fallback_callback = move(callback); }
 
@@ -67,6 +100,7 @@ public:
 private:
     RefPtr<Font const> m_last_resort_font;
     mutable Vector<Entry> m_fonts;
+    mutable Vector<NonnullRefPtr<PendingFace>> m_pending_faces;
     SystemFontFallbackCallback m_system_font_fallback_callback;
 
     // OPTIMIZATION: Cache of resolved fonts for ASCII code points. Since m_fonts only grows and the cascade returns

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -43,7 +43,15 @@ public:
 
     void extend(FontCascadeList const& other);
 
-    Gfx::Font const& font_for_code_point(u32 code_point) const;
+    // A pending-face fetch should only be initiated for codepoints that are actually
+    // being shaped into glyph runs. Callers that merely probe the cascade (e.g. the
+    // U+0020 check in "first available font" metrics) pass No so that probing does
+    // not kick off downloads for subset faces that happen to cover the probe point.
+    enum class TriggerPendingLoads : u8 {
+        No,
+        Yes,
+    };
+    Gfx::Font const& font_for_code_point(u32 code_point, TriggerPendingLoads = TriggerPendingLoads::No) const;
 
     bool equals(FontCascadeList const& other) const;
 

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -121,7 +121,7 @@ Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View 
 
     auto it = string.begin();
     auto substring_begin_offset = string.iterator_offset(it);
-    Font const* last_font = &font_cascade_list.font_for_code_point(*it);
+    Font const* last_font = &font_cascade_list.font_for_code_point(*it, FontCascadeList::TriggerPendingLoads::Yes);
     FloatPoint last_position = baseline_start;
 
     auto add_run = [&runs, &last_position, letter_spacing](Utf16View const& string, Font const& font) {
@@ -132,7 +132,7 @@ Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View 
 
     while (it != string.end()) {
         auto code_point = *it;
-        auto const* font = &font_cascade_list.font_for_code_point(code_point);
+        auto const* font = &font_cascade_list.font_for_code_point(code_point, FontCascadeList::TriggerPendingLoads::Yes);
         if (font != last_font) {
             auto substring = string.substring_view(substring_begin_offset, string.iterator_offset(it) - substring_begin_offset);
             add_run(substring, *last_font);

--- a/Libraries/LibIDL/IDLParser.cpp
+++ b/Libraries/LibIDL/IDLParser.cpp
@@ -402,7 +402,15 @@ Vector<Parameter> Parser::parse_parameters()
         if (lexer.next_is('=') && optional) {
             assert_specific('=');
             consume_whitespace();
-            auto default_value = lexer.consume_until([](auto ch) { return is_ascii_space(ch) || ch == ',' || ch == ')'; });
+            StringView default_value;
+            if (lexer.next_is('"')) {
+                auto start = lexer.tell();
+                lexer.consume_quoted_string();
+                auto end = lexer.tell();
+                default_value = lexer.input().substring_view(start, end - start);
+            } else {
+                default_value = lexer.consume_until([](auto ch) { return is_ascii_space(ch) || ch == ',' || ch == ')'; });
+            }
             parameter.optional_default_value = default_value;
         }
         parameters.append(move(parameter));

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -80,11 +80,21 @@ FontLoader::FontLoader(FontComputer& font_computer, RuleOrDeclaration rule_or_de
     , m_family_name(move(family_name))
     , m_unicode_ranges(move(unicode_ranges))
     , m_urls(move(urls))
-    , m_on_load(move(on_load))
 {
+    if (on_load)
+        m_subscribers.append(*on_load);
 }
 
 FontLoader::~FontLoader() = default;
+
+void FontLoader::subscribe(GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>> callback)
+{
+    if (m_has_completed) {
+        callback->function()(m_typeface);
+        return;
+    }
+    m_subscribers.append(callback);
+}
 
 void FontLoader::visit_edges(Visitor& visitor)
 {
@@ -95,7 +105,7 @@ void FontLoader::visit_edges(Visitor& visitor)
     else if (auto* block = m_rule_or_declaration.value.get_pointer<RuleOrDeclaration::StyleDeclaration>())
         visitor.visit(block->parent_rule);
     visitor.visit(m_fetch_controller);
-    visitor.visit(m_on_load);
+    visitor.visit(m_subscribers);
 }
 
 bool FontLoader::is_loading() const
@@ -195,12 +205,11 @@ void FontLoader::font_did_load_or_fail(RefPtr<Gfx::Typeface const> typeface)
     if (typeface) {
         m_typeface = typeface.release_nonnull();
         m_font_computer->clear_computed_font_cache(m_family_name);
-        if (m_on_load)
-            m_on_load->function()(m_typeface);
-    } else {
-        if (m_on_load)
-            m_on_load->function()(nullptr);
     }
+    m_has_completed = true;
+    for (auto& callback : m_subscribers)
+        callback->function()(m_typeface);
+    m_subscribers.clear();
     m_fetch_controller = nullptr;
 }
 
@@ -293,6 +302,8 @@ void FontComputer::visit_edges(Visitor& visitor)
     visitor.visit(m_document);
     for (auto& [_, faces] : m_font_faces)
         visitor.visit(faces);
+    for (auto& [_, loader] : m_loaders_by_url)
+        visitor.visit(loader);
 }
 
 RefPtr<Gfx::FontCascadeList const> FontComputer::find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, Gfx::FontVariationSettings const& variations, FontFeatureData const& font_feature_data, HashMap<FontFeatureValueKey, Vector<u32>> const& font_feature_values, bool inclusive) const
@@ -767,7 +778,16 @@ GC::Ptr<FontLoader> FontComputer::load_font_face(ParsedFontFace const& font_face
         }
     };
 
-    return heap().allocate<FontLoader>(*this, rule_or_declaration, font_face.font_family(), font_face.unicode_ranges(), move(urls), move(on_load));
+    auto key = urls.first().to_string();
+    if (auto it = m_loaders_by_url.find(key); it != m_loaders_by_url.end()) {
+        if (on_load)
+            it->value->subscribe(*on_load);
+        return it->value;
+    }
+
+    auto loader = heap().allocate<FontLoader>(*this, rule_or_declaration, font_face.font_family(), font_face.unicode_ranges(), move(urls), move(on_load));
+    m_loaders_by_url.set(move(key), loader);
+    return loader;
 }
 
 void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -268,8 +268,18 @@ struct FontComputer::MatchingFontCandidate {
 
         auto font_list = Gfx::FontCascadeList::create();
         for (auto const& face : it->value) {
-            if (auto face_fonts = face->font_with_point_size(point_size, variations, shape_features))
+            if (auto face_fonts = face->font_with_point_size(point_size, variations, shape_features)) {
                 font_list->extend(*face_fonts);
+                continue;
+            }
+            // Unloaded subset face: surface it as a pending entry so the fetch only
+            // fires once font_for_code_point() sees a codepoint in its unicode-range.
+            if (face->has_urls() && face->has_non_default_unicode_range()) {
+                GC::Root<FontFace> rooted_face(*face);
+                font_list->add_pending_face(face->unicode_ranges(), [rooted_face = move(rooted_face)] {
+                    const_cast<FontFace&>(*rooted_face).load();
+                });
+            }
         }
         if (font_list->is_empty())
             return {};
@@ -771,12 +781,18 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
             auto font_face = FontFace::create_css_connected(document().realm(), *font_face_rule);
             document().fonts()->add_css_connected_font(font_face);
 
-            // NB: Load via FontFace::load(), to satisfy this requirement:
-            // https://drafts.csswg.org/css-font-loading/#font-face-load
-            // User agents can initiate font loads on their own, whenever they determine that a given font face is
-            // necessary to render something on the page. When this happens, they must act as if they had called the
-            // corresponding FontFace’s load() method described here.
-            font_face->load();
+            if (font_face->has_non_default_unicode_range()) {
+                // Register for matching, but defer loading until a rendered codepoint
+                // actually falls in this face's unicode-range.
+                register_font_face(font_face);
+            } else {
+                // NB: Load via FontFace::load(), to satisfy this requirement:
+                // https://drafts.csswg.org/css-font-loading/#font-face-load
+                // User agents can initiate font loads on their own, whenever they determine that a given font face is
+                // necessary to render something on the page. When this happens, they must act as if they had called the
+                // corresponding FontFace’s load() method described here.
+                font_face->load();
+            }
         }
 
         if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(*rule))

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -77,6 +77,8 @@ public:
 
     FlyString family_name() const { return m_family_name; }
 
+    void subscribe(GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>);
+
 private:
     virtual void visit_edges(Visitor&) override;
 
@@ -91,7 +93,8 @@ private:
     RefPtr<Gfx::Typeface const> m_typeface;
     Vector<URL> m_urls;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;
-    GC::Ptr<GC::Function<void(RefPtr<Gfx::Typeface const>)>> m_on_load;
+    Vector<GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>> m_subscribers;
+    bool m_has_completed { false };
 };
 
 class WEB_API FontComputer final : public GC::Cell {
@@ -139,6 +142,7 @@ private:
     GC::Ref<DOM::Document> m_document;
 
     HashMap<FontFaceKey, Vector<GC::Ref<FontFace>>> m_font_faces;
+    HashMap<String, GC::Ref<FontLoader>> m_loaders_by_url;
 
     mutable HashMap<ComputedFontCacheKey, NonnullRefPtr<Gfx::FontCascadeList const>> m_computed_font_cache;
     mutable HashMap<FlyString, HashMap<FontFeatureValueKey, Vector<u32>>> m_font_feature_values_cache;

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -100,6 +100,17 @@ public:
 
     RefPtr<Gfx::FontCascadeList const> font_with_point_size(float point_size, Gfx::FontVariationSettings const&, Gfx::ShapeFeatures const&) const;
 
+    Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
+    bool has_urls() const { return !m_urls.is_empty(); }
+
+    bool has_non_default_unicode_range() const
+    {
+        if (m_unicode_ranges.size() != 1)
+            return true;
+        auto const& range = m_unicode_ranges.first();
+        return range.min_code_point() != 0 || range.max_code_point() != 0x10FFFF;
+    }
+
     Bindings::FontFaceLoadStatus status() const { return m_status; }
 
     GC::Ref<WebIDL::Promise> load();

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -379,6 +379,11 @@ void FontFaceSet::set_is_pending_on_the_environment(bool is_pending_on_the_envir
         //        Spec issue: https://github.com/w3c/csswg-drafts/issues/13538#issuecomment-3933951987
         if (m_set_entries->set_size() == 0 || (m_is_stuck_on_the_environment && m_loading_fonts.is_empty()))
             switch_to_loaded();
+        // AD-HOC: Also switch when nothing has ever entered the LoadingFonts list — an empty set, or a set whose
+        //         entries all have deferred unicode-ranges that no rendered codepoint matched. Without this the
+        //         ready promise stays pending forever.
+        else if (m_loading_fonts.is_empty())
+            switch_to_loaded();
 
         // 2. If the FontFaceSet is stuck on the environment, unmark it as such.
         m_is_stuck_on_the_environment = false;

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -203,7 +203,7 @@ WebIDL::CallbackType* FontFaceSet::onloadingerror()
 }
 
 // https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces
-static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm& realm, FontFaceSet& font_face_set, String const& font, String const&)
+static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm& realm, FontFaceSet& font_face_set, String const& font, String const& text)
 {
     // 1. Parse font using the CSS value syntax of the font property. If a syntax error occurs, return a syntax error.
     auto property = parse_css_value(CSS::Parser::ParsingParams(), font, PropertyID::Font);
@@ -250,8 +250,28 @@ static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm&
     }
 
     // FIXME: 7. If matched font faces is empty, set the found faces flag to false. Otherwise, set it to true.
-    // FIXME: 8. For each font face in matched font faces, if its defined unicode-range does not include the codepoint of at
-    //           least one character in text, remove it from the list.
+
+    // 8. For each font face in matched font faces, if its defined unicode-range does not include the codepoint of at
+    //    least one character in text, remove it from the list.
+    auto faces_to_remove = GC::RootVector<JS::Value> { realm.heap() };
+    for (auto entry : *matched_font_faces) {
+        auto& font_face = as<FontFace>(entry.key.as_object());
+        bool includes_at_least_one_text_code_point = false;
+        for (auto code_point : text.code_points()) {
+            for (auto const& range : font_face.unicode_ranges()) {
+                if (range.contains(code_point)) {
+                    includes_at_least_one_text_code_point = true;
+                    break;
+                }
+            }
+            if (includes_at_least_one_text_code_point)
+                break;
+        }
+        if (!includes_at_least_one_text_code_point)
+            faces_to_remove.append(entry.key);
+    }
+    for (auto& key : faces_to_remove)
+        matched_font_faces->set_remove(key);
 
     // 9. Return matched font faces and the found faces flag.
     return matched_font_faces;

--- a/Libraries/LibWeb/CSS/FontFaceSet.idl
+++ b/Libraries/LibWeb/CSS/FontFaceSet.idl
@@ -15,13 +15,11 @@ interface FontFaceSet : EventTarget {
 
     // check and start loads if appropriate
     // and fulfill promise when all loads complete
-    // FIXME: Promise<sequence<FontFace>> load(CSSOMString font, optional CSSOMString text = " ");
-    Promise<sequence<FontFace>> load(CSSOMString font, optional CSSOMString text = "");
+    Promise<sequence<FontFace>> load(CSSOMString font, optional CSSOMString text = " ");
 
     // return whether all fonts in the fontlist are loaded
     // (does not initiate load if not available)
-    // FIXME: boolean check(CSSOMString font, optional CSSOMString text = " ");
-    boolean check(CSSOMString font, optional CSSOMString text = "");
+    boolean check(CSSOMString font, optional CSSOMString text = " ");
 
     // async notification that font loading and layout operations are done
     readonly attribute Promise<FontFaceSet> ready;

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -643,7 +643,7 @@ Gfx::Font const& TextNode::ChunkIterator::font_for_space(size_t at_index, u32 sp
     for (size_t i = at_index; i < m_view.length_in_code_units();) {
         auto cp = m_view.code_point_at(i);
         if (!is_interword_space(cp) && cp != '\t' && cp != '\n') {
-            auto const& font = m_font_cascade_list.font_for_code_point(cp);
+            auto const& font = m_font_cascade_list.font_for_code_point(cp, Gfx::FontCascadeList::TriggerPendingLoads::Yes);
             if (!font.is_emoji_font() && has_glyph(font))
                 return font;
             // Text is coming from an emoji face; we'll fall back to (3).
@@ -653,7 +653,7 @@ Gfx::Font const& TextNode::ChunkIterator::font_for_space(size_t at_index, u32 sp
     }
 
     // 3. No text around (leading/trailing/all spaces) — pick a font with the glyph from the cascade.
-    return m_font_cascade_list.font_for_code_point(space_code_point);
+    return m_font_cascade_list.font_for_code_point(space_code_point, Gfx::FontCascadeList::TriggerPendingLoads::Yes);
 }
 
 Optional<TextNode::Chunk> TextNode::ChunkIterator::next_without_peek()
@@ -680,7 +680,7 @@ Optional<TextNode::Chunk> TextNode::ChunkIterator::next_without_peek()
     auto const& expected_font_for = [&](u32 cp) -> Gfx::Font const& {
         return is_interword_space(cp)
             ? font_for_space(m_current_index, cp)
-            : m_font_cascade_list.font_for_code_point(cp);
+            : m_font_cascade_list.font_for_code_point(cp, Gfx::FontCascadeList::TriggerPendingLoads::Yes);
     };
 
     auto const& font = expected_font_for(current_code_point());

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -14,6 +14,7 @@ Text/input/HTML/media-source-buffered.html
 Text/input/HTML/media-source-setup.html
 Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
+Text/input/css/font-face-load-dedups-same-url.html
 
 ; pushState with path URL requires HTTP(s) scheme.
 Text/input/navigation/history-replace-push-then-back.html

--- a/Tests/LibWeb/Text/expected/css/font-face-load-dedups-same-url.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-load-dedups-same-url.txt
@@ -1,0 +1,4 @@
+faceA.status: loaded
+faceB.status: loaded
+resource entries total: 3
+resource entries for font url: 2

--- a/Tests/LibWeb/Text/expected/css/font-face-load-dedups-same-url.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-load-dedups-same-url.txt
@@ -1,4 +1,4 @@
 faceA.status: loaded
 faceB.status: loaded
-resource entries total: 3
-resource entries for font url: 2
+resource entries total: 2
+resource entries for font url: 1

--- a/Tests/LibWeb/Text/expected/css/font-face-probe-does-not-trigger-load.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-probe-does-not-trigger-load.txt
@@ -1,0 +1,1 @@
+ProbeFont status: error

--- a/Tests/LibWeb/Text/expected/css/font-face-probe-does-not-trigger-load.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-probe-does-not-trigger-load.txt
@@ -1,1 +1,1 @@
-ProbeFont status: error
+ProbeFont status: unloaded

--- a/Tests/LibWeb/Text/expected/css/font-face-set-load-filters-by-text.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-set-load-filters-by-text.txt
@@ -1,4 +1,4 @@
 MultiFont face count: 3
 range=U+41 status=loaded
-range=U+42 status=error
-range=U+43 status=error
+range=U+42 status=unloaded
+range=U+43 status=unloaded

--- a/Tests/LibWeb/Text/expected/css/font-face-set-load-filters-by-text.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-set-load-filters-by-text.txt
@@ -1,0 +1,4 @@
+MultiFont face count: 3
+range=U+41 status=loaded
+range=U+42 status=error
+range=U+43 status=error

--- a/Tests/LibWeb/Text/expected/css/font-face-unicode-range-load-gating.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-unicode-range-load-gating.txt
@@ -1,4 +1,4 @@
 MultiFont face count: 3
 range=U+41 status=loaded
-range=U+42 status=error
-range=U+43 status=error
+range=U+42 status=unloaded
+range=U+43 status=unloaded

--- a/Tests/LibWeb/Text/expected/css/font-face-unicode-range-load-gating.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-unicode-range-load-gating.txt
@@ -1,0 +1,4 @@
+MultiFont face count: 3
+range=U+41 status=loaded
+range=U+42 status=error
+range=U+43 status=error

--- a/Tests/LibWeb/Text/input/css/font-face-load-dedups-same-url.html
+++ b/Tests/LibWeb/Text/input/css/font-face-load-dedups-same-url.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        let fontUrl = new URL(location.href);
+        fontUrl.search = "";
+        fontUrl += "/../../../../Assets/HashSans.woff";
+
+        // Two FontFace objects referencing the exact same src URL. A single variable
+        // woff2 served by Google Fonts is commonly declared under multiple
+        // @font-face rules (one per font-weight), all pointing at the same file.
+        // With URL-keyed dedup in FontComputer, both faces should share a single
+        // in-flight FontLoader so only one network fetch occurs.
+        const faceA = new FontFace("DedupFont", `url(${fontUrl})`, { weight: "400" });
+        const faceB = new FontFace("DedupFont", `url(${fontUrl})`, { weight: "700" });
+
+        await Promise.all([faceA.load(), faceB.load()]);
+
+        println(`faceA.status: ${faceA.status}`);
+        println(`faceB.status: ${faceB.status}`);
+
+        // Use the PerformanceResourceTiming API to count how many resource-timing
+        // entries were recorded for this URL — one means the loaders were deduped,
+        // two means each FontFace kicked off its own fetch.
+        const all = performance.getEntriesByType("resource");
+        const urlStr = String(fontUrl);
+        const matches = all.filter(e => e.name === urlStr || e.name.endsWith("HashSans.woff"));
+        println(`resource entries total: ${all.length}`);
+        println(`resource entries for font url: ${matches.length}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/font-face-probe-does-not-trigger-load.html
+++ b/Tests/LibWeb/Text/input/css/font-face-probe-does-not-trigger-load.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    /* Subset face whose unicode-range covers U+0020 — exactly the codepoint used by the
+       "first-available-font" metric probe. A style-only probe must not load this face. */
+    @font-face {
+        font-family: 'ProbeFont';
+        src: url('unused-probe.woff');
+        unicode-range: U+0020-007F;
+    }
+    /* display:none + empty content: style is computed (metric probe fires via the
+       em-length in `height`) but nothing is ever shaped, so no codepoint actually
+       needs to be rendered by ProbeFont. */
+    .probed { font-family: 'ProbeFont'; display: none; height: 1em; }
+</style>
+</head>
+<body>
+<div class="probed"></div>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        // Force style resolution. getComputedStyle goes through the same
+        // ComputedProperties::first_available_computed_font(' ') path that used to
+        // eagerly trigger the fetch.
+        getComputedStyle(document.querySelector('.probed')).fontFamily;
+        document.body.offsetHeight;
+        // Give any in-flight font fetch enough time to settle. Before the fix the
+        // metric probe fetches ProbeFont and the fetch fails fast with NetworkError;
+        // after the fix no fetch is ever started.
+        await new Promise(r => setTimeout(r, 50));
+
+        const face = [...document.fonts].find(f => f.family === 'ProbeFont');
+        println(`ProbeFont status: ${face.status}`);
+    });
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/css/font-face-set-load-filters-by-text.html
+++ b/Tests/LibWeb/Text/input/css/font-face-set-load-filters-by-text.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    @font-face {
+        font-family: 'MultiFont';
+        src: url('../../../Assets/HashSans.woff');
+        unicode-range: U+0041; /* A */
+    }
+    @font-face {
+        font-family: 'MultiFont';
+        src: url('unused-b.woff');
+        unicode-range: U+0042; /* B */
+    }
+    @font-face {
+        font-family: 'MultiFont';
+        src: url('unused-c.woff');
+        unicode-range: U+0043; /* C */
+    }
+</style>
+</head>
+<body>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const faces = [...document.fonts].filter(f => f.family === 'MultiFont');
+        faces.sort((a, b) => a.unicodeRange.localeCompare(b.unicodeRange));
+
+        // https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces
+        // Step 8: "For each font face in matched font faces, if its defined unicode-range
+        // does not include the codepoint of at least one character in text, remove it from
+        // the list." So asking the FontFaceSet to load "A" must only kick off faceA's fetch;
+        // faceB and faceC have disjoint unicode-ranges and must stay unloaded.
+        // The pre-fix behavior is to pull in faceB and faceC too, which reject with
+        // NetworkError — catch so the test does not time out reporting "wrong" output.
+        await document.fonts.load('16px MultiFont', 'A').catch(() => {});
+        await document.fonts.ready;
+
+        println(`MultiFont face count: ${faces.length}`);
+        for (const f of faces)
+            println(`range=${f.unicodeRange} status=${f.status}`);
+    });
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/css/font-face-unicode-range-load-gating.html
+++ b/Tests/LibWeb/Text/input/css/font-face-unicode-range-load-gating.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    @font-face {
+        font-family: 'MultiFont';
+        src: url('../../../Assets/HashSans.woff');
+        unicode-range: U+0041; /* A */
+    }
+    @font-face {
+        font-family: 'MultiFont';
+        src: url('unused-b.woff');
+        unicode-range: U+0042; /* B */
+    }
+    @font-face {
+        font-family: 'MultiFont';
+        src: url('unused-c.woff');
+        unicode-range: U+0043; /* C */
+    }
+    .text { font-family: 'MultiFont', 'SerenitySans'; font-size: 40px; }
+</style>
+</head>
+<body>
+<div class="text">A</div>
+<!-- Text inside a display:none element (a <script> in this case) must not trigger font loads.
+     Here "BBBCCC" sits in a JSON script block and is never laid out; faceB and faceC therefore
+     stay "unloaded" below even though the content contains codepoints in their unicode-ranges. -->
+<script type="application/json" id="blob">{"letters":"BBBCCC","more":"B and C should not be rendered"}</script>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const faces = [...document.fonts].filter(f => f.family === 'MultiFont');
+        faces.sort((a, b) => a.unicodeRange.localeCompare(b.unicodeRange));
+
+        // Force layout so text shaping runs — this is what triggers the render-path
+        // load for faceA once deferral is implemented.
+        document.body.offsetHeight;
+        // Wait for every in-flight @font-face load to settle. At the pre-fix baseline
+        // faceB and faceC are eagerly fetched and then reject with NetworkError; after
+        // the fix only faceA is loaded and ready resolves immediately.
+        await document.fonts.ready;
+
+        println(`MultiFont face count: ${faces.length}`);
+        for (const f of faces)
+            println(`range=${f.unicodeRange} status=${f.status}`);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
On a fresh YouTube load this brings the initial `@font-face` download count from 177 to 9 or so.

- Defer fetches until a codepoint renders (honor the unicode-range descriptor).
- Only trigger `@font-face` loads from text shaping
- Honor text argument of FontFaceSet.load() / .check(), implement step 8 of find the matching font faces: remove faces whose unicode-range doesn't cover any codepoint in the text argument. Without this a single `document.fonts.load('14px Roboto')` pulled every declared subset under the family.
- Dedup `@font-face` fetches by source URL using a shared FontLoader cache keyed by first src URL.

Adds a couple of test to verify this behavior.