### PR TITLE
LibMedia+LibWeb: Implement HTMLMediaElement.getStartDate()

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -448,6 +448,11 @@ public:
         return UnixDateTime { Duration::from_milliseconds(milliseconds) };
     }
 
+    [[nodiscard]] constexpr static UnixDateTime from_microseconds_since_epoch(i64 microseconds)
+    {
+        return UnixDateTime { Duration::from_microseconds(microseconds) };
+    }
+
     [[nodiscard]] constexpr static UnixDateTime from_nanoseconds_since_epoch(i64 nanoseconds)
     {
         return UnixDateTime { Duration::from_nanoseconds(nanoseconds) };

--- a/Libraries/LibMedia/Demuxer.h
+++ b/Libraries/LibMedia/Demuxer.h
@@ -9,6 +9,7 @@
 #include <AK/AtomicRefCounted.h>
 #include <AK/EnumBits.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Time.h>
 #include <LibCore/EventReceiver.h>
 #include <LibMedia/IncrementallyPopulatedStream.h>
 
@@ -56,6 +57,9 @@ public:
 
     virtual DecoderErrorOr<AK::Duration> duration_of_track(Track const&) = 0;
     virtual DecoderErrorOr<AK::Duration> total_duration() = 0;
+
+    // Returns the timeline offset if the media resource provides one.
+    virtual Optional<AK::UnixDateTime> start_time_realtime() const { return {}; }
 
     virtual TimeRanges buffered_time_ranges() const = 0;
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -128,6 +128,8 @@ DecoderErrorOr<NonnullRefPtr<FFmpegDemuxer>> FFmpegDemuxer::from_stream(NonnullR
 
     auto demuxer = DECODER_TRY_ALLOC(adopt_nonnull_ref_or_enomem(new (nothrow) FFmpegDemuxer(stream)));
     demuxer->m_total_duration = AK::Duration::from_time_units(format_context->duration, 1, AV_TIME_BASE);
+    if (format_context->start_time_realtime != AV_NOPTS_VALUE)
+        demuxer->m_start_time_realtime = AK::UnixDateTime::from_microseconds_since_epoch(format_context->start_time_realtime);
 
     auto format_name = StringView(format_context->iformat->name, strlen(format_context->iformat->name));
     auto seen_types = HashTable<TrackType>();
@@ -217,6 +219,11 @@ static inline i64 duration_to_time_units(AK::Duration duration, AVRational const
 DecoderErrorOr<AK::Duration> FFmpegDemuxer::total_duration()
 {
     return m_total_duration;
+}
+
+Optional<AK::UnixDateTime> FFmpegDemuxer::start_time_realtime() const
+{
+    return m_start_time_realtime;
 }
 
 TimeRanges FFmpegDemuxer::buffered_time_ranges() const

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
@@ -34,6 +34,7 @@ public:
 
     virtual DecoderErrorOr<AK::Duration> duration_of_track(Track const&) override;
     virtual DecoderErrorOr<AK::Duration> total_duration() override;
+    virtual Optional<AK::UnixDateTime> start_time_realtime() const override;
 
     virtual TimeRanges buffered_time_ranges() const override;
 
@@ -81,6 +82,7 @@ private:
 
     NonnullRefPtr<MediaStream> m_stream;
     AK::Duration m_total_duration;
+    Optional<AK::UnixDateTime> m_start_time_realtime;
     Vector<StreamInfo> m_stream_info;
     Array<int, to_underlying(TrackType::Unknown)> m_preferred_track_for_type;
 

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -77,9 +77,10 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
         preferred_audio_track = {};
 
     auto duration = demuxer->total_duration().value_or(AK::Duration::zero());
+    auto start_time_realtime = demuxer->start_time_realtime();
 
     auto main_thread_event_loop = main_thread_event_loop_reference->take();
-    main_thread_event_loop->deferred_invoke([self, video_tracks = move(supported_video_tracks), video_track_datas = move(supported_video_track_datas), preferred_video_track, audio_tracks = move(supported_audio_tracks), audio_track_datas = move(supported_audio_track_datas), preferred_audio_track, duration] mutable {
+    main_thread_event_loop->deferred_invoke([self, video_tracks = move(supported_video_tracks), video_track_datas = move(supported_video_track_datas), preferred_video_track, audio_tracks = move(supported_audio_tracks), audio_track_datas = move(supported_audio_track_datas), preferred_audio_track, duration, start_time_realtime] mutable {
         if (!self)
             return;
 
@@ -109,6 +110,7 @@ DecoderErrorOr<void> PlaybackManager::prepare_playback_from_demuxer(WeakPlayback
         if (!self->m_preferred_audio_track.has_value())
             self->m_preferred_audio_track = preferred_audio_track;
 
+        self->m_start_time_realtime = start_time_realtime;
         self->check_for_duration_change(duration);
 
         self->set_up_data_providers();

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -59,6 +59,8 @@ public:
     void set_duration(AK::Duration duration) { m_duration = duration; }
     AK::Duration current_time() const { return min(m_time_provider->current_time(), duration()); }
 
+    Optional<AK::UnixDateTime> start_time_realtime() const { return m_start_time_realtime; }
+
     auto const& video_tracks() const { return m_video_tracks; }
     auto const& audio_tracks() const { return m_audio_tracks; }
     Optional<Track> preferred_video_track() { return m_preferred_video_track; }
@@ -175,6 +177,7 @@ private:
     Optional<Track> m_preferred_audio_track;
 
     AK::Duration m_duration;
+    Optional<AK::UnixDateTime> m_start_time_realtime;
 
     HashTable<Track> m_tracks_still_buffering;
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/Promise.h>
 #include <LibMedia/IncrementallyPopulatedStream.h>
 #include <LibMedia/PlaybackManager.h>
@@ -473,6 +474,16 @@ double HTMLMediaElement::duration() const
     return m_duration;
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate
+JS::Object* HTMLMediaElement::get_start_date()
+{
+    // The getStartDate() method must return a new Date object representing the current timeline offset.
+    auto date_value = m_timeline_offset.has_value()
+        ? static_cast<double>(m_timeline_offset->milliseconds_since_epoch())
+        : NAN;
+    return JS::Date::create(realm(), date_value).ptr();
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-ended
 bool HTMLMediaElement::ended() const
 {
@@ -752,7 +763,8 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
             });
         }
 
-        // FIXME: 9. Set the timeline offset to Not-a-Number (NaN).
+        // 9. Set the timeline offset to Not-a-Number (NaN).
+        m_timeline_offset = {};
 
         // 10. Update the duration attribute to Not-a-Number (NaN).
         set_duration(NAN);
@@ -1689,8 +1701,9 @@ void HTMLMediaElement::on_metadata_parsed()
     m_source_element_selector = nullptr;
 
     // FIXME: 1. Establish the media timeline for the purposes of the current playback position and the earliest possible position, based on the media data.
-    // FIXME: 2. Update the timeline offset to the date and time that corresponds to the zero time in the media timeline established in the previous step,
-    //           if any. If no explicit time and date is given by the media resource, the timeline offset must be set to Not-a-Number (NaN).
+    // 2. Update the timeline offset to the date and time that corresponds to the zero time in the media timeline established in the previous step,
+    //    if any. If no explicit time and date is given by the media resource, the timeline offset must be set to Not-a-Number (NaN).
+    m_timeline_offset = m_playback_manager->start_time_realtime();
 
     // 3. Set the current playback position and the official playback position to the earliest possible position.
     m_current_playback_position = 0;

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -114,6 +114,7 @@ public:
     void set_current_playback_position(double);
 
     double duration() const;
+    JS::Object* get_start_date();
     bool show_poster() const { return m_show_poster; }
     bool paused() const { return m_paused; }
     bool ended() const;
@@ -318,6 +319,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-duration
     double m_duration { NAN };
+
+    // https://html.spec.whatwg.org/multipage/media.html#timeline-offset
+    Optional<AK::UnixDateTime> m_timeline_offset;
 
     // https://html.spec.whatwg.org/multipage/media.html#list-of-pending-play-promises
     Vector<GC::Ref<WebIDL::Promise>> m_pending_play_promises;

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -50,7 +50,7 @@ interface HTMLMediaElement : HTMLElement {
     attribute double currentTime;
     undefined fastSeek(double time);
     readonly attribute unrestricted double duration;
-    [FIXME] object getStartDate();
+    object getStartDate();
     readonly attribute boolean paused;
     attribute double defaultPlaybackRate;
     attribute double playbackRate;

--- a/Tests/LibWeb/Text/expected/video-get-start-date.txt
+++ b/Tests/LibWeb/Text/expected/video-get-start-date.txt
@@ -1,0 +1,2 @@
+true
+true

--- a/Tests/LibWeb/Text/input/video-get-start-date.html
+++ b/Tests/LibWeb/Text/input/video-get-start-date.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const video = document.createElement("video");
+
+        const date = video.getStartDate();
+        println(date instanceof Date);
+        println(isNaN(date.getTime()));
+    });
+</script>


### PR DESCRIPTION
* Try to extract `start_time_realtime` from ffmpeg parsed headers
* Plumb to PlaybackManager
* New `JS::Object* HTMLMediaElement::get_start_date()`
* Returns NaN if timeline offset does not exist, per HTML spec
* New tests only cover NaN case