### PR TITLE
LibJS: Drop C++-port parity quirks from parser and scope collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ version = "0.1.0"
 dependencies = [
  "bytecode_def",
  "cbindgen",
+ "indexmap",
  "libunicode_rust",
  "num-bigint",
  "num-integer",

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -997,9 +997,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, EvalDeclarationDa
     }
 
     // 17. For each Parse Node f of functionsToInitialize, do
-    // NB: We iterate in reverse order since we appended the functions
-    //     instead of prepending during pre-computation.
-    for (auto const& function_to_initialize : data.functions_to_initialize.in_reverse()) {
+    for (auto const& function_to_initialize : data.functions_to_initialize) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
         auto function = ECMAScriptFunctionObject::create_from_function_data(

--- a/Libraries/LibJS/Rust/Cargo.toml
+++ b/Libraries/LibJS/Rust/Cargo.toml
@@ -13,6 +13,7 @@ libunicode_rust = { path = "../../LibUnicode/Rust", default-features = false }
 num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"
+indexmap = "2"
 
 [build-dependencies]
 bytecode_def = { path = "../BytecodeDef" }

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -7634,14 +7634,27 @@ pub fn emit_function_declaration_instantiation(
         }
     }
 
-    // Determine if arguments object is needed (from parsing insights).
+    // Determine if arguments object is needed. The parser's
+    // `might_need_arguments_object` flag is set when an `arguments` or
+    // `eval` Identifier is consumed as a free reference, but it misses
+    // references created without going through consume(), like shorthand
+    // `{ arguments }`. Fall back to checking whether scope analysis
+    // allocated a non-lexical `arguments` local (an ArgumentsObject
+    // binding). Skip the fallback when a function declaration named
+    // `arguments` claims the same local: that local belongs to the
+    // function, not a real arguments-object reference.
+    let function_scope_data = body_scope.function_scope_data.as_ref();
+    let has_function_named_arguments = function_scope_data.is_some_and(|fsd| fsd.has_function_named_arguments);
+    let has_arguments_local = generator
+        .local_variables
+        .iter()
+        .any(|lv| lv.name == utf16!("arguments") && !lv.is_lexically_declared);
     let mut arguments_object_needed = if is_arrow || parameter_names.iter().any(|p| p.name == utf16!("arguments")) {
         false
     } else {
         function_data.parsing_insights.might_need_arguments_object
+            || (has_arguments_local && !has_function_named_arguments)
     };
-
-    let function_scope_data = body_scope.function_scope_data.as_ref();
 
     if let Some(fsd) = function_scope_data {
         if !has_parameter_expressions && fsd.has_function_named_arguments {

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -1888,24 +1888,30 @@ fn extract_gdi_common(
         }
     }
 
-    // Functions to initialize (reverse order, deduplicated by name).
-    let mut seen_names: HashSet<ast::Utf16String> = HashSet::new();
-    let mut functions_to_init: Vec<(ast::FunctionId, ast::Utf16String)> = Vec::new();
-    for child in scope.children.iter().rev() {
+    // Functions to initialize: keep the last declaration with each name
+    // (ECMAScript hoisting semantics), but emit them in source order. Two
+    // forward passes; SharedUtf16String keys keep the inserts cheap.
+    let mut last_position: std::collections::HashMap<ast::SharedUtf16String, usize> = std::collections::HashMap::new();
+    for (i, child) in scope.children.iter().enumerate() {
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
             && let Some(ref name_ident) = fd.name
-            && seen_names.insert(name_ident.name.to_utf16_string())
         {
-            functions_to_init.push((fd.function_id, name_ident.name.to_utf16_string()));
+            last_position.insert(name_ident.name.clone(), i);
         }
     }
-    for (function_id, name) in &functions_to_init {
-        let function_data = function_table.take(*function_id);
-        let subtable = function_table.extract_reachable(&function_data);
-        let sfd_ptr =
-            unsafe { bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict) };
-        assert!(!sfd_ptr.is_null(), "create_sfd_for_gdi returned null");
-        push_function(sfd_ptr, name);
+    for (i, child) in scope.children.iter().enumerate() {
+        if let StatementKind::FunctionDeclaration(ref fd) = child.inner
+            && let Some(ref name_ident) = fd.name
+            && last_position.get(&name_ident.name).copied() == Some(i)
+        {
+            let function_data = function_table.take(fd.function_id);
+            let subtable = function_table.extract_reachable(&function_data);
+            let sfd_ptr = unsafe {
+                bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict)
+            };
+            assert!(!sfd_ptr.is_null(), "create_sfd_for_gdi returned null");
+            push_function(sfd_ptr, name_ident.name.as_slice());
+        }
     }
 
     // Var-scoped names (var VariableDeclaration names, excluding function declarations)

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -2417,7 +2417,17 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generato
     }
 
     // §10.2.11 steps 15-18: determine if arguments object is needed.
-    let arguments_object_needed = bsi.might_need_arguments
+    // We trust either the parser's conservative "might need arguments" flag
+    // (set when we consume an `arguments` or `eval` Identifier as a free
+    // reference) OR scope analysis having allocated an ArgumentsObject local
+    // for `arguments`. The latter catches references created without going
+    // through consume(), e.g. shorthand `{ arguments }` in an object literal.
+    // Skip the local-driven path when a function named `arguments` shadows
+    // it; in that case the local belongs to the function declaration, not
+    // a real arguments-object reference.
+    let arguments_object_referenced =
+        bsi.might_need_arguments || (bsi.has_arguments_object_local && !bsi.has_function_named_arguments);
+    let arguments_object_needed = arguments_object_referenced
         && !is_arrow
         && !parameter_names.contains(utf16!("arguments"))
         && body_scope.is_some()

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -256,11 +256,6 @@ pub struct Parser<'a> {
     /// Set during synthesize_binding_pattern to allow MemberExpressions as binding targets.
     allow_member_expressions: bool,
 
-    /// Position of the opening bracket/brace in binding patterns.
-    /// Used so all identifiers inside a binding pattern share the pattern's start position,
-    /// matching C++ parser behavior.
-    binding_pattern_start: Option<Position>,
-
     /// True while parsing a class body that has an `extends` clause.
     pub(crate) class_has_super_class: bool,
     /// Depth counter for class bodies — used to reject `#name` outside classes.
@@ -333,7 +328,6 @@ impl<'a> Parser<'a> {
             last_class_name: Utf16String::default(),
             pattern_bound_names: Vec::new(),
             allow_member_expressions: false,
-            binding_pattern_start: None,
             class_has_super_class: false,
             class_scope_depth: 0,
             has_default_export_name: false,

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -199,10 +199,6 @@ pub(crate) struct ParserFlags {
     pub new_target_is_valid: bool,
     pub function_might_need_arguments_object: bool,
     pub previous_token_was_period: bool,
-    /// Set during property key parsing to suppress eval/arguments check.
-    /// C++ uses separate `consume()` and `consume_and_allow_division()` methods;
-    /// we emulate this by skipping the check in property key contexts.
-    pub in_property_key_context: bool,
 }
 
 /// Snapshot of parser state for speculative parsing (backtracking).
@@ -491,12 +487,16 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn consume(&mut self) -> Token {
         let old = std::mem::replace(&mut self.current_token, self.lexer.next());
-        // C++ checks for `arguments`/`eval` in `consume_and_allow_division()` which
-        // is used by `consume_identifier()`. We put the check here (in `consume()`)
-        // but skip it when parsing property keys, matching C++'s behavior.
-        if !self.flags.in_property_key_context {
-            self.check_arguments_or_eval(&old);
-        }
+        self.check_arguments_or_eval(&old);
+        self.flags.previous_token_was_period = old.token_type == TokenType::Period;
+        old
+    }
+
+    /// Like `consume()` but skips the `arguments`/`eval` reference check.
+    /// Use this when consuming a token that is syntactically a property key
+    /// rather than an identifier reference (e.g. `{ arguments: 1 }`).
+    pub(crate) fn consume_property_key_token(&mut self) -> Token {
+        let old = std::mem::replace(&mut self.current_token, self.lexer.next());
         self.flags.previous_token_was_period = old.token_type == TokenType::Period;
         old
     }

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -1455,20 +1455,16 @@ impl Parser<'_> {
                         entry_is_keyword =
                             self.current_token.token_type.is_identifier_name() && !self.match_identifier();
 
-                        // Suppress eval/arguments check for binding pattern property
-                        // keys. C++ uses regular consume() here (no arguments check),
-                        // not consume_and_allow_division().
-                        let saved_prop_key_ctx = self.flags.in_property_key_context;
-                        self.flags.in_property_key_context = true;
-
+                        // Property keys are name tokens, not identifier references,
+                        // so don't run the eval/arguments check on them.
                         if self.match_token(TokenType::StringLiteral) {
-                            let token = self.consume();
+                            let token = self.consume_property_key_token();
                             let (value, _has_octal) = self.parse_string_value(&token);
                             let id = self.make_identifier(entry_start, value);
                             self.scope_collector.register_identifier(id.clone(), None);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else if self.match_token(TokenType::BigIntLiteral) {
-                            let token = self.consume();
+                            let token = self.consume_property_key_token();
                             let value = self.token_value(&token);
                             let name_value = if value.last() == Some(&ch(b'n')) {
                                 value[..value.len() - 1].to_vec()
@@ -1479,17 +1475,13 @@ impl Parser<'_> {
                             self.scope_collector.register_identifier(id.clone(), None);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else {
-                            let token = self.consume();
+                            let token = self.consume_property_key_token();
                             let name = self.token_identifier_name(&token);
                             entry_name_value = name.clone();
                             let id = self.make_identifier(entry_start, name);
-                            // C++ calls parse_identifier() for binding pattern property
-                            // keys, which registers them. Do the same here.
                             self.scope_collector.register_identifier(id.clone(), None);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         }
-
-                        self.flags.in_property_key_context = saved_prop_key_ctx;
                     } else if self.match_token(TokenType::BracketOpen) {
                         self.consume();
                         let expression = self.parse_expression_any();

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -938,17 +938,7 @@ impl Parser<'_> {
                 is_identifier: false,
             }
         } else {
-            // C++ only uses class start position for Identifier and PrivateIdentifier
-            // tokens (handled directly in the switch). Keywords like `return` go through
-            // parse_property_key which uses its own position.
-            let key_override = if self.current_token.token_type == TokenType::Identifier
-                || self.current_token.token_type == TokenType::PrivateIdentifier
-            {
-                Some(class_start)
-            } else {
-                None
-            };
-            self.parse_property_key(key_override)
+            self.parse_property_key()
         };
 
         // https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors
@@ -1381,12 +1371,6 @@ impl Parser<'_> {
                 entries: Vec::new(),
             };
         }
-        // Save the position before consuming '[' or '{'. C++ uses
-        // rule_start.position() (from push_start()) for all identifiers inside
-        // the binding pattern. Each recursive call gets its own push_start(),
-        // so nested patterns use the inner pattern's start position.
-        let outer_pattern_start = self.binding_pattern_start;
-        self.binding_pattern_start = Some(self.position());
         self.consume();
 
         let kind = if is_object {
@@ -1445,8 +1429,7 @@ impl Parser<'_> {
                         || self.match_token(TokenType::NumericLiteral)
                         || self.match_token(TokenType::BigIntLiteral)
                     {
-                        // C++ uses the binding pattern start position for all name identifiers.
-                        let entry_start = self.binding_pattern_start.unwrap_or_else(|| self.position());
+                        let entry_start = self.position();
 
                         if self.match_token(TokenType::StringLiteral) || self.match_token(TokenType::NumericLiteral) {
                             needs_alias = true;
@@ -1517,7 +1500,7 @@ impl Parser<'_> {
                             let nested = self.parse_binding_pattern();
                             entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(nested)));
                         } else if self.match_identifier_name() {
-                            let alias_start = self.binding_pattern_start.unwrap_or_else(|| self.position());
+                            let alias_start = self.position();
                             let token = self.consume();
                             let name = self.token_identifier_name(&token);
                             let id = self.make_identifier(alias_start, name.clone());
@@ -1564,7 +1547,7 @@ impl Parser<'_> {
                 let nested = self.parse_binding_pattern();
                 entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(nested)));
             } else if self.match_identifier_name() {
-                let alias_start = self.binding_pattern_start.unwrap_or_else(|| self.position());
+                let alias_start = self.position();
                 let token = self.consume();
                 let name = self.token_identifier_name(&token);
                 let id = self.make_identifier(alias_start, name.clone());
@@ -1615,7 +1598,6 @@ impl Parser<'_> {
         }
 
         self.consume_token(closing_token);
-        self.binding_pattern_start = outer_pattern_start;
         BindingPattern { kind, entries }
     }
 

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -1680,16 +1680,6 @@ impl Parser<'_> {
     }
 
     pub(crate) fn parse_property_key(&mut self, ident_pos_override: Option<Position>) -> PropertyKey {
-        // Suppress eval/arguments check for property key tokens (C++ uses
-        // regular `consume()` not `consume_and_allow_division()` here).
-        let saved_property_key_ctx = self.flags.in_property_key_context;
-        self.flags.in_property_key_context = true;
-        let result = self.parse_property_key_inner(ident_pos_override);
-        self.flags.in_property_key_context = saved_property_key_ctx;
-        result
-    }
-
-    fn parse_property_key_inner(&mut self, ident_pos_override: Option<Position>) -> PropertyKey {
         let proto_name = utf16!("__proto__");
         let start = self.position();
         match self.current_token_type() {
@@ -1706,7 +1696,7 @@ impl Parser<'_> {
                 }
             }
             TokenType::StringLiteral => {
-                let token = self.consume();
+                let token = self.consume_property_key_token();
                 // C++ calls consume() before push_start() for StringLiteral,
                 // so its position is the token AFTER the string.
                 let after_string = self.position();
@@ -1792,7 +1782,7 @@ impl Parser<'_> {
                     // identifier names). This matters for shorthand properties: { await }
                     // is not valid in class static blocks since await is not an identifier there.
                     let is_ident = self.match_identifier();
-                    let token = self.consume();
+                    let token = self.consume_property_key_token();
                     let value = Utf16String::from(self.token_value(&token));
                     let is_proto = value == proto_name;
                     // C++ uses the object expression start position for identifier-name keys.
@@ -1807,7 +1797,7 @@ impl Parser<'_> {
                     }
                 } else {
                     self.expected("property key");
-                    self.consume();
+                    self.consume_property_key_token();
                     let expression =
                         self.expression(start, ExpressionKind::StringLiteral(Box::new(Utf16String::new())));
                     PropertyKey {

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -875,9 +875,9 @@ impl Parser<'_> {
                     if matches!(lhs.inner, ExpressionKind::Super) {
                         self.syntax_error("Cannot access private field or method via 'super'");
                     }
-                    // C++ uses rule_start (period position) for property identifiers.
-                    let id = self.parse_private_identifier(start);
-                    let property = self.expression(start, ExpressionKind::PrivateIdentifier(Box::new(id)));
+                    let property_start = self.position();
+                    let id = self.parse_private_identifier(property_start);
+                    let property = self.expression(property_start, ExpressionKind::PrivateIdentifier(Box::new(id)));
                     (
                         self.expression(
                             start,
@@ -890,10 +890,10 @@ impl Parser<'_> {
                         ForbiddenTokens::none(),
                     )
                 } else if self.match_identifier_name() {
+                    let property_start = self.position();
                     let token = self.consume();
-                    // C++ uses rule_start (period position) for property identifiers.
-                    let property_identifier = self.make_identifier(start, self.token_identifier_name(&token));
-                    let property = self.expression(start, ExpressionKind::Identifier(property_identifier));
+                    let property_identifier = self.make_identifier(property_start, self.token_identifier_name(&token));
+                    let property = self.expression(property_start, ExpressionKind::Identifier(property_identifier));
                     (
                         self.expression(
                             start,
@@ -1418,11 +1418,11 @@ impl Parser<'_> {
         let mut has_proto_setter = false;
         while !self.match_token(TokenType::CurlyClose) && !self.done() {
             if self.match_token(TokenType::TripleDot) {
+                let spread_start = self.position();
                 self.consume();
                 let expression = self.parse_assignment_expression();
-                // C++ uses object expression start position for all ObjectProperty nodes.
                 properties.push(ObjectProperty {
-                    range: self.range_from(start),
+                    range: self.range_from(spread_start),
                     property_type: ObjectPropertyType::Spread,
                     key: Box::new(expression),
                     is_computed: false,
@@ -1493,31 +1493,13 @@ impl Parser<'_> {
             self.consume();
         }
 
-        // In C++, identifiers matching match_identifier() are consumed directly in
-        // parse_object_expression and get the object's rule_start position. This applies
-        // even after consuming an `async` prefix. Only get/set prefix and generator `*`
-        // cause the key to go through parse_property_key with its own position.
-        // NB: C++ match_identifier() returns true for most EscapedKeyword tokens
-        // (like escaped reserved words "if", "while", etc.), only rejecting
-        // let/yield/await under specific conditions. Rust's match_identifier()
-        // is more restrictive, so we add explicit EscapedKeyword handling here.
-        let is_cpp_identifier = self.match_identifier()
-            || (self.current_token.token_type == TokenType::EscapedKeyword && {
-                let value = self.token_value(&self.current_token);
-                value != utf16!("let") && value != utf16!("yield") && value != utf16!("await")
-            });
-        let ident_override = if !is_getter && !is_setter && !is_generator && is_cpp_identifier {
-            Some(obj_start)
-        } else {
-            None
-        };
         let PropertyKey {
             expression: key,
             name: key_value,
             is_proto,
             is_computed,
             is_identifier,
-        } = self.parse_property_key(ident_override);
+        } = self.parse_property_key();
 
         // https://tc39.es/ecma262/#sec-object-initializer
         // Private names are not allowed in object literals, even inside class bodies.
@@ -1679,7 +1661,7 @@ impl Parser<'_> {
         ) || next.token_type.is_identifier_name()
     }
 
-    pub(crate) fn parse_property_key(&mut self, ident_pos_override: Option<Position>) -> PropertyKey {
+    pub(crate) fn parse_property_key(&mut self) -> PropertyKey {
         let proto_name = utf16!("__proto__");
         let start = self.position();
         match self.current_token_type() {
@@ -1759,12 +1741,10 @@ impl Parser<'_> {
                 if value == utf16!("#constructor") {
                     self.syntax_error("Private property with name '#constructor' is not allowed");
                 }
-                // C++ uses the class start position for private identifiers in class elements.
-                let key_start = ident_pos_override.unwrap_or(start);
                 let expression = self.expression(
-                    key_start,
+                    start,
                     ExpressionKind::PrivateIdentifier(Box::new(PrivateIdentifier {
-                        range: self.range_from(key_start),
+                        range: self.range_from(start),
                         name: value.clone(),
                     })),
                 );
@@ -1785,9 +1765,7 @@ impl Parser<'_> {
                     let token = self.consume_property_key_token();
                     let value = Utf16String::from(self.token_value(&token));
                     let is_proto = value == proto_name;
-                    // C++ uses the object expression start position for identifier-name keys.
-                    let key_start = ident_pos_override.unwrap_or(start);
-                    let expression = self.expression(key_start, ExpressionKind::StringLiteral(Box::new(value.clone())));
+                    let expression = self.expression(start, ExpressionKind::StringLiteral(Box::new(value.clone())));
                     PropertyKey {
                         expression,
                         name: Some(value),
@@ -1824,11 +1802,11 @@ impl Parser<'_> {
                 continue;
             }
             if self.match_token(TokenType::TripleDot) {
+                let spread_start = self.position();
                 self.consume();
                 let expression = self.parse_assignment_expression();
-                // C++ uses the array's rule_start ([ position) for SpreadExpression.
                 elements.push(Some(
-                    self.expression(start, ExpressionKind::Spread(Box::new(expression))),
+                    self.expression(spread_start, ExpressionKind::Spread(Box::new(expression))),
                 ));
             } else {
                 elements.push(Some(self.parse_assignment_expression()));

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -50,7 +50,7 @@
 //!   name within one scope (multiple `foo` refs are grouped together)
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ast::{
@@ -1192,15 +1192,26 @@ impl ScopeCollector {
         let mut non_local_var_count_for_parameter_expressions: usize = 0;
 
         // Build functions_to_initialize by scanning children for FunctionDeclarations.
-        // Walk in reverse order, deduplicating by name.
+        // ECMAScript hoisting keeps the LAST function declaration with a given name,
+        // but we want to emit the resulting list in SOURCE order. Two forward passes:
+        // record the last position for each name, then keep only the entries whose
+        // position matches. Keys are SharedUtf16String so each insert is a cheap
+        // Rc bump rather than a deep clone of the name.
         let mut functions_to_initialize: Vec<crate::ast::FunctionToInit> = Vec::new();
-        let mut seen_function_names: HashSet<Utf16String> = HashSet::new();
+        let mut last_position: HashMap<SharedUtf16String, usize> = HashMap::new();
         {
             let sd = scope_data.borrow();
-            for i in (0..sd.children.len()).rev() {
-                if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = sd.children[i].inner
+            for (i, child) in sd.children.iter().enumerate() {
+                if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
                     && let Some(ref name_ident) = fd.name
-                    && seen_function_names.insert(name_ident.name.to_utf16_string())
+                {
+                    last_position.insert(name_ident.name.clone(), i);
+                }
+            }
+            for (i, child) in sd.children.iter().enumerate() {
+                if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
+                    && let Some(ref name_ident) = fd.name
+                    && last_position.get(&name_ident.name).copied() == Some(i)
                 {
                     functions_to_initialize.push(crate::ast::FunctionToInit { child_index: i });
                 }
@@ -1215,7 +1226,7 @@ impl ScopeCollector {
             var_names.push(name.clone());
 
             let is_parameter = var.flags.intersects(VarFlags::FORBIDDEN_LEXICAL);
-            let is_function_name = seen_function_names.contains(name);
+            let is_function_name = last_position.contains_key(name.as_slice());
 
             let local_info = if let Some(ref ident) = var.var_identifier {
                 if ident.is_local() {
@@ -1249,7 +1260,7 @@ impl ScopeCollector {
         vars_to_initialize.sort_by(|a, b| a.name.cmp(&b.name));
         var_names.sort();
 
-        if seen_function_names.iter().any(|n| n == utf16!("arguments")) {
+        if last_position.contains_key(utf16!("arguments") as &[u16]) {
             has_function_named_arguments = true;
         }
 

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -49,6 +49,7 @@
 //! - `IdentifierGroup` — a set of identifier references with the same
 //!   name within one scope (multiple `foo` refs are grouped together)
 
+use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -189,8 +190,8 @@ struct ScopeRecord {
     scope_level: ScopeLevel,
     scope_data: Option<Rc<RefCell<ScopeData>>>,
 
-    variables: HashMap<Utf16String, ScopeVariable>,
-    identifier_groups: HashMap<SharedUtf16String, IdentifierGroup>,
+    variables: IndexMap<Utf16String, ScopeVariable>,
+    identifier_groups: IndexMap<SharedUtf16String, IdentifierGroup>,
     functions_to_hoist: Vec<HoistableFunction>,
 
     // Parameter tracking
@@ -221,8 +222,8 @@ impl ScopeRecord {
             scope_type,
             scope_level,
             scope_data,
-            variables: HashMap::new(),
-            identifier_groups: HashMap::new(),
+            variables: IndexMap::new(),
+            identifier_groups: IndexMap::new(),
             functions_to_hoist: Vec::new(),
             has_function_parameters: false,
             parameter_names: Vec::new(),
@@ -931,13 +932,11 @@ impl ScopeCollector {
     /// - It's NOT used inside a `with` statement
     /// - The scope chain is NOT poisoned by `eval()`
     fn resolve_identifiers(records: &mut [ScopeRecord], index: usize, initiated_by_eval: bool, suppress_globals: bool) {
+        // identifier_groups is an IndexMap, so iteration is in source order
+        // of first reference. Local variable indices follow that order.
         let groups = std::mem::take(&mut records[index].identifier_groups);
-        // Sort groups by name for deterministic local variable indices
-        // (HashMap iteration order is arbitrary).
-        let mut sorted_groups: Vec<_> = groups.into_iter().collect();
-        sorted_groups.sort_by(|a, b| a.0.cmp(&b.0));
         let mut propagate_to_parent: Vec<(SharedUtf16String, IdentifierGroup)> = Vec::new();
-        for (name, mut group) in sorted_groups {
+        for (name, mut group) in groups {
             // Annotate each Identifier AST node with its declaration kind,
             // so the bytecode generator knows how to handle TDZ checks, etc.
             if let Some(dk) = group.declaration_kind {
@@ -1256,9 +1255,8 @@ impl ScopeCollector {
             });
         }
 
-        // Sort by name for deterministic output (HashMap iteration order is arbitrary).
-        vars_to_initialize.sort_by(|a, b| a.name.cmp(&b.name));
-        var_names.sort();
+        // vars_to_initialize and var_names follow source order via the
+        // insertion order of `record.variables`, which is now an IndexMap.
 
         if last_position.contains_key(utf16!("arguments") as &[u16]) {
             has_function_named_arguments = true;

--- a/Libraries/LibJS/Script.cpp
+++ b/Libraries/LibJS/Script.cpp
@@ -179,9 +179,7 @@ ThrowCompletionOr<void> Script::global_declaration_instantiation(VM& vm, GlobalE
     }
 
     // 16. For each Parse Node f of functionsToInitialize, do
-    // NB: We iterate in reverse order since we appended the functions
-    //     instead of prepending during pre-computation.
-    for (auto const& function_to_initialize : m_functions_to_initialize.in_reverse()) {
+    for (auto const& function_to_initialize : m_functions_to_initialize) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments env and privateEnv.
         auto function = ECMAScriptFunctionObject::create_from_function_data(

--- a/Tests/LibJS/AST/expected/arguments-object.txt
+++ b/Tests/LibJS/AST/expected/arguments-object.txt
@@ -44,7 +44,7 @@ Program (script) @2:1
 │  │  └─ BindingPattern (object)
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "x" @23:38
+│  │           └─ Identifier "x" @23:40
 │  └─ body
 │     └─ FunctionBody @24:5
 │        └─ ReturnStatement @24:5
@@ -60,4 +60,4 @@ Program (script) @2:1
          └─ ReturnStatement @29:5
             └─ MemberExpression @29:21
                ├─ Identifier "arguments" [variable:0] @29:12
-               └─ Identifier "length" @29:21
+               └─ Identifier "length" @29:22

--- a/Tests/LibJS/AST/expected/arrow-destructuring-param.txt
+++ b/Tests/LibJS/AST/expected/arrow-destructuring-param.txt
@@ -7,7 +7,7 @@ Program (script) @1:1
          │  ├─ BindingPattern (array)
          │  │  └─ entry
          │  │     └─ alias
-         │  │        └─ Identifier "a" [variable:0] @1:10
+         │  │        └─ Identifier "a" [variable:0] @1:11
          │  └─ Identifier "b" [argument:1] @1:10
          └─ body
             └─ FunctionBody @1:9

--- a/Tests/LibJS/AST/expected/async-generator-method.txt
+++ b/Tests/LibJS/AST/expected/async-generator-method.txt
@@ -19,7 +19,7 @@ Program (script) @1:1
       │        └─ BlockStatement @7:1
       └─ elements
          └─ ClassMethod @7:1
-            ├─ StringLiteral "bar" @7:1
+            ├─ StringLiteral "bar" @8:12
             └─ FunctionExpression async* "" [strict] @8:5
                └─ body
                   └─ FunctionBody @9:9

--- a/Tests/LibJS/AST/expected/binding-pattern-positions.txt
+++ b/Tests/LibJS/AST/expected/binding-pattern-positions.txt
@@ -1,0 +1,95 @@
+Program (script) @6:1
+├─ VariableDeclaration (let) @6:1
+│  └─ VariableDeclarator @6:1
+│     ├─ BindingPattern (object)
+│     │  ├─ entry
+│     │  │  └─ name
+│     │  │     └─ Identifier "foo" [global] @6:7
+│     │  └─ entry
+│     │     └─ name
+│     │        └─ Identifier "bar" [global] @6:12
+│     └─ ObjectExpression @6:20
+├─ VariableDeclaration (let) @7:1
+│  └─ VariableDeclarator @7:1
+│     ├─ BindingPattern (object)
+│     │  ├─ entry
+│     │  │  ├─ name
+│     │  │  │  └─ Identifier "x" [global] @7:7
+│     │  │  └─ alias
+│     │  │     └─ Identifier "aliased" [global] @7:10
+│     │  └─ entry
+│     │     ├─ name
+│     │     │  └─ Identifier "y" [global] @7:19
+│     │     └─ alias
+│     │        └─ Identifier "also" [global] @7:22
+│     └─ ObjectExpression @7:31
+├─ VariableDeclaration (let) @8:1
+│  └─ VariableDeclarator @8:1
+│     ├─ BindingPattern (array)
+│     │  ├─ entry
+│     │  │  └─ alias
+│     │  │     └─ Identifier "first" [global] @8:7
+│     │  ├─ Elision
+│     │  └─ entry
+│     │     └─ alias
+│     │        └─ Identifier "third" [global] @8:16
+│     └─ ArrayExpression @8:26
+├─ VariableDeclaration (let) @9:1
+│  └─ VariableDeclarator @9:1
+│     ├─ BindingPattern (object)
+│     │  ├─ entry
+│     │  │  ├─ name
+│     │  │  │  └─ Identifier "nested" [global] @9:7
+│     │  │  └─ alias
+│     │  │     └─ BindingPattern (object)
+│     │  │        └─ entry
+│     │  │           └─ name
+│     │  │              └─ Identifier "inner" [global] @9:17
+│     │  └─ entry (rest)
+│     │     └─ name
+│     │        └─ Identifier "rest" [global] @9:29
+│     └─ ObjectExpression @9:38
+├─ VariableDeclaration (let) @10:1
+│  └─ VariableDeclarator @10:1
+│     ├─ BindingPattern (array)
+│     │  ├─ entry
+│     │  │  └─ alias
+│     │  │     └─ Identifier "a" [global] @10:7
+│     │  └─ entry
+│     │     └─ alias
+│     │        └─ BindingPattern (array)
+│     │           ├─ entry
+│     │           │  └─ alias
+│     │           │     └─ Identifier "b" [global] @10:12
+│     │           └─ entry
+│     │              └─ alias
+│     │                 └─ Identifier "c" [global] @10:15
+│     └─ ArrayExpression @10:23
+└─ FunctionDeclaration "destructured" @12:1
+   ├─ parameters
+   │  ├─ BindingPattern (object)
+   │  │  ├─ entry
+   │  │  │  └─ name
+   │  │  │     └─ Identifier "p" [variable:0] @12:25
+   │  │  └─ entry
+   │  │     ├─ name
+   │  │     │  └─ Identifier "q" [global] @12:28
+   │  │     └─ alias
+   │  │        └─ Identifier "r" [variable:1] @12:31
+   │  └─ BindingPattern (array)
+   │     ├─ entry
+   │     │  └─ alias
+   │     │     └─ Identifier "s" [variable:2] @12:38
+   │     └─ entry
+   │        └─ alias
+   │           └─ Identifier "t" [variable:3] @12:41
+   └─ body
+      └─ FunctionBody @13:5
+         └─ ReturnStatement @13:5
+            └─ BinaryExpression (+) @13:22
+               ├─ BinaryExpression (+) @13:18
+               │  ├─ BinaryExpression (+) @13:14
+               │  │  ├─ Identifier "p" [variable:0] @13:12
+               │  │  └─ Identifier "r" [variable:1] @13:16
+               │  └─ Identifier "s" [variable:2] @13:20
+               └─ Identifier "t" [variable:3] @13:24

--- a/Tests/LibJS/AST/expected/binding-pattern-property-keys.txt
+++ b/Tests/LibJS/AST/expected/binding-pattern-property-keys.txt
@@ -4,17 +4,17 @@ Program (script) @1:1
       ├─ BindingPattern (object)
       │  ├─ entry
       │  │  ├─ name
-      │  │  │  └─ Identifier "foo" [global] @1:5
+      │  │  │  └─ Identifier "foo" [global] @1:7
       │  │  └─ alias
-      │  │     └─ Identifier "a" [global] @1:5
+      │  │     └─ Identifier "a" [global] @1:12
       │  └─ entry
       │     ├─ name
-      │     │  └─ Identifier "1" [global] @1:5
+      │     │  └─ Identifier "1" [global] @1:15
       │     └─ alias
-      │        └─ Identifier "b" [global] @1:5
+      │        └─ Identifier "b" [global] @1:18
       └─ ObjectExpression @1:24
          ├─ ObjectProperty @1:24
-         │  ├─ StringLiteral "foo" @1:24
+         │  ├─ StringLiteral "foo" @1:26
          │  └─ NumericLiteral 1 @1:31
          └─ ObjectProperty @1:24
             ├─ NumericLiteral 1 @1:34

--- a/Tests/LibJS/AST/expected/catch-param-scope.txt
+++ b/Tests/LibJS/AST/expected/catch-param-scope.txt
@@ -34,15 +34,15 @@ Program (script) @2:1
 │                 │  └─ BindingPattern (object)
 │                 │     ├─ entry
 │                 │     │  └─ name
-│                 │     │     └─ Identifier "msg" [variable:1] @14:16
+│                 │     │     └─ Identifier "msg" [variable:0] @14:16
 │                 │     └─ entry
 │                 │        └─ name
-│                 │           └─ Identifier "code" [variable:0] @14:21
+│                 │           └─ Identifier "code" [variable:1] @14:21
 │                 └─ BlockStatement @14:29
 │                    └─ ReturnStatement @15:9
 │                       └─ BinaryExpression (+) @15:20
-│                          ├─ Identifier "msg" [variable:1] @15:16
-│                          └─ Identifier "code" [variable:0] @15:22
+│                          ├─ Identifier "msg" [variable:0] @15:16
+│                          └─ Identifier "code" [variable:1] @15:22
 ├─ FunctionDeclaration "catch_shadow" @20:1
 │  └─ body
 │     └─ FunctionBody @21:5

--- a/Tests/LibJS/AST/expected/catch-param-scope.txt
+++ b/Tests/LibJS/AST/expected/catch-param-scope.txt
@@ -23,10 +23,10 @@ Program (script) @2:1
 │           │     └─ ThrowStatement @13:9
 │           │        └─ ObjectExpression @13:15
 │           │           ├─ ObjectProperty @13:15
-│           │           │  ├─ StringLiteral "msg" @13:15
+│           │           │  ├─ StringLiteral "msg" @13:17
 │           │           │  └─ StringLiteral "oops" @13:28
 │           │           └─ ObjectProperty @13:15
-│           │              ├─ StringLiteral "code" @13:15
+│           │              ├─ StringLiteral "code" @13:30
 │           │              └─ NumericLiteral 42 @13:36
 │           └─ handler
 │              └─ CatchClause @14:7
@@ -34,10 +34,10 @@ Program (script) @2:1
 │                 │  └─ BindingPattern (object)
 │                 │     ├─ entry
 │                 │     │  └─ name
-│                 │     │     └─ Identifier "msg" [variable:1] @14:14
+│                 │     │     └─ Identifier "msg" [variable:1] @14:16
 │                 │     └─ entry
 │                 │        └─ name
-│                 │           └─ Identifier "code" [variable:0] @14:14
+│                 │           └─ Identifier "code" [variable:0] @14:21
 │                 └─ BlockStatement @14:29
 │                    └─ ReturnStatement @15:9
 │                       └─ BinaryExpression (+) @15:20
@@ -89,7 +89,7 @@ Program (script) @2:1
 │           │     │  │     └─ ThrowStatement @44:13
 │           │     │  │        └─ ObjectExpression @44:19
 │           │     │  │           └─ ObjectProperty @44:19
-│           │     │  │              ├─ StringLiteral "a" @44:19
+│           │     │  │              ├─ StringLiteral "a" @44:21
 │           │     │  │              └─ NumericLiteral 1 @44:24
 │           │     │  └─ handler
 │           │     │     └─ CatchClause @45:11
@@ -97,14 +97,14 @@ Program (script) @2:1
 │           │     │        │  └─ BindingPattern (object)
 │           │     │        │     └─ entry
 │           │     │        │        └─ name
-│           │     │        │           └─ Identifier "a" [variable:0] @45:18
+│           │     │        │           └─ Identifier "a" [variable:0] @45:20
 │           │     │        └─ BlockStatement @45:25
 │           │     │           └─ ExpressionStatement @46:13
 │           │     │              └─ Identifier "a" [variable:0] @46:13
 │           │     └─ ThrowStatement @48:9
 │           │        └─ ObjectExpression @48:15
 │           │           └─ ObjectProperty @48:15
-│           │              ├─ StringLiteral "b" @48:15
+│           │              ├─ StringLiteral "b" @48:17
 │           │              └─ NumericLiteral 2 @48:20
 │           └─ handler
 │              └─ CatchClause @49:7
@@ -112,7 +112,7 @@ Program (script) @2:1
 │                 │  └─ BindingPattern (object)
 │                 │     └─ entry
 │                 │        └─ name
-│                 │           └─ Identifier "b" [variable:1] @49:14
+│                 │           └─ Identifier "b" [variable:1] @49:16
 │                 └─ BlockStatement @49:21
 │                    └─ ReturnStatement @50:9
 │                       └─ Identifier "b" [variable:1] @50:16

--- a/Tests/LibJS/AST/expected/class-field-edge-cases.txt
+++ b/Tests/LibJS/AST/expected/class-field-edge-cases.txt
@@ -16,7 +16,7 @@ Program (script) @1:1
 │     │        └─ BlockStatement @5:1
 │     └─ elements
 │        └─ ClassField static @5:1
-│           └─ StringLiteral "a" @5:1
+│           └─ StringLiteral "a" @6:12
 └─ ClassDeclaration @9:1
    └─ ClassExpression "C" @9:1
       ├─ constructor
@@ -25,8 +25,8 @@ Program (script) @1:1
       │        └─ BlockStatement @9:1
       └─ elements
          └─ ClassField @9:1
-            ├─ StringLiteral "super_field" @9:1
+            ├─ StringLiteral "super_field" @10:5
             └─ initializer
                └─ MemberExpression @10:24
                   ├─ SuperExpression @10:19
-                  └─ Identifier "foo" @10:24
+                  └─ Identifier "foo" @10:25

--- a/Tests/LibJS/AST/expected/class-scope.txt
+++ b/Tests/LibJS/AST/expected/class-scope.txt
@@ -41,7 +41,7 @@ Program (script) @2:1
 │     └─ FunctionBody @20:5
 │        ├─ VariableDeclaration (let) @20:5
 │        │  └─ VariableDeclarator @20:5
-│        │     ├─ Identifier "key" [variable:1] (let) @20:9
+│        │     ├─ Identifier "key" [variable:0] (let) @20:9
 │        │     └─ StringLiteral "hello" @20:22
 │        ├─ ClassDeclaration @21:5
 │        │  └─ ClassExpression "Bar" @21:5
@@ -51,7 +51,7 @@ Program (script) @2:1
 │        │     │        └─ BlockStatement @21:5
 │        │     └─ elements
 │        │        └─ ClassMethod @21:5
-│        │           ├─ Identifier "key" [variable:1] (let) @22:10
+│        │           ├─ Identifier "key" [variable:0] (let) @22:10
 │        │           └─ FunctionExpression "" [strict] @22:9
 │        │              └─ body
 │        │                 └─ FunctionBody @23:13
@@ -59,7 +59,7 @@ Program (script) @2:1
 │        │                       └─ NumericLiteral 1 @23:20
 │        └─ ReturnStatement @26:5
 │           └─ NewExpression @26:12
-│              └─ Identifier "Bar" [variable:0] @26:16
+│              └─ Identifier "Bar" [variable:1] @26:16
 └─ FunctionDeclaration "static_members" @30:1
    └─ body
       └─ FunctionBody @31:5

--- a/Tests/LibJS/AST/expected/class-scope.txt
+++ b/Tests/LibJS/AST/expected/class-scope.txt
@@ -9,7 +9,7 @@ Program (script) @2:1
 │        │        └─ BlockStatement @2:9
 │        └─ elements
 │           └─ ClassMethod @2:9
-│              ├─ StringLiteral "method" @2:9
+│              ├─ StringLiteral "method" @3:5
 │              └─ FunctionExpression "" [strict] @3:5
 │                 └─ body
 │                    └─ FunctionBody @4:9
@@ -26,7 +26,7 @@ Program (script) @2:1
 │        │     │        └─ BlockStatement @10:5
 │        │     └─ elements
 │        │        └─ ClassMethod @10:5
-│        │           ├─ StringLiteral "method" @10:5
+│        │           ├─ StringLiteral "method" @11:9
 │        │           └─ FunctionExpression "" [strict] @11:9
 │        │              └─ body
 │        │                 └─ FunctionBody @12:13
@@ -71,20 +71,20 @@ Program (script) @2:1
          │     │        └─ BlockStatement @31:5
          │     └─ elements
          │        ├─ ClassField static @31:5
-         │        │  ├─ StringLiteral "x" @31:5
+         │        │  ├─ StringLiteral "x" @32:16
          │        │  └─ initializer
          │        │     └─ NumericLiteral 1 @32:20
          │        └─ ClassMethod static @31:5
-         │           ├─ StringLiteral "method" @31:5
+         │           ├─ StringLiteral "method" @33:16
          │           └─ FunctionExpression "" [strict] @33:16
          │              └─ body
          │                 └─ FunctionBody @34:13
          │                    └─ ReturnStatement @34:13
          │                       └─ MemberExpression @34:23
          │                          ├─ Identifier "Baz" @34:20
-         │                          └─ Identifier "x" @34:23
+         │                          └─ Identifier "x" @34:24
          └─ ReturnStatement @37:5
             └─ CallExpression @37:22
                └─ MemberExpression @37:15
                   ├─ Identifier "Baz" [variable:0] @37:12
-                  └─ Identifier "method" @37:15
+                  └─ Identifier "method" @37:16

--- a/Tests/LibJS/AST/expected/class-static-field.txt
+++ b/Tests/LibJS/AST/expected/class-static-field.txt
@@ -7,6 +7,6 @@ Program (script) @1:1
       │        └─ BlockStatement @1:1
       └─ elements
          └─ ClassField static @1:1
-            ├─ StringLiteral "x" @1:1
+            ├─ StringLiteral "x" @2:12
             └─ initializer
                └─ NumericLiteral 1 @2:16

--- a/Tests/LibJS/AST/expected/classes.txt
+++ b/Tests/LibJS/AST/expected/classes.txt
@@ -11,27 +11,27 @@ Program (script) @1:1
 │     │              └─ AssignmentExpression (=) @3:19
 │     │                 ├─ MemberExpression @3:13
 │     │                 │  ├─ ThisExpression @3:9
-│     │                 │  └─ Identifier "name" @3:13
+│     │                 │  └─ Identifier "name" @3:14
 │     │                 └─ Identifier "name" [argument:0] @3:21
 │     └─ elements
 │        ├─ ClassMethod @1:1
-│        │  ├─ StringLiteral "speak" @1:1
+│        │  ├─ StringLiteral "speak" @6:5
 │        │  └─ FunctionExpression "" [strict] [uses-this] @6:5
 │        │     └─ body
 │        │        └─ FunctionBody @7:9
 │        │           └─ ReturnStatement @7:9
 │        │              └─ MemberExpression @7:20
 │        │                 ├─ ThisExpression @7:16
-│        │                 └─ Identifier "name" @7:20
+│        │                 └─ Identifier "name" @7:21
 │        └─ ClassMethod (getter) @1:1
-│           ├─ StringLiteral "info" @1:1
+│           ├─ StringLiteral "info" @10:9
 │           └─ FunctionExpression "" [strict] [uses-this] @10:5
 │              └─ body
 │                 └─ FunctionBody @11:9
 │                    └─ ReturnStatement @11:9
 │                       └─ MemberExpression @11:20
 │                          ├─ ThisExpression @11:16
-│                          └─ Identifier "name" @11:20
+│                          └─ Identifier "name" @11:21
 └─ ClassDeclaration @15:1
    └─ ClassExpression "Dog" @15:1
       ├─ super class

--- a/Tests/LibJS/AST/expected/closure-captures.txt
+++ b/Tests/LibJS/AST/expected/closure-captures.txt
@@ -73,7 +73,7 @@ Program (script) @3:1
 │        │           └─ CallExpression @30:17
 │        │              ├─ MemberExpression @30:12
 │        │              │  ├─ Identifier "fns" [variable:0] (var) @30:9
-│        │              │  └─ Identifier "push" @30:12
+│        │              │  └─ Identifier "push" @30:13
 │        │              └─ FunctionExpression "" @30:18
 │        │                 └─ body
 │        │                    └─ FunctionBody @31:13
@@ -107,7 +107,7 @@ Program (script) @3:1
          │           └─ CallExpression @40:17
          │              ├─ MemberExpression @40:12
          │              │  ├─ Identifier "fns" [variable:0] (var) @40:9
-         │              │  └─ Identifier "push" @40:12
+         │              │  └─ Identifier "push" @40:13
          │              └─ FunctionExpression "" @40:18
          │                 └─ body
          │                    └─ FunctionBody @41:13

--- a/Tests/LibJS/AST/expected/closure-captures.txt
+++ b/Tests/LibJS/AST/expected/closure-captures.txt
@@ -8,7 +8,7 @@ Program (script) @3:1
 │        │     └─ NumericLiteral 1 @4:20
 │        ├─ VariableDeclaration (let) @5:5
 │        │  └─ VariableDeclarator @5:5
-│        │     ├─ Identifier "not_captured" [variable:1] (let) @5:9
+│        │     ├─ Identifier "not_captured" [variable:0] (let) @5:9
 │        │     └─ NumericLiteral 2 @5:24
 │        ├─ FunctionDeclaration "inner" @6:5
 │        │  └─ body
@@ -18,8 +18,8 @@ Program (script) @3:1
 │        └─ ReturnStatement @9:5
 │           └─ BinaryExpression (+) @9:20
 │              ├─ CallExpression @9:17
-│              │  └─ Identifier "inner" [variable:0] @9:12
-│              └─ Identifier "not_captured" [variable:1] (let) @9:22
+│              │  └─ Identifier "inner" [variable:1] @9:12
+│              └─ Identifier "not_captured" [variable:0] (let) @9:22
 ├─ FunctionDeclaration "level0" @13:1
 │  └─ body
 │     └─ FunctionBody @14:5

--- a/Tests/LibJS/AST/expected/cover-initialized-name-destructuring.txt
+++ b/Tests/LibJS/AST/expected/cover-initialized-name-destructuring.txt
@@ -10,7 +10,7 @@ Program (script) @5:1
          │     │        └─ BindingPattern (object)
          │     │           └─ entry
          │     │              ├─ name
-         │     │              │  └─ Identifier "a" [global] @6:6
+         │     │              │  └─ Identifier "a" [global] @6:8
          │     │              └─ initializer
          │     │                 └─ NumericLiteral 0 @6:12
          │     └─ ArrayExpression @6:19
@@ -22,7 +22,7 @@ Program (script) @5:1
                │        └─ MemberExpression @7:14
                │           ├─ ObjectExpression @7:6
                │           │  └─ ObjectProperty @7:6
-               │           │     ├─ StringLiteral "a" @7:6
+               │           │     ├─ StringLiteral "a" @7:8
                │           │     └─ NumericLiteral 0 @7:11
-               │           └─ Identifier "x" @7:14
+               │           └─ Identifier "x" @7:15
                └─ ArrayExpression @7:20

--- a/Tests/LibJS/AST/expected/default-param-scope.txt
+++ b/Tests/LibJS/AST/expected/default-param-scope.txt
@@ -58,7 +58,7 @@ Program (script) @3:1
    │  └─ BindingPattern (object)
    │     └─ entry
    │        ├─ name
-   │        │  └─ Identifier "x" [variable:0] @23:28
+   │        │  └─ Identifier "x" [variable:0] @23:30
    │        └─ initializer
    │           └─ NumericLiteral 10 @23:34
    │     └─ default

--- a/Tests/LibJS/AST/expected/default-param-scope.txt
+++ b/Tests/LibJS/AST/expected/default-param-scope.txt
@@ -43,16 +43,16 @@ Program (script) @3:1
 │     └─ FunctionBody @17:5
 │        ├─ VariableDeclaration (var) @17:5
 │        │  └─ VariableDeclarator @17:5
-│        │     ├─ Identifier "v" [variable:1] (var) @17:9
+│        │     ├─ Identifier "v" [variable:0] (var) @17:9
 │        │     └─ Identifier "a" [argument:0] @17:13
 │        ├─ VariableDeclaration (let) @18:5
 │        │  └─ VariableDeclarator @18:5
-│        │     ├─ Identifier "l" [variable:0] (let) @18:9
+│        │     ├─ Identifier "l" [variable:1] (let) @18:9
 │        │     └─ Identifier "a" [argument:0] @18:13
 │        └─ ReturnStatement @19:5
 │           └─ BinaryExpression (+) @19:14
-│              ├─ Identifier "v" [variable:1] (var) @19:12
-│              └─ Identifier "l" [variable:0] (let) @19:16
+│              ├─ Identifier "v" [variable:0] (var) @19:12
+│              └─ Identifier "l" [variable:1] (let) @19:16
 └─ FunctionDeclaration "destruct_defaults" @23:1
    ├─ parameters
    │  └─ BindingPattern (object)

--- a/Tests/LibJS/AST/expected/destructured-parameter-locals.txt
+++ b/Tests/LibJS/AST/expected/destructured-parameter-locals.txt
@@ -4,10 +4,10 @@ Program (script) @1:1
 │  │  └─ BindingPattern (array)
 │  │     ├─ entry
 │  │     │  └─ alias
-│  │     │     └─ Identifier "x" [variable:0] @1:29
+│  │     │     └─ Identifier "x" [variable:0] @1:30
 │  │     └─ entry
 │  │        └─ alias
-│  │           └─ Identifier "y" [variable:1] @1:29
+│  │           └─ Identifier "y" [variable:1] @1:33
 │  └─ body
 │     └─ FunctionBody @2:5
 │        └─ ReturnStatement @2:5
@@ -19,10 +19,10 @@ Program (script) @1:1
 │  │  └─ BindingPattern (object)
 │  │     ├─ entry
 │  │     │  └─ name
-│  │     │     └─ Identifier "a" [variable:0] @5:30
+│  │     │     └─ Identifier "a" [variable:0] @5:32
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "b" [variable:1] @5:30
+│  │           └─ Identifier "b" [variable:1] @5:35
 │  └─ body
 │     └─ FunctionBody @6:5
 │        └─ ReturnStatement @6:5
@@ -35,7 +35,7 @@ Program (script) @1:1
 │  │  ├─ BindingPattern (object)
 │  │  │  └─ entry
 │  │  │     └─ name
-│  │  │        └─ Identifier "x" [variable:0] @9:23
+│  │  │        └─ Identifier "x" [variable:0] @9:25
 │  │  └─ rest
 │  │     └─ Identifier "rest" [argument:2] @9:16
 │  └─ body
@@ -47,18 +47,18 @@ Program (script) @1:1
 │              │  └─ Identifier "x" [variable:0] @10:20
 │              └─ MemberExpression @10:28
 │                 ├─ Identifier "rest" [argument:2] @10:24
-│                 └─ Identifier "length" @10:28
+│                 └─ Identifier "length" @10:29
 ├─ FunctionDeclaration "nested" @13:1
 │  ├─ parameters
 │  │  └─ BindingPattern (object)
 │  │     └─ entry
 │  │        ├─ name
-│  │        │  └─ Identifier "a" [global] @13:17
+│  │        │  └─ Identifier "a" [global] @13:19
 │  │        └─ alias
 │  │           └─ BindingPattern (object)
 │  │              └─ entry
 │  │                 └─ name
-│  │                    └─ Identifier "b" [variable:0] @13:22
+│  │                    └─ Identifier "b" [variable:0] @13:24
 │  └─ body
 │     └─ FunctionBody @14:5
 │        └─ ReturnStatement @14:5
@@ -68,7 +68,7 @@ Program (script) @1:1
 │  │  └─ BindingPattern (object)
 │  │     └─ entry
 │  │        ├─ name
-│  │        │  └─ Identifier "x" [variable:0] @17:24
+│  │        │  └─ Identifier "x" [variable:0] @17:26
 │  │        └─ initializer
 │  │           └─ NumericLiteral 10 @17:30
 │  │     └─ default
@@ -82,9 +82,9 @@ Program (script) @1:1
    │  └─ BindingPattern (object)
    │     └─ entry
    │        ├─ name
-   │        │  └─ Identifier "a" [global] @21:18
+   │        │  └─ Identifier "a" [global] @21:20
    │        └─ alias
-   │           └─ Identifier "renamed" [variable:0] @21:18
+   │           └─ Identifier "renamed" [variable:0] @21:23
    └─ body
       └─ FunctionBody @22:5
          └─ ReturnStatement @22:5

--- a/Tests/LibJS/AST/expected/destructured-parameter-not-local.txt
+++ b/Tests/LibJS/AST/expected/destructured-parameter-not-local.txt
@@ -4,7 +4,7 @@ Program (script) @2:1
 │  │  └─ BindingPattern (object)
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "x" @2:30
+│  │           └─ Identifier "x" @2:32
 │  └─ body
 │     └─ FunctionBody @3:5
 │        └─ ReturnStatement @3:5
@@ -18,10 +18,10 @@ Program (script) @2:1
 │  │  └─ BindingPattern (object)
 │  │     ├─ entry
 │  │     │  └─ name
-│  │     │     └─ Identifier "a" @9:23
+│  │     │     └─ Identifier "a" @9:25
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "b" @9:23
+│  │           └─ Identifier "b" @9:28
 │  └─ body
 │     └─ FunctionBody @10:5
 │        ├─ ExpressionStatement @10:5
@@ -37,7 +37,7 @@ Program (script) @2:1
 │  │  ├─ BindingPattern (object)
 │  │  │  └─ entry
 │  │  │     └─ name
-│  │  │        └─ Identifier "x" @15:23
+│  │  │        └─ Identifier "x" @15:25
 │  │  └─ Identifier "obj" [argument:1] @15:23
 │  └─ body
 │     └─ FunctionBody @16:5
@@ -53,7 +53,7 @@ Program (script) @2:1
 │  │  └─ BindingPattern (object)
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "x" @22:27
+│  │           └─ Identifier "x" @22:29
 │  └─ body
 │     └─ FunctionBody @23:5
 │        └─ ReturnStatement @23:5
@@ -66,10 +66,10 @@ Program (script) @2:1
    │  └─ BindingPattern (array)
    │     ├─ entry
    │     │  └─ alias
-   │     │     └─ Identifier "a" [variable:0] @28:33
+   │     │     └─ Identifier "a" [variable:0] @28:34
    │     └─ entry
    │        └─ alias
-   │           └─ Identifier "b" [variable:1] @28:33
+   │           └─ Identifier "b" [variable:1] @28:37
    └─ body
       └─ FunctionBody @29:5
          └─ ReturnStatement @29:5

--- a/Tests/LibJS/AST/expected/destructuring.txt
+++ b/Tests/LibJS/AST/expected/destructuring.txt
@@ -7,10 +7,10 @@ Program (script) @1:1
          │     ├─ BindingPattern (array)
          │     │  ├─ entry
          │     │  │  └─ alias
-         │     │  │     └─ Identifier "a" [variable:0] @2:9
+         │     │  │     └─ Identifier "a" [variable:0] @2:10
          │     │  └─ entry
          │     │     └─ alias
-         │     │        └─ Identifier "b" [variable:1] @2:9
+         │     │        └─ Identifier "b" [variable:1] @2:13
          │     └─ ArrayExpression @2:18
          │        ├─ NumericLiteral 1 @2:19
          │        └─ NumericLiteral 2 @2:22
@@ -19,18 +19,18 @@ Program (script) @1:1
          │     ├─ BindingPattern (object)
          │     │  ├─ entry
          │     │  │  └─ name
-         │     │  │     └─ Identifier "x" [variable:2] @3:9
+         │     │  │     └─ Identifier "x" [variable:2] @3:11
          │     │  └─ entry
          │     │     ├─ name
-         │     │     │  └─ Identifier "y" [global] @3:9
+         │     │     │  └─ Identifier "y" [global] @3:14
          │     │     └─ alias
-         │     │        └─ Identifier "z" [variable:3] @3:9
+         │     │        └─ Identifier "z" [variable:3] @3:17
          │     └─ ObjectExpression @3:23
          │        ├─ ObjectProperty @3:23
-         │        │  ├─ StringLiteral "x" @3:23
+         │        │  ├─ StringLiteral "x" @3:25
          │        │  └─ NumericLiteral 3 @3:28
          │        └─ ObjectProperty @3:23
-         │           ├─ StringLiteral "y" @3:23
+         │           ├─ StringLiteral "y" @3:31
          │           └─ NumericLiteral 4 @3:34
          └─ ReturnStatement @4:5
             └─ BinaryExpression (+) @4:22

--- a/Tests/LibJS/AST/expected/eval-binding-pattern-no-arguments.txt
+++ b/Tests/LibJS/AST/expected/eval-binding-pattern-no-arguments.txt
@@ -7,8 +7,8 @@ Program (script) @1:1
                ├─ BindingPattern (object)
                │  └─ entry
                │     └─ name
-               │        └─ Identifier "eval" [global] @2:6
+               │        └─ Identifier "eval" [global] @2:8
                └─ ObjectExpression @2:17
                   └─ ObjectProperty @2:17
-                     ├─ StringLiteral "eval" @2:17
+                     ├─ StringLiteral "eval" @2:19
                      └─ NumericLiteral 1 @2:25

--- a/Tests/LibJS/AST/expected/eval-indirect.txt
+++ b/Tests/LibJS/AST/expected/eval-indirect.txt
@@ -43,13 +43,13 @@ Program (script) @2:1
 │        │     ├─ Identifier "obj" [variable:0] (var) @19:9
 │        │     └─ ObjectExpression @19:15
 │        │        └─ ObjectProperty @19:15
-│        │           ├─ StringLiteral "eval" @19:15
+│        │           ├─ StringLiteral "eval" @19:17
 │        │           └─ Identifier "eval" [global] @19:15
 │        ├─ ExpressionStatement @20:5
 │        │  └─ CallExpression @20:13
 │        │     ├─ MemberExpression @20:8
 │        │     │  ├─ Identifier "obj" [variable:0] (var) @20:5
-│        │     │  └─ Identifier "eval" @20:8
+│        │     │  └─ Identifier "eval" @20:9
 │        │     └─ StringLiteral "x" @20:17
 │        └─ ReturnStatement @21:5
 │           └─ Identifier "x" [variable:1] (let) @21:12

--- a/Tests/LibJS/AST/expected/eval-indirect.txt
+++ b/Tests/LibJS/AST/expected/eval-indirect.txt
@@ -19,28 +19,28 @@ Program (script) @2:1
 │     └─ FunctionBody @10:5
 │        ├─ VariableDeclaration (let) @10:5
 │        │  └─ VariableDeclarator @10:5
-│        │     ├─ Identifier "x" [variable:1] (let) @10:9
+│        │     ├─ Identifier "x" [variable:0] (let) @10:9
 │        │     └─ NumericLiteral 1 @10:13
 │        ├─ VariableDeclaration (var) @11:5
 │        │  └─ VariableDeclarator @11:5
-│        │     ├─ Identifier "e" [variable:0] (var) @11:9
+│        │     ├─ Identifier "e" [variable:1] (var) @11:9
 │        │     └─ Identifier "eval" [global] @11:13
 │        ├─ ExpressionStatement @12:5
 │        │  └─ CallExpression @12:6
-│        │     ├─ Identifier "e" [variable:0] (var) @12:5
+│        │     ├─ Identifier "e" [variable:1] (var) @12:5
 │        │     └─ StringLiteral "x" @12:10
 │        └─ ReturnStatement @13:5
-│           └─ Identifier "x" [variable:1] (let) @13:12
+│           └─ Identifier "x" [variable:0] (let) @13:12
 ├─ FunctionDeclaration "eval_method" @17:1
 │  └─ body
 │     └─ FunctionBody @18:5
 │        ├─ VariableDeclaration (let) @18:5
 │        │  └─ VariableDeclarator @18:5
-│        │     ├─ Identifier "x" [variable:1] (let) @18:9
+│        │     ├─ Identifier "x" [variable:0] (let) @18:9
 │        │     └─ NumericLiteral 1 @18:13
 │        ├─ VariableDeclaration (var) @19:5
 │        │  └─ VariableDeclarator @19:5
-│        │     ├─ Identifier "obj" [variable:0] (var) @19:9
+│        │     ├─ Identifier "obj" [variable:1] (var) @19:9
 │        │     └─ ObjectExpression @19:15
 │        │        └─ ObjectProperty @19:15
 │        │           ├─ StringLiteral "eval" @19:17
@@ -48,11 +48,11 @@ Program (script) @2:1
 │        ├─ ExpressionStatement @20:5
 │        │  └─ CallExpression @20:13
 │        │     ├─ MemberExpression @20:8
-│        │     │  ├─ Identifier "obj" [variable:0] (var) @20:5
+│        │     │  ├─ Identifier "obj" [variable:1] (var) @20:5
 │        │     │  └─ Identifier "eval" @20:9
 │        │     └─ StringLiteral "x" @20:17
 │        └─ ReturnStatement @21:5
-│           └─ Identifier "x" [variable:1] (let) @21:12
+│           └─ Identifier "x" [variable:0] (let) @21:12
 └─ FunctionDeclaration "local_eval_name" [direct-eval] [uses-this] [might-need-arguments] @25:1
    └─ body
       └─ FunctionBody @26:5

--- a/Tests/LibJS/AST/expected/export-default.txt
+++ b/Tests/LibJS/AST/expected/export-default.txt
@@ -10,7 +10,7 @@ Program (module) [strict] @1:1
          │        └─ BlockStatement @1:17
          └─ elements
             └─ ClassMethod @1:17
-               ├─ StringLiteral "valueOf" @1:17
+               ├─ StringLiteral "valueOf" @1:31
                └─ FunctionExpression "" [strict] @1:31
                   └─ body
                      └─ FunctionBody @1:43

--- a/Tests/LibJS/AST/expected/for-in-of-lhs-patterns.txt
+++ b/Tests/LibJS/AST/expected/for-in-of-lhs-patterns.txt
@@ -19,7 +19,7 @@ Program (script) @2:1
 │           ├─ rhs
 │           │  └─ ObjectExpression @4:20
 │           │     └─ ObjectProperty @4:20
-│           │        ├─ StringLiteral "xy" @4:20
+│           │        ├─ StringLiteral "xy" @4:22
 │           │        └─ NumericLiteral 1 @4:26
 │           └─ body
 │              └─ BlockStatement @4:31
@@ -36,14 +36,14 @@ Program (script) @2:1
 │           │  └─ BindingPattern (object)
 │           │     ├─ entry
 │           │     │  └─ name
-│           │     │     └─ Identifier "x" [variable:0] (var) @10:10
+│           │     │     └─ Identifier "x" [variable:0] (var) @10:12
 │           │     └─ entry
 │           │        └─ name
-│           │           └─ Identifier "y" [variable:1] (var) @10:10
+│           │           └─ Identifier "y" [variable:1] (var) @10:15
 │           ├─ rhs
 │           │  └─ ObjectExpression @10:22
 │           │     └─ ObjectProperty @10:22
-│           │        ├─ StringLiteral "ab" @10:22
+│           │        ├─ StringLiteral "ab" @10:24
 │           │        └─ NumericLiteral 1 @10:28
 │           └─ body
 │              └─ BlockStatement @10:33
@@ -84,18 +84,18 @@ Program (script) @2:1
 │           │  └─ BindingPattern (object)
 │           │     ├─ entry
 │           │     │  └─ name
-│           │     │     └─ Identifier "x" [variable:0] (var) @22:10
+│           │     │     └─ Identifier "x" [variable:0] (var) @22:12
 │           │     └─ entry
 │           │        └─ name
-│           │           └─ Identifier "y" [variable:1] (var) @22:10
+│           │           └─ Identifier "y" [variable:1] (var) @22:15
 │           ├─ rhs
 │           │  └─ ArrayExpression @22:22
 │           │     └─ ObjectExpression @22:23
 │           │        ├─ ObjectProperty @22:23
-│           │        │  ├─ StringLiteral "x" @22:23
+│           │        │  ├─ StringLiteral "x" @22:25
 │           │        │  └─ NumericLiteral 1 @22:28
 │           │        └─ ObjectProperty @22:23
-│           │           ├─ StringLiteral "y" @22:23
+│           │           ├─ StringLiteral "y" @22:31
 │           │           └─ NumericLiteral 2 @22:34
 │           └─ body
 │              └─ BlockStatement @22:40
@@ -110,11 +110,11 @@ Program (script) @2:1
 │           ├─ lhs
 │           │  └─ MemberExpression @28:13
 │           │     ├─ Identifier "obj" [variable:0] (var) @28:10
-│           │     └─ Identifier "key" @28:13
+│           │     └─ Identifier "key" @28:14
 │           ├─ rhs
 │           │  └─ ObjectExpression @28:21
 │           │     └─ ObjectProperty @28:21
-│           │        ├─ StringLiteral "a" @28:21
+│           │        ├─ StringLiteral "a" @28:23
 │           │        └─ NumericLiteral 1 @28:26
 │           └─ body
 │              └─ BlockStatement @28:31
@@ -129,7 +129,7 @@ Program (script) @2:1
             ├─ lhs
             │  └─ MemberExpression @34:13
             │     ├─ Identifier "obj" [variable:0] (var) @34:10
-            │     └─ Identifier "key" @34:13
+            │     └─ Identifier "key" @34:14
             ├─ rhs
             │  └─ ArrayExpression @34:21
             │     ├─ NumericLiteral 1 @34:22

--- a/Tests/LibJS/AST/expected/for-in-of-scoping.txt
+++ b/Tests/LibJS/AST/expected/for-in-of-scoping.txt
@@ -61,10 +61,10 @@ Program (script) @2:1
 │           │        └─ BindingPattern (array)
 │           │           ├─ entry
 │           │           │  └─ alias
-│           │           │     └─ Identifier "a" [variable:0] @25:14
+│           │           │     └─ Identifier "a" [variable:0] @25:15
 │           │           └─ entry
 │           │              └─ alias
-│           │                 └─ Identifier "b" [variable:1] @25:14
+│           │                 └─ Identifier "b" [variable:1] @25:18
 │           ├─ rhs
 │           │  └─ Identifier "pairs" [argument:0] @25:24
 │           └─ body

--- a/Tests/LibJS/AST/expected/locals-and-globals.txt
+++ b/Tests/LibJS/AST/expected/locals-and-globals.txt
@@ -24,5 +24,5 @@ Program (script) @1:1
    └─ CallExpression @7:12
       ├─ MemberExpression @7:8
       │  ├─ Identifier "console" [global] @7:1
-      │  └─ Identifier "log" @7:8
+      │  └─ Identifier "log" @7:9
       └─ Identifier "x" [global] (var) @7:13

--- a/Tests/LibJS/AST/expected/multiple-binding-forms.txt
+++ b/Tests/LibJS/AST/expected/multiple-binding-forms.txt
@@ -87,10 +87,10 @@ Program (script) @4:1
 │        │     ├─ BindingPattern (array)
 │        │     │  ├─ entry
 │        │     │  │  └─ alias
-│        │     │  │     └─ Identifier "a" [variable:0] @28:9
+│        │     │  │     └─ Identifier "a" [variable:0] @28:10
 │        │     │  └─ entry
 │        │     │     └─ alias
-│        │     │        └─ Identifier "b" [variable:1] @28:9
+│        │     │        └─ Identifier "b" [variable:1] @28:13
 │        │     └─ ArrayExpression @28:18
 │        │        ├─ NumericLiteral 1 @28:19
 │        │        └─ NumericLiteral 2 @28:22
@@ -99,26 +99,26 @@ Program (script) @4:1
 │        │     ├─ BindingPattern (object)
 │        │     │  ├─ entry
 │        │     │  │  └─ name
-│        │     │  │     └─ Identifier "c" [variable:2] @29:11
+│        │     │  │     └─ Identifier "c" [variable:2] @29:13
 │        │     │  └─ entry
 │        │     │     └─ name
-│        │     │        └─ Identifier "d" [variable:3] @29:11
+│        │     │        └─ Identifier "d" [variable:3] @29:16
 │        │     └─ ObjectExpression @29:22
 │        │        ├─ ObjectProperty @29:22
-│        │        │  ├─ StringLiteral "c" @29:22
+│        │        │  ├─ StringLiteral "c" @29:24
 │        │        │  └─ NumericLiteral 3 @29:27
 │        │        └─ ObjectProperty @29:22
-│        │           ├─ StringLiteral "d" @29:22
+│        │           ├─ StringLiteral "d" @29:30
 │        │           └─ NumericLiteral 4 @29:33
 │        ├─ VariableDeclaration (var) @30:5
 │        │  └─ VariableDeclarator @30:5
 │        │     ├─ BindingPattern (array)
 │        │     │  ├─ entry
 │        │     │  │  └─ alias
-│        │     │  │     └─ Identifier "e" [variable:4] @30:9
+│        │     │  │     └─ Identifier "e" [variable:4] @30:10
 │        │     │  └─ entry (rest)
 │        │     │     └─ alias
-│        │     │        └─ Identifier "f" [variable:5] @30:9
+│        │     │        └─ Identifier "f" [variable:5] @30:16
 │        │     └─ ArrayExpression @30:21
 │        │        ├─ NumericLiteral 5 @30:22
 │        │        ├─ NumericLiteral 6 @30:25

--- a/Tests/LibJS/AST/expected/multiple-destructuring-parameters.txt
+++ b/Tests/LibJS/AST/expected/multiple-destructuring-parameters.txt
@@ -7,20 +7,20 @@ Program (script) @1:1
 │        │  ├─ BindingPattern (object)
 │        │  │  └─ entry
 │        │  │     ├─ name
-│        │  │     │  └─ Identifier "a" [global] @1:10
+│        │  │     │  └─ Identifier "a" [global] @1:12
 │        │  │     └─ alias
-│        │  │        └─ Identifier "b" [variable:0] @1:10
+│        │  │        └─ Identifier "b" [variable:0] @1:15
 │        │  ├─ BindingPattern (object)
 │        │  │  ├─ entry
 │        │  │  │  ├─ name
-│        │  │  │  │  └─ Identifier "c" [global] @1:20
+│        │  │  │  │  └─ Identifier "c" [global] @1:22
 │        │  │  │  └─ alias
-│        │  │  │     └─ Identifier "d" [variable:1] @1:20
+│        │  │  │     └─ Identifier "d" [variable:1] @1:25
 │        │  │  └─ entry
 │        │  │     ├─ name
-│        │  │     │  └─ Identifier "e" [global] @1:20
+│        │  │     │  └─ Identifier "e" [global] @1:28
 │        │  │     └─ alias
-│        │  │        └─ Identifier "g" [variable:2] @1:20
+│        │  │        └─ Identifier "g" [variable:2] @1:31
 │        │  └─ Identifier "h" [argument:2] @1:10
 │        └─ body
 │           └─ FunctionBody @1:9

--- a/Tests/LibJS/AST/expected/object-property-key-no-capture.txt
+++ b/Tests/LibJS/AST/expected/object-property-key-no-capture.txt
@@ -12,7 +12,7 @@ Program (script) @1:1
          │        └─ ReturnStatement @4:9
          │           └─ ObjectExpression @4:16
          │              └─ ObjectProperty @4:16
-         │                 ├─ StringLiteral "x" @4:16
+         │                 ├─ StringLiteral "x" @4:18
          │                 └─ NumericLiteral 42 @4:21
          └─ ReturnStatement @6:5
             └─ Identifier "x" [variable:1] (var) @6:12

--- a/Tests/LibJS/AST/expected/object-property-key-no-capture.txt
+++ b/Tests/LibJS/AST/expected/object-property-key-no-capture.txt
@@ -4,7 +4,7 @@ Program (script) @1:1
       └─ FunctionBody @2:5
          ├─ VariableDeclaration (var) @2:5
          │  └─ VariableDeclarator @2:5
-         │     ├─ Identifier "x" [variable:1] (var) @2:9
+         │     ├─ Identifier "x" [variable:0] (var) @2:9
          │     └─ NumericLiteral 1 @2:13
          ├─ FunctionDeclaration "inner" @3:5
          │  └─ body
@@ -15,4 +15,4 @@ Program (script) @1:1
          │                 ├─ StringLiteral "x" @4:18
          │                 └─ NumericLiteral 42 @4:21
          └─ ReturnStatement @6:5
-            └─ Identifier "x" [variable:1] (var) @6:12
+            └─ Identifier "x" [variable:0] (var) @6:12

--- a/Tests/LibJS/AST/expected/object-shorthand.txt
+++ b/Tests/LibJS/AST/expected/object-shorthand.txt
@@ -7,5 +7,5 @@ Program (script) @1:1
          └─ ReturnStatement @2:5
             └─ ObjectExpression @2:12
                └─ ObjectProperty @2:12
-                  ├─ StringLiteral "x" @2:12
+                  ├─ StringLiteral "x" @2:14
                   └─ Identifier "x" [argument:0] @2:12

--- a/Tests/LibJS/AST/expected/parameter-forms.txt
+++ b/Tests/LibJS/AST/expected/parameter-forms.txt
@@ -11,7 +11,7 @@ Program (script) @1:1
 │              ├─ Identifier "a" [argument:0] @2:12
 │              └─ MemberExpression @2:20
 │                 ├─ Identifier "rest" [argument:1] @2:16
-│                 └─ Identifier "length" @2:20
+│                 └─ Identifier "length" @2:21
 ├─ FunctionDeclaration "default_params" @5:1
 │  ├─ parameters
 │  │  ├─ Identifier "a" [argument:0] @5:25
@@ -29,10 +29,10 @@ Program (script) @1:1
 │  │  └─ BindingPattern (array)
 │  │     ├─ entry
 │  │     │  └─ alias
-│  │     │     └─ Identifier "x" [variable:0] @9:29
+│  │     │     └─ Identifier "x" [variable:0] @9:30
 │  │     └─ entry
 │  │        └─ alias
-│  │           └─ Identifier "y" [variable:1] @9:29
+│  │           └─ Identifier "y" [variable:1] @9:33
 │  └─ body
 │     └─ FunctionBody @10:5
 │        └─ ReturnStatement @10:5
@@ -44,10 +44,10 @@ Program (script) @1:1
 │  │  └─ BindingPattern (object)
 │  │     ├─ entry
 │  │     │  └─ name
-│  │     │     └─ Identifier "a" [variable:0] @13:30
+│  │     │     └─ Identifier "a" [variable:0] @13:32
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "b" [variable:1] @13:30
+│  │           └─ Identifier "b" [variable:1] @13:35
 │  └─ body
 │     └─ FunctionBody @14:5
 │        └─ ReturnStatement @14:5
@@ -60,7 +60,7 @@ Program (script) @1:1
    │  ├─ BindingPattern (object)
    │  │  └─ entry
    │  │     └─ name
-   │  │        └─ Identifier "x" [variable:0] @17:23
+   │  │        └─ Identifier "x" [variable:0] @17:25
    │  └─ rest
    │     └─ Identifier "rest" [argument:2] @17:16
    └─ body
@@ -72,4 +72,4 @@ Program (script) @1:1
                │  └─ Identifier "x" [variable:0] @18:20
                └─ MemberExpression @18:28
                   ├─ Identifier "rest" [argument:2] @18:24
-                  └─ Identifier "length" @18:28
+                  └─ Identifier "length" @18:29

--- a/Tests/LibJS/AST/expected/private-identifier-access-patterns.txt
+++ b/Tests/LibJS/AST/expected/private-identifier-access-patterns.txt
@@ -7,16 +7,16 @@ Program (script) @1:1
       │        └─ BlockStatement @1:1
       └─ elements
          ├─ ClassField @1:1
-         │  └─ PrivateIdentifier "#x" @1:1
+         │  └─ PrivateIdentifier "#x" @2:5
          └─ ClassMethod @1:1
-            ├─ StringLiteral "method" @1:1
+            ├─ StringLiteral "method" @3:5
             └─ FunctionExpression "" [strict] [uses-this] @3:5
                └─ body
                   └─ FunctionBody @4:9
                      ├─ ExpressionStatement @4:9
                      │  └─ MemberExpression @4:13
                      │     ├─ ThisExpression @4:9
-                     │     └─ PrivateIdentifier "#x" @4:13
+                     │     └─ PrivateIdentifier "#x" @4:14
                      ├─ ExpressionStatement @5:9
                      │  └─ OptionalChain @5:13
                      │     ├─ ThisExpression @5:9

--- a/Tests/LibJS/AST/expected/private-names.txt
+++ b/Tests/LibJS/AST/expected/private-names.txt
@@ -7,20 +7,20 @@ Program (script) @1:1
       │        └─ BlockStatement @1:1
       └─ elements
          ├─ ClassField @1:1
-         │  ├─ PrivateIdentifier "#x" @1:1
+         │  ├─ PrivateIdentifier "#x" @2:5
          │  └─ initializer
          │     └─ NumericLiteral 1 @2:10
          ├─ ClassMethod (getter) @1:1
-         │  ├─ PrivateIdentifier "#y" @1:1
+         │  ├─ PrivateIdentifier "#y" @3:9
          │  └─ FunctionExpression "" [strict] [uses-this] @3:5
          │     └─ body
          │        └─ FunctionBody @4:9
          │           └─ ReturnStatement @4:9
          │              └─ MemberExpression @4:20
          │                 ├─ ThisExpression @4:16
-         │                 └─ PrivateIdentifier "#x" @4:20
+         │                 └─ PrivateIdentifier "#x" @4:21
          ├─ ClassMethod (setter) @1:1
-         │  ├─ PrivateIdentifier "#y" @1:1
+         │  ├─ PrivateIdentifier "#y" @6:9
          │  └─ FunctionExpression "" [strict] [uses-this] @6:5
          │     ├─ parameters
          │     │  └─ Identifier "v" [argument:0] @6:12
@@ -30,14 +30,14 @@ Program (script) @1:1
          │              └─ AssignmentExpression (=) @7:17
          │                 ├─ MemberExpression @7:13
          │                 │  ├─ ThisExpression @7:9
-         │                 │  └─ PrivateIdentifier "#x" @7:13
+         │                 │  └─ PrivateIdentifier "#x" @7:14
          │                 └─ Identifier "v" [argument:0] @7:19
          └─ ClassMethod @1:1
-            ├─ StringLiteral "method" @1:1
+            ├─ StringLiteral "method" @9:5
             └─ FunctionExpression "" [strict] [uses-this] @9:5
                └─ body
                   └─ FunctionBody @10:9
                      └─ ReturnStatement @10:9
                         └─ MemberExpression @10:20
                            ├─ ThisExpression @10:16
-                           └─ PrivateIdentifier "#x" @10:20
+                           └─ PrivateIdentifier "#x" @10:21

--- a/Tests/LibJS/AST/expected/property-key-arguments.txt
+++ b/Tests/LibJS/AST/expected/property-key-arguments.txt
@@ -1,0 +1,73 @@
+Program (script) @3:1
+├─ FunctionDeclaration "plain_arguments_key" @3:1
+│  └─ body
+│     └─ FunctionBody @4:5
+│        └─ ReturnStatement @4:5
+│           └─ ObjectExpression @4:12
+│              └─ ObjectProperty @4:12
+│                 ├─ StringLiteral "arguments" @4:12
+│                 └─ NumericLiteral 1 @4:25
+├─ FunctionDeclaration "plain_eval_key" @8:1
+│  └─ body
+│     └─ FunctionBody @9:5
+│        └─ ReturnStatement @9:5
+│           └─ ObjectExpression @9:12
+│              └─ ObjectProperty @9:12
+│                 ├─ StringLiteral "eval" @9:12
+│                 └─ NumericLiteral 1 @9:20
+├─ FunctionDeclaration "shorthand_arguments" @18:1
+│  └─ body
+│     └─ FunctionBody @19:5
+│        └─ ReturnStatement @19:5
+│           └─ ObjectExpression @19:12
+│              └─ ObjectProperty @19:12
+│                 ├─ StringLiteral "arguments" @19:12
+│                 └─ Identifier "arguments" [variable:0] @19:12
+├─ FunctionDeclaration "computed_arguments_key" [might-need-arguments] @24:1
+│  └─ body
+│     └─ FunctionBody @25:5
+│        └─ ReturnStatement @25:5
+│           └─ ObjectExpression @25:12
+│              └─ ObjectProperty @25:12
+│                 ├─ Identifier "arguments" [variable:0] @25:15
+│                 └─ NumericLiteral 1 @25:27
+├─ FunctionDeclaration "computed_eval_key" [might-need-arguments] @29:1
+│  └─ body
+│     └─ FunctionBody @30:5
+│        └─ ReturnStatement @30:5
+│           └─ ObjectExpression @30:12
+│              └─ ObjectProperty @30:12
+│                 ├─ Identifier "eval" [global] @30:15
+│                 └─ NumericLiteral 1 @30:22
+├─ FunctionDeclaration "binding_pattern_arguments_key" @36:1
+│  └─ body
+│     └─ FunctionBody @37:5
+│        ├─ VariableDeclaration (let) @37:5
+│        │  └─ VariableDeclarator @37:5
+│        │     ├─ BindingPattern (object)
+│        │     │  └─ entry
+│        │     │     ├─ name
+│        │     │     │  └─ Identifier "arguments" [variable:0] @37:9
+│        │     │     └─ alias
+│        │     │        └─ Identifier "x" [variable:1] @37:9
+│        │     └─ ObjectExpression @37:28
+│        │        └─ ObjectProperty @37:28
+│        │           ├─ StringLiteral "arguments" @37:28
+│        │           └─ NumericLiteral 1 @37:41
+│        └─ ReturnStatement @38:5
+│           └─ Identifier "x" [variable:1] @38:12
+└─ FunctionDeclaration "method_named_arguments" @42:1
+   └─ body
+      └─ FunctionBody @43:5
+         └─ ReturnStatement @43:5
+            └─ CallExpression @43:51
+               └─ MemberExpression @43:41
+                  ├─ ObjectExpression @43:12
+                  │  └─ ObjectProperty (method) @43:12
+                  │     ├─ StringLiteral "arguments" @43:12
+                  │     └─ FunctionExpression "" @43:14
+                  │        └─ body
+                  │           └─ FunctionBody @43:28
+                  │              └─ ReturnStatement @43:28
+                  │                 └─ NumericLiteral 1 @43:35
+                  └─ Identifier "arguments" @43:41

--- a/Tests/LibJS/AST/expected/property-key-arguments.txt
+++ b/Tests/LibJS/AST/expected/property-key-arguments.txt
@@ -5,7 +5,7 @@ Program (script) @3:1
 │        └─ ReturnStatement @4:5
 │           └─ ObjectExpression @4:12
 │              └─ ObjectProperty @4:12
-│                 ├─ StringLiteral "arguments" @4:12
+│                 ├─ StringLiteral "arguments" @4:14
 │                 └─ NumericLiteral 1 @4:25
 ├─ FunctionDeclaration "plain_eval_key" @8:1
 │  └─ body
@@ -13,7 +13,7 @@ Program (script) @3:1
 │        └─ ReturnStatement @9:5
 │           └─ ObjectExpression @9:12
 │              └─ ObjectProperty @9:12
-│                 ├─ StringLiteral "eval" @9:12
+│                 ├─ StringLiteral "eval" @9:14
 │                 └─ NumericLiteral 1 @9:20
 ├─ FunctionDeclaration "shorthand_arguments" @18:1
 │  └─ body
@@ -21,7 +21,7 @@ Program (script) @3:1
 │        └─ ReturnStatement @19:5
 │           └─ ObjectExpression @19:12
 │              └─ ObjectProperty @19:12
-│                 ├─ StringLiteral "arguments" @19:12
+│                 ├─ StringLiteral "arguments" @19:14
 │                 └─ Identifier "arguments" [variable:0] @19:12
 ├─ FunctionDeclaration "computed_arguments_key" [might-need-arguments] @24:1
 │  └─ body
@@ -47,12 +47,12 @@ Program (script) @3:1
 │        │     ├─ BindingPattern (object)
 │        │     │  └─ entry
 │        │     │     ├─ name
-│        │     │     │  └─ Identifier "arguments" [variable:0] @37:9
+│        │     │     │  └─ Identifier "arguments" [variable:0] @37:11
 │        │     │     └─ alias
-│        │     │        └─ Identifier "x" [variable:1] @37:9
+│        │     │        └─ Identifier "x" [variable:1] @37:22
 │        │     └─ ObjectExpression @37:28
 │        │        └─ ObjectProperty @37:28
-│        │           ├─ StringLiteral "arguments" @37:28
+│        │           ├─ StringLiteral "arguments" @37:30
 │        │           └─ NumericLiteral 1 @37:41
 │        └─ ReturnStatement @38:5
 │           └─ Identifier "x" [variable:1] @38:12
@@ -64,10 +64,10 @@ Program (script) @3:1
                └─ MemberExpression @43:41
                   ├─ ObjectExpression @43:12
                   │  └─ ObjectProperty (method) @43:12
-                  │     ├─ StringLiteral "arguments" @43:12
+                  │     ├─ StringLiteral "arguments" @43:14
                   │     └─ FunctionExpression "" @43:14
                   │        └─ body
                   │           └─ FunctionBody @43:28
                   │              └─ ReturnStatement @43:28
                   │                 └─ NumericLiteral 1 @43:35
-                  └─ Identifier "arguments" @43:41
+                  └─ Identifier "arguments" @43:42

--- a/Tests/LibJS/AST/expected/proto-destructuring-assignment.txt
+++ b/Tests/LibJS/AST/expected/proto-destructuring-assignment.txt
@@ -9,12 +9,12 @@ Program (script) @1:1
       ├─ BindingPattern (object)
       │  ├─ entry
       │  │  ├─ name
-      │  │  │  └─ Identifier "__proto__" [global] @2:2
+      │  │  │  └─ Identifier "__proto__" [global] @2:4
       │  │  └─ alias
       │  │     └─ Identifier "x" [global] (var) @2:15
       │  └─ entry
       │     ├─ name
-      │     │  └─ Identifier "__proto__" [global] @2:2
+      │     │  └─ Identifier "__proto__" [global] @2:18
       │     └─ alias
       │        └─ Identifier "y" [global] (var) @2:29
       └─ ObjectExpression @2:35

--- a/Tests/LibJS/AST/expected/regex-literals.txt
+++ b/Tests/LibJS/AST/expected/regex-literals.txt
@@ -32,7 +32,7 @@ Program (script) @2:1
 │  │  └─ CallExpression @16:16
 │  │     ├─ MemberExpression @16:11
 │  │     │  ├─ RegExpLiteral /test/ @16:5
-│  │     │  └─ Identifier "test" @16:11
+│  │     │  └─ Identifier "test" @16:12
 │  │     └─ StringLiteral "test" @16:23
 │  └─ consequent
 │     └─ BlockStatement @16:26

--- a/Tests/LibJS/AST/expected/rest-parameter-locals.txt
+++ b/Tests/LibJS/AST/expected/rest-parameter-locals.txt
@@ -8,7 +8,7 @@ Program (script) @2:1
 │        └─ ReturnStatement @3:5
 │           └─ MemberExpression @3:16
 │              ├─ Identifier "args" [argument:0] @3:12
-│              └─ Identifier "length" @3:16
+│              └─ Identifier "length" @3:17
 └─ FunctionDeclaration "rest_with_arguments" [might-need-arguments] @8:1
    ├─ parameters
    │  └─ rest
@@ -19,7 +19,7 @@ Program (script) @2:1
             └─ BinaryExpression (+) @9:24
                ├─ MemberExpression @9:16
                │  ├─ Identifier "args" [argument:0] @9:12
-               │  └─ Identifier "length" @9:16
+               │  └─ Identifier "length" @9:17
                └─ MemberExpression @9:35
                   ├─ Identifier "arguments" [variable:0] @9:26
-                  └─ Identifier "length" @9:35
+                  └─ Identifier "length" @9:36

--- a/Tests/LibJS/AST/expected/static-class-field.txt
+++ b/Tests/LibJS/AST/expected/static-class-field.txt
@@ -9,11 +9,11 @@ Program (script) @2:1
 │        │        └─ BlockStatement @2:9
 │        └─ elements
 │           ├─ ClassField static @2:9
-│           │  ├─ StringLiteral "x" @2:9
+│           │  ├─ StringLiteral "x" @3:12
 │           │  └─ initializer
 │           │     └─ NumericLiteral 1 @3:16
 │           └─ ClassField static @2:9
-│              ├─ StringLiteral "y" @2:9
+│              ├─ StringLiteral "y" @4:12
 │              └─ initializer
 │                 └─ NumericLiteral 2 @4:16
 └─ VariableDeclaration (var) @8:1

--- a/Tests/LibJS/AST/expected/super-in-method-params.txt
+++ b/Tests/LibJS/AST/expected/super-in-method-params.txt
@@ -7,7 +7,7 @@ Program (script) @1:1
 │     │        └─ BlockStatement @1:1
 │     └─ elements
 │        └─ ClassMethod (getter) @1:1
-│           ├─ StringLiteral "name" @1:1
+│           ├─ StringLiteral "name" @2:9
 │           └─ FunctionExpression "" [strict] @2:5
 │              └─ body
 │                 └─ FunctionBody @3:9
@@ -29,14 +29,14 @@ Program (script) @1:1
       │                 └─ Identifier "args" @6:1
       └─ elements
          └─ ClassMethod @6:1
-            ├─ StringLiteral "method" @6:1
+            ├─ StringLiteral "method" @7:5
             └─ FunctionExpression "" [strict] [uses-this] [uses-this-from-environment] @7:5
                ├─ parameters
                │  └─ Identifier "x" [argument:0] @7:12
                │     └─ default
                │        └─ MemberExpression @7:21
                │           ├─ SuperExpression @7:16
-               │           └─ Identifier "name" @7:21
+               │           └─ Identifier "name" @7:22
                └─ body
                   └─ FunctionBody @8:9
                      └─ ReturnStatement @8:9

--- a/Tests/LibJS/AST/expected/super-property.txt
+++ b/Tests/LibJS/AST/expected/super-property.txt
@@ -7,7 +7,7 @@ Program (script) @1:1
 │     │        └─ BlockStatement @1:1
 │     └─ elements
 │        └─ ClassMethod @1:1
-│           ├─ StringLiteral "getValue" @1:1
+│           ├─ StringLiteral "getValue" @2:5
 │           └─ FunctionExpression "" [strict] @2:5
 │              └─ body
 │                 └─ FunctionBody @3:9
@@ -29,7 +29,7 @@ Program (script) @1:1
 │     │                 └─ Identifier "args" @7:1
 │     └─ elements
 │        ├─ ClassMethod @7:1
-│        │  ├─ StringLiteral "getValue" @7:1
+│        │  ├─ StringLiteral "getValue" @8:5
 │        │  └─ FunctionExpression "" [strict] [uses-this] [uses-this-from-environment] @8:5
 │        │     └─ body
 │        │        └─ FunctionBody @9:9
@@ -37,9 +37,9 @@ Program (script) @1:1
 │        │              └─ CallExpression @9:30
 │        │                 └─ MemberExpression @9:21
 │        │                    ├─ SuperExpression @9:16
-│        │                    └─ Identifier "getValue" @9:21
+│        │                    └─ Identifier "getValue" @9:22
 │        └─ ClassMethod @7:1
-│           ├─ StringLiteral "getComputed" @7:1
+│           ├─ StringLiteral "getComputed" @11:5
 │           └─ FunctionExpression "" [strict] [uses-this] [uses-this-from-environment] @11:5
 │              ├─ parameters
 │              │  └─ Identifier "key" [argument:0] @11:17
@@ -54,7 +54,7 @@ Program (script) @1:1
       ├─ Identifier "obj" [global] (let) @16:5
       └─ ObjectExpression @16:11
          └─ ObjectProperty (method) @16:11
-            ├─ StringLiteral "foo" @16:11
+            ├─ StringLiteral "foo" @17:5
             └─ FunctionExpression "" [uses-this] [uses-this-from-environment] @17:5
                └─ body
                   └─ FunctionBody @18:9
@@ -62,4 +62,4 @@ Program (script) @1:1
                         └─ CallExpression @18:30
                            └─ MemberExpression @18:21
                               ├─ SuperExpression @18:16
-                              └─ Identifier "toString" @18:21
+                              └─ Identifier "toString" @18:22

--- a/Tests/LibJS/AST/expected/tagged-template-literals.txt
+++ b/Tests/LibJS/AST/expected/tagged-template-literals.txt
@@ -6,7 +6,7 @@ Program (script) @1:1
 │        ├─ tag
 │        │  └─ MemberExpression @1:15
 │        │     ├─ Identifier "String" [global] @1:9
-│        │     └─ Identifier "raw" @1:15
+│        │     └─ Identifier "raw" @1:16
 │        └─ template
 │           └─ TemplateLiteral @1:19
 │              └─ StringLiteral "foo

--- a/Tests/LibJS/AST/expected/var-after-property-name.txt
+++ b/Tests/LibJS/AST/expected/var-after-property-name.txt
@@ -4,7 +4,7 @@ Program (script) @1:1
 │     ├─ Identifier "o" [global] (var) @1:5
 │     └─ ObjectExpression @1:9
 │        └─ ObjectProperty @1:9
-│           ├─ StringLiteral "x" @1:9
+│           ├─ StringLiteral "x" @1:11
 │           └─ NumericLiteral 42 @1:14
 ├─ VariableDeclaration (var) @2:1
 │  └─ VariableDeclarator @2:1

--- a/Tests/LibJS/AST/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/AST/expected/var-shadow-in-default-param.txt
@@ -62,7 +62,7 @@ Program (script) @4:1
 │  │  └─ BindingPattern (object)
 │  │     └─ entry
 │  │        └─ name
-│  │           └─ Identifier "x" [variable:0] @32:26
+│  │           └─ Identifier "x" [variable:0] @32:28
 │  │     └─ default
 │  │        └─ Identifier "shadow" (var) @32:34
 │  └─ body

--- a/Tests/LibJS/AST/input/binding-pattern-positions.js
+++ b/Tests/LibJS/AST/input/binding-pattern-positions.js
@@ -1,0 +1,14 @@
+// Identifiers inside a binding pattern should carry their own start
+// position. Previously they inherited the pattern's opening `[` or `{`
+// position, which made source maps and devtools point at the bracket
+// rather than the binding name.
+
+let { foo, bar } = {};
+let { x: aliased, y: also } = {};
+let [ first, , third ] = [];
+let { nested: { inner }, ...rest } = {};
+let [ a, [ b, c ] ] = [];
+
+function destructured({ p, q: r }, [ s, t ]) {
+    return p + r + s + t;
+}

--- a/Tests/LibJS/AST/input/property-key-arguments.js
+++ b/Tests/LibJS/AST/input/property-key-arguments.js
@@ -1,0 +1,44 @@
+// `arguments` as a non-computed property key is just a name token,
+// not a reference. The function should NOT be marked might-need-arguments.
+function plain_arguments_key() {
+    return { arguments: 1 };
+}
+
+// Same for `eval` as a non-computed property key.
+function plain_eval_key() {
+    return { eval: 1 };
+}
+
+// FIXME: Shorthand `{ arguments }` IS a reference to the binding and
+// should mark the function might-need-arguments. The expected output
+// here currently captures the still-buggy behavior — the function's
+// arguments register is allocated but never initialized, which causes
+// a runtime crash if the property is read. A proper fix needs to also
+// handle the cover-grammar reinterpretation in `({ arguments } = ...)`.
+function shorthand_arguments() {
+    return { arguments };
+}
+
+// Computed `[arguments]` is a real identifier reference inside the
+// computed-key expression, so the function is marked might-need-arguments.
+function computed_arguments_key() {
+    return { [arguments]: 1 };
+}
+
+// Computed `[eval]` similarly.
+function computed_eval_key() {
+    return { [eval]: 1 };
+}
+
+// Binding-pattern non-computed key with name `arguments`. The key
+// is a property name, not a reference; the alias `x` is the bound
+// name. Should NOT mark might-need-arguments on its own.
+function binding_pattern_arguments_key() {
+    let { arguments: x } = { arguments: 1 };
+    return x;
+}
+
+// Method named `arguments` is again a property-key context.
+function method_named_arguments() {
+    return { arguments() { return 1; } }.arguments();
+}

--- a/Tests/LibJS/AST/input/property-key-arguments.js
+++ b/Tests/LibJS/AST/input/property-key-arguments.js
@@ -9,12 +9,12 @@ function plain_eval_key() {
     return { eval: 1 };
 }
 
-// FIXME: Shorthand `{ arguments }` IS a reference to the binding and
-// should mark the function might-need-arguments. The expected output
-// here currently captures the still-buggy behavior — the function's
-// arguments register is allocated but never initialized, which causes
-// a runtime crash if the property is read. A proper fix needs to also
-// handle the cover-grammar reinterpretation in `({ arguments } = ...)`.
+// Shorthand `{ arguments }` IS a reference to the binding. The parser
+// doesn't fire its conservative might-need-arguments flag here (the
+// shorthand path doesn't go through the eval/arguments check on
+// consume), but scope analysis still allocates a local for `arguments`
+// and the bytecode generator falls back to that signal so the
+// arguments object IS materialized at runtime.
 function shorthand_arguments() {
     return { arguments };
 }

--- a/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
@@ -14,21 +14,21 @@ block0:
 f$2bc22ddd delete-expression-register.js:3:7
   Registers: 7
   Blocks:    3
-  Locals:    arguments~0, x~1
+  Locals:    x~0, arguments~1
   Constants:
     [0] = Undefined
     [1] = Bool(false)
     [2] = Int32(0)
 
 block0:
-  [   0] CreateArguments dst:arguments~0, is_immutable:false
-  [  10] Mov3 dst1:x~1, src1:Undefined, dst2:x~1, src2:Bool(false), dst3:reg5, src3:x~1
-  [  30] JumpTrue condition:x~1, target:block2
+  [   0] CreateArguments dst:arguments~1, is_immutable:false
+  [  10] Mov3 dst1:x~0, src1:Undefined, dst2:x~0, src2:Bool(false), dst3:reg5, src3:x~0
+  [  30] JumpTrue condition:x~0, target:block2
 
 block1:
-  [  40] DeleteByValue dst:reg6, base:arguments~0, property:Int32(0)
+  [  40] DeleteByValue dst:reg6, base:arguments~1, property:Int32(0)
   [  50] Mov dst:reg5, src:reg6
 
 block2:
-  [  60] Mov dst:x~1, src:reg5
-  [  70] Return value:x~1
+  [  60] Mov dst:x~0, src:reg5
+  [  70] Return value:x~0

--- a/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
@@ -14,7 +14,7 @@ block0:
 f$0adf9089 for-of-cond-rhs-block-order.js:2:21
   Registers: 17
   Blocks:    20
-  Locals:    n~0, r~1
+  Locals:    r~0, n~1
   Constants:
     [0] = Bool(false)
     [1] = Undefined
@@ -68,7 +68,7 @@ block9:
   [ 1c8] Jump target:block10
 
 block10:
-  [ 1d0] Mov dst:r~1, src:reg16
+  [ 1d0] Mov dst:r~0, src:reg16
   [ 1e0] JumpFalse condition:reg12, target:block12
 
 block11:
@@ -80,11 +80,11 @@ block12:
   [ 220] JumpTrue condition:reg12, target:block11
 
 block13:
-  [ 230] Mov dst:n~0, src:reg16
+  [ 230] Mov dst:n~1, src:reg16
   [ 240] JumpFalse condition:reg12, target:block15
 
 block14:
-  [ 250] ThrowIfTDZ src:r~1
+  [ 250] ThrowIfTDZ src:r~0
   [ 258] Jump target:block2
 
 block15:

--- a/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
@@ -1,0 +1,74 @@
+$ae1c0998 function-decl-source-order.js:17:1
+  Registers: 14
+  Blocks:    1
+  Constants:
+    [0] = Undefined
+
+block0:
+  [   0] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  38] GetGlobal dst:reg9, `alpha`
+  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, alpha
+  [  70] GetGlobal dst:reg10, `beta`
+  [  88] Call dst:reg9, callee:reg10, this_value:Undefined, beta
+  [  a8] GetGlobal dst:reg11, `gamma`
+  [  c0] Call dst:reg10, callee:reg11, this_value:Undefined, gamma
+  [  e0] GetGlobal dst:reg12, `delta`
+  [  f8] Call dst:reg11, callee:reg12, this_value:Undefined, delta
+  [ 118] GetGlobal dst:reg13, `dup`
+  [ 130] Call dst:reg12, callee:reg13, this_value:Undefined, dup
+  [ 150] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8, reg9, reg10, reg11, reg12]
+  [ 188] End value:reg5
+
+
+alpha$3b8324cd function-decl-source-order.js:5:20
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(1)
+
+block0:
+  [   0] Return value:Int32(1)
+
+
+beta$d739d7c6 function-decl-source-order.js:7:19
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(2)
+
+block0:
+  [   0] Return value:Int32(2)
+
+
+gamma$09aead7f function-decl-source-order.js:11:20
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(3)
+
+block0:
+  [   0] Return value:Int32(3)
+
+
+delta$240367f0 function-decl-source-order.js:15:20
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(4)
+
+block0:
+  [   0] Return value:Int32(4)
+
+
+dup$510f266c function-decl-source-order.js:13:18
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = String("second")
+
+block0:
+  [   0] Return value:String("second")
+
+
+1 2 3 4 "second"

--- a/Tests/LibJS/Bytecode/expected/local-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/local-source-order.txt
@@ -1,0 +1,26 @@
+$da832d31 local-source-order.js:12:1
+  Registers: 7
+  Blocks:    1
+  Constants:
+    [0] = Undefined
+
+block0:
+  [   0] GetGlobal dst:reg6, `source_order_locals`
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, source_order_locals
+  [  38] End value:reg5
+
+
+source_order_locals$7988cb5f local-source-order.js:6:5
+  Registers: 7
+  Blocks:    1
+  Locals:    zebra~0, yak~1, aardvark~2
+  Constants:
+    [0] = Int32(1)
+    [1] = Int32(2)
+    [2] = Int32(3)
+
+block0:
+  [   0] Mov3 dst1:zebra~0, src1:Int32(1), dst2:yak~1, src2:Int32(2), dst3:aardvark~2, src3:Int32(3)
+  [  20] Add dst:reg5, lhs:zebra~0, rhs:yak~1
+  [  30] Add dst:reg6, lhs:reg5, rhs:aardvark~2
+  [  40] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
@@ -19,23 +19,23 @@ block0:
 outer$541206d9 nested-function-decl-source-order.js:12:5
   Registers: 11
   Blocks:    1
-  Locals:    alpha~0, beta~1, delta~2, dup~3, gamma~4
+  Locals:    alpha~0, beta~1, dup~2, gamma~3, delta~4
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] Mov3 dst1:alpha~0, src1:Undefined, dst2:beta~1, src2:Undefined, dst3:delta~2, src3:Undefined
-  [  20] Mov2 dst1:dup~3, src1:Undefined, dst2:gamma~4, src2:Undefined
+  [   0] Mov3 dst1:alpha~0, src1:Undefined, dst2:beta~1, src2:Undefined, dst3:dup~2, src3:Undefined
+  [  20] Mov2 dst1:gamma~3, src1:Undefined, dst2:delta~4, src2:Undefined
   [  38] NewFunction dst:alpha~0, shared_function_data_index:0
   [  50] NewFunction dst:beta~1, shared_function_data_index:1
-  [  68] NewFunction dst:gamma~4, shared_function_data_index:2
-  [  80] NewFunction dst:dup~3, shared_function_data_index:3
-  [  98] NewFunction dst:delta~2, shared_function_data_index:4
+  [  68] NewFunction dst:gamma~3, shared_function_data_index:2
+  [  80] NewFunction dst:dup~2, shared_function_data_index:3
+  [  98] NewFunction dst:delta~4, shared_function_data_index:4
   [  b0] Call dst:reg5, callee:alpha~0, this_value:Undefined, alpha
   [  d0] Call dst:reg6, callee:beta~1, this_value:Undefined, beta
-  [  f0] Call dst:reg7, callee:gamma~4, this_value:Undefined, gamma
-  [ 110] Call dst:reg8, callee:delta~2, this_value:Undefined, delta
-  [ 130] Call dst:reg9, callee:dup~3, this_value:Undefined, dup
+  [  f0] Call dst:reg7, callee:gamma~3, this_value:Undefined, gamma
+  [ 110] Call dst:reg8, callee:delta~4, this_value:Undefined, delta
+  [ 130] Call dst:reg9, callee:dup~2, this_value:Undefined, dup
   [ 150] NewArray dst:reg10, elements:[reg5, reg6, reg7, reg8, reg9]
   [ 178] Return value:reg10
 

--- a/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
@@ -1,0 +1,93 @@
+$54f8ba98 nested-function-decl-source-order.js:15:1
+  Registers: 11
+  Blocks:    1
+  Constants:
+    [0] = Undefined
+    [1] = String(",")
+
+block0:
+  [   0] GetGlobal dst:reg6, `console`
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  38] GetGlobal dst:reg10, `outer`
+  [  50] Call dst:reg9, callee:reg10, this_value:Undefined, outer
+  [  70] GetById dst:reg10, base:reg9, `join`
+  [  90] Call dst:reg8, callee:reg10, this_value:reg9, <object>.join, arguments:[String(",")]
+  [  b8] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  e0] End value:reg5
+
+
+outer$541206d9 nested-function-decl-source-order.js:12:5
+  Registers: 11
+  Blocks:    1
+  Locals:    alpha~0, beta~1, delta~2, dup~3, gamma~4
+  Constants:
+    [0] = Undefined
+
+block0:
+  [   0] Mov3 dst1:alpha~0, src1:Undefined, dst2:beta~1, src2:Undefined, dst3:delta~2, src3:Undefined
+  [  20] Mov2 dst1:dup~3, src1:Undefined, dst2:gamma~4, src2:Undefined
+  [  38] NewFunction dst:alpha~0, shared_function_data_index:0
+  [  50] NewFunction dst:beta~1, shared_function_data_index:1
+  [  68] NewFunction dst:gamma~4, shared_function_data_index:2
+  [  80] NewFunction dst:dup~3, shared_function_data_index:3
+  [  98] NewFunction dst:delta~2, shared_function_data_index:4
+  [  b0] Call dst:reg5, callee:alpha~0, this_value:Undefined, alpha
+  [  d0] Call dst:reg6, callee:beta~1, this_value:Undefined, beta
+  [  f0] Call dst:reg7, callee:gamma~4, this_value:Undefined, gamma
+  [ 110] Call dst:reg8, callee:delta~2, this_value:Undefined, delta
+  [ 130] Call dst:reg9, callee:dup~3, this_value:Undefined, dup
+  [ 150] NewArray dst:reg10, elements:[reg5, reg6, reg7, reg8, reg9]
+  [ 178] Return value:reg10
+
+
+alpha$3b8324cd nested-function-decl-source-order.js:6:24
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(1)
+
+block0:
+  [   0] Return value:Int32(1)
+
+
+beta$d739d7c6 nested-function-decl-source-order.js:7:23
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(2)
+
+block0:
+  [   0] Return value:Int32(2)
+
+
+gamma$09aead7f nested-function-decl-source-order.js:9:24
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(3)
+
+block0:
+  [   0] Return value:Int32(3)
+
+
+delta$240367f0 nested-function-decl-source-order.js:11:24
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = Int32(4)
+
+block0:
+  [   0] Return value:Int32(4)
+
+
+dup$510f266c nested-function-decl-source-order.js:10:22
+  Registers: 5
+  Blocks:    1
+  Constants:
+    [0] = String("second")
+
+block0:
+  [   0] Return value:String("second")
+
+
+"1,2,3,4,second"

--- a/Tests/LibJS/Bytecode/input/function-decl-source-order.js
+++ b/Tests/LibJS/Bytecode/input/function-decl-source-order.js
@@ -1,0 +1,17 @@
+// Multiple top-level function declarations should be emitted in source
+// order. ECMAScript "last function with name X wins" hoisting still
+// applies, so the duplicate `dup` keeps the second body.
+
+function alpha() { return 1; }
+
+function beta() { return 2; }
+
+function dup() { return "first"; }
+
+function gamma() { return 3; }
+
+function dup() { return "second"; }
+
+function delta() { return 4; }
+
+console.log(alpha(), beta(), gamma(), delta(), dup());

--- a/Tests/LibJS/Bytecode/input/local-source-order.js
+++ b/Tests/LibJS/Bytecode/input/local-source-order.js
@@ -1,0 +1,12 @@
+// Local variables should be allocated indices in source order, not in
+// alphabetical order. With names that sort in reverse alphabetical
+// order, the difference is visible in the bytecode dump (~0 first, etc).
+
+function source_order_locals() {
+    let zebra = 1;
+    let yak = 2;
+    let aardvark = 3;
+    return zebra + yak + aardvark;
+}
+
+source_order_locals();

--- a/Tests/LibJS/Bytecode/input/nested-function-decl-source-order.js
+++ b/Tests/LibJS/Bytecode/input/nested-function-decl-source-order.js
@@ -1,0 +1,15 @@
+// Same source-order check, but for FunctionDeclarations nested inside a
+// function body. The scope_collector builds functions_to_initialize for
+// these and previously emitted them in reverse source order.
+
+function outer() {
+    function alpha() { return 1; }
+    function beta() { return 2; }
+    function dup() { return "first"; }
+    function gamma() { return 3; }
+    function dup() { return "second"; }
+    function delta() { return 4; }
+    return [alpha(), beta(), gamma(), delta(), dup()];
+}
+
+console.log(outer().join(","));

--- a/Tests/LibJS/Runtime/arguments-shorthand-property.js
+++ b/Tests/LibJS/Runtime/arguments-shorthand-property.js
@@ -1,0 +1,39 @@
+// Regression: shorthand `{ arguments }` and `{ eval }` inside an object
+// literal IS a real reference to the binding, so the function needs to
+// materialize the arguments object. Previously the parser never marked
+// the function (the eval/arguments check was suppressed for property
+// keys), so the local was allocated but uninitialized and reading the
+// property crashed.
+
+test("{ arguments } shorthand returns the arguments object", () => {
+    function f() {
+        return { arguments };
+    }
+    const r = f(1, 2, 3);
+    expect(typeof r.arguments).toBe("object");
+    expect(r.arguments.length).toBe(3);
+    expect(r.arguments[0]).toBe(1);
+    expect(r.arguments[2]).toBe(3);
+});
+
+test("{ arguments } shorthand inside a method", () => {
+    const obj = {
+        m() {
+            return { arguments };
+        },
+    };
+    const r = obj.m("a", "b");
+    expect(r.arguments.length).toBe(2);
+    expect(r.arguments[0]).toBe("a");
+});
+
+test("destructuring assignment { eval } = ... does not require arguments object", () => {
+    // ({ eval } = { eval: 1 }) is a destructuring assignment to the
+    // global eval, not a real `eval` reference inside the function.
+    // It should parse and run without crashing.
+    function fn() {
+        ({ eval } = { eval: 1 });
+        return 42;
+    }
+    expect(fn()).toBe(42);
+});


### PR DESCRIPTION
The Rust parser and scope collector held onto a handful of shapes that only existed to lockstep against the long-gone C++ pipeline.

See individual commits for details.

Along the way, fixed a runtime crash where `function f() { return { arguments } }` allocated an uninitialized arguments local because the shorthand path bypassed the parser's eval/arguments check. We now fall back to "scope analysis allocated a non-lexical arguments local" as the trigger for materializing the arguments object.