### PR TITLE
LibWeb: Schedule rendering updates on demand

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1889,6 +1889,15 @@ void Document::update_animated_style_if_needed()
     m_needs_animated_style_update = false;
 }
 
+void Document::set_needs_animated_style_update()
+{
+    if (m_needs_animated_style_update)
+        return;
+
+    m_needs_animated_style_update = true;
+    set_needs_repaint(InvalidateDisplayList::No);
+}
+
 void Document::update_paint_and_hit_testing_properties_if_needed()
 {
     // NB: Called during paint property resolution.
@@ -3384,6 +3393,9 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
 
     // 2. Set document's current document readiness to readinessValue.
     m_readiness = readiness_value;
+
+    if (readiness_value != HTML::DocumentReadyState::Loading)
+        page().client().request_frame();
 
     // 3. If document is associated with an HTML parser, then:
     if (m_parser) {
@@ -7002,6 +7014,8 @@ void Document::add_render_blocking_element(GC::Ref<Element> element)
 void Document::remove_render_blocking_element(GC::Ref<Element> element)
 {
     m_render_blocking_elements.remove(element);
+    if (m_render_blocking_elements.is_empty())
+        page().client().request_frame();
 }
 
 // https://fullscreen.spec.whatwg.org/#run-the-fullscreen-steps
@@ -7036,6 +7050,7 @@ void Document::run_fullscreen_steps()
 void Document::append_pending_fullscreen_change(PendingFullscreenEvent::Type type, GC::Ref<Element> element)
 {
     m_pending_fullscreen_events.append(PendingFullscreenEvent { type, element });
+    page().client().request_frame();
 }
 
 // https://fullscreen.spec.whatwg.org/#fullscreen-an-element
@@ -7424,7 +7439,7 @@ void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display
     navigable->set_needs_repaint();
 
     if (navigable->is_traversable()) {
-        Web::HTML::main_thread_event_loop().schedule();
+        page().client().request_frame();
         return;
     }
 
@@ -7732,6 +7747,17 @@ void Document::flush_the_update_callback_queue()
 
     // 2. Set document’s update callback queue to an empty list.
     m_update_callback_queue.clear();
+}
+
+void Document::set_rendering_suppression_for_view_transitions(bool value)
+{
+    if (m_rendering_suppression_for_view_transitions == value)
+        return;
+
+    m_rendering_suppression_for_view_transitions = value;
+
+    if (!value)
+        page().client().request_frame();
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#view-transition-page-visibility-change-steps
@@ -8126,6 +8152,8 @@ void Document::add_pending_css_import_rule(Badge<CSS::CSSImportRule>, GC::Ref<CS
 void Document::remove_pending_css_import_rule(Badge<CSS::CSSImportRule>, GC::Ref<CSS::CSSImportRule> rule)
 {
     m_pending_css_import_rules.remove(rule);
+    if (m_pending_css_import_rules.is_empty())
+        page().client().request_frame();
 }
 
 void Document::exit_pointer_lock()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -857,7 +857,7 @@ public:
     GC::RootVector<GC::Ref<Element>> elements_from_point(double x, double y);
     GC::Ptr<Element const> scrolling_element() const;
 
-    void set_needs_animated_style_update() { m_needs_animated_style_update = true; }
+    void set_needs_animated_style_update();
 
     void set_needs_invalidation_of_elements_affected_by_has() { m_needs_invalidation_of_elements_affected_by_has = true; }
 
@@ -959,7 +959,7 @@ public:
     GC::Ptr<HTML::Navigable> navigable() const;
     void set_navigable(GC::Ptr<HTML::Navigable>);
 
-    template<OneOf<Painting::Paintable, HTML::Navigable, CSS::VisualViewport, Web::EventHandler> T>
+    template<OneOf<Node, Painting::Paintable, HTML::Navigable, CSS::VisualViewport, Web::EventHandler> T>
     void set_needs_repaint(Badge<T>, InvalidateDisplayList should_invalidate_display_list = InvalidateDisplayList::Yes)
     {
         set_needs_repaint(should_invalidate_display_list);
@@ -1004,7 +1004,7 @@ public:
     GC::Ptr<ViewTransition::ViewTransition> active_view_transition() const { return m_active_view_transition; }
     void set_active_view_transition(GC::Ptr<ViewTransition::ViewTransition> view_transition) { m_active_view_transition = view_transition; }
     bool rendering_suppression_for_view_transitions() const { return m_rendering_suppression_for_view_transitions; }
-    void set_rendering_suppression_for_view_transitions(bool value) { m_rendering_suppression_for_view_transitions = value; }
+    void set_rendering_suppression_for_view_transitions(bool);
     GC::Ptr<CSS::CSSStyleSheet> dynamic_view_transition_style_sheet() const { return m_dynamic_view_transition_style_sheet; }
     void set_show_view_transition_tree(bool value) { m_show_view_transition_tree = value; }
     Vector<GC::Ptr<ViewTransition::ViewTransition>>& update_callback_queue() { return m_update_callback_queue; }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -63,6 +63,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/XMLSerializer.h>
 #include <LibWeb/Infra/CharacterTypes.h>
+#include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/MathML/MathMLElement.h>
@@ -1711,6 +1712,8 @@ void Node::set_needs_layout_tree_update(bool value, SetNeedsLayoutTreeUpdateReas
     }
 
     if (m_needs_layout_tree_update) {
+        document().set_needs_repaint(Badge<Node> {}, InvalidateDisplayList::No);
+
         for (auto* ancestor = flat_tree_parent(); ancestor; ancestor = ancestor->flat_tree_parent()) {
             if (ancestor->m_child_needs_layout_tree_update)
                 break;
@@ -1750,6 +1753,8 @@ void Node::set_needs_style_update(bool value)
     m_needs_style_update = value;
 
     if (m_needs_style_update) {
+        document().set_needs_repaint(Badge<Node> {}, InvalidateDisplayList::No);
+
         ++document().style_invalidation_counters().style_invalidations;
         for (auto* ancestor = parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host()) {
             if (ancestor->m_child_needs_style_update)
@@ -2661,8 +2666,10 @@ void Node::set_needs_repaint(InvalidateDisplayList should_invalidate_display_lis
 
 void Node::set_needs_layout_update(SetNeedsLayoutReason reason)
 {
-    if (auto* node = unsafe_layout_node())
+    if (auto* node = unsafe_layout_node()) {
         node->set_needs_layout_update(reason);
+        document().set_needs_repaint(Badge<Node> {}, InvalidateDisplayList::No);
+    }
 }
 
 Painting::Paintable const* Node::paintable() const

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -115,6 +115,7 @@ public:
     {
         m_screenshot_tasks.enqueue({ node_id });
         set_needs_repaint();
+        page().client().request_frame();
     }
 
 private:

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1724,12 +1724,14 @@ double Window::device_pixel_ratio() const
 WebIDL::UnsignedLong Window::request_animation_frame(GC::Ref<WebIDL::CallbackType> callback)
 {
     // FIXME: Make this fully spec compliant. Currently implements a mix of 'requestAnimationFrame()' and 'run the animation frame callbacks'.
-    return animation_frame_callback_driver().add(GC::create_function(heap(), [this, callback](double now) {
+    auto handle = animation_frame_callback_driver().add(GC::create_function(heap(), [this, callback](double now) {
         // 3. Invoke callback, passing now as the only argument, and if an exception is thrown, report the exception.
         auto result = WebIDL::invoke_callback(*callback, {}, { { JS::Value(now) } });
         if (result.is_error())
             report_exception(result, realm());
     }));
+    page().client().request_frame();
+    return handle;
 }
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider-cancelanimationframe

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -556,9 +556,14 @@ void Page::for_each_media_element(Callback&& callback)
 
 void Page::update_all_media_element_video_sinks()
 {
-    for_each_media_element([](auto& media_element) {
+    bool should_request_another_frame = false;
+    for_each_media_element([&](auto& media_element) {
         media_element.update_video_frame_and_timeline();
+        should_request_another_frame = true;
     });
+
+    if (should_request_another_frame)
+        client().request_frame();
 }
 
 void Page::register_canvas_element(Badge<HTML::HTMLCanvasElement>, UniqueNodeID canvas_id)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -385,6 +385,7 @@ public:
     virtual size_t screen_count() const = 0;
     virtual Queue<QueuedInputEvent>& input_event_queue() = 0;
     virtual void report_finished_handling_input_event(u64 page_id, EventResult event_was_handled) = 0;
+    virtual void request_frame() = 0;
     virtual void page_did_change_title(Utf16String const&) { }
     virtual void page_did_change_url(URL::URL const&) { }
     virtual void page_did_request_refresh() { }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -89,6 +89,7 @@ public:
     virtual void request_file(FileRequest) override { }
     virtual Queue<QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] EventResult event_was_handled) override { }
+    virtual void request_frame() override { }
 
     virtual DisplayListPlayerType display_list_player_type() const override { return m_host_page->client().display_list_player_type(); }
     virtual bool is_headless() const override { return m_host_page->client().is_headless(); }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -244,6 +244,8 @@ void ConnectionFromClient::mouse_event(u64 page_id, Web::MouseEvent event)
         m_input_event_queue.tail().event = move(event);
         ++m_input_event_queue.tail().coalesced_event_count;
 
+        if (auto page = this->page(page_id); page.has_value())
+            page->page().client().request_frame();
         return;
     }
 
@@ -262,7 +264,11 @@ void ConnectionFromClient::pinch_event(u64 page_id, Web::PinchEvent event)
 
 void ConnectionFromClient::enqueue_input_event(Web::QueuedInputEvent event)
 {
+    auto page_id = event.page_id;
     m_input_event_queue.enqueue(move(event));
+
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().client().request_frame();
 }
 
 void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteString argument)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
+#include <AK/Math.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ShareableBitmap.h>
@@ -28,6 +29,7 @@
 #include <LibWeb/HTML/HTMLLinkElement.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
+#include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableBox.h>
@@ -75,16 +77,10 @@ PageClient::PageClient(PageHost& owner, u64 id)
 {
     setup_palette();
 
-    // FIXME: This removes the decimal part, so the refresh interval will actually be higher than the maximum FPS.
-    //        For example, 60 FPS = 1000ms / 60 = 16.6666...ms, but it will become 16ms, making the interval equivalent
-    //        to 62.5 FPS.
-    int refresh_interval = static_cast<int>(1000.0 / m_maximum_frames_per_second);
-
-    m_paint_refresh_timer = Core::Timer::create_repeating(refresh_interval, [] {
+    m_frame_timer = Core::Timer::create_single_shot(0, [this] {
+        m_last_frame_dispatch_time = Web::HighResolutionTime::unsafe_shared_current_time();
         Web::HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
     });
-
-    m_paint_refresh_timer->start();
 }
 
 PageClient::~PageClient() = default;
@@ -225,17 +221,24 @@ void PageClient::set_zoom_level(double zoom_level)
     page().top_level_traversable()->set_viewport_size(page().device_to_css_size(m_viewport_size), Web::InvalidateDisplayList::Yes);
 }
 
-void PageClient::set_maximum_frames_per_second(u64 maximum_frames_per_second)
+void PageClient::request_frame()
+{
+    if (m_frame_timer->is_active())
+        return;
+
+    auto delay = 0.0;
+    if (m_last_frame_dispatch_time.has_value()) {
+        auto now = Web::HighResolutionTime::unsafe_shared_current_time();
+        auto minimum_frame_interval = 1000.0 / m_maximum_frames_per_second;
+        delay = max(0.0, *m_last_frame_dispatch_time + minimum_frame_interval - now);
+    }
+
+    m_frame_timer->restart(static_cast<int>(AK::ceil(delay)));
+}
+
+void PageClient::set_maximum_frames_per_second(double maximum_frames_per_second)
 {
     m_maximum_frames_per_second = maximum_frames_per_second;
-
-    // FIXME: This removes the decimal part, so the refresh interval will actually be higher than the maximum FPS.
-    //        For example, 60 FPS = 1000ms / 60 = 16.6666...ms, but it will become 16ms, making the interval equivalent
-    //        to 62.5 FPS.
-    int refresh_interval = static_cast<int>(1000.0 / m_maximum_frames_per_second);
-
-    VERIFY(m_paint_refresh_timer);
-    m_paint_refresh_timer->set_interval(refresh_interval);
 }
 
 void PageClient::page_did_request_cursor_change(Gfx::Cursor const& cursor)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -60,7 +60,7 @@ public:
         m_main_screen_index = main_screen_index;
     }
     void set_zoom_level(double zoom_level);
-    void set_maximum_frames_per_second(u64 maximum_frames_per_second);
+    void set_maximum_frames_per_second(double maximum_frames_per_second);
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
     void set_preferred_motion(Web::CSS::PreferredMotion);
@@ -119,6 +119,7 @@ private:
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }
     virtual Web::CSS::PreferredContrast preferred_contrast() const override { return m_preferred_contrast; }
     virtual Web::CSS::PreferredMotion preferred_motion() const override { return m_preferred_motion; }
+    virtual void request_frame() override;
     virtual void page_did_request_cursor_change(Gfx::Cursor const&) override;
     virtual void page_did_change_title(Utf16String const&) override;
     virtual void page_did_change_url(URL::URL const&) override;
@@ -226,7 +227,8 @@ private:
 
     GC::Ptr<WebContentConsoleClient> m_top_level_document_console_client;
 
-    RefPtr<Core::Timer> m_paint_refresh_timer;
+    RefPtr<Core::Timer> m_frame_timer;
+    Optional<double> m_last_frame_dispatch_time;
 
     u64 m_devtools_client_count { 0 };
 };

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -45,6 +45,7 @@ public:
     virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { VERIFY_NOT_REACHED(); }
+    virtual void request_frame() override { VERIFY_NOT_REACHED(); }
     void did_finish_loading_worker_script();
     void did_fail_loading_worker_script();
 


### PR DESCRIPTION
Previously a fixed-rate paint refresh timer kept queueing rendering update tasks at the maximum configured frame rate, regardless of whether anything had actually changed. This wasted CPU on idle pages, which spend most of their time in a steady state where no style, layout, or paint work is needed.

Replace the repeating timer with a single-shot frame timer driven by PageClient::request_frame(). A rendering update is now scheduled only when something requires one. The configured maximum frame rate is preserved as a ceiling on how closely consecutive frames can follow each other.