### PR TITLE
Basic print support

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -631,6 +631,7 @@ set(SOURCES
     HTML/PopoverTargetAttributes.cpp
     HTML/PopStateEvent.cpp
     HTML/PotentialCORSRequest.cpp
+    HTML/PrintSettings.cpp
     HTML/PromiseRejectionEvent.cpp
     HTML/RadioNodeList.cpp
     HTML/RenderingThread.cpp

--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -274,18 +274,16 @@ String MediaQuery::to_string() const
 
 bool MediaQuery::evaluate(DOM::Document const& document)
 {
-    auto matches_media = [](MediaType const& media) -> MatchResult {
+    auto matches_media = [&document](MediaType const& media) -> MatchResult {
         if (!media.known_type.has_value())
             return MatchResult::False;
         switch (media.known_type.value()) {
         case KnownMediaType::All:
             return MatchResult::True;
         case KnownMediaType::Print:
-            // FIXME: Enable for printing, when we have printing!
-            return MatchResult::False;
+            return document.page().is_printing() ? MatchResult::True : MatchResult::False;
         case KnownMediaType::Screen:
-            // FIXME: Disable for printing, when we have printing!
-            return MatchResult::True;
+            return document.page().is_printing() ? MatchResult::False : MatchResult::True;
         }
         VERIFY_NOT_REACHED();
     };

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -504,6 +504,7 @@ void EventLoop::update_the_rendering()
         if (navigable->is_traversable()) {
             auto traversable = navigable->traversable_navigable();
             traversable->process_screenshot_requests();
+            traversable->process_print_tasks();
         }
     }
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2829,6 +2829,23 @@ CSSPixelPoint Navigable::to_top_level_position(CSSPixelPoint a_position)
     return position;
 }
 
+CSSPixelSize Navigable::viewport_size() const
+{
+    return m_print_viewport_size.value_or(m_viewport_size);
+}
+
+CSSPixelRect Navigable::viewport_rect() const
+{
+    if (m_print_viewport_size.has_value())
+        return { CSSPixelPoint {}, *m_print_viewport_size };
+    return { m_viewport_scroll_offset, m_viewport_size };
+}
+
+void Navigable::set_print_viewport_size(Optional<CSSPixelSize> size)
+{
+    m_print_viewport_size = move(size);
+}
+
 void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList invalidate_display_list)
 {
     if (m_viewport_size == size && invalidate_display_list == InvalidateDisplayList::No)

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -191,9 +191,10 @@ public:
     CSSPixelRect to_top_level_rect(CSSPixelRect const&);
 
     CSSPixelPoint viewport_scroll_offset() const { return m_viewport_scroll_offset; }
-    CSSPixelRect viewport_rect() const { return { m_viewport_scroll_offset, m_viewport_size }; }
-    CSSPixelSize viewport_size() const { return m_viewport_size; }
+    CSSPixelRect viewport_rect() const;
+    CSSPixelSize viewport_size() const;
     void set_viewport_size(CSSPixelSize, InvalidateDisplayList = InvalidateDisplayList::No);
+    void set_print_viewport_size(Optional<CSSPixelSize>);
     void perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position);
     void clamp_viewport_scroll_offset();
 
@@ -311,6 +312,7 @@ private:
 
     CSSPixelSize m_viewport_size;
     CSSPixelPoint m_viewport_scroll_offset;
+    Optional<CSSPixelSize> m_print_viewport_size;
 
     Web::EventHandler m_event_handler;
 

--- a/Libraries/LibWeb/HTML/PrintSettings.cpp
+++ b/Libraries/LibWeb/HTML/PrintSettings.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/PrintSettings.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::PrintSettings const& settings)
+{
+    TRY(encoder.encode(settings.paper_width_mm));
+    TRY(encoder.encode(settings.paper_height_mm));
+    TRY(encoder.encode(settings.margin_top_mm));
+    TRY(encoder.encode(settings.margin_right_mm));
+    TRY(encoder.encode(settings.margin_bottom_mm));
+    TRY(encoder.encode(settings.margin_left_mm));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::PrintSettings> IPC::decode(Decoder& decoder)
+{
+    auto paper_width_mm = TRY(decoder.decode<float>());
+    auto paper_height_mm = TRY(decoder.decode<float>());
+    auto margin_top_mm = TRY(decoder.decode<float>());
+    auto margin_right_mm = TRY(decoder.decode<float>());
+    auto margin_bottom_mm = TRY(decoder.decode<float>());
+    auto margin_left_mm = TRY(decoder.decode<float>());
+
+    return Web::HTML::PrintSettings {
+        paper_width_mm,
+        paper_height_mm,
+        margin_top_mm,
+        margin_right_mm,
+        margin_bottom_mm,
+        margin_left_mm,
+    };
+}

--- a/Libraries/LibWeb/HTML/PrintSettings.h
+++ b/Libraries/LibWeb/HTML/PrintSettings.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
+
+namespace Web::HTML {
+
+struct PrintSettings {
+    float paper_width_mm { 210.0f }; // A4 portrait default
+    float paper_height_mm { 297.0f };
+    float margin_top_mm { 12.7f }; // ~0.5 inch default
+    float margin_right_mm { 12.7f };
+    float margin_bottom_mm { 12.7f };
+    float margin_left_mm { 12.7f };
+};
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::PrintSettings const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::PrintSettings> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -11,10 +11,12 @@
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Event.h>
 #include <LibWeb/Geolocation/GeolocationCoordinates.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/BrowsingContextGroup.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/History.h>
 #include <LibWeb/HTML/NavigableContainer.h>
 #include <LibWeb/HTML/Navigation.h>
@@ -27,6 +29,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 
@@ -1774,6 +1777,107 @@ void TraversableNavigable::set_emulated_position_data(Geolocation::EmulatedPosit
 {
     VERIFY(is_top_level_traversable());
     m_emulated_position_data = data;
+}
+
+void TraversableNavigable::queue_print_task(Web::HTML::PrintSettings settings)
+{
+    m_pending_print_settings = move(settings);
+    m_print_pending = true;
+    set_needs_repaint();
+}
+
+// https://www.w3.org/TR/css-page-3/#page-based-margins
+// Viewport is the printable area: paper minus margins. Content overflowing a single page height
+// flows naturally; the frontend slices the bitmap into per-page strips.
+static CSSPixelSize printable_size(Web::HTML::PrintSettings const& settings)
+{
+    auto to_px = [](float mm) { return CSSPixels::nearest_value_for(mm / 25.4f * 96.0f); };
+    return {
+        to_px(settings.paper_width_mm - settings.margin_left_mm - settings.margin_right_mm),
+        to_px(settings.paper_height_mm - settings.margin_top_mm - settings.margin_bottom_mm),
+    };
+}
+
+void TraversableNavigable::with_print_mode(Web::HTML::PrintSettings const& settings, Function<void()>&& callback)
+{
+    auto document = active_document();
+    if (!document)
+        return;
+    auto& page_obj = page();
+
+    set_print_viewport_size(printable_size(settings));
+    page_obj.set_printing(true);
+    document->invalidate_style(DOM::StyleInvalidationReason::NavigableSetViewportSize);
+    document->set_needs_media_query_evaluation();
+    document->evaluate_media_queries_and_report_changes();
+    document->update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
+
+    callback();
+
+    // This must happen before the next paint_next_frame so the compositor only ever sees the screen
+    // layout; the print display list is already enqueued.
+    page_obj.set_printing(false);
+    set_print_viewport_size({});
+    document->invalidate_style(DOM::StyleInvalidationReason::NavigableSetViewportSize);
+    document->set_needs_media_query_evaluation();
+    document->evaluate_media_queries_and_report_changes();
+    document->update_layout(DOM::UpdateLayoutReason::ProcessScreenshot);
+}
+
+void TraversableNavigable::process_print_tasks()
+{
+    if (!m_print_pending)
+        return;
+    m_print_pending = false;
+
+    // https://www.w3.org/TR/css-page-3/#page-size-a4
+    // A4 portrait with ~0.5 inch margins is the fallback when the UI has not supplied settings.
+    auto settings = m_pending_print_settings.value_or(Web::HTML::PrintSettings {});
+    m_pending_print_settings = {};
+
+    auto document = active_document();
+    if (!document)
+        return;
+
+    auto& page_obj = page();
+    auto& client = page_obj.client();
+
+    // Fire beforeprint before we change any rendering state.
+    if (auto window = document->window())
+        window->dispatch_event(DOM::Event::create(window->realm(), EventNames::beforeprint));
+
+    with_print_mode(settings, [&] {
+        if (!document->layout_node() || !document->layout_node()->paintable_box())
+            return;
+        auto scrollable_overflow_rect = document->layout_node()->paintable_box()->scrollable_overflow_rect();
+        if (!scrollable_overflow_rect.has_value())
+            return;
+
+        auto rect = page_obj.enclosing_device_rect(scrollable_overflow_rect.value());
+        auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().template to_type<int>());
+        if (bitmap_or_error.is_error())
+            return;
+
+        auto bitmap = bitmap_or_error.release_value();
+        auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
+        PaintConfig paint_config { .canvas_fill_rect = rect.template to_type<int>() };
+
+        render_screenshot(*painting_surface, paint_config, [bitmap, &client] {
+            client.page_did_finish_rendering_for_print(bitmap->to_shareable_bitmap());
+        });
+    });
+
+    set_needs_repaint();
+}
+
+void TraversableNavigable::finish_print()
+{
+    auto document = active_document();
+    if (!document)
+        return;
+    document->evaluate_media_queries_and_report_changes();
+    if (auto window = document->window())
+        window->dispatch_event(DOM::Event::create(window->realm(), EventNames::afterprint));
 }
 
 void TraversableNavigable::process_screenshot_requests()

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -13,6 +13,7 @@
 #include <LibWeb/Geolocation/Geolocation.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigationType.h>
+#include <LibWeb/HTML/PrintSettings.h>
 #include <LibWeb/HTML/SessionHistoryTraversalQueue.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/Page/Page.h>
@@ -117,6 +118,11 @@ public:
         set_needs_repaint();
     }
 
+    void with_print_mode(Web::HTML::PrintSettings const&, AK::Function<void()>&& callback);
+    void process_print_tasks();
+    void queue_print_task(Web::HTML::PrintSettings);
+    void finish_print();
+
 private:
     friend class ApplyHistoryStepState;
 
@@ -186,6 +192,8 @@ private:
         Optional<Web::UniqueNodeID> node_id;
     };
     Queue<ScreenshotTask> m_screenshot_tasks;
+    bool m_print_pending { false };
+    Optional<Web::HTML::PrintSettings> m_pending_print_settings;
 };
 
 struct BrowsingContextAndDocument {

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -990,6 +990,30 @@ void Window::blur()
     // The Window blur() method steps are to do nothing.
 }
 
+// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#printing
+void Window::print()
+{
+    // 1. Let document be this's associated Document.
+    auto& document = associated_document();
+
+    // 2. If document is not fully active, then return.
+    if (!document.is_fully_active())
+        return;
+
+    // 3. If document's unload counter is greater than 0, then return.
+    if (document.unload_counter() > 0)
+        return;
+
+    // 4. If document is ready for post-load tasks, then run the printing steps for document.
+    if (document.ready_for_post_load_tasks()) {
+        page().client().page_did_request_print();
+        return;
+    }
+
+    // 5. Otherwise, set document's print when loaded flag.
+    // FIXME: Implement print when loaded.
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-locationbar
 GC::Ref<BarProp const> Window::locationbar()
 {

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -205,6 +205,7 @@ public:
     void alert(String const& message = {});
     bool confirm(Optional<String> const& message);
     Optional<String> prompt(Optional<String> const& message, Optional<String> const& default_);
+    void print();
 
     WebIDL::ExceptionOr<void> post_message(JS::Value message, String const&, Vector<GC::Root<JS::Object>> const&);
     WebIDL::ExceptionOr<void> post_message(JS::Value message, WindowPostMessageOptions const&);

--- a/Libraries/LibWeb/HTML/Window.idl
+++ b/Libraries/LibWeb/HTML/Window.idl
@@ -16,6 +16,7 @@ interface Window : EventTarget {
     undefined stop();
     undefined focus();
     undefined blur();
+    undefined print();
 
     [Replaceable] readonly attribute BarProp locationbar;
     [Replaceable] readonly attribute BarProp menubar;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -124,6 +124,9 @@ public:
     CSS::PreferredContrast preferred_contrast() const;
     CSS::PreferredMotion preferred_motion() const;
 
+    bool is_printing() const { return m_printing; }
+    void set_printing(bool printing) { m_printing = printing; }
+
     bool is_scripting_enabled() const { return m_is_scripting_enabled; }
     void set_is_scripting_enabled(bool b) { m_is_scripting_enabled = b; }
 
@@ -288,6 +291,7 @@ private:
 
     GC::Ptr<HTML::TraversableNavigable> m_top_level_traversable;
 
+    bool m_printing { false };
     bool m_is_scripting_enabled { true };
     bool m_should_block_pop_ups { true };
     bool m_enable_autoscroll { true };

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -490,6 +490,7 @@ public:
 
     virtual void page_did_paint([[maybe_unused]] Gfx::IntRect const& content_rect, [[maybe_unused]] i32 bitmap_id) { }
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const&) { }
+    virtual void page_did_finish_rendering_for_print(Gfx::ShareableBitmap const&) { }
 
     virtual void received_message_from_web_ui([[maybe_unused]] String const& name, [[maybe_unused]] JS::Value data) { }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -417,6 +417,7 @@ public:
     virtual void page_did_hover_link(URL::URL const&) { }
     virtual void page_did_unhover_link() { }
     virtual void page_did_change_favicon(Gfx::Bitmap const&) { }
+    virtual void page_did_request_print() { }
     virtual void page_did_request_alert(String const&) { }
     virtual void page_did_request_confirm(String const&) { }
     virtual void page_did_request_prompt(String const&, String const&) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -894,6 +894,15 @@ void Application::initialize_actions()
             view->select_all();
     });
 
+    m_print_action = Action::create("Print..."sv, ActionID::Print, [this]() {
+        if (auto view = active_web_view(); view.has_value()) {
+            if (view->on_print_request)
+                view->on_print_request();
+            else
+                view->trigger_print();
+        }
+    });
+
     m_open_about_page_action = Action::create("About Ladybird"sv, ActionID::OpenAboutPage, [this]() {
         open_url_in_new_tab(URL::about_version(), Web::HTML::ActivateTab::Yes);
     });

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -136,6 +136,8 @@ public:
     Action& paste_action() { return *m_paste_action; }
     Action& select_all_action() { return *m_select_all_action; }
 
+    Action& print_action() { return *m_print_action; }
+
     Action& open_about_page_action() { return *m_open_about_page_action; }
     Action& open_settings_page_action() { return *m_open_settings_page_action; }
 
@@ -289,6 +291,7 @@ private:
     RefPtr<Action> m_copy_selection_action;
     RefPtr<Action> m_paste_action;
     RefPtr<Action> m_select_all_action;
+    RefPtr<Action> m_print_action;
 
     RefPtr<Action> m_open_about_page_action;
     RefPtr<Action> m_open_settings_page_action;

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -37,6 +37,8 @@ enum class ActionID {
     TakeVisibleScreenshot,
     TakeFullScreenshot,
 
+    Print,
+
     ManageBookmarks,
     ToggleBookmark,
     ToggleBookmarkViaToolbar,

--- a/Libraries/LibWebView/PageInfo.h
+++ b/Libraries/LibWebView/PageInfo.h
@@ -16,6 +16,7 @@ enum class PageInfoType {
     PaintTree = 1 << 3,
     GCGraph = 1 << 4,
     StackingContextTree = 1 << 5,
+    PrintLayoutTree = 1 << 6,
 };
 
 AK_ENUM_BITWISE_OPERATORS(PageInfoType);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -847,6 +847,28 @@ void ViewImplementation::did_receive_screenshot(Badge<WebContentClient>, Gfx::Sh
     m_pending_screenshot = nullptr;
 }
 
+void ViewImplementation::trigger_print(Web::HTML::PrintSettings const& settings)
+{
+    client().async_print_page(page_id(), settings);
+}
+
+void ViewImplementation::did_finish_print()
+{
+    client().async_finish_print(page_id());
+}
+
+void ViewImplementation::did_receive_print_request(Badge<WebContentClient>)
+{
+    if (on_print_request)
+        on_print_request();
+}
+
+void ViewImplementation::did_receive_print_bitmap(Badge<WebContentClient>, Gfx::ShareableBitmap const& bitmap)
+{
+    if (on_request_print_bitmap)
+        on_request_print_bitmap(bitmap);
+}
+
 NonnullRefPtr<Core::Promise<String>> ViewImplementation::request_internal_page_info(PageInfoType type)
 {
     auto promise = Core::Promise<String>::construct();

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/PrintSettings.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -178,6 +179,11 @@ public:
     NonnullRefPtr<Core::Promise<LexicalPath>> take_dom_node_screenshot(Web::UniqueNodeID);
     virtual void did_receive_screenshot(Badge<WebContentClient>, Gfx::ShareableBitmap const&);
 
+    void trigger_print(Web::HTML::PrintSettings const& = {});
+    void did_finish_print();
+    void did_receive_print_request(Badge<WebContentClient>);
+    void did_receive_print_bitmap(Badge<WebContentClient>, Gfx::ShareableBitmap const&);
+
     NonnullRefPtr<Core::Promise<String>> request_internal_page_info(PageInfoType);
     void did_receive_internal_page_info(Badge<WebContentClient>, PageInfoType, Optional<Core::AnonymousBuffer> const&);
 
@@ -215,6 +221,8 @@ public:
     Function<void()> on_stop_tooltip_override;
     Function<void(ByteString const&)> on_enter_tooltip_area;
     Function<void()> on_leave_tooltip_area;
+    Function<void()> on_print_request;
+    Function<void(Gfx::ShareableBitmap)> on_request_print_bitmap;
     Function<void(String const& message)> on_request_alert;
     Function<void(String const& message)> on_request_confirm;
     Function<void(String const& message, String const& default_)> on_request_prompt;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -481,6 +481,18 @@ void WebContentClient::did_take_screenshot(u64 page_id, Gfx::ShareableBitmap scr
         view->did_receive_screenshot({}, screenshot);
 }
 
+void WebContentClient::did_request_print(u64 page_id)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_receive_print_request({});
+}
+
+void WebContentClient::did_finish_rendering_for_print(u64 page_id, Gfx::ShareableBitmap bitmap)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_receive_print_bitmap({}, bitmap);
+}
+
 void WebContentClient::did_get_internal_page_info(u64 page_id, WebView::PageInfoType type, Optional<Core::AnonymousBuffer> info)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -98,6 +98,8 @@ private:
     virtual void did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> stylesheets) override;
     virtual void did_get_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier, URL::URL, String source) override;
     virtual void did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) override;
+    virtual void did_request_print(u64 page_id) override;
+    virtual void did_finish_rendering_for_print(u64 page_id, Gfx::ShareableBitmap bitmap) override;
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, Optional<Core::AnonymousBuffer>) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;
     virtual void did_output_js_console_message(u64 page_id, ConsoleOutput) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -939,6 +939,24 @@ void ConnectionFromClient::take_dom_node_screenshot(u64 page_id, Web::UniqueNode
     page->queue_screenshot_task(node_id);
 }
 
+void ConnectionFromClient::print_page(u64 page_id, Web::HTML::PrintSettings settings)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    page->queue_print_task(settings);
+}
+
+void ConnectionFromClient::finish_print(u64 page_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    page->finish_print();
+}
+
 static void append_page_text(Web::Page& page, StringBuilder& builder)
 {
     auto* document = page.top_level_browsing_context().active_document();
@@ -1067,6 +1085,19 @@ void ConnectionFromClient::request_internal_page_info(u64 page_id, WebView::Page
         if (!builder.is_empty())
             builder.append("\n"sv);
         append_gc_graph(builder);
+    }
+
+    if (has_flag(type, WebView::PageInfoType::PrintLayoutTree)) {
+        if (!builder.is_empty())
+            builder.append("\n"sv);
+        auto& web_page = page->page();
+        if (web_page.top_level_traversable_is_initialized()) {
+            auto navigable = web_page.top_level_traversable();
+            // https://www.w3.org/TR/css-page-3/#page-size-a4
+            navigable->with_print_mode(Web::HTML::PrintSettings {}, [&] {
+                append_layout_tree(web_page, builder);
+            });
+        }
     }
 
     auto buffer = MUST(Core::AnonymousBuffer::create_with_size(builder.length()));

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -152,6 +152,9 @@ private:
     virtual void take_document_screenshot(u64 page_id) override;
     virtual void take_dom_node_screenshot(u64 page_id, Web::UniqueNodeID node_id) override;
 
+    virtual void print_page(u64 page_id, Web::HTML::PrintSettings) override;
+    virtual void finish_print(u64 page_id) override;
+
     virtual void request_internal_page_info(u64 page_id, WebView::PageInfoType) override;
 
     virtual Messages::WebContentServer::GetSelectedTextResponse get_selected_text(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -424,6 +424,11 @@ void PageClient::page_did_request_media_context_menu(Web::CSSPixelPoint content_
     client().async_did_request_media_context_menu(m_id, page().css_to_device_point(content_position).to_type<int>(), target, modifiers, menu);
 }
 
+void PageClient::page_did_request_print()
+{
+    client().async_did_request_print(m_id);
+}
+
 void PageClient::page_did_request_alert(String const& message)
 {
     client().async_did_request_alert(m_id, message);
@@ -795,6 +800,11 @@ void PageClient::page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot
     client().async_did_take_screenshot(m_id, screenshot);
 }
 
+void PageClient::page_did_finish_rendering_for_print(Gfx::ShareableBitmap const& bitmap)
+{
+    client().async_did_finish_rendering_for_print(m_id, bitmap);
+}
+
 ErrorOr<void> PageClient::connect_to_webdriver(ByteString const& webdriver_endpoint)
 {
     VERIFY(!m_webdriver);
@@ -1014,6 +1024,16 @@ Web::DisplayListPlayerType PageClient::display_list_player_type() const
 void PageClient::queue_screenshot_task(Optional<Web::UniqueNodeID> node_id)
 {
     page().top_level_traversable()->queue_screenshot_task(node_id);
+}
+
+void PageClient::queue_print_task(Web::HTML::PrintSettings settings)
+{
+    page().top_level_traversable()->queue_print_task(settings);
+}
+
+void PageClient::finish_print()
+{
+    page().top_level_traversable()->finish_print();
 }
 
 }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/PrintSettings.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BackingStoreManager.h>
 #include <LibWeb/PixelUnits.h>
@@ -103,6 +104,8 @@ public:
     virtual Web::DisplayListPlayerType display_list_player_type() const override;
 
     void queue_screenshot_task(Optional<Web::UniqueNodeID> node_id);
+    void queue_print_task(Web::HTML::PrintSettings);
+    void finish_print();
 
 private:
     PageClient(PageHost&, u64 id);
@@ -146,6 +149,7 @@ private:
     virtual void page_did_create_new_document(Web::DOM::Document&) override;
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(URL::URL const&) override;
+    virtual void page_did_request_print() override;
     virtual void page_did_request_alert(String const&) override;
     virtual void page_did_request_confirm(String const&) override;
     virtual void page_did_request_prompt(String const&, String const&) override;
@@ -193,6 +197,7 @@ private:
     virtual void page_did_mutate_dom(FlyString const& type, Web::DOM::Node const& target, Web::DOM::NodeList& added_nodes, Web::DOM::NodeList& removed_nodes, GC::Ptr<Web::DOM::Node> previous_sibling, GC::Ptr<Web::DOM::Node> next_sibling, Optional<String> const& attribute_name) override;
     virtual void page_did_paint(Gfx::IntRect const& content_rect, i32 bitmap_id) override;
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot) override;
+    virtual void page_did_finish_rendering_for_print(Gfx::ShareableBitmap const& bitmap) override;
     virtual void received_message_from_web_ui(String const& name, JS::Value data) override;
     virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>) override;
     virtual void page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String>, Vector<HTTP::Header> const&) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -74,6 +74,8 @@ endpoint WebContentClient
     did_get_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier, URL::URL base_url, String source) =|
 
     did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) =|
+    did_request_print(u64 page_id) =|
+    did_finish_rendering_for_print(u64 page_id, Gfx::ShareableBitmap bitmap) =|
 
     did_get_internal_page_info(u64 page_id, WebView::PageInfoType type, Optional<Core::AnonymousBuffer> info) =|
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -20,6 +20,7 @@
 #include <LibWebView/Attribute.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/PageInfo.h>
+#include <LibWeb/HTML/PrintSettings.h>
 #include <LibWebView/Settings.h>
 
 endpoint WebContentServer
@@ -85,6 +86,9 @@ endpoint WebContentServer
 
     take_document_screenshot(u64 page_id) =|
     take_dom_node_screenshot(u64 page_id, Web::UniqueNodeID node_id) =|
+
+    print_page(u64 page_id, Web::HTML::PrintSettings settings) =|
+    finish_print(u64 page_id) =|
 
     request_internal_page_info(u64 page_id, WebView::PageInfoType type) =|
 

--- a/Tests/LibWeb/PrintLayout/expected/media-print-basic.txt
+++ b/Tests/LibWeb/PrintLayout/expected/media-print-basic.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at [0,0] [0+0+0 697.703125 0+0+0] [0+0+0 1026.515625 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 697.703125 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 697.703125 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 681.703125 0+0+8] [8+0+0 36 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 681.703125 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <div.print-only> at [8,8] [0+0+0 681.703125 0+0+0] [0+0+0 18 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 41.390625x18] baseline: 13.796875
+            "Print"
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,26] [0+0+0 681.703125 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,26] [0+0+0 681.703125 0+0+0] [0+0+0 18 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 4, rect: [8,26 35.859375x18] baseline: 13.796875
+            "Both"
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,44] [0+0+0 681.703125 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)

--- a/Tests/LibWeb/PrintLayout/input/media-print-basic.html
+++ b/Tests/LibWeb/PrintLayout/input/media-print-basic.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  .screen-only { display: block; }
+  .print-only  { display: none; }
+  @media print {
+    .screen-only { display: none; }
+    .print-only  { display: block; }
+  }
+</style>
+</head>
+<body>
+  <div class="screen-only">Screen</div>
+  <div class="print-only">Print</div>
+  <div>Both</div>
+</body>
+</html>

--- a/Tests/LibWeb/Text/expected/window-print-beforeprint-event.txt
+++ b/Tests/LibWeb/Text/expected/window-print-beforeprint-event.txt
@@ -1,0 +1,1 @@
+beforeprint fired: 1

--- a/Tests/LibWeb/Text/input/window-print-beforeprint-event.html
+++ b/Tests/LibWeb/Text/input/window-print-beforeprint-event.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+asyncTest(async done => {
+    let count = 0;
+    window.addEventListener("beforeprint", () => { count++; });
+
+    await new Promise(resolve => {
+        window.addEventListener("beforeprint", resolve, { once: true });
+        window.print();
+    });
+
+    println(`beforeprint fired: ${count}`);
+    done();
+});
+</script>

--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -26,6 +26,7 @@ enum class TestMode {
     Ref,
     Screenshot,
     Crash,
+    PrintLayout,
 };
 
 constexpr StringView test_mode_to_string(TestMode mode)
@@ -41,6 +42,8 @@ constexpr StringView test_mode_to_string(TestMode mode)
         return "Screenshot"sv;
     case TestMode::Crash:
         return "Crash"sv;
+    case TestMode::PrintLayout:
+        return "PrintLayout"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -42,6 +42,7 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibURL/Parser.h>
 #include <LibURL/URL.h>
+#include <LibWeb/HTML/PrintSettings.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/Utilities.h>
@@ -607,6 +608,17 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
             if (test.did_finish_loading)
                 on_test_complete();
         };
+    } else if (test.mode == TestMode::PrintLayout) {
+        view.on_load_finish = [&view, &context, url, test_index, on_test_complete = move(on_test_complete)](auto const& loaded_url) {
+            if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
+                return;
+
+            auto promise = view.request_internal_page_info(WebView::PageInfoType::PrintLayoutTree);
+            promise->when_resolved([&context, test_index, on_test_complete = move(on_test_complete)](auto const& text) {
+                context.tests[test_index].text = text;
+                on_test_complete();
+            });
+        };
     }
 
     view.load(url);
@@ -943,6 +955,7 @@ static void run_test(TestWebView& view, TestRunContext& context, size_t test_ind
         case TestMode::Crash:
         case TestMode::Text:
         case TestMode::Layout:
+        case TestMode::PrintLayout:
             run_dump_test(view, context, test, *url);
             return;
         case TestMode::Ref:
@@ -1007,6 +1020,9 @@ static void set_ui_callbacks_for_tests(TestWebView& view, TestRunCapture& test_r
         view.alert_closed();
     };
 
+    view.on_print_request = [&view]() { view.trigger_print(Web::HTML::PrintSettings {}); };
+    view.on_request_print_bitmap = [&view](auto const&) { view.did_finish_print(); };
+
     view.on_web_content_crashed = [&view, &test_run_capture]() {
         test_run_capture.write_test_output(view);
 
@@ -1046,6 +1062,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
     TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Layout", app.test_root_path), "."sv, TestMode::Layout));
     TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Text", app.test_root_path), "."sv, TestMode::Text));
+    TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/PrintLayout", app.test_root_path), "."sv, TestMode::PrintLayout));
     TRY(collect_ref_tests(app, tests, ByteString::formatted("{}/Ref", app.test_root_path), "."sv));
     TRY(collect_crash_tests(app, tests, ByteString::formatted("{}/Crash", app.test_root_path), "."sv));
     TRY(collect_screenshot_tests(app, tests, ByteString::formatted("{}/Screenshot", app.test_root_path), "."sv));

--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -29,6 +29,7 @@ NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
         adw_init();
         m_adw_application = ADW_APPLICATION(adw_application_new("org.ladybird.Ladybird",
             static_cast<GApplicationFlags>(G_APPLICATION_DEFAULT_FLAGS | G_APPLICATION_HANDLES_OPEN)));
+        g_set_application_name("Ladybird");
         GError* error = nullptr;
         g_application_register(G_APPLICATION(m_adw_application), nullptr, &error);
         if (error) {

--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -129,6 +129,7 @@ void BrowserWindow::register_actions()
     add_action_to_map(G_ACTION_MAP(m_window), "reload", app.reload_action());
     add_action_to_map(G_ACTION_MAP(m_window), "preferences", app.open_settings_page_action());
     add_action_to_map(G_ACTION_MAP(m_window), "about", app.open_about_page_action());
+    add_action_to_map(G_ACTION_MAP(m_window), "print", app.print_action());
 }
 
 void BrowserWindow::setup_ui(AdwApplication* app)
@@ -265,6 +266,7 @@ void BrowserWindow::setup_keyboard_shortcuts()
     set_accels("win.fullscreen", { "F11" });
     set_accels("win.quit", { "<Ctrl>q" });
     set_accels("win.new-window", { "<Ctrl>n" });
+    set_accels("win.print", { "<Ctrl>p" });
 }
 
 void BrowserWindow::on_tab_switched()

--- a/UI/Gtk/CMakeLists.txt
+++ b/UI/Gtk/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK4 REQUIRED IMPORTED_TARGET gtk4)
+pkg_check_modules(GTK4_PRINT REQUIRED IMPORTED_TARGET gtk4-unix-print)
 pkg_check_modules(LIBADWAITA REQUIRED IMPORTED_TARGET libadwaita-1>=1.4)
 
 add_executable(ladybird main.cpp)
@@ -41,6 +42,6 @@ target_sources(ladybird PRIVATE
     Widgets/LadybirdWebView.cpp
     "${GTK_GRESOURCE_SOURCE}"
 )
-target_link_libraries(ladybird PRIVATE PkgConfig::GTK4 PkgConfig::LIBADWAITA)
+target_link_libraries(ladybird PRIVATE PkgConfig::GTK4 PkgConfig::GTK4_PRINT PkgConfig::LIBADWAITA)
 add_dependencies(ladybird gtk_ui_resources)
 create_ladybird_bundle(ladybird)

--- a/UI/Gtk/Dialogs.cpp
+++ b/UI/Gtk/Dialogs.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/HTML/PrintSettings.h>
 #include <UI/Gtk/Dialogs.h>
 #include <UI/Gtk/GLibPtr.h>
 #include <UI/Gtk/WebContentView.h>
@@ -201,6 +202,99 @@ void show_file_picker(GtkWindow* parent, WebContentView* view, Web::HTML::FileFi
                 }
                 view->file_picker_closed(move(selected)); }, view);
     }
+}
+
+struct PrintData {
+    WebContentView* view { nullptr };
+    Gfx::ShareableBitmap bitmap;
+    int pages { 0 };
+    double scale { 1.0 };
+};
+
+void show_print_dialog(GtkWindow* parent, WebContentView* view)
+{
+    GObjectPtr<GtkPrintOperation> op { gtk_print_operation_new() };
+    gtk_print_operation_set_job_name(op.ptr(), "Ladybird");
+    gtk_print_operation_set_track_print_status(op.ptr(), TRUE);
+
+    auto* data = new PrintData;
+    data->view = view;
+
+    // Temporarily claim on_request_print_bitmap to deliver bitmap into PrintData.
+    view->on_request_print_bitmap = [data](Gfx::ShareableBitmap bmp) {
+        data->bitmap = bmp;
+    };
+
+    g_signal_connect(op.ptr(), "begin-print", G_CALLBACK(+[](GtkPrintOperation* op, GtkPrintContext* context, gpointer user_data) {
+        auto* data = static_cast<PrintData*>(user_data);
+        // GtkPrintContext dimensions are in points (1 pt = 0.352778 mm)
+        constexpr float pts_to_mm = 0.352778f;
+        Web::HTML::PrintSettings settings;
+        settings.paper_width_mm = static_cast<float>(gtk_print_context_get_width(context)) * pts_to_mm;
+        settings.paper_height_mm = static_cast<float>(gtk_print_context_get_height(context)) * pts_to_mm;
+        // GtkPrintContext dimensions already exclude margins; use zero margins so
+        // with_print_mode renders exactly to the available area.
+        settings.margin_top_mm = 0.0f;
+        settings.margin_right_mm = 0.0f;
+        settings.margin_bottom_mm = 0.0f;
+        settings.margin_left_mm = 0.0f;
+
+        data->view->trigger_print(settings);
+
+        // Spin the GLib main loop until WebContent delivers the bitmap.
+        while (!data->bitmap.is_valid())
+            g_main_context_iteration(nullptr, TRUE);
+
+        double page_width = gtk_print_context_get_width(context);
+        double page_height = gtk_print_context_get_height(context);
+        double bmp_width = data->bitmap.bitmap()->width();
+        data->scale = (bmp_width > 0) ? page_width / bmp_width : 1.0;
+        double scaled_height = data->bitmap.bitmap()->height() * data->scale;
+        data->pages = static_cast<int>(ceil(scaled_height / page_height));
+        if (data->pages < 1)
+            data->pages = 1;
+        gtk_print_operation_set_n_pages(op, data->pages);
+    }),
+        data);
+
+    g_signal_connect(op.ptr(), "draw-page", G_CALLBACK(+[](GtkPrintOperation*, GtkPrintContext* context, gint page_num, gpointer user_data) {
+        auto* data = static_cast<PrintData*>(user_data);
+        auto* bmp = data->bitmap.bitmap();
+        if (!bmp)
+            return;
+        auto* cr = gtk_print_context_get_cairo_context(context);
+        double page_height = gtk_print_context_get_height(context);
+
+        // Paint bitmap via a Cairo image surface (BGRA8888 matches CAIRO_FORMAT_ARGB32 on LE)
+        int width = bmp->width();
+        int height = bmp->height();
+        auto* surface = cairo_image_surface_create_for_data(
+            const_cast<unsigned char*>(bmp->scanline_u8(0)),
+            CAIRO_FORMAT_ARGB32,
+            width, height, bmp->pitch());
+        if (!surface)
+            return;
+
+        cairo_save(cr);
+        cairo_scale(cr, data->scale, data->scale);
+        double y_offset = -page_num * (page_height / data->scale);
+        cairo_set_source_surface(cr, surface, 0, y_offset);
+        cairo_paint(cr);
+        cairo_restore(cr);
+        cairo_surface_destroy(surface);
+    }),
+        data);
+
+    g_signal_connect_swapped(op.ptr(), "done", G_CALLBACK(+[](PrintData* data) {
+        data->view->on_request_print_bitmap = {};
+        if (data->view)
+            data->view->did_finish_print();
+        delete data;
+    }),
+        data);
+
+    g_autoptr(GError) error = nullptr;
+    gtk_print_operation_run(op.ptr(), GTK_PRINT_OPERATION_ACTION_PRINT_DIALOG, parent, &error);
 }
 
 }

--- a/UI/Gtk/Dialogs.h
+++ b/UI/Gtk/Dialogs.h
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/SelectedFile.h>
 
 #include <gtk/gtk.h>
+#include <gtk/gtkunixprint.h>
 
 namespace Ladybird {
 
@@ -25,6 +26,7 @@ void show_confirm(GtkWindow* parent, WebContentView* view, String const& message
 void show_prompt(GtkWindow* parent, WebContentView* view, String const& message, String const& default_value);
 void show_color_picker(GtkWindow* parent, WebContentView* view, Color current_color);
 void show_file_picker(GtkWindow* parent, WebContentView* view, Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple);
+void show_print_dialog(GtkWindow* parent, WebContentView* view);
 
 }
 

--- a/UI/Gtk/Menu.cpp
+++ b/UI/Gtk/Menu.cpp
@@ -140,6 +140,11 @@ static void initialize_native_control(WebView::Action& action, GSimpleAction* ga
         set_icon("image-x-generic-symbolic");
         break;
 
+    case WebView::ActionID::Print:
+        set_icon("document-print-symbolic");
+        set_accel("<Ctrl>p");
+        break;
+
     case WebView::ActionID::ToggleBookmark:
     case WebView::ActionID::ToggleBookmarkViaToolbar:
         set_icon(action.engaged() ? "starred-symbolic" : "non-starred-symbolic");

--- a/UI/Gtk/Resources/browser-window.ui
+++ b/UI/Gtk/Resources/browser-window.ui
@@ -240,6 +240,13 @@
           </object>
         </child>
         <child>
+          <object class="GtkButton" id="print_menu_button">
+            <property name="action-name">win.print</property>
+            <property name="icon-name">document-print-symbolic</property>
+            <property name="tooltip-text">Print (Ctrl+P)</property>
+          </object>
+        </child>
+        <child>
           <object class="GtkButton" id="fullscreen_menu_button">
             <property name="action-name">win.fullscreen</property>
             <property name="icon-name">view-fullscreen-symbolic</property>

--- a/UI/Gtk/Tab.cpp
+++ b/UI/Gtk/Tab.cpp
@@ -175,6 +175,12 @@ void Tab::setup_callbacks()
         m_window.update_zoom_label();
     };
 
+    // Print
+    m_view->on_print_request = [this]() {
+        Dialogs::show_print_dialog(m_window.gtk_window(), m_view.ptr());
+    };
+    // on_request_print_bitmap is set by show_print_dialog internally
+
     // Dialogs
     m_view->on_request_alert = [this](auto const& message) {
         Dialogs::show_alert(m_window.gtk_window(), m_view.ptr(), message);

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -228,6 +228,11 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     m_hamburger_menu->addAction(open_file_action);
     file_menu->addAction(open_file_action);
 
+    file_menu->addSeparator();
+    auto* print_action = create_application_action(*this, Application::the().print_action());
+    m_hamburger_menu->addAction(print_action);
+    file_menu->addAction(print_action);
+
     m_hamburger_menu->addSeparator();
 
     auto* edit_menu = m_hamburger_menu->addMenu("&Edit");

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets PrintSupport)
 
 qt_add_executable(ladybird main.cpp)
 target_sources(ladybird PRIVATE
@@ -23,7 +23,7 @@ target_sources(ladybird PRIVATE
     WebContentView.cpp
     ladybird.qrc
 )
-target_link_libraries(ladybird PRIVATE Qt::Core Qt::Gui Qt::Widgets)
+target_link_libraries(ladybird PRIVATE Qt::Core Qt::Gui Qt::Widgets Qt::PrintSupport)
 create_ladybird_bundle(ladybird)
 
 if (WIN32)

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -186,6 +186,11 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/filetype-image.png"sv));
         break;
 
+    case WebView::ActionID::Print:
+        qaction.setIcon(QIcon::fromTheme("document-print"));
+        qaction.setShortcut(QKeySequence::Print);
+        break;
+
     case WebView::ActionID::OpenInNewTab:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/new-tab.png"sv));
         break;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibURL/URL.h>
+#include <LibWeb/HTML/PrintSettings.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
 #include <UI/Qt/BrowserWindow.h>
@@ -16,6 +17,8 @@
 #include <UI/Qt/StringUtils.h>
 
 #include <QColorDialog>
+#include <QDialogButtonBox>
+#include <QEventLoop>
 #include <QFileDialog>
 #include <QFont>
 #include <QFontMetrics>
@@ -25,6 +28,11 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QMimeDatabase>
+#include <QPainter>
+#include <QPrintDialog>
+#include <QPrintPreviewDialog>
+#include <QPrinter>
+#include <QPushButton>
 #include <QResizeEvent>
 
 namespace Ladybird {
@@ -365,6 +373,105 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     view().on_find_in_page = [this](auto current_match_index, auto const& total_match_count) {
         m_find_in_page->update_result_label(current_match_index, total_match_count);
+    };
+
+    // Renders a ShareableBitmap onto a QPrinter, paginating as needed.
+    auto render_to_printer = [](Gfx::ShareableBitmap const& bitmap, QPrinter& printer) {
+        auto* bmp = bitmap.bitmap();
+        if (!bmp)
+            return;
+
+        // Gfx::BitmapFormat::BGRA8888 maps to QImage::Format_ARGB32_Premultiplied on little-endian
+        QImage image(
+            reinterpret_cast<uchar const*>(bmp->scanline_u8(0)),
+            bmp->width(), bmp->height(),
+            bmp->pitch(),
+            QImage::Format_ARGB32_Premultiplied);
+
+        QRectF page_rect = printer.pageRect(QPrinter::DevicePixel);
+        double scale = (image.width() > 0) ? page_rect.width() / image.width() : 1.0;
+        double scaled_height = image.height() * scale;
+        int num_pages = qMax(1, static_cast<int>(std::ceil(scaled_height / page_rect.height())));
+
+        QPainter painter(&printer);
+        for (int page = 0; page < num_pages; ++page) {
+            if (page > 0)
+                printer.newPage();
+            double y_offset = page * (page_rect.height() / scale);
+            double slice_height = qMin(static_cast<double>(image.height()) - y_offset,
+                page_rect.height() / scale);
+            QRectF src_rect(0, y_offset, image.width(), slice_height);
+            QRectF dest_rect(0, 0, page_rect.width(), slice_height * scale);
+            painter.drawImage(dest_rect, image, src_rect);
+        }
+        painter.end();
+    };
+
+    // Builds a PrintSettings from the current QPrinter page layout.
+    auto settings_from_printer = [](QPrinter const& p) {
+        auto layout = p.pageLayout();
+        auto size_mm = layout.pageSize().size(QPageSize::Millimeter);
+        auto margins_mm = layout.margins(QPageLayout::Millimeter);
+        return Web::HTML::PrintSettings {
+            .paper_width_mm = static_cast<float>(size_mm.width()),
+            .paper_height_mm = static_cast<float>(size_mm.height()),
+            .margin_top_mm = static_cast<float>(margins_mm.top()),
+            .margin_right_mm = static_cast<float>(margins_mm.right()),
+            .margin_bottom_mm = static_cast<float>(margins_mm.bottom()),
+            .margin_left_mm = static_cast<float>(margins_mm.left()),
+        };
+    };
+
+    // Renders for a QPrinter synchronously: triggers WebContent, spins event loop, paints.
+    auto render_sync = [this, render_to_printer, settings_from_printer](QPrinter* p) mutable {
+        Optional<Gfx::ShareableBitmap> result;
+        QEventLoop loop;
+        view().on_request_print_bitmap = [&result, &loop](Gfx::ShareableBitmap bmp) {
+            result = bmp;
+            loop.quit();
+        };
+        view().trigger_print(settings_from_printer(*p));
+        loop.exec();
+        view().on_request_print_bitmap = {};
+        if (result.has_value())
+            render_to_printer(*result, *p);
+    };
+
+    view().on_print_request = [this, render_sync, settings_from_printer]() mutable {
+        auto printer = make<QPrinter>();
+        QPrintDialog dialog(printer.ptr(), m_window);
+
+        // Add a "Preview..." button alongside the standard Print/Cancel buttons.
+        auto* preview_button = new QPushButton(tr("Preview..."), &dialog);
+        if (auto* button_box = dialog.findChild<QDialogButtonBox*>())
+            button_box->addButton(preview_button, QDialogButtonBox::ActionRole);
+
+        QObject::connect(preview_button, &QPushButton::clicked, [this, &printer, &render_sync, &dialog]() {
+            dialog.hide();
+            QPrintPreviewDialog preview(printer.ptr(), m_window);
+            QObject::connect(&preview, &QPrintPreviewDialog::paintRequested, [&render_sync](QPrinter* p) {
+                render_sync(p);
+            });
+            preview.exec();
+            // After preview closes, dismiss the print dialog too (user already committed or cancelled in preview).
+            dialog.reject();
+        });
+
+        if (dialog.exec() != QDialog::Accepted)
+            return;
+
+        m_pending_printer = AK::move(printer);
+        view().trigger_print(settings_from_printer(*m_pending_printer));
+    };
+
+    view().on_request_print_bitmap = [this, render_to_printer](Gfx::ShareableBitmap bitmap) mutable {
+        auto printer = AK::move(m_pending_printer);
+        if (!printer) {
+            view().did_finish_print();
+            return;
+        }
+        render_to_printer(bitmap, *printer);
+        view().did_finish_print();
     };
 
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <UI/Qt/BookmarksBar.h>
 #include <UI/Qt/FindInPageWidget.h>
@@ -17,6 +18,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QPointer>
+#include <QPrinter>
 #include <QToolBar>
 #include <QToolButton>
 #include <QWidget>
@@ -105,6 +107,7 @@ private:
     BrowserWindow* m_window { nullptr };
     QString m_title;
     HyperlinkLabel* m_hover_label { nullptr };
+    OwnPtr<QPrinter> m_pending_printer;
     QIcon m_favicon;
 
     QMenu* m_context_menu { nullptr };


### PR DESCRIPTION
Add end-to-end print support

- Add `@media` print support in LibWeb, print-specific CSS now applies during printing.
- Implement window.print() per spec, including correct beforeprint+afterprint event dispatch and A4 viewport rendering at 96 DPI.
- Add a print rendering pipeline in TraversableNavigable that renders a print display list on the rendering thread and restores screen layout afterward.
- Add print dialog support (Ctrl+P) in the GTK and Qt frontends.
- Add support for print layout tests and add a basic test ensuring `@media print` is honored

Example wikipedia page:
[output.pdf](https://github.com/user-attachments/files/27086678/output.pdf)
