### PR TITLE
LibWeb: Don't let shape-triggered @font-face rules block page load

### DIFF
--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -240,4 +240,11 @@ void CSSFontFaceRule::set_parent_style_sheet(CSSStyleSheet* parent_style_sheet)
         m_parent_style_sheet->add_critical_subresource(*this);
 }
 
+bool CSSFontFaceRule::should_block_stylesheet_while_unloaded() const
+{
+    if (!m_css_connected_font_face)
+        return false;
+    return m_css_connected_font_face->has_urls() && !m_css_connected_font_face->has_non_default_unicode_range();
+}
+
 }

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.h
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.h
@@ -49,6 +49,7 @@ private:
     void handle_src_descriptor_change();
 
     virtual void set_parent_style_sheet(CSSStyleSheet*) override;
+    virtual bool should_block_stylesheet_while_unloaded() const override;
 
     GC::Ptr<CSSStyleSheet> parent_style_sheet_for_subresource() override { return parent_style_sheet(); }
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -601,6 +601,9 @@ CSSStyleSheet::LoadingState CSSStyleSheet::loading_state() const
     for (auto const& subresource : m_critical_subresources) {
         switch (subresource.loading_state()) {
         case LoadingState::Unloaded:
+            if (subresource.should_block_stylesheet_while_unloaded())
+                any_loading = true;
+            break;
         case LoadingState::Loading:
             any_loading = true;
             break;

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -50,6 +50,7 @@ public:
 
         virtual GC::Ptr<CSSStyleSheet> parent_style_sheet_for_subresource() = 0;
         LoadingState loading_state() const { return m_loading_state; }
+        virtual bool should_block_stylesheet_while_unloaded() const { return true; }
         virtual void visit_edges(Cell::Visitor&) = 0;
 
         void set_loading_state(LoadingState);

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,6 +20,7 @@ Text/input/css/font-face-load-dedups-same-url.html
 Text/input/navigation/history-replace-push-then-back.html
 
 ; CSS @font-face url() requires HTTP(s) scheme.
+Text/input/css/deferred-font-face-does-not-block-load.html
 Text/input/selection-rect-consistency-with-kerning.html
 
 ; Form submission to /common/blank.html requires HTTP(s) scheme.

--- a/Tests/LibWeb/Text/expected/css/deferred-font-face-does-not-block-load.txt
+++ b/Tests/LibWeb/Text/expected/css/deferred-font-face-does-not-block-load.txt
@@ -1,0 +1,3 @@
+Window load fired after stylesheet load: true
+DeferredFontFace found: true
+DeferredFontFace status: unloaded

--- a/Tests/LibWeb/Text/input/css/deferred-font-face-does-not-block-load.css
+++ b/Tests/LibWeb/Text/input/css/deferred-font-face-does-not-block-load.css
@@ -1,0 +1,9 @@
+@font-face {
+    font-family: 'DeferredFontFace';
+    src: url('deferred-font-face-does-not-block-load.woff');
+    unicode-range: U+2603;
+}
+
+body {
+    color: green;
+}

--- a/Tests/LibWeb/Text/input/css/deferred-font-face-does-not-block-load.html
+++ b/Tests/LibWeb/Text/input/css/deferred-font-face-does-not-block-load.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="stylesheet" href="deferred-font-face-does-not-block-load.css">
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        let windowLoaded = false;
+        window.addEventListener("load", () => {
+            windowLoaded = true;
+        }, { once: true });
+
+        await timeout(50);
+
+        const face = [...document.fonts].find(font => font.family === "DeferredFontFace");
+        println(`Window load fired after stylesheet load: ${windowLoaded}`);
+        println(`DeferredFontFace found: ${face !== undefined}`);
+        println(`DeferredFontFace status: ${face?.status}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Deferred @font-face rules were being counted as critical_subresources when they had not started any fetch and might never be needed. This change makes the loading state decision come from the subresource itself.

The errror was observed at https://news.google.com where only a single section appeared, another showed as a placeholder, and the rest were never loaded. This resulted from a non-default unicode-range @font-face which kept the critical stylesheet open, blocking parser completion.