### PR TITLE
LibWeb: Remove unused m_skip_event_loop_processing_steps flag

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -119,9 +119,6 @@ void EventLoop::spin_until(GC::Ref<GC::Function<bool()>> goal_condition)
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
 void EventLoop::process()
 {
-    if (m_skip_event_loop_processing_steps)
-        return;
-
     // 1. Let oldestTask and taskStartTime be null.
     GC::Ptr<Task> oldest_task;
     [[maybe_unused]] double task_start_time = 0;

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -141,8 +141,6 @@ private:
 
     bool m_execution_paused { false };
 
-    bool m_skip_event_loop_processing_steps { false };
-
     bool m_running_rendering_task { false };
 
     GC::Ptr<GC::Function<void()>> m_rendering_task_function;


### PR DESCRIPTION
This member was always false and never written, so the early-return in EventLoop::process() was dead code.