### PR TITLE
LibJS: Use the real globalThis value

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -114,7 +114,7 @@ void set_default_global_bindings(Realm& realm)
     global.define_direct_property(vm.names.encodeURIComponent, realm.intrinsics().encode_uri_component_function(), attr);
 
     // 19.1 Value Properties of the Global Object, https://tc39.es/ecma262/#sec-value-properties-of-the-global-object
-    global.define_direct_property(vm.names.globalThis, &global, attr);
+    global.define_direct_property(vm.names.globalThis, &realm.global_environment().global_this_value(), attr);
     global.define_direct_property(vm.names.Infinity, js_infinity(), 0);
     global.define_direct_property(vm.names.NaN, js_nan(), 0);
     global.define_direct_property(vm.names.undefined, js_undefined(), 0);

--- a/Tests/LibWeb/Text/expected/HTML/globalThis-is-WindowProxy.txt
+++ b/Tests/LibWeb/Text/expected/HTML/globalThis-is-WindowProxy.txt
@@ -1,0 +1,9 @@
+globalThis === window: true
+globalThis === self: true
+globalThis === frames: true
+globalThis === this: true
+iframe contentWindow === iframe globalThis: true
+iframe globalThis === iframe self: true
+iframe realm globalThis === window: true
+globalThis !== iframe globalThis: true
+Object.getPrototypeOf(globalThis) === Object.getPrototypeOf(window): true

--- a/Tests/LibWeb/Text/input/HTML/globalThis-is-WindowProxy.html
+++ b/Tests/LibWeb/Text/input/HTML/globalThis-is-WindowProxy.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<iframe id="ifr" srcdoc=""></iframe>
+<script>
+    test(() => {
+        println(`globalThis === window: ${globalThis === window}`);
+        println(`globalThis === self: ${globalThis === self}`);
+        println(`globalThis === frames: ${globalThis === frames}`);
+        println(`globalThis === this: ${globalThis === this}`);
+
+        const iframeWindow = ifr.contentWindow;
+        println(`iframe contentWindow === iframe globalThis: ${iframeWindow === iframeWindow.globalThis}`);
+        println(`iframe globalThis === iframe self: ${iframeWindow.globalThis === iframeWindow.self}`);
+
+        iframeWindow.eval("window.__check = globalThis === window;");
+        println(`iframe realm globalThis === window: ${iframeWindow.__check}`);
+
+        println(`globalThis !== iframe globalThis: ${globalThis !== iframeWindow.globalThis}`);
+
+        println(`Object.getPrototypeOf(globalThis) === Object.getPrototypeOf(window): ${Object.getPrototypeOf(globalThis) === Object.getPrototypeOf(window)}`);
+    });
+</script>


### PR DESCRIPTION
Previously it used `realm.[[GlobalObject]]` instead of `realm.[[GlobalEnv]].[[GlobalThisValue]]`.

In LibWeb, that corresponds to Window and WindowProxy respectively.