### PR TITLE
LibGfx: Add the mimalloc allocator shim to liblagom-gfx.so

### DIFF
--- a/Libraries/LibGfx/Rust/src/lib.rs
+++ b/Libraries/LibGfx/Rust/src/lib.rs
@@ -4,4 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#[path = "../../../RustAllocator.rs"]
+mod rust_allocator;
+
 pub mod yuv;


### PR DESCRIPTION
This keeps our Rust crates on the same allocator in shared builds.

This fixes the same ELF debug crash as #9026, where mimalloc detects heap corruption as soon as liblagom-regex.so starts using the first allocator it finds.

When generating liblagom-regex.so during shared-library linkage, the normal linker sees that those allocator symbols are already provided by liblagom-unicode.so, which it depends on, so the corresponding object file is not pulled in from libregex_rust.a.

Fast forward to runtime, if liblagom-gfx.so is loaded first, as seems to happen in debug builds, then its exported allocator is picked up by liblagom-regex.so instead.