### PR TITLE
Devcontainer: Various fixes to get things working again

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
+        "ghcr.io/devcontainers/features/rust:1": {
+            "profile": "default"
+        },
         "./features/ladybird": {
             "llvm_version": 20
         },

--- a/.devcontainer/features/ladybird/install-fedora.sh
+++ b/.devcontainer/features/ladybird/install-fedora.sh
@@ -8,6 +8,3 @@ dnf install -y git gh
 dnf install -y autoconf-archive automake bison ccache cmake curl google-noto-sans-mono-fonts liberation-sans-fonts \
     libglvnd-devel libtool nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel \
     qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
-
-# Install Rust toolchain
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.devcontainer/features/ladybird/install-fedora.sh
+++ b/.devcontainer/features/ladybird/install-fedora.sh
@@ -6,5 +6,5 @@ dnf install -y git gh
 
 # Ladybird dev dependencies
 dnf install -y autoconf-archive automake bison ccache cmake curl google-noto-sans-mono-fonts liberation-sans-fonts \
-    libglvnd-devel libtool nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel \
+    libdrm-devel libglvnd-devel libtool nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib perl-Time-Piece qt6-qtbase-devel \
     qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static

--- a/.devcontainer/features/ladybird/install-ubuntu.sh
+++ b/.devcontainer/features/ladybird/install-ubuntu.sh
@@ -21,10 +21,19 @@ install_llvm_key() {
     apt update -y
 }
 
+install_cmake() {
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/kitware.list
+    apt update -y
+    apt install -y cmake
+}
+
 ### Install packages
 
 apt update -y
-apt install -y lsb-release git python3 autoconf autoconf-archive automake bison build-essential cmake libdrm-dev libgl1-mesa-dev libtool libxkbcommon-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-wayland ccache fonts-liberation2 zip unzip curl tar
+apt install -y autoconf autoconf-archive automake bison build-essential ccache curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libtool libxkbcommon-dev lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
+
+install_cmake
 
 ### Ensure new enough host compiler is available
 

--- a/.devcontainer/features/ladybird/install-ubuntu.sh
+++ b/.devcontainer/features/ladybird/install-ubuntu.sh
@@ -26,9 +26,6 @@ install_llvm_key() {
 apt update -y
 apt install -y lsb-release git python3 autoconf autoconf-archive automake bison build-essential cmake libdrm-dev libgl1-mesa-dev libtool libxkbcommon-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-wayland ccache fonts-liberation2 zip unzip curl tar
 
-### Install Rust toolchain
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
 ### Ensure new enough host compiler is available
 
 VERSION="0.0.0"

--- a/.devcontainer/fedora-ci/devcontainer.json
+++ b/.devcontainer/fedora-ci/devcontainer.json
@@ -13,6 +13,9 @@
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/rust:1": {
+            "profile": "default"
+        },
         "../features/ladybird" : {
             "distro": "fedora"
         }


### PR DESCRIPTION
I ran into these issues getting a functional ubuntu based devcontainer:
- the rust toolchain was only functional for the `root` user, not the `vscode` user. Fixed by installing via the devcontainer feature for rust installation.
- Ubuntu's CMake does not meet the minimum version required, 3.30.0.  Fixed by installing latest CMake version via Kitware apt repo
- While testing the Fedora devcontainer, added additional packages to get a successful vcpkg compile (openssl want perl-Time-Piece)
- Added `shellcheck` to the Ubuntu package list so pre-commit checks pass.

Testing done:
- `./Meta/ladybird.py build` is successful in the Ubuntu devcontainer
- `./Meta/ladybird.py build` is successful in the Fedora devcontainer


For another time: Seems the cached vcpkg binary assets are not used. Firing up a devcontainer after a rebuild results in vcpkg rebuilding from source instead.