### PR TITLE
LibWeb: Notify only affected layout nodes when a CSS image loads

### DIFF
--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -156,16 +156,6 @@ GC::Ptr<HTML::SharedResourceRequest> fetch_an_external_image_for_a_stylesheet(St
     auto& realm = document.realm();
 
     auto shared_resource_request = HTML::SharedResourceRequest::get_or_create(realm, document.page(), request->url());
-    shared_resource_request->add_callbacks(
-        [&document, weak_document = GC::Weak { document }] {
-            if (!weak_document)
-                return;
-
-            if (auto navigable = document.navigable()) {
-                document.notify_css_background_image_loaded();
-            }
-        },
-        nullptr);
 
     if (shared_resource_request->needs_fetching())
         shared_resource_request->fetch_resource(realm, *request);

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -44,6 +44,8 @@ public:
     virtual void paint(DisplayListRecordingContext&, DevicePixelRect const&, ImageRendering) const override;
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const override;
 
+    AbstractImageStyleValue const* selected_image() const { return m_selected_image; }
+
 private:
     explicit ImageSetStyleValue(Vector<Option>);
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -229,19 +229,19 @@ ValueComparingNonnullRefPtr<StyleValue const> ImageStyleValue::absolutized(Compu
     return *this;
 }
 
-void ImageStyleValue::register_client(Client& client)
+void ImageStyleValue::register_client(Client& client) const
 {
     auto result = m_clients.set(&client);
     VERIFY(result == AK::HashSetResult::InsertedNewEntry);
 }
 
-void ImageStyleValue::unregister_client(Client& client)
+void ImageStyleValue::unregister_client(Client& client) const
 {
     auto did_remove = m_clients.remove(&client);
     VERIFY(did_remove);
 }
 
-ImageStyleValue::Client::Client(ImageStyleValue& image_style_value)
+ImageStyleValue::Client::Client(ImageStyleValue const& image_style_value)
     : m_image_style_value(image_style_value)
 {
     m_image_style_value.register_client(*this);

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -26,14 +26,14 @@ class ImageStyleValue final
 public:
     class Client {
     public:
-        Client(ImageStyleValue&);
+        Client(ImageStyleValue const&);
         virtual ~Client();
         virtual void image_style_value_did_update(ImageStyleValue&) = 0;
 
     protected:
         void image_style_value_finalize();
 
-        ImageStyleValue& m_image_style_value;
+        ImageStyleValue const& m_image_style_value;
     };
 
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&);
@@ -68,8 +68,8 @@ private:
 
     ImageStyleValue(URL const&);
 
-    void register_client(Client&);
-    void unregister_client(Client&);
+    void register_client(Client&) const;
+    void unregister_client(Client&) const;
 
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
 
@@ -87,7 +87,7 @@ private:
     size_t m_loops_completed { 0 };
     GC::Ptr<Platform::Timer> m_timer;
 
-    HashTable<Client*> m_clients;
+    mutable HashTable<Client*> m_clients;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7525,18 +7525,6 @@ void Document::set_navigable(GC::Ptr<HTML::Navigable> navigable)
     HTML::main_thread_event_loop().document_navigable_did_change({});
 }
 
-void Document::notify_css_background_image_loaded()
-{
-    // FIXME: Do less than a full repaint if possible?
-    if (auto* paintable = unsafe_paintable()) {
-        paintable->for_each_in_inclusive_subtree_of_type<Painting::PaintableBox>([](auto& paintable_box) {
-            paintable_box.invalidate_paint_cache();
-            return TraversalDecision::Continue;
-        });
-    }
-    set_needs_repaint();
-}
-
 void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)
 {
     auto navigable = this->navigable();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -966,8 +966,6 @@ public:
         set_needs_repaint(should_invalidate_display_list);
     }
 
-    void notify_css_background_image_loaded();
-
     RefPtr<Painting::DisplayList> cached_display_list() const;
     RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig);
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -11,6 +11,8 @@
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageSetStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
@@ -37,6 +39,7 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/SVG/SVGFilterElement.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
 
@@ -580,6 +583,70 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullOw
     m_is_body = node && node == document.body();
 }
 
+NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)
+    : CSS::ImageStyleValue::Client(*image)
+    , m_owner(owner)
+    , m_image(move(image))
+{
+}
+
+NodeWithStyle::ImageObserver::~ImageObserver()
+{
+    image_style_value_finalize();
+}
+
+void NodeWithStyle::ImageObserver::image_style_value_did_update(CSS::ImageStyleValue&)
+{
+    VERIFY(m_owner);
+
+    for (auto& paintable : m_owner->paintables())
+        paintable.set_needs_repaint();
+
+    // The body's background propagates to the root element's paintable, which holds the cached draw commands.
+    if (m_owner->is_body()) {
+        auto* html_element = m_owner->document().html_element();
+        if (html_element) {
+            if (auto html_layout_node = html_element->unsafe_layout_node()) {
+                if (html_element->should_use_body_background_properties()) {
+                    for (auto& paintable : html_layout_node->paintables())
+                        paintable.set_needs_repaint();
+                }
+            }
+        }
+    }
+}
+
+void NodeWithStyle::ImageObserver::visit_edges(JS::Cell::Visitor& visitor) const
+{
+    m_image->visit_edges(visitor);
+}
+
+void NodeWithStyle::rebuild_image_observers()
+{
+    auto add_observer_for = [&](CSS::AbstractImageStyleValue const* abstract_image, Vector<NonnullOwnPtr<ImageObserver>>& observers) {
+        if (!abstract_image)
+            return;
+        CSS::ImageStyleValue const* image_to_observe = nullptr;
+        if (abstract_image->is_image()) {
+            image_to_observe = &abstract_image->as_image();
+        } else if (abstract_image->is_image_set()) {
+            if (auto const* selected = abstract_image->as_image_set().selected_image(); selected && selected->is_image())
+                image_to_observe = &selected->as_image();
+        }
+        if (!image_to_observe)
+            return;
+        observers.append(make<ImageObserver>(*this, *image_to_observe));
+    };
+
+    Vector<NonnullOwnPtr<ImageObserver>> new_observers;
+    for (auto const& layer : computed_values().background_layers())
+        add_observer_for(layer.background_image.ptr(), new_observers);
+    add_observer_for(m_list_style_image.ptr(), new_observers);
+    add_observer_for(computed_values().mask_image().ptr(), new_observers);
+
+    m_image_observers = move(new_observers);
+}
+
 void NodeWithStyle::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
@@ -590,6 +657,9 @@ void NodeWithStyle::visit_edges(Visitor& visitor)
         m_list_style_image->visit_edges(visitor);
 
     m_computed_values->visit_edges(visitor);
+
+    for (auto const& image_observer : m_image_observers)
+        image_observer->visit_edges(visitor);
 }
 
 void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
@@ -985,6 +1055,8 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
 
     if (auto* box_node = as_if<NodeWithStyleAndBoxModelMetrics>(*this))
         box_node->propagate_style_along_continuation(computed_style);
+
+    rebuild_image_observers();
 }
 
 CSS::StyleScope const& NodeWithStyle::style_scope() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -7,10 +7,13 @@
 
 #pragma once
 
+#include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
+#include <LibGC/Weak.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
@@ -265,6 +268,19 @@ class WEB_API NodeWithStyle : public Node {
 public:
     virtual ~NodeWithStyle() override = default;
 
+    class ImageObserver final : public CSS::ImageStyleValue::Client {
+    public:
+        ImageObserver(NodeWithStyle&, NonnullRefPtr<CSS::ImageStyleValue const> image);
+        virtual ~ImageObserver() override;
+
+        virtual void image_style_value_did_update(CSS::ImageStyleValue&) override;
+        void visit_edges(JS::Cell::Visitor&) const;
+
+    private:
+        GC::Weak<NodeWithStyle> m_owner;
+        NonnullRefPtr<CSS::ImageStyleValue const> m_image;
+    };
+
     CSS::ImmutableComputedValues const& computed_values() const { return static_cast<CSS::ImmutableComputedValues const&>(*m_computed_values); }
     CSS::MutableComputedValues& mutable_computed_values() { return static_cast<CSS::MutableComputedValues&>(*m_computed_values); }
 
@@ -300,8 +316,11 @@ private:
     void propagate_non_inherit_values(NodeWithStyle& target_node) const;
     void propagate_style_to_anonymous_wrappers();
 
+    void rebuild_image_observers();
+
     NonnullOwnPtr<CSS::ComputedValues> m_computed_values;
     RefPtr<CSS::AbstractImageStyleValue const> m_list_style_image;
+    Vector<NonnullOwnPtr<ImageObserver>> m_image_observers;
     u32 m_layout_index { 0 };
 };
 


### PR DESCRIPTION
Previously, `Document::notify_css_background_image_loaded()` walked the entire `PaintableBox` subtree and cleared each box's paintable cache whenever any CSS image finished loading.

Replace this with per-image observers owned by the layout node. During `apply_style`, each node registers as an `ImageStyleValue::Client` for the images its style references. On load, only the affected layout node's paintables are invalidated.

This gets us a very noticable improvement on https://en.wikipedia.org/wiki/2023_in_American_television, where this invalidation was previously burning ~35% of all recorded frames in a 30 second profile