### PR TITLE
LibCore: Fix shm_open() crash on macOS Tahoe 26.x

### DIFF
--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -168,16 +168,21 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
     static size_t shared_memory_id = 0;
 
     auto name = ByteString::formatted("/shm-{}-{}", getpid(), shared_memory_id++);
-    fd = shm_open(name.characters(), O_RDWR | O_CREAT | options, 0600);
+    // NOTE: macOS Tahoe (26.x) does not support O_CLOEXEC in shm_open(),
+    //       so we open without it and set FD_CLOEXEC via fcntl() instead.
+    fd = shm_open(name.characters(), O_RDWR | O_CREAT, 0600);
+
+    if (fd < 0)
+        return Error::from_errno(errno);
+
+    if ((options & O_CLOEXEC) != 0)
+        TRY(fcntl(fd, F_SETFD, FD_CLOEXEC));
 
     if (shm_unlink(name.characters()) == -1) {
         auto saved_errno = errno;
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
-
-    if (fd < 0)
-        return Error::from_errno(errno);
 
     if (::ftruncate(fd, size) < 0) {
         auto saved_errno = errno;


### PR DESCRIPTION
## TL;DR

Fix `shm_open()` crash on macOS Tahoe 26.x by removing `O_CLOEXEC` flag (unsupported) and setting `FD_CLOEXEC` via `fcntl()` instead.

## Problem

macOS Tahoe (26.x) introduced a regression where `shm_open()` rejects the `O_CLOEXEC` flag with `EINVAL`. This causes `AnonymousBuffer::create_with_size()` to fail, which cascades into a crash during `create_system_palette()` at browser startup.

**Crash trace:**
```
VERIFICATION FAILED: !is_error() at AK/Error.h:171
→ Ladybird::create_system_palette() + 896
→ Ladybird::WebViewBridge::update_palette()
→ Ladybird::WebViewBridge::initialize_client()
```

**Root cause:** `shm_open(name, O_RDWR | O_CREAT | O_CLOEXEC, 0600)` returns `-1` with `errno=22 (EINVAL)` on macOS Tahoe 26.x. The code then attempts `shm_unlink()` and `close(-1)`, producing the secondary "Bad file descriptor" error.

**Verified with a test program:**
```c
// O_CLOEXEC → fails with EINVAL on macOS Tahoe 26.x
shm_open("/test", O_RDWR | O_CREAT | O_CLOEXEC, 0600); // fd=-1, errno=22

// Without O_CLOEXEC → works fine
shm_open("/test", O_RDWR | O_CREAT, 0600); // fd=3, errno=0
```

## Fix

1. Strip `O_CLOEXEC` from the `shm_open()` call on BSD-generic platforms
2. Set `FD_CLOEXEC` via `fcntl(fd, F_SETFD, FD_CLOEXEC)` after a successful open
3. Move the `fd < 0` check **before** `shm_unlink()` to avoid operating on an invalid fd (pre-existing bug)

## Testing

- **Before fix:** Ladybird crashes immediately on startup on macOS Tahoe 26.4.1 (25E253), Apple M1 Max
- **After fix:** Ladybird launches successfully with full multi-process architecture (WebContent, RequestServer, ImageDecoder)

## Environment

- macOS Tahoe 26.4.1
- Apple M1 Max (MacBookPro18,2)
- Apple Clang 21.0.0

🌸 Generated with [AdaL](https://github.com/nicepkg/adal)
