### PR TITLE
Build: Add MI_DEBUG_FULL=OFF to debug triplet for mimalloc

### DIFF
--- a/Meta/CMake/vcpkg/debug-triplets/debug.cmake
+++ b/Meta/CMake/vcpkg/debug-triplets/debug.cmake
@@ -1,3 +1,4 @@
 # Ideally, we would set VCPKG_BUILD_TYPE="debug", but that is currently not supported as a standalone build type.
 # See: https://github.com/microsoft/vcpkg/issues/38224
 set(VCPKG_LIBRARY_LINKAGE dynamic)
+list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS_DEBUG "-DMI_DEBUG_FULL=OFF")


### PR DESCRIPTION
This works around a pathological, 3-5 minute, pegged-single-core clusterf**k when GenerateWindowOrWorkerInterface is run during debug builds.

Heap checking is not as strict with this. But a debug build should not discourage its own usage by forcing long coffee breaks during codegen.