### PR TITLE
Add a PDF reader using PDF.js

### DIFF
--- a/Base/res/ladybird/pdfjs/pdfjs-ladybird-transport.mjs
+++ b/Base/res/ladybird/pdfjs/pdfjs-ladybird-transport.mjs
@@ -1,0 +1,32 @@
+async function openPdf(response) {
+    await window.PDFViewerApplication.initializedPromise;
+
+    const workerSrc = "resource://ladybird/pdfjs/build/pdf.worker.mjs";
+    window.PDFViewerApplicationOptions.set("workerSrc", workerSrc);
+
+    const sourceUrl = response.url;
+    if (sourceUrl) window.PDFViewerApplication.setTitleUsingUrl(sourceUrl, sourceUrl);
+
+    const contentLength = parseInt(response.headers.get("Content-Length") ?? "0", 10);
+    const { PDFDataRangeTransport } = globalThis.pdfjsLib;
+    const transport = new PDFDataRangeTransport(contentLength, new Uint8Array());
+    window.PDFViewerApplication.open({ range: transport, disableRange: true });
+    if (response.body) {
+        const reader = response.body.getReader();
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                transport.onDataProgressiveRead(value);
+            }
+        } finally {
+            transport.onDataProgressiveDone();
+        }
+    } else {
+        const buf = await response.arrayBuffer();
+        transport.onDataProgressiveRead(new Uint8Array(buf));
+        transport.onDataProgressiveDone();
+    }
+}
+document.addEventListener("ladybirdpdf", ({ detail: response }) => openPdf(response), { once: true });
+document.dispatchEvent(new CustomEvent("ladybirdviewerready"));

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -364,9 +364,13 @@ Origin URL::origin() const
         return Origin(scheme(), host().value(), port());
     }
 
+    // AD-HOC: resource:// URLs are internal browser resources; give them a shared tuple origin
+    // so that same-origin checks pass between any two resource:// documents or worker scripts.
+    if (scheme() == "resource"sv)
+        return Origin(scheme(), String {}, {});
+
     // -> "file"
-    // AD-HOC: Our resource:// is basically an alias to file://
-    if (scheme() == "file"sv || scheme() == "resource"sv) {
+    if (scheme() == "file"sv) {
         // Unfortunate as it is, this is left as an exercise to the reader. When in doubt, return a new opaque origin.
 
         // Our implementation-defined behavior is to return an opaque origin for file:// URLs,

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -8,18 +8,26 @@
 
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
+#include <AK/Utf16FlyString.h>
 #include <LibCore/Promise.h>
+#include <LibCore/Resource.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
+#include <LibJS/Runtime/NativeFunction.h>
 #include <LibTextCodec/Decoder.h>
+#include <LibURL/URL.h>
+#include <LibWeb/DOM/CustomEvent.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentLoading.h>
+#include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/MIME.h>
+#include <LibWeb/Fetch/Response.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/Parser/HTMLEncodingDetection.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Parser/IncrementalDocumentParser.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/MimeSniff/Resource.h>
 #include <LibWeb/Namespace.h>
@@ -399,6 +407,45 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_media_document(HTML::Nav
     // be true for the Document.
 }
 
+// Renders the PDF using the bundled pdf.js viewer at an internal resource:// URL.
+static GC::Ref<DOM::Document> load_pdf_document(HTML::NavigationParams const& navigation_params)
+{
+    VERIFY(navigation_params.response->url().has_value());
+    auto pdf_url = navigation_params.response->url().value();
+
+    static auto const s_viewer_bytes = MUST(Core::Resource::load_from_uri("resource://ladybird/pdfjs/web/viewer.html"sv))->clone_data();
+
+    auto document = MUST(DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params));
+    document->set_origin(URL::Origin("resource"_string, String {}, {}));
+
+    auto& realm = document->realm();
+    auto js_response = Fetch::Response::create(realm, GC::Ref(*navigation_params.response), Fetch::Headers::Guard::Response);
+
+    auto listener_fn = JS::NativeFunction::create(
+        realm, [document, js_response](JS::VM&) mutable -> JS::ThrowCompletionOr<JS::Value> {
+            DOM::CustomEventInit init;
+            init.detail = JS::Value(js_response.ptr());
+            document->dispatch_event(*DOM::CustomEvent::create(document->realm(), "ladybirdpdf"_fly_string, init));
+            return JS::js_undefined();
+        },
+        0, Utf16FlyString {}, &realm);
+    auto callback = realm.heap().allocate<WebIDL::CallbackType>(*listener_fn, realm);
+    document->add_event_listener_without_options("ladybirdviewerready"_fly_string, *DOM::IDLEventListener::create(realm, *callback));
+
+    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(document->heap(), [document, pdf_url] {
+        auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, s_viewer_bytes);
+        if (document->ready_to_run_scripts()) {
+            parser->run(pdf_url);
+        } else {
+            document->set_deferred_parser_start(GC::create_function(document->heap(), [parser, pdf_url] {
+                parser->run(pdf_url);
+            }));
+        }
+    }));
+
+    return document;
+}
+
 bool can_load_document_with_type(MimeSniff::MimeType const& type)
 {
     if (type.is_html())
@@ -489,9 +536,7 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     // -> "text/pdf"
     if (type.essence() == "application/pdf"_string
         || type.essence() == "text/pdf"_string) {
-        // FIXME: If the user agent's PDF viewer supported is true, return the result of creating a document for inline
-        //        content that doesn't have a DOM given navigationParams's navigable, navigationParams's id,
-        //        navigationParams's navigation timing type, and navigationParams's user involvement.
+        return load_pdf_document(navigation_params);
     }
 
     // Otherwise, proceed onward.

--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -677,6 +677,38 @@
       ]
     },
     {
+      "name": "pdfjs",
+      "buildsystem": "simple",
+      "build-commands": [
+        "patch -p1 -i 0001-ladybird-embed.patch",
+        "install -d /app/share/pdfjs/build /app/share/pdfjs/web/images /app/share/pdfjs/web/locale/en-US",
+        "install -m644 build/*.mjs /app/share/pdfjs/build/",
+        "install -m644 web/viewer.html web/viewer.mjs web/viewer.css /app/share/pdfjs/web/",
+        "cp -r web/images/. /app/share/pdfjs/web/images/",
+        "install -m644 web/locale/locale.json /app/share/pdfjs/web/locale/",
+        "install -m644 web/locale/en-US/viewer.ftl /app/share/pdfjs/web/locale/en-US/"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/mozilla/pdf.js.git",
+          "tag": "v5.6.205",
+          "dest": "pdfjs-src"
+        },
+        {
+          "type": "archive",
+          "url": "https://github.com/mozilla/pdf.js/releases/download/v5.6.205/pdfjs-5.6.205-dist.zip",
+          "sha256": "0555ef47464e456125dcd0b9742cfa2aaed6d282e804e4dd1f1b99316b46ac00",
+          "dest": ".",
+          "strip-components": 0
+        },
+        {
+          "type": "file",
+          "path": "../vcpkg/overlay-ports/pdfjs/0001-ladybird-embed.patch"
+        }
+      ]
+    },
+    {
       "name": "Ladybird",
       "buildsystem": "cmake-ninja",
       "sources": [

--- a/Meta/CMake/vcpkg/overlay-ports/pdfjs/0001-ladybird-embed.patch
+++ b/Meta/CMake/vcpkg/overlay-ports/pdfjs/0001-ladybird-embed.patch
@@ -1,0 +1,42 @@
+--- a/web/viewer.html
++++ b/web/viewer.html
+@@ -22,18 +22,19 @@
+ -->
+ <html dir="ltr" mozdisallowselectionprint>
+   <head>
++    <base href="resource://ladybird/pdfjs/web/">
+     <meta charset="utf-8" />
+     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+     <meta name="google" content="notranslate" />
+     <title>PDF.js viewer</title>
+ 
+ <!-- This snippet is used in production (included from viewer.html) -->
+-<link rel="resource" type="application/l10n" href="locale/locale.json" />
+ <script src="../build/pdf.mjs" type="module"></script>
+ 
+     <link rel="stylesheet" href="viewer.css" />
+ 
+   <script src="viewer.mjs" type="module"></script>
++  <script src="pdfjs-ladybird-transport.mjs" type="module"></script>
+   </head>
+ 
+   <body tabindex="0">
+--- a/web/viewer.mjs
++++ b/web/viewer.mjs
+@@ -18255,7 +18255,7 @@
+     let file;
+     const queryString = document.location.search.substring(1);
+     const params = parseQueryString(queryString);
+-    file = params.get("file") ?? AppOptions.get("defaultUrl");
++    file = params.get("file") ?? "";
+     try {
+       file = new URL(file).href;
+     } catch {
+@@ -18886,7 +18886,6 @@
+     this.metadata = metadata;
+     this._contentDispositionFilename ??= contentDispositionFilename;
+     this._contentLength ??= contentLength;
+-    console.log(`PDF ${pdfDocument.fingerprints[0]} [${info.PDFFormatVersion} ` + `${(metadata?.get("pdf:producer") || info.Producer || "-").trim()} / ` + `${(metadata?.get("xmp:creatortool") || info.Creator || "-").trim()}` + `] (PDF.js: ${version || "?"} [${build || "?"}])`);
+     const pdfTitle = this._docTitle;
+     if (pdfTitle) {
+       this.setTitle(`${pdfTitle} - ${this._contentDispositionFilename || this._title}`);

--- a/Meta/CMake/vcpkg/overlay-ports/pdfjs/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/pdfjs/portfile.cmake
@@ -1,0 +1,48 @@
+# pdf.js is a prebuilt web asset — nothing to compile.
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/mozilla/pdf.js/releases/download/v${VERSION}/pdfjs-${VERSION}-dist.zip"
+    FILENAME "pdfjs-${VERSION}-dist.zip"
+    SHA512 66fecdb8a80d013b592c361e85abd7eeea5bc35f0131b771cc25a1878d7737704458dc715670aace3c7d3437f85388dff04796fe117eef01be81fd0d192f73a2
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+# Patch viewer.mjs so the internal Ladybird PDF viewer origin is accepted.
+z_vcpkg_apply_patches(
+    SOURCE_PATH "${SOURCE_PATH}"
+    PATCHES 0001-ladybird-embed.patch
+)
+
+# build/: pdf.mjs, pdf.worker.mjs, pdf.sandbox.mjs (no .map files)
+file(GLOB BUILD_MJS "${SOURCE_PATH}/build/*.mjs")
+file(INSTALL ${BUILD_MJS} DESTINATION "${CURRENT_PACKAGES_DIR}/share/pdfjs/build")
+
+# web/: viewer HTML, scripts and CSS
+file(INSTALL
+    "${SOURCE_PATH}/web/viewer.html"
+    "${SOURCE_PATH}/web/viewer.mjs"
+    "${SOURCE_PATH}/web/viewer.css"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/pdfjs/web"
+)
+
+# web/images/: toolbar icons
+file(INSTALL "${SOURCE_PATH}/web/images/"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/pdfjs/web/images")
+
+# web/locale/: en-US only with a minimal locale.json
+file(INSTALL "${SOURCE_PATH}/web/locale/en-US/"
+     DESTINATION "${CURRENT_PACKAGES_DIR}/share/pdfjs/web/locale/en-US")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/pdfjs/web/locale/locale.json"
+    "{\"en-us\":\"en-US/viewer.ftl\"}")
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/pdfjs/copyright"
+    "pdf.js is licensed under the Apache 2.0 License.\n"
+    "See https://github.com/mozilla/pdf.js/blob/master/LICENSE\n")

--- a/Meta/CMake/vcpkg/overlay-ports/pdfjs/vcpkg.json
+++ b/Meta/CMake/vcpkg/overlay-ports/pdfjs/vcpkg.json
@@ -1,0 +1,5 @@
+{
+  "name": "pdfjs",
+  "version": "5.6.205",
+  "description": "PDF.js prebuilt web viewer assets"
+}

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -786,6 +786,29 @@ TEST_CASE(same_origin_domain)
     EXPECT(!opaque1.is_same_origin_domain(a_relaxed));
 }
 
+// resource:// URLs are internal browser resources. They share a single tuple origin regardless
+// of host, so that same-origin checks pass between any resource:// documents or worker scripts.
+TEST_CASE(resource_url_origin)
+{
+    auto url_a = URL::Parser::basic_parse("resource://ladybird/pdfjs/web/viewer.html"sv).value();
+    auto url_b = URL::Parser::basic_parse("resource://ladybird/pdfjs/build/pdf.worker.mjs"sv).value();
+    auto url_c = URL::Parser::basic_parse("resource://icons/something.png"sv).value();
+
+    // resource:// origins must be tuple origins, not opaque.
+    EXPECT(!url_a.origin().is_opaque());
+
+    // All resource:// URLs share the same origin regardless of host or path.
+    EXPECT(url_a.origin().is_same_origin(url_b.origin()));
+    EXPECT(url_a.origin().is_same_origin(url_c.origin()));
+
+    // resource:// and https:// are never same-origin.
+    auto https_origin = URL::Parser::basic_parse("https://ladybird.org"sv).value().origin();
+    EXPECT(!url_a.origin().is_same_origin(https_origin));
+
+    // resource:// and an opaque origin are never same-origin.
+    EXPECT(!url_a.origin().is_same_origin(URL::Origin::create_opaque()));
+}
+
 TEST_CASE(authority_state_lots_of_at_symbols)
 {
     auto many_at_symbols = MUST(String::repeated('@', 500'000));

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -1,0 +1,538 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div#outerContainer> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          BlockContainer <span#viewer-alert.visuallyHidden> at [0,0] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+          Box <div#mainContainer> at [0,0] positioned flex-container(column) [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <div.toolbar> at [0,0] flex-item [0+0+0 800 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div#toolbarContainer> at [1,2] positioned [0+0+1 798 1+0+0] [0+0+2 28 2+0+0] children: inline
+                frag 0 from Box start: 0, length: 0, rect: [1,2 798x28] baseline: 14
+                TextNode <#text> (not painted)
+                Box <div#toolbarViewer.toolbarHorizontalGroup> at [1,2] flex-container(row) [0+0+0 798 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                  BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                    TextNode <#text> (not painted)
+                  Box <div#toolbarViewerLeft.toolbarHorizontalGroup> at [9,2] flex-container(row) flex-item [8+0+0 240.359375 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <button#viewsManagerToggleButton.toolbarButton> at [9,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> at [15,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <span> at [31,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                        frag 0 from TextNode start: 0, length: 6, rect: [31,16 56.34375x18] baseline: 13.796875
+                            "Manage"
+                        frag 1 from TextNode start: 7, length: 5, rect: [31,34 44.390625x18] baseline: 13.796875
+                            "pages"
+                        TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                      TextNode <#text> (not painted)
+                      TextNode <#text> (not painted)
+                    BlockContainer <div.toolbarButtonSpacer> at [38,15.5] flex-item [0+0+0 30 0+0+0] [0+0+0 1 0+0+0] [BFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    BlockContainer <div.toolbarButtonWithContainer> at [69,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
+                      BlockContainer <(anonymous)> at [69,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#viewFindButton.toolbarButton> at [69,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [75,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [91,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 4, rect: [91,16 34.578125x18] baseline: 13.796875
+                              "Find"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> at [69,30] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                        TextNode <#text> (not painted)
+                        TextNode <#text> (not painted)
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <div.toolbarHorizontalGroup.hiddenSmallView> at [98,2] flex-container(row) flex-item [0+0+0 59 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#previous.toolbarButton> at [98,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [104,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [120,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 8, rect: [120,16 71.3125x18] baseline: 13.796875
+                              "Previous"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <div.splitToolbarButtonSeparator> at [128,7.328125] flex-item [0+1+0 0 0+0+0] [0+0+0 17.359375 0+0+0] [BFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#next.toolbarButton> at [129,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [135,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [151,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 4, rect: [151,16 35.5625x18] baseline: 13.796875
+                              "Next"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <div.toolbarHorizontalGroup> at [158,2] flex-container(row) flex-item [0+0+0 91.359375 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <span.loadingInput.start.toolbarHorizontalGroup> at [158,2] positioned flex-container(row) flex-item [0+0+0 56 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        TextInputBox <input#pageNumber.toolbarField> at [166,7] flex-item [0+1+7 40 7+1+0] [3+1+4 18 4+1+3] [BFC] children: not-inline
+                          Box <div> at [168,8] flex-container(row) [0+0+2 36 2+0+0] [0+0+1 16 1+0+0] [FFC] children: not-inline
+                            BlockContainer <div> at [168,8] flex-item [0+0+0 36 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                              frag 0 from TextNode start: 0, length: 1, rect: [199.234375,8 4.765625x16] baseline: 11.59375
+                                  "1"
+                              TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <span#numPages.toolbarLabel> at [220,2] flex-container(column) flex-item [2+0+3 23.359375 4+0+2] [2+0+0 28 0+0+2] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [220,9] flex-item [0+0+0 23.359375 0+0+0] [0+0+0 14 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 6, rect: [220,9 23.359375x14] baseline: 10.59375
+                              "of ⁨1⁩"
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                  BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                    TextNode <#text> (not painted)
+                  Box <div#toolbarViewerMiddle.toolbarHorizontalGroup> at [313.9375,2] flex-container(row) flex-item [0+0+0 206.484375 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <div.toolbarHorizontalGroup> at [313.9375,2] flex-container(row) flex-item [0+0+0 59 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#zoomOutButton.toolbarButton> at [313.9375,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [319.9375,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [335.9375,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 4, rect: [335.9375,16 45.53125x18] baseline: 13.796875
+                              "Zoom"
+                          frag 1 from TextNode start: 5, length: 3, rect: [335.9375,34 28.109375x18] baseline: 13.796875
+                              "Out"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <div.splitToolbarButtonSeparator> at [343.9375,7.328125] flex-item [0+1+0 0 0+0+0] [0+0+0 17.359375 0+0+0] [BFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#zoomInButton.toolbarButton> at [344.9375,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [350.9375,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [366.9375,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 4, rect: [366.9375,16 45.53125x18] baseline: 13.796875
+                              "Zoom"
+                          frag 1 from TextNode start: 5, length: 2, rect: [366.9375,34 14.203125x18] baseline: 13.796875
+                              "In"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <span#scaleSelectContainer.dropdownToolbarButton> at [373.9375,2] positioned flex-container(row) flex-item [0+0+0 146.484375 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <select#scaleSelect> at [379.9375,3] flex-item [0+0+6 102.484375 38+0+0] [0+0+1 25 2+0+0] [BFC] children: not-inline
+                        Box <div> at [379.9375,3] flex-container(row) [0+0+0 102.484375 0+0+0] [0+0+0 25 0+0+0] [FFC] children: not-inline
+                          BlockContainer <div> at [379.9375,8.5] flex-item [0+0+0 102.484375 0+0+0] [0+0+0 14 0+0+0] [BFC] children: inline
+                            frag 0 from TextNode start: 0, length: 14, rect: [379.9375,8.5 102.484375x14] baseline: 10.59375
+                                "Automatic Zoom"
+                            TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> at [500.421875,8] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                  BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                    TextNode <#text> (not painted)
+                  Box <div#toolbarViewerRight.toolbarHorizontalGroup> at [585,2] flex-container(row) flex-item [0+0+0 214 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <div#editorModeButtons.toolbarHorizontalGroup> at [585,2] flex-container(row) flex-item [0+0+0 115 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                        TextNode <#text> (not painted)
+                        TextNode <#text> (not painted)
+                      BlockContainer <div#editorHighlight.toolbarButtonWithContainer> at [585,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
+                        BlockContainer <(anonymous)> at [585,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                        Box <button#editorHighlightButton.toolbarButton> at [585,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                          BlockContainer <(anonymous)> at [591,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <span> at [607,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                            frag 0 from TextNode start: 0, length: 9, rect: [607,16 66.171875x18] baseline: 13.796875
+                                "Highlight"
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> at [585,30] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <div#editorFreeText.toolbarButtonWithContainer> at [614,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
+                        BlockContainer <(anonymous)> at [614,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                        Box <button#editorFreeTextButton.toolbarButton> at [614,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                          BlockContainer <(anonymous)> at [620,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <span> at [636,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                            frag 0 from TextNode start: 0, length: 4, rect: [636,16 37.578125x18] baseline: 13.796875
+                                "Text"
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> at [614,30] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <div#editorInk.toolbarButtonWithContainer> at [643,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
+                        BlockContainer <(anonymous)> at [643,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                        Box <button#editorInkButton.toolbarButton> at [643,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                          BlockContainer <(anonymous)> at [649,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <span> at [665,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                            frag 0 from TextNode start: 0, length: 4, rect: [665,16 40.53125x18] baseline: 13.796875
+                                "Draw"
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> at [643,30] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      BlockContainer <div#editorStamp.toolbarButtonWithContainer> at [672,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
+                        BlockContainer <(anonymous)> at [672,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                        Box <button#editorStampButton.toolbarButton> at [672,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                          BlockContainer <(anonymous)> at [678,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                          BlockContainer <span> at [694,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                            frag 0 from TextNode start: 0, length: 3, rect: [694,16 29.984375x18] baseline: 13.796875
+                                "Add"
+                            frag 1 from TextNode start: 4, length: 2, rect: [694,34 19.1875x18] baseline: 13.796875
+                                "or"
+                            frag 2 from TextNode start: 7, length: 4, rect: [694,52 28x18] baseline: 13.796875
+                                "edit"
+                            frag 3 from TextNode start: 12, length: 6, rect: [694,70 51.734375x18] baseline: 13.796875
+                                "images"
+                            TextNode <#text> (not painted)
+                          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                            TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> at [672,30] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                          TextNode <#text> (not painted)
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    BlockContainer <div#editorModeSeparator.verticalToolbarSeparator> at [704,4.796875] flex-item [2+1+0 0 0+0+2] [0+0+0 22.40625 0+0+0] [BFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    Box <div.toolbarHorizontalGroup.hiddenMediumView> at [707,2] flex-container(row) flex-item [0+0+0 57 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#printButton.toolbarButton> at [707,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [713,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [729,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 5, rect: [729,16 41.390625x18] baseline: 13.796875
+                              "Print"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#downloadButton.toolbarButton> at [736,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [742,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [758,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 4, rect: [758,16 38.234375x18] baseline: 13.796875
+                              "Save"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    BlockContainer <div.verticalToolbarSeparator.hiddenMediumView> at [768,4.796875] flex-item [2+1+0 0 0+0+2] [0+0+0 22.40625 0+0+0] [BFC] children: not-inline
+                    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                      TextNode <#text> (not painted)
+                    BlockContainer <div#secondaryToolbarToggle.toolbarButtonWithContainer> at [771,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
+                      BlockContainer <(anonymous)> at [771,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                        TextNode <#text> (not painted)
+                      Box <button#secondaryToolbarToggleButton.toolbarButton> at [771,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
+                        BlockContainer <(anonymous)> at [777,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+                          TextNode <#text> (not painted)
+                        BlockContainer <span> at [793,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 5, rect: [793,16 46.59375x18] baseline: 13.796875
+                              "Tools"
+                          TextNode <#text> (not painted)
+                        BlockContainer <(anonymous)> at [771,2] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                          TextNode <#text> (not painted)
+                      BlockContainer <(anonymous)> at [771,30] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
+                        TextNode <#text> (not painted)
+                        TextNode <#text> (not painted)
+                        TextNode <#text> (not painted)
+                    BlockContainer <(anonymous)> at [585,2] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                      TextNode <#text> (not painted)
+                  BlockContainer <(anonymous)> at [1,2] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+                    TextNode <#text> (not painted)
+                TextNode <#text> (not painted)
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> at [0,32] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <div#viewerContainer> at [0,32] positioned [0+0+0 800 0+0+0] [0+0+0 568 0+0+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [0,32] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div#viewer.pdfViewer> at [0,33] [0+0+0 800 0+0+0] [0+0+0 151 0+0+-8] children: not-inline
+                BlockContainer <div.page> at [233.5,42] positioned [224.5+9+0 333 0+9+224.5] [1+9+0 133 0+9+-8] children: not-inline
+                  BlockContainer <div.canvasWrapper> at [233.5,42] [0+0+0 333 0+0+0] [0+0+0 133 0+0+0] [BFC] children: not-inline
+                    CanvasBox <canvas> at [233.5,42] positioned [0+0+0 333 0+0+0] [0+0+0 133 0+0+0] children: not-inline
+                  BlockContainer <div.textLayer> at [233.5,42] positioned [0+0+0 333 0+0+0] [0+0+0 133 0+0+0] [BFC] children: not-inline
+                    BlockContainer <span> at [316.75,64.9375] positioned [0+0+0 121.046875 0+0+0] [0+0+0 23.328125 0+0+0] [BFC] children: inline
+                      frag 0 from TextNode start: 0, length: 9, rect: [316.75,64.9375 121.046875x23.328125] baseline: 18.65625
+                          "Hello PDF"
+                      TextNode <#text> (not painted)
+                    BlockContainer <div.endOfContent> at [233.5,175] positioned [0+0+0 333 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+                  BlockContainer <div.annotationLayer> at [233.5,42] positioned [0+0+0 333 0+0+0] [0+0+0 133 0+0+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [0,176] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        BlockContainer <div#dialogContainer> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,600] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x600]
+      PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#outerContainer) [0,0 800x600]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+          PaintableWithLines (BlockContainer<SPAN>#viewer-alert.visuallyHidden) [0,0 0x0]
+          PaintableBox (Box<DIV>#mainContainer) [0,0 800x600]
+            PaintableWithLines (BlockContainer<DIV>.toolbar) [0,0 800x32]
+              PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+              PaintableWithLines (BlockContainer<DIV>#toolbarContainer) [0,0 800x32]
+                PaintableBox (Box<DIV>#toolbarViewer.toolbarHorizontalGroup) [1,2 798x28]
+                  PaintableBox (Box<DIV>#toolbarViewerLeft.toolbarHorizontalGroup) [9,2 240.359375x28]
+                    PaintableBox (Box<BUTTON>#viewsManagerToggleButton.toolbarButton) [9,2 28x28]
+                      PaintableWithLines (BlockContainer(anonymous)) [15,8 16x16]
+                      PaintableWithLines (BlockContainer<SPAN>) [31,16 0x0] overflow: [31,16 56.34375x36]
+                        TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer<DIV>.toolbarButtonSpacer) [38,15.5 30x1]
+                    PaintableWithLines (BlockContainer<DIV>.toolbarButtonWithContainer) [69,2 28x28]
+                      PaintableWithLines (BlockContainer(anonymous)) [69,2 28x0]
+                      PaintableBox (Box<BUTTON>#viewFindButton.toolbarButton) [69,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [75,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [91,16 0x0] overflow: [91,16 34.578125x18]
+                          TextPaintable (TextNode<#text>)
+                      PaintableWithLines (BlockContainer(anonymous)) [69,30 28x0]
+                    PaintableBox (Box<DIV>.toolbarHorizontalGroup.hiddenSmallView) [98,2 59x28]
+                      PaintableBox (Box<BUTTON>#previous.toolbarButton) [98,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [104,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [120,16 0x0] overflow: [120,16 71.3125x18]
+                          TextPaintable (TextNode<#text>)
+                      PaintableWithLines (BlockContainer<DIV>.splitToolbarButtonSeparator) [127,7.328125 1x17.359375]
+                      PaintableBox (Box<BUTTON>#next.toolbarButton) [129,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [135,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [151,16 0x0] overflow: [151,16 35.5625x18]
+                          TextPaintable (TextNode<#text>)
+                    PaintableBox (Box<DIV>.toolbarHorizontalGroup) [158,2 91.359375x28]
+                      PaintableBox (Box<SPAN>.loadingInput.start.toolbarHorizontalGroup) [158,2 56x28]
+                        PaintableWithLines (TextInputBox<INPUT>#pageNumber.toolbarField) [158,2 56x28]
+                          PaintableBox (Box<DIV>) [166,7 40x18]
+                            PaintableWithLines (BlockContainer<DIV>) [168,8 36x16]
+                              TextPaintable (TextNode<#text>)
+                      PaintableBox (Box<SPAN>#numPages.toolbarLabel) [217,2 30.359375x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [220,9 23.359375x14]
+                          TextPaintable (TextNode<#text>)
+                  PaintableBox (Box<DIV>#toolbarViewerMiddle.toolbarHorizontalGroup) [313.9375,2 206.484375x28]
+                    PaintableBox (Box<DIV>.toolbarHorizontalGroup) [313.9375,2 59x28]
+                      PaintableBox (Box<BUTTON>#zoomOutButton.toolbarButton) [313.9375,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [319.9375,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [335.9375,16 0x0] overflow: [335.9375,16 45.53125x36]
+                          TextPaintable (TextNode<#text>)
+                      PaintableWithLines (BlockContainer<DIV>.splitToolbarButtonSeparator) [342.9375,7.328125 1x17.359375]
+                      PaintableBox (Box<BUTTON>#zoomInButton.toolbarButton) [344.9375,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [350.9375,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [366.9375,16 0x0] overflow: [366.9375,16 45.53125x36]
+                          TextPaintable (TextNode<#text>)
+                    PaintableBox (Box<SPAN>#scaleSelectContainer.dropdownToolbarButton) [373.9375,2 146.484375x28]
+                      PaintableWithLines (BlockContainer<SELECT>#scaleSelect) [373.9375,2 146.484375x28]
+                        PaintableBox (Box<DIV>) [379.9375,3 102.484375x25]
+                          PaintableWithLines (BlockContainer<DIV>) [379.9375,8.5 102.484375x14]
+                            TextPaintable (TextNode<#text>)
+                      PaintableWithLines (BlockContainer(anonymous)) [500.421875,8 16x16]
+                  PaintableBox (Box<DIV>#toolbarViewerRight.toolbarHorizontalGroup) [585,2 214x28]
+                    PaintableBox (Box<DIV>#editorModeButtons.toolbarHorizontalGroup) [585,2 115x28]
+                      PaintableWithLines (BlockContainer<DIV>#editorHighlight.toolbarButtonWithContainer) [585,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [585,2 28x0]
+                        PaintableBox (Box<BUTTON>#editorHighlightButton.toolbarButton) [585,2 28x28]
+                          PaintableWithLines (BlockContainer(anonymous)) [591,8 16x16]
+                          PaintableWithLines (BlockContainer<SPAN>) [607,16 0x0] overflow: [607,16 66.171875x18]
+                            TextPaintable (TextNode<#text>)
+                        PaintableWithLines (BlockContainer(anonymous)) [585,30 28x0]
+                      PaintableWithLines (BlockContainer<DIV>#editorFreeText.toolbarButtonWithContainer) [614,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [614,2 28x0]
+                        PaintableBox (Box<BUTTON>#editorFreeTextButton.toolbarButton) [614,2 28x28]
+                          PaintableWithLines (BlockContainer(anonymous)) [620,8 16x16]
+                          PaintableWithLines (BlockContainer<SPAN>) [636,16 0x0] overflow: [636,16 37.578125x18]
+                            TextPaintable (TextNode<#text>)
+                        PaintableWithLines (BlockContainer(anonymous)) [614,30 28x0]
+                      PaintableWithLines (BlockContainer<DIV>#editorInk.toolbarButtonWithContainer) [643,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [643,2 28x0]
+                        PaintableBox (Box<BUTTON>#editorInkButton.toolbarButton) [643,2 28x28]
+                          PaintableWithLines (BlockContainer(anonymous)) [649,8 16x16]
+                          PaintableWithLines (BlockContainer<SPAN>) [665,16 0x0] overflow: [665,16 40.53125x18]
+                            TextPaintable (TextNode<#text>)
+                        PaintableWithLines (BlockContainer(anonymous)) [643,30 28x0]
+                      PaintableWithLines (BlockContainer<DIV>#editorStamp.toolbarButtonWithContainer) [672,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [672,2 28x0]
+                        PaintableBox (Box<BUTTON>#editorStampButton.toolbarButton) [672,2 28x28]
+                          PaintableWithLines (BlockContainer(anonymous)) [678,8 16x16]
+                          PaintableWithLines (BlockContainer<SPAN>) [694,16 0x0] overflow: [694,16 51.734375x72]
+                            TextPaintable (TextNode<#text>)
+                        PaintableWithLines (BlockContainer(anonymous)) [672,30 28x0]
+                    PaintableWithLines (BlockContainer<DIV>#editorModeSeparator.verticalToolbarSeparator) [703,4.796875 1x22.40625]
+                    PaintableBox (Box<DIV>.toolbarHorizontalGroup.hiddenMediumView) [707,2 57x28]
+                      PaintableBox (Box<BUTTON>#printButton.toolbarButton) [707,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [713,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [729,16 0x0] overflow: [729,16 41.390625x18]
+                          TextPaintable (TextNode<#text>)
+                      PaintableBox (Box<BUTTON>#downloadButton.toolbarButton) [736,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [742,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [758,16 0x0] overflow: [758,16 38.234375x18]
+                          TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer<DIV>.verticalToolbarSeparator.hiddenMediumView) [767,4.796875 1x22.40625]
+                    PaintableWithLines (BlockContainer<DIV>#secondaryToolbarToggle.toolbarButtonWithContainer) [771,2 28x28]
+                      PaintableWithLines (BlockContainer(anonymous)) [771,2 28x0]
+                      PaintableBox (Box<BUTTON>#secondaryToolbarToggleButton.toolbarButton) [771,2 28x28]
+                        PaintableWithLines (BlockContainer(anonymous)) [777,8 16x16]
+                        PaintableWithLines (BlockContainer<SPAN>) [793,16 0x0] overflow: [793,16 46.59375x18]
+                          TextPaintable (TextNode<#text>)
+                        PaintableWithLines (BlockContainer(anonymous)) [771,2 0x0]
+                      PaintableWithLines (BlockContainer(anonymous)) [771,30 28x0]
+                    PaintableWithLines (BlockContainer(anonymous)) [585,2 0x0]
+                  PaintableWithLines (BlockContainer(anonymous)) [1,2 0x0]
+              PaintableWithLines (BlockContainer(anonymous)) [0,32 800x0]
+            PaintableWithLines (BlockContainer<DIV>#viewerContainer) [0,32 800x568]
+              PaintableWithLines (BlockContainer(anonymous)) [0,32 800x0]
+              PaintableWithLines (BlockContainer<DIV>#viewer.pdfViewer) [0,33 800x151]
+                PaintableWithLines (BlockContainer<DIV>.page) [224.5,33 351x151]
+                  PaintableWithLines (BlockContainer<DIV>.canvasWrapper) [233.5,42 333x133]
+                    CanvasPaintable (CanvasBox<CANVAS>) [233.5,42 333x133]
+                  PaintableWithLines (BlockContainer<DIV>.textLayer) [233.5,42 333x133]
+                    PaintableWithLines (BlockContainer<SPAN>) [316.75,64.9375 121.046875x23.328125]
+                      TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer<DIV>.endOfContent) [233.5,175 333x0]
+                  PaintableWithLines (BlockContainer<DIV>.annotationLayer) [233.5,42 333x133]
+              PaintableWithLines (BlockContainer(anonymous)) [0,176 800x0]
+        PaintableWithLines (BlockContainer<DIV>#dialogContainer) [0,0 800x0]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,600 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x600] [children: 2] (z-index: auto)
+  SC for BlockContainer<DIV>#viewerContainer [0,32 800x568] [children: 2] (z-index: 0)
+   SC for CanvasBox<CANVAS> [233.5,42 333x133] [children: 0] (z-index: auto)
+   SC for BlockContainer<DIV>.textLayer [233.5,42 333x133] [children: 2] (z-index: 0)
+    SC for BlockContainer<DIV>.endOfContent [233.5,175 333x0] [children: 0] (z-index: 0), has_transform
+    SC for BlockContainer<SPAN> [316.75,64.9375 121.046875x23.328125] [children: 0] (z-index: 1), has_transform
+  SC for BlockContainer<DIV>.toolbar [0,0 800x32] [children: 14] (z-index: 2)
+   SC for BlockContainer(anonymous) [15,8 16x16] [children: 0] (z-index: auto), has_transform
+   SC for BlockContainer(anonymous) [75,8 16x16] [children: 0] (z-index: auto)
+   SC for Box<BUTTON>#previous.toolbarButton [98,2 28x28] [children: 1] (z-index: auto)
+    SC for BlockContainer(anonymous) [104,8 16x16] [children: 0] (z-index: auto)
+   SC for Box<BUTTON>#next.toolbarButton [129,2 28x28] [children: 1] (z-index: auto)
+    SC for BlockContainer(anonymous) [135,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [319.9375,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [350.9375,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [500.421875,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [591,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [620,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [649,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [678,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [713,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [742,8 16x16] [children: 0] (z-index: auto)
+   SC for BlockContainer(anonymous) [777,8 16x16] [children: 0] (z-index: auto), has_transform

--- a/Tests/LibWeb/Layout/input/pdf-viewer.pdf
+++ b/Tests/LibWeb/Layout/input/pdf-viewer.pdf
@@ -1,0 +1,35 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R
+   /MediaBox [0 0 200 80]
+   /Resources << /Font << /F1 5 0 R >> >>
+   /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 39 >>
+stream
+BT /F1 14 Tf 50 55 Td (Hello PDF) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000249 00000 n 
+0000000338 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+408
+%%EOF

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -79,7 +79,7 @@ static ErrorOr<ByteString> prepare_output_path(Test const& test)
 
 static bool is_valid_test_name(StringView test_name)
 {
-    auto valid_test_file_suffixes = { ".htm"sv, ".html"sv, ".svg"sv, ".xhtml"sv, ".xht"sv };
+    auto valid_test_file_suffixes = { ".htm"sv, ".html"sv, ".svg"sv, ".xhtml"sv, ".xht"sv, ".pdf"sv };
     return AK::any_of(valid_test_file_suffixes, [&](auto suffix) { return test_name.ends_with(suffix); });
 }
 
@@ -273,6 +273,17 @@ static auto wait_for_test_completion = generate_wait_for_test_string("test-wait"
 static auto wait_for_reftest_completion = generate_wait_for_test_string("reftest-wait"sv, R"(
     afterFontsAndPaint(() => document.documentElement.dispatchEvent(new Event("TestRendered", { bubbles: true })));
 )"sv);
+
+// For PDF tests: by the time this runs (after on_load_finish), ladybirdpdf has already fired
+// and openPdf() is in progress; initializedPromise lets us hook in at the right moment.
+// Text mode uses the page count; Layout mode ignores the signalTestIsDone argument.
+static auto const wait_for_pdf_done = R"(
+window.PDFViewerApplication.initializedPromise.then(() => {
+    window.PDFViewerApplication.eventBus.on('pagesloaded', () => {
+        internals.signalTestIsDone(`Pages: ${window.PDFViewerApplication.pagesCount}`);
+    });
+});
+)"_string;
 
 static ErrorOr<void> generate_result_files(ReadonlySpan<Test> tests, ReadonlySpan<TestCompletion> non_passing_tests)
 {
@@ -504,12 +515,16 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
     };
 
     if (test.mode == TestMode::Layout) {
-        view.on_load_finish = [&view, url](auto const& loaded_url) {
+        view.on_load_finish = [&view, &context, test_index, url](auto const& loaded_url) {
             // We don't want subframe loads to trigger the test finish.
             if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
                 return;
 
-            view.run_javascript(wait_for_test_completion);
+            auto const& test = context.tests[test_index];
+            auto const& script = LexicalPath(test.input_path).extension() == "pdf"sv
+                ? wait_for_pdf_done
+                : wait_for_test_completion;
+            view.run_javascript(script);
         };
 
         view.on_test_finish = [&view, &context, test_index, on_test_complete = move(on_test_complete)](auto const&) {

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -108,6 +108,31 @@ set(CONFIG_RESOURCES
 )
 list(TRANSFORM CONFIG_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/default-config/")
 
+# pdf.js viewer assets installed by the pdfjs vcpkg port.
+# Only populated when building with vcpkg and pdfjs is installed.
+set(PDFJS_BUILD_FILES "")
+set(PDFJS_WEB_BASE_FILES "")
+set(PDFJS_WEB_IMAGE_FILES "")
+set(PDFJS_WEB_LOCALE_JSON "")
+set(PDFJS_WEB_LOCALE_EN_US "")
+set(PDFJS_VIEWER_HTML "")
+if (NOT "${VCPKG_INSTALLED_DIR}" STREQUAL "" AND NOT "${VCPKG_TARGET_TRIPLET}" STREQUAL "")
+    set(_pdfjs_vcpkg_dir "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/pdfjs")
+    if (EXISTS "${_pdfjs_vcpkg_dir}/build/pdf.mjs")
+        file(GLOB PDFJS_BUILD_FILES "${_pdfjs_vcpkg_dir}/build/*.mjs")
+        set(_pdfjs_ladybird_dir "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/pdfjs")
+        set(PDFJS_WEB_BASE_FILES
+            "${_pdfjs_ladybird_dir}/pdfjs-ladybird-transport.mjs"
+            "${_pdfjs_vcpkg_dir}/web/viewer.mjs"
+            "${_pdfjs_vcpkg_dir}/web/viewer.css"
+        )
+        file(GLOB PDFJS_WEB_IMAGE_FILES "${_pdfjs_vcpkg_dir}/web/images/*")
+        set(PDFJS_WEB_LOCALE_JSON "${_pdfjs_vcpkg_dir}/web/locale/locale.json")
+        set(PDFJS_WEB_LOCALE_EN_US "${_pdfjs_vcpkg_dir}/web/locale/en-US/viewer.ftl")
+        set(PDFJS_VIEWER_HTML "${_pdfjs_vcpkg_dir}/web/viewer.html")
+    endif()
+endif()
+
 function(copy_resource_set subdir)
     cmake_parse_arguments(PARSE_ARGV 1 "COPY" "" "TARGET;DESTINATION" "RESOURCES")
     set(inputs ${COPY_RESOURCES})
@@ -192,6 +217,24 @@ function(copy_resources_to_build base_directory bundle_target)
         DESTINATION ${base_directory} TARGET ${bundle_target}
     )
 
+    if (PDFJS_BUILD_FILES)
+        copy_resource_set(ladybird/pdfjs/build RESOURCES ${PDFJS_BUILD_FILES}
+            DESTINATION ${base_directory} TARGET ${bundle_target}
+        )
+        copy_resource_set(ladybird/pdfjs/web RESOURCES ${PDFJS_WEB_BASE_FILES} ${PDFJS_VIEWER_HTML}
+            DESTINATION ${base_directory} TARGET ${bundle_target}
+        )
+        copy_resource_set(ladybird/pdfjs/web/images RESOURCES ${PDFJS_WEB_IMAGE_FILES}
+            DESTINATION ${base_directory} TARGET ${bundle_target}
+        )
+        copy_resource_set(ladybird/pdfjs/web/locale RESOURCES ${PDFJS_WEB_LOCALE_JSON}
+            DESTINATION ${base_directory} TARGET ${bundle_target}
+        )
+        copy_resource_set(ladybird/pdfjs/web/locale/en-US RESOURCES ${PDFJS_WEB_LOCALE_EN_US}
+            DESTINATION ${base_directory} TARGET ${bundle_target}
+        )
+    endif()
+
     add_dependencies(${bundle_target} "${bundle_target}_build_resource_files")
 endfunction()
 
@@ -208,4 +251,11 @@ function(install_ladybird_resources destination component)
     install(FILES ${ABOUT_SETTINGS_RESOURCES} DESTINATION "${destination}/ladybird/about-pages/settings" COMPONENT ${component})
     install(FILES ${WEB_TEMPLATES} DESTINATION "${destination}/ladybird/templates" COMPONENT ${component})
     install(FILES ${CONFIG_RESOURCES} DESTINATION "${destination}/ladybird/default-config" COMPONENT ${component})
+    if (PDFJS_BUILD_FILES)
+        install(FILES ${PDFJS_BUILD_FILES} DESTINATION "${destination}/ladybird/pdfjs/build" COMPONENT ${component})
+        install(FILES ${PDFJS_WEB_BASE_FILES} ${PDFJS_VIEWER_HTML} DESTINATION "${destination}/ladybird/pdfjs/web" COMPONENT ${component})
+        install(FILES ${PDFJS_WEB_IMAGE_FILES} DESTINATION "${destination}/ladybird/pdfjs/web/images" COMPONENT ${component})
+        install(FILES ${PDFJS_WEB_LOCALE_JSON} DESTINATION "${destination}/ladybird/pdfjs/web/locale" COMPONENT ${component})
+        install(FILES ${PDFJS_WEB_LOCALE_EN_US} DESTINATION "${destination}/ladybird/pdfjs/web/locale/en-US" COMPONENT ${component})
+    endif()
 endfunction()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -115,6 +115,7 @@
     },
     "mimalloc",
     "openssl",
+    "pdfjs",
     {
       "name": "pthread",
       "platform": "windows"
@@ -367,6 +368,10 @@
     {
       "name": "openssl",
       "version": "3.5.3#0"
+    },
+    {
+      "name": "pdfjs",
+      "version": "5.6.205"
     },
     {
       "name": "pthread",


### PR DESCRIPTION
Adds inline PDF viewing using the bundled pdf.js viewer. 

When Ladybird loads a PDF response, it renders it at an internal `ladybird-pdfjs-viewer://` scheme
(isolated origin, same-origin checks work) while showing the original PDF URL in the address bar, which is similar to how it is implemented in WebKit.

The pdf.js dist is pulled in as a vcpkg overlay port.

Tested to work with a few example pdfs over file://, http:// and https://.

<img width="1028" height="777" alt="image" src="https://github.com/user-attachments/assets/78be6faf-0978-4048-b629-c1a4693f9fae" />
