### PR TITLE
Stop sharing the Skia backend context between threads

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     ImageFormats/WebPWriter.cpp
     ImageFormats/WebPWriterLossless.cpp
     ImmutableBitmap.cpp
+    ImmutableBitmapSkiaImageCache.cpp
     PaintStyle.cpp
     Painter.cpp
     PainterSkia.cpp

--- a/Libraries/LibGfx/ColorSpace.cpp
+++ b/Libraries/LibGfx/ColorSpace.cpp
@@ -162,6 +162,12 @@ sk_sp<SkColorSpace>& ColorSpace::color_space()
     return m_color_space->color_space;
 }
 
+template<>
+sk_sp<SkColorSpace> const& ColorSpace::color_space() const
+{
+    return m_color_space->color_space;
+}
+
 }
 
 namespace IPC {

--- a/Libraries/LibGfx/ColorSpace.h
+++ b/Libraries/LibGfx/ColorSpace.h
@@ -37,6 +37,8 @@ public:
     // and only provide a specialization for sk_sp<SkColorSpace>.
     template<typename T>
     T& color_space();
+    template<typename T>
+    T const& color_space() const;
 
 private:
     template<typename T>

--- a/Libraries/LibGfx/Filter.cpp
+++ b/Libraries/LibGfx/Filter.cpp
@@ -292,7 +292,12 @@ Filter Filter::image(Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src
     auto skia_dest_rect = to_skia_rect(dest_rect);
     auto sampling_options = to_skia_sampling_options(scaling_mode);
 
-    return Filter(Impl::create(SkImageFilters::Image(sk_ref_sp(bitmap.sk_image()), skia_src_rect, skia_dest_rect, sampling_options)));
+    auto source_bitmap = bitmap.bitmap();
+    if (!source_bitmap)
+        return Filter(Impl::create(nullptr));
+
+    auto image = sk_image_from_bitmap(*source_bitmap, bitmap.color_space());
+    return Filter(Impl::create(SkImageFilters::Image(move(image), skia_src_rect, skia_dest_rect, sampling_options)));
 }
 
 Filter Filter::merge(Vector<Optional<Filter>> const& inputs)

--- a/Libraries/LibGfx/Forward.h
+++ b/Libraries/LibGfx/Forward.h
@@ -10,6 +10,7 @@ namespace Gfx {
 
 class Bitmap;
 class CMYKBitmap;
+class ColorSpace;
 class ImmutableBitmap;
 class Color;
 

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  * Copyright (c) 2026, Gregory Bertilson <gregory@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -6,20 +6,16 @@
  */
 
 #include <AK/OwnPtr.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintingSurface.h>
-#include <LibGfx/SkiaBackendContext.h>
 #include <LibGfx/SkiaUtils.h>
 #include <LibGfx/YUVData.h>
 
-#include <core/SkBitmap.h>
 #include <core/SkCanvas.h>
 #include <core/SkColorSpace.h>
 #include <core/SkImage.h>
 #include <core/SkSurface.h>
-#include <core/SkYUVAPixmaps.h>
-#include <gpu/ganesh/GrDirectContext.h>
-#include <gpu/ganesh/SkImageGanesh.h>
 
 namespace Gfx {
 
@@ -36,21 +32,25 @@ StringView export_format_name(ExportFormat format)
 }
 
 struct ImmutableBitmapImpl {
-    RefPtr<SkiaBackendContext> context;
-    sk_sp<SkImage> sk_image;
-    SkBitmap sk_bitmap;
     RefPtr<Gfx::Bitmap const> bitmap;
+    OwnPtr<YUVData> yuv_data;
     ColorSpace color_space;
 };
 
 int ImmutableBitmap::width() const
 {
-    return m_impl->sk_image->width();
+    if (m_impl->bitmap)
+        return m_impl->bitmap->width();
+    VERIFY(m_impl->yuv_data);
+    return m_impl->yuv_data->size().width();
 }
 
 int ImmutableBitmap::height() const
 {
-    return m_impl->sk_image->height();
+    if (m_impl->bitmap)
+        return m_impl->bitmap->height();
+    VERIFY(m_impl->yuv_data);
+    return m_impl->yuv_data->size().height();
 }
 
 IntRect ImmutableBitmap::rect() const
@@ -65,14 +65,20 @@ IntSize ImmutableBitmap::size() const
 
 AlphaType ImmutableBitmap::alpha_type() const
 {
-    // We assume premultiplied alpha type for opaque surfaces since that is Skia's preferred alpha type and the
-    // effective pixel data is identical between premultiplied and unpremultiplied in that case.
-    return m_impl->sk_image->alphaType() == kUnpremul_SkAlphaType ? AlphaType::Unpremultiplied : AlphaType::Premultiplied;
+    if (m_impl->bitmap)
+        return m_impl->bitmap->alpha_type();
+
+    return AlphaType::Premultiplied;
 }
 
-SkImage const* ImmutableBitmap::sk_image() const
+YUVData const* ImmutableBitmap::yuv_data() const
 {
-    return m_impl->sk_image.get();
+    return m_impl->yuv_data.ptr();
+}
+
+ColorSpace const& ImmutableBitmap::color_space() const
+{
+    return m_impl->color_space;
 }
 
 static int bytes_per_pixel_for_export_format(ExportFormat format)
@@ -120,9 +126,6 @@ static SkColorType export_format_to_skia_color_type(ExportFormat format)
 
 ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat format, int flags, Optional<int> target_width, Optional<int> target_height) const
 {
-    if (SkiaBackendContext::the_main_thread_context() && !ensure_sk_image(*SkiaBackendContext::the_main_thread_context()))
-        return Error::from_string_literal("Failed to create a Skia image for this ImmutableBitmap");
-
     int width = target_width.value_or(this->width());
     int height = target_height.value_or(this->height());
 
@@ -158,6 +161,14 @@ ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat 
                 }
             }
         } else {
+            auto bitmap = this->bitmap();
+            if (!bitmap)
+                return Error::from_string_literal("Failed to create a Bitmap for this ImmutableBitmap");
+
+            auto image = sk_image_from_bitmap(*bitmap, m_impl->color_space);
+            if (!image)
+                return Error::from_string_literal("Failed to create a Skia image for this ImmutableBitmap");
+
             auto skia_format = export_format_to_skia_color_type(format);
             auto color_space = SkColorSpace::MakeSRGB();
 
@@ -172,7 +183,7 @@ ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat 
                 surface_canvas->scale(1, -1);
             }
 
-            surface_canvas->drawImageRect(sk_image(), dst_rect, Gfx::to_skia_sampling_options(Gfx::ScalingMode::NearestNeighbor));
+            surface_canvas->drawImageRect(image.get(), dst_rect, Gfx::to_skia_sampling_options(Gfx::ScalingMode::NearestNeighbor));
         }
     } else {
         VERIFY(buffer.is_empty());
@@ -187,16 +198,11 @@ ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat 
 
 RefPtr<Gfx::Bitmap const> ImmutableBitmap::bitmap() const
 {
-    if (!m_impl->bitmap && m_impl->sk_image) {
-        auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, { m_impl->sk_image->width(), m_impl->sk_image->height() }));
-        auto image_info = SkImageInfo::Make(bitmap->width(), bitmap->height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-        SkPixmap pixmap(image_info, bitmap->begin(), bitmap->pitch());
-        if (m_impl->context)
-            m_impl->context->lock();
-        m_impl->sk_image->readPixels(pixmap, 0, 0);
-        if (m_impl->context)
-            m_impl->context->unlock();
-        m_impl->bitmap = move(bitmap);
+    if (!m_impl->bitmap && m_impl->yuv_data) {
+        auto bitmap_or_error = m_impl->yuv_data->to_bitmap();
+        if (bitmap_or_error.is_error())
+            return nullptr;
+        m_impl->bitmap = bitmap_or_error.release_value();
     }
     return m_impl->bitmap;
 }
@@ -205,94 +211,29 @@ ErrorOr<NonnullRefPtr<ImmutableBitmap>> ImmutableBitmap::create_from_yuv(Nonnull
 {
     auto color_space = TRY(ColorSpace::from_cicp(yuv_data->cicp()));
 
-    auto context = SkiaBackendContext::the_main_thread_context();
-    auto* gr_context = context ? context->sk_context() : nullptr;
-
-    if (!gr_context) {
-        auto bitmap = TRY(yuv_data->to_bitmap());
-        return create(move(bitmap), move(color_space));
-    }
-
     if (yuv_data->bit_depth() > 8)
         yuv_data->expand_samples_to_full_16_bit_range();
 
-    context->lock();
-    auto sk_image = SkImages::TextureFromYUVAPixmaps(
-        gr_context,
-        yuv_data->make_pixmaps(),
-        skgpu::Mipmapped::kNo,
-        false,
-        color_space.color_space<sk_sp<SkColorSpace>>());
-    context->unlock();
-
-    if (!sk_image)
-        return Error::from_string_literal("Failed to upload YUV data");
-
     ImmutableBitmapImpl impl {
-        .context = context,
-        .sk_image = move(sk_image),
-        .sk_bitmap = {},
         .bitmap = nullptr,
-        .color_space = {},
+        .yuv_data = move(yuv_data),
+        .color_space = move(color_space),
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
 }
 
-bool ImmutableBitmap::ensure_sk_image(SkiaBackendContext& context) const
-{
-    if (m_impl->context) {
-        VERIFY(m_impl->context.ptr() == &context);
-        return true;
-    }
-
-    context.lock();
-    ScopeGuard unlock_guard = [&context] {
-        context.unlock();
-    };
-
-    auto* gr_context = context.sk_context();
-
-    VERIFY(m_impl->sk_image);
-    if (!gr_context)
-        return true; // No GPU, but raster image is still usable
-    auto gpu_image = SkImages::TextureFromImage(gr_context, m_impl->sk_image.get(), skgpu::Mipmapped::kNo, skgpu::Budgeted::kYes);
-    if (gpu_image) {
-        m_impl->context = context;
-        m_impl->sk_image = move(gpu_image);
-    }
-    return true;
-}
-
 Color ImmutableBitmap::get_pixel(int x, int y) const
 {
-    return m_impl->bitmap->get_pixel(x, y);
-}
-
-static SkAlphaType to_skia_alpha_type(Gfx::AlphaType alpha_type)
-{
-    switch (alpha_type) {
-    case AlphaType::Premultiplied:
-        return kPremul_SkAlphaType;
-    case AlphaType::Unpremultiplied:
-        return kUnpremul_SkAlphaType;
-    default:
-        VERIFY_NOT_REACHED();
-    }
+    auto bitmap = this->bitmap();
+    VERIFY(bitmap);
+    return bitmap->get_pixel(x, y);
 }
 
 NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap const> const& bitmap, ColorSpace color_space)
 {
-    SkBitmap sk_bitmap;
-    auto info = SkImageInfo::Make(bitmap->width(), bitmap->height(), to_skia_color_type(bitmap->format()), to_skia_alpha_type(bitmap->alpha_type()), color_space.color_space<sk_sp<SkColorSpace>>());
-    sk_bitmap.installPixels(info, const_cast<void*>(static_cast<void const*>(bitmap->scanline(0))), bitmap->pitch());
-    sk_bitmap.setImmutable();
-    auto sk_image = sk_bitmap.asImage();
-
     ImmutableBitmapImpl impl {
-        .context = nullptr,
-        .sk_image = move(sk_image),
-        .sk_bitmap = move(sk_bitmap),
         .bitmap = bitmap,
+        .yuv_data = nullptr,
         .color_space = move(color_space),
     };
     return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
@@ -315,18 +256,9 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap cons
 
 NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create_snapshot_from_painting_surface(NonnullRefPtr<PaintingSurface> const& painting_surface)
 {
-    painting_surface->lock_context();
-    auto sk_image = painting_surface->sk_image_snapshot<sk_sp<SkImage>>();
-    painting_surface->unlock_context();
-
-    ImmutableBitmapImpl impl {
-        .context = painting_surface->skia_backend_context(),
-        .sk_image = move(sk_image),
-        .sk_bitmap = {},
-        .bitmap = nullptr,
-        .color_space = {},
-    };
-    return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(move(impl))));
+    auto bitmap = MUST(Bitmap::create(BitmapFormat::BGRA8888, AlphaType::Premultiplied, painting_surface->size()));
+    painting_surface->read_into_bitmap(*bitmap);
+    return create(bitmap);
 }
 
 ImmutableBitmap::ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl>&& impl)
@@ -336,23 +268,6 @@ ImmutableBitmap::ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl>&& impl)
 
 ImmutableBitmap::~ImmutableBitmap()
 {
-    lock_context();
-    m_impl->sk_image = nullptr;
-    unlock_context();
-}
-
-void ImmutableBitmap::lock_context()
-{
-    auto& context = m_impl->context;
-    if (context)
-        context->lock();
-}
-
-void ImmutableBitmap::unlock_context()
-{
-    auto& context = m_impl->context;
-    if (context)
-        context->unlock();
 }
 
 }

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -120,7 +120,7 @@ static SkColorType export_format_to_skia_color_type(ExportFormat format)
 
 ErrorOr<BitmapExportResult> ImmutableBitmap::export_to_byte_buffer(ExportFormat format, int flags, Optional<int> target_width, Optional<int> target_height) const
 {
-    if (SkiaBackendContext::the() && !ensure_sk_image(*SkiaBackendContext::the()))
+    if (SkiaBackendContext::the_main_thread_context() && !ensure_sk_image(*SkiaBackendContext::the_main_thread_context()))
         return Error::from_string_literal("Failed to create a Skia image for this ImmutableBitmap");
 
     int width = target_width.value_or(this->width());
@@ -205,7 +205,7 @@ ErrorOr<NonnullRefPtr<ImmutableBitmap>> ImmutableBitmap::create_from_yuv(Nonnull
 {
     auto color_space = TRY(ColorSpace::from_cicp(yuv_data->cicp()));
 
-    auto context = SkiaBackendContext::the();
+    auto context = SkiaBackendContext::the_main_thread_context();
     auto* gr_context = context ? context->sk_context() : nullptr;
 
     if (!gr_context) {

--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  * Copyright (c) 2026, Gregory Bertilson <gregory@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -17,8 +17,6 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/YUVData.h>
 
-class SkImage;
-
 namespace Gfx {
 
 struct ImmutableBitmapImpl;
@@ -56,30 +54,26 @@ public:
 
     ~ImmutableBitmap();
 
-    bool ensure_sk_image(SkiaBackendContext&) const;
-
     int width() const;
     int height() const;
     IntRect rect() const;
     IntSize size() const;
 
     AlphaType alpha_type() const;
+    YUVData const* yuv_data() const;
+    ColorSpace const& color_space() const;
 
-    SkImage const* sk_image() const;
     [[nodiscard]] ErrorOr<BitmapExportResult> export_to_byte_buffer(ExportFormat format, int flags, Optional<int> target_width, Optional<int> target_height) const;
 
     Color get_pixel(int x, int y) const;
 
-    // Returns nullptr for YUV-backed bitmaps
+    // May lazily convert YUV-backed bitmaps to CPU pixels.
     RefPtr<Bitmap const> bitmap() const;
 
 private:
     mutable NonnullOwnPtr<ImmutableBitmapImpl> m_impl;
 
     explicit ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl>&&);
-
-    void lock_context();
-    void unlock_context();
 };
 
 }

--- a/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.cpp
+++ b/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.cpp
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/ColorSpace.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/ImmutableBitmapSkiaImageCache.h>
 #include <LibGfx/SkiaBackendContext.h>
+#include <LibGfx/SkiaUtils.h>
 
+#include <core/SkColorSpace.h>
 #include <core/SkImage.h>
+#include <gpu/ganesh/GrDirectContext.h>
+#include <gpu/ganesh/SkImageGanesh.h>
 
 namespace Gfx {
 
@@ -30,11 +35,17 @@ sk_sp<SkImage> ImmutableBitmapSkiaImageCache::image_for_bitmap(ImmutableBitmap c
         return it->value.image;
     }
 
-    auto context = m_skia_backend_context ? m_skia_backend_context : SkiaBackendContext::the();
-    if (context && !bitmap.ensure_sk_image(*context))
+    auto source_bitmap = bitmap.bitmap();
+    if (!source_bitmap)
         return nullptr;
 
-    auto image = sk_ref_sp(bitmap.sk_image());
+    auto image = sk_image_from_bitmap(*source_bitmap, bitmap.color_space());
+    if (auto* gr_context = m_skia_backend_context ? m_skia_backend_context->sk_context() : nullptr) {
+        auto gpu_image = SkImages::TextureFromImage(gr_context, image.get(), skgpu::Mipmapped::kNo, skgpu::Budgeted::kYes);
+        if (gpu_image)
+            image = move(gpu_image);
+    }
+
     if (!image)
         return nullptr;
 

--- a/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.cpp
+++ b/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ImmutableBitmap.h>
+#include <LibGfx/ImmutableBitmapSkiaImageCache.h>
+#include <LibGfx/SkiaBackendContext.h>
+
+#include <core/SkImage.h>
+
+namespace Gfx {
+
+static constexpr u64 image_cache_max_unused_generations = 120;
+
+ImmutableBitmapSkiaImageCache::ImmutableBitmapSkiaImageCache() = default;
+
+ImmutableBitmapSkiaImageCache::ImmutableBitmapSkiaImageCache(RefPtr<SkiaBackendContext> skia_backend_context)
+    : m_skia_backend_context(move(skia_backend_context))
+{
+}
+
+ImmutableBitmapSkiaImageCache::~ImmutableBitmapSkiaImageCache() = default;
+
+sk_sp<SkImage> ImmutableBitmapSkiaImageCache::image_for_bitmap(ImmutableBitmap const& bitmap)
+{
+    if (auto it = m_images.find(&bitmap); it != m_images.end()) {
+        it->value.last_used_generation = m_generation;
+        return it->value.image;
+    }
+
+    auto context = m_skia_backend_context ? m_skia_backend_context : SkiaBackendContext::the();
+    if (context && !bitmap.ensure_sk_image(*context))
+        return nullptr;
+
+    auto image = sk_ref_sp(bitmap.sk_image());
+    if (!image)
+        return nullptr;
+
+    CachedImage cached_image {
+        .bitmap = &bitmap,
+        .image = image,
+        .last_used_generation = m_generation,
+    };
+    m_images.set(&bitmap, move(cached_image));
+    return image;
+}
+
+void ImmutableBitmapSkiaImageCache::prune()
+{
+    m_images.remove_all_matching([this](auto const&, auto const& cached_image) {
+        return m_generation - cached_image.last_used_generation > image_cache_max_unused_generations;
+    });
+    ++m_generation;
+}
+
+}

--- a/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.cpp
+++ b/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.cpp
@@ -9,9 +9,11 @@
 #include <LibGfx/ImmutableBitmapSkiaImageCache.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibGfx/SkiaUtils.h>
+#include <LibGfx/YUVData.h>
 
 #include <core/SkColorSpace.h>
 #include <core/SkImage.h>
+#include <core/SkYUVAPixmaps.h>
 #include <gpu/ganesh/GrDirectContext.h>
 #include <gpu/ganesh/SkImageGanesh.h>
 
@@ -35,15 +37,31 @@ sk_sp<SkImage> ImmutableBitmapSkiaImageCache::image_for_bitmap(ImmutableBitmap c
         return it->value.image;
     }
 
-    auto source_bitmap = bitmap.bitmap();
-    if (!source_bitmap)
-        return nullptr;
+    sk_sp<SkImage> image;
+    auto* gr_context = m_skia_backend_context ? m_skia_backend_context->sk_context() : nullptr;
+    if (gr_context && bitmap.yuv_data()) {
+        auto const* yuv_data = bitmap.yuv_data();
+        image = SkImages::TextureFromYUVAPixmaps(
+            gr_context,
+            yuv_data->make_pixmaps(),
+            skgpu::Mipmapped::kNo,
+            false,
+            bitmap.color_space().color_space<sk_sp<SkColorSpace>>());
+    }
 
-    auto image = sk_image_from_bitmap(*source_bitmap, bitmap.color_space());
-    if (auto* gr_context = m_skia_backend_context ? m_skia_backend_context->sk_context() : nullptr) {
-        auto gpu_image = SkImages::TextureFromImage(gr_context, image.get(), skgpu::Mipmapped::kNo, skgpu::Budgeted::kYes);
-        if (gpu_image)
-            image = move(gpu_image);
+    if (!image) {
+        auto source_bitmap = bitmap.bitmap();
+        if (!source_bitmap)
+            return nullptr;
+
+        auto raster_image = sk_image_from_bitmap(*source_bitmap, bitmap.color_space());
+        if (gr_context) {
+            image = SkImages::TextureFromImage(gr_context, raster_image.get(), skgpu::Mipmapped::kNo, skgpu::Budgeted::kYes);
+            if (!image)
+                image = move(raster_image);
+        } else {
+            image = move(raster_image);
+        }
     }
 
     if (!image)

--- a/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.h
+++ b/Libraries/LibGfx/ImmutableBitmapSkiaImageCache.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <LibGfx/Forward.h>
+#include <core/SkRefCnt.h>
+
+class SkImage;
+
+namespace Gfx {
+
+class ImmutableBitmapSkiaImageCache final {
+public:
+    ImmutableBitmapSkiaImageCache();
+    explicit ImmutableBitmapSkiaImageCache(RefPtr<SkiaBackendContext>);
+    ~ImmutableBitmapSkiaImageCache();
+
+    sk_sp<SkImage> image_for_bitmap(ImmutableBitmap const&);
+    void prune();
+
+private:
+    struct CachedImage {
+        RefPtr<ImmutableBitmap const> bitmap;
+        sk_sp<SkImage> image;
+        u64 last_used_generation { 0 };
+    };
+
+    RefPtr<SkiaBackendContext> m_skia_backend_context;
+    HashMap<ImmutableBitmap const*, CachedImage> m_images;
+    u64 m_generation { 0 };
+};
+
+}

--- a/Libraries/LibGfx/Painter.h
+++ b/Libraries/LibGfx/Painter.h
@@ -45,6 +45,7 @@ public:
     virtual void clip(Gfx::Path const&, Gfx::WindingRule) = 0;
 
     virtual void reset() = 0;
+    virtual void prune_caches() { }
 };
 
 }

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -43,11 +43,9 @@ struct PainterSkia::Impl {
     template<typename Callback>
     void with_canvas(Callback&& callback)
     {
-        painting_surface->lock_context();
         auto& canvas = painting_surface->canvas();
         callback(canvas);
         image_cache.prune();
-        painting_surface->unlock_context();
     }
 };
 

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -16,6 +16,7 @@
 #include <AK/TypeCasts.h>
 #include <LibGfx/Filter.h>
 #include <LibGfx/ImmutableBitmap.h>
+#include <LibGfx/ImmutableBitmapSkiaImageCache.h>
 #include <LibGfx/PainterSkia.h>
 #include <LibGfx/PathSkia.h>
 #include <LibGfx/SkiaUtils.h>
@@ -31,9 +32,11 @@ namespace Gfx {
 
 struct PainterSkia::Impl {
     RefPtr<Gfx::PaintingSurface> painting_surface;
+    ImmutableBitmapSkiaImageCache image_cache;
 
     Impl(Gfx::PaintingSurface& surface)
         : painting_surface(surface)
+        , image_cache(surface.skia_backend_context())
     {
     }
 
@@ -43,11 +46,12 @@ struct PainterSkia::Impl {
         painting_surface->lock_context();
         auto& canvas = painting_surface->canvas();
         callback(canvas);
+        image_cache.prune();
         painting_surface->unlock_context();
     }
 };
 
-static void apply_paint_style(SkPaint& paint, PaintStyle const& style)
+static void apply_paint_style(SkPaint& paint, PaintStyle const& style, ImmutableBitmapSkiaImageCache& image_cache)
 {
     if (auto const& solid_color = as_if<SolidColorPaintStyle>(style)) {
         paint.setColor(to_skia_color(solid_color->color()));
@@ -95,7 +99,9 @@ static void apply_paint_style(SkPaint& paint, PaintStyle const& style)
         auto image = canvas_pattern->image();
         if (!image)
             return;
-        auto const* sk_image = image->sk_image();
+        auto sk_image = image_cache.image_for_bitmap(*image);
+        if (!sk_image)
+            return;
 
         auto repetition = canvas_pattern->repetition();
         auto repeat_x = first_is_one_of(repetition, CanvasPatternPaintStyle::Repetition::Repeat, CanvasPatternPaintStyle::Repetition::RepeatX);
@@ -127,11 +133,11 @@ static void apply_filter(SkPaint& paint, Gfx::Filter const& filter)
     paint.setImageFilter(to_skia_image_filter(filter));
 }
 
-static SkPaint to_skia_paint(Gfx::PaintStyle const& style, Optional<Gfx::Filter const&> filter)
+static SkPaint to_skia_paint(Gfx::PaintStyle const& style, Optional<Gfx::Filter const&> filter, ImmutableBitmapSkiaImageCache& image_cache)
 {
     SkPaint paint;
 
-    apply_paint_style(paint, style);
+    apply_paint_style(paint, style, image_cache);
 
     if (filter.has_value())
         apply_filter(paint, move(filter.value()));
@@ -148,6 +154,11 @@ PainterSkia::PainterSkia(NonnullRefPtr<Gfx::PaintingSurface> painting_surface)
 }
 
 PainterSkia::~PainterSkia() = default;
+
+void PainterSkia::prune_caches()
+{
+    impl().image_cache.prune();
+}
 
 void PainterSkia::clear_rect(Gfx::FloatRect const& rect, Gfx::Color color)
 {
@@ -179,8 +190,12 @@ void PainterSkia::draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitm
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
 
     impl().with_canvas([&](auto& canvas) {
+        auto sk_image = impl().image_cache.image_for_bitmap(src_bitmap);
+        if (!sk_image)
+            return;
+
         canvas.drawImageRect(
-            src_bitmap.sk_image(),
+            sk_image.get(),
             to_skia_rect(src_rect),
             to_skia_rect(dst_rect),
             to_skia_sampling_options(scaling_mode),
@@ -248,14 +263,14 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& pain
         return;
 
     auto sk_path = to_skia_path(path);
-    auto paint = to_skia_paint(paint_style, filter);
-    paint.setAntiAlias(true);
-    float alpha = paint.getAlphaf();
-    paint.setAlphaf(alpha * global_alpha);
-    paint.setStyle(SkPaint::Style::kStroke_Style);
-    paint.setStrokeWidth(thickness);
-    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     impl().with_canvas([&](auto& canvas) {
+        auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
+        paint.setAntiAlias(true);
+        float alpha = paint.getAlphaf();
+        paint.setAlphaf(alpha * global_alpha);
+        paint.setStyle(SkPaint::Style::kStroke_Style);
+        paint.setStrokeWidth(thickness);
+        paint.setBlender(to_skia_blender(compositing_and_blending_operator));
         canvas.drawPath(sk_path, paint);
     });
 }
@@ -267,18 +282,18 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& pain
         return;
 
     auto sk_path = to_skia_path(path);
-    auto paint = to_skia_paint(paint_style, filter);
-    paint.setAntiAlias(true);
-    float alpha = paint.getAlphaf();
-    paint.setAlphaf(alpha * global_alpha);
-    paint.setStyle(SkPaint::Style::kStroke_Style);
-    paint.setStrokeWidth(thickness);
-    paint.setStrokeCap(to_skia_cap(cap_style));
-    paint.setStrokeJoin(to_skia_join(join_style));
-    paint.setStrokeMiter(miter_limit);
-    paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
-    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     impl().with_canvas([&](auto& canvas) {
+        auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
+        paint.setAntiAlias(true);
+        float alpha = paint.getAlphaf();
+        paint.setAlphaf(alpha * global_alpha);
+        paint.setStyle(SkPaint::Style::kStroke_Style);
+        paint.setStrokeWidth(thickness);
+        paint.setStrokeCap(to_skia_cap(cap_style));
+        paint.setStrokeJoin(to_skia_join(join_style));
+        paint.setStrokeMiter(miter_limit);
+        paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
+        paint.setBlender(to_skia_blender(compositing_and_blending_operator));
         canvas.drawPath(sk_path, paint);
     });
 }
@@ -313,12 +328,12 @@ void PainterSkia::fill_path(Gfx::Path const& path, Gfx::PaintStyle const& paint_
 {
     auto sk_path = to_skia_path(path);
     sk_path.setFillType(to_skia_path_fill_type(winding_rule));
-    auto paint = to_skia_paint(paint_style, filter);
-    paint.setAntiAlias(true);
-    float alpha = paint.getAlphaf();
-    paint.setAlphaf(alpha * global_alpha);
-    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     impl().with_canvas([&](auto& canvas) {
+        auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
+        paint.setAntiAlias(true);
+        float alpha = paint.getAlphaf();
+        paint.setAlphaf(alpha * global_alpha);
+        paint.setBlender(to_skia_blender(compositing_and_blending_operator));
         canvas.drawPath(sk_path, paint);
     });
 }

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -39,14 +39,6 @@ struct PainterSkia::Impl {
         , image_cache(surface.skia_backend_context())
     {
     }
-
-    template<typename Callback>
-    void with_canvas(Callback&& callback)
-    {
-        auto& canvas = painting_surface->canvas();
-        callback(canvas);
-        image_cache.prune();
-    }
 };
 
 static void apply_paint_style(SkPaint& paint, PaintStyle const& style, ImmutableBitmapSkiaImageCache& image_cache)
@@ -146,9 +138,7 @@ static SkPaint to_skia_paint(Gfx::PaintStyle const& style, Optional<Gfx::Filter 
 PainterSkia::PainterSkia(NonnullRefPtr<Gfx::PaintingSurface> painting_surface)
     : m_impl(adopt_own(*new Impl { move(painting_surface) }))
 {
-    m_impl->with_canvas([this](auto& canvas) {
-        m_initial_save_count = canvas.save();
-    });
+    m_initial_save_count = m_impl->painting_surface->canvas().save();
 }
 
 PainterSkia::~PainterSkia() = default;
@@ -160,21 +150,19 @@ void PainterSkia::prune_caches()
 
 void PainterSkia::clear_rect(Gfx::FloatRect const& rect, Gfx::Color color)
 {
-    impl().with_canvas([&](auto& canvas) {
-        canvas.save();
-        canvas.clipRect(to_skia_rect(rect));
-        canvas.clear(to_skia_color(color));
-        canvas.restore();
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.save();
+    canvas.clipRect(to_skia_rect(rect));
+    canvas.clear(to_skia_color(color));
+    canvas.restore();
 }
 
 void PainterSkia::fill_rect(Gfx::FloatRect const& rect, Color color)
 {
     SkPaint paint;
     paint.setColor(to_skia_color(color));
-    impl().with_canvas([&](auto& canvas) {
-        canvas.drawRect(to_skia_rect(rect), paint);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawRect(to_skia_rect(rect), paint);
 }
 
 void PainterSkia::draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode, Optional<Gfx::Filter> filter, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
@@ -187,19 +175,18 @@ void PainterSkia::draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitm
     paint.setAlpha(static_cast<u8>(global_alpha * 255));
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
 
-    impl().with_canvas([&](auto& canvas) {
-        auto sk_image = impl().image_cache.image_for_bitmap(src_bitmap);
-        if (!sk_image)
-            return;
+    auto sk_image = impl().image_cache.image_for_bitmap(src_bitmap);
+    if (!sk_image)
+        return;
 
-        canvas.drawImageRect(
-            sk_image.get(),
-            to_skia_rect(src_rect),
-            to_skia_rect(dst_rect),
-            to_skia_sampling_options(scaling_mode),
-            &paint,
-            SkCanvas::kStrict_SrcRectConstraint);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawImageRect(
+        sk_image.get(),
+        to_skia_rect(src_rect),
+        to_skia_rect(dst_rect),
+        to_skia_sampling_options(scaling_mode),
+        &paint,
+        SkCanvas::kStrict_SrcRectConstraint);
 }
 
 void PainterSkia::set_transform(Gfx::AffineTransform const& transform)
@@ -209,9 +196,8 @@ void PainterSkia::set_transform(Gfx::AffineTransform const& transform)
         transform.b(), transform.d(), transform.f(),
         0, 0, 1);
 
-    impl().with_canvas([&](auto& canvas) {
-        canvas.setMatrix(matrix);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.setMatrix(matrix);
 }
 
 void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thickness)
@@ -226,9 +212,8 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thi
     paint.setStrokeWidth(thickness);
     paint.setColor(to_skia_color(color));
     auto sk_path = to_skia_path(path);
-    impl().with_canvas([&](auto& canvas) {
-        canvas.drawPath(sk_path, paint);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle cap_style, Gfx::Path::JoinStyle join_style, float miter_limit, Vector<float> const& dash_array, float dash_offset)
@@ -249,9 +234,8 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::Color color, float thi
     paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     auto sk_path = to_skia_path(path);
-    impl().with_canvas([&](auto& canvas) {
-        canvas.drawPath(sk_path, paint);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, Optional<Gfx::Filter> filter, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
@@ -261,16 +245,15 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& pain
         return;
 
     auto sk_path = to_skia_path(path);
-    impl().with_canvas([&](auto& canvas) {
-        auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
-        paint.setAntiAlias(true);
-        float alpha = paint.getAlphaf();
-        paint.setAlphaf(alpha * global_alpha);
-        paint.setStyle(SkPaint::Style::kStroke_Style);
-        paint.setStrokeWidth(thickness);
-        paint.setBlender(to_skia_blender(compositing_and_blending_operator));
-        canvas.drawPath(sk_path, paint);
-    });
+    auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
+    paint.setAntiAlias(true);
+    float alpha = paint.getAlphaf();
+    paint.setAlphaf(alpha * global_alpha);
+    paint.setStyle(SkPaint::Style::kStroke_Style);
+    paint.setStrokeWidth(thickness);
+    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, Optional<Gfx::Filter> filter, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const& cap_style, Gfx::Path::JoinStyle const& join_style, float miter_limit, Vector<float> const& dash_array, float dash_offset)
@@ -280,20 +263,19 @@ void PainterSkia::stroke_path(Gfx::Path const& path, Gfx::PaintStyle const& pain
         return;
 
     auto sk_path = to_skia_path(path);
-    impl().with_canvas([&](auto& canvas) {
-        auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
-        paint.setAntiAlias(true);
-        float alpha = paint.getAlphaf();
-        paint.setAlphaf(alpha * global_alpha);
-        paint.setStyle(SkPaint::Style::kStroke_Style);
-        paint.setStrokeWidth(thickness);
-        paint.setStrokeCap(to_skia_cap(cap_style));
-        paint.setStrokeJoin(to_skia_join(join_style));
-        paint.setStrokeMiter(miter_limit);
-        paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
-        paint.setBlender(to_skia_blender(compositing_and_blending_operator));
-        canvas.drawPath(sk_path, paint);
-    });
+    auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
+    paint.setAntiAlias(true);
+    float alpha = paint.getAlphaf();
+    paint.setAlphaf(alpha * global_alpha);
+    paint.setStyle(SkPaint::Style::kStroke_Style);
+    paint.setStrokeWidth(thickness);
+    paint.setStrokeCap(to_skia_cap(cap_style));
+    paint.setStrokeJoin(to_skia_join(join_style));
+    paint.setStrokeMiter(miter_limit);
+    paint.setPathEffect(SkDashPathEffect::Make(dash_array.data(), dash_array.size(), dash_offset));
+    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::fill_path(Gfx::Path const& path, Gfx::Color color, Gfx::WindingRule winding_rule)
@@ -303,9 +285,8 @@ void PainterSkia::fill_path(Gfx::Path const& path, Gfx::Color color, Gfx::Windin
     paint.setColor(to_skia_color(color));
     auto sk_path = to_skia_path(path);
     sk_path.setFillType(to_skia_path_fill_type(winding_rule));
-    impl().with_canvas([&](auto& canvas) {
-        canvas.drawPath(sk_path, paint);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::fill_path(Gfx::Path const& path, Gfx::Color color, Gfx::WindingRule winding_rule, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
@@ -317,53 +298,47 @@ void PainterSkia::fill_path(Gfx::Path const& path, Gfx::Color color, Gfx::Windin
     paint.setBlender(to_skia_blender(compositing_and_blending_operator));
     auto sk_path = to_skia_path(path);
     sk_path.setFillType(to_skia_path_fill_type(winding_rule));
-    impl().with_canvas([&](auto& canvas) {
-        canvas.drawPath(sk_path, paint);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::fill_path(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, Optional<Gfx::Filter> filter, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule winding_rule)
 {
     auto sk_path = to_skia_path(path);
     sk_path.setFillType(to_skia_path_fill_type(winding_rule));
-    impl().with_canvas([&](auto& canvas) {
-        auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
-        paint.setAntiAlias(true);
-        float alpha = paint.getAlphaf();
-        paint.setAlphaf(alpha * global_alpha);
-        paint.setBlender(to_skia_blender(compositing_and_blending_operator));
-        canvas.drawPath(sk_path, paint);
-    });
+    auto paint = to_skia_paint(paint_style, filter, impl().image_cache);
+    paint.setAntiAlias(true);
+    float alpha = paint.getAlphaf();
+    paint.setAlphaf(alpha * global_alpha);
+    paint.setBlender(to_skia_blender(compositing_and_blending_operator));
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.drawPath(sk_path, paint);
 }
 
 void PainterSkia::save()
 {
-    impl().with_canvas([&](auto& canvas) {
-        canvas.save();
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.save();
 }
 
 void PainterSkia::restore()
 {
-    impl().with_canvas([&](auto& canvas) {
-        canvas.restore();
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.restore();
 }
 
 void PainterSkia::clip(Gfx::Path const& path, Gfx::WindingRule winding_rule)
 {
     auto sk_path = to_skia_path(path);
     sk_path.setFillType(to_skia_path_fill_type(winding_rule));
-    impl().with_canvas([&](auto& canvas) {
-        canvas.clipPath(sk_path, SkClipOp::kIntersect, true);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.clipPath(sk_path, SkClipOp::kIntersect, true);
 }
 
 void PainterSkia::reset()
 {
-    impl().with_canvas([&](auto& canvas) {
-        canvas.restoreToCount(m_initial_save_count);
-    });
+    auto& canvas = impl().painting_surface->canvas();
+    canvas.restoreToCount(m_initial_save_count);
 }
 
 }

--- a/Libraries/LibGfx/PainterSkia.h
+++ b/Libraries/LibGfx/PainterSkia.h
@@ -33,6 +33,7 @@ public:
     virtual void restore() override;
     virtual void clip(Gfx::Path const&, Gfx::WindingRule) override;
     virtual void reset() override;
+    virtual void prune_caches() override;
 
 private:
     struct Impl;

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -102,7 +102,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(IntSize size, B
     auto sk_alpha_type = to_skia_alpha_type(color_type, alpha_type);
     auto image_info = SkImageInfo::Make(size.width(), size.height(), sk_color_type, sk_alpha_type, SkColorSpace::MakeSRGB());
 
-    auto context = SkiaBackendContext::the();
+    auto context = SkiaBackendContext::the_main_thread_context();
     if (context) {
         context->lock();
         auto surface = SkSurfaces::RenderTarget(context->sk_context(), skgpu::Budgeted::kNo, image_info);

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -67,11 +67,6 @@ static void release_vulkan_image(void* context)
 
 NonnullRefPtr<PaintingSurface> PaintingSurface::create_from_vkimage(NonnullRefPtr<SkiaBackendContext> context, NonnullRefPtr<VulkanImage> vulkan_image, Origin origin)
 {
-    context->lock();
-    ScopeGuard unlock_guard([&context] {
-        context->unlock();
-    });
-
     IntSize size(vulkan_image->info.extent.width, vulkan_image->info.extent.height);
     GrVkImageInfo info = {
         .fImage = vulkan_image->image,
@@ -103,9 +98,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(IntSize size, B
     auto image_info = SkImageInfo::Make(size.width(), size.height(), sk_color_type, sk_alpha_type, SkColorSpace::MakeSRGB());
 
     if (context) {
-        context->lock();
         auto surface = SkSurfaces::RenderTarget(context->sk_context(), skgpu::Budgeted::kNo, image_info);
-        context->unlock();
         if (surface)
             return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
         dbgln("Unable to create GPU surface for size {}x{}, falling back to CPU", size.width(), size.height());
@@ -131,11 +124,6 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::wrap_bitmap(Bitmap& bitmap)
 #ifdef AK_OS_MACOS
 NonnullRefPtr<PaintingSurface> PaintingSurface::create_from_shared_image_buffer(SharedImageBuffer& shared_image_buffer, NonnullRefPtr<SkiaBackendContext> context, Origin origin)
 {
-    context->lock();
-    ScopeGuard unlock_guard([&context] {
-        context->unlock();
-    });
-
     auto const& iosurface_handle = shared_image_buffer.iosurface_handle();
     auto metal_texture = context->metal_context().create_texture_from_iosurface(iosurface_handle);
     IntSize const size { metal_texture->width(), metal_texture->height() };
@@ -155,31 +143,25 @@ PaintingSurface::PaintingSurface(NonnullOwnPtr<Impl>&& impl)
 
 PaintingSurface::~PaintingSurface()
 {
-    lock_context();
     m_impl->surface = nullptr;
-    unlock_context();
 }
 
 void PaintingSurface::read_into_bitmap(Bitmap& bitmap)
 {
-    lock_context();
     auto color_type = to_skia_color_type(bitmap.format());
     auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->readPixels(pixmap, 0, 0);
-    unlock_context();
 }
 
 void PaintingSurface::write_from_bitmap(Bitmap const& bitmap)
 {
-    lock_context();
     auto color_type = to_skia_color_type(bitmap.format());
     auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->writePixels(pixmap, 0, 0);
-    unlock_context();
 }
 
 IntSize PaintingSurface::size() const
@@ -204,9 +186,7 @@ SkSurface& PaintingSurface::sk_surface() const
 
 void PaintingSurface::notify_content_will_change()
 {
-    lock_context();
     m_impl->surface->notifyContentWillChange(SkSurface::kDiscard_ContentChangeMode);
-    unlock_context();
 }
 
 template<>
@@ -224,20 +204,6 @@ void PaintingSurface::flush()
 {
     if (on_flush)
         on_flush(*this);
-}
-
-void PaintingSurface::lock_context() const
-{
-    auto& context = m_impl->context;
-    if (context)
-        context->lock();
-}
-
-void PaintingSurface::unlock_context() const
-{
-    auto& context = m_impl->context;
-    if (context)
-        context->unlock();
 }
 
 }

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -96,13 +96,12 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_from_vkimage(NonnullRefPt
 }
 #endif
 
-NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(IntSize size, BitmapFormat color_type, AlphaType alpha_type)
+NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(IntSize size, BitmapFormat color_type, AlphaType alpha_type, RefPtr<SkiaBackendContext> context)
 {
     auto sk_color_type = to_skia_color_type(color_type);
     auto sk_alpha_type = to_skia_alpha_type(color_type, alpha_type);
     auto image_info = SkImageInfo::Make(size.width(), size.height(), sk_color_type, sk_alpha_type, SkColorSpace::MakeSRGB());
 
-    auto context = SkiaBackendContext::the_main_thread_context();
     if (context) {
         context->lock();
         auto surface = SkSurfaces::RenderTarget(context->sk_context(), skgpu::Budgeted::kNo, image_info);
@@ -110,6 +109,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(IntSize size, B
         if (surface)
             return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
         dbgln("Unable to create GPU surface for size {}x{}, falling back to CPU", size.width(), size.height());
+        context = nullptr;
     }
 
     auto bitmap = Bitmap::create(color_type, alpha_type, size).value();

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -71,9 +71,6 @@ public:
 
     ~PaintingSurface();
 
-    void lock_context() const;
-    void unlock_context() const;
-
 private:
     struct Impl;
 

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -40,7 +40,7 @@ public:
 
     Function<void(PaintingSurface&)> on_flush;
 
-    static NonnullRefPtr<PaintingSurface> create_with_size(IntSize size, BitmapFormat color_type, AlphaType alpha_type);
+    static NonnullRefPtr<PaintingSurface> create_with_size(IntSize size, BitmapFormat color_type, AlphaType alpha_type, RefPtr<SkiaBackendContext> = {});
     static NonnullRefPtr<PaintingSurface> wrap_bitmap(Bitmap&);
 
 #ifdef AK_OS_MACOS

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -27,13 +27,13 @@
 
 namespace Gfx {
 
-static RefPtr<SkiaBackendContext> s_the;
+static RefPtr<SkiaBackendContext> s_main_thread_context;
 
 void SkiaBackendContext::initialize_gpu_backend()
 {
-    VERIFY(!s_the);
+    VERIFY(!s_main_thread_context);
 
-    s_the = create_independent_gpu_backend();
+    s_main_thread_context = create_independent_gpu_backend();
 }
 
 RefPtr<SkiaBackendContext> SkiaBackendContext::create_independent_gpu_backend()
@@ -56,9 +56,9 @@ RefPtr<SkiaBackendContext> SkiaBackendContext::create_independent_gpu_backend()
 #endif
 }
 
-RefPtr<SkiaBackendContext> SkiaBackendContext::the()
+RefPtr<SkiaBackendContext> SkiaBackendContext::the_main_thread_context()
 {
-    return s_the;
+    return s_main_thread_context;
 }
 
 #ifdef USE_VULKAN

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2024-2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -33,17 +33,26 @@ void SkiaBackendContext::initialize_gpu_backend()
 {
     VERIFY(!s_the);
 
+    s_the = create_independent_gpu_backend();
+}
+
+RefPtr<SkiaBackendContext> SkiaBackendContext::create_independent_gpu_backend()
+{
 #ifdef AK_OS_MACOS
     auto metal_context = get_metal_context();
-    s_the = create_metal_context(*metal_context);
+    if (!metal_context)
+        return {};
+    return create_metal_context(*metal_context);
 #elif USE_VULKAN
     auto maybe_vulkan_context = Gfx::create_vulkan_context();
     if (maybe_vulkan_context.is_error()) {
         dbgln("Vulkan context creation failed: {}", maybe_vulkan_context.error());
-        return;
+        return {};
     }
     auto vulkan_context = maybe_vulkan_context.release_value();
-    s_the = create_vulkan_context(vulkan_context);
+    return create_vulkan_context(vulkan_context);
+#else
+    return {};
 #endif
 }
 
@@ -65,7 +74,18 @@ public:
     {
     }
 
-    ~SkiaVulkanBackendContext() override { }
+    ~SkiaVulkanBackendContext() override
+    {
+        m_context.reset();
+#    ifdef USE_VULKAN_DMABUF_IMAGES
+        if (m_vulkan_context.command_pool != VK_NULL_HANDLE)
+            vkDestroyCommandPool(m_vulkan_context.logical_device, m_vulkan_context.command_pool, nullptr);
+#    endif
+        if (m_vulkan_context.logical_device != VK_NULL_HANDLE)
+            vkDestroyDevice(m_vulkan_context.logical_device, nullptr);
+        if (m_vulkan_context.instance != VK_NULL_HANDLE)
+            vkDestroyInstance(m_vulkan_context.instance, nullptr);
+    }
 
     void flush_and_submit(SkSurface* surface) override
     {
@@ -126,7 +146,10 @@ public:
     {
     }
 
-    ~SkiaMetalBackendContext() override { }
+    ~SkiaMetalBackendContext() override
+    {
+        m_context.reset();
+    }
 
     void flush_and_submit(SkSurface* surface) override
     {

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -8,7 +8,6 @@
 
 #include <AK/AtomicRefCounted.h>
 #include <AK/Noncopyable.h>
-#include <LibThreading/Mutex.h>
 
 #ifdef USE_VULKAN
 #    include <LibGfx/VulkanContext.h>
@@ -51,12 +50,6 @@ public:
 
     virtual MetalContext& metal_context() = 0;
     virtual VulkanContext const& vulkan_context() = 0;
-
-    void lock() { m_mutex.lock(); }
-    void unlock() { m_mutex.unlock(); }
-
-private:
-    Threading::Mutex m_mutex;
 };
 
 }

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2024-2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -40,6 +40,7 @@ public:
 #endif
 
     static void initialize_gpu_backend();
+    static RefPtr<SkiaBackendContext> create_independent_gpu_backend();
     static RefPtr<SkiaBackendContext> the();
 
     SkiaBackendContext() { }

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -41,7 +41,7 @@ public:
 
     static void initialize_gpu_backend();
     static RefPtr<SkiaBackendContext> create_independent_gpu_backend();
-    static RefPtr<SkiaBackendContext> the();
+    static RefPtr<SkiaBackendContext> the_main_thread_context();
 
     SkiaBackendContext() { }
     virtual ~SkiaBackendContext() { }

--- a/Libraries/LibGfx/SkiaUtils.cpp
+++ b/Libraries/LibGfx/SkiaUtils.cpp
@@ -5,10 +5,15 @@
  */
 
 #include <AK/Assertions.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/ColorSpace.h>
 #include <LibGfx/Filter.h>
 #include <LibGfx/FilterImpl.h>
 #include <LibGfx/SkiaUtils.h>
+#include <core/SkBitmap.h>
 #include <core/SkBlender.h>
+#include <core/SkColorSpace.h>
+#include <core/SkImage.h>
 #include <core/SkImageFilter.h>
 #include <core/SkString.h>
 #include <effects/SkRuntimeEffect.h>
@@ -23,6 +28,15 @@ SkPath to_skia_path(Path const& path)
 sk_sp<SkImageFilter> to_skia_image_filter(Gfx::Filter const& filter)
 {
     return filter.impl().filter;
+}
+
+sk_sp<SkImage> sk_image_from_bitmap(Bitmap const& bitmap, ColorSpace const& color_space)
+{
+    auto info = SkImageInfo::Make(bitmap.width(), bitmap.height(), to_skia_color_type(bitmap.format()), to_skia_alpha_type(bitmap.format(), bitmap.alpha_type()), color_space.color_space<sk_sp<SkColorSpace>>());
+    SkBitmap sk_bitmap;
+    sk_bitmap.installPixels(info, const_cast<void*>(static_cast<void const*>(bitmap.scanline(0))), bitmap.pitch());
+    sk_bitmap.setImmutable();
+    return sk_bitmap.asImage();
 }
 
 sk_sp<SkBlender> to_skia_blender(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)

--- a/Libraries/LibGfx/SkiaUtils.h
+++ b/Libraries/LibGfx/SkiaUtils.h
@@ -19,6 +19,7 @@
 #include <core/SkBlender.h>
 #include <core/SkColor.h>
 #include <core/SkColorType.h>
+#include <core/SkImage.h>
 #include <core/SkImageFilter.h>
 #include <core/SkPaint.h>
 #include <core/SkPath.h>
@@ -139,5 +140,9 @@ constexpr SkSamplingOptions to_skia_sampling_options(ScalingMode scaling_mode)
 SkPath to_skia_path(Path const& path);
 sk_sp<SkImageFilter> to_skia_image_filter(Gfx::Filter const& filter);
 sk_sp<SkBlender> to_skia_blender(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator);
+
+// The returned SkImage references the source bitmap's pixels without copying; the caller
+// must keep `bitmap` alive for as long as the SkImage (or anything derived from it) is in use.
+sk_sp<SkImage> sk_image_from_bitmap(Bitmap const& bitmap, ColorSpace const& color_space);
 
 }

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -235,6 +235,12 @@ void CanvasRenderingContext2D::set_size(Gfx::IntSize const& size)
     m_painter = nullptr;
 }
 
+void CanvasRenderingContext2D::present()
+{
+    if (m_painter)
+        m_painter->prune_caches();
+}
+
 void CanvasRenderingContext2D::allocate_painting_surface_if_needed()
 {
     if (m_surface || m_size.is_empty())

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -126,6 +126,7 @@ public:
     [[nodiscard]] Gfx::Painter* painter();
 
     void set_size(Gfx::IntSize const&);
+    void present();
 
     RefPtr<Gfx::PaintingSurface> surface() { return m_surface; }
     void allocate_painting_surface_if_needed();

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -451,8 +451,8 @@ void HTMLCanvasElement::present()
     m_canvas_content_dirty = false;
 
     m_context.visit(
-        [](GC::Ref<CanvasRenderingContext2D>&) {
-            // Do nothing, CRC2D writes directly to the canvas bitmap.
+        [](GC::Ref<CanvasRenderingContext2D>& context) {
+            context->present();
         },
         [](GC::Ref<WebGL::WebGLRenderingContext>& context) {
             context->present();

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -52,7 +52,6 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/ExternalContentSource.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableBox.h>
@@ -287,7 +286,6 @@ Navigable::Navigable(GC::Ref<Page> page, bool is_svg_page)
 
     if (!m_is_svg_page) {
         auto display_list_player_type = page->client().display_list_player_type();
-        m_rendering_thread.set_skia_player(make<Painting::DisplayListPlayerSkia>());
         m_rendering_thread.start(display_list_player_type);
     }
 }

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -7,11 +7,19 @@
 #include <LibCore/EventLoop.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/SharedImageBuffer.h>
+#include <LibGfx/SkiaBackendContext.h>
 #include <LibThreading/Thread.h>
 #include <LibWeb/HTML/RenderingThread.h>
-#include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/ExternalContentSource.h>
+
+#ifdef USE_VULKAN_DMABUF_IMAGES
+#    include <AK/Array.h>
+#    include <LibGfx/VulkanImage.h>
+#    include <libdrm/drm_fourcc.h>
+#endif
 
 #include <core/SkCanvas.h>
 #include <core/SkColor.h>
@@ -41,10 +49,10 @@ struct UpdateDisplayListCommand {
 };
 
 struct UpdateBackingStoresCommand {
-    RefPtr<Gfx::PaintingSurface> front_store;
-    RefPtr<Gfx::PaintingSurface> back_store;
+    Gfx::IntSize size;
     i32 front_bitmap_id;
     i32 back_bitmap_id;
+    Function<void(i32, Gfx::SharedImage, i32, Gfx::SharedImage)> allocation_callback;
 };
 
 struct ScreenshotCommand {
@@ -53,6 +61,77 @@ struct ScreenshotCommand {
 };
 
 using CompositorCommand = Variant<UpdateDisplayListCommand, UpdateBackingStoresCommand, ScreenshotCommand>;
+
+struct BackingStorePair {
+    RefPtr<Gfx::PaintingSurface> front;
+    RefPtr<Gfx::PaintingSurface> back;
+};
+
+#ifdef USE_VULKAN
+static NonnullRefPtr<Gfx::PaintingSurface> create_gpu_painting_surface_with_bitmap_flush(Gfx::IntSize size, Gfx::SharedImageBuffer& buffer)
+{
+    auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
+    auto bitmap = buffer.bitmap();
+    surface->on_flush = [bitmap = move(bitmap)](auto& surface) {
+        surface.read_into_bitmap(*bitmap);
+    };
+    return surface;
+}
+#endif
+
+static BackingStorePair create_shareable_bitmap_backing_stores([[maybe_unused]] Gfx::IntSize size, Gfx::SharedImageBuffer& front_buffer, Gfx::SharedImageBuffer& back_buffer, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
+{
+#ifdef AK_OS_MACOS
+    if (skia_backend_context) {
+        return {
+            .front = Gfx::PaintingSurface::create_from_shared_image_buffer(front_buffer, *skia_backend_context),
+            .back = Gfx::PaintingSurface::create_from_shared_image_buffer(back_buffer, *skia_backend_context),
+        };
+    }
+#else
+#    ifdef USE_VULKAN
+    if (skia_backend_context) {
+        return {
+            .front = create_gpu_painting_surface_with_bitmap_flush(size, front_buffer),
+            .back = create_gpu_painting_surface_with_bitmap_flush(size, back_buffer),
+        };
+    }
+#    else
+    (void)skia_backend_context;
+#    endif
+#endif
+
+    return {
+        .front = Gfx::PaintingSurface::wrap_bitmap(*front_buffer.bitmap()),
+        .back = Gfx::PaintingSurface::wrap_bitmap(*back_buffer.bitmap()),
+    };
+}
+
+#ifdef USE_VULKAN_DMABUF_IMAGES
+struct DMABufBackingStorePair {
+    RefPtr<Gfx::PaintingSurface> front;
+    RefPtr<Gfx::PaintingSurface> back;
+    Gfx::SharedImage front_shared_image;
+    Gfx::SharedImage back_shared_image;
+};
+
+static ErrorOr<DMABufBackingStorePair> create_linear_dmabuf_backing_stores(Gfx::IntSize size, Gfx::SkiaBackendContext& skia_backend_context)
+{
+    auto const& vulkan_context = skia_backend_context.vulkan_context();
+    static constexpr Array<uint64_t, 1> linear_modifiers = { DRM_FORMAT_MOD_LINEAR };
+    auto front_image = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
+    auto back_image = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
+    auto front_shared_image = Gfx::duplicate_shared_image(*front_image);
+    auto back_shared_image = Gfx::duplicate_shared_image(*back_image);
+
+    return DMABufBackingStorePair {
+        .front = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(front_image), Gfx::PaintingSurface::Origin::TopLeft),
+        .back = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(back_image), Gfx::PaintingSurface::Origin::TopLeft),
+        .front_shared_image = move(front_shared_image),
+        .back_shared_image = move(back_shared_image),
+    };
+}
+#endif
 
 class RenderingThread::ThreadData final : public AtomicRefCounted<ThreadData> {
 public:
@@ -150,8 +229,7 @@ public:
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
                     },
                     [this](UpdateBackingStoresCommand& cmd) {
-                        m_backing_stores.front_store = move(cmd.front_store);
-                        m_backing_stores.back_store = move(cmd.back_store);
+                        allocate_backing_stores(cmd);
                         m_backing_stores.front_bitmap_id = cmd.front_bitmap_id;
                         m_backing_stores.back_bitmap_id = cmd.back_bitmap_id;
                     },
@@ -235,6 +313,42 @@ public:
     }
 
 private:
+    void publish_backing_store_pair(UpdateBackingStoresCommand& cmd, Gfx::SharedImage front_shared_image, Gfx::SharedImage back_shared_image)
+    {
+        if (!cmd.allocation_callback)
+            return;
+        invoke_on_main_thread([callback = move(cmd.allocation_callback), front_bitmap_id = cmd.front_bitmap_id, front_shared_image = move(front_shared_image), back_bitmap_id = cmd.back_bitmap_id, back_shared_image = move(back_shared_image)]() mutable {
+            callback(front_bitmap_id, move(front_shared_image), back_bitmap_id, move(back_shared_image));
+        });
+    }
+
+    void allocate_backing_stores(UpdateBackingStoresCommand& cmd)
+    {
+        auto skia_backend_context = Gfx::SkiaBackendContext::the();
+
+#ifdef USE_VULKAN_DMABUF_IMAGES
+        if (skia_backend_context && cmd.allocation_callback) {
+            auto backing_stores = create_linear_dmabuf_backing_stores(cmd.size, *skia_backend_context);
+            if (!backing_stores.is_error()) {
+                auto backing_store_pair = backing_stores.release_value();
+                m_backing_stores.front_store = move(backing_store_pair.front);
+                m_backing_stores.back_store = move(backing_store_pair.back);
+                publish_backing_store_pair(cmd, move(backing_store_pair.front_shared_image), move(backing_store_pair.back_shared_image));
+                return;
+            }
+        }
+#endif
+
+        auto front_buffer = Gfx::SharedImageBuffer::create(cmd.size);
+        auto back_buffer = Gfx::SharedImageBuffer::create(cmd.size);
+        auto front_shared_image = front_buffer.export_shared_image();
+        auto back_shared_image = back_buffer.export_shared_image();
+        auto backing_store_pair = create_shareable_bitmap_backing_stores(cmd.size, front_buffer, back_buffer, skia_backend_context);
+        m_backing_stores.front_store = move(backing_store_pair.front);
+        m_backing_stores.back_store = move(backing_store_pair.back);
+        publish_backing_store_pair(cmd, move(front_shared_image), move(back_shared_image));
+    }
+
     template<typename Invokee>
     void invoke_on_main_thread(Invokee invokee)
     {
@@ -319,9 +433,9 @@ void RenderingThread::update_display_list(NonnullRefPtr<Painting::DisplayList> d
     m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot) });
 }
 
-void RenderingThread::update_backing_stores(RefPtr<Gfx::PaintingSurface> front, RefPtr<Gfx::PaintingSurface> back, i32 front_id, i32 back_id)
+void RenderingThread::update_backing_stores(Gfx::IntSize size, i32 front_id, i32 back_id, Function<void(i32, Gfx::SharedImage, i32, Gfx::SharedImage)>&& allocation_callback)
 {
-    m_thread_data->enqueue_command(UpdateBackingStoresCommand { move(front), move(back), front_id, back_id });
+    m_thread_data->enqueue_command(UpdateBackingStoresCommand { size, front_id, back_id, move(allocation_callback) });
 }
 
 u64 RenderingThread::present_frame(Gfx::IntRect viewport_rect)

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -282,9 +282,7 @@ public:
                     if (should_clear_back_store) {
                         // Embedded navigables leave their PaintConfig canvas unfilled, so double-buffered back stores
                         // must be cleared before repainting.
-                        m_backing_stores.back_store->lock_context();
                         m_backing_stores.back_store->canvas().clear(SK_ColorTRANSPARENT);
-                        m_backing_stores.back_store->unlock_context();
                     }
                     m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *m_backing_stores.back_store);
                     i32 rendered_bitmap_id = m_backing_stores.back_bitmap_id;

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -68,9 +68,9 @@ struct BackingStorePair {
 };
 
 #ifdef USE_VULKAN
-static NonnullRefPtr<Gfx::PaintingSurface> create_gpu_painting_surface_with_bitmap_flush(Gfx::IntSize size, Gfx::SharedImageBuffer& buffer)
+static NonnullRefPtr<Gfx::PaintingSurface> create_gpu_painting_surface_with_bitmap_flush(Gfx::IntSize size, Gfx::SharedImageBuffer& buffer, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
 {
-    auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
+    auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, skia_backend_context);
     auto bitmap = buffer.bitmap();
     surface->on_flush = [bitmap = move(bitmap)](auto& surface) {
         surface.read_into_bitmap(*bitmap);
@@ -92,8 +92,8 @@ static BackingStorePair create_shareable_bitmap_backing_stores([[maybe_unused]] 
 #    ifdef USE_VULKAN
     if (skia_backend_context) {
         return {
-            .front = create_gpu_painting_surface_with_bitmap_flush(size, front_buffer),
-            .back = create_gpu_painting_surface_with_bitmap_flush(size, back_buffer),
+            .front = create_gpu_painting_surface_with_bitmap_flush(size, front_buffer, skia_backend_context),
+            .back = create_gpu_painting_surface_with_bitmap_flush(size, back_buffer, skia_backend_context),
         };
     }
 #    else
@@ -143,13 +143,6 @@ public:
 
     ~ThreadData() = default;
 
-    void set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player)
-    {
-        m_skia_player = move(player);
-    }
-
-    bool has_skia_player() const { return m_skia_player != nullptr; }
-
     void set_presentation_mode(RenderingThread::PresentationMode mode)
     {
         Threading::MutexLocker const locker { m_mutex };
@@ -196,8 +189,10 @@ public:
             m_frame_completed.wait();
     }
 
-    void compositor_loop()
+    void compositor_loop(DisplayListPlayerType display_list_player_type)
     {
+        initialize_skia_player(display_list_player_type);
+
         while (true) {
             {
                 Threading::MutexLocker const locker { m_mutex };
@@ -313,6 +308,18 @@ public:
     }
 
 private:
+    void initialize_skia_player(DisplayListPlayerType display_list_player_type)
+    {
+        switch (display_list_player_type) {
+        case DisplayListPlayerType::SkiaGPUIfAvailable:
+            m_skia_backend_context = Gfx::SkiaBackendContext::create_independent_gpu_backend();
+            break;
+        case DisplayListPlayerType::SkiaCPU:
+            break;
+        }
+        m_skia_player = make<Painting::DisplayListPlayerSkia>(m_skia_backend_context);
+    }
+
     void publish_backing_store_pair(UpdateBackingStoresCommand& cmd, Gfx::SharedImage front_shared_image, Gfx::SharedImage back_shared_image)
     {
         if (!cmd.allocation_callback)
@@ -324,11 +331,9 @@ private:
 
     void allocate_backing_stores(UpdateBackingStoresCommand& cmd)
     {
-        auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
-
 #ifdef USE_VULKAN_DMABUF_IMAGES
-        if (skia_backend_context && cmd.allocation_callback) {
-            auto backing_stores = create_linear_dmabuf_backing_stores(cmd.size, *skia_backend_context);
+        if (m_skia_backend_context && cmd.allocation_callback) {
+            auto backing_stores = create_linear_dmabuf_backing_stores(cmd.size, *m_skia_backend_context);
             if (!backing_stores.is_error()) {
                 auto backing_store_pair = backing_stores.release_value();
                 m_backing_stores.front_store = move(backing_store_pair.front);
@@ -343,7 +348,7 @@ private:
         auto back_buffer = Gfx::SharedImageBuffer::create(cmd.size);
         auto front_shared_image = front_buffer.export_shared_image();
         auto back_shared_image = back_buffer.export_shared_image();
-        auto backing_store_pair = create_shareable_bitmap_backing_stores(cmd.size, front_buffer, back_buffer, skia_backend_context);
+        auto backing_store_pair = create_shareable_bitmap_backing_stores(cmd.size, front_buffer, back_buffer, m_skia_backend_context);
         m_backing_stores.front_store = move(backing_store_pair.front);
         m_backing_stores.back_store = move(backing_store_pair.back);
         publish_backing_store_pair(cmd, move(front_shared_image), move(back_shared_image));
@@ -372,6 +377,7 @@ private:
     Queue<CompositorCommand> m_command_queue;
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
+    RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
     RefPtr<Painting::DisplayList> m_cached_display_list;
     Painting::ScrollStateSnapshot m_cached_scroll_state_snapshot;
     BackingStoreState m_backing_stores;
@@ -407,20 +413,14 @@ RenderingThread::~RenderingThread()
     m_thread_data->exit();
 }
 
-void RenderingThread::start(DisplayListPlayerType)
+void RenderingThread::start(DisplayListPlayerType display_list_player_type)
 {
-    VERIFY(m_thread_data->has_skia_player());
-    m_thread = Threading::Thread::construct("Renderer"sv, [thread_data = m_thread_data] {
-        thread_data->compositor_loop();
+    m_thread = Threading::Thread::construct("Renderer"sv, [thread_data = m_thread_data, display_list_player_type] {
+        thread_data->compositor_loop(display_list_player_type);
         return static_cast<intptr_t>(0);
     });
     m_thread->start();
     m_thread->detach();
-}
-
-void RenderingThread::set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player)
-{
-    m_thread_data->set_skia_player(move(player));
 }
 
 void RenderingThread::set_presentation_mode(PresentationMode mode)

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -324,7 +324,7 @@ private:
 
     void allocate_backing_stores(UpdateBackingStoresCommand& cmd)
     {
-        auto skia_backend_context = Gfx::SkiaBackendContext::the();
+        auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
 
 #ifdef USE_VULKAN_DMABUF_IMAGES
         if (skia_backend_context && cmd.allocation_callback) {

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -38,7 +38,6 @@ public:
     ~RenderingThread();
 
     void start(DisplayListPlayerType);
-    void set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player);
     void set_presentation_mode(PresentationMode);
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&);

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -10,6 +10,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Queue.h>
 #include <AK/Variant.h>
+#include <LibGfx/SharedImage.h>
 #include <LibThreading/ConditionVariable.h>
 #include <LibThreading/Forward.h>
 #include <LibThreading/Mutex.h>
@@ -41,7 +42,7 @@ public:
     void set_presentation_mode(PresentationMode);
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&);
-    void update_backing_stores(RefPtr<Gfx::PaintingSurface> front, RefPtr<Gfx::PaintingSurface> back, i32 front_id, i32 back_id);
+    void update_backing_stores(Gfx::IntSize, i32 front_id, i32 back_id, Function<void(i32, Gfx::SharedImage, i32, Gfx::SharedImage)>&& = {});
     u64 present_frame(Gfx::IntRect);
     void wait_for_frame(u64 frame_id);
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);

--- a/Libraries/LibWeb/Painting/BackingStoreManager.cpp
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.cpp
@@ -4,18 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <LibCore/Timer.h>
-#include <LibGfx/PaintingSurface.h>
-#include <LibGfx/SharedImageBuffer.h>
-#include <LibGfx/SkiaBackendContext.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Painting/BackingStoreManager.h>
-#include <WebContent/PageClient.h>
-
-#ifdef USE_VULKAN_DMABUF_IMAGES
-#    include <LibGfx/VulkanImage.h>
-#endif
 
 namespace Web::Painting {
 
@@ -40,107 +31,21 @@ void BackingStoreManager::restart_resize_timer()
     m_backing_store_shrink_timer->restart();
 }
 
-static void publish_backing_store_pair_if_needed(HTML::Navigable& navigable, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)
-{
-    if (!navigable.is_top_level_traversable())
-        return;
-
-    auto& page_client = navigable.top_level_traversable()->page().client();
-    page_client.page_did_allocate_backing_stores(front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
-}
-
-struct BackingStorePair {
-    RefPtr<Gfx::PaintingSurface> front;
-    RefPtr<Gfx::PaintingSurface> back;
-};
-
-#ifdef USE_VULKAN
-static NonnullRefPtr<Gfx::PaintingSurface> create_gpu_painting_surface_with_bitmap_flush(Gfx::IntSize size, Gfx::SharedImageBuffer& buffer)
-{
-    auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
-    auto bitmap = buffer.bitmap();
-    surface->on_flush = [bitmap = move(bitmap)](auto& surface) {
-        surface.read_into_bitmap(*bitmap);
-    };
-    return surface;
-}
-#endif
-
-static BackingStorePair create_shareable_bitmap_backing_stores(HTML::Navigable& navigable, Gfx::IntSize size, i32 front_bitmap_id, i32 back_bitmap_id, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
-{
-    auto front_buffer = Gfx::SharedImageBuffer::create(size);
-    auto back_buffer = Gfx::SharedImageBuffer::create(size);
-    publish_backing_store_pair_if_needed(navigable, front_bitmap_id, front_buffer.export_shared_image(), back_bitmap_id, back_buffer.export_shared_image());
-
-#ifdef AK_OS_MACOS
-    if (skia_backend_context) {
-        return {
-            .front = Gfx::PaintingSurface::create_from_shared_image_buffer(front_buffer, *skia_backend_context),
-            .back = Gfx::PaintingSurface::create_from_shared_image_buffer(back_buffer, *skia_backend_context),
-        };
-    }
-#else
-#    ifdef USE_VULKAN
-    if (skia_backend_context) {
-        return {
-            .front = create_gpu_painting_surface_with_bitmap_flush(size, front_buffer),
-            .back = create_gpu_painting_surface_with_bitmap_flush(size, back_buffer),
-        };
-    }
-#    else
-    (void)skia_backend_context;
-#    endif
-#endif
-
-    return {
-        .front = Gfx::PaintingSurface::wrap_bitmap(*front_buffer.bitmap()),
-        .back = Gfx::PaintingSurface::wrap_bitmap(*back_buffer.bitmap()),
-    };
-}
-
-#ifdef USE_VULKAN_DMABUF_IMAGES
-static ErrorOr<BackingStorePair> create_linear_dmabuf_backing_stores(HTML::Navigable& navigable, Gfx::IntSize size, i32 front_bitmap_id, i32 back_bitmap_id, Gfx::SkiaBackendContext& skia_backend_context)
-{
-    VERIFY(navigable.is_top_level_traversable());
-
-    auto const& vulkan_context = skia_backend_context.vulkan_context();
-    static constexpr Array<uint64_t, 1> linear_modifiers = { DRM_FORMAT_MOD_LINEAR };
-    auto front_image_value = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
-    auto back_image_value = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
-    publish_backing_store_pair_if_needed(navigable, front_bitmap_id, Gfx::duplicate_shared_image(*front_image_value), back_bitmap_id, Gfx::duplicate_shared_image(*back_image_value));
-
-    return BackingStorePair {
-        .front = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(front_image_value), Gfx::PaintingSurface::Origin::TopLeft),
-        .back = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(back_image_value), Gfx::PaintingSurface::Origin::TopLeft),
-    };
-}
-#endif
-
 void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
 {
-    auto skia_backend_context = Gfx::SkiaBackendContext::the();
-
     m_front_bitmap_id = m_next_bitmap_id++;
     m_back_bitmap_id = m_next_bitmap_id++;
+    m_allocated_size = size;
 
-    auto update_backing_stores = [&](RefPtr<Gfx::PaintingSurface> front_store, RefPtr<Gfx::PaintingSurface> back_store) {
-        m_allocated_size = size;
-        m_navigable->rendering_thread().update_backing_stores(move(front_store), move(back_store), m_front_bitmap_id, m_back_bitmap_id);
-    };
-
-#ifdef USE_VULKAN_DMABUF_IMAGES
-    if (skia_backend_context && m_navigable->is_top_level_traversable()) {
-        auto backing_stores = create_linear_dmabuf_backing_stores(*m_navigable, size, m_front_bitmap_id, m_back_bitmap_id, *skia_backend_context);
-        if (!backing_stores.is_error()) {
-            auto backing_store_pair = backing_stores.release_value();
-            update_backing_stores(move(backing_store_pair.front), move(backing_store_pair.back));
-            return;
-        }
+    Function<void(i32, Gfx::SharedImage, i32, Gfx::SharedImage)> allocation_callback;
+    if (m_navigable->is_top_level_traversable()) {
+        auto* page_client = &m_navigable->top_level_traversable()->page().client();
+        allocation_callback = [page_client](i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) mutable {
+            page_client->page_did_allocate_backing_stores(front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+        };
     }
-#endif
 
-    auto backing_stores = create_shareable_bitmap_backing_stores(*m_navigable, size, m_front_bitmap_id, m_back_bitmap_id, skia_backend_context);
-    update_backing_stores(move(backing_stores.front), move(backing_stores.back));
+    m_navigable->rendering_thread().update_backing_stores(size, m_front_bitmap_id, m_back_bitmap_id, move(allocation_callback));
 }
 
 void BackingStoreManager::resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress)

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -42,17 +42,11 @@ static bool command_is_clip(DisplayListCommand const& command)
 
 void DisplayListPlayer::execute(DisplayList& display_list, ScrollStateSnapshot const& scroll_state_snapshot, RefPtr<Gfx::PaintingSurface> surface)
 {
-    if (surface) {
-        surface->lock_context();
-    }
     m_surface = surface;
     execute_impl(display_list, scroll_state_snapshot);
     if (surface)
         flush();
     m_surface = nullptr;
-    if (surface) {
-        surface->unlock_context();
-    }
 }
 
 void DisplayListPlayer::execute_display_list_into_surface(DisplayList& display_list, Gfx::PaintingSurface& target_surface)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -93,7 +93,7 @@ static SkM44 to_skia_matrix4x4(Gfx::FloatMatrix4x4 const& matrix)
 
 void DisplayListPlayerSkia::flush()
 {
-    if (auto context = Gfx::SkiaBackendContext::the())
+    if (auto context = Gfx::SkiaBackendContext::the_main_thread_context())
         context->flush_and_submit(&surface().sk_surface());
     surface().flush();
 }
@@ -139,7 +139,7 @@ void DisplayListPlayerSkia::draw_external_content(DrawExternalContent const& com
     auto bitmap = command.source->current_bitmap();
     if (!bitmap)
         return;
-    if (Gfx::SkiaBackendContext::the() && !bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the()))
+    if (Gfx::SkiaBackendContext::the_main_thread_context() && !bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the_main_thread_context()))
         return;
     auto dst_rect = to_skia_rect(command.dst_rect);
     SkRect src_rect = SkRect::MakeIWH(bitmap->width(), bitmap->height());
@@ -151,7 +151,7 @@ void DisplayListPlayerSkia::draw_external_content(DrawExternalContent const& com
 
 void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const& command)
 {
-    if (Gfx::SkiaBackendContext::the() && !command.bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the()))
+    if (Gfx::SkiaBackendContext::the_main_thread_context() && !command.bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the_main_thread_context()))
         return;
 
     auto dst_rect = to_skia_rect(command.dst_rect);
@@ -167,7 +167,7 @@ void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitm
 
 void DisplayListPlayerSkia::draw_repeated_immutable_bitmap(DrawRepeatedImmutableBitmap const& command)
 {
-    if (Gfx::SkiaBackendContext::the() && !command.bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the()))
+    if (Gfx::SkiaBackendContext::the_main_thread_context() && !command.bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the_main_thread_context()))
         return;
 
     SkMatrix matrix;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -96,6 +96,7 @@ void DisplayListPlayerSkia::flush()
     if (auto context = Gfx::SkiaBackendContext::the_main_thread_context())
         context->flush_and_submit(&surface().sk_surface());
     surface().flush();
+    m_image_cache.prune();
 }
 
 void DisplayListPlayerSkia::draw_glyph_run(DrawGlyphRun const& command)
@@ -139,19 +140,21 @@ void DisplayListPlayerSkia::draw_external_content(DrawExternalContent const& com
     auto bitmap = command.source->current_bitmap();
     if (!bitmap)
         return;
-    if (Gfx::SkiaBackendContext::the_main_thread_context() && !bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the_main_thread_context()))
+    auto image = m_image_cache.image_for_bitmap(*bitmap);
+    if (!image)
         return;
     auto dst_rect = to_skia_rect(command.dst_rect);
-    SkRect src_rect = SkRect::MakeIWH(bitmap->width(), bitmap->height());
+    SkRect src_rect = SkRect::MakeIWH(image->width(), image->height());
     auto& canvas = surface().canvas();
     SkPaint paint;
     paint.setAntiAlias(true);
-    canvas.drawImageRect(bitmap->sk_image(), src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
+    canvas.drawImageRect(image.get(), src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
 }
 
 void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const& command)
 {
-    if (Gfx::SkiaBackendContext::the_main_thread_context() && !command.bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the_main_thread_context()))
+    auto image = m_image_cache.image_for_bitmap(*command.bitmap);
+    if (!image)
         return;
 
     auto dst_rect = to_skia_rect(command.dst_rect);
@@ -161,13 +164,14 @@ void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitm
     paint.setAntiAlias(true);
     canvas.save();
     canvas.clipRect(clip_rect, true);
-    canvas.drawImageRect(command.bitmap->sk_image(), dst_rect, to_skia_sampling_options(command.scaling_mode), &paint);
+    canvas.drawImageRect(image.get(), dst_rect, to_skia_sampling_options(command.scaling_mode), &paint);
     canvas.restore();
 }
 
 void DisplayListPlayerSkia::draw_repeated_immutable_bitmap(DrawRepeatedImmutableBitmap const& command)
 {
-    if (Gfx::SkiaBackendContext::the_main_thread_context() && !command.bitmap->ensure_sk_image(*Gfx::SkiaBackendContext::the_main_thread_context()))
+    auto image = m_image_cache.image_for_bitmap(*command.bitmap);
+    if (!image)
         return;
 
     SkMatrix matrix;
@@ -179,7 +183,7 @@ void DisplayListPlayerSkia::draw_repeated_immutable_bitmap(DrawRepeatedImmutable
 
     auto tile_mode_x = command.repeat.x ? SkTileMode::kRepeat : SkTileMode::kDecal;
     auto tile_mode_y = command.repeat.y ? SkTileMode::kRepeat : SkTileMode::kDecal;
-    auto shader = command.bitmap->sk_image()->makeShader(tile_mode_x, tile_mode_y, sampling_options, matrix);
+    auto shader = image->makeShader(tile_mode_x, tile_mode_y, sampling_options, matrix);
 
     SkPaint paint;
     paint.setAntiAlias(true);

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -37,6 +37,7 @@
 namespace Web::Painting {
 
 DisplayListPlayerSkia::DisplayListPlayerSkia()
+    : m_image_cache(Gfx::SkiaBackendContext::the())
 {
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -37,7 +37,13 @@
 namespace Web::Painting {
 
 DisplayListPlayerSkia::DisplayListPlayerSkia()
-    : m_image_cache(Gfx::SkiaBackendContext::the())
+    : DisplayListPlayerSkia(Gfx::SkiaBackendContext::the_main_thread_context())
+{
+}
+
+DisplayListPlayerSkia::DisplayListPlayerSkia(RefPtr<Gfx::SkiaBackendContext> skia_backend_context)
+    : m_skia_backend_context(move(skia_backend_context))
+    , m_image_cache(m_skia_backend_context)
 {
 }
 
@@ -94,7 +100,7 @@ static SkM44 to_skia_matrix4x4(Gfx::FloatMatrix4x4 const& matrix)
 
 void DisplayListPlayerSkia::flush()
 {
-    if (auto context = Gfx::SkiaBackendContext::the_main_thread_context())
+    if (auto context = surface().skia_backend_context())
         context->flush_and_submit(&surface().sk_surface());
     surface().flush();
     m_image_cache.prune();
@@ -489,7 +495,7 @@ SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(Painting::SVGPaintServe
         if (tile_size.is_empty())
             return {};
 
-        auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
+        auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_skia_backend_context);
 
         execute_display_list_into_surface(*pattern->tile_display_list(), *tile_surface);
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -19,6 +19,7 @@ namespace Web::Painting {
 class DisplayListPlayerSkia final : public DisplayListPlayer {
 public:
     DisplayListPlayerSkia();
+    explicit DisplayListPlayerSkia(RefPtr<Gfx::SkiaBackendContext>);
     ~DisplayListPlayerSkia();
 
 private:
@@ -59,6 +60,7 @@ private:
 
     SkPaint paint_style_to_skia_paint(SVGPaintServerPaintStyle const&, Gfx::FloatRect const& bounding_rect);
 
+    RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
     Gfx::ImmutableBitmapSkiaImageCache m_image_cache;
 };
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/ImmutableBitmapSkiaImageCache.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
@@ -57,6 +58,8 @@ private:
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
     SkPaint paint_style_to_skia_paint(SVGPaintServerPaintStyle const&, Gfx::FloatRect const& bounding_rect);
+
+    Gfx::ImmutableBitmapSkiaImageCache m_image_cache;
 };
 
 }

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -34,7 +34,7 @@ JS::ThrowCompletionOr<GC::Ptr<WebGL2RenderingContext>> WebGL2RenderingContext::c
     // We should be coming here from getContext being called on a wrapped <canvas> element.
     auto context_attributes = TRY(convert_value_to_context_attributes_dictionary(canvas_element.vm(), options));
 
-    auto skia_backend_context = Gfx::SkiaBackendContext::the();
+    auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
     if (!skia_backend_context) {
         fire_webgl_context_creation_error(canvas_element);
         return GC::Ptr<WebGL2RenderingContext> { nullptr };

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -50,7 +50,7 @@ JS::ThrowCompletionOr<GC::Ptr<WebGLRenderingContext>> WebGLRenderingContext::cre
     // We should be coming here from getContext being called on a wrapped <canvas> element.
     auto context_attributes = TRY(convert_value_to_context_attributes_dictionary(canvas_element.vm(), options));
 
-    auto skia_backend_context = Gfx::SkiaBackendContext::the();
+    auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
     if (!skia_backend_context) {
         fire_webgl_context_creation_error(canvas_element);
         return GC::Ptr<WebGLRenderingContext> { nullptr };


### PR DESCRIPTION
Skia GPU work currently funnels through a single process-wide SkiaBackendContext that is shared between the main thread and the rendering thread, with a mutex serializing every GPU operation between them. That lock is the wrong shape for what we actually want — these two threads should be able to make GPU progress independently rather than take turns through a shared context.

This branch lets each thread own its own Skia backend context, so there is no shared GPU state left to guard. With the sharing gone, the SkiaBackendContext mutex and the lock_context() / unlock_context() helpers that wrapped every painting operation become dead weight and are removed.