### PR TITLE
LibWeb: Skip backward sibling invalidation when no child needs it

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -859,6 +859,7 @@ public:
         u64 element_style_noop_recomputations { 0 };
         u64 element_inherited_style_recomputations { 0 };
         u64 element_inherited_style_noop_recomputations { 0 };
+        u64 previous_sibling_invalidation_walk_visits { 0 };
     };
     StyleInvalidationCounters& style_invalidation_counters() const { return m_style_invalidation_counters; }
     void reset_style_invalidation_counters() const { m_style_invalidation_counters = {}; }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -134,6 +134,24 @@ Element::Element(Document& document, DOM::QualifiedName qualified_name)
 
 Element::~Element() = default;
 
+void Element::set_affected_by_last_child_pseudo_class(bool value)
+{
+    m_affected_by_last_child_pseudo_class = value;
+    if (value) {
+        if (auto* parent = as_if<ParentNode>(this->parent()))
+            parent->set_has_child_affected_by_backward_structural_changes(true);
+    }
+}
+
+void Element::set_affected_by_backward_positional_pseudo_class(bool value)
+{
+    m_affected_by_backward_positional_pseudo_class = value;
+    if (value) {
+        if (auto* parent = as_if<ParentNode>(this->parent()))
+            parent->set_has_child_affected_by_backward_structural_changes(true);
+    }
+}
+
 void Element::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Element);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -533,13 +533,13 @@ public:
     void set_affected_by_first_child_pseudo_class(bool value) { m_affected_by_first_child_pseudo_class = value; }
 
     bool affected_by_last_child_pseudo_class() const { return m_affected_by_last_child_pseudo_class; }
-    void set_affected_by_last_child_pseudo_class(bool value) { m_affected_by_last_child_pseudo_class = value; }
+    void set_affected_by_last_child_pseudo_class(bool value);
 
     bool affected_by_forward_positional_pseudo_class() const { return m_affected_by_forward_positional_pseudo_class; }
     void set_affected_by_forward_positional_pseudo_class(bool value) { m_affected_by_forward_positional_pseudo_class = value; }
 
     bool affected_by_backward_positional_pseudo_class() const { return m_affected_by_backward_positional_pseudo_class; }
-    void set_affected_by_backward_positional_pseudo_class(bool value) { m_affected_by_backward_positional_pseudo_class = value; }
+    void set_affected_by_backward_positional_pseudo_class(bool value);
 
     size_t sibling_invalidation_distance() const { return m_sibling_invalidation_distance; }
     void set_sibling_invalidation_distance(size_t value) { m_sibling_invalidation_distance = value; }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -551,11 +551,16 @@ void Node::invalidate_style(StyleInvalidationReason reason)
     };
 
     if (reason == StyleInvalidationReason::NodeInsertBefore || reason == StyleInvalidationReason::NodeRemove) {
-        auto& counters = document().style_invalidation_counters();
-        for (auto* sibling = previous_sibling(); sibling; sibling = sibling->previous_sibling()) {
-            ++counters.previous_sibling_invalidation_walk_visits;
-            if (auto* element = as_if<Element>(sibling); element && previous_sibling_needs_structural_invalidation(*element))
-                mark_entire_subtree_for_style_update(*element);
+        // OPTIMIZATION: Only walk previous siblings if the parent has been observed to contain a child that matches a
+        //               pseudo-class whose match result can depend on siblings after that element. Otherwise, no
+        //               previous sibling can possibly need invalidation due to this insertion or removal.
+        if (auto* parent_node = as_if<ParentNode>(parent()); parent_node && parent_node->has_child_affected_by_backward_structural_changes()) {
+            auto& counters = document().style_invalidation_counters();
+            for (auto* sibling = previous_sibling(); sibling; sibling = sibling->previous_sibling()) {
+                ++counters.previous_sibling_invalidation_walk_visits;
+                if (auto* element = as_if<Element>(sibling); element && previous_sibling_needs_structural_invalidation(*element))
+                    mark_entire_subtree_for_style_update(*element);
+            }
         }
     }
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -551,7 +551,9 @@ void Node::invalidate_style(StyleInvalidationReason reason)
     };
 
     if (reason == StyleInvalidationReason::NodeInsertBefore || reason == StyleInvalidationReason::NodeRemove) {
+        auto& counters = document().style_invalidation_counters();
         for (auto* sibling = previous_sibling(); sibling; sibling = sibling->previous_sibling()) {
+            ++counters.previous_sibling_invalidation_walk_visits;
             if (auto* element = as_if<Element>(sibling); element && previous_sibling_needs_structural_invalidation(*element))
                 mark_entire_subtree_for_style_update(*element);
         }

--- a/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Libraries/LibWeb/DOM/ParentNode.h
@@ -42,6 +42,9 @@ public:
 
     GC::Ptr<Element> get_element_by_id(FlyString const& id) const;
 
+    bool has_child_affected_by_backward_structural_changes() const { return m_has_child_affected_by_backward_structural_changes; }
+    void set_has_child_affected_by_backward_structural_changes(bool value) { m_has_child_affected_by_backward_structural_changes = value; }
+
 protected:
     ParentNode(JS::Realm& realm, Document& document, NodeType type)
         : Node(realm, document, type)
@@ -57,6 +60,7 @@ protected:
 
 private:
     GC::Ptr<HTMLCollection> m_children;
+    bool m_has_child_affected_by_backward_structural_changes { false };
 };
 
 template<>

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -612,6 +612,7 @@ JS::Object* Internals::get_style_invalidation_counters()
     object->define_direct_property("elementStyleNoopRecomputations"_utf16_fly_string, JS::Value(counters.element_style_noop_recomputations), JS::default_attributes);
     object->define_direct_property("elementInheritedStyleRecomputations"_utf16_fly_string, JS::Value(counters.element_inherited_style_recomputations), JS::default_attributes);
     object->define_direct_property("elementInheritedStyleNoopRecomputations"_utf16_fly_string, JS::Value(counters.element_inherited_style_noop_recomputations), JS::default_attributes);
+    object->define_direct_property("previousSiblingInvalidationWalkVisits"_utf16_fly_string, JS::Value(counters.previous_sibling_invalidation_walk_visits), JS::default_attributes);
     return object;
 }
 

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/structural-previous-sibling-walk-skipped.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/structural-previous-sibling-walk-skipped.txt
@@ -1,0 +1,4 @@
+PASS: no backward-structural rule: append does not invalidate previous siblings | previousSiblingInvalidationWalkVisits=0
+PASS: forward-only rule (:first-child): append does not invalidate previous siblings | previousSiblingInvalidationWalkVisits=0
+PASS: backward-structural rule on unrelated subtree: append does not invalidate previous siblings | previousSiblingInvalidationWalkVisits=0
+PASS: backward-structural rule on fixture: append DOES invalidate previous siblings | previousSiblingInvalidationWalkVisits=20

--- a/Tests/LibWeb/Text/input/css/style-invalidation/structural-previous-sibling-walk-skipped.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/structural-previous-sibling-walk-skipped.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script src="structural-matrix.js"></script>
+<script>
+    test(() => {
+        // Demonstrates that appending a child to a parent does not invalidate the styles of existing previous siblings
+        // when no backward-structural pseudo-class applies to any of that parent's children.
+
+        function buildSubtree(child_count) {
+            const fixture = document.createElement("section");
+            for (let i = 0; i < child_count; ++i) {
+                const child = document.createElement("div");
+                child.appendChild(document.createElement("span"));
+                child.appendChild(document.createElement("span"));
+                fixture.appendChild(child);
+            }
+            return fixture;
+        }
+
+        function appendOneChild(fixture) {
+            const child = document.createElement("div");
+            child.appendChild(document.createElement("span"));
+            child.appendChild(document.createElement("span"));
+            fixture.appendChild(child);
+        }
+
+        function runCase(testName, ruleSetup) {
+            const cleanup = ruleSetup();
+            const fixture = buildSubtree(20);
+            document.body.appendChild(fixture);
+
+            // Force initial style resolution so the existing children have computed styles
+            document.body.offsetWidth;
+
+            resetStyleCounters();
+            appendOneChild(fixture);
+            document.body.offsetWidth;
+
+            const visits = internals.getStyleInvalidationCounters().previousSiblingInvalidationWalkVisits;
+            println(`PASS: ${testName} | previousSiblingInvalidationWalkVisits=${visits}`);
+
+            fixture.remove();
+            cleanup();
+        }
+
+        // Case 1: No backward-structural rule anywhere in the document.
+        //         The optimization skips the previous-sibling walk entirely; only the inserted child has its style
+        //         computed.
+        runCase("no backward-structural rule: append does not invalidate previous siblings", () => () => {});
+
+        // Case 2: A forward-only rule (:first-child) is present.
+        //         This sets the per-element first-child flag during matching, but does NOT set the parent's
+        //         has_child_affected_by_backward_structural_changes flag. The optimization still skips.
+        runCase("forward-only rule (:first-child): append does not invalidate previous siblings", () => {
+            const style = addStyle(document.head, "section > div:first-child { color: rebeccapurple; }");
+            return () => style.remove();
+        });
+
+        // Case 3: A backward-structural rule (:last-child) targets an unrelated subtree.
+        //         The flag is set on that unrelated parent, not on our fixture, so the optimization still skips the
+        //         walk for our fixture.
+        runCase("backward-structural rule on unrelated subtree: append does not invalidate previous siblings", () => {
+            const unrelated = document.createElement("aside");
+            unrelated.appendChild(document.createElement("p"));
+            unrelated.appendChild(document.createElement("p"));
+            document.body.appendChild(unrelated);
+            const style = addStyle(document.head, "aside > p:last-child { color: rebeccapurple; }");
+            document.body.offsetWidth;
+            return () => {
+                unrelated.remove();
+                style.remove();
+            };
+        });
+
+        // Case 4: A backward-structural rule (:last-child) DOES apply to our fixture's children.
+        //         The optimization correctly does not skip the walk — the previously-last child must be re-styled
+        //         when a new last child is appended. This case exists to confirm the optimization does not over-apply.
+        runCase("backward-structural rule on fixture: append DOES invalidate previous siblings", () => {
+            const style = addStyle(document.head, "section > div:last-child { color: rebeccapurple; }");
+            return () => style.remove();
+        });
+    });
+</script>


### PR DESCRIPTION
We now track when a parent has a child affected by a backward structural pseudo-class. These are selectors whose match result for an element can depend on siblings after that element, such as `:last-child`, `:only-child`, `:last-of-type`, `:only-of-type`, `:nth-last-child`, and `:nth-last-of-type`.

When inserting or removing a node, previous siblings only need style invalidation if one of them was matched against such a selector. Use the parent-level flag to skip the previous-sibling walk when no child under that parent can be affected.

This reduces the time to display the results on https://wpt.fyi from ~150s to ~10s on my machine.