### PR TITLE
LibJS: Remove `gc` from the global object

### DIFF
--- a/Libraries/LibJS/Contrib/Test262/262Object.cpp
+++ b/Libraries/LibJS/Contrib/Test262/262Object.cpp
@@ -40,9 +40,9 @@ void $262Object::initialize(Realm& realm)
     define_native_function(realm, "createRealm"_utf16_fly_string, create_realm, 0, attr);
     define_native_function(realm, "detachArrayBuffer"_utf16_fly_string, detach_array_buffer, 1, attr);
     define_native_function(realm, "evalScript"_utf16_fly_string, eval_script, 1, attr);
+    define_native_function(realm, "gc"_utf16_fly_string, collect_garbage, 1, attr);
 
     define_direct_property("agent"_utf16_fly_string, m_agent, attr);
-    define_direct_property("gc"_utf16_fly_string, realm.global_object().get_without_side_effects("gc"_utf16_fly_string), attr);
     define_direct_property("global"_utf16_fly_string, &realm.global_object(), attr);
     define_direct_property("IsHTMLDDA"_utf16_fly_string, m_is_htmldda, attr);
 }
@@ -58,6 +58,12 @@ JS_DEFINE_NATIVE_FUNCTION($262Object::clear_kept_objects)
 {
     vm.finish_execution_generation();
     return js_undefined();
+}
+
+JS_DEFINE_NATIVE_FUNCTION($262Object::collect_garbage)
+{
+    vm.heap().collect_garbage();
+    return JS::js_undefined();
 }
 
 JS_DEFINE_NATIVE_FUNCTION($262Object::create_realm)

--- a/Libraries/LibJS/Contrib/Test262/262Object.h
+++ b/Libraries/LibJS/Contrib/Test262/262Object.h
@@ -30,6 +30,7 @@ private:
     GC::Ptr<IsHTMLDDA> m_is_htmldda;
 
     JS_DECLARE_NATIVE_FUNCTION(clear_kept_objects);
+    JS_DECLARE_NATIVE_FUNCTION(collect_garbage);
     JS_DECLARE_NATIVE_FUNCTION(create_realm);
     JS_DECLARE_NATIVE_FUNCTION(detach_array_buffer);
     JS_DECLARE_NATIVE_FUNCTION(eval_script);

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -194,7 +194,6 @@ namespace JS {
     P(fromHex)                               \
     P(fround)                                \
     P(Function)                              \
-    P(gc)                                    \
     P(get)                                   \
     P(getBigInt64)                           \
     P(getBigUint64)                          \

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -185,24 +185,7 @@ void set_default_global_bindings(Realm& realm)
     // 3. Return unused.
 }
 
-void GlobalObject::initialize(Realm& realm)
-{
-    Base::initialize(realm);
-
-    auto& vm = this->vm();
-
-    // Non-standard
-    u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_native_function(realm, vm.names.gc, gc, 0, attr);
-}
-
 GlobalObject::~GlobalObject() = default;
-
-JS_DEFINE_NATIVE_FUNCTION(GlobalObject::gc)
-{
-    vm.heap().collect_garbage();
-    return js_undefined();
-}
 
 // 19.2.1 eval ( x ), https://tc39.es/ecma262/#sec-eval-x
 JS_DEFINE_NATIVE_FUNCTION(GlobalObject::eval)

--- a/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Libraries/LibJS/Runtime/GlobalObject.h
@@ -21,7 +21,6 @@ class JS_API GlobalObject : public Object {
     friend class Intrinsics;
 
 public:
-    virtual void initialize(Realm&) override;
     virtual ~GlobalObject() override;
 
 protected:
@@ -30,7 +29,6 @@ protected:
 private:
     virtual bool is_global_object() const final { return true; }
 
-    JS_DECLARE_NATIVE_FUNCTION(gc);
     JS_DECLARE_NATIVE_FUNCTION(is_nan);
     JS_DECLARE_NATIVE_FUNCTION(is_finite);
     JS_DECLARE_NATIVE_FUNCTION(parse_float);

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -26,6 +26,12 @@ TESTJS_GLOBAL_FUNCTION(can_parse_source, canParseSource)
     return JS::Value(!script.is_error());
 }
 
+TESTJS_GLOBAL_FUNCTION(collect_garbage, gc)
+{
+    vm.heap().collect_garbage();
+    return JS::js_undefined();
+}
+
 // Based on $262.evalScript
 TESTJS_GLOBAL_FUNCTION(evaluate_source, evaluateSource)
 {


### PR DESCRIPTION
No other engine defines this function, so it is an observable difference of our engine. This traces back to the earliest days of LibJS.

We now define `gc` in just the test-js and test262 runners.