### PR TITLE
LibWeb: Preserve old insertion points across reentrant scripts

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3598,7 +3598,7 @@ void HTMLParser::handle_text(HTMLToken& token)
         m_insertion_mode = m_original_insertion_mode;
 
         // Let the old insertion point have the same value as the current insertion point.
-        m_tokenizer.store_insertion_point();
+        m_tokenizer.store_old_insertion_point();
 
         // Let the insertion point be just before the next input character.
         m_tokenizer.update_insertion_point();
@@ -3624,7 +3624,7 @@ void HTMLParser::handle_text(HTMLToken& token)
             m_parser_pause_flag = false;
 
         // Let the insertion point have the value of the old insertion point.
-        m_tokenizer.restore_insertion_point();
+        m_tokenizer.restore_old_insertion_point();
 
         // At this stage, if the pending parsing-blocking script is not null, then:
         if (document().pending_parsing_blocking_script()) {
@@ -4844,7 +4844,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         // Pop the current node off the stack of open elements.
         auto& script_element = as<SVG::SVGScriptElement>(*m_stack_of_open_elements.pop());
         // Let the old insertion point have the same value as the current insertion point.
-        m_tokenizer.store_insertion_point();
+        m_tokenizer.store_old_insertion_point();
         // Let the insertion point be just before the next input character.
         m_tokenizer.update_insertion_point();
         // Increment the parser's script nesting level by one.
@@ -4866,7 +4866,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
             m_parser_pause_flag = false;
 
         // Let the insertion point have the value of the old insertion point.
-        m_tokenizer.restore_insertion_point();
+        m_tokenizer.restore_old_insertion_point();
 
         // If the SVG script registered itself as a pending parsing-blocking script (external fetch in flight),
         // pause the parser and schedule a resume check. The parser will resume from

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2904,7 +2904,7 @@ void HTMLTokenizer::parser_did_run(Badge<HTMLParser>)
     if (m_current_offset > 0
         && static_cast<size_t>(m_current_offset) == m_decoded_input.size()
         && (!m_insertion_point.has_value() || *m_insertion_point == 0)
-        && (!m_old_insertion_point.has_value() || *m_old_insertion_point == 0)) {
+        && m_old_insertion_points.is_empty()) {
         m_decoded_input.clear();
         m_current_offset = 0;
         m_prev_offset = 0;
@@ -2925,7 +2925,8 @@ void HTMLTokenizer::insert_input_at_insertion_point(StringView input)
     Vector<u32> new_decoded_input;
     new_decoded_input.ensure_capacity(m_decoded_input.size() + input.length());
 
-    auto before = m_decoded_input.span().slice(0, *m_insertion_point);
+    auto insertion_point = *m_insertion_point;
+    auto before = m_decoded_input.span().slice(0, insertion_point);
     new_decoded_input.append(before.data(), before.size());
 
     auto utf8_to_insert = MUST(String::from_utf8(input));
@@ -2935,11 +2936,15 @@ void HTMLTokenizer::insert_input_at_insertion_point(StringView input)
         ++code_points_inserted;
     }
 
-    auto after = m_decoded_input.span().slice(*m_insertion_point);
+    auto after = m_decoded_input.span().slice(insertion_point);
     new_decoded_input.append(after.data(), after.size());
     m_decoded_input = move(new_decoded_input);
 
     m_insertion_point.value() += code_points_inserted;
+    for (auto& old_insertion_point : m_old_insertion_points) {
+        if (old_insertion_point.has_value() && insertion_point <= *old_insertion_point)
+            old_insertion_point.value() += code_points_inserted;
+    }
 }
 
 void HTMLTokenizer::insert_eof()

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -11,6 +11,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibGC/Cell.h>
 #include <LibGC/Ptr.h>
 #include <LibWeb/Export.h>
@@ -141,8 +142,8 @@ public:
     bool is_insertion_point_defined() const { return m_insertion_point.has_value(); }
     bool is_insertion_point_reached() { return m_insertion_point.has_value() && m_current_offset >= *m_insertion_point; }
     void undefine_insertion_point() { m_insertion_point = {}; }
-    void store_insertion_point() { m_old_insertion_point = m_insertion_point; }
-    void restore_insertion_point() { m_insertion_point = move(m_old_insertion_point); }
+    void store_old_insertion_point() { m_old_insertion_points.append(m_insertion_point); }
+    void restore_old_insertion_point() { m_insertion_point = m_old_insertion_points.take_last(); }
     void update_insertion_point() { m_insertion_point = m_current_offset; }
 
     // This permanently cuts off the tokenizer input stream.
@@ -200,7 +201,8 @@ private:
     Vector<u32> m_decoded_input;
 
     Optional<ssize_t> m_insertion_point;
-    Optional<ssize_t> m_old_insertion_point;
+    // Spec algorithms have an "old insertion point" local; reentrant script execution can nest those locals.
+    Vector<Optional<ssize_t>> m_old_insertion_points;
 
     ssize_t m_current_offset { 0 };
     ssize_t m_prev_offset { 0 };

--- a/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/html5lib_scripted_webkit01@run_type=write_single.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/html5lib_scripted_webkit01@run_type=write_single.txt
@@ -2,6 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	html5lib_scripted_webkit01.html 3ff6ec1125852c7933bf6d89ecb375354e6e1b40
-Fail	html5lib_scripted_webkit01.html 46ae362de712eb9c55916de93110299dbbcb5726
+2 Pass
+Pass	html5lib_scripted_webkit01.html 3ff6ec1125852c7933bf6d89ecb375354e6e1b40
+Pass	html5lib_scripted_webkit01.html 46ae362de712eb9c55916de93110299dbbcb5726

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_003.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	document.write script into iframe
+1 Pass
+Pass	document.write script into iframe


### PR DESCRIPTION
The HTML parser's script end tag algorithms save the current insertion point in an "old insertion point" local before executing a script, then restore that local after script execution. Ladybird modeled that local as a single tokenizer field, so nested script execution via document.write() could overwrite the outer script's saved value.

Keep a stack of old insertion points instead, and adjust saved offsets when document.write() inserts new input before them. This keeps the normal script and SVG script paths aligned with the spec text while leaving the parser-blocking script resume path to set the insertion point to undefined again.