### PR TITLE
LibWeb: Add `align-content` support for block-level boxes

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -197,7 +197,7 @@ public:
     static JustifyContent justify_content() { return JustifyContent::FlexStart; }
     static JustifyItems justify_items() { return JustifyItems::Legacy; }
     static JustifySelf justify_self() { return JustifySelf::Auto; }
-    static AlignContent align_content() { return AlignContent::Stretch; }
+    static AlignContent align_content() { return AlignContent::Normal; }
     static AlignItems align_items() { return AlignItems::Stretch; }
     static AlignSelf align_self() { return AlignSelf::Auto; }
     static Appearance appearance() { return Appearance::Auto; }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1024,6 +1024,53 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             block_container_state.set_content_height(bottom_of_lowest_margin_box);
         }
     }
+
+    apply_align_content_offset(block_container);
+}
+
+// https://www.w3.org/TR/css-align-3/#distribution-block
+void BlockFormattingContext::apply_align_content_offset(BlockContainer const& block_container) const
+{
+    auto const& block_container_state = m_state.get_mutable(block_container);
+
+    if (block_container.has_child_of_type<NodeWithStyle>()) {
+        Optional<LayoutState::UsedValues const&> first_child_state;
+        Optional<LayoutState::UsedValues const&> last_child_state;
+
+        for (auto const* first_child = block_container.first_child_of_type<NodeWithStyle>();
+            first_child;
+            first_child = first_child->next_sibling_of_type<NodeWithStyle>()) {
+            if (auto* const state = m_state.try_get_mutable(*first_child)) {
+                first_child_state = *state;
+                break;
+            }
+        }
+
+        for (auto const* last_child = block_container.last_child_of_type<NodeWithStyle>();
+            last_child;
+            last_child = last_child->next_sibling_of_type<NodeWithStyle>()) {
+            if (auto* const state = m_state.try_get_mutable(*last_child)) {
+                last_child_state = *state;
+                break;
+            }
+        }
+
+        if (first_child_state.has_value() && last_child_state.has_value()) {
+            auto const children_height = last_child_state->offset.y() + last_child_state->content_height() - first_child_state->offset.y();
+            auto content_offset = calculate_align_content_offset(
+                block_container.computed_values().align_content(),
+                block_container_state.content_height(),
+                children_height);
+
+            if (content_offset > 0) {
+                block_container.for_each_child_of_type<NodeWithStyle>([&](auto const& child) {
+                    auto& child_state = m_state.get_mutable(child);
+                    child_state.offset.set_y(child_state.offset.y() + content_offset);
+                    return IterationDecision::Continue;
+                });
+            }
+        }
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -106,6 +106,8 @@ private:
     void layout_inline_children(BlockContainer const&, AvailableSpace const&);
     void layout_fieldset_with_rendered_legend(FieldSetBox const&, AvailableSpace const&);
 
+    void apply_align_content_offset(BlockContainer const&) const;
+
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -140,6 +140,11 @@ bool FormattingContext::creates_block_formatting_context(Box const& box)
 
     // FIXME: column-span: all should always create a new formatting context, even when the column-span: all element isn't contained by a multicol container (Spec change, Chrome bug).
 
+    // https://www.w3.org/TR/css-align-3/#distribution-block
+    // All values other than 'normal' force the block container to establish an independent formatting context.
+    if (box.display().is_block_outside() && box.computed_values().align_content() != CSS::AlignContent::Normal)
+        return true;
+
     // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
     if (box.is_fieldset_box())
         // The fieldset element, when it generates a CSS box, is expected to act as follows:
@@ -147,6 +152,28 @@ bool FormattingContext::creates_block_formatting_context(Box const& box)
         return true;
 
     return false;
+}
+
+CSSPixels FormattingContext::calculate_align_content_offset(CSS::AlignContent const align_content, CSSPixels const container_height, CSSPixels const content_height)
+{
+    CSSPixels content_offset;
+    // FIXME: Add <baseline-position> and <overflow-position> values and handle them here (see https://www.w3.org/TR/css-align-3/#propdef-align-content).
+    switch (align_content) {
+    case CSS::AlignContent::Center:
+    case CSS::AlignContent::SpaceAround:
+    case CSS::AlignContent::SpaceEvenly: {
+        auto const space_above_and_below = container_height - content_height;
+        content_offset = space_above_and_below / 2;
+        break;
+    }
+    case CSS::AlignContent::End: {
+        content_offset = container_height - content_height;
+        break;
+    }
+    default:
+        break;
+    }
+    return max(content_offset, 0);
 }
 
 Optional<FormattingContext::Type> FormattingContext::formatting_context_type_created_by_box(Box const& box)

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -117,6 +117,8 @@ public:
 
     [[nodiscard]] static Optional<Type> formatting_context_type_created_by_box(Box const&);
 
+    [[nodiscard]] static CSSPixels calculate_align_content_offset(CSS::AlignContent, CSSPixels container_height, CSSPixels content_height);
+
     static bool creates_block_formatting_context(Box const&);
 
     CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&);

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -92,6 +92,16 @@ void InlineFormattingContext::run(AvailableSpace const& available_space)
     for (auto& line_box : m_containing_block_used_values.line_boxes)
         content_height += line_box.height();
 
+    auto const content_offset = calculate_align_content_offset(
+        containing_block().computed_values().align_content(),
+        m_containing_block_used_values.content_height(),
+        content_height);
+
+    if (content_offset > 0) {
+        for (auto& line_box : m_containing_block_used_values.line_boxes)
+            line_box.translate_block_offset(content_offset);
+    }
+
     // NOTE: We ask the parent BFC to calculate the automatic content width of this IFC.
     //       This ensures that any floated boxes are taken into account.
     m_automatic_content_width = parent().greatest_child_width(containing_block());

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -60,6 +60,16 @@ void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length,
     m_block_length = max(m_block_length, content_height + border_box_top + border_box_bottom);
 }
 
+void LineBox::translate_block_offset(CSSPixels delta)
+{
+    if (delta == 0)
+        return;
+    for (auto& fragment : m_fragments)
+        fragment.set_block_offset(fragment.block_offset() + delta);
+    m_bottom += delta;
+    m_baseline += delta;
+}
+
 CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespace should_remove)
 {
     auto should_trim = [](LineBoxFragment* fragment) {

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -32,6 +32,8 @@ public:
     Vector<LineBoxFragment> const& fragments() const { return m_fragments; }
     Vector<LineBoxFragment>& fragments() { return m_fragments; }
 
+    void translate_block_offset(CSSPixels);
+
     CSSPixels get_trailing_whitespace_width() const;
     void trim_trailing_whitespace();
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-center-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-center-inline.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: not-inline
+      BlockContainer <div> at [9,9] [0+1+0 50 0+1+732] [0+1+0 100 0+1+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [9,50] [0+0+0 51.625 0+0+0] [0+0+0 18 0+0+0]
+          frag 0 from TextNode start: 0, length: 6, rect: [9,50 51.625x18] baseline: 13.796875
+              "center"
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,110] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 52x102]
+        PaintableWithLines (InlineNode<SPAN>) [9,50 51.625x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-center.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-center.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: not-inline
+      BlockContainer <div.container> at [9,9] [0+1+0 50 0+1+732] [0+1+0 100 0+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [9,34] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.box> at [9,34] [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [9,84] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,110] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 52x102]
+        PaintableWithLines (BlockContainer(anonymous)) [9,34 50x0]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,34 50x50]
+        PaintableWithLines (BlockContainer(anonymous)) [9,84 50x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-end-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-end-inline.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: not-inline
+      BlockContainer <div> at [9,9] [0+1+0 50 0+1+732] [0+1+0 100 0+1+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [9,91] [0+0+0 26.1875 0+0+0] [0+0+0 18 0+0+0]
+          frag 0 from TextNode start: 0, length: 3, rect: [9,91 26.1875x18] baseline: 13.796875
+              "end"
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,110] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 52x102]
+        PaintableWithLines (InlineNode<SPAN>) [9,91 26.1875x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-end.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-end.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: not-inline
+      BlockContainer <div.container> at [9,9] [0+1+0 50 0+1+732] [0+1+0 100 0+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [9,59] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.box> at [9,59] [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [9,109] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,110] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 52x102]
+        PaintableWithLines (BlockContainer(anonymous)) [9,59 50x0]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,59 50x50]
+        PaintableWithLines (BlockContainer(anonymous)) [9,109 50x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-start-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-start-inline.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: not-inline
+      BlockContainer <div> at [9,9] [0+1+0 50 0+1+732] [0+1+0 100 0+1+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [9,9] [0+0+0 41.234375 0+0+0] [0+0+0 18 0+0+0]
+          frag 0 from TextNode start: 0, length: 5, rect: [9,9 41.234375x18] baseline: 13.796875
+              "start"
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,110] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 52x102]
+        PaintableWithLines (InlineNode<SPAN>) [9,9 41.234375x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-start.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-align-content-start.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: not-inline
+      BlockContainer <div.container> at [9,9] [0+1+0 50 0+1+732] [0+1+0 100 0+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [9,9] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.box> at [9,9] [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [9,59] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,110] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 52x102]
+        PaintableWithLines (BlockContainer(anonymous)) [9,9 50x0]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 50x50]
+        PaintableWithLines (BlockContainer(anonymous)) [9,59 50x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-center-inline.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-center-inline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    div {
+        align-content: center;
+        border: 1px solid black;
+        width: 50px;
+        height: 100px;
+    }
+</style>
+
+<div>
+    <span>center</span>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-center.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-center.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        align-content: center;
+        border: 1px solid black;
+        width: 50px;
+        height: 100px;
+    }
+    .box {
+        width: 50px;
+        height: 50px;
+        background: red;
+    }
+</style>
+
+<div class="container">
+    <div class="box"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-end-inline.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-end-inline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    div {
+        align-content: end;
+        border: 1px solid black;
+        width: 50px;
+        height: 100px;
+    }
+</style>
+
+<div>
+    <span>end</span>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-end.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-end.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        align-content: end;
+        border: 1px solid black;
+        width: 50px;
+        height: 100px;
+    }
+    .box {
+        width: 50px;
+        height: 50px;
+        background: red;
+    }
+</style>
+
+<div class="container">
+    <div class="box"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-start-inline.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-start-inline.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    div {
+        align-content: start;
+        border: 1px solid black;
+        width: 50px;
+        height: 100px;
+    }
+</style>
+
+<div>
+    <span>start</span>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-start.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-align-content-start.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        align-content: start;
+        border: 1px solid black;
+        width: 50px;
+        height: 100px;
+    }
+    .box {
+        width: 50px;
+        height: 50px;
+        background: red;
+    }
+</style>
+
+<div class="container">
+    <div class="box"></div>
+</div>


### PR DESCRIPTION
Closes #4214

As correctly pointed out [here](https://github.com/LadybirdBrowser/ladybird/issues/4214#issuecomment-3192444243), the issue is that `align-content` isn't considered for block containers.

Here are the test cases provided in #4214 with the fix:

<img width="533" height="344" alt="image" src="https://github.com/user-attachments/assets/8cf6d10d-f1ed-4d31-a130-953588f55bec" />
<img width="531" height="344" alt="image" src="https://github.com/user-attachments/assets/cee89804-9b30-421b-9952-2bdd31f29e47" />