### PR TITLE
LibWeb: Some more small prepatory changes for removing IDL #imports and resolving namespaces

### DIFF
--- a/Libraries/LibIDL/Types.cpp
+++ b/Libraries/LibIDL/Types.cpp
@@ -52,21 +52,6 @@ Module* Context::find_parsed_module(ByteString const& module_path)
     return nullptr;
 }
 
-static Optional<Interface const&> find_imported_interface(Vector<Module&> const& imported_modules, ByteString const& name)
-{
-    for (auto const& module : imported_modules) {
-        if (module.interface.has_value() && module.interface->name == name)
-            return module.interface.value();
-    }
-
-    return {};
-}
-
-Optional<Interface const&> find_imported_interface(Interface const& interface, ByteString const& name)
-{
-    return find_imported_interface(interface.imported_modules, name);
-}
-
 ParameterizedType const& Type::as_parameterized() const
 {
     return as<ParameterizedType const>(*this);
@@ -246,7 +231,7 @@ bool Type::is_distinguishable_from(IDL::Interface const& interface, IDL::Type co
 }
 
 // https://webidl.spec.whatwg.org/#dfn-json-types
-bool Type::is_json(Interface const& interface) const
+bool Type::is_json(Context const& context) const
 {
     // The JSON types are:
     // - numeric types,
@@ -258,7 +243,7 @@ bool Type::is_json(Interface const& interface) const
         return true;
 
     // - string types,
-    if (is_string() || interface.context.enumerations.find(m_name) != interface.context.enumerations.end())
+    if (is_string() || context.enumerations.contains(m_name))
         return true;
 
     // - object,
@@ -274,7 +259,7 @@ bool Type::is_json(Interface const& interface) const
         auto const& union_type = as_union();
 
         for (auto const& type : union_type.member_types()) {
-            if (!type->is_json(interface))
+            if (!type->is_json(context))
                 return false;
         }
 
@@ -282,9 +267,9 @@ bool Type::is_json(Interface const& interface) const
     }
 
     // - typedefs whose type being given a new name is a JSON type,
-    auto typedef_iterator = interface.context.typedefs.find(m_name);
-    if (typedef_iterator != interface.context.typedefs.end())
-        return typedef_iterator->value.type->is_json(interface);
+    auto typedef_iterator = context.typedefs.find(m_name);
+    if (typedef_iterator != context.typedefs.end())
+        return typedef_iterator->value.type->is_json(context);
 
     // - sequence types whose parameterized type is a JSON type,
     // - frozen array types whose parameterized type is a JSON type,
@@ -293,7 +278,7 @@ bool Type::is_json(Interface const& interface) const
         auto const& parameterized_type = as_parameterized();
 
         for (auto const& parameter : parameterized_type.parameters()) {
-            if (!parameter->is_json(interface))
+            if (!parameter->is_json(context))
                 return false;
         }
 
@@ -301,11 +286,11 @@ bool Type::is_json(Interface const& interface) const
     }
 
     // - dictionary types where the types of all members declared on the dictionary and all its inherited dictionaries are JSON types,
-    auto dictionary_iterator = interface.context.dictionaries.find(m_name);
-    if (dictionary_iterator != interface.context.dictionaries.end()) {
+    auto dictionary_iterator = context.dictionaries.find(m_name);
+    if (dictionary_iterator != context.dictionaries.end()) {
         auto const& dictionary = dictionary_iterator->value;
         for (auto const& member : dictionary.members) {
-            if (!member.type->is_json(interface))
+            if (!member.type->is_json(context))
                 return false;
         }
 
@@ -313,32 +298,20 @@ bool Type::is_json(Interface const& interface) const
     }
 
     // - interface types that have a toJSON operation declared on themselves or one of their inherited interfaces.
-    Optional<Interface const&> current_interface_for_to_json;
-    if (m_name == interface.name) {
-        current_interface_for_to_json = interface;
-    } else {
-        // NOTE: Interface types must have the IDL file of their interface imported.
-        //       Though the type name may not refer to an interface, so we don't assert this here.
-        current_interface_for_to_json = find_imported_interface(interface, m_name);
-    }
-
-    while (current_interface_for_to_json.has_value()) {
-        auto to_json_iterator = current_interface_for_to_json->functions.find_if([](IDL::Function const& function) {
+    auto current_interface = context.interfaces.get(m_name);
+    while (current_interface.has_value()) {
+        auto to_json_iterator = current_interface.value()->functions.find_if([](IDL::Function const& function) {
             return function.name == "toJSON"sv;
         });
 
-        if (to_json_iterator != current_interface_for_to_json->functions.end())
+        if (to_json_iterator != current_interface.value()->functions.end())
             return true;
 
-        if (current_interface_for_to_json->parent_name.is_empty())
+        if (current_interface.value()->parent_name.is_empty())
             break;
 
-        auto imported_interface = find_imported_interface(*current_interface_for_to_json, current_interface_for_to_json->parent_name);
-
-        // Inherited interfaces must have their IDL files imported.
-        VERIFY(imported_interface.has_value());
-
-        current_interface_for_to_json = imported_interface.release_value();
+        current_interface = context.interfaces.get(current_interface.value()->parent_name);
+        VERIFY(current_interface.has_value());
     }
 
     return false;

--- a/Libraries/LibIDL/Types.h
+++ b/Libraries/LibIDL/Types.h
@@ -137,7 +137,7 @@ public:
     // https://webidl.spec.whatwg.org/#dfn-distinguishable
     bool is_distinguishable_from(Interface const&, Type const& other) const;
 
-    bool is_json(Interface const&) const;
+    bool is_json(Context const&) const;
 
     bool is_restricted_floating_point() const { return m_name.is_one_of("float", "double"); }
     bool is_unrestricted_floating_point() const { return m_name.is_one_of("unrestricted float", "unrestricted double"); }
@@ -458,8 +458,6 @@ public:
 
     Vector<NonnullOwnPtr<Module>> owned_modules;
 };
-
-Optional<Interface const&> find_imported_interface(Interface const&, ByteString const& name);
 
 // https://webidl.spec.whatwg.org/#dfn-optionality-value
 enum class Optionality {

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -189,7 +189,7 @@ static WebIDL::ExceptionOr<::Crypto::Certificate::PrivateKey> parse_a_private_ke
     return parse_an_ASN1_structure<::Crypto::Certificate::PrivateKey>(realm, bytes, true);
 }
 
-static WebIDL::ExceptionOr<::Crypto::PK::RSAPrivateKey> parse_jwk_rsa_private_key(JS::Realm& realm, Bindings::JsonWebKey const& jwk)
+static WebIDL::ExceptionOr<::Crypto::PK::RSAPrivateKey> parse_jwk_rsa_private_key(JS::Realm& realm, JsonWebKey const& jwk)
 {
     auto n = TRY(base64_url_uint_decode(realm, *jwk.n));
     auto d = TRY(base64_url_uint_decode(realm, *jwk.d));
@@ -208,7 +208,7 @@ static WebIDL::ExceptionOr<::Crypto::PK::RSAPrivateKey> parse_jwk_rsa_private_ke
     return ::Crypto::PK::RSAPrivateKey(move(n), move(d), move(e), move(p), move(q), move(dp), move(dq), move(qi));
 }
 
-static WebIDL::ExceptionOr<::Crypto::PK::RSAPublicKey> parse_jwk_rsa_public_key(JS::Realm& realm, Bindings::JsonWebKey const& jwk)
+static WebIDL::ExceptionOr<::Crypto::PK::RSAPublicKey> parse_jwk_rsa_public_key(JS::Realm& realm, JsonWebKey const& jwk)
 {
     auto e = TRY(base64_url_uint_decode(realm, *jwk.e));
     auto n = TRY(base64_url_uint_decode(realm, *jwk.n));
@@ -216,7 +216,7 @@ static WebIDL::ExceptionOr<::Crypto::PK::RSAPublicKey> parse_jwk_rsa_public_key(
     return ::Crypto::PK::RSAPublicKey(move(n), move(e));
 }
 
-static WebIDL::ExceptionOr<ByteBuffer> parse_jwk_symmetric_key(JS::Realm& realm, Bindings::JsonWebKey const& jwk)
+static WebIDL::ExceptionOr<ByteBuffer> parse_jwk_symmetric_key(JS::Realm& realm, JsonWebKey const& jwk)
 {
     if (!jwk.k.has_value()) {
         return WebIDL::DataError::create(realm, "JWK has no 'k' field"_utf16);
@@ -225,7 +225,7 @@ static WebIDL::ExceptionOr<ByteBuffer> parse_jwk_symmetric_key(JS::Realm& realm,
 }
 
 // https://www.rfc-editor.org/rfc/rfc7517#section-4.3
-static WebIDL::ExceptionOr<void> validate_jwk_key_ops(JS::Realm& realm, Bindings::JsonWebKey const& jwk, Vector<Bindings::KeyUsage> const& usages)
+static WebIDL::ExceptionOr<void> validate_jwk_key_ops(JS::Realm& realm, JsonWebKey const& jwk, Vector<Bindings::KeyUsage> const& usages)
 {
     // Use of the "key_ops" member is OPTIONAL, unless the application requires its presence.
     if (!jwk.key_ops.has_value())
@@ -1030,9 +1030,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> RSAOAEP::import_key(Web::Crypto::Algorit
         //         Let jwk equal keyData.
         //    -> Otherwise:
         //         Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field of jwk is present and usages contains an entry which is not "decrypt" or "unwrapKey", then throw a SyntaxError.
         if (jwk.d.has_value()) {
@@ -1270,7 +1270,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> RSAOAEP::export_key(Bindings::KeyFormat
     // If format is "jwk"
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "RSA".
         jwk.kty = "RSA"_string;
@@ -1613,9 +1613,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> RSAPSS::import_key(AlgorithmParams const
         //         Let jwk equal keyData.
         //    -> Otherwise:
         //         Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field of jwk is present and usages contains an entry which is not "sign", or,
         //    if the d field of jwk is not present and usages contains an entry which is not "verify"
@@ -1852,7 +1852,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> RSAPSS::export_key(Bindings::KeyFormat 
     // If format is "jwk"
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "RSA".
         jwk.kty = "RSA"_string;
@@ -2190,9 +2190,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> RSASSAPKCS1::import_key(AlgorithmParams 
         //         Let jwk equal keyData.
         //    -> Otherwise:
         //         Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field of jwk is present and usages contains an entry which is not "sign", or,
         //    if the d field of jwk is not present and usages contains an entry which is not "verify"
@@ -2429,7 +2429,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> RSASSAPKCS1::export_key(Bindings::KeyFo
     // If format is "jwk"
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "RSA".
         jwk.kty = "RSA"_string;
@@ -2593,9 +2593,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> AesCbc::import_key(AlgorithmParams const
         //                Let jwk equal keyData.
         //       ->   Otherwise:
         //                Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         //    2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"_string)
@@ -2748,7 +2748,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> AesCbc::export_key(Bindings::KeyFormat 
     //    -> If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -2841,10 +2841,10 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> AesCtr::import_key(AlgorithmParams const
         //         Let jwk equal keyData.
         //    -> Otherwise:
         //         Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
 
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"_string)
@@ -2950,7 +2950,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> AesCtr::export_key(Bindings::KeyFormat 
     // 2. If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -3161,10 +3161,10 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> AesGcm::import_key(AlgorithmParams const
         //         Let jwk equal keyData.
         //    -> Otherwise:
         //         Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
 
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"_string)
@@ -3270,7 +3270,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> AesGcm::export_key(Bindings::KeyFormat 
     // 2. If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -3511,10 +3511,10 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> AesKw::import_key(AlgorithmParams const&
         //         Let jwk equal keyData.
         //    -> Otherwise:
         //         Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
 
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"_string)
@@ -3618,7 +3618,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> AesKw::export_key(Bindings::KeyFormat f
     // 2. If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -4364,9 +4364,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ECDSA::import_key(AlgorithmParams const&
     else if (key_format == Bindings::KeyFormat::Jwk) {
         // 1. If keyData is a JsonWebKey dictionary: Let jwk equal keyData.
         //    Otherwise: Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field is present and usages contains a value which is not "sign", or,
         //    if the d field is not present and usages contains a value which is not "verify" then throw a SyntaxError.
@@ -4757,7 +4757,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ECDSA::export_key(Bindings::KeyFormat f
     // 3. If format is "jwt":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to "EC".
         jwk.kty = "EC"_string;
@@ -5350,9 +5350,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ECDH::import_key(AlgorithmParams const& 
     else if (key_format == Bindings::KeyFormat::Jwk) {
         // 1. If keyData is a JsonWebKey dictionary: Let jwk equal keyData.
         //    Otherwise: Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field is present and if usages contains an entry which is not "deriveKey" or "deriveBits" then throw a SyntaxError.
         if (jwk.d.has_value() && !usages.is_empty()) {
@@ -5703,7 +5703,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ECDH::export_key(Bindings::KeyFormat fo
     // 3. If format is "jwt":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to "EC".
         jwk.kty = "EC"_string;
@@ -6022,9 +6022,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ED25519::import_key(
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. If keyData is a JsonWebKey dictionary: Let jwk equal keyData.
         //    Otherwise: Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field is present and usages contains a value which is not "sign",
         //    or, if the d field is not present and usages contains a value which is not "verify" then throw a SyntaxError.
@@ -6241,7 +6241,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ED25519::export_key(Bindings::KeyFormat
     // 2. If format is "jwk":
     if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk;
+        JsonWebKey jwk;
 
         // 2. Set the kty attribute of jwk to "OKP".
         jwk.kty = "OKP"_string;
@@ -6532,9 +6532,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ED448::import_key(
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. If keyData is a JsonWebKey dictionary: Let jwk equal keyData.
         //    Otherwise: Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field is present and usages contains a value which is not "sign",
         //    or, if the d field is not present and usages contains a value which is not "verify" then throw a SyntaxError.
@@ -6751,7 +6751,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ED448::export_key(Bindings::KeyFormat f
     // 2. If format is "jwk":
     if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk;
+        JsonWebKey jwk;
 
         // 2. Set the kty attribute of jwk to "OKP".
         jwk.kty = "OKP"_string;
@@ -7273,9 +7273,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> X25519::import_key([[maybe_unused]] Web:
     else if (key_format == Bindings::KeyFormat::Jwk) {
         // 1. If keyData is a JsonWebKey dictionary: Let jwk equal keyData.
         //    Otherwise: Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field is present and if usages contains an entry which is not "deriveKey" or "deriveBits" then throw a SyntaxError.
         if (jwk.d.has_value() && !usages.is_empty()) {
@@ -7482,7 +7482,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> X25519::export_key(Bindings::KeyFormat 
     // 3. If format is "jwt":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionar1y.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to "OKP".
         jwk.kty = "OKP"_string;
@@ -7733,7 +7733,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> X448::export_key(Bindings::KeyFormat fo
     // 3. If format is "jwk":
     if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to "OKP".
         jwk.kty = "OKP"_string;
@@ -7888,9 +7888,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> X448::import_key(
         //    Let jwk equal keyData.
         //    Otherwise:
         //    Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "Data is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the d field is present and if usages contains an entry which is not "deriveKey" or "deriveBits" then throw a SyntaxError.
         if (jwk.d.has_value()) {
@@ -8216,9 +8216,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> HMAC::import_key(Web::Crypto::AlgorithmP
         //    Let jwk equal keyData.
         //    Otherwise:
         //    Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "Data is not a JsonWebKey dictionary"_utf16);
-        auto& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"sv)
@@ -8366,7 +8366,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> HMAC::export_key(Bindings::KeyFormat fo
     // If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk {};
+        JsonWebKey jwk {};
 
         // Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -8827,7 +8827,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> MLDSA::import_key(AlgorithmParams const&
         //        Let jwk equal keyData.
         //     => Otherwise:
         //        Throw a DataError.
-        auto* const jwk = key_data.get_pointer<Bindings::JsonWebKey>();
+        auto* const jwk = key_data.get_pointer<JsonWebKey>();
 
         if (!jwk)
             return WebIDL::DataError::create(m_realm, "Data is not a JsonWebKey dictionary"_utf16);
@@ -9055,7 +9055,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> MLDSA::export_key(Bindings::KeyFormat f
     //   -> If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        auto jwk = Bindings::JsonWebKey {};
+        auto jwk = JsonWebKey {};
 
         // 2. Set the kty attribute of jwk to "AKP".
         jwk.kty = "AKP"_string;
@@ -9968,10 +9968,10 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ChaCha20Poly1305::import_key(AlgorithmPa
         //        Let jwk equal keyData.
         //    Otherwise:
         //        Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "Invalid JWK key data"_utf16);
 
-        auto const& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto const& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"_string)
@@ -10045,7 +10045,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ChaCha20Poly1305::export_key(Bindings::
     // 2. If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -10274,10 +10274,10 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> AesOcb::import_key(AlgorithmParams const
         //        Let jwk equal keyData.
         //    Otherwise:
         //        Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "Invalid JWK key data"_utf16);
 
-        auto const& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto const& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"_string)
@@ -10376,7 +10376,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> AesOcb::export_key(Bindings::KeyFormat 
     // 2. If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;
@@ -10611,10 +10611,10 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> KMAC::import_key(AlgorithmParams const& 
         //        Let jwk equal keyData.
         //    Otherwise:
         //        Throw a DataError.
-        if (!key_data.has<Bindings::JsonWebKey>())
+        if (!key_data.has<JsonWebKey>())
             return WebIDL::DataError::create(m_realm, "Data is not a JsonWebKey dictionary"_utf16);
 
-        auto const& jwk = key_data.get<Bindings::JsonWebKey>();
+        auto const& jwk = key_data.get<JsonWebKey>();
 
         // 2. If the kty field of jwk is not "oct", then throw a DataError.
         if (jwk.kty != "oct"sv)
@@ -10720,7 +10720,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> KMAC::export_key(Bindings::KeyFormat fo
     // 2. If format is "jwk":
     else if (format == Bindings::KeyFormat::Jwk) {
         // 1. Let jwk be a new JsonWebKey dictionary.
-        Bindings::JsonWebKey jwk = {};
+        JsonWebKey jwk = {};
 
         // 2. Set the kty attribute of jwk to the string "oct".
         jwk.kty = "oct"_string;

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -24,7 +24,7 @@ namespace Web::Crypto {
 
 using AlgorithmIdentifier = Variant<GC::Root<JS::Object>, String>;
 using NamedCurve = String;
-using KeyDataType = Variant<GC::Root<WebIDL::BufferSource>, Bindings::JsonWebKey>;
+using KeyDataType = Variant<GC::Root<WebIDL::BufferSource>, JsonWebKey>;
 
 // https://wicg.github.io/webcrypto-modern-algos/#encapsulation
 struct EncapsulatedKey {

--- a/Libraries/LibWeb/Crypto/CryptoBindings.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoBindings.cpp
@@ -13,7 +13,7 @@
 #include <LibWeb/Crypto/CryptoBindings.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
-namespace Web::Bindings {
+namespace Web::Crypto {
 
 #define JWK_PARSE_STRING_PROPERTY(name)                                      \
     if (auto value = json_object.get_string(#name##sv); value.has_value()) { \

--- a/Libraries/LibWeb/Crypto/CryptoBindings.h
+++ b/Libraries/LibWeb/Crypto/CryptoBindings.h
@@ -13,7 +13,7 @@
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 
 // FIXME: Generate these from IDL
-namespace Web::Bindings {
+namespace Web::Crypto {
 
 // https://w3c.github.io/webcrypto/#JsonWebKey-dictionary
 struct RsaOtherPrimesInfo {

--- a/Libraries/LibWeb/Crypto/CryptoKey.h
+++ b/Libraries/LibWeb/Crypto/CryptoKey.h
@@ -27,7 +27,7 @@ class CryptoKey final
     GC_DECLARE_ALLOCATOR(CryptoKey);
 
 public:
-    using InternalKeyData = Variant<ByteBuffer, Bindings::JsonWebKey, ::Crypto::PK::RSAPublicKey, ::Crypto::PK::RSAPrivateKey, ::Crypto::PK::ECPublicKey, ::Crypto::PK::ECPrivateKey, ::Crypto::PK::MLDSAPublicKey, ::Crypto::PK::MLDSAPrivateKey, ::Crypto::PK::MLKEMPublicKey, ::Crypto::PK::MLKEMPrivateKey>;
+    using InternalKeyData = Variant<ByteBuffer, JsonWebKey, ::Crypto::PK::RSAPublicKey, ::Crypto::PK::RSAPrivateKey, ::Crypto::PK::ECPublicKey, ::Crypto::PK::ECPrivateKey, ::Crypto::PK::MLDSAPublicKey, ::Crypto::PK::MLDSAPrivateKey, ::Crypto::PK::MLKEMPublicKey, ::Crypto::PK::MLKEMPrivateKey>;
 
     static constexpr bool OVERRIDES_FINALIZE = true;
 

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -416,7 +416,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Binding
     // 1. Let format, algorithm, extractable and usages, be the format, algorithm, extractable
     // and key_usages parameters passed to the importKey() method, respectively.
 
-    Variant<ByteBuffer, Bindings::JsonWebKey, Empty> real_key_data;
+    Variant<ByteBuffer, JsonWebKey, Empty> real_key_data;
     // 2. If format is equal to the string "raw", "pkcs8", or "spki":
     if (format == Bindings::KeyFormat::Raw
         || format == Bindings::KeyFormat::RawPublic
@@ -426,7 +426,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Binding
         || format == Bindings::KeyFormat::Pkcs8
         || format == Bindings::KeyFormat::Spki) {
         // 1. If the keyData parameter passed to the importKey() method is a JsonWebKey dictionary, throw a TypeError.
-        if (key_data.has<Bindings::JsonWebKey>()) {
+        if (key_data.has<JsonWebKey>()) {
             return realm.vm().throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
         }
 
@@ -436,12 +436,12 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Binding
 
     if (format == Bindings::KeyFormat::Jwk) {
         // 1. If the keyData parameter passed to the importKey() method is not a JsonWebKey dictionary, throw a TypeError.
-        if (!key_data.has<Bindings::JsonWebKey>()) {
+        if (!key_data.has<JsonWebKey>()) {
             return realm.vm().throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "JsonWebKey");
         }
 
         // 2. Let keyData be the keyData parameter passed to the importKey() method.
-        real_key_data = key_data.get<Bindings::JsonWebKey>();
+        real_key_data = key_data.get<JsonWebKey>();
     }
 
     // NOTE: The spec jumps to 5 here for some reason?
@@ -1091,12 +1091,12 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::unwrap_key(Bindings::KeyFormat format, Ke
 
         auto bytes = bytes_or_error.release_value();
 
-        Variant<ByteBuffer, Bindings::JsonWebKey, Empty> key;
+        Variant<ByteBuffer, JsonWebKey, Empty> key;
 
         // 15. If format is equal to the string "jwk":
         if (format == Bindings::KeyFormat::Jwk) {
             // Let key be the result of executing the parse a JWK algorithm, with bytes as the data to be parsed.
-            auto maybe_parsed = Bindings::JsonWebKey::parse(realm, bytes->buffer());
+            auto maybe_parsed = JsonWebKey::parse(realm, bytes->buffer());
             if (maybe_parsed.is_error()) {
                 WebIDL::reject_promise(realm, promise, maybe_parsed.release_error().release_value());
                 return;

--- a/Libraries/LibWeb/EncryptedMediaExtensions/Algorithms.cpp
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/Algorithms.cpp
@@ -16,13 +16,13 @@ bool supports_container([[maybe_unused]] Utf16String const& container)
 }
 
 // https://w3c.github.io/encrypted-media/#get-supported-capabilities-for-audio-video-type
-Optional<Vector<Bindings::MediaKeySystemMediaCapability>> get_supported_capabilities_for_audio_video_type(KeySystem const& implementation, CapabilitiesType type, Vector<Bindings::MediaKeySystemMediaCapability> requested_capabilities, Bindings::MediaKeySystemConfiguration config, MediaKeyRestrictions restrictions)
+Optional<Vector<MediaKeySystemMediaCapability>> get_supported_capabilities_for_audio_video_type(KeySystem const& implementation, CapabilitiesType type, Vector<MediaKeySystemMediaCapability> requested_capabilities, MediaKeySystemConfiguration config, MediaKeyRestrictions restrictions)
 {
     // 1. Let local accumulated configuration be a local copy of accumulated configuration.
-    Bindings::MediaKeySystemConfiguration accumulated_configuration = config;
+    MediaKeySystemConfiguration accumulated_configuration = config;
 
     // 2. Let supported media capabilities be an empty sequence of MediaKeySystemMediaCapability dictionaries.
-    Vector<Bindings::MediaKeySystemMediaCapability> supported_media_capabilities;
+    Vector<MediaKeySystemMediaCapability> supported_media_capabilities;
 
     // 3. For each requested media capability in requested media capabilities:
     for (auto& capability : requested_capabilities) {
@@ -143,7 +143,7 @@ bool is_persistent_session_type(Utf16String const& session_type)
 }
 
 // https://w3c.github.io/encrypted-media/#get-consent-status
-ConsentStatus get_consent_status(Bindings::MediaKeySystemConfiguration const& accumulated_configuration, MediaKeyRestrictions& restrictions, URL::Origin const& origin)
+ConsentStatus get_consent_status(MediaKeySystemConfiguration const& accumulated_configuration, MediaKeyRestrictions& restrictions, URL::Origin const& origin)
 {
     // FIXME: Implement this
     (void)accumulated_configuration;
@@ -156,10 +156,10 @@ ConsentStatus get_consent_status(Bindings::MediaKeySystemConfiguration const& ac
 }
 
 // https://w3c.github.io/encrypted-media/#get-supported-configuration-and-consent
-Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem const& implementation, Bindings::MediaKeySystemConfiguration const& candidate_configuration, MediaKeyRestrictions& restrictions, URL::Origin const& origin)
+Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem const& implementation, MediaKeySystemConfiguration const& candidate_configuration, MediaKeyRestrictions& restrictions, URL::Origin const& origin)
 {
     // 1. Let accumulated configuration be a new MediaKeySystemConfiguration dictionary.
-    Bindings::MediaKeySystemConfiguration accumulated_configuration;
+    MediaKeySystemConfiguration accumulated_configuration;
 
     // 2. Set the label member of accumulated configuration to equal the label member of candidate configuration.
     accumulated_configuration.label = candidate_configuration.label;
@@ -293,7 +293,7 @@ Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem
     // Otherwise:
     else {
         // 1. Set the videoCapabilities member of accumulated configuration to an empty sequence.
-        accumulated_configuration.video_capabilities = Vector<Bindings::MediaKeySystemMediaCapability> {};
+        accumulated_configuration.video_capabilities = Vector<MediaKeySystemMediaCapability> {};
     }
 
     // 1. If the audioCapabilities member in candidate configuration is non-empty:
@@ -312,7 +312,7 @@ Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem
     // Otherwise:
     else {
         // 1. Set the audioCapabilities member of accumulated configuration to an empty sequence.
-        accumulated_configuration.audio_capabilities = Vector<Bindings::MediaKeySystemMediaCapability> {};
+        accumulated_configuration.audio_capabilities = Vector<MediaKeySystemMediaCapability> {};
     }
 
     // 18. If accumulated configuration's distinctiveIdentifier value is "optional", follow the steps for the first matching condition from the following list:
@@ -373,7 +373,7 @@ Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem
 }
 
 // https://w3c.github.io/encrypted-media/#get-supported-configuration
-Optional<ConsentConfiguration> get_supported_configuration(KeySystem const& implementation, Bindings::MediaKeySystemConfiguration const& candidate_configuration, URL::Origin const& origin)
+Optional<ConsentConfiguration> get_supported_configuration(KeySystem const& implementation, MediaKeySystemConfiguration const& candidate_configuration, URL::Origin const& origin)
 {
     // 1. Let supported configuration be ConsentDenied.
     Optional<ConsentConfiguration> supported_configuration = ConsentConfiguration { ConsentStatus::ConsentDenied, {} };

--- a/Libraries/LibWeb/EncryptedMediaExtensions/Algorithms.h
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/Algorithms.h
@@ -19,9 +19,9 @@ bool supports_container(Utf16String const& container);
 bool is_persistent_session_type(Utf16String const& session_type);
 bool is_supported_key_system(Utf16String const& key_system);
 NonnullOwnPtr<KeySystem> key_system_from_string(Utf16String const& key_system);
-ConsentStatus get_consent_status(Bindings::MediaKeySystemConfiguration const&, MediaKeyRestrictions&, URL::Origin const&);
-Optional<Vector<Bindings::MediaKeySystemMediaCapability>> get_supported_capabilities_for_audio_video_type(KeySystem const&, CapabilitiesType, Vector<Bindings::MediaKeySystemMediaCapability>, Bindings::MediaKeySystemConfiguration, MediaKeyRestrictions);
-Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem const&, Bindings::MediaKeySystemConfiguration const&, MediaKeyRestrictions&, URL::Origin const&);
-Optional<ConsentConfiguration> get_supported_configuration(KeySystem const&, Bindings::MediaKeySystemConfiguration const&, URL::Origin const&);
+ConsentStatus get_consent_status(MediaKeySystemConfiguration const&, MediaKeyRestrictions&, URL::Origin const&);
+Optional<Vector<MediaKeySystemMediaCapability>> get_supported_capabilities_for_audio_video_type(KeySystem const&, CapabilitiesType, Vector<MediaKeySystemMediaCapability>, MediaKeySystemConfiguration, MediaKeyRestrictions);
+Optional<ConsentConfiguration> get_supported_configuration_and_consent(KeySystem const&, MediaKeySystemConfiguration const&, MediaKeyRestrictions&, URL::Origin const&);
+Optional<ConsentConfiguration> get_supported_configuration(KeySystem const&, MediaKeySystemConfiguration const&, URL::Origin const&);
 
 }

--- a/Libraries/LibWeb/EncryptedMediaExtensions/EncryptedMediaExtensions.h
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/EncryptedMediaExtensions.h
@@ -10,7 +10,7 @@
 #include <AK/Types.h>
 #include <LibWeb/Bindings/MediaKeySystemAccess.h>
 
-namespace Web::Bindings {
+namespace Web::EncryptedMediaExtensions {
 
 // https://w3c.github.io/encrypted-media/#dom-mediakeysystemmediacapability
 struct MediaKeySystemMediaCapability {
@@ -30,10 +30,6 @@ struct MediaKeySystemConfiguration {
     Optional<Vector<Utf16String>> session_types;
 };
 
-}
-
-namespace Web::EncryptedMediaExtensions {
-
 struct MediaKeyRestrictions {
     bool distinctive_identifiers { true };
     bool persist_state { true };
@@ -52,7 +48,7 @@ enum ConsentStatus {
 
 struct ConsentConfiguration {
     ConsentStatus status { ConsentStatus::ConsentDenied };
-    Optional<Bindings::MediaKeySystemConfiguration> configuration;
+    Optional<MediaKeySystemConfiguration> configuration;
 };
 
 }

--- a/Libraries/LibWeb/EncryptedMediaExtensions/KeySystem.h
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/KeySystem.h
@@ -18,7 +18,7 @@ public:
     virtual bool supports_init_data_type(Utf16String const& init_data_type) const = 0;
     virtual bool supports_encryption_scheme(Utf16String const& encryption_scheme) const = 0;
     virtual bool supports_robustness(Utf16String const& robustness) const = 0;
-    virtual bool definitely_supports_playback(Utf16String const& container, Utf16String const& media_types, Optional<Utf16String> encryption_scheme, Utf16String const& robustness, Bindings::MediaKeySystemConfiguration const& accumulated_configuration, MediaKeyRestrictions const& restrictions) const = 0;
+    virtual bool definitely_supports_playback(Utf16String const& container, Utf16String const& media_types, Optional<Utf16String> encryption_scheme, Utf16String const& robustness, MediaKeySystemConfiguration const& accumulated_configuration, MediaKeyRestrictions const& restrictions) const = 0;
 
 private:
 };
@@ -55,7 +55,7 @@ public:
         return robustness.is_empty();
     }
 
-    virtual bool definitely_supports_playback(Utf16String const& container, Utf16String const& media_types, Optional<Utf16String> encryption_scheme, Utf16String const& robustness, Bindings::MediaKeySystemConfiguration const& accumulated_configuration, MediaKeyRestrictions const& restrictions) const override
+    virtual bool definitely_supports_playback(Utf16String const& container, Utf16String const& media_types, Optional<Utf16String> encryption_scheme, Utf16String const& robustness, MediaKeySystemConfiguration const& accumulated_configuration, MediaKeyRestrictions const& restrictions) const override
     {
         (void)container;
         (void)media_types;

--- a/Libraries/LibWeb/EncryptedMediaExtensions/MediaKeySystemAccess.cpp
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/MediaKeySystemAccess.cpp
@@ -14,7 +14,7 @@ GC_DEFINE_ALLOCATOR(MediaKeySystemAccess);
 
 MediaKeySystemAccess::~MediaKeySystemAccess() = default;
 
-MediaKeySystemAccess::MediaKeySystemAccess(JS::Realm& realm, Utf16String const& key_system, Bindings::MediaKeySystemConfiguration configuration, NonnullOwnPtr<KeySystem> cdm_implementation)
+MediaKeySystemAccess::MediaKeySystemAccess(JS::Realm& realm, Utf16String const& key_system, MediaKeySystemConfiguration configuration, NonnullOwnPtr<KeySystem> cdm_implementation)
     : PlatformObject(realm)
     , m_key_system(key_system)
     , m_configuration(move(configuration))
@@ -22,7 +22,7 @@ MediaKeySystemAccess::MediaKeySystemAccess(JS::Realm& realm, Utf16String const& 
 {
 }
 
-GC::Ref<MediaKeySystemAccess> MediaKeySystemAccess::create(JS::Realm& realm, Utf16String const& key_system, Bindings::MediaKeySystemConfiguration configuration, NonnullOwnPtr<KeySystem> cdm_implementation)
+GC::Ref<MediaKeySystemAccess> MediaKeySystemAccess::create(JS::Realm& realm, Utf16String const& key_system, MediaKeySystemConfiguration configuration, NonnullOwnPtr<KeySystem> cdm_implementation)
 {
     return realm.create<MediaKeySystemAccess>(realm, key_system, configuration, move(cdm_implementation));
 }

--- a/Libraries/LibWeb/EncryptedMediaExtensions/MediaKeySystemAccess.h
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/MediaKeySystemAccess.h
@@ -21,19 +21,19 @@ class MediaKeySystemAccess : public Bindings::PlatformObject {
 
 public:
     virtual ~MediaKeySystemAccess() override;
-    [[nodiscard]] static GC::Ref<MediaKeySystemAccess> create(JS::Realm&, Utf16String const&, Bindings::MediaKeySystemConfiguration, NonnullOwnPtr<KeySystem>);
+    [[nodiscard]] static GC::Ref<MediaKeySystemAccess> create(JS::Realm&, Utf16String const&, MediaKeySystemConfiguration, NonnullOwnPtr<KeySystem>);
 
     [[nodiscard]] Utf16String key_system() const { return m_key_system; }
-    [[nodiscard]] Bindings::MediaKeySystemConfiguration get_configuration() const { return m_configuration; }
+    [[nodiscard]] MediaKeySystemConfiguration get_configuration() const { return m_configuration; }
 
 protected:
-    explicit MediaKeySystemAccess(JS::Realm&, Utf16String const&, Bindings::MediaKeySystemConfiguration, NonnullOwnPtr<KeySystem>);
+    explicit MediaKeySystemAccess(JS::Realm&, Utf16String const&, MediaKeySystemConfiguration, NonnullOwnPtr<KeySystem>);
     virtual void initialize(JS::Realm&) override;
 
 private:
     Utf16String m_key_system;
 
-    Bindings::MediaKeySystemConfiguration m_configuration;
+    MediaKeySystemConfiguration m_configuration;
     NonnullOwnPtr<KeySystem> m_cdm_implementation;
 };
 

--- a/Libraries/LibWeb/EncryptedMediaExtensions/NavigatorEncryptedMediaExtensionsPartial.cpp
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/NavigatorEncryptedMediaExtensionsPartial.cpp
@@ -16,7 +16,7 @@
 namespace Web::EncryptedMediaExtensions {
 
 // https://w3c.github.io/encrypted-media/#dom-navigator-requestmediakeysystemaccess
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> NavigatorEncryptedMediaExtensionsPartial::request_media_key_system_access(Utf16String key_system, Vector<Bindings::MediaKeySystemConfiguration> supported_configurations)
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> NavigatorEncryptedMediaExtensionsPartial::request_media_key_system_access(Utf16String key_system, Vector<MediaKeySystemConfiguration> supported_configurations)
 {
     auto& navigator = as<HTML::Navigator>(*this);
     auto& realm = navigator.realm();

--- a/Libraries/LibWeb/EncryptedMediaExtensions/NavigatorEncryptedMediaExtensionsPartial.h
+++ b/Libraries/LibWeb/EncryptedMediaExtensions/NavigatorEncryptedMediaExtensionsPartial.h
@@ -15,7 +15,7 @@ namespace Web::EncryptedMediaExtensions {
 
 class NavigatorEncryptedMediaExtensionsPartial {
 public:
-    WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> request_media_key_system_access(Utf16String, Vector<Bindings::MediaKeySystemConfiguration>);
+    WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> request_media_key_system_access(Utf16String, Vector<MediaKeySystemConfiguration>);
 
 private:
     virtual ~NavigatorEncryptedMediaExtensionsPartial() = default;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3442,7 +3442,7 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
         for (auto& attribute : interface_in_chain.attributes) {
             if (attribute.extended_attributes.contains("FIXME"))
                 continue;
-            if (!attribute.type->is_json(interface_in_chain))
+            if (!attribute.type->is_json(interface_in_chain.context))
                 continue;
 
             auto attribute_generator = generator_for_member(attribute.name, attribute.extended_attributes);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3384,15 +3384,12 @@ static Vector<Interface const&> create_an_inheritance_stack(IDL::Interface const
     auto const* current_interface = &start_interface;
     while (current_interface && !current_interface->parent_name.is_empty()) {
         // 1. Let I be that interface.
-        auto imported_interface = find_imported_interface(start_interface, current_interface->parent_name);
-
-        // Inherited interfaces must have their IDL files imported.
-        VERIFY(imported_interface.has_value());
+        auto inhereted_interface = start_interface.context.interfaces.get(current_interface->parent_name);
+        VERIFY(inhereted_interface.has_value());
 
         // 2. Push I onto stack.
-        inheritance_chain.append(imported_interface.value());
-
-        current_interface = &imported_interface.value();
+        inheritance_chain.append(*inhereted_interface.value());
+        current_interface = inhereted_interface.value();
     }
 
     // 4. Return stack.


### PR DESCRIPTION
The two namespace changes are steps to removing the using namespace hack in generated code by following a common convention, and the context changes are working towards removing the need for IDL imports.