### PR TITLE
LibWeb: Guard MiddleButtonScrollHandler destructor against stale layout

### DIFF
--- a/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/MiddleButtonScrollHandler.cpp
@@ -31,6 +31,8 @@ MiddleButtonScrollHandler::MiddleButtonScrollHandler(DOM::Element& container, CS
 
 MiddleButtonScrollHandler::~MiddleButtonScrollHandler()
 {
+    if (!m_container_element->document().layout_is_up_to_date())
+        return;
     if (auto* paintable = m_container_element->document().paintable())
         paintable->set_needs_repaint();
 }


### PR DESCRIPTION
Calling document().paintable() asserts layout_is_up_to_date(), which can fail when the handler is destroyed during a navigation. Guard the repaint call so the destructor is safe to run regardless of layout state.