### PR TITLE
LibWeb: Share constructed stylesheet rule caches

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/CSS/StyleSheetInvalidation.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/DOM/Document.h>
@@ -119,6 +120,8 @@ CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& me
     };
 }
 
+CSSStyleSheet::~CSSStyleSheet() = default;
+
 void CSSStyleSheet::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(CSSStyleSheet);
@@ -135,6 +138,8 @@ void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_namespace_rules);
     visitor.visit(m_import_rules);
     visitor.visit(m_owning_documents_or_shadow_roots);
+    if (m_shared_single_constructed_sheet_style_cache)
+        m_shared_single_constructed_sheet_style_cache->visit_edges(visitor);
     for (auto& subresource : m_critical_subresources)
         subresource.visit_edges(visitor);
 }
@@ -417,9 +422,23 @@ void CSSStyleSheet::for_each_owning_style_scope(Function<void(StyleScope&)> cons
     }
 }
 
+NonnullRefPtr<StyleCache> CSSStyleSheet::shared_single_constructed_sheet_style_cache(StyleScope& style_scope)
+{
+    VERIFY(constructed());
+    if (!m_shared_single_constructed_sheet_style_cache)
+        m_shared_single_constructed_sheet_style_cache = StyleCache::create_for_style_scope(style_scope);
+    return *m_shared_single_constructed_sheet_style_cache;
+}
+
+void CSSStyleSheet::invalidate_shared_style_cache()
+{
+    m_shared_single_constructed_sheet_style_cache = nullptr;
+}
+
 void CSSStyleSheet::invalidate_owners(DOM::StyleInvalidationReason reason, ShadowRootStylesheetEffects const* previous_sheet_effects)
 {
     m_did_match = {};
+    invalidate_shared_style_cache();
     invalidate_style_for_style_sheet_owners(*this, reason, ShouldInvalidateRuleCache::Yes, previous_sheet_effects);
 }
 
@@ -457,6 +476,8 @@ bool CSSStyleSheet::evaluate_media_queries(DOM::Document const& document)
         any_media_queries_changed_match_state = true;
 
     m_did_match = now_matches;
+    if (any_media_queries_changed_match_state)
+        invalidate_shared_style_cache();
 
     return any_media_queries_changed_match_state;
 }
@@ -490,6 +511,8 @@ Optional<FlyString> CSSStyleSheet::namespace_uri(StringView namespace_prefix) co
 
 void CSSStyleSheet::recalculate_rule_caches()
 {
+    invalidate_shared_style_cache();
+
     m_default_namespace_rule = nullptr;
     m_namespace_rules.clear();
     m_import_rules.clear();

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefPtr.h>
 #include <LibWeb/CSS/CSSNamespaceRule.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSRuleList.h>
@@ -22,7 +24,9 @@
 namespace Web::CSS {
 
 class CSSImportRule;
+class StyleScope;
 struct ShadowRootStylesheetEffects;
+struct StyleCache;
 
 struct CSSStyleSheetInit {
     Optional<String> base_url {};
@@ -61,7 +65,7 @@ public:
     [[nodiscard]] static GC::Ref<CSSStyleSheet> create(JS::Realm&, CSSRuleList&, MediaList&, Optional<::URL::URL> location);
     static WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> construct_impl(JS::Realm&, Optional<CSSStyleSheetInit> const& options = {});
 
-    virtual ~CSSStyleSheet() override = default;
+    virtual ~CSSStyleSheet() override;
 
     GC::Ptr<CSSRule const> owner_rule() const { return m_owner_css_rule; }
     GC::Ptr<CSSRule> owner_rule() { return m_owner_css_rule; }
@@ -97,6 +101,7 @@ public:
     GC::Ptr<DOM::Document> owning_document() const;
     virtual void set_disabled(bool) override;
     void for_each_owning_style_scope(Function<void(StyleScope&)> const&) const;
+    NonnullRefPtr<StyleCache> shared_single_constructed_sheet_style_cache(StyleScope&);
 
     Optional<FlyString> default_namespace() const;
     GC::Ptr<CSSNamespaceRule> default_namespace_rule() const { return m_default_namespace_rule; }
@@ -134,6 +139,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     void recalculate_rule_caches();
+    void invalidate_shared_style_cache();
 
     void set_constructed(bool constructed) { m_constructed = constructed; }
     void set_disallow_modification(bool disallow_modification) { m_disallow_modification = disallow_modification; }
@@ -155,6 +161,7 @@ private:
     bool m_constructed { false };
     bool m_disallow_modification { false };
     Optional<bool> m_did_match;
+    RefPtr<StyleCache> m_shared_single_constructed_sheet_style_cache;
 
     Vector<Subresource&> m_critical_subresources;
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -172,11 +172,11 @@ RuleCache const* StyleComputer::rule_cache_for_cascade_origin(CascadeOrigin casc
     auto const* rule_caches_by_layer = [&]() -> RuleCaches const* {
         switch (cascade_origin) {
         case CascadeOrigin::Author:
-            return style_scope.m_author_rule_cache;
+            return &style_scope.m_rule_cache->author_rule_cache;
         case CascadeOrigin::User:
-            return style_scope.m_user_rule_cache;
+            return &style_scope.m_rule_cache->user_rule_cache;
         case CascadeOrigin::UserAgent:
-            return style_scope.m_user_agent_rule_cache;
+            return &style_scope.m_rule_cache->user_agent_rule_cache;
         default:
             VERIFY_NOT_REACHED();
         }
@@ -199,9 +199,9 @@ RuleCache const* StyleComputer::rule_cache_for_cascade_origin(CascadeOrigin casc
 NonnullRefPtr<InvalidationPlan> StyleComputer::invalidation_plan_for_properties(Vector<InvalidationSet::Property> const& properties, StyleScope const& style_scope) const
 {
     auto result = InvalidationPlan::create();
-    if (!style_scope.m_style_invalidation_data)
+    if (!style_scope.m_rule_cache)
         return result;
-    auto const& invalidation_plans = style_scope.m_style_invalidation_data->invalidation_plans;
+    auto const& invalidation_plans = style_scope.m_rule_cache->style_invalidation_data.invalidation_plans;
     for (auto const& property : properties) {
         if (auto it = invalidation_plans.find(property); it != invalidation_plans.end()) {
             result->include_all_from(*it->value);
@@ -214,7 +214,7 @@ NonnullRefPtr<InvalidationPlan> StyleComputer::invalidation_plan_for_properties(
 
 Vector<HasInvalidationMetadata> const* StyleComputer::has_invalidation_metadata_for_property(InvalidationSet::Property const& property, StyleScope const& style_scope) const
 {
-    if (!style_scope.m_style_invalidation_data)
+    if (!style_scope.m_rule_cache)
         return nullptr;
 
     auto return_bucket_if_present = [](auto const& map, auto const& key) -> Vector<HasInvalidationMetadata> const* {
@@ -226,15 +226,15 @@ Vector<HasInvalidationMetadata> const* StyleComputer::has_invalidation_metadata_
 
     switch (property.type) {
     case InvalidationSet::Property::Type::Id:
-        return return_bucket_if_present(style_scope.m_style_invalidation_data->ids_used_in_has_selectors, property.name());
+        return return_bucket_if_present(style_scope.m_rule_cache->style_invalidation_data.ids_used_in_has_selectors, property.name());
     case InvalidationSet::Property::Type::Class:
-        return return_bucket_if_present(style_scope.m_style_invalidation_data->class_names_used_in_has_selectors, property.name());
+        return return_bucket_if_present(style_scope.m_rule_cache->style_invalidation_data.class_names_used_in_has_selectors, property.name());
     case InvalidationSet::Property::Type::Attribute:
-        return return_bucket_if_present(style_scope.m_style_invalidation_data->attribute_names_used_in_has_selectors, property.name());
+        return return_bucket_if_present(style_scope.m_rule_cache->style_invalidation_data.attribute_names_used_in_has_selectors, property.name());
     case InvalidationSet::Property::Type::TagName:
-        return return_bucket_if_present(style_scope.m_style_invalidation_data->tag_names_used_in_has_selectors, property.name());
+        return return_bucket_if_present(style_scope.m_rule_cache->style_invalidation_data.tag_names_used_in_has_selectors, property.name());
     case InvalidationSet::Property::Type::PseudoClass:
-        return return_bucket_if_present(style_scope.m_style_invalidation_data->pseudo_classes_used_in_has_selectors, property.value.get<PseudoClass>());
+        return return_bucket_if_present(style_scope.m_rule_cache->style_invalidation_data.pseudo_classes_used_in_has_selectors, property.value.get<PseudoClass>());
     default:
         break;
     }
@@ -1259,7 +1259,7 @@ StyleComputer::MatchingRuleSet StyleComputer::build_matching_rule_set(DOM::Abstr
     sort_matching_rules(matching_rule_set.user_rules);
 
     // @layer-ed author rules
-    for (auto const& layer_name : style_scope.m_qualified_layer_names_in_order) {
+    for (auto const& layer_name : style_scope.m_rule_cache->qualified_layer_names_in_order) {
         auto layer_rules = collect_matching_rules(abstract_element, CascadeOrigin::Author, attempted_pseudo_class_matches, layer_name);
         sort_matching_rules(layer_rules);
         matching_rule_set.author_rules.append({ layer_name, layer_rules });

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -241,7 +241,7 @@ Vector<HasInvalidationMetadata> const* StyleComputer::has_invalidation_metadata_
     return nullptr;
 }
 
-Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name) const
+Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(DOM::AbstractElement abstract_element, CascadeOrigin cascade_origin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name) const
 {
     auto const& root_node = abstract_element.element().root();
     auto shadow_root = as_if<DOM::ShadowRoot>(root_node);
@@ -254,11 +254,10 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
     else if (shadow_root)
         shadow_host = shadow_root->host();
 
-    Vector<MatchingRule const&, 512> rules_to_run;
+    Vector<ScopedMatchingRule, 512> rules_to_run;
 
-    auto add_rule_to_run = [&](MatchingRule const& rule_to_run) {
+    auto add_rule_to_run = [&](MatchingRule const& rule_to_run, GC::Ptr<DOM::ShadowRoot const> rule_root) {
         // FIXME: This needs to be revised when adding support for the ::shadow selector, as it needs to cross shadow boundaries.
-        auto rule_root = rule_to_run.shadow_root;
         auto from_user_agent_or_user_stylesheet = rule_to_run.cascade_origin == CascadeOrigin::UserAgent || rule_to_run.cascade_origin == CascadeOrigin::User;
 
         // NOTE: Inside shadow trees, we only match rules that are defined in the shadow tree's style sheets.
@@ -283,42 +282,42 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
         if (selector.can_use_ancestor_filter() && should_reject_with_ancestor_filter(selector))
             return;
 
-        rules_to_run.unchecked_append(rule_to_run);
+        rules_to_run.unchecked_append({ &rule_to_run, rule_root });
     };
 
-    auto add_rules_to_run = [&](Vector<MatchingRule> const& rules) {
+    auto add_rules_to_run = [&](Vector<MatchingRule> const& rules, GC::Ptr<DOM::ShadowRoot const> rule_root) {
         rules_to_run.grow_capacity(rules_to_run.size() + rules.size());
         if (abstract_element.pseudo_element().has_value()) {
             for (auto const& rule : rules) {
                 if (rule.contains_pseudo_element && filter_namespace_rule(element_namespace_uri, rule))
-                    add_rule_to_run(rule);
+                    add_rule_to_run(rule, rule_root);
             }
         } else {
             for (auto const& rule : rules) {
                 if ((rule.slotted || rule.contains_part_pseudo_element || !rule.contains_pseudo_element) && filter_namespace_rule(element_namespace_uri, rule))
-                    add_rule_to_run(rule);
+                    add_rule_to_run(rule, rule_root);
             }
         }
     };
 
-    auto add_rules_from_cache = [&](RuleCache const& rule_cache) {
+    auto add_rules_from_cache = [&](RuleCache const& rule_cache, GC::Ptr<DOM::ShadowRoot const> rule_root) {
         rule_cache.for_each_matching_rules(abstract_element, [&](auto const& matching_rules) {
-            add_rules_to_run(matching_rules);
+            add_rules_to_run(matching_rules, rule_root);
             return IterationDecision::Continue;
         });
     };
 
     if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, nullptr))
-        add_rules_from_cache(*rule_cache);
+        add_rules_from_cache(*rule_cache, nullptr);
 
     if (shadow_root) {
         if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, shadow_root))
-            add_rules_from_cache(*rule_cache);
+            add_rules_from_cache(*rule_cache, shadow_root);
     }
 
     if (element_shadow_root) {
         if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, element_shadow_root))
-            add_rules_from_cache(*rule_cache);
+            add_rules_from_cache(*rule_cache, element_shadow_root);
     }
 
     // Walk up the slot chain for nested slots. An element can be assigned to a slot
@@ -328,7 +327,7 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
     for (GC::Ptr<HTML::HTMLSlotElement const> slot = abstract_element.element().assigned_slot_internal(); slot; slot = slot->assigned_slot_internal()) {
         if (auto const* slot_shadow_root = as_if<DOM::ShadowRoot>(slot->root())) {
             if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, slot_shadow_root)) {
-                add_rules_to_run(rule_cache->slotted_rules);
+                add_rules_to_run(rule_cache->slotted_rules, slot_shadow_root);
             }
         }
     }
@@ -338,22 +337,22 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
     // (for :host::part() within the shadow DOM's own stylesheet).
     if (shadow_root && (abstract_element.pseudo_element().has_value() || !abstract_element.element().part_names().is_empty())) {
         if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, shadow_root)) {
-            add_rules_to_run(rule_cache->part_rules);
+            add_rules_to_run(rule_cache->part_rules, shadow_root);
         }
         for (auto* part_shadow_root = abstract_element.element().first_flat_tree_ancestor_of_type<DOM::ShadowRoot>();
             part_shadow_root;
             part_shadow_root = part_shadow_root->first_flat_tree_ancestor_of_type<DOM::ShadowRoot>()) {
 
             if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, part_shadow_root)) {
-                add_rules_to_run(rule_cache->part_rules);
+                add_rules_to_run(rule_cache->part_rules, part_shadow_root);
             }
         }
         if (auto const* rule_cache = rule_cache_for_cascade_origin(cascade_origin, qualified_layer_name, nullptr)) {
-            add_rules_to_run(rule_cache->part_rules);
+            add_rules_to_run(rule_cache->part_rules, nullptr);
         }
     }
 
-    Vector<MatchingRule const*> matching_rules;
+    Vector<ScopedMatchingRule> matching_rules;
     matching_rules.ensure_capacity(rules_to_run.size());
 
     for (auto const& rule_to_run : rules_to_run) {
@@ -362,15 +361,16 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
         //       for traversal (which would confine traversal to the element itself).
         //       Instead, use the rule's shadow root's host, so that combinators can traverse
         //       up to the enclosing shadow host (e.g. for `:host(...) .descendant` selectors).
+        auto const& rule = *rule_to_run.rule;
         auto rule_root = rule_to_run.shadow_root;
         auto shadow_host_to_use = shadow_host;
         if (abstract_element.element().is_shadow_host() && rule_root != abstract_element.element().shadow_root())
             shadow_host_to_use = rule_root ? rule_root->host() : nullptr;
 
-        auto const& selector = rule_to_run.selector;
+        auto const& selector = rule.selector;
 
         SelectorEngine::MatchContext context {
-            .style_sheet_for_rule = *rule_to_run.sheet,
+            .style_sheet_for_rule = *rule.sheet,
             .subject = abstract_element.element(),
             .rule_shadow_root = rule_root,
             .collect_per_element_selector_involvement_metadata = true,
@@ -408,21 +408,23 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
                 continue;
         } else if (!SelectorEngine::matches(selector, abstract_element, shadow_host_to_use, context))
             continue;
-        matching_rules.append(&rule_to_run);
+        matching_rules.append(rule_to_run);
     }
 
     return matching_rules;
 }
 
-static void sort_matching_rules(Vector<MatchingRule const*>& matching_rules)
+static void sort_matching_rules(Vector<StyleComputer::ScopedMatchingRule>& matching_rules)
 {
-    quick_sort(matching_rules, [&](MatchingRule const* a, MatchingRule const* b) {
-        if (a->specificity == b->specificity) {
-            if (a->style_sheet_index == b->style_sheet_index)
-                return a->rule_index < b->rule_index;
-            return a->style_sheet_index < b->style_sheet_index;
+    quick_sort(matching_rules, [&](auto const& a, auto const& b) {
+        auto const* a_rule = a.rule;
+        auto const* b_rule = b.rule;
+        if (a_rule->specificity == b_rule->specificity) {
+            if (a_rule->style_sheet_index == b_rule->style_sheet_index)
+                return a_rule->rule_index < b_rule->rule_index;
+            return a_rule->style_sheet_index < b_rule->style_sheet_index;
         }
-        return a->specificity < b->specificity;
+        return a_rule->specificity < b_rule->specificity;
     });
 }
 
@@ -470,7 +472,7 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
 void StyleComputer::cascade_declarations(
     CascadedProperties& cascaded_properties,
     DOM::AbstractElement abstract_element,
-    Vector<MatchingRule const*> const& matching_rules,
+    Vector<ScopedMatchingRule> const& matching_rules,
     CascadeOrigin cascade_origin,
     Important important,
     Optional<FlyString> layer_name) const
@@ -540,7 +542,7 @@ void StyleComputer::cascade_declarations(
     };
 
     for (auto const& match : matching_rules) {
-        cascade_style_declaration(match->declaration(), match->shadow_root);
+        cascade_style_declaration(match.rule->declaration(), match.shadow_root);
     }
 
     if (cascade_origin == CascadeOrigin::Author && !abstract_element.pseudo_element().has_value()) {
@@ -550,11 +552,11 @@ void StyleComputer::cascade_declarations(
     }
 }
 
-static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<MatchingRule const*> const& matching_rules, OrderedHashMap<FlyString, StyleProperty>& custom_properties)
+static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<StyleComputer::ScopedMatchingRule> const& matching_rules, OrderedHashMap<FlyString, StyleProperty>& custom_properties)
 {
     size_t needed_capacity = 0;
     for (auto const& matching_rule : matching_rules)
-        needed_capacity += matching_rule->declaration().custom_properties().size();
+        needed_capacity += matching_rule.rule->declaration().custom_properties().size();
 
     if (!abstract_element.pseudo_element().has_value()) {
         if (auto const inline_style = abstract_element.element().inline_style())
@@ -565,7 +567,7 @@ static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vec
 
     OrderedHashMap<FlyString, StyleProperty> important_custom_properties;
     for (auto const& matching_rule : matching_rules) {
-        for (auto const& it : matching_rule->declaration().custom_properties()) {
+        for (auto const& it : matching_rule.rule->declaration().custom_properties()) {
             auto style_value = it.value.value;
             if (style_value->is_revert_layer())
                 continue;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -106,7 +106,12 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style_with_seeded_ancestors(DOM::AbstractElement);
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::AbstractElement, Optional<bool&> did_change_custom_properties) const;
 
-    [[nodiscard]] Vector<MatchingRule const*> collect_matching_rules(DOM::AbstractElement, CascadeOrigin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;
+    struct ScopedMatchingRule {
+        MatchingRule const* rule { nullptr };
+        GC::Ptr<DOM::ShadowRoot const> shadow_root;
+    };
+
+    [[nodiscard]] Vector<ScopedMatchingRule> collect_matching_rules(DOM::AbstractElement, CascadeOrigin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;
 
     NonnullRefPtr<InvalidationPlan> invalidation_plan_for_properties(Vector<InvalidationSet::Property> const&, StyleScope const&) const;
     Vector<HasInvalidationMetadata> const* has_invalidation_metadata_for_property(InvalidationSet::Property const&, StyleScope const&) const;
@@ -152,12 +157,12 @@ private:
 
     struct LayerMatchingRules {
         FlyString qualified_layer_name;
-        Vector<MatchingRule const*> rules;
+        Vector<ScopedMatchingRule> rules;
     };
 
     struct MatchingRuleSet {
-        Vector<MatchingRule const*> user_agent_rules;
-        Vector<MatchingRule const*> user_rules;
+        Vector<ScopedMatchingRule> user_agent_rules;
+        Vector<ScopedMatchingRule> user_rules;
         Vector<LayerMatchingRules> author_rules;
     };
 
@@ -177,7 +182,7 @@ private:
     void cascade_declarations(
         CascadedProperties&,
         DOM::AbstractElement,
-        Vector<MatchingRule const*> const&,
+        Vector<ScopedMatchingRule> const&,
         CascadeOrigin,
         Important,
         Optional<FlyString> layer_name) const;

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -34,20 +34,37 @@ void RuleCaches::visit_edges(GC::Cell::Visitor& visitor)
     }
 }
 
+NonnullRefPtr<StyleCache> StyleCache::create()
+{
+    auto style_cache = adopt_ref(*new StyleCache);
+    style_cache->qualified_layer_names_in_order.append({});
+    return style_cache;
+}
+
+NonnullRefPtr<StyleCache> StyleCache::create_for_style_scope(StyleScope& style_scope)
+{
+    auto style_cache = StyleCache::create();
+    style_scope.populate_rule_cache(*style_cache);
+    return style_cache;
+}
+
+void StyleCache::visit_edges(GC::Cell::Visitor& visitor)
+{
+    for (auto& cache : pseudo_class_rule_cache) {
+        if (cache)
+            cache->visit_edges(visitor);
+    }
+    author_rule_cache.visit_edges(visitor);
+    user_rule_cache.visit_edges(visitor);
+    user_agent_rule_cache.visit_edges(visitor);
+}
+
 void StyleScope::visit_edges(GC::Cell::Visitor& visitor)
 {
     visitor.visit(m_node);
     visitor.visit(m_user_style_sheet);
-    for (auto& cache : m_pseudo_class_rule_cache) {
-        if (cache)
-            cache->visit_edges(visitor);
-    }
-    if (m_author_rule_cache)
-        m_author_rule_cache->visit_edges(visitor);
-    if (m_user_rule_cache)
-        m_user_rule_cache->visit_edges(visitor);
-    if (m_user_agent_rule_cache)
-        m_user_agent_rule_cache->visit_edges(visitor);
+    if (m_rule_cache)
+        m_rule_cache->visit_edges(visitor);
 }
 
 void MatchingRule::visit_edges(GC::Cell::Visitor& visitor)
@@ -84,51 +101,58 @@ void RuleCache::visit_edges(GC::Cell::Visitor& visitor)
 StyleScope::StyleScope(GC::Ref<DOM::Node> node)
     : m_node(node)
 {
-    m_qualified_layer_names_in_order.append({});
 }
 
 void StyleScope::build_rule_cache()
 {
-    m_author_rule_cache = make<RuleCaches>();
-    m_user_rule_cache = make<RuleCaches>();
-    m_user_agent_rule_cache = make<RuleCaches>();
+    if (auto* shadow_root = as_if<DOM::ShadowRoot>(*m_node)) {
+        GC::Ptr<CSSStyleSheet> constructed_style_sheet;
+        bool saw_more_than_one_style_sheet = false;
+        shadow_root->for_each_active_css_style_sheet([&](CSSStyleSheet& style_sheet) {
+            if (constructed_style_sheet) {
+                saw_more_than_one_style_sheet = true;
+                return;
+            }
+            constructed_style_sheet = style_sheet;
+        });
 
-    m_selector_insights = make<SelectorInsights>();
-    m_style_invalidation_data = make<StyleInvalidationData>();
+        if (constructed_style_sheet && !saw_more_than_one_style_sheet && constructed_style_sheet->constructed() && !document().page().user_style().has_value()) {
+            m_rule_cache = constructed_style_sheet->shared_single_constructed_sheet_style_cache(*this);
+            return;
+        }
+    }
 
+    m_rule_cache = StyleCache::create();
+    populate_rule_cache(*m_rule_cache);
+}
+
+void StyleScope::populate_rule_cache(StyleCache& style_cache)
+{
     build_user_style_sheet_if_needed();
 
-    build_qualified_layer_names_cache();
+    build_qualified_layer_names_cache(style_cache);
 
-    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Hover)] = make<RuleCache>();
-    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Active)] = make<RuleCache>();
-    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Focus)] = make<RuleCache>();
-    m_pseudo_class_rule_cache[to_underlying(PseudoClass::FocusWithin)] = make<RuleCache>();
-    m_pseudo_class_rule_cache[to_underlying(PseudoClass::FocusVisible)] = make<RuleCache>();
-    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Target)] = make<RuleCache>();
+    style_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::Hover)] = make<RuleCache>();
+    style_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::Active)] = make<RuleCache>();
+    style_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::Focus)] = make<RuleCache>();
+    style_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::FocusWithin)] = make<RuleCache>();
+    style_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::FocusVisible)] = make<RuleCache>();
+    style_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::Target)] = make<RuleCache>();
 
-    make_rule_cache_for_cascade_origin(CascadeOrigin::Author, *m_selector_insights);
-    make_rule_cache_for_cascade_origin(CascadeOrigin::User, *m_selector_insights);
-    make_rule_cache_for_cascade_origin(CascadeOrigin::UserAgent, *m_selector_insights);
+    make_rule_cache_for_cascade_origin(CascadeOrigin::Author, style_cache);
+    make_rule_cache_for_cascade_origin(CascadeOrigin::User, style_cache);
+    make_rule_cache_for_cascade_origin(CascadeOrigin::UserAgent, style_cache);
 }
 
 void StyleScope::invalidate_rule_cache()
 {
     invalidate_counter_style_cache();
-    m_author_rule_cache = nullptr;
+    m_rule_cache = nullptr;
 
     // NOTE: We could be smarter about keeping the user rule cache, and style sheet.
     //       Currently we are re-parsing the user style sheet every time we build the caches,
     //       as it may have changed.
-    m_user_rule_cache = nullptr;
     m_user_style_sheet = nullptr;
-
-    // NOTE: It might not be necessary to throw away the UA rule cache.
-    //       If we are sure that it's safe, we could keep it as an optimization.
-    m_user_agent_rule_cache = nullptr;
-
-    m_pseudo_class_rule_cache = {};
-    m_style_invalidation_data = nullptr;
 }
 
 void StyleScope::build_user_style_sheet_if_needed()
@@ -207,7 +231,7 @@ void StyleScope::for_each_stylesheet(CascadeOrigin cascade_origin, Function<void
     }
 }
 
-void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin, SelectorInsights& insights)
+void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin, StyleCache& style_cache)
 {
     Vector<MatchingRule> matching_rules;
     size_t style_sheet_index = 0;
@@ -215,11 +239,11 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
         auto& rule_caches = [&] -> RuleCaches& {
             switch (cascade_origin) {
             case CascadeOrigin::Author:
-                return *m_author_rule_cache;
+                return style_cache.author_rule_cache;
             case CascadeOrigin::User:
-                return *m_user_rule_cache;
+                return style_cache.user_rule_cache;
             case CascadeOrigin::UserAgent:
-                return *m_user_agent_rule_cache;
+                return style_cache.user_agent_rule_cache;
             default:
                 VERIFY_NOT_REACHED();
             }
@@ -236,7 +260,7 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
             }();
 
             for (auto const& selector : absolutized_selectors) {
-                m_style_invalidation_data->build_invalidation_sets_for_selector(selector);
+                style_cache.style_invalidation_data.build_invalidation_sets_for_selector(selector);
             }
 
             for (CSS::Selector const& selector : absolutized_selectors) {
@@ -257,7 +281,7 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                 auto const& qualified_layer_name = matching_rule.qualified_layer_name();
                 auto& rule_cache = qualified_layer_name.is_empty() ? rule_caches.main : *rule_caches.by_layer.ensure(qualified_layer_name, [] { return make<RuleCache>(); });
 
-                collect_selector_insights(selector, insights);
+                collect_selector_insights(selector, style_cache.selector_insights);
 
                 bool contains_root_pseudo_class = false;
                 for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors) {
@@ -272,11 +296,11 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                 for (size_t i = 0; i < to_underlying(PseudoClass::__Count); ++i) {
                     auto pseudo_class = static_cast<PseudoClass>(i);
                     // If we're not building a rule cache for this pseudo class, just ignore it.
-                    if (!m_pseudo_class_rule_cache[i])
+                    if (!style_cache.pseudo_class_rule_cache[i])
                         continue;
                     if (selector.contains_pseudo_class(pseudo_class)) {
                         // For pseudo class rule caches we intentionally pass no pseudo-element, because we don't want to bucket pseudo class rules by pseudo-element type.
-                        m_pseudo_class_rule_cache[i]->add_rule(matching_rule, {}, contains_root_pseudo_class);
+                        style_cache.pseudo_class_rule_cache[i]->add_rule(matching_rule, {}, contains_root_pseudo_class);
                     }
                 }
 
@@ -406,7 +430,7 @@ static void flatten_layer_names_tree(Vector<FlyString>& layer_names, StringView 
     layer_names.append(qualified_name);
 }
 
-void StyleScope::build_qualified_layer_names_cache()
+void StyleScope::build_qualified_layer_names_cache(StyleCache& style_cache)
 {
     LayerNode root;
 
@@ -472,8 +496,8 @@ void StyleScope::build_qualified_layer_names_cache()
     });
 
     // Now, produce a flat list of qualified names to use later
-    m_qualified_layer_names_in_order.clear();
-    flatten_layer_names_tree(m_qualified_layer_names_in_order, ""sv, {}, root);
+    style_cache.qualified_layer_names_in_order.clear();
+    flatten_layer_names_tree(style_cache.qualified_layer_names_in_order, ""sv, {}, root);
 }
 
 void StyleScope::invalidate_counter_style_cache()
@@ -773,13 +797,13 @@ bool StyleScope::may_have_has_selectors() const
         return true;
 
     build_rule_cache_if_needed();
-    return m_selector_insights->has_has_selectors;
+    return m_rule_cache->selector_insights.has_has_selectors;
 }
 
 bool StyleScope::have_has_selectors() const
 {
     build_rule_cache_if_needed();
-    return m_selector_insights->has_has_selectors;
+    return m_rule_cache->selector_insights.has_has_selectors;
 }
 
 bool StyleScope::may_have_has_selectors_with_relative_selector_that_has_sibling_combinator() const
@@ -788,13 +812,13 @@ bool StyleScope::may_have_has_selectors_with_relative_selector_that_has_sibling_
         return true;
 
     build_rule_cache_if_needed();
-    return m_selector_insights->has_has_selectors_with_relative_selector_that_has_sibling_combinator;
+    return m_rule_cache->selector_insights.has_has_selectors_with_relative_selector_that_has_sibling_combinator;
 }
 
 bool StyleScope::have_has_selectors_with_relative_selector_that_has_sibling_combinator() const
 {
     build_rule_cache_if_needed();
-    return m_selector_insights->has_has_selectors_with_relative_selector_that_has_sibling_combinator;
+    return m_rule_cache->selector_insights.has_has_selectors_with_relative_selector_that_has_sibling_combinator;
 }
 
 DOM::Document& StyleScope::document() const
@@ -805,7 +829,7 @@ DOM::Document& StyleScope::document() const
 RuleCache const& StyleScope::get_pseudo_class_rule_cache(PseudoClass pseudo_class) const
 {
     build_rule_cache_if_needed();
-    return *m_pseudo_class_rule_cache[to_underlying(pseudo_class)];
+    return *m_rule_cache->pseudo_class_rule_cache[to_underlying(pseudo_class)];
 }
 
 void StyleScope::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)> const& callback) const

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -52,7 +52,6 @@ void StyleScope::visit_edges(GC::Cell::Visitor& visitor)
 
 void MatchingRule::visit_edges(GC::Cell::Visitor& visitor)
 {
-    visitor.visit(shadow_root);
     visitor.visit(rule);
     visitor.visit(sheet);
 }
@@ -210,10 +209,6 @@ void StyleScope::for_each_stylesheet(CascadeOrigin cascade_origin, Function<void
 
 void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin, SelectorInsights& insights)
 {
-    GC::Ptr<DOM::ShadowRoot const> scope_shadow_root;
-    if (m_node->is_shadow_root())
-        scope_shadow_root = as<DOM::ShadowRoot>(*m_node);
-
     Vector<MatchingRule> matching_rules;
     size_t style_sheet_index = 0;
     for_each_stylesheet(cascade_origin, [&](auto& sheet) {
@@ -246,7 +241,6 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
 
             for (CSS::Selector const& selector : absolutized_selectors) {
                 MatchingRule matching_rule {
-                    .shadow_root = scope_shadow_root,
                     .rule = &rule,
                     .sheet = sheet,
                     .default_namespace = sheet.default_namespace(),

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -22,7 +22,6 @@
 namespace Web::CSS {
 
 struct MatchingRule {
-    GC::Ptr<DOM::ShadowRoot const> shadow_root;
     GC::Ptr<CSSRule const> rule; // Either CSSStyleRule or CSSNestedDeclarations
     GC::Ptr<CSSStyleSheet const> sheet;
     Optional<FlyString> default_namespace;

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -8,7 +8,10 @@
 
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/WeakHashSet.h>
@@ -20,6 +23,8 @@
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
+
+class StyleScope;
 
 struct MatchingRule {
     GC::Ptr<CSSRule const> rule; // Either CSSStyleRule or CSSNestedDeclarations
@@ -74,6 +79,21 @@ struct SelectorInsights {
     bool has_has_selectors_with_relative_selector_that_has_sibling_combinator { false };
 };
 
+struct StyleCache : public RefCounted<StyleCache> {
+    static NonnullRefPtr<StyleCache> create();
+    static NonnullRefPtr<StyleCache> create_for_style_scope(StyleScope&);
+
+    Vector<FlyString> qualified_layer_names_in_order;
+    SelectorInsights selector_insights;
+    Array<OwnPtr<RuleCache>, to_underlying(PseudoClass::__Count)> pseudo_class_rule_cache;
+    StyleInvalidationData style_invalidation_data;
+    RuleCaches author_rule_cache;
+    RuleCaches user_rule_cache;
+    RuleCaches user_agent_rule_cache;
+
+    void visit_edges(GC::Cell::Visitor&);
+};
+
 class StyleScope {
 public:
     explicit StyleScope(GC::Ref<DOM::Node>);
@@ -81,11 +101,11 @@ public:
     DOM::Node& node() const { return m_node; }
     DOM::Document& document() const;
 
-    RuleCaches const& author_rule_cache() const { return *m_author_rule_cache; }
-    RuleCaches const& user_rule_cache() const { return *m_user_rule_cache; }
-    RuleCaches const& user_agent_rule_cache() const { return *m_user_agent_rule_cache; }
+    RuleCaches const& author_rule_cache() const { return m_rule_cache->author_rule_cache; }
+    RuleCaches const& user_rule_cache() const { return m_rule_cache->user_rule_cache; }
+    RuleCaches const& user_agent_rule_cache() const { return m_rule_cache->user_agent_rule_cache; }
 
-    [[nodiscard]] bool has_valid_rule_cache() const { return m_author_rule_cache; }
+    [[nodiscard]] bool has_valid_rule_cache() const { return m_rule_cache; }
     void invalidate_rule_cache();
 
     [[nodiscard]] RuleCache const& get_pseudo_class_rule_cache(PseudoClass) const;
@@ -93,14 +113,15 @@ public:
     void for_each_stylesheet(CascadeOrigin, Function<void(CSS::CSSStyleSheet&)> const&) const;
     void build_user_style_sheet_if_needed();
 
-    void make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&);
+    void make_rule_cache_for_cascade_origin(CascadeOrigin, StyleCache&);
 
     void build_rule_cache();
     void build_rule_cache_if_needed() const;
+    void populate_rule_cache(StyleCache&);
 
     static void collect_selector_insights(Selector const&, SelectorInsights&);
 
-    void build_qualified_layer_names_cache();
+    void build_qualified_layer_names_cache(StyleCache&);
 
     [[nodiscard]] bool may_have_has_selectors() const;
     [[nodiscard]] bool have_has_selectors() const;
@@ -122,13 +143,7 @@ public:
 
     void visit_edges(GC::Cell::Visitor&);
 
-    Vector<FlyString> m_qualified_layer_names_in_order;
-    OwnPtr<SelectorInsights> m_selector_insights;
-    Array<OwnPtr<RuleCache>, to_underlying(PseudoClass::__Count)> m_pseudo_class_rule_cache;
-    OwnPtr<StyleInvalidationData> m_style_invalidation_data;
-    OwnPtr<RuleCaches> m_author_rule_cache;
-    OwnPtr<RuleCaches> m_user_rule_cache;
-    OwnPtr<RuleCaches> m_user_agent_rule_cache;
+    RefPtr<StyleCache> m_rule_cache;
 
     GC::Ptr<CSSStyleSheet> m_user_style_sheet;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2101,14 +2101,6 @@ void Document::invalidate_style_for_elements_affected_by_pseudo_class_change(CSS
 
     auto& style_computer = this->style_computer();
     auto does_rule_match_on_element = [&](Element const& element, CSS::MatchingRule const& rule) {
-        auto rule_root = rule.shadow_root;
-        auto from_user_agent_or_user_stylesheet = rule.cascade_origin == CSS::CascadeOrigin::UserAgent || rule.cascade_origin == CSS::CascadeOrigin::User;
-        bool rule_is_relevant_for_current_scope = rule_root == shadow_root
-            || (element.is_shadow_host() && rule_root == element.shadow_root())
-            || from_user_agent_or_user_stylesheet;
-        if (!rule_is_relevant_for_current_scope)
-            return false;
-
         auto const& selector = rule.selector;
         if (selector.can_use_ancestor_filter() && style_computer.should_reject_with_ancestor_filter(selector))
             return false;

--- a/Tests/LibWeb/Text/expected/css/constructed-stylesheet-shared-cache-shadow-scope.txt
+++ b/Tests/LibWeb/Text/expected/css/constructed-stylesheet-shared-cache-shadow-scope.txt
@@ -1,0 +1,8 @@
+Initial A target: rgb(0, 128, 0)
+Initial B target: rgb(0, 0, 255)
+Initial A slotted: rgb(255, 255, 0)
+Initial B slotted: rgb(255, 255, 0)
+After replace A target: rgb(128, 0, 128)
+After replace B target: rgb(255, 165, 0)
+After replace A slotted: rgb(0, 255, 255)
+After replace B slotted: rgb(0, 255, 255)

--- a/Tests/LibWeb/Text/input/css/constructed-stylesheet-shared-cache-shadow-scope.html
+++ b/Tests/LibWeb/Text/input/css/constructed-stylesheet-shared-cache-shadow-scope.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="host-a" class="primary"><span id="slotted-a" class="slot-target">a</span></div>
+<div id="host-b" class="secondary"><span id="slotted-b" class="slot-target">b</span></div>
+<script>
+    test(() => {
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(`
+            :host(.primary) .target { color: rgb(0, 128, 0); }
+            :host(.secondary) .target { color: rgb(0, 0, 255); }
+            ::slotted(.slot-target) { background-color: rgb(255, 255, 0); }
+        `);
+
+        const hostA = document.getElementById("host-a");
+        const hostB = document.getElementById("host-b");
+        const slottedA = document.getElementById("slotted-a");
+        const slottedB = document.getElementById("slotted-b");
+
+        const shadowA = hostA.attachShadow({ mode: "open" });
+        const shadowB = hostB.attachShadow({ mode: "open" });
+        shadowA.innerHTML = "<span class='target'>a</span><slot></slot>";
+        shadowB.innerHTML = "<span class='target'>b</span><slot></slot>";
+        shadowA.adoptedStyleSheets = [sheet];
+        shadowB.adoptedStyleSheets = [sheet];
+
+        const targetA = shadowA.querySelector(".target");
+        const targetB = shadowB.querySelector(".target");
+
+        println(`Initial A target: ${getComputedStyle(targetA).color}`);
+        println(`Initial B target: ${getComputedStyle(targetB).color}`);
+        println(`Initial A slotted: ${getComputedStyle(slottedA).backgroundColor}`);
+        println(`Initial B slotted: ${getComputedStyle(slottedB).backgroundColor}`);
+
+        sheet.replaceSync(`
+            :host(.primary) .target { color: rgb(128, 0, 128); }
+            :host(.secondary) .target { color: rgb(255, 165, 0); }
+            ::slotted(.slot-target) { background-color: rgb(0, 255, 255); }
+        `);
+
+        println(`After replace A target: ${getComputedStyle(targetA).color}`);
+        println(`After replace B target: ${getComputedStyle(targetB).color}`);
+        println(`After replace A slotted: ${getComputedStyle(slottedA).backgroundColor}`);
+        println(`After replace B slotted: ${getComputedStyle(slottedB).backgroundColor}`);
+    });
+</script>


### PR DESCRIPTION
Share the rule caches for shadow roots whose only active author stylesheet is the same constructed stylesheet.

The cache can now be reused while style matching still receives the effective shadow root from each consuming `StyleScope`. This keeps selectors such as `:host` and `::slotted()` scoped to the correct shadow root without rebuilding or copying the cache for every adopter.

The optimization is intentionally conservative. It only applies when a shadow  root has exactly one active author stylesheet, that sheet is constructed, and no page user stylesheet is active. All other cases use the existing per-scope (private) cache.

This drastically reduces rule cache rebuilding on Reddit (and any other site that shares a single constructed sheet between lots of shadow roots).

When loading https://reddit.com on my Linux machine ...

Before:
- `1,027` rule cache rebuilds
- `3.22s` spent building rule caches

After:
- `1,027` rule-cache build requests
- `688` shared :)
- `370` private :(
- `1.11s` spent building rule caches
