### PR TITLE
LibWeb: Clear stale layout state for hidden slot slottables

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -826,6 +826,16 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             }
 
             pop_parent();
+        } else {
+            // Assigned slottables are not DOM descendants of the slot, so the generic
+            // content-visibility:hidden descendant cleanup above does not reach them.
+            for (auto const& slottable : slot_element.assigned_nodes_internal()) {
+                slottable.visit([&](DOM::Node& slottable_root) {
+                    slottable_root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                        return clear_stale_layout_and_paint_node(node, &slottable_root);
+                    });
+                });
+            }
         }
     }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -639,9 +639,9 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
     ScopeGuard remove_stale_layout_node_guard = [&] {
         // If we didn't create a layout node for this DOM node,
-        // go through the DOM tree and remove any old layout & paint nodes since they are now all stale.
+        // go through the shadow-including subtree and remove any old layout & paint nodes since they are now all stale.
         if (!layout_node) {
-            dom_node.for_each_in_inclusive_subtree([&](auto& node) {
+            dom_node.for_each_shadow_including_inclusive_descendant([&](auto& node) {
                 return clear_stale_layout_and_paint_node(node);
             });
         }

--- a/Tests/LibWeb/Crash/Layout/intersection-observer-details-descendants-slot-stale-paintable.html
+++ b/Tests/LibWeb/Crash/Layout/intersection-observer-details-descendants-slot-stale-paintable.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<style>
+    details {
+        margin: 40px;
+    }
+
+    details-menu {
+        display: none;
+    }
+
+    details[open] details-menu {
+        display: block;
+    }
+
+    .list {
+        height: 200px;
+        overflow: auto;
+    }
+
+    .item {
+        display: flex;
+        height: 32px;
+        align-items: center;
+    }
+
+    .target {
+        width: 20px;
+        height: 20px;
+        background: green;
+    }
+</style>
+<details id="details" open>
+    <summary>summary</summary>
+    <details-menu>
+        <div class="list">
+            <a class="item"><div id="target" class="target"></div></a>
+        </div>
+    </details-menu>
+</details>
+<script>
+    const details = document.getElementById("details");
+    const target = document.getElementById("target");
+
+    new IntersectionObserver(() => {}).observe(target);
+    target.getBoundingClientRect();
+
+    requestAnimationFrame(() => {
+        details.removeAttribute("open");
+
+        requestAnimationFrame(() => {
+            internals.signalTestIsDone("PASS");
+        });
+    });
+</script>

--- a/Tests/LibWeb/Crash/Layout/intersection-observer-shadow-host-display-none-stale-paintable.html
+++ b/Tests/LibWeb/Crash/Layout/intersection-observer-shadow-host-display-none-stale-paintable.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<div id="host"></div>
+<script>
+    const host = document.getElementById("host");
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `
+        <style>
+            #target {
+                width: 20px;
+                height: 20px;
+                background: green;
+                transform: translateX(10px);
+            }
+        </style>
+        <div id="target"></div>
+    `;
+    const target = shadowRoot.getElementById("target");
+
+    new IntersectionObserver(() => {}).observe(target);
+    target.getBoundingClientRect();
+
+    requestAnimationFrame(() => {
+        host.style.display = "none";
+
+        requestAnimationFrame(() => {
+            internals.signalTestIsDone("PASS");
+        });
+    });
+</script>


### PR DESCRIPTION
When a slot gets content-visibility: hidden, the existing subtree cleanup does not reach assigned slottables, since they are not DOM descendants of the slot.

Clear layout and paint nodes from those assigned subtrees as well, so IntersectionObserver cannot later query geometry through stale paintables.