### PR TITLE
LibJS: Replace PromiseResolvingFunction closure with a Kind enum

### DIFF
--- a/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Libraries/LibJS/Runtime/Promise.cpp
@@ -73,92 +73,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
     // 6. Set resolve.[[AlreadyResolved]] to alreadyResolved.
 
     // 27.2.1.3.2 Promise Resolve Functions, https://tc39.es/ecma262/#sec-promise-resolve-functions
-    auto resolve_function = PromiseResolvingFunction::create(realm, *this, *already_resolved, [](auto& vm, auto& promise, auto& already_resolved) {
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolve function was called", &promise);
-
-        auto& realm = *vm.current_realm();
-
-        auto resolution = vm.argument(0);
-
-        // 1. Let F be the active function object.
-        // 2. Assert: F has a [[Promise]] internal slot whose value is an Object.
-        // 3. Let promise be F.[[Promise]].
-
-        // 4. Let alreadyResolved be F.[[AlreadyResolved]].
-        // 5. If alreadyResolved.[[Value]] is true, return undefined.
-        if (already_resolved.value) {
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise is already resolved, returning undefined", &promise);
-            return js_undefined();
-        }
-
-        // 6. Set alreadyResolved.[[Value]] to true.
-        already_resolved.value = true;
-
-        // 7. If SameValue(resolution, promise) is true, then
-        if (resolution.is_object() && &resolution.as_object() == &promise) {
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise can't be resolved with itself, rejecting with error", &promise);
-
-            // a. Let selfResolutionError be a newly created TypeError object.
-            auto self_resolution_error = TypeError::create(realm, "Cannot resolve promise with itself"sv);
-
-            // b. Perform RejectPromise(promise, selfResolutionError).
-            promise.reject(self_resolution_error);
-
-            // c. Return undefined.
-            return js_undefined();
-        }
-
-        // 8. If Type(resolution) is not Object, then
-        if (!resolution.is_object()) {
-            // a. Perform FulfillPromise(promise, resolution).
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolution is not an object, fulfilling with {}", &promise, resolution);
-            promise.fulfill(resolution);
-
-            // b. Return undefined.
-            return js_undefined();
-        }
-
-        // 9. Let then be Completion(Get(resolution, "then")).
-        auto then = resolution.as_object().get(vm.names.then);
-
-        // 10. If then is an abrupt completion, then
-        if (then.is_throw_completion()) {
-            // a. Perform RejectPromise(promise, then.[[Value]]).
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Exception while getting 'then' property, rejecting with error", &promise);
-            promise.reject(then.throw_completion().value());
-
-            // b. Return undefined.
-            return js_undefined();
-        }
-
-        // 11. Let thenAction be then.[[Value]].
-        auto then_action = then.release_value();
-
-        // 12. If IsCallable(thenAction) is false, then
-        if (!then_action.is_function()) {
-            // a. Perform FulfillPromise(promise, resolution).
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Then action is not a function, fulfilling with {}", &promise, resolution);
-            promise.fulfill(resolution);
-
-            // b. Return undefined.
-            return js_undefined();
-        }
-
-        // 13. Let thenJobCallback be HostMakeJobCallback(thenAction).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Creating JobCallback for then action @ {}", &promise, &then_action.as_function());
-        auto then_job_callback = vm.host_make_job_callback(then_action.as_function());
-
-        // 14. Let job be NewPromiseResolveThenableJob(promise, resolution, thenJobCallback).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Creating PromiseJob for thenable {}", &promise, resolution);
-        auto job = create_promise_resolve_thenable_job(vm, promise, resolution, move(then_job_callback));
-
-        // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Enqueuing job @ {} in realm {}", &promise, &job.job, job.realm.ptr());
-        vm.host_enqueue_promise_job(move(job.job), job.realm);
-
-        // 16. Return undefined.
-        return js_undefined();
-    });
+    auto resolve_function = PromiseResolvingFunction::create(realm, *this, *already_resolved, PromiseResolvingFunction::Kind::Resolve);
     resolve_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), Attribute::Configurable);
 
     // 7. Let stepsReject be the algorithm steps defined in Promise Reject Functions.
@@ -168,33 +83,126 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
     // 11. Set reject.[[AlreadyResolved]] to alreadyResolved.
 
     // 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
-    auto reject_function = PromiseResolvingFunction::create(realm, *this, *already_resolved, [](auto& vm, auto& promise, auto& already_resolved) {
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Reject function was called", &promise);
-
-        auto reason = vm.argument(0);
-
-        // 1. Let F be the active function object.
-        // 2. Assert: F has a [[Promise]] internal slot whose value is an Object.
-        // 3. Let promise be F.[[Promise]].
-
-        // 4. Let alreadyResolved be F.[[AlreadyResolved]].
-        // 5. If alreadyResolved.[[Value]] is true, return undefined.
-        if (already_resolved.value)
-            return js_undefined();
-
-        // 6. Set alreadyResolved.[[Value]] to true.
-        already_resolved.value = true;
-
-        // 7. Perform RejectPromise(promise, reason).
-        promise.reject(reason);
-
-        // 8. Return undefined.
-        return js_undefined();
-    });
+    auto reject_function = PromiseResolvingFunction::create(realm, *this, *already_resolved, PromiseResolvingFunction::Kind::Reject);
     reject_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), Attribute::Configurable);
 
     // 12. Return the Record { [[Resolve]]: resolve, [[Reject]]: reject }.
     return { *resolve_function, *reject_function };
+}
+
+// 27.2.1.3.2 Promise Resolve Functions, https://tc39.es/ecma262/#sec-promise-resolve-functions
+Value Promise::resolve_function_steps(VM& vm, Promise& promise, AlreadyResolved& already_resolved)
+{
+    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolve function was called", &promise);
+
+    auto& realm = *vm.current_realm();
+
+    auto resolution = vm.argument(0);
+
+    // 1. Let F be the active function object.
+    // 2. Assert: F has a [[Promise]] internal slot whose value is an Object.
+    // 3. Let promise be F.[[Promise]].
+
+    // 4. Let alreadyResolved be F.[[AlreadyResolved]].
+    // 5. If alreadyResolved.[[Value]] is true, return undefined.
+    if (already_resolved.value) {
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise is already resolved, returning undefined", &promise);
+        return js_undefined();
+    }
+
+    // 6. Set alreadyResolved.[[Value]] to true.
+    already_resolved.value = true;
+
+    // 7. If SameValue(resolution, promise) is true, then
+    if (resolution.is_object() && &resolution.as_object() == &promise) {
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise can't be resolved with itself, rejecting with error", &promise);
+
+        // a. Let selfResolutionError be a newly created TypeError object.
+        auto self_resolution_error = TypeError::create(realm, "Cannot resolve promise with itself"sv);
+
+        // b. Perform RejectPromise(promise, selfResolutionError).
+        promise.reject(self_resolution_error);
+
+        // c. Return undefined.
+        return js_undefined();
+    }
+
+    // 8. If Type(resolution) is not Object, then
+    if (!resolution.is_object()) {
+        // a. Perform FulfillPromise(promise, resolution).
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolution is not an object, fulfilling with {}", &promise, resolution);
+        promise.fulfill(resolution);
+
+        // b. Return undefined.
+        return js_undefined();
+    }
+
+    // 9. Let then be Completion(Get(resolution, "then")).
+    auto then = resolution.as_object().get(vm.names.then);
+
+    // 10. If then is an abrupt completion, then
+    if (then.is_throw_completion()) {
+        // a. Perform RejectPromise(promise, then.[[Value]]).
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Exception while getting 'then' property, rejecting with error", &promise);
+        promise.reject(then.throw_completion().value());
+
+        // b. Return undefined.
+        return js_undefined();
+    }
+
+    // 11. Let thenAction be then.[[Value]].
+    auto then_action = then.release_value();
+
+    // 12. If IsCallable(thenAction) is false, then
+    if (!then_action.is_function()) {
+        // a. Perform FulfillPromise(promise, resolution).
+        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Then action is not a function, fulfilling with {}", &promise, resolution);
+        promise.fulfill(resolution);
+
+        // b. Return undefined.
+        return js_undefined();
+    }
+
+    // 13. Let thenJobCallback be HostMakeJobCallback(thenAction).
+    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Creating JobCallback for then action @ {}", &promise, &then_action.as_function());
+    auto then_job_callback = vm.host_make_job_callback(then_action.as_function());
+
+    // 14. Let job be NewPromiseResolveThenableJob(promise, resolution, thenJobCallback).
+    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Creating PromiseJob for thenable {}", &promise, resolution);
+    auto job = create_promise_resolve_thenable_job(vm, promise, resolution, move(then_job_callback));
+
+    // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
+    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Enqueuing job @ {} in realm {}", &promise, &job.job, job.realm.ptr());
+    vm.host_enqueue_promise_job(move(job.job), job.realm);
+
+    // 16. Return undefined.
+    return js_undefined();
+}
+
+// 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
+Value Promise::reject_function_steps(VM& vm, Promise& promise, AlreadyResolved& already_resolved)
+{
+    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Reject function was called", &promise);
+
+    auto reason = vm.argument(0);
+
+    // 1. Let F be the active function object.
+    // 2. Assert: F has a [[Promise]] internal slot whose value is an Object.
+    // 3. Let promise be F.[[Promise]].
+
+    // 4. Let alreadyResolved be F.[[AlreadyResolved]].
+    // 5. If alreadyResolved.[[Value]] is true, return undefined.
+    if (already_resolved.value)
+        return js_undefined();
+
+    // 6. Set alreadyResolved.[[Value]] to true.
+    already_resolved.value = true;
+
+    // 7. Perform RejectPromise(promise, reason).
+    promise.reject(reason);
+
+    // 8. Return undefined.
+    return js_undefined();
 }
 
 // 27.2.1.4 FulfillPromise ( promise, value ), https://tc39.es/ecma262/#sec-fulfillpromise

--- a/Libraries/LibJS/Runtime/Promise.h
+++ b/Libraries/LibJS/Runtime/Promise.h
@@ -42,6 +42,9 @@ public:
     };
     ResolvingFunctions create_resolving_functions();
 
+    static Value resolve_function_steps(VM&, Promise&, AlreadyResolved&);
+    static Value reject_function_steps(VM&, Promise&, AlreadyResolved&);
+
     void fulfill(Value value);
     void reject(Value reason);
     Value perform_then(Value on_fulfilled, Value on_rejected, GC::Ptr<PromiseCapability> result_capability);

--- a/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -14,16 +14,16 @@ namespace JS {
 GC_DEFINE_ALLOCATOR(AlreadyResolved);
 GC_DEFINE_ALLOCATOR(PromiseResolvingFunction);
 
-GC::Ref<PromiseResolvingFunction> PromiseResolvingFunction::create(Realm& realm, Promise& promise, AlreadyResolved& already_resolved, FunctionType function)
+GC::Ref<PromiseResolvingFunction> PromiseResolvingFunction::create(Realm& realm, Promise& promise, AlreadyResolved& already_resolved, Kind kind)
 {
-    return realm.create<PromiseResolvingFunction>(promise, already_resolved, move(function), realm.intrinsics().function_prototype());
+    return realm.create<PromiseResolvingFunction>(promise, already_resolved, kind, realm.intrinsics().function_prototype());
 }
 
-PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, AlreadyResolved& already_resolved, FunctionType native_function, Object& prototype)
+PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, AlreadyResolved& already_resolved, Kind kind, Object& prototype)
     : NativeFunction(prototype)
     , m_promise(promise)
     , m_already_resolved(already_resolved)
-    , m_native_function(move(native_function))
+    , m_kind(kind)
 {
 }
 
@@ -35,7 +35,13 @@ void PromiseResolvingFunction::initialize(Realm& realm)
 
 ThrowCompletionOr<Value> PromiseResolvingFunction::call()
 {
-    return m_native_function(vm(), m_promise, m_already_resolved);
+    switch (m_kind) {
+    case Kind::Resolve:
+        return Promise::resolve_function_steps(vm(), m_promise, m_already_resolved);
+    case Kind::Reject:
+        return Promise::reject_function_steps(vm(), m_promise, m_already_resolved);
+    }
+    VERIFY_NOT_REACHED();
 }
 
 void PromiseResolvingFunction::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -28,9 +28,12 @@ class PromiseResolvingFunction final : public NativeFunction {
     GC_DECLARE_ALLOCATOR(PromiseResolvingFunction);
 
 public:
-    using FunctionType = Function<Value(VM&, Promise&, AlreadyResolved&)>;
+    enum class Kind : u8 {
+        Resolve,
+        Reject,
+    };
 
-    static GC::Ref<PromiseResolvingFunction> create(Realm&, Promise&, AlreadyResolved&, FunctionType);
+    static GC::Ref<PromiseResolvingFunction> create(Realm&, Promise&, AlreadyResolved&, Kind);
 
     virtual void initialize(Realm&) override;
     virtual ~PromiseResolvingFunction() override = default;
@@ -38,13 +41,13 @@ public:
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
-    explicit PromiseResolvingFunction(Promise&, AlreadyResolved&, FunctionType, Object& prototype);
+    explicit PromiseResolvingFunction(Promise&, AlreadyResolved&, Kind, Object& prototype);
 
     virtual void visit_edges(Visitor&) override;
 
     GC::Ref<Promise> m_promise;
     GC::Ref<AlreadyResolved> m_already_resolved;
-    FunctionType m_native_function;
+    Kind m_kind;
 };
 
 }


### PR DESCRIPTION
Every Promise allocates two PromiseResolvingFunction cells (resolve and reject). Each cell stored an AK::Function holding a closure, but neither closure captured anything beyond the Promise and AlreadyResolved already present as cell fields.

Hoist the two closure bodies into static functions on Promise and dispatch by a Kind enum on the cell. This removes the AK::Function storage embedded in each cell along with its off-GC malloc'd closure capture.