### PR TITLE
LibWeb: Implement `scrollIntoView` for boxes.

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -66,6 +66,7 @@
 #include <LibWeb/HTML/CustomElements/CustomElementRegistry.h>
 #include <LibWeb/HTML/CustomElements/CustomStateSet.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBaseElement.h>
@@ -116,6 +117,7 @@
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/SVG/SVGAElement.h>
 #include <LibWeb/Selection/Selection.h>
@@ -2723,12 +2725,17 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
     // block flow direction position block, an inline base direction position inline, and a scrolling box scrolling box,
     // run the following steps:
 
-    if (!scrolling_box.is_document()) {
-        // FIXME: Add support for scrolling boxes other than the viewport.
+    CSSPixelRect scrolling_box_rect;
+    CSSPixelPoint scroll_offset;
+    if (scrolling_box.is_document()) {
+        // NOTE: For a viewport scrolling box is initial containing block
+        scrolling_box_rect = scrolling_box.document().viewport_rect();
+    } else if (auto paintable_box = scrolling_box.paintable_box()) {
+        scroll_offset = paintable_box->scroll_offset();
+        scrolling_box_rect = paintable_box->absolute_rect().translated(scroll_offset);
+    } else {
         return {};
     }
-    // NOTE: For a viewport scrolling box is initial containing block
-    CSSPixelRect scrolling_box_rect = scrolling_box.document().viewport_rect();
 
     // FIXME: All of this needs to support different block/inline directions.
 
@@ -2736,6 +2743,13 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
     //    getBoundingClientRect(), if target is an Element, or Range’s getBoundingClientRect(),
     //    if target is a Range.
     auto target_bounding_border_box = target.get_bounding_client_rect();
+
+    // AD-HOC: If scrolling_box is a box, translate target bounding box so that the following math works for both the
+    //         viewport and a regular scrollable box.
+    if (!scrolling_box.is_document()) {
+        target_bounding_border_box.translate_by(scroll_offset);
+        target_bounding_border_box.translate_by(-scrolling_box.paintable_box()->absolute_rect().top_left());
+    }
 
     // 2. Let scrolling box edge A be the beginning edge in the block flow direction of scrolling box, and
     //    let element edge A be target bounding border box’s edge on the same physical side as that of
@@ -2783,7 +2797,7 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
         }
         // 2. Otherwise, if block is "end", then align element edge B with scrolling box edge B.
         else if (block == Bindings::ScrollLogicalPosition::End) {
-            y = element_edge_a + element_height - scrolling_box_height;
+            y = element_edge_b - scrolling_box_height;
         }
         // 3. Otherwise, if block is "center", then align the center of target bounding border box with the center of
         //    scrolling box in scrolling box’s block flow direction.
@@ -2806,7 +2820,7 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
             // If element edge B is outside scrolling box edge B and element height is less than scrolling box height
             else if ((element_edge_b >= scrolling_box_height && element_height < scrolling_box_height) || (element_edge_a <= 0 && element_height > scrolling_box_height)) {
                 // Align element edge B with scrolling box edge B.
-                y = element_edge_a + element_height - scrolling_box_height;
+                y = element_edge_b - scrolling_box_height;
             }
         }
 
@@ -2816,7 +2830,7 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
         }
         // 6. Otherwise, if inline is "end", then align element edge D with scrolling box edge D.
         else if (inline_ == Bindings::ScrollLogicalPosition::End) {
-            x = element_edge_d + element_width - scrolling_box_width;
+            x = element_edge_d - scrolling_box_width;
         }
         // 7. Otherwise, if inline is "center", then align the center of target bounding border box with the center of
         //    scrolling box in scrolling box’s inline base direction.
@@ -2839,9 +2853,14 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
             // If element edge D is outside scrolling box edge D and element width is less than scrolling box width
             else if ((element_edge_d >= scrolling_box_width && element_width < scrolling_box_width) || (element_edge_c <= 0 && element_width > scrolling_box_width)) {
                 // Align element edge D with scrolling box edge D.
-                x = element_edge_d + element_width - scrolling_box_width;
+                x = element_edge_d - scrolling_box_width;
             }
         }
+
+        // FIXME: 9. If target is an Element, and the target element defines some scroll snap positions, then the user
+        //           agent must scroll snap the resulting position to one of that element’s scroll snap positions if its
+        //           nearest scroll container is a scroll snap container. The user agent may also do this even when the
+        //           scroll container has scroll-snap-type: none.
 
         return CSSPixelPoint { x, y };
     }();
@@ -2882,8 +2901,9 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
         // FIXME: Actually check this condition.
         if (true) {
             // -> If scrolling box is associated with an element
-            if (scrolling_box.is_element()) {
+            if (auto* element = as_if<Element>(scrolling_box)) {
                 // FIXME: Perform a scroll of the element’s scrolling box to position, with the element as the associated element and behavior as the scroll behavior.
+                element->paintable_box()->set_scroll_offset(position);
             }
             // -> If scrolling box is associated with a viewport
             else if (scrolling_box.is_document()) {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-container.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-container.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Fail
+Fail	scrollIntoView() defaults to scrolling ancestors
+Fail	scrollIntoView({container: 'all'}) scrolls ancestors
+Fail	scrollIntoView({container: 'nearest'}) only scrolls nearest scroll container
+Fail	scrollIntoView({container: 'nearest'}) doesn't stop at itself
+Fail	scrollIntoView({container: 'nearest'}) doesn't propagate to outer frames

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-container.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-container.txt
@@ -2,9 +2,10 @@ Harness status: OK
 
 Found 5 tests
 
-5 Fail
-Fail	scrollIntoView() defaults to scrolling ancestors
-Fail	scrollIntoView({container: 'all'}) scrolls ancestors
-Fail	scrollIntoView({container: 'nearest'}) only scrolls nearest scroll container
-Fail	scrollIntoView({container: 'nearest'}) doesn't stop at itself
+4 Pass
+1 Fail
+Pass	scrollIntoView() defaults to scrolling ancestors
+Pass	scrollIntoView({container: 'all'}) scrolls ancestors
+Pass	scrollIntoView({container: 'nearest'}) only scrolls nearest scroll container
+Pass	scrollIntoView({container: 'nearest'}) doesn't stop at itself
 Fail	scrollIntoView({container: 'nearest'}) doesn't propagate to outer frames

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-horizontal-tb-writing-mode.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-horizontal-tb-writing-mode.txt
@@ -2,13 +2,13 @@ Harness status: OK
 
 Found 9 tests
 
-9 Fail
-Fail	scrollIntoView({"block":"start","inline":"start"})
-Fail	scrollIntoView({"block":"start","inline":"center"})
-Fail	scrollIntoView({"block":"start","inline":"end"})
-Fail	scrollIntoView({"block":"center","inline":"start"})
-Fail	scrollIntoView({"block":"center","inline":"center"})
-Fail	scrollIntoView({"block":"center","inline":"end"})
-Fail	scrollIntoView({"block":"end","inline":"start"})
-Fail	scrollIntoView({"block":"end","inline":"center"})
-Fail	scrollIntoView({"block":"end","inline":"end"})
+9 Pass
+Pass	scrollIntoView({"block":"start","inline":"start"})
+Pass	scrollIntoView({"block":"start","inline":"center"})
+Pass	scrollIntoView({"block":"start","inline":"end"})
+Pass	scrollIntoView({"block":"center","inline":"start"})
+Pass	scrollIntoView({"block":"center","inline":"center"})
+Pass	scrollIntoView({"block":"center","inline":"end"})
+Pass	scrollIntoView({"block":"end","inline":"start"})
+Pass	scrollIntoView({"block":"end","inline":"center"})
+Pass	scrollIntoView({"block":"end","inline":"end"})

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-horizontal-tb-writing-mode.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-horizontal-tb-writing-mode.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Fail
+Fail	scrollIntoView({"block":"start","inline":"start"})
+Fail	scrollIntoView({"block":"start","inline":"center"})
+Fail	scrollIntoView({"block":"start","inline":"end"})
+Fail	scrollIntoView({"block":"center","inline":"start"})
+Fail	scrollIntoView({"block":"center","inline":"center"})
+Fail	scrollIntoView({"block":"center","inline":"end"})
+Fail	scrollIntoView({"block":"end","inline":"start"})
+Fail	scrollIntoView({"block":"end","inline":"center"})
+Fail	scrollIntoView({"block":"end","inline":"end"})

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-scrolling-box-with-large-border.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-scrolling-box-with-large-border.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	scrollIntoView takes into account the border of the scroller

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-scrolling-box-with-large-border.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollIntoView-scrolling-box-with-large-border.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	scrollIntoView takes into account the border of the scroller
+1 Pass
+Pass	scrollIntoView takes into account the border of the scroller

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/resources/scrollIntoView-frame.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/resources/scrollIntoView-frame.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1">
+<style>
+body {
+  height: 600px;
+}
+#target {
+  position: absolute;
+  top: 400px;
+  height: 200px;
+}
+</style>
+<body>
+<div id="target"></div>
+</body>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrollIntoView-container.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrollIntoView-container.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<title>CSSOM View - scrollIntoView container option</title>
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1">
+<link rel="author" title="Rob Flack" href="mailto:flackr@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+.scroller {
+  overflow: auto;
+  height: 200px;
+}
+.spacer {
+  height: 400px;
+}
+#target {
+  height: 200px;
+}
+</style>
+<script>
+let setFrameLoaded = null;
+let frameLoaded = new Promise(resolve => {
+  setFrameLoaded = resolve;
+});
+</script>
+<div id="outer" class="scroller">
+  <div class="spacer"></div>
+  <div id="inner" class="scroller">
+    <div class="spacer"></div>
+    <div id="target"></div>
+    <iframe id="frame" height="200" src="resources/scrollIntoView-frame.html" onload="setFrameLoaded()"></iframe>
+  </div>
+</div>
+<script>
+const outer = document.getElementById('outer');
+const inner = document.getElementById('inner');
+const target = document.getElementById('target');
+
+function reset() {
+  outer.scrollTop = 0;
+  inner.scrollTop = 0;
+}
+
+test(() => {
+  reset();
+  target.scrollIntoView();
+  assert_equals(inner.scrollTop, 400, '#inner scrollTop');
+  assert_equals(outer.scrollTop, 400, '#outer scrollTop');
+}, `scrollIntoView() defaults to scrolling ancestors`);
+
+test(() => {
+  reset();
+  target.scrollIntoView({container: 'all'});
+  assert_equals(inner.scrollTop, 400, '#inner scrollTop');
+  assert_equals(outer.scrollTop, 400, '#outer scrollTop');
+}, `scrollIntoView({container: 'all'}) scrolls ancestors`);
+
+test(() => {
+  reset();
+  target.scrollIntoView({container: 'nearest'});
+  assert_equals(inner.scrollTop, 400, '#inner scrollTop');
+  assert_equals(outer.scrollTop, 0, '#outer scrollTop');
+}, `scrollIntoView({container: 'nearest'}) only scrolls nearest scroll container`);
+
+test(() => {
+  reset();
+  inner.scrollIntoView({container: 'nearest'});
+  assert_equals(outer.scrollTop, 400, '#outer scrollTop');
+  assert_equals(inner.scrollTop, 0, '#inner scrollTop');
+}, `scrollIntoView({container: 'nearest'}) doesn't stop at itself`);
+
+promise_test(async () => {
+  reset();
+  await frameLoaded;
+  const frameDoc = document.getElementById("frame").contentDocument;
+  const frameTarget = frameDoc.getElementById("target");
+  frameTarget.scrollIntoView({container: 'nearest'});
+  assert_equals(frameDoc.scrollingElement.scrollTop, 400, 'frame scrollingElement scrollTop');
+  assert_equals(inner.scrollTop, 0, '#inner scrollTop');
+  assert_equals(outer.scrollTop, 0, '#outer scrollTop');
+}, `scrollIntoView({container: 'nearest'}) doesn't propagate to outer frames`);
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrollIntoView-horizontal-tb-writing-mode.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrollIntoView-horizontal-tb-writing-mode.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<title>CSSOM View - scrollIntoView considers horizontal-tb writing mode</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="author" title="Cathie Chen" href="mailto:cathiechen@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+.box {
+  float: left;
+  width: 200px;
+  height: 200px;
+}
+#scroller {
+  overflow: scroll;
+  width: 300px;
+  height: 300px;
+}
+#container{
+  width: 600px;
+  height: 600px;
+}
+#target {
+  background-color: #ff0;
+}
+</style>
+<body>
+<div id="scroller">
+  <div id="container">
+    <!--  ROW-1  -->
+    <div class="row">
+      <div class="box"></div>
+      <div class="box"></div>
+      <div class="box"></div>
+    </div>
+
+    <!--  ROW-2  -->
+    <div class="row">
+      <div class="box"></div>
+      <div class="box" id="target"></div>
+      <div class="box"></div>
+    </div>
+
+    <!--  ROW-3  -->
+    <div class="row">
+      <div class="box"></div>
+      <div class="box"></div>
+      <div class="box"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+// In horizontal-tb mode, X corresponds to the inline axis and is oriented
+// rightward. Y corresponds to the block axis and is oriented downward.
+// So the beginning edges are the top and left edges and the ending
+// edges are the bottom and right edges.
+
+// This assumes that the horizontal scrollbar is on the bottom side and
+// the vertical scrollbar is on the right side.
+
+var target = document.getElementById("target");
+var scroller = document.getElementById("scroller");
+var scrollbar_width = scroller.offsetWidth - scroller.clientWidth;
+
+var scroller_width = scroller.offsetWidth;
+var scroller_height = scroller.offsetHeight;
+var box_width = target.offsetWidth;
+var box_height = target.offsetHeight;
+
+var expectedX = {
+    inlineStart: box_width,
+    inlineCenter: (3*box_width - scroller_width)/2 + scrollbar_width/2,
+    inlineEnd: 2*box_width - scroller_width + scrollbar_width,
+  };
+
+var expectedY = {
+  blockStart: box_height,
+  blockCenter: (3*box_height - scroller_height)/2 + scrollbar_width/2,
+  blockEnd: 2*box_height - scroller_height + scrollbar_width,
+};
+
+[
+  [{block: "start", inline: "start"}, expectedX.inlineStart, expectedY.blockStart],
+  [{block: "start", inline: "center"}, expectedX.inlineCenter, expectedY.blockStart],
+  [{block: "start", inline: "end"}, expectedX.inlineEnd, expectedY.blockStart],
+  [{block: "center", inline: "start"}, expectedX.inlineStart, expectedY.blockCenter],
+  [{block: "center", inline: "center"}, expectedX.inlineCenter, expectedY.blockCenter],
+  [{block: "center", inline: "end"}, expectedX.inlineEnd, expectedY.blockCenter],
+  [{block: "end", inline: "start"}, expectedX.inlineStart, expectedY.blockEnd],
+  [{block: "end", inline: "center"}, expectedX.inlineCenter, expectedY.blockEnd],
+  [{block: "end", inline: "end"}, expectedX.inlineEnd, expectedY.blockEnd],
+].forEach(([input, expectedX, expectedY]) => {
+  test(() => {
+    scroller.scrollTo(0, 0);
+    target.scrollIntoView(input);
+    assert_approx_equals(scroller.scrollLeft, expectedX, 0.5, "scrollX");
+    assert_approx_equals(scroller.scrollTop, expectedY, 0.5, "scrollY");
+  }, `scrollIntoView(${JSON.stringify(input)})`);
+})
+
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrollIntoView-scrolling-box-with-large-border.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrollIntoView-scrolling-box-with-large-border.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<title>CSSOM View - scrollIntoView should account for the border of scrollable elements.</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id="scroller" style="overflow: scroll; border: solid 100px; width: 100px; height: 100px;">
+    <div style="height: 1000px;"></div>
+    <div id="target" style="background: green; width: 100px; height: 100px"></div>
+    <div style="height: 1000px;"></div>
+</div>
+
+<script>
+    test(function() {
+        target.scrollIntoView();
+        assert_equals(1000, scroller.scrollTop, "Should scroll the target into view.");
+    }, "scrollIntoView takes into account the border of the scroller");
+</script>


### PR DESCRIPTION
Makes `scrollIntoView` work on regular scrollable boxes. With this change there are 14 more WPT tests passing.
This will also help #9060 pass some more WPT tests which fail due to `scrollIntoView` working only on the viewport.

There is still a lot more work to do with supporting different writing directions, but this is a quick win we can take.

Demo:
[Nagranie ekranu_20260503_141512.webm](https://github.com/user-attachments/assets/39bea8d8-85be-41b1-9a1c-9feb94e2792d)
