### PR TITLE
LibWeb+LibJS: Compile top-level JS off-thread

### DIFF
--- a/Libraries/LibJS/Rust/cbindgen.toml
+++ b/Libraries/LibJS/Rust/cbindgen.toml
@@ -14,7 +14,7 @@ sys_includes = ["stdint.h", "stddef.h"]
 usize_is_size_t = true
 
 [export]
-include = ["ConstantTag", "LiteralValueKind", "WellKnownSymbolKind", "FFIToken"]
+include = ["AbstractOperationKind", "ConstantTag", "LiteralValueKind", "WellKnownSymbolKind", "FFIToken"]
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -101,38 +101,51 @@ impl FunctionTable {
         self.functions.insert(id, data);
     }
 
-    /// Extract a subtable containing all `FunctionId`s reachable from the
-    /// given function body and parameters. This recursively takes nested
-    /// functions so that the returned subtable has everything needed to
-    /// compile the function.
+    /// Extract the nested function subtree needed to compile `data` later.
+    ///
+    /// Parser-created functions carry an explicit child list, so this is
+    /// normally proportional to the number of nested functions instead of the
+    /// size of the function body.
     pub fn extract_reachable(&mut self, data: &FunctionData) -> FunctionTable {
         let mut subtable = FunctionTable::new();
-        // Walk parameters first (default values can contain functions).
-        for param in &data.parameters {
-            if let Some(ref default) = param.default_value {
-                self.collect_from_expression(default, &mut subtable);
+        if let Some(nested_function_ids) = &data.nested_function_ids {
+            for id in nested_function_ids {
+                self.transfer(*id, &mut subtable);
             }
-            if let FunctionParameterBinding::BindingPattern(ref pat) = param.binding {
-                self.collect_from_pattern(pat, &mut subtable);
+        } else {
+            // Synthetic function wrappers created during codegen (for example
+            // class field initializers) do not come from the parser's function
+            // context stack, so keep the structural scan for those rare cases.
+            for param in &data.parameters {
+                if let Some(ref default) = param.default_value {
+                    self.collect_from_expression(default, &mut subtable);
+                }
+                if let FunctionParameterBinding::BindingPattern(ref pat) = param.binding {
+                    self.collect_from_pattern(pat, &mut subtable);
+                }
             }
+            self.collect_from_statement(&data.body, &mut subtable);
         }
-        self.collect_from_statement(&data.body, &mut subtable);
         subtable
     }
 
     fn transfer(&mut self, id: FunctionId, result: &mut FunctionTable) {
         if let Some(data) = self.try_take(id) {
-            // Walk parameters (default values / binding patterns can contain functions).
-            for param in &data.parameters {
-                if let Some(ref default) = param.default_value {
-                    self.collect_from_expression(default, result);
+            if let Some(nested_function_ids) = &data.nested_function_ids {
+                for id in nested_function_ids {
+                    self.transfer(*id, result);
                 }
-                if let FunctionParameterBinding::BindingPattern(ref pat) = param.binding {
-                    self.collect_from_pattern(pat, result);
+            } else {
+                for param in &data.parameters {
+                    if let Some(ref default) = param.default_value {
+                        self.collect_from_expression(default, result);
+                    }
+                    if let FunctionParameterBinding::BindingPattern(ref pat) = param.binding {
+                        self.collect_from_pattern(pat, result);
+                    }
                 }
+                self.collect_from_statement(&data.body, result);
             }
-            // Walk the function body.
-            self.collect_from_statement(&data.body, result);
             result.insert_at(id, data);
         }
     }
@@ -863,6 +876,12 @@ pub struct FunctionData {
     pub is_strict_mode: bool,
     pub is_arrow_function: bool,
     pub parsing_insights: FunctionParsingInsights,
+    /// Parser-created functions know their nested function ids up front, so
+    /// lazy-compile payload extraction can move only that subtree instead of
+    /// re-walking the full body. `None` is reserved for synthetic function
+    /// wrappers built during codegen, where the old structural scan is still
+    /// needed to discover nested functions inside the wrapped AST.
+    pub nested_function_ids: Option<Vec<FunctionId>>,
 }
 
 // =============================================================================

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -517,6 +517,7 @@ fn generate_function_expression(
     function_id: FunctionId,
     preferred_dst: Option<&ScopedOperand>,
 ) -> ScopedOperand {
+    let should_eager_compile = generator.eager_compile_function_ids.contains(&function_id);
     let data = generator.function_table.take(function_id);
     let has_name = data.name.is_some();
 
@@ -561,6 +562,13 @@ fn generate_function_expression(
     let lhs_name_str: Option<Utf16String> = lhs_name.map(|index| generator.identifier_table[index.0 as usize].clone());
     let name_override = if !has_name { lhs_name_str.as_deref() } else { None };
     let shared_function_data_index = emit_new_function(generator, data, name_override);
+    if should_eager_compile
+        && let Some(pending) = generator
+            .shared_function_data
+            .get_mut(shared_function_data_index as usize)
+    {
+        pending.should_eager_compile = true;
+    }
     let home_object = generator.home_objects.last().map(|ho| ho.operand());
     generator.emit(Instruction::NewFunction {
         dst: dst.operand(),
@@ -2996,6 +3004,13 @@ fn generate_call_expression(
     preferred_dst: Option<&ScopedOperand>,
     is_new: bool,
 ) -> Option<ScopedOperand> {
+    if generator.eager_compile_direct_iifes
+        && !is_new
+        && let ExpressionKind::Function(function_id) = &data.callee.inner
+    {
+        generator.eager_compile_function_ids.insert(*function_id);
+    }
+
     // Check for builtin abstract operations before anything else.
     if !is_new && let Some(result) = try_generate_builtin_abstract_operation(generator, data, preferred_dst) {
         return result;
@@ -5958,6 +5973,8 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
         subtable: Some(subtable),
         name_override: None,
         class_field_initializer_name: None,
+        should_eager_compile: false,
+        precompiled_function: None,
     })
 }
 
@@ -7562,6 +7579,8 @@ fn emit_new_function(generator: &mut Generator, data: Box<FunctionData>, name_ov
         subtable: Some(subtable),
         name_override: name_override.map(Utf16String::from),
         class_field_initializer_name: None,
+        should_eager_compile: false,
+        precompiled_function: None,
     })
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -47,10 +47,10 @@ use crate::ast::*;
 use crate::lexer::ch;
 use crate::u32_from_usize;
 
-use super::ffi::{LiteralValueKind, WellKnownSymbolKind};
+use super::ffi::WellKnownSymbolKind;
 use super::generator::{
-    BlockBoundaryType, ConstantValue, FinallyContext, Generator, ScopedOperand, choose_dst, constant_to_boolean,
-    parse_bigint,
+    BlockBoundaryType, ConstantValue, FinallyContext, Generator, PendingClassBlueprint, PendingClassElement,
+    PendingLiteralValueKind, PendingSharedFunctionData, ScopedOperand, choose_dst, constant_to_boolean, parse_bigint,
 };
 use super::instruction::Instruction;
 use super::operand::*;
@@ -5655,9 +5655,7 @@ fn generate_class_expression(
     };
 
     // Second pass: register method/field SFDs and build element descriptors.
-    let mut ffi_elements = Vec::with_capacity(data.elements.len());
-    // Keep literal string data alive until FFI call.
-    let mut literal_string_storage: Vec<Utf16String> = Vec::new();
+    let mut class_elements = Vec::with_capacity(data.elements.len());
 
     for element_node in &data.elements {
         match &element_node.inner {
@@ -5679,29 +5677,24 @@ fn generate_class_expression(
                 // correctly handles computed keys (Symbols, etc).
                 let sfd_index = if let ExpressionKind::Function(function_id) = &function.inner {
                     let function_data = generator.function_table.take(*function_id);
-                    super::ffi::FFIOptionalU32::some(emit_new_function(generator, function_data, None))
+                    Some(emit_new_function(generator, function_data, None))
                 } else {
-                    super::ffi::FFIOptionalU32::none()
+                    None
                 };
 
                 // Handle computed vs static keys
                 let is_private = is_private_key(key);
 
-                // Point directly into the AST's PrivateIdentifier name (stable address).
-                let (priv_ptr, priv_len) = get_private_identifier_ptr(key);
-
-                ffi_elements.push(super::ffi::FFIClassElement {
+                class_elements.push(PendingClassElement {
                     kind: ffi_kind,
                     is_static: *is_static,
                     is_private,
-                    private_identifier: priv_ptr,
-                    private_identifier_len: priv_len,
+                    private_identifier: get_private_identifier_name(key),
                     shared_function_data_index: sfd_index,
                     has_initializer: false,
-                    literal_value_kind: LiteralValueKind::None,
+                    literal_value_kind: PendingLiteralValueKind::None,
                     literal_value_number: 0.0,
-                    literal_value_string: std::ptr::null(),
-                    literal_value_string_len: 0,
+                    literal_value_string: None,
                 });
             }
             ClassElement::Field {
@@ -5712,38 +5705,38 @@ fn generate_class_expression(
                 // Detect literal initializers and store the value directly,
                 // avoiding function creation for simple cases like x = 0.
                 // This avoids function creation for simple cases.
-                let mut literal_value_kind = LiteralValueKind::None;
+                let mut literal_value_kind = PendingLiteralValueKind::None;
                 let mut literal_value_number: f64 = 0.0;
-                let mut literal_value_string = Utf16String::new();
-                let mut sfd_index = super::ffi::FFIOptionalU32::none();
+                let mut literal_value_string = None;
+                let mut sfd_index = None;
 
                 if let Some(init_expression) = initializer {
                     let is_literal = match &init_expression.inner {
                         ExpressionKind::NumericLiteral(n) => {
-                            literal_value_kind = LiteralValueKind::Number;
+                            literal_value_kind = PendingLiteralValueKind::Number;
                             literal_value_number = *n;
                             true
                         }
                         ExpressionKind::BooleanLiteral(b) => {
                             literal_value_kind = if *b {
-                                LiteralValueKind::BooleanTrue
+                                PendingLiteralValueKind::BooleanTrue
                             } else {
-                                LiteralValueKind::BooleanFalse
+                                PendingLiteralValueKind::BooleanFalse
                             };
                             true
                         }
                         ExpressionKind::NullLiteral => {
-                            literal_value_kind = LiteralValueKind::Null;
+                            literal_value_kind = PendingLiteralValueKind::Null;
                             true
                         }
                         ExpressionKind::StringLiteral(s) => {
-                            literal_value_kind = LiteralValueKind::String;
-                            literal_value_string = (**s).clone();
+                            literal_value_kind = PendingLiteralValueKind::String;
+                            literal_value_string = Some((**s).clone());
                             true
                         }
                         ExpressionKind::Unary { op, operand } if *op == UnaryOp::Minus => {
                             if let ExpressionKind::NumericLiteral(n) = &operand.inner {
-                                literal_value_kind = LiteralValueKind::Number;
+                                literal_value_kind = PendingLiteralValueKind::Number;
                                 literal_value_number = -n;
                                 true
                             } else {
@@ -5803,8 +5796,6 @@ fn generate_class_expression(
                         });
                         let index = emit_new_function(generator, function_data, Some(utf16!("field")));
 
-                        // Set class_field_initializer_name on the SFD.
-                        let sfd_ptr = generator.shared_function_data[index as usize];
                         let key_is_private = is_private_key(key);
                         let key_name: Utf16String = match &key.inner {
                             ExpressionKind::PrivateIdentifier(ident) => ident.name.clone(),
@@ -5814,45 +5805,25 @@ fn generate_class_expression(
                             _ => Utf16String::new(),
                         };
                         if !key_name.is_empty() {
-                            unsafe {
-                                super::ffi::rust_sfd_set_class_field_initializer_name(
-                                    sfd_ptr,
-                                    key_name.as_ptr(),
-                                    key_name.len(),
-                                    key_is_private,
-                                );
-                            }
+                            generator.set_class_field_initializer_name(index, key_name, key_is_private);
                         }
 
-                        sfd_index = super::ffi::FFIOptionalU32::some(index);
+                        sfd_index = Some(index);
                     }
                 }
 
                 let is_private = is_private_key(key);
 
-                let (priv_ptr, priv_len) = get_private_identifier_ptr(key);
-
-                // Keep literal string data alive until FFI call.
-                let (str_ptr, str_len) = if !literal_value_string.is_empty() {
-                    literal_string_storage.push(literal_value_string);
-                    let s = literal_string_storage.last().expect("just pushed an element");
-                    (s.as_ptr(), s.len())
-                } else {
-                    (std::ptr::null(), 0)
-                };
-
-                ffi_elements.push(super::ffi::FFIClassElement {
+                class_elements.push(PendingClassElement {
                     kind: ClassElementKind::Field as u8,
                     is_static: *is_static,
                     is_private,
-                    private_identifier: priv_ptr,
-                    private_identifier_len: priv_len,
+                    private_identifier: get_private_identifier_name(key),
                     shared_function_data_index: sfd_index,
                     has_initializer: initializer.is_some(),
                     literal_value_kind,
                     literal_value_number,
-                    literal_value_string: str_ptr,
-                    literal_value_string_len: str_len,
+                    literal_value_string,
                 });
             }
             ClassElement::StaticInitializer { body } => {
@@ -5878,54 +5849,39 @@ fn generate_class_expression(
                     // the wrapped block.
                     nested_function_ids: None,
                 });
-                let sfd_index = super::ffi::FFIOptionalU32::some(emit_new_function(generator, function_data, None));
+                let sfd_index = Some(emit_new_function(generator, function_data, None));
 
-                ffi_elements.push(super::ffi::FFIClassElement {
+                class_elements.push(PendingClassElement {
                     kind: ClassElementKind::StaticInitializer as u8,
                     is_static: true,
                     is_private: false,
-                    private_identifier: std::ptr::null(),
-                    private_identifier_len: 0,
+                    private_identifier: None,
                     shared_function_data_index: sfd_index,
                     has_initializer: false,
-                    literal_value_kind: LiteralValueKind::None,
+                    literal_value_kind: PendingLiteralValueKind::None,
                     literal_value_number: 0.0,
-                    literal_value_string: std::ptr::null(),
-                    literal_value_string_len: 0,
+                    literal_value_string: None,
                 });
             }
         }
     }
 
     // Get class name and source text
-    let class_name: Option<&[u16]> = data.name.as_ref().map(|n| n.name.as_slice());
     let has_name = data.name.is_some();
-    let (name_ptr, name_len) = class_name
-        .map(|n| (n.as_ptr(), n.len()))
-        .unwrap_or((std::ptr::null(), 0));
 
     let source_start = data.source_text_start as usize;
     let source_end = data.source_text_end as usize;
     let source_text_len = source_end - source_start;
 
-    // Create the ClassBlueprint via FFI
-    let bp_ptr = unsafe {
-        super::ffi::rust_create_class_blueprint(
-            generator.vm_ptr,
-            generator.source_code_ptr,
-            name_ptr,
-            name_len,
-            source_start,
-            source_text_len,
-            constructor_sfd_index,
-            has_super,
-            has_name,
-            ffi_elements.as_ptr(),
-            ffi_elements.len(),
-        )
-    };
-    assert!(!bp_ptr.is_null(), "rust_create_class_blueprint returned null");
-    let blueprint_index = generator.register_class_blueprint(bp_ptr);
+    let blueprint_index = generator.register_class_blueprint(PendingClassBlueprint {
+        name: data.name.as_ref().map(|n| n.name.to_utf16_string()),
+        source_text_offset: source_start,
+        source_text_length: source_text_len,
+        constructor_sfd_index,
+        has_super_class: has_super,
+        has_name,
+        elements: class_elements,
+    });
 
     // Build element_keys operands for the NewClass instruction
     let element_key_ops: Vec<Option<Operand>> = element_keys.iter().map(|k| k.as_ref().map(|s| s.operand())).collect();
@@ -6000,18 +5956,12 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
     function_data.source_text_end = 0;
 
     let subtable = parser.function_table.extract_reachable(&function_data);
-    let sfd_ptr = unsafe {
-        super::ffi::create_shared_function_data(
-            function_data,
-            subtable,
-            generator.vm_ptr,
-            generator.source_code_ptr,
-            generator.strict,
-            None,
-        )
-    };
-    assert!(!sfd_ptr.is_null(), "default constructor creation returned null");
-    generator.register_shared_function_data(sfd_ptr)
+    generator.register_shared_function_data(PendingSharedFunctionData {
+        function_data: Some(function_data),
+        subtable: Some(subtable),
+        name_override: None,
+        class_field_initializer_name: None,
+    })
 }
 
 /// Check if a key expression is a private identifier, return (is_private, private_name).
@@ -6021,11 +5971,11 @@ fn is_private_key(key: &Expression) -> bool {
 
 /// Get a pointer directly into the AST's PrivateIdentifier name.
 /// The pointer remains valid as long as the AST is alive.
-fn get_private_identifier_ptr(key: &Expression) -> (*const u16, usize) {
+fn get_private_identifier_name(key: &Expression) -> Option<Utf16String> {
     if let ExpressionKind::PrivateIdentifier(ident) = &key.inner {
-        (ident.name.as_ptr(), ident.name.len())
+        Some(ident.name.clone())
     } else {
-        (std::ptr::null(), 0)
+        None
     }
 }
 
@@ -7610,18 +7560,12 @@ fn emit_new_function(generator: &mut Generator, data: Box<FunctionData>, name_ov
     );
 
     let subtable = generator.function_table.extract_reachable(&data);
-    let sfd_ptr = unsafe {
-        super::ffi::create_shared_function_data(
-            data,
-            subtable,
-            generator.vm_ptr,
-            generator.source_code_ptr,
-            generator.strict,
-            name_override,
-        )
-    };
-
-    generator.register_shared_function_data(sfd_ptr)
+    generator.register_shared_function_data(PendingSharedFunctionData {
+        function_data: Some(data),
+        subtable: Some(subtable),
+        name_override: name_override.map(Utf16String::from),
+        class_field_initializer_name: None,
+    })
 }
 
 // =============================================================================

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -5796,6 +5796,10 @@ fn generate_class_expression(
                                 uses_this_from_environment: true,
                                 ..Default::default()
                             },
+                            // This wrapper is synthesized after parsing, so it
+                            // asks FunctionTable to discover nested functions
+                            // from the wrapped initializer expression.
+                            nested_function_ids: None,
                         });
                         let index = emit_new_function(generator, function_data, Some(utf16!("field")));
 
@@ -5869,6 +5873,10 @@ fn generate_class_expression(
                         uses_this_from_environment: true,
                         ..Default::default()
                     },
+                    // Static initializer wrappers are synthesized after parsing;
+                    // keep the structural fallback for nested functions inside
+                    // the wrapped block.
+                    nested_function_ids: None,
                 });
                 let sfd_index = super::ffi::FFIOptionalU32::some(emit_new_function(generator, function_data, None));
 

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -47,7 +47,7 @@ use crate::ast::*;
 use crate::lexer::ch;
 use crate::u32_from_usize;
 
-use super::ffi::WellKnownSymbolKind;
+use super::ffi::{AbstractOperationKind, WellKnownSymbolKind};
 use super::generator::{
     BlockBoundaryType, ConstantValue, FinallyContext, Generator, PendingClassBlueprint, PendingClassElement,
     PendingLiteralValueKind, PendingSharedFunctionData, ScopedOperand, choose_dst, constant_to_boolean, parse_bigint,
@@ -2928,19 +2928,19 @@ fn try_generate_builtin_abstract_operation(
     }
 
     // Operations that map to intrinsic function calls.
-    let known_operations: &[&[u16]] = &[
-        utf16!("AsyncIteratorClose"),
-        utf16!("GetMethod"),
-        utf16!("GetIteratorDirect"),
-        utf16!("GetIteratorFromMethod"),
-        utf16!("IteratorComplete"),
+    let known_operations: &[(&[u16], AbstractOperationKind)] = &[
+        (utf16!("AsyncIteratorClose"), AbstractOperationKind::AsyncIteratorClose),
+        (utf16!("GetMethod"), AbstractOperationKind::GetMethod),
+        (utf16!("GetIteratorDirect"), AbstractOperationKind::GetIteratorDirect),
+        (
+            utf16!("GetIteratorFromMethod"),
+            AbstractOperationKind::GetIteratorFromMethod,
+        ),
+        (utf16!("IteratorComplete"), AbstractOperationKind::IteratorComplete),
     ];
-    for &op_name in known_operations {
+    for &(op_name, operation) in known_operations {
         if *name == op_name {
-            let intrinsic_value = unsafe {
-                super::ffi::get_abstract_operation_function(generator.vm_ptr, op_name.as_ptr(), op_name.len())
-            };
-            let callee = generator.add_constant_raw_value(intrinsic_value);
+            let callee = generator.add_constant_abstract_operation(operation);
             let undefined = generator.add_constant_undefined();
             let expression_string = generator.intern_string(name);
             let mut argument_holders = Vec::with_capacity(data.arguments.len());
@@ -2971,13 +2971,10 @@ fn try_generate_builtin_constant(generator: &mut Generator, name: &Utf16String) 
         return None;
     }
     if *name == utf16!("SYMBOL_ITERATOR") {
-        let value = unsafe { super::ffi::get_well_known_symbol(generator.vm_ptr, WellKnownSymbolKind::SymbolIterator) };
-        return Some(generator.add_constant_raw_value(value));
+        return Some(generator.add_constant_well_known_symbol(WellKnownSymbolKind::SymbolIterator));
     }
     if *name == utf16!("SYMBOL_ASYNC_ITERATOR") {
-        let value =
-            unsafe { super::ffi::get_well_known_symbol(generator.vm_ptr, WellKnownSymbolKind::SymbolAsyncIterator) };
-        return Some(generator.add_constant_raw_value(value));
+        return Some(generator.add_constant_well_known_symbol(WellKnownSymbolKind::SymbolAsyncIterator));
     }
     if *name == utf16!("MAX_ARRAY_LIKE_INDEX") {
         return Some(generator.add_constant_number(9007199254740991.0));

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -130,12 +130,23 @@ fn literal_value_kind_to_ffi(kind: PendingLiteralValueKind) -> LiteralValueKind 
     }
 }
 
-/// Well-known symbol IDs for get_well_known_symbol()
-/// Used to retrieve well known symbols as opaque Values from C++.
+/// Well-known symbol IDs resolved by C++ when materializing an Executable.
 #[repr(u8)]
+#[derive(Debug, Clone, Copy)]
 pub enum WellKnownSymbolKind {
     SymbolIterator = 0,
     SymbolAsyncIterator = 1,
+}
+
+/// NativeJavaScriptBackedFunction intrinsic IDs resolved by C++ when materializing an Executable.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+pub enum AbstractOperationKind {
+    AsyncIteratorClose = 0,
+    GetMethod = 1,
+    GetIteratorDirect = 2,
+    GetIteratorFromMethod = 3,
+    IteratorComplete = 4,
 }
 
 /// Class element descriptor for ClassBlueprint creation
@@ -277,12 +288,6 @@ unsafe extern "C" {
 
     pub fn rust_number_to_utf16(value: f64, buffer: *mut u16, buffer_len: usize) -> usize;
 
-    // Get a well-known symbol as an opaque Value.
-    pub fn get_well_known_symbol(vm_ptr: *mut c_void, symbol_id: WellKnownSymbolKind) -> u64;
-
-    // Get an intrinsic abstract operation function as an opaque Value.
-    // name/name_len is the function name (e.g. "GetMethod").
-    pub fn get_abstract_operation_function(vm_ptr: *mut c_void, name: *const u16, name_len: usize) -> u64;
 }
 
 /// Create a SharedFunctionInstanceData from a FunctionData.
@@ -514,7 +519,8 @@ pub enum ConstantTag {
     Empty = 5,
     String = 6,
     BigInt = 7,
-    RawValue = 8,
+    WellKnownSymbol = 8,
+    AbstractOperation = 9,
 }
 
 /// Encode constants into a tagged byte buffer for FFI.
@@ -545,9 +551,13 @@ fn encode_constants(constants: &[ConstantValue]) -> Vec<u8> {
                 buffer.extend_from_slice(&len.to_le_bytes());
                 buffer.extend_from_slice(s.as_bytes());
             }
-            ConstantValue::RawValue(encoded) => {
-                buffer.push(ConstantTag::RawValue as u8);
-                buffer.extend_from_slice(&encoded.to_le_bytes());
+            ConstantValue::WellKnownSymbol(symbol) => {
+                buffer.push(ConstantTag::WellKnownSymbol as u8);
+                buffer.push(*symbol as u8);
+            }
+            ConstantValue::AbstractOperation(name) => {
+                buffer.push(ConstantTag::AbstractOperation as u8);
+                buffer.push(*name as u8);
             }
         }
     }

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -246,6 +246,16 @@ unsafe extern "C" {
         is_private: bool,
     );
 
+    pub fn rust_sfd_set_precompiled_executable(
+        sfd_ptr: *mut c_void,
+        executable_ptr: *mut c_void,
+        uses_this: bool,
+        function_environment_needed: bool,
+        function_environment_bindings_count: usize,
+        might_need_arguments_object: bool,
+        contains_direct_call_to_eval: bool,
+    );
+
     pub fn rust_create_class_blueprint(
         vm_ptr: *mut c_void,
         source_code_ptr: *const c_void,
@@ -428,6 +438,29 @@ unsafe fn materialize_shared_function_data(
             );
             if let Some((name, is_private)) = &pending.class_field_initializer_name {
                 rust_sfd_set_class_field_initializer_name(sfd_ptr, name.as_ptr(), name.len(), *is_private);
+            }
+            if let Some(precompiled) = pending.precompiled_function.as_mut() {
+                precompiled.generator.vm_ptr = vm_ptr;
+                precompiled.generator.source_code_ptr = source_code_ptr;
+                let executable_ptr = create_executable(
+                    &mut precompiled.generator,
+                    &precompiled.assembled,
+                    vm_ptr,
+                    source_code_ptr,
+                );
+                assert!(
+                    !executable_ptr.is_null(),
+                    "materialize_shared_function_data: eager function executable materialization failed"
+                );
+                rust_sfd_set_precompiled_executable(
+                    sfd_ptr,
+                    executable_ptr,
+                    precompiled.metadata.uses_this,
+                    precompiled.metadata.function_environment_needed,
+                    precompiled.metadata.function_environment_bindings_count,
+                    precompiled.metadata.might_need_arguments,
+                    precompiled.metadata.contains_eval,
+                );
             }
             sfd_ptrs.push(sfd_ptr as *const c_void);
         }

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -23,7 +23,9 @@
 
 use std::ffi::c_void;
 
-use super::generator::{AssembledBytecode, ConstantValue, Generator};
+use super::generator::{
+    AssembledBytecode, ConstantValue, Generator, PendingClassBlueprint, PendingClassElement, PendingLiteralValueKind,
+};
 use crate::ast::Utf16String;
 use crate::u32_from_usize;
 
@@ -115,6 +117,17 @@ pub enum LiteralValueKind {
     BooleanFalse = 3,
     Null = 4,
     String = 5,
+}
+
+fn literal_value_kind_to_ffi(kind: PendingLiteralValueKind) -> LiteralValueKind {
+    match kind {
+        PendingLiteralValueKind::None => LiteralValueKind::None,
+        PendingLiteralValueKind::Number => LiteralValueKind::Number,
+        PendingLiteralValueKind::BooleanTrue => LiteralValueKind::BooleanTrue,
+        PendingLiteralValueKind::BooleanFalse => LiteralValueKind::BooleanFalse,
+        PendingLiteralValueKind::Null => LiteralValueKind::Null,
+        PendingLiteralValueKind::String => LiteralValueKind::String,
+    }
 }
 
 /// Well-known symbol IDs for get_well_known_symbol()
@@ -384,6 +397,112 @@ pub unsafe fn create_sfd_for_gdi(
     unsafe { create_shared_function_data(function_data, subtable, vm_ptr, source_code_ptr, is_strict, None) }
 }
 
+unsafe fn materialize_shared_function_data(
+    generator: &mut Generator,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+) -> Vec<*const c_void> {
+    unsafe {
+        let mut sfd_ptrs = Vec::with_capacity(generator.shared_function_data.len());
+        for pending in &mut generator.shared_function_data {
+            let function_data = pending
+                .function_data
+                .take()
+                .expect("pending shared function data was already materialized");
+            let subtable = pending
+                .subtable
+                .take()
+                .expect("pending shared function data subtable was already materialized");
+            let sfd_ptr = create_shared_function_data(
+                function_data,
+                subtable,
+                vm_ptr,
+                source_code_ptr,
+                generator.strict,
+                pending.name_override.as_ref().map(|name| name.as_slice()),
+            );
+            if let Some((name, is_private)) = &pending.class_field_initializer_name {
+                rust_sfd_set_class_field_initializer_name(sfd_ptr, name.as_ptr(), name.len(), *is_private);
+            }
+            sfd_ptrs.push(sfd_ptr as *const c_void);
+        }
+        sfd_ptrs
+    }
+}
+
+unsafe fn materialize_class_blueprints(
+    generator: &mut Generator,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+) -> Vec<*mut c_void> {
+    unsafe {
+        generator
+            .class_blueprints
+            .iter()
+            .map(|blueprint| materialize_class_blueprint(blueprint, vm_ptr, source_code_ptr))
+            .collect()
+    }
+}
+
+unsafe fn materialize_class_blueprint(
+    blueprint: &PendingClassBlueprint,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+) -> *mut c_void {
+    unsafe {
+        let ffi_elements: Vec<FFIClassElement> = blueprint.elements.iter().map(class_element_to_ffi).collect();
+        let (name, name_len) = blueprint
+            .name
+            .as_ref()
+            .map(|name| (name.as_ptr(), name.len()))
+            .unwrap_or((std::ptr::null(), 0));
+        let bp_ptr = rust_create_class_blueprint(
+            vm_ptr,
+            source_code_ptr,
+            name,
+            name_len,
+            blueprint.source_text_offset,
+            blueprint.source_text_length,
+            blueprint.constructor_sfd_index,
+            blueprint.has_super_class,
+            blueprint.has_name,
+            ffi_elements.as_ptr(),
+            ffi_elements.len(),
+        );
+        assert!(!bp_ptr.is_null(), "rust_create_class_blueprint returned null");
+        bp_ptr
+    }
+}
+
+fn class_element_to_ffi(element: &PendingClassElement) -> FFIClassElement {
+    let (private_identifier, private_identifier_len) = element
+        .private_identifier
+        .as_ref()
+        .map(|name| (name.as_ptr(), name.len()))
+        .unwrap_or((std::ptr::null(), 0));
+    let (literal_value_string, literal_value_string_len) = element
+        .literal_value_string
+        .as_ref()
+        .map(|string| (string.as_ptr(), string.len()))
+        .unwrap_or((std::ptr::null(), 0));
+    FFIClassElement {
+        kind: element.kind,
+        is_static: element.is_static,
+        is_private: element.is_private,
+        private_identifier,
+        private_identifier_len,
+        shared_function_data_index: element
+            .shared_function_data_index
+            .map(FFIOptionalU32::some)
+            .unwrap_or_else(FFIOptionalU32::none),
+        has_initializer: element.has_initializer,
+        literal_value_kind: literal_value_kind_to_ffi(element.literal_value_kind),
+        literal_value_number: element.literal_value_number,
+        literal_value_string,
+        literal_value_string_len,
+    }
+}
+
 /// Constant tags for the FFI constant buffer (ABI-compatible).
 #[repr(u8)]
 pub enum ConstantTag {
@@ -441,7 +560,7 @@ fn encode_constants(constants: &[ConstantValue]) -> Vec<u8> {
 /// `vm_ptr` must be a valid `JS::VM*` and `source_code_ptr` a valid
 /// `JS::SourceCode const*`.
 pub unsafe fn create_executable(
-    generator: &Generator,
+    generator: &mut Generator,
     assembled: &AssembledBytecode,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
@@ -502,15 +621,8 @@ pub unsafe fn create_executable(
             .map(|v| FFIUtf16Slice::from(v.name.as_ref()))
             .collect();
 
-        // Collect shared function data pointers
-        let sfd_ptrs: Vec<*const c_void> = generator
-            .shared_function_data
-            .iter()
-            .map(|ptr| *ptr as *const c_void)
-            .collect();
-
-        // Collect class blueprint pointers
-        let bp_ptrs = &generator.class_blueprints;
+        let sfd_ptrs = materialize_shared_function_data(generator, vm_ptr, source_code_ptr);
+        let bp_ptrs = materialize_class_blueprints(generator, vm_ptr, source_code_ptr);
 
         let ffi_data = FFIExecutableData {
             bytecode: assembled.bytecode.as_ptr(),

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -17,7 +17,7 @@ use super::basic_block::{BasicBlock, SourceMapEntry};
 use super::ffi::{AbstractOperationKind, WellKnownSymbolKind};
 use super::instruction::Instruction;
 use super::operand::*;
-use crate::ast::{FunctionData, FunctionTable, LocalType, Position, Utf16String};
+use crate::ast::{FunctionData, FunctionId, FunctionTable, LocalType, Position, Utf16String};
 use crate::u32_from_usize;
 
 /// Identifies an operand that auto-frees its register when the last
@@ -41,6 +41,25 @@ pub struct PendingSharedFunctionData {
     pub subtable: Option<FunctionTable>,
     pub name_override: Option<Utf16String>,
     pub class_field_initializer_name: Option<(Utf16String, bool)>,
+    pub should_eager_compile: bool,
+    pub precompiled_function: Option<Box<PrecompiledFunction>>,
+}
+
+/// Metadata computed from scope analysis for a SharedFunctionInstanceData.
+pub struct FunctionSfdMetadata {
+    pub uses_this: bool,
+    pub function_environment_needed: bool,
+    pub function_environment_bindings_count: usize,
+    pub var_environment_bindings_count: usize,
+    pub might_need_arguments: bool,
+    pub contains_eval: bool,
+}
+
+/// GC-free compiled bytecode for a function that top-level code will immediately invoke.
+pub struct PrecompiledFunction {
+    pub generator: Box<Generator>,
+    pub assembled: AssembledBytecode,
+    pub metadata: FunctionSfdMetadata,
 }
 
 #[derive(Clone, Copy)]
@@ -243,6 +262,8 @@ pub struct Generator {
     // materialized at the C++ boundary so bytecode generation can run without
     // allocating GC cells.
     pub shared_function_data: Vec<PendingSharedFunctionData>,
+    pub eager_compile_function_ids: HashSet<FunctionId>,
+    pub eager_compile_direct_iifes: bool,
 
     // --- Class blueprints ---
     // Pending descriptors for ClassBlueprint objects. Ownership transfers to
@@ -392,6 +413,8 @@ impl Generator {
                 }),
             },
             shared_function_data: Vec::new(),
+            eager_compile_function_ids: HashSet::new(),
+            eager_compile_direct_iifes: false,
             class_blueprints: Vec::new(),
             length_identifier: None,
             current_unwind_handler: None,

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use super::basic_block::{BasicBlock, SourceMapEntry};
 use super::instruction::Instruction;
 use super::operand::*;
-use crate::ast::{LocalType, Position, Utf16String};
+use crate::ast::{FunctionData, FunctionTable, LocalType, Position, Utf16String};
 use crate::u32_from_usize;
 
 /// Identifies an operand that auto-frees its register when the last
@@ -33,6 +33,45 @@ pub struct ScopedOperand {
 pub(crate) struct ScopedOperandInner {
     operand: Operand,
     free_register_pool: Rc<RefCell<Vec<Register>>>,
+}
+
+pub struct PendingSharedFunctionData {
+    pub function_data: Option<Box<FunctionData>>,
+    pub subtable: Option<FunctionTable>,
+    pub name_override: Option<Utf16String>,
+    pub class_field_initializer_name: Option<(Utf16String, bool)>,
+}
+
+#[derive(Clone, Copy)]
+pub enum PendingLiteralValueKind {
+    None,
+    Number,
+    BooleanTrue,
+    BooleanFalse,
+    Null,
+    String,
+}
+
+pub struct PendingClassElement {
+    pub kind: u8,
+    pub is_static: bool,
+    pub is_private: bool,
+    pub private_identifier: Option<Utf16String>,
+    pub shared_function_data_index: Option<u32>,
+    pub has_initializer: bool,
+    pub literal_value_kind: PendingLiteralValueKind,
+    pub literal_value_number: f64,
+    pub literal_value_string: Option<Utf16String>,
+}
+
+pub struct PendingClassBlueprint {
+    pub name: Option<Utf16String>,
+    pub source_text_offset: usize,
+    pub source_text_length: usize,
+    pub constructor_sfd_index: u32,
+    pub has_super_class: bool,
+    pub has_name: bool,
+    pub elements: Vec<PendingClassElement>,
 }
 
 impl std::fmt::Debug for ScopedOperandInner {
@@ -199,13 +238,15 @@ pub struct Generator {
     this_value: ScopedOperand,
 
     // --- Shared function data ---
-    // Opaque pointers to SharedFunctionInstanceData objects.
-    pub shared_function_data: Vec<*mut std::ffi::c_void>,
+    // Pending descriptors for SharedFunctionInstanceData objects. These are
+    // materialized at the C++ boundary so bytecode generation can run without
+    // allocating GC cells.
+    pub shared_function_data: Vec<PendingSharedFunctionData>,
 
     // --- Class blueprints ---
-    // Opaque pointers to heap-allocated ClassBlueprint objects.
-    // Ownership transfers to the Executable during creation.
-    pub class_blueprints: Vec<*mut std::ffi::c_void>,
+    // Pending descriptors for ClassBlueprint objects. Ownership transfers to
+    // the Executable after materialization.
+    pub class_blueprints: Vec<PendingClassBlueprint>,
 
     // --- Length identifier cache ---
     pub length_identifier: Option<PropertyKeyTableIndex>,
@@ -580,17 +621,23 @@ impl Generator {
         Some(key_index)
     }
 
-    /// Register a SharedFunctionInstanceData (opaque pointer) and return its index.
-    pub fn register_shared_function_data(&mut self, ptr: *mut std::ffi::c_void) -> u32 {
+    /// Register a pending SharedFunctionInstanceData descriptor and return its index.
+    pub fn register_shared_function_data(&mut self, data: PendingSharedFunctionData) -> u32 {
         let index = u32_from_usize(self.shared_function_data.len());
-        self.shared_function_data.push(ptr);
+        self.shared_function_data.push(data);
         index
     }
 
-    /// Register a ClassBlueprint (opaque pointer) and return its index.
-    pub fn register_class_blueprint(&mut self, ptr: *mut std::ffi::c_void) -> u32 {
+    pub fn set_class_field_initializer_name(&mut self, index: u32, name: Utf16String, is_private: bool) {
+        if let Some(data) = self.shared_function_data.get_mut(index as usize) {
+            data.class_field_initializer_name = Some((name, is_private));
+        }
+    }
+
+    /// Register a pending ClassBlueprint descriptor and return its index.
+    pub fn register_class_blueprint(&mut self, data: PendingClassBlueprint) -> u32 {
         let index = u32_from_usize(self.class_blueprints.len());
-        self.class_blueprints.push(ptr);
+        self.class_blueprints.push(data);
         index
     }
 

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use super::basic_block::{BasicBlock, SourceMapEntry};
+use super::ffi::{AbstractOperationKind, WellKnownSymbolKind};
 use super::instruction::Instruction;
 use super::operand::*;
 use crate::ast::{FunctionData, FunctionTable, LocalType, Position, Utf16String};
@@ -568,8 +569,12 @@ impl Generator {
         self.append_constant(ConstantValue::BigInt(value))
     }
 
-    pub fn add_constant_raw_value(&mut self, value: u64) -> ScopedOperand {
-        self.append_constant(ConstantValue::RawValue(value))
+    pub fn add_constant_well_known_symbol(&mut self, symbol: WellKnownSymbolKind) -> ScopedOperand {
+        self.append_constant(ConstantValue::WellKnownSymbol(symbol))
+    }
+
+    pub fn add_constant_abstract_operation(&mut self, operation: AbstractOperationKind) -> ScopedOperand {
+        self.append_constant(ConstantValue::AbstractOperation(operation))
     }
 
     /// Get the constant value for a constant operand.
@@ -1733,13 +1738,15 @@ pub enum ConstantValue {
     Empty,
     String(Utf16String),
     BigInt(String),
-    /// An opaque pre-encoded JS::Value (e.g. well-known symbol, intrinsic function).
-    RawValue(u64),
+    /// A VM-specific well-known symbol resolved when the Executable is materialized.
+    WellKnownSymbol(WellKnownSymbolKind),
+    /// A NativeJavaScriptBackedFunction intrinsic resolved when the Executable is materialized.
+    AbstractOperation(AbstractOperationKind),
 }
 
 /// Convert a constant value to a boolean, matching JS `ToBoolean`.
-/// Returns `None` for opaque `RawValue` constants whose truthiness
-/// cannot be determined at compile time.
+/// Returns `None` for VM-specific constants whose truthiness cannot be
+/// determined until the Executable is materialized.
 pub fn constant_to_boolean(value: &ConstantValue) -> Option<bool> {
     match value {
         ConstantValue::Boolean(b) => Some(*b),
@@ -1747,7 +1754,7 @@ pub fn constant_to_boolean(value: &ConstantValue) -> Option<bool> {
         ConstantValue::Number(n) => Some(*n != 0.0 && !n.is_nan()),
         ConstantValue::String(s) => Some(!s.is_empty()),
         ConstantValue::BigInt(s) => parse_bigint(s).map(|bi| bi != num_bigint::BigInt::ZERO),
-        ConstantValue::RawValue(_) => None,
+        ConstantValue::WellKnownSymbol(_) | ConstantValue::AbstractOperation(_) => None,
     }
 }
 

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -319,6 +319,39 @@ unsafe fn create_executable_from_compiled_bytecode(
     }
 }
 
+fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
+    for pending in &mut generator.shared_function_data {
+        if !pending.should_eager_compile || pending.precompiled_function.is_some() {
+            continue;
+        }
+
+        let function_data = pending
+            .function_data
+            .take()
+            .expect("pending eager function data was already materialized");
+        let subtable = pending
+            .subtable
+            .take()
+            .expect("pending eager function subtable was already materialized");
+        let payload = ast::FunctionPayload {
+            data: *function_data,
+            function_table: subtable,
+        };
+        let (function_data, precompiled) = compile_function_payload_to_bytecode(
+            payload,
+            generator.source_len,
+            generator.builtin_abstract_operations_enabled,
+        );
+
+        pending.function_data = Some(function_data);
+        // The precompiled executable owns any nested lazy function payloads. Keep
+        // an empty payload here only until materialization creates the SFD; it is
+        // immediately cleared after the precompiled executable is attached.
+        pending.subtable = Some(ast::FunctionTable::new());
+        pending.precompiled_function = Some(precompiled);
+    }
+}
+
 /// Shared compilation pipeline: local variable setup → codegen → assemble → create Executable.
 ///
 /// Called by program-level entry points that compile synchronously on the main thread.
@@ -553,7 +586,9 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
             let mut parsed = Box::from_raw(parsed);
             let bytecode = if parsed.has_top_level_await {
                 let mut generator = new_module_async_generator(source_len, std::mem::take(&mut parsed.function_table));
+                generator.eager_compile_direct_iifes = true;
                 let assembled = compile_module_as_async_to_bytecode(&parsed.program, &parsed.scope_ref, &mut generator);
+                precompile_eager_functions(&mut generator);
                 CompiledProgramBytecode::AsyncModule(CompiledBytecode { generator, assembled })
             } else {
                 let mut generator = new_program_generator(
@@ -562,8 +597,10 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                     std::ptr::null(),
                     source_len,
                 );
+                generator.eager_compile_direct_iifes = true;
                 generator.function_table = std::mem::take(&mut parsed.function_table);
                 let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, &parsed.scope_ref);
+                precompile_eager_functions(&mut generator);
                 CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled })
             };
 
@@ -2154,117 +2191,131 @@ pub unsafe extern "C" fn rust_compile_function(
                 return std::ptr::null_mut();
             }
             let payload = Box::from_raw(rust_function_ast as *mut ast::FunctionPayload);
-            let function_data = Box::new(payload.data);
+            let (_function_data, mut precompiled) =
+                compile_function_payload_to_bytecode(*payload, source_len, builtin_abstract_operations_enabled);
 
-            let body_scope = match &function_data.body.inner {
-                StatementKind::FunctionBody { scope, .. } => Some(scope),
-                StatementKind::Block(scope) => Some(scope),
-                _ => None,
-            };
+            precompiled.generator.vm_ptr = vm_ptr;
+            precompiled.generator.source_code_ptr = source_code_ptr;
 
-            // Compute SFD metadata before codegen so the generator can use
-            // function_environment_needed to optimize `this` access.
-            let sfd_metadata = compute_sfd_metadata(&function_data);
+            write_sfd_metadata(sfd_ptr, &precompiled.metadata);
 
-            let mut generator = bytecode::generator::Generator::new();
-            generator.strict = function_data.is_strict_mode;
-            generator.function_environment_needed = sfd_metadata.function_environment_needed;
-            generator.builtin_abstract_operations_enabled = builtin_abstract_operations_enabled;
-            generator.function_table = payload.function_table;
-            generator.vm_ptr = vm_ptr;
-            generator.source_code_ptr = source_code_ptr;
-            generator.source_len = source_len;
-            generator.enclosing_function_kind = function_data.kind;
-
-            if let Some(scope) = body_scope {
-                generator.local_variables = convert_local_variables(&scope.borrow());
-            }
-
-            let entry_block = generator.make_block();
-            generator.switch_to_basic_block(entry_block);
-
-            // https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start
-            // For async (non-generator) functions, emit the initial Yield BEFORE
-            // GetLexicalEnvironment so that parameter evaluation errors are caught
-            // by the async promise wrapper. This matches C++ ordering.
-            if generator.is_in_async_function() && !generator.is_in_generator_function() {
-                let start_block = generator.make_block();
-                let undef = generator.add_constant_undefined();
-                generator.emit(bytecode::instruction::Instruction::Yield {
-                    continuation_label: Some(start_block),
-                    value: undef.operand(),
-                });
-                generator.switch_to_basic_block(start_block);
-            }
-
-            generator.capture_saved_lexical_environment();
-
-            if let Some(scope) = body_scope {
-                bytecode::codegen::emit_function_declaration_instantiation(
-                    &mut generator,
-                    &function_data,
-                    &scope.borrow(),
-                    sfd_metadata.var_environment_bindings_count,
-                );
-            }
-
-            // https://tc39.es/ecma262/#sec-generatorstart
-            // For generator functions (including async generators), emit the initial Yield
-            // AFTER FDI. Parameter evaluation happens synchronously before the generator starts.
-            if generator.is_in_generator_function() {
-                let start_block = generator.make_block();
-                let undef = generator.add_constant_undefined();
-                generator.emit(bytecode::instruction::Instruction::Yield {
-                    continuation_label: Some(start_block),
-                    value: undef.operand(),
-                });
-                generator.switch_to_basic_block(start_block);
-            }
-
-            let result = bytecode::codegen::generate_statement(&function_data.body, &mut generator, None);
-
-            if !generator.is_current_block_terminated() {
-                if generator.is_in_generator_or_async_function() {
-                    // Generator/async functions end with Yield (no continuation = done).
-                    let undef = generator.add_constant_undefined();
-                    generator.emit(bytecode::instruction::Instruction::Yield {
-                        continuation_label: None,
-                        value: undef.operand(),
-                    });
-                } else if let Some(value) = result {
-                    generator.emit(bytecode::instruction::Instruction::End { value: value.operand() });
-                }
-                // If result is None, the assembler will add End(undefined) as a
-                // fallthrough for unterminated blocks, matching C++ compile().
-            }
-
-            // For generator/async functions, terminate all unterminated blocks with Yield.
-            if generator.is_in_generator_or_async_function() {
-                generator.terminate_unterminated_blocks_with_yield();
-            }
-
-            let assembled = generator.assemble();
-
-            write_sfd_metadata(sfd_ptr, &sfd_metadata);
-
-            bytecode::ffi::create_executable(&mut generator, &assembled, vm_ptr, source_code_ptr)
+            bytecode::ffi::create_executable(
+                &mut precompiled.generator,
+                &precompiled.assembled,
+                vm_ptr,
+                source_code_ptr,
+            )
         })
     }
+}
+
+fn compile_function_payload_to_bytecode(
+    payload: ast::FunctionPayload,
+    source_len: usize,
+    builtin_abstract_operations_enabled: bool,
+) -> (Box<ast::FunctionData>, Box<bytecode::generator::PrecompiledFunction>) {
+    let function_data = Box::new(payload.data);
+
+    let body_scope = match &function_data.body.inner {
+        StatementKind::FunctionBody { scope, .. } => Some(scope),
+        StatementKind::Block(scope) => Some(scope),
+        _ => None,
+    };
+
+    // Compute SFD metadata before codegen so the generator can use
+    // function_environment_needed to optimize `this` access.
+    let sfd_metadata = compute_sfd_metadata(&function_data);
+
+    let mut generator = bytecode::generator::Generator::new();
+    generator.strict = function_data.is_strict_mode;
+    generator.function_environment_needed = sfd_metadata.function_environment_needed;
+    generator.builtin_abstract_operations_enabled = builtin_abstract_operations_enabled;
+    generator.function_table = payload.function_table;
+    generator.source_len = source_len;
+    generator.enclosing_function_kind = function_data.kind;
+
+    if let Some(scope) = body_scope {
+        generator.local_variables = convert_local_variables(&scope.borrow());
+    }
+
+    let entry_block = generator.make_block();
+    generator.switch_to_basic_block(entry_block);
+
+    // https://tc39.es/ecma262/#sec-async-functions-abstract-operations-async-function-start
+    // For async (non-generator) functions, emit the initial Yield BEFORE
+    // GetLexicalEnvironment so that parameter evaluation errors are caught
+    // by the async promise wrapper. This matches C++ ordering.
+    if generator.is_in_async_function() && !generator.is_in_generator_function() {
+        let start_block = generator.make_block();
+        let undef = generator.add_constant_undefined();
+        generator.emit(bytecode::instruction::Instruction::Yield {
+            continuation_label: Some(start_block),
+            value: undef.operand(),
+        });
+        generator.switch_to_basic_block(start_block);
+    }
+
+    generator.capture_saved_lexical_environment();
+
+    if let Some(scope) = body_scope {
+        bytecode::codegen::emit_function_declaration_instantiation(
+            &mut generator,
+            &function_data,
+            &scope.borrow(),
+            sfd_metadata.var_environment_bindings_count,
+        );
+    }
+
+    // https://tc39.es/ecma262/#sec-generatorstart
+    // For generator functions (including async generators), emit the initial Yield
+    // AFTER FDI. Parameter evaluation happens synchronously before the generator starts.
+    if generator.is_in_generator_function() {
+        let start_block = generator.make_block();
+        let undef = generator.add_constant_undefined();
+        generator.emit(bytecode::instruction::Instruction::Yield {
+            continuation_label: Some(start_block),
+            value: undef.operand(),
+        });
+        generator.switch_to_basic_block(start_block);
+    }
+
+    let result = bytecode::codegen::generate_statement(&function_data.body, &mut generator, None);
+
+    if !generator.is_current_block_terminated() {
+        if generator.is_in_generator_or_async_function() {
+            // Generator/async functions end with Yield (no continuation = done).
+            let undef = generator.add_constant_undefined();
+            generator.emit(bytecode::instruction::Instruction::Yield {
+                continuation_label: None,
+                value: undef.operand(),
+            });
+        } else if let Some(value) = result {
+            generator.emit(bytecode::instruction::Instruction::End { value: value.operand() });
+        }
+        // If result is None, the assembler will add End(undefined) as a
+        // fallthrough for unterminated blocks, matching C++ compile().
+    }
+
+    // For generator/async functions, terminate all unterminated blocks with Yield.
+    if generator.is_in_generator_or_async_function() {
+        generator.terminate_unterminated_blocks_with_yield();
+    }
+
+    let assembled = generator.assemble();
+
+    (
+        function_data,
+        Box::new(bytecode::generator::PrecompiledFunction {
+            generator: Box::new(generator),
+            assembled,
+            metadata: sfd_metadata,
+        }),
+    )
 }
 
 // =============================================================================
 // SFD metadata computation (ECMA-262 section 10.2.11)
 // =============================================================================
-
-/// Metadata computed from scope analysis for a SharedFunctionInstanceData.
-struct SfdMetadata {
-    uses_this: bool,
-    function_environment_needed: bool,
-    function_environment_bindings_count: usize,
-    var_environment_bindings_count: usize,
-    might_need_arguments: bool,
-    contains_eval: bool,
-}
 
 /// Intermediate scope analysis data extracted from the function body scope.
 struct BodyScopeInfo {
@@ -2283,7 +2334,7 @@ struct BodyScopeInfo {
 
 /// Compute FDI runtime metadata matching the C++ SharedFunctionInstanceData
 /// constructor (ECMA-262 §10.2.11).
-fn compute_sfd_metadata(function_data: &ast::FunctionData) -> SfdMetadata {
+fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generator::FunctionSfdMetadata {
     let body_scope = match &function_data.body.inner {
         ast::StatementKind::FunctionBody { scope, .. } => Some(scope),
         _ => None,
@@ -2442,7 +2493,7 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> SfdMetadata {
         || bsi.uses_this_from_env
         || bsi.contains_eval;
 
-    SfdMetadata {
+    bytecode::generator::FunctionSfdMetadata {
         uses_this: bsi.uses_this,
         function_environment_needed,
         function_environment_bindings_count,
@@ -2456,7 +2507,7 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> SfdMetadata {
 ///
 /// # Safety
 /// `sfd_ptr` must be a valid `JS::SharedFunctionInstanceData*`.
-unsafe fn write_sfd_metadata(sfd_ptr: *mut c_void, metadata: &SfdMetadata) {
+unsafe fn write_sfd_metadata(sfd_ptr: *mut c_void, metadata: &bytecode::generator::FunctionSfdMetadata) {
     unsafe {
         rust_sfd_set_metadata(
             sfd_ptr,

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -121,6 +121,26 @@ pub struct ParsedProgram {
 // SAFETY: Full ownership transfer between threads, never concurrent access.
 unsafe impl Send for ParsedProgram {}
 
+pub struct CompiledProgram {
+    parsed: ParsedProgram,
+    bytecode: CompiledProgramBytecode,
+}
+
+enum CompiledProgramBytecode {
+    Program(CompiledBytecode),
+    AsyncModule(CompiledBytecode),
+}
+
+struct CompiledBytecode {
+    generator: bytecode::generator::Generator,
+    assembled: bytecode::generator::AssembledBytecode,
+}
+
+// SAFETY: This handle owns its parser and bytecode-generator state, and C++ treats it as a move-only handoff object.
+// The Rc/RefCell values inside are only ever touched by one thread at a time: the worker creates the handle, then the
+// main thread consumes or frees it after the event-loop hop.
+unsafe impl Send for CompiledProgram {}
+
 // =============================================================================
 // Internal helpers
 // =============================================================================
@@ -259,9 +279,49 @@ fn new_program_generator(
     generator
 }
 
+/// Shared codegen pipeline: local variable setup → bytecode generation → assembly.
+///
+/// This deliberately stops before `create_executable()`, because executable materialization creates GC-managed objects
+/// and resolves VM-specific constants. Keeping that work separate lets WebContent perform the expensive AST-to-bytecode
+/// pass on a worker thread while preserving all main-thread ownership rules for VM and heap data.
+fn compile_program_body_to_bytecode(
+    generator: &mut bytecode::generator::Generator,
+    program: &ast::Statement,
+    scope_ref: &Rc<RefCell<ast::ScopeData>>,
+) -> bytecode::generator::AssembledBytecode {
+    generator.local_variables = convert_local_variables(&scope_ref.borrow());
+
+    let entry_block = generator.make_block();
+    generator.switch_to_basic_block(entry_block);
+    generator.capture_saved_lexical_environment();
+
+    let result = bytecode::codegen::generate_statement(program, generator, None);
+
+    if !generator.is_current_block_terminated()
+        && let Some(value) = result
+    {
+        generator.emit(bytecode::instruction::Instruction::End { value: value.operand() });
+    }
+    // If result is None, the assembler will add End(undefined) as a fallthrough for unterminated blocks, matching C++.
+
+    generator.assemble()
+}
+
+unsafe fn create_executable_from_compiled_bytecode(
+    bytecode: &mut CompiledBytecode,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+) -> *mut c_void {
+    unsafe {
+        bytecode.generator.vm_ptr = vm_ptr;
+        bytecode.generator.source_code_ptr = source_code_ptr;
+        bytecode::ffi::create_executable(&mut bytecode.generator, &bytecode.assembled, vm_ptr, source_code_ptr)
+    }
+}
+
 /// Shared compilation pipeline: local variable setup → codegen → assemble → create Executable.
 ///
-/// Called by all three program-level entry points after parsing and scope analysis.
+/// Called by program-level entry points that compile synchronously on the main thread.
 unsafe fn compile_program_body(
     generator: &mut bytecode::generator::Generator,
     program: &ast::Statement,
@@ -269,26 +329,8 @@ unsafe fn compile_program_body(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
 ) -> *mut c_void {
-    unsafe {
-        generator.local_variables = convert_local_variables(&scope_ref.borrow());
-
-        let entry_block = generator.make_block();
-        generator.switch_to_basic_block(entry_block);
-        generator.capture_saved_lexical_environment();
-
-        let result = bytecode::codegen::generate_statement(program, generator, None);
-
-        if !generator.is_current_block_terminated()
-            && let Some(value) = result
-        {
-            generator.emit(bytecode::instruction::Instruction::End { value: value.operand() });
-        }
-        // If result is None, the assembler will add End(undefined) as a
-        // fallthrough for unterminated blocks, matching C++ compile().
-
-        let assembled = generator.assemble();
-        bytecode::ffi::create_executable(generator, &assembled, vm_ptr, source_code_ptr)
-    }
+    let assembled = compile_program_body_to_bytecode(generator, program, scope_ref);
+    unsafe { bytecode::ffi::create_executable(generator, &assembled, vm_ptr, source_code_ptr) }
 }
 
 // =============================================================================
@@ -490,6 +532,60 @@ pub unsafe extern "C" fn rust_free_parsed_program(parsed: *mut ParsedProgram) {
     }
 }
 
+/// Compile a parsed program to an off-thread bytecode artifact.
+///
+/// Consumes and frees the ParsedProgram. The returned CompiledProgram still needs to be materialized on the main thread
+/// before it becomes a GC-backed Executable.
+///
+/// # Safety
+/// - `parsed` must be a valid pointer from `rust_parse_program()` with no errors.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
+    parsed: *mut ParsedProgram,
+    source_len: usize,
+) -> *mut CompiledProgram {
+    unsafe {
+        abort_on_panic(|| {
+            if parsed.is_null() {
+                return std::ptr::null_mut();
+            }
+
+            let mut parsed = Box::from_raw(parsed);
+            let bytecode = if parsed.has_top_level_await {
+                let mut generator = new_module_async_generator(source_len, std::mem::take(&mut parsed.function_table));
+                let assembled = compile_module_as_async_to_bytecode(&parsed.program, &parsed.scope_ref, &mut generator);
+                CompiledProgramBytecode::AsyncModule(CompiledBytecode { generator, assembled })
+            } else {
+                let mut generator = new_program_generator(
+                    parsed.is_strict_mode,
+                    std::ptr::null_mut(),
+                    std::ptr::null(),
+                    source_len,
+                );
+                generator.function_table = std::mem::take(&mut parsed.function_table);
+                let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, &parsed.scope_ref);
+                CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled })
+            };
+
+            Box::into_raw(Box::new(CompiledProgram {
+                parsed: *parsed,
+                bytecode,
+            }))
+        })
+    }
+}
+
+/// Free a CompiledProgram without materializing it.
+///
+/// # Safety
+/// `compiled` must be a valid pointer from `rust_compile_parsed_program_off_thread()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_free_compiled_program(compiled: *mut CompiledProgram) {
+    unsafe {
+        drop(Box::from_raw(compiled));
+    }
+}
+
 /// Get the AST dump string from a ParsedProgram.
 ///
 /// Generates the dump on first call and caches it. Writes the pointer
@@ -558,6 +654,50 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
                 source_code_ptr,
                 gdi_context,
                 &mut generator.function_table,
+            );
+
+            exec_ptr
+        })
+    }
+}
+
+/// Materialize an off-thread-compiled script. Consumes and frees the CompiledProgram.
+///
+/// # Safety
+/// - `compiled` must be a valid pointer from `rust_compile_parsed_program_off_thread()`.
+/// - `vm_ptr` must be a valid `JS::VM*`.
+/// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
+/// - `gdi_context` must be a valid pointer to a C++ ScriptGdiBuilder.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_materialize_compiled_script(
+    compiled: *mut CompiledProgram,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    gdi_context: *mut c_void,
+) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if compiled.is_null() {
+                return std::ptr::null_mut();
+            }
+
+            let mut compiled = Box::from_raw(compiled);
+            let CompiledProgramBytecode::Program(ref mut bytecode) = compiled.bytecode else {
+                return std::ptr::null_mut();
+            };
+
+            let exec_ptr = create_executable_from_compiled_bytecode(bytecode, vm_ptr, source_code_ptr);
+            if exec_ptr.is_null() {
+                return std::ptr::null_mut();
+            }
+
+            extract_script_gdi(
+                &compiled.parsed.scope_ref.borrow(),
+                compiled.parsed.is_strict_mode,
+                vm_ptr,
+                source_code_ptr,
+                gdi_context,
+                &mut bytecode.generator.function_table,
             );
 
             exec_ptr
@@ -1007,6 +1147,67 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                     vm_ptr,
                     source_code_ptr,
                 )
+            }
+        })
+    }
+}
+
+/// Materialize an off-thread-compiled module. Consumes and frees the CompiledProgram.
+///
+/// # Safety
+/// - `compiled` must be a valid pointer from `rust_compile_parsed_program_off_thread()`.
+/// - `vm_ptr` must be a valid `JS::VM*`.
+/// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
+/// - `module_context` must be a valid `ModuleBuilder*`.
+/// - `callbacks` must point to a valid `ModuleCallbacks`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_materialize_compiled_module(
+    compiled: *mut CompiledProgram,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    module_context: *mut c_void,
+    callbacks: *const ModuleCallbacks,
+    tla_executable_out: *mut *mut c_void,
+) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if compiled.is_null() {
+                return std::ptr::null_mut();
+            }
+
+            let mut compiled = Box::from_raw(compiled);
+            let cb = &*callbacks;
+
+            (cb.set_has_top_level_await)(module_context, compiled.parsed.has_top_level_await);
+            extract_module_metadata(&compiled.parsed.scope_ref.borrow(), module_context, cb);
+
+            let bytecode = match &mut compiled.bytecode {
+                CompiledProgramBytecode::Program(bytecode) | CompiledProgramBytecode::AsyncModule(bytecode) => bytecode,
+            };
+            extract_module_declarations(
+                &compiled.parsed.scope_ref.borrow(),
+                vm_ptr,
+                source_code_ptr,
+                module_context,
+                cb,
+                &mut bytecode.generator.function_table,
+            );
+            extract_requested_modules(&compiled.parsed.scope_ref.borrow(), module_context, cb);
+
+            match &mut compiled.bytecode {
+                CompiledProgramBytecode::AsyncModule(bytecode) => {
+                    let exec_ptr = create_executable_from_compiled_bytecode(bytecode, vm_ptr, source_code_ptr);
+                    if !tla_executable_out.is_null() {
+                        *tla_executable_out = exec_ptr;
+                    }
+                    std::ptr::null_mut()
+                }
+                CompiledProgramBytecode::Program(bytecode) => {
+                    if !tla_executable_out.is_null() {
+                        *tla_executable_out = std::ptr::null_mut();
+                    }
+                    create_executable_from_compiled_bytecode(bytecode, vm_ptr, source_code_ptr)
+                }
             }
         })
     }
@@ -1523,6 +1724,59 @@ unsafe fn extract_requested_modules(scope: &ast::ScopeData, ctx: *mut c_void, cb
 ///
 /// Emits async-function wrapping (initial Yield, final Yield) around the
 /// module body statements.
+fn new_module_async_generator(source_len: usize, function_table: ast::FunctionTable) -> bytecode::generator::Generator {
+    let mut generator = bytecode::generator::Generator::new();
+    generator.strict = true;
+    generator.function_table = function_table;
+    generator.source_len = source_len;
+    generator.enclosing_function_kind = ast::FunctionKind::Async;
+    generator
+}
+
+fn compile_module_as_async_to_bytecode(
+    program: &ast::Statement,
+    scope_ref: &Rc<RefCell<ast::ScopeData>>,
+    generator: &mut bytecode::generator::Generator,
+) -> bytecode::generator::AssembledBytecode {
+    use bytecode::instruction::Instruction;
+
+    let scope = scope_ref.borrow();
+
+    // Extract local variables from the program scope so the executable has the correct registers_and_locals_count.
+    // Without this, locals are not saved across await suspension points, causing them to become undefined.
+    generator.local_variables = convert_local_variables(&scope);
+
+    let entry_block = generator.make_block();
+    generator.switch_to_basic_block(entry_block);
+
+    // Async function start: emit initial Yield before GetLexicalEnvironment.
+    let start_block = generator.make_block();
+    let undef = generator.add_constant_undefined();
+    generator.emit(Instruction::Yield {
+        continuation_label: Some(start_block),
+        value: undef.operand(),
+    });
+    generator.switch_to_basic_block(start_block);
+    generator.capture_saved_lexical_environment();
+
+    // Generate module body statements.
+    let _result = bytecode::codegen::generate_statement(program, generator, None);
+
+    // Async function end: emit final Yield (no continuation = done).
+    if !generator.is_current_block_terminated() {
+        let undef = generator.add_constant_undefined();
+        generator.emit(Instruction::Yield {
+            continuation_label: None,
+            value: undef.operand(),
+        });
+    }
+
+    // Terminate all unterminated blocks with Yield.
+    generator.terminate_unterminated_blocks_with_yield();
+
+    generator.assemble()
+}
+
 unsafe fn compile_module_as_async(
     program: &ast::Statement,
     scope_ref: &Rc<RefCell<ast::ScopeData>>,
@@ -1533,52 +1787,11 @@ unsafe fn compile_module_as_async(
     function_table: ast::FunctionTable,
 ) -> *mut c_void {
     unsafe {
-        use bytecode::generator::Generator;
-        use bytecode::instruction::Instruction;
-
-        let scope = scope_ref.borrow();
-        let mut generator = Generator::new();
-        generator.strict = true;
-        generator.function_table = function_table;
+        let mut generator = new_module_async_generator(source_len, function_table);
         generator.vm_ptr = vm_ptr;
         generator.source_code_ptr = source_code_ptr;
-        generator.source_len = source_len;
-        generator.enclosing_function_kind = ast::FunctionKind::Async;
 
-        // Extract local variables from the program scope so the executable has the
-        // correct registers_and_locals_count. Without this, locals are not saved
-        // across await suspension points, causing them to become undefined.
-        generator.local_variables = convert_local_variables(&scope);
-
-        let entry_block = generator.make_block();
-        generator.switch_to_basic_block(entry_block);
-
-        // Async function start: emit initial Yield before GetLexicalEnvironment.
-        let start_block = generator.make_block();
-        let undef = generator.add_constant_undefined();
-        generator.emit(Instruction::Yield {
-            continuation_label: Some(start_block),
-            value: undef.operand(),
-        });
-        generator.switch_to_basic_block(start_block);
-        generator.capture_saved_lexical_environment();
-
-        // Generate module body statements.
-        let _result = bytecode::codegen::generate_statement(program, &mut generator, None);
-
-        // Async function end: emit final Yield (no continuation = done).
-        if !generator.is_current_block_terminated() {
-            let undef = generator.add_constant_undefined();
-            generator.emit(Instruction::Yield {
-                continuation_label: None,
-                value: undef.operand(),
-            });
-        }
-
-        // Terminate all unterminated blocks with Yield.
-        generator.terminate_unterminated_blocks_with_yield();
-
-        let assembled = generator.assemble();
+        let assembled = compile_module_as_async_to_bytecode(program, scope_ref, &mut generator);
         bytecode::ffi::create_executable(&mut generator, &assembled, vm_ptr, source_code_ptr)
     }
 }

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -1579,7 +1579,7 @@ unsafe fn compile_module_as_async(
         generator.terminate_unterminated_blocks_with_yield();
 
         let assembled = generator.assemble();
-        bytecode::ffi::create_executable(&generator, &assembled, vm_ptr, source_code_ptr)
+        bytecode::ffi::create_executable(&mut generator, &assembled, vm_ptr, source_code_ptr)
     }
 }
 
@@ -2034,7 +2034,7 @@ pub unsafe extern "C" fn rust_compile_function(
 
             write_sfd_metadata(sfd_ptr, &sfd_metadata);
 
-            bytecode::ffi::create_executable(&generator, &assembled, vm_ptr, source_code_ptr)
+            bytecode::ffi::create_executable(&mut generator, &assembled, vm_ptr, source_code_ptr)
         })
     }
 }

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -37,8 +37,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::ast::{
-    BindingPattern, Expression, ExpressionKind, FunctionParameter, FunctionTable, Identifier, PrivateIdentifier,
-    ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement, StatementKind, Utf16String,
+    BindingPattern, Expression, ExpressionKind, FunctionData, FunctionId, FunctionParameter, FunctionTable, Identifier,
+    PrivateIdentifier, ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement, StatementKind, Utf16String,
 };
 use crate::lexer::{Lexer, ch};
 use crate::scope_collector::{ScopeCollector, ScopeCollectorState};
@@ -211,6 +211,7 @@ struct SavedState {
     errors_len: usize,
     flags: ParserFlags,
     scope_collector_state: ScopeCollectorState,
+    function_context_stack_lengths: Vec<usize>,
 }
 
 /// The main JavaScript parser.
@@ -293,6 +294,13 @@ pub struct Parser<'a> {
     /// Side table owning all FunctionData produced during parsing.
     pub function_table: FunctionTable,
 
+    /// Stack of nested function ids discovered while parsing each active function.
+    ///
+    /// When the parser finishes a function, the top list becomes that
+    /// FunctionData's child list. This lets lazy-compile payload extraction move
+    /// a known function subtree instead of walking the function body again.
+    function_context_stack: Vec<Vec<FunctionId>>,
+
     /// Memoization: offsets where arrow function parsing has already failed.
     /// Prevents exponential re-processing of nested expressions like
     /// `(a=(b=(c=0)))` where each failed arrow attempt would otherwise
@@ -341,6 +349,7 @@ impl<'a> Parser<'a> {
             scope_collector: ScopeCollector::new(),
             exported_names: HashSet::new(),
             function_table: FunctionTable::new(),
+            function_context_stack: Vec::new(),
             arrow_function_failed_positions: HashSet::new(),
         }
     }
@@ -360,6 +369,27 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn statement(&self, start: Position, statement: StatementKind) -> Statement {
         Statement::new(self.range_from(start), statement)
+    }
+
+    pub(crate) fn push_function_context(&mut self) {
+        self.function_context_stack.push(Vec::new());
+    }
+
+    pub(crate) fn pop_function_context(&mut self) -> Vec<FunctionId> {
+        self.function_context_stack
+            .pop()
+            .expect("Parser::pop_function_context: no active function context")
+    }
+
+    pub(crate) fn insert_function_data(&mut self, data: FunctionData) -> FunctionId {
+        let function_id = self.function_table.insert(data);
+        if let Some(context) = self.function_context_stack.last_mut() {
+            // The newly parsed function belongs to the innermost function
+            // context. Top-level functions have no parent and remain reachable
+            // through their AST node, as before.
+            context.push(function_id);
+        }
+        function_id
     }
 
     pub(crate) fn make_identifier(&self, start: Position, name: impl Into<SharedUtf16String>) -> Rc<Identifier> {
@@ -719,6 +749,7 @@ impl<'a> Parser<'a> {
             errors_len: self.errors.len(),
             flags: self.flags,
             scope_collector_state: self.scope_collector.save_state(),
+            function_context_stack_lengths: self.function_context_stack.iter().map(Vec::len).collect(),
         });
     }
 
@@ -728,6 +759,15 @@ impl<'a> Parser<'a> {
         self.errors.truncate(state.errors_len);
         self.flags = state.flags;
         self.scope_collector.load_state(state.scope_collector_state);
+        self.function_context_stack
+            .truncate(state.function_context_stack_lengths.len());
+        for (context, len) in self
+            .function_context_stack
+            .iter_mut()
+            .zip(state.function_context_stack_lengths)
+        {
+            context.truncate(len);
+        }
         self.lexer.load_state();
     }
 

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -406,7 +406,7 @@ impl Parser<'_> {
         );
         let decl_name = fd.name.clone();
         let decl_kind = fd.kind;
-        let function_id = self.function_table.insert(fd);
+        let function_id = self.insert_function_data(fd);
         self.statement(
             start,
             StatementKind::FunctionDeclaration(Box::new(FunctionDeclarationData {
@@ -473,7 +473,7 @@ impl Parser<'_> {
             start,
             saved_might_need_arguments,
         );
-        let function_id = self.function_table.insert(fd);
+        let function_id = self.insert_function_data(fd);
         self.expression(start, ExpressionKind::Function(function_id))
     }
 
@@ -522,6 +522,7 @@ impl Parser<'_> {
         // function body don't steal names from an outer binding context.
         let saved_pattern_bound_names = std::mem::take(&mut self.pattern_bound_names);
 
+        self.push_function_context();
         let parsed = self.parse_formal_parameters();
         self.register_function_parameters_with_scope(&parsed.parameters, &parsed.parameter_info);
 
@@ -548,6 +549,7 @@ impl Parser<'_> {
 
         insights.might_need_arguments_object = self.flags.function_might_need_arguments_object;
         self.flags.function_might_need_arguments_object = saved_might_need_arguments;
+        let nested_function_ids = self.pop_function_context();
 
         FunctionData {
             name,
@@ -560,6 +562,7 @@ impl Parser<'_> {
             is_strict_mode: self.flags.strict_mode || has_use_strict,
             is_arrow_function: false,
             parsing_insights: insights,
+            nested_function_ids: Some(nested_function_ids),
         }
     }
 
@@ -758,7 +761,7 @@ impl Parser<'_> {
                 is_rest: true,
             }];
 
-            let function_id = self.function_table.insert(FunctionData {
+            let function_id = self.insert_function_data(FunctionData {
                 name: ctor_name,
                 source_text_start: start.offset,
                 source_text_end: self.source_text_end_offset(),
@@ -773,12 +776,13 @@ impl Parser<'_> {
                     uses_this_from_environment: true,
                     ..FunctionParsingInsights::default()
                 },
+                nested_function_ids: Some(Vec::new()),
             });
             self.expression(start, ExpressionKind::Function(function_id))
         } else {
             let body = self.statement(start, StatementKind::Block(ScopeData::shared_with_children(Vec::new())));
 
-            let function_id = self.function_table.insert(FunctionData {
+            let function_id = self.insert_function_data(FunctionData {
                 name: ctor_name,
                 source_text_start: start.offset,
                 source_text_end: self.source_text_end_offset(),
@@ -793,6 +797,7 @@ impl Parser<'_> {
                     uses_this_from_environment: true,
                     ..FunctionParsingInsights::default()
                 },
+                nested_function_ids: Some(Vec::new()),
             });
             self.expression(start, ExpressionKind::Function(function_id))
         }

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -2224,6 +2224,7 @@ impl Parser<'_> {
         // load_state() rollback will undo this.
         self.scope_collector.open_function_scope(None);
         self.scope_collector.set_is_arrow_function();
+        self.push_function_context();
 
         // Set await_expression_is_valid during parameter parsing so that
         // 'await' is rejected as an identifier in async arrow parameters.
@@ -2334,7 +2335,8 @@ impl Parser<'_> {
             self.flags.await_expression_is_valid = saved_await_body;
             self.flags.in_class_static_init_block = saved_static_init;
             self.flags.in_formal_parameter_context = saved_formal_parameter_ctx;
-            let function_id = self.function_table.insert(FunctionData {
+            let nested_function_ids = self.pop_function_context();
+            let function_id = self.insert_function_data(FunctionData {
                 name: None,
                 source_text_start: src_start,
                 source_text_end: self.source_text_end_offset(),
@@ -2345,6 +2347,7 @@ impl Parser<'_> {
                 is_strict_mode: self.flags.strict_mode || has_use_strict,
                 is_arrow_function: true,
                 parsing_insights: insights,
+                nested_function_ids: Some(nested_function_ids),
             });
             Some(self.expression(start, ExpressionKind::Function(function_id)))
         } else {
@@ -2382,7 +2385,8 @@ impl Parser<'_> {
             self.flags.await_expression_is_valid = saved_await_body;
             self.flags.in_class_static_init_block = saved_static_init;
             self.flags.in_formal_parameter_context = saved_formal_parameter_ctx;
-            let function_id = self.function_table.insert(FunctionData {
+            let nested_function_ids = self.pop_function_context();
+            let function_id = self.insert_function_data(FunctionData {
                 name: None,
                 source_text_start: src_start,
                 source_text_end: self.source_text_end_offset(),
@@ -2393,6 +2397,7 @@ impl Parser<'_> {
                 is_strict_mode: self.flags.strict_mode,
                 is_arrow_function: true,
                 parsing_insights: insights,
+                nested_function_ids: Some(nested_function_ids),
             });
             Some(self.expression(start, ExpressionKind::Function(function_id)))
         }
@@ -2434,6 +2439,7 @@ impl Parser<'_> {
         // method body don't steal names from an outer binding context.
         let saved_pattern_bound_names = std::mem::take(&mut self.pattern_bound_names);
 
+        self.push_function_context();
         let parsed = self.parse_formal_parameters();
 
         self.register_function_parameters_with_scope(&parsed.parameters, &parsed.parameter_info);
@@ -2479,7 +2485,8 @@ impl Parser<'_> {
             insights.uses_this_from_environment = true;
         }
 
-        let function_id = self.function_table.insert(FunctionData {
+        let nested_function_ids = self.pop_function_context();
+        let function_id = self.insert_function_data(FunctionData {
             name: None,
             source_text_start: function_start.offset,
             source_text_end: self.source_text_end_offset(),
@@ -2490,6 +2497,7 @@ impl Parser<'_> {
             is_strict_mode: self.flags.strict_mode || has_use_strict,
             is_arrow_function: false,
             parsing_insights: insights,
+            nested_function_ids: Some(nested_function_ids),
         });
         self.expression(start, ExpressionKind::Function(function_id))
     }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -695,12 +695,35 @@ static JS::Value decode_constant(JS::VM& vm, uint8_t const*& cursor, uint8_t con
         }();
         return JS::BigInt::create(vm, move(integer));
     }
-    case ConstantTag::RawValue: {
-        VERIFY(cursor + 8 <= end);
-        JS::Value value;
-        memcpy(&value, cursor, 8);
-        cursor += 8;
-        return value;
+    case ConstantTag::WellKnownSymbol: {
+        VERIFY(cursor + 1 <= end);
+        auto symbol_id = static_cast<WellKnownSymbolKind>(*cursor++);
+        switch (symbol_id) {
+        case WellKnownSymbolKind::SymbolIterator:
+            return vm.well_known_symbol_iterator();
+        case WellKnownSymbolKind::SymbolAsyncIterator:
+            return vm.well_known_symbol_async_iterator();
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+    case ConstantTag::AbstractOperation: {
+        VERIFY(cursor + 1 <= end);
+        auto operation = static_cast<AbstractOperationKind>(*cursor++);
+        auto& intrinsics = vm.current_realm()->intrinsics();
+        switch (operation) {
+        case AbstractOperationKind::AsyncIteratorClose:
+            return JS::Value(intrinsics.async_iterator_close_abstract_operation_function().ptr());
+        case AbstractOperationKind::GetMethod:
+            return JS::Value(intrinsics.get_method_abstract_operation_function().ptr());
+        case AbstractOperationKind::GetIteratorDirect:
+            return JS::Value(intrinsics.get_iterator_direct_abstract_operation_function().ptr());
+        case AbstractOperationKind::GetIteratorFromMethod:
+            return JS::Value(intrinsics.get_iterator_from_method_abstract_operation_function().ptr());
+        case AbstractOperationKind::IteratorComplete:
+            return JS::Value(intrinsics.iterator_complete_abstract_operation_function().ptr());
+        }
+        VERIFY_NOT_REACHED();
     }
     default:
         VERIFY_NOT_REACHED();
@@ -1107,39 +1130,6 @@ extern "C" size_t rust_format_double(double value, uint8_t* buffer, size_t buffe
     auto len = min(bytes.size(), buffer_len);
     memcpy(buffer, bytes.data(), len);
     return len;
-}
-
-extern "C" uint64_t get_well_known_symbol(void* vm_ptr, WellKnownSymbolKind symbol_id)
-{
-    auto& vm = *static_cast<JS::VM*>(vm_ptr);
-    JS::Value value;
-    switch (symbol_id) {
-    case WellKnownSymbolKind::SymbolIterator:
-        value = vm.well_known_symbol_iterator();
-        break;
-    case WellKnownSymbolKind::SymbolAsyncIterator:
-        value = vm.well_known_symbol_async_iterator();
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-    return value.encoded();
-}
-
-extern "C" uint64_t get_abstract_operation_function(void* vm_ptr, uint16_t const* name, size_t name_len)
-{
-    auto& vm = *static_cast<JS::VM*>(vm_ptr);
-    auto& intrinsics = vm.current_realm()->intrinsics();
-    auto name_view = JS::RustIntegration::utf16_view_from_bytes(name, name_len);
-    auto name_str = MUST(name_view.to_utf8());
-
-#define __JS_ENUMERATE(snake_name, functionName, length) \
-    if (name_str == #functionName##sv)                   \
-        return JS::Value(intrinsics.snake_name##_abstract_operation_function().ptr()).encoded();
-    JS_ENUMERATE_NATIVE_JAVASCRIPT_BACKED_ABSTRACT_OPERATIONS
-#undef __JS_ENUMERATE
-
-    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -359,6 +359,11 @@ ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in_code_units,
     return rust_parse_program(utf16_data, length_in_code_units, static_cast<u8>(type), line_number_offset, g_dump_ast, g_dump_ast_use_color);
 }
 
+CompiledProgram* compile_parsed_program_off_thread(ParsedProgram* parsed, size_t length_in_code_units)
+{
+    return rust_compile_parsed_program_off_thread(parsed, length_in_code_units);
+}
+
 bool parsed_program_has_errors(ParsedProgram const* parsed)
 {
     return rust_parsed_program_has_errors(const_cast<ParsedProgram*>(parsed));
@@ -367,6 +372,11 @@ bool parsed_program_has_errors(ParsedProgram const* parsed)
 void free_parsed_program(ParsedProgram* parsed)
 {
     rust_free_parsed_program(parsed);
+}
+
+void free_compiled_program(CompiledProgram* compiled)
+{
+    rust_free_compiled_program(compiled);
 }
 
 Optional<Result<ScriptResult, Vector<ParserError>>> compile_parsed_script(ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
@@ -387,6 +397,23 @@ Optional<Result<ScriptResult, Vector<ParserError>>> compile_parsed_script(Parsed
     ScriptGdiBuilder builder;
 
     void* exec_ptr = rust_compile_parsed_script(parsed, &realm.vm(), source_code.ptr(), &builder, length);
+
+    if (!exec_ptr)
+        return Vector<ParserError> {};
+
+    builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
+    return builder.result;
+}
+
+Optional<Result<ScriptResult, Vector<ParserError>>> materialize_compiled_script(CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
+{
+    if (!compiled)
+        return {};
+
+    GC::DeferGC defer_gc(realm.vm().heap());
+    ScriptGdiBuilder builder;
+
+    void* exec_ptr = rust_materialize_compiled_script(compiled, &realm.vm(), source_code.ptr(), &builder);
 
     if (!exec_ptr)
         return Vector<ParserError> {};
@@ -477,6 +504,55 @@ Optional<Result<ModuleResult, Vector<ParserError>>> compile_parsed_module(Parsed
 
     void* exec_ptr = rust_compile_parsed_module(parsed, &realm.vm(), source_code.ptr(),
         &builder, &callbacks, &tla_executable, length);
+
+    if (!exec_ptr && !tla_executable)
+        return Vector<ParserError> {};
+
+    if (tla_executable) {
+        auto& vm = realm.vm();
+        auto* tla_exec = static_cast<Bytecode::Executable*>(tla_executable);
+
+        builder.result.tla_shared_data = vm.heap().allocate<SharedFunctionInstanceData>(
+            vm, FunctionKind::Async,
+            "module code with top-level await"_utf16_fly_string,
+            0, 0, true, false, true,
+            Vector<Utf16FlyString> {}, nullptr);
+        builder.result.tla_shared_data->m_is_module_wrapper = true;
+        builder.result.tla_shared_data->m_uses_this = true;
+        builder.result.tla_shared_data->m_function_environment_needed = true;
+        builder.result.tla_shared_data->update_asm_call_metadata();
+        builder.result.tla_shared_data->set_executable(tla_exec);
+    } else {
+        builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
+    }
+
+    return builder.result;
+}
+
+Optional<Result<ModuleResult, Vector<ParserError>>> materialize_compiled_module(CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
+{
+    if (!compiled)
+        return {};
+
+    GC::DeferGC defer_gc(realm.vm().heap());
+    ModuleBuilder builder;
+    ModuleCallbacks callbacks {
+        .set_has_top_level_await = module_set_has_top_level_await,
+        .push_import_entry = module_push_import_entry,
+        .push_local_export = module_push_local_export,
+        .push_indirect_export = module_push_indirect_export,
+        .push_star_export = module_push_star_export,
+        .push_requested_module = module_push_requested_module,
+        .set_default_export_binding = module_set_default_export_binding,
+        .push_var_name = module_push_var_name,
+        .push_function = module_push_function,
+        .push_lexical_binding = module_push_lexical_binding,
+    };
+
+    void* tla_executable = nullptr;
+
+    void* exec_ptr = rust_materialize_compiled_module(compiled, &realm.vm(), source_code.ptr(),
+        &builder, &callbacks, &tla_executable);
 
     if (!exec_ptr && !tla_executable)
         return Vector<ParserError> {};

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -11,6 +11,7 @@
 #include <AK/kmalloc.h>
 #include <LibGC/DeferGC.h>
 #include <LibJS/Bytecode/ClassBlueprint.h>
+#include <LibJS/Bytecode/Debug.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Bytecode/PropertyKeyTable.h>
@@ -1019,6 +1020,30 @@ extern "C" void rust_sfd_set_class_field_initializer_name(
     } else {
         shared.m_class_field_initializer_name = JS::PropertyKey(utf16_name.to_utf16_string());
     }
+}
+
+extern "C" void rust_sfd_set_precompiled_executable(
+    void* sfd_ptr,
+    void* executable_ptr,
+    bool uses_this,
+    bool function_environment_needed,
+    size_t function_environment_bindings_count,
+    bool might_need_arguments_object,
+    bool contains_direct_call_to_eval)
+{
+    auto& shared = *static_cast<JS::SharedFunctionInstanceData*>(sfd_ptr);
+    auto& executable = *static_cast<JS::Bytecode::Executable*>(executable_ptr);
+
+    shared.m_uses_this = uses_this;
+    shared.m_function_environment_needed = function_environment_needed;
+    shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_might_need_arguments_object = might_need_arguments_object;
+    shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
+    shared.set_executable(executable);
+    executable.name = shared.m_name;
+    if (Bytecode::g_dump_bytecode)
+        executable.dump();
+    shared.clear_compile_inputs();
 }
 
 extern "C" void* rust_create_class_blueprint(

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -25,6 +25,7 @@
 namespace JS::FFI {
 
 struct ParsedProgram;
+struct CompiledProgram;
 
 }
 
@@ -89,16 +90,26 @@ JS_API bool rust_pipeline_available();
 // Parse a program (script or module) without GC interaction. Thread-safe.
 JS_API FFI::ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in_code_units, ProgramType type, size_t line_number_offset = 0);
 
+// Compile a parsed program to bytecode without touching the VM or GC. Thread-safe.
+JS_API FFI::CompiledProgram* compile_parsed_program_off_thread(FFI::ParsedProgram* parsed, size_t length_in_code_units);
+
 // Check if a parsed program has errors. Does not consume the program.
 JS_API bool parsed_program_has_errors(FFI::ParsedProgram const*);
 
 // Free a parsed program without compiling it.
 JS_API void free_parsed_program(FFI::ParsedProgram*);
 
+// Free a compiled program without materializing it.
+JS_API void free_compiled_program(FFI::CompiledProgram*);
+
 // Compile a previously parsed script. Must be called on the main thread.
 // Consumes and frees the Rust ParsedProgram.
 // Returns nullopt if Rust is not available.
 Optional<Result<ScriptResult, Vector<ParserError>>> compile_parsed_script(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm);
+
+// Materialize a previously compiled script. Must be called on the main thread.
+// Consumes and frees the Rust CompiledProgram.
+Optional<Result<ScriptResult, Vector<ParserError>>> materialize_compiled_script(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm);
 
 // Compile a script. Returns nullopt if Rust is not available.
 Optional<Result<ScriptResult, Vector<ParserError>>> compile_script(StringView source_text, Realm& realm, StringView filename, size_t line_number_offset);
@@ -114,6 +125,10 @@ Optional<Result<EvalResult, String>> compile_eval(
 // Consumes and frees the Rust ParsedProgram.
 // Returns nullopt if Rust is not available.
 Optional<Result<ModuleResult, Vector<ParserError>>> compile_parsed_module(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm);
+
+// Materialize a previously compiled module. Must be called on the main thread.
+// Consumes and frees the Rust CompiledProgram.
+Optional<Result<ModuleResult, Vector<ParserError>>> materialize_compiled_module(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm);
 
 // Compile a module. Returns nullopt if Rust is not available.
 Optional<Result<ModuleResult, Vector<ParserError>>> compile_module(StringView source_text, Realm& realm, StringView filename);

--- a/Libraries/LibJS/Script.cpp
+++ b/Libraries/LibJS/Script.cpp
@@ -42,6 +42,17 @@ Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_parsed(FFI::Par
     return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
 }
 
+Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm, HostDefined* host_defined)
+{
+    auto filename = source_code->filename();
+    auto rust_compilation = RustIntegration::materialize_compiled_script(compiled, move(source_code), realm);
+    if (!rust_compilation.has_value())
+        return Vector<ParserError> {};
+    if (rust_compilation->is_error())
+        return rust_compilation->release_error();
+    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
+}
+
 Script::Script(Realm& realm, StringView filename, RustIntegration::ScriptResult&& result, HostDefined* host_defined)
     : m_realm(realm)
     , m_executable(result.executable)

--- a/Libraries/LibJS/Script.h
+++ b/Libraries/LibJS/Script.h
@@ -23,6 +23,7 @@ JS_API extern bool g_dump_ast_use_color;
 namespace FFI {
 
 struct ParsedProgram;
+struct CompiledProgram;
 
 }
 
@@ -54,6 +55,7 @@ public:
     virtual ~Script() override;
     static Result<GC::Ref<Script>, Vector<ParserError>> parse(StringView source_text, Realm&, StringView filename = {}, HostDefined* = nullptr, size_t line_number_offset = 1);
     static Result<GC::Ref<Script>, Vector<ParserError>> create_from_parsed(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm&, HostDefined* = nullptr);
+    static Result<GC::Ref<Script>, Vector<ParserError>> create_from_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm&, HostDefined* = nullptr);
 
     Realm& realm() { return *m_realm; }
     Vector<LoadedModuleRequest>& loaded_modules() { return m_loaded_modules; }

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -83,6 +83,29 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_f
         module_result.executable.ptr(), module_result.tla_shared_data.ptr());
 }
 
+Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_from_pre_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Script::HostDefined* host_defined)
+{
+    auto filename = source_code->filename();
+    auto rust_result = RustIntegration::materialize_compiled_module(compiled, move(source_code), realm);
+    // Always from the Rust pipeline, so the Optional must have a value.
+    VERIFY(rust_result.has_value());
+    if (rust_result->is_error())
+        return rust_result->release_error();
+    auto& module_result = rust_result->value();
+    Vector<FunctionToInitialize> functions_to_initialize;
+    functions_to_initialize.ensure_capacity(module_result.functions_to_initialize.size());
+    for (auto& f : module_result.functions_to_initialize)
+        functions_to_initialize.append({ *f.shared_data, move(f.name) });
+    return realm.heap().allocate<SourceTextModule>(
+        realm, filename, host_defined, module_result.has_top_level_await,
+        move(module_result.requested_modules), move(module_result.import_entries),
+        move(module_result.local_export_entries), move(module_result.indirect_export_entries),
+        move(module_result.star_export_entries), move(module_result.default_export_binding_name),
+        move(module_result.var_declared_names), move(module_result.lexical_bindings),
+        move(functions_to_initialize),
+        module_result.executable.ptr(), module_result.tla_shared_data.ptr());
+}
+
 // 16.2.1.7.1 ParseModule ( sourceText, realm, hostDefined ), https://tc39.es/ecma262/#sec-parsemodule
 Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(StringView source_text, Realm& realm, StringView filename, Script::HostDefined* host_defined)
 {

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -18,6 +18,7 @@ namespace JS {
 namespace FFI {
 
 struct ParsedProgram;
+struct CompiledProgram;
 
 }
 
@@ -31,6 +32,7 @@ public:
 
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse(StringView source_text, Realm&, StringView filename = {}, Script::HostDefined* host_defined = nullptr);
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_pre_parsed(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
+    static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_pre_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
 
     virtual Vector<Utf16FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
     virtual ResolvedBinding resolve_export(VM& vm, Utf16FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -105,6 +105,39 @@ GC::Ref<ClassicScript> ClassicScript::create_from_pre_parsed(ByteString filename
     return script;
 }
 
+GC::Ref<ClassicScript> ClassicScript::create_from_pre_compiled(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject& settings, URL::URL base_url, JS::FFI::CompiledProgram* compiled, MutedErrors muted_errors)
+{
+    auto& realm = settings.realm();
+    auto& vm = realm.vm();
+
+    if (muted_errors == MutedErrors::Yes)
+        base_url = URL::about_blank();
+
+    auto script = vm.heap().allocate<ClassicScript>(move(base_url), move(filename), settings);
+
+    script->m_muted_errors = muted_errors;
+    script->set_parse_error(JS::js_null());
+    script->set_error_to_rethrow(JS::js_null());
+
+    auto parse_timer = Core::ElapsedTimer::start_new();
+    auto result = JS::Script::create_from_compiled(compiled, move(source_code), realm, script);
+    dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Materialized pre-compiled {} in {}ms", script->filename(), parse_timer.elapsed_milliseconds());
+
+    if (result.is_error()) {
+        auto& parse_error = result.error().first();
+        dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Failed to materialize: {}", parse_error.to_string());
+
+        script->set_parse_error(JS::SyntaxError::create(realm, parse_error.to_string()));
+        script->set_error_to_rethrow(script->parse_error());
+
+        return script;
+    }
+
+    script->m_script_record = *result.release_value();
+
+    return script;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script
 JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, GC::Ptr<JS::Environment> lexical_environment_override)
 {

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -27,6 +27,7 @@ public:
     };
     static GC::Ref<ClassicScript> create(ByteString filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No);
     static GC::Ref<ClassicScript> create_from_pre_parsed(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::ParsedProgram* parsed, MutedErrors = MutedErrors::No);
+    static GC::Ref<ClassicScript> create_from_pre_compiled(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::CompiledProgram* compiled, MutedErrors = MutedErrors::No);
 
     JS::Script* script_record() { return m_script_record; }
     JS::Script const* script_record() const { return m_script_record; }

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -39,26 +39,27 @@
 
 namespace Web::HTML {
 
-// Submit a parse_program() call to the thread pool, then bounce back to
-// the main thread via deferred_invoke once parsing completes.
-// `on_parsed` is called on the main thread with the Rust ParsedProgram*
-// and the SourceCode.
-// NB: The SourceCode stays on the main thread (inside the heap-allocated
-//     callback). The worker thread only receives raw UTF-16 data pointers.
-//     The callback is heap-allocated so that if the event loop is
-//     destroyed during parsing, we leak it (and any GC::Root objects it
-//     captures) rather than destroying them on the worker thread.
-static void parse_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, Function<void(JS::FFI::ParsedProgram*, NonnullRefPtr<JS::SourceCode const>)> on_parsed)
+struct OffThreadCompiledProgram {
+    JS::FFI::ParsedProgram* parsed { nullptr };
+    JS::FFI::CompiledProgram* compiled { nullptr };
+};
+
+// Submit parsing and top-level bytecode generation to the thread pool, then bounce back to the main thread via
+// deferred_invoke once the worker is done. Syntax errors still come back as a ParsedProgram so the main thread can
+// report them through the same Script/ModuleScript construction paths; successful programs come back as CompiledProgram
+// artifacts whose GC-backed Executable materialization must still happen on the main thread.
+// NB: The SourceCode stays on the main thread inside the heap-allocated callback. The worker thread only receives raw
+//     UTF-16 data pointers, and the callback intentionally leaks if the event loop is destroyed during compilation.
+static void compile_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, Function<void(OffThreadCompiledProgram, NonnullRefPtr<JS::SourceCode const>)> on_compiled)
 {
     // Extract the raw data the parser needs while still on the main thread.
     auto const* utf16_data = source_code->utf16_data();
     auto length = source_code->length_in_code_units();
 
-    // Capture source_code in the callback so it stays alive (on the main
-    // thread) for the duration of parsing and is available when we compile.
-    auto* callback = new Function<void(JS::FFI::ParsedProgram*)>(
-        [on_parsed = move(on_parsed), source_code = move(source_code)](JS::FFI::ParsedProgram* parsed) mutable {
-            on_parsed(parsed, move(source_code));
+    // Capture source_code in the callback so it stays alive on the main thread and is available for materialization.
+    auto* callback = new Function<void(OffThreadCompiledProgram)>(
+        [on_compiled = move(on_compiled), source_code = move(source_code)](OffThreadCompiledProgram result) mutable {
+            on_compiled(result, move(source_code));
         });
 
     auto event_loop_weak = Core::EventLoop::current_weak();
@@ -67,12 +68,17 @@ static void parse_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS
                                             callback,
                                             event_loop_weak = move(event_loop_weak)]() {
         auto* parsed = JS::RustIntegration::parse_program(utf16_data, length, type, line_number_offset);
+        OffThreadCompiledProgram result { .parsed = parsed };
+        if (parsed && !JS::RustIntegration::parsed_program_has_errors(parsed)) {
+            result.compiled = JS::RustIntegration::compile_parsed_program_off_thread(parsed, length);
+            result.parsed = nullptr;
+        }
 
         auto origin = event_loop_weak->take();
         if (!origin)
             return;
-        origin->deferred_invoke([parsed, callback]() {
-            (*callback)(parsed);
+        origin->deferred_invoke([result, callback]() {
+            (*callback)(result);
             delete callback;
             // AD-HOC: Perform a microtask checkpoint so that any microtasks queued by the callback (e.g. promise
             //         reactions from react_to_promise during module linking) are drained. Without this, module worker
@@ -438,11 +444,13 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                 String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
                 Utf16String::from_utf8(source_text));
 
-            parse_off_thread(move(source_code), JS::RustIntegration::ProgramType::Script, 1,
+            compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Script, 1,
                 [response_url = move(response_url), response_url_string = move(response_url_string),
                     muted_errors, on_complete_root = move(on_complete_root),
-                    settings_root = move(settings_root)](auto* parsed, auto source_code) mutable {
-                    auto script = ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), parsed, muted_errors);
+                    settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                    auto script = result.compiled
+                        ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
+                        : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
                     on_complete_root->function()(script);
                 });
         } else {
@@ -798,12 +806,14 @@ void fetch_single_module_script(JS::Realm& realm,
                         String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
                         Utf16String::from_utf8(source_text));
 
-                    parse_off_thread(move(source_code), JS::RustIntegration::ProgramType::Module, 0,
+                    compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Module, 0,
                         [url = move(url), url_string = move(url_string), response_url = move(response_url),
                             module_type_string = move(module_type_string),
                             on_complete_root = move(on_complete_root),
-                            settings_root = move(settings_root)](auto* parsed, auto source_code) mutable {
-                            auto module_script = ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), parsed).release_value_but_fixme_should_propagate_errors();
+                            settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                            auto module_script = result.compiled
+                                ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
+                                : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
                             settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
                             on_complete_root->function()(module_script);
                         });

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -90,6 +90,27 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_pre_parsed(
     return script;
 }
 
+WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_pre_compiled(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject& settings, URL::URL base_url, JS::FFI::CompiledProgram* compiled)
+{
+    auto& realm = settings.realm();
+    auto script = realm.create<ModuleScript>(move(base_url), filename, settings);
+
+    script->set_parse_error(JS::js_null());
+    script->set_error_to_rethrow(JS::js_null());
+
+    auto result = JS::SourceTextModule::parse_from_pre_compiled(compiled, move(source_code), realm, script);
+
+    if (result.is_error()) {
+        auto& parse_error = result.error().first();
+        dbgln("JavaScriptModuleScript: Failed to materialize: {}", parse_error.to_string());
+        script->set_parse_error(JS::SyntaxError::create(realm, parse_error.to_string()));
+        return script;
+    }
+
+    script->m_record = result.value();
+    return script;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-css-module-script
 WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_css_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject& settings)
 {

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -15,6 +15,7 @@
 namespace JS::FFI {
 
 struct ParsedProgram;
+struct CompiledProgram;
 
 }
 
@@ -32,6 +33,7 @@ public:
 
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create(ByteString const& filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_pre_parsed(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::ParsedProgram* parsed);
+    static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_pre_compiled(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::CompiledProgram* compiled);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_javascript_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_css_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_json_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&);


### PR DESCRIPTION
This branch moves bytecode generation for fetched scripts' top-level code onto the background thread pool.

The worker thread only produces bytecode and the data needed to build the `Executable`. Anything that touches the VM or GC heap still happens back on the main thread.

This covers classic scripts, modules, and IIFEs that are called directly from top-level code. Functions nested inside those IIFEs stay lazy for now.

This moves ~200ms of main thread time onto background threads while loading https://youtube.com/ on my Linux machine :^)