### PR TITLE
LibWeb: A melange of smaller caret & editing improvements

### DIFF
--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -668,6 +668,21 @@ void HitTestDisplayList::find_topmost_caret_item_in_list(Vector<size_t> const& i
     }
 }
 
+void HitTestDisplayList::find_first_empty_editable_item_in_list(Vector<size_t> const& item_indices, CSSPixelPoint local_point, ChromeMetrics const& chrome_metrics, Optional<size_t>& first_item_index) const
+{
+    for (auto item_index : item_indices) {
+        if (first_item_index.has_value() && item_index >= *first_item_index)
+            return;
+        auto const& item = m_items[item_index];
+        if (item.kind != ItemKind::EmptyEditable)
+            continue;
+        if (!item_contains(item, local_point, chrome_metrics))
+            continue;
+        first_item_index = item_index;
+        return;
+    }
+}
+
 void HitTestDisplayList::find_items_in_list(Vector<size_t> const& item_indices, CSSPixelPoint local_point, ChromeMetrics const& chrome_metrics, Vector<size_t>& hit_item_indices) const
 {
     for (auto item_index : item_indices) {
@@ -687,6 +702,8 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
     Optional<CSSPixelPoint> topmost_item_local_point;
     Optional<size_t> topmost_hit_item_index;
     Optional<CSSPixelPoint> topmost_hit_item_local_point;
+    Optional<size_t> first_empty_editable_item_index;
+    Optional<CSSPixelPoint> first_empty_editable_item_local_point;
     for (auto visual_context_index : m_used_visual_context_indices) {
         auto const& spatial_index = m_spatial_indexes[visual_context_index.value()];
         VERIFY(spatial_index);
@@ -697,26 +714,36 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
 
         auto previous_topmost_item_index = topmost_item_index;
         auto previous_topmost_hit_item_index = topmost_hit_item_index;
+        auto previous_first_empty_editable_item_index = first_empty_editable_item_index;
         find_topmost_item_in_list(spatial_index->unbucketed_items, *local_point, chrome_metrics, topmost_hit_item_index);
         find_topmost_caret_item_in_list(spatial_index->unbucketed_items, *local_point, chrome_metrics, topmost_item_index);
+        find_first_empty_editable_item_in_list(spatial_index->unbucketed_items, *local_point, chrome_metrics, first_empty_editable_item_index);
 
         auto x = spatial_index_cell_for(local_point->x());
         auto y = spatial_index_cell_for(local_point->y());
         if (auto bucket = spatial_index->cells.get(spatial_index_cell_key(x, y)); bucket.has_value()) {
             find_topmost_item_in_list(*bucket, *local_point, chrome_metrics, topmost_hit_item_index);
             find_topmost_caret_item_in_list(*bucket, *local_point, chrome_metrics, topmost_item_index);
+            find_first_empty_editable_item_in_list(*bucket, *local_point, chrome_metrics, first_empty_editable_item_index);
         }
 
         if (topmost_item_index != previous_topmost_item_index)
             topmost_item_local_point = local_point;
         if (topmost_hit_item_index != previous_topmost_hit_item_index)
             topmost_hit_item_local_point = local_point;
+        if (first_empty_editable_item_index != previous_first_empty_editable_item_index)
+            first_empty_editable_item_local_point = local_point;
+    }
+
+    if (first_empty_editable_item_index.has_value()) {
+        topmost_item_index = first_empty_editable_item_index;
+        topmost_item_local_point = first_empty_editable_item_local_point;
     }
 
     // Direct caret hits win unless another non-caret item is visibly on top of them.
     auto topmost_caret_item_matches_hit_item = [&] {
         return topmost_hit_item_index.has_value()
-            && *topmost_item_index == *topmost_hit_item_index
+            && (*topmost_item_index == *topmost_hit_item_index || item_can_produce_caret_position(m_items[*topmost_hit_item_index]))
             && item_is_direct_caret_target(m_items[*topmost_item_index]);
     };
     if (topmost_item_index.has_value() && (!topmost_hit_item_index.has_value() || topmost_caret_item_matches_hit_item())) {
@@ -824,12 +851,19 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_from_point(CSSPixelPo
 
         if (closest_line.index.has_value()
             && closest_line.is_before_point
-            && closest_line_after_point.index.has_value()
-            && closest_line_after_point.block_distance <= caret_line_block_axis_compare_slop
-            && closest_line_after_point.inline_distance <= closest_line.inline_distance) {
+            && closest_line_after_point.index.has_value()) {
             auto const& line = m_caret_lines[*closest_line.index];
             auto first_item_index = m_caret_item_indices[line.first_caret_item_index];
             auto const& first_item = m_items[first_item_index];
+            auto const& line_after_point = m_caret_lines[*closest_line_after_point.index];
+            auto first_item_after_point_index = m_caret_item_indices[line_after_point.first_caret_item_index];
+            auto const& first_item_after_point = m_items[first_item_after_point_index];
+            auto line_after_point_is_better = first_item.kind == ItemKind::EmptyEditable && first_item_after_point.kind == ItemKind::EmptyEditable
+                ? caret_line_is_better_candidate(closest_line_after_point.block_distance, closest_line_after_point.inline_distance, closest_line.block_distance, closest_line.inline_distance, caret_line_block_axis_compare_slop)
+                : closest_line_after_point.block_distance <= caret_line_block_axis_compare_slop && closest_line_after_point.inline_distance <= closest_line.inline_distance;
+            if (!line_after_point_is_better)
+                return closest_line;
+
             auto writing_mode = first_item.paintable->computed_values().writing_mode();
             auto block_coordinate = block_axis_coordinate(*closest_line.local_point, writing_mode);
             auto point_is_in_closest_line_block_container_margin = closest_line.block_container_margin_rect.has_value()

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -107,6 +107,7 @@ private:
     [[nodiscard]] bool item_is_inline_adjacent_to_line(Item const&, CaretLine const&) const;
     void find_topmost_item_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Optional<size_t>& topmost_item_index) const;
     void find_topmost_caret_item_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Optional<size_t>& topmost_item_index) const;
+    void find_first_empty_editable_item_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Optional<size_t>& first_item_index) const;
     void find_items_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Vector<size_t>& hit_item_indices) const;
 
     u64 m_visual_context_tree_version { 0 };

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -362,7 +362,7 @@ void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context) cons
             return;
 
         caret_color = computed_values().caret_color();
-        auto content_box = absolute_padding_box_rect();
+        auto content_box = absolute_rect();
         cursor_rect = { content_box.x(), content_box.y(), 1, computed_values().line_height() };
     }
 

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -557,6 +557,14 @@ void Selection::set_range(GC::Ptr<DOM::Range> range)
     if (old_range == range)
         return;
 
+    auto repaint_range_endpoints = [](GC::Ptr<DOM::Range> range) {
+        if (!range)
+            return;
+        range->start_container()->set_needs_repaint();
+        if (range->end_container() != range->start_container())
+            range->end_container()->set_needs_repaint();
+    };
+
     if (old_range)
         old_range->set_associated_selection({}, nullptr);
 
@@ -564,6 +572,9 @@ void Selection::set_range(GC::Ptr<DOM::Range> range)
 
     if (range)
         range->set_associated_selection({}, this);
+
+    repaint_range_endpoints(old_range);
+    repaint_range_endpoints(range);
 
     // https://w3c.github.io/editing/docs/execCommand/#state-override
     // Whenever the number of ranges in the selection changes to something different, and whenever a boundary point of

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret-move-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret-move-invalidation.txt
@@ -1,0 +1,2 @@
+Before:   FillRect@1 rect=[8,8 1x18] color=rgb(0, 0, 0)
+After:   FillRect@1 rect=[71,8 1x18] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-empty-caret-padding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-empty-caret-padding.txt
@@ -1,0 +1,1 @@
+  FillRect@1 rect=[35,35 1x18] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/hit_testing/content-editable-empty-block-descendants.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/content-editable-empty-block-descendants.txt
@@ -1,0 +1,5 @@
+<P id="first">
+<P id="first">
+<P id="second">
+hello
+<#text>

--- a/Tests/LibWeb/Text/expected/hit_testing/content-editable-non-empty-block-descendants.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/content-editable-non-empty-block-descendants.txt
@@ -1,0 +1,3 @@
+first:5
+second:6
+first:5

--- a/Tests/LibWeb/Text/expected/hit_testing/content-editable-overlapping-empty-descendants.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/content-editable-overlapping-empty-descendants.txt
@@ -1,0 +1,1 @@
+<DIV id="first">

--- a/Tests/LibWeb/Text/input/display_list/contenteditable-caret-move-invalidation.html
+++ b/Tests/LibWeb/Text/input/display_list/contenteditable-caret-move-invalidation.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div contenteditable style="font: 16px SerenitySans; width: 100px; height: 20px">foo bar</div>
+<script>
+    test(() => {
+        const div = document.querySelector("div");
+        const text = div.firstChild;
+        const selection = getSelection();
+
+        div.focus();
+        selection.collapse(text, 0);
+        const before = internals.dumpDisplayList();
+
+        selection.collapse(text, text.length);
+        const after = internals.dumpDisplayList();
+
+        const caretLine = displayList => displayList.split("\n").find(line => line.includes("FillRect"));
+        println(`Before: ${caretLine(before)}`);
+        println(`After: ${caretLine(after)}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/display_list/contenteditable-empty-caret-padding.html
+++ b/Tests/LibWeb/Text/input/display_list/contenteditable-empty-caret-padding.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    p {
+        border: 3px solid green;
+        margin: 0;
+        min-height: 100px;
+        padding: 24px;
+        width: 300px;
+    }
+</style>
+<p contenteditable></p>
+<script>
+    test(() => {
+        document.querySelector("p").focus();
+        const caretLine = internals.dumpDisplayList()
+            .split("\n")
+            .find(line => line.includes("FillRect"));
+        println(caretLine);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/hit_testing/content-editable-empty-block-descendants.html
+++ b/Tests/LibWeb/Text/input/hit_testing/content-editable-empty-block-descendants.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<style>
+    body {
+        border: 1px solid red;
+    }
+
+    p {
+        border: 1px solid green;
+    }
+</style>
+<script src="../include.js"></script>
+<body contenteditable>
+    <p id="first"></p>
+    <p id="second"></p>
+    <script>
+        function clickBodyAtY(y) {
+            const bodyRect = document.body.getBoundingClientRect();
+            internals.click(bodyRect.left + 10, y);
+        }
+
+        test(() => {
+            const bodyRect = document.body.getBoundingClientRect();
+            const firstRect = first.getBoundingClientRect();
+            const secondRect = second.getBoundingClientRect();
+
+            clickBodyAtY(bodyRect.top + 10);
+            printElement(document.getSelection().focusNode);
+
+            clickBodyAtY((firstRect.bottom + secondRect.top) / 2);
+            printElement(document.getSelection().focusNode);
+
+            clickBodyAtY((secondRect.bottom + bodyRect.bottom) / 2);
+            printElement(document.getSelection().focusNode);
+
+            internals.sendText(document.body, "hello");
+            println(second.textContent);
+
+            clickBodyAtY((secondRect.bottom + bodyRect.bottom) / 2);
+            printElement(document.getSelection().focusNode);
+        });
+    </script>
+</body>

--- a/Tests/LibWeb/Text/input/hit_testing/content-editable-non-empty-block-descendants.html
+++ b/Tests/LibWeb/Text/input/hit_testing/content-editable-non-empty-block-descendants.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<style>
+    body {
+        border: 1px solid red;
+    }
+
+    p {
+        border: 1px solid green;
+        width: 300px;
+    }
+</style>
+<script src="../include.js"></script>
+<body contenteditable>
+    <p id="first">first</p>
+    <p id="second">second</p>
+    <script>
+        function clickEndOfParagraph(paragraph) {
+            const rect = paragraph.getBoundingClientRect();
+            internals.click(rect.right - 10, (rect.top + rect.bottom) / 2);
+        }
+
+        function printFocus() {
+            const selection = document.getSelection();
+            println(`${selection.focusNode.parentElement.id}:${selection.focusOffset}`);
+        }
+
+        test(() => {
+            document.getSelection().collapse(first.firstChild, first.firstChild.length);
+            printFocus();
+
+            clickEndOfParagraph(second);
+            printFocus();
+
+            clickEndOfParagraph(first);
+            printFocus();
+        });
+    </script>
+</body>

--- a/Tests/LibWeb/Text/input/hit_testing/content-editable-overlapping-empty-descendants.html
+++ b/Tests/LibWeb/Text/input/hit_testing/content-editable-overlapping-empty-descendants.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style>
+    #editor {
+        width: 100px;
+        height: 100px;
+    }
+
+    #editor > div {
+        width: 100px;
+        height: 100px;
+    }
+
+    #second {
+        margin-top: -100px;
+    }
+</style>
+<script src="../include.js"></script>
+<div id="editor" contenteditable>
+    <div id="first"></div>
+    <div id="second"></div>
+</div>
+<script>
+    test(() => {
+        const rect = editor.getBoundingClientRect();
+        internals.click(rect.left + rect.width / 2, rect.top + rect.height / 2);
+        printElement(document.getSelection().focusNode);
+    });
+</script>


### PR DESCRIPTION
* Fix caret drawing when changing the caret position
* Fix three issues with hit testing candidates to make it much easier to switch between editable fragments
* Show the editing caret at the right location if the editable host is still empty and has padding