### PR TITLE
LibWeb: Reuse initial about:blank window for first same-origin load 

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -332,19 +332,17 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
 
     // 5. Let window be null.
     GC::Ptr<HTML::Window> window;
+    bool reused_initial_about_blank_window = false;
 
     // 6. If browsingContext's active document's is initial about:blank is true,
     //    and browsingContext's active document's origin is same origin-domain with navigationParams's origin,
     //    then set window to browsingContext's active window.
-    // FIXME: still_on_its_initial_about_blank_document() is not in the spec anymore.
-    //        However, replacing this with the spec-mandated is_initial_about_blank() results in the browsing context
-    //        holding an incorrect active document for the replace from initial about:blank to the real document.
-    //        See #22293 for more details.
-    if (false
-        && (browsing_context->active_document() && browsing_context->active_document()->origin().is_same_origin(navigation_params.origin))) {
+    VERIFY(browsing_context->active_document());
+    if (browsing_context->active_document()->is_initial_about_blank()
+        && browsing_context->active_document()->origin().is_same_origin_domain(navigation_params.origin)) {
         window = browsing_context->active_window();
+        reused_initial_about_blank_window = true;
     }
-
     // 7. Otherwise:
     else {
         // FIXME: 1. Let oacHeader be the result of getting a structured field value given `Origin-Agent-Cluster` and "item" from response's header list.
@@ -460,7 +458,11 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
     }
 
     // 10. Set window's associated Document to document.
-    window->set_associated_document(*document);
+    // AD-HOC: When replacing the initial about:blank, defer swapping the associated document until activation so the browsing
+    //         context continues to expose the initial document as active until the new document is actually activated.
+    //         See spec issue: https://github.com/whatwg/html/issues/12415
+    if (!reused_initial_about_blank_window)
+        window->set_associated_document(*document);
 
     // 11. Run CSP initialization for a Document given document.
     document->run_csp_initialization();
@@ -5208,6 +5210,9 @@ void Document::make_active()
 {
     // 1. Let window be document's relevant global object.
     auto& window = as<HTML::Window>(HTML::relevant_global_object(*this));
+
+    // AD-HOC: Deferred intialization from Document::create_and_initialize, see: https://github.com/whatwg/html/issues/12415
+    window.set_associated_document(*this);
 
     set_window(window);
 

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -344,16 +344,20 @@ GC::Ptr<BrowsingContext> BrowsingContext::top_level_browsing_context() const
     return navigable->active_browsing_context();
 }
 
+// https://html.spec.whatwg.org/multipage/document-sequences.html#active-document
 DOM::Document const* BrowsingContext::active_document() const
 {
+    // A browsing context's active document is its active window's associated Document.
     auto* window = active_window();
     if (!window)
         return nullptr;
     return &window->associated_document();
 }
 
+// https://html.spec.whatwg.org/multipage/document-sequences.html#active-document
 DOM::Document* BrowsingContext::active_document()
 {
+    // A browsing context's active document is its active window's associated Document.
     auto* window = active_window();
     if (!window)
         return nullptr;
@@ -363,12 +367,14 @@ DOM::Document* BrowsingContext::active_document()
 // https://html.spec.whatwg.org/multipage/browsers.html#active-window
 HTML::Window* BrowsingContext::active_window()
 {
+    // A browsing context's active window is its WindowProxy object's [[Window]] internal slot value.
     return m_window_proxy->window();
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#active-window
 HTML::Window const* BrowsingContext::active_window() const
 {
+    // A browsing context's active window is its WindowProxy object's [[Window]] internal slot value.
     return m_window_proxy->window();
 }
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -225,6 +225,7 @@ Text/input/wpt-import/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml
 Text/input/wpt-import/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-9.htm
 Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.html
 Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url-entry-document-sync-call.window.html
+Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.html
 Text/input/wpt-import/navigation-api/navigation-methods/reload-state-and-info.html
 Text/input/wpt-import/navigation-api/navigation-methods/reload-state-undefined.html
 Text/input/wpt-import/page-visibility/test_child_document.html

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	Fulfillment handler on fulfilled promise
+Pass	Rejection handler on rejected promise
+Pass	Fulfillment handler on pending-then-fulfilled promise
+Pass	Rejection handler on pending-then-rejected promise
+Pass	Thenable resolution

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/promise-job-entry-different-function-realm.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Entry settings object for promise jobs when the function realm is different from the test realm</title>
+<script src="../../../../../resources/testharness.js"></script>
+<script src="../../../../../resources/testharnessreport.js"></script>
+<!-- https://github.com/whatwg/html/pull/5212 -->
+<!-- https://github.com/whatwg/html/issues/1426 -->
+
+<!-- This is what would normally be considered the entry page. However, we use functions from the
+     resources/function/function.html realm. So window.open() should resolve relative to that realm
+     inside promise jobs. -->
+
+<iframe src="resources/promise-job-entry-incumbent.html"></iframe>
+<iframe src="resources/function/function.html" id="function-frame"></iframe>
+
+<script>
+setup({ explicit_done: true });
+
+const relativeURL = "resources/window-to-open.html";
+const expectedURL = (new URL(relativeURL, document.querySelector("#function-frame").src)).href;
+
+const incumbentWindow = frames[0];
+const functionWindow = frames[1];
+const FunctionFromAnotherWindow = frames[1].Function;
+
+window.onload = () => {
+  async_test(t => {
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    Promise.resolve([incumbentWindow, relativeURL, t, assert_equals, expectedURL]).then(func);
+  }, "Fulfillment handler on fulfilled promise");
+
+  async_test(t => {
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    Promise.reject([incumbentWindow, relativeURL, t, assert_equals, expectedURL]).catch(func);
+  }, "Rejection handler on rejected promise");
+
+  async_test(t => {
+    let resolve;
+    const p = new Promise(r => { resolve = r; });
+
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    p.then(func);
+    t.step_timeout(() => resolve([incumbentWindow, relativeURL, t, assert_equals, expectedURL]), 0);
+  }, "Fulfillment handler on pending-then-fulfilled promise");
+
+  async_test(t => {
+    let reject;
+    const p = new Promise((_, r) => { reject = r; });
+
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = arguments[0];
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    p.catch(func);
+    t.step_timeout(() => reject([incumbentWindow, relativeURL, t, assert_equals, expectedURL]), 0);
+  }, "Rejection handler on pending-then-rejected promise");
+
+  async_test(t => {
+    t.add_cleanup(() => { delete frames[1].args; });
+    frames[1].args = [incumbentWindow, relativeURL, t, assert_equals, expectedURL];
+
+    const func = FunctionFromAnotherWindow(`
+      const [incumbentWindow, relativeURL, t, assert_equals, expectedURL] = window.args;
+
+      const w = incumbentWindow.runWindowOpenVeryIndirectly(relativeURL);
+      w.onload = t.step_func_done(() => {
+        t.add_cleanup(() => w.close());
+        assert_equals(w.location.href, expectedURL);
+      });
+    `);
+
+    const thenable = { then: func };
+
+    Promise.resolve(thenable);
+  }, "Thenable resolution");
+
+  done();
+};
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/current.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/current.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Current page used as a test helper</title>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/resources/window-to-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/current/resources/window-to-open.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If the current settings object is used this page will be opened</title>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/function.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/function.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Realm for a "then" function used as a test helper</title>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/resources/window-to-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/function/resources/window-to-open.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If the function's settings object is used this page will be opened</title>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-entry-incumbent.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/promise-job-entry-incumbent.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Incumbent page used as a test helper</title>
+
+<iframe src="relevant/relevant.html" id="r"></iframe>
+<iframe src="current/current.html" id="c"></iframe>
+
+<script>
+  const relevant = document.querySelector("#r");
+  const current = document.querySelector("#c");
+
+  window.runWindowOpenVeryIndirectly = (...args) => {
+    return current.contentWindow.open.call(relevant.contentWindow, ...args);
+  };
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/relevant.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Relevant page used as a test helper</title>
+
+<script>
+// promise-job-incumbent will end up posting a message to here. We need to signal back the "source".
+
+window.onmessage = e => {
+  const testId = e.data;
+  const sourceURL = e.source.document.URL;
+
+  window.dispatchEvent(new CustomEvent("messagereceived", { detail: [testId, sourceURL] }));
+};
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/resources/window-to-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/relevant/resources/window-to-open.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If the relevant settings object is used this page will be opened</title>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/window-to-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-job-queue/resources/window-to-open.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If the entry settings object is used this page will be opened</title>


### PR DESCRIPTION
Follow the spec reuse of the initial same-origin about:blank window for
a browsing context's first real navigation. This fixes a crash in
promise-job-entry-different-function-realm.html by preserving the
correct iframe realm.

Making this change also requires another AD-HOC workaround to defer
updating the reused window's associated document until activation,
since doing so during document creation makes the browsing context's
active document change too early. For this I have raised an issue to the
HTML spec, which was originally suspected as a spec issue in
https://github.com/serenityos/serenity/issues/22293