### PR TITLE
LibWeb: Re-evaluate picture source set on source mutations

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -7,7 +7,9 @@
 #include <LibWeb/Bindings/HTMLSourceElement.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/AttributeNames.h>
+#include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
+#include <LibWeb/HTML/HTMLPictureElement.h>
 #include <LibWeb/HTML/HTMLSourceElement.h>
 
 namespace Web::HTML {
@@ -27,6 +29,14 @@ void HTMLSourceElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
+static void update_image_children_of_picture(DOM::Node& picture)
+{
+    for (auto* child = picture.first_child(); child; child = child->next_sibling()) {
+        if (auto* img = as_if<HTMLImageElement>(child))
+            img->update_the_image_data(true);
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:html-element-insertion-steps
 void HTMLSourceElement::inserted()
 {
@@ -44,8 +54,10 @@ void HTMLSourceElement::inserted()
         media_element->select_resource();
     }
 
-    // FIXME: 3. If parent is a picture element, then for each child of parent's children, if child is an img element, then
-    //           count this as a relevant mutation for child.
+    // 3. If parent is a picture element, then for each child of parent's children, if child is an img element, then
+    //    count this as a relevant mutation for child.
+    if (auto* picture = as_if<HTMLPictureElement>(parent))
+        update_image_children_of_picture(*picture);
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-17
@@ -54,8 +66,17 @@ void HTMLSourceElement::moved_from(IsSubtreeRoot is_subtree_root, GC::Ptr<DOM::N
     // The source HTML element moving steps, given movedNode, isSubtreeRoot, and oldAncestor are:
     Base::moved_from(is_subtree_root, old_ancestor);
 
-    // FIXME: 1. If isSubtreeRoot is true and oldAncestor is a picture element, then for each child of oldAncestor's
-    //        children: if child is an img element, then count this as a relevant mutation for child.
+    // 1. If isSubtreeRoot is true and oldAncestor is a picture element, then for each child of oldAncestor's
+    //    children: if child is an img element, then count this as a relevant mutation for child.
+    if (is_subtree_root == IsSubtreeRoot::Yes) {
+        if (auto* picture = as_if<HTMLPictureElement>(old_ancestor.ptr()))
+            update_image_children_of_picture(*picture);
+    }
+
+    // The img element may also have moved into a (new) picture parent; the "picture's children
+    // changed" mutation covers that for the new ancestor too.
+    if (auto* picture = as_if<HTMLPictureElement>(parent()))
+        update_image_children_of_picture(*picture);
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-18
@@ -64,8 +85,38 @@ void HTMLSourceElement::removed_from(IsSubtreeRoot is_subtree_root, DOM::Node* o
     // The source HTML element removing steps, given removedNode, isSubtreeRoot, and oldAncestor are:
     Base::removed_from(is_subtree_root, old_ancestor, old_root);
 
-    // FIXME: 1. If isSubtreeRoot is true and oldAncestor is a picture element, then for each child of oldAncestor's
-    //        children: if child is an img element, then count this as a relevant mutation for child.
+    // 1. If isSubtreeRoot is true and oldAncestor is a picture element, then for each child of oldAncestor's
+    //    children: if child is an img element, then count this as a relevant mutation for child.
+    if (is_subtree_root == IsSubtreeRoot::Yes) {
+        if (auto* picture = as_if<HTMLPictureElement>(old_ancestor))
+            update_image_children_of_picture(*picture);
+    }
+}
+
+// https://html.spec.whatwg.org/multipage/images.html#relevant-mutations
+// "The element's parent is a picture element and a source element that is a previous sibling has
+//  its srcset, sizes, media, type, width or height attributes set, changed, or removed."
+void HTMLSourceElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_changed(name, old_value, value, namespace_);
+
+    if (!name.is_one_of(
+            HTML::AttributeNames::srcset,
+            HTML::AttributeNames::sizes,
+            HTML::AttributeNames::media,
+            HTML::AttributeNames::type,
+            HTML::AttributeNames::width,
+            HTML::AttributeNames::height))
+        return;
+
+    if (!is<HTMLPictureElement>(parent()))
+        return;
+
+    // Only following img siblings consider this source a "previous sibling".
+    for (auto* sibling = next_sibling(); sibling; sibling = sibling->next_sibling()) {
+        if (auto* img = as_if<HTMLImageElement>(sibling))
+            img->update_the_image_data(true);
+    }
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.h
@@ -25,6 +25,7 @@ private:
     virtual void inserted() override;
     virtual void removed_from(IsSubtreeRoot, DOM::Node* old_ancestor, DOM::Node& old_root) override;
     virtual void moved_from(IsSubtreeRoot, GC::Ptr<Node> old_ancestor) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 };
 
 }

--- a/Tests/LibWeb/Text/expected/HTML/picture-source-mutation.txt
+++ b/Tests/LibWeb/Text/expected/HTML/picture-source-mutation.txt
@@ -1,0 +1,5 @@
+first matches red: true
+second matches blue: true
+re-evaluated on srcset mutation: true
+re-evaluated on source insertion: true
+re-evaluated on source removal: true

--- a/Tests/LibWeb/Text/input/HTML/picture-source-mutation.html
+++ b/Tests/LibWeb/Text/input/HTML/picture-source-mutation.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // 1x1 valid PNGs (red and blue) used to observe re-evaluation of the picture's source set.
+    const RED_PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==";
+    const BLUE_PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII=";
+
+    asyncTest(async done => {
+        const picture = document.createElement("picture");
+        const source = document.createElement("source");
+        source.setAttribute("srcset", RED_PNG_DATA_URL);
+        const img = document.createElement("img");
+
+        picture.appendChild(source);
+        picture.appendChild(img);
+        document.body.appendChild(picture);
+
+        // Wait for first load: img picks up the source's srcset.
+        await new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
+        const firstSrc = img.currentSrc;
+
+        // https://html.spec.whatwg.org/multipage/images.html#relevant-mutations
+        // "The element's parent is a picture element and a source element that is a previous
+        //  sibling has its srcset, sizes, media, type, width or height attributes set, changed,
+        //  or removed."
+        // Mutating the source's srcset must trigger update-the-image-data on the img.
+        const secondLoaded = new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
+        source.setAttribute("srcset", BLUE_PNG_DATA_URL);
+        await secondLoaded;
+        const secondSrc = img.currentSrc;
+
+        println(`first matches red: ${firstSrc === RED_PNG_DATA_URL}`);
+        println(`second matches blue: ${secondSrc === BLUE_PNG_DATA_URL}`);
+        println(`re-evaluated on srcset mutation: ${firstSrc !== secondSrc}`);
+
+        // Inserting a new <source> as a previous sibling of the img must also trigger re-eval.
+        const thirdLoaded = new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
+        const newSource = document.createElement("source");
+        newSource.setAttribute("srcset", RED_PNG_DATA_URL);
+        picture.insertBefore(newSource, source);
+        await thirdLoaded;
+        println(`re-evaluated on source insertion: ${img.currentSrc === RED_PNG_DATA_URL}`);
+
+        // Removing that source must again trigger re-eval, falling back to the remaining source.
+        const fourthLoaded = new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
+        picture.removeChild(newSource);
+        await fourthLoaded;
+        println(`re-evaluated on source removal: ${img.currentSrc === BLUE_PNG_DATA_URL}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
The img inside a <picture> has to re-run "update the image data" when nearby <source> elements change, so script-driven swaps of srcset (and the other dimension/media attributes) actually take effect.

Per the HTML spec, the relevant mutations for an img element include: "The element's parent is a picture element and a source element that
 is a previous sibling has its srcset, sizes, media, type, width or
 height attributes set, changed, or removed."

The same applies to source insertion, moving, and removal.

Fixes image loading on https://www.apple.com/mac/