### PR TITLE
LibWeb: Position list marker to the right of right-to-left text

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -883,7 +883,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     // Before we insert the children of a list item we need to know the location of the marker.
     // If we do not do this then left-floating elements inside the list item will push the marker to the right,
     // in some cases even causing it to overlap with the non-floating content of the list.
-    CSSPixels left_space_before_children_formatted;
+    SpaceUsedByFloats inline_space_used_before_children_formatted;
     if (is_list_item_box_without_css_content && li_box->marker()) {
         // We need to ensure that our height and width are final before we calculate our left offset.
         // Otherwise, the y at which we calculate the intrusion by floats might be incorrect.
@@ -893,9 +893,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         auto const& marker_state = m_state.get(*li_box->marker());
 
         auto offset_y = max(CSSPixels(0), (li_box->marker()->computed_values().line_height() - marker_state.content_height()) / 2);
-        auto space_used_before_children_formatted = intrusion_by_floats_into_box(list_item_state, offset_y);
-
-        left_space_before_children_formatted = space_used_before_children_formatted.left;
+        inline_space_used_before_children_formatted = intrusion_by_floats_into_box(list_item_state, offset_y);
     }
 
     if (independent_formatting_context) {
@@ -965,7 +963,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     // Now that our children are formatted we place the ListItemBox with the left space we remembered.
     if (is_list_item_box_without_css_content)
         // The marker pseudo-element will be created from a ListItemMarkerBox
-        layout_list_item_marker(*li_box, left_space_before_children_formatted);
+        layout_list_item_marker(*li_box, inline_space_used_before_children_formatted);
     // Otherwise, it will be a dealt with as a generic pseudo-element with the content of the ::marker pseudo-element.
 
     if (independent_formatting_context || !margins_collapse_through(box, m_state)) {
@@ -1521,7 +1519,7 @@ void BlockFormattingContext::ensure_sizes_correct_for_left_offset_calculation(Li
     }
 }
 
-void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_item_box, CSSPixels const& left_space_before_list_item_elements_formatted)
+void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_item_box, SpaceUsedByFloats const& inline_space_used_before_list_item_elements_formatted)
 {
     if (!list_item_box.marker())
         return;
@@ -1540,14 +1538,22 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
     auto marker_height = marker_state.content_height();
     auto marker_width = marker_state.content_width();
 
+    auto list_item_direction = list_item_box.computed_values().direction();
+    auto marker_offset_x = list_item_direction == CSS::Direction::Ltr
+        ? inline_space_used_before_list_item_elements_formatted.left - marker_distance - marker_width
+        : list_item_state.content_width() - (inline_space_used_before_list_item_elements_formatted.right - marker_distance);
+    auto marker_offset_y = max(CSSPixels(0), (marker.computed_values().line_height() - marker_height) / 2);
+
     if (marker.list_style_position() == CSS::ListStylePosition::Inside) {
-        list_item_state.set_content_x(list_item_state.offset.x() + marker_width + marker_distance);
-        list_item_state.set_content_width(list_item_state.content_width() - marker_width);
+        // FIXME: Just adjusting the content width and position for an inside marker is wrong, as it will still position
+        //        the marker outside of the box, instead of treating it more like an inline child on the first line.
+        if (list_item_direction == CSS::Direction::Ltr) {
+            list_item_state.set_content_x(list_item_state.offset.x() + marker_width + marker_distance);
+        }
+        list_item_state.set_content_width(list_item_state.content_width() - marker_width - marker_distance);
     }
 
-    auto offset_x = round(left_space_before_list_item_elements_formatted - marker_distance - marker_width);
-    auto offset_y = round(max(CSSPixels(0), (marker.computed_values().line_height() - marker_height) / 2));
-    marker_state.set_content_offset({ offset_x, offset_y });
+    marker_state.set_content_offset({ round(marker_offset_x), round(marker_offset_y) });
 
     if (marker.computed_values().line_height() > list_item_state.content_height())
         list_item_state.set_content_height(marker.computed_values().line_height());

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -110,7 +110,7 @@ private:
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
 
     void ensure_sizes_correct_for_left_offset_calculation(ListItemBox const&);
-    void layout_list_item_marker(ListItemBox const&, CSSPixels const& left_space_before_list_item_elements_formatted);
+    void layout_list_item_marker(ListItemBox const&, SpaceUsedByFloats const& inline_space_used_before_list_item_elements_formatted);
 
     void measure_scrollable_overflow(Box const&, CSSPixels& bottom_edge, CSSPixels& right_edge) const;
 

--- a/Tests/LibWeb/Layout/expected/details-closed.txt
+++ b/Tests/LibWeb/Layout/expected/details-closed.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
       BlockContainer <details> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-        ListItemBox <summary> at [24,8] [0+0+0 776 0+0+0] [0+0+0 18 0+0+0] children: inline
+        ListItemBox <summary> at [24,8] [0+0+0 768 0+0+0] [0+0+0 18 0+0+0] children: inline
           frag 0 from TextNode start: 0, length: 13, rect: [24,8 114.625x18] baseline: 13.796875
               "I'm a summary"
           ListItemMarkerBox <(anonymous)> at [8,13] [0+0+0 8 0+0+0] [0+0+0 8 0+0+0] children: not-inline
@@ -15,7 +15,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableWithLines (BlockContainer<DETAILS>) [8,8 784x18]
-        PaintableWithLines (ListItemBox<SUMMARY>) [24,8 776x18]
+        PaintableWithLines (ListItemBox<SUMMARY>) [24,8 768x18]
           MarkerPaintable (ListItemMarkerBox(anonymous)) [8,13 8x8]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<SLOT>) [8,26 784x0]

--- a/Tests/LibWeb/Layout/expected/details-open.txt
+++ b/Tests/LibWeb/Layout/expected/details-open.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 36 0+0+8] children: not-inline
       BlockContainer <details> at [8,8] [0+0+0 784 0+0+0] [0+0+0 36 0+0+0] children: not-inline
-        ListItemBox <summary> at [24,8] [0+0+0 776 0+0+0] [0+0+0 18 0+0+0] children: inline
+        ListItemBox <summary> at [24,8] [0+0+0 768 0+0+0] [0+0+0 18 0+0+0] children: inline
           frag 0 from TextNode start: 0, length: 13, rect: [24,8 114.625x18] baseline: 13.796875
               "I'm a summary"
           ListItemMarkerBox <(anonymous)> at [8,13] [0+0+0 8 0+0+0] [0+0+0 8 0+0+0] children: not-inline
@@ -22,7 +22,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableWithLines (BlockContainer<DETAILS>) [8,8 784x36]
-        PaintableWithLines (ListItemBox<SUMMARY>) [24,8 776x18]
+        PaintableWithLines (ListItemBox<SUMMARY>) [24,8 768x18]
           MarkerPaintable (ListItemMarkerBox(anonymous)) [8,13 8x8]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<SLOT>) [8,26 784x18]

--- a/Tests/LibWeb/Layout/expected/details-summary-default-ua-style.txt
+++ b/Tests/LibWeb/Layout/expected/details-summary-default-ua-style.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 154 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 138 0+0+8] children: not-inline
       BlockContainer <details> at [68,68] [0+10+50 664 50+10+0] [0+10+50 18 50+10+0] children: not-inline
-        ListItemBox <summary> at [84,68] [0+0+0 656 0+0+0] [0+0+0 18 0+0+0] children: inline
+        ListItemBox <summary> at [84,68] [0+0+0 648 0+0+0] [0+0+0 18 0+0+0] children: inline
           frag 0 from TextNode start: 0, length: 5, rect: [84,68 36.84375x18] baseline: 13.796875
               "hello"
           ListItemMarkerBox <(anonymous)> at [68,73] [0+0+0 8 0+0+0] [0+0+0 8 0+0+0] children: not-inline
@@ -13,7 +13,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x154]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x138]
       PaintableWithLines (BlockContainer<DETAILS>) [8,8 784x138]
-        PaintableWithLines (ListItemBox<SUMMARY>) [84,68 656x18]
+        PaintableWithLines (ListItemBox<SUMMARY>) [84,68 648x18]
           MarkerPaintable (ListItemMarkerBox(anonymous)) [68,73 8x8]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<SLOT>) [68,86 664x0]

--- a/Tests/LibWeb/Layout/expected/inside-list-item-content-offset.txt
+++ b/Tests/LibWeb/Layout/expected/inside-list-item-content-offset.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 418 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,200] [8+0+0 784 0+0+8] [8+0+0 18 0+0+200] children: not-inline
-      ListItemBox <span> at [222,200] [200+0+0 378 0+0+200] [200+0+0 18 0+0+200] children: not-inline
+      ListItemBox <span> at [222,200] [200+0+0 370 0+0+200] [200+0+0 18 0+0+200] children: not-inline
         ListItemMarkerBox <(anonymous)> at [208,206] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] children: not-inline
       BlockContainer <(anonymous)> at [8,418] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
@@ -9,7 +9,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x418]
     PaintableWithLines (BlockContainer<BODY>) [8,200 784x18]
-      PaintableWithLines (ListItemBox<SPAN>) [222,200 378x18]
+      PaintableWithLines (ListItemBox<SPAN>) [222,200 370x18]
         MarkerPaintable (ListItemMarkerBox(anonymous)) [208,206 6x6]
       PaintableWithLines (BlockContainer(anonymous)) [8,418 784x0]
 

--- a/Tests/LibWeb/Layout/expected/list-marker-rtl.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-rtl.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 18 0+0+16] children: not-inline
+      BlockContainer <ul> at [8,16] [0+0+0 744 40+0+0] [16+0+0 18 0+0+16] children: not-inline
+        BlockContainer <(anonymous)> at [8,16] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [8,16] [0+0+0 744 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [635.125,16 116.875x18] baseline: 13.796875
+              "___________"
+          ListItemMarkerBox <(anonymous)> at [760,22] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,34] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,50] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x18]
+      PaintableWithLines (BlockContainer<UL>) [8,16 784x18]
+        PaintableWithLines (BlockContainer(anonymous)) [8,16 744x0]
+        PaintableWithLines (ListItemBox<LI>) [8,16 744x18]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [760,22 6x6]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,34 744x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x50] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/list-marker-rtl.html
+++ b/Tests/LibWeb/Layout/input/list-marker-rtl.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<ul dir="rtl">
+	<li>___________</li>
+</ul>


### PR DESCRIPTION
The rebaselined tests are due to me subtracting the marker distance from inside-positioned markers also. I've manually checked the results, they are still visually correct. (The difference being that the list item's box now doesn't extend 1 marker distance too far to the right anymore)

Here's some before and after pictures from when I go to https://ar.wikipedia.org:
Before:
<img width="1233" height="771" alt="image" src="https://github.com/user-attachments/assets/4ec96f0d-d6c8-4088-9e10-5259d26cd240" />

After:
<img width="1237" height="897" alt="image" src="https://github.com/user-attachments/assets/a9a084f5-c816-4846-a8d5-9daa563bd93c" />
