### PR TITLE
Meta+LibWebView: Expose the current commit SHA in about:version

### DIFF
--- a/Base/res/ladybird/about-pages/version.html
+++ b/Base/res/ladybird/about-pages/version.html
@@ -126,6 +126,10 @@
                     <div id="browser-version" class="detail-value"></div>
                 </div>
                 <div class="detail-row">
+                    <div class="detail-label">Commit</div>
+                    <div id="browser-commit" class="detail-value"></div>
+                </div>
+                <div class="detail-row">
                     <div class="detail-label">Architecture</div>
                     <div id="arch" class="detail-value"></div>
                 </div>
@@ -156,6 +160,7 @@
         <script type="module">
             const browserName = document.querySelector("#browser-name");
             const browserVersion = document.querySelector("#browser-version");
+            const browserCommit = document.querySelector("#browser-commit");
             const arch = document.querySelector("#arch");
             const platformName = document.querySelector("#platform-name");
             const userAgent = document.querySelector("#user-agent");
@@ -167,6 +172,7 @@
 
                 browserName.innerText = document.title;
                 browserVersion.innerText = versionInfo?.browserVersion;
+                browserCommit.innerText = versionInfo?.commitSha;
                 arch.innerText = versionInfo?.arch;
                 platformName.innerText = versionInfo?.platformName;
                 userAgent.innerText = navigator.userAgent;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include(check_for_dependencies)
 include(gui_framework)
 include(cmake_options NO_POLICY_SCOPE)
 include(compile_options)
+include(version)
 
 if(ENABLE_ALL_THE_DEBUG_MACROS)
     include(all_the_debug_macros)

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -77,6 +77,7 @@ compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIClient.ipc ${CMAKE_B
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebUIServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebUIServerEndpoint.h)
 
 ladybird_lib(LibWebView webview EXPLICIT_SYMBOL_EXPORT)
+add_dependencies(LibWebView generate_version_header)
 target_link_libraries(LibWebView PRIVATE LibCore LibDatabase LibDevTools LibFileSystem LibGfx LibHTTP LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSyntax LibTextCodec)
 
 # Third-party

--- a/Libraries/LibWebView/WebUI/VersionUI.cpp
+++ b/Libraries/LibWebView/WebUI/VersionUI.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/JsonObject.h>
 #include <AK/String.h>
+#include <GeneratedVersion.h>
 #include <LibCore/System.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWebView/Application.h>
@@ -24,6 +25,7 @@ void VersionUI::load_version_info()
 {
     static auto browser_name = String::from_utf8_without_validation({ BROWSER_NAME, __builtin_strlen(BROWSER_NAME) });
     static auto browser_version = String::from_utf8_without_validation({ BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) });
+    static auto commit_sha = String::from_utf8_without_validation({ CURRENT_COMMIT_SHA, __builtin_strlen(CURRENT_COMMIT_SHA) });
     static auto arch = String::from_utf8_without_validation({ CPU_STRING, __builtin_strlen(CPU_STRING) });
     static auto platform_name = String::from_utf8_without_validation({ OS_STRING, __builtin_strlen(OS_STRING) });
     static auto command_line = MUST(String::join(' ', Application::the().command_line_arguments().strings));
@@ -32,6 +34,7 @@ void VersionUI::load_version_info()
     JsonObject version_info;
     version_info.set("browserName"_string, browser_name);
     version_info.set("browserVersion"_string, browser_version);
+    version_info.set("commitSha"_string, commit_sha);
     version_info.set("arch"_string, arch);
     version_info.set("platformName"_string, platform_name);
     version_info.set("commandLine"_string, command_line);

--- a/Meta/CMake/Version.h.in
+++ b/Meta/CMake/Version.h.in
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define CURRENT_COMMIT_SHA "@CURRENT_COMMIT_SHA@"

--- a/Meta/CMake/version.cmake
+++ b/Meta/CMake/version.cmake
@@ -1,0 +1,41 @@
+if (DEFINED CMAKE_SCRIPT_MODE_FILE)
+    set(_source_dir "${SOURCE_DIR}")
+    set(_template "${TEMPLATE}")
+    set(_output "${OUTPUT}")
+else()
+    set(_source_dir "${LADYBIRD_SOURCE_DIR}")
+    set(_template "${CMAKE_CURRENT_LIST_DIR}/Version.h.in")
+    set(_output "${CMAKE_BINARY_DIR}/GeneratedVersion.h")
+endif()
+
+find_package(Git QUIET)
+
+set(CURRENT_COMMIT_SHA "")
+if (Git_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+        WORKING_DIRECTORY "${_source_dir}"
+        OUTPUT_VARIABLE CURRENT_COMMIT_SHA
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _git_rev_parse_result
+    )
+    if (NOT _git_rev_parse_result EQUAL 0)
+        set(CURRENT_COMMIT_SHA "")
+    endif()
+endif()
+
+configure_file("${_template}" "${_output}" @ONLY)
+
+if (NOT DEFINED CMAKE_SCRIPT_MODE_FILE)
+    add_custom_target(generate_version_header ALL
+        BYPRODUCTS "${CMAKE_BINARY_DIR}/GeneratedVersion.h"
+        COMMAND ${CMAKE_COMMAND}
+            -D "SOURCE_DIR=${LADYBIRD_SOURCE_DIR}"
+            -D "TEMPLATE=${CMAKE_CURRENT_LIST_DIR}/Version.h.in"
+            -D "OUTPUT=${CMAKE_BINARY_DIR}/GeneratedVersion.h"
+            -P "${CMAKE_CURRENT_LIST_FILE}"
+        COMMENT "Re-checking current commit SHA..."
+        VERBATIM
+    )
+endif()


### PR DESCRIPTION
<img width="1624" height="998" alt="Screenshot 2026-04-24 at 14 33 44" src="https://github.com/user-attachments/assets/f3547ca2-794f-468e-8da8-5d21c427f61d" />
