### PR TITLE
LibJS: Avoid ropes for short flat string concatenations

### DIFF
--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/CharacterTypes.h>
 #include <AK/FlyString.h>
 #include <AK/StringBuilder.h>
@@ -28,6 +29,61 @@ static constexpr size_t MAX_LENGTH_FOR_STRING_CACHE = 256;
 GC_DEFINE_ALLOCATOR(PrimitiveString);
 GC_DEFINE_ALLOCATOR(RopeString);
 GC_DEFINE_ALLOCATOR(Substring);
+
+Optional<StringView> PrimitiveString::short_flat_string_storage_view() const
+{
+    if (m_deferred_kind != DeferredKind::None)
+        return {};
+
+    if (m_utf8_string.has_value() && m_utf8_string->is_short_string())
+        return m_utf8_string->bytes_as_string_view();
+
+    if (m_utf16_string.has_value() && m_utf16_string->has_short_ascii_storage())
+        return m_utf16_string->ascii_view();
+
+    return {};
+}
+
+static bool utf8_views_form_surrogate_pair_across_boundary(StringView lhs, StringView rhs)
+{
+    if (lhs.length() < 3 || rhs.length() < 3)
+        return false;
+
+    // Surrogates encoded as UTF-8 are 3 bytes.
+    if ((static_cast<u8>(lhs[lhs.length() - 3]) & 0xf0) != 0xe0)
+        return false;
+    if ((static_cast<u8>(rhs[0]) & 0xf0) != 0xe0)
+        return false;
+
+    auto high_surrogate = *Utf8View(lhs.substring_view(lhs.length() - 3)).begin();
+    auto low_surrogate = *Utf8View(rhs).begin();
+    return AK::UnicodeUtils::is_utf16_high_surrogate(high_surrogate)
+        && AK::UnicodeUtils::is_utf16_low_surrogate(low_surrogate);
+}
+
+GC::Ptr<PrimitiveString> PrimitiveString::try_create_short_flat_concatenated_string(VM& vm, PrimitiveString const& lhs, PrimitiveString const& rhs)
+{
+    auto lhs_view = lhs.short_flat_string_storage_view();
+    if (!lhs_view.has_value())
+        return nullptr;
+
+    auto rhs_view = rhs.short_flat_string_storage_view();
+    if (!rhs_view.has_value())
+        return nullptr;
+
+    auto const byte_count = lhs_view->length() + rhs_view->length();
+    if (byte_count > String::MAX_SHORT_STRING_BYTE_COUNT)
+        return nullptr;
+
+    if (utf8_views_form_surrogate_pair_across_boundary(*lhs_view, *rhs_view))
+        return nullptr;
+
+    AK::Array<u8, String::MAX_SHORT_STRING_BYTE_COUNT> buffer;
+    lhs_view->bytes().copy_to({ buffer.data(), lhs_view->length() });
+    rhs_view->bytes().copy_to({ buffer.data() + lhs_view->length(), rhs_view->length() });
+
+    return PrimitiveString::create(vm, String::from_utf8_without_validation({ buffer.data(), byte_count }));
+}
 
 GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16String const& string)
 {
@@ -129,6 +185,9 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, P
 
     if (rhs_empty)
         return lhs;
+
+    if (auto short_flat_string = try_create_short_flat_concatenated_string(vm, lhs, rhs))
+        return *short_flat_string;
 
     return vm.heap().allocate<RopeString>(lhs, rhs);
 }

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -96,6 +96,8 @@ private:
     explicit PrimitiveString(String);
 
     void resolve_if_needed(EncodingPreference) const;
+    Optional<StringView> short_flat_string_storage_view() const;
+    static GC::Ptr<PrimitiveString> try_create_short_flat_concatenated_string(VM&, PrimitiveString const& lhs, PrimitiveString const& rhs);
 };
 
 class RopeString final : public PrimitiveString {

--- a/Tests/LibJS/test-primitive-string.cpp
+++ b/Tests/LibJS/test-primitive-string.cpp
@@ -35,9 +35,9 @@ struct TestVM {
 NEVER_INLINE static void materialize_temporary_rope(VM& vm)
 {
     auto rope = PrimitiveString::create(vm,
-        *PrimitiveString::create(vm, "f"_string),
-        *PrimitiveString::create(vm, "oo"_string));
-    EXPECT(rope->utf8_string_view() == "foo"sv);
+        *PrimitiveString::create(vm, "hello"_string),
+        *PrimitiveString::create(vm, "world"_string));
+    EXPECT(rope->utf8_string_view() == "helloworld"sv);
 }
 
 NEVER_INLINE static void materialize_temporary_substring(VM& vm)
@@ -75,12 +75,37 @@ TEST_CASE(primitive_string_substring_materializes_rope_ranges)
     TestVM test_vm;
 
     auto rope = PrimitiveString::create(*test_vm.vm,
-        *PrimitiveString::create(*test_vm.vm, "ab"_string),
-        *PrimitiveString::create(*test_vm.vm, "cd"_string));
-    auto substring = PrimitiveString::create(*test_vm.vm, *rope, 1, 2);
+        *PrimitiveString::create(*test_vm.vm, "abcd"_string),
+        *PrimitiveString::create(*test_vm.vm, "efgh"_string));
+    auto substring = PrimitiveString::create(*test_vm.vm, *rope, 3, 3);
 
-    EXPECT_EQ(substring->length_in_utf16_code_units(), 2u);
-    EXPECT(substring->utf8_string_view() == "bc"sv);
+    EXPECT_EQ(substring->length_in_utf16_code_units(), 3u);
+    EXPECT(substring->utf8_string_view() == "def"sv);
+}
+
+TEST_CASE(primitive_string_concat_short_flat_strings_creates_flat_string)
+{
+    TestVM test_vm;
+
+    auto concatenated = PrimitiveString::create(*test_vm.vm,
+        *PrimitiveString::create(*test_vm.vm, "foo"_string),
+        *PrimitiveString::create(*test_vm.vm, "bar"_string));
+
+    EXPECT(concatenated->has_utf8_string());
+    EXPECT(concatenated->utf8_string_view() == "foobar"sv);
+}
+
+TEST_CASE(primitive_string_concat_longer_strings_stays_deferred)
+{
+    TestVM test_vm;
+
+    auto concatenated = PrimitiveString::create(*test_vm.vm,
+        *PrimitiveString::create(*test_vm.vm, "abcd"_string),
+        *PrimitiveString::create(*test_vm.vm, "efgh"_string));
+
+    EXPECT(!concatenated->has_utf8_string());
+    EXPECT(!concatenated->has_utf16_string());
+    EXPECT(concatenated->utf8_string_view() == "abcdefgh"sv);
 }
 
 TEST_CASE(primitive_string_substring_reuses_cached_single_ascii_strings)
@@ -108,6 +133,21 @@ TEST_CASE(primitive_string_substring_handles_surrogate_boundaries)
     EXPECT_EQ(trailing_surrogate->length_in_utf16_code_units(), 1u);
     EXPECT_EQ(trailing_surrogate->utf16_string_view().code_unit_at(0), static_cast<u16>(0xde00));
     EXPECT(full_code_point->utf8_string_view() == "😀"sv);
+}
+
+TEST_CASE(primitive_string_concat_short_strings_handles_surrogate_boundaries)
+{
+    TestVM test_vm;
+
+    auto string = PrimitiveString::create(*test_vm.vm, "😀"_string);
+    auto leading_surrogate = PrimitiveString::create(*test_vm.vm, *string, 0, 1);
+    auto trailing_surrogate = PrimitiveString::create(*test_vm.vm, *string, 1, 1);
+
+    (void)leading_surrogate->utf8_string_view();
+    (void)trailing_surrogate->utf8_string_view();
+
+    auto concatenated = PrimitiveString::create(*test_vm.vm, *leading_surrogate, *trailing_surrogate);
+    EXPECT(concatenated->utf8_string_view() == "😀"sv);
 }
 
 TEST_CASE(primitive_string_substring_utf16_views_stay_deferred)


### PR DESCRIPTION
Short string concatenations are a common allocation churn pattern in JS execution. Many of these results are immediately observed as flat strings, so the intended win is to avoid spending GC and flattening work on an intermediate representation that does not carry its weight.

Microbenchmark:

    const n = 10_000_000;
    function bench(a, b) {
        let total = 0;
        for (let i = 0; i < n; ++i)
            total += (a + b).length;
        if (total !== n * 2)
            throw new Error(String(total));
    }
    bench("a", "b");

Measured with hyperfine against the same build with the fast path disabled:

    baseline:  822.7 ms +/- 25.7 ms
    optimized: 385.5 ms +/- 21.5 ms
    speedup:   2.13 +/- 0.14 times faster