### PR TITLE
UI/Gtk: Persist window geometry across sessions

### DIFF
--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -13,6 +13,7 @@
 #include <UI/Gtk/BrowserWindow.h>
 #include <UI/Gtk/GLibPtr.h>
 #include <UI/Gtk/Menu.h>
+#include <UI/Gtk/Settings.h>
 #include <UI/Gtk/Tab.h>
 #include <UI/Gtk/WebContentView.h>
 
@@ -237,6 +238,24 @@ void BrowserWindow::setup_ui(AdwApplication* app)
 
     if (WebView::Application::browser_options().devtools_port.has_value())
         on_devtools_enabled();
+
+    if (auto geometry = Settings::the().last_window_geometry(); geometry.has_value()) {
+        gtk_window_set_default_size(GTK_WINDOW(m_window), geometry->width, geometry->height);
+        if (geometry->maximized)
+            gtk_window_maximize(GTK_WINDOW(m_window));
+    }
+
+    g_signal_connect_swapped(m_window, "close-request", G_CALLBACK(+[](BrowserWindow* self, GtkWindow*) -> gboolean {
+        bool maximized = gtk_window_is_maximized(GTK_WINDOW(self->m_window));
+        int width = 0, height = 0;
+        gtk_window_get_default_size(GTK_WINDOW(self->m_window), &width, &height);
+        if (!maximized && width > 0 && height > 0)
+            Settings::the().set_window_geometry({ .width = width, .height = height, .maximized = false });
+        else if (maximized)
+            Settings::the().set_window_geometry({ .maximized = true });
+        return GDK_EVENT_PROPAGATE;
+    }),
+        this);
 }
 
 void BrowserWindow::setup_keyboard_shortcuts()

--- a/UI/Gtk/CMakeLists.txt
+++ b/UI/Gtk/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(ladybird PRIVATE
     Events.cpp
     EventLoopImplementationGtk.cpp
     Menu.cpp
+    Settings.cpp
     Tab.cpp
     WebContentView.cpp
     Widgets/LadybirdBrowserWindow.cpp

--- a/UI/Gtk/Settings.cpp
+++ b/UI/Gtk/Settings.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <UI/Gtk/Settings.h>
+
+#include <glib.h>
+
+namespace Ladybird {
+
+static constexpr char const* GROUP = "Window";
+
+Settings::Settings()
+{
+    auto* config_dir = g_get_user_config_dir();
+    m_path = g_build_filename(config_dir, "Ladybird", "ladybird-gtk.ini", nullptr);
+    m_key_file = g_key_file_new();
+    load();
+}
+
+Settings::~Settings()
+{
+    g_key_file_free(m_key_file);
+    g_free(m_path);
+}
+
+void Settings::load()
+{
+    g_autoptr(GError) error = nullptr;
+    g_key_file_load_from_file(m_key_file, m_path, G_KEY_FILE_NONE, &error);
+}
+
+void Settings::save() const
+{
+    g_autofree char* dir = g_path_get_dirname(m_path);
+    g_mkdir_with_parents(dir, 0755);
+
+    g_autoptr(GError) error = nullptr;
+    g_key_file_save_to_file(m_key_file, m_path, &error);
+}
+
+Optional<Settings::WindowGeometry> Settings::last_window_geometry() const
+{
+    if (!g_key_file_has_group(m_key_file, GROUP))
+        return {};
+
+    WindowGeometry g;
+    g.x = static_cast<int>(g_key_file_get_integer(m_key_file, GROUP, "x", nullptr));
+    g.y = static_cast<int>(g_key_file_get_integer(m_key_file, GROUP, "y", nullptr));
+    g.width = static_cast<int>(g_key_file_get_integer(m_key_file, GROUP, "width", nullptr));
+    g.height = static_cast<int>(g_key_file_get_integer(m_key_file, GROUP, "height", nullptr));
+    g.maximized = g_key_file_get_boolean(m_key_file, GROUP, "maximized", nullptr);
+
+    if (g.width <= 0)
+        g.width = 1024;
+    if (g.height <= 0)
+        g.height = 768;
+
+    return g;
+}
+
+void Settings::set_window_geometry(WindowGeometry const& g)
+{
+    g_key_file_set_integer(m_key_file, GROUP, "x", g.x);
+    g_key_file_set_integer(m_key_file, GROUP, "y", g.y);
+    g_key_file_set_integer(m_key_file, GROUP, "width", g.width);
+    g_key_file_set_integer(m_key_file, GROUP, "height", g.height);
+    g_key_file_set_boolean(m_key_file, GROUP, "maximized", g.maximized);
+    save();
+}
+
+}

--- a/UI/Gtk/Settings.h
+++ b/UI/Gtk/Settings.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, Johan Dahlin <jdahlin@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+
+#include <gdk/gdk.h>
+#include <gtk/gtk.h>
+
+namespace Ladybird {
+
+class Settings {
+public:
+    Settings(Settings const&) = delete;
+    Settings& operator=(Settings const&) = delete;
+
+    static Settings& the()
+    {
+        static Settings instance;
+        return instance;
+    }
+
+    struct WindowGeometry {
+        int x { 0 };
+        int y { 0 };
+        int width { 1024 };
+        int height { 768 };
+        bool maximized { false };
+    };
+
+    Optional<WindowGeometry> last_window_geometry() const;
+    void set_window_geometry(WindowGeometry const&);
+
+private:
+    Settings();
+    ~Settings();
+
+    GKeyFile* m_key_file { nullptr };
+    char* m_path { nullptr };
+
+    void load();
+    void save() const;
+};
+
+}


### PR DESCRIPTION
Save window width/height/maximized state to a GKeyFile-based INI at ~/.config/Ladybird/ladybird-gtk.ini on close-request, and restore it at startup. Introduces Settings::the() as the singleton accessor for persistent UI preferences.
