### PR TITLE
LibWeb: Fix StackingContext painting order

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -198,7 +198,10 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
                 paint_node(child, context, PaintPhase::Border);
                 paint_descendants(context, child, StackingContextPaintPhase::BackgroundAndBorders);
             }
-            paint_descendants(context, child, phase);
+            // https://drafts.csswg.org/css2/#elaborate-stacking-contexts
+            // inline-blocks and inline-tables should be treated as if they create a new stacking context
+            if (!child.layout_node().is_inline_block() && !child.layout_node().is_inline_table())
+                paint_descendants(context, child, phase);
             break;
         case StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced:
             if (child_is_inline_or_replaced) {
@@ -206,6 +209,7 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
                 paint_node(child, context, PaintPhase::Border);
                 paint_node(child, context, PaintPhase::TableCollapsedBorder);
                 paint_descendants(context, child, StackingContextPaintPhase::BackgroundAndBorders);
+                paint_descendants(context, child, StackingContextPaintPhase::Floats);
             }
             paint_descendants(context, child, phase);
             break;

--- a/Tests/LibWeb/Ref/expected/inline-block-with-float-paint-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/inline-block-with-float-paint-order-ref.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+.box {
+    background-color: white;
+    display: inline-block;
+}
+</style><div class="box">test</div>

--- a/Tests/LibWeb/Ref/input/inline-block-with-float-paint-order.html
+++ b/Tests/LibWeb/Ref/input/inline-block-with-float-paint-order.html
@@ -1,0 +1,9 @@
+<!doctype html><link rel="match" href="../expected/inline-block-with-float-paint-order-ref.html" /><style>
+.inline-block {
+    background-color: white;
+    display: inline-block;
+}
+.float {
+    float: left;
+}
+</style><div class="inline-block"><div class="float">test</div></div>


### PR DESCRIPTION
- Add check for painting inline-blocks and inline-tables children in the BackgroundAndBordersForInlineLevelAndReplaced phase
- Add regression css tests

Related issue: https://github.com/LadybirdBrowser/ladybird/issues/6742