### PR TITLE
LibWeb: Avoid global rule cache rebuilds for scoped style changes

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -8,12 +8,14 @@
 #include <LibWeb/Bindings/CSSStyleProperties.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleProperties.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleSheetInvalidation.h>
 #include <LibWeb/CSS/StyleValues/ColorFunctionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FunctionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
@@ -1402,6 +1404,11 @@ void CSSStyleProperties::invalidate_owners(DOM::StyleInvalidationReason reason)
 {
     if (auto rule = parent_rule()) {
         if (auto sheet = rule->parent_style_sheet()) {
+            if (rule->type() == CSSRule::Type::Style || rule->type() == CSSRule::Type::NestedDeclarations) {
+                invalidate_style_for_style_sheet_owners(*sheet, reason, ShouldInvalidateRuleCache::No);
+                return;
+            }
+
             sheet->invalidate_owners(reason);
         }
     }

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -420,51 +420,7 @@ void CSSStyleSheet::for_each_owning_style_scope(Function<void(StyleScope&)> cons
 void CSSStyleSheet::invalidate_owners(DOM::StyleInvalidationReason reason, ShadowRootStylesheetEffects const* previous_sheet_effects)
 {
     m_did_match = {};
-
-    for (auto& document_or_shadow_root : m_owning_documents_or_shadow_roots) {
-        auto& style_scope = document_or_shadow_root->is_shadow_root()
-            ? as<DOM::ShadowRoot>(*document_or_shadow_root).style_scope()
-            : document_or_shadow_root->document().style_scope();
-
-        style_scope.invalidate_rule_cache();
-        style_scope.node().invalidate_style(reason);
-
-        auto* shadow_root = as_if<DOM::ShadowRoot>(style_scope.node());
-        if (!shadow_root)
-            continue;
-
-        invalidate_assigned_elements_for_dirty_slots(*shadow_root);
-
-        auto* host = shadow_root->host();
-        if (!host)
-            continue;
-
-        auto effects = determine_shadow_root_stylesheet_effects(*shadow_root);
-        if (effects.may_match_light_dom_under_shadow_host && !effects.may_match_shadow_host) {
-            host->invalidate_style(reason);
-        } else if (effects.may_match_light_dom_under_shadow_host) {
-            host->root().invalidate_style(reason);
-        } else if (effects.may_affect_assigned_nodes_via_slots) {
-            host->invalidate_style(reason);
-        } else if (effects.may_match_shadow_host) {
-            host->invalidate_style(reason);
-            shadow_root->set_needs_style_update(true);
-        } else if (previous_sheet_effects) {
-            // `replaceSync("")`, `deleteRule()`, or disabling the last host-reaching rule can remove all evidence of
-            // host-side effects from the post-mutation stylesheet set. Fall back to the pre-mutation snapshot so the
-            // host side still gets the right invalidation.
-            if (previous_sheet_effects->may_match_light_dom_under_shadow_host && !previous_sheet_effects->may_match_shadow_host) {
-                host->invalidate_style(reason);
-            } else if (previous_sheet_effects->may_match_light_dom_under_shadow_host) {
-                host->root().invalidate_style(reason);
-            } else if (previous_sheet_effects->may_affect_assigned_nodes_via_slots) {
-                host->invalidate_style(reason);
-            } else if (previous_sheet_effects->may_match_shadow_host) {
-                host->invalidate_style(reason);
-                shadow_root->set_needs_style_update(true);
-            }
-        }
-    }
+    invalidate_style_for_style_sheet_owners(*this, reason, ShouldInvalidateRuleCache::Yes, previous_sheet_effects);
 }
 
 GC::Ptr<DOM::Document> CSSStyleSheet::owning_document() const

--- a/Libraries/LibWeb/CSS/StyleSheetInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetInvalidation.cpp
@@ -548,6 +548,48 @@ ShadowRootStylesheetEffects determine_shadow_root_stylesheet_effects(CSSStyleShe
     return effects;
 }
 
+static bool invalidate_shadow_host_side_for_style_sheet_change(DOM::ShadowRoot& shadow_root, DOM::StyleInvalidationReason reason, ShadowRootStylesheetEffects const& effects)
+{
+    auto* host = shadow_root.host();
+    if (!host)
+        return false;
+
+    if (effects.may_match_light_dom_under_shadow_host && !effects.may_match_shadow_host) {
+        host->invalidate_style(reason);
+    } else if (effects.may_match_light_dom_under_shadow_host) {
+        host->root().invalidate_style(reason);
+    } else if (effects.may_affect_assigned_nodes_via_slots) {
+        host->invalidate_style(reason);
+    } else if (effects.may_match_shadow_host) {
+        host->invalidate_style(reason);
+        shadow_root.set_needs_style_update(true);
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+void invalidate_style_for_style_sheet_owners(CSSStyleSheet const& style_sheet, DOM::StyleInvalidationReason reason, ShouldInvalidateRuleCache rule_cache_invalidation, ShadowRootStylesheetEffects const* previous_sheet_effects)
+{
+    style_sheet.for_each_owning_style_scope([&](StyleScope& style_scope) {
+        if (rule_cache_invalidation == ShouldInvalidateRuleCache::Yes)
+            style_scope.invalidate_rule_cache();
+
+        style_scope.node().invalidate_style(reason);
+
+        auto* shadow_root = as_if<DOM::ShadowRoot>(style_scope.node());
+        if (!shadow_root)
+            return;
+
+        invalidate_assigned_elements_for_dirty_slots(*shadow_root);
+        bool invalidated_host_side = invalidate_shadow_host_side_for_style_sheet_change(*shadow_root, reason, determine_shadow_root_stylesheet_effects(*shadow_root));
+
+        if (!invalidated_host_side && previous_sheet_effects)
+            invalidate_shadow_host_side_for_style_sheet_change(*shadow_root, reason, *previous_sheet_effects);
+    });
+}
+
 void invalidate_owners_for_inserted_keyframes_rule(CSSStyleSheet const& style_sheet, CSSKeyframesRule const& keyframes_rule)
 {
     for (auto& document_or_shadow_root : style_sheet.owning_documents_or_shadow_roots()) {

--- a/Libraries/LibWeb/CSS/StyleSheetInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleSheetInvalidation.h
@@ -45,6 +45,11 @@ struct ShadowRootStylesheetEffects {
     bool may_affect_assigned_nodes_via_slots { false };
 };
 
+enum class ShouldInvalidateRuleCache {
+    No,
+    Yes,
+};
+
 // Extend `result` with the invalidation effects of `style_rule`'s selectors. Falls back to a whole-subtree
 // invalidation flag inside `result` when a selector is not amenable to targeted invalidation.
 void extend_style_sheet_invalidation_set_with_style_rule(StyleSheetInvalidationSet& result, CSSStyleRule const& style_rule);
@@ -71,6 +76,10 @@ void invalidate_assigned_elements_for_dirty_slots(DOM::ShadowRoot&);
 // Summarize how `style_sheet` can escape the shadow subtree across all shadow roots it is owned by. Used to snapshot
 // the pre-mutation reach of a sheet whose own rules are about to change.
 ShadowRootStylesheetEffects determine_shadow_root_stylesheet_effects(CSSStyleSheet const&);
+
+// Invalidate style for every document or shadow root that owns `style_sheet`, including any host-side fallout for
+// shadow-root selectors. Callers choose whether the rule cache must be invalidated for the mutation they perform.
+void invalidate_style_for_style_sheet_owners(CSSStyleSheet const& style_sheet, DOM::StyleInvalidationReason, ShouldInvalidateRuleCache, ShadowRootStylesheetEffects const* previous_sheet_effects = nullptr);
 
 // Apply a targeted invalidation to all documents and shadow roots that own `style_sheet` in response to inserting
 // `style_rule` into it.

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -57,6 +57,7 @@
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
+#include <LibWeb/CSS/StyleSheetInvalidation.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
@@ -4024,26 +4025,32 @@ void Document::evaluate_media_queries_and_report_changes()
 
 void Document::evaluate_media_rules()
 {
-    bool any_media_queries_changed_match_state = false;
+    bool document_media_queries_changed_match_state = false;
     style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
         if (style_sheet.evaluate_media_queries(*this))
-            any_media_queries_changed_match_state = true;
+            document_media_queries_changed_match_state = true;
     });
 
     for_each_shadow_root([&](auto& shadow_root) {
+        bool shadow_root_media_queries_changed_match_state = false;
         shadow_root.style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
             if (style_sheet.evaluate_media_queries(*this))
-                any_media_queries_changed_match_state = true;
+                shadow_root_media_queries_changed_match_state = true;
         });
+
+        if (!shadow_root_media_queries_changed_match_state)
+            return;
+
+        shadow_root.style_scope().invalidate_rule_cache();
+        shadow_root.invalidate_style(StyleInvalidationReason::MediaQueryChangedMatchState);
+        CSS::invalidate_assigned_elements_for_dirty_slots(shadow_root);
+
+        if (auto* host = shadow_root.host())
+            host->root().invalidate_style(StyleInvalidationReason::MediaQueryChangedMatchState);
     });
 
-    if (any_media_queries_changed_match_state) {
-        // FIXME: Make this more efficient
+    if (document_media_queries_changed_match_state) {
         style_scope().invalidate_rule_cache();
-        for_each_shadow_root([&](auto& shadow_root) {
-            shadow_root.style_scope().invalidate_rule_cache();
-        });
-
         invalidate_style(StyleInvalidationReason::MediaQueryChangedMatchState);
     }
 }

--- a/Libraries/LibWeb/DOM/StyleInvalidator.cpp
+++ b/Libraries/LibWeb/DOM/StyleInvalidator.cpp
@@ -170,8 +170,10 @@ void StyleInvalidator::perform_pending_style_invalidations(Node& node, bool inva
         auto& element = static_cast<Element&>(node);
         if (auto shadow_root = element.shadow_root()) {
             perform_pending_style_invalidations(*shadow_root, invalidate_entire_subtree);
-            if (invalidate_entire_subtree)
-                node.set_child_needs_style_update(true);
+            if (invalidate_entire_subtree || shadow_root->needs_style_update() || shadow_root->child_needs_style_update()) {
+                for (auto* ancestor = &node; ancestor; ancestor = ancestor->parent_or_shadow_host())
+                    ancestor->set_child_needs_style_update(true);
+            }
         }
     }
 

--- a/Tests/LibWeb/Text/expected/css/cssom-style-declaration-mutation-uses-existing-rule-cache.txt
+++ b/Tests/LibWeb/Text/expected/css/cssom-style-declaration-mutation-uses-existing-rule-cache.txt
@@ -1,0 +1,2 @@
+Before mutation: rgb(255, 0, 0)
+After mutation: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/expected/css/shadow-media-query-invalidation-stays-scoped.txt
+++ b/Tests/LibWeb/Text/expected/css/shadow-media-query-invalidation-stays-scoped.txt
@@ -1,0 +1,2 @@
+Target color: rgb(0, 128, 0)
+PASS: shadow media query invalidation stayed scoped (12 invalidations)

--- a/Tests/LibWeb/Text/expected/css/shadow-root-dirty-style-update-before-layout.txt
+++ b/Tests/LibWeb/Text/expected/css/shadow-root-dirty-style-update-before-layout.txt
@@ -1,0 +1,1 @@
+Slot color after forced layout: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/input/css/cssom-style-declaration-mutation-uses-existing-rule-cache.html
+++ b/Tests/LibWeb/Text/input/css/cssom-style-declaration-mutation-uses-existing-rule-cache.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .target { color: rgb(255, 0, 0); }
+</style>
+<div class="target"></div>
+<script>
+    test(() => {
+        const target = document.querySelector(".target");
+        const rule = document.styleSheets[0].cssRules[0];
+
+        println(`Before mutation: ${getComputedStyle(target).color}`);
+
+        rule.style.color = "rgb(0, 128, 0)";
+
+        println(`After mutation: ${getComputedStyle(target).color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/shadow-media-query-invalidation-stays-scoped.html
+++ b/Tests/LibWeb/Text/input/css/shadow-media-query-invalidation-stays-scoped.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function createShadowTree(styleText, className) {
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = `
+            <style>${styleText}</style>
+            <div class="${className}">target</div>
+        `;
+        return shadowRoot.querySelector(`.${className}`);
+    }
+
+    test(() => {
+        for (let i = 0; i < 20; ++i)
+            createShadowTree(".bystander { color: rgb(255, 0, 0); }", "bystander");
+
+        getComputedStyle(document.body).color;
+        internals.resetStyleInvalidationCounters();
+
+        const target = createShadowTree("@media (min-width: 1px) { .target { color: rgb(0, 128, 0); } }", "target");
+        println(`Target color: ${getComputedStyle(target).color}`);
+
+        const invalidations = internals.getStyleInvalidationCounters().styleInvalidations;
+        if (invalidations <= 15)
+            println(`PASS: shadow media query invalidation stayed scoped (${invalidations} invalidations)`);
+        else
+            println(`FAIL: shadow media query invalidation was too broad (${invalidations} invalidations)`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/shadow-root-dirty-style-update-before-layout.html
+++ b/Tests/LibWeb/Text/input/css/shadow-root-dirty-style-update-before-layout.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="host">host text</div>
+<script>
+    test(() => {
+        const host = document.getElementById("host");
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        const sheet = new CSSStyleSheet();
+
+        shadowRoot.innerHTML = "<slot></slot>";
+        shadowRoot.adoptedStyleSheets = [sheet];
+
+        sheet.replaceSync("slot { color: rgb(0, 128, 0); }");
+        getComputedStyle(shadowRoot.querySelector("slot")).color;
+
+        sheet.replaceSync("slot { color: rgb(0, 0, 255); }");
+        document.body.innerText;
+
+        println(`Slot color after forced layout: ${getComputedStyle(shadowRoot.querySelector("slot")).color}`);
+    });
+</script>


### PR DESCRIPTION
Avoid rebuilding every style scope's rule cache when only one document or shadow-root scope changed.

This keeps media query invalidation scoped to the affected style scope, preserves dirty shadow-root reachability for forced layout, and keeps rule caches valid for CSSOM declaration mutations that do not affect selector buckets, layer ordering, or keyframe lookup.

On my Linux machine, when opening https://reddit.com, this reduced rule cache rebuilds from 4,473 to 979 and reduced measured rebuild time from 13,174 ms to 3,223 ms.

We still spend way too much time rebuilding these things, but that's a huge improvement.