### PR TITLE
LibWeb: Derive inline flex/grid baselines from the first child line

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2395,7 +2395,9 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
     auto const& overflow_x = box.computed_values().overflow_x();
     auto const& overflow_y = box.computed_values().overflow_y();
     bool has_visible_overflow = overflow_x == CSS::Overflow::Visible && overflow_y == CSS::Overflow::Visible;
-    bool always_derive_from_content = display.is_flex_inside() || display.is_grid_inside() || has_visible_overflow;
+    bool is_flex_or_grid_container = display.is_flex_inside() || display.is_grid_inside();
+    bool is_inline_flex_or_grid_container = display.is_inline_outside() && is_flex_or_grid_container;
+    bool always_derive_from_content = is_flex_or_grid_container || has_visible_overflow;
 
     if (always_derive_from_content && !box_state.line_boxes.is_empty()) {
         auto const& last_line_box = box_state.line_boxes.last();
@@ -2412,6 +2414,22 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
         if (always_derive_from_content || is<HTML::HTMLInputElement>(box.dom_node())) {
             auto const& child_box_state = m_state.get(*child_box);
             auto child_offset_from_margin_edge = child_box_state.offset.y() - child_box_state.margin_box_top();
+
+            // https://drafts.csswg.org/css-flexbox-1/#flex-baselines
+            // Otherwise, if the flex container has at least one flex item, the flex container's first/last main-axis
+            // baseline set is generated from the alignment baseline of the startmost/endmost flex item.
+            // https://drafts.csswg.org/css-grid-1/#grid-baselines
+            // Otherwise, the grid container's first (last) baseline set is generated from the alignment baseline of the
+            // first (last) grid item in row-major grid order.
+            // FIXME: This does not yet select the spec-defined startmost/endmost flex item, or the first/last grid item
+            //        in row-major grid order.
+            if (is_inline_flex_or_grid_container && !child_box_state.line_boxes.is_empty() && !child_box_state.line_boxes.first().is_empty()) {
+                auto const& first_line_box = child_box_state.line_boxes.first();
+                auto first_line_box_top = first_line_box.bottom() - first_line_box.block_length();
+                auto child_first_line_baseline = child_box_state.margin_box_top() + first_line_box_top + first_line_box.baseline();
+                return box_state.margin_box_top() + child_offset_from_margin_edge + child_first_line_baseline;
+            }
+
             return box_state.margin_box_top() + child_offset_from_margin_edge + box_baseline(*child_box);
         }
     }

--- a/Tests/LibWeb/Layout/expected/inline-flex-baseline-with-wrapped-hidden-text.txt
+++ b/Tests/LibWeb/Layout/expected/inline-flex-baseline-with-wrapped-hidden-text.txt
@@ -1,0 +1,44 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 18 0+0+16] children: not-inline
+      BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 18 0+0+16] children: inline
+        frag 0 from TextNode start: 0, length: 4, rect: [8,16 35.15625x18] baseline: 13.796875
+            "foo "
+        frag 1 from TextNode start: 0, length: 4, rect: [92.796875,16 38.53125x18] baseline: 13.796875
+            " qux"
+        TextNode <#text> (not painted)
+        InlineNode <a> at [43.15625,16] [0+0+0 45.640625 0+0+0] [0+0+0 18 0+0+0]
+          frag 0 from TextNode start: 0, length: 3, rect: [43.15625,16 27.640625x18] baseline: 13.796875
+              "bar"
+          frag 1 from Box start: 0, length: 0, rect: [74.796875,16 18x18] baseline: 13.796875
+          TextNode <#text> (not painted)
+          Box <span.icon> at [74.796875,16] flex-container(row) [4+0+0 18 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+            BlockContainer <span.hidden-label> at [74.796875,16] flex-item [0+0+0 27.203125 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 3, rect: [74.796875,16 27.203125x18] baseline: 13.796875
+                  "baz"
+              frag 1 from TextNode start: 4, length: 3, rect: [74.796875,34 27.203125x18] baseline: 13.796875
+                  "baz"
+              frag 2 from TextNode start: 8, length: 3, rect: [74.796875,52 27.203125x18] baseline: 13.796875
+                  "baz"
+              frag 3 from TextNode start: 12, length: 3, rect: [74.796875,70 27.203125x18] baseline: 13.796875
+                  "baz"
+              TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,50] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x18]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x18]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (InlineNode<A>) [43.15625,16 45.640625x18]
+          TextPaintable (TextNode<#text>)
+          PaintableBox (Box<SPAN>.icon) [74.796875,16 18x18]
+            PaintableWithLines (BlockContainer<SPAN>.hidden-label) [74.796875,16 27.203125x18]
+              TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x50] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/inline-flex-baseline-with-wrapped-hidden-text.html
+++ b/Tests/LibWeb/Layout/input/inline-flex-baseline-with-wrapped-hidden-text.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+.icon {
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    margin-left: 4px;
+}
+.hidden-label {
+    width: 64px;
+}
+</style>
+<p>foo <a href="#">bar<span class="icon"><span class="hidden-label">baz baz baz baz</span></span></a> qux</p>


### PR DESCRIPTION
When an inline flex/grid container has no line boxes of its own, we derive its baseline from a child box. The generic recursive path can then use the child's last wrapped line, even though the flex/grid baseline should come from the child item's alignment baseline.

Use the selected child's first line box directly for inline flex/grid containers, avoiding an incorrect baseline when that child wraps.

Fixes the link text / icon layout on [this page](https://nos.nl/artikel/2611417-inspectie-begint-onderzoek-naar-yes-we-can-clinics-na-boos-aflevering-over-misstanden):

| Before | After |
|--|--|
| <img width="672" height="569" alt="image" src="https://github.com/user-attachments/assets/58b495cf-4a24-4ea3-ae99-2edd336f23d7" /> | <img width="679" height="581" src="https://github.com/user-attachments/assets/9b7a3a4c-8b81-4e1e-86bd-04dfee90008d" /> |
