### PR TITLE
LibWeb: Prepend session history index zero for navigation api

### DIFF
--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1397,8 +1397,8 @@ Vector<NonnullRefPtr<SessionHistoryEntry>> TraversableNavigable::get_session_his
     // 6. Let i be startingIndex − 1.
     auto i = starting_index - 1;
 
-    // 7. While i > 0:
-    while (i > 0) {
+    // 7. While i >= 0:
+    while (i >= 0) {
         auto& entry = raw_entries[static_cast<unsigned>(i)];
         // 1. If rawEntries[i]'s document state's origin is not same origin with startingOrigin, then break.
         auto entry_origin = entry->document_state()->origin();


### PR DESCRIPTION
Navigating backward may crash because entries_for_navigation_api is missing the first element.