### PR TITLE
Delay document load event for image-set() candidate fetches

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -229,6 +229,15 @@ void ImageSetStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
 {
     Base::set_style_sheet(style_sheet);
     m_style_sheet = style_sheet;
+
+    // Propagate the style sheet to candidate images whose type() filter does not exclude them. This ensures the
+    // candidate images register themselves as pending image resources on the style sheet, so their fetches start when
+    // the style sheet is associated with the document, properly delaying the document's load event.
+    for (auto const& option : m_options) {
+        if (option.type.has_value() && !HTML::is_supported_image_type(*option.type))
+            continue;
+        const_cast<AbstractImageStyleValue&>(*option.image).set_style_sheet(style_sheet);
+    }
 }
 
 ValueComparingNonnullRefPtr<StyleValue const> ImageSetStyleValue::absolutized(ComputationContext const& context) const


### PR DESCRIPTION
ImageSetStyleValue::set_style_sheet() previously stored the style sheet on itself but didn't propagate to its candidate images. As a result, candidates were never registered as pending image resources, so their fetches didn't start until layout time and didn't delay the document's load event.

This caused css-image-set-background-type.html to be flaky: under load, the screenshot could be captured before the selected SVG candidate had finished decoding, producing an empty box instead of the expected color.

Propagate set_style_sheet() to each candidate image whose type() filter does not exclude it, mirroring StyleValueList and ShorthandStyleValue. The candidates now register themselves as pending so SharedResourceRequest's load event delayer correctly delays the load event until decoding completes.