### PR TITLE
LibWeb: Use an `OrderedHashMap` for pending :has() invalidations

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -60,19 +60,13 @@ void StyleCache::visit_edges(GC::Cell::Visitor& visitor)
     user_agent_rule_cache.visit_edges(visitor);
 }
 
-void PendingHasInvalidation::visit_edges(GC::Cell::Visitor& visitor)
-{
-    visitor.visit(node);
-}
-
 void StyleScope::visit_edges(GC::Cell::Visitor& visitor)
 {
     visitor.visit(m_node);
     visitor.visit(m_user_style_sheet);
     if (m_rule_cache)
         m_rule_cache->visit_edges(visitor);
-    for (auto& pending_has_invalidation : m_pending_has_invalidations)
-        pending_has_invalidation.visit_edges(visitor);
+    visitor.visit(m_pending_has_invalidations);
 }
 
 void MatchingRule::visit_edges(GC::Cell::Visitor& visitor)
@@ -852,13 +846,11 @@ void StyleScope::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleShee
 
 void StyleScope::schedule_ancestors_style_invalidation_due_to_presence_of_has(GC::Ref<DOM::Node> node)
 {
-    for (auto& pending_has_invalidation : m_pending_has_invalidations) {
-        if (pending_has_invalidation.node == node)
-            return;
-    }
-    PendingHasInvalidationMutationFeatures mutation_features;
+    auto previous_size = m_pending_has_invalidations.size();
+    auto& mutation_features = m_pending_has_invalidations.ensure(node);
+    if (m_pending_has_invalidations.size() == previous_size)
+        return;
     mutation_features.is_conservative = true;
-    m_pending_has_invalidations.append({ node, move(mutation_features) });
     document().set_needs_invalidation_of_elements_affected_by_has();
 }
 
@@ -946,26 +938,26 @@ static PendingHasInvalidationMutationFeatures collect_pending_has_invalidation_m
 void StyleScope::record_pending_has_invalidation_mutation_features(GC::Ref<DOM::Node> scheduled_node, GC::Ref<DOM::Node> mutation_root, bool includes_descendants)
 {
     auto features = collect_pending_has_invalidation_mutation_features(*mutation_root, includes_descendants);
-    for (auto& pending_has_invalidation : m_pending_has_invalidations) {
-        if (pending_has_invalidation.node == scheduled_node) {
-            merge_pending_has_invalidation_mutation_features(pending_has_invalidation.mutation_features, features);
-            return;
-        }
+    auto previous_size = m_pending_has_invalidations.size();
+    auto& existing_features = m_pending_has_invalidations.ensure(scheduled_node);
+    if (m_pending_has_invalidations.size() == previous_size) {
+        merge_pending_has_invalidation_mutation_features(existing_features, features);
+        return;
     }
-    m_pending_has_invalidations.append({ scheduled_node, move(features) });
+    existing_features = move(features);
     document().set_needs_invalidation_of_elements_affected_by_has();
 }
 
 void StyleScope::record_pending_has_invalidation_mutation_features(GC::Ref<DOM::Node> scheduled_node, Vector<CSS::InvalidationSet::Property> const& properties)
 {
     auto features = collect_pending_has_invalidation_mutation_features(properties);
-    for (auto& pending_has_invalidation : m_pending_has_invalidations) {
-        if (pending_has_invalidation.node == scheduled_node) {
-            merge_pending_has_invalidation_mutation_features(pending_has_invalidation.mutation_features, features);
-            return;
-        }
+    auto previous_size = m_pending_has_invalidations.size();
+    auto& existing_features = m_pending_has_invalidations.ensure(scheduled_node);
+    if (m_pending_has_invalidations.size() == previous_size) {
+        merge_pending_has_invalidation_mutation_features(existing_features, features);
+        return;
     }
-    m_pending_has_invalidations.append({ scheduled_node, move(features) });
+    existing_features = move(features);
     document().set_needs_invalidation_of_elements_affected_by_has();
 }
 
@@ -1195,11 +1187,7 @@ void StyleScope::invalidate_style_of_elements_affected_by_has()
     HashTable<GC::Ref<DOM::Element>> elements_already_invalidated_for_has;
     auto pending_has_invalidations = m_pending_has_invalidations;
     bool should_scan_ancestor_siblings = have_has_selectors_with_relative_selector_that_has_sibling_combinator();
-    for (auto& pending_has_invalidation : pending_has_invalidations) {
-        GC::Ptr<DOM::Node> node = pending_has_invalidation.node;
-        if (!node)
-            continue;
-
+    for (auto& [node, mutation_features] : pending_has_invalidations) {
         Vector<GC::Ref<DOM::Element>, 16> has_scope_ancestors;
         bool should_delay_ancestor_sibling_scans = false;
         for (GC::Ptr<DOM::Node> ancestor = node; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
@@ -1223,7 +1211,7 @@ void StyleScope::invalidate_style_of_elements_affected_by_has()
 
             ++counters.has_ancestor_walk_visits;
             bool can_skip_unchanged_has_fanout = !element->root().is_shadow_root() && !element->assigned_slot_internal() && !element->is_shadow_host();
-            if (!element->affected_by_has_pseudo_class_in_non_subject_position() || !can_skip_unchanged_has_fanout || has_rule_that_may_be_affected_by_mutation(element, pending_has_invalidation.mutation_features))
+            if (!element->affected_by_has_pseudo_class_in_non_subject_position() || !can_skip_unchanged_has_fanout || has_rule_that_may_be_affected_by_mutation(element, mutation_features))
                 element->invalidate_style_if_affected_by_has();
 
             GC::Ptr<DOM::Node> parent = element->parent_or_shadow_host();

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -103,13 +103,6 @@ struct PendingHasInvalidationMutationFeatures {
     HashTable<FlyString> attribute_names;
 };
 
-struct PendingHasInvalidation {
-    GC::Ptr<DOM::Node> node;
-    PendingHasInvalidationMutationFeatures mutation_features;
-
-    void visit_edges(GC::Cell::Visitor&);
-};
-
 class StyleScope {
 public:
     explicit StyleScope(GC::Ref<DOM::Node>);
@@ -165,7 +158,7 @@ public:
 
     GC::Ptr<CSSStyleSheet> m_user_style_sheet;
 
-    Vector<PendingHasInvalidation> m_pending_has_invalidations;
+    OrderedHashMap<GC::Ref<DOM::Node>, PendingHasInvalidationMutationFeatures> m_pending_has_invalidations;
 
     bool m_needs_counter_style_cache_update : 1 { true };
     bool m_is_doing_counter_style_cache_update : 1 { false };


### PR DESCRIPTION
Every DOM mutation that may affect a :has() selector enqueues an entry in StyleScope keyed by an ancestor node. The entries were previously stored  in a Vector and linearly scanned on every insert to deduplicate by node. We now use an OrderedHashMap instead, eliminating the quadratic deduplication.

This eliminates ~5% of cycles in a 30 second profile of https://en.wikipedia.org/wiki/2023_in_American_television