### PR TITLE
LibWeb: Have speculative HTML parser populate the preload map

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -708,16 +708,11 @@ void HTMLLinkElement::preload(LinkProcessingOptions& options, GC::Ptr<GC::Functi
     //     given a response response and null, failure, or a byte sequence bodyBytes:
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
     fetch_algorithms_input.process_response_consume_body = [&realm, options = GC::Ref { options }, process_response, entry, report_timing](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
-        // FIXME: If the response is CORS cross-origin, we must use its internal response to query any of its data. See:
-        //        https://github.com/whatwg/html/issues/9355
-        response = response->unsafe_response();
-
         // 1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
-        if (auto* byte_sequence = body_bytes.get_pointer<ByteBuffer>())
-            response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, *byte_sequence));
         // 2. Otherwise, set response to a network error.
-        else
-            response = Fetch::Infrastructure::Response::network_error(realm.vm(), "Expected preload response to contain a body"_string);
+        // 5. If entry's on response available is null, then set entry's response to response; otherwise call entry's
+        //    on response available given response.
+        auto final_response = deliver_preload_response(realm, *entry, response, body_bytes.get_pointer<ByteBuffer>());
 
         // FIXME: 3. Set unsafeEndTime to the unsafe shared current time.
 
@@ -725,16 +720,9 @@ void HTMLLinkElement::preload(LinkProcessingOptions& options, GC::Ptr<GC::Functi
         if (options->document)
             report_timing->function()(*options->document);
 
-        // 5. If entry's on response available is null, then set entry's response to response; otherwise call entry's
-        //    on response available given response.
-        if (!entry->on_response_available)
-            entry->response = response;
-        else
-            entry->on_response_available->function()(response);
-
         // 6. If processResponse is given, then call processResponse with response.
         if (process_response)
-            process_response->function()(response);
+            process_response->function()(final_response);
     };
 
     m_fetch_controller = Fetch::Fetching::fetch(realm, *request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.cpp
@@ -84,18 +84,45 @@ Vector<HTMLToken::Attribute> attributes_from_token(HTMLToken const& token)
     return attributes;
 }
 
+// https://html.spec.whatwg.org/multipage/parsing.html#speculative-fetch
+// Step 4 says "fetch url as if the element was processed normally". For the regular parser to
+// dedup against the in-flight speculative fetch, we follow the preload algorithm's shape: create
+// a preload entry, register it under create_a_preload_key(request), and supply a
+// processResponseConsumeBody callback that populates the entry. Then when the regular parser later
+// processes the element, fetch()'s consume_a_preloaded_resource() check joins the entry rather than
+// issuing a duplicate request.
 void issue_speculative_fetch(JS::Realm& realm, DOM::Document& document, URL::URL url, Optional<Fetch::Infrastructure::Request::Destination> destination, CORSSettingAttribute cors_setting)
 {
     auto& vm = realm.vm();
     auto request = create_potential_CORS_request(vm, url, destination, cors_setting);
     request->set_client(&document.relevant_settings_object());
 
+    // Mirrors the preload algorithm step 6 ("Let entry be a new preload entry...") and step 7
+    // ("Let key be the result of creating a preload key given request"):
+    // https://html.spec.whatwg.org/multipage/links.html#preload
+    auto entry = realm.create<PreloadEntry>();
+    auto key = create_a_preload_key(*request);
+
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+    fetch_algorithms_input.process_response_consume_body = [&realm, entry](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
+        // 1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
+        // 2. Otherwise, set response to a network error.
+        // 5. If entry's on response available is null, then set entry's response to response;
+        //    otherwise call entry's on response available given response.
+        // (No processResponse, no reportTiming — those steps only apply to <link rel=preload>.)
+        (void)deliver_preload_response(realm, *entry, response, body_bytes.get_pointer<ByteBuffer>());
+    };
     auto algorithms = Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input));
 
     // The fetch stays alive via ResourceLoader's GC::Root callbacks for the duration of the
     // network request, so we don't need to retain the FetchController.
     (void)Fetch::Fetching::fetch(realm, request, algorithms);
+
+    // Mirrors the preload algorithm step 12.2 ("Set document's map of preloaded resources[key] to
+    // entry"). Note: the insert happens *after* fetch() starts because fetch() runs
+    // consume_a_preloaded_resource() synchronously — registering the entry beforehand would let
+    // the speculative fetch short-circuit itself.
+    document.map_of_preloaded_resources().set(key, entry);
 }
 
 bool rel_contains_keyword(StringView rel, StringView keyword)

--- a/Libraries/LibWeb/HTML/PreloadEntry.cpp
+++ b/Libraries/LibWeb/HTML/PreloadEntry.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/PreloadEntry.h>
@@ -97,6 +98,35 @@ bool consume_a_preloaded_resource(
 
     // 11. Return true.
     return true;
+}
+
+// Implements steps 1, 2, and 5 of the processResponseConsumeBody callback in the preload algorithm:
+// https://html.spec.whatwg.org/multipage/links.html#preload (step 11).
+GC::Ref<Fetch::Infrastructure::Response> deliver_preload_response(
+    JS::Realm& realm,
+    PreloadEntry& entry,
+    GC::Ref<Fetch::Infrastructure::Response> response,
+    ByteBuffer const* body_bytes)
+{
+    // FIXME: If the response is CORS cross-origin, we must use its internal response to query any of its data. See:
+    //        https://github.com/whatwg/html/issues/9355
+    response = response->unsafe_response();
+
+    // 1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
+    if (body_bytes)
+        response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, *body_bytes));
+    // 2. Otherwise, set response to a network error.
+    else
+        response = Fetch::Infrastructure::Response::network_error(realm.vm(), "Expected preload response to contain a body"_string);
+
+    // 5. If entry's on response available is null, then set entry's response to response; otherwise call entry's
+    //    on response available given response.
+    if (!entry.on_response_available)
+        entry.response = response;
+    else
+        entry.on_response_available->function()(response);
+
+    return response;
 }
 
 }

--- a/Libraries/LibWeb/HTML/PreloadEntry.h
+++ b/Libraries/LibWeb/HTML/PreloadEntry.h
@@ -76,6 +76,15 @@ bool consume_a_preloaded_resource(
     String const& integrity_metadata,
     GC::Ref<GC::Function<void(GC::Ref<Fetch::Infrastructure::Response>)>> on_response_available);
 
+// Implements steps 1, 2, and 5 of the processResponseConsumeBody callback in the preload algorithm:
+// https://html.spec.whatwg.org/multipage/links.html#preload (step 11)
+// Returns the (possibly replaced) response so callers can pass it to a processResponse callback (step 6).
+GC::Ref<Fetch::Infrastructure::Response> deliver_preload_response(
+    JS::Realm&,
+    PreloadEntry&,
+    GC::Ref<Fetch::Infrastructure::Response> response,
+    ByteBuffer const* body_bytes);
+
 }
 
 namespace AK {


### PR DESCRIPTION
When the regular HTML parser is blocked on an external script, the speculative parser scans ahead and pre-fetches discoverable sub-resources. Previously those fetches were tracked only in the parser's own URL list and never registered in the document's preload map, so when the regular parser later reached each element fetch()'s consume_a_preloaded_resource() lookup found nothing and issued a duplicate request — every parser-blocked sub-resource was fetched twice.

issue_speculative_fetch now creates a PreloadEntry, registers it under create_a_preload_key(request) in the document's preload map, and supplies a processResponseConsumeBody callback that populates the entry. The map insertion happens after fetch() starts because fetch() runs consume_a_preloaded_resource() synchronously, so registering the entry beforehand would short-circuit the speculative fetch itself.

The body-handling steps (1, 2, 5 of the preload algorithm's processResponseConsumeBody) are factored into a shared deliver_preload_response helper used by both the speculative parser and HTMLLinkElement::preload.