### PR TITLE
LibWeb: Implement smooth scroll

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -850,6 +850,7 @@ set(SOURCES
     Page/InputEvent.cpp
     Page/MiddleButtonScrollHandler.cpp
     Page/Page.cpp
+    Page/SmoothScrollHandler.cpp
     Painting/AccumulatedVisualContext.cpp
     Painting/BackgroundPainting.cpp
     Painting/Blending.cpp

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -2243,6 +2243,12 @@ ScrollbarWidth ComputedProperties::scrollbar_width() const
     return keyword_to_scrollbar_width(value.to_keyword()).release_value();
 }
 
+ScrollBehavior ComputedProperties::scroll_behavior() const
+{
+    auto const& value = property(PropertyID::ScrollBehavior);
+    return keyword_to_scroll_behavior(value.to_keyword()).release_value();
+}
+
 Resize ComputedProperties::resize() const
 {
     auto const& value = property(PropertyID::Resize);

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -273,6 +273,7 @@ public:
 
     ScrollbarColorData scrollbar_color(Layout::NodeWithStyle const& layout_node) const;
     ScrollbarWidth scrollbar_width() const;
+    ScrollBehavior scroll_behavior() const;
     Resize resize() const;
 
     static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold, float point_size);

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -935,6 +935,10 @@
     "to-zero",
     "up"
   ],
+  "scroll-behavior": [
+    "auto",
+    "smooth"
+  ],
   "scrollbar-gutter": [
     "auto",
     "stable",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -3839,10 +3839,7 @@
     "affects-layout": false,
     "animation-type": "none",
     "requires-computation": "never",
-    "valid-identifiers": [
-      "auto",
-      "smooth"
-    ]
+    "valid-types": ["scroll-behavior"]
   },
   "scroll-margin": {
     "initial": "0",
@@ -3940,7 +3937,7 @@
     ]
   },
   "scroll-padding": {
-    "initial": "auto",
+    "initial": "0",
     "positional-value-list-shorthand": true,
     "longhands": [
       "scroll-padding-top",

--- a/Libraries/LibWeb/CSS/VisualViewport.cpp
+++ b/Libraries/LibWeb/CSS/VisualViewport.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/Value.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/VisualViewport.h>
 #include <LibWeb/CSS/VisualViewport.h>
@@ -12,6 +13,11 @@
 #include <LibWeb/DOM/EventDispatcher.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/InvalidateDisplayList.h>
+#include <LibWeb/Page/SmoothScrollHandler.h>
+#include <LibWeb/PixelUnits.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::CSS {
 
@@ -146,6 +152,56 @@ WebIDL::CallbackType* VisualViewport::onscrollend()
     return event_handler_attribute(HTML::EventNames::scrollend);
 }
 
+// https://drafts.csswg.org/cssom-view-1/#perform-a-scroll
+GC::Ref<WebIDL::Promise> VisualViewport::perform_scroll_of_visual_viewport_scrolling_box(CSSPixelPoint offset, Bindings::ScrollBehavior scroll_behavior)
+{
+    // 1. Abort any ongoing smooth scroll for box.
+    // 2. Resolve all pending scroll Promises whose scroll container is box.
+    m_document->smooth_scroll_handler()->abort_any_ongoing_visual_viewport_scroll();
+
+    HTML::TemporaryExecutionContext temporary_execution_context { m_document->realm() };
+    // 3. Let scrollPromise be a new Promise.
+    auto scroll_promise = WebIDL::create_promise(m_document->realm());
+
+    // NB: Step 4 happens out of order, as we can start a smooth scroll or perform an instant scroll first.
+
+    // 5. If the user agent honors the scroll-behavior property and one of the following is true:
+    //      - behavior is "auto" and element is not null and its computed value of the scroll-behavior property is smooth, or
+    //      - behavior is smooth
+    //    then perform a smooth scroll of box to position; otherwise, perform an instant scroll of box to position.
+    // NB: Above determination happens in SmoothScrollHandler::resolve_scroll_behavior.
+    scroll_behavior = SmoothScrollHandler::resolve_scroll_behavior(*this, scroll_behavior);
+    if (scroll_behavior == Bindings::ScrollBehavior::Smooth) {
+        // NB: In this branch steps 6 and 7 are handled by SmoothScrollHander.
+        m_document->smooth_scroll_handler()->start_visual_viewport_scroll(scroll_promise, offset);
+    } else {
+        // 6. Wait until either the position has finished updating, or scrollPromise has been resolved.
+        set_offset(offset);
+        // 7. If scrollPromise is still in the pending state:
+        //      FIXME: 1. If the scroll position changed as a result of this call, emit the scrollend event.
+        //      2. Resolve scrollPromise.
+        WebIDL::resolve_promise(m_document->realm(), scroll_promise);
+    }
+
+    // 4. Return scrollPromise, and run the remaining steps in parallel.
+    return scroll_promise;
+}
+
+GC::Ref<WebIDL::Promise> VisualViewport::perform_scroll_of_visual_viewport_scrolling_box_by_delta(CSSPixelPoint delta, Bindings::ScrollBehavior scroll_behavior)
+{
+    CSSPixelPoint target_offset;
+    auto ongoing_visual_viewport_smooth_scroll = m_document->smooth_scroll_handler()->ongoing_visual_viewport_scroll();
+    if (ongoing_visual_viewport_smooth_scroll) {
+        auto ongoing_scroll_target_offset = ongoing_visual_viewport_smooth_scroll->target_offset();
+
+        target_offset = ongoing_scroll_target_offset + delta;
+    } else {
+        target_offset = m_offset + delta;
+    }
+
+    return perform_scroll_of_visual_viewport_scrolling_box(target_offset, scroll_behavior);
+}
+
 Gfx::AffineTransform VisualViewport::transform() const
 {
     Gfx::AffineTransform transform;
@@ -155,8 +211,26 @@ Gfx::AffineTransform VisualViewport::transform() const
     return transform;
 }
 
+void VisualViewport::set_offset(CSSPixelPoint offset)
+{
+    auto did_change = offset != m_offset;
+    m_offset = offset;
+
+    if (did_change) {
+        m_document->set_needs_accumulated_visual_contexts_update(true);
+        m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::Yes);
+    }
+}
+
+void VisualViewport::scroll_by(CSSPixelPoint delta)
+{
+    set_offset(m_offset + delta);
+}
+
 void VisualViewport::zoom(CSSPixelPoint position, double scale_delta)
 {
+    m_document->smooth_scroll_handler()->abort_any_ongoing_visual_viewport_scroll();
+
     static constexpr double MIN_ALLOWED_SCALE = 1.0;
     static constexpr double MAX_ALLOWED_SCALE = 5.0;
     double new_scale = clamp(m_scale * (1 + scale_delta), MIN_ALLOWED_SCALE, MAX_ALLOWED_SCALE);
@@ -173,9 +247,7 @@ void VisualViewport::zoom(CSSPixelPoint position, double scale_delta)
     new_offset = { clamp(new_offset.x(), 0.0f, max_x_offset), clamp(new_offset.y(), 0.0f, max_y_offset) };
 
     m_scale = new_scale;
-    m_offset = (new_offset / m_scale).to_type<CSSPixels>();
-    m_document->set_needs_accumulated_visual_contexts_update(true);
-    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::Yes);
+    set_offset((new_offset / m_scale).to_type<CSSPixels>());
 }
 
 CSSPixelPoint VisualViewport::map_to_layout_viewport(CSSPixelPoint position) const
@@ -186,10 +258,10 @@ CSSPixelPoint VisualViewport::map_to_layout_viewport(CSSPixelPoint position) con
 
 void VisualViewport::reset()
 {
+    m_document->smooth_scroll_handler()->abort_any_ongoing_visual_viewport_scroll();
+
     m_scale = 1.0;
-    m_offset = { 0, 0 };
-    m_document->set_needs_accumulated_visual_contexts_update(true);
-    m_document->set_needs_repaint(Badge<CSS::VisualViewport> {}, InvalidateDisplayList::Yes);
+    set_offset({ 0, 0 });
 }
 
 }

--- a/Libraries/LibWeb/CSS/VisualViewport.h
+++ b/Libraries/LibWeb/CSS/VisualViewport.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibGfx/AffineTransform.h>
+#include <LibWeb/Bindings/Window.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -43,7 +44,13 @@ public:
     void set_onscrollend(WebIDL::CallbackType*);
     WebIDL::CallbackType* onscrollend();
 
-    void scroll_by(CSSPixelPoint delta) { m_offset += delta; }
+    void set_offset(CSSPixelPoint);
+    void scroll_by(CSSPixelPoint delta);
+
+    GC::Ref<WebIDL::Promise> perform_scroll_of_visual_viewport_scrolling_box_by_delta(CSSPixelPoint delta, Bindings::ScrollBehavior = Bindings::ScrollBehavior::Auto);
+    GC::Ref<WebIDL::Promise> perform_scroll_of_visual_viewport_scrolling_box(CSSPixelPoint offset, Bindings::ScrollBehavior = Bindings::ScrollBehavior::Auto);
+
+    GC::Ptr<DOM::Document> document() { return m_document; }
 
     [[nodiscard]] Gfx::AffineTransform transform() const;
     void zoom(CSSPixelPoint position, double scale_delta);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -184,6 +184,7 @@
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/SmoothScrollHandler.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
@@ -635,6 +636,8 @@ void Document::initialize(JS::Realm& realm)
 
     m_list_of_available_images = realm.create<HTML::ListOfAvailableImages>();
 
+    m_smooth_scroll_handler = heap().allocate<SmoothScrollHandler>(*this);
+
     page().client().page_did_create_new_document(*this);
 
     ensure_cookie_version_index(m_url);
@@ -717,6 +720,9 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observers_being_notified);
     for (auto& pending_scroll_event : m_pending_scroll_events)
         visitor.visit(pending_scroll_event.event_target);
+
+    visitor.visit(m_smooth_scroll_handler);
+
     for (auto& resize_observer : m_resize_observers)
         visitor.visit(resize_observer);
 
@@ -3811,7 +3817,7 @@ void Document::scroll_to_the_beginning_of_the_document()
 {
     // FIXME: Actually implement this algorithm
     if (auto navigable = this->navigable())
-        navigable->perform_scroll_of_viewport_scrolling_box({ 0, 0 });
+        navigable->perform_scroll_of_viewport_scrolling_box(this, { 0, 0 }, Bindings::ScrollBehavior::Auto);
 }
 
 StringView Document::ready_state() const

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -44,6 +44,7 @@
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/InvalidateDisplayList.h>
+#include <LibWeb/Page/SmoothScrollHandler.h>
 #include <LibWeb/ResizeObserver/ResizeObserver.h>
 #include <LibWeb/TrustedTypes/InjectionSink.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -679,6 +680,8 @@ public:
     };
     Vector<PendingScrollEvent>& pending_scroll_events() { return m_pending_scroll_events; }
 
+    GC::Ptr<SmoothScrollHandler> smooth_scroll_handler() { return m_smooth_scroll_handler; }
+
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#completely-loaded
     bool is_completely_loaded() const;
 
@@ -1296,6 +1299,8 @@ private:
     // https://drafts.csswg.org/cssom-view-1/#document-pending-scroll-events
     // Each Document has an associated list of pending scroll events, which stores pairs of (EventTarget, DOMString), initially empty.
     Vector<PendingScrollEvent> m_pending_scroll_events;
+
+    GC::Ptr<SmoothScrollHandler> m_smooth_scroll_handler;
 
     // Used by evaluate_media_queries_and_report_changes().
     bool m_needs_media_query_evaluation { false };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2933,7 +2933,7 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
 static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bindings::ScrollBehavior behavior, Bindings::ScrollLogicalPosition block, Bindings::ScrollLogicalPosition inline_, GC::Ptr<Element> container)
 {
     // 1. Let ancestorPromises be an empty set of Promises.
-    GC::RootVector<GC::Ref<WebIDL::Promise>> ancestor_promises { target.heap() };
+    GC::RootVector<GC::Ref<WebIDL::Promise>> ancestor_promises;
 
     // 2. For each ancestor element or viewport that establishes a scrolling box scrolling box, in order of innermost
     //    to outermost scrolling box, run these substeps:
@@ -3770,6 +3770,9 @@ GC::Ref<WebIDL::Promise> Element::scroll(Bindings::ScrollToOptions options)
         && scroll_offset({}).is_zero()
         && this != document.body()
         && this != document.document_element()) {
+        if (document.layout_is_up_to_date() && paintable_box()) {
+            document.smooth_scroll_handler()->abort_any_ongoing_scroll_of_box(*paintable_box());
+        }
         return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
     }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -127,6 +127,7 @@
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
+#include <LibWeb/WebIDL/Promise.h>
 #include <LibWeb/XML/XMLFragmentParser.h>
 
 namespace Web::DOM {
@@ -2206,7 +2207,7 @@ void Element::set_scroll_left(double x)
     // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(CSSPixels::nearest_value_for(x));
-    paintable_box()->set_scroll_offset(scroll_offset);
+    paintable_box()->perform_scroll(scroll_offset);
 }
 
 void Element::set_scroll_top(double y)
@@ -2263,7 +2264,7 @@ void Element::set_scroll_top(double y)
     // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_y(CSSPixels::nearest_value_for(y));
-    paintable_box()->set_scroll_offset(scroll_offset);
+    paintable_box()->perform_scroll(scroll_offset);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth
@@ -2931,7 +2932,8 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
 // https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view
 static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bindings::ScrollBehavior behavior, Bindings::ScrollLogicalPosition block, Bindings::ScrollLogicalPosition inline_, GC::Ptr<Element> container)
 {
-    // FIXME: 1. Let ancestorPromises be an empty set of Promises.
+    // 1. Let ancestorPromises be an empty set of Promises.
+    GC::RootVector<GC::Ref<WebIDL::Promise>> ancestor_promises { target.heap() };
 
     // 2. For each ancestor element or viewport that establishes a scrolling box scrolling box, in order of innermost
     //    to outermost scrolling box, run these substeps:
@@ -2961,8 +2963,10 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
         if (true) {
             // -> If scrolling box is associated with an element
             if (auto* element = as_if<Element>(scrolling_box)) {
-                // FIXME: Perform a scroll of the element’s scrolling box to position, with the element as the associated element and behavior as the scroll behavior.
-                element->paintable_box()->set_scroll_offset(position);
+                // Perform a scroll of the element’s scrolling box to position, with the element as the associated
+                // element and behavior as the scroll behavior.
+                auto element_scroll_promise = element->paintable_box()->perform_scroll(position, behavior);
+                ancestor_promises.append(element_scroll_promise);
             }
             // -> If scrolling box is associated with a viewport
             else if (scrolling_box.is_document()) {
@@ -2970,15 +2974,16 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
                 auto& document = static_cast<Document&>(scrolling_box);
 
                 // FIXME: 2. Let root element be document’s root element, if there is one, or null otherwise.
-                // FIXME: 3. Perform a scroll of the viewport to position, with root element as the associated element and behavior as the scroll behavior.
+                // 3. Perform a scroll of the viewport to position, with root element as the associated element and
+                //    behavior as the scroll behavior.
                 //           Add the Promise returned from this step in the set ancestorPromises.
-                (void)behavior;
 
                 // AD-HOC:
                 // NOTE: Since calculated position is relative to the viewport, we need to add the viewport's position to it
                 //       before passing to perform_a_scroll_of_the_viewport() that expects a position relative to the page.
                 position.set_y(position.y() + document.viewport_rect().y());
-                document.navigable()->perform_a_scroll_of_the_viewport(position);
+                auto viewport_scroll_promise = document.navigable()->perform_a_scroll_of_the_viewport(position, behavior);
+                ancestor_promises.append(viewport_scroll_promise);
             }
         }
 
@@ -2990,15 +2995,12 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
             break;
     }
 
-    // 3. Let scrollPromise be a new Promise.
-    auto scroll_promise = WebIDL::create_promise(target.realm());
+    HTML::TemporaryExecutionContext temporary_execution_context { target.realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
+    // 3. Let scrollPromise be a new Promise.
     // 4. Return scrollPromise, and run the remaining steps in parallel.
     // 5. Resolve scrollPromise when all Promises in ancestorPromises have settled.
-    // FIXME: Actually wait for those promises.
-    WebIDL::resolve_promise(target.realm(), scroll_promise);
-
-    return scroll_promise;
+    return WebIDL::get_promise_for_wait_for_all(target.realm(), ancestor_promises);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview
@@ -3710,15 +3712,36 @@ bool Element::refresh_inherited_custom_property_data()
 GC::Ref<WebIDL::Promise> Element::scroll(double x, double y)
 {
     // 1. If invoked with one argument, follow these substeps:
-    //    NOTE: Not relevant here.
+    //    NB: Not relevant here.
     // 2. If invoked with two arguments, follow these substeps:
     //     1. Let options be null converted to a ScrollToOptions dictionary. [WEBIDL]
     //     2. Let x and y be the arguments, respectively.
+    Bindings::ScrollToOptions options;
+
+    //     NB: Step 3 happens in scroll(options).
     //     3. Normalize non-finite values for x and y.
+
     //     4. Let the left dictionary member of options have the value x.
+    options.left = x;
     //     5. Let the top dictionary member of options have the value y.
-    x = HTML::normalize_non_finite_values(x);
-    y = HTML::normalize_non_finite_values(y);
+    options.top = y;
+
+    options.behavior = Bindings::ScrollBehavior::Auto;
+    return scroll(options);
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-element-scroll
+GC::Ref<WebIDL::Promise> Element::scroll(Bindings::ScrollToOptions options)
+{
+    // 1. If invoked with one argument, follow these substeps:
+    //     1. Let options be the argument.
+    //     2. Normalize non-finite values for left and top dictionary members of options, if present.
+    //     3. Let x be the value of the left dictionary member of options, if present, or the element’s current scroll position on the x axis otherwise.
+    //     4. Let y be the value of the top dictionary member of options, if present, or the element’s current scroll position on the y axis otherwise.
+    // 2. If invoked with two arguments, follow these substeps:
+    //    NB: Already performed by scroll(x, y)
+    auto x = options.left.has_value() ? HTML::normalize_non_finite_values(options.left.value()) : scroll_left();
+    auto y = options.top.has_value() ? HTML::normalize_non_finite_values(options.top.value()) : scroll_top();
 
     // 3. Let document be the element’s node document.
     auto& document = this->document();
@@ -3776,25 +3799,10 @@ GC::Ref<WebIDL::Promise> Element::scroll(double x, double y)
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(CSSPixels::nearest_value_for(x));
     scroll_offset.set_y(CSSPixels::nearest_value_for(y));
-    paintable_box()->set_scroll_offset(scroll_offset);
-    auto scroll_promise = WebIDL::create_resolved_promise(realm(), JS::js_undefined());
+    auto scroll_promise = paintable_box()->perform_scroll(scroll_offset, options.behavior);
 
     // 12. Return scrollPromise.
     return scroll_promise;
-}
-
-// https://drafts.csswg.org/cssom-view/#dom-element-scroll
-GC::Ref<WebIDL::Promise> Element::scroll(Bindings::ScrollToOptions options)
-{
-    // 1. If invoked with one argument, follow these substeps:
-    //     1. Let options be the argument.
-    //     2. Normalize non-finite values for left and top dictionary members of options, if present.
-    //     3. Let x be the value of the left dictionary member of options, if present, or the element’s current scroll position on the x axis otherwise.
-    //     4. Let y be the value of the top dictionary member of options, if present, or the element’s current scroll position on the y axis otherwise.
-    // NOTE: remaining steps performed by Element::scroll(double x, double y)
-    auto x = options.left.has_value() ? HTML::normalize_non_finite_values(options.left.value()) : scroll_left();
-    auto y = options.top.has_value() ? HTML::normalize_non_finite_values(options.top.value()) : scroll_top();
-    return scroll(x, y);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollby

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -358,6 +358,10 @@ void EventLoop::update_the_rendering()
     for (auto& document : docs)
         document->page().update_all_media_element_video_sinks();
 
+    // AD-HOC: Process smooth scrolls.
+    for (auto& document : docs)
+        document->smooth_scroll_handler()->process();
+
     // FIXME: 4. Unnecessary rendering: Remove from docs any Document object doc for which all of the following are true:
 
     // FIXME: 5. Remove from docs all Document objects for which the user agent believes that it's preferable to skip updating the rendering for other reasons.

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -6,7 +6,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/Function.h>
+#include <LibJS/Runtime/Value.h>
+#include <LibWeb/Bindings/Window.h>
 #include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/VisualViewport.h>
@@ -56,9 +60,11 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/SmoothScrollHandler.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/InputTypes.h>
@@ -2966,14 +2972,11 @@ void Navigable::clamp_viewport_scroll_offset()
         max(CSSPixels(0), min(m_viewport_scroll_offset.y(), max_y)),
     };
     if (clamped != m_viewport_scroll_offset)
-        perform_scroll_of_viewport_scrolling_box(clamped);
+        set_viewport_scroll_offset(clamped);
 }
 
-void Navigable::perform_scroll_of_viewport_scrolling_box(CSSPixelPoint new_position)
+void Navigable::set_viewport_scroll_offset(CSSPixelPoint new_position)
 {
-    // NB: This method is ad-hoc, but is currently called where "perform a scroll of a scrolling box" would be,
-    //     where the box is the viewport.
-    //     https://drafts.csswg.org/cssom-view/#perform-a-scroll
     if (m_viewport_scroll_offset != new_position) {
         m_viewport_scroll_offset = new_position;
         scroll_offset_did_change();
@@ -3098,7 +3101,7 @@ static bool adopt_async_viewport_scroll_delta(Navigable& navigable, CSSPixelPoin
     scroll_offset.translate_by(scroll_delta);
     if (scroll_offset == navigable.viewport_scroll_offset())
         return false;
-    navigable.perform_scroll_of_viewport_scrolling_box(scroll_offset);
+    navigable.set_viewport_scroll_offset(scroll_offset);
     return true;
 }
 
@@ -3146,6 +3149,54 @@ void Navigable::adopt_pending_async_scroll_offsets()
 
     for (auto operation_id : async_scroll_updates.completed_operation_ids)
         resolve_async_scroll_operation(operation_id);
+}
+
+Optional<GC::Ref<WebIDL::Promise>> Navigable::perform_scroll_of_viewport_scrolling_box(CSSPixelPoint new_position, Bindings::ScrollBehavior scroll_behavior)
+{
+    auto doc = active_document();
+
+    if (!doc) {
+        return {};
+    }
+
+    return perform_scroll_of_viewport_scrolling_box(doc, new_position, scroll_behavior);
+}
+
+// https://drafts.csswg.org/cssom-view-1/#perform-a-scroll
+GC::Ref<WebIDL::Promise> Navigable::perform_scroll_of_viewport_scrolling_box(GC::Ptr<DOM::Document> doc, CSSPixelPoint new_position, Bindings::ScrollBehavior scroll_behavior)
+{
+    // 1. Abort any ongoing smooth scroll for box.
+    // 2. Resolve all pending scroll Promises whose scroll container is box.
+    doc->smooth_scroll_handler()->abort_any_ongoing_viewport_scroll();
+
+    HTML::TemporaryExecutionContext temporary_execution_context { doc->realm() };
+    // 3. Let scrollPromise be a new Promise.
+    auto scroll_promise = WebIDL::create_promise(doc->realm());
+
+    // NB: Step 4 happens out of order, as we can start a smooth scroll or perform an instant scroll first.
+
+    // 5. If the user agent honors the scroll-behavior property and one of the following is true:
+    //        - behavior is "auto" and element is not null and its computed value of the scroll-behavior property
+    //          is smooth, or
+    //        - behavior is smooth
+    //    then perform a smooth scroll of box to position; otherwise, perform an instant scroll of box to position.
+    // NB: Above determination happens in SmoothScrollHandler::resolve_scroll_behavior.
+    scroll_behavior = SmoothScrollHandler::resolve_scroll_behavior(*this, scroll_behavior);
+    if (scroll_behavior == Bindings::ScrollBehavior::Smooth) {
+        // NB: In this branch steps 6 and 7 are handled by SmoothScrollHander.
+        doc->smooth_scroll_handler()->start_viewport_scroll(scroll_promise, new_position);
+    } else {
+        // 6. Wait until either the position has finished updating, or scrollPromise has been resolved.
+        set_viewport_scroll_offset(new_position);
+
+        // 7. If scrollPromise is still in the pending state:
+        //      FIXME: 1. If the scroll position changed as a result of this call, emit the scrollend event.
+        //      2. Resolve scrollPromise.
+        WebIDL::resolve_promise(doc->realm(), scroll_promise);
+    }
+
+    // 4. Return scrollPromise, and run the remaining steps in parallel.
+    return scroll_promise;
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity
@@ -3481,15 +3532,22 @@ void Navigable::render_screenshot(Gfx::PaintingSurface& painting_surface, PaintC
     compositor_context().request_screenshot(painting_surface, move(callback));
 }
 
-GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta)
+GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta, Bindings::ScrollBehavior scroll_behavior)
 {
+    auto doc = active_document();
+    auto ongoing_viewport_scroll = doc->smooth_scroll_handler()->ongoing_viewport_scroll();
+
+    if (ongoing_viewport_scroll) {
+        return perform_a_scroll_of_the_viewport(ongoing_viewport_scroll->target_offset() + delta, scroll_behavior);
+    }
+
     auto vv = active_document()->visual_viewport();
     CSSPixelPoint page_position { CSSPixels(vv->page_left()), CSSPixels(vv->page_top()) };
-    return perform_a_scroll_of_the_viewport(page_position + delta);
+    return perform_a_scroll_of_the_viewport(page_position + delta, scroll_behavior);
 }
 
 // https://drafts.csswg.org/cssom-view/#viewport-perform-a-scroll
-GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoint position)
+GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoint position, Bindings::ScrollBehavior scroll_behavior)
 {
     // 1. Let doc be the viewport’s associated Document.
     auto doc = active_document();
@@ -3534,7 +3592,7 @@ GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoi
     // 14. Perform a scroll of the viewport’s scrolling box to its current scroll position + (layout dx, layout dy)
     //     with element as the associated element, and behavior as the scroll behavior. Let scrollPromise1 be the
     //     Promise returned from this step.
-    TemporaryExecutionContext temporary_execution_context { doc->realm() };
+    TemporaryExecutionContext temporary_execution_context { doc->realm(), TemporaryExecutionContext::CallbacksEnabled::Yes };
 
     // NB: Must update layout before accessing paintables.
     doc->update_layout(DOM::UpdateLayoutReason::NavigableViewportScroll);
@@ -3554,28 +3612,57 @@ GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoi
     if (new_viewport_scroll_offset.to_type<CSSPixels>() == m_viewport_scroll_offset && visual_dx == 0.0 && visual_dy == 0.0)
         return WebIDL::create_resolved_promise(doc->realm(), JS::js_undefined());
 
-    // FIXME: Get a Promise from this.
-    perform_scroll_of_viewport_scrolling_box(new_viewport_scroll_offset.to_type<CSSPixels>());
+    auto& realm = doc->realm();
 
-    // 15. Perform a scroll of vv’s scrolling box to its current scroll position + (visual dx, visual dy) with element
-    //     as the associated element, and behavior as the scroll behavior. Let scrollPromise2 be the Promise returned
-    //     from this step.
-    // FIXME: Get a Promise from this.
-    vv->scroll_by({ visual_dx, visual_dy });
-    if (visual_dx != 0.0 || visual_dy != 0.0) {
-        doc->set_needs_accumulated_visual_contexts_update(true);
-        doc->set_needs_repaint(Badge<HTML::Navigable> {}, InvalidateDisplayList::Yes);
-    } else {
-        doc->set_needs_repaint(Badge<HTML::Navigable> {}, InvalidateDisplayList::No);
-    }
+    auto scroll_promise_1 = perform_scroll_of_viewport_scrolling_box(doc, new_viewport_scroll_offset.to_type<CSSPixels>(), scroll_behavior);
+
+    // NB: Steps defined out of order due to variable scoping.
 
     // 16. Let scrollPromise be a new Promise.
-    auto scroll_promise = WebIDL::create_promise(doc->realm());
+    auto scroll_promise = WebIDL::create_promise(realm);
+
+    // FIXME: This whole part with promises does not look pretty.
+    auto reject_scroll_promise = GC::create_function(heap(), [&realm, scroll_promise](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+        WebIDL::reject_promise(realm, scroll_promise, JS::js_undefined());
+
+        return JS::js_undefined();
+    });
+
+    auto on_scroll_promise_1_fulfilled = [this, vv, visual_dx, visual_dy, scroll_behavior, &realm, scroll_promise, reject_scroll_promise](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+        // 15. Perform a scroll of vv’s scrolling box to its current scroll position + (visual dx, visual dy) with element
+        //     as the associated element, and behavior as the scroll behavior. Let scrollPromise2 be the Promise returned
+        //     from this step.
+        auto scroll_promise_2 = vv->perform_scroll_of_visual_viewport_scrolling_box_by_delta({ visual_dx, visual_dy }, scroll_behavior);
+
+        if (WebIDL::is_promise_fulfilled(scroll_promise_2)) {
+            // 18. Resolve scrollPromise when both scrollPromise1 and scrollPromise2 have settled.
+            WebIDL::resolve_promise(realm, scroll_promise);
+        } else {
+            WebIDL::react_to_promise(scroll_promise_2, GC::create_function(heap(), [&realm, scroll_promise](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+                // 18. Resolve scrollPromise when both scrollPromise1 and scrollPromise2 have settled.
+                WebIDL::resolve_promise(realm, scroll_promise);
+
+                return JS::js_undefined();
+            }),
+                reject_scroll_promise);
+        }
+
+        return JS::js_undefined();
+    };
+
+    if (WebIDL::is_promise_fulfilled(scroll_promise_1)) {
+        (void)on_scroll_promise_1_fulfilled(JS::js_undefined());
+    } else {
+        WebIDL::react_to_promise(scroll_promise_1, GC::create_function(heap(), [&realm, scroll_promise](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+            // 18. Resolve scrollPromise when both scrollPromise1 and scrollPromise2 have settled.
+            WebIDL::resolve_promise(realm, scroll_promise);
+
+            return JS::js_undefined();
+        }),
+            reject_scroll_promise);
+    }
 
     // 17. Return scrollPromise, and run the remaining steps in parallel.
-    // 18. Resolve scrollPromise when both scrollPromise1 and scrollPromise2 have settled.
-    // FIXME: Actually wait for scroll to occur. For now, all our scrolls are instant.
-    WebIDL::resolve_promise(doc->realm(), scroll_promise);
     return scroll_promise;
 }
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -14,7 +14,9 @@
 #include <AK/Tuple.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Bindings/Navigation.h>
+#include <LibWeb/Bindings/Window.h>
 #include <LibWeb/Compositor/CompositorHost.h>
+#include <LibWeb/Compositor/CompositorThread.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -200,6 +202,9 @@ public:
     void perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position);
     void adopt_pending_async_scroll_offsets();
     void wait_for_async_scroll_operation(Compositor::AsyncScrollOperationID, GC::Ref<WebIDL::Promise>);
+    Optional<GC::Ref<WebIDL::Promise>> perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position, Bindings::ScrollBehavior scroll_behavior = Bindings::ScrollBehavior::Auto);
+    GC::Ref<WebIDL::Promise> perform_scroll_of_viewport_scrolling_box(GC::Ptr<DOM::Document>, CSSPixelPoint position, Bindings::ScrollBehavior scroll_behavior = Bindings::ScrollBehavior::Auto);
+    void set_viewport_scroll_offset(CSSPixelPoint position);
     void clamp_viewport_scroll_offset();
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity
@@ -261,8 +266,8 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
-    GC::Ref<WebIDL::Promise> scroll_viewport_by_delta(CSSPixelPoint delta);
-    GC::Ref<WebIDL::Promise> perform_a_scroll_of_the_viewport(CSSPixelPoint position);
+    GC::Ref<WebIDL::Promise> scroll_viewport_by_delta(CSSPixelPoint delta, Bindings::ScrollBehavior scroll_behavior = Bindings::ScrollBehavior::Auto);
+    GC::Ref<WebIDL::Promise> perform_a_scroll_of_the_viewport(CSSPixelPoint position, Bindings::ScrollBehavior scroll_behavior = Bindings::ScrollBehavior::Auto);
     void reset_zoom();
 
 protected:

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1604,6 +1604,8 @@ GC::Ref<WebIDL::Promise> Window::scroll(Bindings::ScrollToOptions const& options
     //     smooth scroll, return a resolved Promise and abort the remaining steps.
     if (position == viewport_rect.location()) {
         TemporaryExecutionContext temporary_execution_context { realm() };
+        document->smooth_scroll_handler()->abort_any_ongoing_viewport_scroll();
+        document->smooth_scroll_handler()->abort_any_ongoing_visual_viewport_scroll();
         return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
     }
 
@@ -1613,7 +1615,7 @@ GC::Ref<WebIDL::Promise> Window::scroll(Bindings::ScrollToOptions const& options
     // 12. Perform a scroll of the viewport to position, document’s root element as the associated element, if there is
     //     one, or null otherwise, and the scroll behavior being the value of the behavior dictionary member of options.
     //     Let scrollPromise be the Promise returned from this step.
-    auto scroll_promise = navigable->perform_a_scroll_of_the_viewport({ x, y });
+    auto scroll_promise = navigable->perform_a_scroll_of_the_viewport({ x, y }, options.behavior);
 
     // 13. Return scrollPromise.
     return scroll_promise;

--- a/Libraries/LibWeb/Page/SmoothScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/SmoothScrollHandler.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Badge.h>
+#include <AK/StdLibExtras.h>
+#include <LibGC/CellAllocator.h>
+#include <LibGC/Ptr.h>
+#include <LibJS/Runtime/Value.h>
+#include <LibWeb/Bindings/Window.h>
+#include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/CSS/PseudoElement.h>
+#include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HighResolutionTime/TimeOrigin.h>
+#include <LibWeb/Page/SmoothScrollHandler.h>
+#include <LibWeb/PixelUnits.h>
+#include <LibWeb/WebIDL/Promise.h>
+
+namespace Web {
+
+GC_DEFINE_ALLOCATOR(SmoothScrollTask);
+GC_DEFINE_ALLOCATOR(SmoothScrollHandler);
+
+SmoothScrollTask::SmoothScrollTask(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint source_offset, CSSPixelPoint target_offset, double timestamp)
+    : m_scroll_promise(promise)
+    , m_source_offset(source_offset)
+    , m_target_offset(target_offset)
+    , m_start_time(timestamp)
+{
+    m_is_ongoing = true;
+
+    update_duration();
+}
+
+void SmoothScrollTask::update_duration()
+{
+    static constexpr double SCROLL_SPEED_IN_PIXELS_PER_SECOND = 10000;
+    static constexpr double SCROLL_MIN_DURATION = 250;
+
+    auto delta = target_offset() - source_offset();
+    auto distance = abs(delta.x().to_double()) + abs(delta.y().to_double());
+
+    m_duration = max((distance / (SCROLL_SPEED_IN_PIXELS_PER_SECOND)) * 1000, SCROLL_MIN_DURATION);
+}
+
+void SmoothScrollTask::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_scroll_promise);
+}
+
+GC::Ref<SmoothScrollHandler> SmoothScrollHandler::create(GC::Heap& heap, GC::Ref<DOM::Document> document)
+{
+    return heap.allocate<SmoothScrollHandler>(document);
+}
+
+SmoothScrollHandler::SmoothScrollHandler(GC::Ref<DOM::Document> document)
+    : m_document(document)
+{
+}
+
+void SmoothScrollHandler::process()
+{
+    auto timestamp = HighResolutionTime::unsafe_shared_current_time();
+
+    if (m_ongoing_viewport_scroll) {
+        if (m_ongoing_viewport_scroll->is_ongoing()) {
+            auto progress = task_progress(*m_ongoing_viewport_scroll, timestamp);
+            CSSPixelPoint current_offset = current_scroll_offset(*m_ongoing_viewport_scroll, progress);
+
+            m_document->navigable()->set_viewport_scroll_offset(current_offset);
+
+            if (progress >= 1) {
+                finish(*m_ongoing_viewport_scroll);
+                m_ongoing_viewport_scroll = nullptr;
+            }
+        } else {
+            m_ongoing_viewport_scroll = nullptr;
+        }
+    }
+
+    if (m_ongoing_visual_viewport_scroll) {
+        if (m_ongoing_visual_viewport_scroll->is_ongoing()) {
+            auto progress = task_progress(*m_ongoing_visual_viewport_scroll, timestamp);
+            CSSPixelPoint current_offset = current_scroll_offset(*m_ongoing_visual_viewport_scroll, progress);
+
+            m_document->visual_viewport()->set_offset(current_offset);
+
+            if (progress >= 1) {
+                finish(*m_ongoing_visual_viewport_scroll);
+                m_ongoing_visual_viewport_scroll = nullptr;
+            }
+        } else {
+            m_ongoing_visual_viewport_scroll = nullptr;
+        }
+    }
+}
+
+void SmoothScrollHandler::start_viewport_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset)
+{
+    VERIFY(!m_ongoing_viewport_scroll);
+
+    auto source_offset = m_document->navigable()->viewport_scroll_offset();
+    m_ongoing_viewport_scroll = heap().allocate<SmoothScrollTask>(promise, source_offset, target_offset, HighResolutionTime::unsafe_shared_current_time());
+}
+
+void SmoothScrollHandler::start_visual_viewport_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset)
+{
+    VERIFY(!m_ongoing_visual_viewport_scroll);
+
+    auto source_offset = m_document->visual_viewport()->offset();
+    m_ongoing_visual_viewport_scroll = heap().allocate<SmoothScrollTask>(promise, source_offset, target_offset, HighResolutionTime::unsafe_shared_current_time());
+}
+
+void SmoothScrollHandler::abort_any_ongoing_viewport_scroll()
+{
+    if (!m_ongoing_viewport_scroll)
+        return;
+
+    finish(*m_ongoing_viewport_scroll);
+    m_ongoing_viewport_scroll = nullptr;
+}
+
+void SmoothScrollHandler::abort_any_ongoing_visual_viewport_scroll()
+{
+    if (!m_ongoing_visual_viewport_scroll)
+        return;
+
+    finish(*m_ongoing_visual_viewport_scroll);
+    m_ongoing_visual_viewport_scroll = nullptr;
+}
+
+// https://drafts.csswg.org/cssom-view-1/#ref-for-propdef-scroll-behavior
+Bindings::ScrollBehavior SmoothScrollHandler::resolve_scroll_behavior(DOM::Element const& element, Bindings::ScrollBehavior scroll_behavior)
+{
+    // If the user agent honors the scroll-behavior property and one of the following is true:
+
+    // - behavior is "auto" and element is not null and its computed value of the scroll-behavior property is smooth,
+    //   or
+    // - behavior is smooth
+    if ((scroll_behavior == Bindings::ScrollBehavior::Auto
+            && element.computed_properties()
+            && element.computed_properties()->scroll_behavior() == CSS::ScrollBehavior::Smooth)
+        || scroll_behavior == Bindings::ScrollBehavior::Smooth) {
+        // then perform a smooth scroll of box to position;
+        return Bindings::ScrollBehavior::Smooth;
+    }
+
+    // otherwise, perform an instant scroll of box to position.
+    return Bindings::ScrollBehavior::Instant;
+}
+
+Bindings::ScrollBehavior SmoothScrollHandler::resolve_scroll_behavior(HTML::Navigable const& navigable, Bindings::ScrollBehavior scroll_behavior)
+{
+    if (auto doc = navigable.active_document()) {
+        if (auto element = doc->scrolling_element()) {
+            return resolve_scroll_behavior(*element, scroll_behavior);
+        }
+    }
+
+    return Bindings::ScrollBehavior::Instant;
+}
+
+Bindings::ScrollBehavior SmoothScrollHandler::resolve_scroll_behavior(CSS::VisualViewport& visual_viewport, Bindings::ScrollBehavior scroll_behavior)
+{
+    if (auto doc = visual_viewport.document()) {
+        if (auto element = doc->scrolling_element()) {
+            return resolve_scroll_behavior(*element, scroll_behavior);
+        }
+    }
+
+    return Bindings::ScrollBehavior::Instant;
+}
+
+void SmoothScrollHandler::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_document);
+
+    visitor.visit(m_ongoing_viewport_scroll);
+    visitor.visit(m_ongoing_visual_viewport_scroll);
+}
+
+// Steps 6 and 7 of https://drafts.csswg.org/cssom-view-1/#perform-a-scroll
+void SmoothScrollHandler::finish(SmoothScrollTask& task)
+{
+    task.set_is_ongoing(false);
+    // 6. Wait until either the position has finished updating, or scrollPromise has been resolved.
+
+    HTML::TemporaryExecutionContext execution_context { m_document->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    // 7. If scrollPromise is still in the pending state:
+    //      FIXME: 1. If the scroll position changed as a result of this call, emit the scrollend event.
+    //      2. Resolve scrollPromise.
+    WebIDL::resolve_promise(m_document->realm(), task.scroll_promise());
+}
+
+CSSPixelPoint SmoothScrollHandler::current_scroll_offset(SmoothScrollTask& task, double progress)
+{
+    CSSPixelPoint source_offset = task.source_offset();
+    CSSPixelPoint target_offset = task.target_offset();
+
+    auto t = ease(progress);
+
+    auto x = mix(source_offset.x().to_double(), target_offset.x().to_double(), t);
+    auto y = mix(source_offset.y().to_double(), target_offset.y().to_double(), t);
+
+    return { x, y };
+}
+
+double SmoothScrollHandler::task_progress(SmoothScrollTask& task, double timestamp)
+{
+    return clamp((timestamp - task.start_time()) / task.duration(), 0, 1);
+}
+
+double SmoothScrollHandler::ease(double t)
+{
+    return 1 - ((1 - t) * (1 - t));
+}
+
+}

--- a/Libraries/LibWeb/Page/SmoothScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/SmoothScrollHandler.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/RefPtr.h>
 #include <AK/StdLibExtras.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Ptr.h>
@@ -20,6 +21,7 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/Page/SmoothScrollHandler.h>
+#include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -37,6 +39,21 @@ SmoothScrollTask::SmoothScrollTask(GC::Ref<WebIDL::Promise> promise, CSSPixelPoi
     m_is_ongoing = true;
 
     update_duration();
+}
+
+SmoothScrollTask::SmoothScrollTask(RefPtr<Painting::PaintableBox> const& box, GC::Ref<WebIDL::Promise> promise, CSSPixelPoint source_offset, CSSPixelPoint target_offset, double timestamp)
+    : SmoothScrollTask(promise, source_offset, target_offset, timestamp)
+{
+    m_box = box;
+}
+
+RefPtr<Painting::PaintableBox> SmoothScrollTask::box()
+{
+    if (auto box = m_box.strong_ref()) {
+        return static_cast<Painting::PaintableBox&>(*m_box);
+    }
+
+    return nullptr;
 }
 
 void SmoothScrollTask::update_duration()
@@ -69,6 +86,35 @@ SmoothScrollHandler::SmoothScrollHandler(GC::Ref<DOM::Document> document)
 void SmoothScrollHandler::process()
 {
     auto timestamp = HighResolutionTime::unsafe_shared_current_time();
+
+    for (auto& task : m_ongoing_box_scrolls) {
+        if (!task->is_ongoing())
+            continue;
+
+        auto box = task->box();
+        if (!box) {
+            finish(task);
+            continue;
+        }
+
+        auto progress = task_progress(task, timestamp);
+        CSSPixelPoint current_offset = current_scroll_offset(task, progress);
+
+        auto scroll_handled = box->set_scroll_offset(current_offset);
+
+        if (progress >= 1 || scroll_handled == Painting::PaintableBox::ScrollHandled::No) {
+            finish(task);
+        }
+    }
+
+    GC::RootVector<GC::Ref<SmoothScrollTask>> ongoing_box_scrolls;
+    for (auto& task : m_ongoing_box_scrolls) {
+        if (task->is_ongoing()) {
+            ongoing_box_scrolls.append(task);
+        }
+    }
+
+    m_ongoing_box_scrolls = ongoing_box_scrolls;
 
     if (m_ongoing_viewport_scroll) {
         if (m_ongoing_viewport_scroll->is_ongoing()) {
@@ -119,6 +165,28 @@ void SmoothScrollHandler::start_visual_viewport_scroll(GC::Ref<WebIDL::Promise> 
     m_ongoing_visual_viewport_scroll = heap().allocate<SmoothScrollTask>(promise, source_offset, target_offset, HighResolutionTime::unsafe_shared_current_time());
 }
 
+void SmoothScrollHandler::start_box_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset, RefPtr<Painting::PaintableBox> const& box)
+{
+    auto ongoing_scroll = ongoing_scroll_of_box(*box);
+    VERIFY(!ongoing_scroll || !ongoing_scroll->is_ongoing());
+
+    auto source_offset = box->scroll_offset();
+    auto task = heap().allocate<SmoothScrollTask>(box, promise, source_offset, target_offset, HighResolutionTime::unsafe_shared_current_time());
+
+    m_ongoing_box_scrolls.append(task);
+}
+
+GC::Ptr<SmoothScrollTask> SmoothScrollHandler::ongoing_scroll_of_box(Painting::PaintableBox& box)
+{
+    for (auto& task : m_ongoing_box_scrolls) {
+        if (task->box() && task->box() == box && task->is_ongoing()) {
+            return task;
+        }
+    }
+
+    return nullptr;
+}
+
 void SmoothScrollHandler::abort_any_ongoing_viewport_scroll()
 {
     if (!m_ongoing_viewport_scroll)
@@ -135,6 +203,14 @@ void SmoothScrollHandler::abort_any_ongoing_visual_viewport_scroll()
 
     finish(*m_ongoing_visual_viewport_scroll);
     m_ongoing_visual_viewport_scroll = nullptr;
+}
+
+void SmoothScrollHandler::abort_any_ongoing_scroll_of_box(Painting::PaintableBox& box)
+{
+    auto task = ongoing_scroll_of_box(box);
+    if (task) {
+        finish(*task);
+    }
 }
 
 // https://drafts.csswg.org/cssom-view-1/#ref-for-propdef-scroll-behavior
@@ -179,6 +255,20 @@ Bindings::ScrollBehavior SmoothScrollHandler::resolve_scroll_behavior(CSS::Visua
     return Bindings::ScrollBehavior::Instant;
 }
 
+Bindings::ScrollBehavior SmoothScrollHandler::resolve_scroll_behavior(Painting::PaintableBox& box, Bindings::ScrollBehavior scroll_behavior)
+{
+    auto& node = box.layout_node();
+    if (auto pseudo_element = node.generated_for_pseudo_element(); pseudo_element.has_value()) {
+        return resolve_scroll_behavior(*node.pseudo_element_generator(), scroll_behavior);
+    }
+
+    if (auto* element = as_if<DOM::Element>(*box.dom_node())) {
+        return resolve_scroll_behavior(*element, scroll_behavior);
+    }
+
+    return Bindings::ScrollBehavior::Instant;
+}
+
 void SmoothScrollHandler::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
@@ -186,6 +276,8 @@ void SmoothScrollHandler::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_ongoing_viewport_scroll);
     visitor.visit(m_ongoing_visual_viewport_scroll);
+
+    visitor.visit(m_ongoing_box_scrolls);
 }
 
 // Steps 6 and 7 of https://drafts.csswg.org/cssom-view-1/#perform-a-scroll

--- a/Libraries/LibWeb/Page/SmoothScrollHandler.h
+++ b/Libraries/LibWeb/Page/SmoothScrollHandler.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/RefPtr.h>
+#include <AK/Vector.h>
 #include <LibGC/Cell.h>
 #include <LibGC/CellAllocator.h>
 #include <LibJS/Heap/Cell.h>
@@ -23,6 +25,7 @@ class SmoothScrollTask : public GC::Cell {
 
 public:
     SmoothScrollTask(GC::Ref<WebIDL::Promise>, CSSPixelPoint source_offset, CSSPixelPoint target_offset, double timestamp);
+    SmoothScrollTask(AK::RefPtr<Painting::PaintableBox> const&, GC::Ref<WebIDL::Promise>, CSSPixelPoint source_offset, CSSPixelPoint target_offset, double timestamp);
 
     void set_source_offset(CSSPixelPoint value) { m_source_offset = value; }
     void set_target_offset(CSSPixelPoint value) { m_target_offset = value; }
@@ -30,6 +33,7 @@ public:
     void set_is_ongoing(bool value) { m_is_ongoing = value; }
 
     GC::Ref<WebIDL::Promise> scroll_promise() { return m_scroll_promise; }
+    AK::RefPtr<Painting::PaintableBox> box();
     CSSPixelPoint source_offset() { return m_source_offset; }
     CSSPixelPoint target_offset() { return m_target_offset; }
     double start_time() const { return m_start_time; }
@@ -41,6 +45,7 @@ public:
 
 private:
     GC::Ref<WebIDL::Promise> m_scroll_promise;
+    AK::WeakPtr<Painting::PaintableBox> m_box;
     CSSPixelPoint m_source_offset;
     CSSPixelPoint m_target_offset;
     double m_start_time;
@@ -59,16 +64,20 @@ public:
     void process();
     void start_viewport_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset);
     void start_visual_viewport_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset);
+    void start_box_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset, AK::RefPtr<Painting::PaintableBox> const& box);
 
     GC::Ptr<SmoothScrollTask> ongoing_viewport_scroll() { return m_ongoing_viewport_scroll; }
     GC::Ptr<SmoothScrollTask> ongoing_visual_viewport_scroll() { return m_ongoing_visual_viewport_scroll; }
+    GC::Ptr<SmoothScrollTask> ongoing_scroll_of_box(Painting::PaintableBox& box);
 
     void abort_any_ongoing_viewport_scroll();
     void abort_any_ongoing_visual_viewport_scroll();
+    void abort_any_ongoing_scroll_of_box(Painting::PaintableBox& box);
 
     static Bindings::ScrollBehavior resolve_scroll_behavior(DOM::Element const&, Bindings::ScrollBehavior);
     static Bindings::ScrollBehavior resolve_scroll_behavior(HTML::Navigable const&, Bindings::ScrollBehavior);
     static Bindings::ScrollBehavior resolve_scroll_behavior(CSS::VisualViewport&, Bindings::ScrollBehavior);
+    static Bindings::ScrollBehavior resolve_scroll_behavior(Painting::PaintableBox&, Bindings::ScrollBehavior);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -77,6 +86,7 @@ private:
 
     GC::Ptr<SmoothScrollTask> m_ongoing_viewport_scroll;
     GC::Ptr<SmoothScrollTask> m_ongoing_visual_viewport_scroll;
+    Vector<GC::Ref<SmoothScrollTask>> m_ongoing_box_scrolls;
 
     void finish(SmoothScrollTask&);
 

--- a/Libraries/LibWeb/Page/SmoothScrollHandler.h
+++ b/Libraries/LibWeb/Page/SmoothScrollHandler.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <LibGC/Cell.h>
+#include <LibGC/CellAllocator.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibWeb/Bindings/Window.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web {
+
+class SmoothScrollTask : public GC::Cell {
+    GC_CELL(SmoothScrollTask, GC::Cell);
+    GC_DECLARE_ALLOCATOR(SmoothScrollTask);
+
+public:
+    SmoothScrollTask(GC::Ref<WebIDL::Promise>, CSSPixelPoint source_offset, CSSPixelPoint target_offset, double timestamp);
+
+    void set_source_offset(CSSPixelPoint value) { m_source_offset = value; }
+    void set_target_offset(CSSPixelPoint value) { m_target_offset = value; }
+    void set_start_time(double value) { m_start_time = value; }
+    void set_is_ongoing(bool value) { m_is_ongoing = value; }
+
+    GC::Ref<WebIDL::Promise> scroll_promise() { return m_scroll_promise; }
+    CSSPixelPoint source_offset() { return m_source_offset; }
+    CSSPixelPoint target_offset() { return m_target_offset; }
+    double start_time() const { return m_start_time; }
+    void update_duration();
+    double duration() const { return m_duration; }
+    bool is_ongoing() const { return m_is_ongoing; }
+
+    virtual void visit_edges(Cell::Visitor&) override;
+
+private:
+    GC::Ref<WebIDL::Promise> m_scroll_promise;
+    CSSPixelPoint m_source_offset;
+    CSSPixelPoint m_target_offset;
+    double m_start_time;
+    double m_duration;
+    bool m_is_ongoing { false };
+};
+
+class SmoothScrollHandler : public GC::Cell {
+    GC_CELL(SmoothScrollHandler, GC::Cell);
+    GC_DECLARE_ALLOCATOR(SmoothScrollHandler);
+
+public:
+    [[nodiscard]] static GC::Ref<SmoothScrollHandler> create(GC::Heap&, GC::Ref<DOM::Document>);
+    SmoothScrollHandler(GC::Ref<DOM::Document> document);
+
+    void process();
+    void start_viewport_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset);
+    void start_visual_viewport_scroll(GC::Ref<WebIDL::Promise> promise, CSSPixelPoint target_offset);
+
+    GC::Ptr<SmoothScrollTask> ongoing_viewport_scroll() { return m_ongoing_viewport_scroll; }
+    GC::Ptr<SmoothScrollTask> ongoing_visual_viewport_scroll() { return m_ongoing_visual_viewport_scroll; }
+
+    void abort_any_ongoing_viewport_scroll();
+    void abort_any_ongoing_visual_viewport_scroll();
+
+    static Bindings::ScrollBehavior resolve_scroll_behavior(DOM::Element const&, Bindings::ScrollBehavior);
+    static Bindings::ScrollBehavior resolve_scroll_behavior(HTML::Navigable const&, Bindings::ScrollBehavior);
+    static Bindings::ScrollBehavior resolve_scroll_behavior(CSS::VisualViewport&, Bindings::ScrollBehavior);
+
+    virtual void visit_edges(Cell::Visitor&) override;
+
+private:
+    GC::Ref<DOM::Document> m_document;
+
+    GC::Ptr<SmoothScrollTask> m_ongoing_viewport_scroll;
+    GC::Ptr<SmoothScrollTask> m_ongoing_visual_viewport_scroll;
+
+    void finish(SmoothScrollTask&);
+
+    static CSSPixelPoint current_scroll_offset(SmoothScrollTask& task, double progress);
+    static double task_progress(SmoothScrollTask& task, double timestamp);
+    static double ease(double);
+};
+
+}

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/GenericShorthands.h>
 #include <LibGfx/Font/Font.h>
+#include <LibJS/Runtime/Value.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/StyleScope.h>
@@ -39,6 +40,7 @@
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/FontPlugin.h>
 #include <LibWeb/SVG/SVGFilterElement.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::Painting {
 
@@ -249,7 +251,7 @@ PaintableBox::ScrollHandled PaintableBox::set_scroll_offset(CSSPixelPoint offset
     if (is_viewport_paintable()) {
         auto navigable = document().navigable();
         VERIFY(navigable);
-        navigable->perform_scroll_of_viewport_scrolling_box(offset);
+        navigable->set_viewport_scroll_offset(offset);
         return ScrollHandled::Yes;
     }
 
@@ -293,6 +295,42 @@ PaintableBox::ScrollHandled PaintableBox::set_scroll_offset(CSSPixelPoint offset
 
     set_needs_repaint(InvalidateDisplayList::No);
     return ScrollHandled::Yes;
+}
+
+// https://drafts.csswg.org/cssom-view-1/#perform-a-scroll
+GC::Ref<WebIDL::Promise> PaintableBox::perform_scroll(CSSPixelPoint offset, Bindings::ScrollBehavior scroll_behavior)
+{
+    auto& doc = document();
+
+    if (is_viewport_paintable()) {
+        auto navigable = document().navigable();
+        VERIFY(navigable);
+        return navigable->perform_scroll_of_viewport_scrolling_box(document(), offset, scroll_behavior);
+    }
+
+    // FIXME: 1. Abort any ongoing smooth scroll for box.
+    // FIXME: 2. Resolve all pending scroll Promises whose scroll container is box.
+
+    // 3. Let scrollPromise be a new Promise.
+    auto scroll_promise = WebIDL::create_promise(doc.realm());
+
+    // 4. Return scrollPromise, and run the remaining steps in parallel.
+
+    // FIXME: 5. If the user agent honors the scroll-behavior property and one of the following is true:
+    //        - behavior is "auto" and element is not null and its computed value of the scroll-behavior property
+    //          is smooth, or
+    //        - behavior is smooth
+    //    then perform a smooth scroll of box to position; otherwise, perform an instant scroll of box to position.
+
+    // 6. Wait until either the position has finished updating, or scrollPromise has been resolved.
+    set_scroll_offset(offset);
+
+    // 7. If scrollPromise is still in the pending state:
+    //      FIXME: 1. If the scroll position changed as a result of this call, emit the scrollend event.
+    //      2. Resolve scrollPromise.
+    WebIDL::resolve_promise(doc.realm(), scroll_promise);
+
+    return scroll_promise;
 }
 
 PaintableBox::ScrollHandled PaintableBox::scroll_by(double delta_x, double delta_y)

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/MiddleButtonScrollHandler.h>
@@ -308,27 +309,36 @@ GC::Ref<WebIDL::Promise> PaintableBox::perform_scroll(CSSPixelPoint offset, Bind
         return navigable->perform_scroll_of_viewport_scrolling_box(document(), offset, scroll_behavior);
     }
 
-    // FIXME: 1. Abort any ongoing smooth scroll for box.
-    // FIXME: 2. Resolve all pending scroll Promises whose scroll container is box.
+    HTML::TemporaryExecutionContext temporary_execution_context { doc.realm() };
+
+    // 1. Abort any ongoing smooth scroll for box.
+    // 2. Resolve all pending scroll Promises whose scroll container is box.
+    doc.smooth_scroll_handler()->abort_any_ongoing_scroll_of_box(*this);
 
     // 3. Let scrollPromise be a new Promise.
     auto scroll_promise = WebIDL::create_promise(doc.realm());
 
-    // 4. Return scrollPromise, and run the remaining steps in parallel.
+    // NB: Step 4 happens out of order, as we can start a smooth scroll or perform an instant scroll first.
 
-    // FIXME: 5. If the user agent honors the scroll-behavior property and one of the following is true:
+    // 5. If the user agent honors the scroll-behavior property and one of the following is true:
     //        - behavior is "auto" and element is not null and its computed value of the scroll-behavior property
     //          is smooth, or
     //        - behavior is smooth
     //    then perform a smooth scroll of box to position; otherwise, perform an instant scroll of box to position.
+    // NB: Above determination happens in SmoothScrollHandler::resolve_scroll_behavior.
+    scroll_behavior = SmoothScrollHandler::resolve_scroll_behavior(*this, scroll_behavior);
+    if (scroll_behavior == Bindings::ScrollBehavior::Smooth) {
+        // NB: In this branch steps 6 and 7 are handled by SmoothScrollHander.
+        doc.smooth_scroll_handler()->start_box_scroll(scroll_promise, offset, this);
+    } else {
+        // 6. Wait until either the position has finished updating, or scrollPromise has been resolved.
+        set_scroll_offset(offset);
 
-    // 6. Wait until either the position has finished updating, or scrollPromise has been resolved.
-    set_scroll_offset(offset);
-
-    // 7. If scrollPromise is still in the pending state:
-    //      FIXME: 1. If the scroll position changed as a result of this call, emit the scrollend event.
-    //      2. Resolve scrollPromise.
-    WebIDL::resolve_promise(doc.realm(), scroll_promise);
+        // 7. If scrollPromise is still in the pending state:
+        //      FIXME: 1. If the scroll position changed as a result of this call, emit the scrollend event.
+        //      2. Resolve scrollPromise.
+        WebIDL::resolve_promise(doc.realm(), scroll_promise);
+    }
 
     return scroll_promise;
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefPtr.h>
 #include <LibGfx/Forward.h>
+#include <LibWeb/Bindings/Window.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/Box.h>
@@ -81,6 +82,7 @@ public:
     ScrollHandled set_scroll_offset(CSSPixelPoint);
     ScrollHandled scroll_by(double delta_x, double delta_y);
     void scroll_into_view(CSSPixelRect);
+    GC::Ref<WebIDL::Promise> perform_scroll(CSSPixelPoint, Bindings::ScrollBehavior = Bindings::ScrollBehavior::Auto);
 
     void set_offset(CSSPixelPoint);
     void set_offset(float x, float y) { set_offset({ x, y }); }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-default-css.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-default-css.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	Make sure the page is ready for animation.
 Pass	Instant scrolling of an element with default scroll-behavior
-Fail	Smooth scrolling of an element with default scroll-behavior
+Pass	Smooth scrolling of an element with default scroll-behavior

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-element.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-element.txt
@@ -2,44 +2,43 @@ Harness status: OK
 
 Found 39 tests
 
-21 Pass
-18 Fail
+39 Pass
 Pass	Make sure the page is ready for animation.
 Pass	Element with auto scroll-behavior ; scroll() with default behavior
 Pass	Element with auto scroll-behavior ; scroll() with auto behavior
 Pass	Element with auto scroll-behavior ; scroll() with instant behavior
-Fail	Element with auto scroll-behavior ; scroll() with smooth behavior
-Fail	Element with smooth scroll-behavior ; scroll() with default behavior
-Fail	Element with smooth scroll-behavior ; scroll() with auto behavior
+Pass	Element with auto scroll-behavior ; scroll() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scroll() with default behavior
+Pass	Element with smooth scroll-behavior ; scroll() with auto behavior
 Pass	Element with smooth scroll-behavior ; scroll() with instant behavior
-Fail	Element with smooth scroll-behavior ; scroll() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scroll() with smooth behavior
 Pass	Element with auto scroll-behavior ; scrollTo() with default behavior
 Pass	Element with auto scroll-behavior ; scrollTo() with auto behavior
 Pass	Element with auto scroll-behavior ; scrollTo() with instant behavior
-Fail	Element with auto scroll-behavior ; scrollTo() with smooth behavior
-Fail	Element with smooth scroll-behavior ; scrollTo() with default behavior
-Fail	Element with smooth scroll-behavior ; scrollTo() with auto behavior
+Pass	Element with auto scroll-behavior ; scrollTo() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scrollTo() with default behavior
+Pass	Element with smooth scroll-behavior ; scrollTo() with auto behavior
 Pass	Element with smooth scroll-behavior ; scrollTo() with instant behavior
-Fail	Element with smooth scroll-behavior ; scrollTo() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scrollTo() with smooth behavior
 Pass	Element with auto scroll-behavior ; scrollBy() with default behavior
 Pass	Element with auto scroll-behavior ; scrollBy() with auto behavior
 Pass	Element with auto scroll-behavior ; scrollBy() with instant behavior
-Fail	Element with auto scroll-behavior ; scrollBy() with smooth behavior
-Fail	Element with smooth scroll-behavior ; scrollBy() with default behavior
-Fail	Element with smooth scroll-behavior ; scrollBy() with auto behavior
+Pass	Element with auto scroll-behavior ; scrollBy() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scrollBy() with default behavior
+Pass	Element with smooth scroll-behavior ; scrollBy() with auto behavior
 Pass	Element with smooth scroll-behavior ; scrollBy() with instant behavior
-Fail	Element with smooth scroll-behavior ; scrollBy() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scrollBy() with smooth behavior
 Pass	Element with auto scroll-behavior ; scrollIntoView() with default behavior
 Pass	Element with auto scroll-behavior ; scrollIntoView() with auto behavior
 Pass	Element with auto scroll-behavior ; scrollIntoView() with instant behavior
-Fail	Element with auto scroll-behavior ; scrollIntoView() with smooth behavior
-Fail	Element with smooth scroll-behavior ; scrollIntoView() with default behavior
-Fail	Element with smooth scroll-behavior ; scrollIntoView() with auto behavior
+Pass	Element with auto scroll-behavior ; scrollIntoView() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scrollIntoView() with default behavior
+Pass	Element with smooth scroll-behavior ; scrollIntoView() with auto behavior
 Pass	Element with smooth scroll-behavior ; scrollIntoView() with instant behavior
-Fail	Element with smooth scroll-behavior ; scrollIntoView() with smooth behavior
+Pass	Element with smooth scroll-behavior ; scrollIntoView() with smooth behavior
 Pass	Set scrollLeft to element with auto scroll-behavior
-Fail	Set scrollLeft to element with smooth scroll-behavior
+Pass	Set scrollLeft to element with smooth scroll-behavior
 Pass	Set scrollTop to element with auto scroll-behavior
-Fail	Set scrollTop to element with smooth scroll-behavior
+Pass	Set scrollTop to element with smooth scroll-behavior
 Pass	Aborting an ongoing smooth scrolling on an element with another smooth scrolling
 Pass	Aborting an ongoing smooth scrolling on an element with an instant scrolling

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-element.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-element.txt
@@ -1,0 +1,45 @@
+Harness status: OK
+
+Found 39 tests
+
+21 Pass
+18 Fail
+Pass	Make sure the page is ready for animation.
+Pass	Element with auto scroll-behavior ; scroll() with default behavior
+Pass	Element with auto scroll-behavior ; scroll() with auto behavior
+Pass	Element with auto scroll-behavior ; scroll() with instant behavior
+Fail	Element with auto scroll-behavior ; scroll() with smooth behavior
+Fail	Element with smooth scroll-behavior ; scroll() with default behavior
+Fail	Element with smooth scroll-behavior ; scroll() with auto behavior
+Pass	Element with smooth scroll-behavior ; scroll() with instant behavior
+Fail	Element with smooth scroll-behavior ; scroll() with smooth behavior
+Pass	Element with auto scroll-behavior ; scrollTo() with default behavior
+Pass	Element with auto scroll-behavior ; scrollTo() with auto behavior
+Pass	Element with auto scroll-behavior ; scrollTo() with instant behavior
+Fail	Element with auto scroll-behavior ; scrollTo() with smooth behavior
+Fail	Element with smooth scroll-behavior ; scrollTo() with default behavior
+Fail	Element with smooth scroll-behavior ; scrollTo() with auto behavior
+Pass	Element with smooth scroll-behavior ; scrollTo() with instant behavior
+Fail	Element with smooth scroll-behavior ; scrollTo() with smooth behavior
+Pass	Element with auto scroll-behavior ; scrollBy() with default behavior
+Pass	Element with auto scroll-behavior ; scrollBy() with auto behavior
+Pass	Element with auto scroll-behavior ; scrollBy() with instant behavior
+Fail	Element with auto scroll-behavior ; scrollBy() with smooth behavior
+Fail	Element with smooth scroll-behavior ; scrollBy() with default behavior
+Fail	Element with smooth scroll-behavior ; scrollBy() with auto behavior
+Pass	Element with smooth scroll-behavior ; scrollBy() with instant behavior
+Fail	Element with smooth scroll-behavior ; scrollBy() with smooth behavior
+Pass	Element with auto scroll-behavior ; scrollIntoView() with default behavior
+Pass	Element with auto scroll-behavior ; scrollIntoView() with auto behavior
+Pass	Element with auto scroll-behavior ; scrollIntoView() with instant behavior
+Fail	Element with auto scroll-behavior ; scrollIntoView() with smooth behavior
+Fail	Element with smooth scroll-behavior ; scrollIntoView() with default behavior
+Fail	Element with smooth scroll-behavior ; scrollIntoView() with auto behavior
+Pass	Element with smooth scroll-behavior ; scrollIntoView() with instant behavior
+Fail	Element with smooth scroll-behavior ; scrollIntoView() with smooth behavior
+Pass	Set scrollLeft to element with auto scroll-behavior
+Fail	Set scrollLeft to element with smooth scroll-behavior
+Pass	Set scrollTop to element with auto scroll-behavior
+Fail	Set scrollTop to element with smooth scroll-behavior
+Pass	Aborting an ongoing smooth scrolling on an element with another smooth scrolling
+Pass	Aborting an ongoing smooth scrolling on an element with an instant scrolling

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-main-frame-window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-main-frame-window.txt
@@ -1,0 +1,34 @@
+Harness status: OK
+
+Found 28 tests
+
+16 Pass
+12 Fail
+Pass	Page loaded
+Pass	Make sure the page is ready for animation.
+Pass	Main frame with auto scroll-behavior ; scroll() with default behavior
+Pass	Main frame with auto scroll-behavior ; scroll() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scroll() with instant behavior
+Fail	Main frame with auto scroll-behavior ; scroll() with smooth behavior
+Fail	Main frame with smooth scroll-behavior ; scroll() with default behavior
+Fail	Main frame with smooth scroll-behavior ; scroll() with auto behavior
+Pass	Main frame with smooth scroll-behavior ; scroll() with instant behavior
+Fail	Main frame with smooth scroll-behavior ; scroll() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with default behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with instant behavior
+Fail	Main frame with auto scroll-behavior ; scrollTo() with smooth behavior
+Fail	Main frame with smooth scroll-behavior ; scrollTo() with default behavior
+Fail	Main frame with smooth scroll-behavior ; scrollTo() with auto behavior
+Pass	Main frame with smooth scroll-behavior ; scrollTo() with instant behavior
+Fail	Main frame with smooth scroll-behavior ; scrollTo() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with default behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with instant behavior
+Fail	Main frame with auto scroll-behavior ; scrollBy() with smooth behavior
+Fail	Main frame with smooth scroll-behavior ; scrollBy() with default behavior
+Fail	Main frame with smooth scroll-behavior ; scrollBy() with auto behavior
+Pass	Main frame with smooth scroll-behavior ; scrollBy() with instant behavior
+Fail	Main frame with smooth scroll-behavior ; scrollBy() with smooth behavior
+Pass	Aborting an ongoing smooth scrolling on the main frame with another smooth scrolling
+Pass	Aborting an ongoing smooth scrolling on the main frame with an instant scrolling

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-main-frame-window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-main-frame-window.txt
@@ -2,33 +2,32 @@ Harness status: OK
 
 Found 28 tests
 
-16 Pass
-12 Fail
+28 Pass
 Pass	Page loaded
 Pass	Make sure the page is ready for animation.
 Pass	Main frame with auto scroll-behavior ; scroll() with default behavior
 Pass	Main frame with auto scroll-behavior ; scroll() with auto behavior
 Pass	Main frame with auto scroll-behavior ; scroll() with instant behavior
-Fail	Main frame with auto scroll-behavior ; scroll() with smooth behavior
-Fail	Main frame with smooth scroll-behavior ; scroll() with default behavior
-Fail	Main frame with smooth scroll-behavior ; scroll() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scroll() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scroll() with default behavior
+Pass	Main frame with smooth scroll-behavior ; scroll() with auto behavior
 Pass	Main frame with smooth scroll-behavior ; scroll() with instant behavior
-Fail	Main frame with smooth scroll-behavior ; scroll() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scroll() with smooth behavior
 Pass	Main frame with auto scroll-behavior ; scrollTo() with default behavior
 Pass	Main frame with auto scroll-behavior ; scrollTo() with auto behavior
 Pass	Main frame with auto scroll-behavior ; scrollTo() with instant behavior
-Fail	Main frame with auto scroll-behavior ; scrollTo() with smooth behavior
-Fail	Main frame with smooth scroll-behavior ; scrollTo() with default behavior
-Fail	Main frame with smooth scroll-behavior ; scrollTo() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scrollTo() with default behavior
+Pass	Main frame with smooth scroll-behavior ; scrollTo() with auto behavior
 Pass	Main frame with smooth scroll-behavior ; scrollTo() with instant behavior
-Fail	Main frame with smooth scroll-behavior ; scrollTo() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scrollTo() with smooth behavior
 Pass	Main frame with auto scroll-behavior ; scrollBy() with default behavior
 Pass	Main frame with auto scroll-behavior ; scrollBy() with auto behavior
 Pass	Main frame with auto scroll-behavior ; scrollBy() with instant behavior
-Fail	Main frame with auto scroll-behavior ; scrollBy() with smooth behavior
-Fail	Main frame with smooth scroll-behavior ; scrollBy() with default behavior
-Fail	Main frame with smooth scroll-behavior ; scrollBy() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scrollBy() with default behavior
+Pass	Main frame with smooth scroll-behavior ; scrollBy() with auto behavior
 Pass	Main frame with smooth scroll-behavior ; scrollBy() with instant behavior
-Fail	Main frame with smooth scroll-behavior ; scrollBy() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scrollBy() with smooth behavior
 Pass	Aborting an ongoing smooth scrolling on the main frame with another smooth scrolling
 Pass	Aborting an ongoing smooth scrolling on the main frame with an instant scrolling

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-smooth-positions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-smooth-positions.txt
@@ -1,0 +1,28 @@
+Harness status: OK
+
+Found 23 tests
+
+23 Pass
+Pass	Make sure the page is ready for animation.
+Pass	Scroll positions when performing smooth scrolling from (0, 0) to (500, 250) using scroll() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 0) to (500, 250) using scroll() 
+Pass	Scroll positions when performing smooth scrolling from (0, 500) to (500, 250) using scroll() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 500) to (500, 250) using scroll() 
+Pass	Scroll positions when performing smooth scrolling from (0, 0) to (500, 250) using scrollTo() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 0) to (500, 250) using scrollTo() 
+Pass	Scroll positions when performing smooth scrolling from (0, 500) to (500, 250) using scrollTo() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 500) to (500, 250) using scrollTo() 
+Pass	Scroll positions when performing smooth scrolling from (0, 0) to (500, 250) using scrollBy() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 0) to (500, 250) using scrollBy() 
+Pass	Scroll positions when performing smooth scrolling from (0, 500) to (500, 250) using scrollBy() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 500) to (500, 250) using scrollBy() 
+Pass	Scroll positions when performing smooth scrolling from (0, 0) to (500, 250) using scrollIntoView() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 0) to (500, 250) using scrollIntoView() 
+Pass	Scroll positions when performing smooth scrolling from (0, 500) to (500, 250) using scrollIntoView() 
+Pass	Scroll positions when performing smooth scrolling from (1000, 500) to (500, 250) using scrollIntoView() 
+Pass	Scroll positions when performing smooth scrolling from 0 to 500 by setting scrollLeft 
+Pass	Scroll positions when performing smooth scrolling from 1000 to 500 by setting scrollLeft 
+Pass	Scroll positions when performing smooth scrolling from 0 to 250 by setting scrollTop 
+Pass	Scroll positions when performing smooth scrolling from 500 to 250 by setting scrollTop 
+Pass	Scroll positions when aborting a smooth scrolling with another smooth scrolling
+Pass	Scroll positions when aborting a smooth scrolling with an instant scrolling

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-subframe-window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-subframe-window.txt
@@ -2,33 +2,33 @@ Harness status: OK
 
 Found 28 tests
 
-16 Pass
-12 Fail
+22 Pass
+6 Fail
 Pass	iframe loaded
 Pass	Make sure the page is ready for animation.
 Pass	Main frame with auto scroll-behavior ; scroll() with default behavior
 Pass	Main frame with auto scroll-behavior ; scroll() with auto behavior
 Pass	Main frame with auto scroll-behavior ; scroll() with instant behavior
-Fail	Main frame with auto scroll-behavior ; scroll() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scroll() with smooth behavior
 Fail	Main frame with smooth scroll-behavior ; scroll() with default behavior
 Fail	Main frame with smooth scroll-behavior ; scroll() with auto behavior
 Pass	Main frame with smooth scroll-behavior ; scroll() with instant behavior
-Fail	Main frame with smooth scroll-behavior ; scroll() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scroll() with smooth behavior
 Pass	Main frame with auto scroll-behavior ; scrollTo() with default behavior
 Pass	Main frame with auto scroll-behavior ; scrollTo() with auto behavior
 Pass	Main frame with auto scroll-behavior ; scrollTo() with instant behavior
-Fail	Main frame with auto scroll-behavior ; scrollTo() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with smooth behavior
 Fail	Main frame with smooth scroll-behavior ; scrollTo() with default behavior
 Fail	Main frame with smooth scroll-behavior ; scrollTo() with auto behavior
 Pass	Main frame with smooth scroll-behavior ; scrollTo() with instant behavior
-Fail	Main frame with smooth scroll-behavior ; scrollTo() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scrollTo() with smooth behavior
 Pass	Main frame with auto scroll-behavior ; scrollBy() with default behavior
 Pass	Main frame with auto scroll-behavior ; scrollBy() with auto behavior
 Pass	Main frame with auto scroll-behavior ; scrollBy() with instant behavior
-Fail	Main frame with auto scroll-behavior ; scrollBy() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with smooth behavior
 Fail	Main frame with smooth scroll-behavior ; scrollBy() with default behavior
 Fail	Main frame with smooth scroll-behavior ; scrollBy() with auto behavior
 Pass	Main frame with smooth scroll-behavior ; scrollBy() with instant behavior
-Fail	Main frame with smooth scroll-behavior ; scrollBy() with smooth behavior
+Pass	Main frame with smooth scroll-behavior ; scrollBy() with smooth behavior
 Pass	Aborting an ongoing smooth scrolling on the main frame with another smooth scrolling
 Pass	Aborting an ongoing smooth scrolling on the main frame with an instant scrolling

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-subframe-window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-subframe-window.txt
@@ -1,0 +1,34 @@
+Harness status: OK
+
+Found 28 tests
+
+16 Pass
+12 Fail
+Pass	iframe loaded
+Pass	Make sure the page is ready for animation.
+Pass	Main frame with auto scroll-behavior ; scroll() with default behavior
+Pass	Main frame with auto scroll-behavior ; scroll() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scroll() with instant behavior
+Fail	Main frame with auto scroll-behavior ; scroll() with smooth behavior
+Fail	Main frame with smooth scroll-behavior ; scroll() with default behavior
+Fail	Main frame with smooth scroll-behavior ; scroll() with auto behavior
+Pass	Main frame with smooth scroll-behavior ; scroll() with instant behavior
+Fail	Main frame with smooth scroll-behavior ; scroll() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with default behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scrollTo() with instant behavior
+Fail	Main frame with auto scroll-behavior ; scrollTo() with smooth behavior
+Fail	Main frame with smooth scroll-behavior ; scrollTo() with default behavior
+Fail	Main frame with smooth scroll-behavior ; scrollTo() with auto behavior
+Pass	Main frame with smooth scroll-behavior ; scrollTo() with instant behavior
+Fail	Main frame with smooth scroll-behavior ; scrollTo() with smooth behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with default behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with auto behavior
+Pass	Main frame with auto scroll-behavior ; scrollBy() with instant behavior
+Fail	Main frame with auto scroll-behavior ; scrollBy() with smooth behavior
+Fail	Main frame with smooth scroll-behavior ; scrollBy() with default behavior
+Fail	Main frame with smooth scroll-behavior ; scrollBy() with auto behavior
+Pass	Main frame with smooth scroll-behavior ; scrollBy() with instant behavior
+Fail	Main frame with smooth scroll-behavior ; scrollBy() with smooth behavior
+Pass	Aborting an ongoing smooth scrolling on the main frame with another smooth scrolling
+Pass	Aborting an ongoing smooth scrolling on the main frame with an instant scrolling

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-element.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-element.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<title>Testing scrollOptions' behavior for Element.scroll* and scroll-behavior on an element</title>
+<meta name="timeout" content="long"/>
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-box">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../dom/events/scrolling/scroll_support.js"></script>
+<script src="support/scroll-behavior.js"></script>
+<style>
+  .scrollable {
+    overflow: auto;
+    width: 400px;
+    height: 200px;
+  }
+  .autoBehavior {
+    scroll-behavior: auto;
+  }
+  .smoothBehavior {
+    scroll-behavior: smooth;
+  }
+</style>
+<div id="log">
+</div>
+<div id="overflowNode" class="scrollable">
+  <div style="width: 2000px; height: 1000px; background: linear-gradient(135deg, red, green);">
+    <span style="display: inline-block; width: 500px; height: 250px;"></span><span id="elementToReveal" style="display: inline-block; vertical-align: -15px; width: 10px; height: 15px; background: black;"></span>
+  </div>
+</div>
+<script>
+  var scrollingElement = overflowNode;
+  var styledElement = overflowNode;
+  var elementToRevealLeft = 500;
+  var elementToRevealTop = 250;
+
+  promise_test(async () => {
+    await waitForCompositorReady();
+  }, "Make sure the page is ready for animation.");
+
+  ["scroll", "scrollTo", "scrollBy", "scrollIntoView"].forEach((scrollFunction) => {
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "autoBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, null, elementToRevealLeft, elementToRevealTop);
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Should set scrollLeft immediately");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Should set scrollTop immediately");
+      return new Promise((resolve) => { resolve(); });
+    }, `Element with auto scroll-behavior ; ${scrollFunction}() with default behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "autoBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, "auto", elementToRevealLeft, elementToRevealTop);
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Should set scrollLeft immediately");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Should set scrollTop immediately");
+      return new Promise((resolve) => { resolve(); });
+    }, `Element with auto scroll-behavior ; ${scrollFunction}() with auto behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "autoBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, "instant", elementToRevealLeft, elementToRevealTop);
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Should set scrollLeft immediately");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Should set scrollTop immediately");
+      return new Promise((resolve) => { resolve(); });
+    }, `Element with auto scroll-behavior ; ${scrollFunction}() with instant behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "autoBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, "smooth", elementToRevealLeft, elementToRevealTop);
+      assert_less_than(scrollingElement.scrollLeft, elementToRevealLeft, "Should not set scrollLeft immediately");
+      assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Should not set scrollTop immediately");
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft");
+        assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+      });
+    }, `Element with auto scroll-behavior ; ${scrollFunction}() with smooth behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, null, elementToRevealLeft, elementToRevealTop);
+      assert_less_than(scrollingElement.scrollLeft, elementToRevealLeft, "Should not set scrollLeft immediately");
+      assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Should not set scrollTop immediately");
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft");
+        assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+      });
+    }, `Element with smooth scroll-behavior ; ${scrollFunction}() with default behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, "auto", elementToRevealLeft, elementToRevealTop);
+      assert_less_than(scrollingElement.scrollLeft, elementToRevealLeft, "Should not set scrollLeft immediately");
+      assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Should not set scrollTop immediately");
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft");
+        assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+      });
+    }, `Element with smooth scroll-behavior ; ${scrollFunction}() with auto behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, "instant", elementToRevealLeft, elementToRevealTop);
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Should set scrollLeft immediately");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Should set scrollTop immediately");
+      return new Promise((resolve) => { resolve(); });
+    }, `Element with smooth scroll-behavior ; ${scrollFunction}() with instant behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      scrollNode(scrollingElement, scrollFunction, "smooth", elementToRevealLeft, elementToRevealTop);
+      assert_less_than(scrollingElement.scrollLeft, elementToRevealLeft, "Should not set scrollLeft immediately");
+      assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Should not set scrollTop immediately");
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft");
+        assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+      });
+   }, `Element with smooth scroll-behavior ; ${scrollFunction}() with smooth behavior`);
+  });
+
+  [{scrollAttribute: "scrollLeft", scrollValue: elementToRevealLeft}, {scrollAttribute: "scrollTop", scrollValue: elementToRevealTop}].forEach((attributeTest) => {
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "autoBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      var expectedValue = Number(attributeTest.scrollValue);
+      scrollingElement[attributeTest.scrollAttribute] = expectedValue;
+      assert_equals( scrollingElement[attributeTest.scrollAttribute], expectedValue, "Should set scroll attribute immediately");
+      return new Promise((resolve) => { resolve(); });
+    }, `Set ${attributeTest.scrollAttribute} to element with auto scroll-behavior`);
+
+    promise_test(() => {
+      resetScroll(scrollingElement);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingElement.scrollLeft, 0);
+      assert_equals(scrollingElement.scrollTop, 0);
+      var expectedValue = Number(attributeTest.scrollValue);
+      scrollingElement[attributeTest.scrollAttribute] = expectedValue;
+      assert_less_than(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Shouldn't set scroll attribute immediately");
+      return waitForScrollEnd(scrollingElement).then(() => {
+        assert_equals(scrollingElement[attributeTest.scrollAttribute], expectedValue, "Final value of scroll attribute");
+      });
+    }, `Set ${attributeTest.scrollAttribute} to element with smooth scroll-behavior`);
+  });
+
+  promise_test(() => {
+    resetScroll(scrollingElement);
+    setScrollBehavior(styledElement, "smoothBehavior");
+    assert_equals(scrollingElement.scrollLeft, 0);
+    assert_equals(scrollingElement.scrollTop, 0);
+    scrollNode(scrollingElement, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+    scrollNode(scrollingElement, "scroll", "smooth", elementToRevealLeft / 2, elementToRevealTop / 2);
+    return waitForScrollEnd(scrollingElement).then(() => {
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft / 2, "Final value of scrollLeft");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop / 2, "Final value of scrollTop");
+    });
+  }, "Aborting an ongoing smooth scrolling on an element with another smooth scrolling");
+
+  promise_test(() => {
+    resetScroll(scrollingElement);
+    setScrollBehavior(styledElement, "smoothBehavior");
+    assert_equals(scrollingElement.scrollLeft, 0);
+    assert_equals(scrollingElement.scrollTop, 0);
+    scrollNode(scrollingElement, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+    scrollNode(scrollingElement, "scroll", "instant", 0, 0);
+    return waitForScrollEnd(scrollingElement).then(() => {
+      assert_equals(scrollingElement.scrollLeft, 0, "Final value of scrollLeft");
+      assert_equals(scrollingElement.scrollTop, 0, "Final value of scrollTop");
+    });
+  }, "Aborting an ongoing smooth scrolling on an element with an instant scrolling");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-main-frame-window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-main-frame-window.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<title>Testing scrollOptions' behavior for Element.scroll* on the window of the main frame</title>
+<meta name="timeout" content="long"/>
+<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-box">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../dom/events/scrolling/scroll_support.js"></script>
+<script src="support/scroll-behavior.js"></script>
+<style>
+  body {
+    margin: 0;
+  }
+  .autoBehavior {
+    scroll-behavior: auto;
+  }
+  .smoothBehavior {
+    scroll-behavior: smooth;
+  }
+</style>
+<div id="log">
+</div>
+<div id="pageContent" style="position: absolute; left: 0; top: 0;">
+  <div id="elementToReveal" style="position: absolute; display: inline-block; width: 10px; height: 15px; background: black;"></div>
+</div>
+<script>
+  var pageLoaded = async_test("Page loaded");
+  var scrollingWindow, styledElement, elementToRevealLeft, elementToRevealTop;
+  window.addEventListener("load", pageLoaded.step_func_done(function() {
+    scrollingWindow = window;
+    styledElement = document.documentElement;
+    pageContent.style.width = (10 + window.innerWidth) * 5 + "px";
+    pageContent.style.height = (20 + window.innerHeight) * 6 + "px";
+    elementToRevealLeft = (10 + window.innerWidth) * 3;
+    elementToRevealTop = (20 + window.innerHeight) * 4;
+    elementToReveal.style.left = elementToRevealLeft + "px";
+    elementToReveal.style.top = elementToRevealTop + "px";
+
+    add_completion_callback(() => { resetScrollForWindow(window); });
+
+    promise_test(async () => {
+      await waitForCompositorReady();
+    }, "Make sure the page is ready for animation.");
+
+    ["scroll", "scrollTo", "scrollBy"].forEach((scrollFunction) => {
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, null, elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with default behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "auto", elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with auto behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "instant", elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with instant behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "smooth", elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with smooth behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, null, elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with default behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "auto", elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with auto behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "instant", elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with instant behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "smooth", elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+     }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with smooth behavior`);
+    });
+
+    promise_test(() => {
+      resetScrollForWindow(scrollingWindow);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingWindow.scrollX, 0);
+      assert_equals(scrollingWindow.scrollY, 0);
+      scrollWindow(scrollingWindow, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+      scrollWindow(scrollingWindow, "scroll", "smooth", elementToRevealLeft / 2, elementToRevealTop / 2);
+      return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft / 2, "Final value of scrollLeft");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop / 2, "Final value of scrollTop");
+      });
+    }, "Aborting an ongoing smooth scrolling on the main frame with another smooth scrolling");
+
+    promise_test(() => {
+      resetScrollForWindow(scrollingWindow);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingWindow.scrollX, 0);
+      assert_equals(scrollingWindow.scrollY, 0);
+      scrollWindow(scrollingWindow, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+      scrollWindow(scrollingWindow, "scroll", "instant", 0, 0);
+      return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+        assert_equals(scrollingWindow.scrollX, 0, "Final value of scrollLeft");
+        assert_equals(scrollingWindow.scrollY, 0, "Final value of scrollTop");
+    });
+  }, "Aborting an ongoing smooth scrolling on the main frame with an instant scrolling");
+  }));
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-smooth-positions.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-smooth-positions.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<title>Testing scroll positions when scrolling an element with smooth behavior</title>
+<meta name="timeout" content="long"/>
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-box">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../dom/events/scrolling/scroll_support.js"></script>
+<script src="support/scroll-behavior.js"></script>
+<style>
+  .scrollable {
+    overflow: auto;
+    width: 400px;
+    height: 200px;
+    scroll-behavior: smooth;
+  }
+</style>
+<div id="log">
+</div>
+<div id="overflowNode" class="scrollable">
+  <div style="width: 2000px; height: 1000px; background: linear-gradient(135deg, red, green);">
+    <span style="display: inline-block; width: 500px; height: 250px;"></span><span id="elementToReveal" style="display: inline-block; vertical-align: -15px; width: 10px; height: 15px; background: black;"></span>
+  </div>
+</div>
+<script>
+  promise_test(async () => {
+    await waitForCompositorReady();
+  }, "Make sure the page is ready for animation.");
+
+  // For smooth behavior, evolution of scroll positions over time is not specified by CSSOM View.
+  // This test relies on the minimal assumption that scroll position functions are monotonic.
+  ["scroll", "scrollTo", "scrollBy", "scrollIntoView"].forEach(function(scrollFunction) {
+    [{left:0, top:0}, {left:1000, top:0}, {left:0, top:500}, {left:1000, top:500}].forEach((initial) => {
+      var finalLeft = 500;
+      var finalTop = 250;
+      promise_test(() => {
+        return new Promise(function(resolve, reject) {
+          scrollNode(overflowNode, "scroll", "instant", initial.left, initial.top);
+          var oldLeft = overflowNode.scrollLeft;
+          var oldTop = overflowNode.scrollTop;
+          assert_equals(oldLeft, initial.left, "ScrollLeft should be at initial position");
+          assert_equals(oldTop, initial.top, "ScrollTop should be at initial position");
+          if (scrollFunction === "scrollBy")
+            scrollNode(overflowNode, scrollFunction, "smooth", finalLeft - initial.left, finalTop - initial.top);
+          else
+            scrollNode(overflowNode, scrollFunction, "smooth", finalLeft, finalTop);
+          observeScrolling(overflowNode, function(done) {
+            try {
+              var newLeft = overflowNode.scrollLeft;
+              var newTop = overflowNode.scrollTop;
+              assert_less_than_equal(Math.hypot(finalLeft - newLeft, finalTop - newTop), Math.hypot(finalLeft - oldLeft, finalTop - oldTop), "Scroll position should move towards the final position");
+              if (done) {
+                assert_equals(newLeft, finalLeft, "ScrollLeft should reach final position");
+                assert_equals(newTop, finalTop, "ScrollTop should reach final position");
+              }
+              oldLeft = newLeft;
+              oldTop = newTop;
+            } catch(e) {
+              reject(e);
+            }
+            if (done)
+              resolve();
+          });
+        });
+      }, `Scroll positions when performing smooth scrolling from (${initial.left}, ${initial.top}) to (${finalLeft}, ${finalTop}) using ${scrollFunction}() `);
+    });
+  });
+
+  [{scrollAttribute: "scrollLeft", scrollValue: 500}, {scrollAttribute: "scrollTop", scrollValue: 250}].forEach(function(scrollTest) {
+    var initialPosition = Number(scrollTest.scrollValue) * 2;
+    [0, initialPosition].forEach((initial) => {
+      promise_test(() => {
+        return new Promise(function(resolve, reject) {
+          scrollNode(overflowNode, "scroll", "instant", initial, initial);
+          var oldValue = overflowNode[scrollTest.scrollAttribute];
+          assert_equals(oldValue, initial, `${scrollTest.scrollAttribute} should be at initial position`);
+          var expectedValue = Number(scrollTest.scrollValue);
+          overflowNode[scrollTest.scrollAttribute] = expectedValue;
+          observeScrolling(overflowNode, function(done) {
+            try {
+              var newValue = overflowNode[scrollTest.scrollAttribute];
+              assert_less_than_equal(Math.abs(expectedValue - newValue), Math.abs(expectedValue - oldValue), "Scroll position should move towards the final position");
+              if (done)
+                assert_equals(newValue, expectedValue, `${scrollTest.scrollAttribute} should reach final position`);
+              oldValue = newValue;
+            } catch(e) {
+              reject(e);
+            }
+            if (done)
+              resolve();
+          });
+        });
+      }, `Scroll positions when performing smooth scrolling from ${initial} to ${scrollTest.scrollValue} by setting ${scrollTest.scrollAttribute} `);
+    });
+  });
+
+  promise_test(() => {
+    return new Promise(function(resolve, reject) {
+      resetScroll(overflowNode);
+      var initialScrollAborted = false;
+      var scrollDirectionChanged = false;
+      var oldLeft = overflowNode.scrollLeft;
+      var oldTop = overflowNode.scrollTop;
+      assert_equals(oldLeft, 0);
+      assert_equals(oldTop, 0);
+      scrollNode(overflowNode, "scroll", "smooth", 1500, 750);
+      observeScrolling(overflowNode, function(done) {
+        try {
+          var newLeft = overflowNode.scrollLeft;
+          var newTop = overflowNode.scrollTop;
+          if (initialScrollAborted) {
+            if (scrollDirectionChanged) {
+              assert_greater_than_equal(oldLeft, newLeft, "ScrollLeft keeps decreasing");
+              assert_greater_than_equal(oldTop, newTop, "ScrollTop keeps decreasing");
+            } else
+              scrollDirectionChanged = newLeft <= oldLeft && newTop <= oldTop;
+          } else {
+              assert_less_than_equal(oldLeft, newLeft, "ScrollLeft keeps increasing");
+              assert_less_than_equal(oldTop, newTop, "ScrollTop keeps increasing");
+              if (newLeft > 1000 && newTop > 500) {
+                // Abort the initial scroll.
+                initialScrollAborted = true;
+                scrollNode(overflowNode, "scroll", "smooth", 500, 250);
+                newLeft = overflowNode.scrollLeft;
+                newTop = overflowNode.scrollTop;
+              }
+          }
+          if (done) {
+            assert_equals(newLeft, 500, "ScrollLeft should reach final position");
+            assert_equals(newTop, 250, "ScrollTop should reach final position");
+          }
+          oldLeft = newLeft;
+          oldTop = newTop;
+        } catch(e) {
+          reject(e);
+        }
+        if (done)
+          resolve();
+      });
+    });
+  }, "Scroll positions when aborting a smooth scrolling with another smooth scrolling");
+
+  promise_test(() => {
+    return new Promise(function(resolve, reject) {
+      resetScroll(overflowNode);
+      var initialScrollAborted = false;
+      var oldLeft = overflowNode.scrollLeft;
+      var oldTop = overflowNode.scrollTop;
+      assert_equals(oldLeft, 0);
+      assert_equals(oldTop, 0);
+      scrollNode(overflowNode, "scroll", "smooth", 1500, 750);
+      observeScrolling(overflowNode, function(done) {
+        try {
+          var newLeft = overflowNode.scrollLeft;
+          var newTop = overflowNode.scrollTop;
+          if (!initialScrollAborted) {
+              assert_less_than_equal(oldLeft, newLeft, "ScrollLeft keeps increasing");
+              assert_less_than_equal(oldTop, newTop, "ScrollTop keeps increasing");
+              if (newLeft > 1000 && newTop > 500) {
+                // Abort the initial scroll.
+                initialScrollAborted = true;
+                scrollNode(overflowNode, "scroll", "instant", 500, 250);
+                newLeft = overflowNode.scrollLeft;
+                newTop = overflowNode.scrollTop;
+                assert_equals(newLeft, 500, "ScrollLeft should reach final position");
+                assert_equals(newTop, 250, "ScrollTop should reach final position");
+              }
+          }
+          if (done) {
+            assert_equals(newLeft, 500, "ScrollLeft should stay at final position");
+            assert_equals(newTop, 250, "ScrollTop should stay at final position");
+          }
+          oldLeft = newLeft;
+          oldTop = newTop;
+        } catch(e) {
+          reject(e);
+        }
+        if (done)
+          resolve();
+      });
+    });
+  }, "Scroll positions when aborting a smooth scrolling with an instant scrolling");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-subframe-window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-subframe-window.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<title>Testing scrollOptions' behavior for Element.scroll* and scroll-behavior on the root of a subframe</title>
+<meta name="timeout" content="long"/>
+<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-box">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../dom/events/scrolling/scroll_support.js"></script>
+<script src="support/scroll-behavior.js"></script>
+<div id="log">
+</div>
+<iframe id="iframeNode" width="400px" height="200px" srcdoc="<!DOCTYPE>
+<html>
+  <style>
+    body {
+      margin: 0;
+    }
+    .autoBehavior {
+      scroll-behavior: auto;
+    }
+    .smoothBehavior {
+      scroll-behavior: smooth;
+    }
+  </style>
+  <body>
+    <div style='width: 2000px; height: 1000px; background: linear-gradient(135deg, red, green);'>
+      <span style='display: inline-block; width: 500px; height: 250px;'></span><span id='elementToReveal' style='display: inline-block; vertical-align: -15px; width: 10px; height: 15px; background: black;'></span>
+    </div>
+  </body>
+</html>">
+</iframe>
+<script>
+  var iframeLoadTest = async_test("iframe loaded");
+  var scrollingWindow, styledElement, elementToReveal;
+  var elementToRevealLeft = 500;
+  var elementToRevealTop = 250;
+  iframeNode.addEventListener("load", iframeLoadTest.step_func_done(() => {
+    promise_test(async () => {
+      await waitForCompositorReady();
+    }, "Make sure the page is ready for animation.");
+
+    scrollingWindow = iframeNode.contentWindow;
+    styledElement = iframeNode.contentDocument.documentElement;
+    elementToReveal = iframeNode.contentDocument.getElementById("elementToReveal");
+
+    ["scroll", "scrollTo", "scrollBy"].forEach((scrollFunction) => {
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, null, elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with default behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "auto", elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with auto behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "instant", elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with instant behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "autoBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "smooth", elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+      }, `Main frame with auto scroll-behavior ; ${scrollFunction}() with smooth behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, null, elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with default behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "auto", elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with auto behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "instant", elementToRevealLeft, elementToRevealTop);
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Should set scrollLeft immediately");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Should set scrollTop immediately");
+        return new Promise((resolve) => { resolve(); });
+      }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with instant behavior`);
+
+      promise_test(() => {
+        resetScrollForWindow(scrollingWindow);
+        setScrollBehavior(styledElement, "smoothBehavior");
+        assert_equals(scrollingWindow.scrollX, 0);
+        assert_equals(scrollingWindow.scrollY, 0);
+        scrollWindow(scrollingWindow, scrollFunction, "smooth", elementToRevealLeft, elementToRevealTop);
+        assert_less_than(scrollingWindow.scrollX, elementToRevealLeft, "Should not set scrollLeft immediately");
+        assert_less_than(scrollingWindow.scrollY, elementToRevealTop, "Should not set scrollTop immediately");
+        return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+          assert_equals(scrollingWindow.scrollX, elementToRevealLeft, "Final value of scrollLeft");
+          assert_equals(scrollingWindow.scrollY, elementToRevealTop, "Final value of scrollTop");
+        });
+     }, `Main frame with smooth scroll-behavior ; ${scrollFunction}() with smooth behavior`);
+    });
+
+    promise_test(() => {
+      resetScrollForWindow(scrollingWindow);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingWindow.scrollX, 0);
+      assert_equals(scrollingWindow.scrollY, 0);
+      scrollWindow(scrollingWindow, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+      scrollWindow(scrollingWindow, "scroll", "smooth", elementToRevealLeft / 2, elementToRevealTop / 2);
+      return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+        assert_equals(scrollingWindow.scrollX, elementToRevealLeft / 2, "Final value of scrollLeft");
+        assert_equals(scrollingWindow.scrollY, elementToRevealTop / 2, "Final value of scrollTop");
+      });
+    }, "Aborting an ongoing smooth scrolling on the main frame with another smooth scrolling");
+
+    promise_test(() => {
+      resetScrollForWindow(scrollingWindow);
+      setScrollBehavior(styledElement, "smoothBehavior");
+      assert_equals(scrollingWindow.scrollX, 0);
+      assert_equals(scrollingWindow.scrollY, 0);
+      scrollWindow(scrollingWindow, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+      scrollWindow(scrollingWindow, "scroll", "instant", 0, 0);
+      return waitForScrollEnd(scrollingWindow.document.scrollingElement).then(() => {
+        assert_equals(scrollingWindow.scrollX, 0, "Final value of scrollLeft");
+        assert_equals(scrollingWindow.scrollY, 0, "Final value of scrollTop");
+    });
+  }, "Aborting an ongoing smooth scrolling on the main frame with an instant scrolling");
+
+  }));
+</script>


### PR DESCRIPTION
### Implement smooth scrolling.
~~Default to smooth scroll for wheel events to make scrolling with the mouse more pleasant.~~

I've tried to keep the smooth scrolling logic centralized and separated as its own thing.

There are ~~101~~ 113 new WPT tests we're passing.

### A little demo:
#### Anchors on a page with `scroll-behavior: smooth`:
Before - a jarring jump:
[Nagranie ekranu_20260423_210656.webm](https://github.com/user-attachments/assets/8bde7963-3440-4fe9-acb9-b7f878f8d20d)

After - beautiful, smooth scroll:
[Nagranie ekranu_20260423_205600.webm](https://github.com/user-attachments/assets/66599796-9603-494e-bed8-83c97c63b1ea)
