### PR TITLE
UI/Gtk: Add find-in-page case sensitivity toggle

### DIFF
--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -144,14 +144,31 @@ void BrowserWindow::setup_ui(AdwApplication* app)
     m_find_bar_revealer = LadybirdWidgets::browser_window_find_bar_revealer(browser_window_widget);
     m_find_entry = LadybirdWidgets::browser_window_find_entry(browser_window_widget);
     m_find_result_label = LadybirdWidgets::browser_window_find_result_label(browser_window_widget);
+    m_find_match_case = LadybirdWidgets::browser_window_find_match_case(browser_window_widget);
     m_toast_overlay = LadybirdWidgets::browser_window_toast_overlay(browser_window_widget);
 
     // Connect find entry signals
     g_signal_connect_swapped(m_find_entry, "search-changed", G_CALLBACK(+[](BrowserWindow* self, GtkSearchEntry* entry) {
         auto* text = gtk_editable_get_text(GTK_EDITABLE(entry));
         if (auto* tab = self->current_tab()) {
-            if (text && text[0] != '\0')
-                tab->view().find_in_page(MUST(String::from_utf8(StringView(text, strlen(text)))));
+            if (text && text[0] != '\0') {
+                auto case_sensitive = gtk_check_button_get_active(self->m_find_match_case)
+                    ? CaseSensitivity::CaseSensitive
+                    : CaseSensitivity::CaseInsensitive;
+                tab->view().find_in_page(MUST(String::from_utf8(StringView(text, strlen(text)))), case_sensitive);
+            }
+        }
+    }),
+        this);
+    g_signal_connect_swapped(m_find_match_case, "toggled", G_CALLBACK(+[](BrowserWindow* self, GtkCheckButton*) {
+        auto* text = gtk_editable_get_text(GTK_EDITABLE(self->m_find_entry));
+        if (auto* tab = self->current_tab()) {
+            if (text && text[0] != '\0') {
+                auto case_sensitive = gtk_check_button_get_active(self->m_find_match_case)
+                    ? CaseSensitivity::CaseSensitive
+                    : CaseSensitivity::CaseInsensitive;
+                tab->view().find_in_page(MUST(String::from_utf8(StringView(text, strlen(text)))), case_sensitive);
+            }
         }
     }),
         this);

--- a/UI/Gtk/BrowserWindow.h
+++ b/UI/Gtk/BrowserWindow.h
@@ -72,6 +72,7 @@ private:
     GtkRevealer* m_find_bar_revealer { nullptr };
     GtkSearchEntry* m_find_entry { nullptr };
     GtkLabel* m_find_result_label { nullptr };
+    GtkCheckButton* m_find_match_case { nullptr };
     AdwToastOverlay* m_toast_overlay { nullptr };
 
     struct ActionBinding {

--- a/UI/Gtk/Resources/browser-window.ui
+++ b/UI/Gtk/Resources/browser-window.ui
@@ -92,6 +92,12 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="find_match_case">
+                    <property name="label">Match _Case</property>
+                    <property name="use-underline">true</property>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkButton" id="find_prev_button">
                     <property name="action-name">win.find-previous</property>
                     <property name="icon-name">go-up-symbolic</property>

--- a/UI/Gtk/Widgets/LadybirdBrowserWindow.cpp
+++ b/UI/Gtk/Widgets/LadybirdBrowserWindow.cpp
@@ -22,6 +22,7 @@ struct LadybirdBrowserWindow {
     GtkRevealer* find_bar_revealer { nullptr };
     GtkSearchEntry* find_entry { nullptr };
     GtkLabel* find_result_label { nullptr };
+    GtkCheckButton* find_match_case { nullptr };
     GtkButton* zoom_reset_button { nullptr };
     GtkLabel* zoom_label { nullptr };
     AdwBanner* devtools_banner { nullptr };
@@ -53,6 +54,7 @@ static void ladybird_browser_window_class_init(LadybirdBrowserWindowClass* klass
     gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, find_bar_revealer);
     gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, find_entry);
     gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, find_result_label);
+    gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, find_match_case);
     gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, zoom_reset_button);
     gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, zoom_label);
     gtk_widget_class_bind_template_child(widget_class, LadybirdBrowserWindow, devtools_banner);
@@ -81,6 +83,7 @@ AdwBanner* browser_window_devtools_banner(LadybirdBrowserWindow* window) { retur
 GtkRevealer* browser_window_find_bar_revealer(LadybirdBrowserWindow* window) { return window->find_bar_revealer; }
 GtkSearchEntry* browser_window_find_entry(LadybirdBrowserWindow* window) { return window->find_entry; }
 GtkLabel* browser_window_find_result_label(LadybirdBrowserWindow* window) { return window->find_result_label; }
+GtkCheckButton* browser_window_find_match_case(LadybirdBrowserWindow* window) { return window->find_match_case; }
 GMenu* browser_window_hamburger_menu(LadybirdBrowserWindow* window) { return window->hamburger_menu; }
 AdwToastOverlay* browser_window_toast_overlay(LadybirdBrowserWindow* window) { return window->toast_overlay; }
 GtkMenuButton* browser_window_menu_button(LadybirdBrowserWindow* window) { return window->menu_button; }

--- a/UI/Gtk/Widgets/LadybirdBrowserWindow.h
+++ b/UI/Gtk/Widgets/LadybirdBrowserWindow.h
@@ -22,6 +22,7 @@ AdwBanner* browser_window_devtools_banner(LadybirdBrowserWindow*);
 GtkRevealer* browser_window_find_bar_revealer(LadybirdBrowserWindow*);
 GtkSearchEntry* browser_window_find_entry(LadybirdBrowserWindow*);
 GtkLabel* browser_window_find_result_label(LadybirdBrowserWindow*);
+GtkCheckButton* browser_window_find_match_case(LadybirdBrowserWindow*);
 GMenu* browser_window_hamburger_menu(LadybirdBrowserWindow*);
 AdwToastOverlay* browser_window_toast_overlay(LadybirdBrowserWindow*);
 GtkMenuButton* browser_window_menu_button(LadybirdBrowserWindow*);


### PR DESCRIPTION
Add a "Match Case" checkbox to the find bar. The checkbox is wired to
both the search-changed signal (so existing results update immediately)
and a toggled signal (so toggling the checkbox re-runs the search).

# Before

<img width="735" height="357" alt="image" src="https://github.com/user-attachments/assets/08b8fbfe-944d-4fd5-b302-d4438176032b" />


# After
<img width="840" height="103" alt="image" src="https://github.com/user-attachments/assets/15f6d1ca-5e9c-4189-8d30-11bd082e4160" />
<img width="840" height="103" alt="image" src="https://github.com/user-attachments/assets/99aa1535-219e-4610-948a-d70e515dabdd" />


