### PR TITLE
LibWeb: Stream Rust CSS tokenizer tokens over FFI

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/RustTokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RustTokenizer.cpp
@@ -240,6 +240,7 @@ Vector<Token> RustTokenizer::tokenize(StringView input, StringView encoding)
     auto filtered_input = decode_and_filter_code_points(input, encoding);
     auto filtered_input_bytes = filtered_input.bytes();
     CallbackContext context;
+    context.tokens.ensure_capacity((filtered_input_bytes.size() / 2) + 1);
     FFI::rust_css_tokenize(
         filtered_input_bytes.data(),
         filtered_input_bytes.size(),

--- a/Libraries/LibWeb/Rust/src/css_tokenizer.rs
+++ b/Libraries/LibWeb/Rust/src/css_tokenizer.rs
@@ -220,20 +220,17 @@ impl Token {
     }
 }
 
-pub(crate) struct TokenizationResult {
-    pub filtered_input: String,
-    pub tokens: Vec<Token>,
+pub fn tokenize<F>(filtered_input: &[u8], callback: F)
+where
+    F: FnMut(&Token, &str),
+{
+    let filtered_input =
+        std::str::from_utf8(filtered_input).expect("rust_css_tokenize received non-UTF-8 input after C++ decoding");
+    Tokenizer::new(filtered_input).tokenize(callback);
 }
 
-pub fn tokenize(filtered_input: &[u8]) -> TokenizationResult {
-    let filtered_input = std::str::from_utf8(filtered_input)
-        .expect("rust_css_tokenize received non-UTF-8 input after C++ decoding")
-        .to_owned();
-    Tokenizer::new(filtered_input).tokenize()
-}
-
-struct Tokenizer {
-    input: String,
+struct Tokenizer<'a> {
+    input: &'a str,
     code_points: Vec<(usize, u32)>,
     index: usize,
     prev_index: usize,
@@ -241,12 +238,14 @@ struct Tokenizer {
     prev_position: Position,
 }
 
-impl Tokenizer {
-    fn new(input: String) -> Self {
-        let code_points = input
-            .char_indices()
-            .map(|(offset, code_point)| (offset, code_point as u32))
-            .collect();
+impl<'a> Tokenizer<'a> {
+    fn new(input: &'a str) -> Self {
+        let mut code_points = Vec::with_capacity(input.len());
+        code_points.extend(
+            input
+                .char_indices()
+                .map(|(offset, code_point)| (offset, code_point as u32)),
+        );
 
         Self {
             input,
@@ -258,21 +257,19 @@ impl Tokenizer {
         }
     }
 
-    fn tokenize(mut self) -> TokenizationResult {
-        let mut tokens = Vec::new();
-
+    fn tokenize<F>(mut self, mut callback: F)
+    where
+        F: FnMut(&Token, &str),
+    {
         loop {
             let token_start = self.position;
             let mut token = self.consume_a_token();
             token.range = token_start..self.position;
             let is_eof = matches!(token.token_type, TokenType::EndOfFile);
-            tokens.push(token);
+            callback(&token, self.input);
 
             if is_eof {
-                return TokenizationResult {
-                    filtered_input: self.input,
-                    tokens,
-                };
+                return;
             }
         }
     }

--- a/Libraries/LibWeb/Rust/src/lib.rs
+++ b/Libraries/LibWeb/Rust/src/lib.rs
@@ -61,11 +61,10 @@ pub unsafe extern "C" fn rust_css_tokenize(
                 return;
             };
 
-            let tokenization_result = css_tokenizer::tokenize(input);
-            for token in &tokenization_result.tokens {
-                let ffi_token = token.as_ffi(&tokenization_result.filtered_input);
+            css_tokenizer::tokenize(input, |token, filtered_input| {
+                let ffi_token = token.as_ffi(filtered_input);
                 callback(ctx, &raw const ffi_token);
-            }
+            });
         });
     }
 }

--- a/Tests/LibWeb/css-tokenizer.cpp
+++ b/Tests/LibWeb/css-tokenizer.cpp
@@ -16,10 +16,12 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     StringView backend = "cpp"sv;
     StringView encoding = "utf-8"sv;
     StringView input_path;
+    bool silent = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(backend, "Tokenizer backend to use (cpp or rust)", "backend", 'b', "backend");
     args_parser.add_option(encoding, "Source encoding label", "encoding", 'e', "encoding");
+    args_parser.add_option(silent, "Don't print the tokens (useful for perf testing)", "silent", 's');
     args_parser.add_positional_argument(input_path, "Path to the CSS input file", "input", Core::ArgsParser::Required::Yes);
     args_parser.parse(arguments);
 
@@ -34,8 +36,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         ? Web::CSS::Parser::RustTokenizer::tokenize(input, encoding)
         : Web::CSS::Parser::Tokenizer::tokenize(input, encoding);
 
-    for (auto const& token : tokens)
-        outln("{}", token.to_debug_string());
+    if (!silent) {
+        for (auto const& token : tokens)
+            outln("{}", token.to_debug_string());
+    }
 
     return 0;
 }


### PR DESCRIPTION
Avoid building a temporary Rust token vector before calling back into
C++. The tokenizer now invokes the callback as each token is produced,
while borrowing the already-filtered input for source slices.

Reserve an initial C++ token capacity from the input size so the common
path avoids repeated growth while appending the converted tokens.

With this change, the Rust CSS tokenizer is now ~1.3x faster than the
C++ CSS tokenizer at churning through all the https://vercel.com/ CSS.

```console
✗ hyperfine "./bin/css-tokenizer --silent --backend cpp vercelmaxxing.css" "./bin/css-tokenizer --silent --backend rust vercelmaxxing.css"
Benchmark 1: ./bin/css-tokenizer --silent --backend cpp vercelmaxxing.css
  Time (mean ± σ):     186.3 ms ±   3.7 ms    [User: 146.0 ms, System: 37.9 ms]
  Range (min … max):   180.2 ms … 190.7 ms    15 runs

Benchmark 2: ./bin/css-tokenizer --silent --backend rust vercelmaxxing.css
  Time (mean ± σ):     137.3 ms ±   0.9 ms    [User: 114.6 ms, System: 21.1 ms]
  Range (min … max):   135.3 ms … 139.1 ms    21 runs

Summary
  ./bin/css-tokenizer --silent --backend rust vercelmaxxing.css ran
    1.36 ± 0.03 times faster than ./bin/css-tokenizer --silent --backend cpp vercelmaxxing.css
```