### PR TITLE
LibWebView+UI: Show an error page when we cannot sanitize a URL

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -293,7 +293,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         disable_site_isolation = true;
 
     m_browser_options = {
-        .urls = sanitize_urls(raw_urls, m_settings.new_tab_page_url()),
+        .urls = sanitize_urls(raw_urls),
         .raw_urls = move(raw_urls),
         .headless_mode = headless_mode,
         .new_window = new_window ? NewWindow::Yes : NewWindow::No,

--- a/Libraries/LibWebView/BrowserProcess.cpp
+++ b/Libraries/LibWebView/BrowserProcess.cpp
@@ -183,13 +183,13 @@ void UIProcessConnectionFromClient::die()
 void UIProcessConnectionFromClient::create_new_tab(Vector<ByteString> urls)
 {
     if (on_new_tab)
-        on_new_tab(sanitize_urls(urls, Application::settings().new_tab_page_url()));
+        on_new_tab(sanitize_urls(urls));
 }
 
 void UIProcessConnectionFromClient::create_new_window(Vector<ByteString> urls)
 {
     if (on_new_window)
-        on_new_window(sanitize_urls(urls, Application::settings().new_tab_page_url()));
+        on_new_window(sanitize_urls(urls));
 }
 
 }

--- a/Libraries/LibWebView/ErrorHTML.h
+++ b/Libraries/LibWebView/ErrorHTML.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace WebView {
+
+// FIXME: Move these to an HTML file in Base/res/ladybird.
+
+constexpr inline auto ERROR_HTML_HEADER = R"~~~(
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Error!</title>
+        <style>
+            :root {{
+                color-scheme: light dark;
+                font-family: system-ui, sans-serif;
+            }}
+            body {{
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                min-height: 100vh;
+                box-sizing: border-box;
+                margin: 0;
+                padding: 1rem;
+                text-align: center;
+            }}
+            header {{
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                gap: 2rem;
+                margin-bottom: 1rem;
+            }}
+            svg {{
+                height: 64px;
+                width: auto;
+                stroke: currentColor;
+                fill: none;
+                stroke-width: 1.5;
+                stroke-linecap: round;
+                stroke-linejoin: round;
+            }}
+            h1 {{
+                margin: 0;
+                font-size: 1.5rem;
+            }}
+            p {{
+                font-size: 1rem;
+                color: #555;
+            }}
+        </style>
+    </head>
+    <body>
+        <header>
+            {}
+            <h1>{}</h1>
+        </header>
+)~~~"sv;
+
+constexpr inline auto ERROR_HTML_FOOTER = R"~~~(
+    </body>
+    </html>
+)~~~"sv;
+
+constexpr inline auto ERROR_SVG = R"~~~(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.5 21.5">
+        <path d="M11.75.75h-9c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-13l-5-5z" />
+        <path d="M10.75.75v4c0 1.1.9 2 2 2h4M5.75 9.75v2M11.75 9.75v2M5.75 16.75c1-2.67 5-2.67 6 0" />
+    </svg>
+)~~~"sv;
+
+constexpr inline auto CRASH_ERROR_SVG = R"~~~(
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.5 21.5">
+        <path class="b" d="M11.75.75h-9c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-13l-5-5z" />
+        <path class="b" d="M10.75.75v4c0 1.1.9 2 2 2h4M4.75 9.75l2 2M10.75 9.75l2 2M12.75 9.75l-2 2M6.75 9.75l-2 2M5.75 16.75c1-2.67 5-2.67 6 0" />
+    </svg>
+)~~~"sv;
+
+}

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -11,6 +11,7 @@
 #include <LibFileSystem/FileSystem.h>
 #include <LibURL/Parser.h>
 #include <LibURL/PublicSuffixData.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/Autocomplete.h>
 #include <LibWebView/URL.h>
 
@@ -158,7 +159,7 @@ bool autocomplete_url_can_complete(StringView query, StringView suggestion)
     return normalized_suggestion.starts_with_bytes(normalized_query, CaseSensitivity::CaseInsensitive);
 }
 
-Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls, URL::URL const& new_tab_page_url)
+Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls)
 {
     Vector<URL::URL> sanitized_urls;
     sanitized_urls.ensure_capacity(raw_urls.size());
@@ -169,7 +170,7 @@ Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls, URL::URL const
     }
 
     if (sanitized_urls.is_empty())
-        sanitized_urls.append(new_tab_page_url);
+        sanitized_urls.append(Application::settings().new_tab_page_url());
 
     return sanitized_urls;
 }

--- a/Libraries/LibWebView/URL.h
+++ b/Libraries/LibWebView/URL.h
@@ -20,7 +20,7 @@ enum class AppendTLD {
 };
 WEBVIEW_API Optional<URL::URL> sanitize_url(StringView, Optional<SearchEngine> const& search_engine = {}, AppendTLD = AppendTLD::No);
 WEBVIEW_API bool location_looks_like_url(StringView, AppendTLD = AppendTLD::No);
-WEBVIEW_API Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls, URL::URL const& new_tab_page_url);
+WEBVIEW_API Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls);
 
 struct URLParts {
     StringView scheme_and_subdomain;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/Infra/Strings.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/BookmarkStore.h>
+#include <LibWebView/ErrorHTML.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/HistoryStore.h>
 #include <LibWebView/Menu.h>
@@ -184,6 +185,17 @@ void ViewImplementation::load(URL::URL const& url)
 void ViewImplementation::load_html(StringView html)
 {
     client().async_load_html(page_id(), html);
+}
+
+void ViewImplementation::load_navigation_error_page(StringView text)
+{
+    auto message = MUST(String::formatted("Failed to load \"{}\"", text));
+
+    StringBuilder builder;
+    builder.appendff(ERROR_HTML_HEADER, ERROR_SVG, message);
+    builder.append("<p>If you were trying to enter a search query, please enable search in <a href=\"about:settings#search\">settings</a>.</p>"sv);
+    builder.append(ERROR_HTML_FOOTER);
+    load_html(builder.string_view());
 }
 
 void ViewImplementation::reload()
@@ -692,25 +704,13 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
     handle_resize();
 
     if (load_error_page == LoadErrorPage::Yes) {
+        auto escaped_url = escape_html_entities(m_url.serialize());
+
         StringBuilder builder;
-        builder.append("<!DOCTYPE html>"sv);
-        builder.append("<html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Error!</title><style>"
-                       ":root { color-scheme: light dark; font-family: system-ui, sans-serif; }"
-                       "body { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; box-sizing: border-box; margin: 0; padding: 1rem; text-align: center; }"
-                       "header { display: flex; flex-direction: column; align-items: center; gap: 2rem; margin-bottom: 1rem; }"
-                       "svg { height: 64px; width: auto; stroke: currentColor; fill: none; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }"
-                       "h1 { margin: 0; font-size: 1.5rem; }"
-                       "p { font-size: 1rem; color: #555; }"
-                       "</style></head><body>"sv);
-        builder.append("<header>"sv);
-        builder.append("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 17.5 21.5\">"sv);
-        builder.append("<path class=\"b\" d=\"M11.75.75h-9c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-13l-5-5z\"/>"sv);
-        builder.append("<path class=\"b\" d=\"M10.75.75v4c0 1.1.9 2 2 2h4M4.75 9.75l2 2M10.75 9.75l2 2M12.75 9.75l-2 2M6.75 9.75l-2 2M5.75 16.75c1-2.67 5-2.67 6 0\"/></svg>"sv);
-        auto escaped_url = escape_html_entities(m_url.to_byte_string());
-        builder.append("<h1>Ladybird flew off-course!</h1>"sv);
+        builder.appendff(ERROR_HTML_HEADER, CRASH_ERROR_SVG, "Ladybird flew off-course!"sv);
         builder.appendff("<p>The web page <a href=\"{}\">{}</a> has crashed.<br><br>You can reload the page to try again.</p>", escaped_url, escaped_url);
-        builder.append("</body></html>"sv);
-        load_html(builder.to_byte_string());
+        builder.append(ERROR_HTML_FOOTER);
+        load_html(builder.string_view());
     }
 }
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -79,6 +79,8 @@ public:
 
     void load(URL::URL const&);
     void load_html(StringView);
+    void load_navigation_error_page(StringView);
+
     void reload();
     void traverse_the_history_by_delta(int delta);
 

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -609,6 +609,8 @@ static NSInteger autocomplete_suggestion_index(NSString* suggestion_text, Vector
 
     if (auto url = WebView::sanitize_url(location, WebView::Application::settings().search_engine()); url.has_value()) {
         [self loadURL:*url];
+    } else {
+        [[[self tab] web_view] view].load_navigation_error_page(location);
     }
 
     self.current_inline_autocomplete_suggestion = nil;

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -180,8 +180,8 @@ LocationEdit::LocationEdit(QWidget* parent)
         auto ctrl_held = QApplication::keyboardModifiers() & Qt::ControlModifier;
         auto append_tld = ctrl_held ? WebView::AppendTLD::Yes : WebView::AppendTLD::No;
 
-        if (auto url = WebView::sanitize_url(query, WebView::Application::settings().search_engine(), append_tld); url.has_value())
-            set_url(url.release_value());
+        auto url = WebView::sanitize_url(query, WebView::Application::settings().search_engine(), append_tld);
+        set_url(AK::move(url));
     });
 
     connect(this, &QLineEdit::textEdited, this, [this] {
@@ -229,8 +229,8 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
 
     if (m_url_is_hidden) {
         m_url_is_hidden = false;
-        if (text().isEmpty())
-            setText(qstring_from_ak_string(m_url.serialize()));
+        if (text().isEmpty() && m_url.has_value())
+            setText(qstring_from_ak_string(m_url->serialize()));
     }
 
     if (event->reason() != Qt::PopupFocusReason) {
@@ -245,7 +245,8 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
         if (m_autocomplete->close())
             return;
         reset_autocomplete_state();
-        setText(qstring_from_ak_string(m_url.serialize()));
+        if (m_url.has_value())
+            setText(qstring_from_ak_string(m_url->serialize()));
         clearFocus();
         return;
     }
@@ -331,14 +332,14 @@ void LocationEdit::highlight_location()
     QCoreApplication::sendEvent(this, &event);
 }
 
-void LocationEdit::set_url(URL::URL url)
+void LocationEdit::set_url(Optional<URL::URL> url)
 {
     m_url = AK::move(url);
 
     if (m_url_is_hidden) {
         clear();
-    } else {
-        setText(qstring_from_ak_string(m_url.serialize()));
+    } else if (m_url.has_value()) {
+        setText(qstring_from_ak_string(m_url->serialize()));
         setCursorPosition(0);
     }
 }

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -27,8 +27,8 @@ class LocationEdit final
 public:
     explicit LocationEdit(QWidget*);
 
-    URL::URL const& url() const { return m_url; }
-    void set_url(URL::URL);
+    Optional<URL::URL const&> url() const { return m_url; }
+    void set_url(Optional<URL::URL>);
 
     bool url_is_hidden() const { return m_url_is_hidden; }
     void set_url_is_hidden(bool url_is_hidden) { m_url_is_hidden = url_is_hidden; }
@@ -52,7 +52,7 @@ private:
 
     Autocomplete* m_autocomplete { nullptr };
 
-    URL::URL m_url;
+    Optional<URL::URL> m_url;
     bool m_url_is_hidden { false };
 
     bool m_is_applying_inline_autocomplete { false };

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -485,9 +485,14 @@ void Tab::load_html(StringView html)
 
 void Tab::location_edit_return_pressed()
 {
-    if (m_location_edit->text().isEmpty())
+    auto text = m_location_edit->text();
+    if (text.isEmpty())
         return;
-    navigate(m_location_edit->url());
+
+    if (auto url = m_location_edit->url(); url.has_value())
+        navigate(*url);
+    else
+        view().load_navigation_error_page(ak_string_from_qstring(text));
 }
 
 void Tab::open_file()


### PR DESCRIPTION
Previously, if search was disabled, entering non-URL text would just silently drop the search query (and on Qt, we would reload the current URL). We now detect that the query did not result in a navigation and load an error page instead, which directs the user to enable search.

<img width="1355" height="1093" alt="search" src="https://github.com/user-attachments/assets/e6f0ef49-ea42-4a11-ae1a-db67278ec2fe" />
