### PR TITLE
LibWeb: Restrict ShadowRoot layout update to node when setting innerHTML

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -58,8 +58,7 @@ enum class QuirksMode {
     X(DocumentAddAnElementToTheTopLayer)                  \
     X(DocumentRequestAnElementToBeRemovedFromTheTopLayer) \
     X(DocumentImmediatelyRemoveElementFromTheTopLayer)    \
-    X(DocumentPendingTopLayerRemovalsProcessed)           \
-    X(ShadowRootSetInnerHTML)
+    X(DocumentPendingTopLayerRemovalsProcessed)
 
 enum class InvalidateLayoutTreeReason {
 #define ENUMERATE_INVALIDATE_LAYOUT_TREE_REASON(e) e,

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -96,6 +96,7 @@ enum class SetNeedsLayoutReason {
     X(NodeRemove)                                         \
     X(NodeSetTextContent)                                 \
     X(None)                                               \
+    X(ShadowRootSetInnerHTML)                             \
     X(StyleChange)
 
 enum class SetNeedsLayoutTreeUpdateReason {

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -128,8 +128,8 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(TrustedTypes::TrustedHTMLOr
         this->set_needs_style_update(true);
 
         if (this->is_connected()) {
-            // NOTE: Since the DOM has changed, we have to rebuild the layout tree.
-            this->document().invalidate_layout_tree(InvalidateLayoutTreeReason::ShadowRootSetInnerHTML);
+            // NOTE: Since the DOM has changed, we have to rebuild this shadow root's layout subtree.
+            this->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::ShadowRootSetInnerHTML);
         }
     }
 


### PR DESCRIPTION
We were invalidating the entire document's layout tree when a shadow root's innerHTML was updated, but we already support more granular layout updates for shadow roots - so make sure to only invalidate the node's layout.

Reduces the time needed to obtain a layout and painting tree for https://pomax.github.io/bezierinfo/ by 21% on my machine.