### PR TITLE
LibWeb: Paint inline-block floats during inline-level painting

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -110,6 +110,32 @@ static PaintPhase to_paint_phase(StackingContext::StackingContextPaintPhase phas
     }
 }
 
+static bool establishes_inline_level_painting_context(Paintable const& paintable)
+{
+    // CSS 2.2 painting order puts inline-block and inline-table boxes in the inline-level painting step and
+    // says to paint each "as if it created a new stacking context", while keeping positioned descendants and
+    // actual child stacking contexts in the parent stacking context:
+    // https://drafts.csswg.org/css2/#painting-order
+    // https://drafts.csswg.org/css2/#elaborate-stacking-contexts
+    auto const& layout_node = paintable.layout_node();
+    return layout_node.is_inline_block() || layout_node.is_inline_table();
+}
+
+static void paint_inline_level_non_positioned_descendant(DisplayListRecordingContext& context, Paintable const& paintable)
+{
+    paint_node(paintable, context, PaintPhase::Background);
+    paint_node(paintable, context, PaintPhase::Border);
+    paint_node(paintable, context, PaintPhase::TableCollapsedBorder);
+    StackingContext::paint_descendants(context, paintable, StackingContext::StackingContextPaintPhase::BackgroundAndBorders);
+
+    // https://drafts.csswg.org/css2/#elaborate-stacking-contexts
+    // "For inline-block and inline-table elements: [...] treat the element as if it created a new stacking context,
+    // but any positioned descendants and descendants which actually create a new stacking context should be
+    // considered part of the parent stacking context, not this new one."
+    if (establishes_inline_level_painting_context(paintable))
+        StackingContext::paint_descendants(context, paintable, StackingContext::StackingContextPaintPhase::Floats);
+}
+
 void StackingContext::paint_node_as_stacking_context(Paintable const& paintable, DisplayListRecordingContext& context)
 {
     if (paintable.is_svg_svg_paintable()) {
@@ -181,6 +207,7 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
         }
 
         bool child_is_inline_or_replaced = child.is_inline() || is<Layout::ReplacedBox>(child.layout_node());
+        bool child_has_inline_level_painting_context = establishes_inline_level_painting_context(child);
         switch (phase) {
         case StackingContextPaintPhase::BackgroundAndBorders:
             if (!child_is_inline_or_replaced && !child.is_floating()) {
@@ -196,14 +223,15 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
                 paint_node(child, context, PaintPhase::Border);
                 paint_descendants(context, child, StackingContextPaintPhase::BackgroundAndBorders);
             }
-            paint_descendants(context, child, phase);
+            // Atomic inline-level descendants such as inline-blocks and inline tables participate in the parent's
+            // inline-level painting step, so their internal floats must not be painted early during the ancestor's
+            // float sweep.
+            if (!child_has_inline_level_painting_context)
+                paint_descendants(context, child, phase);
             break;
         case StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced:
             if (child_is_inline_or_replaced) {
-                paint_node(child, context, PaintPhase::Background);
-                paint_node(child, context, PaintPhase::Border);
-                paint_node(child, context, PaintPhase::TableCollapsedBorder);
-                paint_descendants(context, child, StackingContextPaintPhase::BackgroundAndBorders);
+                paint_inline_level_non_positioned_descendant(context, child);
             }
             paint_descendants(context, child, phase);
             break;

--- a/Tests/LibWeb/Ref/expected/inline-block-with-float-paint-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/inline-block-with-float-paint-order-ref.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+.box {
+    background-color: white;
+    display: inline-block;
+}
+</style><div class="box">test</div>

--- a/Tests/LibWeb/Ref/input/inline-block-with-float-paint-order.html
+++ b/Tests/LibWeb/Ref/input/inline-block-with-float-paint-order.html
@@ -1,0 +1,9 @@
+<!doctype html><link rel="match" href="../expected/inline-block-with-float-paint-order-ref.html" /><style>
+.inline-block {
+    background-color: white;
+    display: inline-block;
+}
+.float {
+    float: left;
+}
+</style><div class="inline-block"><div class="float">test</div></div>

--- a/Tests/LibWeb/Text/expected/hit_testing/inline-block-with-float-paint-order.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/inline-block-with-float-paint-order.txt
@@ -1,0 +1,1 @@
+<DIV id="float">

--- a/Tests/LibWeb/Text/input/hit_testing/inline-block-with-float-paint-order.html
+++ b/Tests/LibWeb/Text/input/hit_testing/inline-block-with-float-paint-order.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #inline-block {
+        background: white;
+        display: inline-block;
+        padding: 10px;
+    }
+
+    #float {
+        background: orange;
+        float: left;
+        height: 40px;
+        width: 40px;
+    }
+</style>
+<div id="inline-block">
+    <div id="float"></div>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const rect = document.getElementById("float").getBoundingClientRect();
+        printElement(internals.hitTest(rect.left + 20, rect.top + 20).node);
+    });
+</script>


### PR DESCRIPTION
Avoid recursing into atomic inline-level descendants during the ancestor float sweep.

CSS 2.2 paints inline-block and inline-table boxes in the inline-level painting step, as if they created their own stacking contexts. Paint their internal floats during BackgroundAndBordersForInlineLevelAndReplaced instead.

Fixes some missing text. 

Before:

<img width="446" height="214" alt="image" src="https://github.com/user-attachments/assets/7b5f2a03-f7a2-4bb5-b9b1-80a1b3faddb7" />


After:

<img width="446" height="214" alt="image" src="https://github.com/user-attachments/assets/8e8a8007-af98-4344-a5db-feb7b7ce5954" />

Fixes #6742