### PR TITLE
Clang-format: Prevent space in curly braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,7 @@ RemoveSemicolon: true
 RequiresClausePosition: WithFollowing
 RequiresExpressionIndentation: OuterScope
 SpaceAfterTemplateKeyword: false
+SpaceInEmptyBraces: Never
 WrapNamespaceBodyWithEmptyLines: Always
 
 ---


### PR DESCRIPTION
Clang-format 22 added SpaceInEmptyBraces and it defaults to Always resulting in `{ }`. Ladybird uses `{}`. Now set to Never.

https://clang.llvm.org/docs/ClangFormatStyleOptions.html#spaceinemptybraces