### PR TITLE
LibWeb: Avoid redundant `matches()` calls during hover invalidation

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2099,13 +2099,17 @@ void Document::invalidate_style_for_elements_affected_by_pseudo_class_change(CSS
             return false;
 
         SelectorEngine::MatchContext context;
-        if (SelectorEngine::matches(selector, element, {}, context))
-            return true;
-        if (SelectorEngine::matches(selector, { element, CSS::PseudoElement::Before }, {}, context))
-            return true;
-        if (SelectorEngine::matches(selector, { element, CSS::PseudoElement::After }, {}, context))
-            return true;
-        return false;
+        auto const& target_pseudo = selector.target_pseudo_element();
+        if (!target_pseudo.has_value())
+            return SelectorEngine::matches(selector, element, {}, context);
+        switch (target_pseudo->type()) {
+        case CSS::PseudoElement::Before:
+            return SelectorEngine::matches(selector, { element, CSS::PseudoElement::Before }, {}, context);
+        case CSS::PseudoElement::After:
+            return SelectorEngine::matches(selector, { element, CSS::PseudoElement::After }, {}, context);
+        default:
+            return false;
+        }
     };
 
     auto matches_different_set_of_rules_after_state_change = [&](Element& element) {


### PR DESCRIPTION
Previously, `Document::invalidate_style_for_elements_affected_by_pseudo_class_change()`  ran `SelectorEngine::matches()` three times per rule: once for the  element, once for `::before`, and once for `::after`. A selector only ever targets one of those, and Selector already caches its target pseudo-element, so we can dispatch directly to the matching case instead.

This makes hovering over items more responsive when [browsing groceries](https://www.sainsburys.co.uk/groceries/search?searchTerm=dog%20food) on https://sainsburys.co.uk.