### PR TITLE
Fix min-content collapsing to 0 with min-width: 0 descendant

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -332,10 +332,9 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    if (!computed_values.min_width().is_auto()) {
+    if (!computed_values.min_width().is_auto() && !used_width.is_auto()) {
         auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width());
-        auto used_width_px = used_width.is_auto() ? remaining_available_space.width : AvailableSize::make_definite(used_width.to_px_or_zero(box));
-        if (used_width_px < min_width)
+        if (used_width.to_px_or_zero(box) < min_width)
             used_width = try_compute_width(CSS::Length::make_px(min_width));
     }
 

--- a/Tests/LibWeb/Layout/expected/min-content-width-with-min-width-zero-descendant.txt
+++ b/Tests/LibWeb/Layout/expected/min-content-width-with-min-width-zero-descendant.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
+      BlockContainer <div.bubble> at [8,8] [0+0+0 300 0+0+484] [0+0+0 20 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,8] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.inner> at [8,8] [0+0+0 300 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> at [8,8] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.child> at [8,8] [0+0+0 300 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> at [8,28] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,28] [0+0+0 300 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,28] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
+      PaintableWithLines (BlockContainer<DIV>.bubble) [8,8 300x20]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 300x0]
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,8 300x20]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 300x0]
+          PaintableWithLines (BlockContainer<DIV>.child) [8,8 300x20]
+          PaintableWithLines (BlockContainer(anonymous)) [8,28 300x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,28 300x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/min-content-width-with-min-width-zero-descendant.html
+++ b/Tests/LibWeb/Layout/input/min-content-width-with-min-width-zero-descendant.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+  .bubble {
+    width: min-content;
+  }
+  .inner {
+    min-width: 0;
+  }
+  .child {
+    width: 300px;
+    height: 20px;
+  }
+</style>
+<div class="bubble">
+  <div class="inner">
+    <div class="child"></div>
+  </div>
+</div>


### PR DESCRIPTION
During intrinsic sizing, compute_width() ran on block descendants with an intrinsic-sizing available space. For a non-FC-establishing block with auto width, used_width stayed auto, and the min-width clamp then compared AvailableSize::min-content against min-width via operator<, which always returns true when the left side is min-content. The clamp fired with min-width: 0 and set content_width to 0 permanently.

Skip the min-width clamp when used_width is still auto, mirroring the max-width clamp a few lines above which already no-ops via to_px_or_zero. The real width is then set by the IntrinsicSizing branch in layout_block_level_children.