### PR TITLE
LibWeb: Apply backwards fill to CSS transitions

### DIFF
--- a/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -122,6 +122,10 @@ CSSTransition::CSSTransition(
     m_keyframe_effect->set_target(abstract_element);
     m_keyframe_effect->set_specified_start_delay(delay);
     m_keyframe_effect->set_specified_iteration_duration(end_time - start_time);
+    // AD-HOC: CSS Transitions require the start value to apply during transition-delay. A default KeyframeEffect does
+    //         not fill in the before phase, so use backwards fill to keep the transition value in the cascade until
+    //         the active interval starts.
+    m_keyframe_effect->set_fill_mode(Bindings::FillMode::Backwards);
     // https://drafts.csswg.org/web-animations-2/#updating-animationeffect-timing
     // Timing properties may also be updated due to a style change. Any change to a CSS animation property that affects
     // timing requires rerunning the procedure to normalize specified timing.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/CSSTransition-currentTime.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/CSSTransition-currentTime.tentative.txt
@@ -2,10 +2,10 @@ Harness status: OK
 
 Found 5 tests
 
-3 Pass
-2 Fail
+4 Pass
+1 Fail
 Pass	currentTime can be used to seek a CSS transition
-Fail	Skipping forwards through transition
+Pass	Skipping forwards through transition
 Pass	Skipping backwards through transition
 Pass	Setting currentTime to null on a CSS transition throws
 Fail	Transition reversing behavior respects currentTime and uses the transition's current position.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/transition-zero-duration-with-delay.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/transition-zero-duration-with-delay.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	0-duration transition with delay applies change after delay period

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/transition-zero-duration-with-delay.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/transition-zero-duration-with-delay.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+<meta charset=utf-8>
+<title>CSS Transitions Test: 0-duration transition with delay applies after delay</title>
+<meta name="assert" content="Transition with 0s duration and 0.3s delay applies property change after delay period">
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#starting">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="./support/helper.js"></script>
+
+</head>
+<body>
+<div id="log"></div>
+
+<script>
+promise_test(async t => {
+  const div = addDiv(t, {
+    style: 'transition: width 0.1s; width: 0px;'
+  });
+
+  // Flush initial state
+  getComputedStyle(div).width;
+  // First transition to 100px
+  div.style.width = '100px';
+  await waitForTransitionEnd(div);
+
+  // Change transition to 0s duration with 300ms delay
+  div.style.transition = 'width 0s linear 0.3s';
+
+  // Set width back to 0
+  div.style.width = '0px';
+  // Immediate check - should NOT have changed yet
+  const computedStart = getComputedStyle(div).width;
+  assert_equals(
+    computedStart,
+    '100px',
+    'Width should remain at 100px initially'
+  );
+  // Wait for transitionend (should trigger after 300ms delay)
+  await waitForTransitionEnd(div);
+
+  // Verify final state
+  const finalWidth = getComputedStyle(div).width;
+
+  assert_equals(
+    finalWidth,
+    '0px',
+    'Width should reset to 0 after delay'
+  );
+
+}, '0-duration transition with delay applies change after delay period');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
CSS transitions must keep their start value in the cascade during the `transition-delay` period. Set the transition effect fill mode to backwards so the before phase resolves to the start keyframe.

This matches the behavior of other engines.

Improves the hero section animation on: https://anthropic.com - although the text still appears visible initially when it shouldn't.