### PR TITLE
LibWeb/HTML: Support `align` attributes on table sections and rows

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -71,16 +71,8 @@ void HTMLTableCellElement::apply_presentational_hints(GC::Ref<CSS::CascadedPrope
             return;
         }
         if (name == HTML::AttributeNames::align) {
-            if (value.equals_ignoring_ascii_case("center"sv) || value.equals_ignoring_ascii_case("middle"sv)) {
-                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::KeywordStyleValue::create(CSS::Keyword::LibwebCenter));
-            } else if (value.equals_ignoring_ascii_case("left"sv)) {
-                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::KeywordStyleValue::create(CSS::Keyword::LibwebLeft));
-            } else if (value.equals_ignoring_ascii_case("right"sv)) {
-                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::KeywordStyleValue::create(CSS::Keyword::LibwebRight));
-            } else {
-                if (auto parsed_value = parse_css_value(CSS::Parser::ParsingParams { document() }, value, CSS::PropertyID::TextAlign))
-                    cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());
-            }
+            if (auto parsed_value = parse_table_child_element_align_value(value))
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());
             return;
         }
         if (name == HTML::AttributeNames::width) {

--- a/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -46,6 +46,7 @@ bool HTMLTableRowElement::is_presentational_hint(FlyString const& name) const
         return true;
 
     return first_is_one_of(name,
+        HTML::AttributeNames::align,
         HTML::AttributeNames::bgcolor,
         HTML::AttributeNames::background,
         HTML::AttributeNames::height,
@@ -56,7 +57,10 @@ void HTMLTableRowElement::apply_presentational_hints(GC::Ref<CSS::CascadedProper
 {
     Base::apply_presentational_hints(cascaded_properties);
     for_each_attribute([&](auto& name, auto& value) {
-        if (name == HTML::AttributeNames::bgcolor) {
+        if (name == HTML::AttributeNames::align) {
+            if (auto parsed_value = parse_table_child_element_align_value(value))
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());
+        } else if (name == HTML::AttributeNames::bgcolor) {
             // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())

--- a/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -108,6 +108,7 @@ bool HTMLTableSectionElement::is_presentational_hint(FlyString const& name) cons
         return true;
 
     return first_is_one_of(name,
+        HTML::AttributeNames::align,
         HTML::AttributeNames::background,
         HTML::AttributeNames::bgcolor,
         HTML::AttributeNames::height);
@@ -117,8 +118,12 @@ void HTMLTableSectionElement::apply_presentational_hints(GC::Ref<CSS::CascadedPr
 {
     Base::apply_presentational_hints(cascaded_properties);
     for_each_attribute([&](auto& name, auto& value) {
+        if (name == HTML::AttributeNames::align) {
+            if (auto parsed_value = parse_table_child_element_align_value(value))
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());
+        }
         // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:encoding-parsing-and-serializing-a-url
-        if (name == HTML::AttributeNames::background) {
+        else if (name == HTML::AttributeNames::background) {
             if (auto parsed_value = document().encoding_parse_url(value); parsed_value.has_value())
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BackgroundImage, CSS::StyleValueList::create({ CSS::ImageStyleValue::create(*parsed_value) }, CSS::StyleValueList::Separator::Comma));
         }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -13,6 +13,7 @@
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/DOM/Attr.h>
@@ -5760,6 +5761,37 @@ Optional<Color> parse_legacy_color_value(StringView string_view)
 
     // 19. Return result.
     return result;
+}
+
+// https://html.spec.whatwg.org/multipage/rendering.html#tables-2
+RefPtr<CSS::StyleValue const> parse_table_child_element_align_value(StringView string_view)
+{
+    // The thead, tbody, tfoot, tr, td, and th elements, when they have an align attribute whose value is an ASCII
+    // case-insensitive match for either the string "center" or the string "middle", are expected to center text within
+    // themselves, as if they had their 'text-align' property set to 'center' in a presentational hint, and to align
+    // descendants to the center.
+    if (string_view.equals_ignoring_ascii_case("center"sv) || string_view.equals_ignoring_ascii_case("middle"sv))
+        return CSS::KeywordStyleValue::create(CSS::Keyword::LibwebCenter);
+
+    // The thead, tbody, tfoot, tr, td, and th elements, when they have an align attribute whose value is an ASCII
+    // case-insensitive match for the string "left", are expected to left-align text within themselves, as if they had
+    // their 'text-align' property set to 'left' in a presentational hint, and to align descendants to the left.
+    if (string_view.equals_ignoring_ascii_case("left"sv))
+        return CSS::KeywordStyleValue::create(CSS::Keyword::LibwebLeft);
+
+    // The thead, tbody, tfoot, tr, td, and th elements, when they have an align attribute whose value is an ASCII
+    // case-insensitive match for the string "right", are expected to right-align text within themselves, as if they
+    // had their 'text-align' property set to 'right' in a presentational hint, and to align descendants to the right.
+    if (string_view.equals_ignoring_ascii_case("right"sv))
+        return CSS::KeywordStyleValue::create(CSS::Keyword::LibwebRight);
+
+    // The thead, tbody, tfoot, tr, td, and th elements, when they have an align attribute whose value is an ASCII
+    // case-insensitive match for the string "justify", are expected to full-justify text within themselves, as if they
+    // had their 'text-align' property set to 'justify' in a presentational hint, and to align descendants to the left.
+    if (string_view.equals_ignoring_ascii_case("justify"sv))
+        return CSS::KeywordStyleValue::create(CSS::Keyword::Justify);
+
+    return nullptr;
 }
 
 JS::Realm& HTMLParser::realm()

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -281,5 +281,6 @@ private:
 RefPtr<CSS::StyleValue const> parse_dimension_value(StringView);
 RefPtr<CSS::StyleValue const> parse_nonzero_dimension_value(StringView);
 Optional<Color> parse_legacy_color_value(StringView);
+RefPtr<CSS::StyleValue const> parse_table_child_element_align_value(StringView);
 
 }

--- a/Tests/LibWeb/Layout/expected/table/align-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-is-inherited.txt
@@ -1,0 +1,243 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 208 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 192 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <thead> at [10,10] table-header-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,10] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,11] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 5, rect: [747.03125,11 41.96875x18] baseline: 13.796875
+                    "Right"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,32] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,32] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,32] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [10,34] table-row-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,34] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,35] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 6, rect: [373.46875,35 53.046875x18] baseline: 13.796875
+                    "Center"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,56] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,56] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,56] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tfoot> at [10,58] table-footer-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,58] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,59] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 4, rect: [11,59 32.875x18] baseline: 13.796875
+                    "Left"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,80] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,80] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,80] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [10,82] table-row-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,82] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,83] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 7, rect: [11,83 53.046875x18] baseline: 13.796875
+                    "Justify"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,104] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <thead> at [10,106] table-header-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,106] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,107] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 5, rect: [747.03125,107 41.96875x18] baseline: 13.796875
+                    "Right"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,128] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,128] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,128] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [10,130] table-row-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,130] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,131] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 6, rect: [373.46875,131 53.046875x18] baseline: 13.796875
+                    "Center"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,152] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,152] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,152] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tfoot> at [10,154] table-footer-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,154] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,155] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 4, rect: [11,155 32.875x18] baseline: 13.796875
+                    "Left"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,176] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      TableWrapper <(anonymous)> at [8,176] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,176] table-box [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [10,178] table-row-group [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [10,178] table-row [0+0+0 780 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [11,179] table-cell [0+0+1 778 1+0+0] [0+0+1 18 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 9, length: 7, rect: [11,179 53.046875x18] baseline: 13.796875
+                    "Justify"
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,200] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x208]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x192]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x24]
+        PaintableBox (Box<TABLE>) [8,8 784x24]
+          PaintableBox (Box<THEAD>) [10,10 780x20]
+            PaintableBox (Box<TR>) [10,10 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,10 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,32 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,32 784x24]
+        PaintableBox (Box<TABLE>) [8,32 784x24]
+          PaintableBox (Box<TBODY>) [10,34 780x20]
+            PaintableBox (Box<TR>) [10,34 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,34 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,56 784x24]
+        PaintableBox (Box<TABLE>) [8,56 784x24]
+          PaintableBox (Box<TFOOT>) [10,58 780x20]
+            PaintableBox (Box<TR>) [10,58 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,58 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,80 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,80 784x24]
+        PaintableBox (Box<TABLE>) [8,80 784x24]
+          PaintableBox (Box<TBODY>) [10,82 780x20]
+            PaintableBox (Box<TR>) [10,82 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,82 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,104 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,104 784x24]
+        PaintableBox (Box<TABLE>) [8,104 784x24]
+          PaintableBox (Box<THEAD>) [10,106 780x20]
+            PaintableBox (Box<TR>) [10,106 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,106 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,128 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,128 784x24]
+        PaintableBox (Box<TABLE>) [8,128 784x24]
+          PaintableBox (Box<TBODY>) [10,130 780x20]
+            PaintableBox (Box<TR>) [10,130 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,130 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,152 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,152 784x24]
+        PaintableBox (Box<TABLE>) [8,152 784x24]
+          PaintableBox (Box<TFOOT>) [10,154 780x20]
+            PaintableBox (Box<TR>) [10,154 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,154 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,176 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,176 784x24]
+        PaintableBox (Box<TABLE>) [8,176 784x24]
+          PaintableBox (Box<TBODY>) [10,178 780x20]
+            PaintableBox (Box<TR>) [10,178 780x20]
+              PaintableWithLines (BlockContainer<TD>) [10,178 780x20]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,200 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x208] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/align-is-inherited.html
+++ b/Tests/LibWeb/Layout/input/table/align-is-inherited.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!-- align on sections (thead, tbody, tfoot) is inherited -->
+
+<table style="width: 100%">
+  <thead align="right">
+    <tr>
+      <td>
+        Right
+      </td>
+    </tr>
+  </thead>
+</table>
+
+<table style="width: 100%">
+  <tbody align="center">
+    <tr>
+      <td>
+        Center
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table style="width: 100%">
+  <tfoot align="left">
+    <tr>
+      <td>
+        Left
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<table style="width: 100%">
+  <tbody align="justify">
+    <tr>
+      <td>
+        Justify
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- align on rows is inherited -->
+
+<table style="width: 100%">
+  <thead>
+    <tr align="right">
+      <td>
+        Right
+      </td>
+    </tr>
+  </thead>
+</table>
+
+<table style="width: 100%">
+  <tbody>
+    <tr align="center">
+      <td>
+        Center
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table style="width: 100%">
+  <tfoot>
+    <tr align="left">
+      <td>
+        Left
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<table style="width: 100%">
+  <tbody>
+    <tr align="justify">
+      <td>
+        Justify
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
thead, tbody, tfoot, tr, td, and th all have an `align` presentational attribute with identical definitions. We previously only supported it for td and th, and also allowed arbitrary text-align values instead of the 4 dictated by the spec.

Gives some progress on [bricklink](https://www.bricklink.com/v2/catalog/catalogitem.page?P=3020#T=S&C=4&O={%22color%22:%224%22,%22ss%22:%22UK%22,%22rpp%22:%22100%22,%22iconly%22:0}), by putting the Reset and Search buttons in the right place:

Before:
<img width="1175" height="962" alt="Screenshot_20260430_111706" src="https://github.com/user-attachments/assets/cba31103-da98-40bc-8cb0-fe5f3364f9e8" />

After:
<img width="1175" height="962" alt="Screenshot_20260430_111638" src="https://github.com/user-attachments/assets/24cefac9-7a5c-4d38-9fa5-a52937684e61" />
