### PR TITLE
LibWeb: Preserve non-ASCII characters in canvas text preparation

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -785,7 +785,7 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(Ut
     // 2. Replace all ASCII whitespace in text with U+0020 SPACE characters.
     StringBuilder builder { StringBuilder::Mode::UTF16, text.length_in_code_units() };
     for (auto c : text) {
-        builder.append(Infra::is_ascii_whitespace(c) ? ' ' : c);
+        builder.append_code_point(Infra::is_ascii_whitespace(c) ? ' ' : c);
     }
     auto replaced_text = builder.to_utf16_string();
 

--- a/Tests/LibWeb/Text/expected/canvas/textmetrics-actual-bounding-box-accent.txt
+++ b/Tests/LibWeb/Text/expected/canvas/textmetrics-actual-bounding-box-accent.txt
@@ -1,0 +1,3 @@
+precomposed accent has positive width: true
+precomposed and decomposed accent widths match: true
+word width includes precomposed accent: true

--- a/Tests/LibWeb/Text/input/canvas/textmetrics-actual-bounding-box-accent.html
+++ b/Tests/LibWeb/Text/input/canvas/textmetrics-actual-bounding-box-accent.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<style>
+    @font-face {
+        font-family: "LatoTest";
+        src: url("../../../Assets/Lato-Bold.ttf");
+    }
+</style>
+<span style="font-family: LatoTest; position: absolute; visibility: hidden">Kraków</span>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        await document.fonts.ready;
+
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+        ctx.font = "48px LatoTest";
+
+        const accented = ctx.measureText("ó");
+        const decomposed = ctx.measureText("o\u0301");
+        println(`precomposed accent has positive width: ${accented.width > 0}`);
+        println(`precomposed and decomposed accent widths match: ${Math.abs(accented.width - decomposed.width) < 1}`);
+
+        const text = "Kraków";
+        const metrics = ctx.measureText(text);
+        println(`word width includes precomposed accent: ${metrics.width > ctx.measureText("Krakw").width}`);
+    });
+</script>


### PR DESCRIPTION
The whitespace-normalization loop in prepare_text() called StringBuilder::append() on each code point, which resolves to the `char` overload and truncates non-ASCII characters. measureText("ó") therefore returned a width of 0, despite fillText painting the glyph.

Use append_code_point() instead, and add a regression test for both precomposed and decomposed accented text.

Before:
<img width="1132" height="324" alt="CleanShot 2026-04-25 at 14 25 21@2x" src="https://github.com/user-attachments/assets/c933946d-77b5-4475-a918-3941f56031f3" />

After:
<img width="1140" height="372" alt="CleanShot 2026-04-25 at 14 25 00@2x" src="https://github.com/user-attachments/assets/1117c6fb-ee0a-4dea-b007-bbeadb0865a2" />
