### PR TITLE
LibWebView: Persist and restore zoom level per host

### DIFF
--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -28,6 +28,8 @@ static constexpr auto DEFAULT_SHOW_BOOKMARKS_BAR = true;
 static constexpr auto DEFAULT_ZOOM_LEVEL_FACTOR_KEY = "defaultZoomLevelFactor"sv;
 static constexpr double INITIAL_ZOOM_LEVEL_FACTOR = 1.0;
 
+static constexpr auto ZOOM_PER_HOST_KEY = "zoomPerHost"sv;
+
 static constexpr auto LANGUAGES_KEY = "languages"sv;
 static auto DEFAULT_LANGUAGE = "en"_string;
 
@@ -79,6 +81,13 @@ Settings Settings::create(Badge<Application>)
 
     if (auto factor = settings_json.value().get_double_with_precision_loss(DEFAULT_ZOOM_LEVEL_FACTOR_KEY); factor.has_value())
         settings.m_default_zoom_level_factor = factor.release_value();
+
+    if (auto zoom_per_host = settings_json.value().get_object(ZOOM_PER_HOST_KEY); zoom_per_host.has_value()) {
+        zoom_per_host->for_each_member([&](auto const& host, JsonValue const& value) {
+            if (auto zoom_level = value.get_double_with_precision_loss(); zoom_level.has_value())
+                settings.m_zoom_per_host.set(host, *zoom_level);
+        });
+    }
 
     if (auto languages = settings_json.value().get(LANGUAGES_KEY); languages.has_value())
         settings.m_languages = parse_json_languages(*languages);
@@ -155,6 +164,13 @@ JsonValue Settings::serialize_json() const
     settings.set(NEW_TAB_PAGE_URL_KEY, m_new_tab_page_url.serialize());
     settings.set(SHOW_BOOKMARKS_BAR_KEY, m_show_bookmarks_bar);
     settings.set(DEFAULT_ZOOM_LEVEL_FACTOR_KEY, m_default_zoom_level_factor);
+
+    if (!m_zoom_per_host.is_empty()) {
+        JsonObject zoom_per_host;
+        for (auto const& [host, zoom_level] : m_zoom_per_host)
+            zoom_per_host.set(host, zoom_level);
+        settings.set(ZOOM_PER_HOST_KEY, move(zoom_per_host));
+    }
 
     JsonArray languages;
     languages.ensure_capacity(m_languages.size());
@@ -272,6 +288,34 @@ void Settings::set_default_zoom_level_factor(double zoom_level)
 
     for (auto& observer : m_observers)
         observer.default_zoom_level_factor_changed();
+}
+
+Optional<double> Settings::zoom_for_host(StringView host) const
+{
+    if (host.is_empty())
+        return {};
+    return m_zoom_per_host.get(host);
+}
+
+void Settings::set_zoom_for_host(StringView host, double zoom_level)
+{
+    if (host.is_empty())
+        return;
+
+    if (zoom_level == m_default_zoom_level_factor) {
+        if (!m_zoom_per_host.remove(host))
+            return;
+    } else {
+        auto existing = m_zoom_per_host.get(host);
+        if (existing.has_value() && *existing == zoom_level)
+            return;
+        m_zoom_per_host.set(String::from_utf8_without_validation(host.bytes()), zoom_level);
+    }
+
+    persist_settings();
+
+    for (auto& observer : m_observers)
+        observer.zoom_per_host_changed(host);
 }
 
 Vector<String> Settings::parse_json_languages(JsonValue const& languages)

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/JsonValue.h>
 #include <AK/Optional.h>
@@ -48,6 +49,7 @@ public:
     virtual void new_tab_page_url_changed() { }
     virtual void show_bookmarks_bar_changed() { }
     virtual void default_zoom_level_factor_changed() { }
+    virtual void zoom_per_host_changed(StringView host) { (void)host; }
     virtual void languages_changed() { }
     virtual void browsing_behavior_changed() { }
     virtual void search_engine_changed() { }
@@ -72,6 +74,9 @@ public:
 
     double default_zoom_level_factor() const { return m_default_zoom_level_factor; }
     void set_default_zoom_level_factor(double);
+
+    Optional<double> zoom_for_host(StringView host) const;
+    void set_zoom_for_host(StringView host, double zoom_level);
 
     static Vector<String> parse_json_languages(JsonValue const&);
     Vector<String> const& languages() const { return m_languages; }
@@ -123,6 +128,7 @@ private:
     URL::URL m_new_tab_page_url;
     bool m_show_bookmarks_bar { true };
     double m_default_zoom_level_factor { 0 };
+    HashMap<String, double> m_zoom_per_host;
     Vector<String> m_languages;
     BrowsingBehavior m_browsing_behavior;
     Optional<SearchEngine> m_search_engine;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -100,8 +100,12 @@ void ViewImplementation::set_url(URL::URL url)
     if (m_url == url)
         return;
 
+    auto previous_host = current_host();
     m_url = move(url);
     update_bookmark_action();
+
+    if (current_host() != previous_host)
+        apply_zoom_for_current_host();
 }
 
 void ViewImplementation::set_favicon(Badge<WebContentClient>, Gfx::Bitmap const& favicon)
@@ -214,6 +218,7 @@ void ViewImplementation::zoom_in()
         return;
     m_zoom_level = round_to<int>((m_zoom_level + ZOOM_STEP) * 100) / 100.0;
     update_zoom();
+    Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
 }
 
 void ViewImplementation::zoom_out()
@@ -222,6 +227,7 @@ void ViewImplementation::zoom_out()
         return;
     m_zoom_level = round_to<int>((m_zoom_level - ZOOM_STEP) * 100) / 100.0;
     update_zoom();
+    Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
 }
 
 void ViewImplementation::set_zoom(double zoom_level)
@@ -235,6 +241,7 @@ void ViewImplementation::reset_zoom()
     m_zoom_level = 1.0;
     update_zoom();
     client().async_reset_zoom(m_client_state.page_index);
+    Application::settings().set_zoom_for_host(current_host(), m_zoom_level);
 }
 
 void ViewImplementation::enqueue_input_event(Web::InputEvent event)
@@ -628,6 +635,23 @@ void ViewImplementation::update_zoom()
     client().async_set_zoom_level(m_client_state.page_index, m_zoom_level);
 }
 
+String ViewImplementation::current_host() const
+{
+    if (!m_url.host().has_value())
+        return {};
+    return m_url.serialized_host();
+}
+
+void ViewImplementation::apply_zoom_for_current_host()
+{
+    auto& settings = Application::settings();
+    auto zoom_level = settings.zoom_for_host(current_host()).value_or(settings.default_zoom_level_factor());
+    if (zoom_level == m_zoom_level)
+        return;
+    m_zoom_level = zoom_level;
+    update_zoom();
+}
+
 void ViewImplementation::handle_resize()
 {
     client().async_set_viewport(page_id(), viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
@@ -716,8 +740,14 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
 
 void ViewImplementation::default_zoom_level_factor_changed()
 {
-    auto const default_zoom_level_factor = Application::settings().default_zoom_level_factor();
-    set_zoom(default_zoom_level_factor);
+    apply_zoom_for_current_host();
+}
+
+void ViewImplementation::zoom_per_host_changed(StringView host)
+{
+    if (current_host() != host)
+        return;
+    apply_zoom_for_current_host();
 }
 
 void ViewImplementation::languages_changed()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -292,6 +292,8 @@ protected:
     void set_url(URL::URL);
 
     virtual void update_zoom();
+    String current_host() const;
+    void apply_zoom_for_current_host();
 
     void handle_resize();
 
@@ -308,6 +310,7 @@ protected:
     void handle_web_content_process_crash(LoadErrorPage = LoadErrorPage::Yes);
 
     virtual void default_zoom_level_factor_changed() override;
+    virtual void zoom_per_host_changed(StringView host) override;
     virtual void languages_changed() override;
     virtual void browsing_behavior_changed() override;
     virtual void autoplay_settings_changed() override;


### PR DESCRIPTION
Remember the zoom level for each host so that returning to a site restores the zoom the user previously chose, matching what other browsers have done for years.

When the user zooms in, zooms out, or resets the zoom, the resulting level is written to `Settings` keyed by the current page's host. On navigation, when a view's URL host changes, the stored level for the new host is applied (or the global default if there is no override).

Per-host zoom changes are broadcast through the `SettingsObserver` so that two tabs viewing the same host stay in sync as soon as the user adjusts zoom in either one. Zoom changes from within the page (such as `internals.setBrowserZoom` hook) and the WebContent restart path do not persist, only user-initiated zoom changes do.