### PR TITLE
LibWeb: Add AVIF and WebP to the Accept header for images

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -267,7 +267,10 @@ GC::Ref<Infrastructure::FetchController> fetch(JS::Realm& realm, Infrastructure:
             // -> "image"
             case Infrastructure::Request::Destination::Image:
                 // `image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`
-                value = "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"sv;
+                // AD-HOC: The spec default omits AVIF and WebP, which causes CDNs that perform format negotiation to
+                //         potentially fall back to non alpha-preserving formats.
+                //         Spec issue: https://github.com/whatwg/fetch/issues/1740
+                value = "image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"sv;
                 break;
             // -> "json"
             case Infrastructure::Request::Destination::JSON:

--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -56,6 +56,9 @@ class Echo:
 # In-memory store for echo responses
 echo_store: Dict[str, Echo] = {}
 
+# Headers from the most recent request at each echo path, queryable via GET /recorded-request-headers<echo-path>.
+recorded_request_headers: Dict[str, Dict[str, list]] = {}
+
 
 class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     static_directory: str
@@ -98,6 +101,8 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path.startswith("/echo"):
             self.handle_echo()
+        elif self.path.startswith("/recorded-request-headers/"):
+            self._serve_recorded_request_headers()
         else:
             self._serve_static_request()
 
@@ -201,9 +206,23 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(json.dumps(fetch_config).encode("utf-8"))
 
+    def _serve_recorded_request_headers(self):
+        echo_path = self.path[len("/recorded-request-headers") :]
+        headers = recorded_request_headers.get(echo_path)
+        if headers is None:
+            self.send_error(404, f"No recorded request at {echo_path}")
+            return
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(headers).encode("utf-8"))
+
     def handle_echo(self):
         method = self.command.upper()
         key = f"{method} {self.path}"
+
+        recorded_request_headers[self.path] = {header: self.headers.get_all(header) for header in self.headers.keys()}
 
         is_revalidation_request = "If-Modified-Since" in self.headers
         send_not_modified = is_revalidation_request and "X-Ladybird-Respond-With-Not-Modified" in self.headers

--- a/Tests/LibWeb/Text/expected/Fetch/image-accept-header.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/image-accept-header.txt
@@ -1,0 +1,1 @@
+image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5

--- a/Tests/LibWeb/Text/input/Fetch/image-accept-header.html
+++ b/Tests/LibWeb/Text/input/Fetch/image-accept-header.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const httpServer = httpTestServer();
+
+        // A 1x1 transparent PNG.
+        const transparentPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+        const url = await httpServer.createEcho("GET", "/image-accept-header-probe", {
+            status: 200,
+            headers: {
+                "Content-Type": "image/png",
+            },
+            body_encoding: "base64",
+            body: transparentPng,
+        });
+
+        const image = new Image();
+        await new Promise((resolve) => {
+            image.onload = resolve;
+            image.onerror = resolve;
+            image.src = url;
+        });
+
+        const echoUrl = new URL(url);
+        const response = await fetch(`${echoUrl.origin}/recorded-request-headers${echoUrl.pathname}`);
+        const headers = await response.json();
+
+        println(headers["Accept"][0]);
+    });
+</script>


### PR DESCRIPTION
This matches the behavior of other engines. Some CDNs that do content negotiation will fall back to non alpha-preserving formats if these values are not present.

Example from https://www.uk.pedigree.com/:

Before:
<img width="1255" height="143" alt="image" src="https://github.com/user-attachments/assets/5ea31db4-4a6e-48ee-98f1-a7900441f6dd" />

After: 

<img width="1255" height="143" alt="image" src="https://github.com/user-attachments/assets/ed00f9fd-44a0-4f3b-9f48-59ddb558b9de" />

Relevant spec issue: https://github.com/whatwg/fetch/issues/1740

