### PR TITLE
LibWeb: Skip `@media` rule re-evaluation when nothing has changed

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1865,7 +1865,8 @@ void Document::update_style()
     // Fetch the viewport rect once, instead of repeatedly, during style computation.
     style_computer().set_viewport_rect({}, viewport_rect());
 
-    evaluate_media_rules();
+    if (m_needs_media_query_evaluation)
+        evaluate_media_rules();
 
     style_computer().reset_has_result_cache();
     style_computer().reset_ancestor_filter();


### PR DESCRIPTION
The `m_needs_media_query_evaluation` tracks when we need to evaluate media rules, but we were evaluating them unconditionally during style updates.

While watching a YouTube video for 30 seconds, this drops `CSSRuleList::evaluate_media_queries()` from ~2% to <0.1% total time.