### PR TITLE
LibJS: Fix crash when arrow function accesses mapped arguments object

### DIFF
--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -448,16 +448,26 @@ impl ScopeCollector {
     pub fn close_scope(&mut self) {
         let index = self.current.expect("close_scope with no current scope");
 
-        if let Some(parent_index) = self.records[index].parent
-            && !self.records[index].has_function_parameters
-        {
-            let c = &self.records[index];
-            let arguments = c.contains_access_to_arguments_object_in_non_strict_mode;
-            let eval = c.contains_direct_call_to_eval;
-            let contains_await = c.contains_await_expression;
-            self.records[parent_index].contains_access_to_arguments_object_in_non_strict_mode |= arguments;
-            self.records[parent_index].contains_direct_call_to_eval |= eval;
-            self.records[parent_index].contains_await_expression |= contains_await;
+        if let Some(parent_index) = self.records[index].parent {
+            if !self.records[index].has_function_parameters {
+                // Non-function scopes (blocks, catch, etc.): propagate all flags.
+                let c = &self.records[index];
+                let arguments = c.contains_access_to_arguments_object_in_non_strict_mode;
+                let eval = c.contains_direct_call_to_eval;
+                let contains_await = c.contains_await_expression;
+                self.records[parent_index].contains_access_to_arguments_object_in_non_strict_mode |= arguments;
+                self.records[parent_index].contains_direct_call_to_eval |= eval;
+                self.records[parent_index].contains_await_expression |= contains_await;
+            } else if self.records[index].is_arrow_function {
+                // https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluation
+                // Arrow functions do not have their own `arguments` binding;
+                // references to `arguments` inside an arrow resolve to the
+                // enclosing non-arrow function's `arguments`. Propagate the
+                // flag so the enclosing function knows its parameters must
+                // stay in the environment for the mapped arguments object.
+                self.records[parent_index].contains_access_to_arguments_object_in_non_strict_mode |=
+                    self.records[index].contains_access_to_arguments_object_in_non_strict_mode;
+            }
         }
 
         self.current = self.records[index].parent;

--- a/Tests/LibJS/Runtime/arguments-object.js
+++ b/Tests/LibJS/Runtime/arguments-object.js
@@ -13,3 +13,29 @@ test("basic arguments object", () => {
     expect(bar("hello", "friends", ":^)")).toBe("friends");
     expect(bar("hello")).toBe(undefined);
 });
+
+test("mapped arguments object accessed from arrow function", () => {
+    function outer(value) {
+        return (() => arguments[0])();
+    }
+    expect(outer(42)).toBe(42);
+    expect(outer("hello")).toBe("hello");
+
+    function multipleParams(a, b, c) {
+        return (() => [arguments[0], arguments[1], arguments[2]])();
+    }
+    expect(multipleParams(1, 2, 3)).toEqual([1, 2, 3]);
+
+    function nestedArrows(x) {
+        return (() => (() => arguments[0])())();
+    }
+    expect(nestedArrows(99)).toBe(99);
+
+    function arrowWritesMappedArguments(x) {
+        return (() => {
+            arguments[0] = 100;
+            return x;
+        })();
+    }
+    expect(arrowWritesMappedArguments(1)).toBe(100);
+});


### PR DESCRIPTION
Closes #8805

## Summary

Arrow functions do not have their own `arguments` binding — references to `arguments` inside an arrow resolve to the enclosing non-arrow function's `arguments` object (per [ECMA-262 §15.3.4](https://tc39.es/ecma262/#sec-arrow-function-definitions-runtime-semantics-evaluation)).

The scope collector's `close_scope()` did not propagate the `contains_access_to_arguments_object_in_non_strict_mode` flag from arrow function scopes to the parent scope. The guard condition `!has_function_parameters` was `false` for all functions — including parameterless arrow functions — because `set_function_parameters()` unconditionally sets it to `true`.

This caused the enclosing function to be unaware that `arguments` was referenced, so it optimized its formal parameters to local argument registers. When the mapped `ArgumentsObject` later tried to look up the parameter binding via the `DeclarativeEnvironment`, the binding did not exist, triggering:

```
VERIFICATION FAILED: binding_and_index.has_value()
    at DeclarativeEnvironment.cpp:186
```

### Minimal repro (from the issue)

```js
function outer(value) { return (() => arguments[0])(); }
outer(42) === 42;
```

## Root cause

In `scope_collector.rs`, `close_scope()` propagates flags to the parent only when `!has_function_parameters`. Since arrow functions always have `has_function_parameters = true` (even with zero parameters), the `arguments` access flag was silently dropped, preventing the enclosing function from knowing it needed an environment-backed parameter binding.

## Fix

Propagate `contains_access_to_arguments_object_in_non_strict_mode` from arrow function scopes to the parent, since arrows inherit the enclosing function's `arguments`.

| File | Change |
|------|--------|
| `Libraries/LibJS/Rust/src/scope_collector.rs` | Propagate `arguments` access flag from arrow functions to parent scope |
| `Tests/LibJS/Runtime/arguments-object.js` | Add tests for mapped arguments accessed from arrow functions |

## Test plan

- [x] Add test: single parameter accessed via `arguments[0]` in arrow
- [x] Add test: multiple parameters
- [x] Add test: doubly-nested arrow functions
- [x] Add test: arrow writes to `arguments[0]`, verifying mapped two-way binding
- [x] Run `LibJS` test suite to check for regressions