### PR TITLE
LibWeb: Coalesce safe :has() child-list invalidations

### DIFF
--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
@@ -39,6 +39,51 @@ static void invalidate_children_affected_by_has_sibling_combinators(DOM::Node& p
     });
 }
 
+static bool pending_has_invalidation_covers_all_child_list_mutation_features(StyleScope& scope, DOM::Node& parent)
+{
+    auto pending_invalidation = scope.m_pending_has_invalidations.find(parent);
+    if (pending_invalidation == scope.m_pending_has_invalidations.end())
+        return false;
+
+    auto const& mutation_features = pending_invalidation->value;
+    if (mutation_features.is_conservative)
+        return true;
+
+    auto const* data = scope.m_rule_cache ? &scope.m_rule_cache->style_invalidation_data : nullptr;
+    if (!data)
+        return false;
+
+    if (!mutation_features.may_affect_sibling_relationships)
+        return false;
+
+    auto contains_all_keys = [](auto const& existing_features, auto const& used_features) {
+        for (auto const& entry : used_features) {
+            if (!existing_features.contains(entry.key))
+                return false;
+        }
+        return true;
+    };
+
+    if (!contains_all_keys(mutation_features.tag_names, data->tag_names_used_in_has_selectors))
+        return false;
+    if (!contains_all_keys(mutation_features.ids, data->ids_used_in_has_selectors))
+        return false;
+    if (!contains_all_keys(mutation_features.class_names, data->class_names_used_in_has_selectors))
+        return false;
+    if (!contains_all_keys(mutation_features.attribute_names, data->attribute_names_used_in_has_selectors))
+        return false;
+    if (!data->pseudo_classes_used_in_has_selectors.is_empty() && !mutation_features.may_affect_pseudo_classes)
+        return false;
+
+    return true;
+}
+
+static bool scope_has_featureless_sensitive_has_selectors(StyleScope const& scope)
+{
+    auto const* data = scope.m_rule_cache ? &scope.m_rule_cache->style_invalidation_data : nullptr;
+    return data && data->has_selectors_sensitive_to_featureless_subtree_changes;
+}
+
 void invalidate_element_if_affected_by_has(DOM::Element& element)
 {
     if (element.affected_by_has_pseudo_class_in_subject_position())
@@ -369,6 +414,16 @@ static void schedule_has_invalidation_for_child_list_mutation(DOM::Node& parent,
         return;
 
     auto has_sibling_combinator_has_selectors = scope.may_have_has_selectors_with_relative_selector_that_has_sibling_combinator();
+
+    if (pending_has_invalidation_covers_all_child_list_mutation_features(scope, parent))
+        return;
+
+    if (scope_has_featureless_sensitive_has_selectors(scope)) {
+        scope.record_conservative_pending_has_invalidation(parent, true);
+        if (has_sibling_combinator_has_selectors)
+            invalidate_children_affected_by_has_sibling_combinators(parent);
+        return;
+    }
 
     // Sibling-combinator :has() selectors are sensitive to featureless insertions/removals because a plain node can
     // still change adjacency and following-sibling relationships.

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -890,6 +890,18 @@ static void collect_pending_has_invalidation_features_from_element(PendingHasInv
     });
 }
 
+void StyleScope::record_conservative_pending_has_invalidation(GC::Ref<DOM::Node> scheduled_node, bool may_affect_sibling_relationships)
+{
+    auto previous_size = m_pending_has_invalidations.size();
+    auto& mutation_features = m_pending_has_invalidations.ensure(scheduled_node);
+    mutation_features.is_conservative = true;
+    mutation_features.may_affect_sibling_relationships |= may_affect_sibling_relationships;
+    mutation_features.may_affect_pseudo_classes = true;
+
+    if (m_pending_has_invalidations.size() != previous_size)
+        document().set_needs_invalidation_of_elements_affected_by_has();
+}
+
 static PendingHasInvalidationMutationFeatures collect_pending_has_invalidation_mutation_features(DOM::Node& mutation_root, bool includes_descendants)
 {
     PendingHasInvalidationMutationFeatures features;

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -147,6 +147,7 @@ public:
     RefPtr<CSS::CounterStyle const> get_registered_counter_style(FlyString const& name) const;
 
     void schedule_ancestors_style_invalidation_due_to_presence_of_has(GC::Ref<DOM::Node>);
+    void record_conservative_pending_has_invalidation(GC::Ref<DOM::Node>, bool may_affect_sibling_relationships);
     void record_pending_has_invalidation_mutation_features(GC::Ref<DOM::Node>, GC::Ref<DOM::Node>, bool includes_descendants);
     void record_pending_has_invalidation_mutation_features(GC::Ref<DOM::Node>, Vector<CSS::InvalidationSet::Property> const&);
 

--- a/Tests/LibWeb/Text/expected/css-has-invalidation/has-featureless-and-concrete-child-list-coalescing.txt
+++ b/Tests/LibWeb/Text/expected/css-has-invalidation/has-featureless-and-concrete-child-list-coalescing.txt
@@ -1,0 +1,4 @@
+[mixed featureless and class feature insertions] rgb(255, 0, 0)
+[mixed featureless and id feature insertions] rgb(255, 0, 0)
+[mixed featureless and attribute feature insertions] rgb(255, 0, 0)
+[mixed featureless and tag feature insertions] rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/input/css-has-invalidation/has-featureless-and-concrete-child-list-coalescing.html
+++ b/Tests/LibWeb/Text/input/css-has-invalidation/has-featureless-and-concrete-child-list-coalescing.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script src="_helpers.js"></script>
+<style>
+    .other:has(*) .watched { color: green; }
+    .class-case:has(.target-class) .watched { color: red; }
+    .id-case:has(#target-id) .watched { color: red; }
+    .attribute-case:has([data-target]) .watched { color: red; }
+    .tag-case:has(target-tag) .watched { color: red; }
+</style>
+<div class="class-case" id="class-case"><span class="watched" id="class-watched">class</span></div>
+<div class="id-case" id="id-case"><span class="watched" id="id-watched">id</span></div>
+<div class="attribute-case" id="attribute-case"><span class="watched" id="attribute-watched">attribute</span></div>
+<div class="tag-case" id="tag-case"><span class="watched" id="tag-watched">tag</span></div>
+<div class="other" id="other"><span class="watched">other</span></div>
+<script>
+    test(() => {
+        let cases = [
+            {
+                id: "class-case",
+                watchedID: "class-watched",
+                label: "class feature",
+                makeTarget() {
+                    let target = document.createElement("span");
+                    target.className = "target-class";
+                    return target;
+                },
+            },
+            {
+                id: "id-case",
+                watchedID: "id-watched",
+                label: "id feature",
+                makeTarget() {
+                    let target = document.createElement("span");
+                    target.id = "target-id";
+                    return target;
+                },
+            },
+            {
+                id: "attribute-case",
+                watchedID: "attribute-watched",
+                label: "attribute feature",
+                makeTarget() {
+                    let target = document.createElement("span");
+                    target.setAttribute("data-target", "");
+                    return target;
+                },
+            },
+            {
+                id: "tag-case",
+                watchedID: "tag-watched",
+                label: "tag feature",
+                makeTarget() {
+                    return document.createElement("target-tag");
+                },
+            },
+        ];
+
+        settleAndReset(document.getElementById("class-case"));
+
+        for (let testCase of cases) {
+            let container = document.getElementById(testCase.id);
+            container.appendChild(document.createElement("span"));
+            container.appendChild(testCase.makeTarget());
+        }
+
+        for (let testCase of cases) {
+            let watched = document.getElementById(testCase.watchedID);
+            println(`[mixed featureless and ${testCase.label} insertions] ${getComputedStyle(watched).color}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Avoid repeated `:has()` child-list scheduling when pending data already covers every concrete feature bucket used by :has() selectors in a style scope. Featureless-sensitive scopes record child-list mutations conservatively instead.

That conservative path avoids scanning mutation subtrees for concrete features when invalidation cannot rely on them anyway. When loading the [combined Intel ISA PDF](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) in pdf.js, instrumented subtree feature-collection visits at about 40k style invalidations dropped from around 71k to 1.6k, saving ~650ms of main thread time on my Linux machine. :^)