### PR TITLE
Everywhere: Add initial support for the Tracy profiler

### DIFF
--- a/AK/Tracy.h
+++ b/AK/Tracy.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if defined(TRACY_ENABLE)
+#    include <tracy/Tracy.hpp>
+#    define TRACY_ZONE_SCOPED() ZoneScoped
+#    define TRACY_ZONE_SCOPED_NAMED(name) ZoneScopedN(name)
+#    define TRACY_SET_ZONE_NAME(name, length) ZoneName(name, length)
+#    define TRACY_FRAME_MARK() FrameMark
+#    define TRACY_FRAME_MARK_NAMED(name) FrameMarkNamed(name)
+#    define TRACY_SET_PROGRAM_NAME(name) TracySetProgramName(name)
+#    define TRACY_PLOT(name, value) TracyPlot(name, value)
+#    if defined(TRACY_ENABLE_MEMORY)
+#        define TRACY_ALLOCATED_MEMORY(ptr, size) TracyAlloc(ptr, size)
+#        define TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, name) TracyAllocN(ptr, size, name)
+#        define TRACY_FREED_MEMORY(ptr) TracyFree(ptr)
+#        define TRACY_FREED_MEMORY_NAMED(ptr, name) TracyFreeN(ptr, name)
+#    else
+#        define TRACY_ALLOCATED_MEMORY(ptr, size)
+#        define TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, name)
+#        define TRACY_FREED_MEMORY(ptr)
+#        define TRACY_FREED_MEMORY_NAMED(ptr, name)
+#    endif
+#else
+#    define TRACY_ZONE_SCOPED()
+#    define TRACY_ZONE_SCOPED_NAMED(name)
+#    define TRACY_SET_ZONE_NAME(name, length)
+#    define TRACY_FRAME_MARK()
+#    define TRACY_FRAME_MARK_NAMED(name)
+#    define TRACY_SET_PROGRAM_NAME(name)
+#    define TRACY_PLOT(name, value)
+#    define TRACY_ALLOCATED_MEMORY(ptr, size)
+#    define TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, name)
+#    define TRACY_FREED_MEMORY(ptr)
+#    define TRACY_FREED_MEMORY_NAMED(ptr, name)
+#endif

--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -5,88 +5,27 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
+#include <AK/Tracy.h>
 #include <AK/kmalloc.h>
 
-#if defined(AK_OS_SERENITY)
+#include <cstddef>
+#include <cstring>
 
-#    include <AK/Assertions.h>
-
-// However deceptively simple these functions look, they must not be inlined.
-// Memory allocated in one translation unit has to be deallocatable in another
-// translation unit, so these functions must be the same everywhere.
-// By making these functions global, this invariant is enforced.
-
-void* operator new(size_t size)
-{
-    void* ptr = malloc(size);
-    VERIFY(ptr);
-    return ptr;
-}
-
-void* operator new(size_t size, std::nothrow_t const&) noexcept
-{
-    return malloc(size);
-}
-
-void operator delete(void* ptr) noexcept
-{
-    return free(ptr);
-}
-
-void operator delete(void* ptr, size_t) noexcept
-{
-    return free(ptr);
-}
-
-void* operator new[](size_t size)
-{
-    void* ptr = malloc(size);
-    VERIFY(ptr);
-    return ptr;
-}
-
-void* operator new[](size_t size, std::nothrow_t const&) noexcept
-{
-    return malloc(size);
-}
-
-void operator delete[](void* ptr) noexcept
-{
-    return free(ptr);
-}
-
-void operator delete[](void* ptr, size_t) noexcept
-{
-    return free(ptr);
-}
-
-// This is usually provided by libstdc++ in most cases, and the kernel has its own definition in
-// Kernel/Heap/kmalloc.cpp. If neither of those apply, the following should suffice to not fail during linking.
-namespace AK_REPLACED_STD_NAMESPACE {
-
-nothrow_t const nothrow;
-
-}
-
-#else
-
-#    include <cstddef>
-#    include <cstring>
-
-#    if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
 // LeakSanitizer does not reliably trace references stored in mimalloc-managed
 // AK containers, so sanitizer builds fall back to the system allocator.
-#        define AK_USE_SYSTEM_ALLOCATOR_INSTRUMENTED 1
-#    else
-#        include <mimalloc.h>
-#    endif
+#    define AK_USE_SYSTEM_ALLOCATOR_INSTRUMENTED 1
+#else
+#    include <mimalloc.h>
+#endif
 
 static bool allocation_needs_explicit_alignment(size_t alignment)
 {
     return alignment > alignof(std::max_align_t);
 }
 
-#    ifdef AK_USE_SYSTEM_ALLOCATOR_INSTRUMENTED
+#ifdef AK_USE_SYSTEM_ALLOCATOR_INSTRUMENTED
 
 static void* aligned_alloc_with_system_allocator(size_t size, size_t alignment, bool zeroed)
 {
@@ -101,17 +40,32 @@ static void* aligned_alloc_with_system_allocator(size_t size, size_t alignment, 
 
 void* ak_kcalloc(size_t count, size_t size)
 {
-    return calloc(count, size);
+    void* ptr = calloc(count, size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY(ptr, count * size);
+    }
+    return ptr;
 }
 
 void* ak_kmalloc(size_t size)
 {
-    return malloc(size);
+    void* ptr = malloc(size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY(ptr, size);
+    }
+    return ptr;
 }
 
 void* ak_krealloc(void* ptr, size_t size)
 {
-    return realloc(ptr, size);
+    if (ptr) {
+        TRACY_FREED_MEMORY(ptr);
+    }
+    void* new_ptr = realloc(ptr, size);
+    if (new_ptr) {
+        TRACY_ALLOCATED_MEMORY(new_ptr, size);
+    }
+    return new_ptr;
 }
 
 size_t ak_kmalloc_good_size(size_t size)
@@ -121,6 +75,9 @@ size_t ak_kmalloc_good_size(size_t size)
 
 void ak_kfree(void* ptr)
 {
+    if (ptr) {
+        TRACY_FREED_MEMORY(ptr);
+    }
     free(ptr);
 }
 
@@ -133,52 +90,101 @@ void* ladybird_rust_realloc(void* ptr, size_t old_size, size_t new_size, size_t 
 
 extern "C" void* ladybird_rust_alloc(size_t size, size_t alignment)
 {
-    if (allocation_needs_explicit_alignment(alignment))
-        return aligned_alloc_with_system_allocator(size, alignment, false);
-    return malloc(size);
+    if (allocation_needs_explicit_alignment(alignment)) {
+        void* ptr = aligned_alloc_with_system_allocator(size, alignment, false);
+        if (ptr) {
+            TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+        }
+        return ptr;
+    }
+
+    void* ptr = malloc(size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+    }
+    return ptr;
 }
 
 extern "C" void* ladybird_rust_alloc_zeroed(size_t size, size_t alignment)
 {
-    if (allocation_needs_explicit_alignment(alignment))
-        return aligned_alloc_with_system_allocator(size, alignment, true);
-    return calloc(1, size);
+    if (allocation_needs_explicit_alignment(alignment)) {
+        void* ptr = aligned_alloc_with_system_allocator(size, alignment, true);
+        if (ptr) {
+            TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+        }
+        return ptr;
+    }
+
+    void* ptr = calloc(1, size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+    }
+    return ptr;
 }
 
 extern "C" void ladybird_rust_dealloc(void* ptr, size_t)
 {
+    if (ptr) {
+        TRACY_FREED_MEMORY_NAMED(ptr, "Rust");
+    }
     free(ptr);
 }
 
 extern "C" void* ladybird_rust_realloc(void* ptr, size_t old_size, size_t new_size, size_t alignment)
 {
-    if (!allocation_needs_explicit_alignment(alignment))
-        return realloc(ptr, new_size);
+    if (!allocation_needs_explicit_alignment(alignment)) {
+        if (ptr) {
+            TRACY_FREED_MEMORY_NAMED(ptr, "Rust");
+        }
+        void* new_ptr = realloc(ptr, new_size);
+        if (new_ptr) {
+            TRACY_ALLOCATED_MEMORY_NAMED(new_ptr, new_size, "Rust");
+        }
+        return new_ptr;
+    }
 
     auto* new_ptr = aligned_alloc_with_system_allocator(new_size, alignment, false);
     if (!new_ptr)
         return nullptr;
-    if (ptr)
+    if (ptr) {
         __builtin_memcpy(new_ptr, ptr, old_size < new_size ? old_size : new_size);
+        TRACY_FREED_MEMORY_NAMED(ptr, "Rust");
+    }
     free(ptr);
+    TRACY_ALLOCATED_MEMORY_NAMED(new_ptr, new_size, "Rust");
     return new_ptr;
 }
 
-#    else
+#else
 
 void* ak_kcalloc(size_t count, size_t size)
 {
-    return mi_calloc(count, size);
+    void* ptr = mi_calloc(count, size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY(ptr, count * size);
+    }
+    return ptr;
 }
 
 void* ak_kmalloc(size_t size)
 {
-    return mi_malloc(size);
+    void* ptr = mi_malloc(size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY(ptr, size);
+    }
+    return ptr;
 }
 
 void* ak_krealloc(void* ptr, size_t size)
 {
-    return mi_realloc(ptr, size);
+    if (ptr) {
+        TRACY_FREED_MEMORY(ptr);
+    }
+    void* new_ptr = mi_realloc(ptr, size);
+    if (new_ptr) {
+        TRACY_ALLOCATED_MEMORY(new_ptr, size);
+    }
+    return new_ptr;
 }
 
 size_t ak_kmalloc_good_size(size_t size)
@@ -188,6 +194,9 @@ size_t ak_kmalloc_good_size(size_t size)
 
 void ak_kfree(void* ptr)
 {
+    if (ptr) {
+        TRACY_FREED_MEMORY(ptr);
+    }
     mi_free(ptr);
 }
 
@@ -200,30 +209,116 @@ void* ladybird_rust_realloc(void* ptr, size_t old_size, size_t new_size, size_t 
 
 extern "C" void* ladybird_rust_alloc(size_t size, size_t alignment)
 {
-    if (allocation_needs_explicit_alignment(alignment))
-        return mi_malloc_aligned(size, alignment);
-    return mi_malloc(size);
+    if (allocation_needs_explicit_alignment(alignment)) {
+        void* ptr = mi_malloc_aligned(size, alignment);
+        if (ptr) {
+            TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+        }
+        return ptr;
+    }
+
+    void* ptr = mi_malloc(size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+    }
+    return ptr;
 }
 
 extern "C" void* ladybird_rust_alloc_zeroed(size_t size, size_t alignment)
 {
-    if (allocation_needs_explicit_alignment(alignment))
-        return mi_zalloc_aligned(size, alignment);
-    return mi_zalloc(size);
+    if (allocation_needs_explicit_alignment(alignment)) {
+        void* ptr = mi_zalloc_aligned(size, alignment);
+        if (ptr) {
+            TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+        }
+        return ptr;
+    }
+
+    void* ptr = mi_zalloc(size);
+    if (ptr) {
+        TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, "Rust");
+    }
+    return ptr;
 }
 
 extern "C" void ladybird_rust_dealloc(void* ptr, size_t)
 {
+    if (ptr) {
+        TRACY_FREED_MEMORY_NAMED(ptr, "Rust");
+    }
     mi_free(ptr);
 }
 
 extern "C" void* ladybird_rust_realloc(void* ptr, size_t, size_t new_size, size_t alignment)
 {
-    if (allocation_needs_explicit_alignment(alignment))
-        return mi_realloc_aligned(ptr, new_size, alignment);
-    return mi_realloc(ptr, new_size);
+    if (allocation_needs_explicit_alignment(alignment)) {
+        if (ptr) {
+            TRACY_FREED_MEMORY_NAMED(ptr, "Rust");
+        }
+        void* new_ptr = mi_realloc_aligned(ptr, new_size, alignment);
+        if (new_ptr) {
+            TRACY_ALLOCATED_MEMORY_NAMED(new_ptr, new_size, "Rust");
+        }
+        return new_ptr;
+    }
+
+    if (ptr) {
+        TRACY_FREED_MEMORY_NAMED(ptr, "Rust");
+    }
+    void* new_ptr = mi_realloc(ptr, new_size);
+    if (new_ptr) {
+        TRACY_ALLOCATED_MEMORY_NAMED(new_ptr, new_size, "Rust");
+    }
+    return new_ptr;
 }
 
-#    endif
-
 #endif
+
+// However deceptively simple these functions look, they must not be inlined.
+// Memory allocated in one translation unit has to be deallocatable in another
+// translation unit, so these functions must be the same everywhere.
+// By making these functions global, this invariant is enforced.
+
+void* operator new(size_t size)
+{
+    void* ptr = ak_kmalloc(size);
+    VERIFY(ptr);
+    return ptr;
+}
+
+void* operator new(size_t size, std::nothrow_t const&) noexcept
+{
+    return ak_kmalloc(size);
+}
+
+void operator delete(void* ptr) noexcept
+{
+    return ak_kfree(ptr);
+}
+
+void operator delete(void* ptr, size_t) noexcept
+{
+    return ak_kfree(ptr);
+}
+
+void* operator new[](size_t size)
+{
+    void* ptr = ak_kmalloc(size);
+    VERIFY(ptr);
+    return ptr;
+}
+
+void* operator new[](size_t size, std::nothrow_t const&) noexcept
+{
+    return ak_kmalloc(size);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+    return ak_kfree(ptr);
+}
+
+void operator delete[](void* ptr, size_t) noexcept
+{
+    return ak_kfree(ptr);
+}

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -9,16 +9,10 @@
 
 #include <AK/Checked.h>
 #include <AK/Platform.h>
+
 #include <new>
 #include <stdlib.h>
 
-#if defined(AK_OS_SERENITY)
-#    define kcalloc calloc
-#    define kfree free
-#    define kmalloc malloc
-#    define krealloc realloc
-#    define kmalloc_good_size malloc_good_size
-#else
 [[nodiscard]] void* ak_kcalloc(size_t count, size_t size);
 void ak_kfree(void* ptr);
 [[nodiscard]] void* ak_kmalloc(size_t size);
@@ -49,7 +43,6 @@ inline void kfree(void* ptr)
 {
     return ak_kmalloc_good_size(size);
 }
-#endif
 
 using std::nothrow;
 

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -31,6 +31,9 @@ There are some optional features that can be enabled during compilation that are
 - `LADYBIRD_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set manually unless managing a distribution package.
 - `ENABLE_NETWORK_DOWNLOADS`: allows downloading files from the internet during the build. Default on, turning off enables offline builds. For offline builds, the structure of the LADYBIRD_CACHE_DIR must be set up the way that the build expects.
 - `ENABLE_CLANG_PLUGINS`: enables Clang plugins which analyze the code for programming mistakes. See [Clang Plugins](#clang-plugins) below.
+- `ENABLE_TRACY`: enables support for the [Tracy](https://github.com/wolfpld/tracy) profiling tool.
+- `ENABLE_TRACY_MEMORY`: enables support for memory usage tracking for the [Tracy](https://github.com/wolfpld/tracy) profiling tool. This option also enables Tracy in general.
+- `TRACY_CALLSTACK_DEPTH`: enables stack frame capturing at [Tracy](https://github.com/wolfpld/tracy) zones, up to the specified depth.
 
 Many parts of the codebase have debug functionality, mostly consisting of additional messages printed to the debug console. This is done via the `<component_name>_DEBUG` macros, which can be enabled individually at build time. They are listed in [this file](../Meta/CMake/all_the_debug_macros.cmake).
 

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/Tracy.h>
 #include <AK/Vector.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/EventLoopImplementation.h>
@@ -108,6 +109,7 @@ void EventLoop::spin_until(Function<bool()> goal_condition)
 
 size_t EventLoop::pump(WaitMode mode)
 {
+    TRACY_ZONE_SCOPED_NAMED("EventLoop::pump");
     return m_impl->pump(mode == WaitMode::WaitForEvents ? EventLoopImplementation::PumpMode::WaitForEvents : EventLoopImplementation::PumpMode::DontWaitForEvents);
 }
 

--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/Platform.h>
 #include <AK/Random.h>
+#include <AK/Tracy.h>
 #include <AK/Vector.h>
 #include <LibGC/BlockAllocator.h>
 #include <LibGC/HeapBlock.h>
@@ -34,6 +35,7 @@ BlockAllocator::~BlockAllocator()
 {
     for (auto* block : m_blocks) {
         ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
+        TRACY_FREED_MEMORY_NAMED(block, "GC Blocks");
 #if defined(AK_OS_MACOS)
         kern_return_t kr = mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(block), HeapBlock::BLOCK_SIZE);
         VERIFY(kr == KERN_SUCCESS);
@@ -56,6 +58,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
         auto* block = m_blocks.unstable_take(random_index);
         ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
         LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+        TRACY_ALLOCATED_MEMORY_NAMED(block, HeapBlock::BLOCK_SIZE, "GC Blocks");
 #if defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
         if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSE) < 0) {
             perror("madvise(MADV_FREE_REUSE)");
@@ -90,6 +93,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
     VERIFY(rc == 0);
 #endif
     LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+    TRACY_ALLOCATED_MEMORY_NAMED(block, HeapBlock::BLOCK_SIZE, "GC Blocks");
     return block;
 }
 
@@ -122,6 +126,7 @@ void BlockAllocator::deallocate_block(void* block)
 
     ASAN_POISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
     LSAN_UNREGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+    TRACY_FREED_MEMORY_NAMED(block, "GC Blocks");
     m_blocks.append(block);
 }
 

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -17,6 +17,7 @@
 #include <AK/StackInfo.h>
 #include <AK/StackUnwinder.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
@@ -75,6 +76,11 @@ void Heap::will_allocate(size_t size)
     }
 
     m_allocated_bytes_since_last_gc += size;
+
+#if defined(TRACY_ENABLE_MEMORY)
+    m_live_heap_size += size;
+    TRACY_PLOT("Live GC Heap Size", static_cast<i64>(m_live_heap_size));
+#endif
 }
 
 static void add_possible_value(HashMap<FlatPtr, HeapRoot>& possible_pointers, FlatPtr data, HeapRoot origin, FlatPtr min_block_address, FlatPtr max_block_address)
@@ -295,6 +301,7 @@ AK::JsonObject Heap::dump_graph()
 
 void Heap::collect_garbage(CollectionType collection_type, bool print_report)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::collect_garbage");
     VERIFY(!m_collecting_garbage);
 
     {
@@ -412,6 +419,7 @@ void Heap::register_sweep_callback(AK::Function<void()> callback)
 
 void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots, HashTable<HeapBlock*>& all_live_heap_blocks, Vector<StackFrameInfo>* out_stack_frames)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::gather_roots");
     for_each_block([&](auto& block) {
         all_live_heap_blocks.set(&block);
 
@@ -675,6 +683,7 @@ private:
 
 void Heap::mark_live_cells(HashMap<Cell*, HeapRoot> const& roots, HashTable<HeapBlock*> const& all_live_heap_blocks)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::mark_live_cells");
     dbgln_if(HEAP_DEBUG, "mark_live_cells:");
 
     MarkingVisitor visitor(*this, roots, all_live_heap_blocks);
@@ -717,6 +726,7 @@ void Heap::sweep_weak_blocks()
 
 void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measurement_timer)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::sweep_dead_cells");
     dbgln_if(HEAP_DEBUG, "sweep_dead_cells:");
     Vector<HeapBlock*, 32> empty_blocks;
     Vector<HeapBlock*, 32> full_blocks_that_became_usable;
@@ -773,6 +783,11 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
     }
 
     m_gc_bytes_threshold = live_cell_bytes > GC_MIN_BYTES_THRESHOLD ? live_cell_bytes : GC_MIN_BYTES_THRESHOLD;
+
+#if defined(TRACY_ENABLE_MEMORY)
+    m_live_heap_size = live_cell_bytes;
+    TRACY_PLOT("Live GC Heap Size", static_cast<i64>(m_live_heap_size));
+#endif
 
     if (print_report) {
         AK::Duration const time_spent = measurement_timer.elapsed_time();

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -159,6 +159,10 @@ private:
     size_t m_gc_bytes_threshold { GC_MIN_BYTES_THRESHOLD };
     size_t m_allocated_bytes_since_last_gc { 0 };
 
+#if defined(TRACY_ENABLE_MEMORY)
+    size_t m_live_heap_size { 0 };
+#endif
+
     bool m_should_collect_on_every_allocation { false };
 
     Vector<NonnullOwnPtr<CellAllocator>> m_size_based_cell_allocators;

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -8,6 +8,7 @@
 #include <AK/Debug.h>
 #include <AK/HashTable.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibGC/RootHashMap.h>
 #include <LibJS/Bytecode/AsmInterpreter/AsmInterpreter.h>
 #include <LibJS/Bytecode/BasicBlock.h>
@@ -420,6 +421,19 @@ NEVER_INLINE void VM::unwind_inline_frame_for_exception()
 
 void VM::run_bytecode(size_t entry_point)
 {
+#if defined(TRACY_ENABLE)
+    TRACY_ZONE_SCOPED();
+    auto& executable = current_executable();
+    if (executable.name.is_ascii()) {
+        auto name_view = executable.name.view();
+        auto name_span = name_view.ascii_span();
+        TRACY_SET_ZONE_NAME(name_span.data(), name_span.size());
+    } else {
+        constexpr auto FunctionName = "JS::Interpreter::run_bytecode()"sv;
+        TRACY_SET_ZONE_NAME(FunctionName.characters_without_null_termination(), FunctionName.length());
+    }
+#endif
+
     if (vm().interpreter_stack().is_exhausted() || vm().did_reach_stack_space_limit()) [[unlikely]] {
         reg(Register::exception()) = vm().throw_completion<InternalError>(ErrorType::CallStackSizeExceeded).value();
         return;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -20,6 +20,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
 #include <AK/Time.h>
+#include <AK/Tracy.h>
 #include <AK/Utf8View.h>
 #include <LibCore/Timer.h>
 #include <LibGC/RootVector.h>
@@ -1488,6 +1489,7 @@ void Document::update_layout_if_needed_for_node(Node const& node, UpdateLayoutRe
 
 void Document::update_layout(UpdateLayoutReason reason)
 {
+    TRACY_ZONE_SCOPED_NAMED("Document::update_layout");
     auto navigable = this->navigable();
     if (!navigable || navigable->active_document() != this)
         return;
@@ -1673,6 +1675,8 @@ bool Document::layout_is_up_to_date() const
 
 [[nodiscard]] static CSS::RequiredInvalidationAfterStyleChange update_style_recursively(Node& node, CSS::StyleComputer& style_computer, bool needs_inherited_style_update, bool recompute_elements_depending_on_custom_properties, bool parent_display_changed)
 {
+    TRACY_ZONE_SCOPED_NAMED("update_style_recursively");
+
     bool const needs_full_style_update = node.document().needs_full_style_update();
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
@@ -1768,6 +1772,8 @@ bool Document::layout_is_up_to_date() const
 
 void Document::update_style()
 {
+    TRACY_ZONE_SCOPED_NAMED("Document::update_style");
+
     // NOTE: If our parent document needs a relayout, we must do that *first*. This is required as it may cause the
     // viewport to change which will can affect media query evaluation and the value of the `vw` unit.
     if (auto navigable = this->navigable(); navigable && navigable->container() && &navigable->container()->document() != this)

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibCore/EventLoop.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -119,6 +120,7 @@ void EventLoop::spin_until(GC::Ref<GC::Function<bool()>> goal_condition)
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
 void EventLoop::process()
 {
+    TRACY_ZONE_SCOPED_NAMED("HTML::EventLoop::process");
     if (m_skip_event_loop_processing_steps)
         return;
 
@@ -305,6 +307,7 @@ void EventLoop::process_input_events() const
 // https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering
 void EventLoop::update_the_rendering()
 {
+    TRACY_ZONE_SCOPED_NAMED("EventLoop::update_the_rendering");
     VERIFY(!m_running_rendering_task);
     m_running_rendering_task = true;
     ScopeGuard const guard = [this] {
@@ -521,6 +524,8 @@ void EventLoop::update_the_rendering()
         TemporaryExecutionContext context(document->realm(), TemporaryExecutionContext::CallbacksEnabled::Yes);
         document->fonts()->set_is_pending_on_the_environment(document->readiness() == DocumentReadyState::Loading);
     }
+
+    TRACY_FRAME_MARK();
 }
 
 void run_when_event_loop_reaches_step_1(GC::Ref<GC::Function<void()>> steps)
@@ -599,6 +604,7 @@ void perform_a_microtask_checkpoint()
 // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
 void EventLoop::perform_a_microtask_checkpoint()
 {
+    TRACY_ZONE_SCOPED_NAMED("EventLoop::perform_a_microtask_checkpoint");
     if (execution_paused())
         return;
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibWeb/Painting/DisplayList.h>
 
@@ -42,6 +43,7 @@ static bool command_is_clip(DisplayListCommand const& command)
 
 void DisplayListPlayer::execute(DisplayList& display_list, ScrollStateSnapshot const& scroll_state_snapshot, RefPtr<Gfx::PaintingSurface> surface)
 {
+    TRACY_ZONE_SCOPED_NAMED("DisplayListPlayer::execute");
     if (surface) {
         surface->lock_context();
     }

--- a/Meta/CMake/cmake_options.cmake
+++ b/Meta/CMake/cmake_options.cmake
@@ -46,6 +46,9 @@ set(LAGOM_USE_LINKER "" CACHE STRING "The linker to use (e.g. lld, mold) instead
 set(LAGOM_LINK_POOL_SIZE "" CACHE STRING "The maximum number of parallel jobs to use for linking")
 option(ENABLE_LTO_FOR_RELEASE "Enable link-time optimization for release builds" ${RELEASE_LTO_DEFAULT})
 option(ENABLE_LAGOM_COVERAGE_COLLECTION "Enable code coverage instrumentation for lagom binaries in clang" OFF)
+option(ENABLE_TRACY "Enable Tracy profiler instrumentation" OFF)
+option(ENABLE_TRACY_MEMORY "Enable Tracy profiler memory instrumentation" OFF)
+set(TRACY_CALLSTACK_DEPTH 0 CACHE STRING "Tracy call stack capture depth on zones (0 = disabled, 16+ recommended)")
 
 if (ENABLE_FUZZERS_LIBFUZZER)
     # With libfuzzer, we need to avoid a duplicate main() linker error giving false negatives

--- a/Meta/CMake/compile_options.cmake
+++ b/Meta/CMake/compile_options.cmake
@@ -188,6 +188,7 @@ elseif (MSVC)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/sanitizers.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/tracy.cmake)
 
 include(CheckPIESupported)
 check_pie_supported(LANGUAGES CXX)

--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -677,6 +677,23 @@
       ]
     },
     {
+      "name": "tracy",
+      "buildsystem": "cmake-ninja",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/wolfpld/tracy.git",
+          "tag": "v0.13.1"
+        }
+      ],
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_PREFIX_PATH=/app",
+        "-DCMAKE_INSTALL_LIBDIR=lib",
+        "-DTRACY_ON_DEMAND=ON"
+      ]
+    },
+    {
       "name": "Ladybird",
       "buildsystem": "cmake-ninja",
       "sources": [

--- a/Meta/CMake/tracy.cmake
+++ b/Meta/CMake/tracy.cmake
@@ -1,0 +1,30 @@
+if (ENABLE_TRACY OR ENABLE_TRACY_MEMORY)
+    find_package(Tracy CONFIG REQUIRED)
+    add_compile_definitions(TRACY_ENABLE)
+
+    if (ENABLE_TRACY_MEMORY)
+        add_compile_definitions(TRACY_ENABLE_MEMORY)
+    endif()
+
+    if (TRACY_CALLSTACK_DEPTH GREATER 0)
+        add_compile_definitions(TRACY_CALLSTACK=${TRACY_CALLSTACK_DEPTH})
+    endif()
+
+    if (NOT WIN32)
+        add_cxx_compile_options(-fno-omit-frame-pointer)
+    endif()
+
+    # Tracy needs full debug info to resolve call stack symbols.
+    if (NOT WIN32)
+        add_cxx_compile_options(-g2)
+    else()
+        add_cxx_compile_options(/Z7)
+    endif()
+
+    if (NOT APPLE AND NOT WIN32)
+        # Export symbols from executables so Tracy can resolve call stack addresses.
+        add_link_options(-rdynamic)
+    endif()
+
+    link_libraries(Tracy::TracyClient)
+endif()

--- a/Services/ImageDecoder/main.cpp
+++ b/Services/ImageDecoder/main.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <ImageDecoder/ConnectionFromClient.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
@@ -15,6 +16,7 @@
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("ImageDecoder");
     AK::set_rich_debug_enabled(true);
 
     Core::ArgsParser args_parser;

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -8,6 +8,7 @@
 #include <AK/ByteString.h>
 #include <AK/Format.h>
 #include <AK/StringView.h>
+#include <AK/Tracy.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
@@ -36,6 +37,7 @@ static void handle_signal(int signal)
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("RequestServer");
     AK::set_rich_debug_enabled(true);
 
     Vector<ByteString> certificates;

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/LexicalPath.h>
+#include <AK/Tracy.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -106,6 +107,7 @@ static ErrorOr<void> connect_to_image_decoder(IPC::TransportHandle const& handle
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("WebContent");
     AK::set_rich_debug_enabled(true);
 
 #if !defined(AK_OS_WINDOWS)

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Platform.h>
+#include <AK/Tracy.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
@@ -76,6 +77,7 @@ static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint,
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("WebDriver");
     AK::set_rich_debug_enabled(true);
 
     auto listen_address = "0.0.0.0"sv;

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
@@ -46,6 +47,7 @@ static ErrorOr<Web::Bindings::AgentType> agent_type_from_string(StringView type)
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("WebWorker");
     AK::set_rich_debug_enabled(true);
 
     StringView serenity_resource_root;

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Enumerate.h>
+#include <AK/Tracy.h>
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/BrowserProcess.h>
@@ -37,6 +38,7 @@ static void open_urls_from_client(Vector<URL::URL> const& urls, WebView::NewWind
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("Ladybird");
     AK::set_rich_debug_enabled(true);
 
     auto app = TRY(Ladybird::Application::create(arguments));

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/BrowserProcess.h>
@@ -41,6 +42,7 @@ bool is_using_dark_system_theme(QWidget& widget)
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("Ladybird");
     AK::set_rich_debug_enabled(true);
 
     auto app = TRY(Ladybird::Application::create(arguments));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -169,6 +169,12 @@
     },
     "sqlite3",
     {
+      "name": "tracy",
+      "features": [
+        "on-demand"
+      ]
+    },
+    {
       "name": "tiff",
       "features": [
         "zstd"
@@ -399,6 +405,10 @@
     {
       "name": "tiff",
       "version": "4.7.1#0"
+    },
+    {
+      "name": "tracy",
+      "version": "0.13.1"
     },
     {
       "name": "vulkan",


### PR DESCRIPTION
This is a revival of https://github.com/LadybirdBrowser/ladybird/pull/8189

This allows us to get explicit zones (complimented with full call stacks on Linux and Windows) plus plot graphs such as memory usage (including GC blocks and live GC heap size), in per-frame boundaries or across the capture lifetime.

Demos:
- Loading a Ladybird newsletter and finding memory allocation churn when playing a video:

https://github.com/user-attachments/assets/12baba31-7a7e-41b8-ade3-1c28a78ff41d

- Loading Google and investigating a long frame, seeing layout update takes a long time and allocates ~1 MB of memory

https://github.com/user-attachments/assets/de9c6577-8007-4c9a-8e85-875e597c0a16

- Long JS execution frame on Google:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 15 47 29" src="https://github.com/user-attachments/assets/5c706943-55fb-427d-8b81-2ee068970082" />

- Ghost frames (i.e. stack traces) from a remote Linux machine with perf_event_paranoid=1:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 16 41 06" src="https://github.com/user-attachments/assets/f188b281-6420-4a4c-963d-54cd07570ca5" />

- Active allocations with stack traces:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 16 42 55" src="https://github.com/user-attachments/assets/8d8ffc46-1271-4974-8af7-691d2ed141bf" />

- Memory pool categorisation:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 16 47 25" src="https://github.com/user-attachments/assets/bb3aa923-4914-4502-ae62-4cd5ed63289b" />