### PR TITLE
Don't track @font-face rules as critical subresources

### DIFF
--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -222,22 +222,8 @@ void CSSFontFaceRule::dump(StringBuilder& builder, int indent_levels) const
     Base::dump(builder, indent_levels);
 
     dump_indent(builder, indent_levels + 1);
-    builder.appendff("Loading state: {}\n", CSSStyleSheet::loading_state_name(loading_state()));
-
-    dump_indent(builder, indent_levels + 1);
     builder.appendff("Valid: {}\n", is_valid());
     dump_descriptors(builder, descriptors(), indent_levels + 1);
-}
-
-void CSSFontFaceRule::set_parent_style_sheet(CSSStyleSheet* parent_style_sheet)
-{
-    if (m_parent_style_sheet)
-        m_parent_style_sheet->remove_critical_subresource(*this);
-
-    Base::set_parent_style_sheet(parent_style_sheet);
-
-    if (m_parent_style_sheet)
-        m_parent_style_sheet->add_critical_subresource(*this);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.h
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.h
@@ -9,16 +9,13 @@
 
 #include <LibWeb/CSS/CSSFontFaceDescriptors.h>
 #include <LibWeb/CSS/CSSRule.h>
-#include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ParsedFontFace.h>
 
 namespace Web::CSS {
 
 class FontFace;
 
-class CSSFontFaceRule final
-    : public CSSRule
-    , public CSSStyleSheet::Subresource {
+class CSSFontFaceRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSFontFaceRule, CSSRule);
     GC_DECLARE_ALLOCATOR(CSSFontFaceRule);
 
@@ -47,10 +44,6 @@ private:
     virtual void dump(StringBuilder&, int indent_levels) const override;
 
     void handle_src_descriptor_change();
-
-    virtual void set_parent_style_sheet(CSSStyleSheet*) override;
-
-    GC::Ptr<CSSStyleSheet> parent_style_sheet_for_subresource() override { return parent_style_sheet(); }
 
     GC::Ref<CSSFontFaceDescriptors> m_style;
     GC::Ptr<FontFace> m_css_connected_font_face;

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Bindings/FontFace.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
+#include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFace.h>
@@ -737,8 +738,6 @@ GC::Ref<WebIDL::Promise> FontFace::load()
     // 3. Otherwise, set font face’s status attribute to "loading", return font face’s [[FontStatusPromise]],
     //    and continue executing the rest of this algorithm asynchronously.
     m_status = Bindings::FontFaceLoadStatus::Loading;
-    if (m_css_font_face_rule)
-        m_css_font_face_rule->set_loading_state(CSSStyleSheet::LoadingState::Loading);
 
     // AD-HOC: Switch the containing FontFaceSets to "loading" for URL-backed fonts too, mirroring the step the
     //         constructor performs for BufferSource-backed fonts.
@@ -764,8 +763,6 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                 //    is "NetworkError" and set font face’s status attribute to "error".
                 if (!maybe_typeface) {
                     m_status = Bindings::FontFaceLoadStatus::Error;
-                    if (m_css_font_face_rule)
-                        m_css_font_face_rule->set_loading_state(CSSStyleSheet::LoadingState::Error);
                     WebIDL::reject_promise(realm(), m_font_status_promise, WebIDL::NetworkError::create(realm(), "Failed to load font"_utf16));
 
                     // For each FontFaceSet font face is in:
@@ -787,8 +784,6 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                     m_parsed_font = maybe_typeface;
                     m_status = Bindings::FontFaceLoadStatus::Loaded;
                     WebIDL::resolve_promise(realm(), m_font_status_promise, this);
-                    if (m_css_font_face_rule)
-                        m_css_font_face_rule->set_loading_state(CSSStyleSheet::LoadingState::Loaded);
 
                     if (auto font_computer = this->font_computer(); font_computer.has_value())
                         font_computer->register_font_face(*this);

--- a/Tests/LibWeb/Text/expected/load-event-fires-with-unused-font-face.txt
+++ b/Tests/LibWeb/Text/expected/load-event-fires-with-unused-font-face.txt
@@ -1,0 +1,1 @@
+load event fired

--- a/Tests/LibWeb/Text/input/load-event-fires-with-unused-font-face.html
+++ b/Tests/LibWeb/Text/input/load-event-fires-with-unused-font-face.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+var xhr = new XMLHttpRequest();
+xhr.open("POST", "/echo", false);
+xhr.setRequestHeader("Content-Type", "application/json");
+xhr.send(JSON.stringify({
+    method: "GET",
+    path: "/echo/font-face-unused-unicode-range.css",
+    status: 200,
+    headers: {"Content-Type": "text/css", "Cache-Control": "no-store"},
+    body: "@font-face { font-family: 'NeverUsed'; src: url('https://invalid.example/never.woff2') format('woff2'); unicode-range: U+E000-F8FF; }",
+}));
+</script>
+<link rel="stylesheet" href="/echo/font-face-unused-unicode-range.css">
+<script>
+asyncTest((done) => {
+    window.addEventListener("load", () => {
+        println("load event fired");
+        done();
+    });
+});
+</script>

--- a/Tests/LibWeb/Text/input/load-event-fires-with-unused-font-face.html.headers
+++ b/Tests/LibWeb/Text/input/load-event-fires-with-unused-font-face.html.headers
@@ -1,0 +1,1 @@
+Content-Type: text/html


### PR DESCRIPTION
CSSFontFaceRule inherited from CSSStyleSheet::Subresource, which made each face a critical subresource of its parent stylesheet. New subresources start in the Unloaded state, and the stylesheet's loading_state() treats Unloaded as Loading.

When a @font-face declares a unicode-range and no codepoint in that range is ever rendered, FontComputer only registers the face for matching and never calls FontFace::load() on it. The face stays Unloaded, so the parent stylesheet stays stuck reporting Loading, which keeps HTMLLinkElement's load-event delayer alive and prevents the document load event from firing. HTMLParserEndState then times out in phase 2 (WaitingForLoadEventDelay) after 15 seconds.

Decouple @font-face from the stylesheet's loading state. Font loading remains tracked by FontFaceSet, which is the correct place.