### PR TITLE
LibJS: Store AlreadyResolved bit on the resolve function itself

### DIFF
--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -221,7 +221,6 @@ class PrototypeChainValidity;
 class Value;
 class WrappedFunction;
 enum class DeclarationKind;
-struct AlreadyResolved;
 class JobCallback;
 struct ModuleRequest;
 struct LoadedModuleRequest;

--- a/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Libraries/LibJS/Runtime/Promise.cpp
@@ -64,7 +64,8 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
     auto& realm = *vm.current_realm();
 
     // 1. Let alreadyResolved be the Record { [[Value]]: false }.
-    auto already_resolved = vm.heap().allocate<AlreadyResolved>();
+    // NOTE: This is stored directly on the resolve function. The reject function keeps the resolve function alive and
+    //       uses the same bit.
 
     // 2. Let stepsResolve be the algorithm steps defined in Promise Resolve Functions.
     // 3. Let lengthResolve be the number of non-optional parameters of the function definition in Promise Resolve Functions.
@@ -73,7 +74,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
     // 6. Set resolve.[[AlreadyResolved]] to alreadyResolved.
 
     // 27.2.1.3.2 Promise Resolve Functions, https://tc39.es/ecma262/#sec-promise-resolve-functions
-    auto resolve_function = PromiseResolvingFunction::create(realm, *this, *already_resolved, PromiseResolvingFunction::Kind::Resolve);
+    auto resolve_function = PromiseResolvingFunction::create_resolve(realm, *this);
     resolve_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), Attribute::Configurable);
 
     // 7. Let stepsReject be the algorithm steps defined in Promise Reject Functions.
@@ -83,7 +84,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
     // 11. Set reject.[[AlreadyResolved]] to alreadyResolved.
 
     // 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
-    auto reject_function = PromiseResolvingFunction::create(realm, *this, *already_resolved, PromiseResolvingFunction::Kind::Reject);
+    auto reject_function = PromiseResolvingFunction::create_reject(realm, *this, resolve_function);
     reject_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), Attribute::Configurable);
 
     // 12. Return the Record { [[Resolve]]: resolve, [[Reject]]: reject }.
@@ -91,7 +92,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 }
 
 // 27.2.1.3.2 Promise Resolve Functions, https://tc39.es/ecma262/#sec-promise-resolve-functions
-Value Promise::resolve_function_steps(VM& vm, Promise& promise, AlreadyResolved& already_resolved)
+Value Promise::resolve_function_steps(VM& vm, Promise& promise, bool& already_resolved)
 {
     dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolve function was called", &promise);
 
@@ -105,13 +106,13 @@ Value Promise::resolve_function_steps(VM& vm, Promise& promise, AlreadyResolved&
 
     // 4. Let alreadyResolved be F.[[AlreadyResolved]].
     // 5. If alreadyResolved.[[Value]] is true, return undefined.
-    if (already_resolved.value) {
+    if (already_resolved) {
         dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise is already resolved, returning undefined", &promise);
         return js_undefined();
     }
 
     // 6. Set alreadyResolved.[[Value]] to true.
-    already_resolved.value = true;
+    already_resolved = true;
 
     // 7. If SameValue(resolution, promise) is true, then
     if (resolution.is_object() && &resolution.as_object() == &promise) {
@@ -180,7 +181,7 @@ Value Promise::resolve_function_steps(VM& vm, Promise& promise, AlreadyResolved&
 }
 
 // 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
-Value Promise::reject_function_steps(VM& vm, Promise& promise, AlreadyResolved& already_resolved)
+Value Promise::reject_function_steps(VM& vm, Promise& promise, bool& already_resolved)
 {
     dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Reject function was called", &promise);
 
@@ -192,11 +193,11 @@ Value Promise::reject_function_steps(VM& vm, Promise& promise, AlreadyResolved& 
 
     // 4. Let alreadyResolved be F.[[AlreadyResolved]].
     // 5. If alreadyResolved.[[Value]] is true, return undefined.
-    if (already_resolved.value)
+    if (already_resolved)
         return js_undefined();
 
     // 6. Set alreadyResolved.[[Value]] to true.
-    already_resolved.value = true;
+    already_resolved = true;
 
     // 7. Perform RejectPromise(promise, reason).
     promise.reject(reason);

--- a/Libraries/LibJS/Runtime/Promise.h
+++ b/Libraries/LibJS/Runtime/Promise.h
@@ -42,8 +42,8 @@ public:
     };
     ResolvingFunctions create_resolving_functions();
 
-    static Value resolve_function_steps(VM&, Promise&, AlreadyResolved&);
-    static Value reject_function_steps(VM&, Promise&, AlreadyResolved&);
+    static Value resolve_function_steps(VM&, Promise&, bool& already_resolved);
+    static Value reject_function_steps(VM&, Promise&, bool& already_resolved);
 
     void fulfill(Value value);
     void reject(Value reason);

--- a/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -11,18 +11,22 @@
 
 namespace JS {
 
-GC_DEFINE_ALLOCATOR(AlreadyResolved);
 GC_DEFINE_ALLOCATOR(PromiseResolvingFunction);
 
-GC::Ref<PromiseResolvingFunction> PromiseResolvingFunction::create(Realm& realm, Promise& promise, AlreadyResolved& already_resolved, Kind kind)
+GC::Ref<PromiseResolvingFunction> PromiseResolvingFunction::create_resolve(Realm& realm, Promise& promise)
 {
-    return realm.create<PromiseResolvingFunction>(promise, already_resolved, kind, realm.intrinsics().function_prototype());
+    return realm.create<PromiseResolvingFunction>(promise, Kind::Resolve, nullptr, realm.intrinsics().function_prototype());
 }
 
-PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, AlreadyResolved& already_resolved, Kind kind, Object& prototype)
+GC::Ref<PromiseResolvingFunction> PromiseResolvingFunction::create_reject(Realm& realm, Promise& promise, PromiseResolvingFunction& resolve_function)
+{
+    return realm.create<PromiseResolvingFunction>(promise, Kind::Reject, &resolve_function, realm.intrinsics().function_prototype());
+}
+
+PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, Kind kind, GC::Ptr<PromiseResolvingFunction> resolve_function, Object& prototype)
     : NativeFunction(prototype)
     , m_promise(promise)
-    , m_already_resolved(already_resolved)
+    , m_resolve_function(resolve_function)
     , m_kind(kind)
 {
 }
@@ -37,9 +41,9 @@ ThrowCompletionOr<Value> PromiseResolvingFunction::call()
 {
     switch (m_kind) {
     case Kind::Resolve:
-        return Promise::resolve_function_steps(vm(), m_promise, m_already_resolved);
+        return Promise::resolve_function_steps(vm(), m_promise, already_resolved());
     case Kind::Reject:
-        return Promise::reject_function_steps(vm(), m_promise, m_already_resolved);
+        return Promise::reject_function_steps(vm(), m_promise, already_resolved());
     }
     VERIFY_NOT_REACHED();
 }
@@ -48,7 +52,17 @@ void PromiseResolvingFunction::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_promise);
-    visitor.visit(m_already_resolved);
+    if (m_resolve_function)
+        visitor.visit(m_resolve_function);
+}
+
+bool& PromiseResolvingFunction::already_resolved()
+{
+    if (m_kind == Kind::Resolve)
+        return m_already_resolved;
+
+    VERIFY(m_resolve_function);
+    return m_resolve_function->m_already_resolved;
 }
 
 }

--- a/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -11,18 +11,6 @@
 
 namespace JS {
 
-struct AlreadyResolved final : public Cell {
-    GC_CELL(AlreadyResolved, Cell);
-    GC_DECLARE_ALLOCATOR(AlreadyResolved);
-
-    bool value { false };
-
-protected:
-    // Allocated cells must be >= sizeof(FreelistEntry), which is 24 bytes -
-    // but AlreadyResolved is only 16 bytes without this.
-    u8 dummy[8];
-};
-
 class PromiseResolvingFunction final : public NativeFunction {
     JS_OBJECT(PromiseResolvingFunction, NativeFunction);
     GC_DECLARE_ALLOCATOR(PromiseResolvingFunction);
@@ -33,7 +21,8 @@ public:
         Reject,
     };
 
-    static GC::Ref<PromiseResolvingFunction> create(Realm&, Promise&, AlreadyResolved&, Kind);
+    static GC::Ref<PromiseResolvingFunction> create_resolve(Realm&, Promise&);
+    static GC::Ref<PromiseResolvingFunction> create_reject(Realm&, Promise&, PromiseResolvingFunction& resolve_function);
 
     virtual void initialize(Realm&) override;
     virtual ~PromiseResolvingFunction() override = default;
@@ -41,12 +30,14 @@ public:
     virtual ThrowCompletionOr<Value> call() override;
 
 private:
-    explicit PromiseResolvingFunction(Promise&, AlreadyResolved&, Kind, Object& prototype);
+    explicit PromiseResolvingFunction(Promise&, Kind, GC::Ptr<PromiseResolvingFunction>, Object& prototype);
 
     virtual void visit_edges(Visitor&) override;
+    bool& already_resolved();
 
     GC::Ref<Promise> m_promise;
-    GC::Ref<AlreadyResolved> m_already_resolved;
+    GC::Ptr<PromiseResolvingFunction> m_resolve_function;
+    bool m_already_resolved { false };
     Kind m_kind;
 };
 


### PR DESCRIPTION
Previously, each pair of promise resolving functions allocated a dedicated AlreadyResolved GC cell to hold a single shared bool. Move the bit onto the resolve function as a plain member, and have the reject function reach it through a GC::Ptr back to its paired resolve function.

in my GC stats capture we previously allocated 73K AlreadyResolved on instagram. all gone now!!