### PR TITLE
UI/Gtk: Enhance address bar autocomplete with rich rows, sections, and inline completion

### DIFF
--- a/UI/Gtk/Widgets/LadybirdLocationEntry.cpp
+++ b/UI/Gtk/Widgets/LadybirdLocationEntry.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Base64.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
@@ -15,11 +16,17 @@
 #include <UI/Gtk/Widgets/Builder.h>
 #include <UI/Gtk/Widgets/LadybirdLocationEntry.h>
 
+struct RowInfo {
+    bool is_section_header;
+    size_t suggestion_index; // only meaningful when !is_section_header
+};
+
 struct LocationEntryState {
     NonnullOwnPtr<WebView::Autocomplete> autocomplete;
     Vector<WebView::AutocompleteSuggestion> suggestions;
     Ladybird::GObjectPtr<GdkPaintable> favicon;
-    int selected_index { -1 };
+    Vector<RowInfo> row_info;
+    int selected_row { -1 }; // row index in list_box (-1 = none)
     String user_text;
     bool is_focused { false };
     bool is_loading { false };
@@ -93,7 +100,8 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
         .autocomplete = make<WebView::Autocomplete>(),
         .suggestions = {},
         .favicon = {},
-        .selected_index = -1,
+        .row_info = {},
+        .selected_row = -1,
         .user_text = {},
         .is_focused = false,
         .is_loading = false,
@@ -119,23 +127,45 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
 
     // Clicking a suggestion navigates to it
     g_signal_connect_swapped(self->list_box, "row-activated", G_CALLBACK(+[](LadybirdLocationEntry* self, GtkListBoxRow* row) {
-        auto index = gtk_list_box_row_get_index(row);
-        if (index >= 0 && static_cast<size_t>(index) < self->state->suggestions.size()) {
-            set_entry_text_suppressed(self, self->state->suggestions[index].text.to_byte_string().characters());
-            ladybird_location_entry_hide_completions(self);
-            ladybird_location_entry_navigate(self);
-        }
+        auto row_index = gtk_list_box_row_get_index(row);
+        if (row_index < 0 || static_cast<size_t>(row_index) >= self->state->row_info.size())
+            return;
+        auto const& info = self->state->row_info[row_index];
+        if (info.is_section_header)
+            return;
+        set_entry_text_suppressed(self, self->state->suggestions[info.suggestion_index].text.to_byte_string().characters());
+        ladybird_location_entry_hide_completions(self);
+        ladybird_location_entry_navigate(self);
     }),
         self);
 
     // Autocomplete results callback
-    self->state->autocomplete->on_autocomplete_query_complete = [self](auto suggestions, auto) {
+    self->state->autocomplete->on_autocomplete_query_complete = [self](auto suggestions, auto result_kind) {
         if (suggestions.is_empty() || !self->state->is_focused) {
             ladybird_location_entry_hide_completions(self);
             return;
         }
+
+        bool popup_visible = gtk_widget_get_visible(GTK_WIDGET(self->popover));
+        if (result_kind == WebView::AutocompleteResultKind::Intermediate && popup_visible) {
+            if (self->state->selected_row >= 0
+                && static_cast<size_t>(self->state->selected_row) < self->state->row_info.size()) {
+                auto const& info = self->state->row_info[self->state->selected_row];
+                if (!info.is_section_header) {
+                    auto const& current_text = self->state->suggestions[info.suggestion_index].text;
+                    for (auto const& suggestion : suggestions) {
+                        if (suggestion.text == current_text)
+                            return;
+                    }
+                }
+            }
+            self->state->selected_row = -1;
+            gtk_list_box_unselect_all(self->list_box);
+            return;
+        }
+
         self->state->suggestions = move(suggestions);
-        self->state->selected_index = -1;
+        self->state->selected_row = -1;
         ladybird_location_entry_show_completions(self);
     };
 
@@ -338,22 +368,119 @@ static void ladybird_location_entry_navigate(LadybirdLocationEntry* self)
     }
 }
 
+static constexpr int AUTOCOMPLETE_ICON_SIZE = 16;
+
+static GtkWidget* make_suggestion_icon(WebView::AutocompleteSuggestion const& suggestion)
+{
+    if (suggestion.source == WebView::AutocompleteSuggestionSource::Search) {
+        auto* image = gtk_image_new_from_icon_name("edit-find-symbolic");
+        gtk_image_set_pixel_size(GTK_IMAGE(image), AUTOCOMPLETE_ICON_SIZE);
+        return image;
+    }
+
+    if (suggestion.favicon_base64_png.has_value()) {
+        auto decoded = decode_base64(*suggestion.favicon_base64_png);
+        if (!decoded.is_error()) {
+            auto& bytes = decoded.value();
+            Ladybird::GObjectPtr<GBytes> gbytes { g_bytes_new(bytes.data(), bytes.size()) };
+            g_autoptr(GError) error = nullptr;
+            Ladybird::GObjectPtr<GdkTexture> texture { gdk_texture_new_from_bytes(gbytes.ptr(), &error) };
+            if (texture.ptr()) {
+                auto* image = gtk_image_new_from_paintable(GDK_PAINTABLE(texture.ptr()));
+                gtk_image_set_pixel_size(GTK_IMAGE(image), AUTOCOMPLETE_ICON_SIZE);
+                return image;
+            }
+        }
+    }
+
+    auto* image = gtk_image_new_from_icon_name("web-browser-symbolic");
+    gtk_image_set_pixel_size(GTK_IMAGE(image), AUTOCOMPLETE_ICON_SIZE);
+    return image;
+}
+
+static GtkWidget* make_suggestion_row_widget(WebView::AutocompleteSuggestion const& suggestion)
+{
+    auto* row_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
+    gtk_widget_set_margin_start(row_box, 8);
+    gtk_widget_set_margin_end(row_box, 8);
+    gtk_widget_set_margin_top(row_box, 5);
+    gtk_widget_set_margin_bottom(row_box, 5);
+
+    gtk_box_append(GTK_BOX(row_box), make_suggestion_icon(suggestion));
+
+    if (suggestion.title.has_value()) {
+        auto* text_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
+        gtk_widget_set_hexpand(text_box, TRUE);
+
+        auto title_str = suggestion.title->to_byte_string();
+        auto* title_label = gtk_label_new(title_str.characters());
+        gtk_label_set_xalign(GTK_LABEL(title_label), 0.0);
+        gtk_label_set_ellipsize(GTK_LABEL(title_label), PANGO_ELLIPSIZE_END);
+        gtk_widget_add_css_class(title_label, "caption-heading");
+        gtk_box_append(GTK_BOX(text_box), title_label);
+
+        auto url_str = suggestion.text.to_byte_string();
+        auto* url_label = gtk_label_new(url_str.characters());
+        gtk_label_set_xalign(GTK_LABEL(url_label), 0.0);
+        gtk_label_set_ellipsize(GTK_LABEL(url_label), PANGO_ELLIPSIZE_END);
+        gtk_widget_add_css_class(url_label, "dim-label");
+        gtk_widget_add_css_class(url_label, "caption");
+        gtk_box_append(GTK_BOX(text_box), url_label);
+
+        gtk_box_append(GTK_BOX(row_box), text_box);
+    } else {
+        auto url_str = suggestion.text.to_byte_string();
+        auto* url_label = gtk_label_new(url_str.characters());
+        gtk_label_set_xalign(GTK_LABEL(url_label), 0.0);
+        gtk_label_set_ellipsize(GTK_LABEL(url_label), PANGO_ELLIPSIZE_END);
+        gtk_widget_set_hexpand(url_label, TRUE);
+        gtk_box_append(GTK_BOX(row_box), url_label);
+    }
+
+    return row_box;
+}
+
 static void ladybird_location_entry_show_completions(LadybirdLocationEntry* self)
 {
     GtkWidget* child;
     while ((child = gtk_widget_get_first_child(GTK_WIDGET(self->list_box))) != nullptr)
         gtk_list_box_remove(self->list_box, child);
 
-    for (auto const& suggestion : self->state->suggestions) {
-        auto byte_str = suggestion.text.to_byte_string();
-        auto* label = gtk_label_new(byte_str.characters());
-        gtk_label_set_xalign(GTK_LABEL(label), 0.0);
-        gtk_label_set_ellipsize(GTK_LABEL(label), PANGO_ELLIPSIZE_END);
-        gtk_widget_set_margin_start(label, 8);
-        gtk_widget_set_margin_end(label, 8);
-        gtk_widget_set_margin_top(label, 4);
-        gtk_widget_set_margin_bottom(label, 4);
-        gtk_list_box_append(self->list_box, label);
+    auto& state = *self->state;
+    state.row_info.clear();
+
+    auto current_section = WebView::AutocompleteSuggestionSection::None;
+    for (size_t i = 0; i < state.suggestions.size(); ++i) {
+        auto const& suggestion = state.suggestions[i];
+
+        if (suggestion.section != WebView::AutocompleteSuggestionSection::None
+            && suggestion.section != current_section) {
+            current_section = suggestion.section;
+
+            auto section_title = WebView::autocomplete_section_title(current_section);
+            auto title_str = ByteString(section_title);
+            auto* header_label = gtk_label_new(title_str.characters());
+            gtk_label_set_xalign(GTK_LABEL(header_label), 0.0);
+            gtk_widget_set_margin_start(header_label, 10);
+            gtk_widget_set_margin_end(header_label, 10);
+            gtk_widget_set_margin_top(header_label, 4);
+            gtk_widget_set_margin_bottom(header_label, 4);
+            gtk_widget_add_css_class(header_label, "dim-label");
+            gtk_widget_add_css_class(header_label, "caption");
+
+            auto* header_row = gtk_list_box_row_new();
+            gtk_list_box_row_set_activatable(GTK_LIST_BOX_ROW(header_row), FALSE);
+            gtk_list_box_row_set_selectable(GTK_LIST_BOX_ROW(header_row), FALSE);
+            gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(header_row), header_label);
+            gtk_list_box_append(self->list_box, header_row);
+            state.row_info.append({ .is_section_header = true, .suggestion_index = 0 });
+        }
+
+        auto* row_widget = make_suggestion_row_widget(suggestion);
+        auto* row = gtk_list_box_row_new();
+        gtk_list_box_row_set_child(GTK_LIST_BOX_ROW(row), row_widget);
+        gtk_list_box_append(self->list_box, row);
+        state.row_info.append({ .is_section_header = false, .suggestion_index = i });
     }
 
     gtk_list_box_unselect_all(self->list_box);
@@ -368,26 +495,42 @@ static void ladybird_location_entry_show_completions(LadybirdLocationEntry* self
 static void ladybird_location_entry_hide_completions(LadybirdLocationEntry* self)
 {
     self->state->suggestions.clear();
-    self->state->selected_index = -1;
+    self->state->row_info.clear();
+    self->state->selected_row = -1;
     gtk_popover_popdown(self->popover);
+}
+
+static int ladybird_location_entry_step_to_selectable_row(LadybirdLocationEntry* self, int from, int direction)
+{
+    auto& state = *self->state;
+    int n = static_cast<int>(state.row_info.size());
+    if (n == 0)
+        return -1;
+    int candidate = from;
+    for (int attempt = 0; attempt < n; ++attempt) {
+        candidate += direction;
+        if (candidate < 0)
+            candidate = n - 1;
+        else if (candidate >= n)
+            candidate = 0;
+        if (!state.row_info[candidate].is_section_header)
+            return candidate;
+    }
+    return -1;
 }
 
 static void ladybird_location_entry_move_selection(LadybirdLocationEntry* self, int delta)
 {
     auto& state = *self->state;
-    if (state.suggestions.is_empty())
+    if (state.row_info.is_empty())
         return;
 
-    auto new_index = state.selected_index + delta;
-    if (new_index < -1)
-        new_index = static_cast<int>(state.suggestions.size()) - 1;
-    if (new_index >= static_cast<int>(state.suggestions.size()))
-        new_index = -1;
+    int new_row = ladybird_location_entry_step_to_selectable_row(self, state.selected_row, delta);
 
-    state.selected_index = new_index;
+    state.selected_row = new_row;
 
-    if (state.selected_index >= 0) {
-        auto* row = gtk_list_box_get_row_at_index(self->list_box, state.selected_index);
+    if (new_row >= 0) {
+        auto* row = gtk_list_box_get_row_at_index(self->list_box, new_row);
         gtk_list_box_select_row(self->list_box, row);
         ladybird_location_entry_apply_selected_suggestion(self);
     } else {
@@ -399,8 +542,10 @@ static void ladybird_location_entry_move_selection(LadybirdLocationEntry* self, 
 static void ladybird_location_entry_apply_selected_suggestion(LadybirdLocationEntry* self)
 {
     auto& state = *self->state;
-    if (state.selected_index < 0 || static_cast<size_t>(state.selected_index) >= state.suggestions.size())
+    if (state.selected_row < 0 || static_cast<size_t>(state.selected_row) >= state.row_info.size())
         return;
-
-    set_entry_text_suppressed(self, state.suggestions[state.selected_index].text.to_byte_string().characters(), true);
+    auto const& info = state.row_info[state.selected_row];
+    if (info.is_section_header)
+        return;
+    set_entry_text_suppressed(self, state.suggestions[info.suggestion_index].text.to_byte_string().characters(), true);
 }

--- a/UI/Gtk/Widgets/LadybirdLocationEntry.cpp
+++ b/UI/Gtk/Widgets/LadybirdLocationEntry.cpp
@@ -32,8 +32,47 @@ struct LocationEntryState {
     bool is_loading { false };
     bool updating_text { false };
     guint loading_pulse_source_id { 0 };
+    // Inline autocomplete state
+    String current_inline_suggestion;
+    Optional<String> suppressed_query;
+    bool suppress_on_next_change { false };
+    bool applying_inline { false };
     Function<void(String)> on_navigate;
 };
+
+static Optional<String> inline_completion_for_suggestion(StringView query, StringView suggestion_url)
+{
+    // Strip trailing root slash: "example.com/" → "example.com" (but not "example.com/path/")
+    StringView candidate = suggestion_url;
+    if (candidate.ends_with('/')) {
+        auto without_slash = candidate.substring_view(0, candidate.length() - 1);
+        if (!without_slash.contains('/'))
+            candidate = without_slash;
+    }
+
+    auto try_prefix = [&](StringView url) -> Optional<String> {
+        if (!WebView::autocomplete_url_can_complete(query, url))
+            return {};
+        return MUST(String::formatted("{}{}", query, url.substring_view(query.length())));
+    };
+
+    if (auto r = try_prefix(candidate); r.has_value())
+        return r;
+    if (candidate.starts_with("www."sv))
+        if (auto r = try_prefix(candidate.substring_view(4)); r.has_value())
+            return r;
+    for (auto scheme : { "https://"sv, "http://"sv }) {
+        if (!candidate.starts_with(scheme))
+            continue;
+        auto rest = candidate.substring_view(scheme.length());
+        if (auto r = try_prefix(rest); r.has_value())
+            return r;
+        if (rest.starts_with("www."sv))
+            if (auto r = try_prefix(rest.substring_view(4)); r.has_value())
+                return r;
+    }
+    return {};
+}
 
 #define LADYBIRD_LOCATION_ENTRY(obj) (reinterpret_cast<LadybirdLocationEntry*>(obj))
 #define LADYBIRD_TYPE_LOCATION_ENTRY (ladybird_location_entry_get_type())
@@ -60,6 +99,11 @@ static void ladybird_location_entry_show_completions(LadybirdLocationEntry* self
 static void ladybird_location_entry_hide_completions(LadybirdLocationEntry* self);
 static void ladybird_location_entry_navigate(LadybirdLocationEntry* self);
 static void ladybird_location_entry_move_selection(LadybirdLocationEntry* self, int delta);
+static int ladybird_location_entry_apply_inline_autocomplete(LadybirdLocationEntry* self, Vector<WebView::AutocompleteSuggestion> const& suggestions);
+static void ladybird_location_entry_apply_inline_text(LadybirdLocationEntry* self, StringView inline_text, StringView query);
+static void ladybird_location_entry_restore_query(LadybirdLocationEntry* self);
+static void ladybird_location_entry_reset_inline_state(LadybirdLocationEntry* self);
+static String ladybird_location_entry_current_query(LadybirdLocationEntry* self);
 static void ladybird_location_entry_apply_selected_suggestion(LadybirdLocationEntry* self);
 static void ladybird_location_entry_update_leading_icon(LadybirdLocationEntry* self);
 
@@ -107,6 +151,10 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
         .is_loading = false,
         .updating_text = false,
         .loading_pulse_source_id = 0,
+        .current_inline_suggestion = {},
+        .suppressed_query = {},
+        .suppress_on_next_change = false,
+        .applying_inline = false,
         .on_navigate = {},
     });
 
@@ -146,6 +194,8 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
             return;
         }
 
+        int selected_row = ladybird_location_entry_apply_inline_autocomplete(self, suggestions);
+
         bool popup_visible = gtk_widget_get_visible(GTK_WIDGET(self->popover));
         if (result_kind == WebView::AutocompleteResultKind::Intermediate && popup_visible) {
             if (self->state->selected_row >= 0
@@ -167,18 +217,52 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
         self->state->suggestions = move(suggestions);
         self->state->selected_row = -1;
         ladybird_location_entry_show_completions(self);
+
+        if (selected_row >= 0) {
+            for (size_t i = 0; i < self->state->row_info.size(); ++i) {
+                auto const& info = self->state->row_info[i];
+                if (!info.is_section_header && info.suggestion_index == static_cast<size_t>(selected_row)) {
+                    self->state->selected_row = static_cast<int>(i);
+                    auto* row = gtk_list_box_get_row_at_index(self->list_box, static_cast<int>(i));
+                    if (row)
+                        gtk_list_box_select_row(self->list_box, row);
+                    break;
+                }
+            }
+        }
     };
 
     // Text changed -> query autocomplete
     g_signal_connect_swapped(self, "changed", G_CALLBACK(+[](LadybirdLocationEntry* self, GtkEditable*) {
-        if (!self->state->is_focused || self->state->updating_text)
+        if (!self->state->is_focused || self->state->updating_text || self->state->applying_inline)
             return;
         auto* text = gtk_editable_get_text(GTK_EDITABLE(self));
         if (!text || text[0] == '\0') {
             ladybird_location_entry_hide_completions(self);
             return;
         }
-        self->state->user_text = MUST(String::from_utf8(StringView { text, strlen(text) }));
+
+        auto query = ladybird_location_entry_current_query(self);
+
+        if (self->state->suppress_on_next_change) {
+            self->state->suppressed_query = query;
+            self->state->suppress_on_next_change = false;
+        } else if (self->state->suppressed_query.has_value() && self->state->suppressed_query.value() != query) {
+            self->state->suppressed_query = {};
+        }
+
+        if (!self->state->suppressed_query.has_value() && !self->state->current_inline_suggestion.is_empty()) {
+            auto query_sv = query.bytes_as_string_view();
+            auto completion = inline_completion_for_suggestion(query_sv, self->state->current_inline_suggestion.bytes_as_string_view());
+            if (!completion.has_value() || completion.value() == query) {
+                ladybird_location_entry_restore_query(self);
+                self->state->current_inline_suggestion = {};
+            } else {
+                ladybird_location_entry_apply_inline_text(self, completion.value(), query_sv);
+            }
+        }
+
+        self->state->user_text = query;
         self->state->autocomplete->query_autocomplete_engine(self->state->user_text);
     }),
         self);
@@ -193,6 +277,9 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
     // Key controller for Up/Down/Escape
     auto* key_controller = gtk_event_controller_key_new();
     g_signal_connect_swapped(key_controller, "key-pressed", G_CALLBACK(+[](LadybirdLocationEntry* self, guint keyval, guint, GdkModifierType) -> gboolean {
+        if (keyval == GDK_KEY_BackSpace || keyval == GDK_KEY_Delete)
+            self->state->suppress_on_next_change = true;
+
         if (!gtk_widget_get_visible(GTK_WIDGET(self->popover)))
             return GDK_EVENT_PROPAGATE;
 
@@ -205,6 +292,7 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
             return GDK_EVENT_STOP;
         case GDK_KEY_Escape:
             ladybird_location_entry_hide_completions(self);
+            ladybird_location_entry_reset_inline_state(self);
             if (!self->state->user_text.is_empty())
                 set_entry_text_suppressed(self, self->state->user_text.to_byte_string().characters());
             return GDK_EVENT_STOP;
@@ -224,7 +312,9 @@ static void ladybird_location_entry_init(LadybirdLocationEntry* self)
         self);
     g_signal_connect_swapped(focus_controller, "leave", G_CALLBACK(+[](LadybirdLocationEntry* self, GtkEventControllerFocus*) {
         self->state->is_focused = false;
+        self->state->autocomplete->cancel_pending_query();
         ladybird_location_entry_hide_completions(self);
+        ladybird_location_entry_reset_inline_state(self);
         ladybird_location_entry_update_display_attributes(self);
     }),
         self);
@@ -382,9 +472,9 @@ static GtkWidget* make_suggestion_icon(WebView::AutocompleteSuggestion const& su
         auto decoded = decode_base64(*suggestion.favicon_base64_png);
         if (!decoded.is_error()) {
             auto& bytes = decoded.value();
-            Ladybird::GObjectPtr<GBytes> gbytes { g_bytes_new(bytes.data(), bytes.size()) };
+            g_autoptr(GBytes) gbytes = g_bytes_new(bytes.data(), bytes.size());
             g_autoptr(GError) error = nullptr;
-            Ladybird::GObjectPtr<GdkTexture> texture { gdk_texture_new_from_bytes(gbytes.ptr(), &error) };
+            Ladybird::GObjectPtr<GdkTexture> texture { gdk_texture_new_from_bytes(gbytes, &error) };
             if (texture.ptr()) {
                 auto* image = gtk_image_new_from_paintable(GDK_PAINTABLE(texture.ptr()));
                 gtk_image_set_pixel_size(GTK_IMAGE(image), AUTOCOMPLETE_ICON_SIZE);
@@ -419,8 +509,8 @@ static GtkWidget* make_suggestion_row_widget(WebView::AutocompleteSuggestion con
         gtk_widget_add_css_class(title_label, "caption-heading");
         gtk_box_append(GTK_BOX(text_box), title_label);
 
-        auto url_str = suggestion.text.to_byte_string();
-        auto* url_label = gtk_label_new(url_str.characters());
+        auto secondary_str = (suggestion.subtitle.has_value() ? *suggestion.subtitle : suggestion.text).to_byte_string();
+        auto* url_label = gtk_label_new(secondary_str.characters());
         gtk_label_set_xalign(GTK_LABEL(url_label), 0.0);
         gtk_label_set_ellipsize(GTK_LABEL(url_label), PANGO_ELLIPSIZE_END);
         gtk_widget_add_css_class(url_label, "dim-label");
@@ -548,4 +638,144 @@ static void ladybird_location_entry_apply_selected_suggestion(LadybirdLocationEn
     if (info.is_section_header)
         return;
     set_entry_text_suppressed(self, state.suggestions[info.suggestion_index].text.to_byte_string().characters(), true);
+}
+
+static String ladybird_location_entry_current_query(LadybirdLocationEntry* self)
+{
+    auto* text = gtk_editable_get_text(GTK_EDITABLE(self));
+    if (!text || text[0] == '\0')
+        return {};
+    size_t text_bytes = strlen(text);
+    int text_chars = static_cast<int>(g_utf8_strlen(text, -1));
+    int start, end;
+    if (!gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &start, &end))
+        return MUST(String::from_utf8(StringView(text, text_bytes)));
+    if (end != text_chars)
+        return MUST(String::from_utf8(StringView(text, text_bytes)));
+    size_t start_bytes = static_cast<size_t>(g_utf8_offset_to_pointer(text, start) - text);
+    return MUST(String::from_utf8(StringView(text, start_bytes)));
+}
+
+static void ladybird_location_entry_apply_inline_text(LadybirdLocationEntry* self, StringView inline_text, StringView query)
+{
+    if (!self->state->is_focused)
+        return;
+    int completion_start = static_cast<int>(g_utf8_strlen(query.characters_without_null_termination(), static_cast<gssize>(query.length())));
+    int completion_end = static_cast<int>(g_utf8_strlen(inline_text.characters_without_null_termination(), static_cast<gssize>(inline_text.length())));
+    if (completion_end <= completion_start)
+        return;
+    auto* current_text = gtk_editable_get_text(GTK_EDITABLE(self));
+    int cur_start, cur_end;
+    bool has_selection = gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &cur_start, &cur_end);
+    auto inline_bs = ByteString(inline_text);
+    if (current_text && inline_bs == current_text && has_selection
+        && cur_start == completion_start && cur_end == completion_end)
+        return;
+    self->state->applying_inline = true;
+    gtk_editable_set_text(GTK_EDITABLE(self), inline_bs.characters());
+    gtk_editable_select_region(GTK_EDITABLE(self), completion_start, completion_end);
+    self->state->applying_inline = false;
+}
+
+static void ladybird_location_entry_restore_query(LadybirdLocationEntry* self)
+{
+    if (!self->state->is_focused)
+        return;
+    auto query = ladybird_location_entry_current_query(self);
+    auto* current_text = gtk_editable_get_text(GTK_EDITABLE(self));
+    int start, end;
+    bool has_selection = gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &start, &end);
+    if (current_text && query.bytes_as_string_view() == StringView(current_text, strlen(current_text)) && !has_selection)
+        return;
+    auto query_bs = query.to_byte_string();
+    self->state->applying_inline = true;
+    gtk_editable_set_text(GTK_EDITABLE(self), query_bs.characters());
+    gtk_editable_set_position(GTK_EDITABLE(self), static_cast<int>(g_utf8_strlen(query_bs.characters(), -1)));
+    self->state->applying_inline = false;
+}
+
+static void ladybird_location_entry_reset_inline_state(LadybirdLocationEntry* self)
+{
+    self->state->current_inline_suggestion = {};
+    self->state->suppressed_query = {};
+    self->state->suppress_on_next_change = false;
+}
+
+static int ladybird_location_entry_apply_inline_autocomplete(LadybirdLocationEntry* self, Vector<WebView::AutocompleteSuggestion> const& suggestions)
+{
+    if (self->state->applying_inline || !self->state->is_focused)
+        return -1;
+
+    auto* text = gtk_editable_get_text(GTK_EDITABLE(self));
+    size_t text_bytes = text ? strlen(text) : 0;
+    int text_chars = text ? static_cast<int>(g_utf8_strlen(text, -1)) : 0;
+
+    String query;
+    int start, end;
+    if (!gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &start, &end)) {
+        if (gtk_editable_get_position(GTK_EDITABLE(self)) != text_chars)
+            return -1;
+        query = MUST(String::from_utf8(StringView(text, text_bytes)));
+    } else {
+        if (end != text_chars)
+            return -1;
+        size_t start_bytes = static_cast<size_t>(g_utf8_offset_to_pointer(text, start) - text);
+        query = MUST(String::from_utf8(StringView(text, start_bytes)));
+    }
+
+    if (suggestions.is_empty())
+        return -1;
+
+    auto& state = *self->state;
+    auto query_sv = query.bytes_as_string_view();
+
+    if (suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL) {
+        state.current_inline_suggestion = {};
+        int cur_start2, cur_end2;
+        if (gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &cur_start2, &cur_end2)
+            || (text && query_sv != StringView(text, text_bytes)))
+            ladybird_location_entry_restore_query(self);
+        return 0;
+    }
+
+    if (state.suppressed_query.has_value() && state.suppressed_query.value() == query) {
+        state.current_inline_suggestion = {};
+        int cur_start2, cur_end2;
+        if (gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &cur_start2, &cur_end2)
+            || (text && query_sv != StringView(text, text_bytes)))
+            ladybird_location_entry_restore_query(self);
+        return 0;
+    }
+
+    if (!state.current_inline_suggestion.is_empty()) {
+        int preserved = -1;
+        for (size_t i = 0; i < suggestions.size(); ++i) {
+            if (suggestions[i].text == state.current_inline_suggestion) {
+                preserved = static_cast<int>(i);
+                break;
+            }
+        }
+        if (preserved != -1) {
+            auto preserved_inline = inline_completion_for_suggestion(query_sv, state.current_inline_suggestion.bytes_as_string_view());
+            if (preserved_inline.has_value()) {
+                ladybird_location_entry_apply_inline_text(self, preserved_inline.value(), query_sv);
+                return preserved;
+            }
+        }
+    }
+
+    auto const& first_text = suggestions.first().text;
+    auto first_inline = inline_completion_for_suggestion(query_sv, first_text.bytes_as_string_view());
+    if (first_inline.has_value()) {
+        state.current_inline_suggestion = first_text;
+        ladybird_location_entry_apply_inline_text(self, first_inline.value(), query_sv);
+        return 0;
+    }
+
+    state.current_inline_suggestion = {};
+    int cur_start2, cur_end2;
+    if (gtk_editable_get_selection_bounds(GTK_EDITABLE(self), &cur_start2, &cur_end2)
+        || (text && query_sv != StringView(text, text_bytes)))
+        ladybird_location_entry_restore_query(self);
+    return 0;
 }


### PR DESCRIPTION
Replaces the flat plain-text suggestion list with rich rows showing an icon, title, and dimmed URL.

- Favicons are loaded and search suggestions show a search icon.
- Section headers separate History from Search Suggestions
- Up/Down navigation skipping them.

Adds inline type-ahead completion: the best match is appended and selected as the user types, with
Backspace/Delete suppressing the suffix and Escape restoring the typed query.

# Before
<img width="838" height="180" alt="image" src="https://github.com/user-attachments/assets/5d4ffe3e-2424-400f-9ba9-db3e33e6f4c0" />
# After
<img width="1031" height="285" alt="image" src="https://github.com/user-attachments/assets/1db7beb8-1c3e-465a-854a-c44e7476799e" />

