### PR TITLE
Meta: Ignore log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Tests/LibWeb/WPT/metadata
 Tests/LibWeb/WPT/MANIFEST.json
 
 test-dumps
+*.log
 
 # HTTP Test server artifacts from ./Tests/LibWeb/Fixtures/http-test-server.py
 http-test-server.pid.txt


### PR DESCRIPTION
`test-js` and `test-wasm` now create log files. Let's just ignore all log files, as there aren't any in the repository.