### PR TITLE
LibWeb: Skip layout update in handle_mousemove when not needed

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1496,6 +1496,10 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
     // NB: Dispatching an event may have disturbed the world.
     if (m_navigable->active_document() != document)
         return EventResult::Accepted;
+
+    if (!m_middle_button_scroll_handler && !is_handling_mouse_selection())
+        return EventResult::Handled;
+
     document->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseMove);
     if (!paint_root())
         return EventResult::Accepted;


### PR DESCRIPTION
Only run update_layout() during mousemove handling when the result is actually consumed, i.e. when the middle-button autoscroll handler or mouse selection is active. This avoids forcing a synchronous layout on every mousemove event in the common case.