### PR TITLE
LibWeb: Update stale `ScrollTimeline`s after layout

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -47,15 +47,6 @@ NullableCSSNumberish AnimationTimeline::duration_for_bindings() const
     return NullableCSSNumberish::from_optional_css_numberish_time(realm(), duration());
 }
 
-void AnimationTimeline::set_associated_document(GC::Ptr<DOM::Document> document)
-{
-    if (document)
-        document->associate_with_timeline(*this);
-    if (m_associated_document)
-        m_associated_document->disassociate_with_timeline(*this);
-    m_associated_document = document;
-}
-
 // https://drafts.csswg.org/web-animations-1/#timeline
 bool AnimationTimeline::is_inactive() const
 {
@@ -63,22 +54,23 @@ bool AnimationTimeline::is_inactive() const
     return !m_current_time.has_value();
 }
 
-AnimationTimeline::AnimationTimeline(JS::Realm& realm)
+AnimationTimeline::AnimationTimeline(JS::Realm& realm, GC::Ref<DOM::Document> document)
     : Bindings::PlatformObject(realm)
+    , m_associated_document(document)
 {
 }
 
 void AnimationTimeline::finalize()
 {
     Base::finalize();
-    if (m_associated_document)
-        m_associated_document->disassociate_with_timeline(*this);
+    m_associated_document->disassociate_with_timeline(*this);
 }
 
 void AnimationTimeline::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(AnimationTimeline);
     Base::initialize(realm);
+    m_associated_document->associate_with_timeline(*this);
 }
 
 void AnimationTimeline::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -24,15 +24,32 @@ Optional<TimeValue> AnimationTimeline::current_time() const
 
 void AnimationTimeline::set_current_time(Optional<TimeValue> value)
 {
-    if (value == m_current_time)
-        return;
-
     if (m_is_monotonically_increasing && m_current_time.has_value() && (!value.has_value() || *value < *m_current_time)) {
         dbgln("AnimationTimeline::set_current_time({}): monotonically increasing timeline can only move forward", value);
         return;
     }
 
     m_current_time = value;
+
+    update_associated_animations_and_dispatch_events();
+}
+
+void AnimationTimeline::update_associated_animations_and_dispatch_events()
+{
+    // https://drafts.csswg.org/web-animations-1/#animation-frame-loop
+    // Note: Due to the hierarchical nature of the timing model, updating the current time of a timeline also involves:
+    // - Updating the current time of any animations associated with the timeline.
+    // - Running the update an animation's finished state procedure for any animations whose current time has been
+    //   updated.
+    // - Queueing animation events for any such animations.
+    for (auto& animation : m_associated_animations)
+        animation.update();
+
+    auto animations = GC::RootVector<GC::Ref<Animations::Animation>> { heap() };
+    for (auto& animation : m_associated_animations)
+        animations.append(animation);
+    for (auto& animation : animations)
+        m_associated_document->dispatch_events_for_animation_if_necessary(animation);
 }
 
 // https://drafts.csswg.org/web-animations-2/#timeline-duration

--- a/Libraries/LibWeb/Animations/AnimationTimeline.h
+++ b/Libraries/LibWeb/Animations/AnimationTimeline.h
@@ -32,8 +32,7 @@ public:
     NullableCSSNumberish duration_for_bindings() const;
     virtual Optional<TimeValue> duration() const = 0;
 
-    GC::Ptr<DOM::Document> associated_document() const { return m_associated_document; }
-    void set_associated_document(GC::Ptr<DOM::Document>);
+    GC::Ref<DOM::Document> associated_document() const { return m_associated_document; }
 
     virtual bool is_inactive() const;
     bool is_monotonically_increasing() const { return m_is_monotonically_increasing; }
@@ -48,7 +47,7 @@ public:
     GC::WeakHashSet<Animation> const& associated_animations() const { return m_associated_animations; }
 
 protected:
-    AnimationTimeline(JS::Realm&);
+    AnimationTimeline(JS::Realm&, GC::Ref<DOM::Document>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -63,7 +62,7 @@ protected:
     bool m_is_monotonically_increasing { false };
 
     // https://www.w3.org/TR/web-animations-1/#timeline-associated-with-a-document
-    GC::Ptr<DOM::Document> m_associated_document {};
+    GC::Ref<DOM::Document> m_associated_document;
 
     GC::WeakHashSet<Animation> m_associated_animations;
 };

--- a/Libraries/LibWeb/Animations/AnimationTimeline.h
+++ b/Libraries/LibWeb/Animations/AnimationTimeline.h
@@ -54,6 +54,7 @@ protected:
     virtual void finalize() override;
 
     void set_current_time(Optional<TimeValue> value);
+    void update_associated_animations_and_dispatch_events();
 
     // https://www.w3.org/TR/web-animations-1/#dom-animationtimeline-currenttime
     Optional<TimeValue> m_current_time {};

--- a/Libraries/LibWeb/Animations/DocumentTimeline.cpp
+++ b/Libraries/LibWeb/Animations/DocumentTimeline.cpp
@@ -79,10 +79,9 @@ bool DocumentTimeline::is_inactive() const
 }
 
 DocumentTimeline::DocumentTimeline(JS::Realm& realm, DOM::Document& document, HighResolutionTime::DOMHighResTimeStamp origin_time)
-    : AnimationTimeline(realm)
+    : AnimationTimeline(realm, document)
     , m_origin_time(origin_time)
 {
-    set_associated_document(document);
 }
 
 void DocumentTimeline::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/Animations/ScrollTimeline.cpp
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.cpp
@@ -158,6 +158,24 @@ static Optional<ScrollOffsetData> compute_scroll_offset_data(Variant<GC::Ptr<DOM
     };
 }
 
+bool ScrollTimeline::is_stale() const
+{
+    // FIXME: This should probably be a spec bug
+
+    // https://drafts.csswg.org/scroll-animations-1/#stale-timelines
+    // AD-HOC: The spec only lists two criteria for a scroll timeline to be considered stale: a) it was newly created
+    //         within the current frame or; b) style update and layout within the current frame changed it's associated
+    //         named timeline ranges. However, WPT expects us to also consider the source element resizing as a cause
+    //         for staleness, so we use a more broad definition of staleness and consider any timeline whose max scroll
+    //         offset has changed since the last call to `update_current_time` to be stale. This matches the (admittedly
+    //         narrow) tests in WPT and is the same behavior as is implemented by WebKit.
+
+    // FIXME: Account for the named timeline ranges of view progress timelines once they are implemented.
+    auto scroll_offset_data = compute_scroll_offset_data(get_propagated_source(), m_axis);
+
+    return scroll_offset_data.map([](auto const& data) { return data.max_scroll_offset; }) != m_last_max_scroll_offset;
+}
+
 void ScrollTimeline::update_current_time(double)
 {
     // https://drafts.csswg.org/scroll-animations-1/#ref-for-dom-animationtimeline-currenttime
@@ -167,9 +185,12 @@ void ScrollTimeline::update_current_time(double)
 
     auto scroll_offset_data = compute_scroll_offset_data(get_propagated_source(), m_axis);
 
+    m_last_max_scroll_offset = scroll_offset_data.map([](auto const& data) { return data.max_scroll_offset; });
+
     // If the source of a ScrollTimeline is an element whose principal box does not exist or is not a scroll container,
     // or if there is no scrollable overflow, then the ScrollTimeline is inactive.
     // NB: Called during animation timeline update, which runs before layout is up to date.
+
     if (!scroll_offset_data.has_value()) {
         set_current_time({});
         return;

--- a/Libraries/LibWeb/Animations/ScrollTimeline.cpp
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.cpp
@@ -128,35 +128,39 @@ void ScrollTimeline::update_current_time(double)
     // representing its startmost scroll position (in the writing mode of the scroll container). Null when the timeline
     // is inactive.
 
-    // NB: We set the current time to null at the start of this so we can easily just return when the timeline should be
-    //     inactive, only setting it to a resolved value if the timeline is active.
-    set_current_time({});
-
     auto propagated_source = get_propagated_source();
 
-    if (propagated_source.visit([](auto const& source) { return source == nullptr; }))
+    if (propagated_source.visit([](auto const& source) { return source == nullptr; })) {
+        set_current_time({});
         return;
+    }
 
     // If the source of a ScrollTimeline is an element whose principal box does not exist or is not a scroll container,
     // or if there is no scrollable overflow, then the ScrollTimeline is inactive.
     // NB: Called during animation timeline update, which runs before layout is up to date.
     auto const& layout_node = propagated_source.visit([](auto const& source) -> Layout::NodeWithStyle const* { return source->unsafe_layout_node(); });
 
-    if (!layout_node || !layout_node->is_scroll_container())
+    if (!layout_node || !layout_node->is_scroll_container()) {
+        set_current_time({});
         return;
+    }
 
     auto paintable_box = propagated_source.visit([](auto const& source) -> RefPtr<Painting::PaintableBox const> { return source->unsafe_paintable_box(); });
 
-    if (!paintable_box || !paintable_box->has_scrollable_overflow())
+    if (!paintable_box || !paintable_box->has_scrollable_overflow()) {
+        set_current_time({});
         return;
+    }
 
     auto const& scrollable_overflow_rect = paintable_box->scrollable_overflow_rect().value();
     auto const& computed_axis = computed_scroll_axis(m_axis, paintable_box->computed_values().writing_mode(), paintable_box->computed_values().direction());
 
     // https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress
     // If the 0% position and 100% position coincide (i.e. the denominator in the current time formula is zero), the timeline is inactive.
-    if ((computed_axis.is_vertical && scrollable_overflow_rect.height() == paintable_box->content_height()) || (!computed_axis.is_vertical && scrollable_overflow_rect.width() == paintable_box->content_width()))
+    if ((computed_axis.is_vertical && scrollable_overflow_rect.height() == paintable_box->content_height()) || (!computed_axis.is_vertical && scrollable_overflow_rect.width() == paintable_box->content_width())) {
+        set_current_time({});
         return;
+    }
 
     // FIXME: In paged media, scroll progress timelines that would otherwise reference the document viewport are also inactive.
 

--- a/Libraries/LibWeb/Animations/ScrollTimeline.cpp
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.cpp
@@ -121,6 +121,43 @@ static ComputedScrollAxis computed_scroll_axis(Bindings::ScrollAxis axis, CSS::W
     VERIFY_NOT_REACHED();
 }
 
+struct ScrollOffsetData {
+    double scroll_offset;
+    double max_scroll_offset;
+};
+static Optional<ScrollOffsetData> compute_scroll_offset_data(Variant<GC::Ptr<DOM::Element const>, GC::Ptr<DOM::Document>> propagated_source, Bindings::ScrollAxis axis)
+{
+    if (propagated_source.visit([](auto const& source) { return source == nullptr; }))
+        return {};
+
+    auto const& layout_node = propagated_source.visit([](auto const& source) -> Layout::NodeWithStyle const* { return source->unsafe_layout_node(); });
+
+    if (!layout_node || !layout_node->is_scroll_container())
+        return {};
+
+    auto const& paintable_box = propagated_source.visit([](auto const& source) -> RefPtr<Painting::PaintableBox const> { return source->unsafe_paintable_box(); });
+
+    if (!paintable_box || !paintable_box->has_scrollable_overflow())
+        return {};
+
+    auto const& scrollable_overflow_rect = paintable_box->scrollable_overflow_rect().value();
+    auto const& computed_axis = computed_scroll_axis(axis, paintable_box->computed_values().writing_mode(), paintable_box->computed_values().direction());
+
+    // FIXME: Scroll offset is currently incorrect as it is always relative to the top left of the scrollable overflow
+    //        rect when it should instead be relative to the scroll origin.
+
+    // FIXME: Support the case where the computed scroll axis is reversed
+
+    return ScrollOffsetData {
+        .scroll_offset = computed_axis.is_vertical
+            ? paintable_box->scroll_offset().y().to_double()
+            : paintable_box->scroll_offset().x().to_double(),
+        .max_scroll_offset = computed_axis.is_vertical
+            ? scrollable_overflow_rect.height().to_double() - paintable_box->content_height().to_double()
+            : scrollable_overflow_rect.width().to_double() - paintable_box->content_width().to_double(),
+    };
+}
+
 void ScrollTimeline::update_current_time(double)
 {
     // https://drafts.csswg.org/scroll-animations-1/#ref-for-dom-animationtimeline-currenttime
@@ -128,36 +165,19 @@ void ScrollTimeline::update_current_time(double)
     // representing its startmost scroll position (in the writing mode of the scroll container). Null when the timeline
     // is inactive.
 
-    auto propagated_source = get_propagated_source();
-
-    if (propagated_source.visit([](auto const& source) { return source == nullptr; })) {
-        set_current_time({});
-        return;
-    }
+    auto scroll_offset_data = compute_scroll_offset_data(get_propagated_source(), m_axis);
 
     // If the source of a ScrollTimeline is an element whose principal box does not exist or is not a scroll container,
     // or if there is no scrollable overflow, then the ScrollTimeline is inactive.
     // NB: Called during animation timeline update, which runs before layout is up to date.
-    auto const& layout_node = propagated_source.visit([](auto const& source) -> Layout::NodeWithStyle const* { return source->unsafe_layout_node(); });
-
-    if (!layout_node || !layout_node->is_scroll_container()) {
+    if (!scroll_offset_data.has_value()) {
         set_current_time({});
         return;
     }
-
-    auto paintable_box = propagated_source.visit([](auto const& source) -> RefPtr<Painting::PaintableBox const> { return source->unsafe_paintable_box(); });
-
-    if (!paintable_box || !paintable_box->has_scrollable_overflow()) {
-        set_current_time({});
-        return;
-    }
-
-    auto const& scrollable_overflow_rect = paintable_box->scrollable_overflow_rect().value();
-    auto const& computed_axis = computed_scroll_axis(m_axis, paintable_box->computed_values().writing_mode(), paintable_box->computed_values().direction());
 
     // https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress
     // If the 0% position and 100% position coincide (i.e. the denominator in the current time formula is zero), the timeline is inactive.
-    if ((computed_axis.is_vertical && scrollable_overflow_rect.height() == paintable_box->content_height()) || (!computed_axis.is_vertical && scrollable_overflow_rect.width() == paintable_box->content_width())) {
+    if (scroll_offset_data->max_scroll_offset == 0) {
         set_current_time({});
         return;
     }
@@ -167,13 +187,7 @@ void ScrollTimeline::update_current_time(double)
     // https://drafts.csswg.org/scroll-animations-1/#scroll-timeline-progress
     // Progress (the current time) for a scroll progress timeline is calculated as:
     //     scroll offset ÷ (scrollable overflow size − scroll container size)
-    // FIXME: Scroll offset is currently incorrect as it is always relative to the top left of the scrollable overflow
-    //        rect when it should instead be relative to the scroll origin.
-    auto progress = computed_axis.is_vertical
-        ? paintable_box->scroll_offset().y().to_double() / (scrollable_overflow_rect.height().to_double() - paintable_box->content_height().to_double())
-        : paintable_box->scroll_offset().x().to_double() / (scrollable_overflow_rect.width().to_double() - paintable_box->content_width().to_double());
-
-    // FIXME: Support the case where the computed scroll axis is reversed
+    auto progress = scroll_offset_data->scroll_offset / scroll_offset_data->max_scroll_offset;
 
     set_current_time(TimeValue { TimeValue::Type::Percentage, progress * 100 });
 }

--- a/Libraries/LibWeb/Animations/ScrollTimeline.cpp
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.cpp
@@ -175,11 +175,10 @@ void ScrollTimeline::update_current_time(double)
 }
 
 ScrollTimeline::ScrollTimeline(JS::Realm& realm, DOM::Document& document, Source source, Bindings::ScrollAxis axis)
-    : AnimationTimeline(realm)
+    : AnimationTimeline(realm, document)
     , m_source(source)
     , m_axis(axis)
 {
-    set_associated_document(document);
 }
 
 void ScrollTimeline::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Animations/ScrollTimeline.h
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.h
@@ -44,6 +44,7 @@ public:
 
     Source source_internal() const { return m_source; }
 
+    bool is_stale() const;
     virtual void update_current_time(double timestamp) override;
 
     virtual bool is_progress_based() const override { return true; }
@@ -63,6 +64,8 @@ private:
 
     // https://drafts.csswg.org/scroll-animations-1/#dom-scrolltimeline-axis
     Bindings::ScrollAxis m_axis { Bindings::ScrollAxis::Block };
+
+    Optional<double> m_last_max_scroll_offset;
 };
 
 Bindings::ScrollAxis css_axis_to_bindings_scroll_axis(CSS::Axis);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6039,24 +6039,8 @@ void Document::update_animations_and_send_events(double timestamp)
     {
         HTML::TemporaryExecutionContext temporary_execution_context { realm() };
         // 1. Update the current time of all timelines associated with doc passing now as the timestamp.
-        //
-        // Note: Due to the hierarchical nature of the timing model, updating the current time of a timeline also involves:
-        // - Updating the current time of any animations associated with the timeline.
-        // - Running the update an animation’s finished state procedure for any animations whose current time has been
-        //   updated.
-        // - Queueing animation events for any such animations.
-        for (auto const& timeline : timelines_to_update) {
+        for (auto const& timeline : timelines_to_update)
             timeline->update_current_time(timestamp);
-
-            for (auto& animation : timeline->associated_animations())
-                animation.update();
-
-            auto animations = GC::RootVector<GC::Ref<Animations::Animation>> { heap() };
-            for (auto& animation : timeline->associated_animations())
-                animations.append(animation);
-            for (auto& animation : animations)
-                dispatch_events_for_animation_if_necessary(animation);
-        }
 
         // 2. Remove replaced animations for doc.
         remove_replaced_animations();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -824,6 +824,7 @@ public:
     };
     void append_pending_animation_event(PendingAnimationEvent const&);
     void update_animations_and_send_events(double timestamp);
+    void dispatch_events_for_animation_if_necessary(GC::Ref<Animations::Animation>);
     void remove_replaced_animations();
 
     WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> get_animations();
@@ -1146,7 +1147,6 @@ private:
     Element* find_a_potential_indicated_element(FlyString const& fragment) const;
 
     void dispatch_events_for_transition(GC::Ref<CSS::CSSTransition>);
-    void dispatch_events_for_animation_if_necessary(GC::Ref<Animations::Animation>);
 
     template<typename GetNotifier, typename... Args>
     void notify_each_document_observer(GetNotifier&& get_notifier, Args&&... args)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -828,6 +828,7 @@ public:
     void remove_replaced_animations();
 
     WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> get_animations();
+    HashTable<GC::Ref<Animations::AnimationTimeline>> const& associated_animation_timelines() const { return m_associated_animation_timelines; }
 
     bool ready_to_run_scripts() const { return m_ready_to_run_scripts; }
     void set_ready_to_run_scripts();

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -8,6 +8,7 @@
 #include <AK/TemporaryChange.h>
 #include <LibCore/EventLoop.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibWeb/Animations/ScrollTimeline.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFaceSet.h>
@@ -465,6 +466,37 @@ void EventLoop::update_the_rendering()
         if (document->has_skipped_resize_observations()) {
             // FIXME: Deliver resize loop error.
         }
+
+        // https://drafts.csswg.org/scroll-animations-1/#event-loop
+        // During step 7.14.1 of the HTML Processing Model, any created scroll progress timelines or view progress
+        // timelines are collected into a stale timelines set. After step 7.14 if any timelines' named timeline ranges
+        // have changed, these timelines are added to the stale timelines set. If there are any stale timelines they now
+        // update their current time and associated ranges, the set of stale timelines is cleared and we run an additional
+        // step to recalculate styles and update layout.
+
+        // AD-HOC: This was step 7.14.1 at the time the CSS web-animations spec was written, but it has since been
+        //         moved, see https://github.com/w3c/csswg-drafts/issues/12120
+
+        bool requires_style_and_layout_update = false;
+
+        TemporaryExecutionContext context { document->realm() };
+
+        for (auto const& timeline : document->associated_animation_timelines()) {
+            auto* scroll_timeline = as_if<Animations::ScrollTimeline>(*timeline);
+
+            if (!scroll_timeline)
+                continue;
+
+            if (!scroll_timeline->is_stale())
+                continue;
+
+            // NB: The passed timestamp is ignored for ScrollTimelines so we can just use 0.
+            timeline->update_current_time(0);
+            requires_style_and_layout_update = true;
+        }
+
+        if (requires_style_and_layout_update)
+            document->update_layout(DOM::UpdateLayoutReason::HTMLEventLoopRenderingUpdate);
     }
 
     // FIXME: 17. For each doc of docs, if the focused area of doc is not a focusable area, then run the focusing steps for doc's viewport, and set doc's relevant global object's navigation API's focus changed during ongoing navigation to false.

--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
@@ -17,22 +17,12 @@ GC_DEFINE_ALLOCATOR(InternalAnimationTimeline);
 
 void InternalAnimationTimeline::update_current_time(double)
 {
-    // Do nothing
+    update_associated_animations_and_dispatch_events();
 }
 
 void InternalAnimationTimeline::set_time(Optional<double> time)
 {
     set_current_time(time.map([](double value) -> Animations::TimeValue { return { Animations::TimeValue::Type::Milliseconds, value }; }));
-
-    // https://drafts.csswg.org/web-animations-1/#animation-frame-loop
-    // Note: Due to the hierarchical nature of the timing model, updating the current time of a timeline also involves:
-    // - Updating the current time of any animations associated with the timeline.
-    // - Running the update an animation's finished state procedure for any animations whose current time has been
-    //   updated.
-    // - Queueing animation events for any such animations.
-    // NB: This mirrors what the event loop does for DocumentTimeline in Document::update_animations_and_send_events().
-    for (auto& animation : associated_animations())
-        animation.update();
 }
 
 InternalAnimationTimeline::InternalAnimationTimeline(JS::Realm& realm, GC::Ref<DOM::Document> document)

--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
@@ -35,14 +35,11 @@ void InternalAnimationTimeline::set_time(Optional<double> time)
         animation.update();
 }
 
-InternalAnimationTimeline::InternalAnimationTimeline(JS::Realm& realm)
-    : AnimationTimeline(realm)
+InternalAnimationTimeline::InternalAnimationTimeline(JS::Realm& realm, GC::Ref<DOM::Document> document)
+    : AnimationTimeline(realm, document)
 {
     m_current_time = { Animations::TimeValue::Type::Milliseconds, 0.0 };
     m_is_monotonically_increasing = true;
-
-    auto& document = as<HTML::Window>(HTML::relevant_global_object(*this)).associated_document();
-    document.associate_with_timeline(*this);
 }
 
 void InternalAnimationTimeline::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.h
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.h
@@ -17,12 +17,14 @@ public:
 
     virtual Optional<Animations::TimeValue> duration() const override { return {}; }
 
+    virtual Optional<double> convert_a_timeline_time_to_an_origin_relative_time(Optional<Animations::TimeValue>) override { return {}; }
+
     virtual void update_current_time(double timestamp) override;
 
     void set_time(Optional<double> time);
 
 private:
-    explicit InternalAnimationTimeline(JS::Realm&);
+    explicit InternalAnimationTimeline(JS::Realm&, GC::Ref<DOM::Document>);
     virtual ~InternalAnimationTimeline() override = default;
 
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -380,7 +380,7 @@ void Internals::spoof_current_url(String const& url_string)
 GC::Ref<InternalAnimationTimeline> Internals::create_internal_animation_timeline()
 {
     auto& realm = this->realm();
-    return realm.create<InternalAnimationTimeline>(realm);
+    return realm.create<InternalAnimationTimeline>(realm, as<HTML::Window>(realm.global_object()).associated_document());
 }
 
 void Internals::simulate_drag_start(double x, double y, String const& name, String const& contents)

--- a/Tests/LibWeb/Text/expected/wpt-import/scroll-animations/scroll-timelines/scroll-timeline-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/scroll-animations/scroll-timelines/scroll-timeline-invalidation.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	Animation current time and effect local time are updated after scroller content size changes.
 Pass	Animation current time and effect local time are updated after scroller size changes.
-Fail	If scroll animation resizes its scroll timeline scroller, layout reruns once per frame.
+Pass	If scroll animation resizes its scroll timeline scroller, layout reruns once per frame.


### PR DESCRIPTION
This is required by the spec and fixes a flaky test (e.g. [this run](https://github.com/LadybirdBrowser/ladybird/actions/runs/24784689842/job/72525254384?pr=9039)).

See individual commits for details.