### PR TITLE
UI/Gtk: Make the tab audio indicator icon clickable to mute/unmute

### DIFF
--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -7,6 +7,7 @@
 #include <AK/Format.h>
 #include <LibCore/EventLoop.h>
 #include <LibURL/Parser.h>
+#include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Menu.h>
 #include <LibWebView/URL.h>
 #include <UI/Gtk/Application.h>
@@ -180,6 +181,20 @@ void BrowserWindow::setup_ui(AdwApplication* app)
     g_signal_connect_swapped(m_tab_view, "close-page", G_CALLBACK(+[](BrowserWindow* self, AdwTabPage* page) -> gboolean {
         self->on_tab_close_request(page);
         return GDK_EVENT_STOP;
+    }),
+        this);
+
+    g_signal_connect_swapped(m_tab_view, "indicator-activated", G_CALLBACK(+[](BrowserWindow* self, AdwTabPage* page) {
+        for (auto& tab : self->m_tabs) {
+            if (tab->tab_page() != page)
+                continue;
+            tab->view().toggle_page_mute_state();
+            bool muted = tab->view().page_mute_state() == Web::HTML::MuteState::Muted;
+            GObjectPtr icon { g_themed_icon_new(muted ? "audio-volume-muted-symbolic" : "audio-volume-high-symbolic") };
+            adw_tab_page_set_indicator_icon(page, G_ICON(icon.ptr()));
+            adw_tab_page_set_indicator_tooltip(page, muted ? "Unmute tab" : "Mute tab");
+            return;
+        }
     }),
         this);
 

--- a/UI/Gtk/Tab.cpp
+++ b/UI/Gtk/Tab.cpp
@@ -244,11 +244,18 @@ void Tab::setup_callbacks()
     };
 
     m_view->on_audio_play_state_changed = [this](auto play_state) {
-        if (m_tab_page) {
-            adw_tab_page_set_indicator_icon(m_tab_page,
-                play_state == Web::HTML::AudioPlayState::Playing
-                    ? g_themed_icon_new("audio-volume-high-symbolic")
-                    : nullptr);
+        if (!m_tab_page)
+            return;
+        if (play_state == Web::HTML::AudioPlayState::Playing) {
+            bool muted = m_view->page_mute_state() == Web::HTML::MuteState::Muted;
+            GObjectPtr icon { g_themed_icon_new(muted ? "audio-volume-muted-symbolic" : "audio-volume-high-symbolic") };
+            adw_tab_page_set_indicator_icon(m_tab_page, G_ICON(icon.ptr()));
+            adw_tab_page_set_indicator_tooltip(m_tab_page, muted ? "Unmute tab" : "Mute tab");
+            adw_tab_page_set_indicator_activatable(m_tab_page, TRUE);
+        } else {
+            adw_tab_page_set_indicator_icon(m_tab_page, nullptr);
+            adw_tab_page_set_indicator_tooltip(m_tab_page, nullptr);
+            adw_tab_page_set_indicator_activatable(m_tab_page, FALSE);
         }
     };
 


### PR DESCRIPTION
Set indicator-activatable on the AdwTabPage when audio is playing so the audio icon in the tab strip is clickable. Clicking it toggles the mute state and updates the icon and tooltip to reflect the new state (audio-volume-high-symbolic / "Mute tab" or audio-volume-muted-symbolic / "Unmute tab").
