### PR TITLE
LibWeb: Stop storing `CascadedProperties` on each element

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -822,7 +822,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
 
         // Traversal of the subtree is necessary to update the animated properties inherited from the target element.
         target->for_each_in_subtree_of_type<DOM::Element>([&](auto& element) {
-            if (!element.cascaded_properties({}))
+            if (!element.computed_properties())
                 return TraversalDecision::SkipChildrenAndContinue;
             auto element_invalidation = element.recompute_inherited_style();
             if (element_invalidation.is_none())

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -284,6 +284,12 @@ public:
         m_attempted_pseudo_class_matches = results;
     }
 
+    HashMap<PropertyID, NonnullRefPtr<StyleValue const>> const& inheritance_dependent_specified_values() const { return m_inheritance_dependent_specified_values; }
+    void add_inheritance_dependent_specified_value(PropertyID property_id, NonnullRefPtr<StyleValue const> value) { m_inheritance_dependent_specified_values.set(property_id, move(value)); }
+
+    RefPtr<StyleValue const> raw_cascaded_font_size() const { return m_raw_cascaded_font_size; }
+    void set_raw_cascaded_font_size(NonnullRefPtr<StyleValue const> value) { m_raw_cascaded_font_size = move(value); }
+
 private:
     ComputedProperties();
 
@@ -314,6 +320,9 @@ private:
     Optional<CSSPixels> m_line_height;
 
     PseudoClassBitmap m_attempted_pseudo_class_matches;
+
+    HashMap<PropertyID, NonnullRefPtr<StyleValue const>> m_inheritance_dependent_specified_values;
+    RefPtr<StyleValue const> m_raw_cascaded_font_size;
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1832,10 +1832,6 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
 
         auto style = compute_style(abstract_element_for_pseudo_element);
 
-        // Copy cascaded properties to the element itself so that elements
-        // slotted into this slot can find them via element_to_inherit_style_from().
-        abstract_element.set_cascaded_properties(abstract_element_for_pseudo_element.cascaded_properties());
-
         // Merge back inline styles
         if (auto inline_style = element.inline_style()) {
             for (auto const& property : inline_style->properties())
@@ -1863,10 +1859,9 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
             PseudoElement::Marker,
             PseudoElement::Placeholder);
 
-        // Bail if no pseudo-element rules matched. Clear any stale cascaded/custom property data so
+        // Bail if no pseudo-element rules matched. Clear any stale custom property data so
         // getComputedStyle() doesn't return values from a previous match.
         if (!did_match_any_pseudo_element_rules && !has_implicit_style) {
-            abstract_element.set_cascaded_properties(nullptr);
             abstract_element.set_custom_property_data(nullptr);
             return {};
         }
@@ -1910,7 +1905,6 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
     }
 
     auto cascaded_properties = compute_cascaded_values(abstract_element, did_match_any_pseudo_element_rules, mode, matching_rule_set);
-    abstract_element.set_cascaded_properties(cascaded_properties);
 
     if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
         // Bail if no pseudo-element would be generated due to...

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1992,8 +1992,10 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
     CSSPixels current_size_in_px = default_monospace_font_size_in_px;
 
     for (auto& ancestor : ancestors.in_reverse()) {
-        auto& ancestor_cascaded_properties = *ancestor.cascaded_properties();
-        auto font_size_value = ancestor_cascaded_properties.property(CSS::PropertyID::FontSize);
+        auto ancestor_computed_properties = ancestor.computed_properties();
+        if (!ancestor_computed_properties)
+            continue;
+        auto font_size_value = ancestor_computed_properties->raw_cascaded_font_size();
 
         if (!font_size_value)
             continue;
@@ -2107,6 +2109,12 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
                 computed_style->set_property_important(property_id, Important::Yes);
             value = cascaded_style_property->value;
             requires_computation = property_requires_computation_with_cascaded_value(property_id);
+
+            // Store the raw winning cascaded font-size. This is needed to implement the time-traveling inheritance for
+            // font-size when font-family is monospace.
+            // See the recascade_font_size_if_needed() function for further details.
+            if (property_id == PropertyID::FontSize)
+                computed_style->set_raw_cascaded_font_size(*cascaded_style_property->value);
         }
 
         // NOTE: We've already handled font-size above.
@@ -2147,6 +2155,16 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
             value = property_initial_value(property_id);
             requires_computation = property_requires_computation_with_initial_value(property_id);
         }
+
+        // Store the resolved specified value for properties whose computation depends on inherited info, so they can
+        // be re-resolved when an ancestor changes without keeping CascadedProperties alive on the element.
+        // FIXME: Consider other style values that rely on relative lengths (e.g. CalculatedStyleValue, StyleValues
+        //        which contain lengths (e.g. StyleValueList)) - maybe we can use `is_computationally_independent()`
+        bool depends_on_inherited_info = (value->is_length() && value->as_length().length().is_font_relative())
+            || (property_id == PropertyID::FontWeight && first_is_one_of(value->to_keyword(), Keyword::Bolder, Keyword::Lighter))
+            || (property_id == PropertyID::FontSize && first_is_one_of(value->to_keyword(), Keyword::Larger, Keyword::Smaller));
+        if (depends_on_inherited_info)
+            computed_style->add_inheritance_dependent_specified_value(property_id, *value);
 
         // NB: We compute using the inherited (physical) property to avoid having to add cases for all the logical
         //     alias properties in `compute_value_of_property`

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1623,20 +1623,18 @@ static void compute_text_align(ComputedProperties& style, DOM::AbstractElement a
         }
     }
 
-    // AD-HOC: The -libweb-inherit-or-center style defaults to centering, unless a style value usually would have been
-    //         inherited. This is used to support the ad-hoc default <th> text-align behavior.
+    // AD-HOC: The -libweb-inherit-or-center style defaults to centering, unless the parent element has a non-initial
+    //         computed text-align value. This is used to support the ad-hoc default <th> text-align behavior.
     if (text_align_keyword == Keyword::LibwebInheritOrCenter && abstract_element.element().local_name() == HTML::TagNames::th) {
-        for (auto parent_element = abstract_element.element_to_inherit_style_from(); parent_element.has_value(); parent_element = parent_element->element_to_inherit_style_from()) {
-            auto parent_computed = parent_element->computed_properties();
-            auto parent_cascaded = parent_element->cascaded_properties();
-            if (!parent_computed || !parent_cascaded)
-                break;
-            if (parent_cascaded->property(PropertyID::TextAlign)) {
-                auto const& style_value = parent_computed->property(PropertyID::TextAlign);
-                style.set_property(PropertyID::TextAlign, style_value, ComputedProperties::Inherited::Yes);
-                break;
+        auto parent_element = abstract_element.element_to_inherit_style_from();
+        if (parent_element.has_value() && parent_element->computed_properties()) {
+            auto const& parent_text_align = parent_element->computed_properties()->property(PropertyID::TextAlign);
+            if (parent_text_align.to_keyword() != Keyword::Start) {
+                style.set_property(PropertyID::TextAlign, parent_text_align, ComputedProperties::Inherited::Yes);
+                return;
             }
         }
+        style.set_property(PropertyID::TextAlign, KeywordStyleValue::create(Keyword::Center));
     }
 }
 

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -165,16 +165,6 @@ RefPtr<CSS::StyleValue const> AbstractElement::get_custom_property(FlyString con
     return nullptr;
 }
 
-GC::Ptr<CSS::CascadedProperties> AbstractElement::cascaded_properties() const
-{
-    return m_element->cascaded_properties(m_pseudo_element);
-}
-
-void AbstractElement::set_cascaded_properties(GC::Ptr<CSS::CascadedProperties> cascaded_properties)
-{
-    m_element->set_cascaded_properties(m_pseudo_element, cascaded_properties);
-}
-
 bool AbstractElement::has_non_empty_counters_set() const
 {
     if (m_pseudo_element.has_value())

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -52,9 +52,6 @@ public:
     [[nodiscard]] RefPtr<CSS::CustomPropertyData const> custom_property_data() const;
     RefPtr<CSS::StyleValue const> get_custom_property(FlyString const& name) const;
 
-    GC::Ptr<CSS::CascadedProperties> cascaded_properties() const;
-    void set_cascaded_properties(GC::Ptr<CSS::CascadedProperties>);
-
     bool has_non_empty_counters_set() const;
     Optional<CSS::CountersSet const&> counters_set() const;
     CSS::CountersSet& ensure_counters_set();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1060,36 +1060,21 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
     counters.element_inherited_style_recomputations++;
 
     auto computed_properties = this->computed_properties();
-    VERIFY(m_cascaded_properties);
     VERIFY(computed_properties);
 
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
     HashMap<size_t, RefPtr<CSS::StyleValue const>> property_values_affected_by_inherited_style;
+
+    for (auto const& [property_id, specified_value] : computed_properties->inheritance_dependent_specified_values()) {
+        RefPtr old_value = computed_properties->property(property_id);
+        computed_properties->set_property_without_modifying_flags(property_id, specified_value);
+        property_values_affected_by_inherited_style.set(to_underlying(property_id), old_value);
+    }
+
     for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = static_cast<CSS::PropertyID>(i);
-        // FIXME: We should use the specified value rather than the cascaded value as the cascaded value may include
-        //        unresolved CSS-wide keywords (e.g. 'initial' or 'inherit') rather than the resolved value.
-        auto const& preabsolutized_value = m_cascaded_properties->property(property_id);
         RefPtr old_value = computed_properties->property(property_id);
-
-        if (preabsolutized_value) {
-            // A property needs updating if:
-            // - It uses relative units as it might have been affected by a change in ancestor element style.
-            //   FIXME: Consider other style values that rely on relative lengths (e.g. CalculatedStyleValue,
-            //          StyleValues which contain lengths (e.g. StyleValueList)) - maybe we can use
-            //          `is_computationally_independent()`
-            // - font-weight is `bolder` or `lighter`
-            // - font-size is `larger` or `smaller`
-            // FIXME: Consider any other properties that rely on inherited values for computation.
-            auto needs_updating = (preabsolutized_value->is_length() && preabsolutized_value->as_length().length().is_font_relative())
-                || (property_id == CSS::PropertyID::FontWeight && first_is_one_of(preabsolutized_value->to_keyword(), CSS::Keyword::Bolder, CSS::Keyword::Lighter))
-                || (property_id == CSS::PropertyID::FontSize && first_is_one_of(preabsolutized_value->to_keyword(), CSS::Keyword::Larger, CSS::Keyword::Smaller));
-            if (needs_updating) {
-                computed_properties->set_property_without_modifying_flags(property_id, *preabsolutized_value);
-                property_values_affected_by_inherited_style.set(i, old_value);
-            }
-        }
 
         if (!computed_properties->is_property_inherited(property_id))
             continue;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -26,7 +26,6 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/CSS/CSSStyleProperties.h>
-#include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Invalidation/AttributeInvalidator.h>
@@ -178,7 +177,6 @@ void Element::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_custom_element_registry);
     visitor.visit(m_custom_element_definition);
     visitor.visit(m_custom_state_set);
-    visitor.visit(m_cascaded_properties);
     visitor.visit(m_computed_properties);
     visitor.visit(m_computed_style_map_cache);
     visitor.visit(m_attribute_style_map);
@@ -3435,31 +3433,6 @@ bool Element::has_attributes() const
 size_t Element::attribute_list_size() const
 {
     return m_attributes ? m_attributes->length() : 0;
-}
-
-GC::Ptr<CSS::CascadedProperties> Element::cascaded_properties(Optional<CSS::PseudoElement> pseudo_element) const
-{
-    if (pseudo_element.has_value()) {
-        auto pseudo_element_data = get_pseudo_element(pseudo_element.value());
-        if (pseudo_element_data.has_value())
-            return pseudo_element_data->cascaded_properties();
-        return nullptr;
-    }
-    return m_cascaded_properties;
-}
-
-void Element::set_cascaded_properties(Optional<CSS::PseudoElement> pseudo_element, GC::Ptr<CSS::CascadedProperties> cascaded_properties)
-{
-    if (pseudo_element.has_value()) {
-        if (pseudo_element.value() >= CSS::PseudoElement::KnownPseudoElementCount)
-            return;
-        if (cascaded_properties)
-            ensure_pseudo_element(pseudo_element.value()).set_cascaded_properties(cascaded_properties);
-        else if (auto existing_pseudo_element = get_pseudo_element(pseudo_element.value()); existing_pseudo_element.has_value())
-            existing_pseudo_element->set_cascaded_properties({});
-        return;
-    }
-    m_cascaded_properties = cascaded_properties;
 }
 
 GC::Ptr<CSS::ComputedProperties> Element::computed_properties(Optional<CSS::PseudoElement> pseudo_element_type)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -239,9 +239,6 @@ public:
     GC::Ptr<CSS::ComputedProperties const> computed_properties(Optional<CSS::PseudoElement> = {}) const;
     void set_computed_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::ComputedProperties>);
 
-    [[nodiscard]] GC::Ptr<CSS::CascadedProperties> cascaded_properties(Optional<CSS::PseudoElement>) const;
-    void set_cascaded_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::CascadedProperties>);
-
     Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
 
     GC::Ptr<CSS::CSSStyleProperties> inline_style() { return m_inline_style; }
@@ -675,7 +672,6 @@ private:
     GC::Ptr<ShadowRoot> m_shadow_root;
     GC::Ptr<DOMTokenList> m_part_list;
 
-    GC::Ptr<CSS::CascadedProperties> m_cascaded_properties;
     GC::Ptr<CSS::ComputedProperties> m_computed_properties;
     RefPtr<CSS::CustomPropertyData const> m_custom_property_data;
 

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/DOM/PseudoElement.h>
 #include <LibWeb/Layout/Node.h>
@@ -18,7 +17,6 @@ void PseudoElement::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
 
-    visitor.visit(m_cascaded_properties);
     visitor.visit(m_computed_properties);
     visitor.visit(m_layout_node);
     if (m_counters_set)

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -25,9 +25,6 @@ class WEB_API PseudoElement : public JS::Cell {
     GC::Ptr<Layout::NodeWithStyle> unsafe_layout_node() const { return m_layout_node; }
     void set_layout_node(GC::Ptr<Layout::NodeWithStyle> value) { m_layout_node = value; }
 
-    GC::Ptr<CSS::CascadedProperties> cascaded_properties() const { return m_cascaded_properties; }
-    void set_cascaded_properties(GC::Ptr<CSS::CascadedProperties> value) { m_cascaded_properties = value; }
-
     GC::Ptr<CSS::ComputedProperties> computed_properties() const { return m_computed_properties; }
     void set_computed_properties(GC::Ptr<CSS::ComputedProperties> value) { m_computed_properties = value; }
 
@@ -46,7 +43,6 @@ class WEB_API PseudoElement : public JS::Cell {
 
 private:
     GC::Ptr<Layout::NodeWithStyle> m_layout_node;
-    GC::Ptr<CSS::CascadedProperties> m_cascaded_properties;
     GC::Ptr<CSS::ComputedProperties> m_computed_properties;
     RefPtr<CSS::CustomPropertyData const> m_custom_property_data;
     OwnPtr<CSS::CountersSet> m_counters_set;

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -146,14 +146,14 @@ void dump_tree(StringBuilder& builder, DOM::Node const& node)
     --indent;
 }
 
-void dump_tree(Layout::Node const& layout_node, bool show_cascaded_properties)
+void dump_tree(Layout::Node const& layout_node, bool show_computed_properties)
 {
     StringBuilder builder;
-    dump_tree(builder, layout_node, show_cascaded_properties, true);
+    dump_tree(builder, layout_node, show_computed_properties, true);
     dbgln("{}", builder.string_view());
 }
 
-void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool show_cascaded_properties, bool interactive)
+void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool show_computed_properties, bool interactive)
 {
     static size_t indent = 0;
     builder.append_repeated("  "sv, indent);
@@ -333,7 +333,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
                 builder.append("\n"sv);
                 if (auto const* nested_layout_root = document->layout_node()) {
                     ++indent;
-                    dump_tree(builder, *nested_layout_root, show_cascaded_properties, interactive);
+                    dump_tree(builder, *nested_layout_root, show_computed_properties, interactive);
                     --indent;
                 }
             }
@@ -357,7 +357,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
                         builder.append("  "sv);
                     builder.append("(SVG-as-image isolated context)\n"sv);
 
-                    dump_tree(builder, *svg_data.svg_document().unsafe_layout_node(), show_cascaded_properties, interactive);
+                    dump_tree(builder, *svg_data.svg_document().unsafe_layout_node(), show_computed_properties, interactive);
                     --indent;
                 }
             }
@@ -401,7 +401,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         }
     }
 
-    if (show_cascaded_properties && layout_node.dom_node() && layout_node.dom_node()->is_element() && as<DOM::Element>(layout_node.dom_node())->computed_properties()) {
+    if (show_computed_properties && layout_node.dom_node() && layout_node.dom_node()->is_element() && as<DOM::Element>(layout_node.dom_node())->computed_properties()) {
         struct NameAndValue {
             FlyString name;
             String value;
@@ -420,7 +420,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
 
     ++indent;
     layout_node.for_each_child([&](auto& child) {
-        dump_tree(builder, child, show_cascaded_properties, interactive);
+        dump_tree(builder, child, show_computed_properties, interactive);
         return IterationDecision::Continue;
     });
     --indent;

--- a/Libraries/LibWeb/Dump.h
+++ b/Libraries/LibWeb/Dump.h
@@ -17,8 +17,8 @@ namespace Web {
 WEB_API void dump_tree(HTML::TraversableNavigable&);
 void dump_tree(StringBuilder&, DOM::Node const&);
 WEB_API void dump_tree(DOM::Node const&);
-WEB_API void dump_tree(StringBuilder&, Layout::Node const&, bool show_cascaded_properties = false, bool colorize = false);
-WEB_API void dump_tree(Layout::Node const&, bool show_cascaded_properties = false);
+WEB_API void dump_tree(StringBuilder&, Layout::Node const&, bool show_computed_properties = false, bool colorize = false);
+WEB_API void dump_tree(Layout::Node const&, bool show_computed_properties = false);
 WEB_API void dump_tree(StringBuilder&, Painting::Paintable const&, bool colorize = false, int indent = 0);
 WEB_API void dump_tree(Painting::Paintable const&);
 void dump_sheet(StringBuilder&, CSS::StyleSheet const&, int indent_levels = 0);

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-tables/th-text-align-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-tables/th-text-align-ref.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <link rel="author" title="David Shin" href="mailto:dshin@mozilla.com">
+  <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+  <link rel="help" href="https://html.spec.whatwg.org/#tables-2">
+
+  <style>
+  table {
+    font-size: 15px;
+    border: 1px solid green;
+    margin-bottom: 5px;
+  }
+
+  th {
+    width: 150px;
+    border: 1px solid blue;
+  }
+
+  td {
+    border: 1px solid purple;
+  }
+  </style>
+
+  <body>
+    <table>
+      <tr>
+        <th style="text-align: center;">A</th>
+      </tr>
+      <tr>
+        <td style="text-align: start;">A</td>
+      </tr>
+    </table>
+    <table>
+      <tr>
+        <th style="text-align: end;">A</th>
+      </tr>
+      <tr>
+        <td style="text-align: end;">A</td>
+      </tr>
+    </table>
+    <table>
+      <tr>
+        <th style="text-align: start;">A</th>
+      </tr>
+      <tr>
+        <td style="text-align: start;">A</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-tables/th-text-align.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-tables/th-text-align.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <link rel="author" title="David Shin" href="mailto:dshin@mozilla.com">
+  <link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+  <link rel="help" href="https://html.spec.whatwg.org/#tables-2">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-tables/th-text-align-ref.html">
+
+  <style>
+  table {
+    font-size: 15px;
+    border: 1px solid green;
+    margin-bottom: 5px;
+  }
+
+  th {
+    width: 150px;
+    border: 1px solid blue;
+  }
+
+  td {
+    border: 1px solid purple;
+  }
+  </style>
+
+  <body>
+    <table style="text-align: start;">
+      <tr>
+        <th>A</th>
+      </tr>
+      <tr>
+        <td>A</td>
+      </tr>
+    </table>
+    <table style="text-align: end;">
+      <tr>
+        <th>A</th>
+      </tr>
+      <tr>
+        <td>A</td>
+      </tr>
+    </table>
+    <table>
+      <tr>
+        <th style="text-align: inherit;">A</th>
+      </tr>
+      <tr>
+        <td>A</td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Previously, we consulted `cascaded_properties()` in a few places after style resolution was complete. This PR either changes those sites to use `computed_properties()` where possible, or stores the needed values on `ComputedProperties`

This gives a slight improvement in Speedometer scores:
```
Benchmark     Old Score     New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  57.98 ± 1.26  59.37 ± 1.24                1.024  8750.74 ± 69.45        8455.86 ± 40.40            1.035
Speedometer3  3.46 ± 0.13   3.57 ± 0.11                 1.033  7660.72 ± 258.20       7439.82 ± 226.99           1.03
```

As far as I'm aware the only change in behavior is our `<th>` text-align behavior, which now matches what WPT expects.