### PR TITLE
Meta: Lint internal Ladybird pages

### DIFF
--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -9,6 +9,7 @@
         <h1>List of About URLs</h1>
         <ul>
             <li><a href="about:about">about:about</a></li>
+            <li><a href="about:bookmarks">about:bookmarks</a></li>
             <li><a href="about:newtab">about:newtab</a></li>
             <li><a href="about:processes">about:processes</a></li>
             <li><a href="about:settings">about:settings</a></li>

--- a/Base/res/ladybird/about-pages/bookmarks.html
+++ b/Base/res/ladybird/about-pages/bookmarks.html
@@ -234,20 +234,20 @@
                 <img src="resource://icons/128x128/app-browser-dark.png" />
             </picture>
             <h1>Bookmarks</h1>
-                <div class="header-menu">
-                    <button class="menu-toggle" id="menu-toggle" aria-label="Bookmark options">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                            <circle cx="12" cy="5" r="2" />
-                            <circle cx="12" cy="12" r="2" />
-                            <circle cx="12" cy="19" r="2" />
-                        </svg>
-                    </button>
-                    <div class="menu-dropdown hidden" id="menu-dropdown">
-                        <button class="menu-item" id="import-button">Import from HTML...</button>
-                        <button class="menu-item" id="export-button">Export to HTML...</button>
-                    </div>
+            <div class="header-menu">
+                <button class="menu-toggle" id="menu-toggle" aria-label="Bookmark options">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <circle cx="12" cy="5" r="2" />
+                        <circle cx="12" cy="12" r="2" />
+                        <circle cx="12" cy="19" r="2" />
+                    </svg>
+                </button>
+                <div class="menu-dropdown hidden" id="menu-dropdown">
+                    <button class="menu-item" id="import-button">Import from HTML...</button>
+                    <button class="menu-item" id="export-button">Export to HTML...</button>
                 </div>
-                <input type="file" id="import-file" accept=".html,text/html" hidden />
+            </div>
+            <input type="file" id="import-file" accept=".html,text/html" hidden />
         </header>
 
         <div class="card">
@@ -587,7 +587,9 @@
                     }
 
                     for (const dt of dl.children) {
-                        if (dt.tagName !== "DT") continue;
+                        if (dt.tagName !== "DT") {
+                            continue;
+                        }
 
                         const anchor = dt.querySelector(":scope > A");
                         if (anchor) {
@@ -663,7 +665,9 @@
 
             importFileInput.addEventListener("change", () => {
                 const file = importFileInput.files[0];
-                if (!file) return;
+                if (!file) {
+                    return;
+                }
 
                 const reader = new FileReader();
                 reader.onload = () => {

--- a/Base/res/ladybird/about-pages/newtab.html
+++ b/Base/res/ladybird/about-pages/newtab.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/Base/res/ladybird/about-pages/processes.html
+++ b/Base/res/ladybird/about-pages/processes.html
@@ -103,14 +103,14 @@
             <tbody id="process-table"></tbody>
         </table>
         <script type="module">
-            import { getByteFormatter }  from "resource://ladybird/utils.js";
+            import { getByteFormatter } from "resource://ladybird/utils.js";
             const memoryFormatter = getByteFormatter(() => {
                 return {
                     unitDisplay: "narrow",
                     minimumFractionDigits: 2,
                     maximumFractionDigits: 2,
-                }
-            })
+                };
+            });
             const cpuFormatter = new Intl.NumberFormat([], {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,

--- a/Base/res/ladybird/about-pages/version.html
+++ b/Base/res/ladybird/about-pages/version.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/Base/res/ladybird/templates/directory.html
+++ b/Base/res/ladybird/templates/directory.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8" />

--- a/Base/res/ladybird/templates/error.html
+++ b/Base/res/ladybird/templates/error.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -13,12 +13,12 @@ if [ "$#" -eq "0" ]; then
         git ls-files \
             --exclude-from .prettierignore \
             -- \
-            '*.js' '*.mjs'
+            '*.js' '*.mjs' 'Base/*.html'
     )
 else
     files=()
     for file in "$@"; do
-        if [[ "${file}" == *".js" ]] || [[ "${file}" == *".mjs" ]]; then
+        if [[ "${file}" == *".js" ]] || [[ "${file}" == *".mjs" ]] || [[ "${file}" == "Base"*".html" ]]; then
             files+=("${file}")
         fi
     done
@@ -37,5 +37,5 @@ if (( ${#files[@]} )); then
 
     prettier --check "${files[@]}"
 else
-    echo "No .js or .mjs files to check."
+    echo "No .js, .mjs, or .html files to check."
 fi


### PR DESCRIPTION
We were only enforcing `prettier` on JS files. Let's ensure our internal HTML files are formatted as well.