### PR TITLE
LibJS: Switch AsmInt handlers to named temporaries

### DIFF
--- a/Libraries/LibJS/AsmIntGen/src/allocator.rs
+++ b/Libraries/LibJS/AsmIntGen/src/allocator.rs
@@ -1354,6 +1354,39 @@ end
     }
 
     #[test]
+    fn aarch64_call_helper_named_input_and_output_share_x0() {
+        // On aarch64, the named-call form can put the dying input and
+        // newly-born output in x0, which is both t0 and the ABI argument
+        // register. That lets codegen skip the legacy x1 -> x0 bridge.
+        let src = "
+handler Test
+    temp value, result
+    load_operand value, m_condition
+    call_helper asm_helper_to_boolean, value, result
+    branch_nonzero result, .take
+    dispatch_next
+.take:
+    load_label value, m_target
+    goto_handler value
+end
+";
+        let out = build(src, Arch::Aarch64).expect("allocation should succeed");
+        let mut saw_call = false;
+        for insn in &out {
+            if insn.mnemonic == "call_helper" {
+                saw_call = true;
+                if let Some(Operand::Register(name)) = insn.operands.get(1) {
+                    assert_eq!(name, "x0", "call_helper input must be pinned to x0");
+                }
+                if let Some(Operand::Register(name)) = insn.operands.get(2) {
+                    assert_eq!(name, "x0", "call_helper output must be pinned to x0");
+                }
+            }
+        }
+        assert!(saw_call);
+    }
+
+    #[test]
     fn rejects_temp_live_across_call() {
         let src = "
 handler Test

--- a/Libraries/LibJS/AsmIntGen/src/allocator.rs
+++ b/Libraries/LibJS/AsmIntGen/src/allocator.rs
@@ -1,0 +1,1467 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Register allocator for named DSL temporaries.
+//!
+//! When a handler (or any macro it invokes) declares named temporaries via
+//! `temp foo, bar` / `ftemp baz`, this module:
+//!
+//!   1. Flattens the handler body, expanding macros and uniquifying any
+//!      `temp` / `ftemp` declarations and label references that live
+//!      inside macro bodies. Macro-local temps and labels never leak.
+//!   2. Computes per-instruction use/def sets and runs an iterative
+//!      backward dataflow to derive liveness.
+//!   3. Builds an interference graph between named temporaries (and
+//!      between named temps and physical registers killed by hidden
+//!      clobbers, implicit i/o, fixed operand requirements, and
+//!      caller-saved kills at C++ calls).
+//!   4. Greedily assigns each named temporary a physical register from
+//!      the public DSL pool. Hard-errors if a temp cannot be placed; we
+//!      never spill to the stack.
+//!   5. Rewrites operands so the codegen sees only physical register
+//!      names.
+//!
+//! Handlers that don't use named temps go through the existing codegen
+//! path with no allocator involvement.
+
+#![allow(dead_code)]
+
+use crate::instructions::{InstructionInfo, OperandKind, lookup};
+use crate::parser::{AsmInstruction, Handler, Operand, Program};
+use crate::registers::{Arch, mapping_for, resolve_register};
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// Registers x86-64 calls clobber (caller-saved). System V AMD64.
+const X86_64_CALLER_SAVED_GPR: &[&str] = &[
+    "rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11",
+];
+const X86_64_CALLER_SAVED_FPR: &[&str] =
+    &["xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5"];
+
+/// Registers aarch64 calls clobber. AAPCS64 caller-saved set; we only list
+/// the ones in (or adjacent to) the public temp pool, since pinned
+/// registers (x19-x28, d8) survive by ABI.
+const AARCH64_CALLER_SAVED_GPR: &[&str] = &[
+    "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10",
+    "x11", "x12", "x13", "x14", "x15", "x16", "x17",
+];
+const AARCH64_CALLER_SAVED_FPR: &[&str] =
+    &["d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7"];
+
+fn caller_saved(arch: Arch) -> (&'static [&'static str], &'static [&'static str]) {
+    match arch {
+        Arch::X86_64 => (X86_64_CALLER_SAVED_GPR, X86_64_CALLER_SAVED_FPR),
+        Arch::Aarch64 => (AARCH64_CALLER_SAVED_GPR, AARCH64_CALLER_SAVED_FPR),
+    }
+}
+
+#[derive(Debug)]
+pub struct AllocationError {
+    pub handler: String,
+    pub message: String,
+}
+
+/// Decide whether a handler needs the allocator. Returns true if the
+/// handler's body or any macro it transitively invokes contains a `temp`
+/// or `ftemp` declaration.
+pub fn handler_uses_named_temps(handler: &Handler, program: &Program) -> bool {
+    let mut visited_macros = HashSet::new();
+    body_uses_named_temps(&handler.instructions, program, &mut visited_macros)
+}
+
+fn body_uses_named_temps(
+    body: &[AsmInstruction],
+    program: &Program,
+    visited: &mut HashSet<String>,
+) -> bool {
+    for insn in body {
+        if insn.mnemonic == "temp" || insn.mnemonic == "ftemp" {
+            return true;
+        }
+        if let Some(mac) = program.macros.get(&insn.mnemonic) {
+            if visited.insert(insn.mnemonic.clone())
+                && body_uses_named_temps(&mac.body, program, visited)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Flatten a handler body and run register allocation on it. Returns the
+/// rewritten flat instruction list with all named-temp references replaced
+/// by their assigned physical registers.
+pub fn flatten_and_allocate(
+    handler: &Handler,
+    program: &Program,
+    arch: Arch,
+    macro_counter: &mut u32,
+) -> Result<Vec<AsmInstruction>, AllocationError> {
+    let flat = flatten(handler, program, macro_counter);
+    let needs = flat
+        .iter()
+        .any(|i| i.mnemonic == "temp" || i.mnemonic == "ftemp");
+    if !needs {
+        return Ok(flat);
+    }
+    let assignments = allocate(handler, &flat, program, arch)?;
+    Ok(rewrite(flat, &assignments))
+}
+
+// ============================================================================
+// Flattening (macro expansion + per-expansion uniquification)
+// ============================================================================
+
+/// Expand all macro invocations into a flat instruction list. Each macro
+/// expansion uniquifies its local labels (matching the existing
+/// `uniquify_macro_labels` behavior) and its `temp` / `ftemp` declarations
+/// so two invocations of the same macro produce disjoint name sets.
+pub fn flatten(
+    handler: &Handler,
+    program: &Program,
+    counter: &mut u32,
+) -> Vec<AsmInstruction> {
+    let mut out = Vec::new();
+    flatten_into(&handler.instructions, program, counter, &HashMap::new(), &mut out);
+    out
+}
+
+fn flatten_into(
+    insns: &[AsmInstruction],
+    program: &Program,
+    counter: &mut u32,
+    parent_substitution: &HashMap<String, Operand>,
+    out: &mut Vec<AsmInstruction>,
+) {
+    for insn in insns {
+        // Apply any inherited macro-parameter substitution first so the
+        // mnemonic itself can be a parameter (the existing macro semantics
+        // treats the mnemonic as a substitutable name).
+        let substituted = substitute_operands(insn, parent_substitution);
+
+        if let Some(mac) = program.macros.get(&substituted.mnemonic) {
+            // Build a substitution map: each parameter maps to the operand
+            // the caller passed at that position.
+            let mut param_map: HashMap<String, Operand> = HashMap::new();
+            for (i, param) in mac.params.iter().enumerate() {
+                if let Some(op) = substituted.operands.get(i) {
+                    param_map.insert(param.clone(), op.clone());
+                }
+            }
+
+            let id = *counter;
+            *counter += 1;
+
+            // Uniquify any self-contained labels in the macro body.
+            let body = uniquify_macro_locals(&mac.body, id);
+            flatten_into(&body, program, counter, &param_map, out);
+        } else {
+            out.push(substituted);
+        }
+    }
+}
+
+/// Rename labels that are both defined and referenced inside the macro
+/// body, and rename `temp` / `ftemp` declarations together with all their
+/// references inside the body. Names that appear to cross the macro
+/// boundary (defined here, referenced outside, or vice versa) are left
+/// alone so they keep matching the caller's view.
+fn uniquify_macro_locals(body: &[AsmInstruction], suffix: u32) -> Vec<AsmInstruction> {
+    // Collect label definitions and references separately.
+    let mut label_defs: HashSet<String> = HashSet::new();
+    let mut label_refs: HashSet<String> = HashSet::new();
+    let mut temps_declared: HashSet<String> = HashSet::new();
+    for insn in body {
+        if insn.mnemonic == "label" {
+            if let Some(Operand::Label(name)) = insn.operands.first() {
+                if name.starts_with('.') {
+                    label_defs.insert(name.clone());
+                }
+            }
+        } else if insn.mnemonic == "temp" || insn.mnemonic == "ftemp" {
+            for op in &insn.operands {
+                if let Operand::Register(name) = op {
+                    temps_declared.insert(name.clone());
+                }
+            }
+        } else {
+            for op in &insn.operands {
+                if let Operand::Label(name) = op {
+                    if name.starts_with('.') {
+                        label_refs.insert(name.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let label_renames: HashMap<String, String> = label_defs
+        .intersection(&label_refs)
+        .map(|name| (name.clone(), format!("{name}_m{suffix}")))
+        .collect();
+
+    let temp_renames: HashMap<String, String> = temps_declared
+        .iter()
+        .map(|name| (name.clone(), format!("{name}_m{suffix}")))
+        .collect();
+
+    if label_renames.is_empty() && temp_renames.is_empty() {
+        return body.to_vec();
+    }
+
+    body.iter()
+        .map(|insn| rename_in_instruction(insn, &label_renames, &temp_renames))
+        .collect()
+}
+
+fn rename_in_instruction(
+    insn: &AsmInstruction,
+    label_renames: &HashMap<String, String>,
+    temp_renames: &HashMap<String, String>,
+) -> AsmInstruction {
+    let rename_string = |s: &str| -> String {
+        if let Some(new) = temp_renames.get(s) {
+            new.clone()
+        } else {
+            s.to_string()
+        }
+    };
+    let operands = insn
+        .operands
+        .iter()
+        .map(|op| match op {
+            Operand::Label(name) => {
+                if let Some(new_name) = label_renames.get(name) {
+                    Operand::Label(new_name.clone())
+                } else {
+                    op.clone()
+                }
+            }
+            Operand::Register(name) => {
+                if let Some(new_name) = temp_renames.get(name) {
+                    Operand::Register(new_name.clone())
+                } else {
+                    op.clone()
+                }
+            }
+            Operand::Memory { base, index, scale } => Operand::Memory {
+                base: rename_string(base),
+                index: index.as_ref().map(|s| rename_string(s)),
+                scale: scale.as_ref().map(|s| rename_string(s)),
+            },
+            _ => op.clone(),
+        })
+        .collect();
+    AsmInstruction {
+        mnemonic: insn.mnemonic.clone(),
+        operands,
+    }
+}
+
+/// Replace operand-level references named in `param_map` with the caller's
+/// operand. Memory operands have their base/index/scale strings substituted
+/// when those strings happen to be parameter names.
+fn substitute_operands(
+    insn: &AsmInstruction,
+    param_map: &HashMap<String, Operand>,
+) -> AsmInstruction {
+    if param_map.is_empty() {
+        return insn.clone();
+    }
+
+    let substitute_string = |s: &str| -> String {
+        match param_map.get(s) {
+            Some(Operand::Register(n)) => n.clone(),
+            Some(Operand::Constant(n)) => n.clone(),
+            Some(Operand::FieldRef(n)) => n.clone(),
+            Some(Operand::Immediate(v)) => v.to_string(),
+            _ => s.to_string(),
+        }
+    };
+
+    let operands = insn
+        .operands
+        .iter()
+        .map(|op| match op {
+            Operand::Register(name) => param_map
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| op.clone()),
+            Operand::Constant(name) => param_map
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| op.clone()),
+            Operand::FieldRef(name) => param_map
+                .get(name)
+                .cloned()
+                .unwrap_or_else(|| op.clone()),
+            Operand::Memory { base, index, scale } => Operand::Memory {
+                base: substitute_string(base),
+                index: index.as_ref().map(|s| substitute_string(s)),
+                scale: scale.as_ref().map(|s| substitute_string(s)),
+            },
+            _ => op.clone(),
+        })
+        .collect();
+
+    let mnemonic = match param_map.get(&insn.mnemonic) {
+        Some(Operand::Register(n)) => n.clone(),
+        _ => insn.mnemonic.clone(),
+    };
+
+    AsmInstruction { mnemonic, operands }
+}
+
+// ============================================================================
+// Use/def computation
+// ============================================================================
+
+/// Per-instruction register footprint. All entries are register *names*
+/// (either a named-temp string like "foo" or a physical reg like "rax");
+/// the allocator distinguishes by checking whether each name is a declared
+/// temp or a known physical/positional reg.
+#[derive(Debug, Default, Clone)]
+struct UseDef {
+    uses: BTreeSet<String>,
+    defs: BTreeSet<String>,
+    // Physical registers killed at this instruction even when not explicitly
+    // listed as a def (hidden clobbers, implicit outputs, all-caller-saved
+    // for is_call=true).
+    kills: BTreeSet<String>,
+}
+
+fn analyze_instruction(
+    insn: &AsmInstruction,
+    arch: Arch,
+    declared_gpr_temps: &HashSet<String>,
+    declared_fpr_temps: &HashSet<String>,
+) -> UseDef {
+    let mut ud = UseDef::default();
+
+    // `temp` / `ftemp` decls are pure annotations; they do not contribute
+    // uses or defs by themselves. (The first use of the named temp later
+    // in the body is what starts its live range.)
+    if insn.mnemonic == "temp" || insn.mnemonic == "ftemp" {
+        return ud;
+    }
+
+    // `label` is a pure marker. (Its operand is a Label, not a register.)
+    if insn.mnemonic == "label" {
+        return ud;
+    }
+
+    // `xor dst, dst` is the canonical zero-the-register idiom on x86. The
+    // generated machine instruction reads no input; treat both operands as
+    // pure defs so the temp doesn't appear live before this point.
+    if insn.mnemonic == "xor" && insn.operands.len() == 2 {
+        if let (Operand::Register(a), Operand::Register(b)) =
+            (&insn.operands[0], &insn.operands[1])
+        {
+            if a == b
+                && is_register_name(a, arch, declared_gpr_temps, declared_fpr_temps)
+            {
+                ud.defs.insert(a.clone());
+                return ud;
+            }
+        }
+    }
+
+    let info = lookup(&insn.mnemonic);
+
+    let push_register_use = |ud: &mut UseDef, name: &str| {
+        if is_register_name(name, arch, declared_gpr_temps, declared_fpr_temps) {
+            ud.uses.insert(name.to_string());
+        }
+    };
+    let push_register_def = |ud: &mut UseDef, name: &str| {
+        if is_register_name(name, arch, declared_gpr_temps, declared_fpr_temps) {
+            ud.defs.insert(name.to_string());
+        }
+    };
+
+    // Walk operands using the metadata if available.
+    if let Some(info) = info {
+        for (i, op) in insn.operands.iter().enumerate() {
+            let kind = operand_kind_at(info, i);
+            apply_operand_kind(&mut ud, op, kind, &push_register_use, &push_register_def);
+        }
+        // Hidden clobbers / implicit i/o / all-caller-saved kills.
+        let arch_spec = info.arch(arch);
+        for r in arch_spec.implicit_inputs {
+            ud.uses.insert((*r).to_string());
+        }
+        for r in arch_spec.implicit_outputs {
+            ud.defs.insert((*r).to_string());
+            ud.kills.insert((*r).to_string());
+        }
+        for r in arch_spec.clobbers_gpr {
+            ud.kills.insert((*r).to_string());
+        }
+        for r in arch_spec.clobbers_fpr {
+            ud.kills.insert((*r).to_string());
+        }
+        if info.is_call {
+            let (gpr, fpr) = caller_saved(arch);
+            for r in gpr {
+                ud.kills.insert((*r).to_string());
+            }
+            for r in fpr {
+                ud.kills.insert((*r).to_string());
+            }
+        }
+    } else {
+        // No metadata: conservative fallback. Treat every operand as both a
+        // use and a def. The InstructionInfo table is supposed to cover
+        // every codegen mnemonic, so this branch should be rare.
+        for op in &insn.operands {
+            collect_operand_registers(op, &mut |name| push_register_use(&mut ud, name));
+            collect_operand_registers(op, &mut |name| push_register_def(&mut ud, name));
+        }
+    }
+
+    ud
+}
+
+fn operand_kind_at(info: &InstructionInfo, index: usize) -> OperandKind {
+    if let Some(k) = info.operands.get(index) {
+        return *k;
+    }
+    info.variadic_kind
+        .expect("operand index out of range without variadic_kind")
+}
+
+fn apply_operand_kind(
+    ud: &mut UseDef,
+    op: &Operand,
+    kind: OperandKind,
+    push_use: &dyn Fn(&mut UseDef, &str),
+    push_def: &dyn Fn(&mut UseDef, &str),
+) {
+    match kind {
+        OperandKind::GprIn | OperandKind::FprIn => {
+            if let Operand::Register(name) = op {
+                push_use(ud, name);
+            }
+        }
+        OperandKind::GprOut | OperandKind::FprOut => {
+            if let Operand::Register(name) = op {
+                push_def(ud, name);
+            }
+        }
+        OperandKind::GprInOut | OperandKind::FprInOut => {
+            if let Operand::Register(name) = op {
+                push_use(ud, name);
+                push_def(ud, name);
+            }
+        }
+        OperandKind::GprInOrImm => {
+            if let Operand::Register(name) = op {
+                push_use(ud, name);
+            }
+        }
+        OperandKind::Memory => {
+            // Any GPR named inside the brackets is a use.
+            if let Operand::Memory { base, index, scale } = op {
+                push_use(ud, base);
+                if let Some(s) = index {
+                    push_use(ud, s);
+                }
+                if let Some(s) = scale {
+                    push_use(ud, s);
+                }
+            }
+        }
+        OperandKind::Imm
+        | OperandKind::Label
+        | OperandKind::FieldRef
+        | OperandKind::FuncSymbol => {}
+    }
+}
+
+fn collect_operand_registers<F: FnMut(&str)>(op: &Operand, f: &mut F) {
+    match op {
+        Operand::Register(name) => f(name),
+        Operand::Memory { base, index, scale } => {
+            f(base);
+            if let Some(s) = index {
+                f(s);
+            }
+            if let Some(s) = scale {
+                f(s);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Whether a name refers to *any* register: a declared named temp, a
+/// positional alias (t0, ft1, pc, ...), or a known physical reg.
+fn is_register_name(
+    name: &str,
+    arch: Arch,
+    declared_gpr_temps: &HashSet<String>,
+    declared_fpr_temps: &HashSet<String>,
+) -> bool {
+    declared_gpr_temps.contains(name)
+        || declared_fpr_temps.contains(name)
+        || resolve_register(name, arch).is_some()
+        || is_physical_register(name, arch)
+}
+
+fn is_physical_register(name: &str, arch: Arch) -> bool {
+    match arch {
+        Arch::X86_64 => name.starts_with('r')
+            || name.starts_with('e')
+            || name.starts_with("xmm"),
+        Arch::Aarch64 => {
+            (name.starts_with('x') || name.starts_with('w'))
+                && name[1..].chars().all(|c| c.is_ascii_digit())
+                || (name.starts_with('d') || name.starts_with('s'))
+                    && name[1..].chars().all(|c| c.is_ascii_digit())
+        }
+    }
+}
+
+// ============================================================================
+// Liveness (iterative backward dataflow)
+// ============================================================================
+
+#[derive(Debug, Default)]
+struct Liveness {
+    /// Successors of each instruction by index.
+    successors: Vec<Vec<usize>>,
+    /// `live_in[i]` = registers live just before instruction `i`.
+    live_in: Vec<BTreeSet<String>>,
+    /// `live_out[i]` = registers live just after instruction `i`.
+    live_out: Vec<BTreeSet<String>>,
+    /// Per-instruction use/def/kill sets.
+    use_def: Vec<UseDef>,
+}
+
+fn compute_liveness(
+    handler_name: &str,
+    instructions: &[AsmInstruction],
+    arch: Arch,
+    declared_gpr_temps: &HashSet<String>,
+    declared_fpr_temps: &HashSet<String>,
+) -> Result<Liveness, AllocationError> {
+    let n = instructions.len();
+    let mut successors: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    // Map label -> instruction index for branch resolution.
+    let mut labels: HashMap<String, usize> = HashMap::new();
+    for (i, insn) in instructions.iter().enumerate() {
+        if insn.mnemonic == "label" {
+            if let Some(Operand::Label(name)) = insn.operands.first() {
+                labels.insert(name.clone(), i);
+            }
+        }
+    }
+
+    for (i, insn) in instructions.iter().enumerate() {
+        // The only mnemonics without an InstructionInfo entry are the
+        // declaration pseudo-instructions `temp` and `ftemp`, which are
+        // pure annotations and never end the basic block.
+        let terminal = match lookup(&insn.mnemonic) {
+            Some(info) => info.terminal,
+            None => {
+                assert!(
+                    insn.mnemonic == "temp" || insn.mnemonic == "ftemp",
+                    "no InstructionInfo for mnemonic '{}' in handler '{handler_name}'",
+                    insn.mnemonic
+                );
+                false
+            }
+        };
+
+        // Branch targets (any Label operand is a possible successor for
+        // non-jmp branches; jmp itself replaces fall-through).
+        for op in &insn.operands {
+            if let Operand::Label(name) = op {
+                if let Some(&target) = labels.get(name) {
+                    successors[i].push(target);
+                }
+            }
+        }
+
+        // Fall-through unless terminal.
+        if !terminal && i + 1 < n {
+            successors[i].push(i + 1);
+        }
+    }
+
+    let use_def: Vec<UseDef> = instructions
+        .iter()
+        .map(|insn| analyze_instruction(insn, arch, declared_gpr_temps, declared_fpr_temps))
+        .collect();
+
+    let mut live_in: Vec<BTreeSet<String>> = vec![BTreeSet::new(); n];
+    let mut live_out: Vec<BTreeSet<String>> = vec![BTreeSet::new(); n];
+
+    // Iterative backward dataflow until fixpoint.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for i in (0..n).rev() {
+            let mut new_out: BTreeSet<String> = BTreeSet::new();
+            for &succ in &successors[i] {
+                new_out.extend(live_in[succ].iter().cloned());
+            }
+            // live_in = use ∪ (live_out - def - kill)
+            let mut new_in: BTreeSet<String> = use_def[i].uses.clone();
+            for r in &new_out {
+                if !use_def[i].defs.contains(r) && !use_def[i].kills.contains(r) {
+                    new_in.insert(r.clone());
+                }
+            }
+            if new_in != live_in[i] || new_out != live_out[i] {
+                changed = true;
+                live_in[i] = new_in;
+                live_out[i] = new_out;
+            }
+        }
+    }
+
+    // Sanity-check: a temp must be defined before its first use along
+    // every path. We catch the simplest case: the handler entry has no
+    // declared temps live-in.
+    let entry_live = &live_in[0];
+    for r in entry_live {
+        if declared_gpr_temps.contains(r) || declared_fpr_temps.contains(r) {
+            // Walk forward and find the first instruction that pulls this
+            // temp into its live-in without having defined it yet, so the
+            // error points at the actual problem.
+            let mut culprit = String::from("(unknown)");
+            for (i, ud) in use_def.iter().enumerate() {
+                if ud.uses.contains(r) && !ud.defs.contains(r) {
+                    culprit = format!("instruction #{i}: {:?}", instructions[i]);
+                    break;
+                }
+            }
+            return Err(AllocationError {
+                handler: handler_name.to_string(),
+                message: format!(
+                    "named temp '{r}' is used before being assigned (live at handler entry); first use: {culprit}"
+                ),
+            });
+        }
+    }
+
+    Ok(Liveness {
+        successors,
+        live_in,
+        live_out,
+        use_def,
+    })
+}
+
+// ============================================================================
+// Interference and allocation
+// ============================================================================
+
+#[derive(Debug)]
+struct AllocationPlan {
+    gpr_assignments: HashMap<String, &'static str>,
+    fpr_assignments: HashMap<String, &'static str>,
+}
+
+fn allocate(
+    handler: &Handler,
+    instructions: &[AsmInstruction],
+    program: &Program,
+    arch: Arch,
+) -> Result<AllocationPlan, AllocationError> {
+    let _ = program;
+
+    // Collect named temp declarations.
+    let mut declared_gpr_temps: HashSet<String> = HashSet::new();
+    let mut declared_fpr_temps: HashSet<String> = HashSet::new();
+    for insn in instructions {
+        match insn.mnemonic.as_str() {
+            "temp" => {
+                for op in &insn.operands {
+                    if let Operand::Register(name) = op {
+                        if !declared_gpr_temps.insert(name.clone()) {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!("named temp '{name}' declared more than once"),
+                            });
+                        }
+                        if declared_fpr_temps.contains(name) {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!(
+                                    "named temp '{name}' declared as both temp and ftemp"
+                                ),
+                            });
+                        }
+                        if resolve_register(name, arch).is_some() {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!(
+                                    "named temp '{name}' shadows a positional alias or pinned register"
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+            "ftemp" => {
+                for op in &insn.operands {
+                    if let Operand::Register(name) = op {
+                        if !declared_fpr_temps.insert(name.clone()) {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!("named ftemp '{name}' declared more than once"),
+                            });
+                        }
+                        if declared_gpr_temps.contains(name) {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!(
+                                    "named temp '{name}' declared as both temp and ftemp"
+                                ),
+                            });
+                        }
+                        if resolve_register(name, arch).is_some() {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!(
+                                    "named ftemp '{name}' shadows a positional alias or pinned register"
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // For each named temp, the set of instruction indices where it is
+    // alive (in live_in or live_out). This is its live range.
+    let liveness = compute_liveness(
+        &handler.name,
+        instructions,
+        arch,
+        &declared_gpr_temps,
+        &declared_fpr_temps,
+    )?;
+
+    // Per-temp sets of instruction indices, split by "alive before the
+    // instruction begins" (live_in) and "alive after the instruction
+    // ends" (live_out). The split matters for interference: a use-only
+    // operand at instruction i (live_in but not live_out) does not
+    // collide with a def-only operand at the same instruction (live_out
+    // but not live_in), because the codegen reads inputs before writing
+    // outputs. The original positional code exploited this directly by
+    // reusing the same physical register as a load's address operand and
+    // its destination operand.
+    let mut alive_in: HashMap<String, BTreeSet<usize>> = HashMap::new();
+    let mut alive_out: HashMap<String, BTreeSet<usize>> = HashMap::new();
+    let mut crosses: HashMap<String, BTreeSet<usize>> = HashMap::new();
+    for name in declared_gpr_temps.iter().chain(declared_fpr_temps.iter()) {
+        let mut ain = BTreeSet::new();
+        let mut aout = BTreeSet::new();
+        let mut crossing = BTreeSet::new();
+        for i in 0..instructions.len() {
+            let live_before = liveness.live_in[i].contains(name);
+            let live_after = liveness.live_out[i].contains(name);
+            if live_before {
+                ain.insert(i);
+            }
+            if live_after {
+                aout.insert(i);
+            }
+            if live_before
+                && live_after
+                && !liveness.use_def[i].defs.contains(name)
+            {
+                crossing.insert(i);
+            }
+        }
+        alive_in.insert(name.clone(), ain);
+        alive_out.insert(name.clone(), aout);
+        crosses.insert(name.clone(), crossing);
+    }
+
+    // Per-instruction set of physical registers killed (defs + kills).
+    let mut killed_phys_per_insn: Vec<BTreeSet<String>> = vec![BTreeSet::new(); instructions.len()];
+    for (i, ud) in liveness.use_def.iter().enumerate() {
+        for r in ud.defs.iter().chain(ud.kills.iter()) {
+            if !declared_gpr_temps.contains(r) && !declared_fpr_temps.contains(r) {
+                killed_phys_per_insn[i].insert(r.clone());
+            }
+        }
+    }
+
+    // Hard fixed-operand constraints: for each instruction, if operand i
+    // must resolve to physical reg P and operand i is a named temp, the
+    // temp must be allocated to P.
+    let mut hard_pins: HashMap<String, &'static str> = HashMap::new();
+    for insn in instructions {
+        let info = match lookup(&insn.mnemonic) {
+            Some(info) => info,
+            None => continue,
+        };
+        let arch_spec = info.arch(arch);
+        for &(op_index, phys) in arch_spec.fixed_operands {
+            if let Some(Operand::Register(name)) = insn.operands.get(op_index) {
+                if declared_gpr_temps.contains(name) || declared_fpr_temps.contains(name) {
+                    if let Some(prev) = hard_pins.insert(name.clone(), phys) {
+                        if prev != phys {
+                            return Err(AllocationError {
+                                handler: handler.name.clone(),
+                                message: format!(
+                                    "named temp '{name}' is pinned to two different physical registers ({prev} and {phys})"
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Per-temp set of physical regs forbidden because the temp is named as
+    // an operand at an instruction that clobbers them as scratch. This is
+    // distinct from the "passes through" rule -- an operand register that
+    // also happens to be the codegen's scratch register collides even when
+    // the operand is a brand-new def, because the codegen's scratch use is
+    // interleaved with the operand write (see e.g. x86 box_int32_clean,
+    // which clobbers rax while it's also writing the dst operand).
+    //
+    // Implicit-output registers are treated the same way: an x86 idiv
+    // writes rax/rdx and any operand-temp that overlaps either of those
+    // physical regs would be clobbered before the idiv reads it. The
+    // exception is the pinned operand at that index -- fixed_operands
+    // already places it in the implicit-output reg by design.
+    let mut operand_forbids: HashMap<String, HashSet<&'static str>> = HashMap::new();
+    for insn in instructions {
+        let info = match lookup(&insn.mnemonic) {
+            Some(info) => info,
+            None => continue,
+        };
+        let arch_spec = info.arch(arch);
+        if arch_spec.clobbers_gpr.is_empty()
+            && arch_spec.clobbers_fpr.is_empty()
+            && arch_spec.implicit_outputs.is_empty()
+        {
+            continue;
+        }
+        for (op_index, op) in insn.operands.iter().enumerate() {
+            if let Operand::Register(name) = op {
+                if !(declared_gpr_temps.contains(name) || declared_fpr_temps.contains(name)) {
+                    continue;
+                }
+                let pinned_here = arch_spec
+                    .fixed_operands
+                    .iter()
+                    .find_map(|&(idx, phys)| (idx == op_index).then_some(phys));
+                let entry = operand_forbids.entry(name.clone()).or_default();
+                let mut add = |r: &'static str| {
+                    if Some(r) != pinned_here {
+                        entry.insert(r);
+                    }
+                };
+                for r in arch_spec.clobbers_gpr {
+                    add(*r);
+                }
+                for r in arch_spec.clobbers_fpr {
+                    add(*r);
+                }
+                for r in arch_spec.implicit_outputs {
+                    add(*r);
+                }
+            }
+        }
+    }
+
+    // Build candidate physical-register pools.
+    let mapping = mapping_for(arch);
+    let gpr_pool: Vec<&'static str> = mapping.temporaries.to_vec();
+    let fpr_pool: Vec<&'static str> = mapping.fp_temporaries.to_vec();
+
+    // Allocate. Order temps by descending live-range size so the most
+    // constrained temps go first; hard-pinned temps always go first.
+    let mut all_temps: Vec<(String, bool)> = declared_gpr_temps
+        .iter()
+        .map(|n| (n.clone(), true))
+        .chain(declared_fpr_temps.iter().map(|n| (n.clone(), false)))
+        .collect();
+    all_temps.sort_by(|a, b| {
+        let ap = hard_pins.contains_key(&a.0);
+        let bp = hard_pins.contains_key(&b.0);
+        bp.cmp(&ap).then_with(|| {
+            let aw = alive_in
+                .get(&a.0)
+                .map_or(0, |s| s.len())
+                + alive_out.get(&a.0).map_or(0, |s| s.len());
+            let bw = alive_in
+                .get(&b.0)
+                .map_or(0, |s| s.len())
+                + alive_out.get(&b.0).map_or(0, |s| s.len());
+            bw.cmp(&aw)
+        })
+    });
+
+    let mut gpr_assignments: HashMap<String, &'static str> = HashMap::new();
+    let mut fpr_assignments: HashMap<String, &'static str> = HashMap::new();
+
+    for (name, is_gpr) in &all_temps {
+        let pool = if *is_gpr { &gpr_pool } else { &fpr_pool };
+        let my_in = alive_in
+            .get(name)
+            .expect("missing live_in for declared temp");
+        let my_out = alive_out
+            .get(name)
+            .expect("missing live_out for declared temp");
+        let crossing = crosses.get(name).expect("missing cross-set for declared temp");
+
+        // Build the set of physical regs we cannot use for this temp:
+        //   - any phys reg killed at an instruction the temp passes
+        //     through (alive on both sides without being redefined). A
+        //     temp that only enters (use, dying here) or only exits (def,
+        //     newly born here) the instruction is fine: the kill happens
+        //     between input read and output write, so the temp's value
+        //     is no longer needed (or not yet needed) at that moment.
+        //   - any phys reg listed in operand_forbids for this temp.
+        //   - any phys reg already assigned to another temp that overlaps
+        //     ours either before-the-instruction (alive_in vs alive_in)
+        //     or after-the-instruction (alive_out vs alive_out). A
+        //     "before only" overlap with an "after only" overlap at the
+        //     same instruction does NOT collide: the codegen reads input
+        //     operands before writing output operands, so the same
+        //     physical register can host an outgoing value at one
+        //     instruction and an incoming value at the same instruction
+        //     -- this is exactly how the original positional code
+        //     reused `t6` for vm_ptr (read) and frame_base (written) in
+        //     the same load_pair64.
+        let mut forbidden: HashSet<&'static str> = HashSet::new();
+        for &i in crossing {
+            for r in &killed_phys_per_insn[i] {
+                if let Some(slot) = pool.iter().find(|p| **p == r.as_str()) {
+                    forbidden.insert(*slot);
+                }
+            }
+        }
+        if let Some(extra) = operand_forbids.get(name) {
+            for r in extra {
+                if pool.iter().any(|p| *p == *r) {
+                    forbidden.insert(*r);
+                }
+            }
+        }
+
+        for (other, &other_phys) in gpr_assignments.iter().chain(fpr_assignments.iter()) {
+            if other == name {
+                continue;
+            }
+            let other_in = alive_in
+                .get(other)
+                .expect("missing live_in for already-assigned temp");
+            let other_out = alive_out
+                .get(other)
+                .expect("missing live_out for already-assigned temp");
+            let inputs_overlap = !my_in.is_disjoint(other_in);
+            let outputs_overlap = !my_out.is_disjoint(other_out);
+            if inputs_overlap || outputs_overlap {
+                forbidden.insert(other_phys);
+            }
+        }
+
+        let pick = if let Some(&pinned) = hard_pins.get(name) {
+            if !pool.iter().any(|p| *p == pinned) {
+                return Err(AllocationError {
+                    handler: handler.name.clone(),
+                    message: format!(
+                        "named temp '{name}' must be pinned to '{pinned}', but that register is not in the {} pool",
+                        if *is_gpr { "GPR" } else { "FPR" }
+                    ),
+                });
+            }
+            if forbidden.contains(&pinned) {
+                let mut sorted: Vec<&str> = forbidden.iter().copied().collect();
+                sorted.sort();
+                return Err(AllocationError {
+                    handler: handler.name.clone(),
+                    message: format!(
+                        "named temp '{name}' must be pinned to '{pinned}', but that register is killed or occupied across its live range (forbidden: {sorted:?})"
+                    ),
+                });
+            }
+            pinned
+        } else {
+            *pool
+                .iter()
+                .find(|p| !forbidden.contains(*p))
+                .ok_or_else(|| AllocationError {
+                    handler: handler.name.clone(),
+                    message: format!(
+                        "could not allocate {} '{name}': {} pool exhausted (forbidden: {:?})",
+                        if *is_gpr { "temp" } else { "ftemp" },
+                        if *is_gpr { "GPR" } else { "FPR" },
+                        forbidden,
+                    ),
+                })?
+        };
+
+        if *is_gpr {
+            gpr_assignments.insert(name.clone(), pick);
+        } else {
+            fpr_assignments.insert(name.clone(), pick);
+        }
+    }
+
+    Ok(AllocationPlan {
+        gpr_assignments,
+        fpr_assignments,
+    })
+}
+
+// ============================================================================
+// Operand rewriting
+// ============================================================================
+
+fn rewrite(instructions: Vec<AsmInstruction>, plan: &AllocationPlan) -> Vec<AsmInstruction> {
+    let mut combined: HashMap<String, &'static str> = HashMap::new();
+    combined.extend(plan.gpr_assignments.iter().map(|(k, v)| (k.clone(), *v)));
+    combined.extend(plan.fpr_assignments.iter().map(|(k, v)| (k.clone(), *v)));
+
+    instructions
+        .into_iter()
+        .filter_map(|insn| {
+            // Drop the declarations themselves; codegen no-ops them anyway,
+            // but pruning here keeps the IR cleaner if other passes look at
+            // it.
+            if insn.mnemonic == "temp" || insn.mnemonic == "ftemp" {
+                return None;
+            }
+            let operands = insn
+                .operands
+                .into_iter()
+                .map(|op| rewrite_operand(op, &combined))
+                .collect();
+            Some(AsmInstruction {
+                mnemonic: insn.mnemonic,
+                operands,
+            })
+        })
+        .collect()
+}
+
+fn rewrite_operand(op: Operand, table: &HashMap<String, &'static str>) -> Operand {
+    let rewrite_str = |s: String| -> String {
+        match table.get(&s) {
+            Some(p) => (*p).to_string(),
+            None => s,
+        }
+    };
+    match op {
+        Operand::Register(name) => match table.get(&name) {
+            Some(p) => Operand::Register((*p).to_string()),
+            None => Operand::Register(name),
+        },
+        Operand::Memory { base, index, scale } => Operand::Memory {
+            base: rewrite_str(base),
+            index: index.map(|s| rewrite_str(s)),
+            scale: scale.map(|s| rewrite_str(s)),
+        },
+        other => other,
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse;
+
+    fn build(source: &str, arch: Arch) -> Result<Vec<AsmInstruction>, AllocationError> {
+        let mut program = parse(source);
+        // Inject a minimal Mov layout so dispatch_next has a known size.
+        use bytecode_def::OpLayout;
+        program.op_layouts.insert(
+            "Test".into(),
+            OpLayout {
+                field_offsets: HashMap::new(),
+                size: Some(4),
+            },
+        );
+        let mut counter = 0u32;
+        flatten_and_allocate(&program.handlers[0], &program, arch, &mut counter)
+    }
+
+    fn assignment_for(insns: &[AsmInstruction], mnemonic: &str, op_index: usize) -> String {
+        for insn in insns {
+            if insn.mnemonic == mnemonic {
+                if let Some(Operand::Register(name)) = insn.operands.get(op_index) {
+                    return name.clone();
+                }
+            }
+        }
+        panic!("no '{mnemonic}' instruction found");
+    }
+
+    #[test]
+    fn allocates_simple_named_temp() {
+        let src = "
+handler Test
+    temp foo
+    mov foo, 42
+    add foo, 1
+    store_operand m_dst, foo
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        // `foo` should be assigned to one of t0..t8 = rax..r11.
+        let name = assignment_for(&out, "mov", 0);
+        assert!(
+            ["rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11"]
+                .iter()
+                .any(|p| *p == name),
+            "expected physical reg, got {name}"
+        );
+        // No `temp` decl should remain in the rewritten output.
+        for insn in &out {
+            assert_ne!(insn.mnemonic, "temp");
+            assert_ne!(insn.mnemonic, "ftemp");
+        }
+    }
+
+    #[test]
+    fn allocates_two_temps_to_distinct_registers_when_overlapping() {
+        let src = "
+handler Test
+    temp a, b
+    mov a, 1
+    mov b, 2
+    add a, b
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        let a = assignment_for(&out, "mov", 0);
+        // The second mov target is `b` after rewriting.
+        let mut bs: Vec<&Operand> = Vec::new();
+        let mut seen_first = false;
+        for insn in &out {
+            if insn.mnemonic == "mov" {
+                if seen_first {
+                    bs.push(&insn.operands[0]);
+                    break;
+                }
+                seen_first = true;
+            }
+        }
+        let b = match bs[0] {
+            Operand::Register(n) => n.clone(),
+            _ => unreachable!(),
+        };
+        assert_ne!(a, b, "overlapping temps must get distinct regs");
+    }
+
+    #[test]
+    fn pins_named_temp_to_rcx_for_shift_count() {
+        let src = "
+handler Test
+    temp value, count
+    mov value, 0xff
+    mov count, 3
+    shr value, count
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        // Find the `shr` and check operand 1 is rcx.
+        for insn in &out {
+            if insn.mnemonic == "shr" {
+                if let Some(Operand::Register(name)) = insn.operands.get(1) {
+                    assert_eq!(name, "rcx", "shift count must be pinned to rcx");
+                    return;
+                }
+            }
+        }
+        panic!("no shr in output");
+    }
+
+    #[test]
+    fn rejects_double_declaration() {
+        let src = "
+handler Test
+    temp foo
+    temp foo
+end
+";
+        let err = build(src, Arch::X86_64).expect_err("should reject re-declaration");
+        assert!(err.message.contains("declared more than once"));
+    }
+
+    #[test]
+    fn rejects_shadowing_positional_alias() {
+        let src = "
+handler Test
+    temp t0
+end
+";
+        let err = build(src, Arch::X86_64).expect_err("should reject shadowing");
+        assert!(err.message.contains("shadows"));
+    }
+
+    #[test]
+    fn call_helper_with_named_input_and_output_pins_to_t1_and_t0() {
+        // Named-call form: input pinned to rcx, output pinned to rax.
+        // The input dies at the call (so being in the killed set is OK),
+        // and the output is born there (so it survives).
+        let src = "
+handler Test
+    temp value, result
+    load_operand value, m_condition
+    call_helper asm_helper_to_boolean, value, result
+    branch_nonzero result, .take
+    dispatch_next
+.take:
+    load_label value, m_target
+    goto_handler value
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        let mut saw_call = false;
+        for insn in &out {
+            if insn.mnemonic == "call_helper" {
+                saw_call = true;
+                if let Some(Operand::Register(name)) = insn.operands.get(1) {
+                    assert_eq!(name, "rcx", "call_helper input must be pinned to rcx");
+                }
+                if let Some(Operand::Register(name)) = insn.operands.get(2) {
+                    assert_eq!(name, "rax", "call_helper output must be pinned to rax");
+                }
+            }
+        }
+        assert!(saw_call);
+    }
+
+    #[test]
+    fn rejects_temp_live_across_call() {
+        let src = "
+handler Test
+    temp value
+    mov value, 7
+    call_helper asm_helper_to_boolean
+    add value, 1
+end
+";
+        let err = build(src, Arch::X86_64)
+            .expect_err("should reject value live across call_helper");
+        assert!(
+            err.message.contains("could not allocate") || err.message.contains("pool exhausted"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn separates_gpr_and_fpr_pools() {
+        let src = "
+handler Test
+    temp i
+    ftemp f
+    mov i, 1
+    int_to_double f, i
+    fp_mov i, f
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        // `i` should land in a GPR; `f` should land in an FPR.
+        let i_reg = assignment_for(&out, "mov", 0);
+        assert!(
+            ["rax", "rcx", "rdx", "rsi", "rdi", "r8", "r9", "r10", "r11"]
+                .iter()
+                .any(|p| *p == i_reg)
+        );
+        for insn in &out {
+            if insn.mnemonic == "fp_mov" {
+                if let Some(Operand::Register(name)) = insn.operands.get(1) {
+                    assert!(
+                        ["xmm0", "xmm1", "xmm2", "xmm3"].iter().any(|p| *p == name),
+                        "fp source not in xmm pool: {name}"
+                    );
+                    return;
+                }
+            }
+        }
+        panic!("no fp_mov in output");
+    }
+
+    #[test]
+    fn flattens_macros_and_uniquifies_local_temps() {
+        // Two invocations of a macro that each declare `tmp`. The
+        // rewritten output must contain neither the bare name `tmp` nor
+        // any unresolved `tmp_m*` form: each invocation's `tmp` is its
+        // own temp, allocated independently.
+        let src = "
+macro use_tmp(out_arg)
+    temp tmp
+    mov tmp, 5
+    add out_arg, tmp
+end
+
+handler Test
+    temp a, b
+    mov a, 0
+    mov b, 0
+    use_tmp a
+    use_tmp b
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        for insn in &out {
+            assert_ne!(insn.mnemonic, "temp");
+            for op in &insn.operands {
+                if let Operand::Register(name) = op {
+                    assert_ne!(name, "tmp", "unresolved macro-local temp leaked: {insn:?}");
+                    assert!(
+                        !name.starts_with("tmp_m"),
+                        "uniquified temp not assigned: {name}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn xor_self_zeroes_without_a_phantom_use() {
+        // The `xor reg, reg` idiom must not look like a self-read; if it
+        // did, the allocator would treat the temp as live at the handler
+        // entry and reject the program.
+        let src = "
+handler Test
+    temp counter
+    xor counter, counter
+    add counter, 1
+    store_operand m_dst, counter
+    dispatch_next
+end
+";
+        let _out = build(src, Arch::X86_64).expect("xor reg, reg should be a pure def");
+    }
+
+    #[test]
+    fn divmod_pins_outputs_and_keeps_inputs_off_rax_rdx() {
+        // x86 idiv reads rax/rdx, so dividend / divisor operands must not
+        // be allocated to rax or rdx (the implicit_outputs); the quotient
+        // and remainder, however, are pinned to rax/rdx by fixed_operands
+        // and that pin must NOT be vetoed by the operand-forbids rule.
+        let src = "
+handler Test
+    temp dividend, divisor, quot, rem, dst
+    load_operand dividend, m_lhs
+    load_operand divisor, m_rhs
+    divmod quot, rem, dividend, divisor
+    box_int32 dst, rem
+    store_operand m_dst, dst
+    dispatch_next
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        for insn in &out {
+            if insn.mnemonic == "divmod" {
+                let names: Vec<&str> = insn
+                    .operands
+                    .iter()
+                    .map(|op| match op {
+                        Operand::Register(n) => n.as_str(),
+                        _ => "<non-reg>",
+                    })
+                    .collect();
+                assert_eq!(names[0], "rax", "quot must be pinned to rax");
+                assert_eq!(names[1], "rdx", "rem must be pinned to rdx");
+                assert_ne!(names[2], "rax", "dividend must not be rax");
+                assert_ne!(names[2], "rdx", "dividend must not be rdx");
+                assert_ne!(names[3], "rax", "divisor must not be rax");
+                assert_ne!(names[3], "rdx", "divisor must not be rdx");
+                return;
+            }
+        }
+        panic!("no divmod in output");
+    }
+
+    #[test]
+    fn dst_operand_avoids_codegen_scratch_register() {
+        // box_int32_clean uses rax as scratch on x86 while writing the dst
+        // operand. If the allocator placed `dst` in rax, the scratch and
+        // the dst would collide and the boxed value would be lost.
+        // (Real-world repro: PostfixIncrement after migration produced
+        // garbage because the dst temp landed in rax.)
+        let src = "
+handler Test
+    temp value, int_value, dst
+    load_operand value, m_src
+    unbox_int32 int_value, value
+    box_int32_clean dst, int_value
+    store_operand m_dst, dst
+    dispatch_next
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        for insn in &out {
+            if insn.mnemonic == "box_int32_clean" {
+                if let Some(Operand::Register(name)) = insn.operands.first() {
+                    assert_ne!(
+                        name, "rax",
+                        "box_int32_clean dst must avoid rax (the codegen's scratch reg)"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn macro_local_temps_can_share_a_physical_register_across_invocations() {
+        // Two non-overlapping invocations of the same macro should be
+        // free to put their private `tmp` in the same physical register.
+        // This exercises the per-invocation rename + per-temp live range.
+        let src = "
+macro touch(arg)
+    temp tmp
+    mov tmp, 1
+    add arg, tmp
+end
+
+handler Test
+    temp out
+    mov out, 0
+    touch out
+    touch out
+    store_operand m_dst, out
+end
+";
+        let out = build(src, Arch::X86_64).expect("allocation should succeed");
+        // Find the two `mov ?, 1` instructions (the two `tmp` defs) and
+        // assert they target the same physical register, demonstrating
+        // re-use of the slot once the first invocation's tmp dies.
+        let tmp_targets: Vec<&str> = out
+            .iter()
+            .filter_map(|insn| {
+                if insn.mnemonic == "mov" && insn.operands.len() == 2 {
+                    if let Operand::Immediate(1) = insn.operands[1] {
+                        if let Operand::Register(name) = &insn.operands[0] {
+                            return Some(name.as_str());
+                        }
+                    }
+                }
+                None
+            })
+            .collect();
+        assert_eq!(tmp_targets.len(), 2, "expected two mov ?, 1 emissions");
+        assert_eq!(
+            tmp_targets[0], tmp_targets[1],
+            "macro-local tmp should re-use the same physical register \
+             across non-overlapping invocations"
+        );
+    }
+}

--- a/Libraries/LibJS/AsmIntGen/src/allocator.rs
+++ b/Libraries/LibJS/AsmIntGen/src/allocator.rs
@@ -1203,10 +1203,13 @@ end
     }
 
     #[test]
-    fn rejects_shadowing_positional_alias() {
+    fn rejects_shadowing_pinned_register() {
+        // `pc` is a pinned (callee-saved) DSL name; declaring a temp with
+        // that name would silently break dispatch, so the allocator
+        // rejects it up front.
         let src = "
 handler Test
-    temp t0
+    temp pc
 end
 ";
         let err = build(src, Arch::X86_64).expect_err("should reject shadowing");

--- a/Libraries/LibJS/AsmIntGen/src/allocator.rs
+++ b/Libraries/LibJS/AsmIntGen/src/allocator.rs
@@ -31,7 +31,7 @@
 
 use crate::instructions::{InstructionInfo, OperandKind, lookup};
 use crate::parser::{AsmInstruction, Handler, Operand, Program};
-use crate::registers::{Arch, mapping_for, resolve_register};
+use crate::registers::{Arch, mapping_for, register_cost, resolve_register};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// Registers x86-64 calls clobber (caller-saved). System V AMD64.
@@ -482,6 +482,25 @@ fn apply_operand_kind(
     }
 }
 
+/// Count how many times each register name appears in the operand stream.
+/// This is a coarse spill-cost proxy: the more an x86_64 temp is referenced,
+/// the more bytes we save by placing it in a low-encoding-cost register.
+fn count_register_uses(instructions: &[AsmInstruction]) -> HashMap<String, u32> {
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    for insn in instructions {
+        if insn.mnemonic == "temp" || insn.mnemonic == "ftemp" {
+            // Declarations themselves are not real uses.
+            continue;
+        }
+        for op in &insn.operands {
+            collect_operand_registers(op, &mut |name| {
+                *counts.entry(name.to_string()).or_insert(0) += 1;
+            });
+        }
+    }
+    counts
+}
+
 fn collect_operand_registers<F: FnMut(&str)>(op: &Operand, f: &mut F) {
     match op {
         Operand::Register(name) => f(name),
@@ -886,34 +905,112 @@ fn allocate(
     let gpr_pool: Vec<&'static str> = mapping.temporaries.to_vec();
     let fpr_pool: Vec<&'static str> = mapping.fp_temporaries.to_vec();
 
-    // Allocate. Order temps by descending live-range size so the most
-    // constrained temps go first; hard-pinned temps always go first.
-    let mut all_temps: Vec<(String, bool)> = declared_gpr_temps
+    // Per-temp use count: every operand-level reference to the temp's name
+    // (including occurrences inside memory operands) contributes one use.
+    // On x86_64 each saved use of a low-cost register saves an encoding
+    // byte, so hot temps want to land in cheap registers.
+    let use_counts = count_register_uses(instructions);
+
+    let all_temps: Vec<(String, bool)> = declared_gpr_temps
         .iter()
         .map(|n| (n.clone(), true))
         .chain(declared_fpr_temps.iter().map(|n| (n.clone(), false)))
         .collect();
-    all_temps.sort_by(|a, b| {
+
+    // Greedy graph coloring is sensitive to the order temps are processed
+    // in. Two orders are useful here:
+    //
+    //   - Use-count-first is cost-optimal: the temp with the most operand
+    //     references claims the cheapest register, so byte savings
+    //     concentrate where they matter most.
+    //
+    //   - Live-range-first is fit-optimal: the most constrained temps
+    //     (those alive across the most instructions, which see the most
+    //     interference) claim registers first and are the most likely to
+    //     fit. Some packed handlers (e.g. `Call`) only color successfully
+    //     under this order.
+    //
+    // We try cost-first and fall back to fit-first only when cost-first
+    // can't color. This wins the byte savings when the handler has slack
+    // and never regresses fit when it doesn't.
+    let try_color = |sorted: &[(String, bool)]| -> Result<AllocationPlan, AllocationError> {
+        color(
+            handler,
+            sorted,
+            &alive_in,
+            &alive_out,
+            &crosses,
+            &killed_phys_per_insn,
+            &operand_forbids,
+            &hard_pins,
+            &gpr_pool,
+            &fpr_pool,
+            arch,
+        )
+    };
+
+    let by_use_count_first = |a: &(String, bool), b: &(String, bool)| {
         let ap = hard_pins.contains_key(&a.0);
         let bp = hard_pins.contains_key(&b.0);
-        bp.cmp(&ap).then_with(|| {
-            let aw = alive_in
-                .get(&a.0)
-                .map_or(0, |s| s.len())
-                + alive_out.get(&a.0).map_or(0, |s| s.len());
-            let bw = alive_in
-                .get(&b.0)
-                .map_or(0, |s| s.len())
-                + alive_out.get(&b.0).map_or(0, |s| s.len());
-            bw.cmp(&aw)
-        })
-    });
+        let au = use_counts.get(&a.0).copied().unwrap_or(0);
+        let bu = use_counts.get(&b.0).copied().unwrap_or(0);
+        let aw = alive_in.get(&a.0).map_or(0, |s| s.len())
+            + alive_out.get(&a.0).map_or(0, |s| s.len());
+        let bw = alive_in.get(&b.0).map_or(0, |s| s.len())
+            + alive_out.get(&b.0).map_or(0, |s| s.len());
+        bp.cmp(&ap)
+            .then_with(|| bu.cmp(&au))
+            .then_with(|| bw.cmp(&aw))
+            .then_with(|| a.0.cmp(&b.0))
+    };
+    let by_live_range_first = |a: &(String, bool), b: &(String, bool)| {
+        let ap = hard_pins.contains_key(&a.0);
+        let bp = hard_pins.contains_key(&b.0);
+        let au = use_counts.get(&a.0).copied().unwrap_or(0);
+        let bu = use_counts.get(&b.0).copied().unwrap_or(0);
+        let aw = alive_in.get(&a.0).map_or(0, |s| s.len())
+            + alive_out.get(&a.0).map_or(0, |s| s.len());
+        let bw = alive_in.get(&b.0).map_or(0, |s| s.len())
+            + alive_out.get(&b.0).map_or(0, |s| s.len());
+        bp.cmp(&ap)
+            .then_with(|| bw.cmp(&aw))
+            .then_with(|| bu.cmp(&au))
+            .then_with(|| a.0.cmp(&b.0))
+    };
 
+    let mut sorted = all_temps.clone();
+    sorted.sort_by(by_use_count_first);
+    if let Ok(plan) = try_color(&sorted) {
+        return Ok(plan);
+    }
+
+    let mut sorted = all_temps;
+    sorted.sort_by(by_live_range_first);
+    try_color(&sorted)
+}
+
+/// Greedy linear-scan coloring driven by the order in `sorted_temps`.
+/// Returns Err if any temp can't be placed; the caller decides whether to
+/// retry with a different ordering.
+#[allow(clippy::too_many_arguments)]
+fn color(
+    handler: &Handler,
+    sorted_temps: &[(String, bool)],
+    alive_in: &HashMap<String, BTreeSet<usize>>,
+    alive_out: &HashMap<String, BTreeSet<usize>>,
+    crosses: &HashMap<String, BTreeSet<usize>>,
+    killed_phys_per_insn: &[BTreeSet<String>],
+    operand_forbids: &HashMap<String, HashSet<&'static str>>,
+    hard_pins: &HashMap<String, &'static str>,
+    gpr_pool: &[&'static str],
+    fpr_pool: &[&'static str],
+    arch: Arch,
+) -> Result<AllocationPlan, AllocationError> {
     let mut gpr_assignments: HashMap<String, &'static str> = HashMap::new();
     let mut fpr_assignments: HashMap<String, &'static str> = HashMap::new();
 
-    for (name, is_gpr) in &all_temps {
-        let pool = if *is_gpr { &gpr_pool } else { &fpr_pool };
+    for (name, is_gpr) in sorted_temps {
+        let pool: &[&'static str] = if *is_gpr { gpr_pool } else { fpr_pool };
         let my_in = alive_in
             .get(name)
             .expect("missing live_in for declared temp");
@@ -996,9 +1093,16 @@ fn allocate(
             }
             pinned
         } else {
+            // Pick the cheapest available register for this temp. Pool
+            // position breaks ties so behavior stays deterministic when
+            // several registers tie in cost (e.g. all FPRs, or all
+            // aarch64 GPRs).
             *pool
                 .iter()
-                .find(|p| !forbidden.contains(*p))
+                .enumerate()
+                .filter(|(_, p)| !forbidden.contains(*p))
+                .min_by_key(|(i, p)| (register_cost(p, arch), *i))
+                .map(|(_, p)| p)
                 .ok_or_else(|| AllocationError {
                     handler: handler.name.clone(),
                     message: format!(

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1033,6 +1033,11 @@ fn emit_instruction(
             }
         }
 
+        // Named-temporary declarations: `temp foo, bar` / `ftemp baz`.
+        // The register allocator consumes these before codegen runs; here
+        // they emit nothing.
+        "temp" | "ftemp" => {}
+
         // dispatch_current: dispatch the instruction at current pc (without advancing).
         // Overrides the DSL macro to ensure x21 is set for the next handler.
         "dispatch_current" => {

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1243,8 +1243,11 @@ fn emit_instruction(
                 let rem = resolve_op(&insn.operands[1], handler, program);
                 let dividend = resolve_op(&insn.operands[2], handler, program);
                 let divisor = resolve_op(&insn.operands[3], handler, program);
-                w!(out, "    sdiv {quot}, {dividend}, {divisor}");
-                w!(out, "    msub {rem}, {quot}, {divisor}, {dividend}");
+                w!(out, "    sdiv x9, {dividend}, {divisor}");
+                w!(out, "    msub {rem}, x9, {divisor}, {dividend}");
+                if quot != rem {
+                    w!(out, "    mov {quot}, x9");
+                }
             }
         }
 

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::allocator::{flatten_and_allocate, handler_uses_named_temps};
 use crate::parser::{AsmInstruction, Handler, ObjectFormat, Operand, Program};
 use crate::registers::{Arch, resolve_register};
 use crate::shared::{
@@ -399,8 +400,27 @@ fn generate_handler(
 
     let mut state = HandlerState::new();
 
-    for insn in &handler.instructions {
-        emit_instruction(out, insn, handler, program, &mut state, pinned);
+    if handler_uses_named_temps(handler, program) {
+        // The allocator pre-expands macros and rewrites named temps to
+        // physical registers. The shared unique_counter continues from
+        // the value the allocator left it at, so canonicalize_nan fixup
+        // labels emitted later don't collide with macro-id labels.
+        let mut counter = state.unique_counter;
+        let flat = flatten_and_allocate(handler, program, Arch::Aarch64, &mut counter)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "register allocation failed for handler '{}': {}",
+                    err.handler, err.message
+                )
+            });
+        state.unique_counter = counter;
+        for insn in &flat {
+            emit_instruction(out, insn, handler, program, &mut state, pinned);
+        }
+    } else {
+        for insn in &handler.instructions {
+            emit_instruction(out, insn, handler, program, &mut state, pinned);
+        }
     }
 
     // Emit cold fixup blocks after the main handler body
@@ -604,14 +624,28 @@ fn emit_load_pair(
         return;
     }
 
+    // Fallback to two scalar loads. If dst1 aliases the base register,
+    // writing dst1 first would clobber the address before the second load
+    // can use it; emit dst2 first in that case.
+    let dst1_aliases_base = dst1 == base;
     match element_size {
         4 => {
-            emit_ldr32(out, &to_w_reg(dst1), base, first_offset);
-            emit_ldr32(out, &to_w_reg(dst2), base, first_offset + 4);
+            if dst1_aliases_base {
+                emit_ldr32(out, &to_w_reg(dst2), base, first_offset + 4);
+                emit_ldr32(out, &to_w_reg(dst1), base, first_offset);
+            } else {
+                emit_ldr32(out, &to_w_reg(dst1), base, first_offset);
+                emit_ldr32(out, &to_w_reg(dst2), base, first_offset + 4);
+            }
         }
         8 => {
-            emit_ldr64(out, dst1, base, first_offset);
-            emit_ldr64(out, dst2, base, first_offset + 8);
+            if dst1_aliases_base {
+                emit_ldr64(out, dst2, base, first_offset + 8);
+                emit_ldr64(out, dst1, base, first_offset);
+            } else {
+                emit_ldr64(out, dst1, base, first_offset);
+                emit_ldr64(out, dst2, base, first_offset + 8);
+            }
         }
         _ => unreachable!("unsupported paired load size"),
     }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -1158,11 +1158,19 @@ fn emit_instruction(
         }
 
         // call_helper: NON-TERMINAL call to C++ helper
-        // Passes t1 (x1 on aarch64) as first argument to the helper.
+        // The named 3-operand form passes its input directly in x0; the
+        // legacy 1-operand form still reads from t1 (x1).
         "call_helper" => {
             if let Some(Operand::Register(func_name)) = insn.operands.first() {
-                // t1 on aarch64 is x1. Move to x0 for the call.
-                w!(out, "    mov x0, x1");
+                if let Some(input) = insn.operands.get(1) {
+                    let input = resolve_op(input, handler, program);
+                    if input != "x0" {
+                        w!(out, "    mov x0, {input}");
+                    }
+                } else {
+                    // t1 on aarch64 is x1. Move to x0 for the call.
+                    w!(out, "    mov x0, x1");
+                }
                 w!(out, "    bl CSYM({func_name})");
                 // Result is in x0 (= t0 on aarch64), which is correct.
             }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -405,6 +405,13 @@ fn emit_instruction(
             }
         }
 
+        // Named-temporary declarations: `temp foo, bar` introduces GPR
+        // temps named `foo` and `bar`; `ftemp baz` introduces an FPR temp.
+        // The register allocator processes these before codegen runs --
+        // by the time we get here they are pure annotations and emit
+        // nothing.
+        "temp" | "ftemp" => {}
+
         // Macro invocations
         _ if program.macros.contains_key(m) => {
             let mac = program.macros[m].clone();

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -1543,9 +1543,11 @@ mod tests {
     fn preserves_scaled_index_memory_operands() {
         let program = test_program();
         let handler = call_handler();
+        // Operands that already resolved to platform registers (post-
+        // allocation) flow through resolve_op unchanged.
         let memory = Operand::Memory {
-            base: "t0".into(),
-            index: Some("t8".into()),
+            base: "rax".into(),
+            index: Some("r11".into()),
             scale: Some("8".into()),
         };
 
@@ -1557,8 +1559,8 @@ mod tests {
         let program = test_program();
         let handler = call_handler();
         let memory = Operand::Memory {
-            base: "t6".into(),
-            index: Some("t3".into()),
+            base: "r9".into(),
+            index: Some("rsi".into()),
             scale: Some("0".into()),
         };
 
@@ -1591,7 +1593,7 @@ mod tests {
         let instruction = AsmInstruction {
             mnemonic: "branch_bits_clear".into(),
             operands: vec![
-                Operand::Register("t2".into()),
+                Operand::Register("rdx".into()),
                 Operand::Constant("HIGH_BIT".into()),
                 Operand::Label(".slow".into()),
             ],

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::allocator::{flatten_and_allocate, handler_uses_named_temps};
 use crate::parser::{AsmInstruction, Handler, ObjectFormat, Operand, Program};
 use crate::registers::{Arch, resolve_register};
 use crate::shared::{
@@ -288,9 +289,29 @@ fn generate_handler(out: &mut String, handler: &Handler, program: &Program) {
 
     let mut state = HandlerState::new();
 
-    // Expand macros and emit instructions
-    for insn in &handler.instructions {
-        emit_instruction(out, insn, handler, program, &mut state);
+    if handler_uses_named_temps(handler, program) {
+        // The allocator pre-expands macros and rewrites named temps to
+        // physical registers, so emit_instruction iterates a flat list and
+        // never re-enters the macro-expansion arm. The shared
+        // unique_counter is consumed for canonicalize_nan fixup labels
+        // continuing after the macro-id range used by the allocator.
+        let mut counter = state.unique_counter;
+        let flat = flatten_and_allocate(handler, program, Arch::X86_64, &mut counter)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "register allocation failed for handler '{}': {}",
+                    err.handler, err.message
+                )
+            });
+        state.unique_counter = counter;
+        for insn in &flat {
+            emit_instruction(out, insn, handler, program, &mut state);
+        }
+    } else {
+        // Existing path: expand macros recursively in emit_instruction.
+        for insn in &handler.instructions {
+            emit_instruction(out, insn, handler, program, &mut state);
+        }
     }
 
     // Emit cold fixup blocks after the main handler body
@@ -382,6 +403,19 @@ fn resolve_pair_memory_op(op: &Operand, handler: &Handler, program: &Program) ->
     let mem = resolve_memory_operand(op, handler, program, Arch::X86_64)
         .expect("x86_64 pair memory operands should always resolve");
     format_x86_memory_operand(&mem)
+}
+
+/// True when writing `dst1` would clobber a register that the second load
+/// of a pair still needs (the base or index of either memory operand).
+/// `mem1` / `mem2` are the already-formatted x86 memory text (e.g.
+/// `[rcx + r10 * 8]`); we check whether the formatted text mentions the
+/// destination register name as a whole word.
+fn pair_dst_aliases_address(dst1: &str, mem1: &str, mem2: &str) -> bool {
+    let mention_in = |s: &str, reg: &str| -> bool {
+        s.split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .any(|tok| tok == reg)
+    };
+    mention_in(mem1, dst1) || mention_in(mem2, dst1)
 }
 
 fn emit_instruction(
@@ -825,8 +859,17 @@ fn emit_instruction(
                 let dst2 = resolve_op(&insn.operands[1], handler, program);
                 let mem1 = resolve_pair_memory_op(&insn.operands[2], handler, program);
                 let mem2 = resolve_pair_memory_op(&insn.operands[3], handler, program);
-                w!(out, "    mov {dst1}, QWORD PTR {mem1}");
-                w!(out, "    mov {dst2}, QWORD PTR {mem2}");
+                // x86 has no real "load pair", so this is two movs. If dst1
+                // is the same physical register as the address's base or
+                // index, writing dst1 first clobbers the address before the
+                // second load can use it; emit dst2 first in that case.
+                if pair_dst_aliases_address(&dst1, &mem1, &mem2) {
+                    w!(out, "    mov {dst2}, QWORD PTR {mem2}");
+                    w!(out, "    mov {dst1}, QWORD PTR {mem1}");
+                } else {
+                    w!(out, "    mov {dst1}, QWORD PTR {mem1}");
+                    w!(out, "    mov {dst2}, QWORD PTR {mem2}");
+                }
             }
         }
 
@@ -848,8 +891,13 @@ fn emit_instruction(
                 let dst2 = resolve_op(&insn.operands[1], handler, program);
                 let mem1 = resolve_pair_memory_op(&insn.operands[2], handler, program);
                 let mem2 = resolve_pair_memory_op(&insn.operands[3], handler, program);
-                w!(out, "    mov {}, DWORD PTR {mem1}", to_32bit_reg(&dst1));
-                w!(out, "    mov {}, DWORD PTR {mem2}", to_32bit_reg(&dst2));
+                if pair_dst_aliases_address(&dst1, &mem1, &mem2) {
+                    w!(out, "    mov {}, DWORD PTR {mem2}", to_32bit_reg(&dst2));
+                    w!(out, "    mov {}, DWORD PTR {mem1}", to_32bit_reg(&dst1));
+                } else {
+                    w!(out, "    mov {}, DWORD PTR {mem1}", to_32bit_reg(&dst1));
+                    w!(out, "    mov {}, DWORD PTR {mem2}", to_32bit_reg(&dst2));
+                }
             }
         }
 
@@ -1518,6 +1566,19 @@ mod tests {
             resolve_pair_memory_op(&memory, &handler, &program),
             "[r9 + rsi]"
         );
+    }
+
+    #[test]
+    fn pair_dst_aliasing_base_keeps_address_alive() {
+        // load_pair64 dst1, dst2, [base + 0], [base + 8] must not start by
+        // writing dst1 if dst1 happens to be the same physical register
+        // as base; the second load would otherwise read from the wrong
+        // address. The codegen swaps the load order in that case.
+        assert!(pair_dst_aliases_address("rcx", "[rcx]", "[rcx + 8]"));
+        assert!(pair_dst_aliases_address("r10", "[r10 + 16]", "[r10 + 24]"));
+        assert!(pair_dst_aliases_address("rdx", "[rcx + rdx * 8]", "[rcx + rdx * 8 + 8]"));
+        assert!(!pair_dst_aliases_address("rax", "[rcx + 16]", "[rcx + 24]"));
+        assert!(!pair_dst_aliases_address("rax", "[r10]", "[r10 + 8]"));
     }
 
     #[test]

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -265,9 +265,11 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
     // call_helper func [, input_temp, output_temp]
     //   u64 func(u64 value).
     //   1-operand form: reads from t1 / writes to t0 by convention.
-    //   3-operand form: input_temp is pinned to t1 (rcx/x1), output_temp
-    //   is pinned to t0 (rax/x0). Both forms still kill all caller-saved
-    //   registers as per `is_call`.
+    //   3-operand form: input_temp/output_temp are pinned to call/result
+    //   registers. On x86_64 that is rcx -> rax to match the historical
+    //   t1 -> t0 convention; on aarch64 both use x0, matching the ABI
+    //   argument/result register and avoiding the old x1 -> x0 bridge move.
+    //   Both forms still kill all caller-saved registers as per `is_call`.
     info(
         "call_helper",
         &[FuncSymbol, GprIn, GprOut],
@@ -281,9 +283,9 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
             ..ArchSpec::NONE
         },
         ArchSpec {
-            implicit_inputs: &["x1"],
+            implicit_inputs: &["x0"],
             implicit_outputs: &["x0"],
-            fixed_operands: &[(1, "x1"), (2, "x0")],
+            fixed_operands: &[(1, "x0"), (2, "x0")],
             ..ArchSpec::NONE
         },
     ),

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -1,0 +1,1087 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Canonical metadata for every DSL instruction.
+//!
+//! This table describes each DSL instruction's operand kinds, control-flow
+//! semantics, and per-architecture register footprint (hidden clobbers,
+//! implicit inputs/outputs, hard register requirements). The register
+//! allocator for named temporaries consumes this metadata; it is the
+//! canonical contract between the DSL surface and the codegen.
+//!
+//! ## What gets recorded here
+//!
+//! - **Operand kinds** -- the role of each named operand position in the DSL
+//!   (read-only GPR, written GPR, FPR, immediate, memory, label, ...). The
+//!   allocator reads this to derive use/def sets for liveness analysis.
+//! - **`terminal`** -- whether control falls through to the next instruction.
+//!   Terminal instructions (jmp, exit, dispatch_*, goto_handler,
+//!   call_slow_path) end the basic block; the allocator does not extend any
+//!   liveness past them.
+//! - **`is_call`** -- whether the instruction performs a non-terminal C++
+//!   call that clobbers every caller-saved register. The allocator must
+//!   forbid keeping any temporary live across such instructions, since no
+//!   register survives the call.
+//! - **`clobbers_gpr` / `clobbers_fpr`** -- physical scratch registers used
+//!   by codegen besides operand outputs. A live temp may not occupy these
+//!   registers across the instruction.
+//! - **`implicit_inputs` / `implicit_outputs`** -- hidden register operands
+//!   not exposed in the DSL operand list. Examples: `call_helper` reads from
+//!   t1 (rcx/x1) and writes to t0 (rax/x0); `divmod` writes its results to
+//!   rax/rdx on x86_64 regardless of the named operands.
+//! - **`fixed_operands`** -- a constraint that operand position N must
+//!   resolve to a specific physical register (e.g., x86 shifts require the
+//!   count register to be `rcx`).
+//!
+//! ## What is *not* recorded
+//!
+//! Codegen emit logic itself (the assembly text). The codegen functions
+//! remain authoritative for the actual emitted bytes; this metadata only
+//! describes what the allocator needs to know to feed them safely.
+//!
+//! ## Caller-saved register sets
+//!
+//! These are the registers an `is_call=true` instruction kills (in addition
+//! to any explicitly listed clobbers). Pinned registers (pc, pb, values,
+//! exec_ctx, dispatch, sp, fp) survive calls because they live in
+//! callee-saved slots; aarch64 also pins x21 (ip cache), x22, x23, x24
+//! (tag constants).
+//!
+//! - x86_64: rax, rcx, rdx, rsi, rdi, r8, r9, r10, r11, xmm0-xmm5
+//! - aarch64: x0-x18, d0-d7, d16-d31
+
+// Suppress dead-code warnings while the table lands independently of its
+// consumers (the named-temporary register allocator).
+#![allow(dead_code)]
+
+use crate::registers::Arch;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+/// Kind of a single DSL operand position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperandKind {
+    /// GPR read as input.
+    GprIn,
+    /// GPR written; previous contents discarded.
+    GprOut,
+    /// GPR both read and written.
+    GprInOut,
+    /// FP register read as input.
+    FprIn,
+    /// FP register written; previous contents discarded.
+    FprOut,
+    /// FP register both read and written.
+    FprInOut,
+    /// GPR (read) or immediate.
+    GprInOrImm,
+    /// Compile-time integer (immediate, named constant, or field reference).
+    Imm,
+    /// Memory operand `[base, ...]`. Reads the GPRs referenced inside the
+    /// brackets; the memory itself may be loaded from or stored to depending
+    /// on the mnemonic.
+    Memory,
+    /// Branch-target label (local `.foo` or global symbol).
+    Label,
+    /// Bytecode instruction field reference (`m_*`).
+    FieldRef,
+    /// Function symbol used by `call_*` instructions.
+    FuncSymbol,
+}
+
+/// Per-architecture register footprint of an instruction.
+#[derive(Debug, Clone, Copy)]
+pub struct ArchSpec {
+    /// Hidden GPR scratch clobbers (besides regs written via output operands
+    /// and besides the all-caller-saved kill implied by `is_call=true`).
+    pub clobbers_gpr: &'static [&'static str],
+    /// Hidden FPR scratch clobbers.
+    pub clobbers_fpr: &'static [&'static str],
+    /// Hidden register inputs not visible in the operand list.
+    /// E.g. `call_helper` reads its first argument from rcx (x1).
+    pub implicit_inputs: &'static [&'static str],
+    /// Hidden register outputs not visible in the operand list.
+    /// E.g. `call_helper` returns its result in rax (x0).
+    pub implicit_outputs: &'static [&'static str],
+    /// Constraints requiring specific operand positions to resolve to fixed
+    /// physical registers. Pairs of `(operand_index, physical_register)`.
+    pub fixed_operands: &'static [(usize, &'static str)],
+}
+
+impl ArchSpec {
+    pub const NONE: ArchSpec = ArchSpec {
+        clobbers_gpr: &[],
+        clobbers_fpr: &[],
+        implicit_inputs: &[],
+        implicit_outputs: &[],
+        fixed_operands: &[],
+    };
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct InstructionInfo {
+    pub mnemonic: &'static str,
+    pub operands: &'static [OperandKind],
+    /// Final operand kind that may repeat (variadic). `None` means fixed
+    /// arity.
+    pub variadic_kind: Option<OperandKind>,
+    /// Control does not fall through to the next instruction.
+    pub terminal: bool,
+    /// Non-terminal C++ call. Implies all caller-saved temps are killed.
+    pub is_call: bool,
+    pub x86_64: ArchSpec,
+    pub aarch64: ArchSpec,
+}
+
+impl InstructionInfo {
+    /// Look up the per-arch spec for this instruction.
+    pub fn arch(&self, arch: Arch) -> &ArchSpec {
+        match arch {
+            Arch::X86_64 => &self.x86_64,
+            Arch::Aarch64 => &self.aarch64,
+        }
+    }
+}
+
+// Convenience constructors so the table stays readable.
+const fn info(
+    mnemonic: &'static str,
+    operands: &'static [OperandKind],
+    variadic_kind: Option<OperandKind>,
+    terminal: bool,
+    is_call: bool,
+    x86_64: ArchSpec,
+    aarch64: ArchSpec,
+) -> InstructionInfo {
+    InstructionInfo {
+        mnemonic,
+        operands,
+        variadic_kind,
+        terminal,
+        is_call,
+        x86_64,
+        aarch64,
+    }
+}
+
+const fn plain(
+    mnemonic: &'static str,
+    operands: &'static [OperandKind],
+) -> InstructionInfo {
+    info(mnemonic, operands, None, false, false, ArchSpec::NONE, ArchSpec::NONE)
+}
+
+use OperandKind::*;
+
+/// The canonical table of every DSL instruction known to the codegen.
+///
+/// Keep entries grouped by category to mirror the reference comment in
+/// `main.rs` (Control flow, C++ interop, Memory, Integer ALU, ...).
+pub const INSTRUCTIONS: &[InstructionInfo] = &[
+    // ------------------------------------------------------------------
+    // Pseudo / control flow
+    // ------------------------------------------------------------------
+    // `label` is a pseudo-instruction emitted by the parser when it sees
+    // `.foo:`; it never appears in user-written DSL.
+    info("label", &[Label], None, false, false, ArchSpec::NONE, ArchSpec::NONE),
+
+    // Unconditional branch within a handler.
+    info("jmp", &[Label], None, true, false, ArchSpec::NONE, ArchSpec::NONE),
+
+    // Exit the interpreter loop, returning to C++.
+    info("exit", &[], None, true, false, ArchSpec::NONE, ArchSpec::NONE),
+
+    // dispatch_next: advance pc by the handler's instruction size and
+    // dispatch to the next bytecode handler. Terminal: the tail jump
+    // through the dispatch table never falls through.
+    info(
+        "dispatch_next",
+        &[],
+        None,
+        true,
+        false,
+        // x86_64: dispatch tail uses rax to hold the next opcode byte.
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        // aarch64: dispatch tail uses x9 (next opcode) and x10 (handler ptr).
+        ArchSpec { clobbers_gpr: &["x9", "x10"], ..ArchSpec::NONE },
+    ),
+
+    // dispatch_variable: advance pc by an arbitrary amount and dispatch.
+    info(
+        "dispatch_variable",
+        &[GprIn],
+        None,
+        true,
+        false,
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_gpr: &["x9", "x10"], ..ArchSpec::NONE },
+    ),
+
+    // dispatch_current: dispatch the instruction at the current pc without
+    // advancing. On x86 this is a macro (load8 + indirect jmp); on aarch64
+    // the codegen recognizes it directly.
+    info(
+        "dispatch_current",
+        &[],
+        None,
+        true,
+        false,
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_gpr: &["x9", "x10"], ..ArchSpec::NONE },
+    ),
+
+    // goto_handler reg: set pc to `reg` (32-bit) and dispatch.
+    info(
+        "goto_handler",
+        &[GprIn],
+        None,
+        true,
+        false,
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_gpr: &["x9", "x10"], ..ArchSpec::NONE },
+    ),
+
+    // ------------------------------------------------------------------
+    // C++ interop
+    // ------------------------------------------------------------------
+    // call_slow_path func: i64 func(VM*, u32 pc). Terminal -- after the
+    // return value is examined the handler either exits or dispatches to a
+    // new pc; control never re-enters the DSL handler body.
+    info(
+        "call_slow_path",
+        &[FuncSymbol],
+        None,
+        true,
+        true,
+        // Even though it's terminal, list known scratch (rcx for the state
+        // reload, rax for the dispatch tail) so the table is precise.
+        ArchSpec { clobbers_gpr: &["rax", "rcx"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_gpr: &["x9", "x10"], ..ArchSpec::NONE },
+    ),
+
+    // call_helper func [, input_temp, output_temp]
+    //   u64 func(u64 value).
+    //   1-operand form: reads from t1 / writes to t0 by convention.
+    //   3-operand form: input_temp is pinned to t1 (rcx/x1), output_temp
+    //   is pinned to t0 (rax/x0). Both forms still kill all caller-saved
+    //   registers as per `is_call`.
+    info(
+        "call_helper",
+        &[FuncSymbol, GprIn, GprOut],
+        None,
+        false,
+        true,
+        ArchSpec {
+            implicit_inputs: &["rcx"],
+            implicit_outputs: &["rax"],
+            fixed_operands: &[(1, "rcx"), (2, "rax")],
+            ..ArchSpec::NONE
+        },
+        ArchSpec {
+            implicit_inputs: &["x1"],
+            implicit_outputs: &["x0"],
+            fixed_operands: &[(1, "x1"), (2, "x0")],
+            ..ArchSpec::NONE
+        },
+    ),
+
+    // call_interp func [, output_temp]
+    //   i64 func(VM*, u32 pc). Result lands in t0; the named form pins
+    //   that temp to t0 so the value can be carried into a downstream
+    //   named-temp world.
+    info(
+        "call_interp",
+        &[FuncSymbol, GprOut],
+        None,
+        false,
+        true,
+        ArchSpec {
+            implicit_outputs: &["rax"],
+            fixed_operands: &[(1, "rax")],
+            ..ArchSpec::NONE
+        },
+        ArchSpec {
+            implicit_outputs: &["x0"],
+            fixed_operands: &[(1, "x0")],
+            ..ArchSpec::NONE
+        },
+    ),
+
+    // call_raw_native reg [, payload_temp, variant_idx_temp]
+    //   Indirect call to a `ThrowCompletionOr<Value> (*)(VM&)`. Returns
+    //   the variant payload in t0 and the variant index in t1. The named
+    //   form pins those temps to t0/t1.
+    info(
+        "call_raw_native",
+        &[GprIn, GprOut, GprOut],
+        None,
+        false,
+        true,
+        ArchSpec {
+            clobbers_gpr: &["r11"],
+            implicit_outputs: &["rax", "rcx"],
+            fixed_operands: &[(1, "rax"), (2, "rcx")],
+            ..ArchSpec::NONE
+        },
+        ArchSpec {
+            clobbers_gpr: &["x9"],
+            implicit_outputs: &["x0", "x1"],
+            fixed_operands: &[(1, "x0"), (2, "x1")],
+            ..ArchSpec::NONE
+        },
+    ),
+
+    // reload_exec_ctx: refresh the exec_ctx register from VM* on the stack.
+    info(
+        "reload_exec_ctx",
+        &[],
+        None,
+        false,
+        false,
+        ArchSpec { clobbers_gpr: &["rcx"], ..ArchSpec::NONE },
+        ArchSpec::NONE,
+    ),
+
+    // load_vm dst: copy the hidden VM* into dst.
+    plain("load_vm", &[GprOut]),
+
+    // ------------------------------------------------------------------
+    // Bytecode operand access
+    // ------------------------------------------------------------------
+    // load_operand dst, m_field: load the Value referenced by the u32
+    // operand at m_field. On x86 the codegen materializes the operand
+    // index in rax; on aarch64 it uses w9.
+    info(
+        "load_operand",
+        &[GprOut, FieldRef],
+        None,
+        false,
+        false,
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    // store_operand m_field, src: x86 normally uses r11 to materialize the
+    // operand index, falling back to rax when src is itself r11 (so the
+    // src register survives the index load). Only r11 is reported here as
+    // the clobber: the rax fallback is reachable only when src is already
+    // forbidden from being r11 by this entry.
+    info(
+        "store_operand",
+        &[FieldRef, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec { clobbers_gpr: &["r11"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    // load_label dst, m_field: read a 32-bit Label from the bytecode.
+    plain("load_label", &[GprOut, FieldRef]),
+
+    // ------------------------------------------------------------------
+    // Memory access
+    // ------------------------------------------------------------------
+    // aarch64 needs x9 to materialize large offsets / non-imm12 displacements.
+    info(
+        "load64",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "load32",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "load16",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "load16s",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "load8",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "load8s",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "loadf32",
+        &[FprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "store64",
+        &[Memory, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        // Materializes large offsets or immediate values via x9.
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "store32",
+        &[Memory, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "store16",
+        &[Memory, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "store8",
+        &[Memory, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "storef32",
+        &[Memory, FprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    // Pair load/store: aarch64 uses x10 when the address is not the cached
+    // pb+pc tuple; x86 emits two sequential mov instructions.
+    info(
+        "load_pair64",
+        &[GprOut, GprOut, Memory, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x10"], ..ArchSpec::NONE },
+    ),
+    info(
+        "load_pair32",
+        &[GprOut, GprOut, Memory, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x10"], ..ArchSpec::NONE },
+    ),
+    info(
+        "store_pair64",
+        &[Memory, Memory, GprIn, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x10"], ..ArchSpec::NONE },
+    ),
+    info(
+        "store_pair32",
+        &[Memory, Memory, GprIn, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x10"], ..ArchSpec::NONE },
+    ),
+    info(
+        "inc32_mem",
+        &[Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "lea",
+        &[GprOut, Memory],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        // Large offsets / non-power-of-two scales go through x9.
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+
+    // ------------------------------------------------------------------
+    // Integer ALU
+    // ------------------------------------------------------------------
+    info(
+        "mov",
+        &[GprOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+    info(
+        "movsxd",
+        &[GprOut, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+    // Two-operand form: dst = dst OP src.
+    info(
+        "add",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "sub",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    // mul: 2-operand (dst *= src) or 3-operand (dst = src * imm). On
+    // x86 imul handles both forms; on aarch64 the 3-operand path needs x9
+    // when the multiplier is an immediate, and the 2-operand path uses x9
+    // for the smull-based overflow check.
+    info(
+        "mul",
+        &[GprOut, GprIn],
+        Some(GprInOrImm),
+        false,
+        false,
+        // x86_64 imul: clobbers rax (movabs of multiplier when needed) -- in
+        // practice the codegen only emits raw `imul` in the 3-operand form
+        // and assumes the multiplier is a small immediate, so no scratch
+        // is needed today. Leave empty.
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "neg",
+        &[GprInOut],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+    info(
+        "not",
+        &[GprInOut],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+    info(
+        "and",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "or",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "xor",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    // Shifts: x86 variable shifts require the count register to be `cl`,
+    // hence the fixed-operand constraint on operand 1. aarch64 has no such
+    // constraint.
+    info(
+        "shl",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec { fixed_operands: &[(1, "rcx")], ..ArchSpec::NONE },
+        ArchSpec::NONE,
+    ),
+    info(
+        "shr",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec { fixed_operands: &[(1, "rcx")], ..ArchSpec::NONE },
+        ArchSpec::NONE,
+    ),
+    info(
+        "sar",
+        &[GprInOut, GprInOrImm],
+        None,
+        false,
+        false,
+        ArchSpec { fixed_operands: &[(1, "rcx")], ..ArchSpec::NONE },
+        ArchSpec::NONE,
+    ),
+    // divmod q, r, n, d: signed divide. On x86, idiv reads/writes rax/rdx,
+    // so the named q/r operands MUST resolve to rax/rdx respectively.
+    // aarch64 has no such constraint -- it uses sdiv + msub on the named
+    // registers directly.
+    info(
+        "divmod",
+        &[GprOut, GprOut, GprIn, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec {
+            fixed_operands: &[(0, "rax"), (1, "rdx")],
+            implicit_outputs: &["rax", "rdx"],
+            ..ArchSpec::NONE
+        },
+        ArchSpec::NONE,
+    ),
+
+    // ------------------------------------------------------------------
+    // 32-bit arithmetic with overflow detection
+    // ------------------------------------------------------------------
+    info(
+        "add32_overflow",
+        &[GprInOut, GprInOrImm, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "sub32_overflow",
+        &[GprInOut, GprInOrImm, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "mul32_overflow",
+        &[GprInOut, GprIn, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        // smull writes a full 64-bit result into the destination, then sxtw
+        // into x9 for the round-trip overflow check.
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "neg32_overflow",
+        &[GprInOut, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+    info(
+        "not32",
+        &[GprInOut],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+
+    // ------------------------------------------------------------------
+    // NaN-boxing operations
+    // ------------------------------------------------------------------
+    plain("extract_tag", &[GprOut, GprIn]),
+    plain("unbox_int32", &[GprOut, GprIn]),
+    plain("unbox_object", &[GprOut, GprIn]),
+    // box_int32 / box_int32_clean: x86 materializes the shifted tag in rax
+    // and ORs it with dst. aarch64 emits movk directly into dst.
+    info(
+        "box_int32",
+        &[GprOut, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        ArchSpec::NONE,
+    ),
+    info(
+        "box_int32_clean",
+        &[GprOut, GprIn],
+        None,
+        false,
+        false,
+        ArchSpec { clobbers_gpr: &["rax"], ..ArchSpec::NONE },
+        ArchSpec::NONE,
+    ),
+
+    // ------------------------------------------------------------------
+    // Bit manipulation
+    // ------------------------------------------------------------------
+    info(
+        "toggle_bit",
+        &[GprInOut, Imm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "clear_bit",
+        &[GprInOut, Imm],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+
+    // ------------------------------------------------------------------
+    // Floating-point
+    // ------------------------------------------------------------------
+    plain("fp_add", &[FprInOut, FprIn]),
+    plain("fp_sub", &[FprInOut, FprIn]),
+    plain("fp_mul", &[FprInOut, FprIn]),
+    plain("fp_div", &[FprInOut, FprIn]),
+    plain("fp_sqrt", &[FprOut, FprIn]),
+    plain("fp_floor", &[FprOut, FprIn]),
+    plain("fp_ceil", &[FprOut, FprIn]),
+    // fp_mov bridges GPR <-> FPR. The codegen looks at register names to
+    // decide direction; the allocator just sees one read and one write.
+    plain("fp_mov", &[GprOut, FprIn]),
+    plain("int_to_double", &[FprOut, GprIn]),
+    plain("float_to_double", &[FprOut, FprIn]),
+    plain("double_to_float", &[FprOut, FprIn]),
+    // double_to_int32 dst, fpr, fail_label
+    // x86 cvttsd2si + round-trip check uses rcx and xmm3 as scratch.
+    // aarch64 fcvtzs + scvtf round-trip uses d16 (outside the public FPR
+    // pool, so no conflict) and no GPR scratch.
+    info(
+        "double_to_int32",
+        &[GprOut, FprIn, Label],
+        None,
+        false,
+        false,
+        ArchSpec {
+            clobbers_gpr: &["rcx"],
+            clobbers_fpr: &["xmm3"],
+            ..ArchSpec::NONE
+        },
+        ArchSpec { clobbers_fpr: &["d16"], ..ArchSpec::NONE },
+    ),
+    // js_to_int32: same shape on x86 (clobbers rcx). On aarch64 with
+    // FEAT_JSCVT this is a single fjcvtzs; otherwise the fallback uses d16
+    // for the round-trip check.
+    info(
+        "js_to_int32",
+        &[GprOut, FprIn, Label],
+        None,
+        false,
+        false,
+        ArchSpec { clobbers_gpr: &["rcx"], ..ArchSpec::NONE },
+        ArchSpec { clobbers_fpr: &["d16"], ..ArchSpec::NONE },
+    ),
+    // canonicalize_nan: the cold fixup path materializes CANON_NAN_BITS.
+    // x86: movabs to dst (no extra scratch). aarch64: pinned d8 holds the
+    // constant, so no scratch.
+    plain("canonicalize_nan", &[GprOut, FprIn]),
+
+    // ------------------------------------------------------------------
+    // Branching
+    // ------------------------------------------------------------------
+    plain("branch_eq", &[GprIn, GprInOrImm, Label]),
+    plain("branch_ne", &[GprIn, GprInOrImm, Label]),
+    plain("branch_ge_unsigned", &[GprIn, GprInOrImm, Label]),
+    plain("branch_lt_signed", &[GprIn, GprInOrImm, Label]),
+    plain("branch_le_signed", &[GprIn, GprInOrImm, Label]),
+    plain("branch_gt_signed", &[GprIn, GprInOrImm, Label]),
+    plain("branch_ge_signed", &[GprIn, GprInOrImm, Label]),
+    plain("branch_zero", &[GprIn, Label]),
+    plain("branch_nonzero", &[GprIn, Label]),
+    plain("branch_negative", &[GprIn, Label]),
+    plain("branch_not_negative", &[GprIn, Label]),
+    plain("branch_zero32", &[GprIn, Label]),
+    plain("branch_nonzero32", &[GprIn, Label]),
+    info(
+        "branch_bits_set",
+        &[GprIn, GprInOrImm, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        // Materializes non-logical-immediate masks via x9.
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "branch_bits_clear",
+        &[GprIn, GprInOrImm, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    info(
+        "branch_bit_set",
+        &[GprIn, Imm, Label],
+        None,
+        false,
+        false,
+        ArchSpec::NONE,
+        // Variable bit count goes through x9.
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
+    ),
+    // branch_any_eq reg, v1, v2, ..., label -- variadic.
+    info(
+        "branch_any_eq",
+        &[GprIn],
+        Some(GprInOrImm),
+        false,
+        false,
+        ArchSpec::NONE,
+        ArchSpec::NONE,
+    ),
+    plain("branch_fp_unordered", &[FprIn, FprIn, Label]),
+    plain("branch_fp_equal", &[FprIn, FprIn, Label]),
+    plain("branch_fp_less", &[FprIn, FprIn, Label]),
+    plain("branch_fp_less_or_equal", &[FprIn, FprIn, Label]),
+    plain("branch_fp_greater", &[FprIn, FprIn, Label]),
+    plain("branch_fp_greater_or_equal", &[FprIn, FprIn, Label]),
+];
+
+/// Lazily-built mnemonic -> info index. Populated on first lookup.
+static INDEX: OnceLock<HashMap<&'static str, usize>> = OnceLock::new();
+
+fn index() -> &'static HashMap<&'static str, usize> {
+    INDEX.get_or_init(|| {
+        let mut map = HashMap::with_capacity(INSTRUCTIONS.len());
+        for (i, info) in INSTRUCTIONS.iter().enumerate() {
+            let prev = map.insert(info.mnemonic, i);
+            assert!(
+                prev.is_none(),
+                "duplicate InstructionInfo entry for '{}'",
+                info.mnemonic
+            );
+        }
+        map
+    })
+}
+
+/// Look up the metadata for a DSL mnemonic. Returns `None` for macro
+/// invocations and unknown names.
+pub fn lookup(mnemonic: &str) -> Option<&'static InstructionInfo> {
+    index().get(mnemonic).map(|&i| &INSTRUCTIONS[i])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every mnemonic the codegens dispatch on must have an entry here.
+    /// When you add a new DSL instruction, add it to `INSTRUCTIONS` and
+    /// to this list.
+    const CODEGEN_MNEMONICS: &[&str] = &[
+        "label",
+        "jmp",
+        "exit",
+        "dispatch_next",
+        "dispatch_variable",
+        "dispatch_current",
+        "goto_handler",
+        "call_slow_path",
+        "call_helper",
+        "call_interp",
+        "call_raw_native",
+        "reload_exec_ctx",
+        "load_vm",
+        "load_operand",
+        "store_operand",
+        "load_label",
+        "load64",
+        "load32",
+        "load16",
+        "load16s",
+        "load8",
+        "load8s",
+        "loadf32",
+        "store64",
+        "store32",
+        "store16",
+        "store8",
+        "storef32",
+        "load_pair64",
+        "load_pair32",
+        "store_pair64",
+        "store_pair32",
+        "inc32_mem",
+        "lea",
+        "mov",
+        "movsxd",
+        "add",
+        "sub",
+        "mul",
+        "neg",
+        "not",
+        "and",
+        "or",
+        "xor",
+        "shl",
+        "shr",
+        "sar",
+        "divmod",
+        "add32_overflow",
+        "sub32_overflow",
+        "mul32_overflow",
+        "neg32_overflow",
+        "not32",
+        "extract_tag",
+        "unbox_int32",
+        "unbox_object",
+        "box_int32",
+        "box_int32_clean",
+        "toggle_bit",
+        "clear_bit",
+        "fp_add",
+        "fp_sub",
+        "fp_mul",
+        "fp_div",
+        "fp_sqrt",
+        "fp_floor",
+        "fp_ceil",
+        "fp_mov",
+        "int_to_double",
+        "float_to_double",
+        "double_to_float",
+        "double_to_int32",
+        "js_to_int32",
+        "canonicalize_nan",
+        "branch_eq",
+        "branch_ne",
+        "branch_ge_unsigned",
+        "branch_lt_signed",
+        "branch_le_signed",
+        "branch_gt_signed",
+        "branch_ge_signed",
+        "branch_zero",
+        "branch_nonzero",
+        "branch_negative",
+        "branch_not_negative",
+        "branch_zero32",
+        "branch_nonzero32",
+        "branch_bits_set",
+        "branch_bits_clear",
+        "branch_bit_set",
+        "branch_any_eq",
+        "branch_fp_unordered",
+        "branch_fp_equal",
+        "branch_fp_less",
+        "branch_fp_less_or_equal",
+        "branch_fp_greater",
+        "branch_fp_greater_or_equal",
+    ];
+
+    #[test]
+    fn every_codegen_mnemonic_is_in_the_table() {
+        for m in CODEGEN_MNEMONICS {
+            assert!(lookup(m).is_some(), "missing InstructionInfo for '{m}'");
+        }
+    }
+
+    #[test]
+    fn no_orphan_table_entries() {
+        use std::collections::HashSet;
+        let known: HashSet<&str> = CODEGEN_MNEMONICS.iter().copied().collect();
+        for info in INSTRUCTIONS {
+            assert!(
+                known.contains(info.mnemonic),
+                "table entry '{}' is not declared in CODEGEN_MNEMONICS",
+                info.mnemonic
+            );
+        }
+    }
+
+    #[test]
+    fn table_entries_are_unique() {
+        // Force the lazy index to build, which asserts uniqueness.
+        let _ = index();
+    }
+
+    #[test]
+    fn calls_imply_non_terminal_or_terminal_consistently() {
+        // call_slow_path is the one call that is also terminal.
+        for info in INSTRUCTIONS {
+            if info.is_call && info.terminal {
+                assert_eq!(
+                    info.mnemonic, "call_slow_path",
+                    "unexpected terminal call: {}",
+                    info.mnemonic
+                );
+            }
+        }
+    }
+}

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -685,8 +685,8 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
     ),
     // divmod q, r, n, d: signed divide. On x86, idiv reads/writes rax/rdx,
     // so the named q/r operands MUST resolve to rax/rdx respectively.
-    // aarch64 has no such constraint -- it uses sdiv + msub on the named
-    // registers directly.
+    // aarch64 computes the quotient in x9 first so q may overlap n/d when
+    // only the remainder is live.
     info(
         "divmod",
         &[GprOut, GprOut, GprIn, GprIn],
@@ -698,7 +698,7 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
             implicit_outputs: &["rax", "rdx"],
             ..ArchSpec::NONE
         },
-        ArchSpec::NONE,
+        ArchSpec { clobbers_gpr: &["x9"], ..ArchSpec::NONE },
     ),
 
     // ------------------------------------------------------------------

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -284,6 +284,7 @@
 
 mod codegen_aarch64;
 mod codegen_x86_64;
+mod instructions;
 mod parser;
 mod registers;
 mod shared;

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -296,6 +296,7 @@
 //! "UNKNOWN" comment for any unhandled mnemonic, which makes it easy to find
 //! missing instructions during development.
 
+mod allocator;
 mod codegen_aarch64;
 mod codegen_x86_64;
 mod instructions;

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -255,9 +255,17 @@
 //! end
 //!
 //! handler OpName, size=N       # Bytecode handler (size optional if in Bytecode.def)
+//!     temp name1, name2, ...   # Declare GPR temporaries (allocator-assigned)
+//!     ftemp name1, ...         # Declare FPR temporaries
 //!     instructions...
 //! end
 //! ```
+//!
+//! Named temporaries declared with `temp` / `ftemp` are scoped to the
+//! enclosing handler or macro body. The register allocator assigns each
+//! to a physical register from the public temp pool; positional aliases
+//! (`t0`-`t8`, `ft0`-`ft3`) remain available for code that wants to pin
+//! a value to a specific platform register.
 //!
 //! Labels within handlers: `.name:` (local, prefixed with handler name in output).
 //!

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -37,14 +37,20 @@
 //!
 //! ## Temporary registers
 //!
-//! | DSL name  | Purpose                                            |
-//! |-----------|----------------------------------------------------|
-//! | `t0`-`t9` | General-purpose scratch (caller-saved)              |
-//! | `ft0`-`ft3` | Floating-point scratch (caller-saved)            |
+//! | DSL name    | Purpose                                            |
+//! |-------------|----------------------------------------------------|
+//! | `t0`-`t8`   | General-purpose scratch (caller-saved)             |
+//! | `ft0`-`ft3` | Floating-point scratch (caller-saved)              |
 //!
 //! Temporaries are **not preserved across C++ calls** (`call_slow_path`,
 //! `call_helper`, `call_interp`, `call_raw_native`). The DSL also provides
 //! `sp` and `fp`.
+//!
+//! On aarch64, `x9`, `x10`, and `d16` are reserved as codegen scratch and
+//! are not addressable by DSL name. On x86_64 several positional aliases
+//! double as hidden scratch (`rax`=t0, `rcx`=t1, `rdx`=t2, `r11`=t8,
+//! `xmm3`=ft3); the per-instruction metadata in `instructions.rs` records
+//! exactly which DSL ops kill which physical registers.
 //!
 //! ## DSL instruction reference
 //!

--- a/Libraries/LibJS/AsmIntGen/src/main.rs
+++ b/Libraries/LibJS/AsmIntGen/src/main.rs
@@ -37,20 +37,19 @@
 //!
 //! ## Temporary registers
 //!
-//! | DSL name    | Purpose                                            |
-//! |-------------|----------------------------------------------------|
-//! | `t0`-`t8`   | General-purpose scratch (caller-saved)             |
-//! | `ft0`-`ft3` | Floating-point scratch (caller-saved)              |
+//! Temporaries are introduced by name with `temp` (GPR) and `ftemp` (FPR)
+//! at the top of a handler or macro body; the register allocator assigns
+//! each to a physical register from the platform's caller-saved pool. The
+//! DSL also exposes `sp` and `fp`. None of the temporaries survive C++
+//! calls (`call_slow_path`, `call_helper`, `call_interp`, `call_raw_native`).
 //!
-//! Temporaries are **not preserved across C++ calls** (`call_slow_path`,
-//! `call_helper`, `call_interp`, `call_raw_native`). The DSL also provides
-//! `sp` and `fp`.
-//!
-//! On aarch64, `x9`, `x10`, and `d16` are reserved as codegen scratch and
-//! are not addressable by DSL name. On x86_64 several positional aliases
-//! double as hidden scratch (`rax`=t0, `rcx`=t1, `rdx`=t2, `r11`=t8,
-//! `xmm3`=ft3); the per-instruction metadata in `instructions.rs` records
-//! exactly which DSL ops kill which physical registers.
+//! Some physical registers are reserved as codegen scratch and are not
+//! addressable as DSL names. On aarch64 these are `x9`, `x10`, and `d16`.
+//! On x86_64 the codegen claims `rax`, `rcx`, `r11`, and `xmm3` as scratch
+//! at specific instructions -- the per-instruction metadata in
+//! `instructions.rs` records exactly which physical registers are killed
+//! by each DSL operation, and the allocator avoids placing a live named
+//! temp in any of those.
 //!
 //! ## DSL instruction reference
 //!

--- a/Libraries/LibJS/AsmIntGen/src/parser.rs
+++ b/Libraries/LibJS/AsmIntGen/src/parser.rs
@@ -305,3 +305,40 @@ fn parse_single_operand(s: &str) -> Operand {
 
     Operand::Register(s.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_temp_declaration_as_instruction() {
+        let prog = parse(
+            "handler Mov\n    temp foo, bar\n    dispatch_next\nend\n",
+        );
+        let handler = &prog.handlers[0];
+        assert_eq!(handler.instructions.len(), 2);
+        let temp = &handler.instructions[0];
+        assert_eq!(temp.mnemonic, "temp");
+        assert_eq!(temp.operands.len(), 2);
+        match &temp.operands[0] {
+            Operand::Register(name) => assert_eq!(name, "foo"),
+            other => panic!("expected Register, got {other:?}"),
+        }
+        match &temp.operands[1] {
+            Operand::Register(name) => assert_eq!(name, "bar"),
+            other => panic!("expected Register, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_ftemp_declaration_as_instruction() {
+        let prog = parse("handler Mov\n    ftemp baz\nend\n");
+        let temp = &prog.handlers[0].instructions[0];
+        assert_eq!(temp.mnemonic, "ftemp");
+        assert_eq!(temp.operands.len(), 1);
+        match &temp.operands[0] {
+            Operand::Register(name) => assert_eq!(name, "baz"),
+            other => panic!("expected Register, got {other:?}"),
+        }
+    }
+}

--- a/Libraries/LibJS/AsmIntGen/src/registers.rs
+++ b/Libraries/LibJS/AsmIntGen/src/registers.rs
@@ -11,7 +11,28 @@ pub enum Arch {
 }
 
 /// DSL register names and their platform mappings.
-/// All of pc, pb, values, exec_ctx, dispatch are callee-saved so they survive C++ calls.
+///
+/// All of pc, pb, values, exec_ctx, dispatch are callee-saved so they
+/// survive C++ calls.
+///
+/// `temporaries` and `fp_temporaries` are the public DSL temp pool: every
+/// listed register is exposed as `tN`/`ftN` and is available to the
+/// register allocator for named temporaries. Registers that the codegen
+/// itself uses as hidden scratch are deliberately *excluded* from these
+/// lists so they cannot collide with user-visible names.
+///
+/// Reserved codegen scratch (not in the temp pool):
+/// - x86_64: none -- the codegen's hidden scratch (rax, rcx, rdx, r11,
+///   xmm3) overlaps with t0/t1/t2/t8/ft3, and the per-instruction
+///   metadata in `instructions.rs` records exactly when each is killed.
+///   The named-temp allocator avoids those registers across the affected
+///   instructions; positional `tN` users are responsible for knowing the
+///   convention.
+/// - aarch64: x9, x10 are universal scratch in the codegen (large-imm
+///   materialization, dispatch tail, pair-memory base computation), and
+///   d16 is FPR scratch for double-to-int32 round-trip checks. x21
+///   caches `pb + pc` for fast dispatch; x22/x23/x24 hold pinned tag
+///   constants. None of these are addressable by DSL name.
 pub struct RegisterMapping {
     pub pc: &'static str,
     pub pb: &'static str,
@@ -42,10 +63,10 @@ pub const AARCH64_REGS: RegisterMapping = RegisterMapping {
     values: "x27",
     exec_ctx: "x28",
     dispatch: "x19",
-    temporaries: &[
-        "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13",
-        "x14", "x15", "x16", "x17",
-    ],
+    // x9 and x10 are reserved as codegen scratch (see the comment on
+    // RegisterMapping). The public pool is t0..t8 = x0..x8, matching the
+    // x86_64 temp count.
+    temporaries: &["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8"],
     fp_temporaries: &["d0", "d1", "d2", "d3"],
     sp: "sp",
     fp: "x29",

--- a/Libraries/LibJS/AsmIntGen/src/registers.rs
+++ b/Libraries/LibJS/AsmIntGen/src/registers.rs
@@ -79,7 +79,10 @@ pub fn mapping_for(arch: Arch) -> &'static RegisterMapping {
     }
 }
 
-/// Resolve a DSL register name to a platform register name.
+/// Resolve a DSL register name to a platform register name. Only the
+/// pinned names are publicly addressable; named temporaries declared via
+/// `temp` / `ftemp` are mapped to physical registers by the allocator
+/// and substituted into the IR before this function is reached.
 pub fn resolve_register(name: &str, arch: Arch) -> Option<String> {
     let m = mapping_for(arch);
     match name {
@@ -90,24 +93,6 @@ pub fn resolve_register(name: &str, arch: Arch) -> Option<String> {
         "dispatch" => Some(m.dispatch.to_string()),
         "sp" => Some(m.sp.to_string()),
         "fp" => Some(m.fp.to_string()),
-        _ => {
-            // t0-t9 -> temporaries
-            if let Some(idx_str) = name.strip_prefix('t') {
-                if let Ok(idx) = idx_str.parse::<usize>() {
-                    if idx < m.temporaries.len() {
-                        return Some(m.temporaries[idx].to_string());
-                    }
-                }
-            }
-            // ft0-ft3 -> fp temporaries
-            if let Some(idx_str) = name.strip_prefix("ft") {
-                if let Ok(idx) = idx_str.parse::<usize>() {
-                    if idx < m.fp_temporaries.len() {
-                        return Some(m.fp_temporaries[idx].to_string());
-                    }
-                }
-            }
-            None
-        }
+        _ => None,
     }
 }

--- a/Libraries/LibJS/AsmIntGen/src/registers.rs
+++ b/Libraries/LibJS/AsmIntGen/src/registers.rs
@@ -96,3 +96,32 @@ pub fn resolve_register(name: &str, arch: Arch) -> Option<String> {
         _ => None,
     }
 }
+
+/// Encoding-cost score for a physical register. Lower is cheaper, so the
+/// allocator should prefer assigning hot named temporaries to low-cost
+/// registers.
+///
+/// On x86_64:
+///   * `rax` is the cheapest. Many arithmetic and logical instructions have
+///     a 1-byte-shorter accumulator-form encoding when the destination is
+///     `rax`/`eax` (e.g. `add eax, imm32` is one byte shorter than
+///     `add r/m32, imm32`).
+///   * The remaining "classic" GPRs (`rcx`, `rdx`, `rbx`, `rsi`, `rdi`)
+///     fit in three encoding bits, so 32-bit forms do not need a REX
+///     prefix at all -- saving one byte per instruction compared to the
+///     "modern" GPRs.
+///   * `r8`..`r15` always need REX.B (or REX.R) to extend the register
+///     field, so they are the most expensive to encode.
+///
+/// On aarch64 every general-purpose register encodes the same way, so the
+/// cost is uniformly zero.
+pub fn register_cost(name: &str, arch: Arch) -> u32 {
+    match arch {
+        Arch::X86_64 => match name {
+            "rax" | "eax" => 0,
+            "rcx" | "rdx" | "rbx" | "rsi" | "rdi" | "ecx" | "edx" | "ebx" | "esi" | "edi" => 1,
+            _ => 2,
+        },
+        Arch::Aarch64 => 0,
+    }
+}

--- a/Libraries/LibJS/AsmIntGen/src/shared.rs
+++ b/Libraries/LibJS/AsmIntGen/src/shared.rs
@@ -142,7 +142,10 @@ pub fn resolve_label(op: &Operand, handler: &Handler) -> String {
                 name.clone()
             }
         }
-        _ => panic!("expected label operand"),
+        other => panic!(
+            "expected label operand in handler '{}', got {other:?}",
+            handler.name
+        ),
     }
 }
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -490,26 +490,29 @@ end
 # ============================================================================
 
 handler Mov
-    load_operand t1, m_src
-    store_operand m_dst, t1
+    temp value
+    load_operand value, m_src
+    store_operand m_dst, value
     dispatch_next
 end
 
 handler Mov2
-    load_operand t1, m_src1
-    store_operand m_dst1, t1
-    load_operand t2, m_src2
-    store_operand m_dst2, t2
+    temp v1, v2
+    load_operand v1, m_src1
+    store_operand m_dst1, v1
+    load_operand v2, m_src2
+    store_operand m_dst2, v2
     dispatch_next
 end
 
 handler Mov3
-    load_operand t1, m_src1
-    store_operand m_dst1, t1
-    load_operand t2, m_src2
-    store_operand m_dst2, t2
-    load_operand t3, m_src3
-    store_operand m_dst3, t3
+    temp v1, v2, v3
+    load_operand v1, m_src1
+    store_operand m_dst1, v1
+    load_operand v2, m_src2
+    store_operand m_dst2, v2
+    load_operand v3, m_src3
+    store_operand m_dst3, v3
     dispatch_next
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1995,8 +1995,8 @@ handler Call
     #    helper that unwinds the callee frame before dispatching to a JS
     #    handler (see .call_raw_native_exception).
     #
-    # Everything else — non-functions, NativeJavaScriptBackedFunction,
-    # ECMAScript functions that can't inline, Proxies, ... — falls through
+    # Everything else -- non-functions, NativeJavaScriptBackedFunction,
+    # ECMAScript functions that can't inline, Proxies, ... -- falls through
     # to .call_slow, i.e. asm_slow_path_call.
     #
     # High-level flow of the ECMAScript fast path:
@@ -2005,394 +2005,389 @@ handler Call
     #   3. Reserve an InterpreterStack frame and populate ExecutionContext.
     #   4. Materialize [registers | locals | constants | arguments].
     #   5. Swap VM state over to the callee frame and dispatch at pc = 0.
-    #
-    # Register usage within this handler:
-    #   t3 = callee ECMAScriptFunctionObject*
-    #   t2 = asm-call metadata / later callee ExecutionContext*
-    #   t7 = callee Executable* carried across `this` binding
-    #   t8 = boxed `this` value carried into the callee
-    load_operand t0, m_callee
-    extract_tag t1, t0
-    branch_ne t1, OBJECT_TAG, .call_slow
-    unbox_object t0, t0
-    mov t3, t0
+    temp callee, callee_value, flags, shared_data, exec_ptr, meta, this_value, tag, scratch, formal_count, passed_count, arg_count, total_slots, regs_locals_count, frame_bytes, vm_ptr, stack_limit, frame_base, value_tail, realm, lex_env, priv_env, empty_tag, som_src, som_lo, som_hi, return_pc, return_dst, base_pc, slot_offset, slot_end, const_count, const_data, const_idx, const_value, write_idx, arg_idx, arg_ops, arg_value, undef_slot, fill_end, native_func, variant, native_return, helper_arg, native_pc, exception_pc, native_total_bytes, after_pc, dst_offset, after_offset, result
+    load_operand callee_value, m_callee
+    extract_tag tag, callee_value
+    branch_ne tag, OBJECT_TAG, .call_slow
+    unbox_object callee, callee_value
 
-    # Non-functions still go through the normal Call slow path for proper error
-    # reporting. Non-ECMAScript function objects get a RawNativeFunction fast
-    # path attempt before we fully give up.
-    load8 t1, [t3, OBJECT_FLAGS]
-    branch_bits_clear t1, OBJECT_FLAG_IS_FUNCTION, .call_slow
-    branch_bits_clear t1, OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT, .call_try_native
+    # Non-functions still go through the normal Call slow path for proper
+    # error reporting. Non-ECMAScript function objects get a
+    # RawNativeFunction fast path attempt before we fully give up.
+    load8 flags, [callee, OBJECT_FLAGS]
+    branch_bits_clear flags, OBJECT_FLAG_IS_FUNCTION, .call_slow
+    branch_bits_clear flags, OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT, .call_try_native
 
-    load64 t2, [t3, ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA]
-    load_pair64 t7, t2, [t2, SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE], [t2, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA]
-    branch_bits_clear t2, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_CAN_INLINE_CALL, .call_slow
+    load64 shared_data, [callee, ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA]
+    load_pair64 exec_ptr, meta, [shared_data, SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE], [shared_data, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA]
+    branch_bits_clear meta, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_CAN_INLINE_CALL, .call_slow
     # NewFunctionEnvironment() allocates and has to stay out of the pure asm
     # path, but we still preserve inline-call semantics via .call_interp_inline.
-    branch_bits_set t2, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_FUNCTION_ENVIRONMENT_NEEDED, .call_interp_inline
+    branch_bits_set meta, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_FUNCTION_ENVIRONMENT_NEEDED, .call_interp_inline
 
     # Bind this without allocations. Sloppy primitive this-values still need
     # ToObject(), so they use the C++ inline-frame helper.
     #
-    # t8 starts as "empty" to match the normal interpreter behavior for
-    # callees that never observe `this`.
-    mov t8, EMPTY_TAG_SHIFTED
-    branch_bits_clear t2, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_USES_THIS, .this_ready
-    load_operand t8, m_this_value
-    branch_bits_set t2, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_STRICT, .this_ready
+    # this_value starts as "empty" to match the normal interpreter behavior
+    # for callees that never observe `this`.
+    mov this_value, EMPTY_TAG_SHIFTED
+    branch_bits_clear meta, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_USES_THIS, .this_ready
+    load_operand this_value, m_this_value
+    branch_bits_set meta, SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_STRICT, .this_ready
 
     # Sloppy null/undefined binds the callee realm's global object.
-    # Sloppy primitive receivers need ToObject(), which may allocate wrappers,
-    # so they go through the helper instead of the full Call slow path.
-    extract_tag t1, t8
-    mov t0, t1
-    and t0, 0xFFFE
-    branch_eq t0, UNDEFINED_TAG, .sloppy_global_this
-    branch_eq t1, OBJECT_TAG, .this_ready
+    # Sloppy primitive receivers need ToObject(), which may allocate
+    # wrappers, so they go through the helper instead of the full slow path.
+    extract_tag tag, this_value
+    mov scratch, tag
+    and scratch, 0xFFFE
+    branch_eq scratch, UNDEFINED_TAG, .sloppy_global_this
+    branch_eq tag, OBJECT_TAG, .this_ready
     jmp .call_interp_inline
 
 .sloppy_global_this:
-    load64 t1, [t3, OBJECT_SHAPE]
-    load64 t1, [t1, SHAPE_REALM]
-    load64 t1, [t1, REALM_GLOBAL_ENVIRONMENT]
-    load64 t1, [t1, GLOBAL_ENVIRONMENT_GLOBAL_THIS_VALUE]
+    load64 scratch, [callee, OBJECT_SHAPE]
+    load64 scratch, [scratch, SHAPE_REALM]
+    load64 scratch, [scratch, REALM_GLOBAL_ENVIRONMENT]
+    load64 scratch, [scratch, GLOBAL_ENVIRONMENT_GLOBAL_THIS_VALUE]
     # Match Value(Object*): keep only the low 48 pointer bits before boxing.
-    shl t1, 16
-    shr t1, 16
-    mov t8, OBJECT_TAG_SHIFTED
-    or t8, t1
+    shl scratch, 16
+    shr scratch, 16
+    mov this_value, OBJECT_TAG_SHIFTED
+    or this_value, scratch
 
 .this_ready:
     # The low 32 bits of the packed metadata word hold the formal parameter count.
-    and t2, 0xFFFFFFFF
+    and meta, 0xFFFFFFFF
 
-    load32 t6, [pb, pc, m_argument_count]
-    mov t4, t2
-    branch_ge_unsigned t4, t6, .arg_count_ready
-    mov t4, t6
+    load32 passed_count, [pb, pc, m_argument_count]
+    mov formal_count, meta
+    branch_ge_unsigned formal_count, passed_count, .arg_count_ready
+    mov formal_count, passed_count
 .arg_count_ready:
-    load_pair32 t5, t1, [t7, EXECUTABLE_REGISTERS_AND_LOCALS_COUNT], [t7, EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT]
+    load_pair32 regs_locals_count, total_slots, [exec_ptr, EXECUTABLE_REGISTERS_AND_LOCALS_COUNT], [exec_ptr, EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT]
 
     # Inline InterpreterStack::allocate().
-    # t1 = total Value slots, t2 = new stack top, t6 = current frame base.
-    add t1, t4
-    mov t2, t1
-    shl t2, 3
-    add t2, SIZEOF_EXECUTION_CONTEXT
+    add total_slots, formal_count
+    mov frame_bytes, total_slots
+    shl frame_bytes, 3
+    add frame_bytes, SIZEOF_EXECUTION_CONTEXT
 
-    load_vm t0
-    lea t0, [t0, VM_INTERPRETER_STACK]
-    load_pair64 t6, t0, [t0, INTERPRETER_STACK_TOP], [t0, INTERPRETER_STACK_LIMIT]
-    add t2, t6
-    branch_ge_unsigned t0, t2, .stack_ok
+    load_vm vm_ptr
+    lea vm_ptr, [vm_ptr, VM_INTERPRETER_STACK]
+    load_pair64 frame_base, stack_limit, [vm_ptr, INTERPRETER_STACK_TOP], [vm_ptr, INTERPRETER_STACK_LIMIT]
+    add frame_bytes, frame_base
+    branch_ge_unsigned stack_limit, frame_bytes, .stack_ok
     jmp .call_slow
 
 .stack_ok:
-    load_vm t0
-    store64 [t0, VM_INTERPRETER_STACK_TOP], t2
+    load_vm vm_ptr
+    store64 [vm_ptr, VM_INTERPRETER_STACK_TOP], frame_bytes
 
     # Set up the callee ExecutionContext header exactly the way
     # VM::push_inline_frame() / run_executable() would see it.
-    mov t2, t6
-    lea t6, [t6, SIZEOF_EXECUTION_CONTEXT]
-    store_pair32 [t2, EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT], [t2, EXECUTION_CONTEXT_ARGUMENT_COUNT], t1, t4
-    load32 t0, [pb, pc, m_argument_count]
-    store32 [t2, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT], t0
+    lea value_tail, [frame_base, SIZEOF_EXECUTION_CONTEXT]
+    store_pair32 [frame_base, EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT], [frame_base, EXECUTION_CONTEXT_ARGUMENT_COUNT], total_slots, formal_count
+    load32 scratch, [pb, pc, m_argument_count]
+    store32 [frame_base, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT], scratch
 
-    load64 t0, [t3, OBJECT_SHAPE]
-    load64 t0, [t0, SHAPE_REALM]
-    store_pair64 [t2, EXECUTION_CONTEXT_FUNCTION], [t2, EXECUTION_CONTEXT_REALM], t3, t0
+    load64 realm, [callee, OBJECT_SHAPE]
+    load64 realm, [realm, SHAPE_REALM]
+    store_pair64 [frame_base, EXECUTION_CONTEXT_FUNCTION], [frame_base, EXECUTION_CONTEXT_REALM], callee, realm
 
-    load_pair64 t0, t1, [t3, ECMASCRIPT_FUNCTION_OBJECT_ENVIRONMENT], [t3, ECMASCRIPT_FUNCTION_OBJECT_PRIVATE_ENVIRONMENT]
-    store_pair64 [t2, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [t2, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT], t0, t0
-    store64 [t2, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT], t1
-    store_pair64 [t2, EXECUTION_CONTEXT_THIS_VALUE], [t2, EXECUTION_CONTEXT_EXECUTABLE], t8, t7
+    load_pair64 lex_env, priv_env, [callee, ECMASCRIPT_FUNCTION_OBJECT_ENVIRONMENT], [callee, ECMASCRIPT_FUNCTION_OBJECT_PRIVATE_ENVIRONMENT]
+    store_pair64 [frame_base, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [frame_base, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT], lex_env, lex_env
+    store64 [frame_base, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT], priv_env
+    store_pair64 [frame_base, EXECUTION_CONTEXT_THIS_VALUE], [frame_base, EXECUTION_CONTEXT_EXECUTABLE], this_value, exec_ptr
 
-    mov t1, EMPTY_TAG_SHIFTED
-    store_pair64 [t6, ACCUMULATOR_REG_OFFSET], [t6, EXCEPTION_REG_OFFSET], t1, t1
-    store64 [t6, THIS_VALUE_REG_OFFSET], t8
-    store_pair64 [t6, RETURN_VALUE_REG_OFFSET], [t6, SAVED_LEXICAL_ENVIRONMENT_REG_OFFSET], t1, t1
+    mov empty_tag, EMPTY_TAG_SHIFTED
+    store_pair64 [value_tail, ACCUMULATOR_REG_OFFSET], [value_tail, EXCEPTION_REG_OFFSET], empty_tag, empty_tag
+    store64 [value_tail, THIS_VALUE_REG_OFFSET], this_value
+    store_pair64 [value_tail, RETURN_VALUE_REG_OFFSET], [value_tail, SAVED_LEXICAL_ENVIRONMENT_REG_OFFSET], empty_tag, empty_tag
 
     # ScriptOrModule is a two-word Variant in ExecutionContext, so copy both
     # machine words explicitly.
-    lea t0, [t2, EXECUTION_CONTEXT_SCRIPT_OR_MODULE]
-    lea t7, [t3, ECMASCRIPT_FUNCTION_OBJECT_SCRIPT_OR_MODULE]
-    load_pair64 t3, t8, [t7, 0], [t7, 8]
-    store64 [t0, 0], t3
-    store64 [t0, 8], t8
+    lea scratch, [frame_base, EXECUTION_CONTEXT_SCRIPT_OR_MODULE]
+    lea som_src, [callee, ECMASCRIPT_FUNCTION_OBJECT_SCRIPT_OR_MODULE]
+    load_pair64 som_lo, som_hi, [som_src, 0], [som_src, 8]
+    store64 [scratch, 0], som_lo
+    store64 [scratch, 8], som_hi
 
-    store32 [t2, EXECUTION_CONTEXT_PROGRAM_COUNTER], 0
-    store32 [t2, EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER], 0
-    mov t0, EXECUTION_CONTEXT_NO_YIELD_CONTINUATION
-    store32 [t2, EXECUTION_CONTEXT_YIELD_CONTINUATION], t0
-    store8 [t2, EXECUTION_CONTEXT_YIELD_IS_AWAIT], 0
-    store8 [t2, EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT], 0
-    store64 [t2, EXECUTION_CONTEXT_CALLER_FRAME], exec_ctx
-    load_pair32 t0, t1, [pb, pc, m_length], [pb, pc, m_dst]
-    lea t3, [pb, pc]
-    sub t3, pb
-    add t0, t3
-    store_pair32 [t2, EXECUTION_CONTEXT_CALLER_RETURN_PC], [t2, EXECUTION_CONTEXT_CALLER_DST_RAW], t0, t1
+    store32 [frame_base, EXECUTION_CONTEXT_PROGRAM_COUNTER], 0
+    store32 [frame_base, EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER], 0
+    mov scratch, EXECUTION_CONTEXT_NO_YIELD_CONTINUATION
+    store32 [frame_base, EXECUTION_CONTEXT_YIELD_CONTINUATION], scratch
+    store8 [frame_base, EXECUTION_CONTEXT_YIELD_IS_AWAIT], 0
+    store8 [frame_base, EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT], 0
+    store64 [frame_base, EXECUTION_CONTEXT_CALLER_FRAME], exec_ctx
+    load_pair32 return_pc, return_dst, [pb, pc, m_length], [pb, pc, m_dst]
+    lea base_pc, [pb, pc]
+    sub base_pc, pb
+    add return_pc, base_pc
+    store_pair32 [frame_base, EXECUTION_CONTEXT_CALLER_RETURN_PC], [frame_base, EXECUTION_CONTEXT_CALLER_DST_RAW], return_pc, return_dst
 
     # values = [registers | locals | constants | arguments]
-    # Keep t2 at the ExecutionContext base while t6 walks the Value tail.
-    mov t0, t5
-    shl t0, 3
-    mov t3, RESERVED_REGISTERS_SIZE
+    # Walk value_tail with two cursors: slot_offset for the byte index and
+    # write_idx for the element index when copying constants/arguments.
+    mov slot_end, regs_locals_count
+    shl slot_end, 3
+    mov slot_offset, RESERVED_REGISTERS_SIZE
 .clear_registers_and_locals:
-    mov t8, t3
-    add t8, 8
-    branch_ge_unsigned t8, t0, .clear_registers_and_locals_tail
-    store_pair64 [t6, t3, 0], [t6, t3, 8], t1, t1
-    add t3, 16
+    mov scratch, slot_offset
+    add scratch, 8
+    branch_ge_unsigned scratch, slot_end, .clear_registers_and_locals_tail
+    store_pair64 [value_tail, slot_offset, 0], [value_tail, slot_offset, 8], empty_tag, empty_tag
+    add slot_offset, 16
     jmp .clear_registers_and_locals
 
 .clear_registers_and_locals_tail:
-    branch_ge_unsigned t3, t0, .copy_constants
-    store64 [t6, t3], t1
+    branch_ge_unsigned slot_offset, slot_end, .copy_constants
+    store64 [value_tail, slot_offset], empty_tag
 
 .copy_constants:
-    load64 t0, [t2, EXECUTION_CONTEXT_EXECUTABLE]
-    load_pair64 t3, t0, [t0, EXECUTABLE_ASM_CONSTANTS_SIZE], [t0, EXECUTABLE_ASM_CONSTANTS_DATA]
-    mov t1, t5
-    xor t8, t8
+    load64 const_data, [frame_base, EXECUTION_CONTEXT_EXECUTABLE]
+    load_pair64 const_count, const_data, [const_data, EXECUTABLE_ASM_CONSTANTS_SIZE], [const_data, EXECUTABLE_ASM_CONSTANTS_DATA]
+    mov write_idx, regs_locals_count
+    xor const_idx, const_idx
 .copy_constants_loop:
-    branch_ge_unsigned t8, t3, .copy_arguments
-    load64 t7, [t0, t8, 8]
-    store64 [t6, t1, 8], t7
-    add t8, 1
-    add t1, 1
+    branch_ge_unsigned const_idx, const_count, .copy_arguments
+    load64 const_value, [const_data, const_idx, 8]
+    store64 [value_tail, write_idx, 8], const_value
+    add const_idx, 1
+    add write_idx, 1
     jmp .copy_constants_loop
 
 .copy_arguments:
-    load32 t7, [pb, pc, m_argument_count]
-    mov t1, t5
-    add t1, t3
-    lea t0, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    lea t8, [pb, pc]
-    add t8, m_expression_string
-    add t8, 4
-    xor t3, t3
+    load32 arg_count, [pb, pc, m_argument_count]
+    mov write_idx, regs_locals_count
+    add write_idx, const_count
+    lea scratch, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    lea arg_ops, [pb, pc]
+    add arg_ops, m_expression_string
+    add arg_ops, 4
+    xor arg_idx, arg_idx
 .copy_arguments_loop:
     # The operand array in the bytecode stores caller register indices.
-    branch_ge_unsigned t3, t7, .fill_missing_arguments
-    load32 t5, [t8, t3, 4]
-    load64 t5, [t0, t5, 8]
-    store64 [t6, t1, 8], t5
-    add t3, 1
-    add t1, 1
+    branch_ge_unsigned arg_idx, arg_count, .fill_missing_arguments
+    load32 arg_value, [arg_ops, arg_idx, 4]
+    load64 arg_value, [scratch, arg_value, 8]
+    store64 [value_tail, write_idx, 8], arg_value
+    add arg_idx, 1
+    add write_idx, 1
     jmp .copy_arguments_loop
 
 .fill_missing_arguments:
-    mov t3, t1
-    add t3, t4
-    sub t3, t7
-    mov t0, UNDEFINED_SHIFTED
+    mov fill_end, write_idx
+    add fill_end, formal_count
+    sub fill_end, arg_count
+    mov undef_slot, UNDEFINED_SHIFTED
 .fill_missing_arguments_loop:
-    branch_ge_unsigned t1, t3, .enter_callee
-    store64 [t6, t1, 8], t0
-    add t1, 1
+    branch_ge_unsigned write_idx, fill_end, .enter_callee
+    store64 [value_tail, write_idx, 8], undef_slot
+    add write_idx, 1
     jmp .fill_missing_arguments_loop
 
 .enter_callee:
-    load64 pb, [t2, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [frame_base, EXECUTION_CONTEXT_EXECUTABLE]
     load64 pb, [pb, EXECUTABLE_BYTECODE_DATA]
-    load_vm t0
-    store64 [t0, VM_RUNNING_EXECUTION_CONTEXT], t2
-    mov exec_ctx, t2
+    load_vm vm_ptr
+    store64 [vm_ptr, VM_RUNNING_EXECUTION_CONTEXT], frame_base
+    mov exec_ctx, frame_base
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
     xor pc, pc
     goto_handler pc
 .call_interp_inline:
-    # Shared escape hatch for the cases that need C++ help to build the inline
-    # frame correctly but must not take the full Call slow path, since that
-    # would insert a run_executable() boundary and observable microtask drain.
-    call_interp asm_try_inline_call
-    branch_nonzero t0, .call_slow
-    load_vm t0
-    load64 exec_ctx, [t0, VM_RUNNING_EXECUTION_CONTEXT]
+    # Shared escape hatch for the cases that need C++ help to build the
+    # inline frame correctly but must not take the full Call slow path,
+    # since that would insert a run_executable() boundary and observable
+    # microtask drain.
+    call_interp asm_try_inline_call, result
+    branch_nonzero result, .call_slow
+    load_vm vm_ptr
+    load64 exec_ctx, [vm_ptr, VM_RUNNING_EXECUTION_CONTEXT]
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    load64 t0, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
-    load64 pb, [t0, EXECUTABLE_BYTECODE_DATA]
+    load64 scratch, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [scratch, EXECUTABLE_BYTECODE_DATA]
     xor pc, pc
     goto_handler pc
 .call_try_native:
     # Fast path for RawNativeFunction: the callee is a plain C++ function
     # pointer with no JS-visible prologue, so we can build the callee frame
-    # ourselves and jump straight at the entry point. NativeFunction objects
-    # that still carry a callback (NativeJavaScriptBackedFunction) do not have
-    # this flag set and fall through to .call_slow.
-    load8 t0, [t3, OBJECT_FLAGS]
-    branch_bits_clear t0, OBJECT_FLAG_IS_RAW_NATIVE_FUNCTION, .call_slow
+    # ourselves and jump straight at the entry point. NativeFunction
+    # objects that still carry a callback (NativeJavaScriptBackedFunction)
+    # do not have this flag set and fall through to .call_slow.
+    load8 flags, [callee, OBJECT_FLAGS]
+    branch_bits_clear flags, OBJECT_FLAG_IS_RAW_NATIVE_FUNCTION, .call_slow
 
     # Unlike the ECMAScript path we don't pad to the formal parameter count:
     # native functions read their arguments via the passed-count API, so we
-    # only need space for the call-site arguments plus the ExecutionContext
-    # header. t4 = argument count, t5 = total bytes needed for this frame.
-    load32 t4, [pb, pc, m_argument_count]
-    mov t5, t4
-    shl t5, 3
-    add t5, SIZEOF_EXECUTION_CONTEXT
+    # only need space for the call-site arguments plus the EC header.
+    load32 arg_count, [pb, pc, m_argument_count]
+    mov native_total_bytes, arg_count
+    shl native_total_bytes, 3
+    add native_total_bytes, SIZEOF_EXECUTION_CONTEXT
 
     # Inline InterpreterStack::allocate(): bail to C++ if the interpreter
-    # stack doesn't have room for the new frame. t6 = new frame base (old
-    # top), t5 becomes the new top after the add below.
-    load_vm t0
-    lea t0, [t0, VM_INTERPRETER_STACK]
-    load_pair64 t6, t7, [t0, INTERPRETER_STACK_TOP], [t0, INTERPRETER_STACK_LIMIT]
-    add t5, t6
-    branch_ge_unsigned t7, t5, .native_interpreter_stack_ok
+    # stack doesn't have room for the new frame.
+    load_vm vm_ptr
+    lea vm_ptr, [vm_ptr, VM_INTERPRETER_STACK]
+    load_pair64 frame_base, stack_limit, [vm_ptr, INTERPRETER_STACK_TOP], [vm_ptr, INTERPRETER_STACK_LIMIT]
+    add native_total_bytes, frame_base
+    branch_ge_unsigned stack_limit, native_total_bytes, .native_interpreter_stack_ok
     jmp .call_slow
 
 .native_interpreter_stack_ok:
-    # RawNativeFunctions run real C++ code on the host stack, so we also have
-    # to check that we're not about to blow past the VM's reserved stack
-    # limit. The ECMAScript path can skip this because it never leaves asm.
-    load_vm t0
-    lea t0, [t0, VM_STACK_INFO]
-    load64 t7, [t0, STACK_INFO_BASE]
-    add t7, VM_STACK_SPACE_LIMIT
-    branch_ge_unsigned fp, t7, .native_stack_space_ok
+    # RawNativeFunctions run real C++ code on the host stack, so we also
+    # have to check that we're not about to blow past the VM's reserved
+    # stack limit. The ECMAScript path can skip this because it never
+    # leaves asm.
+    load_vm vm_ptr
+    lea vm_ptr, [vm_ptr, VM_STACK_INFO]
+    load64 stack_limit, [vm_ptr, STACK_INFO_BASE]
+    add stack_limit, VM_STACK_SPACE_LIMIT
+    branch_ge_unsigned fp, stack_limit, .native_stack_space_ok
     jmp .call_slow
 
 .native_stack_space_ok:
-    # Commit the new interpreter stack top. From here on we own [t6, t5).
-    load_vm t0
-    store64 [t0, VM_INTERPRETER_STACK_TOP], t5
+    # Commit the new interpreter stack top.
+    load_vm vm_ptr
+    store64 [vm_ptr, VM_INTERPRETER_STACK_TOP], native_total_bytes
 
-    # Populate the callee ExecutionContext to match what VM::push_execution_context
-    # plus NativeFunction::internal_call would produce. t2 tracks the EC
-    # header, t6 advances to the argument Value array that follows it.
-    mov t2, t6
-    lea t6, [t6, SIZEOF_EXECUTION_CONTEXT]
-    # For natives, argument_count and "registers+..." total are both just the
-    # call-site argument count: there are no registers, locals, or constants.
-    store_pair32 [t2, EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT], [t2, EXECUTION_CONTEXT_ARGUMENT_COUNT], t4, t4
-    store32 [t2, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT], t4
+    # Populate the callee EC to match VM::push_execution_context plus
+    # NativeFunction::internal_call. value_tail walks past the EC header to
+    # the argument Value array.
+    lea value_tail, [frame_base, SIZEOF_EXECUTION_CONTEXT]
+    # For natives, argument_count and "registers+..." total are both just
+    # the call-site argument count: there are no registers, locals, or
+    # constants.
+    store_pair32 [frame_base, EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT], [frame_base, EXECUTION_CONTEXT_ARGUMENT_COUNT], arg_count, arg_count
+    store32 [frame_base, EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT], arg_count
 
     # Shape stores a Realm pointer; use it as the callee EC realm.
-    load64 t0, [t3, OBJECT_SHAPE]
-    load64 t0, [t0, SHAPE_REALM]
-    store_pair64 [t2, EXECUTION_CONTEXT_FUNCTION], [t2, EXECUTION_CONTEXT_REALM], t3, t0
+    load64 realm, [callee, OBJECT_SHAPE]
+    load64 realm, [realm, SHAPE_REALM]
+    store_pair64 [frame_base, EXECUTION_CONTEXT_FUNCTION], [frame_base, EXECUTION_CONTEXT_REALM], callee, realm
 
-    # Mirror NativeFunction::internal_call: a raw native has no environment of
-    # its own, so lexical/variable/private environments are copied straight
-    # from the caller frame.
-    load_pair64 t0, t7, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [exec_ctx, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT]
-    store_pair64 [t2, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [t2, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT], t0, t7
-    load64 t0, [exec_ctx, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT]
-    store64 [t2, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT], t0
-    # |this| is forwarded unchanged. Native builtins do their own type checks
-    # on the receiver where they need to.
-    load_operand t0, m_this_value
-    store64 [t2, EXECUTION_CONTEXT_THIS_VALUE], t0
+    # Mirror NativeFunction::internal_call: a raw native has no environment
+    # of its own, so lexical/variable/private environments are copied
+    # straight from the caller frame.
+    load_pair64 lex_env, scratch, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [exec_ctx, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT]
+    store_pair64 [frame_base, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT], [frame_base, EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT], lex_env, scratch
+    load64 priv_env, [exec_ctx, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT]
+    store64 [frame_base, EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT], priv_env
+    # |this| is forwarded unchanged. Native builtins do their own type
+    # checks on the receiver where they need to.
+    load_operand this_value, m_this_value
+    store64 [frame_base, EXECUTION_CONTEXT_THIS_VALUE], this_value
 
-    # Zero out the ScriptOrModule variant (two words) and Executable pointer.
-    # Native frames don't belong to any script/module and have no bytecode.
-    xor t0, t0
-    lea t7, [t2, EXECUTION_CONTEXT_SCRIPT_OR_MODULE]
-    store_pair64 [t7, 0], [t7, 8], t0, t0
-    store64 [t2, EXECUTION_CONTEXT_EXECUTABLE], t0
-    store32 [t2, EXECUTION_CONTEXT_PROGRAM_COUNTER], 0
-    store32 [t2, EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER], 0
-    mov t0, EXECUTION_CONTEXT_NO_YIELD_CONTINUATION
-    store32 [t2, EXECUTION_CONTEXT_YIELD_CONTINUATION], t0
-    store8 [t2, EXECUTION_CONTEXT_YIELD_IS_AWAIT], 0
-    store8 [t2, EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT], 0
+    # Zero out the ScriptOrModule variant (two words) and Executable
+    # pointer. Native frames don't belong to any script/module.
+    xor scratch, scratch
+    lea som_src, [frame_base, EXECUTION_CONTEXT_SCRIPT_OR_MODULE]
+    store_pair64 [som_src, 0], [som_src, 8], scratch, scratch
+    store64 [frame_base, EXECUTION_CONTEXT_EXECUTABLE], scratch
+    store32 [frame_base, EXECUTION_CONTEXT_PROGRAM_COUNTER], 0
+    store32 [frame_base, EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER], 0
+    mov scratch, EXECUTION_CONTEXT_NO_YIELD_CONTINUATION
+    store32 [frame_base, EXECUTION_CONTEXT_YIELD_CONTINUATION], scratch
+    store8 [frame_base, EXECUTION_CONTEXT_YIELD_IS_AWAIT], 0
+    store8 [frame_base, EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT], 0
 
     # While asm runs, the authoritative program counter lives in the `pc`
-    # register and the caller EC's stored program_counter is stale. Before we
-    # leave asm to run native C++ that may throw, sync `pc` into the caller
-    # EC as a bytecode offset (pc - pb). asm_helper_handle_raw_native_exception
-    # and VM::handle_exception both read from the caller EC after unwind.
-    lea t7, [pb, pc]
-    sub t7, pb
-    store32 [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER], t7
-    store64 [t2, EXECUTION_CONTEXT_CALLER_FRAME], exec_ctx
-    # CALLER_RETURN_PC is the bytecode offset of the instruction after the
-    # Call (Call offset + Call length). CALLER_DST_RAW records where the
-    # return value should be written in the caller's value array.
-    load32 t0, [pb, pc, m_length]
-    add t0, t7
-    store32 [t2, EXECUTION_CONTEXT_CALLER_RETURN_PC], t0
-    load32 t0, [pb, pc, m_dst]
-    store32 [t2, EXECUTION_CONTEXT_CALLER_DST_RAW], t0
+    # register and the caller EC's stored program_counter is stale. Before
+    # we leave asm to run native C++ that may throw, sync `pc` into the
+    # caller EC as a bytecode offset (pc - pb). The exception helper and
+    # VM::handle_exception both read from the caller EC after unwind.
+    lea native_pc, [pb, pc]
+    sub native_pc, pb
+    store32 [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER], native_pc
+    store64 [frame_base, EXECUTION_CONTEXT_CALLER_FRAME], exec_ctx
+    # CALLER_RETURN_PC is the bytecode offset of the instruction after
+    # the Call. CALLER_DST_RAW records where the return value should
+    # be written in the caller's value array.
+    load32 after_pc, [pb, pc, m_length]
+    add after_pc, native_pc
+    store32 [frame_base, EXECUTION_CONTEXT_CALLER_RETURN_PC], after_pc
+    load32 dst_offset, [pb, pc, m_dst]
+    store32 [frame_base, EXECUTION_CONTEXT_CALLER_DST_RAW], dst_offset
 
     # Copy the call-site arguments from the caller's value array into the
-    # callee frame's argument tail. t0 points at the caller's value array,
-    # t8 at the Operand[] that trails the fixed Call instruction fields.
-    # The Call layout ends with `m_expression_string: Optional<StringTableIndex>`
-    # (4 bytes via the sentinel specialization) followed by `m_arguments`, so
-    # base + offsetof(m_expression_string) + 4 is the operand array.
-    lea t0, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    lea t8, [pb, pc]
-    add t8, m_expression_string
-    add t8, 4
-    xor t7, t7
+    # callee frame's argument tail. scratch points at the caller's value
+    # array, arg_ops at the Operand[] that trails the fixed Call instruction
+    # fields. The Call layout ends with `m_expression_string:
+    # Optional<StringTableIndex>` (4 bytes via the sentinel specialization)
+    # followed by `m_arguments`, so base + offsetof(m_expression_string) + 4
+    # is the operand array.
+    lea scratch, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
+    lea arg_ops, [pb, pc]
+    add arg_ops, m_expression_string
+    add arg_ops, 4
+    xor arg_idx, arg_idx
 .copy_native_arguments_loop:
-    branch_ge_unsigned t7, t4, .enter_raw_native
-    load32 t5, [t8, t7, 4]
-    load64 t5, [t0, t5, 8]
-    store64 [t6, t7, 8], t5
-    add t7, 1
+    branch_ge_unsigned arg_idx, arg_count, .enter_raw_native
+    load32 arg_value, [arg_ops, arg_idx, 4]
+    load64 arg_value, [scratch, arg_value, 8]
+    store64 [value_tail, arg_idx, 8], arg_value
+    add arg_idx, 1
     jmp .copy_native_arguments_loop
 
 .enter_raw_native:
     # Swap the running ExecutionContext over to the callee and point the
     # asm `values` register at its argument array. After this, we look like
     # a normal inline frame from the VM's perspective.
-    load_vm t0
-    store64 [t0, VM_RUNNING_EXECUTION_CONTEXT], t2
-    mov exec_ctx, t2
+    load_vm vm_ptr
+    store64 [vm_ptr, VM_RUNNING_EXECUTION_CONTEXT], frame_base
+    mov exec_ctx, frame_base
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
 
-    # Invoke the raw C++ function pointer. call_raw_native lowers to a native
-    # call through the platform ABI and surfaces the returned
-    # ThrowCompletionOr<Value> via (t0, t1): t0 is the Value payload and t1
-    # holds the Variant discriminator in its low byte (0 = Value, 1 =
-    # ErrorValue). Anything non-zero in that byte means the native threw and
-    # t0 is the thrown Value, not a return value.
-    load64 t3, [t3, RAW_NATIVE_FUNCTION_NATIVE_FUNCTION]
-    call_raw_native t3
-    and t1, 0xFF
-    branch_nonzero t1, .call_raw_native_exception
+    # Invoke the raw C++ function pointer. call_raw_native lowers to a
+    # native call through the platform ABI and surfaces the returned
+    # ThrowCompletionOr<Value> via (payload, variant). The variant low byte
+    # is 0 for a Value, 1 for an ErrorValue; anything else means the native
+    # threw and payload is the thrown Value, not a return value.
+    load64 native_func, [callee, RAW_NATIVE_FUNCTION_NATIVE_FUNCTION]
+    call_raw_native native_func, native_return, variant
+    and variant, 0xFF
+    branch_nonzero variant, .call_raw_native_exception
 
     # Normal return path: tear the callee frame off the interpreter stack,
     # restore the caller as the running ExecutionContext, write the return
     # value into the caller's m_dst operand, and dispatch the next insn.
-    load64 t2, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
-    load_vm t3
-    store64 [t3, VM_RUNNING_EXECUTION_CONTEXT], t2
-    store64 [t3, VM_INTERPRETER_STACK_TOP], exec_ctx
-    mov exec_ctx, t2
+    load64 frame_base, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
+    load_vm vm_ptr
+    store64 [vm_ptr, VM_RUNNING_EXECUTION_CONTEXT], frame_base
+    store64 [vm_ptr, VM_INTERPRETER_STACK_TOP], exec_ctx
+    mov exec_ctx, frame_base
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    store_operand m_dst, t0
-    load32 t0, [pb, pc, m_length]
-    dispatch_variable t0
+    store_operand m_dst, native_return
+    load32 after_offset, [pb, pc, m_length]
+    dispatch_variable after_offset
 
 .call_raw_native_exception:
     # The native threw. Hand the thrown Value off to a C++ helper, which
     # unwinds the callee frame off the interpreter stack and calls through
-    # to VM::handle_exception. Return value (t0) follows the standard asm
+    # to VM::handle_exception. Return value follows the standard asm
     # slow-path convention (see AsmInterpreter.cpp:127):
-    #   >= 0 : an enclosing handler was found; t0 is the new program counter
-    #          to resume at inside the (post-unwind) running execution context.
+    #   >= 0 : an enclosing handler was found; the result is the new
+    #          program counter to resume at inside the (post-unwind)
+    #          running execution context.
     #    < 0 : no handler; bail out of the asm dispatch loop entirely.
-    mov t1, t0
-    call_helper asm_helper_handle_raw_native_exception
-    branch_negative t0, .call_exit_asm
-    jmp .call_exception_handled
-.call_exception_handled:
-    # Reload exec_ctx/values/pb/pc from the caller frame the helper left us
-    # on, and resume dispatching at its program_counter (which the helper
-    # already updated to the handler entry).
-    load_vm t0
-    load64 exec_ctx, [t0, VM_RUNNING_EXECUTION_CONTEXT]
+    # native_return is pinned to rax by call_raw_native; helper_arg is
+    # pinned to rcx by call_helper, so this mov is the explicit bridge
+    # between the two ABIs.
+    mov helper_arg, native_return
+    call_helper asm_helper_handle_raw_native_exception, helper_arg, exception_pc
+    branch_negative exception_pc, .call_exit_asm
+    # Reload exec_ctx/values/pb/pc from the caller frame the helper left
+    # us on, and resume dispatching at its program_counter (which the
+    # helper already updated to the handler entry).
+    load_vm vm_ptr
+    load64 exec_ctx, [vm_ptr, VM_RUNNING_EXECUTION_CONTEXT]
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    load64 t0, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
-    load64 pb, [t0, EXECUTABLE_BYTECODE_DATA]
-    load32 t2, [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER]
-    mov pc, t2
+    load64 scratch, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [scratch, EXECUTABLE_BYTECODE_DATA]
+    load32 native_pc, [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER]
+    mov pc, native_pc
     goto_handler pc
 .call_exit_asm:
     # No JS handler caught the native exception; bail out of the asm

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -11,9 +11,11 @@
 #   exec_ctx = running ExecutionContext*
 #   dispatch = dispatch table base pointer (256 entries, 8 bytes each)
 #
-# Temporary registers (caller-saved, clobbered by C++ calls):
-#   t0-t8    = general-purpose scratch
-#   ft0-ft3  = floating-point scratch (scalar double)
+# Temporary registers are declared by name with `temp` (GPR) and
+# `ftemp` (FPR) inside each handler or macro; the register allocator
+# assigns them to physical registers from the platform's caller-saved
+# pool. None of the temps survive C++ calls (`call_slow_path`,
+# `call_helper`, `call_interp`, `call_raw_native`).
 #
 # NaN-boxing encoding:
 #   Every JS Value is a 64-bit NaN-boxed value. The upper 16 bits encode the type tag.
@@ -477,24 +479,23 @@ end
 # Input:
 #   caller_frame = ExecutionContext* of the caller
 #   value_reg = NaN-boxed return value
-# Clobbers:
-#   t2, t3, t4
 macro pop_inline_frame_and_resume(caller_frame, value_reg)
-    load_pair32 t2, t4, [exec_ctx, EXECUTION_CONTEXT_CALLER_RETURN_PC], [exec_ctx, EXECUTION_CONTEXT_CALLER_DST_RAW]
-    store32 [caller_frame, EXECUTION_CONTEXT_PROGRAM_COUNTER], t2
-    lea t3, [caller_frame, SIZEOF_EXECUTION_CONTEXT]
-    store64 [t3, t4, 8], value_reg
+    temp ret_pc, dst_idx, value_addr, vm, exe
+    load_pair32 ret_pc, dst_idx, [exec_ctx, EXECUTION_CONTEXT_CALLER_RETURN_PC], [exec_ctx, EXECUTION_CONTEXT_CALLER_DST_RAW]
+    store32 [caller_frame, EXECUTION_CONTEXT_PROGRAM_COUNTER], ret_pc
+    lea value_addr, [caller_frame, SIZEOF_EXECUTION_CONTEXT]
+    store64 [value_addr, dst_idx, 8], value_reg
 
-    load_vm t3
-    store64 [t3, VM_RUNNING_EXECUTION_CONTEXT], caller_frame
-    store64 [t3, VM_INTERPRETER_STACK_TOP], exec_ctx
-    inc32_mem [t3, VM_EXECUTION_GENERATION]
+    load_vm vm
+    store64 [vm, VM_RUNNING_EXECUTION_CONTEXT], caller_frame
+    store64 [vm, VM_INTERPRETER_STACK_TOP], exec_ctx
+    inc32_mem [vm, VM_EXECUTION_GENERATION]
 
     mov exec_ctx, caller_frame
-    load64 t3, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
-    load64 pb, [t3, EXECUTABLE_BYTECODE_DATA]
+    load64 exe, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 pb, [exe, EXECUTABLE_BYTECODE_DATA]
     lea values, [exec_ctx, SIZEOF_EXECUTION_CONTEXT]
-    mov pc, t2
+    mov pc, ret_pc
     dispatch_current
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -384,50 +384,46 @@ macro validate_callee_builtin(expected_builtin, fail)
 end
 
 # Load a UTF-16 code unit from a primitive string with resident UTF-16 data.
-# Input:
-#   t2 = PrimitiveString*
-#   t4 = non-negative code-unit index
-# Output:
-#   t0 = zero-extended code unit
-# Clobbers:
-#   t3, t5
+# string is the PrimitiveString*; index is the non-negative code-unit
+# index; code_unit is the destination GPR for the zero-extended result.
 # Jumps to out_of_bounds if index >= string length.
 # Jumps to fail if the string would require resolving deferred data.
-macro load_primitive_string_utf16_code_unit(out_of_bounds, fail)
-    load8 t3, [t2, PRIMITIVE_STRING_DEFERRED_KIND]
-    branch_ne t3, PRIMITIVE_STRING_DEFERRED_KIND_NONE, fail
+macro load_primitive_string_utf16_code_unit(string, index, code_unit, out_of_bounds, fail)
+    temp scratch, utf16_data
+    load8 scratch, [string, PRIMITIVE_STRING_DEFERRED_KIND]
+    branch_ne scratch, PRIMITIVE_STRING_DEFERRED_KIND_NONE, fail
 
-    load64 t5, [t2, PRIMITIVE_STRING_UTF16_STRING]
-    branch_zero t5, fail
+    load64 utf16_data, [string, PRIMITIVE_STRING_UTF16_STRING]
+    branch_zero utf16_data, fail
 
-    load8 t3, [t2, PRIMITIVE_STRING_UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG]
-    and t3, UTF16_SHORT_STRING_FLAG
-    branch_zero t3, .long_storage
+    load8 scratch, [string, PRIMITIVE_STRING_UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG]
+    and scratch, UTF16_SHORT_STRING_FLAG
+    branch_zero scratch, .long_storage
 
-    load8 t3, [t2, PRIMITIVE_STRING_UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG]
-    shr t3, UTF16_SHORT_STRING_BYTE_COUNT_SHIFT_COUNT
-    branch_ge_unsigned t4, t3, out_of_bounds
-    mov t0, t2
-    add t0, PRIMITIVE_STRING_UTF16_SHORT_STRING_STORAGE
-    load8 t0, [t0, t4]
+    load8 scratch, [string, PRIMITIVE_STRING_UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG]
+    shr scratch, UTF16_SHORT_STRING_BYTE_COUNT_SHIFT_COUNT
+    branch_ge_unsigned index, scratch, out_of_bounds
+    mov code_unit, string
+    add code_unit, PRIMITIVE_STRING_UTF16_SHORT_STRING_STORAGE
+    load8 code_unit, [code_unit, index]
     jmp .done
 
 .long_storage:
-    load64 t3, [t5, UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS]
-    branch_negative t3, .utf16_storage
-    branch_ge_unsigned t4, t3, out_of_bounds
-    add t5, UTF16_STRING_DATA_STRING_STORAGE
-    load8 t0, [t5, t4]
+    load64 scratch, [utf16_data, UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS]
+    branch_negative scratch, .utf16_storage
+    branch_ge_unsigned index, scratch, out_of_bounds
+    add utf16_data, UTF16_STRING_DATA_STRING_STORAGE
+    load8 code_unit, [utf16_data, index]
     jmp .done
 
 .utf16_storage:
-    shl t3, 1
-    shr t3, 1
-    branch_ge_unsigned t4, t3, out_of_bounds
-    mov t0, t4
-    add t0, t4
-    add t5, UTF16_STRING_DATA_STRING_STORAGE
-    load16 t0, [t5, t0]
+    shl scratch, 1
+    shr scratch, 1
+    branch_ge_unsigned index, scratch, out_of_bounds
+    mov code_unit, index
+    add code_unit, index
+    add utf16_data, UTF16_STRING_DATA_STRING_STORAGE
+    load16 code_unit, [utf16_data, code_unit]
 
 .done:
 end
@@ -2591,24 +2587,23 @@ handler CallBuiltinStringIteratorPrototypeNext
 end
 
 handler CallBuiltinStringFromCharCode
+    temp arg, tag, code_unit, result
     validate_callee_builtin BUILTIN_STRING_FROM_CHAR_CODE, .slow
 
-    load_operand t1, m_argument
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    unbox_int32 t0, t1
-    and t0, 0xffff
-    branch_ge_unsigned t0, 0x80, .single_code_unit
+    load_operand arg, m_argument
+    extract_tag tag, arg
+    branch_ne tag, INT32_TAG, .slow
+    unbox_int32 code_unit, arg
+    and code_unit, 0xffff
+    branch_ge_unsigned code_unit, 0x80, .single_code_unit
 
-    mov t1, t0
-    call_helper asm_helper_single_ascii_character_string
-    store_operand m_dst, t0
+    call_helper asm_helper_single_ascii_character_string, code_unit, result
+    store_operand m_dst, result
     dispatch_next
 
 .single_code_unit:
-    mov t1, t0
-    call_helper asm_helper_single_utf16_code_unit_string
-    store_operand m_dst, t0
+    call_helper asm_helper_single_utf16_code_unit_string, code_unit, result
+    store_operand m_dst, result
     dispatch_next
 
 .slow:
@@ -2616,27 +2611,28 @@ handler CallBuiltinStringFromCharCode
 end
 
 handler CallBuiltinStringPrototypeCharCodeAt
+    temp this_value, tag, string, arg, index, code_unit, dst
     validate_callee_builtin BUILTIN_STRING_PROTOTYPE_CHAR_CODE_AT, .slow
 
-    load_operand t1, m_this_value
-    extract_tag t3, t1
-    branch_ne t3, STRING_TAG, .slow
-    unbox_object t2, t1
+    load_operand this_value, m_this_value
+    extract_tag tag, this_value
+    branch_ne tag, STRING_TAG, .slow
+    unbox_object string, this_value
 
-    load_operand t1, m_argument
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    unbox_int32 t4, t1
-    branch_negative t4, .out_of_bounds
+    load_operand arg, m_argument
+    extract_tag tag, arg
+    branch_ne tag, INT32_TAG, .slow
+    unbox_int32 index, arg
+    branch_negative index, .out_of_bounds
 
-    load_primitive_string_utf16_code_unit .out_of_bounds, .slow
-    box_int32_clean t1, t0
-    store_operand m_dst, t1
+    load_primitive_string_utf16_code_unit string, index, code_unit, .out_of_bounds, .slow
+    box_int32_clean dst, code_unit
+    store_operand m_dst, dst
     dispatch_next
 
 .out_of_bounds:
-    mov t0, CANON_NAN_BITS
-    store_operand m_dst, t0
+    mov dst, CANON_NAN_BITS
+    store_operand m_dst, dst
     dispatch_next
 
 .slow:
@@ -2644,31 +2640,31 @@ handler CallBuiltinStringPrototypeCharCodeAt
 end
 
 handler CallBuiltinStringPrototypeCharAt
+    temp this_value, tag, string, arg, index, code_unit, zero, result
     validate_callee_builtin BUILTIN_STRING_PROTOTYPE_CHAR_AT, .slow
 
-    load_operand t1, m_this_value
-    extract_tag t3, t1
-    branch_ne t3, STRING_TAG, .slow
-    unbox_object t2, t1
+    load_operand this_value, m_this_value
+    extract_tag tag, this_value
+    branch_ne tag, STRING_TAG, .slow
+    unbox_object string, this_value
 
-    load_operand t1, m_argument
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    unbox_int32 t4, t1
-    branch_negative t4, .empty
+    load_operand arg, m_argument
+    extract_tag tag, arg
+    branch_ne tag, INT32_TAG, .slow
+    unbox_int32 index, arg
+    branch_negative index, .empty
 
-    load_primitive_string_utf16_code_unit .empty, .slow
-    branch_ge_unsigned t0, 0x80, .slow
+    load_primitive_string_utf16_code_unit string, index, code_unit, .empty, .slow
+    branch_ge_unsigned code_unit, 0x80, .slow
 
-    mov t1, t0
-    call_helper asm_helper_single_ascii_character_string
-    store_operand m_dst, t0
+    call_helper asm_helper_single_ascii_character_string, code_unit, result
+    store_operand m_dst, result
     dispatch_next
 
 .empty:
-    mov t1, 0
-    call_helper asm_helper_empty_string
-    store_operand m_dst, t0
+    mov zero, 0
+    call_helper asm_helper_empty_string, zero, result
+    store_operand m_dst, result
     dispatch_next
 
 .slow:

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1015,25 +1015,27 @@ end
 
 # x++: save original to dst first, then increment src in-place.
 handler PostfixIncrement
-    load_operand t1, m_src
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .slow
+    temp value, tag, int_value, dst
+    ftemp result_dbl, one_dbl
+    load_operand value, m_src
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .slow
     # Save original value to dst (the "postfix" part)
-    store_operand m_dst, t1
+    store_operand m_dst, value
     # Increment in-place: src = src + 1
-    unbox_int32 t3, t1
-    add32_overflow t3, 1, .overflow_after_store
-    box_int32_clean t4, t3
-    store_operand m_src, t4
+    unbox_int32 int_value, value
+    add32_overflow int_value, 1, .overflow_after_store
+    box_int32_clean dst, int_value
+    store_operand m_src, dst
     dispatch_next
 .overflow_after_store:
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
-    mov t0, DOUBLE_ONE
-    fp_mov ft1, t0
-    fp_add ft0, ft1
-    fp_mov t4, ft0
-    store_operand m_src, t4
+    unbox_int32 int_value, value
+    int_to_double result_dbl, int_value
+    mov dst, DOUBLE_ONE
+    fp_mov one_dbl, dst
+    fp_add result_dbl, one_dbl
+    fp_mov dst, result_dbl
+    store_operand m_src, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_postfix_increment
@@ -1354,33 +1356,35 @@ handler LooselyInequals
 end
 
 handler UnaryMinus
-    load_operand t1, m_src
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .try_double
-    unbox_int32 t3, t1
+    temp value, tag, int_value, dst
+    ftemp dst_dbl
+    load_operand value, m_src
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .try_double
+    unbox_int32 int_value, value
     # -0 check: if value is 0, result is -0.0 (double)
-    branch_zero t3, .negative_zero
+    branch_zero int_value, .negative_zero
     # 32-bit negate with overflow detection (INT32_MIN)
-    neg32_overflow t3, .overflow
-    box_int32_clean t4, t3
-    store_operand m_dst, t4
+    neg32_overflow int_value, .overflow
+    box_int32_clean dst, int_value
+    store_operand m_dst, dst
     dispatch_next
 .negative_zero:
-    mov t0, NEGATIVE_ZERO
-    store_operand m_dst, t0
+    mov dst, NEGATIVE_ZERO
+    store_operand m_dst, dst
     dispatch_next
 .overflow:
     # INT32_MIN: -(-2147483648) = 2147483648.0
-    int_to_double ft0, t3
-    fp_mov t4, ft0
-    store_operand m_dst, t4
+    int_to_double dst_dbl, int_value
+    fp_mov dst, dst_dbl
+    store_operand m_dst, dst
     dispatch_next
 .try_double:
-    # t2 already has tag
-    check_tag_is_double t2, .slow
+    # tag already has the lhs tag
+    check_tag_is_double tag, .slow
     # Negate double: flip sign bit (bit 63)
-    toggle_bit t1, 63
-    store_operand m_dst, t1
+    toggle_bit value, 63
+    store_operand m_dst, value
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_unary_minus
@@ -1388,55 +1392,61 @@ end
 
 # x--: save original to dst first, then decrement src in-place.
 handler PostfixDecrement
-    load_operand t1, m_src
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .slow
+    temp value, tag, int_value, dst
+    ftemp result_dbl, one_dbl
+    load_operand value, m_src
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .slow
     # Save original value to dst (the "postfix" part)
-    store_operand m_dst, t1
+    store_operand m_dst, value
     # Decrement in-place: src = src - 1
-    unbox_int32 t3, t1
-    sub32_overflow t3, 1, .overflow_after_store
-    box_int32_clean t4, t3
-    store_operand m_src, t4
+    unbox_int32 int_value, value
+    sub32_overflow int_value, 1, .overflow_after_store
+    box_int32_clean dst, int_value
+    store_operand m_src, dst
     dispatch_next
 .overflow_after_store:
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
-    mov t0, DOUBLE_ONE
-    fp_mov ft1, t0
-    fp_sub ft0, ft1
-    fp_mov t4, ft0
-    store_operand m_src, t4
+    unbox_int32 int_value, value
+    int_to_double result_dbl, int_value
+    mov dst, DOUBLE_ONE
+    fp_mov one_dbl, dst
+    fp_sub result_dbl, one_dbl
+    fp_mov dst, result_dbl
+    store_operand m_src, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_postfix_decrement
 end
 
 handler ToInt32
-    load_operand t1, m_value
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .try_double
+    temp value, tag, tag_copy, dst
+    ftemp value_dbl
+    load_operand value, m_value
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .try_double
     # Already int32, just copy
-    store_operand m_dst, t1
+    store_operand m_dst, value
     dispatch_next
 .try_double:
-    # t2 already has tag; check if double (copy first, t2 needed at .try_boolean)
-    mov t3, t2
-    check_tag_is_double t3, .try_boolean
+    # `tag` already has the value's tag; check if double (copy first because
+    # check_tag_is_double clobbers its argument and `tag` is needed again
+    # at .try_boolean for the boolean check).
+    mov tag_copy, tag
+    check_tag_is_double tag_copy, .try_boolean
     # Convert double to int32 using JS ToInt32 semantics.
     # With FEAT_JSCVT: fjcvtzs handles everything in one instruction.
     # Without: truncate + round-trip check, slow path on mismatch.
-    fp_mov ft0, t1
-    js_to_int32 t2, ft0, .slow
-    box_int32_clean t2, t2
-    store_operand m_dst, t2
+    fp_mov value_dbl, value
+    js_to_int32 dst, value_dbl, .slow
+    box_int32_clean dst, dst
+    store_operand m_dst, dst
     dispatch_next
 .try_boolean:
-    branch_ne t2, BOOLEAN_TAG, .slow
+    branch_ne tag, BOOLEAN_TAG, .slow
     # Convert boolean to int32: false -> 0, true -> 1
-    and t1, 1
-    box_int32_clean t1, t1
-    store_operand m_dst, t1
+    and value, 1
+    box_int32_clean dst, value
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     # Slow path handles other types (string, object, nullish, etc) and uncommon cases.

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -419,8 +419,7 @@ end
 # Dispatch the instruction at current pc (without advancing).
 # Clobbers t0.
 macro dispatch_current()
-    load8 t0, [pb, pc]
-    jmp [dispatch, t0, 8]
+    goto_handler pc
 end
 
 # Walk the environment chain using a cached EnvironmentCoordinate.
@@ -793,22 +792,24 @@ end
 # Fast path for ++x: int32 + 1 with overflow check.
 # On overflow, convert to double and add 1.0.
 handler Increment
-    load_operand t1, m_dst
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .slow
-    unbox_int32 t3, t1
-    add32_overflow t3, 1, .overflow
-    box_int32_clean t4, t3
-    store_operand m_dst, t4
+    temp value, tag, int_value, dst
+    ftemp result_dbl, one_dbl
+    load_operand value, m_dst
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .slow
+    unbox_int32 int_value, value
+    add32_overflow int_value, 1, .overflow
+    box_int32_clean dst, int_value
+    store_operand m_dst, dst
     dispatch_next
 .overflow:
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
-    mov t0, DOUBLE_ONE
-    fp_mov ft1, t0
-    fp_add ft0, ft1
-    fp_mov t4, ft0
-    store_operand m_dst, t4
+    unbox_int32 int_value, value
+    int_to_double result_dbl, int_value
+    mov dst, DOUBLE_ONE
+    fp_mov one_dbl, dst
+    fp_add result_dbl, one_dbl
+    fp_mov dst, result_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_increment
@@ -816,56 +817,59 @@ end
 
 # Fast path for --x: int32 - 1 with overflow check.
 handler Decrement
-    load_operand t1, m_dst
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .slow
-    unbox_int32 t3, t1
-    sub32_overflow t3, 1, .overflow
-    box_int32_clean t4, t3
-    store_operand m_dst, t4
+    temp value, tag, int_value, dst
+    ftemp result_dbl, one_dbl
+    load_operand value, m_dst
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .slow
+    unbox_int32 int_value, value
+    sub32_overflow int_value, 1, .overflow
+    box_int32_clean dst, int_value
+    store_operand m_dst, dst
     dispatch_next
 .overflow:
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
-    mov t0, DOUBLE_ONE
-    fp_mov ft1, t0
-    fp_sub ft0, ft1
-    fp_mov t4, ft0
-    store_operand m_dst, t4
+    unbox_int32 int_value, value
+    int_to_double result_dbl, int_value
+    mov dst, DOUBLE_ONE
+    fp_mov one_dbl, dst
+    fp_sub result_dbl, one_dbl
+    fp_mov dst, result_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_decrement
 end
 
 handler Not
-    load_operand t1, m_src
-    extract_tag t2, t1
+    temp value, tag, nullish_check, truthy, result
+    load_operand value, m_src
+    extract_tag tag, value
     # Boolean fast path
-    branch_eq t2, BOOLEAN_TAG, .is_bool
+    branch_eq tag, BOOLEAN_TAG, .is_bool
     # Int32 fast path
-    branch_eq t2, INT32_TAG, .is_int32
+    branch_eq tag, INT32_TAG, .is_int32
     # Undefined/null -> !nullish = true
-    mov t3, t2
-    and t3, 0xFFFE
-    branch_eq t3, UNDEFINED_TAG, .store_true
+    mov nullish_check, tag
+    and nullish_check, 0xFFFE
+    branch_eq nullish_check, UNDEFINED_TAG, .store_true
     # Slow path for remaining types (object, string, etc)
     # NB: Objects go through slow path to handle [[IsHTMLDDA]]
-    call_helper asm_helper_to_boolean
-    branch_zero t0, .store_true
+    call_helper asm_helper_to_boolean, value, truthy
+    branch_zero truthy, .store_true
     jmp .store_false
 .is_bool:
-    branch_bits_clear t1, 1, .store_true
+    branch_bits_clear value, 1, .store_true
     jmp .store_false
 .is_int32:
-    branch_zero32 t1, .store_true
+    branch_zero32 value, .store_true
     jmp .store_false
 .store_true:
-    mov t0, BOOLEAN_TRUE
-    store_operand m_dst, t0
+    mov result, BOOLEAN_TRUE
+    store_operand m_dst, result
     dispatch_next
 .store_false:
-    mov t0, BOOLEAN_FALSE
-    store_operand m_dst, t0
+    mov result, BOOLEAN_FALSE
+    store_operand m_dst, result
     dispatch_next
 end
 
@@ -876,22 +880,23 @@ end
 handler Return
     # Empty is the internal "no explicit value" marker. Returning it from
     # bytecode means "return undefined" at the JS level.
-    load_operand t0, m_value
-    mov t2, EMPTY_TAG_SHIFTED
-    branch_ne t0, t2, .value_ready
-    mov t0, UNDEFINED_SHIFTED
+    temp value, empty_tag, caller_frame
+    load_operand value, m_value
+    mov empty_tag, EMPTY_TAG_SHIFTED
+    branch_ne value, empty_tag, .value_ready
+    mov value, UNDEFINED_SHIFTED
 .value_ready:
     # Inline JS-to-JS calls resume the caller directly from asm. Top-level
     # returns instead exit back to the outer interpreter entry point.
-    load64 t1, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
-    branch_zero t1, .top_level
-    pop_inline_frame_and_resume t1, t0
+    load64 caller_frame, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
+    branch_zero caller_frame, .top_level
+    pop_inline_frame_and_resume caller_frame, value
 .top_level:
     # Top-level return matches VM::run_executable(): write return_value,
     # clear the exception slot, and leave the asm interpreter entirely.
     # values[3] = return_value, values[1] = empty (clear exception)
-    store64 [values, 24], t0
-    store64 [values, 8], t2
+    store64 [values, 24], value
+    store64 [values, 8], empty_tag
     exit
 end
 
@@ -900,29 +905,31 @@ end
 handler End
     # End shares the same inline-frame unwind logic as Return. The only
     # top-level difference is that End preserves the current exception slot.
-    load_operand t0, m_value
-    mov t2, EMPTY_TAG_SHIFTED
-    branch_ne t0, t2, .value_ready
-    mov t0, UNDEFINED_SHIFTED
+    temp value, empty_tag, caller_frame
+    load_operand value, m_value
+    mov empty_tag, EMPTY_TAG_SHIFTED
+    branch_ne value, empty_tag, .value_ready
+    mov value, UNDEFINED_SHIFTED
 .value_ready:
     # Inline frame: resume the caller immediately.
-    load64 t1, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
-    branch_zero t1, .top_level
-    pop_inline_frame_and_resume t1, t0
+    load64 caller_frame, [exec_ctx, EXECUTION_CONTEXT_CALLER_FRAME]
+    branch_zero caller_frame, .top_level
+    pop_inline_frame_and_resume caller_frame, value
 .top_level:
     # Top-level end: publish the return value and exit without touching
     # values[1], since End does not model a user-visible `return` opcode.
-    store64 [values, 24], t0
+    store64 [values, 24], value
     exit
 end
 
 # Loads running_execution_context().lexical_environment into dst,
 # NaN-boxed as a cell pointer.
 handler GetLexicalEnvironment
-    load64 t0, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT]
-    mov t1, CELL_TAG_SHIFTED
-    or t0, t1
-    store_operand m_dst, t0
+    temp env, tag
+    load64 env, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT]
+    mov tag, CELL_TAG_SHIFTED
+    or env, tag
+    store_operand m_dst, env
     dispatch_next
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -61,11 +61,12 @@
 
 # Check if a value is a double (not a NaN-boxed tagged value).
 # All tagged types have (tag & NAN_BASE_TAG) == NAN_BASE_TAG in their upper 16 bits.
-# Clobbers t3. Jumps to fail if not a double.
+# Jumps to fail if not a double.
 macro check_is_double(reg, fail)
-    extract_tag t3, reg
-    and t3, NAN_BASE_TAG
-    branch_eq t3, NAN_BASE_TAG, fail
+    temp tag
+    extract_tag tag, reg
+    and tag, NAN_BASE_TAG
+    branch_eq tag, NAN_BASE_TAG, fail
 end
 
 # Check if an already-extracted tag represents a non-double type.
@@ -76,14 +77,15 @@ macro check_tag_is_double(tag, fail)
 end
 
 # Check if both values are doubles.
-# Clobbers t3, t4. Jumps to fail if either is not a double.
+# Jumps to fail if either is not a number tag.
 macro check_both_double(lhs, rhs, fail)
-    extract_tag t3, lhs
-    and t3, NAN_BASE_TAG
-    branch_eq t3, NAN_BASE_TAG, fail
-    extract_tag t4, rhs
-    and t4, NAN_BASE_TAG
-    branch_eq t4, NAN_BASE_TAG, fail
+    temp lhs_tag, rhs_tag
+    extract_tag lhs_tag, lhs
+    and lhs_tag, NAN_BASE_TAG
+    branch_eq lhs_tag, NAN_BASE_TAG, fail
+    extract_tag rhs_tag, rhs
+    and rhs_tag, NAN_BASE_TAG
+    branch_eq rhs_tag, NAN_BASE_TAG, fail
 end
 
 # Coerce two operands (already in t1/t2) to numeric types for arithmetic/comparison.
@@ -134,16 +136,18 @@ end
 # JS::Value(double) constructor so that downstream int32 fast paths fire.
 # dst: destination GPR for the boxed value.
 # src_fpr: source FPR containing the double result.
-# Clobbers: t1 (x86-64), t3, ft3 (x86-64).
+# The macro uses a macro-local temp; the allocator will pick a register
+# that doesn't conflict with the caller's live values.
 macro box_double_or_int32(dst, src_fpr)
-    double_to_int32 t3, src_fpr, .bdi_not_int
-    branch_zero t3, .bdi_check_neg_zero
-    box_int32 dst, t3
+    temp int_value
+    double_to_int32 int_value, src_fpr, .bdi_not_int
+    branch_zero int_value, .bdi_check_neg_zero
+    box_int32 dst, int_value
     jmp .bdi_done
 .bdi_check_neg_zero:
     fp_mov dst, src_fpr
     branch_negative dst, .bdi_not_int
-    box_int32 dst, t3
+    box_int32 dst, int_value
     jmp .bdi_done
 .bdi_not_int:
     canonicalize_nan dst, src_fpr

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -369,17 +369,18 @@ end
 # Validate that the callee still points at the expected builtin function.
 # Jumps to fail if the call target has been replaced or is not a function.
 macro validate_callee_builtin(expected_builtin, fail)
-    load_operand t2, m_callee
-    extract_tag t3, t2
-    branch_ne t3, OBJECT_TAG, fail
-    unbox_object t2, t2
-    load8 t3, [t2, OBJECT_FLAGS]
-    and t3, OBJECT_FLAG_IS_FUNCTION
-    branch_zero t3, fail
-    load8 t3, [t2, FUNCTION_OBJECT_BUILTIN_HAS_VALUE]
-    branch_zero t3, fail
-    load8 t3, [t2, FUNCTION_OBJECT_BUILTIN_VALUE]
-    branch_ne t3, expected_builtin, fail
+    temp callee, scratch
+    load_operand callee, m_callee
+    extract_tag scratch, callee
+    branch_ne scratch, OBJECT_TAG, fail
+    unbox_object callee, callee
+    load8 scratch, [callee, OBJECT_FLAGS]
+    and scratch, OBJECT_FLAG_IS_FUNCTION
+    branch_zero scratch, fail
+    load8 scratch, [callee, FUNCTION_OBJECT_BUILTIN_HAS_VALUE]
+    branch_zero scratch, fail
+    load8 scratch, [callee, FUNCTION_OBJECT_BUILTIN_VALUE]
+    branch_ne scratch, expected_builtin, fail
 end
 
 # Load a UTF-16 code unit from a primitive string with resident UTF-16 data.
@@ -2473,82 +2474,92 @@ end
 # Before using the fast path, we validate that the callee is still the
 # original builtin function (user code may have reassigned e.g. Math.abs).
 handler CallBuiltinMathAbs
+    temp arg, tag, int_value, dst
+    ftemp arg_dbl
     validate_callee_builtin BUILTIN_MATH_ABS, .slow
-    load_operand t1, m_argument
-    check_is_double t1, .try_abs_int32
+    load_operand arg, m_argument
+    check_is_double arg, .try_abs_int32
     # abs(double) = clear sign bit (bit 63)
-    clear_bit t1, 63
-    store_operand m_dst, t1
+    clear_bit arg, 63
+    store_operand m_dst, arg
     dispatch_next
 .try_abs_int32:
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
+    extract_tag tag, arg
+    branch_ne tag, INT32_TAG, .slow
     # abs(int32): negate if negative
-    unbox_int32 t3, t1
-    branch_not_negative t3, .abs_positive
-    neg32_overflow t3, .abs_overflow
+    unbox_int32 int_value, arg
+    branch_not_negative int_value, .abs_positive
+    neg32_overflow int_value, .abs_overflow
 .abs_positive:
-    box_int32_clean t4, t3
-    store_operand m_dst, t4
+    box_int32_clean dst, int_value
+    store_operand m_dst, dst
     dispatch_next
 .abs_overflow:
     # INT32_MIN: abs(-2147483648) = 2147483648.0
-    unbox_int32 t3, t1
-    neg t3
-    int_to_double ft0, t3
-    fp_mov t4, ft0
-    store_operand m_dst, t4
+    unbox_int32 int_value, arg
+    neg int_value
+    int_to_double arg_dbl, int_value
+    fp_mov dst, arg_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_call_builtin_math_abs
 end
 
 handler CallBuiltinMathFloor
+    temp arg, dst
+    ftemp arg_dbl
     validate_callee_builtin BUILTIN_MATH_FLOOR, .slow
-    load_operand t1, m_argument
-    check_is_double t1, .slow
-    fp_mov ft0, t1
-    fp_floor ft0, ft0
-    box_double_or_int32 t5, ft0
-    store_operand m_dst, t5
+    load_operand arg, m_argument
+    check_is_double arg, .slow
+    fp_mov arg_dbl, arg
+    fp_floor arg_dbl, arg_dbl
+    box_double_or_int32 dst, arg_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_call_builtin_math_floor
 end
 
 handler CallBuiltinMathCeil
+    temp arg, dst
+    ftemp arg_dbl
     validate_callee_builtin BUILTIN_MATH_CEIL, .slow
-    load_operand t1, m_argument
-    check_is_double t1, .slow
-    fp_mov ft0, t1
-    fp_ceil ft0, ft0
-    box_double_or_int32 t5, ft0
-    store_operand m_dst, t5
+    load_operand arg, m_argument
+    check_is_double arg, .slow
+    fp_mov arg_dbl, arg
+    fp_ceil arg_dbl, arg_dbl
+    box_double_or_int32 dst, arg_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_call_builtin_math_ceil
 end
 
 handler CallBuiltinMathSqrt
+    temp arg, dst
+    ftemp arg_dbl
     validate_callee_builtin BUILTIN_MATH_SQRT, .slow
-    load_operand t1, m_argument
-    check_is_double t1, .slow
-    fp_mov ft0, t1
-    fp_sqrt ft0, ft0
-    box_double_or_int32 t5, ft0
-    store_operand m_dst, t5
+    load_operand arg, m_argument
+    check_is_double arg, .slow
+    fp_mov arg_dbl, arg
+    fp_sqrt arg_dbl, arg_dbl
+    box_double_or_int32 dst, arg_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_call_builtin_math_sqrt
 end
 
 handler CallBuiltinMathExp
+    temp arg, result
+    ftemp arg_dbl
     validate_callee_builtin BUILTIN_MATH_EXP, .slow
-    load_operand t1, m_argument
-    check_is_double t1, .slow
-    fp_mov ft0, t1
-    call_helper asm_helper_math_exp
-    store_operand m_dst, t0
+    load_operand arg, m_argument
+    check_is_double arg, .slow
+    fp_mov arg_dbl, arg
+    call_helper asm_helper_math_exp, arg, result
+    store_operand m_dst, result
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_call_builtin_math_exp
@@ -2831,9 +2842,10 @@ end
 
 # Fast path: if this_value register is already cached (non-empty), skip the slow path.
 handler ResolveThisBinding
-    load64 t0, [values, THIS_VALUE_REG_OFFSET]
-    mov t1, EMPTY_VALUE
-    branch_eq t0, t1, .slow
+    temp this_value, empty
+    load64 this_value, [values, THIS_VALUE_REG_OFFSET]
+    mov empty, EMPTY_VALUE
+    branch_eq this_value, empty, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_resolve_this_binding

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -88,41 +88,43 @@ macro check_both_double(lhs, rhs, fail)
     branch_eq rhs_tag, NAN_BASE_TAG, fail
 end
 
-# Coerce two operands (already in t1/t2) to numeric types for arithmetic/comparison.
-# If both are int32: jumps to both_int_label with t3=sign-extended lhs, t4=sign-extended rhs.
-# If one or both are double: falls through with ft0=lhs as double, ft1=rhs as double.
+# Coerce two operands to numeric types for arithmetic / comparison.
+# If both are int32: jumps to both_int_label with lhs_int / rhs_int holding
+# the sign-extended 64-bit ints.
+# If one or both are double: falls through with lhs_dbl / rhs_dbl holding
+# the values as doubles.
 # If either is not a number (int32 or double): jumps to fail.
-# Clobbers t3, t4.
-macro coerce_to_doubles(both_int_label, fail)
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .lhs_not_int
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .int_rhs_maybe_double
+macro coerce_to_doubles(lhs, rhs, lhs_int, rhs_int, lhs_dbl, rhs_dbl, both_int_label, fail)
+    temp tag
+    extract_tag tag, lhs
+    branch_ne tag, INT32_TAG, .lhs_not_int
+    extract_tag tag, rhs
+    branch_ne tag, INT32_TAG, .int_rhs_maybe_double
     # Both int32
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
+    unbox_int32 lhs_int, lhs
+    unbox_int32 rhs_int, rhs
     jmp both_int_label
 .int_rhs_maybe_double:
-    # t4 already has rhs tag, known != INT32_TAG
-    check_tag_is_double t4, fail
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
-    fp_mov ft1, t2
+    # tag already has rhs tag, known != INT32_TAG
+    check_tag_is_double tag, fail
+    unbox_int32 lhs_int, lhs
+    int_to_double lhs_dbl, lhs_int
+    fp_mov rhs_dbl, rhs
     jmp .coerced
 .lhs_not_int:
-    # t3 already has lhs tag, known != INT32_TAG
-    check_tag_is_double t3, fail
-    extract_tag t4, t2
-    branch_eq t4, INT32_TAG, .double_rhs_int
-    # t4 already has rhs tag, known != INT32_TAG
-    check_tag_is_double t4, fail
-    fp_mov ft0, t1
-    fp_mov ft1, t2
+    # tag already has lhs tag, known != INT32_TAG
+    check_tag_is_double tag, fail
+    extract_tag tag, rhs
+    branch_eq tag, INT32_TAG, .double_rhs_int
+    # tag already has rhs tag, known != INT32_TAG
+    check_tag_is_double tag, fail
+    fp_mov lhs_dbl, lhs
+    fp_mov rhs_dbl, rhs
     jmp .coerced
 .double_rhs_int:
-    fp_mov ft0, t1
-    unbox_int32 t4, t2
-    int_to_double ft1, t4
+    fp_mov lhs_dbl, lhs
+    unbox_int32 rhs_int, rhs
+    int_to_double rhs_dbl, rhs_int
 .coerced:
 end
 
@@ -251,53 +253,56 @@ end
 
 # Numeric compare with coercion (for jump variants).
 # Uses coerce_to_doubles to handle mixed int32+double operands.
-# Expects t1=lhs, t2=rhs (NaN-boxed values).
 # int_cc: signed comparison branch for int32 (branch_lt_signed, etc.)
 # double_cc: unsigned comparison branch for doubles (branch_fp_less, etc.)
-# Jumps to true_label/false_label/slow_label.
-macro numeric_compare_coerce(int_cc, double_cc, true_label, false_label, slow_label)
-    coerce_to_doubles .both_int, slow_label
-    branch_fp_unordered ft0, ft1, false_label
-    double_cc ft0, ft1, true_label
+# Jumps to true_label / false_label / slow_label.
+macro numeric_compare_coerce(lhs, rhs, int_cc, double_cc, true_label, false_label, slow_label)
+    temp lhs_int, rhs_int
+    ftemp lhs_dbl, rhs_dbl
+    coerce_to_doubles lhs, rhs, lhs_int, rhs_int, lhs_dbl, rhs_dbl, .both_int, slow_label
+    branch_fp_unordered lhs_dbl, rhs_dbl, false_label
+    double_cc lhs_dbl, rhs_dbl, true_label
     jmp false_label
 .both_int:
-    int_cc t3, t4, true_label
+    int_cc lhs_int, rhs_int, true_label
     jmp false_label
 end
 
 # Numeric compare without coercion (for non-jump variants).
 # Only handles both-int32 or both-double fast paths.
-# Expects t1=lhs, t2=rhs (NaN-boxed values).
-macro numeric_compare(int_cc, double_cc, true_label, false_label, slow_label)
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .try_double
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, slow_label
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
-    int_cc t3, t4, true_label
+macro numeric_compare(lhs, rhs, int_cc, double_cc, true_label, false_label, slow_label)
+    temp tag, lhs_int, rhs_int
+    ftemp lhs_dbl, rhs_dbl
+    extract_tag tag, lhs
+    branch_ne tag, INT32_TAG, .try_double
+    extract_tag tag, rhs
+    branch_ne tag, INT32_TAG, slow_label
+    unbox_int32 lhs_int, lhs
+    unbox_int32 rhs_int, rhs
+    int_cc lhs_int, rhs_int, true_label
     jmp false_label
 .try_double:
-    # t3 already has lhs tag
-    check_tag_is_double t3, slow_label
-    check_is_double t2, slow_label
-    fp_mov ft0, t1
-    fp_mov ft1, t2
-    branch_fp_unordered ft0, ft1, false_label
-    double_cc ft0, ft1, true_label
+    # tag already has lhs tag
+    check_tag_is_double tag, slow_label
+    check_is_double rhs, slow_label
+    fp_mov lhs_dbl, lhs
+    fp_mov rhs_dbl, rhs
+    branch_fp_unordered lhs_dbl, rhs_dbl, false_label
+    double_cc lhs_dbl, rhs_dbl, true_label
     jmp false_label
 end
 
 # Epilogue for comparison/equality handlers that produce a boolean result.
 # Defines .store_true, .store_false, and .slow labels.
 macro boolean_result_epilogue(slow_path_func)
+    temp result
 .store_true:
-    mov t0, BOOLEAN_TRUE
-    store_operand m_dst, t0
+    mov result, BOOLEAN_TRUE
+    store_operand m_dst, result
     dispatch_next
 .store_false:
-    mov t0, BOOLEAN_FALSE
-    store_operand m_dst, t0
+    mov result, BOOLEAN_FALSE
+    store_operand m_dst, result
     dispatch_next
 .slow:
     call_slow_path slow_path_func
@@ -306,14 +311,15 @@ end
 # Epilogue for jump comparison/equality handlers.
 # Defines .take_true, .take_false, and .slow labels.
 macro jump_binary_epilogue(slow_path_func)
+    temp target
 .slow:
     call_slow_path slow_path_func
 .take_true:
-    load_label t0, m_true_target
-    goto_handler t0
+    load_label target, m_true_target
+    goto_handler target
 .take_false:
-    load_label t0, m_false_target
-    goto_handler t0
+    load_label target, m_false_target
+    goto_handler target
 end
 
 # Coerce two operands (already in t1/t2) to int32 for bitwise operations.
@@ -529,30 +535,30 @@ end
 # box_double_or_int32 re-boxes double results as Int32 when possible,
 # mirroring JS::Value(double), so downstream int32 fast paths can fire.
 handler Add
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    coerce_to_doubles .both_int, .slow
-    # One or both doubles: ft0=lhs, ft1=rhs
-    fp_add ft0, ft1
-    box_double_or_int32 t5, ft0
-    store_operand m_dst, t5
+    temp lhs, rhs, lhs_int, rhs_int, dst
+    ftemp lhs_dbl, rhs_dbl
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    coerce_to_doubles lhs, rhs, lhs_int, rhs_int, lhs_dbl, rhs_dbl, .both_int, .slow
+    fp_add lhs_dbl, rhs_dbl
+    box_double_or_int32 dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .both_int:
-    # t3=lhs (sign-extended), t4=rhs (sign-extended)
     # 32-bit add with hardware overflow detection
-    add32_overflow t3, t4, .overflow
-    box_int32_clean t5, t3
-    store_operand m_dst, t5
+    add32_overflow lhs_int, rhs_int, .overflow
+    box_int32_clean dst, lhs_int
+    store_operand m_dst, dst
     dispatch_next
 .overflow:
     # Int32 overflow: convert both to double and redo the operation
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
-    int_to_double ft0, t3
-    int_to_double ft1, t4
-    fp_add ft0, ft1
-    fp_mov t5, ft0
-    store_operand m_dst, t5
+    unbox_int32 lhs_int, lhs
+    unbox_int32 rhs_int, rhs
+    int_to_double lhs_dbl, lhs_int
+    int_to_double rhs_dbl, rhs_int
+    fp_add lhs_dbl, rhs_dbl
+    fp_mov dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_add
@@ -560,28 +566,28 @@ end
 
 # Same pattern as Add but with subtraction.
 handler Sub
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    coerce_to_doubles .both_int, .slow
-    # One or both doubles: ft0=lhs, ft1=rhs
-    fp_sub ft0, ft1
-    box_double_or_int32 t5, ft0
-    store_operand m_dst, t5
+    temp lhs, rhs, lhs_int, rhs_int, dst
+    ftemp lhs_dbl, rhs_dbl
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    coerce_to_doubles lhs, rhs, lhs_int, rhs_int, lhs_dbl, rhs_dbl, .both_int, .slow
+    fp_sub lhs_dbl, rhs_dbl
+    box_double_or_int32 dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .both_int:
-    # t3=lhs (sign-extended), t4=rhs (sign-extended)
-    sub32_overflow t3, t4, .overflow
-    box_int32_clean t5, t3
-    store_operand m_dst, t5
+    sub32_overflow lhs_int, rhs_int, .overflow
+    box_int32_clean dst, lhs_int
+    store_operand m_dst, dst
     dispatch_next
 .overflow:
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
-    int_to_double ft0, t3
-    int_to_double ft1, t4
-    fp_sub ft0, ft1
-    fp_mov t5, ft0
-    store_operand m_dst, t5
+    unbox_int32 lhs_int, lhs
+    unbox_int32 rhs_int, rhs
+    int_to_double lhs_dbl, lhs_int
+    int_to_double rhs_dbl, rhs_int
+    fp_sub lhs_dbl, rhs_dbl
+    fp_mov dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_sub
@@ -590,38 +596,38 @@ end
 # Same pattern as Add but with multiplication.
 # Extra complexity: 0 * negative = -0.0 (must produce negative zero double).
 handler Mul
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    coerce_to_doubles .both_int, .slow
-    # One or both doubles: ft0=lhs, ft1=rhs
-    fp_mul ft0, ft1
-    box_double_or_int32 t5, ft0
-    store_operand m_dst, t5
+    temp lhs, rhs, lhs_int, rhs_int, dst, sign_check
+    ftemp lhs_dbl, rhs_dbl
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    coerce_to_doubles lhs, rhs, lhs_int, rhs_int, lhs_dbl, rhs_dbl, .both_int, .slow
+    fp_mul lhs_dbl, rhs_dbl
+    box_double_or_int32 dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .both_int:
-    # t3=lhs (sign-extended), t4=rhs (sign-extended)
-    mul32_overflow t3, t4, .overflow
-    branch_nonzero t3, .store_int
+    mul32_overflow lhs_int, rhs_int, .overflow
+    branch_nonzero lhs_int, .store_int
     # Result is 0: check if either operand was negative -> -0.0
-    unbox_int32 t5, t1
-    or t5, t4
-    branch_negative t5, .negative_zero
+    unbox_int32 sign_check, lhs
+    or sign_check, rhs_int
+    branch_negative sign_check, .negative_zero
 .store_int:
-    box_int32_clean t5, t3
-    store_operand m_dst, t5
+    box_int32_clean dst, lhs_int
+    store_operand m_dst, dst
     dispatch_next
 .negative_zero:
-    mov t5, NEGATIVE_ZERO
-    store_operand m_dst, t5
+    mov dst, NEGATIVE_ZERO
+    store_operand m_dst, dst
     dispatch_next
 .overflow:
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
-    int_to_double ft0, t3
-    int_to_double ft1, t4
-    fp_mul ft0, ft1
-    fp_mov t5, ft0
-    store_operand m_dst, t5
+    unbox_int32 lhs_int, lhs
+    unbox_int32 rhs_int, rhs
+    int_to_double lhs_dbl, lhs_int
+    int_to_double rhs_dbl, rhs_int
+    fp_mul lhs_dbl, rhs_dbl
+    fp_mov dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_mul
@@ -738,30 +744,34 @@ end
 # Jump comparison handlers: use numeric_compare_coerce (handles mixed int32+double)
 # combined with jump_binary_epilogue (provides .take_true, .take_false, .slow labels).
 handler JumpLessThan
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare_coerce branch_lt_signed, branch_fp_less, .take_true, .take_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare_coerce lhs, rhs, branch_lt_signed, branch_fp_less, .take_true, .take_false, .slow
     jump_binary_epilogue asm_slow_path_jump_less_than
 end
 
 handler JumpGreaterThan
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare_coerce branch_gt_signed, branch_fp_greater, .take_true, .take_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare_coerce lhs, rhs, branch_gt_signed, branch_fp_greater, .take_true, .take_false, .slow
     jump_binary_epilogue asm_slow_path_jump_greater_than
 end
 
 handler JumpLessThanEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare_coerce branch_le_signed, branch_fp_less_or_equal, .take_true, .take_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare_coerce lhs, rhs, branch_le_signed, branch_fp_less_or_equal, .take_true, .take_false, .slow
     jump_binary_epilogue asm_slow_path_jump_less_than_equals
 end
 
 handler JumpGreaterThanEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare_coerce branch_ge_signed, branch_fp_greater_or_equal, .take_true, .take_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare_coerce lhs, rhs, branch_ge_signed, branch_fp_greater_or_equal, .take_true, .take_false, .slow
     jump_binary_epilogue asm_slow_path_jump_greater_than_equals
 end
 
@@ -1100,30 +1110,34 @@ end
 # both-double fast paths, fall back to slow path for mixed/non-numeric types.
 # The boolean_result_epilogue macro provides .store_true, .store_false, .slow labels.
 handler LessThan
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare branch_lt_signed, branch_fp_less, .store_true, .store_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare lhs, rhs, branch_lt_signed, branch_fp_less, .store_true, .store_false, .slow
     boolean_result_epilogue asm_slow_path_less_than
 end
 
 handler LessThanEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare branch_le_signed, branch_fp_less_or_equal, .store_true, .store_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare lhs, rhs, branch_le_signed, branch_fp_less_or_equal, .store_true, .store_false, .slow
     boolean_result_epilogue asm_slow_path_less_than_equals
 end
 
 handler GreaterThan
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare branch_gt_signed, branch_fp_greater, .store_true, .store_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare lhs, rhs, branch_gt_signed, branch_fp_greater, .store_true, .store_false, .slow
     boolean_result_epilogue asm_slow_path_greater_than
 end
 
 handler GreaterThanEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    numeric_compare branch_ge_signed, branch_fp_greater_or_equal, .store_true, .store_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    numeric_compare lhs, rhs, branch_ge_signed, branch_fp_greater_or_equal, .store_true, .store_false, .slow
     boolean_result_epilogue asm_slow_path_greater_than_equals
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -2660,88 +2660,90 @@ handler GetObjectPropertyIterator
 end
 
 handler ObjectPropertyIteratorNext
-    load_operand t1, m_iterator_object
-    extract_tag t2, t1
-    branch_ne t2, OBJECT_TAG, .slow
-    unbox_object t3, t1
+    temp it_value, tag, iterator, fast_path, expected, cache, cached_shape, receiver, current_shape, is_dict, cur_dict_gen, dict_gen, storage_kind, packed_kind, size, expected_size, validity, valid, indexed_count, next_indexed, key, key_index, named_index, named_size, named_data, exhausted, packed_kind_byte, slow_kind, scratch
+    load_operand it_value, m_iterator_object
+    extract_tag tag, it_value
+    branch_ne tag, OBJECT_TAG, .slow
+    unbox_object iterator, it_value
 
-    load8 t4, [t3, PROPERTY_NAME_ITERATOR_FAST_PATH]
-    mov t0, OBJECT_PROPERTY_ITERATOR_FAST_PATH_NONE
-    branch_eq t4, t0, .slow
+    load8 fast_path, [iterator, PROPERTY_NAME_ITERATOR_FAST_PATH]
+    mov expected, OBJECT_PROPERTY_ITERATOR_FAST_PATH_NONE
+    branch_eq fast_path, expected, .slow
 
-    # These guards mirror PropertyNameIterator::fast_path_still_valid(). If the
-    # receiver or prototype chain no longer matches the cached snapshot, we drop
-    # to C++ and continue in deoptimized mode for the rest of the enumeration.
-    load_pair64 t5, t7, [t3, PROPERTY_NAME_ITERATOR_PROPERTY_CACHE], [t3, PROPERTY_NAME_ITERATOR_SHAPE]
-    load64 t6, [t3, PROPERTY_NAME_ITERATOR_OBJECT]
-    load64 t8, [t6, OBJECT_SHAPE]
-    branch_ne t8, t7, .slow
+    # These guards mirror PropertyNameIterator::fast_path_still_valid(). If
+    # the receiver or prototype chain no longer matches the cached snapshot,
+    # we drop to C++ and continue in deoptimized mode for the rest of the
+    # enumeration.
+    load_pair64 cache, cached_shape, [iterator, PROPERTY_NAME_ITERATOR_PROPERTY_CACHE], [iterator, PROPERTY_NAME_ITERATOR_SHAPE]
+    load64 receiver, [iterator, PROPERTY_NAME_ITERATOR_OBJECT]
+    load64 current_shape, [receiver, OBJECT_SHAPE]
+    branch_ne current_shape, cached_shape, .slow
 
-    load8 t2, [t3, PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY]
-    branch_zero t2, .check_receiver
-    load32 t0, [t8, SHAPE_DICTIONARY_GENERATION]
-    load32 t2, [t3, PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION]
-    branch_ne t0, t2, .slow
+    load8 is_dict, [iterator, PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY]
+    branch_zero is_dict, .check_receiver
+    load32 cur_dict_gen, [current_shape, SHAPE_DICTIONARY_GENERATION]
+    load32 dict_gen, [iterator, PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION]
+    branch_ne cur_dict_gen, dict_gen, .slow
 
 .check_receiver:
-    mov t0, OBJECT_PROPERTY_ITERATOR_FAST_PATH_PACKED_INDEXED
-    branch_ne t4, t0, .check_proto
-    load8 t0, [t6, OBJECT_INDEXED_STORAGE_KIND]
-    mov t2, INDEXED_STORAGE_KIND_PACKED
-    branch_ne t0, t2, .slow
-    load32 t0, [t6, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
-    load32 t2, [t3, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT]
-    branch_ne t0, t2, .slow
+    mov packed_kind_byte, OBJECT_PROPERTY_ITERATOR_FAST_PATH_PACKED_INDEXED
+    branch_ne fast_path, packed_kind_byte, .check_proto
+    load8 storage_kind, [receiver, OBJECT_INDEXED_STORAGE_KIND]
+    mov packed_kind, INDEXED_STORAGE_KIND_PACKED
+    branch_ne storage_kind, packed_kind, .slow
+    load32 size, [receiver, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    load32 expected_size, [iterator, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT]
+    branch_ne size, expected_size, .slow
 
 .check_proto:
-    load64 t0, [t3, PROPERTY_NAME_ITERATOR_PROTOTYPE_CHAIN_VALIDITY]
-    branch_zero t0, .next_key
-    load8 t2, [t0, PROTOTYPE_CHAIN_VALIDITY_VALID]
-    branch_zero t2, .slow
+    load64 validity, [iterator, PROPERTY_NAME_ITERATOR_PROTOTYPE_CHAIN_VALIDITY]
+    branch_zero validity, .next_key
+    load8 valid, [validity, PROTOTYPE_CHAIN_VALIDITY_VALID]
+    branch_zero valid, .slow
 
 .next_key:
     # property_values is laid out as:
     #   [receiver packed index keys..., flattened named keys...]
-    load_pair32 t2, t0, [t3, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT], [t3, PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY]
-    branch_ge_unsigned t0, t2, .named
-    load64 t8, [t5, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA]
-    load64 t8, [t8, t0, 8]
-    add t0, 1
-    store32 [t3, PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY], t0
-    store_operand m_dst_value, t8
-    mov t0, BOOLEAN_FALSE
-    store_operand m_dst_done, t0
+    load_pair32 indexed_count, next_indexed, [iterator, PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT], [iterator, PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY]
+    branch_ge_unsigned next_indexed, indexed_count, .named
+    load64 key, [cache, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA]
+    load64 key, [key, next_indexed, 8]
+    add next_indexed, 1
+    store32 [iterator, PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY], next_indexed
+    store_operand m_dst_value, key
+    mov scratch, BOOLEAN_FALSE
+    store_operand m_dst_done, scratch
     dispatch_next
 
 .named:
-    load64 t0, [t3, PROPERTY_NAME_ITERATOR_NEXT_PROPERTY]
-    load64 t8, [t5, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE]
-    sub t8, t2
-    branch_ge_unsigned t0, t8, .done
-    mov t8, t0
-    add t8, t2
-    load64 t5, [t5, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA]
-    load64 t8, [t5, t8, 8]
-    add t0, 1
-    store64 [t3, PROPERTY_NAME_ITERATOR_NEXT_PROPERTY], t0
-    store_operand m_dst_value, t8
-    mov t0, BOOLEAN_FALSE
-    store_operand m_dst_done, t0
+    load64 named_index, [iterator, PROPERTY_NAME_ITERATOR_NEXT_PROPERTY]
+    load64 named_size, [cache, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE]
+    sub named_size, indexed_count
+    branch_ge_unsigned named_index, named_size, .done
+    mov key_index, named_index
+    add key_index, indexed_count
+    load64 named_data, [cache, OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA]
+    load64 key, [named_data, key_index, 8]
+    add named_index, 1
+    store64 [iterator, PROPERTY_NAME_ITERATOR_NEXT_PROPERTY], named_index
+    store_operand m_dst_value, key
+    mov scratch, BOOLEAN_FALSE
+    store_operand m_dst_done, scratch
     dispatch_next
 
 .done:
-    load64 t5, [t3, PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT]
-    branch_zero t5, .store_done
+    load64 exhausted, [iterator, PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT]
+    branch_zero exhausted, .store_done
     # Return the exhausted iterator object to the bytecode-site cache so the
     # next execution of this loop can reset and reuse it.
-    mov t0, 0
-    store64 [t3, PROPERTY_NAME_ITERATOR_OBJECT], t0
-    store64 [t5, OBJECT_PROPERTY_ITERATOR_CACHE_REUSABLE_PROPERTY_NAME_ITERATOR], t3
-    store64 [t3, PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT], t0
+    mov scratch, 0
+    store64 [iterator, PROPERTY_NAME_ITERATOR_OBJECT], scratch
+    store64 [exhausted, OBJECT_PROPERTY_ITERATOR_CACHE_REUSABLE_PROPERTY_NAME_ITERATOR], iterator
+    store64 [iterator, PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT], scratch
 
 .store_done:
-    mov t0, BOOLEAN_TRUE
-    store_operand m_dst_done, t0
+    mov scratch, BOOLEAN_TRUE
+    store_operand m_dst_done, scratch
     dispatch_next
 
 .slow:

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1868,48 +1868,44 @@ end
 # Fast path for Array.length (magical length property).
 # Also includes IC fast path for non-array objects (same as GetById).
 handler GetLength
-    load_operand t1, m_base
-    # Check base is an object
-    extract_tag t2, t1
-    branch_ne t2, OBJECT_TAG, .slow
-    # Extract Object*
-    unbox_object t3, t1
-    # Check has_magical_length_property flag
-    load8 t0, [t3, OBJECT_FLAGS]
-    branch_bits_set t0, OBJECT_FLAG_HAS_MAGICAL_LENGTH, .magical_length
+    temp base, tag, obj, flags, shape, plc, cache_shape, cache_proto, prop_offset, dict_gen, cur_dict_gen, props, value, length, sign_check, dst
+    ftemp length_dbl
+    load_operand base, m_base
+    extract_tag tag, base
+    branch_ne tag, OBJECT_TAG, .slow
+    unbox_object obj, base
+    load8 flags, [obj, OBJECT_FLAGS]
+    branch_bits_set flags, OBJECT_FLAG_HAS_MAGICAL_LENGTH, .magical_length
     # Non-magical length: IC fast path (same as GetById)
-    load64 t4, [t3, OBJECT_SHAPE]
-    load64 t5, [pb, pc, m_cache]
-    # Check entry[0].shape and entry[0].prototype.
-    load_pair64 t1, t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
-    branch_ne t1, t4, .slow
-    branch_nonzero t0, .slow
-    # Check dictionary generation
-    load_pair32 t1, t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
-    load32 t2, [t4, SHAPE_DICTIONARY_GENERATION]
-    branch_ne t0, t2, .slow
-    # IC hit
-    load64 t5, [t3, OBJECT_NAMED_PROPERTIES]
-    load64 t0, [t5, t1, 8]
-    extract_tag t2, t0
-    branch_eq t2, ACCESSOR_TAG, .slow
-    store_operand m_dst, t0
+    load64 shape, [obj, OBJECT_SHAPE]
+    load64 plc, [pb, pc, m_cache]
+    load_pair64 cache_shape, cache_proto, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
+    branch_ne cache_shape, shape, .slow
+    branch_nonzero cache_proto, .slow
+    load_pair32 prop_offset, dict_gen, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    load32 cur_dict_gen, [shape, SHAPE_DICTIONARY_GENERATION]
+    branch_ne dict_gen, cur_dict_gen, .slow
+    load64 props, [obj, OBJECT_NAMED_PROPERTIES]
+    load64 value, [props, prop_offset, 8]
+    extract_tag tag, value
+    branch_eq tag, ACCESSOR_TAG, .slow
+    store_operand m_dst, value
     dispatch_next
 .magical_length:
-    # Object.m_indexed_array_like_size (u32)
-    load32 t0, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
-    # Box as int32 if fits (u32 always fits since bit 31 check is for sign)
-    mov t2, t0
-    shr t2, 31
-    branch_nonzero t2, .length_double
-    # Tag as int32
-    box_int32 t3, t0
-    store_operand m_dst, t3
+    # Object.m_indexed_array_like_size (u32). Box as int32 when bit 31 is
+    # clear; otherwise widen to a double so the value isn't reinterpreted
+    # as a negative int32.
+    load32 length, [obj, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    mov sign_check, length
+    shr sign_check, 31
+    branch_nonzero sign_check, .length_double
+    box_int32 dst, length
+    store_operand m_dst, dst
     dispatch_next
 .length_double:
-    int_to_double ft0, t0
-    fp_mov t0, ft0
-    store_operand m_dst, t0
+    int_to_double length_dbl, length
+    fp_mov dst, length_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_get_length
@@ -1917,55 +1913,47 @@ end
 
 # Inline cache fast path for global variable access via the global object.
 handler GetGlobal
-    # Load global_declarative_environment and global_object via realm
-    load64 t0, [exec_ctx, EXECUTION_CONTEXT_REALM]
-    load_pair64 t2, t1, [t0, REALM_GLOBAL_OBJECT], [t0, REALM_GLOBAL_DECLARATIVE_ENVIRONMENT]
-    # Get GlobalVariableCache* (direct pointer from instruction stream)
-    load64 t3, [pb, pc, m_cache]
-    # Check environment_serial_number matches
-    load64 t0, [t3, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL]
-    load64 t4, [t1, DECLARATIVE_ENVIRONMENT_SERIAL]
-    branch_ne t0, t4, .slow
+    temp realm, global_object, env, gvc, cache_serial, env_serial, shape, cache_shape, cur_dict_gen, prop_offset, dict_gen, props, value, tag, has_env, in_module, idx, binding, init, result
+    load64 realm, [exec_ctx, EXECUTION_CONTEXT_REALM]
+    load_pair64 global_object, env, [realm, REALM_GLOBAL_OBJECT], [realm, REALM_GLOBAL_DECLARATIVE_ENVIRONMENT]
+    load64 gvc, [pb, pc, m_cache]
+    load64 cache_serial, [gvc, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL]
+    load64 env_serial, [env, DECLARATIVE_ENVIRONMENT_SERIAL]
+    branch_ne cache_serial, env_serial, .slow
     # Shape-based fast path: check entries[0].shape matches global_object.shape
     # (falls through to env binding path on shape mismatch)
-    load64 t4, [t2, OBJECT_SHAPE]
-    load64 t0, [t3, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE]
-    branch_ne t0, t4, .try_env_binding
-    # Check dictionary generation
-    load32 t5, [t4, SHAPE_DICTIONARY_GENERATION]
-    load_pair32 t4, t0, [t3, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [t3, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
-    branch_ne t0, t5, .try_env_binding
+    load64 shape, [global_object, OBJECT_SHAPE]
+    load64 cache_shape, [gvc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE]
+    branch_ne cache_shape, shape, .try_env_binding
+    load32 cur_dict_gen, [shape, SHAPE_DICTIONARY_GENERATION]
+    load_pair32 prop_offset, dict_gen, [gvc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [gvc, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    branch_ne dict_gen, cur_dict_gen, .try_env_binding
     # IC hit! Load property value via get_direct
-    load64 t5, [t2, OBJECT_NAMED_PROPERTIES]
-    load64 t0, [t5, t4, 8]
-    # Check not accessor
-    extract_tag t5, t0
-    branch_eq t5, ACCESSOR_TAG, .slow
-    store_operand m_dst, t0
+    load64 props, [global_object, OBJECT_NAMED_PROPERTIES]
+    load64 value, [props, prop_offset, 8]
+    extract_tag tag, value
+    branch_eq tag, ACCESSOR_TAG, .slow
+    store_operand m_dst, value
     dispatch_next
 .try_env_binding:
-    # Check if cache has an environment binding index (global let/const)
-    load8 t0, [t3, GLOBAL_VARIABLE_CACHE_HAS_ENVIRONMENT_BINDING]
-    branch_zero t0, .slow
-    # Bail to C++ for module environments (rare)
-    load8 t0, [t3, GLOBAL_VARIABLE_CACHE_IN_MODULE_ENVIRONMENT]
-    branch_nonzero t0, .slow_env
-    # Inline env binding: index into global_declarative_environment bindings
-    # t1 = global_declarative_environment (loaded at handler entry)
-    load32 t0, [t3, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_BINDING_INDEX]
-    load64 t4, [t1, BINDINGS_DATA_PTR]
-    mul t0, t0, SIZEOF_BINDING
-    add t4, t0
-    # Check binding is initialized (TDZ)
-    load8 t0, [t4, BINDING_INITIALIZED]
-    branch_zero t0, .slow
-    # Load binding value
-    load64 t0, [t4, BINDING_VALUE]
-    store_operand m_dst, t0
+    load8 has_env, [gvc, GLOBAL_VARIABLE_CACHE_HAS_ENVIRONMENT_BINDING]
+    branch_zero has_env, .slow
+    # Bail to C++ for module environments (rare).
+    load8 in_module, [gvc, GLOBAL_VARIABLE_CACHE_IN_MODULE_ENVIRONMENT]
+    branch_nonzero in_module, .slow_env
+    # Inline env binding: index into global_declarative_environment bindings.
+    load32 idx, [gvc, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_BINDING_INDEX]
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
+    load8 init, [binding, BINDING_INITIALIZED]
+    branch_zero init, .slow
+    load64 value, [binding, BINDING_VALUE]
+    store_operand m_dst, value
     dispatch_next
 .slow_env:
-    call_interp asm_try_get_global_env_binding
-    branch_nonzero t0, .slow
+    call_interp asm_try_get_global_env_binding, result
+    branch_nonzero result, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_get_global
@@ -1973,59 +1961,46 @@ end
 
 # Inline cache fast path for global variable store via the global object.
 handler SetGlobal
-    # Load global_declarative_environment and global_object via realm
-    load64 t0, [exec_ctx, EXECUTION_CONTEXT_REALM]
-    load_pair64 t2, t1, [t0, REALM_GLOBAL_OBJECT], [t0, REALM_GLOBAL_DECLARATIVE_ENVIRONMENT]
-    # Get GlobalVariableCache* (direct pointer from instruction stream)
-    load64 t3, [pb, pc, m_cache]
-    # Check environment_serial_number matches
-    load64 t0, [t3, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL]
-    load64 t4, [t1, DECLARATIVE_ENVIRONMENT_SERIAL]
-    branch_ne t0, t4, .slow
-    # Shape-based fast path: check entries[0].shape matches global_object.shape
-    # (falls through to env binding path on shape mismatch)
-    load64 t4, [t2, OBJECT_SHAPE]
-    load64 t0, [t3, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE]
-    branch_ne t0, t4, .try_env_binding
-    # Check dictionary generation
-    load32 t5, [t4, SHAPE_DICTIONARY_GENERATION]
-    load_pair32 t4, t0, [t3, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [t3, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
-    branch_ne t0, t5, .try_env_binding
-    # IC hit! Load current value to check it's not an accessor
-    load64 t5, [t2, OBJECT_NAMED_PROPERTIES]
-    load64 t0, [t5, t4, 8]
-    extract_tag t0, t0
-    branch_eq t0, ACCESSOR_TAG, .slow
-    # Store new value via put_direct
-    # NB: load_operand clobbers t0, so property offset stays in t4.
-    load_operand t0, m_src
-    store64 [t5, t4, 8], t0
+    temp realm, global_object, env, gvc, cache_serial, env_serial, shape, cache_shape, cur_dict_gen, prop_offset, dict_gen, props, value, tag, has_env, in_module, idx, binding, flag, src, result
+    load64 realm, [exec_ctx, EXECUTION_CONTEXT_REALM]
+    load_pair64 global_object, env, [realm, REALM_GLOBAL_OBJECT], [realm, REALM_GLOBAL_DECLARATIVE_ENVIRONMENT]
+    load64 gvc, [pb, pc, m_cache]
+    load64 cache_serial, [gvc, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL]
+    load64 env_serial, [env, DECLARATIVE_ENVIRONMENT_SERIAL]
+    branch_ne cache_serial, env_serial, .slow
+    load64 shape, [global_object, OBJECT_SHAPE]
+    load64 cache_shape, [gvc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE]
+    branch_ne cache_shape, shape, .try_env_binding
+    load32 cur_dict_gen, [shape, SHAPE_DICTIONARY_GENERATION]
+    load_pair32 prop_offset, dict_gen, [gvc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [gvc, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    branch_ne dict_gen, cur_dict_gen, .try_env_binding
+    # IC hit! Load current value to check it's not an accessor.
+    load64 props, [global_object, OBJECT_NAMED_PROPERTIES]
+    load64 value, [props, prop_offset, 8]
+    extract_tag tag, value
+    branch_eq tag, ACCESSOR_TAG, .slow
+    load_operand src, m_src
+    store64 [props, prop_offset, 8], src
     dispatch_next
 .try_env_binding:
-    # Check if cache has an environment binding index (global let/const)
-    load8 t0, [t3, GLOBAL_VARIABLE_CACHE_HAS_ENVIRONMENT_BINDING]
-    branch_zero t0, .slow
-    # Bail to C++ for module environments (rare)
-    load8 t0, [t3, GLOBAL_VARIABLE_CACHE_IN_MODULE_ENVIRONMENT]
-    branch_nonzero t0, .slow_env
-    # Inline env binding: index into global_declarative_environment bindings
-    # t1 = global_declarative_environment (loaded at handler entry)
-    load32 t0, [t3, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_BINDING_INDEX]
-    load64 t4, [t1, BINDINGS_DATA_PTR]
-    mul t0, t0, SIZEOF_BINDING
-    add t4, t0
-    # Check binding is initialized (TDZ) and mutable
-    load8 t0, [t4, BINDING_INITIALIZED]
-    branch_zero t0, .slow
-    load8 t0, [t4, BINDING_MUTABLE]
-    branch_zero t0, .slow
-    # Store value into binding
-    load_operand t0, m_src
-    store64 [t4, BINDING_VALUE], t0
+    load8 has_env, [gvc, GLOBAL_VARIABLE_CACHE_HAS_ENVIRONMENT_BINDING]
+    branch_zero has_env, .slow
+    load8 in_module, [gvc, GLOBAL_VARIABLE_CACHE_IN_MODULE_ENVIRONMENT]
+    branch_nonzero in_module, .slow_env
+    load32 idx, [gvc, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_BINDING_INDEX]
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
+    load8 flag, [binding, BINDING_INITIALIZED]
+    branch_zero flag, .slow
+    load8 flag, [binding, BINDING_MUTABLE]
+    branch_zero flag, .slow
+    load_operand src, m_src
+    store64 [binding, BINDING_VALUE], src
     dispatch_next
 .slow_env:
-    call_interp asm_try_set_global_env_binding
-    branch_nonzero t0, .slow
+    call_interp asm_try_set_global_env_binding, result
+    branch_nonzero result, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_set_global

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -638,66 +638,69 @@ end
 # For JumpIf/JumpTrue/JumpFalse, a boolean's truth value is just bit 0.
 # For int32, any nonzero low 32 bits means truthy.
 handler JumpIf
-    load_operand t1, m_condition
-    extract_tag t2, t1
+    temp condition, tag, truthy, target
+    load_operand condition, m_condition
+    extract_tag tag, condition
     # Boolean fast path
-    branch_eq t2, BOOLEAN_TAG, .is_bool
+    branch_eq tag, BOOLEAN_TAG, .is_bool
     # Int32 fast path
-    branch_eq t2, INT32_TAG, .is_int32
+    branch_eq tag, INT32_TAG, .is_int32
     # Slow path: call helper to convert to boolean
-    call_helper asm_helper_to_boolean
-    branch_nonzero t0, .take_true
+    call_helper asm_helper_to_boolean, condition, truthy
+    branch_nonzero truthy, .take_true
     jmp .take_false
 .is_bool:
-    branch_bits_set t1, 1, .take_true
+    branch_bits_set condition, 1, .take_true
     jmp .take_false
 .is_int32:
-    branch_nonzero32 t1, .take_true
+    branch_nonzero32 condition, .take_true
     jmp .take_false
 .take_true:
-    load_label t0, m_true_target
-    goto_handler t0
+    load_label target, m_true_target
+    goto_handler target
 .take_false:
-    load_label t0, m_false_target
-    goto_handler t0
+    load_label target, m_false_target
+    goto_handler target
 end
 
 handler JumpTrue
-    load_operand t1, m_condition
-    extract_tag t2, t1
-    branch_eq t2, BOOLEAN_TAG, .is_bool
-    branch_eq t2, INT32_TAG, .is_int32
-    call_helper asm_helper_to_boolean
-    branch_nonzero t0, .take
+    temp condition, tag, truthy, target
+    load_operand condition, m_condition
+    extract_tag tag, condition
+    branch_eq tag, BOOLEAN_TAG, .is_bool
+    branch_eq tag, INT32_TAG, .is_int32
+    call_helper asm_helper_to_boolean, condition, truthy
+    branch_nonzero truthy, .take
     dispatch_next
 .is_bool:
-    branch_bits_set t1, 1, .take
+    branch_bits_set condition, 1, .take
     dispatch_next
 .is_int32:
-    branch_nonzero32 t1, .take
+    branch_nonzero32 condition, .take
     dispatch_next
 .take:
-    load_label t0, m_target
-    goto_handler t0
+    load_label target, m_target
+    goto_handler target
 end
 
 handler JumpFalse
-    load_operand t1, m_condition
-    extract_tag t2, t1
-    branch_eq t2, BOOLEAN_TAG, .is_bool
-    branch_eq t2, INT32_TAG, .is_int32
-    call_helper asm_helper_to_boolean
-    branch_zero t0, .take
+    temp condition, tag, truthy, target
+    load_operand condition, m_condition
+    extract_tag tag, condition
+    branch_eq tag, BOOLEAN_TAG, .is_bool
+    branch_eq tag, INT32_TAG, .is_int32
+    call_helper asm_helper_to_boolean, condition, truthy
+    branch_zero truthy, .take
     dispatch_next
 .is_bool:
-    branch_bits_clear t1, 1, .take
+    branch_bits_clear condition, 1, .take
     dispatch_next
 .is_int32:
-    branch_zero32 t1, .take
+    branch_zero32 condition, .take
     dispatch_next
 .take:
-    load_label t0, m_target
-    goto_handler t0
+    load_label target, m_target
+    goto_handler target
 end
 
 # Nullish check: undefined and null tags differ only in bit 0,

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -324,40 +324,43 @@ macro jump_binary_epilogue(slow_path_func)
     goto_handler target
 end
 
-# Coerce two operands (already in t1/t2) to int32 for bitwise operations.
-# On success: t3 = lhs as int32, t4 = rhs as int32. Falls through.
-# If either operand is not a number (int32, boolean, or double): jumps to fail.
-# Clobbers t1 (on x86_64, js_to_int32 clobbers rcx=t1), t3, t4.
-macro coerce_to_int32s(fail)
-    extract_tag t3, t1
-    branch_any_eq t3, INT32_TAG, BOOLEAN_TAG, .lhs_is_int
-    check_tag_is_double t3, fail
-    fp_mov ft0, t1
-    js_to_int32 t3, ft0, fail
+# Coerce two operands to int32 for bitwise operations.
+# On success: lhs_int / rhs_int hold the sign-extended int32 values.
+# If either operand is not a number (int32, boolean, or double):
+# jumps to fail.
+macro coerce_to_int32s(lhs, rhs, lhs_int, rhs_int, fail)
+    temp tag
+    ftemp fp_scratch
+    extract_tag tag, lhs
+    branch_any_eq tag, INT32_TAG, BOOLEAN_TAG, .lhs_is_int
+    check_tag_is_double tag, fail
+    fp_mov fp_scratch, lhs
+    js_to_int32 lhs_int, fp_scratch, fail
     jmp .lhs_done
 .lhs_is_int:
-    unbox_int32 t3, t1
+    unbox_int32 lhs_int, lhs
 .lhs_done:
-    extract_tag t4, t2
-    branch_any_eq t4, INT32_TAG, BOOLEAN_TAG, .rhs_is_int
-    check_tag_is_double t4, fail
-    fp_mov ft0, t2
-    js_to_int32 t4, ft0, fail
+    extract_tag tag, rhs
+    branch_any_eq tag, INT32_TAG, BOOLEAN_TAG, .rhs_is_int
+    check_tag_is_double tag, fail
+    fp_mov fp_scratch, rhs
+    js_to_int32 rhs_int, fp_scratch, fail
     jmp .rhs_done
 .rhs_is_int:
-    unbox_int32 t4, t2
+    unbox_int32 rhs_int, rhs
 .rhs_done:
 end
 
 # Fast path for bitwise binary operations on int32/boolean/double operands.
 # op_insn: the bitwise instruction to apply (xor, and, or).
 macro bitwise_op(op_insn, slow_path_func)
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    coerce_to_int32s .slow
-    op_insn t3, t4
-    box_int32 t4, t3
-    store_operand m_dst, t4
+    temp lhs, rhs, lhs_int, rhs_int, dst
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    coerce_to_int32s lhs, rhs, lhs_int, rhs_int, .slow
+    op_insn lhs_int, rhs_int
+    box_int32 dst, lhs_int
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path slow_path_func
@@ -1158,14 +1161,15 @@ end
 
 # Fast path for numeric values: +x is a no-op for int32 and double.
 handler UnaryPlus
-    load_operand t1, m_src
+    temp value, tag
+    load_operand value, m_src
     # Check if int32
-    extract_tag t0, t1
-    branch_eq t0, INT32_TAG, .done
-    # t0 already has tag; check if double
-    check_tag_is_double t0, .slow
+    extract_tag tag, value
+    branch_eq tag, INT32_TAG, .done
+    # tag already holds value's tag; check if double
+    check_tag_is_double tag, .slow
 .done:
-    store_operand m_dst, t1
+    store_operand m_dst, value
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_unary_plus

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1705,146 +1705,132 @@ end
 
 # Fast path for array[int32_index] with Packed/Holey indexed storage.
 handler GetByValue
-    load_operand t1, m_base
-    load_operand t2, m_property
-    # Check base is an object
-    extract_tag t3, t1
-    branch_ne t3, OBJECT_TAG, .slow
-    # Check property is non-negative int32
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .slow
-    mov t4, t2
-    and t4, 0xFFFFFFFF
-    # t4 = index (zero-extended u32)
-    # Check high bit (negative int32)
-    branch_bit_set t4, 31, .slow
-    # Extract Object*
-    unbox_object t3, t1
-    # Check IsTypedArray flag -- branch to C++ helper early
-    load8 t0, [t3, OBJECT_FLAGS]
-    branch_bits_set t0, OBJECT_FLAG_IS_TYPED_ARRAY, .try_typed_array
-    # Check !may_interfere_with_indexed_property_access
-    branch_bits_set t0, OBJECT_FLAG_MAY_INTERFERE, .slow
+    temp base, prop, base_tag, prop_tag, index, obj, flags, storage_kind, size, elements, slot, capacity_addr, capacity, kind_byte, raw, addr, neg_zero, dst, result
+    ftemp slot_dbl
+    load_operand base, m_base
+    load_operand prop, m_property
+    extract_tag base_tag, base
+    branch_ne base_tag, OBJECT_TAG, .slow
+    extract_tag prop_tag, prop
+    branch_ne prop_tag, INT32_TAG, .slow
+    mov index, prop
+    and index, 0xFFFFFFFF
+    branch_bit_set index, 31, .slow
+    unbox_object obj, base
+    load8 flags, [obj, OBJECT_FLAGS]
+    branch_bits_set flags, OBJECT_FLAG_IS_TYPED_ARRAY, .try_typed_array
+    branch_bits_set flags, OBJECT_FLAG_MAY_INTERFERE, .slow
     # Packed is the hot path: in-bounds elements are always present.
-    load8 t0, [t3, OBJECT_INDEXED_STORAGE_KIND]
-    branch_ne t0, INDEXED_STORAGE_KIND_PACKED, .not_packed
-    # Check index < array_like_size
-    load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
-    branch_ge_unsigned t4, t5, .slow
-    load64 t5, [t3, OBJECT_INDEXED_ELEMENTS]
-    load64 t0, [t5, t4, 8]
+    load8 storage_kind, [obj, OBJECT_INDEXED_STORAGE_KIND]
+    branch_ne storage_kind, INDEXED_STORAGE_KIND_PACKED, .not_packed
+    load32 size, [obj, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    branch_ge_unsigned index, size, .slow
+    load64 elements, [obj, OBJECT_INDEXED_ELEMENTS]
+    load64 dst, [elements, index, 8]
     # NB: No accessor check needed -- Packed/Holey storage
     #     can only hold default-attributed data properties.
-    store_operand m_dst, t0
+    store_operand m_dst, dst
     dispatch_next
 .not_packed:
-    branch_ne t0, INDEXED_STORAGE_KIND_HOLEY, .slow
+    branch_ne storage_kind, INDEXED_STORAGE_KIND_HOLEY, .slow
     # Holey arrays need a slot load to distinguish present elements from holes.
-    load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
-    branch_ge_unsigned t4, t5, .slow
-    load64 t5, [t3, OBJECT_INDEXED_ELEMENTS]
-    branch_zero t5, .slow
-    mov t0, t5
-    sub t0, 8
-    load32 t0, [t0, 0]
-    branch_ge_unsigned t4, t0, .slow
-    load64 t0, [t5, t4, 8]
-    mov t5, EMPTY_TAG_SHIFTED
-    branch_eq t0, t5, .slow
-    store_operand m_dst, t0
+    load32 size, [obj, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    branch_ge_unsigned index, size, .slow
+    load64 elements, [obj, OBJECT_INDEXED_ELEMENTS]
+    branch_zero elements, .slow
+    mov capacity_addr, elements
+    sub capacity_addr, 8
+    load32 capacity, [capacity_addr, 0]
+    branch_ge_unsigned index, capacity, .slow
+    load64 slot, [elements, index, 8]
+    mov neg_zero, EMPTY_TAG_SHIFTED
+    branch_eq slot, neg_zero, .slow
+    store_operand m_dst, slot
     dispatch_next
 .try_typed_array:
-    # t3 = Object*, t4 = index (u32, non-negative)
-    # Load cached data pointer (pre-computed: buffer.data() + byte_offset)
-    # nullptr means uncached -> C++ helper will resolve the access.
-    load64 t5, [t3, TYPED_ARRAY_CACHED_DATA_PTR]
-    branch_zero t5, .try_typed_array_slow
+    load64 elements, [obj, TYPED_ARRAY_CACHED_DATA_PTR]
+    branch_zero elements, .try_typed_array_slow
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.
-    load32 t0, [t3, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
-    branch_ge_unsigned t4, t0, .try_typed_array_slow
-    # t5 = data base pointer, t4 = index
-    # Dispatch on kind
-    load8 t0, [t3, TYPED_ARRAY_KIND]
-    branch_eq t0, TYPED_ARRAY_KIND_INT32, .ta_int32
-    branch_any_eq t0, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED, .ta_uint8
-    branch_eq t0, TYPED_ARRAY_KIND_UINT16, .ta_uint16
-    branch_eq t0, TYPED_ARRAY_KIND_INT8, .ta_int8
-    branch_eq t0, TYPED_ARRAY_KIND_INT16, .ta_int16
-    branch_eq t0, TYPED_ARRAY_KIND_UINT32, .ta_uint32
-    branch_eq t0, TYPED_ARRAY_KIND_FLOAT32, .ta_float32
-    branch_eq t0, TYPED_ARRAY_KIND_FLOAT64, .ta_float64
+    load32 capacity, [obj, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
+    branch_ge_unsigned index, capacity, .try_typed_array_slow
+    load8 kind_byte, [obj, TYPED_ARRAY_KIND]
+    branch_eq kind_byte, TYPED_ARRAY_KIND_INT32, .ta_int32
+    branch_any_eq kind_byte, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_UINT8_CLAMPED, .ta_uint8
+    branch_eq kind_byte, TYPED_ARRAY_KIND_UINT16, .ta_uint16
+    branch_eq kind_byte, TYPED_ARRAY_KIND_INT8, .ta_int8
+    branch_eq kind_byte, TYPED_ARRAY_KIND_INT16, .ta_int16
+    branch_eq kind_byte, TYPED_ARRAY_KIND_UINT32, .ta_uint32
+    branch_eq kind_byte, TYPED_ARRAY_KIND_FLOAT32, .ta_float32
+    branch_eq kind_byte, TYPED_ARRAY_KIND_FLOAT64, .ta_float64
     jmp .try_typed_array_slow
 .ta_int32:
-    load32 t0, [t5, t4, 4]
+    load32 raw, [elements, index, 4]
     jmp .ta_box_int32
 .ta_uint8:
-    load8 t0, [t5, t4]
+    load8 raw, [elements, index]
     jmp .ta_box_int32
 .ta_uint16:
-    mov t0, t4
-    add t0, t4
-    load16 t0, [t5, t0]
+    mov addr, index
+    add addr, index
+    load16 raw, [elements, addr]
     jmp .ta_box_int32
 .ta_int8:
-    load8s t0, [t5, t4]
+    load8s raw, [elements, index]
     jmp .ta_box_int32
 .ta_int16:
-    mov t0, t4
-    add t0, t4
-    load16s t0, [t5, t0]
+    mov addr, index
+    add addr, index
+    load16s raw, [elements, addr]
     jmp .ta_box_int32
 .ta_float32:
-    mov t0, t4
-    shl t0, 2
-    add t0, t5
-    loadf32 ft0, [t0, 0]
-    float_to_double ft0, ft0
-    fp_mov t1, ft0
-    mov t3, NEGATIVE_ZERO
-    branch_eq t1, t3, .ta_f64_as_double
-    double_to_int32 t0, ft0, .ta_f64_as_double
-    branch_nonzero t0, .ta_f64_as_int
+    mov addr, index
+    shl addr, 2
+    add addr, elements
+    loadf32 slot_dbl, [addr, 0]
+    float_to_double slot_dbl, slot_dbl
+    fp_mov slot, slot_dbl
+    mov neg_zero, NEGATIVE_ZERO
+    branch_eq slot, neg_zero, .ta_f64_as_double
+    double_to_int32 raw, slot_dbl, .ta_f64_as_double
+    branch_nonzero raw, .ta_f64_as_int
     jmp .ta_f64_as_int
 .ta_float64:
-    # index * 8 for f64 elements
-    mov t0, t4
-    shl t0, 3
-    add t0, t5
-    load64 t1, [t0, 0]
-    fp_mov ft0, t1
-    # Exclude negative zero early (t1 gets clobbered by double_to_int32)
-    mov t3, NEGATIVE_ZERO
-    branch_eq t1, t3, .ta_f64_as_double
-    # Try to store as int32 if the value is an integer in i32 range.
-    double_to_int32 t0, ft0, .ta_f64_as_double
-    branch_nonzero t0, .ta_f64_as_int
+    mov addr, index
+    shl addr, 3
+    add addr, elements
+    load64 slot, [addr, 0]
+    fp_mov slot_dbl, slot
+    # Exclude negative zero early (slot gets clobbered by double_to_int32).
+    mov neg_zero, NEGATIVE_ZERO
+    branch_eq slot, neg_zero, .ta_f64_as_double
+    double_to_int32 raw, slot_dbl, .ta_f64_as_double
+    branch_nonzero raw, .ta_f64_as_int
     # double_to_int32 succeeded with 0 -- this is +0.0, box as int
 .ta_f64_as_int:
-    box_int32 t3, t0
-    store_operand m_dst, t3
+    box_int32 dst, raw
+    store_operand m_dst, dst
     dispatch_next
 .ta_f64_as_double:
-    canonicalize_nan t0, ft0
-    store_operand m_dst, t0
+    canonicalize_nan dst, slot_dbl
+    store_operand m_dst, dst
     dispatch_next
 .ta_uint32:
-    load32 t0, [t5, t4, 4]
-    branch_bit_set t0, 31, .ta_uint32_to_double
+    load32 raw, [elements, index, 4]
+    branch_bit_set raw, 31, .ta_uint32_to_double
     jmp .ta_box_int32
 .ta_uint32_to_double:
-    # Value > INT32_MAX, convert to double
-    int_to_double ft0, t0
-    fp_mov t0, ft0
-    store_operand m_dst, t0
+    int_to_double slot_dbl, raw
+    fp_mov dst, slot_dbl
+    store_operand m_dst, dst
     dispatch_next
 .ta_box_int32:
-    box_int32_clean t3, t0
-    store_operand m_dst, t3
+    box_int32_clean dst, raw
+    store_operand m_dst, dst
     dispatch_next
 .try_typed_array_slow:
-    call_interp asm_try_get_by_value_typed_array
-    branch_nonzero t0, .slow
+    call_interp asm_try_get_by_value_typed_array, result
+    branch_nonzero result, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_get_by_value

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -438,27 +438,29 @@ macro dispatch_current()
 end
 
 # Walk the environment chain using a cached EnvironmentCoordinate.
-# Input: m_cache field offset for the EnvironmentCoordinate in the instruction.
-# Output: t3 = target environment, t2 = binding index.
+# Input: m_cache_field is the offset of the EnvironmentCoordinate inside
+# the bytecode instruction.
+# Output: target_env points at the resolved environment, bind_index holds
+# the binding index within it.
 # On failure (invalid cache, screwed by eval): jumps to fail_label.
-# Clobbers t0, t1, t2, t3, t4.
-macro walk_env_chain(m_cache_field, fail_label)
-    lea t0, [pb, pc]
-    add t0, m_cache_field
-    load_pair32 t1, t2, [t0, ENVIRONMENT_COORDINATE_HOPS], [t0, ENVIRONMENT_COORDINATE_INDEX]
-    mov t4, ENVIRONMENT_COORDINATE_INVALID
-    branch_eq t1, t4, fail_label
-    load64 t3, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT]
-    branch_zero t1, .walk_done
+macro walk_env_chain(m_cache_field, target_env, bind_index, fail_label)
+    temp coord_addr, hops, sentinel, screw
+    lea coord_addr, [pb, pc]
+    add coord_addr, m_cache_field
+    load_pair32 hops, bind_index, [coord_addr, ENVIRONMENT_COORDINATE_HOPS], [coord_addr, ENVIRONMENT_COORDINATE_INDEX]
+    mov sentinel, ENVIRONMENT_COORDINATE_INVALID
+    branch_eq hops, sentinel, fail_label
+    load64 target_env, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT]
+    branch_zero hops, .walk_done
 .walk_loop:
-    load8 t0, [t3, ENVIRONMENT_SCREWED_BY_EVAL]
-    branch_nonzero t0, fail_label
-    load64 t3, [t3, ENVIRONMENT_OUTER]
-    sub t1, 1
-    branch_nonzero t1, .walk_loop
+    load8 screw, [target_env, ENVIRONMENT_SCREWED_BY_EVAL]
+    branch_nonzero screw, fail_label
+    load64 target_env, [target_env, ENVIRONMENT_OUTER]
+    sub hops, 1
+    branch_nonzero hops, .walk_loop
 .walk_done:
-    load8 t0, [t3, ENVIRONMENT_SCREWED_BY_EVAL]
-    branch_nonzero t0, fail_label
+    load8 screw, [target_env, ENVIRONMENT_SCREWED_BY_EVAL]
+    branch_nonzero screw, fail_label
 end
 
 # Pop an inline frame and resume the caller without bouncing through C++.
@@ -966,16 +968,16 @@ end
 
 # Inline environment chain walk + binding value load with TDZ check.
 handler GetBinding
-    walk_env_chain m_cache, .slow
-    # t3 = target environment, t2 = binding index
-    load64 t0, [t3, BINDINGS_DATA_PTR]
-    mul t2, t2, SIZEOF_BINDING
-    add t0, t2
+    temp env, idx, binding, init, value
+    walk_env_chain m_cache, env, idx, .slow
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
     # Check binding is initialized (TDZ)
-    load8 t1, [t0, BINDING_INITIALIZED]
-    branch_zero t1, .slow
-    load64 t1, [t0, BINDING_VALUE]
-    store_operand m_dst, t1
+    load8 init, [binding, BINDING_INITIALIZED]
+    branch_zero init, .slow
+    load64 value, [binding, BINDING_VALUE]
+    store_operand m_dst, value
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_get_binding
@@ -983,13 +985,13 @@ end
 
 # Inline environment chain walk + direct binding value load.
 handler GetInitializedBinding
-    walk_env_chain m_cache, .slow
-    # t3 = target environment, t2 = binding index
-    load64 t0, [t3, BINDINGS_DATA_PTR]
-    mul t2, t2, SIZEOF_BINDING
-    add t0, t2
-    load64 t1, [t0, BINDING_VALUE]
-    store_operand m_dst, t1
+    temp env, idx, binding, value
+    walk_env_chain m_cache, env, idx, .slow
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
+    load64 value, [binding, BINDING_VALUE]
+    store_operand m_dst, value
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_get_initialized_binding
@@ -997,18 +999,16 @@ end
 
 # Inline environment chain walk + initialize binding (set value + initialized=true).
 handler InitializeLexicalBinding
-    walk_env_chain m_cache, .slow
-    # t3 = target environment, t2 = binding index
-    load64 t3, [t3, BINDINGS_DATA_PTR]
-    mul t2, t2, SIZEOF_BINDING
-    add t3, t2
-    # Store source value into binding
-    # NB: load_operand clobbers t0, so binding address must be in t3.
-    load_operand t1, m_src
-    store64 [t3, BINDING_VALUE], t1
+    temp env, idx, binding, value, one
+    walk_env_chain m_cache, env, idx, .slow
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
+    load_operand value, m_src
+    store64 [binding, BINDING_VALUE], value
     # Set initialized = true
-    mov t1, 1
-    store8 [t3, BINDING_INITIALIZED], t1
+    mov one, 1
+    store8 [binding, BINDING_INITIALIZED], one
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_initialize_lexical_binding
@@ -1016,21 +1016,19 @@ end
 
 # Inline environment chain walk + set mutable binding.
 handler SetLexicalBinding
-    walk_env_chain m_cache, .slow
-    # t3 = target environment, t2 = binding index
-    load64 t3, [t3, BINDINGS_DATA_PTR]
-    mul t2, t2, SIZEOF_BINDING
-    add t3, t2
+    temp env, idx, binding, flag, value
+    walk_env_chain m_cache, env, idx, .slow
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
     # Check initialized (TDZ)
-    load8 t1, [t3, BINDING_INITIALIZED]
-    branch_zero t1, .slow
+    load8 flag, [binding, BINDING_INITIALIZED]
+    branch_zero flag, .slow
     # Check mutable
-    load8 t1, [t3, BINDING_MUTABLE]
-    branch_zero t1, .slow
-    # Store source value into binding
-    # NB: load_operand clobbers t0, so binding address must be in t3.
-    load_operand t1, m_src
-    store64 [t3, BINDING_VALUE], t1
+    load8 flag, [binding, BINDING_MUTABLE]
+    branch_zero flag, .slow
+    load_operand value, m_src
+    store64 [binding, BINDING_VALUE], value
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_set_lexical_binding
@@ -1352,20 +1350,20 @@ end
 
 # Inline environment chain walk + get callee and this.
 handler GetCalleeAndThisFromEnvironment
-    walk_env_chain m_cache, .slow
-    # t3 = target environment, t2 = binding index
-    load64 t0, [t3, BINDINGS_DATA_PTR]
-    mul t2, t2, SIZEOF_BINDING
-    add t0, t2
+    temp env, idx, binding, init, value
+    walk_env_chain m_cache, env, idx, .slow
+    load64 binding, [env, BINDINGS_DATA_PTR]
+    mul idx, idx, SIZEOF_BINDING
+    add binding, idx
     # TDZ state lives in Binding.initialized; the value slot itself starts as
     # undefined, so checking for EMPTY would miss cached second-hit calls.
-    load8 t1, [t0, BINDING_INITIALIZED]
-    branch_zero t1, .slow
-    load64 t1, [t0, BINDING_VALUE]
-    store_operand m_callee, t1
+    load8 init, [binding, BINDING_INITIALIZED]
+    branch_zero init, .slow
+    load64 value, [binding, BINDING_VALUE]
+    store_operand m_callee, value
     # this = undefined (DeclarativeEnvironment.with_base_object() always returns nullptr)
-    mov t0, UNDEFINED_SHIFTED
-    store_operand m_this_value, t0
+    mov value, UNDEFINED_SHIFTED
+    store_operand m_this_value, value
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_get_callee_and_this

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1147,9 +1147,10 @@ end
 
 # Check if value is TDZ (empty). If not, just continue.
 handler ThrowIfTDZ
-    load_operand t1, m_src
-    mov t0, EMPTY_VALUE
-    branch_eq t1, t0, .slow
+    temp value, empty
+    load_operand value, m_src
+    mov empty, EMPTY_VALUE
+    branch_eq value, empty, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_throw_if_tdz
@@ -1157,9 +1158,10 @@ end
 
 # Check if value is an object. Only throws on non-object (rare).
 handler ThrowIfNotObject
-    load_operand t1, m_src
-    extract_tag t0, t1
-    branch_ne t0, OBJECT_TAG, .slow
+    temp value, tag
+    load_operand value, m_src
+    extract_tag tag, value
+    branch_ne tag, OBJECT_TAG, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_throw_if_not_object
@@ -1167,10 +1169,11 @@ end
 
 # Check if value is nullish (undefined or null). Only throws on nullish (rare).
 handler ThrowIfNullish
-    load_operand t1, m_src
-    extract_tag t0, t1
-    and t0, 0xFFFE
-    branch_eq t0, UNDEFINED_TAG, .slow
+    temp value, tag
+    load_operand value, m_src
+    extract_tag tag, value
+    and tag, 0xFFFE
+    branch_eq tag, UNDEFINED_TAG, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_throw_if_nullish
@@ -1178,14 +1181,15 @@ end
 
 # Fast path for int32: ~value
 handler BitwiseNot
-    load_operand t1, m_src
-    extract_tag t2, t1
-    branch_ne t2, INT32_TAG, .slow
+    temp value, tag, dst
+    load_operand value, m_src
+    extract_tag tag, value
+    branch_ne tag, INT32_TAG, .slow
     # NOT the low 32 bits (not32 zeros upper 32), then re-box
-    mov t3, t1
-    not32 t3
-    box_int32_clean t3, t3
-    store_operand m_dst, t3
+    mov dst, value
+    not32 dst
+    box_int32_clean dst, dst
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_bitwise_not
@@ -1201,36 +1205,38 @@ end
 
 # Shift ops: int32-only fast path, shift count masked to 0-31 per spec.
 handler LeftShift
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .slow
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
-    and t4, 31
-    shl t3, t4
-    box_int32 t4, t3
-    store_operand m_dst, t4
+    temp lhs, rhs, lhs_tag, rhs_tag, lhs_int, count, dst
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    extract_tag lhs_tag, lhs
+    branch_ne lhs_tag, INT32_TAG, .slow
+    extract_tag rhs_tag, rhs
+    branch_ne rhs_tag, INT32_TAG, .slow
+    unbox_int32 lhs_int, lhs
+    unbox_int32 count, rhs
+    and count, 31
+    shl lhs_int, count
+    box_int32 dst, lhs_int
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_left_shift
 end
 
 handler RightShift
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .slow
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
-    and t4, 31
-    sar t3, t4
-    box_int32 t4, t3
-    store_operand m_dst, t4
+    temp lhs, rhs, lhs_tag, rhs_tag, lhs_int, count, dst
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    extract_tag lhs_tag, lhs
+    branch_ne lhs_tag, INT32_TAG, .slow
+    extract_tag rhs_tag, rhs
+    branch_ne rhs_tag, INT32_TAG, .slow
+    unbox_int32 lhs_int, lhs
+    unbox_int32 count, rhs
+    and count, 31
+    sar lhs_int, count
+    box_int32 dst, lhs_int
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_right_shift
@@ -1239,27 +1245,29 @@ end
 # Unsigned right shift: result is always unsigned, so values > INT32_MAX
 # must be stored as double (can't fit in a signed int32 NaN-box).
 handler UnsignedRightShift
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .slow
+    temp lhs, rhs, lhs_tag, rhs_tag, value, count, dst
+    ftemp dst_dbl
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    extract_tag lhs_tag, lhs
+    branch_ne lhs_tag, INT32_TAG, .slow
+    extract_tag rhs_tag, rhs
+    branch_ne rhs_tag, INT32_TAG, .slow
     # u32 result = (u32)lhs >> (rhs % 32)
-    mov t3, t1
-    and t3, 0xFFFFFFFF
-    unbox_int32 t4, t2
-    and t4, 31
-    shr t3, t4
+    mov value, lhs
+    and value, 0xFFFFFFFF
+    unbox_int32 count, rhs
+    and count, 31
+    shr value, count
     # If result > INT32_MAX, store as double
-    branch_bit_set t3, 31, .as_double
-    box_int32_clean t3, t3
-    store_operand m_dst, t3
+    branch_bit_set value, 31, .as_double
+    box_int32_clean dst, value
+    store_operand m_dst, dst
     dispatch_next
 .as_double:
-    int_to_double ft0, t3
-    fp_mov t3, ft0
-    store_operand m_dst, t3
+    int_to_double dst_dbl, value
+    fp_mov dst, dst_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_unsigned_right_shift

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1486,145 +1486,134 @@ end
 
 # Fast path for array[int32_index] = value with Packed/Holey indexed storage.
 handler PutByValue
+    temp kind, base, prop, base_tag, prop_tag, index, obj, flags, storage_kind, size, elements, src, capacity_addr, capacity, slot, empty_tag, kind_byte, addr, src_int32, max, result
+    ftemp src_dbl
     # Only fast-path Normal puts (not Getter/Setter/Own)
-    load8 t0, [pb, pc, m_kind]
-    branch_ne t0, PUT_KIND_NORMAL, .slow
-    load_operand t1, m_base
-    load_operand t2, m_property
-    # Check base is an object
-    extract_tag t3, t1
-    branch_ne t3, OBJECT_TAG, .slow
+    load8 kind, [pb, pc, m_kind]
+    branch_ne kind, PUT_KIND_NORMAL, .slow
+    load_operand base, m_base
+    load_operand prop, m_property
+    extract_tag base_tag, base
+    branch_ne base_tag, OBJECT_TAG, .slow
     # Check property is non-negative int32
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .slow
-    mov t4, t2
-    and t4, 0xFFFFFFFF
-    # Check high bit (negative int32)
-    branch_bit_set t4, 31, .slow
-    # Extract Object*
-    unbox_object t3, t1
-    # Check IsTypedArray flag -- branch to C++ helper early
-    load8 t0, [t3, OBJECT_FLAGS]
-    branch_bits_set t0, OBJECT_FLAG_IS_TYPED_ARRAY, .try_typed_array
+    extract_tag prop_tag, prop
+    branch_ne prop_tag, INT32_TAG, .slow
+    mov index, prop
+    and index, 0xFFFFFFFF
+    branch_bit_set index, 31, .slow
+    unbox_object obj, base
+    # Check IsTypedArray flag -- branch to typed-array path early.
+    load8 flags, [obj, OBJECT_FLAGS]
+    branch_bits_set flags, OBJECT_FLAG_IS_TYPED_ARRAY, .try_typed_array
     # Check !may_interfere_with_indexed_property_access
-    branch_bits_set t0, OBJECT_FLAG_MAY_INTERFERE, .slow
+    branch_bits_set flags, OBJECT_FLAG_MAY_INTERFERE, .slow
     # Packed is the hot path: existing elements can be overwritten directly.
-    load8 t0, [t3, OBJECT_INDEXED_STORAGE_KIND]
-    branch_ne t0, INDEXED_STORAGE_KIND_PACKED, .not_packed
-    # Check index vs array_like_size
-    load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
-    branch_ge_unsigned t4, t5, .slow
-    load64 t5, [t3, OBJECT_INDEXED_ELEMENTS]
-    load_operand t1, m_src
-    store64 [t5, t4, 8], t1
+    load8 storage_kind, [obj, OBJECT_INDEXED_STORAGE_KIND]
+    branch_ne storage_kind, INDEXED_STORAGE_KIND_PACKED, .not_packed
+    load32 size, [obj, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    branch_ge_unsigned index, size, .slow
+    load64 elements, [obj, OBJECT_INDEXED_ELEMENTS]
+    load_operand src, m_src
+    store64 [elements, index, 8], src
     dispatch_next
 .not_packed:
-    branch_ne t0, INDEXED_STORAGE_KIND_HOLEY, .slow
+    branch_ne storage_kind, INDEXED_STORAGE_KIND_HOLEY, .slow
     # Holey arrays need a slot load to distinguish existing elements from holes.
-    load32 t5, [t3, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
-    branch_ge_unsigned t4, t5, .slow
-    load64 t5, [t3, OBJECT_INDEXED_ELEMENTS]
-    branch_zero t5, .try_holey_array_slow
-    mov t0, t5
-    sub t0, 8
-    load32 t0, [t0, 0]
-    branch_ge_unsigned t4, t0, .try_holey_array_slow
-    load64 t1, [t5, t4, 8]
-    mov t0, EMPTY_TAG_SHIFTED
-    branch_eq t1, t0, .try_holey_array_slow
-    load_operand t1, m_src
-    store64 [t5, t4, 8], t1
+    load32 size, [obj, OBJECT_INDEXED_ARRAY_LIKE_SIZE]
+    branch_ge_unsigned index, size, .slow
+    load64 elements, [obj, OBJECT_INDEXED_ELEMENTS]
+    branch_zero elements, .try_holey_array_slow
+    mov capacity_addr, elements
+    sub capacity_addr, 8
+    load32 capacity, [capacity_addr, 0]
+    branch_ge_unsigned index, capacity, .try_holey_array_slow
+    load64 slot, [elements, index, 8]
+    mov empty_tag, EMPTY_TAG_SHIFTED
+    branch_eq slot, empty_tag, .try_holey_array_slow
+    load_operand src, m_src
+    store64 [elements, index, 8], src
     dispatch_next
 .try_holey_array_slow:
-    call_interp asm_try_put_by_value_holey_array
-    branch_nonzero t0, .slow
+    call_interp asm_try_put_by_value_holey_array, result
+    branch_nonzero result, .slow
     dispatch_next
 .try_typed_array:
-    # t3 = Object*, t4 = index (u32, non-negative)
     # Load cached data pointer (pre-computed: buffer.data() + byte_offset)
     # nullptr means uncached -> C++ helper will resolve the access.
-    load64 t5, [t3, TYPED_ARRAY_CACHED_DATA_PTR]
-    branch_zero t5, .try_typed_array_slow
+    load64 elements, [obj, TYPED_ARRAY_CACHED_DATA_PTR]
+    branch_zero elements, .try_typed_array_slow
     # Cached pointers only exist for fixed-length typed arrays, so array_length
     # is known to hold a concrete u32 value here.
-    load32 t0, [t3, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
-    branch_ge_unsigned t4, t0, .slow
-    # t5 = data base pointer, t4 = index
-    # Load kind into t2 before load_operand clobbers t0
-    load8 t2, [t3, TYPED_ARRAY_KIND]
-    # Load source value into t1 (clobbers t0)
-    load_operand t1, m_src
-    # Check if source is int32
-    extract_tag t0, t1
-    branch_eq t0, INT32_TAG, .ta_store_int32
-    # Non-int32 value: only handle float typed arrays with double sources
-    branch_eq t2, TYPED_ARRAY_KIND_FLOAT32, .ta_store_float32
-    branch_ne t2, TYPED_ARRAY_KIND_FLOAT64, .try_typed_array_slow
-    # Compute store address before check_is_double clobbers t4
-    mov t0, t4
-    shl t0, 3
-    add t0, t5
-    # Verify value is actually a double
-    check_is_double t1, .try_typed_array_slow
-    # Float64Array: store raw double bits
-    store64 [t0, 0], t1
+    load32 capacity, [obj, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
+    branch_ge_unsigned index, capacity, .slow
+    load8 kind_byte, [obj, TYPED_ARRAY_KIND]
+    load_operand src, m_src
+    extract_tag base_tag, src
+    branch_eq base_tag, INT32_TAG, .ta_store_int32
+    # Non-int32 value: only handle float typed arrays with double sources.
+    branch_eq kind_byte, TYPED_ARRAY_KIND_FLOAT32, .ta_store_float32
+    branch_ne kind_byte, TYPED_ARRAY_KIND_FLOAT64, .try_typed_array_slow
+    # Compute store address before check_is_double mangles its argument.
+    mov addr, index
+    shl addr, 3
+    add addr, elements
+    check_is_double src, .try_typed_array_slow
+    store64 [addr, 0], src
     dispatch_next
 .ta_store_float32:
-    mov t0, t4
-    shl t0, 2
-    add t0, t5
-    check_is_double t1, .try_typed_array_slow
-    fp_mov ft0, t1
-    double_to_float ft0, ft0
-    storef32 [t0, 0], ft0
+    mov addr, index
+    shl addr, 2
+    add addr, elements
+    check_is_double src, .try_typed_array_slow
+    fp_mov src_dbl, src
+    double_to_float src_dbl, src_dbl
+    storef32 [addr, 0], src_dbl
     dispatch_next
 .ta_store_int32:
-    # t1 = NaN-boxed int32, sign-extend it into t0
-    unbox_int32 t0, t1
-    # Dispatch on kind (in t2)
-    branch_any_eq t2, TYPED_ARRAY_KIND_INT32, TYPED_ARRAY_KIND_UINT32, .ta_put_int32
-    branch_eq t2, TYPED_ARRAY_KIND_FLOAT32, .ta_put_float32
-    branch_eq t2, TYPED_ARRAY_KIND_UINT8_CLAMPED, .ta_put_uint8_clamped
-    branch_any_eq t2, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_INT8, .ta_put_uint8
-    branch_any_eq t2, TYPED_ARRAY_KIND_UINT16, TYPED_ARRAY_KIND_INT16, .ta_put_uint16
+    unbox_int32 src_int32, src
+    branch_any_eq kind_byte, TYPED_ARRAY_KIND_INT32, TYPED_ARRAY_KIND_UINT32, .ta_put_int32
+    branch_eq kind_byte, TYPED_ARRAY_KIND_FLOAT32, .ta_put_float32
+    branch_eq kind_byte, TYPED_ARRAY_KIND_UINT8_CLAMPED, .ta_put_uint8_clamped
+    branch_any_eq kind_byte, TYPED_ARRAY_KIND_UINT8, TYPED_ARRAY_KIND_INT8, .ta_put_uint8
+    branch_any_eq kind_byte, TYPED_ARRAY_KIND_UINT16, TYPED_ARRAY_KIND_INT16, .ta_put_uint16
     jmp .try_typed_array_slow
 .ta_put_int32:
-    store32 [t5, t4, 4], t0
+    store32 [elements, index, 4], src_int32
     dispatch_next
 .ta_put_float32:
-    int_to_double ft0, t0
-    double_to_float ft0, ft0
-    mov t3, t4
-    shl t3, 2
-    add t3, t5
-    storef32 [t3, 0], ft0
+    int_to_double src_dbl, src_int32
+    double_to_float src_dbl, src_dbl
+    mov addr, index
+    shl addr, 2
+    add addr, elements
+    storef32 [addr, 0], src_dbl
     dispatch_next
 .ta_put_uint8_clamped:
-    branch_negative t0, .ta_put_uint8_clamped_zero
-    mov t3, 255
-    branch_ge_unsigned t0, t3, .ta_put_uint8_clamped_max
-    store8 [t5, t4], t0
+    branch_negative src_int32, .ta_put_uint8_clamped_zero
+    mov max, 255
+    branch_ge_unsigned src_int32, max, .ta_put_uint8_clamped_max
+    store8 [elements, index], src_int32
     dispatch_next
 .ta_put_uint8_clamped_zero:
-    mov t0, 0
-    store8 [t5, t4], t0
+    mov src_int32, 0
+    store8 [elements, index], src_int32
     dispatch_next
 .ta_put_uint8_clamped_max:
-    mov t0, 255
-    store8 [t5, t4], t0
+    mov src_int32, 255
+    store8 [elements, index], src_int32
     dispatch_next
 .ta_put_uint8:
-    store8 [t5, t4], t0
+    store8 [elements, index], src_int32
     dispatch_next
 .ta_put_uint16:
-    mov t3, t4
-    add t3, t4
-    add t3, t5
-    store16 [t3, 0], t0
+    mov addr, index
+    add addr, index
+    add addr, elements
+    store16 [addr, 0], src_int32
     dispatch_next
 .try_typed_array_slow:
-    call_interp asm_try_put_by_value_typed_array
-    branch_nonzero t0, .slow
+    call_interp asm_try_put_by_value_typed_array, result
+    branch_nonzero result, .slow
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_put_by_value

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -157,97 +157,99 @@ macro box_double_or_int32(dst, src_fpr)
 end
 
 # Shared same-tag equality dispatch.
-# Expects t3=lhs_tag (known equal to rhs_tag), t1=lhs, t2=rhs.
-# For int32, boolean, object, symbol, undefined, null: bitwise compare.
-# For string: pointer shortcut, else slow. For bigint: always slow.
-# Falls through to .double_compare for doubles.
-macro equality_same_tag(equal_label, not_equal_label, slow_label)
-    branch_any_eq t3, INT32_TAG, BOOLEAN_TAG, .fast_compare
-    branch_any_eq t3, OBJECT_TAG, SYMBOL_TAG, .fast_compare
-    branch_eq t3, STRING_TAG, .string_compare
-    branch_eq t3, BIGINT_TAG, slow_label
+# lhs_tag is known equal to rhs's tag. For int32, boolean, object, symbol,
+# undefined, null: bitwise compare. For string: pointer shortcut, else
+# slow. For bigint: always slow. Falls through to .double_compare for
+# doubles. The macro destroys lhs_tag (clobbers it during the
+# undefined/null check).
+macro equality_same_tag(lhs, rhs, lhs_tag, equal_label, not_equal_label, slow_label)
+    branch_any_eq lhs_tag, INT32_TAG, BOOLEAN_TAG, .fast_compare
+    branch_any_eq lhs_tag, OBJECT_TAG, SYMBOL_TAG, .fast_compare
+    branch_eq lhs_tag, STRING_TAG, .string_compare
+    branch_eq lhs_tag, BIGINT_TAG, slow_label
     # Check undefined/null: (tag & 0xFFFE) == UNDEFINED_TAG matches both.
-    # Safe to clobber t3 here since all other tagged types are handled above.
-    and t3, 0xFFFE
-    branch_eq t3, UNDEFINED_TAG, .fast_compare
+    # Safe to clobber lhs_tag here since every other tagged type is
+    # already routed.
+    and lhs_tag, 0xFFFE
+    branch_eq lhs_tag, UNDEFINED_TAG, .fast_compare
     # Must be a double
     jmp .double_compare
 .string_compare:
-    branch_eq t1, t2, equal_label
+    branch_eq lhs, rhs, equal_label
     jmp slow_label
 .fast_compare:
-    branch_eq t1, t2, equal_label
+    branch_eq lhs, rhs, equal_label
     jmp not_equal_label
 end
 
-# Compare t1/t2 as doubles with NaN awareness.
+# Compare lhs/rhs as doubles with NaN awareness.
 # Defines .double_compare label (referenced by equality_same_tag).
-macro double_equality_compare(equal_label, not_equal_label)
+macro double_equality_compare(lhs, rhs, equal_label, not_equal_label)
+    ftemp lhs_dbl, rhs_dbl
 .double_compare:
-    fp_mov ft0, t1
-    fp_mov ft1, t2
-    branch_fp_unordered ft0, ft1, not_equal_label
-    branch_fp_equal ft0, ft1, equal_label
+    fp_mov lhs_dbl, lhs
+    fp_mov rhs_dbl, rhs
+    branch_fp_unordered lhs_dbl, rhs_dbl, not_equal_label
+    branch_fp_equal lhs_dbl, rhs_dbl, equal_label
     jmp not_equal_label
 end
 
 # Strict equality check core logic.
-# Expects t1=lhs, t2=rhs. Extracts tags into t3/t4.
-# Jumps to equal_label if definitely equal, not_equal_label if definitely not,
-# or slow_label if we can't determine quickly.
-# Handles: int32, boolean, undefined/null, object, symbol (bitwise compare),
-# string (pointer shortcut), bigint (slow), doubles.
-macro strict_equality_core(equal_label, not_equal_label, slow_label)
-    extract_tag t3, t1
-    extract_tag t4, t2
-    branch_ne t3, t4, .diff_tags
-    equality_same_tag equal_label, not_equal_label, slow_label
-    double_equality_compare equal_label, not_equal_label
+# Jumps to equal_label if definitely equal, not_equal_label if definitely
+# not, or slow_label if we can't determine quickly. Handles: int32,
+# boolean, undefined/null, object, symbol (bitwise compare), string
+# (pointer shortcut), bigint (slow), doubles.
+macro strict_equality_core(lhs, rhs, equal_label, not_equal_label, slow_label)
+    temp lhs_tag, rhs_tag, lhs_int
+    ftemp lhs_dbl, rhs_dbl
+    extract_tag lhs_tag, lhs
+    extract_tag rhs_tag, rhs
+    branch_ne lhs_tag, rhs_tag, .diff_tags
+    equality_same_tag lhs, rhs, lhs_tag, equal_label, not_equal_label, slow_label
+    double_equality_compare lhs, rhs, equal_label, not_equal_label
 .diff_tags:
     # Different tags but possibly equal: int32(1) === double(1.0) is true.
     # Handle int32 vs double inline; all other tag mismatches are not equal.
-    branch_eq t3, INT32_TAG, .lhs_int32_diff
-    branch_eq t4, INT32_TAG, .rhs_int32_diff
+    branch_eq lhs_tag, INT32_TAG, .lhs_int32_diff
+    branch_eq rhs_tag, INT32_TAG, .rhs_int32_diff
     # Neither is int32. If both are doubles, compare. Otherwise not equal.
-    # t3/t4 already have the tags, check them directly.
-    check_tag_is_double t3, not_equal_label
-    check_tag_is_double t4, not_equal_label
+    check_tag_is_double lhs_tag, not_equal_label
+    check_tag_is_double rhs_tag, not_equal_label
     jmp .double_compare
 .lhs_int32_diff:
-    # t4 already has rhs tag
-    check_tag_is_double t4, not_equal_label
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
-    fp_mov ft1, t2
-    branch_fp_equal ft0, ft1, equal_label
+    check_tag_is_double rhs_tag, not_equal_label
+    unbox_int32 lhs_int, lhs
+    int_to_double lhs_dbl, lhs_int
+    fp_mov rhs_dbl, rhs
+    branch_fp_equal lhs_dbl, rhs_dbl, equal_label
     jmp not_equal_label
 .rhs_int32_diff:
-    # t3 already has lhs tag
-    check_tag_is_double t3, not_equal_label
-    fp_mov ft0, t1
-    unbox_int32 t4, t2
-    int_to_double ft1, t4
-    branch_fp_equal ft0, ft1, equal_label
+    check_tag_is_double lhs_tag, not_equal_label
+    fp_mov lhs_dbl, lhs
+    unbox_int32 lhs_int, rhs
+    int_to_double rhs_dbl, lhs_int
+    branch_fp_equal lhs_dbl, rhs_dbl, equal_label
     jmp not_equal_label
 end
 
 # Loose equality check core logic.
 # Same as strict_equality_core but with null==undefined cross-type handling.
-macro loose_equality_core(equal_label, not_equal_label, slow_label)
-    extract_tag t3, t1
-    extract_tag t4, t2
-    branch_ne t3, t4, .diff_tags
-    equality_same_tag equal_label, not_equal_label, slow_label
-    double_equality_compare equal_label, not_equal_label
+macro loose_equality_core(lhs, rhs, equal_label, not_equal_label, slow_label)
+    temp lhs_tag, rhs_tag
+    extract_tag lhs_tag, lhs
+    extract_tag rhs_tag, rhs
+    branch_ne lhs_tag, rhs_tag, .diff_tags
+    equality_same_tag lhs, rhs, lhs_tag, equal_label, not_equal_label, slow_label
+    double_equality_compare lhs, rhs, equal_label, not_equal_label
 .diff_tags:
     # null == undefined (and vice versa): (tag & 0xFFFE) == UNDEFINED_TAG
-    and t3, 0xFFFE
-    branch_ne t3, UNDEFINED_TAG, .try_double
-    and t4, 0xFFFE
-    branch_eq t4, UNDEFINED_TAG, equal_label
+    and lhs_tag, 0xFFFE
+    branch_ne lhs_tag, UNDEFINED_TAG, .try_double
+    and rhs_tag, 0xFFFE
+    branch_eq rhs_tag, UNDEFINED_TAG, equal_label
     jmp slow_label
 .try_double:
-    check_both_double t1, t2, slow_label
+    check_both_double lhs, rhs, slow_label
     jmp .double_compare
 end
 
@@ -776,30 +778,34 @@ handler JumpGreaterThanEquals
 end
 
 handler JumpLooselyEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    loose_equality_core .take_true, .take_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    loose_equality_core lhs, rhs, .take_true, .take_false, .slow
     jump_binary_epilogue asm_slow_path_jump_loosely_equals
 end
 
 handler JumpLooselyInequals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    loose_equality_core .take_false, .take_true, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    loose_equality_core lhs, rhs, .take_false, .take_true, .slow
     jump_binary_epilogue asm_slow_path_jump_loosely_inequals
 end
 
 handler JumpStrictlyEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    strict_equality_core .take_true, .take_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    strict_equality_core lhs, rhs, .take_true, .take_false, .slow
     jump_binary_epilogue asm_slow_path_jump_strictly_equals
 end
 
 handler JumpStrictlyInequals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    strict_equality_core .take_false, .take_true, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    strict_equality_core lhs, rhs, .take_false, .take_true, .slow
     jump_binary_epilogue asm_slow_path_jump_strictly_inequals
 end
 
@@ -1325,16 +1331,18 @@ end
 # type-specific comparisons (int32, boolean, undefined/null bitwise compare,
 # double with NaN awareness, string pointer shortcut, bigint -> slow path).
 handler StrictlyEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    strict_equality_core .store_true, .store_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    strict_equality_core lhs, rhs, .store_true, .store_false, .slow
     boolean_result_epilogue asm_slow_path_strictly_equals
 end
 
 handler StrictlyInequals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    strict_equality_core .store_false, .store_true, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    strict_equality_core lhs, rhs, .store_false, .store_true, .slow
     boolean_result_epilogue asm_slow_path_strictly_inequals
 end
 
@@ -1360,16 +1368,18 @@ handler GetCalleeAndThisFromEnvironment
 end
 
 handler LooselyEquals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    loose_equality_core .store_true, .store_false, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    loose_equality_core lhs, rhs, .store_true, .store_false, .slow
     boolean_result_epilogue asm_slow_path_loosely_equals
 end
 
 handler LooselyInequals
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    loose_equality_core .store_false, .store_true, .slow
+    temp lhs, rhs
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    loose_equality_core lhs, rhs, .store_false, .store_true, .slow
     boolean_result_epilogue asm_slow_path_loosely_inequals
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1067,47 +1067,47 @@ end
 # coerce_to_doubles here because we never need the both-int32 branch --
 # both operands go straight to FP regs.
 handler Div
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    extract_tag t3, t1
-    branch_eq t3, INT32_TAG, .lhs_is_int32
-    # t3 already has lhs tag
-    check_tag_is_double t3, .slow
-    fp_mov ft0, t1
+    temp lhs, rhs, tag, scratch_int, dst
+    ftemp lhs_dbl, rhs_dbl
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    extract_tag tag, lhs
+    branch_eq tag, INT32_TAG, .lhs_is_int32
+    # tag already has lhs tag
+    check_tag_is_double tag, .slow
+    fp_mov lhs_dbl, lhs
     jmp .lhs_ok
 .lhs_is_int32:
-    unbox_int32 t3, t1
-    int_to_double ft0, t3
+    unbox_int32 scratch_int, lhs
+    int_to_double lhs_dbl, scratch_int
 .lhs_ok:
-    # ft0 = lhs as double
-    extract_tag t3, t2
-    branch_eq t3, INT32_TAG, .rhs_is_int32
-    # t3 already has rhs tag
-    check_tag_is_double t3, .slow
-    fp_mov ft1, t2
+    extract_tag tag, rhs
+    branch_eq tag, INT32_TAG, .rhs_is_int32
+    # tag already has rhs tag
+    check_tag_is_double tag, .slow
+    fp_mov rhs_dbl, rhs
     jmp .do_div
 .rhs_is_int32:
-    unbox_int32 t3, t2
-    int_to_double ft1, t3
+    unbox_int32 scratch_int, rhs
+    int_to_double rhs_dbl, scratch_int
 .do_div:
-    # ft0 = lhs, ft1 = rhs
-    fp_div ft0, ft1
+    fp_div lhs_dbl, rhs_dbl
     # Try to store result as int32 if it's an integer in i32 range.
     # NB: We can't use js_to_int32 here because fjcvtzs applies modular
     # reduction (e.g. 2^33 -> 0) which is wrong -- we need a strict
     # round-trip check: truncate to int32, convert back, compare.
-    double_to_int32 t5, ft0, .store_double
+    double_to_int32 dst, lhs_dbl, .store_double
     # Exclude negative zero: -0.0 truncates to 0 but must stay double.
-    branch_nonzero t5, .store_int
-    fp_mov t5, ft0
-    branch_negative t5, .store_double
+    branch_nonzero dst, .store_int
+    fp_mov dst, lhs_dbl
+    branch_negative dst, .store_double
 .store_int:
-    box_int32 t5, t5
-    store_operand m_dst, t5
+    box_int32 dst, dst
+    store_operand m_dst, dst
     dispatch_next
 .store_double:
-    canonicalize_nan t5, ft0
-    store_operand m_dst, t5
+    canonicalize_nan dst, lhs_dbl
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_div
@@ -1304,22 +1304,22 @@ end
 # Modulo: int32-only fast path for non-negative dividend.
 # Negative dividend falls to slow path to handle -0 and INT_MIN correctly.
 handler Mod
-    load_operand t1, m_lhs
-    load_operand t2, m_rhs
-    extract_tag t3, t1
-    branch_ne t3, INT32_TAG, .slow
-    extract_tag t4, t2
-    branch_ne t4, INT32_TAG, .slow
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
+    temp lhs, rhs, lhs_tag, rhs_tag, lhs_int, rhs_int, quot, rem, dst
+    load_operand lhs, m_lhs
+    load_operand rhs, m_rhs
+    extract_tag lhs_tag, lhs
+    branch_ne lhs_tag, INT32_TAG, .slow
+    extract_tag rhs_tag, rhs
+    branch_ne rhs_tag, INT32_TAG, .slow
+    unbox_int32 lhs_int, lhs
+    unbox_int32 rhs_int, rhs
     # Check d == 0
-    branch_zero t4, .slow
+    branch_zero rhs_int, .slow
     # Check n >= 0 (positive fast path avoids INT_MIN/-1 and negative zero)
-    branch_negative t3, .slow
-    # divmod: quotient in t0, remainder in t2
-    divmod t0, t2, t3, t4
-    box_int32 t2, t2
-    store_operand m_dst, t2
+    branch_negative lhs_int, .slow
+    divmod quot, rem, lhs_int, rhs_int
+    box_int32 dst, rem
+    store_operand m_dst, dst
     dispatch_next
 .slow:
     call_slow_path asm_slow_path_mod

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -629,8 +629,9 @@ end
 # ============================================================================
 
 handler Jump
-    load_label t0, m_target
-    goto_handler t0
+    temp target
+    load_label target, m_target
+    goto_handler target
 end
 
 # Conditional jumps: check boolean first (most common), then int32, then slow path.
@@ -702,27 +703,29 @@ end
 # Nullish check: undefined and null tags differ only in bit 0,
 # so (tag & 0xFFFE) == UNDEFINED_TAG matches both.
 handler JumpNullish
-    load_operand t1, m_condition
+    temp condition, tag, target
+    load_operand condition, m_condition
     # Nullish: (tag & 0xFFFE) == 0x7FFE (matches undefined=0x7FFE and null=0x7FFF)
-    extract_tag t2, t1
-    and t2, 0xFFFE
-    branch_eq t2, UNDEFINED_TAG, .nullish
-    load_label t0, m_false_target
-    goto_handler t0
+    extract_tag tag, condition
+    and tag, 0xFFFE
+    branch_eq tag, UNDEFINED_TAG, .nullish
+    load_label target, m_false_target
+    goto_handler target
 .nullish:
-    load_label t0, m_true_target
-    goto_handler t0
+    load_label target, m_true_target
+    goto_handler target
 end
 
 handler JumpUndefined
-    load_operand t1, m_condition
-    mov t0, UNDEFINED_SHIFTED
-    branch_eq t1, t0, .is_undefined
-    load_label t0, m_false_target
-    goto_handler t0
+    temp condition, undef, target
+    load_operand condition, m_condition
+    mov undef, UNDEFINED_SHIFTED
+    branch_eq condition, undef, .is_undefined
+    load_label target, m_false_target
+    goto_handler target
 .is_undefined:
-    load_label t0, m_true_target
-    goto_handler t0
+    load_label target, m_true_target
+    goto_handler target
 end
 
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1636,55 +1636,48 @@ end
 
 # Inline cache fast path for property access (own + prototype chain).
 handler GetById
-    load_operand t1, m_base
-    # Check base is an object
-    extract_tag t2, t1
-    branch_ne t2, OBJECT_TAG, .try_cache
-    # Extract Object* from NaN-boxed value (sign-extend lower 48 bits)
-    unbox_object t3, t1
-    # Load Object.m_shape
-    load64 t4, [t3, OBJECT_SHAPE]
+    temp base, tag, obj, shape, plc, cache_shape, cache_proto, prop_offset, dict_gen, cur_dict_gen, props, value, result
+    load_operand base, m_base
+    extract_tag tag, base
+    branch_ne tag, OBJECT_TAG, .try_cache
+    unbox_object obj, base
+    load64 shape, [obj, OBJECT_SHAPE]
     # Get PropertyLookupCache* (direct pointer from instruction stream)
-    load64 t5, [pb, pc, m_cache]
-    # Check entry[0].shape and entry[0].prototype.
-    load_pair64 t1, t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
-    branch_ne t1, t4, .try_cache
-    branch_nonzero t0, .proto
+    load64 plc, [pb, pc, m_cache]
+    load_pair64 cache_shape, cache_proto, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
+    branch_ne cache_shape, shape, .try_cache
+    branch_nonzero cache_proto, .proto
     # Check dictionary generation matches
-    load_pair32 t1, t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
-    load32 t2, [t4, SHAPE_DICTIONARY_GENERATION]
-    branch_ne t0, t2, .try_cache
+    load_pair32 prop_offset, dict_gen, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    load32 cur_dict_gen, [shape, SHAPE_DICTIONARY_GENERATION]
+    branch_ne dict_gen, cur_dict_gen, .try_cache
     # IC hit! Load property value via get_direct (own property)
-    load64 t5, [t3, OBJECT_NAMED_PROPERTIES]
-    load64 t0, [t5, t1, 8]
+    load64 props, [obj, OBJECT_NAMED_PROPERTIES]
+    load64 value, [props, prop_offset, 8]
     # Check value is not an accessor
-    extract_tag t2, t0
-    branch_eq t2, ACCESSOR_TAG, .try_cache
-    store_operand m_dst, t0
+    extract_tag tag, value
+    branch_eq tag, ACCESSOR_TAG, .try_cache
+    store_operand m_dst, value
     dispatch_next
 .proto:
-    # t0 = prototype Object*, t4 = object's shape, t5 = PLC base
-    # Check prototype chain validity (direct pointer, null = invalid)
-    load64 t1, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE_CHAIN_VALIDITY]
-    branch_zero t1, .try_cache
-    load8 t2, [t1, PROTOTYPE_CHAIN_VALIDITY_VALID]
-    branch_zero t2, .try_cache
-    # Check dictionary generation matches
-    load_pair32 t2, t1, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
-    load32 t4, [t4, SHAPE_DICTIONARY_GENERATION]
-    branch_ne t1, t4, .try_cache
-    # IC hit! Load property value via get_direct (from prototype)
-    load64 t1, [t0, OBJECT_NAMED_PROPERTIES]
-    load64 t0, [t1, t2, 8]
-    # Check value is not an accessor
-    extract_tag t1, t0
-    branch_eq t1, ACCESSOR_TAG, .try_cache
-    store_operand m_dst, t0
+    # cache_proto = prototype Object*, shape = object's shape, plc = PLC base
+    load64 prop_offset, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE_CHAIN_VALIDITY]
+    branch_zero prop_offset, .try_cache
+    load8 tag, [prop_offset, PROTOTYPE_CHAIN_VALIDITY_VALID]
+    branch_zero tag, .try_cache
+    load_pair32 prop_offset, dict_gen, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    load32 cur_dict_gen, [shape, SHAPE_DICTIONARY_GENERATION]
+    branch_ne dict_gen, cur_dict_gen, .try_cache
+    load64 props, [cache_proto, OBJECT_NAMED_PROPERTIES]
+    load64 value, [props, prop_offset, 8]
+    extract_tag tag, value
+    branch_eq tag, ACCESSOR_TAG, .try_cache
+    store_operand m_dst, value
     dispatch_next
 .try_cache:
     # Try all cache entries via C++ helper
-    call_interp asm_try_get_by_id_cache
-    branch_zero t0, .done
+    call_interp asm_try_get_by_id_cache, result
+    branch_zero result, .done
 .slow:
     call_slow_path asm_slow_path_get_by_id
 .done:
@@ -1693,39 +1686,32 @@ end
 
 # Inline cache fast path for own-property store (ChangeOwnProperty).
 handler PutById
-    load_operand t1, m_base
-    # Check base is an object
-    extract_tag t2, t1
-    branch_ne t2, OBJECT_TAG, .try_cache
-    # Extract Object* from NaN-boxed value (sign-extend lower 48 bits)
-    unbox_object t3, t1
-    # Load Object.m_shape
-    load64 t4, [t3, OBJECT_SHAPE]
-    # Get PropertyLookupCache* (direct pointer from instruction stream)
-    load64 t5, [pb, pc, m_cache]
-    # Check entry[0].shape and entry[0].prototype.
-    load_pair64 t1, t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
-    branch_ne t1, t4, .try_cache
-    branch_nonzero t0, .try_cache
-    # Check dictionary generation matches
-    load_pair32 t1, t0, [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [t5, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
-    load32 t2, [t4, SHAPE_DICTIONARY_GENERATION]
-    branch_ne t0, t2, .try_cache
-    # Check current value at property_offset is not an accessor
-    load64 t5, [t3, OBJECT_NAMED_PROPERTIES]
-    load64 t2, [t5, t1, 8]
-    extract_tag t4, t2
-    branch_eq t4, ACCESSOR_TAG, .try_cache
-    # IC hit! Store new value via put_direct
-    # Save property offset in t4 before load_operand clobbers t0 (rax)
-    mov t4, t1
-    load_operand t1, m_src
-    store64 [t5, t4, 8], t1
+    temp base, tag, obj, shape, plc, cache_shape, cache_proto, prop_offset, dict_gen, cur_dict_gen, props, value, src, result
+    load_operand base, m_base
+    extract_tag tag, base
+    branch_ne tag, OBJECT_TAG, .try_cache
+    unbox_object obj, base
+    load64 shape, [obj, OBJECT_SHAPE]
+    load64 plc, [pb, pc, m_cache]
+    load_pair64 cache_shape, cache_proto, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
+    branch_ne cache_shape, shape, .try_cache
+    branch_nonzero cache_proto, .try_cache
+    load_pair32 prop_offset, dict_gen, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROPERTY_OFFSET], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_DICTIONARY_GENERATION]
+    load32 cur_dict_gen, [shape, SHAPE_DICTIONARY_GENERATION]
+    branch_ne dict_gen, cur_dict_gen, .try_cache
+    # Check current value at prop_offset is not an accessor
+    load64 props, [obj, OBJECT_NAMED_PROPERTIES]
+    load64 value, [props, prop_offset, 8]
+    extract_tag tag, value
+    branch_eq tag, ACCESSOR_TAG, .try_cache
+    # IC hit! Store new value via put_direct.
+    load_operand src, m_src
+    store64 [props, prop_offset, 8], src
     dispatch_next
 .try_cache:
     # Try all cache entries via C++ helper (handles AddOwnProperty)
-    call_interp asm_try_put_by_id_cache
-    branch_zero t0, .done
+    call_interp asm_try_put_by_id_cache, result
+    branch_zero result, .done
 .slow:
     call_slow_path asm_slow_path_put_by_id
 .done:


### PR DESCRIPTION
Bytecode handlers in AsmInt used to share a fixed pool of positional slots (`t0`..`t8`, `ft0`..`ft3`) that authors hand-assigned per handler. This made the file genuinely dangerous to hack on: it was very easy to clobber a live value across a macro call, and the result was usually a latent bug that only surfaced much later under the right input.

This branch teaches `AsmIntGen` to accept named `temp` and `ftemp` declarations in the DSL and adds a register allocator that assigns each named temporary to a concrete machine register based on liveness. Every handler and macro is migrated, and the positional aliases are retired entirely. Writing a handler is now just declaring the temps you need by name, and the allocator handles the rest.

The allocator is also biased toward cheap x86_64 encodings, and on aarch64 it avoids the helper-call bridge moves that used to appear whenever a named temp outlived a runtime call. The net effect is slightly smaller generated code on both architectures while the handlers themselves became much easier to read. :^)

The diff in asmint.asm is large but mechanical: all of it is register renumbering produced by the allocator, with no behavioral change.

Benchmarks basically neutral:
```
Suite           Test                                            Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  ----------------------------------------------  ---------  ---------------------------------  ---------------------------------  ----------------
LongSpider      3d-cube.js                                      0.961      4.596 ± 4.544 … 4.649              4.784 ± 4.705 … 4.862              -0.4% (-0.1 MB)
LongSpider      3d-morph.js                                     0.969      1.561 ± 1.470 … 1.651              1.611 ± 1.507 … 1.715              +0.0% (+0.0 MB)
LongSpider      3d-raytrace.js                                  1.006      2.875 ± 2.868 … 2.882              2.858 ± 2.857 … 2.859              -0.1% (-0.0 MB)
LongSpider      access-binary-trees.js                          1.046      8.245 ± 8.174 … 8.315              7.881 ± 7.877 … 7.885              +0.3% (+0.4 MB)
LongSpider      access-fannkuch.js                              1.021      1.726 ± 1.699 … 1.752              1.690 ± 1.688 … 1.692              +0.0% (+0.0 MB)
LongSpider      access-nbody.js                                 0.970      3.771 ± 3.758 … 3.783              3.888 ± 3.867 … 3.909              +0.0% (+0.0 MB)
LongSpider      access-nsieve.js                                0.988      0.922 ± 0.919 … 0.925              0.933 ± 0.926 … 0.940              +0.1% (+0.3 MB)
LongSpider      bitops-3bit-bits-in-byte.js                     1.017      0.451 ± 0.450 … 0.452              0.444 ± 0.444 … 0.444              +0.0% (+0.0 MB)
LongSpider      bitops-bits-in-byte.js                          0.921      0.690 ± 0.689 … 0.692              0.750 ± 0.736 … 0.764              +0.0% (+0.0 MB)
LongSpider      bitops-nsieve-bits.js                           1.025      1.873 ± 1.779 … 1.968              1.827 ± 1.775 … 1.880              -0.3% (-0.1 MB)
LongSpider      controlflow-recursive.js                        1.004      1.784 ± 1.782 … 1.785              1.776 ± 1.771 … 1.782              +0.0% (+0.0 MB)
LongSpider      crypto-aes.js                                   0.989      4.355 ± 4.347 … 4.363              4.403 ± 4.385 … 4.421              +0.3% (+0.1 MB)
LongSpider      crypto-md5.js                                   1.102      4.904 ± 4.599 … 5.209              4.450 ± 4.449 … 4.451              +0.0% (+0.0 MB)
LongSpider      crypto-sha1.js                                  0.992      8.733 ± 8.604 … 8.862              8.803 ± 8.668 … 8.938              +0.2% (+0.1 MB)
LongSpider      date-format-tofte.js                            1.009      3.615 ± 3.595 … 3.634              3.582 ± 3.564 … 3.601              +0.6% (+0.2 MB)
LongSpider      date-format-xparb.js                            1.011      4.229 ± 4.174 … 4.283              4.182 ± 4.176 … 4.187              +0.2% (+0.1 MB)
LongSpider      hash-map.js                                     0.968      0.990 ± 0.986 … 0.994              1.023 ± 1.015 … 1.031              -0.0% (-0.0 MB)
LongSpider      math-cordic.js                                  0.997      5.293 ± 5.291 … 5.295              5.309 ± 5.274 … 5.344              +0.0% (+0.0 MB)
LongSpider      math-partial-sums.js                            0.945      0.804 ± 0.800 … 0.807              0.850 ± 0.803 … 0.898              +0.0% (+0.0 MB)
LongSpider      math-spectral-norm.js                           1.005      4.769 ± 4.757 … 4.781              4.747 ± 4.746 … 4.748              +0.0% (+0.0 MB)
LongSpider      string-base64.js                                0.935      1.434 ± 1.427 … 1.440              1.533 ± 1.439 … 1.627              -0.0% (-0.0 MB)
LongSpider      string-fasta.js                                 1.009      1.562 ± 1.548 … 1.576              1.547 ± 1.546 … 1.549              +0.5% (+0.2 MB)
LongSpider      string-tagcloud.js                              1.007      0.750 ± 0.736 … 0.765              0.745 ± 0.740 … 0.749              -0.3% (-0.2 MB)
Kraken          ai-astar.js                                     0.979      0.632 ± 0.623 … 0.641              0.646 ± 0.640 … 0.652              -0.0% (-0.0 MB)
Kraken          audio-beat-detection.js                         1.037      0.541 ± 0.540 … 0.543              0.522 ± 0.513 … 0.531              +0.6% (+0.4 MB)
Kraken          audio-dft.js                                    0.996      0.362 ± 0.360 … 0.365              0.364 ± 0.353 … 0.374              +0.4% (+0.2 MB)
Kraken          audio-fft.js                                    1.069      0.465 ± 0.463 … 0.467              0.435 ± 0.424 … 0.446              +0.1% (+0.1 MB)
Kraken          audio-oscillator.js                             1.022      0.385 ± 0.360 … 0.410              0.377 ± 0.368 … 0.385              +0.3% (+0.3 MB)
Kraken          imaging-darkroom.js                             1.036      0.555 ± 0.552 … 0.559              0.536 ± 0.534 … 0.538              -0.0% (-0.0 MB)
Kraken          imaging-desaturate.js                           1.084      0.623 ± 0.618 … 0.629              0.575 ± 0.572 … 0.578              +0.0% (+0.0 MB)
Kraken          imaging-gaussian-blur.js                        0.975      2.604 ± 2.517 … 2.692              2.671 ± 2.668 … 2.674              +0.1% (+0.0 MB)
Kraken          json-parse-financial.js                         1.006      0.055 ± 0.054 … 0.056              0.055 ± 0.054 … 0.055              -0.1% (-0.0 MB)
Kraken          json-stringify-tinderbox.js                     1.037      0.053 ± 0.052 … 0.053              0.051 ± 0.050 … 0.052              +0.9% (+0.3 MB)
Kraken          stanford-crypto-aes.js                          1.016      0.217 ± 0.216 … 0.219              0.214 ± 0.212 … 0.215              -0.3% (-0.1 MB)
Kraken          stanford-crypto-ccm.js                          0.983      0.164 ± 0.163 … 0.166              0.167 ± 0.165 … 0.169              +0.6% (+0.3 MB)
Kraken          stanford-crypto-pbkdf2.js                       1.030      0.379 ± 0.379 … 0.380              0.368 ± 0.360 … 0.376              +0.5% (+0.2 MB)
Kraken          stanford-crypto-sha256-iterative.js             1.011      0.136 ± 0.135 … 0.137              0.134 ± 0.134 … 0.135              +0.4% (+0.1 MB)
Octane          box2d.js                                        0.982      8658.000 ± 8632.000 … 8684.000     8504.000 ± 8279.000 … 8729.000     +0.1% (+0.0 MB)
Octane          code-load.js                                    1.014      18586.500 ± 18562.000 … 18611.000  18849.500 ± 18828.000 … 18871.000  -0.0% (-0.2 MB)
Octane          crypto.js                                       1.048      2731.000 ± 2699.000 … 2763.000     2861.500 ± 2759.000 … 2964.000     -0.6% (-0.2 MB)
Octane          deltablue.js                                    1.005      2341.500 ± 2318.000 … 2365.000     2352.500 ± 2312.000 … 2393.000     -0.8% (-0.2 MB)
Octane          earley-boyer.js                                 1.004      4844.500 ± 4834.000 … 4855.000     4865.000 ± 4863.000 … 4867.000     -0.6% (-0.3 MB)
Octane          gbemu.js                                        1.006      16821.500 ± 16683.000 … 16960.000  16916.500 ± 16683.000 … 17150.000  -0.1% (-0.1 MB)
Octane          mandreel.js                                     1.010      16031.000 ± 15876.000 … 16186.000  16187.500 ± 16030.000 … 16345.000  +0.1% (+0.4 MB)
Octane          navier-stokes.js                                0.905      5474.500 ± 5399.000 … 5550.000     4954.000 ± 4947.000 … 4961.000     -0.5% (-0.1 MB)
Octane          pdfjs.js                                        0.995      7623.500 ± 7620.000 … 7627.000     7584.500 ± 7542.000 … 7627.000     +3.7% (+3.4 MB)
Octane          raytrace.js                                     0.965      3745.500 ± 3740.000 … 3751.000     3616.000 ± 3569.000 … 3663.000     +0.4% (+0.1 MB)
Octane          regexp.js                                       1.001      2044.000 ± 2038.000 … 2050.000     2047.000 ± 2042.000 … 2052.000     +0.4% (+0.2 MB)
Octane          richards.js                                     1.017      2488.500 ± 2478.000 … 2499.000     2532.000 ± 2529.000 … 2535.000     +0.1% (+0.0 MB)
Octane          splay.js                                        1.015      5465.000 ± 5426.000 … 5504.000     5548.000 ± 5528.000 … 5568.000     +0.0% (+0.0 MB)
Octane          typescript.js                                   0.991      21338.500 ± 21301.000 … 21376.000  21136.500 ± 21054.000 … 21219.000  +0.9% (+2.4 MB)
Octane          zlib.js                                         0.979      5675.000 ± 5567.000 … 5783.000     5555.500 ± 5435.000 … 5676.000     -0.0% (-0.0 MB)
JetStream       bigfib.cpp.js                                   0.972      4.914 ± 4.709 … 5.119              5.055 ± 4.928 … 5.182              +0.1% (+0.1 MB)
JetStream       cdjs.js                                         1.009      1.932 ± 1.930 … 1.934              1.915 ± 1.913 … 1.917              +0.3% (+0.1 MB)
JetStream       container.cpp.js                                0.998      20.580 ± 20.531 … 20.629           20.620 ± 20.561 … 20.680           +0.0% (+0.0 MB)
JetStream       dry.c.js                                        0.908      11.208 ± 10.488 … 11.929           12.350 ± 11.951 … 12.749           -0.2% (-0.1 MB)
JetStream       float-mm.c.js                                   1.082      13.648 ± 13.358 … 13.938           12.610 ± 12.607 … 12.614           -0.1% (-0.1 MB)
JetStream       gcc-loops.cpp.js                                1.025      72.586 ± 70.642 … 74.530           70.839 ± 70.432 … 71.246           +0.1% (+0.2 MB)
JetStream       hash-map.js                                     0.986      1.008 ± 1.002 … 1.013              1.022 ± 1.010 … 1.035              +0.1% (+0.1 MB)
JetStream       n-body.c.js                                     1.087      18.055 ± 17.956 … 18.154           16.607 ± 16.555 … 16.659           +0.0% (+0.0 MB)
JetStream       quicksort.c.js                                  1.138      3.260 ± 3.257 … 3.262              2.864 ± 2.787 … 2.941              -0.3% (-0.1 MB)
JetStream       towers.c.js                                     1.080      3.533 ± 3.480 … 3.587              3.270 ± 3.125 … 3.416              -0.1% (-0.0 MB)
JetStream3      js-tokens.js                                    1.007      0.276 ± 0.276 … 0.276              0.274 ± 0.272 … 0.276              +0.7% (+0.2 MB)
JetStream3      lazy-collections.js                             0.981      0.816 ± 0.812 … 0.819              0.832 ± 0.823 … 0.840              -0.5% (-0.2 MB)
JetStream3      raytrace-private-class-fields.js                1.002      3.537 ± 3.529 … 3.545              3.530 ± 3.529 … 3.532              +0.1% (+0.0 MB)
JetStream3      raytrace-public-class-fields.js                 0.990      2.597 ± 2.585 … 2.608              2.624 ± 2.600 … 2.647              +0.0% (+0.0 MB)
JetStream3      sync-file-system.js                             1.005      1.777 ± 1.772 … 1.782              1.769 ± 1.768 … 1.769              -3.8% (-1.3 MB)
AsyncBench      async-call-return.js                            1.011      0.178 ± 0.177 … 0.179              0.176 ± 0.176 … 0.176              -0.4% (-0.1 MB)
AsyncBench      async-class-method.js                           0.989      0.202 ± 0.202 … 0.202              0.204 ± 0.204 … 0.205              -0.3% (-0.1 MB)
AsyncBench      async-fan-out.js                                0.999      0.175 ± 0.174 … 0.176              0.175 ± 0.174 … 0.176              +0.3% (+0.1 MB)
AsyncBench      async-generator.js                              0.987      0.259 ± 0.258 … 0.260              0.263 ± 0.260 … 0.265              +0.1% (+0.0 MB)
AsyncBench      async-iife.js                                   1.012      0.278 ± 0.277 … 0.279              0.275 ± 0.274 … 0.276              -0.3% (-0.1 MB)
AsyncBench      async-nested-calls.js                           1.001      0.292 ± 0.290 … 0.293              0.291 ± 0.291 … 0.291              -0.2% (-0.1 MB)
AsyncBench      async-pipeline.js                               0.965      0.349 ± 0.347 … 0.352              0.362 ± 0.350 … 0.374              +0.1% (+0.0 MB)
AsyncBench      async-sequential-awaits.js                      1.001      0.092 ± 0.092 … 0.093              0.092 ± 0.092 … 0.093              -0.1% (-0.0 MB)
AsyncBench      async-try-catch-reject.js                       0.998      0.502 ± 0.502 … 0.502              0.503 ± 0.503 … 0.504              -0.4% (-0.2 MB)
AsyncBench      await-primitive.js                              0.976      0.051 ± 0.051 … 0.051              0.052 ± 0.052 … 0.053              -0.4% (-0.2 MB)
AsyncBench      await-resolved-promise.js                       0.989      0.415 ± 0.415 … 0.415              0.420 ± 0.418 … 0.421              -0.4% (-0.2 MB)
AsyncBench      await-thenable.js                               1.012      0.051 ± 0.051 … 0.052              0.051 ± 0.050 … 0.052              +0.3% (+0.2 MB)
AsyncBench      promise-all.js                                  1.011      0.495 ± 0.493 … 0.497              0.489 ± 0.488 … 0.491              -0.4% (-0.2 MB)
AsyncBench      promise-allSettled.js                           1.004      0.564 ± 0.563 … 0.564              0.561 ± 0.560 … 0.563              -0.4% (-0.2 MB)
AsyncBench      promise-chain.js                                0.995      0.266 ± 0.263 … 0.270              0.268 ± 0.267 … 0.269              +0.0% (+0.0 MB)
AsyncBench      promise-new-resolve.js                          1.004      0.269 ± 0.266 … 0.272              0.268 ± 0.266 … 0.270              -0.4% (-0.2 MB)
AsyncBench      promise-race.js                                 0.999      0.519 ± 0.517 … 0.521              0.520 ± 0.514 … 0.527              -0.4% (-0.2 MB)
ARES-6          Air.js                                          1.018      1.702 ± 1.676 … 1.729              1.672 ± 1.667 … 1.678              +0.3% (+0.2 MB)
ARES-6          Babylon.js                                      1.013      1.036 ± 1.030 … 1.042              1.023 ± 1.020 … 1.027              -0.4% (-0.2 MB)
ARES-6          Basic.js                                        0.981      1.317 ± 1.315 … 1.318              1.342 ± 1.322 … 1.362              -0.4% (-0.2 MB)
ARES-6          ML.js                                           0.951      1.469 ± 1.462 … 1.476              1.544 ± 1.463 … 1.625              -0.4% (-0.2 MB)
JetStreamExtra  FlightPlanner.js                                1.022      1.096 ± 1.078 … 1.114              1.073 ± 1.068 … 1.078              +0.0% (+0.1 MB)
JetStreamExtra  OfflineAssembler.js                             0.968      1.084 ± 1.083 … 1.085              1.120 ± 1.118 … 1.121              -0.3% (-0.2 MB)
JetStreamExtra  UniPoker.js                                     1.004      1.233 ± 1.227 … 1.239              1.229 ± 1.228 … 1.229              -0.4% (-0.2 MB)
JetStreamExtra  async-fs.js                                     0.990      1.699 ± 1.693 … 1.705              1.716 ± 1.700 … 1.733              -0.4% (-0.2 MB)
JetStreamExtra  babylonjs-startup-es5.js                        1.001      1.119 ± 1.116 … 1.122              1.118 ± 1.114 … 1.123              +0.0% (+0.0 MB)
JetStreamExtra  babylonjs-startup-es6.js                        0.996      1.355 ± 1.353 … 1.356              1.360 ± 1.359 … 1.360              -0.2% (-1.4 MB)
JetStreamExtra  bigint-bigdenary.js                             1.002      1.680 ± 1.673 … 1.687              1.676 ± 1.663 … 1.689              -0.4% (-0.2 MB)
JetStreamExtra  bigint-noble-bls12-381.js                       1.003      1.793 ± 1.780 … 1.807              1.787 ± 1.783 … 1.792              -0.4% (-0.2 MB)
JetStreamExtra  bigint-noble-ed25519.js                         1.009      1.831 ± 1.826 … 1.836              1.814 ± 1.808 … 1.820              -0.7% (-0.4 MB)
JetStreamExtra  bigint-noble-secp256k1.js                       1.000      1.687 ± 1.686 … 1.687              1.686 ± 1.671 … 1.700              -0.5% (-0.3 MB)
JetStreamExtra  bigint-paillier.js                              1.014      1.837 ± 1.824 … 1.850              1.811 ± 1.801 … 1.821              +0.0% (+0.0 MB)
JetStreamExtra  doxbee-async.js                                 1.006      1.615 ± 1.608 … 1.622              1.605 ± 1.601 … 1.608              +0.1% (+0.0 MB)
JetStreamExtra  doxbee-promise.js                               0.989      1.596 ± 1.590 … 1.603              1.614 ± 1.607 … 1.621              -0.1% (-0.0 MB)
JetStreamExtra  first-inspector-code-load.js                    1.005      1.982 ± 1.975 … 1.990              1.972 ± 1.970 … 1.973              +0.0% (+0.1 MB)
JetStreamExtra  jsdom-d3-startup.js                             1.003      1.481 ± 1.471 … 1.492              1.478 ± 1.469 … 1.486              +0.0% (+0.0 MB)
JetStreamExtra  json-parse-inspector.js                         0.986      1.091 ± 1.085 … 1.098              1.107 ± 1.086 … 1.127              -0.6% (-1.8 MB)
JetStreamExtra  json-stringify-inspector.js                     1.004      0.949 ± 0.944 … 0.954              0.945 ± 0.936 … 0.954              +1.2% (+3.7 MB)
JetStreamExtra  mobx-startup.js                                 1.007      1.363 ± 1.355 … 1.371              1.353 ± 1.347 … 1.359              -0.6% (-0.3 MB)
JetStreamExtra  multi-inspector-code-load.js                    0.992      1.982 ± 1.981 … 1.983              1.998 ± 1.977 … 2.018              +0.1% (+1.4 MB)
JetStreamExtra  prismjs-startup-es5.js                          0.993      1.629 ± 1.613 … 1.645              1.640 ± 1.635 … 1.646              -0.4% (-0.2 MB)
JetStreamExtra  prismjs-startup-es6.js                          0.997      1.634 ± 1.626 … 1.643              1.640 ± 1.631 … 1.649              -0.4% (-0.2 MB)
JetStreamExtra  proxy-mobx.js                                   0.994      1.219 ± 1.215 … 1.224              1.227 ± 1.223 … 1.231              -0.4% (-0.2 MB)
JetStreamExtra  proxy-vue.js                                    1.051      1.262 ± 1.150 … 1.374              1.201 ± 1.153 … 1.248              -3.2% (-1.8 MB)
JetStreamExtra  threejs.js                                      1.009      1.674 ± 1.659 … 1.689              1.658 ± 1.648 … 1.668              -0.0% (-0.0 MB)
JetStreamExtra  typescript-lib.js                               0.995      0.695 ± 0.695 … 0.696              0.699 ± 0.695 … 0.703              +0.5% (+1.4 MB)
JetStreamExtra  validatorjs.js                                  1.000      1.473 ± 1.468 … 1.477              1.473 ± 1.470 … 1.476              -1.8% (-1.0 MB)
JetStreamExtra  web-ssr.js                                      1.001      1.733 ± 1.727 … 1.738              1.731 ± 1.722 … 1.740              +0.1% (+0.2 MB)
GarBench        array-of-objects.js                             1.005      0.872 ± 0.870 … 0.874              0.868 ± 0.866 … 0.870              -0.0% (-0.0 MB)
GarBench        closures.js                                     1.001      1.220 ± 1.218 … 1.222              1.218 ± 1.211 … 1.226              +0.0% (+0.1 MB)
GarBench        cyclic-graph.js                                 1.031      1.271 ± 1.271 … 1.271              1.233 ± 1.195 … 1.270              +0.1% (+0.2 MB)
GarBench        deep-linked-list.js                             1.031      0.835 ± 0.825 … 0.846              0.810 ± 0.808 … 0.813              -0.0% (-0.0 MB)
GarBench        finalization.js                                 1.028      0.983 ± 0.948 … 1.018              0.955 ± 0.950 … 0.961              +0.0% (+0.1 MB)
GarBench        many-properties.js                              1.000      2.685 ± 2.679 … 2.691              2.686 ± 2.685 … 2.686              -0.0% (-0.0 MB)
GarBench        marking-stress.js                               1.371      1.845 ± 1.843 … 1.847              1.346 ± 1.197 … 1.495              +2.8% (+18.6 MB)
GarBench        mixed-sizes.js                                  1.005      1.071 ± 1.067 … 1.076              1.066 ± 1.064 … 1.068              +0.0% (+0.1 MB)
GarBench        sparse-arrays.js                                1.003      2.252 ± 2.252 … 2.253              2.246 ± 2.244 … 2.247              +0.0% (+0.1 MB)
GarBench        string-heavy.js                                 1.045      1.683 ± 1.632 … 1.735              1.610 ± 1.608 … 1.612              +0.0% (+0.3 MB)
GarBench        wide-tree.js                                    0.988      1.509 ± 1.507 … 1.512              1.528 ± 1.514 … 1.541              +0.0% (+0.0 MB)
MicroBench      array-destructuring-assignment-rest.js          1.045      0.328 ± 0.320 … 0.337              0.314 ± 0.308 … 0.321              -0.4% (-0.2 MB)
MicroBench      array-destructuring-assignment.js               0.956      2.981 ± 2.971 … 2.990              3.118 ± 3.110 … 3.126              +0.0% (+0.1 MB)
MicroBench      array-prototype-map.js                          0.994      1.199 ± 1.191 … 1.206              1.206 ± 1.186 … 1.226              +0.1% (+0.2 MB)
MicroBench      array-prototype-shift.js                        2.373      0.017 ± 0.008 … 0.027              0.007 ± 0.007 … 0.007              -0.4% (-0.2 MB)
MicroBench      bound-call-00-args.js                           1.022      1.468 ± 1.459 … 1.478              1.436 ± 1.433 … 1.439              -0.4% (-0.2 MB)
MicroBench      bound-call-04-args.js                           1.005      1.581 ± 1.581 … 1.582              1.573 ± 1.561 … 1.584              -0.4% (-0.2 MB)
MicroBench      bound-call-16-args.js                           0.996      1.793 ± 1.793 … 1.794              1.801 ± 1.787 … 1.815              -0.4% (-0.2 MB)
MicroBench      call-00-args.js                                 0.903      0.465 ± 0.465 … 0.466              0.515 ± 0.478 … 0.552              -0.4% (-0.2 MB)
MicroBench      call-01-args.js                                 0.988      0.499 ± 0.497 … 0.501              0.505 ± 0.503 … 0.506              -0.4% (-0.2 MB)
MicroBench      call-02-args.js                                 1.022      0.526 ± 0.520 … 0.531              0.515 ± 0.503 … 0.527              -0.4% (-0.2 MB)
MicroBench      call-03-args.js                                 1.068      0.564 ± 0.563 … 0.565              0.528 ± 0.528 … 0.528              -0.4% (-0.2 MB)
MicroBench      call-04-args.js                                 0.924      0.547 ± 0.543 … 0.550              0.592 ± 0.578 … 0.605              -0.4% (-0.2 MB)
MicroBench      call-16-args.js                                 1.006      0.719 ± 0.709 … 0.729              0.715 ± 0.713 … 0.716              -0.4% (-0.2 MB)
MicroBench      call-32-args.js                                 0.973      0.918 ± 0.918 … 0.918              0.943 ± 0.943 … 0.944              -0.4% (-0.2 MB)
MicroBench      call-with-function-environment-2.js             1.015      0.906 ± 0.899 … 0.913              0.893 ± 0.892 … 0.893              -0.4% (-0.2 MB)
MicroBench      call-with-function-environment-captured-var.js  1.002      0.939 ± 0.939 … 0.940              0.937 ± 0.935 … 0.940              -0.4% (-0.2 MB)
MicroBench      call-with-function-environment.js               1.005      0.469 ± 0.467 … 0.472              0.467 ± 0.465 … 0.469              -0.4% (-0.2 MB)
MicroBench      for-in-indexed-properties.js                    1.001      0.239 ± 0.233 … 0.244              0.238 ± 0.236 … 0.240              +0.0% (+0.0 MB)
MicroBench      for-in-named-properties.js                      0.993      0.172 ± 0.170 … 0.173              0.173 ± 0.171 … 0.175              -0.4% (-0.2 MB)
MicroBench      for-of.js                                       1.021      0.526 ± 0.512 … 0.540              0.515 ± 0.501 … 0.529              -0.4% (-0.2 MB)
MicroBench      function-prototype-call.js                      1.005      0.382 ± 0.380 … 0.384              0.380 ± 0.379 … 0.381              -0.4% (-0.2 MB)
MicroBench      object-keys.js                                  1.033      1.292 ± 1.266 … 1.318              1.250 ± 1.249 … 1.251              +0.1% (+0.1 MB)
MicroBench      object-set-with-rope-strings.js                 1.015      0.701 ± 0.693 … 0.709              0.690 ± 0.689 … 0.692              -0.4% (-0.2 MB)
MicroBench      pic-add-own.js                                  1.013      0.428 ± 0.426 … 0.430              0.423 ± 0.422 … 0.423              -0.4% (-0.2 MB)
MicroBench      pic-get-own.js                                  1.011      0.512 ± 0.506 … 0.518              0.506 ± 0.504 … 0.509              -0.4% (-0.2 MB)
MicroBench      pic-get-pchain.js                               0.955      0.535 ± 0.521 … 0.549              0.560 ± 0.551 … 0.568              -0.4% (-0.2 MB)
MicroBench      pic-put-own.js                                  0.870      0.525 ± 0.524 … 0.525              0.603 ± 0.533 … 0.673              -0.4% (-0.2 MB)
MicroBench      pic-put-pchain.js                               1.021      1.967 ± 1.907 … 2.027              1.926 ± 1.913 … 1.939              -0.4% (-0.2 MB)
MicroBench      setter-in-prototype-chain.js                    0.921      1.973 ± 1.943 … 2.004              2.144 ± 2.064 … 2.224              -0.4% (-0.2 MB)
MicroBench      strictly-equals-object.js                       1.238      0.902 ± 0.736 … 1.068              0.729 ± 0.728 … 0.729              -0.4% (-0.2 MB)
LongSpider      Total                                           1.005      69.929                             69.616                             +0.0% (+0.8 MB)
Kraken          Total                                           1.008      7.172                              7.114                              +0.2% (+1.8 MB)
Octane          Total                                           0.997      123868.500                         123510.000                         +0.2% (+5.5 MB)
JetStream       Total                                           1.024      150.723                            147.153                            +0.0% (+0.2 MB)
JetStream3      Total                                           0.997      9.002                              9.029                              -0.8% (-1.2 MB)
AsyncBench      Total                                           0.997      4.958                              4.971                              -0.1% (-1.4 MB)
ARES-6          Total                                           0.990      5.524                              5.582                              -0.2% (-0.4 MB)
JetStreamExtra  Total                                           1.002      39.792                             39.729                             -0.0% (-1.8 MB)
GarBench        Total                                           1.042      16.228                             15.566                             +0.2% (+19.5 MB)
MicroBench      Total                                           0.995      26.072                             26.201                             -0.1% (-4.7 MB)
All Suites      Total                                           1.009      393.784                            390.093                            +0.1% (+18.3 MB)
```