### PR TITLE
LibJS: Introduce string interning for identifiers in the Rust parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ name = "bytecode_def"
 version = "0.1.0"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "calendrical_calculations"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +195,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "getrandom"
@@ -375,6 +390,7 @@ version = "0.1.0"
 dependencies = [
  "bytecode_def",
  "cbindgen",
+ "fxhash",
  "indexmap",
  "libunicode_rust",
  "num-bigint",

--- a/Libraries/LibJS/Rust/Cargo.toml
+++ b/Libraries/LibJS/Rust/Cargo.toml
@@ -14,6 +14,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"
 indexmap = "2"
+fxhash = "0.2"
 
 [build-dependencies]
 bytecode_def = { path = "../BytecodeDef" }

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -26,7 +26,7 @@ use std::ffi::c_void;
 use std::fmt;
 use std::rc::Rc;
 
-use std::collections::HashMap;
+use fxhash::FxHashMap;
 
 // =============================================================================
 // Function table (side table for FunctionData)
@@ -47,7 +47,7 @@ pub struct FunctionId(u32);
 /// moved out exactly once (during codegen / GDI). This eliminates the
 /// deep clone that was previously required in `create_shared_function_data`.
 pub struct FunctionTable {
-    functions: HashMap<FunctionId, Box<FunctionData>>,
+    functions: FxHashMap<FunctionId, Box<FunctionData>>,
     next_id: u32,
 }
 
@@ -60,7 +60,7 @@ impl Default for FunctionTable {
 impl FunctionTable {
     pub fn new() -> Self {
         Self {
-            functions: HashMap::default(),
+            functions: FxHashMap::default(),
             next_id: 0,
         }
     }
@@ -458,10 +458,12 @@ impl FunctionTable {
 }
 
 /// Bundles a `FunctionData` with a subtable of all nested functions
-/// reachable from its body. Stored as the raw pointer in C++ SFDs.
+/// reachable from its body, plus the parser interner used by its interned
+/// identifiers. Stored as the raw pointer in C++ SFDs.
 pub struct FunctionPayload {
     pub data: FunctionData,
     pub function_table: FunctionTable,
+    pub interner: crate::string_interner::StringInterner,
 }
 
 // =============================================================================
@@ -800,7 +802,7 @@ pub enum LocalType {
 #[derive(Clone, Debug)]
 pub struct Identifier {
     pub range: SourceRange,
-    pub name: SharedUtf16String,
+    pub name: crate::string_interner::InternedId,
     // Scope analysis results — set by scope collector after parsing.
     pub local_type: Cell<Option<LocalType>>,
     pub local_index: Cell<u32>,
@@ -810,7 +812,7 @@ pub struct Identifier {
 }
 
 impl Identifier {
-    pub fn new(range: SourceRange, name: SharedUtf16String) -> Self {
+    pub fn new(range: SourceRange, name: crate::string_interner::InternedId) -> Self {
         Self {
             range,
             name,
@@ -830,7 +832,7 @@ impl Identifier {
 #[derive(Clone, Debug)]
 pub struct PrivateIdentifier {
     pub range: SourceRange,
-    pub name: Utf16String,
+    pub name: crate::string_interner::InternedId,
 }
 
 // =============================================================================

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -10,6 +10,7 @@
 //! the C++ `outln` calls.
 
 use crate::ast::*;
+use crate::string_interner::StringInterner;
 use std::cell::RefCell;
 use std::fmt::Write;
 
@@ -68,6 +69,7 @@ struct DumpState<'a> {
     use_color: bool,
     output: Option<&'a RefCell<String>>,
     function_table: &'a FunctionTable,
+    interner: &'a StringInterner,
 }
 
 impl DumpState<'_> {
@@ -118,6 +120,7 @@ fn child_state<'a>(state: &DumpState<'a>, is_last: bool) -> DumpState<'a> {
         use_color: state.use_color,
         output: state.output,
         function_table: state.function_table,
+        interner: state.interner,
     }
 }
 
@@ -303,7 +306,7 @@ fn dump_labeled_statement(label: &str, statement: &Statement, is_last: bool, sta
 // Entry point
 // ============================================================================
 
-pub fn dump_program(program: &Statement, use_color: bool, function_table: &FunctionTable) {
+pub fn dump_program(program: &Statement, use_color: bool, function_table: &FunctionTable, interner: &StringInterner) {
     let state = DumpState {
         prefix: String::new(),
         is_last: false,
@@ -311,12 +314,17 @@ pub fn dump_program(program: &Statement, use_color: bool, function_table: &Funct
         use_color,
         output: None,
         function_table,
+        interner,
     };
     dump_statement(program, &state);
     println!();
 }
 
-pub fn dump_program_to_string(program: &Statement, function_table: &FunctionTable) -> String {
+pub fn dump_program_to_string(
+    program: &Statement,
+    function_table: &FunctionTable,
+    interner: &StringInterner,
+) -> String {
     let output = RefCell::new(String::new());
     let state = DumpState {
         prefix: String::new(),
@@ -325,6 +333,7 @@ pub fn dump_program_to_string(program: &Statement, function_table: &FunctionTabl
         use_color: false,
         output: Some(&output),
         function_table,
+        interner,
     };
     dump_statement(program, &state);
     output.into_inner()
@@ -690,7 +699,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
                 state,
                 "PrivateIdentifier",
                 &expression.range,
-                color_string_utf16(state, &ident.name)
+                color_string_utf16(state, state.interner.lookup(ident.name))
             );
         }
 
@@ -813,7 +822,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
                             &format!(
                                 "{} {}{}",
                                 color_node_name(state, "PrivateIdentifier"),
-                                color_string_utf16(state, &private_identifier.name),
+                                color_string_utf16(state, state.interner.lookup(private_identifier.name)),
                                 format_position(state, &private_identifier.range)
                             ),
                         );
@@ -944,7 +953,10 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
 
 fn dump_identifier(ident: &Identifier, range: &SourceRange, state: &DumpState) {
     let mut desc = color_node_name(state, "Identifier");
-    desc.push_str(&format!(" {}", color_string_utf16(state, &ident.name)));
+    desc.push_str(&format!(
+        " {}",
+        color_string_utf16(state, state.interner.lookup(ident.name))
+    ));
     if ident.is_local() {
         let kind = if ident.local_type.get() == Some(LocalType::Argument) {
             "argument"
@@ -991,7 +1003,7 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
         desc.push('*');
     }
     let name_str = match &function_data.name {
-        Some(ident) => utf16_to_string(&ident.name),
+        Some(ident) => utf16_to_string(state.interner.lookup(ident.name)),
         None => String::new(),
     };
     desc.push_str(&format!(" {}", color_string(state, &name_str)));
@@ -1066,7 +1078,7 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
 
 fn dump_class(class_data: &ClassData, range: &SourceRange, state: &DumpState, root_state: &DumpState) {
     let name_str = match &class_data.name {
-        Some(ident) => utf16_to_string(&ident.name),
+        Some(ident) => utf16_to_string(state.interner.lookup(ident.name)),
         None => String::new(),
     };
     print_node(

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -45,6 +45,7 @@ use num_traits::{One, Signed, ToPrimitive, Zero};
 
 use crate::ast::*;
 use crate::lexer::ch;
+use crate::string_interner::{InternedId, StringInterner};
 use crate::u32_from_usize;
 
 use super::ffi::{AbstractOperationKind, WellKnownSymbolKind};
@@ -328,7 +329,7 @@ fn generate_unary_expression(
             && !ident.is_local()
         {
             let dst = choose_dst(generator, preferred_dst);
-            let id = generator.intern_identifier(&ident.name);
+            let id = generator.intern_identifier_by_id(ident.name);
             generator.emit(Instruction::TypeofBinding {
                 dst: dst.operand(),
                 identifier: id,
@@ -448,7 +449,7 @@ fn generate_binary_expression(
     {
         let base = generate_expression(rhs, generator, None)?;
         let dst = choose_dst(generator, preferred_dst);
-        let id = generator.intern_identifier(&priv_ident.name);
+        let id = generator.intern_identifier_by_id(priv_ident.name);
         generator.emit(Instruction::HasPrivateId {
             dst: dst.operand(),
             base: base.operand(),
@@ -538,7 +539,8 @@ fn generate_function_expression(
         });
         generator.lexical_environment_register_stack.push(new_env);
 
-        let id = generator.intern_identifier(&data.name.as_ref().expect("function declaration must have a name").name);
+        let id =
+            generator.intern_identifier_by_id(data.name.as_ref().expect("function declaration must have a name").name);
         generator.emit(Instruction::CreateVariable {
             identifier: id,
             mode: EnvironmentMode::Lexical as u32,
@@ -711,7 +713,7 @@ fn generate_member_expression(
         if let Some(key) = computed_key {
             emit_get_by_value_with_this(generator, &dst, &super_base, &key, &this_value);
         } else if let ExpressionKind::Identifier(ident) = &property.inner {
-            emit_get_by_id_with_this(generator, &dst, &super_base, &ident.name, &this_value);
+            emit_get_by_id_with_this(generator, &dst, &super_base, ident.name, &this_value);
         }
         return Some(dst);
     }
@@ -727,9 +729,9 @@ fn generate_member_expression(
     // Non-computed: property must be an Identifier
     let dst = choose_dst(generator, preferred_dst);
     if let ExpressionKind::Identifier(ident) = &property.inner {
-        emit_get_by_id(generator, &dst, &obj, &ident.name, base_id);
+        emit_get_by_id(generator, &dst, &obj, ident.name, base_id);
     } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &property.inner {
-        let id = generator.intern_identifier(&priv_ident.name);
+        let id = generator.intern_identifier_by_id(priv_ident.name);
         generator.emit(Instruction::GetPrivateById {
             dst: dst.operand(),
             base: obj.operand(),
@@ -887,7 +889,8 @@ pub fn generate_statement(
             // into the var-scoped binding on each case entry).
             let scope = data.scope.borrow();
             for name in &scope.annexb_function_names {
-                generator.annexb_function_names.insert(name.clone());
+                let id = generator.interner.intern(name);
+                generator.annexb_function_names.insert(id);
             }
             generate_scope_children(generator, &scope, preferred_dst)
         }
@@ -986,7 +989,7 @@ pub fn generate_statement(
                 // Annex B.3.3: Copy the function from the lexical (block) scope
                 // to the var scope.
                 if let Some(name_ident) = &fd.name {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_by_id(name_ident.name);
                     let value = generator.allocate_register();
                     generator.emit(Instruction::GetBinding {
                         dst: value.operand(),
@@ -1058,7 +1061,7 @@ pub fn generate_statement(
                         generator.resolve_local(name_ident.local_index.get(), name_ident.local_type.get().unwrap());
                     generator.emit_mov(&local, &value);
                 } else {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_by_id(name_ident.name);
                     generator.emit(Instruction::InitializeLexicalBinding {
                         identifier: id,
                         src: value.operand(),
@@ -1316,7 +1319,7 @@ fn generate_yield_from(
 
     // iv. Let done be ? IteratorComplete(innerResult).
     let done = generator.allocate_register();
-    emit_get_by_id(generator, &done, &inner_result, utf16!("done"), None);
+    emit_get_by_id_impl(generator, &done, &inner_result, utf16!("done"), None);
 
     // v. If done is true, then return ? IteratorValue(innerResult).
     let type_is_normal_done_block = generator.make_block();
@@ -1325,14 +1328,14 @@ fn generate_yield_from(
 
     generator.switch_to_basic_block(type_is_normal_done_block);
     let return_value = generator.allocate_register();
-    emit_get_by_id(generator, &return_value, &inner_result, utf16!("value"), None);
+    emit_get_by_id_impl(generator, &return_value, &inner_result, utf16!("value"), None);
     generator.emit(Instruction::Jump { target: loop_end_block });
 
     // vi/vii. Yield IteratorValue(innerResult), receive new completion.
     generator.switch_to_basic_block(type_is_normal_not_done_block);
     {
         let current_value = generator.allocate_register();
-        emit_get_by_id(generator, &current_value, &inner_result, utf16!("value"), None);
+        emit_get_by_id_impl(generator, &current_value, &inner_result, utf16!("value"), None);
 
         generate_yield(
             generator,
@@ -1410,7 +1413,7 @@ fn generate_yield_from(
     });
 
     // 5. Let done be ? IteratorComplete(innerResult).
-    emit_get_by_id(generator, &done, &inner_result, utf16!("done"), None);
+    emit_get_by_id_impl(generator, &done, &inner_result, utf16!("done"), None);
 
     // 6. If done is true, return ? IteratorValue(innerResult).
     let type_is_throw_done_block = generator.make_block();
@@ -1418,14 +1421,14 @@ fn generate_yield_from(
     generator.emit_jump_if(&done, type_is_throw_done_block, type_is_throw_not_done_block);
 
     generator.switch_to_basic_block(type_is_throw_done_block);
-    emit_get_by_id(generator, &return_value, &inner_result, utf16!("value"), None);
+    emit_get_by_id_impl(generator, &return_value, &inner_result, utf16!("value"), None);
     generator.emit(Instruction::Jump { target: loop_end_block });
 
     // 7/8. Yield IteratorValue(innerResult), receive new completion.
     generator.switch_to_basic_block(type_is_throw_not_done_block);
     {
         let yield_value = generator.allocate_register();
-        emit_get_by_id(generator, &yield_value, &inner_result, utf16!("value"), None);
+        emit_get_by_id_impl(generator, &yield_value, &inner_result, utf16!("value"), None);
         generate_yield(
             generator,
             continuation_block,
@@ -1572,7 +1575,7 @@ fn generate_yield_from(
     });
 
     // vii. Let done be ? IteratorComplete(innerReturnResult).
-    emit_get_by_id(generator, &done, &inner_return_result, utf16!("done"), None);
+    emit_get_by_id_impl(generator, &done, &inner_return_result, utf16!("done"), None);
 
     // viii. If done is true, return IteratorValue(innerReturnResult).
     let type_is_return_done_block = generator.make_block();
@@ -1581,7 +1584,7 @@ fn generate_yield_from(
 
     generator.switch_to_basic_block(type_is_return_done_block);
     let inner_return_result_value = generator.allocate_register();
-    emit_get_by_id(
+    emit_get_by_id_impl(
         generator,
         &inner_return_result_value,
         &inner_return_result,
@@ -1593,7 +1596,7 @@ fn generate_yield_from(
     // ix/x. Yield IteratorValue(innerReturnResult), receive new completion.
     generator.switch_to_basic_block(type_is_return_not_done_block);
     let received = generator.allocate_register();
-    emit_get_by_id(generator, &received, &inner_return_result, utf16!("value"), None);
+    emit_get_by_id_impl(generator, &received, &inner_return_result, utf16!("value"), None);
     generate_yield(
         generator,
         continuation_block,
@@ -1760,14 +1763,14 @@ fn generate_identifier(
 
     // OPTIMIZATION: Generate builtin constants (undefined, NaN, Infinity) directly.
     if ident.is_global.get()
-        && let Some(constant) = maybe_generate_builtin_constant(generator, &ident.name)
+        && let Some(constant) = maybe_generate_builtin_constant(generator, &generator.resolve_name(ident.name).to_vec())
     {
         return constant;
     }
 
     let dst = choose_dst(generator, preferred_dst);
     if ident.is_global.get() {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_by_id(ident.name);
         let cache = generator.next_global_variable_cache();
         generator.emit(Instruction::GetGlobal {
             dst: dst.operand(),
@@ -1775,14 +1778,14 @@ fn generate_identifier(
             cache: cache as u64,
         });
     } else if ident.declaration_kind.get() == Some(DeclarationKind::Var) {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_by_id(ident.name);
         generator.emit(Instruction::GetInitializedBinding {
             dst: dst.operand(),
             identifier: id,
             cache: EnvironmentCoordinate::empty(),
         });
     } else {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_by_id(ident.name);
         generator.emit(Instruction::GetBinding {
             dst: dst.operand(),
             identifier: id,
@@ -2328,7 +2331,7 @@ fn generate_for_statement(
     {
         let mut non_local_names: Vec<(Utf16String, bool)> = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut non_local_names);
+            collect_target_names(&declaration.target, &mut non_local_names, &generator.interner);
         }
         if !non_local_names.is_empty() {
             has_lexical_environment = true;
@@ -2588,7 +2591,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, &generator.interner);
                     for (name, _) in &names {
                         let id = generator.intern_identifier(name);
                         if is_constant {
@@ -2610,7 +2613,7 @@ fn emit_lexical_declarations_for_block<'a>(
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, &generator.interner);
                     for (name, _) in &names {
                         let id = generator.intern_identifier(name);
                         generator.emit(Instruction::CreateImmutableBinding {
@@ -2625,7 +2628,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 if let Some(ref name_ident) = class_data.name
                     && !name_ident.is_local()
                 {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_by_id(name_ident.name);
                     generator.emit(Instruction::CreateMutableBinding {
                         environment: environment.operand(),
                         identifier: id,
@@ -2637,7 +2640,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 let name_ident = fd.name.as_ref().unwrap();
                 // a. Create binding.
                 if !name_ident.is_local() {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_by_id(name_ident.name);
                     generator.emit(Instruction::CreateMutableBinding {
                         environment: environment.operand(),
                         identifier: id,
@@ -2660,7 +2663,7 @@ fn emit_lexical_declarations_for_block<'a>(
                     generator.emit_mov(&local, &fo);
                     generator.mark_local_initialized(local_index);
                 } else {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_by_id(name_ident.name);
                     generator.emit(Instruction::InitializeLexicalBinding {
                         identifier: id,
                         src: fo.operand(),
@@ -2674,7 +2677,7 @@ fn emit_lexical_declarations_for_block<'a>(
 }
 
 fn emit_block_declaration_instantiation(generator: &mut Generator, scope: &ScopeData) -> bool {
-    if !needs_block_declaration_instantiation(scope) {
+    if !needs_block_declaration_instantiation(scope, &generator.interner) {
         return false;
     }
 
@@ -2716,7 +2719,7 @@ fn generate_variable_declaration(
 
         // Set pending LHS name for function name inference.
         if let VariableDeclaratorTarget::Identifier(ident) = &declaration.target {
-            generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+            generator.pending_lhs_name = Some(generator.intern_identifier_by_id(ident.name));
         }
         let init_value = declaration
             .init
@@ -2741,7 +2744,7 @@ fn generate_variable_declaration(
                     generator.emit_mov(&local, &value);
                     generator.mark_local_initialized(local_index);
                 } else {
-                    let id = generator.intern_identifier(&ident.name);
+                    let id = generator.intern_identifier_by_id(ident.name);
                     match kind {
                         DeclarationKind::Var => {
                             if ident.is_global.get() {
@@ -2794,13 +2797,15 @@ fn try_generate_builtin_abstract_operation(
     if !generator.builtin_abstract_operations_enabled {
         return None;
     }
-    let name = match &data.callee.inner {
-        ExpressionKind::Identifier(ident) => &ident.name,
+    let name_id = match &data.callee.inner {
+        ExpressionKind::Identifier(ident) => ident.name,
         _ => return None,
     };
     if data.arguments.iter().any(|a| a.is_spread) {
         return None;
     }
+
+    let name = generator.resolve_name(name_id).to_vec();
 
     let dst = choose_dst(generator, preferred_dst);
 
@@ -2921,8 +2926,8 @@ fn try_generate_builtin_abstract_operation(
             let val = generate_expression_or_undefined(&argument.value, generator, None);
             argument_holders.push(generator.copy_if_needed_to_preserve_evaluation_order(&val));
         }
-        let callee_name =
-            expression_string_approximation(&data.arguments[0].value).map(|s| generator.intern_string(&s));
+        let callee_name = expression_string_approximation(&data.arguments[0].value, &generator.interner)
+            .map(|s| generator.intern_string(&s));
         let arguments: Vec<Operand> = argument_holders.iter().map(|a| a.operand()).collect();
         generator.emit(Instruction::Call {
             dst: dst.operand(),
@@ -2947,10 +2952,10 @@ fn try_generate_builtin_abstract_operation(
         (utf16!("IteratorComplete"), AbstractOperationKind::IteratorComplete),
     ];
     for &(op_name, operation) in known_operations {
-        if *name == op_name {
+        if name == op_name {
             let callee = generator.add_constant_abstract_operation(operation);
             let undefined = generator.add_constant_undefined();
-            let expression_string = generator.intern_string(name);
+            let expression_string = generator.intern_string(&name);
             let mut argument_holders = Vec::with_capacity(data.arguments.len());
             for argument in &data.arguments {
                 let val = generate_expression_or_undefined(&argument.value, generator, None);
@@ -3020,14 +3025,18 @@ fn generate_call_expression(
 
     // Compute expression_string for error messages (e.g. "true is not a function (evaluated from 'a')").
     let expression_string: Option<StringTableIndex> =
-        expression_string_approximation(&data.callee).map(|s| generator.intern_string(&s));
+        expression_string_approximation(&data.callee, &generator.interner).map(|s| generator.intern_string(&s));
 
     // Detect direct eval calls: bare identifier "eval" as callee.
-    let is_direct_eval =
-        !is_new && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if ident.name == utf16!("eval"));
+    let is_direct_eval = !is_new
+        && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if generator.resolve_name(ident.name) == utf16!("eval"));
 
     // Detect known builtins for member expression callees (e.g. Math.abs).
-    let builtin: Option<u8> = if !is_new { get_builtin(&data.callee) } else { None };
+    let builtin: Option<u8> = if !is_new {
+        get_builtin(&data.callee, &generator.interner)
+    } else {
+        None
+    };
 
     // For method calls (obj.method()), we need to use the object as `this`.
     let (callee, this_value) = if !is_new {
@@ -3053,7 +3062,7 @@ fn generate_call_expression(
                 if let Some(key) = computed_key {
                     emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id_with_this(generator, &method, &super_base, &ident.name, &this_value);
+                    emit_get_by_id_with_this(generator, &method, &super_base, ident.name, &this_value);
                 }
                 (method, Some(this_value))
             }
@@ -3065,9 +3074,9 @@ fn generate_call_expression(
                     let property = generate_expression_or_undefined(&data.property, generator, None);
                     emit_get_by_value(generator, &method, &obj, &property, None);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id(generator, &method, &obj, &ident.name, base_id);
+                    emit_get_by_id(generator, &method, &obj, ident.name, base_id);
                 } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &data.property.inner {
-                    let id = generator.intern_identifier(&priv_ident.name);
+                    let id = generator.intern_identifier_by_id(priv_ident.name);
                     generator.emit(Instruction::GetPrivateById {
                         dst: method.operand(),
                         base: obj.operand(),
@@ -3096,7 +3105,7 @@ fn generate_call_expression(
                 // to properly handle with-statement bindings and eval.
                 let callee_reg = generator.allocate_register();
                 let this_reg = generator.allocate_register();
-                let id = generator.intern_identifier(&ident.name);
+                let id = generator.intern_identifier_by_id(ident.name);
                 generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
                     callee: callee_reg.operand(),
                     this_value: this_reg.operand(),
@@ -3324,7 +3333,7 @@ fn generate_update_expression(
                 if let Some(ref key) = computed_key {
                     emit_get_by_value_with_this(generator, &value, &base, key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id_with_this(generator, &value, &base, &ident.name, &this_value);
+                    emit_get_by_id_with_this(generator, &value, &base, ident.name, &this_value);
                 }
                 let result = emit_update_op(generator, op, prefixed, &value);
                 emit_super_put(
@@ -3350,8 +3359,8 @@ fn generate_update_expression(
                     Some(result)
                 } else if let ExpressionKind::Identifier(property_ident) = &data.property.inner {
                     let value = generator.allocate_register();
-                    emit_get_by_id(generator, &value, &base, &property_ident.name, base_id);
-                    let key = generator.intern_property_key(&property_ident.name);
+                    emit_get_by_id(generator, &value, &base, property_ident.name, base_id);
+                    let key = generator.intern_property_key_by_id(property_ident.name);
                     let result = emit_update_op(generator, op, prefixed, &value);
                     let cache2 = generator.next_property_lookup_cache();
                     generator.emit(Instruction::PutById {
@@ -3364,7 +3373,7 @@ fn generate_update_expression(
                     });
                     Some(result)
                 } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &data.property.inner {
-                    let id = generator.intern_identifier(&priv_ident.name);
+                    let id = generator.intern_identifier_by_id(priv_ident.name);
                     let value = generator.allocate_register();
                     generator.emit(Instruction::GetPrivateById {
                         dst: value.operand(),
@@ -3416,7 +3425,7 @@ fn generate_assignment_expression(
             // Simple assignment to identifier
             if let ExpressionKind::Identifier(ident) = &lhs_expression.inner {
                 if op == AssignmentOp::Assignment {
-                    generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+                    generator.pending_lhs_name = Some(generator.intern_identifier_by_id(ident.name));
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     generator.pending_lhs_name = None;
                     if ident.is_local() {
@@ -3457,7 +3466,7 @@ fn generate_assignment_expression(
                     }
                     // RHS block: evaluate RHS, assign, jump to end.
                     generator.switch_to_basic_block(rhs_block);
-                    generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+                    generator.pending_lhs_name = Some(generator.intern_identifier_by_id(ident.name));
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     generator.pending_lhs_name = None;
                     // Allocate dst after RHS evaluation.
@@ -3534,7 +3543,7 @@ fn generate_assignment_expression(
                     if let Some(ref key) = computed_key {
                         emit_get_by_value_with_this(generator, &old_val, &base, key, &super_this);
                     } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                        emit_get_by_id_with_this(generator, &old_val, &base, &ident.name, &super_this);
+                        emit_get_by_id_with_this(generator, &old_val, &base, ident.name, &super_this);
                     }
                     let is_logical = matches!(
                         op,
@@ -3649,7 +3658,7 @@ fn generate_assignment_expression(
                     return Some(dst);
                 } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                     let old_val = generator.allocate_register();
-                    emit_get_by_id(generator, &old_val, &base, &ident.name, base_id);
+                    emit_get_by_id(generator, &old_val, &base, ident.name, base_id);
                     if is_logical {
                         let rhs_block = generator.make_block();
                         let lhs_block = generator.make_block();
@@ -3659,7 +3668,7 @@ fn generate_assignment_expression(
                         let rhs_val = generate_expression(rhs, generator, None)?;
                         let dst = choose_dst(generator, preferred_dst);
                         generator.emit_mov(&dst, &rhs_val);
-                        let key = generator.intern_property_key(&ident.name);
+                        let key = generator.intern_property_key_by_id(ident.name);
                         let cache2 = generator.next_property_lookup_cache();
                         generator.emit(Instruction::PutById {
                             base: base.operand(),
@@ -3679,7 +3688,7 @@ fn generate_assignment_expression(
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     let dst = choose_dst(generator, preferred_dst);
                     emit_compound_assignment(generator, op, &dst, &old_val, &rhs_val);
-                    let key = generator.intern_property_key(&ident.name);
+                    let key = generator.intern_property_key_by_id(ident.name);
                     let cache2 = generator.next_property_lookup_cache();
                     generator.emit(Instruction::PutById {
                         base: base.operand(),
@@ -3692,7 +3701,7 @@ fn generate_assignment_expression(
                     return Some(dst);
                 } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
                     let old_val = generator.allocate_register();
-                    let id = generator.intern_identifier(&priv_ident.name);
+                    let id = generator.intern_identifier_by_id(priv_ident.name);
                     generator.emit(Instruction::GetPrivateById {
                         dst: old_val.operand(),
                         base: base.operand(),
@@ -3708,7 +3717,7 @@ fn generate_assignment_expression(
                         // Allocate dst after RHS evaluation.
                         let dst = choose_dst(generator, preferred_dst);
                         generator.emit_mov(&dst, &rhs_val);
-                        let id2 = generator.intern_identifier(&priv_ident.name);
+                        let id2 = generator.intern_identifier_by_id(priv_ident.name);
                         generator.emit(Instruction::PutPrivateById {
                             base: base.operand(),
                             property: id2,
@@ -3724,7 +3733,7 @@ fn generate_assignment_expression(
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     let dst = choose_dst(generator, preferred_dst);
                     emit_compound_assignment(generator, op, &dst, &old_val, &rhs_val);
-                    let id2 = generator.intern_identifier(&priv_ident.name);
+                    let id2 = generator.intern_identifier_by_id(priv_ident.name);
                     generator.emit(Instruction::PutPrivateById {
                         base: base.operand(),
                         property: id2,
@@ -3787,7 +3796,7 @@ fn emit_super_get(
         emit_get_by_value_with_this(generator, dst, base, &property, this_value);
         Some(property)
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
-        emit_get_by_id_with_this(generator, dst, base, &ident.name, this_value);
+        emit_get_by_id_with_this(generator, dst, base, ident.name, this_value);
         None
     } else {
         None
@@ -3814,7 +3823,7 @@ fn emit_super_put(
         };
         emit_put_normal_by_value_with_this(generator, base, &property, this_value, value);
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
-        let key = generator.intern_property_key(&ident.name);
+        let key = generator.intern_property_key_by_id(ident.name);
         let cache = generator.next_property_lookup_cache();
         generator.emit(Instruction::PutByIdWithThis {
             base: base.operand(),
@@ -3828,7 +3837,7 @@ fn emit_super_put(
 }
 
 /// Emit a property access by name, using GetLength for the "length" property.
-fn emit_get_by_id(
+fn emit_get_by_id_impl(
     generator: &mut Generator,
     dst: &ScopedOperand,
     base: &ScopedOperand,
@@ -3857,9 +3866,20 @@ fn emit_get_by_id(
     }
 }
 
+fn emit_get_by_id(
+    generator: &mut Generator,
+    dst: &ScopedOperand,
+    base: &ScopedOperand,
+    property_name: InternedId,
+    base_identifier: Option<IdentifierTableIndex>,
+) {
+    let name = generator.resolve_name(property_name).to_vec();
+    emit_get_by_id_impl(generator, dst, base, &name, base_identifier);
+}
+
 /// Emit a property access by name with a this value, using GetLengthWithThis
 /// for the "length" property.
-fn emit_get_by_id_with_this(
+fn emit_get_by_id_with_this_impl(
     generator: &mut Generator,
     dst: &ScopedOperand,
     base: &ScopedOperand,
@@ -3886,6 +3906,17 @@ fn emit_get_by_id_with_this(
             cache: cache as u64,
         });
     }
+}
+
+fn emit_get_by_id_with_this(
+    generator: &mut Generator,
+    dst: &ScopedOperand,
+    base: &ScopedOperand,
+    property_name: InternedId,
+    this_value: &ScopedOperand,
+) {
+    let name = generator.resolve_name(property_name).to_vec();
+    emit_get_by_id_with_this_impl(generator, dst, base, &name, this_value);
 }
 
 /// Emit a "Invalid left-hand side in assignment" ReferenceError followed by Throw.
@@ -4185,7 +4216,7 @@ fn emit_set_variable(generator: &mut Generator, ident: &Identifier, value: &Scop
             src: value.operand(),
         });
     } else if ident.is_global.get() {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_by_id(ident.name);
         let cache = generator.next_global_variable_cache();
         generator.emit(Instruction::SetGlobal {
             identifier: id,
@@ -4195,7 +4226,7 @@ fn emit_set_variable(generator: &mut Generator, ident: &Identifier, value: &Scop
     } else {
         // Non-local, non-global: use SetLexicalBinding which searches
         // the lexical environment chain (important for with-statement support).
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_by_id(ident.name);
         generator.emit(Instruction::SetLexicalBinding {
             identifier: id,
             src: value.operand(),
@@ -4217,7 +4248,7 @@ fn emit_put_to_member(
         let property = generate_expression_or_undefined(property, generator, None);
         emit_put_normal_by_value(generator, base, &property, value, base_id);
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
-        let key = generator.intern_property_key(&ident.name);
+        let key = generator.intern_property_key_by_id(ident.name);
         let cache = generator.next_property_lookup_cache();
         generator.emit(Instruction::PutById {
             base: base.operand(),
@@ -4228,7 +4259,7 @@ fn emit_put_to_member(
             kind: 0,
         });
     } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &property.inner {
-        let id = generator.intern_identifier(&priv_ident.name);
+        let id = generator.intern_identifier_by_id(priv_ident.name);
         generator.emit(Instruction::PutPrivateById {
             base: base.operand(),
             property: id,
@@ -4245,7 +4276,7 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                 return generator.add_constant_boolean(false);
             }
             let dst = generator.allocate_register();
-            let id = generator.intern_identifier(&ident.name);
+            let id = generator.intern_identifier_by_id(ident.name);
             generator.emit(Instruction::DeleteVariable {
                 dst: dst.operand(),
                 identifier: id,
@@ -4293,7 +4324,7 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                     property: key.operand(),
                 });
             } else if let ExpressionKind::Identifier(property_ident) = &data.property.inner {
-                let key = generator.intern_property_key(&property_ident.name);
+                let key = generator.intern_property_key_by_id(property_ident.name);
                 generator.emit(Instruction::DeleteById {
                     dst: dst.operand(),
                     base: base.operand(),
@@ -4378,7 +4409,7 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                     }
                 }
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                let key = generator.intern_property_key(&ident.name);
+                let key = generator.intern_property_key_by_id(ident.name);
                 let cache = generator.next_property_lookup_cache();
                 EvaluatedReference::SuperMemberId {
                     base,
@@ -4413,7 +4444,7 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                     }
                 }
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                let key = generator.intern_property_key(&ident.name);
+                let key = generator.intern_property_key_by_id(ident.name);
                 let cache = generator.next_property_lookup_cache();
                 EvaluatedReference::MemberId {
                     base,
@@ -4422,7 +4453,7 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                     base_identifier: None,
                 }
             } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
-                let id = generator.intern_identifier(&priv_ident.name);
+                let id = generator.intern_identifier_by_id(priv_ident.name);
                 EvaluatedReference::PrivateMember { base, property: id }
             } else {
                 unreachable!("non-computed member property must be an identifier or private identifier")
@@ -4721,7 +4752,7 @@ fn generate_tagged_template_literal(
             if let Some(key) = computed_key {
                 emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                emit_get_by_id_with_this(generator, &method, &super_base, &ident.name, &this_value);
+                emit_get_by_id_with_this(generator, &method, &super_base, ident.name, &this_value);
             }
             (method, Some(this_value))
         }
@@ -4733,9 +4764,9 @@ fn generate_tagged_template_literal(
                 emit_get_by_value(generator, &method, &obj, &property, None);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
-                emit_get_by_id(generator, &method, &obj, &ident.name, base_id);
+                emit_get_by_id(generator, &method, &obj, ident.name, base_id);
             } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
-                let id = generator.intern_identifier(&priv_ident.name);
+                let id = generator.intern_identifier_by_id(priv_ident.name);
                 generator.emit(Instruction::GetPrivateById {
                     dst: method.operand(),
                     base: obj.operand(),
@@ -4753,7 +4784,7 @@ fn generate_tagged_template_literal(
             // to properly handle with-statement bindings.
             let callee_reg = generator.allocate_register();
             let this_reg = generator.allocate_register();
-            let id = generator.intern_identifier(&ident.name);
+            let id = generator.intern_identifier_by_id(ident.name);
             generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
                 callee: callee_reg.operand(),
                 this_value: this_reg.operand(),
@@ -4916,9 +4947,9 @@ fn generate_switch_statement(
             if did_create_env
                 && let StatementKind::FunctionDeclaration(ref fd) = child.inner
                 && let Some(ref name_ident) = fd.name
-                && generator.annexb_function_names.contains(name_ident.name.as_slice())
+                && generator.annexb_function_names.contains(&name_ident.name)
             {
-                let id = generator.intern_identifier(&name_ident.name);
+                let id = generator.intern_identifier_by_id(name_ident.name);
                 let value = generator.allocate_register();
                 generator.emit(Instruction::GetBinding {
                     dst: value.operand(),
@@ -4987,7 +5018,7 @@ fn emit_switch_block_declaration_instantiation(generator: &mut Generator, data: 
         {
             vd.declarations.iter().any(|declaration| {
                 let mut names = Vec::new();
-                collect_target_names(&declaration.target, &mut names);
+                collect_target_names(&declaration.target, &mut names, &generator.interner);
                 !names.is_empty()
             })
         }
@@ -5094,7 +5125,7 @@ fn generate_object_expression(
         if !effectively_computed && property.property_type != ObjectPropertyType::ProtoSetter {
             let base_name: Option<Utf16String> = match &property.key.inner {
                 ExpressionKind::StringLiteral(s) => Some((**s).clone()),
-                ExpressionKind::Identifier(ident) => Some(ident.name.to_utf16_string()),
+                ExpressionKind::Identifier(ident) => Some(generator.resolve_name_owned(ident.name)),
                 _ => None,
             };
             if let Some(name) = base_name {
@@ -5156,7 +5187,7 @@ fn generate_object_expression(
                 } else {
                     // Non-simple object: use PutOwnById instead of InitObjectLiteralProperty
                     let property_key = match &property.key.inner {
-                        ExpressionKind::Identifier(ident) => generator.intern_property_key(&ident.name),
+                        ExpressionKind::Identifier(ident) => generator.intern_property_key_by_id(ident.name),
                         ExpressionKind::StringLiteral(s) => generator.intern_property_key(s),
                         _ => {
                             emit_object_property_set_by_key(
@@ -5244,7 +5275,7 @@ fn emit_object_property_set_by_key(
     }
     match &key.inner {
         ExpressionKind::Identifier(ident) => {
-            let property_key = generator.intern_property_key(&ident.name);
+            let property_key = generator.intern_property_key_by_id(ident.name);
             generator.emit(Instruction::InitObjectLiteralProperty {
                 object: object.operand(),
                 property: property_key,
@@ -5347,7 +5378,10 @@ fn emit_object_accessor_by_key(
     }
 
     match &key.inner {
-        ExpressionKind::Identifier(ident) => emit_by_id(generator, &ident.name),
+        ExpressionKind::Identifier(ident) => {
+            let name_slice = generator.resolve_name(ident.name).to_vec();
+            emit_by_id(generator, &name_slice);
+        }
         ExpressionKind::StringLiteral(s) => emit_by_id(generator, s),
         _ => emit_by_value(generator, key),
     }
@@ -5396,10 +5430,10 @@ fn generate_optional_chain_inner(
                 generator.emit_mov(current_base, &obj);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
-                emit_get_by_id(generator, &val, &obj, &ident.name, base_id);
+                emit_get_by_id(generator, &val, &obj, ident.name, base_id);
                 generator.emit_mov(current_base, &obj);
             } else if let ExpressionKind::PrivateIdentifier(name) = &member_data.property.inner {
-                let id = generator.intern_identifier(&name.name);
+                let id = generator.intern_identifier_by_id(name.name);
                 generator.emit(Instruction::GetPrivateById {
                     dst: val.operand(),
                     base: obj.operand(),
@@ -5454,7 +5488,7 @@ fn generate_optional_chain_inner(
         match reference {
             OptionalChainReference::MemberReference { identifier, .. } => {
                 generator.emit_mov(current_base, current_value);
-                emit_get_by_id(generator, current_value, current_value, &identifier.name, None);
+                emit_get_by_id(generator, current_value, current_value, identifier.name, None);
             }
             OptionalChainReference::ComputedReference { expression, .. } => {
                 generator.emit_mov(current_base, current_value);
@@ -5475,7 +5509,7 @@ fn generate_optional_chain_inner(
             }
             OptionalChainReference::PrivateMemberReference { private_identifier, .. } => {
                 generator.emit_mov(current_base, current_value);
-                let id = generator.intern_identifier(&private_identifier.name);
+                let id = generator.intern_identifier_by_id(private_identifier.name);
                 generator.emit(Instruction::GetPrivateById {
                     dst: current_value.operand(),
                     base: current_value.operand(),
@@ -5579,7 +5613,7 @@ fn generate_class_expression(
     // (skip this for anonymous classes with lhs_name).
     if data.name.is_some() || lhs_name.is_none() {
         let name = if let Some(name_ident) = &data.name {
-            name_ident.name.to_utf16_string()
+            generator.resolve_name_owned(name_ident.name)
         } else {
             Utf16String::new()
         };
@@ -5618,7 +5652,7 @@ fn generate_class_expression(
                 generator.emit(Instruction::CreatePrivateEnvironment);
                 has_private_env = true;
             }
-            let name_id = generator.intern_identifier(&name);
+            let name_id = generator.intern_identifier_by_id(name);
             generator.emit(Instruction::AddPrivateName { name: name_id });
         }
     }
@@ -5761,9 +5795,9 @@ fn generate_class_expression(
                     if !is_literal {
                         // Determine field name for anonymous function naming.
                         let field_name = match &key.inner {
-                            ExpressionKind::Identifier(ident) => ident.name.to_utf16_string(),
+                            ExpressionKind::Identifier(ident) => generator.resolve_name_owned(ident.name),
                             ExpressionKind::StringLiteral(s) => (**s).clone(),
-                            ExpressionKind::PrivateIdentifier(p) => p.name.clone(),
+                            ExpressionKind::PrivateIdentifier(p) => generator.resolve_name_owned(p.name),
                             ExpressionKind::NumericLiteral(n) => super::ffi::js_number_to_utf16(*n),
                             ExpressionKind::BigIntLiteral(s) => {
                                 let digits = s.strip_suffix('n').unwrap_or(s.as_str());
@@ -5810,8 +5844,8 @@ fn generate_class_expression(
 
                         let key_is_private = is_private_key(key);
                         let key_name: Utf16String = match &key.inner {
-                            ExpressionKind::PrivateIdentifier(ident) => ident.name.clone(),
-                            ExpressionKind::Identifier(ident) => ident.name.to_utf16_string(),
+                            ExpressionKind::PrivateIdentifier(ident) => generator.resolve_name_owned(ident.name),
+                            ExpressionKind::Identifier(ident) => generator.resolve_name_owned(ident.name),
                             ExpressionKind::StringLiteral(s) => (**s).clone(),
                             ExpressionKind::NumericLiteral(n) => super::ffi::js_number_to_utf16(*n),
                             _ => Utf16String::new(),
@@ -5886,7 +5920,7 @@ fn generate_class_expression(
     let source_text_len = source_end - source_start;
 
     let blueprint_index = generator.register_class_blueprint(PendingClassBlueprint {
-        name: data.name.as_ref().map(|n| n.name.to_utf16_string()),
+        name: data.name.as_ref().map(|n| generator.resolve_name_owned(n.name)),
         source_text_offset: source_start,
         source_text_length: source_text_len,
         constructor_sfd_index,
@@ -5941,7 +5975,7 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
         parser.flags.allow_super_constructor_call = true;
     }
     let program = parser.parse_program(false);
-    parser.scope_collector.analyze(false);
+    parser.scope_collector.analyze(false, &parser.interner);
 
     assert!(!parser.has_errors(), "default constructor parse failed");
 
@@ -5983,11 +6017,10 @@ fn is_private_key(key: &Expression) -> bool {
     matches!(&key.inner, ExpressionKind::PrivateIdentifier(_))
 }
 
-/// Get a pointer directly into the AST's PrivateIdentifier name.
-/// The pointer remains valid as long as the AST is alive.
-fn get_private_identifier_name(key: &Expression) -> Option<Utf16String> {
+/// Get the InternedId of a PrivateIdentifier's name.
+fn get_private_identifier_name(key: &Expression) -> Option<InternedId> {
     if let ExpressionKind::PrivateIdentifier(ident) = &key.inner {
-        Some(ident.name.clone())
+        Some(ident.name)
     } else {
         None
     }
@@ -5995,14 +6028,14 @@ fn get_private_identifier_name(key: &Expression) -> Option<Utf16String> {
 
 /// Check if a for-in/for-of LHS is a `let`/`const` declaration with non-local identifiers,
 /// meaning we need a per-iteration lexical environment.
-fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs) -> bool {
+fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs, interner: &StringInterner) -> bool {
     if let ForInOfLhs::Declaration(statement) = lhs
         && let StatementKind::VariableDeclaration(vd) = &statement.inner
         && (vd.kind == DeclarationKind::Let || vd.kind == DeclarationKind::Const)
     {
         let mut names = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut names);
+            collect_target_names(&declaration.target, &mut names, interner);
         }
         return !names.is_empty();
     }
@@ -6010,36 +6043,44 @@ fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs) -> bool {
 }
 
 /// Collect all non-local binding names from a variable declarator target.
-fn collect_target_names(target: &VariableDeclaratorTarget, names: &mut Vec<(Utf16String, bool)>) {
+fn collect_target_names(
+    target: &VariableDeclaratorTarget,
+    names: &mut Vec<(Utf16String, bool)>,
+    interner: &StringInterner,
+) {
     match target {
         VariableDeclaratorTarget::Identifier(ident) => {
             if !ident.is_local() {
-                names.push((ident.name.to_utf16_string(), false));
+                names.push((Utf16String(interner.lookup(ident.name).to_vec()), false));
             }
         }
         VariableDeclaratorTarget::BindingPattern(pattern) => {
-            collect_pattern_binding_names(pattern, names);
+            collect_pattern_binding_names(pattern, names, interner);
         }
     }
 }
 
 /// Collect all non-local binding names from a binding pattern (recursive).
-fn collect_pattern_binding_names(pattern: &BindingPattern, names: &mut Vec<(Utf16String, bool)>) {
+fn collect_pattern_binding_names(
+    pattern: &BindingPattern,
+    names: &mut Vec<(Utf16String, bool)>,
+    interner: &StringInterner,
+) {
     for entry in &pattern.entries {
         match &entry.alias {
             Some(BindingEntryAlias::Identifier(ident)) => {
                 if !ident.is_local() {
-                    names.push((ident.name.to_utf16_string(), false));
+                    names.push((Utf16String(interner.lookup(ident.name).to_vec()), false));
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub)) => {
-                collect_pattern_binding_names(sub, names);
+                collect_pattern_binding_names(sub, names, interner);
             }
             None => {
                 if let Some(BindingEntryName::Identifier(ident)) = &entry.name
                     && !ident.is_local()
                 {
-                    names.push((ident.name.to_utf16_string(), false));
+                    names.push((Utf16String(interner.lookup(ident.name).to_vec()), false));
                 }
             }
             Some(BindingEntryAlias::MemberExpression(_)) => {}
@@ -6060,7 +6101,7 @@ fn create_for_in_of_lexical_env(generator: &mut Generator, lhs: &ForInOfLhs) -> 
     {
         is_constant = vd.kind == DeclarationKind::Const;
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut binding_names);
+            collect_target_names(&declaration.target, &mut binding_names, &generator.interner);
         }
     }
 
@@ -6094,7 +6135,7 @@ fn enter_for_in_of_head_tdz(generator: &mut Generator, lhs: &ForInOfLhs) -> bool
     {
         let mut names = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut names);
+            collect_target_names(&declaration.target, &mut names, &generator.interner);
         }
         if !names.is_empty() {
             generator.push_new_lexical_environment(0);
@@ -6155,7 +6196,7 @@ fn generate_for_in_statement(
         && let Some(declaration) = vd.declarations.first()
         && let (VariableDeclaratorTarget::Identifier(ident), Some(init)) = (&declaration.target, &declaration.init)
     {
-        generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+        generator.pending_lhs_name = Some(generator.intern_identifier_by_id(ident.name));
         let value = generate_expression_or_undefined(init, generator, None);
         generator.pending_lhs_name = None;
         emit_set_variable(generator, ident, &value);
@@ -6165,7 +6206,7 @@ fn generate_for_in_statement(
     // continuation_block during head evaluation.
     let end_block = generator.make_block();
     let update_block = generator.make_block();
-    let needs_lexical_env = for_in_of_needs_lexical_env(lhs);
+    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.interner);
 
     // B.3.5 Initializers in ForIn Statement Heads: evaluate initializer before RHS.
     // Create TDZ for lexical declarations before evaluating the RHS expression.
@@ -6343,7 +6384,7 @@ fn generate_for_of_statement_inner(
 
     // Create TDZ for lexical declarations before evaluating the RHS expression.
     let entered_tdz = enter_for_in_of_head_tdz(generator, lhs);
-    let needs_lexical_env = for_in_of_needs_lexical_env(lhs);
+    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.interner);
     let old_handler = generator.current_unwind_handler;
 
     // Evaluate RHS into `object`, allocate iterator registers, and emit
@@ -6436,14 +6477,14 @@ fn generate_for_of_statement_inner(
             src: next_result.operand(),
         });
         // IteratorComplete — get .done property
-        emit_get_by_id(generator, &done, &next_result, utf16!("done"), None);
+        emit_get_by_id_impl(generator, &done, &next_result, utf16!("done"), None);
 
         let loop_continue_block = generator.make_block();
         generator.emit_jump_if(&done, end_block, loop_continue_block);
         generator.switch_to_basic_block(loop_continue_block);
 
         // IteratorValue — get .value property
-        emit_get_by_id(generator, &next_value, &next_result, utf16!("value"), None);
+        emit_get_by_id_impl(generator, &next_value, &next_result, utf16!("value"), None);
     } else {
         generator.emit(Instruction::IteratorNextUnpack {
             dst_value: next_value.operand(),
@@ -6823,7 +6864,7 @@ fn set_pending_lhs_name_for_entry(generator: &mut Generator, entry: &BindingEntr
         _ => None,
     };
     if let Some(name) = name {
-        generator.pending_lhs_name = Some(generator.intern_identifier(name));
+        generator.pending_lhs_name = Some(generator.intern_identifier_by_id(*name));
     }
 }
 
@@ -6853,7 +6894,7 @@ fn emit_set_variable_with_mode(
         let local = generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
         generator.emit_mov(&local, value);
     } else {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_by_id(ident.name);
         match mode {
             BindingMode::InitializeLexical => {
                 generator.emit(Instruction::InitializeLexicalBinding {
@@ -7110,9 +7151,9 @@ fn generate_object_binding_pattern(
 
         match &entry.name {
             Some(BindingEntryName::Identifier(ident)) => {
-                emit_get_by_id(generator, &value, object, &ident.name, None);
+                emit_get_by_id(generator, &value, object, ident.name, None);
                 if has_rest {
-                    let name_val = generator.add_constant_string(ident.name.to_utf16_string());
+                    let name_val = generator.add_constant_string(generator.resolve_name_owned(ident.name));
                     excluded_names.push(name_val);
                 }
             }
@@ -7265,7 +7306,7 @@ fn generate_try_statement(
                         generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
                         created_catch_scope = true;
 
-                        let id = generator.intern_identifier(&ident.name);
+                        let id = generator.intern_identifier_by_id(ident.name);
                         generator.emit(Instruction::CreateVariable {
                             identifier: id,
                             mode: EnvironmentMode::Lexical as u32,
@@ -7282,7 +7323,7 @@ fn generate_try_statement(
                 }
                 CatchBinding::BindingPattern(pattern) => {
                     let mut names: Vec<(Utf16String, bool)> = Vec::new();
-                    collect_pattern_binding_names(pattern, &mut names);
+                    collect_pattern_binding_names(pattern, &mut names, &generator.interner);
 
                     if !names.is_empty() {
                         generator.push_new_lexical_environment(0);
@@ -7620,7 +7661,7 @@ pub fn emit_function_declaration_instantiation(
     for parameter in &function_data.parameters {
         match &parameter.binding {
             FunctionParameterBinding::Identifier(ident) => {
-                let name = ident.name.to_utf16_string();
+                let name = generator.resolve_name_owned(ident.name);
                 let is_local = ident.is_local();
                 if !seen_names.insert(name.clone()) {
                     has_duplicates = true;
@@ -7629,7 +7670,13 @@ pub fn emit_function_declaration_instantiation(
                 }
             }
             FunctionParameterBinding::BindingPattern(pattern) => {
-                collect_binding_pattern_names(pattern, &mut parameter_names, &mut seen_names, &mut has_duplicates);
+                collect_binding_pattern_names(
+                    pattern,
+                    &mut parameter_names,
+                    &mut seen_names,
+                    &mut has_duplicates,
+                    &generator.interner,
+                );
             }
         }
     }
@@ -7779,7 +7826,7 @@ pub fn emit_function_declaration_instantiation(
                         None => {}
                     }
                 } else {
-                    let id = generator.intern_identifier(&ident.name);
+                    let id = generator.intern_identifier_by_id(ident.name);
                     if has_duplicates {
                         generator.emit(Instruction::SetLexicalBinding {
                             identifier: id,
@@ -7910,7 +7957,8 @@ pub fn emit_function_declaration_instantiation(
     if !strict {
         let var_names = function_scope_data.map(|fsd| &fsd.var_names);
         for name in &body_scope.annexb_function_names {
-            generator.annexb_function_names.insert(name.clone());
+            let name_id = generator.interner.intern(name);
+            generator.annexb_function_names.insert(name_id);
             // Skip creating a var binding if this name is already declared as a var.
             if var_names.is_some_and(|names| names.contains(name)) {
                 continue;
@@ -7935,7 +7983,7 @@ pub fn emit_function_declaration_instantiation(
     // --- Step 7: Lexical environment for non-local declarations ---
     // Note: this counts only let/const/class declarations (not function declarations,
     // which are var-hoisted in function bodies).
-    let lex_bindings_count = count_non_local_lexical_bindings(body_scope);
+    let lex_bindings_count = count_non_local_lexical_bindings(body_scope, &generator.interner);
 
     if !strict && lex_bindings_count > 0 {
         generator.push_new_lexical_environment(lex_bindings_count);
@@ -7951,7 +7999,7 @@ pub fn emit_function_declaration_instantiation(
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, &generator.interner);
                     for (name, _) in names {
                         let id = generator.intern_identifier(&name);
                         generator.emit(Instruction::CreateVariable {
@@ -7969,7 +8017,7 @@ pub fn emit_function_declaration_instantiation(
                 if let Some(ref name_ident) = class_data.name
                     && !name_ident.is_local()
                 {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_by_id(name_ident.name);
                     generator.emit(Instruction::CreateVariable {
                         identifier: id,
                         mode: EnvironmentMode::Lexical as u32,
@@ -8012,7 +8060,7 @@ pub fn emit_function_declaration_instantiation(
                             home_object: None,
                             lhs_name: None,
                         });
-                        let id = generator.intern_identifier(&name_ident.name);
+                        let id = generator.intern_identifier_by_id(name_ident.name);
                         generator.emit(Instruction::SetVariableBinding {
                             identifier: id,
                             src: function_reg.operand(),
@@ -8032,7 +8080,7 @@ fn is_for_loop(statement: &Statement) -> bool {
 
 /// Check if a block needs block declaration instantiation.
 /// True when the block has function declarations or non-local let/const/class.
-fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
+fn needs_block_declaration_instantiation(scope: &ScopeData, interner: &StringInterner) -> bool {
     for child in &scope.children {
         match &child.inner {
             StatementKind::FunctionDeclaration(_) => {
@@ -8043,7 +8091,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
             {
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, interner);
                     if !names.is_empty() {
                         return true;
                     }
@@ -8059,7 +8107,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, interner);
                     if !names.is_empty() {
                         return true;
                     }
@@ -8072,7 +8120,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
 }
 
 /// Count non-local lexical bindings in a function body scope.
-fn count_non_local_lexical_bindings(scope: &ScopeData) -> u32 {
+fn count_non_local_lexical_bindings(scope: &ScopeData, interner: &StringInterner) -> u32 {
     let mut count = 0u32;
     for child in &scope.children {
         match &child.inner {
@@ -8081,7 +8129,7 @@ fn count_non_local_lexical_bindings(scope: &ScopeData) -> u32 {
             {
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, interner);
                     count += u32_from_usize(names.len());
                 }
             }
@@ -8105,12 +8153,13 @@ fn collect_binding_pattern_names(
     parameter_names: &mut Vec<FdiParameterName>,
     seen_names: &mut HashSet<Utf16String>,
     has_duplicates: &mut bool,
+    interner: &StringInterner,
 ) {
     for entry in &pattern.entries {
         // The bound name can be in the alias (for object patterns) or name (for array patterns).
         match &entry.alias {
             Some(BindingEntryAlias::Identifier(ident)) => {
-                let name = ident.name.to_utf16_string();
+                let name = Utf16String(interner.lookup(ident.name).to_vec());
                 let is_local = ident.is_local();
                 if !seen_names.insert(name.clone()) {
                     *has_duplicates = true;
@@ -8119,12 +8168,11 @@ fn collect_binding_pattern_names(
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub_pattern)) => {
-                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates);
+                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates, interner);
             }
             None => {
-                // No alias — the name itself is the binding.
                 if let Some(BindingEntryName::Identifier(ident)) = &entry.name {
-                    let name = ident.name.to_utf16_string();
+                    let name = Utf16String(interner.lookup(ident.name).to_vec());
                     let is_local = ident.is_local();
                     if !seen_names.insert(name.clone()) {
                         *has_duplicates = true;
@@ -8172,7 +8220,7 @@ const BUILTIN_STRING_PROTOTYPE_CHAR_AT: u8 = 23;
 
 /// Detect known builtin methods from a callee expression (e.g. Math.abs).
 /// Returns the Builtin enum value as u8, matching Builtins.h ordering.
-fn get_builtin(callee: &Expression) -> Option<u8> {
+fn get_builtin(callee: &Expression, interner: &StringInterner) -> Option<u8> {
     let ExpressionKind::Member(member_data) = &callee.inner else {
         return None;
     };
@@ -8182,10 +8230,11 @@ fn get_builtin(callee: &Expression) -> Option<u8> {
     let ExpressionKind::Identifier(property_ident) = &member_data.property.inner else {
         return None;
     };
-    if property_ident.name == utf16!("charAt") {
+    let property_name = interner.lookup(property_ident.name);
+    if property_name == utf16!("charAt") {
         return Some(BUILTIN_STRING_PROTOTYPE_CHAR_AT);
     }
-    if property_ident.name == utf16!("charCodeAt") {
+    if property_name == utf16!("charCodeAt") {
         return Some(BUILTIN_STRING_PROTOTYPE_CHAR_CODE_AT);
     }
     let ExpressionKind::Identifier(base_ident) = &member_data.object.inner else {
@@ -8244,8 +8293,9 @@ fn get_builtin(callee: &Expression) -> Option<u8> {
         ),
         (utf16!("String"), utf16!("fromCharCode"), BUILTIN_STRING_FROM_CHAR_CODE),
     ];
+    let base_name = interner.lookup(base_ident.name);
     for &(base, property, id) in BUILTINS {
-        if base_ident.name == base && property_ident.name == property {
+        if base_name == base && property_name == property {
             return Some(id);
         }
     }
@@ -9078,14 +9128,14 @@ fn nanboxed_empty() -> u64 {
 /// Intern the base expression as an identifier for error messages like
 /// "Cannot access property X on null object Y".
 fn intern_base_identifier(generator: &mut Generator, base: &Expression) -> Option<IdentifierTableIndex> {
-    expression_identifier(base).map(|s| generator.intern_identifier(&s))
+    expression_identifier(base, &generator.interner).map(|s| generator.intern_identifier(&s))
 }
 
 /// Try to produce a human-readable name for an expression (for error messages).
 /// Returns None for expressions that have no meaningful name.
-fn expression_identifier(expression: &Expression) -> Option<Utf16String> {
+fn expression_identifier(expression: &Expression, interner: &StringInterner) -> Option<Utf16String> {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => Some(ident.name.to_utf16_string()),
+        ExpressionKind::Identifier(ident) => Some(Utf16String(interner.lookup(ident.name).to_vec())),
         ExpressionKind::StringLiteral(s) => {
             let mut result = Utf16String(utf16!("'").to_vec());
             result.0.extend_from_slice(s);
@@ -9096,10 +9146,10 @@ fn expression_identifier(expression: &Expression) -> Option<Utf16String> {
         ExpressionKind::This => Some(Utf16String(utf16!("this").to_vec())),
         ExpressionKind::Member(data) => {
             let mut s = Utf16String::new();
-            if let Some(obj_id) = expression_identifier(&data.object) {
+            if let Some(obj_id) = expression_identifier(&data.object, interner) {
                 s.0.extend_from_slice(&obj_id);
             }
-            if let Some(property_id) = expression_identifier(&data.property) {
+            if let Some(property_id) = expression_identifier(&data.property, interner) {
                 if data.computed {
                     s.0.extend_from_slice(utf16!("["));
                     s.0.extend_from_slice(&property_id);
@@ -9118,20 +9168,20 @@ fn expression_identifier(expression: &Expression) -> Option<Utf16String> {
 /// Produce a human-readable string for call expression error messages.
 /// Unlike expression_identifier, this always produces output for known types
 /// (using "<object>" for unrecognized sub-expressions).
-fn expression_string_approximation(expression: &Expression) -> Option<Utf16String> {
+fn expression_string_approximation(expression: &Expression, interner: &StringInterner) -> Option<Utf16String> {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => Some(ident.name.to_utf16_string()),
-        ExpressionKind::Member(_) => Some(member_to_string_approximation(expression)),
+        ExpressionKind::Identifier(ident) => Some(Utf16String(interner.lookup(ident.name).to_vec())),
+        ExpressionKind::Member(_) => Some(member_to_string_approximation(expression, interner)),
         _ => None,
     }
 }
 
-fn member_to_string_approximation(expression: &Expression) -> Utf16String {
+fn member_to_string_approximation(expression: &Expression, interner: &StringInterner) -> Utf16String {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => ident.name.to_utf16_string(),
+        ExpressionKind::Identifier(ident) => Utf16String(interner.lookup(ident.name).to_vec()),
         ExpressionKind::Member(data) => {
-            let mut s = member_to_string_approximation(&data.object);
-            let property_str = member_to_string_approximation(&data.property);
+            let mut s = member_to_string_approximation(&data.object, interner);
+            let property_str = member_to_string_approximation(&data.property, interner);
             if data.computed {
                 s.0.extend_from_slice(utf16!("["));
                 s.0.extend_from_slice(&property_str);
@@ -9153,7 +9203,7 @@ fn member_to_string_approximation(expression: &Expression) -> Utf16String {
             s.encode_utf16().collect()
         }
         ExpressionKind::This => Utf16String(utf16!("this").to_vec()),
-        ExpressionKind::PrivateIdentifier(ident) => ident.name.clone(),
+        ExpressionKind::PrivateIdentifier(ident) => Utf16String(interner.lookup(ident.name).to_vec()),
         _ => Utf16String(utf16!("<object>").to_vec()),
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -320,6 +320,7 @@ pub unsafe fn create_shared_function_data(
     source_code_ptr: *const c_void,
     is_strict: bool,
     name_override: Option<&[u16]>,
+    interner: &crate::string_interner::StringInterner,
 ) -> *mut c_void {
     unsafe {
         use crate::ast::FunctionParameterBinding;
@@ -331,7 +332,8 @@ pub unsafe fn create_shared_function_data(
         let (name_ptr, name_len) = if let Some(name) = name_override {
             (name.as_ptr(), name.len())
         } else if let Some(ref name_ident) = function_data.name {
-            (name_ident.name.as_ptr(), name_ident.name.len())
+            let name_slice = interner.lookup(name_ident.name);
+            (name_slice.as_ptr(), name_slice.len())
         } else {
             (std::ptr::null(), 0)
         };
@@ -346,7 +348,7 @@ pub unsafe fn create_shared_function_data(
                 .iter()
                 .map(|p| {
                     if let FunctionParameterBinding::Identifier(ref id) = p.binding {
-                        FFIUtf16Slice::from(id.name.as_ref())
+                        FFIUtf16Slice::from(interner.lookup(id.name))
                     } else {
                         unreachable!("has_simple_parameter_list guarantees all bindings are identifiers")
                     }
@@ -367,6 +369,7 @@ pub unsafe fn create_shared_function_data(
         let payload = Box::new(crate::ast::FunctionPayload {
             data: *function_data,
             function_table: subtable,
+            interner: interner.clone(),
         });
         let rust_ast_ptr = Box::into_raw(payload) as *mut c_void;
 
@@ -408,8 +411,19 @@ pub unsafe fn create_sfd_for_gdi(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     is_strict: bool,
+    interner: &crate::string_interner::StringInterner,
 ) -> *mut c_void {
-    unsafe { create_shared_function_data(function_data, subtable, vm_ptr, source_code_ptr, is_strict, None) }
+    unsafe {
+        create_shared_function_data(
+            function_data,
+            subtable,
+            vm_ptr,
+            source_code_ptr,
+            is_strict,
+            None,
+            interner,
+        )
+    }
 }
 
 unsafe fn materialize_shared_function_data(
@@ -435,6 +449,7 @@ unsafe fn materialize_shared_function_data(
                 source_code_ptr,
                 generator.strict,
                 pending.name_override.as_ref().map(|name| name.as_slice()),
+                &generator.interner,
             );
             if let Some((name, is_private)) = &pending.class_field_initializer_name {
                 rust_sfd_set_class_field_initializer_name(sfd_ptr, name.as_ptr(), name.len(), *is_private);
@@ -477,7 +492,7 @@ unsafe fn materialize_class_blueprints(
         generator
             .class_blueprints
             .iter()
-            .map(|blueprint| materialize_class_blueprint(blueprint, vm_ptr, source_code_ptr))
+            .map(|blueprint| materialize_class_blueprint(blueprint, vm_ptr, source_code_ptr, &generator.interner))
             .collect()
     }
 }
@@ -486,9 +501,14 @@ unsafe fn materialize_class_blueprint(
     blueprint: &PendingClassBlueprint,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    interner: &crate::string_interner::StringInterner,
 ) -> *mut c_void {
     unsafe {
-        let ffi_elements: Vec<FFIClassElement> = blueprint.elements.iter().map(class_element_to_ffi).collect();
+        let ffi_elements: Vec<FFIClassElement> = blueprint
+            .elements
+            .iter()
+            .map(|e| class_element_to_ffi(e, interner))
+            .collect();
         let (name, name_len) = blueprint
             .name
             .as_ref()
@@ -512,11 +532,16 @@ unsafe fn materialize_class_blueprint(
     }
 }
 
-fn class_element_to_ffi(element: &PendingClassElement) -> FFIClassElement {
+fn class_element_to_ffi(
+    element: &PendingClassElement,
+    interner: &crate::string_interner::StringInterner,
+) -> FFIClassElement {
     let (private_identifier, private_identifier_len) = element
         .private_identifier
-        .as_ref()
-        .map(|name| (name.as_ptr(), name.len()))
+        .map(|id| {
+            let s = interner.lookup(id);
+            (s.as_ptr(), s.len())
+        })
         .unwrap_or((std::ptr::null(), 0));
     let (literal_value_string, literal_value_string_len) = element
         .literal_value_string

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -10,14 +10,17 @@
 //! needed for bytecode generation from the AST.
 
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::rc::Rc;
+
+use fxhash::FxHashMap;
 
 use super::basic_block::{BasicBlock, SourceMapEntry};
 use super::ffi::{AbstractOperationKind, WellKnownSymbolKind};
 use super::instruction::Instruction;
 use super::operand::*;
 use crate::ast::{FunctionData, FunctionId, FunctionTable, LocalType, Position, Utf16String};
+use crate::string_interner::{InternedId, StringInterner};
 use crate::u32_from_usize;
 
 /// Identifies an operand that auto-frees its register when the last
@@ -76,7 +79,7 @@ pub struct PendingClassElement {
     pub kind: u8,
     pub is_static: bool,
     pub is_private: bool,
-    pub private_identifier: Option<Utf16String>,
+    pub private_identifier: Option<InternedId>,
     pub shared_function_data_index: Option<u32>,
     pub has_initializer: bool,
     pub literal_value_kind: PendingLiteralValueKind,
@@ -199,17 +202,17 @@ pub struct Generator {
     null_constant: Option<ScopedOperand>,
     undefined_constant: Option<ScopedOperand>,
     empty_constant: Option<ScopedOperand>,
-    int32_constants: HashMap<i32, ScopedOperand>,
-    double_constants: HashMap<u64, ScopedOperand>,
-    string_constants: HashMap<Utf16String, ScopedOperand>,
+    int32_constants: FxHashMap<i32, ScopedOperand>,
+    double_constants: FxHashMap<u64, ScopedOperand>,
+    string_constants: FxHashMap<Utf16String, ScopedOperand>,
 
     // --- String/identifier/property tables (with deduplication) ---
     pub string_table: Vec<Utf16String>,
-    string_table_index: HashMap<Utf16String, StringTableIndex>,
+    string_table_index: FxHashMap<Utf16String, StringTableIndex>,
     pub identifier_table: Vec<Utf16String>,
-    identifier_table_index: HashMap<Utf16String, IdentifierTableIndex>,
+    identifier_table_index: FxHashMap<Utf16String, IdentifierTableIndex>,
     pub property_key_table: Vec<Utf16String>,
-    property_key_table_index: HashMap<Utf16String, PropertyKeyTableIndex>,
+    property_key_table_index: FxHashMap<Utf16String, PropertyKeyTableIndex>,
     pub compiled_regexes: Vec<*mut std::ffi::c_void>,
 
     // --- Scope/unwind state ---
@@ -280,7 +283,7 @@ pub struct Generator {
     // --- AnnexB function names ---
     // Names approved for AnnexB.3.3 hoisting by the scope collector.
     // Populated during FDI, checked in switch case codegen.
-    pub annexb_function_names: HashSet<Utf16String>,
+    pub annexb_function_names: HashSet<InternedId>,
 
     // --- Builtin abstract operations ---
     // When true, calls to known abstract operations (e.g. IsCallable, GetMethod)
@@ -299,6 +302,11 @@ pub struct Generator {
     // Side table owning all FunctionData from the parser. Codegen
     // takes ownership of individual entries via `take()`.
     pub function_table: crate::ast::FunctionTable,
+
+    // --- String interner ---
+    // Shared interner from the parser. Used to resolve InternedId values
+    // in Identifier AST nodes to actual string data during codegen.
+    pub interner: StringInterner,
 }
 
 macro_rules! singleton_constant {
@@ -358,15 +366,15 @@ impl Generator {
             null_constant: None,
             undefined_constant: None,
             empty_constant: None,
-            int32_constants: HashMap::new(),
-            double_constants: HashMap::new(),
-            string_constants: HashMap::new(),
+            int32_constants: FxHashMap::default(),
+            double_constants: FxHashMap::default(),
+            string_constants: FxHashMap::default(),
             string_table: Vec::new(),
-            string_table_index: HashMap::new(),
+            string_table_index: FxHashMap::default(),
             identifier_table: Vec::new(),
-            identifier_table_index: HashMap::new(),
+            identifier_table_index: FxHashMap::default(),
             property_key_table: Vec::new(),
-            property_key_table_index: HashMap::new(),
+            property_key_table_index: FxHashMap::default(),
             compiled_regexes: Vec::new(),
             boundaries: Vec::new(),
             continuable_scopes: Vec::new(),
@@ -424,6 +432,7 @@ impl Generator {
             source_code_ptr: std::ptr::null(),
             source_len: 0,
             function_table: crate::ast::FunctionTable::new(),
+            interner: StringInterner::new(),
             free_register_pool,
         }
     }
@@ -624,6 +633,32 @@ impl Generator {
         property_key_table,
         property_key_table_index
     );
+
+    /// Resolve an InternedId to a string slice using the interner.
+    #[inline]
+    pub fn resolve_name(&self, id: InternedId) -> &[u16] {
+        self.interner.lookup(id)
+    }
+
+    /// Intern an identifier by InternedId (resolves through the interner).
+    #[inline]
+    pub fn intern_identifier_by_id(&mut self, id: InternedId) -> IdentifierTableIndex {
+        let s = self.interner.lookup(id).to_vec();
+        self.intern_identifier(&s)
+    }
+
+    /// Intern a property key by InternedId (resolves through the interner).
+    #[inline]
+    pub fn intern_property_key_by_id(&mut self, id: InternedId) -> PropertyKeyTableIndex {
+        let s = self.interner.lookup(id).to_vec();
+        self.intern_property_key(&s)
+    }
+
+    /// Resolve an InternedId name to Utf16String (owned copy for FFI/storage).
+    #[inline]
+    pub fn resolve_name_owned(&self, id: InternedId) -> Utf16String {
+        Utf16String(self.interner.lookup(id).to_vec())
+    }
 
     /// If `operand` is a constant string that is not an array index, intern it
     /// as a property key and return the index. Uses split borrows to avoid

--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -34,7 +34,7 @@
 //! type, because escaped keywords have different semantics (they can be
 //! used as identifiers in some contexts).
 
-use crate::ast::{SharedUtf16String, Utf16String};
+use crate::ast::Utf16String;
 use crate::token::{Token, TokenType};
 use crate::u32_from_usize;
 
@@ -70,8 +70,6 @@ pub struct Lexer<'a> {
     allow_html_comments: bool,
     template_states: Vec<TemplateState>,
     saved_states: Vec<SavedLexerState>,
-    short_identifier_cache: [Option<SharedUtf16String>; 128],
-    recent_identifier_cache: [Option<SharedUtf16String>; 128],
 }
 
 // Unicode constants used by the lexical grammar.
@@ -410,8 +408,6 @@ impl<'a> Lexer<'a> {
             allow_html_comments: true,
             template_states: Vec::new(),
             saved_states: Vec::new(),
-            short_identifier_cache: std::array::from_fn(|_| None),
-            recent_identifier_cache: std::array::from_fn(|_| None),
         };
         lexer.consume();
         lexer
@@ -433,43 +429,14 @@ impl<'a> Lexer<'a> {
             allow_html_comments: true,
             template_states: Vec::new(),
             saved_states: Vec::new(),
-            short_identifier_cache: std::array::from_fn(|_| None),
-            recent_identifier_cache: std::array::from_fn(|_| None),
         };
         lexer.consume();
         lexer
     }
 
-    fn shared_identifier_from_slice(&mut self, value: &[u16]) -> Option<SharedUtf16String> {
-        if value.is_empty() {
-            return None;
-        }
-
-        let first = value[0] as usize;
-        if value.len() == 1 && first < 128 {
-            if let Some(existing) = &self.short_identifier_cache[first] {
-                return Some(existing.clone());
-            }
-            let shared = SharedUtf16String::from(value);
-            self.short_identifier_cache[first] = Some(shared.clone());
-            return Some(shared);
-        }
-
-        let slot = first % 128;
-        if let Some(existing) = &self.recent_identifier_cache[slot]
-            && existing.as_slice() == value
-        {
-            return Some(existing.clone());
-        }
-
-        let shared = SharedUtf16String::from(value);
-        self.recent_identifier_cache[slot] = Some(shared.clone());
-        Some(shared)
-    }
-
-    fn shared_identifier_from_owned(&mut self, value: &Utf16String) -> Option<SharedUtf16String> {
-        self.shared_identifier_from_slice(value.as_slice())
-    }
+    /// No-op placeholder: identifier interning is now handled by the Parser
+    /// via its StringInterner. The Token carries offset/length for source
+    /// slices and `identifier_value` for decoded (escaped) identifiers.
 
     fn current_template_state(&self) -> &TemplateState {
         self.template_states.last().expect("template_states must not be empty")
@@ -997,7 +964,6 @@ impl<'a> Lexer<'a> {
         let did_consume_whitespace_or_comments = trivia_start != value_start;
 
         let mut identifier_value: Option<Utf16String> = None;
-        let mut shared_identifier_value: Option<SharedUtf16String> = None;
 
         if self.current_token_type == TokenType::RegexLiteral
             && !self.is_eof()
@@ -1068,11 +1034,7 @@ impl<'a> Lexer<'a> {
                 let has_escape = self.scan_identifier_body(len);
                 if has_escape {
                     let decoded = self.build_identifier_value(value_start);
-                    shared_identifier_value = self.shared_identifier_from_owned(&decoded);
                     identifier_value = Some(decoded);
-                } else {
-                    let source_slice = &self.source[value_start - 1..self.position - 1];
-                    shared_identifier_value = self.shared_identifier_from_slice(source_slice);
                 }
                 token_type = TokenType::PrivateIdentifier;
             } else {
@@ -1088,7 +1050,6 @@ impl<'a> Lexer<'a> {
                 // It is a Syntax Error if the source text matched by this production
                 // is a ReservedWord after processing unicode escape sequences.
                 let decoded = self.build_identifier_value(value_start);
-                shared_identifier_value = self.shared_identifier_from_owned(&decoded);
                 if keyword_from_str(&decoded).is_some() {
                     token_type = TokenType::EscapedKeyword;
                 } else {
@@ -1101,7 +1062,6 @@ impl<'a> Lexer<'a> {
                     token_type = kw;
                 } else {
                     token_type = TokenType::Identifier;
-                    shared_identifier_value = self.shared_identifier_from_slice(source_slice);
                 }
             }
         } else if self.is_numeric_literal_start() {
@@ -1297,7 +1257,7 @@ impl<'a> Lexer<'a> {
             offset: u32_from_usize(value_start.saturating_sub(1)),
             trivia_has_line_terminator,
             identifier_value,
-            shared_identifier_value,
+            interned_identifier: None,
             message: token_message,
         }
     }
@@ -1388,7 +1348,7 @@ impl<'a> Lexer<'a> {
             offset: u32_from_usize(value_start.saturating_sub(1)),
             trivia_has_line_terminator: false,
             identifier_value: None,
-            shared_identifier_value: None,
+            interned_identifier: None,
             message: None,
         }
     }

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -86,6 +86,7 @@ pub mod bytecode;
 pub mod lexer;
 pub mod parser;
 pub mod scope_collector;
+pub mod string_interner;
 pub mod token;
 
 /// Convert a `usize` to `u32`, panicking if the value exceeds `u32::MAX`.
@@ -111,6 +112,7 @@ use std::rc::Rc;
 pub struct ParsedProgram {
     program: ast::Statement,
     function_table: ast::FunctionTable,
+    interner: crate::string_interner::StringInterner,
     scope_ref: Rc<RefCell<ast::ScopeData>>,
     is_strict_mode: bool,
     has_top_level_await: bool,
@@ -176,6 +178,7 @@ fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
 unsafe fn write_ast_dump_output(
     program: &ast::Statement,
     function_table: &ast::FunctionTable,
+    interner: &crate::string_interner::StringInterner,
     output_ptr: *mut *mut u8,
     output_len: *mut usize,
 ) {
@@ -183,7 +186,7 @@ unsafe fn write_ast_dump_output(
         if output_ptr.is_null() || output_len.is_null() {
             return;
         }
-        let dump_string = ast_dump::dump_program_to_string(program, function_table);
+        let dump_string = ast_dump::dump_program_to_string(program, function_table, interner);
         let mut boxed = dump_string.into_bytes().into_boxed_slice();
         *output_ptr = boxed.as_mut_ptr();
         *output_len = boxed.len();
@@ -336,6 +339,7 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
         let payload = ast::FunctionPayload {
             data: *function_data,
             function_table: subtable,
+            interner: generator.interner.clone(),
         };
         let (function_data, precompiled) = compile_function_payload_to_bytecode(
             payload,
@@ -422,7 +426,7 @@ pub unsafe extern "C" fn rust_compile_program(
                 return std::ptr::null_mut();
             }
 
-            parser.scope_collector.analyze(initiated_by_eval);
+            parser.scope_collector.analyze(initiated_by_eval, &parser.interner);
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -432,6 +436,7 @@ pub unsafe extern "C" fn rust_compile_program(
 
             let mut generator = new_program_generator(starts_in_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
+            generator.interner = std::mem::take(&mut parser.interner);
             compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr)
         })
     }
@@ -487,12 +492,12 @@ pub unsafe extern "C" fn rust_parse_program(
             }
 
             if errors.is_empty() {
-                parser.scope_collector.analyze(false);
+                parser.scope_collector.analyze(false, &parser.interner);
             }
 
             // Dump AST if requested (after scope analysis).
             if dump_ast && errors.is_empty() {
-                ast_dump::dump_program(&program, use_color, &parser.function_table);
+                ast_dump::dump_program(&program, use_color, &parser.function_table, &parser.interner);
             }
 
             let (scope_ref, is_strict, has_tla) = if errors.is_empty() {
@@ -510,6 +515,7 @@ pub unsafe extern "C" fn rust_parse_program(
             let parsed = ParsedProgram {
                 program,
                 function_table: std::mem::take(&mut parser.function_table),
+                interner: std::mem::take(&mut parser.interner),
                 scope_ref,
                 is_strict_mode: is_strict,
                 has_top_level_await: has_tla,
@@ -586,6 +592,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
             let mut parsed = Box::from_raw(parsed);
             let bytecode = if parsed.has_top_level_await {
                 let mut generator = new_module_async_generator(source_len, std::mem::take(&mut parsed.function_table));
+                generator.interner = std::mem::take(&mut parsed.interner);
                 generator.eager_compile_direct_iifes = true;
                 let assembled = compile_module_as_async_to_bytecode(&parsed.program, &parsed.scope_ref, &mut generator);
                 precompile_eager_functions(&mut generator);
@@ -599,6 +606,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                 );
                 generator.eager_compile_direct_iifes = true;
                 generator.function_table = std::mem::take(&mut parsed.function_table);
+                generator.interner = std::mem::take(&mut parsed.interner);
                 let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, &parsed.scope_ref);
                 precompile_eager_functions(&mut generator);
                 CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled })
@@ -641,7 +649,7 @@ pub unsafe extern "C" fn rust_parsed_program_ast_dump(
     unsafe {
         let parsed = &mut *parsed;
         let dump = parsed.ast_dump.get_or_insert_with(|| {
-            ast_dump::dump_program_to_string(&parsed.program, &parsed.function_table).into_bytes()
+            ast_dump::dump_program_to_string(&parsed.program, &parsed.function_table, &parsed.interner).into_bytes()
         });
         *output_ptr = dump.as_ptr();
         *output_len = dump.len();
@@ -673,6 +681,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
 
             let mut generator = new_program_generator(parsed.is_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parsed.function_table);
+            generator.interner = std::mem::take(&mut parsed.interner);
             let exec_ptr = compile_program_body(
                 &mut generator,
                 &parsed.program,
@@ -691,6 +700,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
                 source_code_ptr,
                 gdi_context,
                 &mut generator.function_table,
+                &generator.interner,
             );
 
             exec_ptr
@@ -735,6 +745,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_script(
                 source_code_ptr,
                 gdi_context,
                 &mut bytecode.generator.function_table,
+                &bytecode.generator.interner,
             );
 
             exec_ptr
@@ -793,9 +804,15 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             }
 
-            parser.scope_collector.analyze(true);
+            parser.scope_collector.analyze(true, &parser.interner);
 
-            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
+            write_ast_dump_output(
+                &program,
+                &parser.function_table,
+                &parser.interner,
+                ast_dump_output,
+                ast_dump_output_len,
+            );
 
             let (scope_ref, is_strict) = if let StatementKind::Program(ref data) = program.inner {
                 (data.scope.clone(), data.is_strict_mode)
@@ -805,6 +822,7 @@ pub unsafe extern "C" fn rust_compile_eval(
 
             let mut generator = new_program_generator(is_strict, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
+            generator.interner = std::mem::take(&mut parser.interner);
             let exec_ptr = compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr);
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
@@ -817,6 +835,7 @@ pub unsafe extern "C" fn rust_compile_eval(
                 source_code_ptr,
                 gdi_context,
                 &mut generator.function_table,
+                &generator.interner,
             );
 
             exec_ptr
@@ -968,7 +987,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // Run scope analysis. Use analyze_as_dynamic_function() to suppress
             // marking identifiers as global, matching the C++ path which parses
             // as a FunctionExpression (no Program scope for globals to bind to).
-            parser.scope_collector.analyze_as_dynamic_function();
+            parser.scope_collector.analyze_as_dynamic_function(&parser.interner);
 
             if parser.scope_collector.has_errors() {
                 if let Some(cb) = error_callback {
@@ -980,7 +999,13 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
                 return std::ptr::null_mut();
             }
 
-            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
+            write_ast_dump_output(
+                &program,
+                &parser.function_table,
+                &parser.interner,
+                ast_dump_output,
+                ast_dump_output_len,
+            );
 
             // Extract the FunctionExpression from the program.
             // The program should contain a single ExpressionStatement wrapping a FunctionExpression.
@@ -1018,7 +1043,14 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             let is_strict = function_data.is_strict_mode;
             let subtable = parser.function_table.extract_reachable(&function_data);
 
-            bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict)
+            bytecode::ffi::create_sfd_for_gdi(
+                function_data,
+                subtable,
+                vm_ptr,
+                source_code_ptr,
+                is_strict,
+                &parser.interner,
+            )
         })
     }
 }
@@ -1071,9 +1103,15 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 panic!("Parse errors in builtin file: {}", errors.join("; "));
             }
 
-            parser.scope_collector.analyze(false);
+            parser.scope_collector.analyze(false, &parser.interner);
 
-            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
+            write_ast_dump_output(
+                &program,
+                &parser.function_table,
+                &parser.interner,
+                ast_dump_output,
+                ast_dump_output_len,
+            );
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -1092,11 +1130,13 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                         vm_ptr,
                         source_code_ptr,
                         true, // strict
+                        &parser.interner,
                     );
                     if !sfd_ptr.is_null()
                         && let Some(name_ident) = &fd.name
                     {
-                        push_function(ctx, sfd_ptr, name_ident.name.as_ptr(), name_ident.name.len());
+                        let name_slice = parser.interner.lookup(name_ident.name);
+                        push_function(ctx, sfd_ptr, name_slice.as_ptr(), name_slice.len());
                     }
                 }
             }
@@ -1151,6 +1191,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                 module_context,
                 cb,
                 &mut parsed.function_table,
+                &parsed.interner,
             );
 
             // 4. Compute requested modules (sorted by source offset).
@@ -1177,6 +1218,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                 }
                 let mut generator = new_program_generator(true, vm_ptr, source_code_ptr, source_len);
                 generator.function_table = std::mem::take(&mut parsed.function_table);
+                generator.interner = std::mem::take(&mut parsed.interner);
                 compile_program_body(
                     &mut generator,
                     &parsed.program,
@@ -1228,6 +1270,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
                 module_context,
                 cb,
                 &mut bytecode.generator.function_table,
+                &bytecode.generator.interner,
             );
             extract_requested_modules(&compiled.parsed.scope_ref.borrow(), module_context, cb);
 
@@ -1425,6 +1468,7 @@ pub unsafe extern "C" fn rust_compile_module(
             write_ast_dump_output(
                 &(*parsed).program,
                 &(*parsed).function_table,
+                &(*parsed).interner,
                 ast_dump_output,
                 ast_dump_output_len,
             );
@@ -1589,15 +1633,16 @@ unsafe fn extract_module_declarations(
     ctx: *mut c_void,
     cb: &ModuleCallbacks,
     function_table: &mut ast::FunctionTable,
+    interner: &crate::string_interner::StringInterner,
 ) {
     unsafe {
         use ast::StatementKind;
 
-        let default_name: ast::Utf16String = utf16!("*default*").into();
+        let default_name: &[u16] = utf16!("*default*");
 
         // Var declared names (walk all nesting levels).
         for child in &scope.children {
-            collect_module_var_names(&child.inner, ctx, cb.push_var_name);
+            collect_module_var_names(&child.inner, ctx, cb.push_var_name, interner);
         }
 
         // Lexical bindings and functions to initialize.
@@ -1616,19 +1661,29 @@ unsafe fn extract_module_declarations(
 
             match declaration {
                 StatementKind::FunctionDeclaration(fd) => {
-                    let is_default = is_exported && fd.name.as_ref().is_some_and(|n| n.name == default_name);
+                    let is_default = is_exported
+                        && fd
+                            .name
+                            .as_ref()
+                            .is_some_and(|n| interner.lookup(n.name) == default_name);
 
                     let function_data = function_table.take(fd.function_id);
                     let subtable = function_table.extract_reachable(&function_data);
-                    let sfd_ptr =
-                        bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, true);
+                    let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
+                        function_data,
+                        subtable,
+                        vm_ptr,
+                        source_code_ptr,
+                        true,
+                        interner,
+                    );
                     if sfd_ptr.is_null() {
                         continue;
                     }
 
                     // Get the binding name from the AST (e.g., "*default*" for anonymous defaults).
                     let binding_name = if let Some(name_ident) = &fd.name {
-                        name_ident.name.to_utf16_string()
+                        ast::Utf16String::from(interner.lookup(name_ident.name))
                     } else {
                         continue;
                     };
@@ -1652,20 +1707,21 @@ unsafe fn extract_module_declarations(
                 }
                 StatementKind::ClassDeclaration(class_data) => {
                     if let Some(ref name_ident) = class_data.name {
-                        (cb.push_lexical_binding)(ctx, name_ident.name.as_ptr(), name_ident.name.len(), false, -1);
+                        let name_slice = interner.lookup(name_ident.name);
+                        (cb.push_lexical_binding)(ctx, name_slice.as_ptr(), name_slice.len(), false, -1);
                     }
                 }
                 StatementKind::VariableDeclaration(vd) if vd.kind != ast::DeclarationKind::Var => {
                     let is_constant = vd.kind == ast::DeclarationKind::Const;
                     for declaration in &vd.declarations {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, interner, &mut |name| {
                             (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), is_constant, -1);
                         });
                     }
                 }
                 StatementKind::UsingDeclaration(declarations) => {
                     for declaration in declarations.iter() {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, interner, &mut |name| {
                             (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), false, -1);
                         });
                     }
@@ -1681,24 +1737,25 @@ unsafe fn collect_module_var_names(
     statement: &ast::StatementKind,
     ctx: *mut c_void,
     push_var_name: ModuleNameCallback,
+    interner: &crate::string_interner::StringInterner,
 ) {
     unsafe {
         match statement {
             ast::StatementKind::VariableDeclaration(vd) if vd.kind == ast::DeclarationKind::Var => {
                 for declaration in &vd.declarations {
-                    for_each_bound_name(&declaration.target, &mut |name| {
+                    for_each_bound_name(&declaration.target, interner, &mut |name| {
                         push_var_name(ctx, name.as_ptr(), name.len());
                     });
                 }
             }
             ast::StatementKind::Export(export_data) => {
                 if let Some(ref stmt) = export_data.statement {
-                    collect_module_var_names(&stmt.inner, ctx, push_var_name);
+                    collect_module_var_names(&stmt.inner, ctx, push_var_name, interner);
                 }
             }
             _ => {
                 for_each_child_statement(statement, &mut |child| {
-                    collect_module_var_names(child, ctx, push_var_name);
+                    collect_module_var_names(child, ctx, push_var_name, interner);
                 });
             }
         }
@@ -1843,16 +1900,20 @@ unsafe extern "C" {
 
 /// Recursively collect var-declared names from a statement and all nested
 /// statements, excluding function/class bodies (which create new var scopes).
-fn collect_var_names_recursive(statement: &ast::StatementKind, push_name: &mut dyn FnMut(&[u16])) {
+fn collect_var_names_recursive(
+    statement: &ast::StatementKind,
+    push_name: &mut dyn FnMut(&[u16]),
+    interner: &crate::string_interner::StringInterner,
+) {
     match statement {
         ast::StatementKind::VariableDeclaration(vd) if vd.kind == ast::DeclarationKind::Var => {
             for declaration in &vd.declarations {
-                for_each_bound_name(&declaration.target, push_name);
+                for_each_bound_name(&declaration.target, interner, push_name);
             }
         }
         _ => {
             for_each_child_statement(statement, &mut |child| {
-                collect_var_names_recursive(child, push_name);
+                collect_var_names_recursive(child, push_name, interner);
             });
         }
     }
@@ -1875,28 +1936,29 @@ fn extract_gdi_common(
     push_annex_b_name: &mut dyn FnMut(&[u16]),
     push_lexical_binding: &mut dyn FnMut(&[u16], bool),
     function_table: &mut ast::FunctionTable,
+    interner: &crate::string_interner::StringInterner,
 ) {
     use ast::{DeclarationKind, StatementKind};
 
     // Var names (var declarations at any nesting level + top-level function declarations)
     for child in &scope.children {
-        collect_var_names_recursive(&child.inner, push_var_name);
+        collect_var_names_recursive(&child.inner, push_var_name, interner);
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
             && let Some(ref name_ident) = fd.name
         {
-            push_var_name(&name_ident.name);
+            push_var_name(interner.lookup(name_ident.name));
         }
     }
 
     // Functions to initialize: keep the last declaration with each name
     // (ECMAScript hoisting semantics), but emit them in source order. Two
-    // forward passes; SharedUtf16String keys keep the inserts cheap.
-    let mut last_position: std::collections::HashMap<ast::SharedUtf16String, usize> = std::collections::HashMap::new();
+    // forward passes; InternedId keys keep the inserts cheap.
+    let mut last_position: fxhash::FxHashMap<crate::string_interner::InternedId, usize> = fxhash::FxHashMap::default();
     for (i, child) in scope.children.iter().enumerate() {
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
             && let Some(ref name_ident) = fd.name
         {
-            last_position.insert(name_ident.name.clone(), i);
+            last_position.insert(name_ident.name, i);
         }
     }
     for (i, child) in scope.children.iter().enumerate() {
@@ -1907,16 +1969,16 @@ fn extract_gdi_common(
             let function_data = function_table.take(fd.function_id);
             let subtable = function_table.extract_reachable(&function_data);
             let sfd_ptr = unsafe {
-                bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict)
+                bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict, interner)
             };
             assert!(!sfd_ptr.is_null(), "create_sfd_for_gdi returned null");
-            push_function(sfd_ptr, name_ident.name.as_slice());
+            push_function(sfd_ptr, interner.lookup(name_ident.name));
         }
     }
 
     // Var-scoped names (var VariableDeclaration names, excluding function declarations)
     for child in &scope.children {
-        collect_var_names_recursive(&child.inner, push_var_scoped_name);
+        collect_var_names_recursive(&child.inner, push_var_scoped_name, interner);
     }
 
     for name in &scope.annexb_function_names {
@@ -1928,21 +1990,21 @@ fn extract_gdi_common(
             StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
-                    for_each_bound_name(&declaration.target, &mut |name| {
+                    for_each_bound_name(&declaration.target, interner, &mut |name| {
                         push_lexical_binding(name, is_constant);
                     });
                 }
             }
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
-                    for_each_bound_name(&declaration.target, &mut |name| {
+                    for_each_bound_name(&declaration.target, interner, &mut |name| {
                         push_lexical_binding(name, false);
                     });
                 }
             }
             StatementKind::ClassDeclaration(class_data) => {
                 if let Some(ref name) = class_data.name {
-                    push_lexical_binding(&name.name, false);
+                    push_lexical_binding(interner.lookup(name.name), false);
                 }
             }
             _ => {}
@@ -1959,6 +2021,7 @@ unsafe fn extract_eval_gdi(
     source_code_ptr: *const c_void,
     ctx: *mut c_void,
     function_table: &mut ast::FunctionTable,
+    interner: &crate::string_interner::StringInterner,
 ) {
     unsafe {
         use bytecode::ffi::{
@@ -1981,6 +2044,7 @@ unsafe fn extract_eval_gdi(
                 eval_gdi_push_lexical_binding(ctx, name.as_ptr(), name.len(), is_const);
             },
             function_table,
+            interner,
         );
     }
 }
@@ -1994,6 +2058,7 @@ unsafe fn extract_script_gdi(
     source_code_ptr: *const c_void,
     ctx: *mut c_void,
     function_table: &mut ast::FunctionTable,
+    interner: &crate::string_interner::StringInterner,
 ) {
     unsafe {
         use ast::{DeclarationKind, StatementKind};
@@ -2007,21 +2072,22 @@ unsafe fn extract_script_gdi(
             match &child.inner {
                 StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                     for declaration in &vd.declarations {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, interner, &mut |name| {
                             script_gdi_push_lexical_name(ctx, name.as_ptr(), name.len());
                         });
                     }
                 }
                 StatementKind::UsingDeclaration(declarations) => {
                     for declaration in declarations.iter() {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, interner, &mut |name| {
                             script_gdi_push_lexical_name(ctx, name.as_ptr(), name.len());
                         });
                     }
                 }
                 StatementKind::ClassDeclaration(class_data) => {
                     if let Some(ref name) = class_data.name {
-                        script_gdi_push_lexical_name(ctx, name.name.as_ptr(), name.name.len());
+                        let name_slice = interner.lookup(name.name);
+                        script_gdi_push_lexical_name(ctx, name_slice.as_ptr(), name_slice.len());
                     }
                 }
                 _ => {}
@@ -2041,6 +2107,7 @@ unsafe fn extract_script_gdi(
                 script_gdi_push_lexical_binding(ctx, name.as_ptr(), name.len(), is_const);
             },
             function_table,
+            interner,
         );
     }
 }
@@ -2107,26 +2174,34 @@ fn for_each_child_statement(statement: &ast::StatementKind, f: &mut dyn FnMut(&a
     }
 }
 
-fn for_each_bound_name(target: &ast::VariableDeclaratorTarget, f: &mut dyn FnMut(&[u16])) {
+fn for_each_bound_name(
+    target: &ast::VariableDeclaratorTarget,
+    interner: &crate::string_interner::StringInterner,
+    f: &mut dyn FnMut(&[u16]),
+) {
     match target {
-        ast::VariableDeclaratorTarget::Identifier(id) => f(&id.name),
+        ast::VariableDeclaratorTarget::Identifier(id) => f(interner.lookup(id.name)),
         ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            for_each_bound_name_in_pattern(pattern, f);
+            for_each_bound_name_in_pattern(pattern, interner, f);
         }
     }
 }
 
-fn for_each_bound_name_in_pattern(pattern: &ast::BindingPattern, f: &mut dyn FnMut(&[u16])) {
+fn for_each_bound_name_in_pattern(
+    pattern: &ast::BindingPattern,
+    interner: &crate::string_interner::StringInterner,
+    f: &mut dyn FnMut(&[u16]),
+) {
     for entry in &pattern.entries {
         match &entry.alias {
             None => {
                 if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name {
-                    f(&id.name);
+                    f(interner.lookup(id.name));
                 }
             }
-            Some(ast::BindingEntryAlias::Identifier(id)) => f(&id.name),
+            Some(ast::BindingEntryAlias::Identifier(id)) => f(interner.lookup(id.name)),
             Some(ast::BindingEntryAlias::BindingPattern(inner)) => {
-                for_each_bound_name_in_pattern(inner, f);
+                for_each_bound_name_in_pattern(inner, interner, f);
             }
             Some(ast::BindingEntryAlias::MemberExpression(_)) => {}
         }
@@ -2228,11 +2303,12 @@ fn compile_function_payload_to_bytecode(
         _ => None,
     };
 
+    let mut generator = bytecode::generator::Generator::new();
+    generator.interner = payload.interner;
+
     // Compute SFD metadata before codegen so the generator can use
     // function_environment_needed to optimize `this` access.
-    let sfd_metadata = compute_sfd_metadata(&function_data);
-
-    let mut generator = bytecode::generator::Generator::new();
+    let sfd_metadata = compute_sfd_metadata(&function_data, &generator.interner);
     generator.strict = function_data.is_strict_mode;
     generator.function_environment_needed = sfd_metadata.function_environment_needed;
     generator.builtin_abstract_operations_enabled = builtin_abstract_operations_enabled;
@@ -2340,7 +2416,10 @@ struct BodyScopeInfo {
 
 /// Compute FDI runtime metadata matching the C++ SharedFunctionInstanceData
 /// constructor (ECMA-262 §10.2.11).
-fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generator::FunctionSfdMetadata {
+fn compute_sfd_metadata(
+    function_data: &ast::FunctionData,
+    interner: &crate::string_interner::StringInterner,
+) -> bytecode::generator::FunctionSfdMetadata {
     let body_scope = match &function_data.body.inner {
         ast::StatementKind::FunctionBody { scope, .. } => Some(scope),
         _ => None,
@@ -2397,18 +2476,18 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generato
     });
 
     // §10.2.11 steps 5-8: count non-local unique parameter names.
-    let mut parameter_names: HashSet<ast::Utf16String> = HashSet::new();
+    let mut parameter_names: HashSet<crate::string_interner::InternedId> = HashSet::new();
     let mut parameters_in_environment: usize = 0;
     for parameter in &function_data.parameters {
         match &parameter.binding {
             ast::FunctionParameterBinding::Identifier(ident) => {
-                if parameter_names.insert(ident.name.to_utf16_string()) && !ident.is_local() {
+                if parameter_names.insert(ident.name) && !ident.is_local() {
                     parameters_in_environment += 1;
                 }
             }
             ast::FunctionParameterBinding::BindingPattern(pattern) => {
                 for_each_binding_pattern_identifier(pattern, &mut |ident| {
-                    if parameter_names.insert(ident.name.to_utf16_string()) && !ident.is_local() {
+                    if parameter_names.insert(ident.name) && !ident.is_local() {
                         parameters_in_environment += 1;
                     }
                 });
@@ -2429,7 +2508,9 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generato
         bsi.might_need_arguments || (bsi.has_arguments_object_local && !bsi.has_function_named_arguments);
     let arguments_object_needed = arguments_object_referenced
         && !is_arrow
-        && !parameter_names.contains(utf16!("arguments"))
+        && !interner
+            .find_id(utf16!("arguments"))
+            .is_some_and(|id| parameter_names.contains(&id))
         && body_scope.is_some()
         && (has_parameter_expressions || !bsi.has_function_named_arguments)
         && (has_parameter_expressions || !bsi.has_lexically_declared_arguments);

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -32,7 +32,7 @@
 //! save and restore the full parser state including lexer position, current
 //! token, error list, and all boolean flags.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use std::rc::Rc;
 
@@ -42,6 +42,7 @@ use crate::ast::{
 };
 use crate::lexer::{Lexer, ch};
 use crate::scope_collector::{ScopeCollector, ScopeCollectorState};
+use crate::string_interner::InternedId;
 use crate::token::{Token, TokenType};
 
 mod declarations;
@@ -216,6 +217,7 @@ struct SavedState {
 /// `statements`, and `declarations` submodules (all `impl Parser`).
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
+    pub interner: crate::string_interner::StringInterner,
     /// `consume()` returns this and advances to the next token.
     current_token: Token,
     errors: Vec<ParseError>,
@@ -233,7 +235,7 @@ pub struct Parser<'a> {
 
     /// Labels currently in scope. Value is Some(line, col) if a `continue`
     /// statement referenced this label, None otherwise.
-    labels_in_scope: HashMap<Utf16String, Option<(u32, u32)>>,
+    labels_in_scope: fxhash::FxHashMap<Utf16String, Option<(u32, u32)>>,
 
     /// Set by try_parse_labelled_statement to propagate iteration-ness
     /// through nested labels (e.g., `a: b: for(...)`).
@@ -251,7 +253,7 @@ pub struct Parser<'a> {
     /// Caller drains this after calling parse_binding_pattern.
     /// Each entry is (name, identifier) — allows scope analysis to annotate
     /// binding pattern identifiers with local variable info.
-    pub(crate) pattern_bound_names: Vec<(SharedUtf16String, Rc<Identifier>)>,
+    pub(crate) pattern_bound_names: Vec<(InternedId, Rc<Identifier>)>,
 
     /// Set during synthesize_binding_pattern to allow MemberExpressions as binding targets.
     allow_member_expressions: bool,
@@ -312,6 +314,7 @@ impl<'a> Parser<'a> {
         let first_token = lexer.next();
         Self {
             lexer,
+            interner: crate::string_interner::StringInterner::new(),
             current_token: first_token,
             errors: Vec::new(),
             saved_states: Vec::new(),
@@ -320,7 +323,7 @@ impl<'a> Parser<'a> {
             flags: ParserFlags::default(),
             initiated_by_eval: false,
             in_eval_function_context: false,
-            labels_in_scope: HashMap::new(),
+            labels_in_scope: fxhash::FxHashMap::default(),
             last_inner_label_is_iteration: false,
             last_primary_was_parenthesized: false,
             last_function_name: Utf16String::default(),
@@ -382,18 +385,41 @@ impl<'a> Parser<'a> {
         function_id
     }
 
-    pub(crate) fn make_identifier(&self, start: Position, name: impl Into<SharedUtf16String>) -> Rc<Identifier> {
-        Rc::new(Identifier::new(self.range_from(start), name.into()))
+    pub(crate) fn make_identifier(&mut self, start: Position, token: &Token) -> Rc<Identifier> {
+        let name = self.token_identifier_interned(token);
+        Rc::new(Identifier::new(self.range_from(start), name))
     }
 
-    pub(crate) fn token_identifier_name(&self, token: &Token) -> SharedUtf16String {
-        if let Some(value) = &token.shared_identifier_value {
-            value.clone()
-        } else if let Some(value) = &token.identifier_value {
-            SharedUtf16String::from(value.clone())
+    pub(crate) fn make_identifier_from_id(&self, start: Position, name: InternedId) -> Rc<Identifier> {
+        Rc::new(Identifier::new(self.range_from(start), name))
+    }
+
+    /// Get the identifier string as a SharedUtf16String (for places that still need it).
+    pub(crate) fn token_identifier_name(&mut self, token: &Token) -> SharedUtf16String {
+        let id = self.token_identifier_interned(token);
+        self.interner.get_shared(id)
+    }
+
+    /// Intern the token's identifier value and return an InternedId.
+    pub(crate) fn token_identifier_interned(&mut self, token: &Token) -> InternedId {
+        if let Some(value) = &token.identifier_value {
+            self.interner.intern(value.as_slice())
         } else {
-            SharedUtf16String::from(self.token_value(token))
+            let start = token.value_start as usize;
+            let end = start + token.value_len as usize;
+            let slice = &self.source[start..end];
+            self.interner.intern(slice)
         }
+    }
+
+    /// Resolve an InternedId to a string slice.
+    pub(crate) fn resolve_name(&self, id: InternedId) -> &[u16] {
+        self.interner.lookup(id)
+    }
+
+    /// Intern a raw UTF-16 slice.
+    pub(crate) fn intern(&mut self, s: &[u16]) -> InternedId {
+        self.interner.intern(s)
     }
 
     pub(crate) fn register_function_parameters_with_scope(
@@ -417,7 +443,7 @@ impl<'a> Parser<'a> {
                         info_index += 1;
                         (pi.name.clone(), pi.is_rest, pi.is_from_pattern)
                     } else {
-                        (id.name.to_utf16_string(), parameter.is_rest, false)
+                        (Utf16String::from(self.resolve_name(id.name)), parameter.is_rest, false)
                     };
                     entries.push(ParameterEntry {
                         name,
@@ -456,7 +482,7 @@ impl<'a> Parser<'a> {
             }
         }
         self.scope_collector
-            .set_function_parameters(&entries, has_parameter_expressions);
+            .set_function_parameters(&entries, has_parameter_expressions, &self.interner);
     }
 
     // === Token access ===
@@ -665,9 +691,10 @@ impl<'a> Parser<'a> {
         }
         let token = self.consume();
         let value = self.token_value(&token).to_vec();
+        let name = self.intern(&value);
         PrivateIdentifier {
             range: self.range_from(range_start),
-            name: value.into(),
+            name,
         }
     }
 
@@ -825,12 +852,17 @@ impl<'a> Parser<'a> {
         value != utf16!("let") && value != utf16!("static")
     }
 
-    pub(crate) fn check_identifier_name_for_assignment_validity(&mut self, name: &[u16], force_strict: bool) {
+    pub(crate) fn check_identifier_name_for_assignment_validity(
+        &mut self,
+        name_id: crate::string_interner::InternedId,
+        force_strict: bool,
+    ) {
+        let name = self.resolve_name(name_id).to_vec();
         if self.flags.strict_mode || force_strict {
             if name == utf16!("arguments") || name == utf16!("eval") {
                 self.syntax_error("Binding pattern target may not be called 'arguments' or 'eval' in strict mode");
-            } else if is_strict_reserved_word(name) {
-                let name_str = String::from_utf16_lossy(name);
+            } else if is_strict_reserved_word(&name) {
+                let name_str = String::from_utf16_lossy(&name);
                 self.syntax_error(&format!(
                     "Identifier must not be a reserved word in strict mode ('{name_str}')"
                 ));
@@ -877,7 +909,8 @@ impl<'a> Parser<'a> {
             if name.is_empty() {
                 continue;
             }
-            self.check_identifier_name_for_assignment_validity(name, force_strict);
+            let name_id = self.intern(name);
+            self.check_identifier_name_for_assignment_validity(name_id, force_strict);
             if !seen_names.insert(&**name) {
                 let name_str = String::from_utf16_lossy(name);
                 self.syntax_error(&format!("Duplicate parameter '{name_str}' not allowed in strict mode"));
@@ -886,9 +919,6 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn token_value<'b>(&'b self, token: &'b Token) -> &'b [u16] {
-        if let Some(ref value) = token.shared_identifier_value {
-            return value.as_slice();
-        }
         if let Some(ref value) = token.identifier_value {
             return value;
         }
@@ -1097,7 +1127,7 @@ impl<'a> Parser<'a> {
         // Collect all declared names at module level.
         let mut declared_names: HashSet<Utf16String> = HashSet::new();
         for child in children {
-            collect_module_declared_names(child, &mut declared_names);
+            collect_module_declared_names(child, &mut declared_names, &self.interner);
         }
 
         // Check each export's local bindings.
@@ -1352,32 +1382,40 @@ fn is_use_strict(raw: &[u16]) -> bool {
 }
 
 /// Collect all binding names introduced by a variable declarator target.
-fn collect_binding_names(target: &crate::ast::VariableDeclaratorTarget, names: &mut HashSet<Utf16String>) {
+fn collect_binding_names(
+    target: &crate::ast::VariableDeclaratorTarget,
+    names: &mut HashSet<Utf16String>,
+    interner: &crate::string_interner::StringInterner,
+) {
     match target {
         crate::ast::VariableDeclaratorTarget::Identifier(identifier) => {
-            names.insert(identifier.name.to_utf16_string());
+            names.insert(Utf16String::from(interner.lookup(identifier.name)));
         }
         crate::ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            collect_binding_pattern_names(pattern, names);
+            collect_binding_pattern_names(pattern, names, interner);
         }
     }
 }
 
 /// Collect all binding names from a binding pattern (object or array destructuring).
-fn collect_binding_pattern_names(pattern: &crate::ast::BindingPattern, names: &mut HashSet<Utf16String>) {
+fn collect_binding_pattern_names(
+    pattern: &crate::ast::BindingPattern,
+    names: &mut HashSet<Utf16String>,
+    interner: &crate::string_interner::StringInterner,
+) {
     for entry in &pattern.entries {
         if let Some(ref alias) = entry.alias {
             match alias {
                 crate::ast::BindingEntryAlias::Identifier(identifier) => {
-                    names.insert(identifier.name.to_utf16_string());
+                    names.insert(Utf16String::from(interner.lookup(identifier.name)));
                 }
                 crate::ast::BindingEntryAlias::BindingPattern(nested) => {
-                    collect_binding_pattern_names(nested, names);
+                    collect_binding_pattern_names(nested, names, interner);
                 }
                 crate::ast::BindingEntryAlias::MemberExpression(_) => {}
             }
         } else if let Some(crate::ast::BindingEntryName::Identifier(identifier)) = &entry.name {
-            names.insert(identifier.name.to_utf16_string());
+            names.insert(Utf16String::from(interner.lookup(identifier.name)));
         }
     }
 }
@@ -1386,23 +1424,27 @@ fn collect_binding_pattern_names(pattern: &crate::ast::BindingPattern, names: &m
 /// This includes lexical declarations (let/const), function/class declarations, imports,
 /// and also `var` declarations which hoist to module scope even when nested inside
 /// blocks, loops, if/else, etc.
-fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut HashSet<Utf16String>) {
+fn collect_module_declared_names(
+    statement: &crate::ast::Statement,
+    names: &mut HashSet<Utf16String>,
+    interner: &crate::string_interner::StringInterner,
+) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) => {
             // All top-level declarations (var, let, const) are module-scoped.
             for decl in &data.declarations {
-                collect_binding_names(&decl.target, names);
+                collect_binding_names(&decl.target, names, interner);
             }
         }
         StatementKind::FunctionDeclaration(data) => {
             if let Some(ref name) = data.name {
-                names.insert(name.name.to_utf16_string());
+                names.insert(Utf16String::from(interner.lookup(name.name)));
             }
         }
         StatementKind::ClassDeclaration(data) => {
             if let Some(ref name) = data.name {
-                names.insert(name.name.to_utf16_string());
+                names.insert(Utf16String::from(interner.lookup(name.name)));
             }
         }
         StatementKind::Import(data) => {
@@ -1412,12 +1454,12 @@ fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut 
         }
         StatementKind::Export(data) => {
             if let Some(ref stmt) = data.statement {
-                collect_module_declared_names(stmt, names);
+                collect_module_declared_names(stmt, names, interner);
             }
         }
         // For any other statement, recurse to find hoisted var declarations.
         _ => {
-            collect_var_declared_names(statement, names);
+            collect_var_declared_names(statement, names, interner);
         }
     }
 }
@@ -1426,61 +1468,65 @@ fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut 
 /// `var` declarations are hoisted to the enclosing function/module scope,
 /// so we must walk into blocks, loops, if/else, switch, try/catch, etc.
 /// We do NOT walk into function bodies since `var` does not hoist out of functions.
-fn collect_var_declared_names(statement: &crate::ast::Statement, names: &mut HashSet<Utf16String>) {
+fn collect_var_declared_names(
+    statement: &crate::ast::Statement,
+    names: &mut HashSet<Utf16String>,
+    interner: &crate::string_interner::StringInterner,
+) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) if matches!(data.kind, DeclarationKind::Var) => {
             for decl in &data.declarations {
-                collect_binding_names(&decl.target, names);
+                collect_binding_names(&decl.target, names, interner);
             }
         }
         StatementKind::Block(scope) => {
             for child in &scope.borrow().children {
-                collect_var_declared_names(child, names);
+                collect_var_declared_names(child, names, interner);
             }
         }
         StatementKind::If(data) => {
-            collect_var_declared_names(&data.consequent, names);
+            collect_var_declared_names(&data.consequent, names, interner);
             if let Some(ref alt) = data.alternate {
-                collect_var_declared_names(alt, names);
+                collect_var_declared_names(alt, names, interner);
             }
         }
         StatementKind::While(data) | StatementKind::DoWhile(data) => {
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, interner);
         }
         StatementKind::With(data) => {
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, interner);
         }
         StatementKind::For(data) => {
             if let Some(ForInit::Declaration(ref decl)) = data.init {
-                collect_var_declared_names(decl, names);
+                collect_var_declared_names(decl, names, interner);
             }
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, interner);
         }
         StatementKind::ForInOf(data) => {
             if let ForInOfLhs::Declaration(ref decl) = data.lhs {
-                collect_var_declared_names(decl, names);
+                collect_var_declared_names(decl, names, interner);
             }
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, interner);
         }
         StatementKind::Switch(data) => {
             for case in &data.cases {
                 for child in &case.scope.borrow().children {
-                    collect_var_declared_names(child, names);
+                    collect_var_declared_names(child, names, interner);
                 }
             }
         }
         StatementKind::Try(data) => {
-            collect_var_declared_names(&data.block, names);
+            collect_var_declared_names(&data.block, names, interner);
             if let Some(ref handler) = data.handler {
-                collect_var_declared_names(&handler.body, names);
+                collect_var_declared_names(&handler.body, names, interner);
             }
             if let Some(ref finalizer) = data.finalizer {
-                collect_var_declared_names(finalizer, names);
+                collect_var_declared_names(finalizer, names, interner);
             }
         }
         StatementKind::Labelled(data) => {
-            collect_var_declared_names(&data.item, names);
+            collect_var_declared_names(&data.item, names, interner);
         }
         // Don't recurse into functions (var doesn't hoist out of functions).
         // Don't recurse into let/const (they are block-scoped, not hoisted).

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -16,6 +16,7 @@ use crate::parser::{
     Associativity, DeclarationKind, ForbiddenTokens, FunctionKind, MethodKind, PRECEDENCE_ASSIGNMENT, ParamInfo,
     ParsedParameters, Parser, Position, ProgramType, PropertyKey,
 };
+use crate::string_interner::{InternedId, StringInterner};
 use crate::token::TokenType;
 
 fn expression_into_identifier(expression: Expression) -> Rc<Identifier> {
@@ -26,12 +27,12 @@ fn expression_into_identifier(expression: Expression) -> Rc<Identifier> {
 }
 
 /// Extract bound names from a declaration for export statements.
-fn get_declaration_export_names(statement: &Statement) -> Vec<Utf16String> {
+fn get_declaration_export_names(statement: &Statement, interner: &StringInterner) -> Vec<Utf16String> {
     match &statement.inner {
         StatementKind::VariableDeclaration(vd) => {
             let mut names = Vec::new();
             for declaration in &vd.declarations {
-                collect_declarator_names(&declaration.target, &mut names);
+                collect_declarator_names(&declaration.target, &mut names, interner);
             }
             names
         }
@@ -39,21 +40,21 @@ fn get_declaration_export_names(statement: &Statement) -> Vec<Utf16String> {
             let mut names = Vec::new();
             for declaration in declarations.iter() {
                 if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
-                    names.push(id.name.to_utf16_string());
+                    names.push(Utf16String::from(interner.lookup(id.name)));
                 }
             }
             names
         }
         StatementKind::FunctionDeclaration(fd) => {
             if let Some(ref name) = fd.name {
-                vec![name.name.to_utf16_string()]
+                vec![Utf16String::from(interner.lookup(name.name))]
             } else {
                 Vec::new()
             }
         }
         StatementKind::ClassDeclaration(class) => {
             if let Some(ref name) = class.name {
-                vec![name.name.to_utf16_string()]
+                vec![Utf16String::from(interner.lookup(name.name))]
             } else {
                 Vec::new()
             }
@@ -62,24 +63,28 @@ fn get_declaration_export_names(statement: &Statement) -> Vec<Utf16String> {
     }
 }
 
-fn collect_declarator_names(target: &VariableDeclaratorTarget, names: &mut Vec<Utf16String>) {
+fn collect_declarator_names(
+    target: &VariableDeclaratorTarget,
+    names: &mut Vec<Utf16String>,
+    interner: &StringInterner,
+) {
     match target {
-        VariableDeclaratorTarget::Identifier(id) => names.push(id.name.to_utf16_string()),
-        VariableDeclaratorTarget::BindingPattern(pat) => collect_pattern_names(pat, names),
+        VariableDeclaratorTarget::Identifier(id) => names.push(Utf16String::from(interner.lookup(id.name))),
+        VariableDeclaratorTarget::BindingPattern(pat) => collect_pattern_names(pat, names, interner),
     }
 }
 
-fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>) {
+fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>, interner: &StringInterner) {
     for entry in &pat.entries {
         match &entry.alias {
-            Some(BindingEntryAlias::Identifier(id)) => names.push(id.name.to_utf16_string()),
-            Some(BindingEntryAlias::BindingPattern(nested)) => collect_pattern_names(nested, names),
+            Some(BindingEntryAlias::Identifier(id)) => names.push(Utf16String::from(interner.lookup(id.name))),
+            Some(BindingEntryAlias::BindingPattern(nested)) => collect_pattern_names(nested, names, interner),
             _ => {}
         }
         if entry.alias.is_none()
             && let Some(BindingEntryName::Identifier(id)) = &entry.name
         {
-            names.push(id.name.to_utf16_string());
+            names.push(Utf16String::from(interner.lookup(id.name)));
         }
     }
 }
@@ -142,26 +147,25 @@ impl Parser<'_> {
 
             let target = if self.match_identifier() {
                 let token = self.consume();
-                let name = self.token_identifier_name(&token);
-                self.check_identifier_name_for_assignment_validity(&name, false);
-                if kind != DeclarationKind::Var && *name == *utf16!("let") {
+                let name = self.token_identifier_interned(&token);
+                self.check_identifier_name_for_assignment_validity(name, false);
+                if kind != DeclarationKind::Var && self.resolve_name(name) == utf16!("let") {
                     self.syntax_error("Lexical binding may not be called 'let'");
                 }
-                let id = self.make_identifier(declaration_start, name.clone());
+                let id = self.make_identifier(declaration_start, &token);
 
                 if kind == DeclarationKind::Var {
+                    let name_slice = self.interner.lookup(name);
                     self.scope_collector.add_var_declaration(
-                        &[(name.as_slice(), Some(id.clone()))],
+                        &[(name_slice, Some(id.clone()))],
                         declaration_line,
                         declaration_column,
                         Some(DeclarationKind::Var),
                     );
                 } else {
-                    self.scope_collector.add_lexical_declaration(
-                        &[name.as_slice()],
-                        declaration_line,
-                        declaration_column,
-                    );
+                    let name_slice = self.interner.lookup(name);
+                    self.scope_collector
+                        .add_lexical_declaration(&[name_slice], declaration_line, declaration_column);
                     self.scope_collector.register_identifier(id.clone(), Some(kind));
                 }
 
@@ -171,16 +175,16 @@ impl Parser<'_> {
                 let bound_names = std::mem::take(&mut self.pattern_bound_names);
 
                 for (name, _) in &bound_names {
-                    self.check_identifier_name_for_assignment_validity(name, false);
-                    if kind != DeclarationKind::Var && name.as_slice() == utf16!("let") {
+                    self.check_identifier_name_for_assignment_validity(*name, false);
+                    if kind != DeclarationKind::Var && self.resolve_name(*name) == utf16!("let") {
                         self.syntax_error("Lexical binding may not be called 'let'");
                     }
                 }
 
                 if kind != DeclarationKind::Var {
-                    let mut seen: HashSet<&[u16]> = HashSet::new();
+                    let mut seen: HashSet<InternedId> = HashSet::new();
                     for (name, _) in &bound_names {
-                        if !seen.insert(name.as_slice()) {
+                        if !seen.insert(*name) {
                             self.syntax_error("Duplicate parameter names in bindings");
                         }
                     }
@@ -188,16 +192,18 @@ impl Parser<'_> {
 
                 // Register bound names with scope collector.
                 if kind == DeclarationKind::Var {
+                    let interner = &self.interner;
                     let entries: Vec<(&[u16], Option<Rc<Identifier>>)> = bound_names
                         .iter()
-                        .map(|(n, id)| (n.as_slice(), Some(id.clone())))
+                        .map(|(n, id)| (interner.lookup(*n), Some(id.clone())))
                         .collect();
                     // NOTE: Binding pattern identifiers don't get declaration_kind,
                     // matching C++ behavior where only simple identifiers do.
                     self.scope_collector
                         .add_var_declaration(&entries, declaration_line, declaration_column, None);
                 } else {
-                    let refs: Vec<&[u16]> = bound_names.iter().map(|(n, _)| n.as_slice()).collect();
+                    let interner = &self.interner;
+                    let refs: Vec<&[u16]> = bound_names.iter().map(|(n, _)| interner.lookup(*n)).collect();
                     self.scope_collector
                         .add_lexical_declaration(&refs, declaration_line, declaration_column);
                     // Register each binding pattern identifier for scope analysis
@@ -213,7 +219,8 @@ impl Parser<'_> {
             } else {
                 self.expected("identifier or a binding pattern");
                 self.consume();
-                let id = self.make_identifier(declaration_start, Vec::new());
+                let empty_id = self.intern(&[]);
+                let id = self.make_identifier_from_id(declaration_start, empty_id);
                 VariableDeclaratorTarget::Identifier(id)
             };
 
@@ -288,17 +295,18 @@ impl Parser<'_> {
                 break;
             }
             let token = self.consume();
-            let name = self.token_identifier_name(&token);
+            let name = self.token_identifier_interned(&token);
 
-            self.check_identifier_name_for_assignment_validity(&name, false);
-            if *name == *utf16!("let") {
+            self.check_identifier_name_for_assignment_validity(name, false);
+            if self.resolve_name(name) == utf16!("let") {
                 self.syntax_error("Lexical binding may not be called 'let'");
             }
 
-            let id = self.make_identifier(declaration_start, name.clone());
+            let id = self.make_identifier(declaration_start, &token);
 
+            let name_slice = self.interner.lookup(name);
             self.scope_collector
-                .add_lexical_declaration(&[name.as_slice()], declaration_line, declaration_column);
+                .add_lexical_declaration(&[name_slice], declaration_line, declaration_column);
             // C++ calls parse_lexical_binding() without declaration_kind for using,
             // so we pass None to match.
             self.scope_collector.register_identifier(id.clone(), None);
@@ -365,12 +373,13 @@ impl Parser<'_> {
         let (name, fn_name) = if self.has_default_export_name && !self.match_identifier() {
             let default_name = Utf16String::from(utf16!("*default*"));
             self.last_function_name = default_name.clone();
-            (Some(self.make_identifier(start, default_name.clone())), default_name)
+            let default_id = self.intern(utf16!("*default*"));
+            (Some(self.make_identifier_from_id(start, default_id)), default_name)
         } else if self.match_identifier() {
             let token = self.consume();
             let value = Utf16String::from(self.token_value(&token));
             self.last_function_name = value.clone();
-            (Some(self.make_identifier(start, value.clone())), value)
+            (Some(self.make_identifier(start, &token)), value)
         } else {
             self.last_function_name.0.clear();
             (None, Utf16String::default())
@@ -437,13 +446,13 @@ impl Parser<'_> {
         let name = if self.match_identifier() {
             let token = self.consume();
             fn_name_value = Utf16String::from(self.token_value(&token));
-            Some(self.make_identifier(start, fn_name_value.clone()))
+            Some(self.make_identifier(start, &token))
         } else if self.match_token(TokenType::Yield) || self.match_token(TokenType::Await) {
             // C++ explicitly allows yield/await as function expression names
             // even inside generator/async contexts, then validates after.
             let token = self.consume();
             fn_name_value = Utf16String::from(self.token_value(&token));
-            Some(self.make_identifier(start, fn_name_value.clone()))
+            Some(self.make_identifier(start, &token))
         } else {
             None
         };
@@ -541,7 +550,8 @@ impl Parser<'_> {
         self.flags.new_target_is_valid = saved_new_target;
 
         if name.is_some() {
-            self.check_identifier_name_for_assignment_validity(fn_name, has_use_strict);
+            let fn_name_id = self.intern(fn_name);
+            self.check_identifier_name_for_assignment_validity(fn_name_id, has_use_strict);
         }
         if has_use_strict || kind != FunctionKind::Normal {
             self.check_parameters_post_body(&parsed.parameter_info, has_use_strict, kind);
@@ -585,7 +595,7 @@ impl Parser<'_> {
                 let token = self.consume();
                 let value = Utf16String::from(self.token_value(&token));
                 self.last_class_name = value.clone();
-                (Some(self.make_identifier(start, value.clone())), value)
+                (Some(self.make_identifier(start, &token)), value)
             } else if expect_name {
                 self.expected("class name");
                 self.last_class_name.0.clear();
@@ -608,8 +618,8 @@ impl Parser<'_> {
         };
         self.scope_collector.open_class_declaration_scope(class_name_for_scope);
 
-        if name_id.is_some() {
-            self.check_identifier_name_for_assignment_validity(&name_value, true);
+        if let Some(ref name_ident) = name_id {
+            self.check_identifier_name_for_assignment_validity(name_ident.name, true);
             if self.flags.in_class_static_init_block && name_value == utf16!("await") {
                 self.syntax_error("Identifier must not be a reserved word in modules ('await')");
             }
@@ -705,11 +715,9 @@ impl Parser<'_> {
                 // binds the name for self-reference. The outer scope needs the name
                 // registered as a lexical declaration so it's visible to sibling code.
                 if let Some(ref name_ident) = data.name {
-                    self.scope_collector.add_lexical_declaration(
-                        &[&name_ident.name as &[u16]],
-                        start.line,
-                        start.column,
-                    );
+                    let name_slice = self.interner.lookup(name_ident.name);
+                    self.scope_collector
+                        .add_lexical_declaration(&[name_slice], start.line, start.column);
                     self.scope_collector.register_identifier(name_ident.clone(), None);
                 }
                 self.statement(start, StatementKind::ClassDeclaration(data))
@@ -724,7 +732,8 @@ impl Parser<'_> {
     //   - Derived class: constructor(...arguments) { super(...arguments); }
     fn synthesize_default_constructor(&mut self, start: Position, class_name: &[u16], has_super: bool) -> Expression {
         let ctor_name = if !class_name.is_empty() {
-            Some(self.make_identifier(start, Utf16String::from(class_name)))
+            let name_id = self.intern(class_name);
+            Some(self.make_identifier_from_id(start, name_id))
         } else {
             None
         };
@@ -733,9 +742,9 @@ impl Parser<'_> {
         // is stored in the SFD and compiled lazily — scope analysis runs at that point.
 
         if has_super {
-            let arguments_name = Utf16String::from(utf16!("args"));
+            let args_interned = self.intern(utf16!("args"));
 
-            let arguments_ref = Rc::new(Identifier::new(self.range_from(start), arguments_name.clone().into()));
+            let arguments_ref = Rc::new(Identifier::new(self.range_from(start), args_interned));
             let arguments_expression = self.expression(start, ExpressionKind::Identifier(arguments_ref));
 
             let super_call = self.expression(
@@ -754,7 +763,7 @@ impl Parser<'_> {
                 StatementKind::Block(ScopeData::shared_with_children(vec![return_statement])),
             );
 
-            let arguments_binding = Rc::new(Identifier::new(self.range_from(start), arguments_name.into()));
+            let arguments_binding = Rc::new(Identifier::new(self.range_from(start), args_interned));
             let parameters = vec![FunctionParameter {
                 binding: FunctionParameterBinding::Identifier(arguments_binding),
                 default_value: None,
@@ -1235,13 +1244,11 @@ impl Parser<'_> {
                 // Skip validity check for arrow functions; arrow parameter
                 // parsing is speculative and errors would abort the parse.
                 // The check runs after the arrow is confirmed instead.
+                let name_id = self.token_identifier_interned(&token);
                 if !is_arrow {
-                    self.check_identifier_name_for_assignment_validity(&value, false);
+                    self.check_identifier_name_for_assignment_validity(name_id, false);
                 }
-                let id = Rc::new(Identifier::new(
-                    self.range_from(formal_parameters_start),
-                    self.token_identifier_name(&token),
-                ));
+                let id = Rc::new(Identifier::new(self.range_from(formal_parameters_start), name_id));
                 parameter_info.push(ParamInfo {
                     name: value,
                     is_rest: rest,
@@ -1253,7 +1260,7 @@ impl Parser<'_> {
                 let pat = self.parse_binding_pattern();
                 for (n, id) in std::mem::take(&mut self.pattern_bound_names) {
                     parameter_info.push(ParamInfo {
-                        name: n.to_utf16_string(),
+                        name: Utf16String(self.resolve_name(n).to_vec()),
                         is_rest: rest,
                         is_from_pattern: true,
                         identifier: Some(id),
@@ -1263,10 +1270,8 @@ impl Parser<'_> {
             } else {
                 self.expected("parameter name");
                 self.consume();
-                let id = Rc::new(Identifier::new(
-                    self.range_from(parameter_start),
-                    Utf16String::default().into(),
-                ));
+                let empty_id = self.intern(&[]);
+                let id = Rc::new(Identifier::new(self.range_from(parameter_start), empty_id));
                 (FunctionParameterBinding::Identifier(id), false)
             };
 
@@ -1443,7 +1448,8 @@ impl Parser<'_> {
                         if self.match_token(TokenType::StringLiteral) {
                             let token = self.consume_property_key_token();
                             let (value, _has_octal) = self.parse_string_value(&token);
-                            let id = self.make_identifier(entry_start, value);
+                            let interned = self.intern(&value);
+                            let id = self.make_identifier_from_id(entry_start, interned);
                             self.scope_collector.register_identifier(id.clone(), None);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else if self.match_token(TokenType::BigIntLiteral) {
@@ -1454,14 +1460,15 @@ impl Parser<'_> {
                             } else {
                                 value.to_vec()
                             };
-                            let id = self.make_identifier(entry_start, name_value);
+                            let interned = self.intern(&name_value);
+                            let id = self.make_identifier_from_id(entry_start, interned);
                             self.scope_collector.register_identifier(id.clone(), None);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else {
                             let token = self.consume_property_key_token();
                             let name = self.token_identifier_name(&token);
                             entry_name_value = name.clone();
-                            let id = self.make_identifier(entry_start, name);
+                            let id = self.make_identifier(entry_start, &token);
                             self.scope_collector.register_identifier(id.clone(), None);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         }
@@ -1502,8 +1509,8 @@ impl Parser<'_> {
                         } else if self.match_identifier_name() {
                             let alias_start = self.position();
                             let token = self.consume();
-                            let name = self.token_identifier_name(&token);
-                            let id = self.make_identifier(alias_start, name.clone());
+                            let name = self.token_identifier_interned(&token);
+                            let id = self.make_identifier(alias_start, &token);
                             self.pattern_bound_names.push((name, id.clone()));
                             entry_alias = Some(BindingEntryAlias::Identifier(id));
                         } else {
@@ -1519,7 +1526,8 @@ impl Parser<'_> {
                             self.syntax_error("Binding pattern target may not be a reserved word");
                         }
                         if let Some(BindingEntryName::Identifier(ref id)) = entry_name {
-                            self.pattern_bound_names.push((entry_name_value, id.clone()));
+                            let entry_name_id = self.intern(&entry_name_value);
+                            self.pattern_bound_names.push((entry_name_id, id.clone()));
                         }
                     }
                 }
@@ -1537,7 +1545,7 @@ impl Parser<'_> {
                     entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
                 } else if Self::is_identifier(&expression) {
                     let id = expression_into_identifier(expression);
-                    self.pattern_bound_names.push((id.name.clone(), id.clone()));
+                    self.pattern_bound_names.push((id.name, id.clone()));
                     entry_alias = Some(BindingEntryAlias::Identifier(id));
                 } else {
                     self.syntax_error("Invalid destructuring assignment target");
@@ -1549,8 +1557,8 @@ impl Parser<'_> {
             } else if self.match_identifier_name() {
                 let alias_start = self.position();
                 let token = self.consume();
-                let name = self.token_identifier_name(&token);
-                let id = self.make_identifier(alias_start, name.clone());
+                let name = self.token_identifier_interned(&token);
+                let id = self.make_identifier(alias_start, &token);
                 self.pattern_bound_names.push((name, id.clone()));
                 entry_alias = Some(BindingEntryAlias::Identifier(id));
             } else {
@@ -1682,7 +1690,8 @@ impl Parser<'_> {
                             self.consume(); // consume 'as'
                             let alias_token = self.consume_identifier();
                             let alias = self.token_value(&alias_token).to_vec();
-                            self.check_identifier_name_for_assignment_validity(&alias, false);
+                            let alias_id = self.intern(&alias);
+                            self.check_identifier_name_for_assignment_validity(alias_id, false);
                             entries.push(ImportEntry {
                                 import_name: Some(name.into()),
                                 local_name: alias.into(),
@@ -1693,7 +1702,8 @@ impl Parser<'_> {
                                 name_pos,
                             );
                         } else {
-                            self.check_identifier_name_for_assignment_validity(&name, false);
+                            let name_id = self.intern(&name);
+                            self.check_identifier_name_for_assignment_validity(name_id, false);
                             let name: Utf16String = name.into();
                             entries.push(ImportEntry {
                                 import_name: Some(name.clone()),
@@ -1716,7 +1726,8 @@ impl Parser<'_> {
 
                         let alias_token = self.consume_identifier();
                         let alias = self.token_value(&alias_token).to_vec();
-                        self.check_identifier_name_for_assignment_validity(&alias, false);
+                        let alias_id = self.intern(&alias);
+                        self.check_identifier_name_for_assignment_validity(alias_id, false);
                         entries.push(ImportEntry {
                             import_name: Some(name),
                             local_name: alias.into(),
@@ -1794,7 +1805,7 @@ impl Parser<'_> {
                     && let StatementKind::FunctionDeclaration(ref fd) = declaration.inner
                     && let Some(ref name_id) = fd.name
                 {
-                    local_name = Some(name_id.name.to_utf16_string());
+                    local_name = Some(Utf16String::from(self.resolve_name(name_id.name)));
                 }
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Class) {
@@ -1804,7 +1815,7 @@ impl Parser<'_> {
                     if let StatementKind::ClassDeclaration(ref class) = declaration.inner
                         && let Some(ref name_id) = class.name
                     {
-                        local_name = Some(name_id.name.to_utf16_string());
+                        local_name = Some(Utf16String::from(self.resolve_name(name_id.name)));
                     }
                     statement = Some(Box::new(declaration));
                 } else {
@@ -1877,7 +1888,7 @@ impl Parser<'_> {
                 check_for_from = FromSpecifier::Required;
             } else if self.match_declaration() {
                 let declaration = self.parse_declaration();
-                let names = get_declaration_export_names(&declaration);
+                let names = get_declaration_export_names(&declaration, &self.interner);
                 for name in &names {
                     entries.push(ExportEntry {
                         kind: ExportEntryKind::NamedExport,
@@ -1888,7 +1899,7 @@ impl Parser<'_> {
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Var) {
                 let var_declaration = self.parse_variable_declaration(false);
-                let names = get_declaration_export_names(&var_declaration);
+                let names = get_declaration_export_names(&var_declaration, &self.interner);
                 for name in &names {
                     entries.push(ExportEntry {
                         kind: ExportEntryKind::NamedExport,

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -178,13 +178,17 @@ impl Parser<'_> {
         // parse_primary_expression), NOT during consume(). This avoids
         // falsely flagging parameter names like `function f(arguments)`.
         if let ExpressionKind::Identifier(ref id) = expression.inner
-            && id.name == utf16!("arguments")
+            && self.resolve_name(id.name) == utf16!("arguments")
         {
             // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
             // It is a Syntax Error if ContainsArguments of ClassStaticBlockBody is true.
             if self.flags.in_class_static_init_block {
                 self.syntax_error("'arguments' is not allowed in class static initialization blocks");
-            } else if !self.flags.strict_mode && !self.scope_collector.has_declaration_in_current_function(&id.name) {
+            } else if !self.flags.strict_mode
+                && !self
+                    .scope_collector
+                    .has_declaration_in_current_function(self.interner.lookup(id.name))
+            {
                 self.scope_collector
                     .set_contains_access_to_arguments_object_in_non_strict_mode();
             }
@@ -446,7 +450,7 @@ impl Parser<'_> {
                     return (arrow, false);
                 }
                 let token = self.consume_and_check_identifier();
-                let id = self.make_identifier(start, self.token_identifier_name(&token));
+                let id = self.make_identifier(start, &token);
                 self.scope_collector.register_identifier(id.clone(), None);
                 (self.expression(start, ExpressionKind::Identifier(id)), true)
             }
@@ -582,13 +586,13 @@ impl Parser<'_> {
                         self.syntax_error("'yield' is not allowed as an identifier in this context");
                     }
                     let token = self.consume_and_check_identifier();
-                    let id = self.make_identifier(start, self.token_identifier_name(&token));
+                    let id = self.make_identifier(start, &token);
                     self.scope_collector.register_identifier(id.clone(), None);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else if self.match_token(TokenType::EscapedKeyword) {
                     self.syntax_error("Keyword must not contain escaped characters");
                     let token = self.consume_and_check_identifier();
-                    let id = self.make_identifier(start, self.token_identifier_name(&token));
+                    let id = self.make_identifier(start, &token);
                     self.scope_collector.register_identifier(id.clone(), None);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else {
@@ -801,7 +805,7 @@ impl Parser<'_> {
                     // they get resolved as locals during analyze().
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();
                     for (name, id) in &bound_names {
-                        self.check_identifier_name_for_assignment_validity(name, false);
+                        self.check_identifier_name_for_assignment_validity(*name, false);
                         self.scope_collector.register_identifier(id.clone(), None);
                     }
                     self.pattern_bound_names = saved_bound_names;
@@ -829,7 +833,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in assignment");
                 }
                 if let ExpressionKind::Identifier(ref id) = lhs.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                    self.check_identifier_name_for_assignment_validity(id.name, false);
                 }
                 self.consume();
                 let rhs = self.parse_expression(min_precedence, Associativity::Right, forbidden);
@@ -892,7 +896,7 @@ impl Parser<'_> {
                 } else if self.match_identifier_name() {
                     let property_start = self.position();
                     let token = self.consume();
-                    let property_identifier = self.make_identifier(property_start, self.token_identifier_name(&token));
+                    let property_identifier = self.make_identifier(property_start, &token);
                     let property = self.expression(property_start, ExpressionKind::Identifier(property_identifier));
                     (
                         self.expression(
@@ -966,7 +970,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = lhs.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                    self.check_identifier_name_for_assignment_validity(id.name, false);
                 }
                 self.consume();
                 (
@@ -986,7 +990,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = lhs.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                    self.check_identifier_name_for_assignment_validity(id.name, false);
                 }
                 self.consume();
                 (
@@ -1021,7 +1025,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = expression.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                    self.check_identifier_name_for_assignment_validity(id.name, false);
                 }
                 self.expression(
                     start,
@@ -1039,7 +1043,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = expression.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                    self.check_identifier_name_for_assignment_validity(id.name, false);
                 }
                 self.expression(
                     start,
@@ -1188,7 +1192,7 @@ impl Parser<'_> {
         // Check the actual callee expression kind, matching C++ which does
         // is<Identifier>(callee) && callee.string() == "eval".
         if let ExpressionKind::Identifier(ref id) = callee.inner
-            && id.name == utf16!("eval")
+            && self.resolve_name(id.name) == utf16!("eval")
         {
             self.scope_collector.set_contains_direct_call_to_eval();
             self.scope_collector.set_uses_this();
@@ -1277,7 +1281,7 @@ impl Parser<'_> {
                             let property_start = self.position();
                             let token = self.consume();
                             references.push(OptionalChainReference::MemberReference {
-                                identifier: self.make_identifier(property_start, self.token_identifier_name(&token)),
+                                identifier: self.make_identifier(property_start, &token),
                                 mode: OptionalChainMode::Optional,
                             });
                         } else {
@@ -1305,7 +1309,7 @@ impl Parser<'_> {
                     let property_start = self.position();
                     let token = self.consume();
                     references.push(OptionalChainReference::MemberReference {
-                        identifier: self.make_identifier(property_start, self.token_identifier_name(&token)),
+                        identifier: self.make_identifier(property_start, &token),
                         mode: OptionalChainMode::NotOptional,
                     });
                 } else {
@@ -1594,7 +1598,8 @@ impl Parser<'_> {
             && is_identifier
             && let Some(kv) = &key_value
         {
-            let id = self.make_identifier(obj_start, kv.clone());
+            let interned = self.intern(kv);
+            let id = self.make_identifier_from_id(obj_start, interned);
             self.scope_collector.register_identifier(id.clone(), None);
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             self.consume(); // consume '='
@@ -1625,7 +1630,8 @@ impl Parser<'_> {
                 let name_str = String::from_utf16_lossy(&kv);
                 self.syntax_error(&format!("'{name_str}' is a reserved keyword"));
             }
-            let id = self.make_identifier(obj_start, kv);
+            let interned = self.intern(&kv);
+            let id = self.make_identifier_from_id(obj_start, interned);
             self.scope_collector.register_identifier(id.clone(), None);
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             return ObjectProperty {
@@ -1741,11 +1747,12 @@ impl Parser<'_> {
                 if value == utf16!("#constructor") {
                     self.syntax_error("Private property with name '#constructor' is not allowed");
                 }
+                let name_id = self.intern(&value);
                 let expression = self.expression(
                     start,
                     ExpressionKind::PrivateIdentifier(Box::new(PrivateIdentifier {
                         range: self.range_from(start),
-                        name: value.clone(),
+                        name: name_id,
                     })),
                 );
                 PropertyKey {
@@ -2229,7 +2236,8 @@ impl Parser<'_> {
                 self.syntax_error("'await' is a reserved identifier in async functions");
             }
             // C++ uses rule_start (arrow function start, which is `async` for async arrows).
-            let binding = Rc::new(Identifier::new(self.range_from(start), value.clone().into()));
+            let name_id = self.intern(&value);
+            let binding = Rc::new(Identifier::new(self.range_from(start), name_id));
             parsed = ParsedParameters {
                 parameters: vec![FunctionParameter {
                     binding: FunctionParameterBinding::Identifier(binding.clone()),

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 
 use crate::ast::*;
 use crate::parser::{Associativity, ForbiddenTokens, PRECEDENCE_COMMA, Parser, Position};
+use crate::string_interner::InternedId;
 use crate::token::TokenType;
 
 /// Used locally during for-statement parsing before converting to `ast::ForInit`.
@@ -464,7 +465,7 @@ impl Parser<'_> {
                     if init_starts_with_async_keyword
                         && let LocalForInit::Expression(ref expression) = init
                         && let ExpressionKind::Identifier(ref ident) = expression.inner
-                        && ident.name == utf16!("async")
+                        && self.resolve_name(ident.name) == utf16!("async")
                     {
                         self.syntax_error("for-of statement may not use 'async' as the left-hand side");
                     }
@@ -472,7 +473,7 @@ impl Parser<'_> {
                     if let LocalForInit::Expression(ref expression) = init
                         && let ExpressionKind::Member(ref data) = expression.inner
                         && let ExpressionKind::Identifier(ref ident) = data.object.inner
-                        && ident.name == utf16!("let")
+                        && self.resolve_name(ident.name) == utf16!("let")
                     {
                         self.syntax_error("For of statement may not start with let.");
                     }
@@ -714,24 +715,28 @@ impl Parser<'_> {
             let parameter = if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 self.pattern_bound_names.clear();
                 let pattern = self.parse_binding_pattern();
-                let names_to_check: Vec<SharedUtf16String> =
-                    self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect();
+                let names_to_check: Vec<InternedId> = self.pattern_bound_names.iter().map(|(n, _)| *n).collect();
                 // https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors
                 // It is a Syntax Error if BoundNames of CatchParameter
                 // contains any duplicate elements.
                 {
-                    let mut seen: HashSet<&[u16]> = HashSet::new();
+                    let mut seen: HashSet<InternedId> = HashSet::new();
                     for name in &names_to_check {
-                        if !seen.insert(name.as_slice()) {
-                            let name_str = String::from_utf16_lossy(name);
+                        if !seen.insert(*name) {
+                            let name_str = String::from_utf16_lossy(self.resolve_name(*name));
                             self.syntax_error(&format!("Duplicate binding '{name_str}' in catch parameter"));
                         }
                     }
                 }
                 for name in &names_to_check {
-                    self.check_identifier_name_for_assignment_validity(name, false);
+                    self.check_identifier_name_for_assignment_validity(*name, false);
                 }
-                let bound_names: Vec<&[u16]> = self.pattern_bound_names.iter().map(|(n, _)| n.as_slice()).collect();
+                let interner = &self.interner;
+                let bound_names: Vec<&[u16]> = self
+                    .pattern_bound_names
+                    .iter()
+                    .map(|(n, _)| interner.lookup(*n))
+                    .collect();
                 self.scope_collector.add_catch_parameter_pattern(&bound_names);
                 // Register each binding pattern identifier for scope analysis
                 // so they get is_local() annotations (matching variable declarations).
@@ -743,11 +748,9 @@ impl Parser<'_> {
                 let parameter_start = self.position();
                 let token = self.consume();
                 let value = self.token_value(&token).to_vec();
-                self.check_identifier_name_for_assignment_validity(&value, false);
-                let id = Rc::new(Identifier::new(
-                    self.range_from(parameter_start),
-                    self.token_identifier_name(&token),
-                ));
+                let name_id = self.token_identifier_interned(&token);
+                self.check_identifier_name_for_assignment_validity(name_id, false);
+                let id = Rc::new(Identifier::new(self.range_from(parameter_start), name_id));
                 self.scope_collector.register_identifier(id.clone(), None);
                 self.scope_collector.add_catch_parameter_identifier(&value, id.clone());
                 Some(CatchBinding::Identifier(id))
@@ -762,9 +765,9 @@ impl Parser<'_> {
         };
 
         // Collect catch parameter names for post-body validation.
-        let catch_names: Vec<SharedUtf16String> = match &parameter {
-            Some(CatchBinding::Identifier(id)) => vec![id.name.clone()],
-            Some(CatchBinding::BindingPattern(_)) => self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect(),
+        let catch_names: Vec<InternedId> = match &parameter {
+            Some(CatchBinding::Identifier(id)) => vec![id.name],
+            Some(CatchBinding::BindingPattern(_)) => self.pattern_bound_names.iter().map(|(n, _)| *n).collect(),
             None => Vec::new(),
         };
 
@@ -782,8 +785,8 @@ impl Parser<'_> {
                         for decl in &vd.declarations {
                             if let VariableDeclaratorTarget::Identifier(ref id) = decl.target {
                                 for cn in &catch_names {
-                                    if cn.as_slice() == id.name.as_slice() {
-                                        let n = String::from_utf16_lossy(cn);
+                                    if *cn == id.name {
+                                        let n = String::from_utf16_lossy(self.resolve_name(*cn));
                                         self.syntax_error(&format!(
                                             "Identifier '{n}' already declared as catch parameter"
                                         ));
@@ -795,8 +798,8 @@ impl Parser<'_> {
                     StatementKind::FunctionDeclaration(fd) if fd.name.is_some() => {
                         let id = fd.name.as_ref().unwrap();
                         for cn in &catch_names {
-                            if cn.as_slice() == id.name.as_slice() {
-                                let n = String::from_utf16_lossy(cn);
+                            if *cn == id.name {
+                                let n = String::from_utf16_lossy(self.resolve_name(*cn));
                                 self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                             }
                         }
@@ -804,8 +807,8 @@ impl Parser<'_> {
                     StatementKind::ClassDeclaration(data) => {
                         if let Some(ref id) = data.name {
                             for cn in &catch_names {
-                                if cn.as_slice() == id.name.as_slice() {
-                                    let n = String::from_utf16_lossy(cn);
+                                if *cn == id.name {
+                                    let n = String::from_utf16_lossy(self.resolve_name(*cn));
                                     self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                                 }
                             }
@@ -987,7 +990,7 @@ impl Parser<'_> {
 
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();
                     for (name, id) in &bound_names {
-                        self.check_identifier_name_for_assignment_validity(name, false);
+                        self.check_identifier_name_for_assignment_validity(*name, false);
                         self.scope_collector.register_identifier(id.clone(), None);
                     }
                     ForInOfLhs::Pattern(pattern)

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -49,16 +49,16 @@
 //! - `IdentifierGroup` — a set of identifier references with the same
 //!   name within one scope (multiple `foo` refs are grouped together)
 
+use fxhash::FxHashMap;
 use indexmap::IndexMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ast::{
-    FunctionScopeData, Identifier, LocalBinding, LocalVarKind, LocalVariable, ScopeData, SharedUtf16String,
-    Utf16String, VarToInit,
+    FunctionScopeData, Identifier, LocalBinding, LocalVarKind, LocalVariable, ScopeData, Utf16String, VarToInit,
 };
 use crate::parser::{DeclarationKind, FunctionKind, ParseError, ProgramType};
+use crate::string_interner::{InternedId, StringInterner};
 use crate::u32_from_usize;
 
 // === Enums ===
@@ -191,7 +191,7 @@ struct ScopeRecord {
     scope_data: Option<Rc<RefCell<ScopeData>>>,
 
     variables: IndexMap<Utf16String, ScopeVariable>,
-    identifier_groups: IndexMap<SharedUtf16String, IdentifierGroup>,
+    identifier_groups: IndexMap<InternedId, IdentifierGroup>,
     functions_to_hoist: Vec<HoistableFunction>,
 
     // Parameter tracking
@@ -658,7 +658,12 @@ impl ScopeCollector {
 
     // === Function parameters ===
 
-    pub fn set_function_parameters(&mut self, entries: &[ParameterEntry], has_parameter_expressions: bool) {
+    pub fn set_function_parameters(
+        &mut self,
+        entries: &[ParameterEntry],
+        has_parameter_expressions: bool,
+        interner: &StringInterner,
+    ) {
         let index = self.current.expect("no current scope");
         self.records[index].has_function_parameters = true;
         self.records[index].has_parameter_expressions = has_parameter_expressions;
@@ -693,14 +698,14 @@ impl ScopeCollector {
         // declares the same name, it must not be optimized to a local, since the
         // default expression needs to resolve it from the outer scope.
         if has_parameter_expressions {
-            let names_to_mark: Vec<SharedUtf16String> = self.records[index]
+            let names_to_mark: Vec<InternedId> = self.records[index]
                 .identifier_groups
                 .keys()
-                .filter(|name| !self.records[index].has_flag(name, VarFlags::FORBIDDEN_LEXICAL))
-                .cloned()
+                .filter(|name| !self.records[index].has_flag(interner.lookup(**name), VarFlags::FORBIDDEN_LEXICAL))
+                .copied()
                 .collect();
             for name in names_to_mark {
-                self.records[index].variable(&name).flags |= VarFlags::REFERENCED_IN_FORMAL_PARAMETERS;
+                self.records[index].variable(interner.lookup(name)).flags |= VarFlags::REFERENCED_IN_FORMAL_PARAMETERS;
             }
         }
     }
@@ -845,32 +850,38 @@ impl ScopeCollector {
 
     // === Post-parse analysis ===
 
-    pub fn analyze(&mut self, initiated_by_eval: bool) {
-        self.analyze_inner(initiated_by_eval, false);
+    pub fn analyze(&mut self, initiated_by_eval: bool, interner: &StringInterner) {
+        self.analyze_inner(initiated_by_eval, false, interner);
     }
 
     /// Like analyze(), but suppresses marking identifiers as global.
     /// Used for dynamic functions (new Function(...)) where the source is
     /// parsed as a Script but identifiers must not use GetGlobal/SetGlobal,
     /// matching the C++ path which parses as a FunctionExpression.
-    pub fn analyze_as_dynamic_function(&mut self) {
-        self.analyze_inner(false, true);
+    pub fn analyze_as_dynamic_function(&mut self, interner: &StringInterner) {
+        self.analyze_inner(false, true, interner);
     }
 
-    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool) {
+    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool, interner: &StringInterner) {
         if !self.records.is_empty() {
-            self.analyze_recursive(0, initiated_by_eval, suppress_globals);
+            self.analyze_recursive(0, initiated_by_eval, suppress_globals, interner);
         }
     }
 
     /// Analyze a scope and all its descendants, bottom-up.
     /// Children are analyzed first so that unresolved identifiers bubble up
     /// to their parent, and eval poisoning propagates outward.
-    fn analyze_recursive(&mut self, index: usize, initiated_by_eval: bool, suppress_globals: bool) {
+    fn analyze_recursive(
+        &mut self,
+        index: usize,
+        initiated_by_eval: bool,
+        suppress_globals: bool,
+        interner: &StringInterner,
+    ) {
         // Process children first (bottom-up traversal).
         let children = std::mem::take(&mut self.records[index].children);
         for child_index in children {
-            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals);
+            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals, interner);
         }
 
         // Steps 1-3 must run even for scopes without scope_data (e.g. catch
@@ -881,9 +892,9 @@ impl ScopeCollector {
         // 1. Propagate eval() flags from children to parent.
         Self::propagate_eval_poisoning(&mut self.records, index);
         // 2. Match identifier references to declarations; optimize as locals.
-        Self::resolve_identifiers(&mut self.records, index, initiated_by_eval, suppress_globals);
+        Self::resolve_identifiers(&mut self.records, index, initiated_by_eval, suppress_globals, interner);
         // 3. Annex B: hoist block-scoped functions to enclosing function scope.
-        Self::hoist_functions(&mut self.records, index);
+        Self::hoist_functions(&mut self.records, index, interner);
 
         // 4. For function-like scopes, build the var declaration list that
         //    the bytecode generator uses to initialize function-scoped variables.
@@ -893,7 +904,7 @@ impl ScopeCollector {
                 || st == ScopeType::ClassStaticInit
                 || st == ScopeType::ClassField;
             if needs_fsd {
-                Self::build_function_scope_data(&self.records, index);
+                Self::build_function_scope_data(&self.records, index, interner);
             }
         }
     }
@@ -931,11 +942,17 @@ impl ScopeCollector {
     /// - It's NOT captured by a nested function
     /// - It's NOT used inside a `with` statement
     /// - The scope chain is NOT poisoned by `eval()`
-    fn resolve_identifiers(records: &mut [ScopeRecord], index: usize, initiated_by_eval: bool, suppress_globals: bool) {
+    fn resolve_identifiers(
+        records: &mut [ScopeRecord],
+        index: usize,
+        initiated_by_eval: bool,
+        suppress_globals: bool,
+        interner: &StringInterner,
+    ) {
         // identifier_groups is an IndexMap, so iteration is in source order
         // of first reference. Local variable indices follow that order.
         let groups = std::mem::take(&mut records[index].identifier_groups);
-        let mut propagate_to_parent: Vec<(SharedUtf16String, IdentifierGroup)> = Vec::new();
+        let mut propagate_to_parent: Vec<(InternedId, IdentifierGroup)> = Vec::new();
         for (name, mut group) in groups {
             // Annotate each Identifier AST node with its declaration kind,
             // so the bytecode generator knows how to handle TDZ checks, etc.
@@ -945,9 +962,10 @@ impl ScopeCollector {
                 }
             }
 
+            let name_str = interner.lookup(name);
             let var_flags = records[index]
                 .variables
-                .get(name.as_slice())
+                .get(name_str)
                 .map_or(VarFlags::EMPTY, |v| v.flags);
 
             // Determine what kind of local variable this is (if any).
@@ -969,7 +987,7 @@ impl ScopeCollector {
             // references to `arguments` resolve to the enclosing function's.
             if records[index].scope_type == ScopeType::Function
                 && !records[index].is_arrow_function
-                && name == utf16!("arguments")
+                && name_str == utf16!("arguments")
             {
                 local_var_kind = Some(LocalVarKind::ArgumentsObject);
             }
@@ -993,7 +1011,7 @@ impl ScopeCollector {
                 if let Some(parent_index) = records[index].parent {
                     records[parent_index]
                         .identifier_groups
-                        .entry(name.clone())
+                        .entry(name)
                         .or_insert_with(|| IdentifierGroup {
                             captured_by_nested_function: false,
                             used_inside_with_statement: false,
@@ -1005,7 +1023,7 @@ impl ScopeCollector {
                 continue;
             }
 
-            let hoistable = records[index].has_hoistable_function_named(&name);
+            let hoistable = records[index].has_hoistable_function_named(name_str);
 
             // ClassDeclaration with IsBound: skip entirely.
             if records[index].scope_type == ScopeType::ClassDeclaration && var_flags.intersects(VarFlags::BOUND) {
@@ -1030,7 +1048,7 @@ impl ScopeCollector {
             if records[index].scope_type == ScopeType::Function {
                 if var_flags.intersects(VarFlags::PARAMETER_CANDIDATE)
                     && (!records[index].contains_access_to_arguments_object_in_non_strict_mode
-                        || records[index].has_rest_parameter_with_name(&name))
+                        || records[index].has_rest_parameter_with_name(name_str))
                 {
                     is_function_parameter = true;
                 } else if var_flags.intersects(VarFlags::FORBIDDEN_LEXICAL) {
@@ -1068,7 +1086,7 @@ impl ScopeCollector {
                 {
                     records[parent_index]
                         .identifier_groups
-                        .entry(name.clone())
+                        .entry(name)
                         .or_insert_with(|| IdentifierGroup {
                             captured_by_nested_function: false,
                             used_inside_with_statement: false,
@@ -1097,7 +1115,7 @@ impl ScopeCollector {
                         let mut sd = scope_data.borrow_mut();
 
                         if is_function_parameter {
-                            let argument_index = records[ls].get_parameter_index(&name);
+                            let argument_index = records[ls].get_parameter_index(name_str);
                             if let Some(ai) = argument_index {
                                 for id in &group.identifiers {
                                     id.local_index.set(ai);
@@ -1106,7 +1124,7 @@ impl ScopeCollector {
                             } else {
                                 let lvi = u32_from_usize(sd.local_variables.len());
                                 sd.local_variables.push(LocalVariable {
-                                    name: name.to_utf16_string(),
+                                    name: Utf16String::from(name_str),
                                     kind: LocalVarKind::Var,
                                 });
                                 for id in &group.identifiers {
@@ -1118,7 +1136,7 @@ impl ScopeCollector {
                             let kind = local_var_kind.expect("local_var_kind must be set for local variables");
                             let lvi = u32_from_usize(sd.local_variables.len());
                             sd.local_variables.push(LocalVariable {
-                                name: name.to_utf16_string(),
+                                name: Utf16String::from(name_str),
                                 kind,
                             });
                             for id in &group.identifiers {
@@ -1172,7 +1190,7 @@ impl ScopeCollector {
     // - vars_to_initialize: var-declared names and their local variable indices
     // - functions_to_initialize: function declarations to instantiate (in reverse order)
     // - arguments object metadata (has_argument_parameter, has_function_named_arguments, etc.)
-    fn build_function_scope_data(records: &[ScopeRecord], index: usize) {
+    fn build_function_scope_data(records: &[ScopeRecord], index: usize, interner: &StringInterner) {
         let record = &records[index];
         let Some(ref scope_data) = record.scope_data else {
             return;
@@ -1194,17 +1212,16 @@ impl ScopeCollector {
         // ECMAScript hoisting keeps the LAST function declaration with a given name,
         // but we want to emit the resulting list in SOURCE order. Two forward passes:
         // record the last position for each name, then keep only the entries whose
-        // position matches. Keys are SharedUtf16String so each insert is a cheap
-        // Rc bump rather than a deep clone of the name.
+        // position matches.
         let mut functions_to_initialize: Vec<crate::ast::FunctionToInit> = Vec::new();
-        let mut last_position: HashMap<SharedUtf16String, usize> = HashMap::new();
+        let mut last_position: FxHashMap<InternedId, usize> = FxHashMap::default();
         {
             let sd = scope_data.borrow();
             for (i, child) in sd.children.iter().enumerate() {
                 if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
                     && let Some(ref name_ident) = fd.name
                 {
-                    last_position.insert(name_ident.name.clone(), i);
+                    last_position.insert(name_ident.name, i);
                 }
             }
             for (i, child) in sd.children.iter().enumerate() {
@@ -1225,7 +1242,9 @@ impl ScopeCollector {
             var_names.push(name.clone());
 
             let is_parameter = var.flags.intersects(VarFlags::FORBIDDEN_LEXICAL);
-            let is_function_name = last_position.contains_key(name.as_slice());
+            let is_function_name = interner
+                .find_id(name.as_slice())
+                .is_some_and(|id| last_position.contains_key(&id));
 
             let local_info = if let Some(ref ident) = var.var_identifier {
                 if ident.is_local() {
@@ -1258,7 +1277,10 @@ impl ScopeCollector {
         // vars_to_initialize and var_names follow source order via the
         // insertion order of `record.variables`, which is now an IndexMap.
 
-        if last_position.contains_key(utf16!("arguments") as &[u16]) {
+        if interner
+            .find_id(utf16!("arguments"))
+            .is_some_and(|id| last_position.contains_key(&id))
+        {
             has_function_named_arguments = true;
         }
 
@@ -1311,7 +1333,7 @@ impl ScopeCollector {
     /// The function propagates upward through block scopes until it reaches
     /// a function/program scope (top level) or is blocked by an existing
     /// lexical or function declaration with the same name.
-    fn hoist_functions(records: &mut [ScopeRecord], index: usize) {
+    fn hoist_functions(records: &mut [ScopeRecord], index: usize, interner: &StringInterner) {
         let functions = std::mem::take(&mut records[index].functions_to_hoist);
 
         for function in functions {
@@ -1346,7 +1368,10 @@ impl ScopeCollector {
                     let bs = block_scope.borrow();
                     for child in &bs.children {
                         if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
-                            && fd.name.as_ref().is_some_and(|n| n.name == function.name)
+                            && fd
+                                .name
+                                .as_ref()
+                                .is_some_and(|n| interner.lookup(n.name) == function.name.as_slice())
                         {
                             fd.is_hoisted.set(true);
                         }

--- a/Libraries/LibJS/Rust/src/string_interner.rs
+++ b/Libraries/LibJS/Rust/src/string_interner.rs
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! String interner for JavaScript identifiers and string literals.
+//!
+//! Deduplicates UTF-16 strings and returns lightweight `InternedId` handles
+//! (4 bytes) instead of full string allocations. Uses `FxHash` for fast
+//! hashing of trusted compiler inputs.
+//!
+//! Adapted from <https://github.com/anonrig/string_interner>.
+
+use fxhash::{FxBuildHasher, FxHashMap};
+
+use crate::ast::SharedUtf16String;
+
+/// A compact, copyable handle to an interned string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct InternedId(u32);
+
+impl InternedId {
+    pub fn value(self) -> u32 {
+        self.0
+    }
+}
+
+pub struct StringInterner {
+    // The &'static lifetime is a lie: the references point into the Box<[u16]>
+    // entries in `list`. This is safe because:
+    // 1. Box<[u16]> stores data on the heap with a stable address.
+    // 2. Entries are never removed or modified.
+    // 3. The references are invalidated when the StringInterner is dropped,
+    //    at which point the HashMap is also dropped.
+    data: FxHashMap<&'static [u16], InternedId>,
+    list: Vec<Box<[u16]>>,
+    /// Cached SharedUtf16String instances, parallel to `list`. Each unique
+    /// interned string gets one Rc allocation; subsequent lookups return
+    /// clones (Rc bump only).
+    shared: Vec<SharedUtf16String>,
+}
+
+impl Clone for StringInterner {
+    fn clone(&self) -> Self {
+        let list = self.list.clone();
+        let mut data = FxHashMap::with_capacity_and_hasher(list.len(), FxBuildHasher::default());
+
+        for (index, entry) in list.iter().enumerate() {
+            let ptr = entry.as_ptr();
+            let len = entry.len();
+            // SAFETY: The cloned Box<[u16]> entries have stable heap storage
+            // owned by the cloned interner, and remain valid until it is dropped.
+            let key: &'static [u16] = unsafe { std::slice::from_raw_parts(ptr, len) };
+            data.insert(key, InternedId(index as u32));
+        }
+
+        Self {
+            data,
+            list,
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl Default for StringInterner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StringInterner {
+    pub fn new() -> Self {
+        Self {
+            data: FxHashMap::default(),
+            list: Vec::new(),
+            shared: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher::default()),
+            list: Vec::with_capacity(capacity),
+            shared: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Intern a UTF-16 string slice. Returns the existing ID if the string
+    /// is already interned, or allocates and stores it once otherwise.
+    #[inline]
+    pub fn intern(&mut self, input: &[u16]) -> InternedId {
+        if let Some(&id) = self.data.get(input) {
+            return id;
+        }
+
+        let owned: Box<[u16]> = input.into();
+
+        let ptr = owned.as_ptr();
+        let len = owned.len();
+
+        let id = InternedId(self.list.len() as u32);
+        self.shared.push(SharedUtf16String::from(input));
+        self.list.push(owned);
+
+        // SAFETY: Box<[u16]> stores data on the heap. Pushing the box into
+        // the Vec transfers ownership of the Box wrapper (a pointer) but does
+        // not move the heap data it points to. The &[u16] reference we create
+        // here points into that stable heap allocation.
+        //
+        // We transmute to 'static because the data lives as long as the
+        // StringInterner (entries are never removed). The HashMap and its
+        // references are dropped together with the Vec when the interner
+        // is dropped.
+        let k: &'static [u16] = unsafe { std::slice::from_raw_parts(ptr, len) };
+
+        self.data.insert(k, id);
+        id
+    }
+
+    /// Look up the interned string by ID.
+    ///
+    /// # Panics
+    /// Panics if the ID is not valid.
+    #[inline]
+    pub fn lookup(&self, id: InternedId) -> &[u16] {
+        &self.list[id.0 as usize]
+    }
+
+    /// Find the `InternedId` for a string, returning `None` if not interned.
+    #[inline]
+    pub fn find_id(&self, s: &[u16]) -> Option<InternedId> {
+        self.data.get(s).copied()
+    }
+
+    /// Look up the interned string by ID, returning `None` if invalid.
+    #[inline]
+    pub fn try_lookup(&self, id: InternedId) -> Option<&[u16]> {
+        self.list.get(id.0 as usize).map(|s| &**s)
+    }
+
+    /// Intern and return a `SharedUtf16String` backed by the interner's
+    /// cached Rc. Identical strings share the same Rc allocation.
+    #[inline]
+    pub fn intern_shared(&mut self, input: &[u16]) -> SharedUtf16String {
+        let id = self.intern(input);
+        self.shared[id.0 as usize].clone()
+    }
+
+    /// Get a cached `SharedUtf16String` for an already-interned ID.
+    #[inline]
+    pub fn get_shared(&self, id: InternedId) -> SharedUtf16String {
+        self.shared[id.0 as usize].clone()
+    }
+
+    /// Number of unique strings interned.
+    pub fn len(&self) -> usize {
+        self.list.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_and_lookup() {
+        let mut interner = StringInterner::new();
+        let hello: Vec<u16> = "hello".encode_utf16().collect();
+        let id = interner.intern(&hello);
+        assert_eq!(interner.lookup(id), hello.as_slice());
+    }
+
+    #[test]
+    fn deduplication() {
+        let mut interner = StringInterner::new();
+        let hello: Vec<u16> = "hello".encode_utf16().collect();
+        let id1 = interner.intern(&hello);
+        let id2 = interner.intern(&hello);
+        assert_eq!(id1, id2);
+        assert_eq!(interner.len(), 1);
+    }
+
+    #[test]
+    fn distinct_strings() {
+        let mut interner = StringInterner::new();
+        let hello: Vec<u16> = "hello".encode_utf16().collect();
+        let world: Vec<u16> = "world".encode_utf16().collect();
+        let id1 = interner.intern(&hello);
+        let id2 = interner.intern(&world);
+        assert_ne!(id1, id2);
+        assert_eq!(interner.len(), 2);
+        assert_eq!(interner.lookup(id1), hello.as_slice());
+        assert_eq!(interner.lookup(id2), world.as_slice());
+    }
+
+    #[test]
+    fn survives_reallocation() {
+        let mut interner = StringInterner::with_capacity(1);
+        let s1: Vec<u16> = "alpha".encode_utf16().collect();
+        let id1 = interner.intern(&s1);
+
+        // Force reallocation by interning many strings.
+        for i in 0..100 {
+            let s: Vec<u16> = format!("str_{i}").encode_utf16().collect();
+            interner.intern(&s);
+        }
+
+        assert_eq!(interner.lookup(id1), s1.as_slice());
+    }
+
+    #[test]
+    fn cloned_interner_preserves_ids() {
+        let mut interner = StringInterner::new();
+        let first: Vec<u16> = "first".encode_utf16().collect();
+        let second: Vec<u16> = "second".encode_utf16().collect();
+        let id1 = interner.intern(&first);
+        let id2 = interner.intern(&second);
+
+        let clone = interner.clone();
+        assert_eq!(clone.lookup(id1), first.as_slice());
+        assert_eq!(clone.lookup(id2), second.as_slice());
+        assert_eq!(clone.find_id(&first), Some(id1));
+        assert_eq!(clone.find_id(&second), Some(id2));
+    }
+
+    #[test]
+    fn empty_string() {
+        let mut interner = StringInterner::new();
+        let empty: Vec<u16> = Vec::new();
+        let id = interner.intern(&empty);
+        assert_eq!(interner.lookup(id), &[] as &[u16]);
+    }
+}

--- a/Libraries/LibJS/Rust/src/token.rs
+++ b/Libraries/LibJS/Rust/src/token.rs
@@ -194,10 +194,10 @@ pub struct Token {
     pub offset: u32,
     pub trivia_has_line_terminator: bool,
     /// Decoded identifier value, set when the identifier contains unicode
-    /// escape sequences (e.g. `l\u0065t` → `let`).
+    /// escape sequences (e.g. `l\u0065t` -> `let`).
     pub identifier_value: Option<crate::ast::Utf16String>,
-    /// Shared identifier spelling supplied by the lexer for identifier-like tokens.
-    pub shared_identifier_value: Option<crate::ast::SharedUtf16String>,
+    /// Interned identifier ID supplied by the lexer for identifier-like tokens.
+    pub interned_identifier: Option<crate::string_interner::InternedId>,
     /// Error message for Invalid tokens (e.g. "Unterminated multi-line comment").
     pub message: Option<String>,
 }
@@ -215,7 +215,7 @@ impl Token {
             offset: 0,
             trivia_has_line_terminator: false,
             identifier_value: None,
-            shared_identifier_value: None,
+            interned_identifier: None,
             message: None,
         }
     }


### PR DESCRIPTION
Add a FxHash-backed StringInterner that deduplicates all identifier strings during parsing. Identifier AST nodes now store a 4-byte InternedId handle instead of an Rc<Vec<u16>>, reducing per-node overhead and eliminating redundant allocations for repeated names.

Key changes:

- New StringInterner (adapted from [1]) using the stable-heap-pointer trick: Box<[u16]> entries own the data, HashMap keys borrow from them with zero extra allocation per unique string.

- Identifier.name and PrivateIdentifier.name changed from SharedUtf16String/Utf16String to InternedId. The interner is owned by the Parser, transferred to the Generator for codegen, and threaded through scope analysis and FFI materialization.

- All internal HashMaps (parser, scope collector, bytecode generator, AST FunctionTable) switched from SipHash to FxHash for faster lookups on trusted compiler inputs.

- Lexer simplified: removed the two fixed-size identifier caches (short_identifier_cache[128], recent_identifier_cache[128]) which had high collision rates. The parser-level interner provides unlimited collision-free deduplication.

Performance impact for large JS bundles (~8 MB, ~36K functions):
- Identical identifiers share a single allocation (was: one Vec<u16>
  per occurrence)
- Scope analysis compares u32 IDs instead of string slices
- Bytecode generator intern tables use u32 keys (no string hashing on the hot path)

Part of #8582.

[1] https://github.com/anonrig/string_interner