### PR TITLE
LibJS: Skip property-table key marking for non-dictionary shapes

### DIFF
--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -183,9 +183,6 @@ void Shape::visit_edges(Cell::Visitor& visitor)
     if (m_property_key.has_value())
         m_property_key->visit_edges(visitor);
 
-    // NOTE: We don't need to mark the keys in the property table, since they are guaranteed
-    //       to also be marked by the chain of shapes leading up to this one.
-
     visitor.ignore(m_prototype_transitions);
 
     // FIXME: The forward transition keys should be weak, but we have to mark them for now in case they go stale.
@@ -202,7 +199,22 @@ void Shape::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_prototype_chain_validity);
 
-    if (m_property_table) {
+    // Only dictionary shapes actually need us to mark the keys in m_property_table.
+    //
+    // For non-dictionary shapes, m_property_table is a lazily-built cache of the
+    // transition chain: every key it contains was originally inserted into some
+    // ancestor's m_property_key, and that ancestor is kept alive by m_previous
+    // (which we already visit above). So those keys are guaranteed to be marked
+    // transitively via the chain, and re-marking them here is pure overhead.
+    //
+    // The exception used to be the handful of intrinsic shapes populated via
+    // add_property_without_transition() in Intrinsics.cpp (iterator-result,
+    // function, arguments, regexp-exec-array, ...). Those shapes are not
+    // dictionaries and have no m_previous to reach their property keys through.
+    // However, every key they hold is a vm.names.* string or a well-known
+    // symbol, both of which are strongly rooted by the VM for its entire
+    // lifetime, so skipping them here is safe.
+    if (m_dictionary && m_property_table) {
         for (auto& it : *m_property_table)
             it.key.visit_edges(visitor);
     }


### PR DESCRIPTION
`Shape::visit_edges` used to walk every entry of m_property_table and call `PropertyKey::visit_edges` on each key. For non-dictionary shapes that work is redundant: `m_property_table` is a lazily built cache of the transition chain, and every key it contains was originally inserted as some ancestor shape's m_property_key, which is already kept alive via `m_previous`.

Intrinsic shapes populated through `add_property_without_transition()` in Intrinsics.cpp are not dictionaries and have no `m_previous` to reach their keys through, but each of those keys is either a `vm.names.*` string or a well-known symbol and is strongly rooted by the `VM` for its whole lifetime, so skipping them here is safe too.

Measured on the main WebWorker used by https://www.maptiler.com/maps/ this cuts out ~98% of the `PropertyKey::visit_edges` calls made by `Shape::visit_edges` each GC, reducing time spent in GC by ~1.3 seconds on my Linux PC while initially loading the map.