### PR TITLE
LibRegex+LibJS: Fixes for some /v mode bugs and backtracking issues

### DIFF
--- a/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.cpp
+++ b/Libraries/LibJS/Runtime/RegExpLegacyStaticProperties.cpp
@@ -198,8 +198,9 @@ ThrowCompletionOr<Value> get_legacy_regexp_static_property(VM& vm, RegExpConstru
     auto val = (constructor.legacy_static_properties().*property_getter)();
 
     // 4. If val is empty, throw a TypeError exception.
+    // NOTE: The spec says to throw here, but all major browsers return "" instead.
     if (!val)
-        return vm.throw_completion<TypeError>(ErrorType::GetLegacyRegExpStaticPropertyValueEmpty);
+        return &vm.empty_string();
 
     // 5. Return val.
     return val;

--- a/Libraries/LibRegex/Rust/src/ast.rs
+++ b/Libraries/LibRegex/Rust/src/ast.rs
@@ -238,10 +238,10 @@ pub enum ClassSetExpression {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClassSetOperand {
     /// A single character.
-    Char(char),
+    Char(u32),
 
     /// A range: `a-z`.
-    Range(char, char),
+    Range(u32, u32),
 
     /// A nested character class: `[a-z]` inside another class.
     NestedClass(CharacterClass),

--- a/Libraries/LibRegex/Rust/src/bytecode.rs
+++ b/Libraries/LibRegex/Rust/src/bytecode.rs
@@ -213,6 +213,8 @@ pub enum SimpleMatch {
     BuiltinClass(BuiltinCharacterClass),
     /// Unicode property (\p{...}, \P{...}).
     UnicodeProperty(Box<UnicodePropertyData>),
+    /// Union of two matchers: matches if either alternative matches.
+    Union(Box<SimpleMatch>, Box<SimpleMatch>),
 }
 
 /// A character range for CharClass instructions (u32 code points).

--- a/Libraries/LibRegex/Rust/src/compiler.rs
+++ b/Libraries/LibRegex/Rust/src/compiler.rs
@@ -1226,7 +1226,7 @@ impl Compiler {
                     self.emit(Instruction::Fail);
                     return;
                 }
-                self.emit_char_maybe_case_fold(*c as u32);
+                self.emit_char_maybe_case_fold(*c);
             }
             ClassSetOperand::Range(lo, hi) => {
                 if length != 1 {
@@ -1234,10 +1234,7 @@ impl Compiler {
                     return;
                 }
                 self.emit(Instruction::CharClass {
-                    ranges: vec![CharRange {
-                        start: *lo as u32,
-                        end: *hi as u32,
-                    }],
+                    ranges: vec![CharRange { start: *lo, end: *hi }],
                     negated: false,
                 });
             }

--- a/Libraries/LibRegex/Rust/src/compiler.rs
+++ b/Libraries/LibRegex/Rust/src/compiler.rs
@@ -501,34 +501,32 @@ impl Compiler {
                 }
             }
             Atom::BuiltinCharacterClass(class) => Some(SimpleMatch::BuiltinClass(*class)),
-            Atom::CharacterClass(cc) => {
-                // Only use simple match for character classes without v-flag set operations.
-                let ranges_vec = match &cc.body {
-                    CharacterClassBody::Ranges(ranges) => ranges,
-                    CharacterClassBody::UnicodeSet(_) => return None,
-                };
-                let mut ranges = Vec::new();
-                for r in ranges_vec {
-                    match r {
-                        CharacterClassRange::Single(c) => {
-                            if *c > 0xFFFF && !self.program.unicode && !self.program.unicode_sets {
-                                return None;
+            Atom::CharacterClass(cc) => match &cc.body {
+                CharacterClassBody::Ranges(ranges_vec) => {
+                    let mut ranges = Vec::new();
+                    for r in ranges_vec {
+                        match r {
+                            CharacterClassRange::Single(c) => {
+                                if *c > 0xFFFF && !self.program.unicode && !self.program.unicode_sets {
+                                    return None;
+                                }
+                                ranges.push(CharRange { start: *c, end: *c });
                             }
-                            ranges.push(CharRange { start: *c, end: *c });
+                            CharacterClassRange::Range(lo, hi) => {
+                                ranges.push(CharRange { start: *lo, end: *hi });
+                            }
+                            _ => return None,
                         }
-                        CharacterClassRange::Range(lo, hi) => {
-                            ranges.push(CharRange { start: *lo, end: *hi });
-                        }
-                        _ => return None, // BuiltinClass or UnicodeProperty in class
                     }
+                    // Sort ranges by start code point for binary search in the VM.
+                    ranges.sort_by_key(|r| r.start);
+                    Some(SimpleMatch::CharClass {
+                        ranges,
+                        negated: cc.negated,
+                    })
                 }
-                // Sort ranges by start code point for binary search in the VM.
-                ranges.sort_by_key(|r| r.start);
-                Some(SimpleMatch::CharClass {
-                    ranges,
-                    negated: cc.negated,
-                })
-            }
+                CharacterClassBody::UnicodeSet(expr) => self.try_simple_match_for_unicode_set(expr, cc.negated),
+            },
             Atom::UnicodeProperty(up) => {
                 // String properties (e.g. Basic_Emoji) can match multi-character
                 // sequences and cannot use simple matching.
@@ -1083,6 +1081,183 @@ impl Compiler {
         }
     }
 
+    /// Try to extract a `SimpleMatch` for a single `ClassSetOperand` in the context of
+    /// a `LazyLoop`/`GreedyLoop`. Returns `None` for operands that require multi-character
+    /// matching (string literals) or set operations that can't be represented as a simple test.
+    fn try_simple_match_for_operand(operand: &ClassSetOperand) -> Option<SimpleMatch> {
+        match operand {
+            ClassSetOperand::Char(c) => Some(SimpleMatch::Char(*c)),
+            ClassSetOperand::Range(lo, hi) => Some(SimpleMatch::CharClass {
+                ranges: vec![CharRange { start: *lo, end: *hi }],
+                negated: false,
+            }),
+            ClassSetOperand::BuiltinClass(bc) => Some(SimpleMatch::BuiltinClass(*bc)),
+            ClassSetOperand::UnicodeProperty(up) => {
+                if libunicode_rust::character_types::is_string_property(&up.name) {
+                    return None;
+                }
+                Some(SimpleMatch::UnicodeProperty(Box::new(UnicodePropertyData {
+                    negated: up.negated,
+                    name: up.name.clone(),
+                    value: up.value.clone(),
+                    resolved: None,
+                })))
+            }
+            ClassSetOperand::NestedClass(cc) => match &cc.body {
+                CharacterClassBody::Ranges(ranges_vec) => {
+                    let mut ranges = Vec::new();
+                    for r in ranges_vec {
+                        match r {
+                            CharacterClassRange::Single(cp) => {
+                                ranges.push(CharRange { start: *cp, end: *cp });
+                            }
+                            CharacterClassRange::Range(lo, hi) => {
+                                ranges.push(CharRange { start: *lo, end: *hi });
+                            }
+                            _ => return None,
+                        }
+                    }
+                    ranges.sort_by_key(|r| r.start);
+                    Some(SimpleMatch::CharClass {
+                        ranges,
+                        negated: cc.negated,
+                    })
+                }
+                CharacterClassBody::UnicodeSet(inner_expr) => {
+                    if cc.negated {
+                        let ClassSetExpression::Union(inner_operands) = inner_expr else {
+                            return None;
+                        };
+                        let matchers: Option<Vec<SimpleMatch>> =
+                            inner_operands.iter().map(Self::try_simple_match_for_operand).collect();
+                        let matchers = matchers?;
+                        Self::build_union_simple_match_negated(matchers)
+                    } else {
+                        let ClassSetExpression::Union(inner_operands) = inner_expr else {
+                            return None;
+                        };
+                        let matchers: Option<Vec<SimpleMatch>> =
+                            inner_operands.iter().map(Self::try_simple_match_for_operand).collect();
+                        let matchers = matchers?;
+                        Self::build_union_simple_match(matchers)
+                    }
+                }
+            },
+            ClassSetOperand::StringLiteral(_) => None,
+        }
+    }
+
+    fn build_union_simple_match(matchers: Vec<SimpleMatch>) -> Option<SimpleMatch> {
+        let mut iter = matchers.into_iter();
+        let first = iter.next()?;
+        Some(iter.fold(first, |acc, m| SimpleMatch::Union(Box::new(acc), Box::new(m))))
+    }
+
+    fn negate_simple_match(matcher: SimpleMatch) -> Option<SimpleMatch> {
+        match matcher {
+            SimpleMatch::CharClass { ranges, negated } => Some(SimpleMatch::CharClass {
+                ranges,
+                negated: !negated,
+            }),
+            SimpleMatch::UnicodeProperty(mut data) => {
+                data.negated = !data.negated;
+                Some(SimpleMatch::UnicodeProperty(data))
+            }
+            _ => None,
+        }
+    }
+
+    fn build_union_simple_match_negated(matchers: Vec<SimpleMatch>) -> Option<SimpleMatch> {
+        if matchers.len() == 1 {
+            return Self::negate_simple_match(matchers.into_iter().next().unwrap());
+        }
+        None
+    }
+
+    /// Try to build a `SimpleMatch` for a `/v`-mode character class `UnicodeSet` body.
+    ///
+    /// For unions that can't be collapsed into a flat range set, we try to build a `SimpleMatch::Union`
+    /// so that quantifiers can still use the optimized `GreedyLoop`/`LazyLoop` path.
+    fn try_simple_match_for_unicode_set(&self, expr: &ClassSetExpression, negated: bool) -> Option<SimpleMatch> {
+        if let Some(ranges) = Self::try_extract_union_ranges(expr) {
+            let mut sorted = ranges;
+            sorted.sort_by_key(|r| r.start);
+            return Some(SimpleMatch::CharClass {
+                ranges: sorted,
+                negated,
+            });
+        }
+
+        if negated {
+            return None;
+        }
+
+        let ClassSetExpression::Union(operands) = expr else {
+            return None;
+        };
+
+        if operands.is_empty() {
+            return None;
+        }
+
+        let matchers: Option<Vec<SimpleMatch>> = operands.iter().map(Self::try_simple_match_for_operand).collect();
+        let matchers = matchers?;
+        Self::build_union_simple_match(matchers)
+    }
+
+    fn try_extract_union_ranges(expr: &ClassSetExpression) -> Option<Vec<CharRange>> {
+        let ClassSetExpression::Union(operands) = expr else {
+            return None;
+        };
+
+        let mut ranges = Vec::new();
+        for operand in operands {
+            match operand {
+                ClassSetOperand::Char(c) => {
+                    ranges.push(CharRange { start: *c, end: *c });
+                }
+                ClassSetOperand::Range(lo, hi) => {
+                    ranges.push(CharRange { start: *lo, end: *hi });
+                }
+                ClassSetOperand::NestedClass(cc) => match &cc.body {
+                    CharacterClassBody::Ranges(class_ranges) => {
+                        for r in class_ranges {
+                            match r {
+                                CharacterClassRange::Single(cp) => {
+                                    ranges.push(CharRange { start: *cp, end: *cp });
+                                }
+                                CharacterClassRange::Range(lo, hi) => {
+                                    ranges.push(CharRange { start: *lo, end: *hi });
+                                }
+                                CharacterClassRange::BuiltinClass(_) | CharacterClassRange::UnicodeProperty(_) => {
+                                    return None;
+                                }
+                            }
+                        }
+                        if cc.negated {
+                            return None;
+                        }
+                    }
+                    CharacterClassBody::UnicodeSet(inner_expr) => {
+                        if cc.negated {
+                            return None;
+                        }
+                        let inner = Self::try_extract_union_ranges(inner_expr)?;
+                        ranges.extend(inner);
+                    }
+                },
+                ClassSetOperand::BuiltinClass(_)
+                | ClassSetOperand::UnicodeProperty(_)
+                | ClassSetOperand::StringLiteral(_) => {
+                    return None;
+                }
+            }
+        }
+
+        ranges.sort_by_key(|r| r.start);
+        Some(ranges)
+    }
+
     /// Lower a `/v` character class expression.
     ///
     /// Negation is expressed as a negative lookahead plus `AnyChar` because
@@ -1099,8 +1274,11 @@ impl Compiler {
             return;
         }
 
-        // For now, compile unicode set classes as disjunctions of their operands.
-        // This is correct but not optimal — future optimization can merge ranges.
+        if let Some(ranges) = Self::try_extract_union_ranges(expr) {
+            self.emit(Instruction::CharClass { ranges, negated });
+            return;
+        }
+
         if negated {
             let forward = !self.backward;
             let look_start = self.emit(Instruction::LookStart {

--- a/Libraries/LibRegex/Rust/src/compiler.rs
+++ b/Libraries/LibRegex/Rust/src/compiler.rs
@@ -502,29 +502,7 @@ impl Compiler {
             }
             Atom::BuiltinCharacterClass(class) => Some(SimpleMatch::BuiltinClass(*class)),
             Atom::CharacterClass(cc) => match &cc.body {
-                CharacterClassBody::Ranges(ranges_vec) => {
-                    let mut ranges = Vec::new();
-                    for r in ranges_vec {
-                        match r {
-                            CharacterClassRange::Single(c) => {
-                                if *c > 0xFFFF && !self.program.unicode && !self.program.unicode_sets {
-                                    return None;
-                                }
-                                ranges.push(CharRange { start: *c, end: *c });
-                            }
-                            CharacterClassRange::Range(lo, hi) => {
-                                ranges.push(CharRange { start: *lo, end: *hi });
-                            }
-                            _ => return None,
-                        }
-                    }
-                    // Sort ranges by start code point for binary search in the VM.
-                    ranges.sort_by_key(|r| r.start);
-                    Some(SimpleMatch::CharClass {
-                        ranges,
-                        negated: cc.negated,
-                    })
-                }
+                CharacterClassBody::Ranges(ranges_vec) => self.try_simple_match_for_ranges(ranges_vec, cc.negated),
                 CharacterClassBody::UnicodeSet(expr) => self.try_simple_match_for_unicode_set(expr, cc.negated),
             },
             Atom::UnicodeProperty(up) => {
@@ -1172,6 +1150,86 @@ impl Compiler {
             return Self::negate_simple_match(matchers.into_iter().next().unwrap());
         }
         None
+    }
+
+    /// Try to build a `SimpleMatch` for a `CharacterClassBody::Ranges`.
+    ///
+    /// If all elements are plain chars/ranges, returns a single `CharClass`.
+    /// If the class is non-negated and contains builtins or Unicode properties,
+    /// collects plain ranges into one `CharClass` and each builtin/property into its
+    /// own `SimpleMatch`, then folds them into a `Union`.
+    fn try_simple_match_for_ranges(&self, ranges_vec: &[CharacterClassRange], negated: bool) -> Option<SimpleMatch> {
+        let has_complex = ranges_vec.iter().any(|r| {
+            matches!(
+                r,
+                CharacterClassRange::BuiltinClass(_) | CharacterClassRange::UnicodeProperty(_)
+            )
+        });
+
+        if !has_complex {
+            let mut ranges = Vec::new();
+            for r in ranges_vec {
+                match r {
+                    CharacterClassRange::Single(c) => {
+                        if *c > 0xFFFF && !self.program.unicode && !self.program.unicode_sets {
+                            return None;
+                        }
+                        ranges.push(CharRange { start: *c, end: *c });
+                    }
+                    CharacterClassRange::Range(lo, hi) => {
+                        ranges.push(CharRange { start: *lo, end: *hi });
+                    }
+                    _ => return None,
+                }
+            }
+            ranges.sort_by_key(|r| r.start);
+            return Some(SimpleMatch::CharClass { ranges, negated });
+        }
+
+        if negated {
+            return None;
+        }
+
+        let mut plain_ranges: Vec<CharRange> = Vec::new();
+        let mut matchers: Vec<SimpleMatch> = Vec::new();
+
+        for r in ranges_vec {
+            match r {
+                CharacterClassRange::Single(c) => {
+                    if *c > 0xFFFF && !self.program.unicode && !self.program.unicode_sets {
+                        return None;
+                    }
+                    plain_ranges.push(CharRange { start: *c, end: *c });
+                }
+                CharacterClassRange::Range(lo, hi) => {
+                    plain_ranges.push(CharRange { start: *lo, end: *hi });
+                }
+                CharacterClassRange::BuiltinClass(bc) => {
+                    matchers.push(SimpleMatch::BuiltinClass(*bc));
+                }
+                CharacterClassRange::UnicodeProperty(up) => {
+                    if libunicode_rust::character_types::is_string_property(&up.name) {
+                        return None;
+                    }
+                    matchers.push(SimpleMatch::UnicodeProperty(Box::new(UnicodePropertyData {
+                        negated: up.negated,
+                        name: up.name.clone(),
+                        value: up.value.clone(),
+                        resolved: None,
+                    })));
+                }
+            }
+        }
+
+        if !plain_ranges.is_empty() {
+            plain_ranges.sort_by_key(|r| r.start);
+            matchers.push(SimpleMatch::CharClass {
+                ranges: plain_ranges,
+                negated: false,
+            });
+        }
+
+        Self::build_union_simple_match(matchers)
     }
 
     /// Try to build a `SimpleMatch` for a `/v`-mode character class `UnicodeSet` body.

--- a/Libraries/LibRegex/Rust/src/parser.rs
+++ b/Libraries/LibRegex/Rust/src/parser.rs
@@ -1686,7 +1686,7 @@ impl Parser {
                     return Err(Error::InvalidCharacterClass);
                 }
                 self.advance();
-                self.try_parse_class_set_range(ch)
+                self.try_parse_class_set_range(ch as u32)
             }
         }
     }
@@ -1694,20 +1694,17 @@ impl Parser {
     /// Parse the restricted escape forms allowed when a `/v` class set operand
     /// expects a single character.
     /// <https://tc39.es/ecma262/#sec-patterns>
-    fn parse_class_set_char_escape(&mut self) -> Result<char, Error> {
+    fn parse_class_set_char_escape(&mut self) -> Result<u32, Error> {
         let ch = self.advance().ok_or(Error::LoneTrailingBackslash)?;
         match ch {
-            'n' => Ok('\n'),
-            'r' => Ok('\r'),
-            't' => Ok('\t'),
-            'f' => Ok('\u{0C}'),
-            'v' => Ok('\u{0B}'),
-            'b' => Ok('\u{08}'),
-            '0' if !self.peek().is_some_and(|c| c.is_ascii_digit()) => Ok('\0'),
-            'x' => {
-                let val = self.parse_hex_escape(2)?;
-                char::from_u32(val).ok_or(Error::InvalidUnicodeEscape)
-            }
+            'n' => Ok('\n' as u32),
+            'r' => Ok('\r' as u32),
+            't' => Ok('\t' as u32),
+            'f' => Ok(0x0C),
+            'v' => Ok(0x0B),
+            'b' => Ok(0x08),
+            '0' if !self.peek().is_some_and(|c| c.is_ascii_digit()) => Ok(0),
+            'x' => self.parse_hex_escape(2),
             'u' => {
                 let is_braced = self.peek() == Some('{');
                 let val = self.parse_unicode_escape()?;
@@ -1717,22 +1714,22 @@ impl Parser {
                         let low = self.parse_unicode_escape()?;
                         if (0xDC00..=0xDFFF).contains(&low) {
                             let combined = 0x10000 + ((val - 0xD800) << 10) + (low - 0xDC00);
-                            return char::from_u32(combined).ok_or(Error::InvalidUnicodeEscape);
+                            return Ok(combined);
                         }
                         self.pos = saved;
                     } else {
                         self.pos = saved;
                     }
                 }
-                char::from_u32(val).ok_or(Error::InvalidUnicodeEscape)
+                Ok(val)
             }
-            _ if is_syntax_character(ch) || ch == '/' || ch == '-' => Ok(ch),
+            _ if is_syntax_character(ch) || ch == '/' || ch == '-' => Ok(ch as u32),
             _ => Err(Error::InvalidEscape(ch)),
         }
     }
 
     /// After reading a character in a unicode-sets class, check if it's followed by `-` to form a range.
-    fn try_parse_class_set_range(&mut self, first: char) -> Result<ClassSetOperand, Error> {
+    fn try_parse_class_set_range(&mut self, first: u32) -> Result<ClassSetOperand, Error> {
         if self.eat('-') {
             if self.peek() == Some(']') || self.peek() == Some('-') || self.peek_pair() == Some(('&', '&')) {
                 // `-]`, `--`, and `-&&` do not start a character range here.
@@ -1747,10 +1744,10 @@ impl Parser {
                 if is_class_set_syntax_character(c) {
                     return Err(Error::InvalidCharacterClass);
                 }
-                self.advance().ok_or(Error::InvalidCharacterClass)?
+                self.advance().ok_or(Error::InvalidCharacterClass)? as u32
             };
             if first > second {
-                return Err(Error::InvalidCharacterRange(first as u32, second as u32));
+                return Err(Error::InvalidCharacterRange(first, second));
             }
             Ok(ClassSetOperand::Range(first, second))
         } else {

--- a/Libraries/LibRegex/Rust/src/parser.rs
+++ b/Libraries/LibRegex/Rust/src/parser.rs
@@ -279,16 +279,29 @@ impl Parser {
     /// Parse `Disjunction`.
     /// <https://tc39.es/ecma262/#sec-patterns>
     fn parse_disjunction(&mut self) -> Result<Disjunction, Error> {
-        self.alternative_name_stack.push(std::collections::HashSet::new());
+        let inherited = self.alternative_name_stack.last().cloned().unwrap_or_default();
+        self.alternative_name_stack.push(inherited.clone());
         let mut alternatives = vec![self.parse_alternative()?];
         while self.eat('|') {
-            // Reset the current alternative's name set for the next alternative.
-            if let Some(names) = self.alternative_name_stack.last_mut() {
-                names.clear();
+            // Merge names from the just finished alternative into the parent scope so
+            // parent knows these names exist and can reject duplicates from enclosing alternatives
+            let committed = self.alternative_name_stack.last().cloned().unwrap_or_default();
+            if let Some(outer) = self.alternative_name_stack.iter_mut().rev().nth(1) {
+                outer.extend(committed.iter().cloned());
+            }
+
+            // Reset to only the names from outer scopes so the next alternative only sees
+            // names from outer scopes and not from its siblings
+            if let Some(top) = self.alternative_name_stack.last_mut() {
+                *top = inherited.clone();
             }
             alternatives.push(self.parse_alternative()?);
         }
-        self.alternative_name_stack.pop();
+
+        let final_names = self.alternative_name_stack.pop().unwrap_or_default();
+        if let Some(outer) = self.alternative_name_stack.last_mut() {
+            outer.extend(final_names.into_iter().filter(|n| !inherited.contains(n)));
+        }
         Ok(Disjunction { alternatives })
     }
 
@@ -946,8 +959,9 @@ impl Parser {
                             // Named capture group: (?<name>...).
                             let name = self.parse_group_name()?;
                             self.expect('>')?;
-                            // Duplicate names are allowed across alternatives,
-                            // but not within the same alternative.
+                            // Duplicate names are allowed across alternatives of
+                            // the same disjunction, but not within the same
+                            // alternative.
                             if let Some(current_alt_names) = self.alternative_name_stack.last()
                                 && current_alt_names.contains(&name)
                             {
@@ -955,12 +969,8 @@ impl Parser {
                             }
                             let index = self.next_capture_index;
                             self.next_capture_index += 1;
-                            // Propagate the name to every active disjunction
-                            // level so a duplicate later in the same enclosing
-                            // alternative is rejected even if the first use was
-                            // nested inside a child disjunction.
-                            for level in self.alternative_name_stack.iter_mut() {
-                                level.insert(name.clone());
+                            if let Some(top) = self.alternative_name_stack.last_mut() {
+                                top.insert(name.clone());
                             }
                             self.named_groups.push(NamedGroup {
                                 name: name.clone(),

--- a/Libraries/LibRegex/Rust/src/parser.rs
+++ b/Libraries/LibRegex/Rust/src/parser.rs
@@ -1380,7 +1380,10 @@ impl Parser {
     /// Parse `/v` `ClassSetExpression`.
     /// <https://tc39.es/ecma262/#sec-compilecharacterclass>
     fn parse_class_set_expression(&mut self) -> Result<ClassSetExpression, Error> {
+        let saved_negated = self.in_negated_class;
+        self.in_negated_class = false;
         let first = self.parse_class_set_operand()?;
+        self.in_negated_class = saved_negated;
 
         // Check for set operation operators.
         match self.peek_pair() {
@@ -1389,11 +1392,16 @@ impl Parser {
                 // once we see subtraction we stay in that operator family until
                 // the surrounding class or nested operand ends.
                 // Subtraction: A--B--C
+                if saved_negated {
+                    Self::validate_no_string_operand(&first)?;
+                }
                 let mut operands = vec![first];
+                self.in_negated_class = false;
                 while self.peek_pair() == Some(('-', '-')) {
                     self.pos += 2; // consume '--'
                     operands.push(self.parse_class_set_operand()?);
                 }
+                self.in_negated_class = saved_negated;
                 Self::validate_class_set_operation_operands(&operands)?;
                 Ok(ClassSetExpression::Subtraction(operands))
             }
@@ -1402,15 +1410,20 @@ impl Parser {
                 // either an intersection chain or something else, never both.
                 // Intersection: A&&B&&C
                 let mut operands = vec![first];
+                self.in_negated_class = false;
                 while self.peek_pair() == Some(('&', '&')) {
                     self.pos += 2; // consume '&&'
                     operands.push(self.parse_class_set_operand()?);
                 }
+                self.in_negated_class = saved_negated;
                 Self::validate_class_set_operation_operands(&operands)?;
                 Ok(ClassSetExpression::Intersection(operands))
             }
             _ => {
-                // Union (default): just accumulate operands.
+                // Union (default): direct members of [^...] may not be string properties.
+                if saved_negated {
+                    Self::validate_no_string_operand(&first)?;
+                }
                 let mut operands = vec![first];
                 while self.peek() != Some(']') && !self.at_end() {
                     operands.push(self.parse_class_set_operand()?);
@@ -1418,6 +1431,16 @@ impl Parser {
                 Ok(ClassSetExpression::Union(operands))
             }
         }
+    }
+
+    fn validate_no_string_operand(operand: &ClassSetOperand) -> Result<(), Error> {
+        if let ClassSetOperand::UnicodeProperty(up) = operand
+            && !up.negated
+            && Self::is_string_property(&up.name)
+        {
+            return Err(Error::InvalidUnicodeProperty(up.name.clone()));
+        }
+        Ok(())
     }
 
     fn validate_class_set_operation_operands(operands: &[ClassSetOperand]) -> Result<(), Error> {
@@ -1651,9 +1674,9 @@ impl Parser {
                         let negated = esc == 'P';
                         self.advance();
                         let prop = self.parse_unicode_property()?;
-                        // In v-mode, string properties cannot be negated (\P)
-                        // or used inside a negated character class ([^...]).
-                        if prop.1.is_none() && Self::is_string_property(&prop.0) && (negated || self.in_negated_class) {
+                        // In v-mode, \P{string-property} is always forbidden.
+                        // The [^...] negation check is handled at the expression level.
+                        if prop.1.is_none() && Self::is_string_property(&prop.0) && negated {
                             return Err(Error::InvalidUnicodeProperty(prop.0));
                         }
                         Ok(ClassSetOperand::UnicodeProperty(UnicodeProperty {

--- a/Libraries/LibRegex/Rust/src/regex.rs
+++ b/Libraries/LibRegex/Rust/src/regex.rs
@@ -465,23 +465,31 @@ impl Regex {
     /// Post-process the program to resolve Unicode property names to ICU enum IDs.
     /// This allows O(1) trie lookups at match time instead of string-based resolution.
     fn resolve_properties(program: &mut crate::bytecode::Program) {
-        let resolve = |data: &mut crate::bytecode::UnicodePropertyData| {
+        fn resolve_data(data: &mut crate::bytecode::UnicodePropertyData) {
             if data.resolved.is_none() {
                 data.resolved = compiler::resolve_property(&data.name, data.value.as_deref());
             }
-        };
+        }
+        fn resolve_simple_match(matcher: &mut crate::bytecode::SimpleMatch) {
+            match matcher {
+                crate::bytecode::SimpleMatch::UnicodeProperty(data) => resolve_data(data),
+                crate::bytecode::SimpleMatch::Union(lhs, rhs) => {
+                    resolve_simple_match(lhs);
+                    resolve_simple_match(rhs);
+                }
+                _ => {}
+            }
+        }
         for inst in &mut program.instructions {
             match inst {
                 Instruction::UnicodeProperty(data) => {
-                    resolve(data);
+                    resolve_data(data);
                 }
                 Instruction::StringPropertyMatch { property, .. } => {
-                    resolve(property);
+                    resolve_data(property);
                 }
                 Instruction::GreedyLoop { matcher, .. } | Instruction::LazyLoop { matcher, .. } => {
-                    if let crate::bytecode::SimpleMatch::UnicodeProperty(data) = matcher {
-                        resolve(data);
-                    }
+                    resolve_simple_match(matcher);
                 }
                 _ => {}
             }

--- a/Libraries/LibRegex/Rust/src/vm.rs
+++ b/Libraries/LibRegex/Rust/src/vm.rs
@@ -2469,6 +2469,12 @@ impl<'a, I: Input> Vm<'a, I> {
                 let hi = cu;
                 let lo = self.input_code_unit(self.pos + 1) as u32;
                 Some(0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00))
+            } else if self.program.unicode
+                && is_low_surrogate(cu as u16)
+                && self.pos > 0
+                && is_high_surrogate(self.input_code_unit(self.pos - 1))
+            {
+                None
             } else {
                 Some(cu)
             }

--- a/Libraries/LibRegex/Rust/src/vm.rs
+++ b/Libraries/LibRegex/Rust/src/vm.rs
@@ -841,6 +841,38 @@ fn match_simple_scan(scan: &SimpleScan, cp: u32) -> bool {
     }
 }
 
+/// Match a single code point against a SimpleMatch, respecting active modifiers.
+#[inline(always)]
+fn match_simple_with_modifiers(matcher: &SimpleMatch, cp: u32, modifiers: &ActiveModifiers) -> bool {
+    match matcher {
+        SimpleMatch::AnyChar { dot_all } => {
+            let dot_all = *dot_all || modifiers.dot_all;
+            dot_all || !is_line_terminator(cp)
+        }
+        SimpleMatch::Char(c) => {
+            if modifiers.ignore_case {
+                case_fold_eq(cp, *c, false)
+            } else {
+                cp == *c
+            }
+        }
+        SimpleMatch::CharNoCase(lo, _hi) => case_fold_eq(cp, *lo, false),
+        SimpleMatch::CharClass { ranges, negated } => {
+            let in_class = match_char_class(cp, ranges, modifiers.ignore_case, false, false);
+            in_class != *negated
+        }
+        SimpleMatch::BuiltinClass(class) => match_builtin_class(cp, *class, false),
+        SimpleMatch::UnicodeProperty(data) => {
+            let matched =
+                match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
+            matched != data.negated
+        }
+        SimpleMatch::Union(lhs, rhs) => {
+            match_simple_with_modifiers(lhs, cp, modifiers) || match_simple_with_modifiers(rhs, cp, modifiers)
+        }
+    }
+}
+
 /// Match a single code point against a SimpleMatch.
 #[inline(always)]
 fn match_simple_match(matcher: &SimpleMatch, cp: u32) -> bool {
@@ -3168,7 +3200,9 @@ impl<'a, I: Input> Vm<'a, I> {
             SimpleMatch::Union(lhs, rhs) => {
                 while *pos < len && count < limit {
                     let cp = input.code_unit(*pos) as u32;
-                    if !match_simple_match(lhs, cp) && !match_simple_match(rhs, cp) {
+                    if !match_simple_with_modifiers(lhs, cp, modifiers)
+                        && !match_simple_with_modifiers(rhs, cp, modifiers)
+                    {
                         break;
                     }
                     *pos += 1;

--- a/Libraries/LibRegex/Rust/src/vm.rs
+++ b/Libraries/LibRegex/Rust/src/vm.rs
@@ -435,6 +435,9 @@ fn first_filter_matches<I: Input>(program: &Program, input: I, pos: usize, filte
                 match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
             matched != data.negated
         }
+        SimpleMatch::Union(lhs, rhs) => {
+            first_filter_matches(program, input, pos, lhs) || first_filter_matches(program, input, pos, rhs)
+        }
     }
 }
 
@@ -852,6 +855,7 @@ fn match_simple_match(matcher: &SimpleMatch, cp: u32) -> bool {
                 match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
             matched != data.negated
         }
+        SimpleMatch::Union(lhs, rhs) => match_simple_match(lhs, cp) || match_simple_match(rhs, cp),
     }
 }
 
@@ -3018,6 +3022,7 @@ impl<'a, I: Input> Vm<'a, I> {
                     matched != data.negated
                 }
             }
+            SimpleMatch::Union(lhs, rhs) => self.match_simple(cp, lhs) || self.match_simple(cp, rhs),
         }
     }
 
@@ -3154,6 +3159,16 @@ impl<'a, I: Input> Vm<'a, I> {
                     let matched =
                         match_unicode_property_resolved(cp, &data.name, data.value.as_deref(), data.resolved.as_ref());
                     if matched == data.negated {
+                        break;
+                    }
+                    *pos += 1;
+                    count += 1;
+                }
+            }
+            SimpleMatch::Union(lhs, rhs) => {
+                while *pos < len && count < limit {
+                    let cp = input.code_unit(*pos) as u32;
+                    if !match_simple_match(lhs, cp) && !match_simple_match(rhs, cp) {
                         break;
                     }
                     *pos += 1;

--- a/Tests/LibJS/Runtime/3rdparty/v8/regexp-duplicate-named-groups.js
+++ b/Tests/LibJS/Runtime/3rdparty/v8/regexp-duplicate-named-groups.js
@@ -84,7 +84,7 @@ function assertArrayEquals(expected, actual) {
     expect(actual).toEqual(expected);
 }
 
-test.xfail("regexp-duplicate-named-groups", () => {
+test("regexp-duplicate-named-groups", () => {
     assertEarlyError("/(?<a>.)(?<a>.)/");
     assertEarlyError("/((?<a>.)(?<a>.))/");
     assertEarlyError("/(?<a>.)((?<a>.))/");

--- a/Tests/LibJS/Runtime/builtins/RegExp/RegExp.js
+++ b/Tests/LibJS/Runtime/builtins/RegExp/RegExp.js
@@ -930,3 +930,17 @@ test("lone surrogates as \\uXXXX escapes are valid in /v mode character classes"
     expect("".match(/[\udf9e]/v)).toBeNull();
     expect("\udfff".match(/[\udf9e-\udfff]/v)).toEqual(["\udfff"]);
 });
+
+test("string properties allowed as set operation operands in negated /v mode classes", () => {
+    expect(/[^[a]--\p{Emoji_Keycap_Sequence}]/v).toBeInstanceOf(RegExp);
+    expect(/[^\p{Emoji_Keycap_Sequence}&&[a]]/v).toBeInstanceOf(RegExp);
+    expect(/[^[a]&&\p{Emoji_Keycap_Sequence}]/v).toBeInstanceOf(RegExp);
+
+    expect(() => {
+        RegExp("[^\\p{Emoji_Keycap_Sequence}--[a]]", "v");
+    }).toThrowWithMessage(SyntaxError, "RegExp compile error: invalid Unicode property 'Emoji_Keycap_Sequence'");
+
+    expect(() => {
+        RegExp("[^\\p{Emoji_Keycap_Sequence}]", "v");
+    }).toThrowWithMessage(SyntaxError, "RegExp compile error: invalid Unicode property 'Emoji_Keycap_Sequence'");
+});

--- a/Tests/LibJS/Runtime/builtins/RegExp/RegExp.js
+++ b/Tests/LibJS/Runtime/builtins/RegExp/RegExp.js
@@ -253,6 +253,11 @@ test("global unicode matches keep low-surrogate empty matches that V8 finds", ()
     expect(subject.match(/\p{Script=Cyrillic}?(?<!\D)/gv)).toEqual(new Array(24).fill(""));
 });
 
+test("lookahead inside surrogate pair does not match paired low surrogate as a character", () => {
+    expect("💦💦".match(/(?!\W)/gv)).toEqual(["", "", ""]);
+    expect("💦💦".match(/\p{Emoji_Presentation}?(?!\W)/gv)).toEqual(["", "💦", ""]);
+});
+
 test("backward v-mode class-set operations inspect the consumed code point", () => {
     expect("A n".match(/(?<=[[^A-Z]--[A-Z]])\P{N}/gv)).toEqual(["n"]);
     expect("A n".match(/(?<=[[^0-9]&&[^A-Z]])\P{N}/gv)).toEqual(["n"]);

--- a/Tests/LibJS/Runtime/builtins/RegExp/RegExp.js
+++ b/Tests/LibJS/Runtime/builtins/RegExp/RegExp.js
@@ -925,3 +925,8 @@ test("incomplete \\u and \\x escapes", () => {
     expect("\\x\u0000".match(/[\x00]+/)).toEqual(["\u0000"]);
     expect("0\u0000".match(/[\x000]+/)).toEqual(["0\u0000"]);
 });
+
+test("lone surrogates as \\uXXXX escapes are valid in /v mode character classes", () => {
+    expect("".match(/[\udf9e]/v)).toBeNull();
+    expect("\udfff".match(/[\udf9e-\udfff]/v)).toEqual(["\udfff"]);
+});

--- a/Tests/LibJS/Runtime/regexp-duplicate-named-groups-nested.js
+++ b/Tests/LibJS/Runtime/regexp-duplicate-named-groups-nested.js
@@ -1,0 +1,10 @@
+test("duplicate nested named capture groups in same alternative are rejected", () => {
+    expect(() => eval("/(?<a>.)((?<a>.)|(?<b>.))/")).toThrow(SyntaxError);
+    expect(() => eval("/x(?<a>.)((((?<a>.)|(?<a>.))|(?<a>.)|(?<a>.))|(?<a>.))|(?<a>.)y/")).toThrow(SyntaxError);
+    expect(() => eval("/x((?<a>.)(((?<a>.)|(?<a>.))|(?<a>.)|(?<a>.))|(?<a>.))|(?<a>.)y/")).toThrow(SyntaxError);
+    expect(() => eval("/(?<a>.)((?<a>.))/")).toThrow(SyntaxError);
+    expect(() => eval("/(?<b>.)((?<a>.)|(?<b>.))/")).toThrow(SyntaxError);
+    expect(() => eval("/x(((?<a>.)((?<a>.)|(?<a>.))|(?<a>.)|(?<a>.))|(?<a>.))|(?<a>.)y/")).toThrow(SyntaxError);
+    expect(() => eval("/(?<a>(?<a>.)|.)/")).toThrow(SyntaxError);
+    expect(() => eval("/(?<a>.|(?<b>.(?<b>.)|.))/")).toThrow(SyntaxError);
+});

--- a/Tests/LibJS/Runtime/regexp-legacy-static-properties-initial.js
+++ b/Tests/LibJS/Runtime/regexp-legacy-static-properties-initial.js
@@ -1,0 +1,16 @@
+test("legacy static properties return empty string before any match", () => {
+    expect(RegExp.$1).toBe("");
+    expect(RegExp.$2).toBe("");
+    expect(RegExp.$3).toBe("");
+    expect(RegExp.$4).toBe("");
+    expect(RegExp.$5).toBe("");
+    expect(RegExp.$6).toBe("");
+    expect(RegExp.$7).toBe("");
+    expect(RegExp.$8).toBe("");
+    expect(RegExp.$9).toBe("");
+    expect(RegExp.input).toBe("");
+    expect(RegExp.lastMatch).toBe("");
+    expect(RegExp.lastParen).toBe("");
+    expect(RegExp.leftContext).toBe("");
+    expect(RegExp.rightContext).toBe("");
+});

--- a/Tests/LibJS/Runtime/regexp-unicode-set-quantifier-backtracking.js
+++ b/Tests/LibJS/Runtime/regexp-unicode-set-quantifier-backtracking.js
@@ -1,0 +1,15 @@
+test("/v mode negated class in lazy quantifier does not hit backtrack limit", () => {
+    expect(() => "aplmaaaaacdeaabbaaqw".match(/([[^p][^p]]+)(.*).*apl/v)).not.toThrow();
+    expect("aplmaaaaacdeaabbaaqw".match(/([[^p][^p]]+)(.*).*apl/v)).toBeNull();
+});
+
+test("/v mode union of range class and unicode property in lazy quantifier does not hit backtrack limit", () => {
+    let str =
+        "\u0436 \u0442\u0435\u0441\u0442\u5b57({foo \ud83d\ude10\ud83d\ude01\ud83d\ude01\ud83d\ude01 1\ufe0f\u20e34\ufe0f\u20e34\ufe0f\u20e3 = \u0939\u093f\u0928\u094d\u0926\u0940 \u05d5\u05d5;\u0917 @@@\u00d7\u00f7\u2211\u222b\u221e\u222b\u220f\u062f\u062a\n\u2728\u2728\u2728\u2728[=/\ud83c\udf0a\ud83d\udca8\u5c71\nb \u6f22\u5b57 ";
+    expect(() =>
+        str.match(/(?<g27>\P{Emoji}.(?:[[^😀-🚀][^\p{Emoji}]]+?))((?<n96>[[A-Z]]*?)*?).*\k<g27>/gv)
+    ).not.toThrow();
+    expect(str.match(/(?<g27>\P{Emoji}.(?:[[^😀-🚀][^\p{Emoji}]]+?))((?<n96>[[A-Z]]*?)*?).*\k<g27>/gv)).toEqual([
+        "\ufe0f\u20e34\ufe0f\u20e34",
+    ]);
+});

--- a/Tests/LibJS/Runtime/regexp-unicode-set-quantifier-backtracking.js
+++ b/Tests/LibJS/Runtime/regexp-unicode-set-quantifier-backtracking.js
@@ -13,3 +13,14 @@ test("/v mode union of range class and unicode property in lazy quantifier does 
         "\ufe0f\u20e34\ufe0f\u20e34",
     ]);
 });
+
+test("mixed character class in lazy quantifier does not hit backtrack limit", () => {
+    let str =
+        "PYzJdxPYzJdxPYzJdx\t\ud83e\udd84\ud83c\udf0a\ud83d\udd25\t\u304b\u0330\u030a\u0307\t  \n\u65e5\u0332\u0300\u0304\ud83d\udc69\u200d\ud83c\udfa8\ud83d\udc68\u200d\ud83d\udd2c \n\u0433\u0306\u0305\u030b\ue0f9\n\u000b\t ;\n\f\n\u000b\n'+[-\ud83d\udc0d\ud83d\udc0d\ud83d\udc0d\ud83d\udc0d-\u3044\u0306\u0305-\ue567\u08fb\udfeb\ud814\udca0\ud814\udc9d";
+    expect(() =>
+        str.match(/[\x57-\x6cæ\0\SA-M\xa5]*?.{2}\uec19|(?<g1>(?<!\k<g1>))^Q+?\1🍕{0,}|(?<!\k<g1>)\d+?\u{f9bf5}/is)
+    ).not.toThrow();
+    expect(
+        str.match(/[\x57-\x6cæ\0\SA-M\xa5]*?.{2}\uec19|(?<g1>(?<!\k<g1>))^Q+?\1🍕{0,}|(?<!\k<g1>)\d+?\u{f9bf5}/is)
+    ).toBeNull();
+});


### PR DESCRIPTION
First 5 commits are random fixes.

And I noticed that we hit backtracking limits in `v` mode pretty easily because we use lookarounds for quantifiers. I tried to fix this in last two commits by extending the GreedyLoop/LazyLoop emission to cover `v` mode quantified classes. Seems to work for tests that I generate with my hacky fuzzer, but this can definitely be improved to cover even more cases. 