### PR TITLE
LibWeb: Make external SVG script fetches async

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -190,6 +190,7 @@
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
+#include <LibWeb/SVG/SVGScriptElement.h>
 #include <LibWeb/SVG/SVGStyleElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
 #include <LibWeb/Selection/Selection.h>
@@ -605,6 +606,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_associated_inert_template_document);
     visitor.visit(m_appropriate_template_contents_owner_document);
     visitor.visit(m_pending_parsing_blocking_script);
+    visitor.visit(m_pending_parsing_blocking_svg_script);
     visitor.visit(m_history);
     visitor.visit(m_html_parser_end_state);
     visitor.visit(m_style_computer);
@@ -784,7 +786,7 @@ WebIDL::ExceptionOr<void> Document::run_the_document_write_steps(Vector<TrustedT
     //     point at a time, processing resulting tokens as they are emitted, and stopping when the tokenizer reaches
     //     the insertion point or when the processing of the tokenizer is aborted by the tree construction stage (this
     //     can happen if a script end tag token is emitted by the tokenizer).
-    if (!pending_parsing_blocking_script())
+    if (!has_pending_parsing_blocking_script())
         m_parser->run(HTML::HTMLTokenizer::StopAtInsertionPoint::Yes);
 
     return {};
@@ -912,7 +914,7 @@ WebIDL::ExceptionOr<void> Document::close()
     m_parser->tokenizer().insert_eof();
 
     // 5. If there is a pending parsing-blocking script, then return.
-    if (pending_parsing_blocking_script()) {
+    if (has_pending_parsing_blocking_script()) {
         m_parser->set_post_parse_action([this] { completely_finish_loading(); });
         return {};
     }
@@ -921,7 +923,7 @@ WebIDL::ExceptionOr<void> Document::close()
     m_parser->run();
 
     // run() may have paused on a blocking script (e.g. from document.write inside an inline script).
-    if (pending_parsing_blocking_script()) {
+    if (has_pending_parsing_blocking_script()) {
         m_parser->set_post_parse_action([this] { completely_finish_loading(); });
         return {};
     }
@@ -2627,6 +2629,19 @@ GC::Ref<HTML::HTMLScriptElement> Document::take_pending_parsing_blocking_script(
     VERIFY(m_pending_parsing_blocking_script);
     auto script = m_pending_parsing_blocking_script;
     m_pending_parsing_blocking_script = nullptr;
+    return *script;
+}
+
+void Document::set_pending_parsing_blocking_svg_script(SVG::SVGScriptElement* script)
+{
+    m_pending_parsing_blocking_svg_script = script;
+}
+
+GC::Ref<SVG::SVGScriptElement> Document::take_pending_parsing_blocking_svg_script(Badge<HTML::HTMLParser>)
+{
+    VERIFY(m_pending_parsing_blocking_svg_script);
+    auto script = m_pending_parsing_blocking_svg_script;
+    m_pending_parsing_blocking_svg_script = nullptr;
     return *script;
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -449,6 +449,14 @@ public:
     HTML::HTMLScriptElement* pending_parsing_blocking_script() { return m_pending_parsing_blocking_script.ptr(); }
     GC::Ref<HTML::HTMLScriptElement> take_pending_parsing_blocking_script(Badge<HTML::HTMLParser>);
 
+    void set_pending_parsing_blocking_svg_script(SVG::SVGScriptElement*);
+    SVG::SVGScriptElement* pending_parsing_blocking_svg_script() { return m_pending_parsing_blocking_svg_script.ptr(); }
+    GC::Ref<SVG::SVGScriptElement> take_pending_parsing_blocking_svg_script(Badge<HTML::HTMLParser>);
+    bool has_pending_parsing_blocking_script() const
+    {
+        return m_pending_parsing_blocking_script.ptr() || m_pending_parsing_blocking_svg_script.ptr();
+    }
+
     void add_script_to_execute_when_parsing_has_finished(Badge<HTML::HTMLScriptElement>, HTML::HTMLScriptElement&);
     Vector<GC::Root<HTML::HTMLScriptElement>> take_scripts_to_execute_when_parsing_has_finished(Badge<HTML::HTMLParser>);
     Vector<GC::Ref<HTML::HTMLScriptElement>>& scripts_to_execute_when_parsing_has_finished() { return m_scripts_to_execute_when_parsing_has_finished; }
@@ -1200,6 +1208,7 @@ private:
     String m_source;
 
     GC::Ptr<HTML::HTMLScriptElement> m_pending_parsing_blocking_script;
+    GC::Ptr<SVG::SVGScriptElement> m_pending_parsing_blocking_svg_script;
 
     Vector<GC::Ref<HTML::HTMLScriptElement>> m_scripts_to_execute_when_parsing_has_finished;
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3458,7 +3458,13 @@ void HTMLParser::resume_after_parser_blocking_script()
         return;
 
     auto pending = document().pending_parsing_blocking_script();
-    if (!pending)
+    auto pending_svg = document().pending_parsing_blocking_svg_script();
+    bool ready = false;
+    if (pending)
+        ready = pending->is_ready_to_be_parser_executed();
+    else if (pending_svg)
+        ready = pending_svg->is_ready_to_be_parser_executed();
+    else
         return;
 
     // 5. If the parser's Document has a style sheet that is blocking scripts or the script's ready to be
@@ -3468,12 +3474,8 @@ void HTMLParser::resume_after_parser_blocking_script()
     // relevant state changes.
     if (m_document->has_a_style_sheet_that_is_blocking_scripts())
         return;
-    if (!pending->is_ready_to_be_parser_executed())
+    if (!ready)
         return;
-
-    // 1. Let the script be the pending parsing-blocking script.
-    // 2. Set the pending parsing-blocking script to null.
-    auto the_script = document().take_pending_parsing_blocking_script({});
 
     // 3. Start the speculative HTML parser for this instance of the HTML parser.
     // (Done at the pause point in the corresponding insertion-mode handler, so that speculation runs during the wait.)
@@ -3500,8 +3502,13 @@ void HTMLParser::resume_after_parser_blocking_script()
     VERIFY(script_nesting_level() == 0);
     increment_script_nesting_level();
 
+    // 1. Let the script be the pending parsing-blocking script.
+    // 2. Set the pending parsing-blocking script to null.
     // 11. Execute the script element the script.
-    the_script->execute_script();
+    if (pending)
+        document().take_pending_parsing_blocking_script({})->execute_script();
+    else
+        document().take_pending_parsing_blocking_svg_script({})->execute_pending_parser_blocking_script({});
 
     // 12. Decrement the parser's script nesting level by one.
     decrement_script_nesting_level();
@@ -4793,12 +4800,19 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         adjust_foreign_attributes(token);
 
         // Insert a foreign element for the token, with the adjusted current node's namespace and false.
-        (void)insert_foreign_element(token, adjusted_current_node()->namespace_uri(), OnlyAddToElementStack::No);
-
-        // AD-HOC: we don't want to execute script elements just by adding data to it
-        if (token.tag_name() == SVG::TagNames::script && current_node()->namespace_uri() == Namespace::SVG) {
-            auto& script_element = as<SVG::SVGScriptElement>(*current_node());
-            script_element.set_parser_inserted({});
+        // AD-HOC: For SVG script elements, set the parser-inserted flag before the element is
+        //         inserted into the DOM. Otherwise inserted()/attribute_changed() would invoke
+        //         process_the_script_element() with the flag still unset and bypass the
+        //         parser-blocking fetch handling.
+        auto namespace_ = adjusted_current_node()->namespace_uri();
+        if (token.tag_name() == SVG::TagNames::script && namespace_ == Namespace::SVG) {
+            auto adjusted_insertion_location = find_appropriate_place_for_inserting_node();
+            auto element = create_element_for(token, namespace_, *adjusted_insertion_location.parent);
+            as<SVG::SVGScriptElement>(*element).set_parser_inserted({});
+            insert_an_element_at_the_adjusted_insertion_location(element);
+            m_stack_of_open_elements.push(element);
+        } else {
+            (void)insert_foreign_element(token, namespace_, OnlyAddToElementStack::No);
         }
 
         // If the token has its self-closing flag set, then run the appropriate steps from the following list:
@@ -4853,6 +4867,14 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
 
         // Let the insertion point have the value of the old insertion point.
         m_tokenizer.restore_insertion_point();
+
+        // If the SVG script registered itself as a pending parsing-blocking script (external fetch in flight),
+        // pause the parser and schedule a resume check. The parser will resume from
+        // resume_after_parser_blocking_script when the fetch completes.
+        if (document().pending_parsing_blocking_svg_script()) {
+            m_parser_pause_flag = true;
+            schedule_resume_check();
+        }
         return;
     }
 

--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <LibWeb/Bindings/SVGScriptElement.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
@@ -90,9 +91,6 @@ void SVGScriptElement::process_the_script_element()
         }
     }
 
-    IGNORE_USE_IN_ESCAPING_LAMBDA String script_content;
-    auto script_url = m_document->url();
-
     // 2. If the 'script' element references external script content, then the external script content
     //    using the current value of the 'xlink:href' attribute is fetched. Further processing of the
     //    'script' element is dependent on the external script content, and will block here until the
@@ -105,7 +103,7 @@ void SVGScriptElement::process_the_script_element()
             dbgln("Invalid script URL: {}", href_value);
             return;
         }
-        script_url = maybe_script_url.release_value();
+        auto script_url = maybe_script_url.release_value();
 
         auto& vm = realm().vm();
         auto request = Fetch::Infrastructure::Request::create(vm);
@@ -116,67 +114,87 @@ void SVGScriptElement::process_the_script_element()
         request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::SameOrigin);
         request->set_client(&document().relevant_settings_object());
 
-        IGNORE_USE_IN_ESCAPING_LAMBDA bool fetch_done = false;
+        // 3. The 'script' element's "already processed" flag is set to true.
+        // We set this before dispatching the fetch so that re-entrant calls (e.g. from attribute_changed
+        // while the fetch is in flight) early-return at step 1, matching Chromium's `already_started_`
+        // semantics. The in-flight fetch is allowed to finish.
+        m_already_processed = true;
+
+        m_document_load_event_delayer.emplace(*m_document);
+
+        if (m_parser_inserted)
+            m_document->set_pending_parsing_blocking_svg_script(this);
 
         Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
-        fetch_algorithms_input.process_response = [this, &script_content, &fetch_done](GC::Ref<Fetch::Infrastructure::Response> response) {
-            if (response->is_network_error()) {
-                dbgln("Failed to fetch SVG external script.");
-                fetch_done = true;
-                return;
-            }
+        fetch_algorithms_input.process_response_consume_body
+            = [self = GC::Ref { *this }, script_url](auto response, auto body_bytes) {
+                  ByteBuffer body;
+                  if (!response->is_network_error())
+                      body_bytes.visit([&](ByteBuffer& bytes) { body = move(bytes); }, [](auto) {});
 
-            auto& realm = this->realm();
-            auto& global = document().realm().global_object();
+                  self->finish_external_script_fetch(script_url, body);
+              };
 
-            auto on_data_read = GC::create_function(realm.heap(), [&script_content, &fetch_done](ByteBuffer data) {
-                auto content_or_error = String::from_utf8(data);
-                if (content_or_error.is_error()) {
-                    dbgln("Failed to decode script content as UTF-8");
-                } else {
-                    script_content = content_or_error.release_value();
-                }
-                fetch_done = true;
-            });
-
-            auto on_error = GC::create_function(realm.heap(), [&fetch_done](JS::Value) {
-                dbgln("Error occurred while reading script data.");
-                fetch_done = true;
-            });
-
-            VERIFY(response->body());
-            response->body()->fully_read(realm, on_data_read, on_error, GC::Ref { global });
-        };
-
-        (void)Fetch::Fetching::fetch(realm(), request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
-
-        // Block until the resource has been fetched or determined invalid
-        HTML::main_thread_event_loop().spin_until(GC::create_function(heap(), [&] { return fetch_done; }));
-
-        if (script_content.is_empty()) {
-            // Failed to fetch or decode
-            return;
-        }
-
-    } else {
-        // Inline script content
-        script_content = child_text_content().to_utf8_but_should_be_ported_to_utf16();
-        if (script_content.is_empty())
-            return;
+        (void)Fetch::Fetching::fetch(realm(), request,
+            Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
+        return;
     }
+
+    auto script_content = child_text_content().to_utf8_but_should_be_ported_to_utf16();
+    if (script_content.is_empty())
+        return;
 
     // 3. The 'script' element's "already processed" flag is set to true.
     m_already_processed = true;
+    m_script = HTML::ClassicScript::create(m_document->url().basename(), script_content,
+        HTML::relevant_settings_object(*this), m_document->base_url(), m_source_line_number);
+    execute_script();
+}
 
+void SVGScriptElement::finish_external_script_fetch(URL::URL const& script_url, ByteBuffer const& body)
+{
+    if (!body.is_empty() && in_a_document_tree() && !is_scripting_disabled()) {
+        auto script_content = String::from_utf8(body);
+        if (script_content.is_error())
+            dbgln("Failed to decode SVG external script as UTF-8");
+        else
+            m_script = HTML::ClassicScript::create(script_url.basename(), script_content.release_value(),
+                HTML::relevant_settings_object(*this), m_document->base_url(), m_source_line_number);
+    }
+
+    if (m_parser_inserted) {
+        m_ready_to_be_parser_executed = true;
+        m_document->schedule_html_parser_end_check();
+        return;
+    }
+
+    ScopeGuard clear_delayer { [&] { m_document_load_event_delayer.clear(); } };
+    execute_script();
+}
+
+void SVGScriptElement::execute_pending_parser_blocking_script(Badge<HTML::HTMLParser>)
+{
+    VERIFY(m_ready_to_be_parser_executed);
+    m_ready_to_be_parser_executed = false;
+    ScopeGuard clear_delayer { [&] { m_document_load_event_delayer.clear(); } };
+    execute_script();
+}
+
+void SVGScriptElement::execute_script()
+{
     // 4. If the script content is inline, or if it is external and was fetched successfully, then the
     //    script is executed. Note that at this point, these steps may be re-entrant if the execution
     //    of the script results in further 'script' elements being inserted into the document.
 
+    // m_script is null when the external fetch failed; the parser-blocking slot still needs to be drained
+    // so the parser can resume, but there's no script to run.
+    if (!m_script)
+        return;
+
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-html
     // Before any script execution occurs, the user agent must wait for scripts may run for the newly-created document to be true for document.
-    VERIFY(m_document->ready_to_run_scripts());
-
-    m_script = HTML::ClassicScript::create(script_url.basename(), script_content, HTML::relevant_settings_object(*this), m_document->base_url(), m_source_line_number);
+    if (!m_document->ready_to_run_scripts())
+        return;
 
     // FIXME: Note that a load event is dispatched on a 'script' element once it has been processed,
     // unless it referenced external script content with an invalid IRI reference and 'externalResourcesRequired' was set to 'true'.

--- a/Libraries/LibWeb/SVG/SVGScriptElement.h
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <LibURL/URL.h>
+#include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGURIReference.h>
 
@@ -24,6 +26,9 @@ public:
     bool is_parser_inserted() const { return m_parser_inserted; }
     void set_parser_inserted(Badge<HTML::HTMLParser>) { m_parser_inserted = true; }
 
+    bool is_ready_to_be_parser_executed() const { return m_ready_to_be_parser_executed; }
+    void execute_pending_parser_blocking_script(Badge<HTML::HTMLParser>);
+
     void set_source_line_number(Badge<HTML::HTMLParser>, size_t source_line_number) { m_source_line_number = source_line_number; }
 
     virtual void inserted() override;
@@ -40,10 +45,16 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
+    void finish_external_script_fetch(URL::URL const& script_url, ByteBuffer const& body);
+    void execute_script();
+
     bool m_already_processed { false };
     bool m_parser_inserted { false };
+    bool m_ready_to_be_parser_executed { false };
 
     GC::Ptr<HTML::ClassicScript> m_script;
+
+    Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
 
     size_t m_source_line_number { 1 };
 };


### PR DESCRIPTION
Replace the spin_until in SVGScriptElement::process_the_script_element with an async fetch that mirrors HTMLScriptElement's mark_as_ready pattern. External SVG scripts now fetch and execute asynchronously, matching Chromium's behavior.

For HTML-embedded SVG scripts, the parser pauses via the existing schedule_resume_check infrastructure, extended to support SVG scripts through a new pending_parsing_blocking_svg_script slot on Document. For top-level XML/SVG documents, scripts execute when their fetch completes; the load event is delayed via DocumentLoadEventDelayer which the existing XMLDocumentBuilder::document_end already waits on.