### PR TITLE
LibJS: Fast path Array.prototype.indexOf on packed arrays

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -872,6 +872,17 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::index_of)
         k = max(length + n, 0);
     }
 
+    // OPTIMIZATION: Simple packed arrays have an own data property for every index below their length,
+    // so HasProperty and Get cannot produce side effects or observe prototype indexed properties.
+    if (auto* array = as_if<Array>(*object); array && array->is_simple_packed_array() && array->indexed_array_like_size() == length) {
+        auto elements = array->indexed_packed_elements_span();
+        for (; k < elements.size(); ++k) {
+            if (is_strictly_equal(search_element, elements[k]))
+                return Value(k);
+        }
+        return Value(-1);
+    }
+
     // 10. Repeat, while k < len,
     for (; k < length; ++k) {
         auto property_key = PropertyKey { k };

--- a/Tests/LibJS/Runtime/builtins/Array/Array.prototype.indexOf.js
+++ b/Tests/LibJS/Runtime/builtins/Array/Array.prototype.indexOf.js
@@ -23,3 +23,56 @@ test("basic functionality", () => {
     expect([].indexOf()).toBe(-1);
     expect([undefined].indexOf()).toBe(0);
 });
+
+test("fromIndex side effects can mutate array length", () => {
+    var array = ["hello", "friends"];
+    var fromIndex = {
+        valueOf() {
+            array.pop();
+            return 0;
+        },
+    };
+
+    expect(array.indexOf("friends", fromIndex)).toBe(-1);
+});
+
+test("fromIndex side effects can grow array past captured length", () => {
+    var array = ["hello", "friends"];
+    var fromIndex = {
+        valueOf() {
+            array.push("serenity");
+            return 0;
+        },
+    };
+
+    expect(array.indexOf("serenity", fromIndex)).toBe(-1);
+});
+
+test("fromIndex side effects can mutate packed array elements", () => {
+    var array = ["hello", "friends"];
+    var fromIndex = {
+        valueOf() {
+            array[1] = "serenity";
+            return 0;
+        },
+    };
+
+    expect(array.indexOf("serenity", fromIndex)).toBe(1);
+});
+
+test("fromIndex side effects can make prototype indexed properties observable", () => {
+    var array = ["hello", "friends"];
+    var fromIndex = {
+        valueOf() {
+            delete array[1];
+            Array.prototype[1] = "serenity";
+            return 0;
+        },
+    };
+
+    try {
+        expect(array.indexOf("serenity", fromIndex)).toBe(1);
+    } finally {
+        delete Array.prototype[1];
+    }
+});


### PR DESCRIPTION
Skip the generic `HasProperty` and `Get` loop when `indexOf` operates on a simple packed array. In that case every index below length is an own data property, so a direct scan of the packed indexed property storage gives the same strict-equality result without the per-element property lookup ceremony.

Only use the fast path when the current packed storage size still matches the length captured before `fromIndex` coercion, since that coercion can run user code and mutate the receiver. Add coverage for length and storage mutations during `fromIndex` coercion.