### PR TITLE
LibJS: Propagate errors from `AdjustDateDurationRecord` invocations

### DIFF
--- a/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -384,8 +384,8 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
         // c. Let calendar be plainRelativeTo.[[Calendar]].
         auto const& calendar = plain_relative_to->calendar();
 
-        // d. Let dateDuration be ! AdjustDateDurationRecord(internalDuration.[[Date]], targetTime.[[Days]]).
-        auto date_duration = MUST(adjust_date_duration_record(vm, internal_duration.date, target_time.days));
+        // d. Let dateDuration be ? AdjustDateDurationRecord(internalDuration.[[Date]], targetTime.[[Days]]).
+        auto date_duration = TRY(adjust_date_duration_record(vm, internal_duration.date, target_time.days));
 
         // e. Let targetDate be ? CalendarDateAdd(calendar, plainRelativeTo.[[ISODate]], dateDuration, CONSTRAIN).
         auto target_date = TRY(calendar_date_add(vm, calendar, plain_relative_to->iso_date(), date_duration, Overflow::Constrain));
@@ -524,8 +524,8 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::total)
         // c. Let calendar be plainRelativeTo.[[Calendar]].
         auto const& calendar = plain_relative_to->calendar();
 
-        // d. Let dateDuration be ! AdjustDateDurationRecord(internalDuration.[[Date]], targetTime.[[Days]]).
-        auto date_duration = MUST(adjust_date_duration_record(vm, internal_duration.date, target_time.days));
+        // d. Let dateDuration be ? AdjustDateDurationRecord(internalDuration.[[Date]], targetTime.[[Days]]).
+        auto date_duration = TRY(adjust_date_duration_record(vm, internal_duration.date, target_time.days));
 
         // e. Let targetDate be ? CalendarDateAdd(calendar, plainRelativeTo.[[ISODate]], dateDuration, CONSTRAIN).
         auto target_date = TRY(calendar_date_add(vm, calendar, plain_relative_to->iso_date(), date_duration, Overflow::Constrain));

--- a/Tests/LibJS/Runtime/builtins/Temporal/Duration/Duration.prototype.round.js
+++ b/Tests/LibJS/Runtime/builtins/Temporal/Duration/Duration.prototype.round.js
@@ -208,4 +208,20 @@ describe("errors", () => {
             duration.round({ largestUnit: "year" });
         }).toThrowWithMessage(RangeError, "Largest unit must not be year");
     });
+
+    test("out of range component", () => {
+        const minDuration = new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MIN_SAFE_INTEGER);
+        const maxDuration = new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MAX_SAFE_INTEGER);
+        const relativeTo = new Temporal.PlainDate(2020, 1, 1);
+
+        ["year", "month", "week"].forEach(smallestUnit => {
+            expect(() => {
+                minDuration.round({ smallestUnit, relativeTo });
+            }).toThrowWithMessage(RangeError, "Invalid duration");
+
+            expect(() => {
+                maxDuration.round({ smallestUnit, relativeTo });
+            }).toThrowWithMessage(RangeError, "Invalid ISO date");
+        });
+    });
 });

--- a/Tests/LibJS/Runtime/builtins/Temporal/Duration/Duration.prototype.total.js
+++ b/Tests/LibJS/Runtime/builtins/Temporal/Duration/Duration.prototype.total.js
@@ -117,4 +117,20 @@ describe("errors", () => {
             duration.total({ unit: "years", relativeTo: relativeTo });
         }).toThrowWithMessage(RangeError, "Invalid ISO date");
     });
+
+    test("out of range component", () => {
+        const minDuration = new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MIN_SAFE_INTEGER);
+        const maxDuration = new Temporal.Duration(0, 0, 0, 0, 0, 0, Number.MAX_SAFE_INTEGER);
+        const relativeTo = new Temporal.PlainDate(2020, 1, 1);
+
+        ["year", "month", "week"].forEach(unit => {
+            expect(() => {
+                minDuration.total({ unit, relativeTo });
+            }).toThrowWithMessage(RangeError, "Invalid duration");
+
+            expect(() => {
+                maxDuration.total({ unit, relativeTo });
+            }).toThrowWithMessage(RangeError, "Invalid ISO date");
+        });
+    });
 });


### PR DESCRIPTION
This change was made to the stage 4 Temporal PR. Normally we'd let this PR land and pick up editorial updates all at once. But since this causes a crash, let's get this trivial change now. See:

https://github.com/tc39/ecma262/pull/3759/changes/80dc92d8c8069594bd7be11778a17cf8803dc7ce

test262 diff:
```
test/built-ins/Temporal/Duration/prototype/round/relativeto-plaindate-large-time-component-out-of-range.js 💥 -> ✅
test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindate-large-time-component-out-of-range.js 💥 -> ✅
```