### PR TITLE
LibJS: Invalidate prototype chains via per-shape child lists

### DIFF
--- a/Libraries/LibJS/Runtime/Realm.h
+++ b/Libraries/LibJS/Runtime/Realm.h
@@ -71,8 +71,6 @@ public:
 
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
-    HashTable<GC::RawPtr<Shape>>& all_prototype_shapes() { return m_all_prototype_shapes; }
-
 private:
     Realm() = default;
 
@@ -83,8 +81,6 @@ private:
     GC::Ptr<DeclarativeEnvironment> m_global_declarative_environment; // Cached from GlobalEnv
     GC::Ptr<GlobalEnvironment> m_global_environment;                  // [[GlobalEnv]]
     OwnPtr<HostDefined> m_host_defined;                               // [[HostDefined]]
-
-    HashTable<GC::RawPtr<Shape>> m_all_prototype_shapes;
 };
 
 }

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -17,13 +17,6 @@ GC_DEFINE_ALLOCATOR(PrototypeChainValidity);
 
 Shape::~Shape() = default;
 
-void Shape::finalize()
-{
-    Base::finalize();
-    if (m_is_prototype_shape)
-        m_realm->all_prototype_shapes().remove(this);
-}
-
 GC::Ref<Shape> Shape::create_dictionary_transition()
 {
     auto new_shape = heap().allocate<Shape>(m_realm);
@@ -185,6 +178,9 @@ void Shape::visit_edges(Cell::Visitor& visitor)
 
     visitor.ignore(m_prototype_transitions);
 
+    // Child prototype-shape weak refs need no marking; pruning is lazy.
+    visitor.ignore(m_child_prototype_shapes);
+
     // FIXME: The forward transition keys should be weak, but we have to mark them for now in case they go stale.
     if (m_forward_transitions) {
         for (auto& it : *m_forward_transitions)
@@ -335,7 +331,6 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     VERIFY(!m_is_prototype_shape);
     VERIFY(!m_prototype_chain_validity);
     auto new_shape = heap().allocate<Shape>(m_realm);
-    m_realm->all_prototype_shapes().set(new_shape);
     new_shape->m_is_prototype_shape = true;
     new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
@@ -344,6 +339,8 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     (*new_shape->m_property_table) = *m_property_table;
     new_shape->m_property_count = new_shape->m_property_table->size();
     new_shape->m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();
+    if (new_shape->m_prototype)
+        new_shape->m_prototype->shape().add_child_prototype_shape(*new_shape);
     return new_shape;
 }
 
@@ -357,9 +354,19 @@ void Shape::set_prototype_without_transition(Object* new_prototype)
 void Shape::set_prototype_shape()
 {
     VERIFY(!m_is_prototype_shape);
-    m_realm->all_prototype_shapes().set(this);
     m_is_prototype_shape = true;
     m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();
+    if (m_prototype)
+        m_prototype->shape().add_child_prototype_shape(*this);
+}
+
+void Shape::add_child_prototype_shape(GC::Ref<Shape> child)
+{
+    VERIFY(m_is_prototype_shape);
+    VERIFY(child->m_is_prototype_shape);
+    if (!m_child_prototype_shapes)
+        m_child_prototype_shapes = make<Vector<GC::Weak<Shape>>>();
+    m_child_prototype_shapes->append(GC::Weak<Shape> { *child });
 }
 
 void Shape::invalidate_prototype_if_needed_for_new_prototype(GC::Ref<Shape> new_prototype_shape)
@@ -370,6 +377,10 @@ void Shape::invalidate_prototype_if_needed_for_new_prototype(GC::Ref<Shape> new_
     m_prototype_chain_validity->set_valid(false);
 
     invalidate_all_prototype_chains_leading_to_this();
+
+    // The owning object is keeping the same [[Prototype]], so its existing
+    // children descend from new_prototype_shape going forward.
+    new_prototype_shape->m_child_prototype_shapes = move(m_child_prototype_shapes);
 }
 
 void Shape::invalidate_prototype_if_needed_for_change_without_transition()
@@ -384,20 +395,28 @@ void Shape::invalidate_prototype_if_needed_for_change_without_transition()
 
 void Shape::invalidate_all_prototype_chains_leading_to_this()
 {
-    HashTable<Shape*> shapes_to_invalidate;
-    for (auto& candidate : m_realm->all_prototype_shapes()) {
-        if (!candidate->m_prototype)
-            continue;
-        for (auto* current_prototype_shape = &candidate->m_prototype->shape(); current_prototype_shape; current_prototype_shape = current_prototype_shape->prototype() ? &current_prototype_shape->prototype()->shape() : nullptr) {
-            if (current_prototype_shape == this) {
-                VERIFY(candidate->m_is_prototype_shape);
-                shapes_to_invalidate.set(candidate);
-                break;
-            }
-        }
-    }
-    if (shapes_to_invalidate.is_empty())
+    if (!m_child_prototype_shapes || m_child_prototype_shapes->is_empty())
         return;
+
+    HashTable<Shape*> shapes_to_invalidate;
+    Vector<Shape*> worklist;
+    auto enqueue_children_of = [&](Shape& shape) {
+        if (!shape.m_child_prototype_shapes)
+            return;
+        // Prune dead weak refs and enqueue the live ones in one pass.
+        shape.m_child_prototype_shapes->remove_all_matching([&](GC::Weak<Shape> const& weak) {
+            auto child = weak.ptr();
+            if (!child)
+                return true;
+            if (shapes_to_invalidate.set(child.ptr()) == HashSetResult::InsertedNewEntry)
+                worklist.append(child.ptr());
+            return false;
+        });
+    };
+    enqueue_children_of(*this);
+    while (!worklist.is_empty())
+        enqueue_children_of(*worklist.take_last());
+
     for (auto* shape : shapes_to_invalidate) {
         shape->m_prototype_chain_validity->set_valid(false);
         shape->m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -10,6 +10,7 @@
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringView.h>
+#include <AK/Vector.h>
 #include <AK/Weakable.h>
 #include <LibGC/Weak.h>
 #include <LibGC/WeakInlines.h>
@@ -60,8 +61,6 @@ class JS_API Shape final : public Cell {
     GC_DECLARE_ALLOCATOR(Shape);
 
 public:
-    static constexpr bool OVERRIDES_FINALIZE = true;
-
     virtual ~Shape() override;
 
     enum class TransitionType : u8 {
@@ -118,7 +117,8 @@ private:
     void invalidate_prototype_if_needed_for_change_without_transition();
     void invalidate_all_prototype_chains_leading_to_this();
 
-    virtual void finalize() override;
+    void add_child_prototype_shape(GC::Ref<Shape>);
+
     virtual void visit_edges(Visitor&) override;
 
     [[nodiscard]] GC::Ptr<Shape> get_or_prune_cached_forward_transition(TransitionKey const&);
@@ -145,14 +145,17 @@ private:
     Optional<PropertyKey> m_property_key;
     GC::Ptr<Object> m_prototype;
 
+    // The following two are only populated for prototype shapes.
     GC::Ptr<PrototypeChainValidity> m_prototype_chain_validity;
+    // Prototype shapes whose immediate [[Prototype]] is the object that owns this shape.
+    OwnPtr<Vector<GC::Weak<Shape>>> m_child_prototype_shapes;
 
     u32 m_property_count { 0 };
     u32 m_dictionary_generation { 0 };
 };
 
 #if !defined(AK_OS_WINDOWS)
-static_assert(sizeof(Shape) == 96, "Keep the size of JS::Shape down!");
+static_assert(sizeof(Shape) == 104, "Keep the size of JS::Shape down!");
 #endif
 
 }


### PR DESCRIPTION
`invalidate_all_prototype_chains_leading_to_this` used to scan every prototype shape in the realm and walk each one's chain looking for the mutated shape. That was **O(N_prototype_shapes x chain_depth)** per mutation and showed up hot in real profiles when a page churned a lot of prototype state during startup.

Each prototype shape now keeps a weak list of the prototype shapes whose immediate `[[Prototype]]` points at the object that owns this shape. The list is registered on prototype-shape creation (`clone_for_prototype`, `set_prototype_shape`) and migrated to the new prototype shape when the owning prototype object transitions to a new shape. Invalidation is then a recursive walk over this direct- child registry, costing **O(transitive descendants)**.

Saves ~300 ms of main thread time when loading https://youtube.com/ on my Linux machine. :^)