### PR TITLE
LibWeb: Make TransferArrayBuffer zero-copy

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -261,6 +261,21 @@ void ArrayBuffer::detach_buffer()
     m_data_block.byte_buffer = Empty {};
 }
 
+ThrowCompletionOr<ByteBuffer> ArrayBuffer::detach_and_take_bytes(VM& vm)
+{
+    VERIFY(!is_shared_array_buffer());
+
+    if (!same_value(detach_key(), js_undefined()))
+        return vm.throw_completion<TypeError>(ErrorType::DetachKeyMismatch, js_undefined(), detach_key());
+
+    auto bytes = m_data_block.byte_buffer.visit(
+        [](Empty) -> ByteBuffer { VERIFY_NOT_REACHED(); },
+        [](ByteBuffer& value) -> ByteBuffer { return move(value); },
+        [](DataBlock::UnownedFixedLengthByteBuffer& value) -> ByteBuffer { return MUST(ByteBuffer::copy(value.buffer->span())); });
+    detach_buffer();
+    return bytes;
+}
+
 void ArrayBuffer::register_cached_typed_array_view(TypedArrayBase& view)
 {
     m_cached_views.set(view);

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -87,6 +87,11 @@ public:
     ByteBuffer& buffer() { return m_data_block.buffer(); }
     ByteBuffer const& buffer() const { return m_data_block.buffer(); }
 
+    // Detaches this ArrayBuffer and returns its underlying bytes as a ByteBuffer for use in a TransferArrayBuffer-like
+    // operation. Moves the storage when we own it and copies it for externally-owned buffers (e.g. Wasm memory).
+    // If detach fails, the underlying storage is left untouched.
+    ThrowCompletionOr<ByteBuffer> detach_and_take_bytes(VM&);
+
     // [[ArrayBufferMaxByteLength]]
     size_t max_byte_length() const { return m_max_byte_length.value(); }
     void set_max_byte_length(size_t max_byte_length) { m_max_byte_length = max_byte_length; }

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -464,10 +464,9 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> transfer_array_buffer(JS::Realm& r
 
     // 2. Let arrayBufferData be O.[[ArrayBufferData]].
     // 3. Let arrayBufferByteLength be O.[[ArrayBufferByteLength]].
-    auto array_buffer = buffer.buffer();
-
     // 4. Perform ? DetachArrayBuffer(O).
-    TRY(JS::detach_array_buffer(vm, buffer));
+    // NB: We steal the underlying bytes and detach atomically so the transfer is zero-copy.
+    auto array_buffer = TRY(buffer.detach_and_take_bytes(vm));
 
     // 5. Return a new ArrayBuffer object, created in the current Realm, whose [[ArrayBufferData]] internal slot value is arrayBufferData and whose [[ArrayBufferByteLength]] internal slot value is arrayBufferByteLength.
     return JS::ArrayBuffer::create(realm, move(array_buffer));

--- a/Tests/LibWeb/Text/expected/Streams/ReadableStreamBYOBReader-read-non-transferable-buffer.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStreamBYOBReader-read-non-transferable-buffer.txt
@@ -1,0 +1,6 @@
+read() rejected with TypeError: true
+Read buffer byteLength: 65536
+enqueue() threw TypeError: true
+Enqueue buffer byteLength: 65536
+respondWithNewView() rejected with TypeError: true
+RespondWithNewView buffer byteLength: 65536

--- a/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-non-transferable-buffer.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-non-transferable-buffer.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        {
+            const stream = new ReadableStream({ type: "bytes" });
+            const reader = stream.getReader({ mode: "byob" });
+            const memory = new WebAssembly.Memory({ initial: 1 });
+            const view = new Uint8Array(memory.buffer, 0, 8);
+
+            try {
+                await reader.read(view);
+                println("FAIL: read() should reject");
+            } catch (error) {
+                println(`read() rejected with TypeError: ${error instanceof TypeError}`);
+            }
+
+            println(`Read buffer byteLength: ${memory.buffer.byteLength}`);
+        }
+
+        {
+            let controller;
+            new ReadableStream({
+                type: "bytes",
+                start(streamController) {
+                    controller = streamController;
+                },
+            });
+            const memory = new WebAssembly.Memory({ initial: 1 });
+
+            try {
+                controller.enqueue(new Uint8Array(memory.buffer, 0, 8));
+                println("FAIL: enqueue() should throw");
+            } catch (error) {
+                println(`enqueue() threw TypeError: ${error instanceof TypeError}`);
+            }
+
+            println(`Enqueue buffer byteLength: ${memory.buffer.byteLength}`);
+        }
+
+        {
+            const memory = new WebAssembly.Memory({ initial: 1 });
+            const stream = new ReadableStream({
+                type: "bytes",
+                pull(controller) {
+                    controller.byobRequest.respondWithNewView(new Uint8Array(memory.buffer, 0, 8));
+                },
+            });
+            const reader = stream.getReader({ mode: "byob" });
+
+            try {
+                await reader.read(new Uint8Array(new ArrayBuffer(memory.buffer.byteLength), 0, 8));
+                println("FAIL: read() should reject after respondWithNewView()");
+            } catch (error) {
+                println(`respondWithNewView() rejected with TypeError: ${error instanceof TypeError}`);
+            }
+
+            println(`RespondWithNewView buffer byteLength: ${memory.buffer.byteLength}`);
+        }
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Move owned `ArrayBuffer` storage directly when transferring stream buffers instead of copying the bytes before detaching the source. `WebAssembly` memory continues to copy because its `ArrayBuffer` wraps externally-owned storage.

Preserve the abrupt completion from `DetachArrayBuffer` before moving storage so non-transferable buffers, such as `WebAssembly.Memory`-backed views, still surface `TypeError` through stream operations instead of aborting.

This saves ~130ms of main thread time when loading a YouTube video on my Linux computer. :^)