### PR TITLE
LibWeb: Avoid copying custom property maps in StyleComputer

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1920,8 +1920,9 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
     if (did_change_custom_properties.has_value()) {
         auto new_custom_property_data = abstract_element.custom_property_data();
         if (old_custom_property_data.ptr() != new_custom_property_data.ptr()) {
-            auto const& old_own = old_custom_property_data ? old_custom_property_data->own_values() : OrderedHashMap<FlyString, StyleProperty> {};
-            auto const& new_own = new_custom_property_data ? new_custom_property_data->own_values() : OrderedHashMap<FlyString, StyleProperty> {};
+            static OrderedHashMap<FlyString, StyleProperty> const empty_own_values;
+            auto const& old_own = old_custom_property_data ? old_custom_property_data->own_values() : empty_own_values;
+            auto const& new_own = new_custom_property_data ? new_custom_property_data->own_values() : empty_own_values;
             if (old_own != new_own)
                 *did_change_custom_properties = true;
         }


### PR DESCRIPTION
Previously, we were accidentally creating temporary copies of custom property maps on both sides of a ternary in `compute_style_impl()`.  We now bind to a static empty sentinel instead so the reference binds directly to `own_values()` without copying.

This showed up as a 9.5% profile item when browsing groceries on https://sainsburys.co.uk