### PR TITLE
UI/Gtk: Implement popup window support

### DIFF
--- a/UI/Gtk/Application.cpp
+++ b/UI/Gtk/Application.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <LibURL/Parser.h>
+#include <LibWeb/HTML/WebViewHints.h>
+#include <LibWebView/BookmarkStore.h>
 #include <LibWebView/URL.h>
 #include <UI/Gtk/Application.h>
 #include <UI/Gtk/BrowserWindow.h>
@@ -108,13 +110,8 @@ void Application::on_activate()
         new_window({});
 }
 
-BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
+static void track_browser_window(BrowserWindow& window_ref)
 {
-    auto window = make<BrowserWindow>(m_adw_application, initial_urls);
-    auto& window_ref = *window;
-    m_active_window = &window_ref;
-
-    // Track active window via focus
     g_signal_connect(window_ref.gtk_window(), "notify::is-active", G_CALLBACK(+[](GObject* gtk_window, GParamSpec*, gpointer) {
         if (!gtk_window_is_active(GTK_WINDOW(gtk_window)))
             return;
@@ -126,7 +123,6 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
     }),
         nullptr);
 
-    // Clean up when window is destroyed — defer removal to avoid mutating m_windows during iteration
     g_signal_connect(window_ref.gtk_window(), "destroy", G_CALLBACK(+[](GtkWidget* gtk_window, gpointer) {
         auto& app = Application::the();
         BrowserWindow* to_remove = nullptr;
@@ -145,7 +141,25 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
         }
     }),
         nullptr);
+}
 
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls)
+{
+    auto window = make<BrowserWindow>(m_adw_application, initial_urls);
+    auto& window_ref = *window;
+    m_active_window = &window_ref;
+    track_browser_window(window_ref);
+    window_ref.present();
+    m_windows.append(move(window));
+    return window_ref;
+}
+
+BrowserWindow& Application::new_popup_window(Tab& parent_tab, Web::HTML::WebViewHints const& hints, Optional<u64> page_index)
+{
+    auto window = make<BrowserWindow>(m_adw_application, hints, parent_tab, move(page_index));
+    auto& window_ref = *window;
+    m_active_window = &window_ref;
+    track_browser_window(window_ref);
     window_ref.present();
     m_windows.append(move(window));
     return window_ref;

--- a/UI/Gtk/Application.h
+++ b/UI/Gtk/Application.h
@@ -9,6 +9,7 @@
 #include <AK/Function.h>
 #include <AK/Vector.h>
 #include <LibURL/URL.h>
+#include <LibWeb/HTML/WebViewHints.h>
 #include <LibWebView/Application.h>
 
 #include <adwaita.h>
@@ -25,6 +26,7 @@ public:
     virtual ~Application() override;
 
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls);
+    BrowserWindow& new_popup_window(Tab& parent_tab, Web::HTML::WebViewHints const& hints, Optional<u64> page_index);
     void remove_window(BrowserWindow&);
 
     BrowserWindow* active_window() const { return m_active_window; }

--- a/UI/Gtk/BrowserWindow.cpp
+++ b/UI/Gtk/BrowserWindow.cpp
@@ -56,6 +56,22 @@ BrowserWindow::BrowserWindow(AdwApplication* app, Vector<URL::URL> const& initia
     }
 }
 
+BrowserWindow::BrowserWindow(AdwApplication* app, Web::HTML::WebViewHints const& hints, Tab& parent_tab, Optional<u64> page_index)
+    : m_is_popup(true)
+{
+    setup_ui(app);
+    setup_keyboard_shortcuts();
+
+    int width = hints.width.value_or(Web::DevicePixels(800)).value();
+    int height = hints.height.value_or(Web::DevicePixels(600)).value();
+    gtk_window_set_default_size(GTK_WINDOW(m_window), width, height);
+
+    if (page_index.has_value())
+        create_child_tab(Web::HTML::ActivateTab::Yes, parent_tab, *page_index);
+    else
+        create_new_tab(Web::HTML::ActivateTab::Yes);
+}
+
 BrowserWindow::~BrowserWindow()
 {
     m_back_binding.detach();

--- a/UI/Gtk/BrowserWindow.h
+++ b/UI/Gtk/BrowserWindow.h
@@ -9,6 +9,7 @@
 #include <AK/Vector.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/WebViewHints.h>
 #include <LibWebView/Menu.h>
 #include <UI/Gtk/Widgets/LadybirdBrowserWindow.h>
 #include <UI/Gtk/Widgets/LadybirdLocationEntry.h>
@@ -23,6 +24,7 @@ class WebContentView;
 class BrowserWindow {
 public:
     BrowserWindow(AdwApplication* app, Vector<URL::URL> const& initial_urls);
+    BrowserWindow(AdwApplication* app, Web::HTML::WebViewHints const& hints, Tab& parent_tab, Optional<u64> page_index);
     ~BrowserWindow();
 
     GtkWindow* gtk_window() const { return GTK_WINDOW(m_window); }
@@ -60,6 +62,7 @@ private:
     void on_tab_switched();
     void bind_navigation_actions(WebContentView& view);
 
+    bool m_is_popup { false };
     AdwApplicationWindow* m_window { nullptr };
     LadybirdLocationEntry* m_location_entry { nullptr };
     Vector<NonnullOwnPtr<Tab>> m_tabs;

--- a/UI/Gtk/Tab.cpp
+++ b/UI/Gtk/Tab.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWebView/Menu.h>
 #include <LibWebView/URL.h>
+#include <UI/Gtk/Application.h>
 #include <UI/Gtk/BrowserWindow.h>
 #include <UI/Gtk/Dialogs.h>
 #include <UI/Gtk/Events.h>
@@ -154,7 +155,11 @@ void Tab::setup_callbacks()
         gtk_widget_set_tooltip_text(root, nullptr);
     };
 
-    m_view->on_new_web_view = [this](auto activate_tab, auto, auto page_index) -> String {
+    m_view->on_new_web_view = [this](auto activate_tab, auto hints, auto page_index) -> String {
+        if (hints.popup) {
+            auto& window = Application::the().new_popup_window(*this, hints, move(page_index));
+            return window.current_tab()->view().handle();
+        }
         if (page_index.has_value()) {
             auto& new_tab = m_window.create_child_tab(activate_tab, *this, page_index.value());
             return new_tab.view().handle();


### PR DESCRIPTION
When window.open() is called with popup=true, open a new BrowserWindow
instead of a tab. The popup window applies width/height hints from
WebViewHints (defaulting to 800x600 matching Qt behaviour) and skips
saving/restoring the geometry setting used for normal windows.
