### PR TITLE
CMake: Add overlay port for highway 1.4.0

### DIFF
--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -435,7 +435,7 @@
           {
             "type": "git",
             "url": "https://github.com/google/highway.git",
-            "tag": "1.3.0",
+            "tag": "1.4.0",
             "disable-submodules": true
           }
         ],

--- a/Meta/CMake/vcpkg/overlay-ports/highway/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/highway
+    REF "${VERSION}"
+    SHA512 819422857d6a74e3a936c402698e078db5b7b88fb43767e62429ec7bd954fe93b017e75029a4df4a1a97ef3a2486107eef5247da751eb487640dea409f3f2fa2
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        contrib  HWY_ENABLE_CONTRIB
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DHWY_ENABLE_INSTALL=ON
+        -DHWY_ENABLE_EXAMPLES=OFF
+        -DHWY_ENABLE_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME hwy CONFIG_PATH lib/cmake/hwy)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/hwy/highway_export.h" "defined(HWY_SHARED_DEFINE)" "1")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/Meta/CMake/vcpkg/overlay-ports/highway/usage
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/usage
@@ -1,0 +1,4 @@
+highway provides CMake targets:
+
+    find_package(hwy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE hwy::hwy)

--- a/Meta/CMake/vcpkg/overlay-ports/highway/vcpkg.json
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "highway",
+  "version": "1.4.0",
+  "description": "Performance-portable, length-agnostic SIMD with runtime dispatch",
+  "homepage": "https://github.com/google/highway",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "contrib": {
+      "description": "SIMD related utility functions",
+      "supports": "!uwp"
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -305,6 +305,10 @@
       "version": "10.2.0#0"
     },
     {
+      "name": "highway",
+      "version": "1.4.0#0"
+    },
+    {
       "name": "icu",
       "version": "78.2#0"
     },


### PR DESCRIPTION
Until the upstream vcpkg port is updated, this will patch in the new
release of highway. The new release includes fixes for EVEX512 feature
detection in gcc>=15 and clang>=22, and unblocks using those compilers.

ref: https://github.com/microsoft/vcpkg/pull/51357