### PR TITLE
Keep worker startup reachable until script load completes

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/UniversalGlobalScope.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WorkerAgentParent.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/SecureContexts/AbstractOperations.h>
@@ -68,6 +69,7 @@ void EnvironmentSettingsObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_storage_manager);
     visitor.visit(m_service_worker_registration_object_map);
     visitor.visit(m_service_worker_object_map);
+    visitor.visit(m_worker_agents_to_keep_alive_while_starting);
 }
 
 void EnvironmentSettingsObject::discard_environment()
@@ -77,6 +79,18 @@ void EnvironmentSettingsObject::discard_environment()
 
     // 1. Set client’s discarded flag.
     set_discarded(true);
+}
+
+void EnvironmentSettingsObject::keep_worker_agent_alive_while_starting(WorkerAgentParent& worker_agent)
+{
+    m_worker_agents_to_keep_alive_while_starting.append(worker_agent);
+}
+
+void EnvironmentSettingsObject::release_worker_agent_from_startup_keep_alive(WorkerAgentParent& worker_agent)
+{
+    m_worker_agents_to_keep_alive_while_starting.remove_first_matching([&](auto& agent) {
+        return agent.ptr() == &worker_agent;
+    });
 }
 
 JS::ExecutionContext& EnvironmentSettingsObject::realm_execution_context()

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -144,6 +144,9 @@ public:
 
     virtual void discard_environment() override;
 
+    void keep_worker_agent_alive_while_starting(WorkerAgentParent&);
+    void release_worker_agent_from_startup_keep_alive(WorkerAgentParent&);
+
     // FIXME: This method below is from HighResolutionTime spec in section 3. Section for Specification Authors.
     // The following other methods are currently not supported:
     // `current relative timestamp`     https://www.w3.org/TR/hr-time-3/#dfn-current-relative-timestamp
@@ -195,6 +198,8 @@ private:
     // https://w3c.github.io/ServiceWorker/#service-worker-client-discarded-flag
     // A service worker client has an associated discarded flag. It is initially unset.
     bool m_discarded { false };
+
+    Vector<GC::Ref<WorkerAgentParent>> m_worker_agents_to_keep_alive_while_starting;
 };
 
 RunScriptDecision can_run_script(EnvironmentSettingsObject const&);

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -38,6 +38,8 @@ void WorkerAgentParent::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
+    m_outside_settings->keep_worker_agent_alive_while_starting(*this);
+
     m_message_port = MessagePort::create(realm);
     m_message_port->entangle_with(*m_outside_port);
 
@@ -86,13 +88,13 @@ void WorkerAgentParent::setup_worker_ipc_callbacks(JS::Realm& realm)
             return;
         // https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception
         // 7.2: If global implements DedicatedWorkerGlobalScope, queue a global task on the DOM manipulation task source with the global's associated Worker's relevant global object to run these steps:
-        auto& outside_settings = *self->m_outside_settings;
+        auto outside_settings = GC::Ref { *self->m_outside_settings };
         auto worker_event_target = GC::Ref { *self->m_worker_event_target };
-        queue_global_task(Task::Source::DOMManipulation, outside_settings.global_object(), GC::create_function(outside_settings.heap(), [&outside_settings, worker_event_target, message = move(message), filename = move(filename), lineno, colno]() {
+        queue_global_task(Task::Source::DOMManipulation, outside_settings->global_object(), GC::create_function(outside_settings->heap(), [outside_settings, worker_event_target, message = move(message), filename = move(filename), lineno, colno]() {
             // 1. Let workerObject be the Worker object associated with global.
             auto& worker_object = as<Worker>(*worker_event_target);
 
-            auto& realm = outside_settings.realm();
+            auto& realm = outside_settings->realm();
 
             // 2. Set notHandled to the result of firing an event named error at workerObject, using ErrorEvent, with the
             //    cancelable attribute initialized to true, and additional attributes initialized according to errorInfo.
@@ -108,20 +110,36 @@ void WorkerAgentParent::setup_worker_ipc_callbacks(JS::Realm& realm)
 
             // 3. If notHandled is true, then report exception for workerObject's relevant global object with omitError set to true.
             if (not_handled)
-                as<WindowOrWorkerGlobalScopeMixin>(outside_settings.global_object()).report_an_exception(error, WindowOrWorkerGlobalScopeMixin::OmitError::Yes);
+                as<WindowOrWorkerGlobalScopeMixin>(outside_settings->global_object()).report_an_exception(error, WindowOrWorkerGlobalScopeMixin::OmitError::Yes);
         }));
+    };
+    m_worker_ipc->on_worker_close = [self = GC::Weak { *this }]() {
+        if (!self)
+            return;
+        self->release_startup_keep_alive();
+    };
+    m_worker_ipc->on_worker_script_load_success = [self = GC::Weak { *this }]() {
+        if (!self)
+            return;
+        self->release_startup_keep_alive();
     };
     m_worker_ipc->on_worker_script_load_failure = [self = GC::Weak { *this }]() {
         if (!self)
             return;
-        auto& outside_settings = *self->m_outside_settings;
-        auto& event_target = *self->m_worker_event_target;
+        auto outside_settings = GC::Ref { *self->m_outside_settings };
+        auto event_target = GC::Ref { *self->m_worker_event_target };
         // See: https://html.spec.whatwg.org/multipage/workers.html#worker-processing-model, onComplete handler for fetching script.
         // 1. Queue a global task on the DOM manipulation task source given worker's relevant global object to fire an event named error at worker.
-        queue_global_task(Task::Source::DOMManipulation, outside_settings.global_object(), GC::create_function(outside_settings.heap(), [&event_target, &outside_settings]() {
-            event_target.dispatch_event(DOM::Event::create(outside_settings.realm(), EventNames::error));
+        queue_global_task(Task::Source::DOMManipulation, outside_settings->global_object(), GC::create_function(outside_settings->heap(), [event_target, outside_settings]() {
+            event_target->dispatch_event(DOM::Event::create(outside_settings->realm(), EventNames::error));
         }));
+        self->release_startup_keep_alive();
     };
+}
+
+void WorkerAgentParent::release_startup_keep_alive()
+{
+    m_outside_settings->release_worker_agent_from_startup_keep_alive(*this);
 }
 
 void WorkerAgentParent::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -32,6 +32,7 @@ protected:
 
 private:
     void setup_worker_ipc_callbacks(JS::Realm&);
+    void release_startup_keep_alive();
 
     WorkerOptions m_worker_options;
     Bindings::AgentType m_agent_type { Bindings::AgentType::DedicatedWorker };

--- a/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -21,6 +21,12 @@ void WebWorkerClient::did_close_worker()
         on_worker_close();
 }
 
+void WebWorkerClient::did_finish_loading_worker_script()
+{
+    if (on_worker_script_load_success)
+        on_worker_script_load_success();
+}
+
 void WebWorkerClient::did_fail_loading_worker_script()
 {
     if (on_worker_script_load_failure)

--- a/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -35,6 +35,7 @@ public:
     void set_pid(pid_t pid) { m_pid = pid; }
 
     virtual void did_close_worker() override;
+    virtual void did_finish_loading_worker_script() override;
     virtual void did_fail_loading_worker_script() override;
     virtual void did_report_worker_exception(String message, String filename, u32 lineno, u32 colno) override;
     virtual Messages::WebWorkerClient::DidRequestCookieResponse did_request_cookie(URL::URL, HTTP::Cookie::Source) override;
@@ -42,6 +43,7 @@ public:
     virtual Messages::WebWorkerClient::RequestWorkerAgentResponse request_worker_agent(Web::Bindings::AgentType worker_type) override;
 
     Function<void()> on_worker_close;
+    Function<void()> on_worker_script_load_success;
     Function<void()> on_worker_script_load_failure;
     Function<void(String, String, u32, u32)> on_worker_exception;
     Function<HTTP::Cookie::VersionedCookie(URL::URL const&, HTTP::Cookie::Source)> on_request_cookie;

--- a/Libraries/LibWeb/Worker/WebWorkerClient.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.ipc
@@ -6,6 +6,7 @@
 
 endpoint WebWorkerClient {
     did_close_worker() =|
+    did_finish_loading_worker_script() =|
     did_fail_loading_worker_script() =|
     did_report_worker_exception(String message, String filename, u32 lineno, u32 colno) =|
     did_request_cookie(URL::URL url, HTTP::Cookie::Source source) => (HTTP::Cookie::VersionedCookie cookie)

--- a/Services/WebWorker/PageHost.cpp
+++ b/Services/WebWorker/PageHost.cpp
@@ -113,6 +113,11 @@ Web::PageClient::WorkerAgentResponse PageHost::request_worker_agent(Web::Binding
     return { response.take_handle(), response.take_request_server_handle(), response.take_image_decoder_handle() };
 }
 
+void PageHost::did_finish_loading_worker_script()
+{
+    m_client.async_did_finish_loading_worker_script();
+}
+
 void PageHost::did_fail_loading_worker_script()
 {
     m_client.async_did_fail_loading_worker_script();

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -45,6 +45,7 @@ public:
     virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { VERIFY_NOT_REACHED(); }
+    void did_finish_loading_worker_script();
     void did_fail_loading_worker_script();
 
 private:

--- a/Services/WebWorker/WorkerHost.cpp
+++ b/Services/WebWorker/WorkerHost.cpp
@@ -256,6 +256,8 @@ void WorkerHost::run(GC::Ref<Web::Page> page, Web::HTML::TransferDataEncoder mes
         else
             (void)as<Web::HTML::ModuleScript>(*script).run();
 
+        as<WebWorker::PageHost>(page->client()).did_finish_loading_worker_script();
+
         // FIXME: 11. Enable outside port's port message queue.
 
         // 12. If is shared is false, enable the port message queue of the worker's implicit port.

--- a/Tests/LibWeb/Text/expected/Worker/Worker-error-event-after-gc.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-error-event-after-gc.txt
@@ -1,0 +1,2 @@
+shared worker error
+worker error

--- a/Tests/LibWeb/Text/input/Worker/Worker-error-event-after-gc.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-error-event-after-gc.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let completed = 0;
+        const failures = [];
+
+        function finishOne(name) {
+            failures.push(name);
+            if (++completed === 2) {
+                failures.sort().forEach(println);
+                done();
+            }
+        }
+
+        const worker = new Worker("worker-does-not-exist.js");
+        worker.onerror = () => finishOne("worker error");
+
+        const shared = new SharedWorker("shared-worker-does-not-exist.js");
+        shared.onerror = () => finishOne("shared worker error");
+
+        setTimeout(() => internals.gc(), 0);
+    });
+</script>


### PR DESCRIPTION
Fixes flakiness in worker tests that create a Worker or SharedWorker with a missing script URL and only attach an error handler to it. Once the test callback returns, nothing keeps the worker rooted from JavaScript. If GC ran before the WebWorker process reported the script fetch failure, the Worker/WorkerAgentParent cycle could be collected and the error event never delivered, leaving the test hung until timeout.

Hold startup-pending WorkerAgentParents from the outside EnvironmentSettingsObject and release that edge once the script load succeeds, fails, or the worker closes. The worker now survives long enough to deliver its first script-load result.