### PR TITLE
AK: Protect AK's JSON parser against invalid UTF-8

### DIFF
--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -40,7 +40,7 @@ ErrorOr<JsonValue> JsonParser::parse(StringView input)
 //                             │                       │
 //                             ╰─── u[0-9A-Za-z]{4}  ──╯
 //
-ErrorOr<ByteString> JsonParser::consume_and_unescape_string()
+ErrorOr<String> JsonParser::consume_and_unescape_string()
 {
     if (!consume_specific('"'))
         return Error::from_string_literal("JsonParser: Expected '\"'");
@@ -135,7 +135,7 @@ ErrorOr<ByteString> JsonParser::consume_and_unescape_string()
         }
     }
 
-    return final_sb.to_byte_string();
+    return final_sb.to_string();
 }
 
 ErrorOr<JsonValue> JsonParser::parse_object()

--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -24,7 +24,7 @@ private:
     ErrorOr<JsonValue> parse_json();
     ErrorOr<JsonValue> parse_helper();
 
-    ErrorOr<ByteString> consume_and_unescape_string();
+    ErrorOr<String> consume_and_unescape_string();
     ErrorOr<JsonValue> parse_array();
     ErrorOr<JsonValue> parse_object();
     ErrorOr<JsonValue> parse_number();

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -56,6 +56,7 @@ public:
 
     JsonValue(String);
     JsonValue(StringView);
+    JsonValue(ByteString const&) = delete;
 
     template<typename T>
     requires(SameAs<RemoveCVReference<T>, bool>)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -665,3 +665,26 @@ TEST_CASE(json_object_move_from_value)
     EXPECT_EQ(array2->at(0).as_bool(), false);
     EXPECT_EQ(array2->at(1).as_string(), "string"sv);
 }
+
+TEST_CASE(invalid_utf8)
+{
+    // Incomplete 2-byte sequence
+    EXPECT(JsonValue::from_string("{\"key\": \"value\xcf\"}"sv).is_error());
+    EXPECT(JsonValue::from_string("{\"key\xcf\": \"value\"}"sv).is_error());
+
+    // Incomplete 3-byte sequence
+    EXPECT(JsonValue::from_string("{\"key\": \"value\xef\xbf\"}"sv).is_error());
+    EXPECT(JsonValue::from_string("{\"key\xef\xbf\": \"value\"}"sv).is_error());
+
+    // Invalid start byte
+    EXPECT(JsonValue::from_string("{\"key\": \"value\xf8\"}"sv).is_error());
+    EXPECT(JsonValue::from_string("{\"key\xf8\": \"value\"}"sv).is_error());
+
+    // Invalid continuation byte
+    EXPECT(JsonValue::from_string("{\"key\": \"value\xc3\x28\"}"sv).is_error());
+    EXPECT(JsonValue::from_string("{\"key\xc3\x28\": \"value\"}"sv).is_error());
+
+    // Multiple invalid bytes
+    EXPECT(JsonValue::from_string("{\"key\": \"value\xff\xff\"}"sv).is_error());
+    EXPECT(JsonValue::from_string("{\"key\xff\xff\": \"value\"}"sv).is_error());
+}


### PR DESCRIPTION
We were forming parsed JSON strings as a `ByteString` and converting this to a `String` wrapped with a `MUST`. Let's instead create a `String` from the get-go and let the encoding error propagate.

Fixes #9137