### PR TITLE
AK: Align UTF-16 string storage

### DIFF
--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -153,7 +153,8 @@ private:
 
     union {
         char m_ascii_data[0];
-        char16_t m_utf16_data[0];
+        // simdutf writes directly into this buffer, so keep it aligned for its vectorized stores.
+        alignas(16) char16_t m_utf16_data[0];
     };
 };
 

--- a/Tests/LibJS/Runtime/non-ascii-long-source.js
+++ b/Tests/LibJS/Runtime/non-ascii-long-source.js
@@ -1,0 +1,5 @@
+test("long source containing non-ASCII text parses", () => {
+    var value = "ę" + "x".repeat(102);
+
+    expect(value.length).toBe(103);
+});


### PR DESCRIPTION
Align Utf16StringData's UTF-16 flexible storage before it is handed to simdutf for UTF-8 conversion. The previous layout placed the buffer at a 2-byte-aligned offset, so larger vectorized conversions could leave the first code unit corrupted; the Rust parser then saw U+0000 at the start of otherwise valid non-ASCII source and emitted TokenType::Invalid.

Add a LibJS regression covering a long source with non-ASCII text, matching the maps.google.com inline-script failure mode.