### PR TITLE
LibWeb: Run unloading cleanup steps during document unload

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5024,8 +5024,9 @@ void Document::unload(GC::Ptr<Document>)
 
     // FIXME: 17. Set oldDocument's has been scrolled by the user to false.
 
-    // FIXME: 18. Run any unloading document cleanup steps for oldDocument that are defined by this specification and other
+    // 18. Run any unloading document cleanup steps for oldDocument that are defined by this specification and other
     //     applicable specifications.
+    run_unloading_cleanup_steps();
 
     // 19. If oldDocument's salvageable state is false, then destroy oldDocument.
     if (!m_salvageable)


### PR DESCRIPTION
The HTML unload algorithm runs the old document's unloading document cleanup steps before deciding whether the document can be destroyed. Document::unload() still had that step as a FIXME, so cross-spec cleanup could be skipped when test-web reused a view for navigation.

The flake depended on test order. The fullscreen sibling WPT requests fullscreen for one element, then for its sibling, and finishes with that second element still being the document's fullscreen element. test-web then navigates the same view to the next test. Since unload skipped the cleanup hook, the old document kept its fullscreen/top-layer state past that document boundary.

form-reset-callback.html is deterministic when run by itself. The first two subtests call the [CEReactions] form.reset() API and observe the callback synchronously. The failing subtest calls resetButton.click(), which reaches form reset through input activation behavior and expects the formResetCallback reaction to run at the next microtask checkpoint. With the reused view still polluted by the previous fullscreen document, that checkpoint could run without observing the callback, so only that subtest failed.

Run the unloading cleanup steps during unload so navigating away from a fullscreen document clears that state before the next document starts.