### PR TITLE
CI: Use CI build image for Linux jobs

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -57,7 +57,7 @@ runs:
           ccache -M 0
 
           # Reset all ccache modification dates to a known epoch. This provides a baseline that we can prune against.
-          find ${{ inputs.ccache_path }} | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
+          find "${{ inputs.ccache_path }}" | tac | xargs touch -a -m -d "2018-10-10T09:53:07Z"
 
           ccache -s
           ccache -z

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup action'
-description: 'Sets up the dependencies for the CI VM'
+description: 'Sets up shared CI tooling'
 author: 'Andrew Kaster <akaster@serenityos.org>'
 inputs:
   os:
@@ -11,37 +11,52 @@ inputs:
     required: true
     default: 'x86_64'
   toolchain:
-    description: 'Toolchain to set up'
+    description: 'Toolchain to use'
     required: true
     default: 'Clang'
-  gcc_version:
-    description: 'GCC version to install'
-    required: false
-    default: '14'
-  llvm_version:
-    description: 'LLVM version to install'
-    required: false
-    default: '21'
   type:
     description: 'Whether the setup is for building or linting'
     required: false
     default: 'build'
-
 outputs:
-  gcc_version:
-    description: 'The installed GCC version'
-    value: ${{ steps.export-versions.outputs.gcc_version }}
-  llvm_version:
-    description: 'The installed LLVM version'
-    value: ${{ steps.export-versions.outputs.llvm_version }}
+  ccache_path:
+    description: 'Path to the ccache directory'
+    value: ${{ steps.workspace.outputs.ccache_path }}
+  vcpkg_cache_path:
+    description: 'Path to the vcpkg binary cache'
+    value: ${{ steps.workspace.outputs.vcpkg_cache_path }}
 
 runs:
   using: "composite"
   steps:
+    - name: 'Set workspace environment'
+      id: 'workspace'
+      shell: bash
+      run: |
+        echo "LADYBIRD_SOURCE_DIR=${GITHUB_WORKSPACE}" >> "$GITHUB_ENV"
+        echo "CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache" >> "$GITHUB_ENV"
+        echo "VCPKG_ROOT=${GITHUB_WORKSPACE}/Build/vcpkg" >> "$GITHUB_ENV"
+        echo "ccache_path=${GITHUB_WORKSPACE}/.ccache" >> "$GITHUB_OUTPUT"
+        echo "vcpkg_cache_path=${GITHUB_WORKSPACE}/Build/caches/vcpkg-binary-cache" >> "$GITHUB_OUTPUT"
+        echo "GIT_CONFIG_GLOBAL=${RUNNER_TEMP}/gitconfig" >> "$GITHUB_ENV"
+        git config --file "${RUNNER_TEMP}/gitconfig" --add safe.directory "${GITHUB_WORKSPACE}"
+        mkdir -p "${RUNNER_TEMP}/pip-cache"
+        echo "PIP_CACHE_DIR=${RUNNER_TEMP}/pip-cache" >> "$GITHUB_ENV"
+
     - uses: actions/setup-python@v6
+      if: ${{ inputs.os != 'Linux' }}
       with:
         python-version: 3.12
         cache: 'pip'
+
+    # actions/setup-python can fail to find its tool-cache pip inside job containers.
+    - name: 'Set up Python environment'
+      if: ${{ inputs.os == 'Linux' }}
+      shell: bash
+      run: |
+        python3 -m venv "${RUNNER_TEMP}/ladybird-python"
+        echo "${RUNNER_TEMP}/ladybird-python/bin" >> "$GITHUB_PATH"
+        echo "pythonLocation=${RUNNER_TEMP}/ladybird-python" >> "$GITHUB_ENV"
 
     - name: 'Install Python dependencies'
       shell: bash
@@ -53,91 +68,6 @@ runs:
         else
           pip3 install ruff
         fi
-
-    - name: Install apt repositories
-      if: ${{ inputs.os == 'Linux' }}
-      shell: bash
-      run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-
-        UBUNTU_RELEASE=$(lsb_release -cs)
-
-        LLVM_LIST="/etc/apt/sources.list.d/llvm.list"
-        LLVM_TOOLCHAIN="llvm-toolchain-${UBUNTU_RELEASE}-${{ inputs.llvm_version }}"
-
-        if [ ! -f "${LLVM_LIST}" ] || ! grep -q "${LLVM_TOOLCHAIN}" "${LLVM_LIST}" ; then
-          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/${UBUNTU_RELEASE}/ ${LLVM_TOOLCHAIN} main" | sudo tee "${LLVM_LIST}"
-        fi
-
-        sudo apt-get update -y
-
-    - name: Install Dependencies
-      if: ${{ inputs.os == 'Linux' && inputs.type == 'build' }}
-      shell: bash
-      run: |
-        sudo apt-get install -y \
-            autoconf \
-            autoconf-archive \
-            automake \
-            bison \
-            build-essential \
-            ccache \
-            cmake \
-            curl \
-            fonts-liberation2 \
-            g++-${{ inputs.gcc_version }} \
-            gcc-${{ inputs.gcc_version }} \
-            libcurl4-openssl-dev \
-            libdrm-dev \
-            libegl1-mesa-dev \
-            libgl1-mesa-dev \
-            libpulse-dev \
-            libssl-dev \
-            libstdc++-${{ inputs.gcc_version }}-dev \
-            libtool \
-            libxkbcommon-dev \
-            lld-${{ inputs.llvm_version }} \
-            llvm-${{ inputs.llvm_version }} \
-            nasm \
-            ninja-build \
-            pulseaudio \
-            qt6-base-dev \
-            qt6-tools-dev-tools \
-            tar \
-            unzip \
-            zip
-
-        if ${{ inputs.toolchain == 'Clang' }} ; then
-          sudo apt-get install -y \
-              clang-${{ inputs.llvm_version }} \
-              clang++-${{ inputs.llvm_version }} \
-              clang-tools-${{ inputs.llvm_version }}
-
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ inputs.llvm_version }} 100
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ inputs.llvm_version }} 100
-        fi
-
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc_version }} 100
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc_version }} 100
-
-        sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-${{ inputs.llvm_version }} 100
-        sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-${{ inputs.llvm_version }} 100
-        sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-${{ inputs.llvm_version }} 100
-
-    - name: Install Dependencies
-      if: ${{ inputs.os == 'Linux' && inputs.type == 'lint' }}
-      shell: bash
-      run: |
-        sudo apt-get install -y \
-            clang-format-${{ inputs.llvm_version }} \
-            generate-ninja \
-            optipng \
-            shellcheck
-
-        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${{ inputs.llvm_version }} 100
-
-        sudo npm install -g prettier@3.8.1
 
     - name: Ensure clang-cl is available
       if: ${{ inputs.os == 'Windows' && inputs.toolchain == 'ClangCL' }}
@@ -173,7 +103,7 @@ runs:
             ccache \
             coreutils \
             libtool \
-            llvm@${{ inputs.llvm_version }} \
+            llvm@21 \
             nasm \
             ninja \
             pkg-config \
@@ -181,7 +111,7 @@ runs:
             unzip
 
     - name: 'Install Rust toolchain'
-      if: ${{ inputs.os != 'Windows' }}
+      if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: dtolnay/rust-toolchain@stable
 
     - name: 'Install wasm-tools'
@@ -213,23 +143,14 @@ runs:
         fi
         rm "${FILENAME}"
 
-        echo "${{ github.workspace }}/${NAME}" >> $GITHUB_PATH
+        echo "${GITHUB_WORKSPACE}/${NAME}" >> $GITHUB_PATH
 
     - name: 'Set required environment variables'
       if: ${{ inputs.os == 'Linux' && inputs.arch == 'arm64' }}
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('VCPKG_FORCE_SYSTEM_BINARIES', '1')
+      shell: bash
+      run: echo "VCPKG_FORCE_SYSTEM_BINARIES=1" >> "$GITHUB_ENV"
 
     - name: 'Install vcpkg'
       if: ${{ inputs.type == 'build' }}
       shell: bash
       run: ./Meta/Utils/build_vcpkg.py
-
-    - name: 'Export installed versions'
-      id: 'export-versions'
-      shell: bash
-      run: |
-        echo "gcc_version=${{ inputs.gcc_version }}" >> "$GITHUB_OUTPUT"
-        echo "llvm_version=${{ inputs.llvm_version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         toolchain: ['GNU']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3"}']
 
         include:
           - os_name: 'Linux'
@@ -29,6 +30,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: true
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
+            container: *ci_container
 
           - os_name: 'macOS'
             arch: 'arm64'
@@ -36,6 +38,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["macos-15", "self-hosted"]'
+            container: 'null'
 
           - os_name: 'Linux'
             arch: 'arm64'
@@ -43,6 +46,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404-arm"]'
+            container: *ci_container
 
           - os_name: 'Linux'
             arch: 'x86_64'
@@ -50,6 +54,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
+            container: *ci_container
 
           - os_name: 'Linux'
             arch: 'x86_64'
@@ -57,6 +62,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
+            container: *ci_container
 
           - os_name: 'Windows'
             arch: 'x86_64'
@@ -64,6 +70,7 @@ jobs:
             toolchain: 'ClangCL'
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-windows-2025"]'
+            container: 'null'
 
     secrets: inherit
     uses: ./.github/workflows/lagom-template.yml
@@ -74,3 +81,4 @@ jobs:
       arch: ${{ matrix.arch }}
       build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}
+      container: ${{ matrix.container }}

--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: github.repository == 'LadybirdBrowser/ladybird'
     name: ${{ matrix.os_name }}, ${{ matrix.arch }}
+    container: ${{ fromJSON(matrix.container) }}
 
     strategy:
       fail-fast: false
@@ -29,6 +30,7 @@ jobs:
         toolchain: ['Clang']
         package_type: ['Linux-x86_64']
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404"]']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3"}']
 
         include:
           - os_name: 'macOS'
@@ -36,12 +38,14 @@ jobs:
             toolchain: 'Clang'
             package_type: 'macOS-arm64'
             runner_labels: '["macos-15", "self-hosted"]'
+            container: 'null'
 
           - os_name: 'Linux'
             arch: 'arm64'
             toolchain: 'Clang'
             package_type: 'Linux-aarch64'
             runner_labels: '["blacksmith-8vcpu-ubuntu-2404-arm"]'
+            container: *ci_container
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird
@@ -63,8 +67,8 @@ jobs:
           git checkout origin/master -- .github/actions
 
       - name: "Set up environment"
-        uses: ./.github/actions/setup
         id: 'setup'
+        uses: ./.github/actions/setup
         with:
           os: ${{ matrix.os_name }}
           arch: ${{ matrix.arch }}
@@ -77,14 +81,14 @@ jobs:
           arch: ${{ matrix.arch }}
           toolchain: ${{ matrix.toolchain }}
           cache_key_extra: 'LibJS and LibWasm Artifacts'
-          ccache_path: ${{ env.CCACHE_DIR }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
 
       - name: Create build directory Ubuntu
         run: |
           cmake --preset Distribution \
-            -DCMAKE_C_COMPILER=clang-${{ steps.setup.outputs.llvm_version }} \
-            -DCMAKE_CXX_COMPILER=clang++-${{ steps.setup.outputs.llvm_version }} \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
             -DENABLE_CI_BASELINE_CPU=ON \
             -DENABLE_GUI_TARGETS=OFF
         if: ${{ matrix.os_name == 'Linux' }}
@@ -130,9 +134,9 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           arch: 'Lagom'
-          ccache_path: ${{ env.CCACHE_DIR }}
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
 
       - name: Sanity-check the js repl
@@ -154,7 +158,7 @@ jobs:
           path="Build/distribution/ladybird-wasm-${{ matrix.package_type }}.tar.gz"
           if [ -f "${path}" ]; then
             tar -xvzf "${path}"
-            bin/wasm -e run_sanity_check -w ${{ github.workspace }}/Libraries/LibWasm/Tests/CI/ci-sanity-check.wasm > wasm-repl-out.txt
+            bin/wasm -e run_sanity_check -w "${GITHUB_WORKSPACE}/Libraries/LibWasm/Tests/CI/ci-sanity-check.wasm" > wasm-repl-out.txt
             if ! grep -q "Hello, World\!" wasm-repl-out.txt; then
               echo "Sanity check failed: Hello, World\! not found in output."
               exit 1

--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: ${{ github.repository == 'LadybirdBrowser/ladybird' && github.event.workflow_run.conclusion == 'success' }}
     name: ${{ matrix.os_name }}, ${{ matrix.arch }}
+    container: ${{ fromJSON(matrix.container) }}
 
     strategy:
       fail-fast: false
@@ -19,12 +20,14 @@ jobs:
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "js-benchmarks", "self-hosted"]']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3"}']
 
         include:
           - os_name: 'macOS'
             arch: 'arm64'
             package_type: 'macOS-arm64'
             runner_labels: '["macos-15", "js-benchmarks", "self-hosted"]'
+            container: 'null'
 
     permissions:
       actions: read
@@ -44,13 +47,6 @@ jobs:
         run: |
           cd js-benchmarks
           echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-
-      - name: 'Install dependencies'
-        if: ${{ matrix.os_name == 'Linux' }}
-        shell: bash
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y python3-venv
 
       - name: 'Download JS repl artifact'
         uses: dawidd6/action-download-artifact@v21
@@ -97,10 +93,10 @@ jobs:
 
           run_options='--iterations=5'
 
-          js_path="${{ github.workspace }}/js-repl/bin/js"
+          js_path="${GITHUB_WORKSPACE}/js-repl/bin/js"
           run_options="${run_options} --executable=${js_path}"
 
-          wasm_path="${{ github.workspace }}/wasm-repl/bin/wasm"
+          wasm_path="${GITHUB_WORKSPACE}/wasm-repl/bin/wasm"
           if [ -x "${wasm_path}" ]; then
               run_options="${run_options} --wasm-executable=${wasm_path}"
           else

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -22,6 +22,10 @@ on:
         required: false
         type: boolean
         default: false
+      container:
+        required: false
+        type: string
+        default: 'null'
 
 env:
   # runner.workspace = /home/runner/work/ladybird
@@ -39,6 +43,7 @@ env:
 jobs:
   CI:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    container: ${{ fromJSON(inputs.container) }}
 
     steps:
       # Pull requests can trail behind `master` and can cause breakage if merging before running the CI checks on an updated branch.
@@ -76,11 +81,11 @@ jobs:
             fi
 
             if ${{ inputs.toolchain == 'Clang' }} ; then
-              echo "host_cc=clang-${{ steps.setup.outputs.llvm_version }}" >> "$GITHUB_OUTPUT"
-              echo "host_cxx=clang++-${{ steps.setup.outputs.llvm_version }}" >> "$GITHUB_OUTPUT"
+              echo "host_cc=clang" >> "$GITHUB_OUTPUT"
+              echo "host_cxx=clang++" >> "$GITHUB_OUTPUT"
             elif ${{ inputs.toolchain == 'GNU' }} ; then
-              echo "host_cc=gcc-${{ steps.setup.outputs.gcc_version }}" >> "$GITHUB_OUTPUT"
-              echo "host_cxx=g++-${{ steps.setup.outputs.gcc_version }}" >> "$GITHUB_OUTPUT"
+              echo "host_cc=gcc" >> "$GITHUB_OUTPUT"
+              echo "host_cxx=g++" >> "$GITHUB_OUTPUT"
             fi
           elif ${{ inputs.os_name == 'macOS' }} ; then
             echo "host_cc=$(xcrun --find clang)" >> "$GITHUB_OUTPUT"
@@ -109,8 +114,8 @@ jobs:
           arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
           cache_key_extra: ${{ inputs.os_name == 'Windows' && inputs.build_preset || steps.build-parameters.outputs.ccache_key }}
-          ccache_path: ${{ env.CCACHE_DIR }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
 
       - name: Set dynamic environment variables
         if: ${{ inputs.os_name != 'Windows' }}
@@ -149,20 +154,20 @@ jobs:
           VCPKG_CACHE_SAS: ${{ github.ref == 'refs/heads/master' && secrets.VCPKG_CACHE_SAS || '' }}
           VCPKG_CACHE_MODE: ${{ github.ref == 'refs/heads/master' && 'write' || '' }}
         run: |
-          cmake --preset=Distribution -B ${{ github.workspace }}/Build/tools-build \
+          cmake --preset=Distribution -B "${GITHUB_WORKSPACE}/Build/tools-build" \
             -DLAGOM_TOOLS_ONLY=ON \
             -DINSTALL_LAGOM_TOOLS=ON \
-            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/Build/tools-install \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/Build/tools-install" \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -Dpackage=LagomTools
 
-          ninja -C ${{ github.workspace }}/Build/tools-build install
+          ninja -C "${GITHUB_WORKSPACE}/Build/tools-build" install
 
           cmake --preset ${{ inputs.build_preset }} -B Build \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Build/tools-install
+            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/Build/tools-install"
 
       # === BUILD ===
 
@@ -170,7 +175,7 @@ jobs:
         working-directory: ${{ github.workspace }}/Build
         run: |
           cmake --build .
-          cmake --install . --strip --prefix ${{ github.workspace }}/Install
+          cmake --install . --strip --prefix "${GITHUB_WORKSPACE}/Install"
 
       - name: Build with Qt
         if: ${{ (inputs.os_name == 'macOS' || inputs.os_name == 'Linux') && inputs.build_preset == 'Sanitizer' }}
@@ -183,16 +188,20 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           arch: ${{ inputs.arch }}
-          ccache_path: ${{ env.CCACHE_DIR }}
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
 
       # === TEST ===
 
       - name: Start PulseAudio
         if: ${{ inputs.os_name == 'Linux' }}
-        run: pulseaudio -D --exit-idle-time=1800 --load="module-null-sink sink_name=virtual_sink"
+        run: |
+          echo "PULSE_SERVER=unix:/tmp/pulse-native" >> "$GITHUB_ENV"
+          pulseaudio --system -D --exit-idle-time=1800 \
+            --load="module-native-protocol-unix auth-anonymous=1 socket=/tmp/pulse-native" \
+            --load="module-null-sink sink_name=virtual_sink"
 
       - name: Test
         if: ${{ inputs.build_preset == 'Sanitizer' }}
@@ -201,8 +210,8 @@ jobs:
         env:
           TESTS_ONLY: 1
           # NOTE: These are appended to the preset's options.
-          ASAN_OPTIONS: 'log_path="${{ github.workspace }}/asan.log"'
-          UBSAN_OPTIONS: 'log_path="${{ github.workspace }}/ubsan.log"'
+          ASAN_OPTIONS: 'log_path=asan.log'
+          UBSAN_OPTIONS: 'log_path=ubsan.log'
 
       - name: Test
         if: ${{ inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' && inputs.build_preset != 'Sanitizer' }}

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -15,6 +15,8 @@ jobs:
   run_and_update_results:
     runs-on: 'blacksmith-16vcpu-ubuntu-2404'
     if: github.repository == 'LadybirdBrowser/ladybird'
+    container:
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird
@@ -47,8 +49,8 @@ jobs:
           path: test262-parser-tests
 
       - name: Set up environment
-        uses: ./.github/actions/setup
         id: 'setup'
+        uses: ./.github/actions/setup
         with:
           os: 'Linux'
           arch: 'x86_64'
@@ -66,8 +68,8 @@ jobs:
           arch: 'x86_64'
           toolchain: 'Clang'
           cache_key_extra: 'test262'
-          ccache_path: ${{ env.CCACHE_DIR }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
 
       - name: Get previous results
         run: |
@@ -77,8 +79,8 @@ jobs:
       - name: Build test262-runner, test-js, test-wasm and test-js-bytecode
         run: |
           cmake --preset Release -B libjs-test262/Build \
-            -DCMAKE_C_COMPILER=clang-${{ steps.setup.outputs.llvm_version }} \
-            -DCMAKE_CXX_COMPILER=clang++-${{ steps.setup.outputs.llvm_version }} \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
             -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \
             -DINCLUDE_WASM_SPEC_TESTS=ON \
             -DENABLE_GUI_TARGETS=OFF
@@ -88,9 +90,9 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           arch: 'x86_64'
-          ccache_path: ${{ env.CCACHE_DIR }}
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
 
       - name: Run test262 and test262-parser-tests

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -6,18 +6,18 @@ jobs:
   lint:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
+    container:
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3
 
     steps:
       - uses: actions/checkout@v6.0.2
 
       - name: Set Up Environment
         uses: ./.github/actions/setup
-        id: 'setup'
         with:
           os: 'Linux'
           arch: 'x86_64'
-          llvm_version: 21
           type: 'lint'
 
       - name: Lint
-        run: ${{ github.workspace }}/Meta/lint-ci.sh
+        run: "${GITHUB_WORKSPACE}/Meta/lint-ci.sh"

--- a/.github/workflows/nightly-android.yml
+++ b/.github/workflows/nightly-android.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Set Up Environment
+        id: 'setup'
         uses: ./.github/actions/setup
         with:
           os: ${{ matrix.os_name }}
@@ -54,8 +55,8 @@ jobs:
           arch: 'Lagom'
           toolchain: 'Clang'
           cache_key_extra: 'Nightly Android'
-          ccache_path: ${{ env.CCACHE_DIR }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
 
       - name: Assign Build Parameters
         id: 'build-parameters'
@@ -101,7 +102,7 @@ jobs:
         uses: ./.github/actions/cache-save
         with:
           arch: 'Lagom'
-          ccache_path: ${{ env.CCACHE_DIR }}
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -24,6 +24,7 @@ jobs:
         toolchain: ['Clang']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404-arm"]']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3"}']
 
         include:
           - os_name: 'Linux'
@@ -32,6 +33,7 @@ jobs:
             toolchain: 'GNU'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-ubuntu-2404"]'
+            container: *ci_container
 
           - os_name: 'macOS'
             arch: 'arm64'
@@ -39,6 +41,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["macos-15", "self-hosted"]'
+            container: 'null'
 
           - os_name: 'Linux'
             arch: 'arm64'
@@ -46,6 +49,7 @@ jobs:
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-ubuntu-2404-arm"]'
+            container: *ci_container
 
           - os_name: 'Windows'
             arch: 'x86_64'
@@ -53,6 +57,7 @@ jobs:
             toolchain: 'ClangCL'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-windows-2025"]'
+            container: 'null'
 
     secrets: inherit
     uses: ./.github/workflows/lagom-template.yml
@@ -63,6 +68,7 @@ jobs:
       arch: ${{ matrix.arch }}
       build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}
+      container: ${{ matrix.container }}
 
   flatpak:
     if: github.repository == 'LadybirdBrowser/ladybird'

--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: ${{ github.repository == 'LadybirdBrowser/ladybird' }}
     name: ${{ matrix.os_name }}, ${{ matrix.arch }}
+    container: ${{ fromJSON(matrix.container) }}
 
     strategy:
       fail-fast: false
@@ -21,11 +22,13 @@ jobs:
         os_name: ['Linux']
         arch: ['x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "web-benchmarks", "self-hosted"]']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.05.3"}']
 
         include:
           - os_name: 'macOS'
             arch: 'arm64'
             runner_labels: '["macos-15", "web-benchmarks", "self-hosted"]'
+            container: 'null'
 
     permissions:
       actions: read
@@ -58,8 +61,8 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Set Up Environment'
-        uses: ./.github/actions/setup
         id: 'setup'
+        uses: ./.github/actions/setup
         with:
           os: ${{ matrix.os_name }}
           arch: ${{ matrix.arch }}
@@ -73,16 +76,16 @@ jobs:
           arch: ${{ matrix.arch }}
           toolchain: 'Clang'
           cache_key_extra: 'Distribution'
-          ccache_path: ${{ env.CCACHE_DIR }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
 
       - name: 'Assign Build Parameters'
         id: 'build-parameters'
         shell: bash
         run: |
           if ${{ matrix.os_name == 'Linux' }} ; then
-            echo "host_cc=clang-${{ steps.setup.outputs.llvm_version }}" >> "$GITHUB_OUTPUT"
-            echo "host_cxx=clang++-${{ steps.setup.outputs.llvm_version }}" >> "$GITHUB_OUTPUT"
+            echo "host_cc=clang" >> "$GITHUB_OUTPUT"
+            echo "host_cxx=clang++" >> "$GITHUB_OUTPUT"
           elif ${{ matrix.os_name == 'macOS' }} ; then
             echo "host_cc=$(xcrun --find clang)" >> "$GITHUB_OUTPUT"
             echo "host_cxx=$(xcrun --find clang++)" >> "$GITHUB_OUTPUT"
@@ -101,15 +104,15 @@ jobs:
         working-directory: ${{ github.workspace }}/Build
         run: |
           cmake --build .
-          cmake --install . --strip --prefix ${{ github.workspace }}/Install
+          cmake --install . --strip --prefix "${GITHUB_WORKSPACE}/Install"
 
       - name: 'Save Caches'
         uses: ./.github/actions/cache-save
         with:
           arch: ${{ matrix.arch }}
-          ccache_path: ${{ env.CCACHE_DIR }}
+          ccache_path: ${{ steps.setup.outputs.ccache_path }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
-          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_path: ${{ steps.setup.outputs.vcpkg_cache_path }}
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
 
       - name: 'Run the benchmarks'
@@ -121,9 +124,9 @@ jobs:
           python3 -m pip install -r requirements.txt
 
           if [ "${{ matrix.os_name }}" = "macOS" ]; then
-            executable="${{ github.workspace }}/Install/bundle/Ladybird.app/Contents/MacOS/Ladybird"
+            executable="${GITHUB_WORKSPACE}/Install/bundle/Ladybird.app/Contents/MacOS/Ladybird"
           else
-            executable="${{ github.workspace }}/Install/bin/Ladybird"
+            executable="${GITHUB_WORKSPACE}/Install/bin/Ladybird"
           fi
 
           ./run.py --iterations=5 --executable="${executable}"

--- a/Meta/Linters/check_flatpak.py
+++ b/Meta/Linters/check_flatpak.py
@@ -9,13 +9,14 @@ import json
 import os
 import subprocess
 import sys
+import urllib.request
 
 from enum import Enum
 
 VCPKG = "vcpkg.json"
 VCPKG_OVERLAYS_PORTS = "Meta/CMake/vcpkg/overlay-ports/*"
-VCPKG_URL = "https://github.com/microsoft/vcpkg.git"
 VCPKG_REPO = "Build/vcpkg"
+VCPKG_BASELINE_URL = "https://raw.githubusercontent.com/microsoft/vcpkg/{}/versions/baseline.json"
 FLATPAK_MANIFEST = "Meta/CMake/flatpak/org.ladybird.Ladybird.json"
 SELF = "Ladybird"
 
@@ -74,26 +75,42 @@ class DepMatch(Enum):
     Excluded = (3,)
 
 
+baseline_versions = {}
+
+
 def get_baseline_version(baseline, name):
-    if not os.path.isdir(VCPKG_REPO):
-        cmd = f"git clone --revision {baseline} --depth 1 {VCPKG_URL} {VCPKG_REPO}"
-        subprocess.run(cmd, stdout=subprocess.PIPE, shell=True, check=True)
+    if baseline not in baseline_versions:
+        if os.path.isdir(VCPKG_REPO):
+            # Clear GIT_DIR so git operates on the vcpkg repo, not the parent repo (pre-commit sets GIT_DIR)
+            env = {k: v for k, v in os.environ.items() if k != "GIT_DIR"}
+            try:
+                result = subprocess.run(
+                    ["git", "-C", VCPKG_REPO, "show", f"{baseline}:versions/baseline.json"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                    env=env,
+                    text=True,
+                )
+                baseline_versions[baseline] = json.loads(result.stdout)
+            except (subprocess.CalledProcessError, json.JSONDecodeError):
+                pass
 
-    # Query the current vcpkg baseline for its version of this package, this becomes the reference for linting
-    # Clear GIT_DIR so git operates on the vcpkg repo, not the parent repo (pre-commit sets GIT_DIR)
-    env = {k: v for k, v in os.environ.items() if k != "GIT_DIR"}
-    cmd = f"cd {VCPKG_REPO} && git show {baseline}:versions/baseline.json 2> /dev/null | grep -E -A 3 -e '\"{name}\"'"
-    try:
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, shell=True, check=True, env=env)
+        if baseline not in baseline_versions:
+            url = VCPKG_BASELINE_URL.format(baseline)
 
-        if not result.returncode:
-            json_string = result.stdout.decode("utf-8").replace("\n", "").removesuffix(",")
-            result = json.loads(f"{{{json_string}}}")
+            try:
+                with urllib.request.urlopen(url) as response:
+                    baseline_versions[baseline] = json.load(response)
+            except Exception as error:
+                print(f"Failed to fetch vcpkg baseline {baseline[:7]}: {error}")
+                baseline_versions[baseline] = {}
 
-            if "baseline" in result[name]:
-                return result[name]["baseline"]
-    except subprocess.CalledProcessError:
-        print(f"{name} cannot be matched, {VCPKG_REPO} is not at baseline revision: {baseline[:7]}")
+    port = baseline_versions[baseline].get("default", {}).get(name)
+    if port and "baseline" in port:
+        return port["baseline"]
+
+    print(f"{name} cannot be matched, vcpkg baseline revision: {baseline[:7]}")
 
 
 def check_for_match(vcpkg: dict, vcpkg_baseline, name: str, identifier: str) -> DepMatch:


### PR DESCRIPTION
This means running the build inside a Docker container based on a (more) stable build image.

  * The setup action is now largely simplified for Linux.

  * We hardcode llvm@21 for macOS since it allows us to get rid of specifying llvm_version as an input variable. Since we no longer support switching the LLVM version on Linux via that variable, this seems like the best course of action.

We use a trick to optionally introduce a container image: `fromJSON()` allows `null` as a return value, which causes the job to execute on the runner directly. We need this for macOS and Windows jobs.