### PR TITLE
Meta: Add clang-22 to the list of clang candidate compilers

### DIFF
--- a/Meta/Utils/find_compiler.py
+++ b/Meta/Utils/find_compiler.py
@@ -126,6 +126,7 @@ def pick_host_compiler(platform: Platform, cc: str, cxx: str, clang_only: bool =
             "clang-19",
             "clang-20",
             "clang-21",
+            "clang-22",
         ]
 
         gcc_candidates = [


### PR DESCRIPTION
We can build with clang-22 on Linux as of:
309ca11236a954725d8e6fc37b365a113963ff1a