### PR TITLE
LibWeb: Clear stale layout descendants for skipped subtrees

### DIFF
--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -186,8 +186,11 @@ inline bool Node::fast_is<ShadowRoot>() const { return node_type() == to_underly
 template<typename Callback>
 inline TraversalDecision Node::for_each_shadow_including_inclusive_descendant(Callback callback)
 {
-    if (callback(*this) == TraversalDecision::Break)
+    auto decision = callback(*this);
+    if (decision == TraversalDecision::Break)
         return TraversalDecision::Break;
+    if (decision == TraversalDecision::SkipChildrenAndContinue)
+        return TraversalDecision::Continue;
 
     if (this->for_each_shadow_including_descendant(callback) == TraversalDecision::Break)
         return TraversalDecision::Break;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -568,6 +568,49 @@ static bool is_ignorable_whitespace(Layout::Node const& node)
     return false;
 }
 
+static bool is_svg_resource_box(Node const& layout_node)
+{
+    return is<SVGPatternBox>(layout_node) || is<SVGMaskBox>(layout_node) || is<SVGClipBox>(layout_node);
+}
+
+static bool layout_node_is_attached_to_dom_subtree(Node const& layout_node, DOM::Node const& subtree_root)
+{
+    for (auto* ancestor = layout_node.parent(); ancestor; ancestor = ancestor->parent()) {
+        auto* dom_node = ancestor->dom_node();
+        if (dom_node && dom_node->is_shadow_including_inclusive_descendant_of(subtree_root))
+            return true;
+    }
+    return false;
+}
+
+TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* content_visibility_hidden_root)
+{
+    node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
+    node.set_child_needs_layout_tree_update(false);
+
+    // NB: Called during layout tree construction.
+    auto layout_node = node.unsafe_layout_node();
+    // SVGPatternBox, SVGMaskBox, and SVGClipBox are created on behalf of a referencing
+    // element and attached to that element's layout subtree. Skip them so they survive
+    // cleanup of their DOM ancestor, unless their layout attachment is inside the
+    // subtree being hidden too.
+    if (layout_node && is_svg_resource_box(*layout_node)
+        && (!content_visibility_hidden_root || !layout_node_is_attached_to_dom_subtree(*layout_node, *content_visibility_hidden_root))) {
+        return TraversalDecision::SkipChildrenAndContinue;
+    }
+
+    if (layout_node && layout_node->parent())
+        layout_node->remove();
+
+    node.detach_layout_node({});
+    node.clear_paintable();
+
+    if (is<DOM::Element>(node))
+        static_cast<DOM::Element&>(node).clear_pseudo_element_nodes({});
+
+    return TraversalDecision::Continue;
+}
+
 void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree)
 {
     // NB: Called during layout tree construction.
@@ -599,23 +642,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         // go through the DOM tree and remove any old layout & paint nodes since they are now all stale.
         if (!layout_node) {
             dom_node.for_each_in_inclusive_subtree([&](auto& node) {
-                node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
-                node.set_child_needs_layout_tree_update(false);
-                // NB: Called during layout tree construction.
-                auto layout_node = node.unsafe_layout_node();
-                // SVGPatternBox, SVGMaskBox, and SVGClipBox are created on behalf of a referencing
-                // element and attached to that element's layout subtree. Skip them so they survive cleanup of their
-                // DOM ancestor.
-                if (layout_node && (is<SVGPatternBox>(*layout_node) || is<SVGMaskBox>(*layout_node) || is<SVGClipBox>(*layout_node)))
-                    return TraversalDecision::SkipChildrenAndContinue;
-                if (layout_node && layout_node->parent()) {
-                    layout_node->remove();
-                }
-                node.detach_layout_node({});
-                node.clear_paintable();
-                if (is<DOM::Element>(node))
-                    static_cast<DOM::Element&>(node).clear_pseudo_element_nodes({});
-                return TraversalDecision::Continue;
+                return clear_stale_layout_and_paint_node(node);
             });
         }
     };
@@ -736,6 +763,12 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         }
 
         update_layout_tree_before_children(dom_node, *layout_node, context, element_has_content_visibility_hidden);
+    }
+
+    if (element_has_content_visibility_hidden) {
+        dom_node.for_each_shadow_including_descendant([&](auto& node) {
+            return clear_stale_layout_and_paint_node(node, &dom_node);
+        });
     }
 
     if (should_create_layout_node || dom_node.child_needs_layout_tree_update()) {

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -35,6 +35,7 @@ private:
         Yes,
     };
     void update_layout_tree(DOM::Node&, Context&, MustCreateSubtree);
+    TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* content_visibility_hidden_root = nullptr);
 
     void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(node); }
     void pop_parent() { m_ancestor_stack.take_last(); }

--- a/Tests/LibWeb/Crash/Layout/intersection-observer-content-visibility-hidden-stale-paintable.html
+++ b/Tests/LibWeb/Crash/Layout/intersection-observer-content-visibility-hidden-stale-paintable.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<style>
+    body { margin: 0; }
+    .spacer { height: 4000px; }
+    #wrapper {
+        content-visibility: auto;
+        contain-intrinsic-size: 1000px;
+        transform: translateX(1px);
+        height: 1000px;
+    }
+    #target {
+        position: absolute;
+        inset: 0;
+        width: 100px;
+        height: 100px;
+        background: green;
+        transform: translateX(1px);
+    }
+</style>
+<div class="spacer"></div>
+<div id="wrapper">
+    <div id="target"></div>
+</div>
+<script>
+    const wrapper = document.getElementById("wrapper");
+    const target = document.getElementById("target");
+
+    new IntersectionObserver(() => {}).observe(target);
+
+    requestAnimationFrame(() => {
+        scrollTo(0, 4500);
+
+        requestAnimationFrame(() => {
+            wrapper.style.contentVisibility = "hidden";
+
+            requestAnimationFrame(() => {
+                internals.signalTestIsDone("PASS");
+            });
+        });
+    });
+</script>

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/content-visibility-hidden-clears-internal-svg-resource-subtree.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/content-visibility-hidden-clears-internal-svg-resource-subtree.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div#hidden> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>#hidden) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/content-visibility-hidden-preserves-svg-resource-subtree.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/content-visibility-hidden-preserves-svg-resource-subtree.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div#hidden> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] children: inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
+        TextNode <#text> (not painted)
+        SVGSVGBox <svg#visible> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [SVG] children: inline
+          TextNode <#text> (not painted)
+          SVGGeometryBox <rect#target> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+            SVGMaskBox <mask#mask> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: inline
+              TextNode <#text> (not painted)
+              SVGGeometryBox <rect#mask-rect> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+              TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>#hidden) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x100]
+        SVGSVGPaintable (SVGSVGBox<svg>#visible) [8,8 100x100]
+          SVGPathPaintable (SVGGeometryBox<rect>#target) [8,8 100x100]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/content-visibility-hidden-rebuilds-internal-svg-resource-subtree.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/content-visibility-hidden-rebuilds-internal-svg-resource-subtree.txt
@@ -1,0 +1,33 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 166 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 150 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div#container> at [8,8] [0+0+0 784 0+0+0] [0+0+0 150 0+0+0] children: inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+        TextNode <#text> (not painted)
+        SVGSVGBox <svg> at [8,8] [0+0+0 300 0+0+0] [0+0+0 150 0+0+0] [SVG] children: inline
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          SVGGeometryBox <rect#target> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+            SVGMaskBox <mask#mask> at [8,8] [0+0+0 300 0+0+0] [0+0+0 150 0+0+0] children: inline
+              TextNode <#text> (not painted)
+              SVGGeometryBox <rect#mask-rect> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+              TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,158] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>#container) [8,8 784x150]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
+          SVGPathPaintable (SVGGeometryBox<rect>#target) [8,8 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,158 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/layout-tree-update/content-visibility-hidden-clears-internal-svg-resource-subtree.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/content-visibility-hidden-clears-internal-svg-resource-subtree.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<body>
+<div id="hidden">
+    <svg>
+        <defs>
+            <mask id="mask">
+                <rect id="mask-rect" width="100" height="100" fill="white"></rect>
+            </mask>
+        </defs>
+        <rect id="target" width="100" height="100" fill="green" mask="url(#mask)"></rect>
+    </svg>
+</div>
+<script>
+    document.body.offsetWidth;
+    hidden.style.contentVisibility = "hidden";
+    document.body.offsetWidth;
+</script>

--- a/Tests/LibWeb/Layout/input/layout-tree-update/content-visibility-hidden-preserves-svg-resource-subtree.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/content-visibility-hidden-preserves-svg-resource-subtree.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<body>
+<div id="hidden">
+    <svg>
+        <defs>
+            <mask id="mask">
+                <rect id="mask-rect" width="100" height="100" fill="white"></rect>
+            </mask>
+        </defs>
+    </svg>
+</div>
+<svg id="visible" width="100" height="100">
+    <rect id="target" width="100" height="100" fill="green" mask="url(#mask)"></rect>
+</svg>
+<script>
+    document.body.offsetWidth;
+    hidden.style.contentVisibility = "hidden";
+    document.body.offsetWidth;
+</script>

--- a/Tests/LibWeb/Layout/input/layout-tree-update/content-visibility-hidden-rebuilds-internal-svg-resource-subtree.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/content-visibility-hidden-rebuilds-internal-svg-resource-subtree.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<body>
+<div id="container">
+    <svg>
+        <defs>
+            <mask id="mask">
+                <rect id="mask-rect" width="100" height="100" fill="white"></rect>
+            </mask>
+        </defs>
+        <rect id="target" width="100" height="100" fill="green" mask="url(#mask)"></rect>
+    </svg>
+</div>
+<script>
+    document.body.offsetWidth;
+    container.style.contentVisibility = "hidden";
+    document.body.offsetWidth;
+    container.style.contentVisibility = "visible";
+    document.body.offsetWidth;
+</script>


### PR DESCRIPTION
When `content-visibility:hidden` starts skipping a subtree, clear the stale layout and paint nodes for its descendants.

Preserve SVG `mask`, `clipPath`, and `pattern` resource boxes only when they are attached to a referencing layout subtree outside the subtree being hidden. Resources used inside the hidden subtree are cleared with that subtree, so they rebuild under the live referencing layout node when the subtree becomes visible again.

Otherwise observed descendants can keep old paintables around after the current paint tree has been rebuilt without them.

This fixes a crash during "infinite scrolling" on https://reddit.com/