### PR TITLE
LibJS: Add fast path to TypedArraySpeciesCreate for default species

### DIFF
--- a/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -29,8 +29,17 @@ ThrowCompletionOr<TypedArrayBase*> typed_array_from(VM& vm, Value typed_array_va
     return static_cast<TypedArrayBase*>(this_object.ptr());
 }
 
+static ThrowCompletionOr<void> validate_typed_array_length(VM& vm, size_t array_length, size_t element_size)
+{
+    if (array_length > NumericLimits<i32>::max() / element_size)
+        return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");
+    if (Checked<u32>::multiplication_would_overflow(array_length, element_size))
+        return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");
+    return {};
+}
+
 // 22.2.5.1.3 InitializeTypedArrayFromArrayBuffer, https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
-static ThrowCompletionOr<void> initialize_typed_array_from_array_buffer(VM& vm, TypedArrayBase& typed_array, ArrayBuffer& array_buffer, Value byte_offset, Value length)
+ThrowCompletionOr<void> initialize_typed_array_from_array_buffer(VM& vm, TypedArrayBase& typed_array, ArrayBuffer& array_buffer, Value byte_offset, Value length)
 {
     // 1. Let elementSize be TypedArrayElementSize(O).
     auto element_size = typed_array.element_size();
@@ -497,6 +506,17 @@ void TypedArrayBase::finalize()
         return realm.intrinsics().snake_name##_constructor();                                                               \
     }                                                                                                                       \
                                                                                                                             \
+    ThrowCompletionOr<GC::Ref<TypedArrayBase>> ClassName::create_default(Realm& realm, u32 array_length) const              \
+    {                                                                                                                       \
+        TRY(validate_typed_array_length(realm.vm(), array_length, sizeof(UnderlyingBufferDataType)));                       \
+        return GC::Ref<TypedArrayBase> { *TRY(create(realm, array_length)) };                                               \
+    }                                                                                                                       \
+                                                                                                                            \
+    GC::Ref<TypedArrayBase> ClassName::create_default_view_on_buffer(Realm& realm, ArrayBuffer& buffer) const               \
+    {                                                                                                                       \
+        return create(realm, 0, buffer);                                                                                    \
+    }                                                                                                                       \
+                                                                                                                            \
     PrototypeName::PrototypeName(Object& prototype)                                                                         \
         : Object(ConstructWithPrototypeTag::Tag, prototype, MayInterfereWithIndexedPropertyAccess::Yes)                     \
     {                                                                                                                       \
@@ -586,11 +606,7 @@ void TypedArrayBase::finalize()
             return error;                                                                                                   \
         }                                                                                                                   \
         auto array_length = array_length_or_error.release_value();                                                          \
-        if (array_length > NumericLimits<i32>::max() / sizeof(Type))                                                        \
-            return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");                                \
-        /* FIXME: What is the best/correct behavior here? */                                                                \
-        if (Checked<u32>::multiplication_would_overflow(array_length, sizeof(Type)))                                        \
-            return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");                                \
+        TRY(validate_typed_array_length(vm, array_length, sizeof(Type)));                                                   \
         return TRY(ClassName::create(realm, array_length, new_target));                                                     \
     }
 

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -83,6 +83,12 @@ public:
 
     virtual GC::Ref<NativeFunction> intrinsic_constructor(Realm&) const = 0;
 
+    // OPTIMIZATION: Fast-path factories used by TypedArraySpeciesCreate when the resolved species constructor is the
+    // default intrinsic. These bypass the public TypedArray constructor (which would otherwise allocate a throwaway
+    // ArrayBuffer in the `is_object()` branch of its argument handling).
+    virtual ThrowCompletionOr<GC::Ref<TypedArrayBase>> create_default(Realm&, u32 array_length) const = 0;
+    virtual GC::Ref<TypedArrayBase> create_default_view_on_buffer(Realm&, ArrayBuffer&) const = 0;
+
 protected:
     TypedArrayBase(Object& prototype, Kind kind, u32 element_size)
         : Object(ConstructWithPrototypeTag::Tag, prototype, MayInterfereWithIndexedPropertyAccess::Yes)
@@ -546,6 +552,7 @@ protected:
 };
 
 JS_API ThrowCompletionOr<TypedArrayBase*> typed_array_from(VM&, Value);
+ThrowCompletionOr<void> initialize_typed_array_from_array_buffer(VM&, TypedArrayBase&, ArrayBuffer&, Value byte_offset, Value length);
 ThrowCompletionOr<TypedArrayBase*> typed_array_create(VM&, FunctionObject& constructor, GC::RootVector<Value> arguments);
 ThrowCompletionOr<TypedArrayBase*> typed_array_create_same_type(VM&, TypedArrayBase const& exemplar, GC::RootVector<Value> arguments);
 ThrowCompletionOr<TypedArrayWithBufferWitness> validate_typed_array(VM&, Object const&, ArrayBuffer::Order);
@@ -563,6 +570,8 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
         static GC::Ref<ClassName> create(Realm&, u32 length, ArrayBuffer& buffer);                           \
         virtual Utf16FlyString const& element_name() const override;                                         \
         virtual GC::Ref<NativeFunction> intrinsic_constructor(Realm&) const override;                        \
+        virtual ThrowCompletionOr<GC::Ref<TypedArrayBase>> create_default(Realm&, u32) const override;       \
+        virtual GC::Ref<TypedArrayBase> create_default_view_on_buffer(Realm&, ArrayBuffer&) const override;  \
                                                                                                              \
     protected:                                                                                               \
         ClassName(Object& prototype, u32 length, ArrayBuffer& array_buffer);                                 \

--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -92,7 +92,13 @@ static ThrowCompletionOr<GC::Ref<FunctionObject>> callback_from_args(VM& vm, Str
 }
 
 // 23.2.4.1 TypedArraySpeciesCreate ( exemplar, argumentList ), https://tc39.es/ecma262/#typedarray-species-create
-static ThrowCompletionOr<TypedArrayBase*> typed_array_species_create(VM& vm, TypedArrayBase const& exemplar, GC::RootVector<Value> arguments)
+//
+// OPTIMIZATION: When the resolved species constructor is the default intrinsic (the common case), `default_construct`
+// is invoked to build the result directly, bypassing the user-observable Construct(...) call. This avoids the
+// throwaway ArrayBuffer that the public TypedArray constructor allocates in its `is_object()` branch before
+// overwriting it via InitializeTypedArrayFromArrayBuffer/TypedArray/etc.
+template<typename DefaultConstruct>
+static ThrowCompletionOr<TypedArrayBase*> typed_array_species_create(VM& vm, TypedArrayBase const& exemplar, DefaultConstruct&& default_construct, GC::RootVector<Value> slow_path_arguments)
 {
     auto& realm = *vm.current_realm();
 
@@ -102,8 +108,15 @@ static ThrowCompletionOr<TypedArrayBase*> typed_array_species_create(VM& vm, Typ
     // 2. Let constructor be ? SpeciesConstructor(exemplar, defaultConstructor).
     auto* constructor = TRY(species_constructor(vm, exemplar, *default_constructor));
 
-    // 3. Let result be ? TypedArrayCreate(constructor, argumentList).
-    auto* result = TRY(typed_array_create(vm, *constructor, move(arguments)));
+    TypedArrayBase* result;
+    if (constructor == default_constructor.ptr()) {
+        // OPTIMIZATION: Same outcome as `Construct(defaultConstructor, argumentList)` would produce, but without the
+        //               throwaway buffer or the constructor invocation overhead.
+        result = TRY(default_construct());
+    } else {
+        // 3. Let result be ? TypedArrayCreate(constructor, argumentList).
+        result = TRY(typed_array_create(vm, *constructor, move(slow_path_arguments)));
+    }
 
     // 4. Assert: result has [[TypedArrayName]] and [[ContentType]] internal slots.
     // 5. If result.[[ContentType]] ≠ exemplar.[[ContentType]], throw a TypeError exception.
@@ -672,7 +685,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::filter)
     // 9. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(captured) »).
     GC::RootVector<Value> arguments(vm.heap());
     arguments.empend(captured);
-    auto* filter_array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
+    auto& realm = *vm.current_realm();
+    auto* filter_array = TRY(typed_array_species_create(vm, *typed_array, [&]() -> ThrowCompletionOr<GC::Ref<TypedArrayBase>> { return TRY(typed_array->create_default(realm, captured)); }, move(arguments)));
 
     // 10. Let n be 0.
     size_t index = 0;
@@ -1194,7 +1208,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::map)
     // 5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) »).
     GC::RootVector<Value> arguments(vm.heap());
     arguments.empend(length);
-    auto* array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
+    auto& realm = *vm.current_realm();
+    auto* array = TRY(typed_array_species_create(vm, *typed_array, [&]() -> ThrowCompletionOr<GC::Ref<TypedArrayBase>> { return TRY(typed_array->create_default(realm, length)); }, move(arguments)));
 
     // 6. Let k be 0.
     // 7. Repeat, while k < len,
@@ -1676,7 +1691,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
     // 13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
     GC::RootVector<Value> arguments(vm.heap());
     arguments.empend(count);
-    auto* array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
+    auto& realm = *vm.current_realm();
+    auto* array = TRY(typed_array_species_create(vm, *typed_array, [&]() -> ThrowCompletionOr<GC::Ref<TypedArrayBase>> { return TRY(typed_array->create_default(realm, count)); }, move(arguments)));
 
     // 14. If count > 0, then
     if (count > 0) {
@@ -1929,6 +1945,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
     }
 
     GC::RootVector<Value> arguments(vm.heap());
+    Optional<u32> new_length;
 
     // 15. If O.[[ArrayLength]] is auto and end is undefined, then
     if (typed_array->array_length().is_auto() && end.is_undefined()) {
@@ -1957,16 +1974,21 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
             end_index = min(relative_end, source_length);
 
         // e. Let newLength be max(endIndex - beginIndex, 0).
-        auto new_length = max(end_index - begin_index, 0);
+        new_length = max(end_index - begin_index, 0);
 
         // f. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
         arguments.empend(buffer);
         arguments.empend(begin_byte_offset.value());
-        arguments.empend(new_length);
+        arguments.empend(*new_length);
     }
 
+    auto& realm = *vm.current_realm();
+
     // 17. Return ? TypedArraySpeciesCreate(O, argumentsList).
-    return TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
+    return TRY(typed_array_species_create(vm, *typed_array, [&]() -> ThrowCompletionOr<GC::Ref<TypedArrayBase>> {
+        auto view = typed_array->create_default_view_on_buffer(realm, *buffer);
+        TRY(initialize_typed_array_from_array_buffer(vm, *view, *buffer, Value(begin_byte_offset.value()), new_length.has_value() ? Value(*new_length) : js_undefined()));
+        return view; }, move(arguments)));
 }
 
 // 23.2.3.31 %TypedArray%.prototype.toLocaleString ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring

--- a/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.subarray.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.subarray.js
@@ -76,3 +76,117 @@ test("resizable ArrayBuffer resized during `start` parameter access", () => {
         expect(typedArray.subarray(badAccessor, typedArray.length).length).toBe(2);
     });
 });
+
+test("default species: result shares the source buffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const source = new T([1, 2, 3, 4, 5]);
+        const sub = source.subarray(1, 4);
+        expect(sub.buffer).toBe(source.buffer);
+        expect(sub.byteOffset).toBe(T.BYTES_PER_ELEMENT);
+        expect(sub.length).toBe(3);
+        expect(sub.constructor).toBe(T);
+        sub[0] = 9;
+        expect(source[1]).toBe(9);
+    });
+});
+
+test("Symbol.species returns the default constructor", () => {
+    TYPED_ARRAYS.forEach(T => {
+        class Subclass extends T {
+            static get [Symbol.species]() {
+                return T;
+            }
+        }
+        const source = new Subclass([1, 2, 3, 4, 5]);
+        const sub = source.subarray(1, 4);
+        expect(sub.buffer).toBe(source.buffer);
+        expect(sub.constructor).toBe(T);
+        expect(Object.getPrototypeOf(sub)).toBe(T.prototype);
+        expect(sub.length).toBe(3);
+    });
+});
+
+test("Symbol.species returns a different typed array constructor", () => {
+    TYPED_ARRAYS.forEach(T => {
+        class Subclass extends T {
+            static get [Symbol.species]() {
+                return Uint8Array;
+            }
+        }
+        const source = new Subclass(new ArrayBuffer(T.BYTES_PER_ELEMENT * 4));
+        const sub = source.subarray(1, 3);
+        expect(sub.buffer).toBe(source.buffer);
+        expect(sub.constructor).toBe(Uint8Array);
+        expect(sub.byteOffset).toBe(T.BYTES_PER_ELEMENT);
+        expect(sub.length).toBe(2);
+    });
+});
+
+test("buffer detached during species lookup throws TypeError", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const buffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 4);
+        const source = new T(buffer);
+        class Subclass extends T {
+            static get [Symbol.species]() {
+                buffer.transfer();
+                return T;
+            }
+        }
+        Object.setPrototypeOf(source, Subclass.prototype);
+        expect(() => source.subarray(0, 2)).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+    });
+});
+
+test("buffer shrunk below begin offset during species lookup throws RangeError", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const buffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 4, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+        const source = new T(buffer);
+        class Subclass extends T {
+            static get [Symbol.species]() {
+                buffer.resize(0);
+                return T;
+            }
+        }
+        Object.setPrototypeOf(source, Subclass.prototype);
+        expect(() => source.subarray(2, 4)).toThrow(RangeError);
+    });
+});
+
+test("auto-length view: buffer shrunk below begin offset during species lookup throws RangeError", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const buffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 4, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+        const source = new T(buffer);
+        class Subclass extends T {
+            static get [Symbol.species]() {
+                buffer.resize(0);
+                return T;
+            }
+        }
+        Object.setPrototypeOf(source, Subclass.prototype);
+        // No `end` argument: source is auto-length, so subarray builds an auto-length view.
+        expect(() => source.subarray(2)).toThrow(RangeError);
+    });
+});
+
+test("subclass without overriding Symbol.species invokes the subclass constructor", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let constructorCalls = [];
+        class Subclass extends T {
+            constructor(...args) {
+                super(...args);
+                constructorCalls.push(args.length);
+            }
+        }
+        const source = new Subclass([1, 2, 3, 4, 5]);
+        constructorCalls = [];
+        const sub = source.subarray(1, 4);
+        expect(sub).toBeInstanceOf(Subclass);
+        expect(sub.buffer).toBe(source.buffer);
+        expect(sub.length).toBe(3);
+        expect(constructorCalls).toEqual([3]);
+    });
+});

--- a/Tests/LibJS/Runtime/builtins/TypedArray/typed-array-limits.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/typed-array-limits.js
@@ -4,3 +4,26 @@ test("some oversized typed arrays", () => {
     expect(() => new Uint32Array(1024 * 1024 * 1024)).toThrowWithMessage(RangeError, "Invalid typed array length");
     expect(() => new Uint32Array(4 * 1024 * 1024 * 1024)).toThrowWithMessage(RangeError, "Invalid typed array length");
 });
+
+test("default species creation preserves constructor length limits", () => {
+    [
+        Uint8Array,
+        Uint8ClampedArray,
+        Uint16Array,
+        Uint32Array,
+        Int8Array,
+        Int16Array,
+        Int32Array,
+        Float16Array,
+        Float32Array,
+        Float64Array,
+        BigUint64Array,
+        BigInt64Array,
+    ].forEach(T => {
+        const oversizedLength = Math.floor(0x7fffffff / T.BYTES_PER_ELEMENT) + 1;
+        expect(() => createDefaultTypedArray(new T(), oversizedLength)).toThrowWithMessage(
+            RangeError,
+            "Invalid typed array length"
+        );
+    });
+});

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -133,6 +133,18 @@ TESTJS_GLOBAL_FUNCTION(to_utf8_bytes, toUTF8Bytes)
     return typed_array;
 }
 
+TESTJS_GLOBAL_FUNCTION(create_default_typed_array, createDefaultTypedArray)
+{
+    auto& realm = *vm.current_realm();
+
+    auto* typed_array = TRY(JS::typed_array_from(vm, vm.argument(0)));
+    auto length = TRY(vm.argument(1).to_index(vm));
+    if (length > NumericLimits<u32>::max())
+        return vm.throw_completion<JS::RangeError>(JS::ErrorType::InvalidLength, "typed array");
+
+    return TRY(typed_array->create_default(realm, length));
+}
+
 TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::ExecutionContext&)
 {
     if (!test262_parser_tests)


### PR DESCRIPTION
When species resolves to the default intrinsic, construct the result directly instead of going through the public `TypedArray` constructor, skipping the throwaway empty `ArrayBuffer` that the constructor allocates only to immediately overwrite.

Affects `subarray`, `filter`, `map`, and `slice`. The `subarray` path re-checks the buffer state after species lookup, since the lookup can run user code that detaches or resizes the buffer.

Saves ~300ms of load time (in the WebWorker process) when opening the Combined Intel ISA PDF :^)