### PR TITLE
LibJS: Move AST into arenas + use foldhash for fast hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ version = "0.1.0"
 dependencies = [
  "bytecode_def",
  "cbindgen",
+ "foldhash",
  "indexmap",
  "libunicode_rust",
  "num-bigint",

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -311,6 +311,14 @@ if(NOT BUILD_SHARED_LIBS)
         COMMENT "Merging Rust archive into LibJS"
     )
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
+
+    # POST_BUILD steps don't track inputs, so when libjs_rust.a changes ninja
+    # leaves liblagom-js.a alone and the merged archive ends up with stale
+    # Rust objects. Force the C++ FFI bridge file to depend on the Rust
+    # archive: when it changes, RustIntegration.cpp recompiles, LibJS gets
+    # re-archived, and POST_BUILD re-merges the fresh Rust objects.
+    get_target_property(_libjs_rust_lib libjs_rust IMPORTED_LOCATION)
+    set_property(SOURCE RustIntegration.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libjs_rust_lib})
 endif()
 
 # AsmInterpreter: generate platform-specific assembly from DSL

--- a/Libraries/LibJS/Rust/Cargo.toml
+++ b/Libraries/LibJS/Rust/Cargo.toml
@@ -14,6 +14,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 num-integer = "0.1"
 indexmap = "2"
+foldhash = "0.1"
 
 [build-dependencies]
 bytecode_def = { path = "../BytecodeDef" }

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -26,6 +26,8 @@ use std::ffi::c_void;
 use std::fmt;
 use std::ops::{Index, IndexMut};
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
 use std::collections::HashMap;
 
@@ -1281,31 +1283,33 @@ unsafe extern "C" {
 
 /// Handle to a compiled regex from C++.
 ///
-/// Wrapped in `Rc` in `RegExpLiteralData` so that AST clones (e.g. for
+/// Wrapped in `Arc` in `RegExpLiteralData` so that AST clones (e.g. for
 /// class field initializers) share the handle cheaply. The first codegen
 /// path to call `take()` gets the handle; `Drop` frees it if untaken.
-pub struct CompiledRegex(Cell<*mut c_void>);
+/// Uses `AtomicPtr` so the regex can be safely shared across threads
+/// during background compile of sibling functions.
+pub struct CompiledRegex(AtomicPtr<c_void>);
 
 impl CompiledRegex {
     pub fn new(ptr: *mut c_void) -> Self {
-        Self(Cell::new(ptr))
+        Self(AtomicPtr::new(ptr))
     }
 
     /// Take ownership of the compiled regex handle, leaving null behind
     /// so the destructor won't free it.
     pub fn take(&self) -> *mut c_void {
-        self.0.replace(std::ptr::null_mut())
+        self.0.swap(std::ptr::null_mut(), Ordering::AcqRel)
     }
 
     /// Set the compiled regex handle (used by deferred compilation).
     pub fn set(&self, ptr: *mut c_void) {
-        self.0.set(ptr);
+        self.0.store(ptr, Ordering::Release);
     }
 }
 
 impl Drop for CompiledRegex {
     fn drop(&mut self) {
-        let ptr = self.0.get();
+        let ptr = *self.0.get_mut();
         if !ptr.is_null() {
             unsafe { rust_free_compiled_regex(ptr) };
         }
@@ -1314,7 +1318,7 @@ impl Drop for CompiledRegex {
 
 impl fmt::Debug for CompiledRegex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "CompiledRegex({:p})", self.0.get())
+        write!(f, "CompiledRegex({:p})", self.0.load(Ordering::Acquire))
     }
 }
 
@@ -1322,7 +1326,7 @@ impl fmt::Debug for CompiledRegex {
 pub struct RegExpLiteralData {
     pub pattern: Utf16String,
     pub flags: Utf16String,
-    pub compiled_regex: Rc<CompiledRegex>,
+    pub compiled_regex: Arc<CompiledRegex>,
 }
 
 // =============================================================================

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -640,6 +640,10 @@ impl FunctionTable {
 pub struct FunctionPayload {
     pub data: FunctionData,
     pub function_table: FunctionTable,
+    /// Shared access to the program-wide identifier/scope/string tables.
+    /// Each lazy-compile SFD carries an Arc clone so it can resolve its
+    /// identifier IDs without depending on a parent generator.
+    pub arena: Arc<AstArena>,
 }
 
 // =============================================================================
@@ -1037,14 +1041,14 @@ pub struct FunctionParameter {
 
 #[derive(Clone, Debug)]
 pub enum FunctionParameterBinding {
-    Identifier(Rc<Identifier>),
+    Identifier(IdentifierId),
     BindingPattern(BindingPattern),
 }
 
 /// Shared data for FunctionDeclaration and FunctionExpression.
 #[derive(Debug)]
 pub struct FunctionData {
-    pub name: Option<Rc<Identifier>>,
+    pub name: Option<IdentifierId>,
     pub source_text_start: u32,
     pub source_text_end: u32,
     pub body: Box<Statement>,
@@ -1069,7 +1073,7 @@ pub struct FunctionData {
 /// Shared data for ClassDeclaration and ClassExpression.
 #[derive(Clone, Debug)]
 pub struct ClassData {
-    pub name: Option<Rc<Identifier>>,
+    pub name: Option<IdentifierId>,
     pub source_text_start: u32,
     pub source_text_end: u32,
     pub constructor: Option<Box<Expression>>,
@@ -1152,7 +1156,7 @@ pub struct BindingEntry {
 /// - `Expression`: computed property key (`{ [expression]: x }`)
 #[derive(Clone, Debug)]
 pub enum BindingEntryName {
-    Identifier(Rc<Identifier>),
+    Identifier(IdentifierId),
     Expression(Box<Expression>),
 }
 
@@ -1163,7 +1167,7 @@ pub enum BindingEntryName {
 /// - `MemberExpression`: assignment target (`{ x: obj.property }`)
 #[derive(Clone, Debug)]
 pub enum BindingEntryAlias {
-    Identifier(Rc<Identifier>),
+    Identifier(IdentifierId),
     BindingPattern(Box<BindingPattern>),
     MemberExpression(Box<Expression>),
 }
@@ -1181,7 +1185,7 @@ pub struct VariableDeclarator {
 
 #[derive(Clone, Debug)]
 pub enum VariableDeclaratorTarget {
-    Identifier(Rc<Identifier>),
+    Identifier(IdentifierId),
     BindingPattern(BindingPattern),
 }
 
@@ -1254,7 +1258,7 @@ pub enum OptionalChainReference {
         mode: OptionalChainMode,
     },
     MemberReference {
-        identifier: Rc<Identifier>,
+        identifier: IdentifierId,
         mode: OptionalChainMode,
     },
     PrivateMemberReference {
@@ -1349,7 +1353,7 @@ pub struct CatchClause {
 
 #[derive(Clone, Debug)]
 pub enum CatchBinding {
-    Identifier(Rc<Identifier>),
+    Identifier(IdentifierId),
     BindingPattern(BindingPattern),
 }
 
@@ -1646,7 +1650,7 @@ pub enum ExpressionKind {
     RegExpLiteral(Box<RegExpLiteralData>),
 
     // Identifiers
-    Identifier(Rc<Identifier>),
+    Identifier(IdentifierId),
     PrivateIdentifier(Box<PrivateIdentifier>),
 
     // Operators
@@ -1754,7 +1758,7 @@ pub struct VariableDeclarationData {
 #[derive(Clone, Debug)]
 pub struct FunctionDeclarationData {
     pub function_id: FunctionId,
-    pub name: Option<Rc<Identifier>>,
+    pub name: Option<IdentifierId>,
     pub kind: FunctionKind,
     pub is_hoisted: Cell<bool>,
 }

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -28,7 +28,7 @@ use std::ops::{Index, IndexMut};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use std::collections::HashMap;
+use crate::fast_hash::HashMap;
 
 use crate::u32_from_usize;
 
@@ -147,7 +147,7 @@ impl StringInterner {
     pub fn new() -> Self {
         Self {
             storage: Vec::new(),
-            lookup: HashMap::new(),
+            lookup: HashMap::default(),
         }
     }
 

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -24,9 +24,185 @@
 use std::cell::{Cell, RefCell};
 use std::ffi::c_void;
 use std::fmt;
+use std::ops::{Index, IndexMut};
 use std::rc::Rc;
 
 use std::collections::HashMap;
+
+use crate::u32_from_usize;
+
+// =============================================================================
+// AST arena (contiguous storage for identifiers, scopes, and interned strings)
+// =============================================================================
+//
+// Bulk allocation replaces per-node `Rc::new` calls. AST nodes hold opaque
+// `Copy` indexes into the arena's `Vec`s; the actual data lives contiguously
+// for cache-friendly traversal during scope analysis and codegen. After parse
+// the arena is logically frozen and can be shared across threads via
+// `Arc<AstArena>` without atomic refcount churn on individual nodes.
+
+/// Opaque handle into `IdentifierArena`. `Copy` so AST nodes can hold one
+/// without cloning anything.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub struct IdentifierId(u32);
+
+/// Opaque handle into `ScopeArena`.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub struct ScopeId(u32);
+
+/// Opaque handle into `StringInterner`. Equal `StringId`s mean equal strings,
+/// so name comparisons are a single `u32` compare instead of slice equality.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub struct StringId(u32);
+
+/// Contiguous backing store for `Identifier` nodes.
+#[derive(Debug, Default)]
+pub struct IdentifierArena {
+    storage: Vec<Identifier>,
+}
+
+impl IdentifierArena {
+    pub fn new() -> Self {
+        Self { storage: Vec::new() }
+    }
+
+    pub fn insert(&mut self, identifier: Identifier) -> IdentifierId {
+        let id = IdentifierId(u32_from_usize(self.storage.len()));
+        self.storage.push(identifier);
+        id
+    }
+
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+}
+
+impl Index<IdentifierId> for IdentifierArena {
+    type Output = Identifier;
+    fn index(&self, id: IdentifierId) -> &Identifier {
+        &self.storage[id.0 as usize]
+    }
+}
+
+impl IndexMut<IdentifierId> for IdentifierArena {
+    fn index_mut(&mut self, id: IdentifierId) -> &mut Identifier {
+        &mut self.storage[id.0 as usize]
+    }
+}
+
+/// Contiguous backing store for `ScopeData` nodes.
+#[derive(Debug, Default)]
+pub struct ScopeArena {
+    storage: Vec<ScopeData>,
+}
+
+impl ScopeArena {
+    pub fn new() -> Self {
+        Self { storage: Vec::new() }
+    }
+
+    pub fn insert(&mut self, scope: ScopeData) -> ScopeId {
+        let id = ScopeId(u32_from_usize(self.storage.len()));
+        self.storage.push(scope);
+        id
+    }
+
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+}
+
+impl Index<ScopeId> for ScopeArena {
+    type Output = ScopeData;
+    fn index(&self, id: ScopeId) -> &ScopeData {
+        &self.storage[id.0 as usize]
+    }
+}
+
+impl IndexMut<ScopeId> for ScopeArena {
+    fn index_mut(&mut self, id: ScopeId) -> &mut ScopeData {
+        &mut self.storage[id.0 as usize]
+    }
+}
+
+/// Deduplicating string table. Repeated identifier names from the source
+/// (`length`, `i`, `this`, ...) all map to the same `StringId`, so the
+/// per-identifier name no longer allocates after the first occurrence.
+#[derive(Debug, Default)]
+pub struct StringInterner {
+    storage: Vec<Utf16String>,
+    lookup: HashMap<Utf16String, StringId>,
+}
+
+impl StringInterner {
+    pub fn new() -> Self {
+        Self {
+            storage: Vec::new(),
+            lookup: HashMap::new(),
+        }
+    }
+
+    pub fn intern(&mut self, value: &[u16]) -> StringId {
+        if let Some(&id) = self.lookup.get(value) {
+            return id;
+        }
+        let id = StringId(u32_from_usize(self.storage.len()));
+        let owned = Utf16String::from(value);
+        self.storage.push(owned.clone());
+        self.lookup.insert(owned, id);
+        id
+    }
+
+    pub fn intern_owned(&mut self, value: Utf16String) -> StringId {
+        if let Some(&id) = self.lookup.get(value.as_slice()) {
+            return id;
+        }
+        let id = StringId(u32_from_usize(self.storage.len()));
+        self.storage.push(value.clone());
+        self.lookup.insert(value, id);
+        id
+    }
+
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+}
+
+impl Index<StringId> for StringInterner {
+    type Output = Utf16String;
+    fn index(&self, id: StringId) -> &Utf16String {
+        &self.storage[id.0 as usize]
+    }
+}
+
+/// Bundles the three arenas. Owned by the parser during parsing, then handed
+/// to `ParsedProgram`/`CompiledProgram`. Since every contained type is plain
+/// data (no `Cell`/`RefCell`/`Rc`) once the parser is done, this is naturally
+/// `Send + Sync` and can be wrapped in `Arc` for concurrent codegen.
+#[derive(Debug, Default)]
+pub struct AstArena {
+    pub identifiers: IdentifierArena,
+    pub scopes: ScopeArena,
+    pub strings: StringInterner,
+}
+
+impl AstArena {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 // =============================================================================
 // Function table (side table for FunctionData)

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -14,18 +14,17 @@
 //! - `ExpressionKind` and `StatementKind` are flat enums — pattern matching
 //!   replaces virtual dispatch.
 //! - `Node<T>` wraps every AST node with source location info.
-//! - `Identifier` uses `Cell` fields for scope analysis results that are
-//!   written after parsing (by the scope collector).
+//! - `Identifier` carries scope analysis results as plain fields, written
+//!   by the scope collector through `&mut arena.identifiers[id]` after
+//!   parsing.
 //! - Operator enums use `#[repr(u8)]` with ABI-compatible values for
 //!   trivial FFI conversion.
 //! - `ScopeData` is carried by block-like constructs (Program,
 //!   BlockStatement, FunctionBody, etc.) and holds scope analysis results.
 
-use std::cell::{Cell, RefCell};
 use std::ffi::c_void;
 use std::fmt;
 use std::ops::{Index, IndexMut};
-use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
@@ -292,11 +291,11 @@ impl FunctionTable {
     /// Parser-created functions carry an explicit child list, so this is
     /// normally proportional to the number of nested functions instead of the
     /// size of the function body.
-    pub fn extract_reachable(&mut self, data: &FunctionData) -> FunctionTable {
+    pub fn extract_reachable(&mut self, data: &FunctionData, scopes: &ScopeArena) -> FunctionTable {
         let mut subtable = FunctionTable::new();
         if let Some(nested_function_ids) = &data.nested_function_ids {
             for id in nested_function_ids {
-                self.transfer(*id, &mut subtable);
+                self.transfer(*id, &mut subtable, scopes);
             }
         } else {
             // Synthetic function wrappers created during codegen (for example
@@ -304,157 +303,157 @@ impl FunctionTable {
             // context stack, so keep the structural scan for those rare cases.
             for param in &data.parameters {
                 if let Some(ref default) = param.default_value {
-                    self.collect_from_expression(default, &mut subtable);
+                    self.collect_from_expression(default, &mut subtable, scopes);
                 }
                 if let FunctionParameterBinding::BindingPattern(ref pat) = param.binding {
-                    self.collect_from_pattern(pat, &mut subtable);
+                    self.collect_from_pattern(pat, &mut subtable, scopes);
                 }
             }
-            self.collect_from_statement(&data.body, &mut subtable);
+            self.collect_from_statement(&data.body, &mut subtable, scopes);
         }
         subtable
     }
 
-    fn transfer(&mut self, id: FunctionId, result: &mut FunctionTable) {
+    fn transfer(&mut self, id: FunctionId, result: &mut FunctionTable, scopes: &ScopeArena) {
         if let Some(data) = self.try_take(id) {
             if let Some(nested_function_ids) = &data.nested_function_ids {
                 for id in nested_function_ids {
-                    self.transfer(*id, result);
+                    self.transfer(*id, result, scopes);
                 }
             } else {
                 for param in &data.parameters {
                     if let Some(ref default) = param.default_value {
-                        self.collect_from_expression(default, result);
+                        self.collect_from_expression(default, result, scopes);
                     }
                     if let FunctionParameterBinding::BindingPattern(ref pat) = param.binding {
-                        self.collect_from_pattern(pat, result);
+                        self.collect_from_pattern(pat, result, scopes);
                     }
                 }
-                self.collect_from_statement(&data.body, result);
+                self.collect_from_statement(&data.body, result, scopes);
             }
             result.insert_at(id, data);
         }
     }
 
-    fn collect_from_statement(&mut self, stmt: &Statement, result: &mut FunctionTable) {
+    fn collect_from_statement(&mut self, stmt: &Statement, result: &mut FunctionTable, scopes: &ScopeArena) {
         match &stmt.inner {
             StatementKind::FunctionDeclaration(data) => {
-                self.transfer(data.function_id, result);
+                self.transfer(data.function_id, result, scopes);
             }
-            StatementKind::Expression(expr) => self.collect_from_expression(expr, result),
+            StatementKind::Expression(expr) => self.collect_from_expression(expr, result, scopes),
             StatementKind::Block(scope) | StatementKind::FunctionBody { scope, .. } => {
-                for child in &scope.borrow().children {
-                    self.collect_from_statement(child, result);
+                for child in &scopes[*scope].children {
+                    self.collect_from_statement(child, result, scopes);
                 }
             }
             StatementKind::Program(data) => {
-                for child in &data.scope.borrow().children {
-                    self.collect_from_statement(child, result);
+                for child in &scopes[data.scope].children {
+                    self.collect_from_statement(child, result, scopes);
                 }
             }
             StatementKind::If(data) => {
-                self.collect_from_expression(&data.test, result);
-                self.collect_from_statement(&data.consequent, result);
+                self.collect_from_expression(&data.test, result, scopes);
+                self.collect_from_statement(&data.consequent, result, scopes);
                 if let Some(alt) = &data.alternate {
-                    self.collect_from_statement(alt, result);
+                    self.collect_from_statement(alt, result, scopes);
                 }
             }
             StatementKind::While(data) => {
-                self.collect_from_expression(&data.test, result);
-                self.collect_from_statement(&data.body, result);
+                self.collect_from_expression(&data.test, result, scopes);
+                self.collect_from_statement(&data.body, result, scopes);
             }
             StatementKind::DoWhile(data) => {
-                self.collect_from_statement(&data.body, result);
-                self.collect_from_expression(&data.test, result);
+                self.collect_from_statement(&data.body, result, scopes);
+                self.collect_from_expression(&data.test, result, scopes);
             }
             StatementKind::For(data) => {
                 if let Some(init) = &data.init {
                     match init {
-                        ForInit::Expression(expr) => self.collect_from_expression(expr, result),
-                        ForInit::Declaration(decl) => self.collect_from_statement(decl, result),
+                        ForInit::Expression(expr) => self.collect_from_expression(expr, result, scopes),
+                        ForInit::Declaration(decl) => self.collect_from_statement(decl, result, scopes),
                     }
                 }
                 if let Some(test) = &data.test {
-                    self.collect_from_expression(test, result);
+                    self.collect_from_expression(test, result, scopes);
                 }
                 if let Some(update) = &data.update {
-                    self.collect_from_expression(update, result);
+                    self.collect_from_expression(update, result, scopes);
                 }
-                self.collect_from_statement(&data.body, result);
+                self.collect_from_statement(&data.body, result, scopes);
             }
             StatementKind::ForInOf(data) => {
                 match &data.lhs {
-                    ForInOfLhs::Declaration(decl) => self.collect_from_statement(decl, result),
-                    ForInOfLhs::Expression(expr) => self.collect_from_expression(expr, result),
-                    ForInOfLhs::Pattern(pattern) => self.collect_from_pattern(pattern, result),
+                    ForInOfLhs::Declaration(decl) => self.collect_from_statement(decl, result, scopes),
+                    ForInOfLhs::Expression(expr) => self.collect_from_expression(expr, result, scopes),
+                    ForInOfLhs::Pattern(pattern) => self.collect_from_pattern(pattern, result, scopes),
                 }
-                self.collect_from_expression(&data.rhs, result);
-                self.collect_from_statement(&data.body, result);
+                self.collect_from_expression(&data.rhs, result, scopes);
+                self.collect_from_statement(&data.body, result, scopes);
             }
             StatementKind::Switch(data) => {
-                self.collect_from_expression(&data.discriminant, result);
+                self.collect_from_expression(&data.discriminant, result, scopes);
                 for case in &data.cases {
                     if let Some(ref test) = case.test {
-                        self.collect_from_expression(test, result);
+                        self.collect_from_expression(test, result, scopes);
                     }
-                    for child in &case.scope.borrow().children {
-                        self.collect_from_statement(child, result);
+                    for child in &scopes[case.scope].children {
+                        self.collect_from_statement(child, result, scopes);
                     }
                 }
             }
             StatementKind::With(data) => {
-                self.collect_from_expression(&data.object, result);
-                self.collect_from_statement(&data.body, result);
+                self.collect_from_expression(&data.object, result, scopes);
+                self.collect_from_statement(&data.body, result, scopes);
             }
             StatementKind::Labelled(data) => {
-                self.collect_from_statement(&data.item, result);
+                self.collect_from_statement(&data.item, result, scopes);
             }
             StatementKind::Return(arg) => {
                 if let Some(expr) = arg {
-                    self.collect_from_expression(expr, result);
+                    self.collect_from_expression(expr, result, scopes);
                 }
             }
             StatementKind::Throw(expr) => {
-                self.collect_from_expression(expr, result);
+                self.collect_from_expression(expr, result, scopes);
             }
             StatementKind::Try(data) => {
-                self.collect_from_statement(&data.block, result);
+                self.collect_from_statement(&data.block, result, scopes);
                 if let Some(ref handler) = data.handler {
                     if let Some(CatchBinding::BindingPattern(ref pat)) = handler.parameter {
-                        self.collect_from_pattern(pat, result);
+                        self.collect_from_pattern(pat, result, scopes);
                     }
-                    self.collect_from_statement(&handler.body, result);
+                    self.collect_from_statement(&handler.body, result, scopes);
                 }
                 if let Some(ref finalizer) = data.finalizer {
-                    self.collect_from_statement(finalizer, result);
+                    self.collect_from_statement(finalizer, result, scopes);
                 }
             }
             StatementKind::VariableDeclaration(data) => {
                 for decl in &data.declarations {
-                    self.collect_from_target(&decl.target, result);
+                    self.collect_from_target(&decl.target, result, scopes);
                     if let Some(ref init) = decl.init {
-                        self.collect_from_expression(init, result);
+                        self.collect_from_expression(init, result, scopes);
                     }
                 }
             }
             StatementKind::UsingDeclaration(declarations) => {
                 for decl in declarations.iter() {
-                    self.collect_from_target(&decl.target, result);
+                    self.collect_from_target(&decl.target, result, scopes);
                     if let Some(ref init) = decl.init {
-                        self.collect_from_expression(init, result);
+                        self.collect_from_expression(init, result, scopes);
                     }
                 }
             }
             StatementKind::ClassDeclaration(class_data) => {
-                self.collect_from_class(class_data, result);
+                self.collect_from_class(class_data, result, scopes);
             }
             StatementKind::Export(data) => {
                 if let Some(ref stmt) = data.statement {
-                    self.collect_from_statement(stmt, result);
+                    self.collect_from_statement(stmt, result, scopes);
                 }
             }
             StatementKind::ClassFieldInitializer(data) => {
-                self.collect_from_expression(&data.expression, result);
+                self.collect_from_expression(&data.expression, result, scopes);
             }
             StatementKind::Empty
             | StatementKind::Debugger
@@ -466,60 +465,60 @@ impl FunctionTable {
         }
     }
 
-    fn collect_from_expression(&mut self, expr: &Expression, result: &mut FunctionTable) {
+    fn collect_from_expression(&mut self, expr: &Expression, result: &mut FunctionTable, scopes: &ScopeArena) {
         match &expr.inner {
             ExpressionKind::Function(function_id) => {
-                self.transfer(*function_id, result);
+                self.transfer(*function_id, result, scopes);
             }
             ExpressionKind::Class(class_data) => {
-                self.collect_from_class(class_data, result);
+                self.collect_from_class(class_data, result, scopes);
             }
             ExpressionKind::Binary(data) => {
-                self.collect_from_expression(&data.lhs, result);
-                self.collect_from_expression(&data.rhs, result);
+                self.collect_from_expression(&data.lhs, result, scopes);
+                self.collect_from_expression(&data.rhs, result, scopes);
             }
             ExpressionKind::Logical(data) => {
-                self.collect_from_expression(&data.lhs, result);
-                self.collect_from_expression(&data.rhs, result);
+                self.collect_from_expression(&data.lhs, result, scopes);
+                self.collect_from_expression(&data.rhs, result, scopes);
             }
             ExpressionKind::Unary { operand, .. } => {
-                self.collect_from_expression(operand, result);
+                self.collect_from_expression(operand, result, scopes);
             }
             ExpressionKind::Update(data) => {
-                self.collect_from_expression(&data.argument, result);
+                self.collect_from_expression(&data.argument, result, scopes);
             }
             ExpressionKind::Assignment(data) => {
                 match &data.lhs {
-                    AssignmentLhs::Expression(expr) => self.collect_from_expression(expr, result),
-                    AssignmentLhs::Pattern(pat) => self.collect_from_pattern(pat, result),
+                    AssignmentLhs::Expression(expr) => self.collect_from_expression(expr, result, scopes),
+                    AssignmentLhs::Pattern(pat) => self.collect_from_pattern(pat, result, scopes),
                 }
-                self.collect_from_expression(&data.rhs, result);
+                self.collect_from_expression(&data.rhs, result, scopes);
             }
             ExpressionKind::Conditional(data) => {
-                self.collect_from_expression(&data.test, result);
-                self.collect_from_expression(&data.consequent, result);
-                self.collect_from_expression(&data.alternate, result);
+                self.collect_from_expression(&data.test, result, scopes);
+                self.collect_from_expression(&data.consequent, result, scopes);
+                self.collect_from_expression(&data.alternate, result, scopes);
             }
             ExpressionKind::Sequence(exprs) => {
                 for expr in exprs.iter() {
-                    self.collect_from_expression(expr, result);
+                    self.collect_from_expression(expr, result, scopes);
                 }
             }
             ExpressionKind::Member(data) => {
-                self.collect_from_expression(&data.object, result);
-                self.collect_from_expression(&data.property, result);
+                self.collect_from_expression(&data.object, result, scopes);
+                self.collect_from_expression(&data.property, result, scopes);
             }
             ExpressionKind::OptionalChain(data) => {
-                self.collect_from_expression(&data.base, result);
+                self.collect_from_expression(&data.base, result, scopes);
                 for reference in &data.references {
                     match reference {
                         OptionalChainReference::Call { arguments, .. } => {
                             for arg in arguments {
-                                self.collect_from_expression(&arg.value, result);
+                                self.collect_from_expression(&arg.value, result, scopes);
                             }
                         }
                         OptionalChainReference::ComputedReference { expression, .. } => {
-                            self.collect_from_expression(expression, result);
+                            self.collect_from_expression(expression, result, scopes);
                         }
                         OptionalChainReference::MemberReference { .. }
                         | OptionalChainReference::PrivateMemberReference { .. } => {}
@@ -527,50 +526,50 @@ impl FunctionTable {
                 }
             }
             ExpressionKind::Call(data) | ExpressionKind::New(data) => {
-                self.collect_from_expression(&data.callee, result);
+                self.collect_from_expression(&data.callee, result, scopes);
                 for arg in &data.arguments {
-                    self.collect_from_expression(&arg.value, result);
+                    self.collect_from_expression(&arg.value, result, scopes);
                 }
             }
             ExpressionKind::SuperCall(data) => {
                 for arg in &data.arguments {
-                    self.collect_from_expression(&arg.value, result);
+                    self.collect_from_expression(&arg.value, result, scopes);
                 }
             }
             ExpressionKind::Spread(expr) | ExpressionKind::Await(expr) => {
-                self.collect_from_expression(expr, result);
+                self.collect_from_expression(expr, result, scopes);
             }
             ExpressionKind::Array(elements) => {
                 for expr in elements.iter().flatten() {
-                    self.collect_from_expression(expr, result);
+                    self.collect_from_expression(expr, result, scopes);
                 }
             }
             ExpressionKind::Object(properties) => {
                 for prop in properties.iter() {
-                    self.collect_from_expression(&prop.key, result);
+                    self.collect_from_expression(&prop.key, result, scopes);
                     if let Some(ref val) = prop.value {
-                        self.collect_from_expression(val, result);
+                        self.collect_from_expression(val, result, scopes);
                     }
                 }
             }
             ExpressionKind::TemplateLiteral(data) => {
                 for expr in &data.expressions {
-                    self.collect_from_expression(expr, result);
+                    self.collect_from_expression(expr, result, scopes);
                 }
             }
             ExpressionKind::TaggedTemplateLiteral(data) => {
-                self.collect_from_expression(&data.tag, result);
-                self.collect_from_expression(&data.template_literal, result);
+                self.collect_from_expression(&data.tag, result, scopes);
+                self.collect_from_expression(&data.template_literal, result, scopes);
             }
             ExpressionKind::Yield(data) => {
                 if let Some(ref expr) = data.argument {
-                    self.collect_from_expression(expr, result);
+                    self.collect_from_expression(expr, result, scopes);
                 }
             }
             ExpressionKind::ImportCall(data) => {
-                self.collect_from_expression(&data.specifier, result);
+                self.collect_from_expression(&data.specifier, result, scopes);
                 if let Some(ref opts) = data.options {
-                    self.collect_from_expression(opts, result);
+                    self.collect_from_expression(opts, result, scopes);
                 }
             }
             ExpressionKind::NumericLiteral(_)
@@ -588,57 +587,62 @@ impl FunctionTable {
         }
     }
 
-    fn collect_from_class(&mut self, class_data: &ClassData, result: &mut FunctionTable) {
+    fn collect_from_class(&mut self, class_data: &ClassData, result: &mut FunctionTable, scopes: &ScopeArena) {
         if let Some(ref super_class) = class_data.super_class {
-            self.collect_from_expression(super_class, result);
+            self.collect_from_expression(super_class, result, scopes);
         }
         if let Some(ref constructor) = class_data.constructor {
-            self.collect_from_expression(constructor, result);
+            self.collect_from_expression(constructor, result, scopes);
         }
         for element in &class_data.elements {
             match &element.inner {
                 ClassElement::Method { key, function, .. } => {
-                    self.collect_from_expression(key, result);
-                    self.collect_from_expression(function, result);
+                    self.collect_from_expression(key, result, scopes);
+                    self.collect_from_expression(function, result, scopes);
                 }
                 ClassElement::Field { key, initializer, .. } => {
-                    self.collect_from_expression(key, result);
+                    self.collect_from_expression(key, result, scopes);
                     if let Some(init) = initializer {
-                        self.collect_from_expression(init, result);
+                        self.collect_from_expression(init, result, scopes);
                     }
                 }
                 ClassElement::StaticInitializer { body } => {
-                    self.collect_from_statement(body, result);
+                    self.collect_from_statement(body, result, scopes);
                 }
             }
         }
     }
 
-    fn collect_from_pattern(&mut self, pattern: &BindingPattern, result: &mut FunctionTable) {
+    fn collect_from_pattern(&mut self, pattern: &BindingPattern, result: &mut FunctionTable, scopes: &ScopeArena) {
         for entry in &pattern.entries {
             if let Some(BindingEntryName::Expression(expr)) = entry.name.as_ref() {
-                self.collect_from_expression(expr, result);
+                self.collect_from_expression(expr, result, scopes);
             }
             if let Some(ref alias) = entry.alias {
                 match alias {
                     BindingEntryAlias::BindingPattern(sub) => {
-                        self.collect_from_pattern(sub, result);
+                        self.collect_from_pattern(sub, result, scopes);
                     }
                     BindingEntryAlias::MemberExpression(expr) => {
-                        self.collect_from_expression(expr, result);
+                        self.collect_from_expression(expr, result, scopes);
                     }
                     BindingEntryAlias::Identifier(_) => {}
                 }
             }
             if let Some(ref init) = entry.initializer {
-                self.collect_from_expression(init, result);
+                self.collect_from_expression(init, result, scopes);
             }
         }
     }
 
-    fn collect_from_target(&mut self, target: &VariableDeclaratorTarget, result: &mut FunctionTable) {
+    fn collect_from_target(
+        &mut self,
+        target: &VariableDeclaratorTarget,
+        result: &mut FunctionTable,
+        scopes: &ScopeArena,
+    ) {
         if let VariableDeclaratorTarget::BindingPattern(pat) = target {
-            self.collect_from_pattern(pat, result);
+            self.collect_from_pattern(pat, result, scopes);
         }
     }
 }
@@ -1303,7 +1307,7 @@ pub enum CatchBinding {
 
 #[derive(Clone, Debug)]
 pub struct SwitchStatementData {
-    pub scope: Rc<RefCell<ScopeData>>,
+    pub scope: ScopeId,
     pub discriminant: Box<Expression>,
     pub cases: Vec<SwitchCase>,
 }
@@ -1311,7 +1315,7 @@ pub struct SwitchStatementData {
 #[derive(Clone, Debug)]
 pub struct SwitchCase {
     pub range: SourceRange,
-    pub scope: Rc<RefCell<ScopeData>>,
+    pub scope: ScopeId,
     pub test: Option<Expression>,
 }
 
@@ -1433,11 +1437,12 @@ pub struct LocalVariable {
 /// Data shared by all scope-bearing nodes (Program, BlockStatement,
 /// FunctionBody, SwitchStatement, SwitchCase).
 ///
-/// Wrapped in `Rc<RefCell<...>>` for interior mutability during the
-/// scope collector's analysis phase. Borrow safety: the scope
-/// collector's two-phase design (build tree during parsing, then
-/// analyze bottom-up) ensures borrows never overlap — the analysis
-/// phase only borrows one scope at a time in a bottom-up traversal.
+/// AST nodes refer to scopes via `ScopeId` indices into `ScopeArena`,
+/// so the AST itself is plain data — no `Rc`/`RefCell` and naturally
+/// `Send + Sync` once parsing is done. The scope collector's two-phase
+/// design (build tree during parse, analyze bottom-up afterwards)
+/// ensures only one mutable borrow of a given `ScopeData` is ever
+/// live at a time.
 #[derive(Clone, Debug, Default)]
 pub struct ScopeData {
     pub children: Vec<Statement>,
@@ -1453,19 +1458,6 @@ pub struct ScopeData {
     pub uses_this_from_environment: bool,
     pub contains_direct_call_to_eval: bool,
     pub contains_access_to_arguments_object: bool,
-}
-
-impl ScopeData {
-    pub fn new_shared() -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self::default()))
-    }
-
-    pub fn shared_with_children(children: Vec<Statement>) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self {
-            children,
-            ..Default::default()
-        }))
-    }
 }
 
 /// Scope analysis data for function bodies, populated by the scope collector.
@@ -1700,7 +1692,7 @@ pub struct FunctionDeclarationData {
     pub function_id: FunctionId,
     pub name: Option<IdentifierId>,
     pub kind: FunctionKind,
-    pub is_hoisted: Cell<bool>,
+    pub is_hoisted: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1722,11 +1714,8 @@ pub enum StatementKind {
     Debugger,
 
     // Blocks (carry ScopeData for scope analysis)
-    Block(Rc<RefCell<ScopeData>>),
-    FunctionBody {
-        scope: Rc<RefCell<ScopeData>>,
-        in_strict_mode: bool,
-    },
+    Block(ScopeId),
+    FunctionBody { scope: ScopeId, in_strict_mode: bool },
     Program(Box<ProgramData>),
 
     // Control flow
@@ -1740,12 +1729,8 @@ pub enum StatementKind {
     Labelled(Box<LabelledStatementData>),
 
     // Jumps
-    Break {
-        target_label: Option<Utf16String>,
-    },
-    Continue {
-        target_label: Option<Utf16String>,
-    },
+    Break { target_label: Option<Utf16String> },
+    Continue { target_label: Option<Utf16String> },
     Return(Option<Box<Expression>>),
     Throw(Box<Expression>),
     Try(Box<TryStatementData>),
@@ -1771,7 +1756,7 @@ pub enum StatementKind {
 
 #[derive(Clone, Debug)]
 pub struct ProgramData {
-    pub scope: Rc<RefCell<ScopeData>>,
+    pub scope: ScopeId,
     pub program_type: ProgramType,
     pub is_strict_mode: bool,
     pub has_top_level_await: bool,

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -204,6 +204,14 @@ impl AstArena {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn name_of(&self, id: IdentifierId) -> &Utf16String {
+        &self.strings[self.identifiers[id].name]
+    }
+
+    pub fn name_slice(&self, id: IdentifierId) -> &[u16] {
+        self.strings[self.identifiers[id].name].as_slice()
+    }
 }
 
 // =============================================================================
@@ -737,75 +745,6 @@ impl Utf16String {
     }
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Default)]
-pub struct SharedUtf16String(pub Rc<Utf16String>);
-
-impl SharedUtf16String {
-    pub fn new(value: Utf16String) -> Self {
-        Self(Rc::new(value))
-    }
-
-    pub fn to_utf16_string(&self) -> Utf16String {
-        self.0.as_ref().clone()
-    }
-}
-
-impl From<Utf16String> for SharedUtf16String {
-    fn from(value: Utf16String) -> Self {
-        Self::new(value)
-    }
-}
-
-impl From<Vec<u16>> for SharedUtf16String {
-    fn from(value: Vec<u16>) -> Self {
-        Self::new(Utf16String::from(value))
-    }
-}
-
-impl From<&[u16]> for SharedUtf16String {
-    fn from(value: &[u16]) -> Self {
-        Self::new(Utf16String::from(value))
-    }
-}
-
-impl std::ops::Deref for SharedUtf16String {
-    type Target = Utf16String;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
-}
-
-impl std::borrow::Borrow<[u16]> for SharedUtf16String {
-    fn borrow(&self) -> &[u16] {
-        self.0.as_slice()
-    }
-}
-
-impl AsRef<[u16]> for SharedUtf16String {
-    fn as_ref(&self) -> &[u16] {
-        self.0.as_slice()
-    }
-}
-
-impl PartialEq<[u16]> for SharedUtf16String {
-    fn eq(&self, other: &[u16]) -> bool {
-        self.0.as_slice() == other
-    }
-}
-
-impl PartialEq<&[u16]> for SharedUtf16String {
-    fn eq(&self, other: &&[u16]) -> bool {
-        self.0.as_slice() == *other
-    }
-}
-
-impl PartialEq<Utf16String> for SharedUtf16String {
-    fn eq(&self, other: &Utf16String) -> bool {
-        self.0.as_slice() == other.as_slice()
-    }
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct Position {
     pub line: u32,
@@ -983,7 +922,7 @@ pub enum LocalType {
 #[derive(Clone, Debug)]
 pub struct Identifier {
     pub range: SourceRange,
-    pub name: SharedUtf16String,
+    pub name: StringId,
     // Scope analysis results — set by scope collector after parsing.
     pub local_type: Option<LocalType>,
     pub local_index: u32,
@@ -993,7 +932,7 @@ pub struct Identifier {
 }
 
 impl Identifier {
-    pub fn new(range: SourceRange, name: SharedUtf16String) -> Self {
+    pub fn new(range: SourceRange, name: StringId) -> Self {
         Self {
             range,
             name,

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -977,18 +977,19 @@ pub enum LocalType {
 
 /// An identifier reference or binding name.
 ///
-/// Scope analysis results are stored in `Cell` fields because the scope
-/// collector writes them after parsing through shared references.
+/// Scope analysis writes the resolution fields via `&mut arena.identifiers[id]`
+/// during analyze(); after that the arena is logically frozen and these
+/// fields are read-only.
 #[derive(Clone, Debug)]
 pub struct Identifier {
     pub range: SourceRange,
     pub name: SharedUtf16String,
     // Scope analysis results — set by scope collector after parsing.
-    pub local_type: Cell<Option<LocalType>>,
-    pub local_index: Cell<u32>,
-    pub is_global: Cell<bool>,
-    pub is_inside_scope_with_eval: Cell<bool>,
-    pub declaration_kind: Cell<Option<DeclarationKind>>,
+    pub local_type: Option<LocalType>,
+    pub local_index: u32,
+    pub is_global: bool,
+    pub is_inside_scope_with_eval: bool,
+    pub declaration_kind: Option<DeclarationKind>,
 }
 
 impl Identifier {
@@ -996,16 +997,16 @@ impl Identifier {
         Self {
             range,
             name,
-            local_type: Cell::new(None),
-            local_index: Cell::new(0),
-            is_global: Cell::new(false),
-            is_inside_scope_with_eval: Cell::new(false),
-            declaration_kind: Cell::new(None),
+            local_type: None,
+            local_index: 0,
+            is_global: false,
+            is_inside_scope_with_eval: false,
+            declaration_kind: None,
         }
     }
 
     pub fn is_local(&self) -> bool {
-        self.local_type.get().is_some()
+        self.local_type.is_some()
     }
 }
 

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -68,11 +68,15 @@ struct DumpState<'a> {
     use_color: bool,
     output: Option<&'a RefCell<String>>,
     function_table: &'a FunctionTable,
+    identifiers: &'a crate::ast::IdentifierArena,
 }
 
 impl DumpState<'_> {
     fn function_table(&self) -> &FunctionTable {
         self.function_table
+    }
+    fn identifier(&self, id: crate::ast::IdentifierId) -> &crate::ast::Identifier {
+        &self.identifiers[id]
     }
 }
 
@@ -118,6 +122,7 @@ fn child_state<'a>(state: &DumpState<'a>, is_last: bool) -> DumpState<'a> {
         use_color: state.use_color,
         output: state.output,
         function_table: state.function_table,
+        identifiers: state.identifiers,
     }
 }
 
@@ -303,7 +308,12 @@ fn dump_labeled_statement(label: &str, statement: &Statement, is_last: bool, sta
 // Entry point
 // ============================================================================
 
-pub fn dump_program(program: &Statement, use_color: bool, function_table: &FunctionTable) {
+pub fn dump_program(
+    program: &Statement,
+    use_color: bool,
+    function_table: &FunctionTable,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     let state = DumpState {
         prefix: String::new(),
         is_last: false,
@@ -311,12 +321,17 @@ pub fn dump_program(program: &Statement, use_color: bool, function_table: &Funct
         use_color,
         output: None,
         function_table,
+        identifiers,
     };
     dump_statement(program, &state);
     println!();
 }
 
-pub fn dump_program_to_string(program: &Statement, function_table: &FunctionTable) -> String {
+pub fn dump_program_to_string(
+    program: &Statement,
+    function_table: &FunctionTable,
+    identifiers: &crate::ast::IdentifierArena,
+) -> String {
     let output = RefCell::new(String::new());
     let state = DumpState {
         prefix: String::new(),
@@ -325,6 +340,7 @@ pub fn dump_program_to_string(program: &Statement, function_table: &FunctionTabl
         use_color: false,
         output: Some(&output),
         function_table,
+        identifiers,
     };
     dump_statement(program, &state);
     output.into_inner()
@@ -682,7 +698,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
         }
 
         ExpressionKind::Identifier(ident) => {
-            dump_identifier(ident, &expression.range, state);
+            dump_identifier(state.identifier(*ident), &expression.range, state);
         }
 
         ExpressionKind::PrivateIdentifier(ident) => {
@@ -798,7 +814,7 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
                     }
                     OptionalChainReference::MemberReference { identifier, mode } => {
                         print_node(&ref_state, &format!("MemberReference({})", optional_mode_str(*mode)));
-                        dump_identifier(identifier, &identifier.range, &child_state(&ref_state, true));
+                        dump_identifier_id(*identifier, &child_state(&ref_state, true));
                     }
                     OptionalChainReference::PrivateMemberReference {
                         private_identifier,
@@ -942,6 +958,12 @@ fn dump_expression(expression: &Expression, state: &DumpState) {
 // Identifier dumper
 // ============================================================================
 
+fn dump_identifier_id(id: crate::ast::IdentifierId, state: &DumpState) {
+    let ident = state.identifier(id);
+    let range = ident.range;
+    dump_identifier(ident, &range, state);
+}
+
 fn dump_identifier(ident: &Identifier, range: &SourceRange, state: &DumpState) {
     let mut desc = color_node_name(state, "Identifier");
     desc.push_str(&format!(" {}", color_string_utf16(state, &ident.name)));
@@ -990,8 +1012,8 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
     if is_generator {
         desc.push('*');
     }
-    let name_str = match &function_data.name {
-        Some(ident) => utf16_to_string(&ident.name),
+    let name_str = match function_data.name {
+        Some(id) => utf16_to_string(&state.identifier(id).name),
         None => String::new(),
     };
     desc.push_str(&format!(" {}", color_string(state, &name_str)));
@@ -1025,8 +1047,8 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
             if parameter.is_rest {
                 print_node(&parameter_state, &color_label(state, "rest"));
                 match &parameter.binding {
-                    FunctionParameterBinding::Identifier(ident) => {
-                        dump_identifier(ident, &ident.range, &child_state(&parameter_state, !has_default));
+                    FunctionParameterBinding::Identifier(id) => {
+                        dump_identifier_id(*id, &child_state(&parameter_state, !has_default));
                     }
                     FunctionParameterBinding::BindingPattern(pattern) => {
                         dump_binding_pattern(pattern, &child_state(&parameter_state, !has_default), state);
@@ -1034,10 +1056,9 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
                 }
             } else {
                 match &parameter.binding {
-                    FunctionParameterBinding::Identifier(ident) => {
-                        dump_identifier(
-                            ident,
-                            &ident.range,
+                    FunctionParameterBinding::Identifier(id) => {
+                        dump_identifier_id(
+                            *id,
                             &child_state(&parameters_state, i == function_data.parameters.len() - 1),
                         );
                     }
@@ -1065,8 +1086,8 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
 }
 
 fn dump_class(class_data: &ClassData, range: &SourceRange, state: &DumpState, root_state: &DumpState) {
-    let name_str = match &class_data.name {
-        Some(ident) => utf16_to_string(&ident.name),
+    let name_str = match class_data.name {
+        Some(id) => utf16_to_string(&state.identifier(id).name),
         None => String::new(),
     };
     print_node(
@@ -1205,9 +1226,8 @@ fn dump_binding_pattern(pattern: &BindingPattern, state: &DumpState, root_state:
                         &child_state(&entry_state, !has_alias && !has_initializer),
                         &color_label(root_state, "name"),
                     );
-                    dump_identifier(
-                        ident,
-                        &ident.range,
+                    dump_identifier_id(
+                        *ident,
                         &child_state(&child_state(&entry_state, !has_alias && !has_initializer), true),
                     );
                 }
@@ -1232,11 +1252,7 @@ fn dump_binding_pattern(pattern: &BindingPattern, state: &DumpState, root_state:
             );
             match alias {
                 BindingEntryAlias::Identifier(ident) => {
-                    dump_identifier(
-                        ident,
-                        &ident.range,
-                        &child_state(&child_state(&entry_state, !has_initializer), true),
-                    );
+                    dump_identifier_id(*ident, &child_state(&child_state(&entry_state, !has_initializer), true));
                 }
                 BindingEntryAlias::BindingPattern(sub) => {
                     dump_binding_pattern(
@@ -1283,7 +1299,7 @@ fn dump_variable_declarator(declaration: &VariableDeclarator, state: &DumpState,
     let has_init = declaration.init.is_some();
     match &declaration.target {
         VariableDeclaratorTarget::Identifier(ident) => {
-            dump_identifier(ident, &ident.range, &child_state(state, !has_init));
+            dump_identifier_id(*ident, &child_state(state, !has_init));
         }
         VariableDeclaratorTarget::BindingPattern(pattern) => {
             dump_binding_pattern(pattern, &child_state(state, !has_init), root_state);
@@ -1337,7 +1353,7 @@ fn dump_catch_clause(clause: &CatchClause, state: &DumpState, root_state: &DumpS
         match parameter {
             CatchBinding::Identifier(ident) => {
                 print_node(&child_state(state, false), &color_label(root_state, "parameter"));
-                dump_identifier(ident, &ident.range, &child_state(&child_state(state, false), true));
+                dump_identifier_id(*ident, &child_state(&child_state(state, false), true));
             }
             CatchBinding::BindingPattern(pattern) => {
                 print_node(&child_state(state, false), &color_label(root_state, "parameter"));

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -68,7 +68,7 @@ struct DumpState<'a> {
     use_color: bool,
     output: Option<&'a RefCell<String>>,
     function_table: &'a FunctionTable,
-    identifiers: &'a crate::ast::IdentifierArena,
+    arena: &'a crate::ast::AstArena,
 }
 
 impl DumpState<'_> {
@@ -76,7 +76,10 @@ impl DumpState<'_> {
         self.function_table
     }
     fn identifier(&self, id: crate::ast::IdentifierId) -> &crate::ast::Identifier {
-        &self.identifiers[id]
+        &self.arena.identifiers[id]
+    }
+    fn name_slice(&self, id: crate::ast::IdentifierId) -> &[u16] {
+        self.arena.name_slice(id)
     }
 }
 
@@ -122,7 +125,7 @@ fn child_state<'a>(state: &DumpState<'a>, is_last: bool) -> DumpState<'a> {
         use_color: state.use_color,
         output: state.output,
         function_table: state.function_table,
-        identifiers: state.identifiers,
+        arena: state.arena,
     }
 }
 
@@ -312,7 +315,7 @@ pub fn dump_program(
     program: &Statement,
     use_color: bool,
     function_table: &FunctionTable,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     let state = DumpState {
         prefix: String::new(),
@@ -321,7 +324,7 @@ pub fn dump_program(
         use_color,
         output: None,
         function_table,
-        identifiers,
+        arena,
     };
     dump_statement(program, &state);
     println!();
@@ -330,7 +333,7 @@ pub fn dump_program(
 pub fn dump_program_to_string(
     program: &Statement,
     function_table: &FunctionTable,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) -> String {
     let output = RefCell::new(String::new());
     let state = DumpState {
@@ -340,7 +343,7 @@ pub fn dump_program_to_string(
         use_color: false,
         output: Some(&output),
         function_table,
-        identifiers,
+        arena,
     };
     dump_statement(program, &state);
     output.into_inner()
@@ -966,7 +969,10 @@ fn dump_identifier_id(id: crate::ast::IdentifierId, state: &DumpState) {
 
 fn dump_identifier(ident: &Identifier, range: &SourceRange, state: &DumpState) {
     let mut desc = color_node_name(state, "Identifier");
-    desc.push_str(&format!(" {}", color_string_utf16(state, &ident.name)));
+    desc.push_str(&format!(
+        " {}",
+        color_string_utf16(state, state.arena.strings[ident.name].as_slice())
+    ));
     if ident.is_local() {
         let kind = if ident.local_type == Some(LocalType::Argument) {
             "argument"
@@ -1013,7 +1019,7 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
         desc.push('*');
     }
     let name_str = match function_data.name {
-        Some(id) => utf16_to_string(&state.identifier(id).name),
+        Some(id) => utf16_to_string(state.name_slice(id)),
         None => String::new(),
     };
     desc.push_str(&format!(" {}", color_string(state, &name_str)));
@@ -1087,7 +1093,7 @@ fn dump_function(function_data: &FunctionData, class_name: &str, range: &SourceR
 
 fn dump_class(class_data: &ClassData, range: &SourceRange, state: &DumpState, root_state: &DumpState) {
     let name_str = match class_data.name {
-        Some(id) => utf16_to_string(&state.identifier(id).name),
+        Some(id) => utf16_to_string(state.name_slice(id)),
         None => String::new(),
     };
     print_node(

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -369,7 +369,7 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
         }
 
         StatementKind::Block(scope) => {
-            let s = scope.borrow();
+            let s = &state.arena.scopes[*scope];
             // The parser wraps for-loops in a Block for scope. The C++
             // parser does not, so skip the wrapper and dump the child directly.
             if s.children.len() == 1 && matches!(s.children[0].inner, StatementKind::For(_) | StatementKind::ForInOf(_))
@@ -377,16 +377,16 @@ fn dump_statement(statement: &Statement, state: &DumpState) {
                 dump_statement(&s.children[0], state);
                 return;
             }
-            dump_scope_node("BlockStatement", &s, &statement.range, state);
+            dump_scope_node("BlockStatement", s, &statement.range, state);
         }
 
         StatementKind::FunctionBody { scope, .. } => {
-            let s = scope.borrow();
-            dump_scope_node("FunctionBody", &s, &statement.range, state);
+            let s = &state.arena.scopes[*scope];
+            dump_scope_node("FunctionBody", s, &statement.range, state);
         }
 
         StatementKind::Program(data) => {
-            let scope = data.scope.borrow();
+            let scope = &state.arena.scopes[data.scope];
             let mut desc = color_node_name(state, "Program");
             let type_str = if data.program_type == ProgramType::Module {
                 "module"
@@ -1395,7 +1395,7 @@ fn dump_switch_case(case: &SwitchCase, state: &DumpState, root_state: &DumpState
     }
     print_node(&child_state(state, true), &color_label(root_state, "consequent"));
     let consequent_state = child_state(&child_state(state, true), true);
-    let scope = case.scope.borrow();
+    let scope = &state.arena.scopes[case.scope];
     let children = &scope.children;
     for (i, child) in children.iter().enumerate() {
         dump_statement(child, &child_state(&consequent_state, i == children.len() - 1));

--- a/Libraries/LibJS/Rust/src/ast_dump.rs
+++ b/Libraries/LibJS/Rust/src/ast_dump.rs
@@ -968,22 +968,22 @@ fn dump_identifier(ident: &Identifier, range: &SourceRange, state: &DumpState) {
     let mut desc = color_node_name(state, "Identifier");
     desc.push_str(&format!(" {}", color_string_utf16(state, &ident.name)));
     if ident.is_local() {
-        let kind = if ident.local_type.get() == Some(LocalType::Argument) {
+        let kind = if ident.local_type == Some(LocalType::Argument) {
             "argument"
         } else {
             "variable"
         };
-        desc.push_str(&format!(" {}", color_local(state, kind, ident.local_index.get())));
-    } else if ident.is_global.get() {
+        desc.push_str(&format!(" {}", color_local(state, kind, ident.local_index)));
+    } else if ident.is_global {
         desc.push_str(&format!(" {}", color_global(state)));
     }
-    if let Some(declaration_kind) = ident.declaration_kind.get() {
+    if let Some(declaration_kind) = ident.declaration_kind {
         desc.push_str(&format!(
             " {}",
             color_op(state, declaration_kind_to_string(declaration_kind))
         ));
     }
-    if ident.is_inside_scope_with_eval.get() {
+    if ident.is_inside_scope_with_eval {
         desc.push_str(&format!(" {}", color_flag(state, "in-eval-scope")));
     }
     desc.push_str(&format_position(state, range));

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -329,7 +329,7 @@ fn generate_unary_expression(
             && !arena.identifiers[*ident].is_local()
         {
             let dst = choose_dst(generator, preferred_dst);
-            let id = generator.intern_identifier(&arena.identifiers[*ident].name);
+            let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
             generator.emit(Instruction::TypeofBinding {
                 dst: dst.operand(),
                 identifier: id,
@@ -541,7 +541,7 @@ fn generate_function_expression(
 
         let name_id = data.name.expect("function declaration must have a name");
         let arena = generator.arena.clone();
-        let id = generator.intern_identifier(&arena.identifiers[name_id].name);
+        let id = generator.intern_identifier_id(arena.identifiers[name_id].name);
         generator.emit(Instruction::CreateVariable {
             identifier: id,
             mode: EnvironmentMode::Lexical as u32,
@@ -715,13 +715,7 @@ fn generate_member_expression(
             emit_get_by_value_with_this(generator, &dst, &super_base, &key, &this_value);
         } else if let ExpressionKind::Identifier(ident) = &property.inner {
             let arena = generator.arena.clone();
-            emit_get_by_id_with_this(
-                generator,
-                &dst,
-                &super_base,
-                &arena.identifiers[*ident].name,
-                &this_value,
-            );
+            emit_get_by_id_with_this(generator, &dst, &super_base, arena.name_slice(*ident), &this_value);
         }
         return Some(dst);
     }
@@ -738,7 +732,7 @@ fn generate_member_expression(
     let dst = choose_dst(generator, preferred_dst);
     if let ExpressionKind::Identifier(ident) = &property.inner {
         let arena = generator.arena.clone();
-        emit_get_by_id(generator, &dst, &obj, &arena.identifiers[*ident].name, base_id);
+        emit_get_by_id(generator, &dst, &obj, arena.name_slice(*ident), base_id);
     } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &property.inner {
         let id = generator.intern_identifier(&priv_ident.name);
         generator.emit(Instruction::GetPrivateById {
@@ -998,7 +992,7 @@ pub fn generate_statement(
                 // to the var scope.
                 if let Some(name_ident) = fd.name {
                     let arena = generator.arena.clone();
-                    let id = generator.intern_identifier(&arena.identifiers[name_ident].name);
+                    let id = generator.intern_identifier_id(arena.identifiers[name_ident].name);
                     let value = generator.allocate_register();
                     generator.emit(Instruction::GetBinding {
                         dst: value.operand(),
@@ -1071,7 +1065,7 @@ pub fn generate_statement(
                     let local = generator.resolve_local(name_ident.local_index, name_ident.local_type.unwrap());
                     generator.emit_mov(&local, &value);
                 } else {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_id(name_ident.name);
                     generator.emit(Instruction::InitializeLexicalBinding {
                         identifier: id,
                         src: value.operand(),
@@ -1775,14 +1769,14 @@ fn generate_identifier(
 
     // OPTIMIZATION: Generate builtin constants (undefined, NaN, Infinity) directly.
     if ident.is_global
-        && let Some(constant) = maybe_generate_builtin_constant(generator, &ident.name)
+        && let Some(constant) = maybe_generate_builtin_constant(generator, arena.name_slice(id))
     {
         return constant;
     }
 
     let dst = choose_dst(generator, preferred_dst);
     if ident.is_global {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_id(ident.name);
         let cache = generator.next_global_variable_cache();
         generator.emit(Instruction::GetGlobal {
             dst: dst.operand(),
@@ -1790,14 +1784,14 @@ fn generate_identifier(
             cache: cache as u64,
         });
     } else if ident.declaration_kind == Some(DeclarationKind::Var) {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_id(ident.name);
         generator.emit(Instruction::GetInitializedBinding {
             dst: dst.operand(),
             identifier: id,
             cache: EnvironmentCoordinate::empty(),
         });
     } else {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_id(ident.name);
         generator.emit(Instruction::GetBinding {
             dst: dst.operand(),
             identifier: id,
@@ -2343,7 +2337,7 @@ fn generate_for_statement(
     {
         let mut non_local_names: Vec<(Utf16String, bool)> = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut non_local_names, &generator.arena.identifiers);
+            collect_target_names(&declaration.target, &mut non_local_names, &generator.arena);
         }
         if !non_local_names.is_empty() {
             has_lexical_environment = true;
@@ -2603,7 +2597,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
+                    collect_target_names(&declaration.target, &mut names, &generator.arena);
                     for (name, _) in &names {
                         let id = generator.intern_identifier(name);
                         if is_constant {
@@ -2625,7 +2619,7 @@ fn emit_lexical_declarations_for_block<'a>(
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
+                    collect_target_names(&declaration.target, &mut names, &generator.arena);
                     for (name, _) in &names {
                         let id = generator.intern_identifier(name);
                         generator.emit(Instruction::CreateImmutableBinding {
@@ -2641,7 +2635,7 @@ fn emit_lexical_declarations_for_block<'a>(
                     let arena = generator.arena.clone();
                     let name_ident = &arena.identifiers[name_ident_id];
                     if !name_ident.is_local() {
-                        let id = generator.intern_identifier(&name_ident.name);
+                        let id = generator.intern_identifier_id(name_ident.name);
                         generator.emit(Instruction::CreateMutableBinding {
                             environment: environment.operand(),
                             identifier: id,
@@ -2656,7 +2650,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 let name_ident = &arena.identifiers[name_ident_id];
                 // a. Create binding.
                 if !name_ident.is_local() {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_id(name_ident.name);
                     generator.emit(Instruction::CreateMutableBinding {
                         environment: environment.operand(),
                         identifier: id,
@@ -2679,7 +2673,7 @@ fn emit_lexical_declarations_for_block<'a>(
                     generator.emit_mov(&local, &fo);
                     generator.mark_local_initialized(local_index);
                 } else {
-                    let id = generator.intern_identifier(&name_ident.name);
+                    let id = generator.intern_identifier_id(name_ident.name);
                     generator.emit(Instruction::InitializeLexicalBinding {
                         identifier: id,
                         src: fo.operand(),
@@ -2693,7 +2687,7 @@ fn emit_lexical_declarations_for_block<'a>(
 }
 
 fn emit_block_declaration_instantiation(generator: &mut Generator, scope: &ScopeData) -> bool {
-    if !needs_block_declaration_instantiation(scope, &generator.arena.identifiers) {
+    if !needs_block_declaration_instantiation(scope, &generator.arena) {
         return false;
     }
 
@@ -2738,7 +2732,7 @@ fn generate_variable_declaration(
         // Set pending LHS name for function name inference.
         if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
             let ident = &arena.identifiers[*id];
-            generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+            generator.pending_lhs_name = Some(generator.intern_identifier_id(ident.name));
         }
         let init_value = declaration
             .init
@@ -2764,7 +2758,7 @@ fn generate_variable_declaration(
                     generator.emit_mov(&local, &value);
                     generator.mark_local_initialized(local_index);
                 } else {
-                    let id = generator.intern_identifier(&ident.name);
+                    let id = generator.intern_identifier_id(ident.name);
                     match kind {
                         DeclarationKind::Var => {
                             if ident.is_global {
@@ -2819,7 +2813,7 @@ fn try_generate_builtin_abstract_operation(
     }
     let arena = generator.arena.clone();
     let name = match &data.callee.inner {
-        ExpressionKind::Identifier(ident) => &arena.identifiers[*ident].name,
+        ExpressionKind::Identifier(ident) => arena.name_slice(*ident),
         _ => return None,
     };
     if data.arguments.iter().any(|a| a.is_spread) {
@@ -2946,7 +2940,7 @@ fn try_generate_builtin_abstract_operation(
             argument_holders.push(generator.copy_if_needed_to_preserve_evaluation_order(&val));
         }
         let arena_clone = generator.arena.clone();
-        let callee_name = expression_string_approximation(&data.arguments[0].value, &arena_clone.identifiers)
+        let callee_name = expression_string_approximation(&data.arguments[0].value, &arena_clone)
             .map(|s| generator.intern_string(&s));
         let arguments: Vec<Operand> = argument_holders.iter().map(|a| a.operand()).collect();
         generator.emit(Instruction::Call {
@@ -2972,7 +2966,7 @@ fn try_generate_builtin_abstract_operation(
         (utf16!("IteratorComplete"), AbstractOperationKind::IteratorComplete),
     ];
     for &(op_name, operation) in known_operations {
-        if *name == op_name {
+        if name == op_name {
             let callee = generator.add_constant_abstract_operation(operation);
             let undefined = generator.add_constant_undefined();
             let expression_string = generator.intern_string(name);
@@ -3046,15 +3040,15 @@ fn generate_call_expression(
     // Compute expression_string for error messages (e.g. "true is not a function (evaluated from 'a')").
     let arena = generator.arena.clone();
     let expression_string: Option<StringTableIndex> =
-        expression_string_approximation(&data.callee, &arena.identifiers).map(|s| generator.intern_string(&s));
+        expression_string_approximation(&data.callee, &arena).map(|s| generator.intern_string(&s));
 
     // Detect direct eval calls: bare identifier "eval" as callee.
     let is_direct_eval = !is_new
-        && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if arena.identifiers[*ident].name == utf16!("eval"));
+        && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if arena.name_slice(*ident) == utf16!("eval"));
 
     // Detect known builtins for member expression callees (e.g. Math.abs).
     let builtin: Option<u8> = if !is_new {
-        get_builtin(&data.callee, &generator.arena.identifiers)
+        get_builtin(&data.callee, &generator.arena)
     } else {
         None
     };
@@ -3083,13 +3077,7 @@ fn generate_call_expression(
                 if let Some(key) = computed_key {
                     emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id_with_this(
-                        generator,
-                        &method,
-                        &super_base,
-                        &arena.identifiers[*ident].name,
-                        &this_value,
-                    );
+                    emit_get_by_id_with_this(generator, &method, &super_base, arena.name_slice(*ident), &this_value);
                 }
                 (method, Some(this_value))
             }
@@ -3101,7 +3089,7 @@ fn generate_call_expression(
                     let property = generate_expression_or_undefined(&data.property, generator, None);
                     emit_get_by_value(generator, &method, &obj, &property, None);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id(generator, &method, &obj, &arena.identifiers[*ident].name, base_id);
+                    emit_get_by_id(generator, &method, &obj, arena.name_slice(*ident), base_id);
                 } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &data.property.inner {
                     let id = generator.intern_identifier(&priv_ident.name);
                     generator.emit(Instruction::GetPrivateById {
@@ -3133,7 +3121,7 @@ fn generate_call_expression(
                 // to properly handle with-statement bindings and eval.
                 let callee_reg = generator.allocate_register();
                 let this_reg = generator.allocate_register();
-                let id = generator.intern_identifier(&arena.identifiers[*ident].name);
+                let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
                 generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
                     callee: callee_reg.operand(),
                     this_value: this_reg.operand(),
@@ -3362,7 +3350,7 @@ fn generate_update_expression(
                     emit_get_by_value_with_this(generator, &value, &base, key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
                     let arena = generator.arena.clone();
-                    emit_get_by_id_with_this(generator, &value, &base, &arena.identifiers[*ident].name, &this_value);
+                    emit_get_by_id_with_this(generator, &value, &base, arena.name_slice(*ident), &this_value);
                 }
                 let result = emit_update_op(generator, op, prefixed, &value);
                 emit_super_put(
@@ -3389,7 +3377,7 @@ fn generate_update_expression(
                 } else if let ExpressionKind::Identifier(property_ident) = &data.property.inner {
                     let value = generator.allocate_register();
                     let arena = generator.arena.clone();
-                    let property_name = &arena.identifiers[*property_ident].name;
+                    let property_name = arena.name_slice(*property_ident);
                     emit_get_by_id(generator, &value, &base, property_name, base_id);
                     let key = generator.intern_property_key(property_name);
                     let result = emit_update_op(generator, op, prefixed, &value);
@@ -3459,7 +3447,7 @@ fn generate_assignment_expression(
                 let arena = generator.arena.clone();
                 let ident = &arena.identifiers[id];
                 if op == AssignmentOp::Assignment {
-                    generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+                    generator.pending_lhs_name = Some(generator.intern_identifier_id(ident.name));
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     generator.pending_lhs_name = None;
                     if ident.is_local() {
@@ -3500,7 +3488,7 @@ fn generate_assignment_expression(
                     }
                     // RHS block: evaluate RHS, assign, jump to end.
                     generator.switch_to_basic_block(rhs_block);
-                    generator.pending_lhs_name = Some(generator.intern_identifier(&arena.identifiers[id].name));
+                    generator.pending_lhs_name = Some(generator.intern_identifier_id(arena.identifiers[id].name));
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     generator.pending_lhs_name = None;
                     // Allocate dst after RHS evaluation.
@@ -3578,13 +3566,7 @@ fn generate_assignment_expression(
                         emit_get_by_value_with_this(generator, &old_val, &base, key, &super_this);
                     } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                         let arena = generator.arena.clone();
-                        emit_get_by_id_with_this(
-                            generator,
-                            &old_val,
-                            &base,
-                            &arena.identifiers[*ident].name,
-                            &super_this,
-                        );
+                        emit_get_by_id_with_this(generator, &old_val, &base, arena.name_slice(*ident), &super_this);
                     }
                     let is_logical = matches!(
                         op,
@@ -3700,8 +3682,8 @@ fn generate_assignment_expression(
                 } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                     let old_val = generator.allocate_register();
                     let arena = generator.arena.clone();
-                    let property_name = arena.identifiers[*ident].name.clone();
-                    emit_get_by_id(generator, &old_val, &base, &property_name, base_id);
+                    let property_name = arena.name_slice(*ident);
+                    emit_get_by_id(generator, &old_val, &base, property_name, base_id);
                     if is_logical {
                         let rhs_block = generator.make_block();
                         let lhs_block = generator.make_block();
@@ -3711,7 +3693,7 @@ fn generate_assignment_expression(
                         let rhs_val = generate_expression(rhs, generator, None)?;
                         let dst = choose_dst(generator, preferred_dst);
                         generator.emit_mov(&dst, &rhs_val);
-                        let key = generator.intern_property_key(&property_name);
+                        let key = generator.intern_property_key(property_name);
                         let cache2 = generator.next_property_lookup_cache();
                         generator.emit(Instruction::PutById {
                             base: base.operand(),
@@ -3731,7 +3713,7 @@ fn generate_assignment_expression(
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     let dst = choose_dst(generator, preferred_dst);
                     emit_compound_assignment(generator, op, &dst, &old_val, &rhs_val);
-                    let key = generator.intern_property_key(&property_name);
+                    let key = generator.intern_property_key(property_name);
                     let cache2 = generator.next_property_lookup_cache();
                     generator.emit(Instruction::PutById {
                         base: base.operand(),
@@ -3840,7 +3822,7 @@ fn emit_super_get(
         Some(property)
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
         let arena = generator.arena.clone();
-        emit_get_by_id_with_this(generator, dst, base, &arena.identifiers[*ident].name, this_value);
+        emit_get_by_id_with_this(generator, dst, base, arena.name_slice(*ident), this_value);
         None
     } else {
         None
@@ -3868,7 +3850,7 @@ fn emit_super_put(
         emit_put_normal_by_value_with_this(generator, base, &property, this_value, value);
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
         let arena = generator.arena.clone();
-        let key = generator.intern_property_key(&arena.identifiers[*ident].name);
+        let key = generator.intern_property_key_id(arena.identifiers[*ident].name);
         let cache = generator.next_property_lookup_cache();
         generator.emit(Instruction::PutByIdWithThis {
             base: base.operand(),
@@ -4243,7 +4225,7 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
             src: value.operand(),
         });
     } else if ident.is_global {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_id(ident.name);
         let cache = generator.next_global_variable_cache();
         generator.emit(Instruction::SetGlobal {
             identifier: id,
@@ -4253,7 +4235,7 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
     } else {
         // Non-local, non-global: use SetLexicalBinding which searches
         // the lexical environment chain (important for with-statement support).
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_id(ident.name);
         generator.emit(Instruction::SetLexicalBinding {
             identifier: id,
             src: value.operand(),
@@ -4276,7 +4258,7 @@ fn emit_put_to_member(
         emit_put_normal_by_value(generator, base, &property, value, base_id);
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
         let arena = generator.arena.clone();
-        let key = generator.intern_property_key(&arena.identifiers[*ident].name);
+        let key = generator.intern_property_key_id(arena.identifiers[*ident].name);
         let cache = generator.next_property_lookup_cache();
         generator.emit(Instruction::PutById {
             base: base.operand(),
@@ -4306,7 +4288,7 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                 return generator.add_constant_boolean(false);
             }
             let dst = generator.allocate_register();
-            let id = generator.intern_identifier(&identifier.name);
+            let id = generator.intern_identifier_id(identifier.name);
             generator.emit(Instruction::DeleteVariable {
                 dst: dst.operand(),
                 identifier: id,
@@ -4355,7 +4337,7 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                 });
             } else if let ExpressionKind::Identifier(property_ident) = &data.property.inner {
                 let arena = generator.arena.clone();
-                let key = generator.intern_property_key(&arena.identifiers[*property_ident].name);
+                let key = generator.intern_property_key_id(arena.identifiers[*property_ident].name);
                 generator.emit(Instruction::DeleteById {
                     dst: dst.operand(),
                     base: base.operand(),
@@ -4441,7 +4423,7 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                 }
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let arena = generator.arena.clone();
-                let key = generator.intern_property_key(&arena.identifiers[*ident].name);
+                let key = generator.intern_property_key_id(arena.identifiers[*ident].name);
                 let cache = generator.next_property_lookup_cache();
                 EvaluatedReference::SuperMemberId {
                     base,
@@ -4477,7 +4459,7 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                 }
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let arena = generator.arena.clone();
-                let key = generator.intern_property_key(&arena.identifiers[*ident].name);
+                let key = generator.intern_property_key_id(arena.identifiers[*ident].name);
                 let cache = generator.next_property_lookup_cache();
                 EvaluatedReference::MemberId {
                     base,
@@ -4786,13 +4768,7 @@ fn generate_tagged_template_literal(
             if let Some(key) = computed_key {
                 emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                emit_get_by_id_with_this(
-                    generator,
-                    &method,
-                    &super_base,
-                    &arena.identifiers[*ident].name,
-                    &this_value,
-                );
+                emit_get_by_id_with_this(generator, &method, &super_base, arena.name_slice(*ident), &this_value);
             }
             (method, Some(this_value))
         }
@@ -4805,7 +4781,7 @@ fn generate_tagged_template_literal(
                 emit_get_by_value(generator, &method, &obj, &property, None);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
-                emit_get_by_id(generator, &method, &obj, &arena.identifiers[*ident].name, base_id);
+                emit_get_by_id(generator, &method, &obj, arena.name_slice(*ident), base_id);
             } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
                 let id = generator.intern_identifier(&priv_ident.name);
                 generator.emit(Instruction::GetPrivateById {
@@ -4828,7 +4804,7 @@ fn generate_tagged_template_literal(
             let callee_reg = generator.allocate_register();
             let this_reg = generator.allocate_register();
             let arena = generator.arena.clone();
-            let id = generator.intern_identifier(&arena.identifiers[*ident].name);
+            let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
             generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
                 callee: callee_reg.operand(),
                 this_value: this_reg.operand(),
@@ -4993,10 +4969,10 @@ fn generate_switch_statement(
                 && let Some(name_ident_id) = fd.name
                 && generator
                     .annexb_function_names
-                    .contains(generator.arena.identifiers[name_ident_id].name.as_slice())
+                    .contains(generator.arena.name_slice(name_ident_id))
             {
                 let arena = generator.arena.clone();
-                let id = generator.intern_identifier(&arena.identifiers[name_ident_id].name);
+                let id = generator.intern_identifier_id(arena.identifiers[name_ident_id].name);
                 let value = generator.allocate_register();
                 generator.emit(Instruction::GetBinding {
                     dst: value.operand(),
@@ -5065,7 +5041,7 @@ fn emit_switch_block_declaration_instantiation(generator: &mut Generator, data: 
         {
             vd.declarations.iter().any(|declaration| {
                 let mut names = Vec::new();
-                collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
+                collect_target_names(&declaration.target, &mut names, &generator.arena);
                 !names.is_empty()
             })
         }
@@ -5174,7 +5150,7 @@ fn generate_object_expression(
         if !effectively_computed && property.property_type != ObjectPropertyType::ProtoSetter {
             let base_name: Option<Utf16String> = match &property.key.inner {
                 ExpressionKind::StringLiteral(s) => Some((**s).clone()),
-                ExpressionKind::Identifier(ident) => Some(generator.arena.identifiers[*ident].name.to_utf16_string()),
+                ExpressionKind::Identifier(ident) => Some(generator.arena.name_of(*ident).clone()),
                 _ => None,
             };
             if let Some(name) = base_name {
@@ -5238,7 +5214,7 @@ fn generate_object_expression(
                     let arena = generator.arena.clone();
                     let property_key = match &property.key.inner {
                         ExpressionKind::Identifier(ident) => {
-                            generator.intern_property_key(&arena.identifiers[*ident].name)
+                            generator.intern_property_key_id(arena.identifiers[*ident].name)
                         }
                         ExpressionKind::StringLiteral(s) => generator.intern_property_key(s),
                         _ => {
@@ -5328,7 +5304,7 @@ fn emit_object_property_set_by_key(
     match &key.inner {
         ExpressionKind::Identifier(ident) => {
             let arena = generator.arena.clone();
-            let property_key = generator.intern_property_key(&arena.identifiers[*ident].name);
+            let property_key = generator.intern_property_key_id(arena.identifiers[*ident].name);
             generator.emit(Instruction::InitObjectLiteralProperty {
                 object: object.operand(),
                 property: property_key,
@@ -5433,8 +5409,8 @@ fn emit_object_accessor_by_key(
     match &key.inner {
         ExpressionKind::Identifier(ident) => {
             let arena = generator.arena.clone();
-            let name = arena.identifiers[*ident].name.clone();
-            emit_by_id(generator, &name);
+            let name = arena.name_slice(*ident);
+            emit_by_id(generator, name);
         }
         ExpressionKind::StringLiteral(s) => emit_by_id(generator, s),
         _ => emit_by_value(generator, key),
@@ -5485,7 +5461,7 @@ fn generate_optional_chain_inner(
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
                 let arena = generator.arena.clone();
-                emit_get_by_id(generator, &val, &obj, &arena.identifiers[*ident].name, base_id);
+                emit_get_by_id(generator, &val, &obj, arena.name_slice(*ident), base_id);
                 generator.emit_mov(current_base, &obj);
             } else if let ExpressionKind::PrivateIdentifier(name) = &member_data.property.inner {
                 let id = generator.intern_identifier(&name.name);
@@ -5548,7 +5524,7 @@ fn generate_optional_chain_inner(
                     generator,
                     current_value,
                     current_value,
-                    &arena.identifiers[*identifier].name,
+                    arena.name_slice(*identifier),
                     None,
                 );
             }
@@ -5675,7 +5651,7 @@ fn generate_class_expression(
     // (skip this for anonymous classes with lhs_name).
     if data.name.is_some() || lhs_name.is_none() {
         let name = if let Some(name_ident_id) = data.name {
-            generator.arena.identifiers[name_ident_id].name.to_utf16_string()
+            generator.arena.name_of(name_ident_id).clone()
         } else {
             Utf16String::new()
         };
@@ -5858,7 +5834,7 @@ fn generate_class_expression(
                         // Determine field name for anonymous function naming.
                         let arena = generator.arena.clone();
                         let field_name = match &key.inner {
-                            ExpressionKind::Identifier(ident) => arena.identifiers[*ident].name.to_utf16_string(),
+                            ExpressionKind::Identifier(ident) => arena.name_of(*ident).clone(),
                             ExpressionKind::StringLiteral(s) => (**s).clone(),
                             ExpressionKind::PrivateIdentifier(p) => p.name.clone(),
                             ExpressionKind::NumericLiteral(n) => super::ffi::js_number_to_utf16(*n),
@@ -5908,7 +5884,7 @@ fn generate_class_expression(
                         let key_is_private = is_private_key(key);
                         let key_name: Utf16String = match &key.inner {
                             ExpressionKind::PrivateIdentifier(ident) => ident.name.clone(),
-                            ExpressionKind::Identifier(ident) => arena.identifiers[*ident].name.to_utf16_string(),
+                            ExpressionKind::Identifier(ident) => arena.name_of(*ident).clone(),
                             ExpressionKind::StringLiteral(s) => (**s).clone(),
                             ExpressionKind::NumericLiteral(n) => super::ffi::js_number_to_utf16(*n),
                             _ => Utf16String::new(),
@@ -5982,7 +5958,7 @@ fn generate_class_expression(
     let source_end = data.source_text_end as usize;
     let source_text_len = source_end - source_start;
 
-    let class_name = data.name.map(|n| generator.arena.identifiers[n].name.to_utf16_string());
+    let class_name = data.name.map(|n| generator.arena.name_of(n).clone());
     let blueprint_index = generator.register_class_blueprint(PendingClassBlueprint {
         name: class_name,
         source_text_offset: source_start,
@@ -6039,7 +6015,9 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
         parser.flags.allow_super_constructor_call = true;
     }
     let program = parser.parse_program(false);
-    parser.scope_collector.analyze(false, &mut parser.arena.identifiers);
+    parser
+        .scope_collector
+        .analyze(false, &mut parser.arena.identifiers, &parser.arena.strings);
 
     assert!(!parser.has_errors(), "default constructor parse failed");
 
@@ -6093,14 +6071,14 @@ fn get_private_identifier_name(key: &Expression) -> Option<Utf16String> {
 
 /// Check if a for-in/for-of LHS is a `let`/`const` declaration with non-local identifiers,
 /// meaning we need a per-iteration lexical environment.
-fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs, identifiers: &crate::ast::IdentifierArena) -> bool {
+fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs, arena: &crate::ast::AstArena) -> bool {
     if let ForInOfLhs::Declaration(statement) = lhs
         && let StatementKind::VariableDeclaration(vd) = &statement.inner
         && (vd.kind == DeclarationKind::Let || vd.kind == DeclarationKind::Const)
     {
         let mut names = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut names, identifiers);
+            collect_target_names(&declaration.target, &mut names, arena);
         }
         return !names.is_empty();
     }
@@ -6111,17 +6089,17 @@ fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs, identifiers: &crate::ast::Ident
 fn collect_target_names(
     target: &VariableDeclaratorTarget,
     names: &mut Vec<(Utf16String, bool)>,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     match target {
         VariableDeclaratorTarget::Identifier(id) => {
-            let ident = &identifiers[*id];
+            let ident = &arena.identifiers[*id];
             if !ident.is_local() {
-                names.push((ident.name.to_utf16_string(), false));
+                names.push((arena.strings[ident.name].clone(), false));
             }
         }
         VariableDeclaratorTarget::BindingPattern(pattern) => {
-            collect_pattern_binding_names(pattern, names, identifiers);
+            collect_pattern_binding_names(pattern, names, arena);
         }
     }
 }
@@ -6130,24 +6108,24 @@ fn collect_target_names(
 fn collect_pattern_binding_names(
     pattern: &BindingPattern,
     names: &mut Vec<(Utf16String, bool)>,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     for entry in &pattern.entries {
         match &entry.alias {
             Some(BindingEntryAlias::Identifier(id)) => {
-                let ident = &identifiers[*id];
+                let ident = &arena.identifiers[*id];
                 if !ident.is_local() {
-                    names.push((ident.name.to_utf16_string(), false));
+                    names.push((arena.strings[ident.name].clone(), false));
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub)) => {
-                collect_pattern_binding_names(sub, names, identifiers);
+                collect_pattern_binding_names(sub, names, arena);
             }
             None => {
                 if let Some(BindingEntryName::Identifier(id)) = &entry.name {
-                    let ident = &identifiers[*id];
+                    let ident = &arena.identifiers[*id];
                     if !ident.is_local() {
-                        names.push((ident.name.to_utf16_string(), false));
+                        names.push((arena.strings[ident.name].clone(), false));
                     }
                 }
             }
@@ -6169,7 +6147,7 @@ fn create_for_in_of_lexical_env(generator: &mut Generator, lhs: &ForInOfLhs) -> 
     {
         is_constant = vd.kind == DeclarationKind::Const;
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut binding_names, &generator.arena.identifiers);
+            collect_target_names(&declaration.target, &mut binding_names, &generator.arena);
         }
     }
 
@@ -6203,7 +6181,7 @@ fn enter_for_in_of_head_tdz(generator: &mut Generator, lhs: &ForInOfLhs) -> bool
     {
         let mut names = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
+            collect_target_names(&declaration.target, &mut names, &generator.arena);
         }
         if !names.is_empty() {
             generator.push_new_lexical_environment(0);
@@ -6265,7 +6243,7 @@ fn generate_for_in_statement(
         && let (VariableDeclaratorTarget::Identifier(ident_id), Some(init)) = (&declaration.target, &declaration.init)
     {
         let arena = generator.arena.clone();
-        generator.pending_lhs_name = Some(generator.intern_identifier(&arena.identifiers[*ident_id].name));
+        generator.pending_lhs_name = Some(generator.intern_identifier_id(arena.identifiers[*ident_id].name));
         let value = generate_expression_or_undefined(init, generator, None);
         generator.pending_lhs_name = None;
         emit_set_variable(generator, *ident_id, &value);
@@ -6275,7 +6253,7 @@ fn generate_for_in_statement(
     // continuation_block during head evaluation.
     let end_block = generator.make_block();
     let update_block = generator.make_block();
-    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.arena.identifiers);
+    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.arena);
 
     // B.3.5 Initializers in ForIn Statement Heads: evaluate initializer before RHS.
     // Create TDZ for lexical declarations before evaluating the RHS expression.
@@ -6453,7 +6431,7 @@ fn generate_for_of_statement_inner(
 
     // Create TDZ for lexical declarations before evaluating the RHS expression.
     let entered_tdz = enter_for_in_of_head_tdz(generator, lhs);
-    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.arena.identifiers);
+    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.arena);
     let old_handler = generator.current_unwind_handler;
 
     // Evaluate RHS into `object`, allocate iterator registers, and emit
@@ -6923,10 +6901,10 @@ enum BindingMode {
 fn set_pending_lhs_name_for_entry(generator: &mut Generator, entry: &BindingEntry) {
     let arena = generator.arena.clone();
     let name = match &entry.alias {
-        Some(BindingEntryAlias::Identifier(id)) => Some(arena.identifiers[*id].name.clone()),
+        Some(BindingEntryAlias::Identifier(id)) => Some(arena.identifiers[*id].name),
         None => {
             if let Some(BindingEntryName::Identifier(id)) = &entry.name {
-                Some(arena.identifiers[*id].name.clone())
+                Some(arena.identifiers[*id].name)
             } else {
                 None
             }
@@ -6934,7 +6912,7 @@ fn set_pending_lhs_name_for_entry(generator: &mut Generator, entry: &BindingEntr
         _ => None,
     };
     if let Some(name) = name {
-        generator.pending_lhs_name = Some(generator.intern_identifier(&name));
+        generator.pending_lhs_name = Some(generator.intern_identifier_id(name));
     }
 }
 
@@ -6966,7 +6944,7 @@ fn emit_set_variable_with_mode(
         let local = generator.resolve_local(ident.local_index, ident.local_type.unwrap());
         generator.emit_mov(&local, value);
     } else {
-        let id = generator.intern_identifier(&ident.name);
+        let id = generator.intern_identifier_id(ident.name);
         match mode {
             BindingMode::InitializeLexical => {
                 generator.emit(Instruction::InitializeLexicalBinding {
@@ -7224,10 +7202,10 @@ fn generate_object_binding_pattern(
         match &entry.name {
             Some(BindingEntryName::Identifier(ident)) => {
                 let arena = generator.arena.clone();
-                let name = arena.identifiers[*ident].name.clone();
-                emit_get_by_id(generator, &value, object, &name, None);
+                let name = arena.name_slice(*ident);
+                emit_get_by_id(generator, &value, object, name, None);
                 if has_rest {
-                    let name_val = generator.add_constant_string(name.to_utf16_string());
+                    let name_val = generator.add_constant_string(arena.name_of(*ident).clone());
                     excluded_names.push(name_val);
                 }
             }
@@ -7382,7 +7360,7 @@ fn generate_try_statement(
                         generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
                         created_catch_scope = true;
 
-                        let id = generator.intern_identifier(&ident.name);
+                        let id = generator.intern_identifier_id(ident.name);
                         generator.emit(Instruction::CreateVariable {
                             identifier: id,
                             mode: EnvironmentMode::Lexical as u32,
@@ -7399,7 +7377,7 @@ fn generate_try_statement(
                 }
                 CatchBinding::BindingPattern(pattern) => {
                     let mut names: Vec<(Utf16String, bool)> = Vec::new();
-                    collect_pattern_binding_names(pattern, &mut names, &generator.arena.identifiers);
+                    collect_pattern_binding_names(pattern, &mut names, &generator.arena);
 
                     if !names.is_empty() {
                         generator.push_new_lexical_environment(0);
@@ -7739,7 +7717,7 @@ pub fn emit_function_declaration_instantiation(
         match &parameter.binding {
             FunctionParameterBinding::Identifier(ident_id) => {
                 let ident = &arena.identifiers[*ident_id];
-                let name = ident.name.to_utf16_string();
+                let name = arena.strings[ident.name].clone();
                 let is_local = ident.is_local();
                 if !seen_names.insert(name.clone()) {
                     has_duplicates = true;
@@ -7753,7 +7731,7 @@ pub fn emit_function_declaration_instantiation(
                     &mut parameter_names,
                     &mut seen_names,
                     &mut has_duplicates,
-                    &arena.identifiers,
+                    &arena,
                 );
             }
         }
@@ -7906,7 +7884,7 @@ pub fn emit_function_declaration_instantiation(
                         None => {}
                     }
                 } else {
-                    let id = generator.intern_identifier(&ident.name);
+                    let id = generator.intern_identifier_id(ident.name);
                     if has_duplicates {
                         generator.emit(Instruction::SetLexicalBinding {
                             identifier: id,
@@ -8062,7 +8040,7 @@ pub fn emit_function_declaration_instantiation(
     // --- Step 7: Lexical environment for non-local declarations ---
     // Note: this counts only let/const/class declarations (not function declarations,
     // which are var-hoisted in function bodies).
-    let lex_bindings_count = count_non_local_lexical_bindings(body_scope, &generator.arena.identifiers);
+    let lex_bindings_count = count_non_local_lexical_bindings(body_scope, &generator.arena);
 
     if !strict && lex_bindings_count > 0 {
         generator.push_new_lexical_environment(lex_bindings_count);
@@ -8078,7 +8056,7 @@ pub fn emit_function_declaration_instantiation(
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
+                    collect_target_names(&declaration.target, &mut names, &generator.arena);
                     for (name, _) in names {
                         let id = generator.intern_identifier(&name);
                         generator.emit(Instruction::CreateVariable {
@@ -8097,7 +8075,7 @@ pub fn emit_function_declaration_instantiation(
                     let arena = generator.arena.clone();
                     let name_ident = &arena.identifiers[name_ident_id];
                     if !name_ident.is_local() {
-                        let id = generator.intern_identifier(&name_ident.name);
+                        let id = generator.intern_identifier_id(name_ident.name);
                         generator.emit(Instruction::CreateVariable {
                             identifier: id,
                             mode: EnvironmentMode::Lexical as u32,
@@ -8143,7 +8121,7 @@ pub fn emit_function_declaration_instantiation(
                             home_object: None,
                             lhs_name: None,
                         });
-                        let id = generator.intern_identifier(&name_ident.name);
+                        let id = generator.intern_identifier_id(name_ident.name);
                         generator.emit(Instruction::SetVariableBinding {
                             identifier: id,
                             src: function_reg.operand(),
@@ -8163,7 +8141,7 @@ fn is_for_loop(statement: &Statement) -> bool {
 
 /// Check if a block needs block declaration instantiation.
 /// True when the block has function declarations or non-local let/const/class.
-fn needs_block_declaration_instantiation(scope: &ScopeData, identifiers: &crate::ast::IdentifierArena) -> bool {
+fn needs_block_declaration_instantiation(scope: &ScopeData, arena: &crate::ast::AstArena) -> bool {
     for child in &scope.children {
         match &child.inner {
             StatementKind::FunctionDeclaration(_) => {
@@ -8174,7 +8152,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData, identifiers: &crate:
             {
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names, identifiers);
+                    collect_target_names(&declaration.target, &mut names, arena);
                     if !names.is_empty() {
                         return true;
                     }
@@ -8182,7 +8160,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData, identifiers: &crate:
             }
             StatementKind::ClassDeclaration(class_data) => {
                 if let Some(name_ident) = class_data.name
-                    && !identifiers[name_ident].is_local()
+                    && !arena.identifiers[name_ident].is_local()
                 {
                     return true;
                 }
@@ -8190,7 +8168,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData, identifiers: &crate:
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names, identifiers);
+                    collect_target_names(&declaration.target, &mut names, arena);
                     if !names.is_empty() {
                         return true;
                     }
@@ -8203,7 +8181,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData, identifiers: &crate:
 }
 
 /// Count non-local lexical bindings in a function body scope.
-fn count_non_local_lexical_bindings(scope: &ScopeData, identifiers: &crate::ast::IdentifierArena) -> u32 {
+fn count_non_local_lexical_bindings(scope: &ScopeData, arena: &crate::ast::AstArena) -> u32 {
     let mut count = 0u32;
     for child in &scope.children {
         match &child.inner {
@@ -8212,12 +8190,12 @@ fn count_non_local_lexical_bindings(scope: &ScopeData, identifiers: &crate::ast:
             {
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names, identifiers);
+                    collect_target_names(&declaration.target, &mut names, arena);
                     count += u32_from_usize(names.len());
                 }
             }
             StatementKind::ClassDeclaration(class_data)
-                if class_data.name.is_some_and(|n| !identifiers[n].is_local()) =>
+                if class_data.name.is_some_and(|n| !arena.identifiers[n].is_local()) =>
             {
                 count += 1;
             }
@@ -8238,14 +8216,14 @@ fn collect_binding_pattern_names(
     parameter_names: &mut Vec<FdiParameterName>,
     seen_names: &mut HashSet<Utf16String>,
     has_duplicates: &mut bool,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     for entry in &pattern.entries {
         // The bound name can be in the alias (for object patterns) or name (for array patterns).
         match &entry.alias {
             Some(BindingEntryAlias::Identifier(ident_id)) => {
-                let ident = &identifiers[*ident_id];
-                let name = ident.name.to_utf16_string();
+                let ident = &arena.identifiers[*ident_id];
+                let name = arena.strings[ident.name].clone();
                 let is_local = ident.is_local();
                 if !seen_names.insert(name.clone()) {
                     *has_duplicates = true;
@@ -8254,13 +8232,13 @@ fn collect_binding_pattern_names(
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub_pattern)) => {
-                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates, identifiers);
+                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates, arena);
             }
             None => {
                 // No alias — the name itself is the binding.
                 if let Some(BindingEntryName::Identifier(ident_id)) = &entry.name {
-                    let ident = &identifiers[*ident_id];
-                    let name = ident.name.to_utf16_string();
+                    let ident = &arena.identifiers[*ident_id];
+                    let name = arena.strings[ident.name].clone();
                     let is_local = ident.is_local();
                     if !seen_names.insert(name.clone()) {
                         *has_duplicates = true;
@@ -8308,7 +8286,7 @@ const BUILTIN_STRING_PROTOTYPE_CHAR_AT: u8 = 23;
 
 /// Detect known builtin methods from a callee expression (e.g. Math.abs).
 /// Returns the Builtin enum value as u8, matching Builtins.h ordering.
-fn get_builtin(callee: &Expression, identifiers: &crate::ast::IdentifierArena) -> Option<u8> {
+fn get_builtin(callee: &Expression, arena: &crate::ast::AstArena) -> Option<u8> {
     let ExpressionKind::Member(member_data) = &callee.inner else {
         return None;
     };
@@ -8318,7 +8296,7 @@ fn get_builtin(callee: &Expression, identifiers: &crate::ast::IdentifierArena) -
     let ExpressionKind::Identifier(property_ident) = &member_data.property.inner else {
         return None;
     };
-    let property_name = &identifiers[*property_ident].name;
+    let property_name = arena.name_slice(*property_ident);
     if property_name == utf16!("charAt") {
         return Some(BUILTIN_STRING_PROTOTYPE_CHAR_AT);
     }
@@ -8328,7 +8306,7 @@ fn get_builtin(callee: &Expression, identifiers: &crate::ast::IdentifierArena) -
     let ExpressionKind::Identifier(base_ident) = &member_data.object.inner else {
         return None;
     };
-    let base_name = &identifiers[*base_ident].name;
+    let base_name = arena.name_slice(*base_ident);
     // Must match JS_ENUMERATE_BUILTINS order in Builtins.h.
     static BUILTINS: &[(&[u16], &[u16], u8)] = &[
         (utf16!("Math"), utf16!("abs"), BUILTIN_MATH_ABS),
@@ -9217,14 +9195,14 @@ fn nanboxed_empty() -> u64 {
 /// "Cannot access property X on null object Y".
 fn intern_base_identifier(generator: &mut Generator, base: &Expression) -> Option<IdentifierTableIndex> {
     let arena = generator.arena.clone();
-    expression_identifier(base, &arena.identifiers).map(|s| generator.intern_identifier(&s))
+    expression_identifier(base, &arena).map(|s| generator.intern_identifier(&s))
 }
 
 /// Try to produce a human-readable name for an expression (for error messages).
 /// Returns None for expressions that have no meaningful name.
-fn expression_identifier(expression: &Expression, identifiers: &crate::ast::IdentifierArena) -> Option<Utf16String> {
+fn expression_identifier(expression: &Expression, arena: &crate::ast::AstArena) -> Option<Utf16String> {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => Some(identifiers[*ident].name.to_utf16_string()),
+        ExpressionKind::Identifier(ident) => Some(arena.name_of(*ident).clone()),
         ExpressionKind::StringLiteral(s) => {
             let mut result = Utf16String(utf16!("'").to_vec());
             result.0.extend_from_slice(s);
@@ -9235,10 +9213,10 @@ fn expression_identifier(expression: &Expression, identifiers: &crate::ast::Iden
         ExpressionKind::This => Some(Utf16String(utf16!("this").to_vec())),
         ExpressionKind::Member(data) => {
             let mut s = Utf16String::new();
-            if let Some(obj_id) = expression_identifier(&data.object, identifiers) {
+            if let Some(obj_id) = expression_identifier(&data.object, arena) {
                 s.0.extend_from_slice(&obj_id);
             }
-            if let Some(property_id) = expression_identifier(&data.property, identifiers) {
+            if let Some(property_id) = expression_identifier(&data.property, arena) {
                 if data.computed {
                     s.0.extend_from_slice(utf16!("["));
                     s.0.extend_from_slice(&property_id);
@@ -9257,23 +9235,20 @@ fn expression_identifier(expression: &Expression, identifiers: &crate::ast::Iden
 /// Produce a human-readable string for call expression error messages.
 /// Unlike expression_identifier, this always produces output for known types
 /// (using "<object>" for unrecognized sub-expressions).
-fn expression_string_approximation(
-    expression: &Expression,
-    identifiers: &crate::ast::IdentifierArena,
-) -> Option<Utf16String> {
+fn expression_string_approximation(expression: &Expression, arena: &crate::ast::AstArena) -> Option<Utf16String> {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => Some(identifiers[*ident].name.to_utf16_string()),
-        ExpressionKind::Member(_) => Some(member_to_string_approximation(expression, identifiers)),
+        ExpressionKind::Identifier(ident) => Some(arena.name_of(*ident).clone()),
+        ExpressionKind::Member(_) => Some(member_to_string_approximation(expression, arena)),
         _ => None,
     }
 }
 
-fn member_to_string_approximation(expression: &Expression, identifiers: &crate::ast::IdentifierArena) -> Utf16String {
+fn member_to_string_approximation(expression: &Expression, arena: &crate::ast::AstArena) -> Utf16String {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => identifiers[*ident].name.to_utf16_string(),
+        ExpressionKind::Identifier(ident) => arena.name_of(*ident).clone(),
         ExpressionKind::Member(data) => {
-            let mut s = member_to_string_approximation(&data.object, identifiers);
-            let property_str = member_to_string_approximation(&data.property, identifiers);
+            let mut s = member_to_string_approximation(&data.object, arena);
+            let property_str = member_to_string_approximation(&data.property, arena);
             if data.computed {
                 s.0.extend_from_slice(utf16!("["));
                 s.0.extend_from_slice(&property_str);

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -876,10 +876,16 @@ pub fn generate_statement(
         StatementKind::Expression(expression) => generate_expression(expression, generator, None),
 
         // === Block ===
-        StatementKind::Block(scope) => generate_block_statement(generator, &scope.borrow(), preferred_dst),
+        StatementKind::Block(scope) => {
+            let arena = generator.arena.clone();
+            generate_block_statement(generator, &arena.scopes[*scope], preferred_dst)
+        }
 
         // === FunctionBody ===
-        StatementKind::FunctionBody { scope, .. } => generate_scope_children(generator, &scope.borrow(), preferred_dst),
+        StatementKind::FunctionBody { scope, .. } => {
+            let arena = generator.arena.clone();
+            generate_scope_children(generator, &arena.scopes[*scope], preferred_dst)
+        }
 
         // === Program ===
         // Note: GlobalDeclarationInstantiation (GDI) runs before this bytecode
@@ -890,11 +896,12 @@ pub fn generate_statement(
             // GetBinding + SetVariableBinding for AnnexB-hoisted functions
             // (Annex B requires switch cases to copy the block-scoped binding
             // into the var-scoped binding on each case entry).
-            let scope = data.scope.borrow();
+            let arena = generator.arena.clone();
+            let scope = &arena.scopes[data.scope];
             for name in &scope.annexb_function_names {
                 generator.annexb_function_names.insert(name.clone());
             }
-            generate_scope_children(generator, &scope, preferred_dst)
+            generate_scope_children(generator, scope, preferred_dst)
         }
 
         // === If ===
@@ -987,7 +994,7 @@ pub fn generate_statement(
 
         // === FunctionDeclaration ===
         StatementKind::FunctionDeclaration(fd) => {
-            if fd.is_hoisted.get() {
+            if fd.is_hoisted {
                 // Annex B.3.3: Copy the function from the lexical (block) scope
                 // to the var scope.
                 if let Some(name_ident) = fd.name {
@@ -4960,7 +4967,8 @@ fn generate_switch_statement(
             generator.current_completion_register = Some(c.clone());
         }
 
-        let case_scope = case.scope.borrow();
+        let arena = generator.arena.clone();
+        let case_scope = &arena.scopes[case.scope];
         for child in &case_scope.children {
             // For function declarations in switch cases: emit AnnexB hoisting
             // only if the scope collector approved it (name is in annexb_function_names).
@@ -5029,8 +5037,12 @@ fn generate_switch_statement(
 /// share a single lexical environment.
 fn emit_switch_block_declaration_instantiation(generator: &mut Generator, data: &SwitchStatementData) -> bool {
     // Collect all statements across all cases.
-    let case_scopes: Vec<_> = data.cases.iter().map(|c| c.scope.borrow()).collect();
-    let all_children: Vec<&Statement> = case_scopes.iter().flat_map(|scope| scope.children.iter()).collect();
+    let arena = generator.arena.clone();
+    let all_children: Vec<&Statement> = data
+        .cases
+        .iter()
+        .flat_map(|c| arena.scopes[c.scope].children.iter())
+        .collect();
 
     // Check if we need a lexical environment.
     // Only needed if there are non-local lexical declarations.
@@ -5845,7 +5857,9 @@ fn generate_class_expression(
                             _ => Utf16String::new(),
                         };
 
-                        // Wrap the expression in a ClassFieldInitializer statement.
+                        // Use the ClassFieldInitializer statement directly as the
+                        // synthetic function's body. compile_function_payload tolerates
+                        // a non-Block body (body_scope = None for the wrapper).
                         let body_statement = Statement::new(
                             init_expression.range,
                             StatementKind::ClassFieldInitializer(Box::new(ClassFieldInitializerData {
@@ -5853,17 +5867,13 @@ fn generate_class_expression(
                                 field_name,
                             })),
                         );
-                        let wrapper_body = Statement::new(
-                            init_expression.range,
-                            StatementKind::Block(ScopeData::shared_with_children(vec![body_statement])),
-                        );
 
                         // Class bodies are always strict mode.
                         let function_data = Box::new(FunctionData {
                             name: None,
                             source_text_start: init_expression.range.start.offset,
                             source_text_end: init_expression.range.end.offset,
-                            body: Box::new(wrapper_body),
+                            body: Box::new(body_statement),
                             parameters: Vec::new(),
                             function_length: 0,
                             kind: FunctionKind::Normal,
@@ -6015,15 +6025,18 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
         parser.flags.allow_super_constructor_call = true;
     }
     let program = parser.parse_program(false);
-    parser
-        .scope_collector
-        .analyze(false, &mut parser.arena.identifiers, &parser.arena.strings);
+    parser.scope_collector.analyze(
+        false,
+        &mut parser.arena.identifiers,
+        &parser.arena.strings,
+        &mut parser.arena.scopes,
+    );
 
     assert!(!parser.has_errors(), "default constructor parse failed");
 
     // Extract FunctionData from the parsed program.
     let function_id = if let StatementKind::Program(ref data) = program.inner {
-        let scope = data.scope.borrow();
+        let scope = &parser.arena.scopes[data.scope];
         scope.children.iter().find_map(|child| {
             if let StatementKind::FunctionDeclaration(fd) = &child.inner {
                 Some(fd.function_id)
@@ -6043,10 +6056,14 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
     function_data.source_text_start = 0;
     function_data.source_text_end = 0;
 
-    let subtable = parser.function_table.extract_reachable(&function_data);
+    let subtable = parser
+        .function_table
+        .extract_reachable(&function_data, &parser.arena.scopes);
+    let arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
     generator.register_shared_function_data(PendingSharedFunctionData {
         function_data: Some(function_data),
         subtable: Some(subtable),
+        arena: Some(arena),
         name_override: None,
         class_field_initializer_name: None,
         should_eager_compile: false,
@@ -6371,14 +6388,11 @@ fn generate_labelled_statement(
     // begin_breakable_scope/begin_continuable_scope pick them up.
     // NB: The parser wraps for/for-in/for-of loops in a Block for scope
     // management, so we look through single-child Block wrappers.
-    let block_scope_borrow;
-    let effective_inner = if let StatementKind::Block(ref scope) = inner.inner {
-        block_scope_borrow = scope.borrow();
-        if block_scope_borrow.children.len() == 1 {
-            &block_scope_borrow.children[0]
-        } else {
-            inner
-        }
+    let block_arena;
+    let effective_inner = if let StatementKind::Block(scope) = inner.inner {
+        block_arena = generator.arena.clone();
+        let children = &block_arena.scopes[scope].children;
+        if children.len() == 1 { &children[0] } else { inner }
     } else {
         inner
     };
@@ -7668,10 +7682,12 @@ fn emit_new_function(generator: &mut Generator, data: Box<FunctionData>, name_ov
         generator.source_len
     );
 
-    let subtable = generator.function_table.extract_reachable(&data);
+    let arena_clone = generator.arena.clone();
+    let subtable = generator.function_table.extract_reachable(&data, &arena_clone.scopes);
     generator.register_shared_function_data(PendingSharedFunctionData {
         function_data: Some(data),
         subtable: Some(subtable),
+        arena: None,
         name_override: name_override.map(Utf16String::from),
         class_field_initializer_name: None,
         should_eager_compile: false,

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -117,7 +117,7 @@ fn generate_expression_inner(
         }
 
         // === Identifiers ===
-        ExpressionKind::Identifier(ident) => Some(generate_identifier(ident, generator, preferred_dst)),
+        ExpressionKind::Identifier(ident) => Some(generate_identifier(*ident, generator, preferred_dst)),
 
         // === This ===
         ExpressionKind::This => {
@@ -324,11 +324,12 @@ fn generate_unary_expression(
     // evaluating the operand to avoid throwing on unresolvable references.
     // Allocate dst before evaluating typeof/not operands.
     if op == UnaryOp::Typeof {
+        let arena = generator.arena.clone();
         if let ExpressionKind::Identifier(ident) = &operand.inner
-            && !ident.is_local()
+            && !arena.identifiers[*ident].is_local()
         {
             let dst = choose_dst(generator, preferred_dst);
-            let id = generator.intern_identifier(&ident.name);
+            let id = generator.intern_identifier(&arena.identifiers[*ident].name);
             generator.emit(Instruction::TypeofBinding {
                 dst: dst.operand(),
                 identifier: id,
@@ -538,7 +539,9 @@ fn generate_function_expression(
         });
         generator.lexical_environment_register_stack.push(new_env);
 
-        let id = generator.intern_identifier(&data.name.as_ref().expect("function declaration must have a name").name);
+        let name_id = data.name.expect("function declaration must have a name");
+        let arena = generator.arena.clone();
+        let id = generator.intern_identifier(&arena.identifiers[name_id].name);
         generator.emit(Instruction::CreateVariable {
             identifier: id,
             mode: EnvironmentMode::Lexical as u32,
@@ -711,7 +714,14 @@ fn generate_member_expression(
         if let Some(key) = computed_key {
             emit_get_by_value_with_this(generator, &dst, &super_base, &key, &this_value);
         } else if let ExpressionKind::Identifier(ident) = &property.inner {
-            emit_get_by_id_with_this(generator, &dst, &super_base, &ident.name, &this_value);
+            let arena = generator.arena.clone();
+            emit_get_by_id_with_this(
+                generator,
+                &dst,
+                &super_base,
+                &arena.identifiers[*ident].name,
+                &this_value,
+            );
         }
         return Some(dst);
     }
@@ -727,7 +737,8 @@ fn generate_member_expression(
     // Non-computed: property must be an Identifier
     let dst = choose_dst(generator, preferred_dst);
     if let ExpressionKind::Identifier(ident) = &property.inner {
-        emit_get_by_id(generator, &dst, &obj, &ident.name, base_id);
+        let arena = generator.arena.clone();
+        emit_get_by_id(generator, &dst, &obj, &arena.identifiers[*ident].name, base_id);
     } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &property.inner {
         let id = generator.intern_identifier(&priv_ident.name);
         generator.emit(Instruction::GetPrivateById {
@@ -985,8 +996,9 @@ pub fn generate_statement(
             if fd.is_hoisted.get() {
                 // Annex B.3.3: Copy the function from the lexical (block) scope
                 // to the var scope.
-                if let Some(name_ident) = &fd.name {
-                    let id = generator.intern_identifier(&name_ident.name);
+                if let Some(name_ident) = fd.name {
+                    let arena = generator.arena.clone();
+                    let id = generator.intern_identifier(&arena.identifiers[name_ident].name);
                     let value = generator.allocate_register();
                     generator.emit(Instruction::GetBinding {
                         dst: value.operand(),
@@ -1052,7 +1064,9 @@ pub fn generate_statement(
             // (temporal dead zone) until this point, matching `let` semantics.
             // NB: We do NOT mark the local as initialized here, preserving
             // TDZ checks for subsequent uses of the class name.
-            if let Some(name_ident) = &data.name {
+            if let Some(name_ident_id) = data.name {
+                let arena = generator.arena.clone();
+                let name_ident = &arena.identifiers[name_ident_id];
                 if name_ident.is_local() {
                     let local =
                         generator.resolve_local(name_ident.local_index.get(), name_ident.local_type.get().unwrap());
@@ -1730,10 +1744,12 @@ fn generate_yield(
 /// - **Global**: GetGlobal instruction (with inline cache)
 /// - **Environment**: GetBinding/GetInitializedBinding (with environment coordinate cache)
 fn generate_identifier(
-    ident: &Identifier,
+    id: crate::ast::IdentifierId,
     generator: &mut Generator,
     preferred_dst: Option<&ScopedOperand>,
 ) -> ScopedOperand {
+    let arena = generator.arena.clone();
+    let ident = &arena.identifiers[id];
     if ident.is_local() {
         let local_index = ident.local_index.get();
         let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
@@ -2328,7 +2344,7 @@ fn generate_for_statement(
     {
         let mut non_local_names: Vec<(Utf16String, bool)> = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut non_local_names);
+            collect_target_names(&declaration.target, &mut non_local_names, &generator.arena.identifiers);
         }
         if !non_local_names.is_empty() {
             has_lexical_environment = true;
@@ -2588,7 +2604,7 @@ fn emit_lexical_declarations_for_block<'a>(
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
                     for (name, _) in &names {
                         let id = generator.intern_identifier(name);
                         if is_constant {
@@ -2610,7 +2626,7 @@ fn emit_lexical_declarations_for_block<'a>(
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
                     for (name, _) in &names {
                         let id = generator.intern_identifier(name);
                         generator.emit(Instruction::CreateImmutableBinding {
@@ -2622,19 +2638,23 @@ fn emit_lexical_declarations_for_block<'a>(
                 }
             }
             StatementKind::ClassDeclaration(class_data) => {
-                if let Some(ref name_ident) = class_data.name
-                    && !name_ident.is_local()
-                {
-                    let id = generator.intern_identifier(&name_ident.name);
-                    generator.emit(Instruction::CreateMutableBinding {
-                        environment: environment.operand(),
-                        identifier: id,
-                        can_be_deleted: false,
-                    });
+                if let Some(name_ident_id) = class_data.name {
+                    let arena = generator.arena.clone();
+                    let name_ident = &arena.identifiers[name_ident_id];
+                    if !name_ident.is_local() {
+                        let id = generator.intern_identifier(&name_ident.name);
+                        generator.emit(Instruction::CreateMutableBinding {
+                            environment: environment.operand(),
+                            identifier: id,
+                            can_be_deleted: false,
+                        });
+                    }
                 }
             }
             StatementKind::FunctionDeclaration(fd) if fd.name.is_some() => {
-                let name_ident = fd.name.as_ref().unwrap();
+                let name_ident_id = fd.name.unwrap();
+                let arena = generator.arena.clone();
+                let name_ident = &arena.identifiers[name_ident_id];
                 // a. Create binding.
                 if !name_ident.is_local() {
                     let id = generator.intern_identifier(&name_ident.name);
@@ -2674,7 +2694,7 @@ fn emit_lexical_declarations_for_block<'a>(
 }
 
 fn emit_block_declaration_instantiation(generator: &mut Generator, scope: &ScopeData) -> bool {
-    if !needs_block_declaration_instantiation(scope) {
+    if !needs_block_declaration_instantiation(scope, &generator.arena.identifiers) {
         return false;
     }
 
@@ -2695,13 +2715,15 @@ fn generate_variable_declaration(
     declarations: &[VariableDeclarator],
 ) {
     for declaration in declarations {
+        let arena = generator.arena.clone();
         // OPTIMIZATION: For let/const declarations where the target is a local identifier,
         // pass the local as preferred_dst to the initializer. This allows NewArray, NewFunction,
         // Add, etc. to write directly to the local instead of temp+Mov.
         // NB: Not safe for `var` since var declarations can have duplicates, meaning the
         // preferred_dst could be used as input in the initializer.
         let init_dst = if kind != DeclarationKind::Var {
-            if let VariableDeclaratorTarget::Identifier(ident) = &declaration.target {
+            if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
+                let ident = &arena.identifiers[*id];
                 if ident.is_local() && ident.local_type.get() == Some(LocalType::Variable) {
                     Some(generator.local(ident.local_index.get()))
                 } else {
@@ -2715,7 +2737,8 @@ fn generate_variable_declaration(
         };
 
         // Set pending LHS name for function name inference.
-        if let VariableDeclaratorTarget::Identifier(ident) = &declaration.target {
+        if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
+            let ident = &arena.identifiers[*id];
             generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
         }
         let init_value = declaration
@@ -2725,7 +2748,8 @@ fn generate_variable_declaration(
         generator.pending_lhs_name = None;
 
         match &declaration.target {
-            VariableDeclaratorTarget::Identifier(ident) => {
+            VariableDeclaratorTarget::Identifier(id) => {
+                let ident = &arena.identifiers[*id];
                 // var declarations without initializer don't need to assign undefined.
                 // The FDI already handles initialization for var bindings.
                 if init_value.is_none() && kind == DeclarationKind::Var {
@@ -2794,8 +2818,9 @@ fn try_generate_builtin_abstract_operation(
     if !generator.builtin_abstract_operations_enabled {
         return None;
     }
+    let arena = generator.arena.clone();
     let name = match &data.callee.inner {
-        ExpressionKind::Identifier(ident) => &ident.name,
+        ExpressionKind::Identifier(ident) => &arena.identifiers[*ident].name,
         _ => return None,
     };
     if data.arguments.iter().any(|a| a.is_spread) {
@@ -2921,8 +2946,9 @@ fn try_generate_builtin_abstract_operation(
             let val = generate_expression_or_undefined(&argument.value, generator, None);
             argument_holders.push(generator.copy_if_needed_to_preserve_evaluation_order(&val));
         }
-        let callee_name =
-            expression_string_approximation(&data.arguments[0].value).map(|s| generator.intern_string(&s));
+        let arena_clone = generator.arena.clone();
+        let callee_name = expression_string_approximation(&data.arguments[0].value, &arena_clone.identifiers)
+            .map(|s| generator.intern_string(&s));
         let arguments: Vec<Operand> = argument_holders.iter().map(|a| a.operand()).collect();
         generator.emit(Instruction::Call {
             dst: dst.operand(),
@@ -3019,15 +3045,20 @@ fn generate_call_expression(
     let dst = choose_dst(generator, preferred_dst);
 
     // Compute expression_string for error messages (e.g. "true is not a function (evaluated from 'a')").
+    let arena = generator.arena.clone();
     let expression_string: Option<StringTableIndex> =
-        expression_string_approximation(&data.callee).map(|s| generator.intern_string(&s));
+        expression_string_approximation(&data.callee, &arena.identifiers).map(|s| generator.intern_string(&s));
 
     // Detect direct eval calls: bare identifier "eval" as callee.
-    let is_direct_eval =
-        !is_new && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if ident.name == utf16!("eval"));
+    let is_direct_eval = !is_new
+        && matches!(&data.callee.inner, ExpressionKind::Identifier(ident) if arena.identifiers[*ident].name == utf16!("eval"));
 
     // Detect known builtins for member expression callees (e.g. Math.abs).
-    let builtin: Option<u8> = if !is_new { get_builtin(&data.callee) } else { None };
+    let builtin: Option<u8> = if !is_new {
+        get_builtin(&data.callee, &generator.arena.identifiers)
+    } else {
+        None
+    };
 
     // For method calls (obj.method()), we need to use the object as `this`.
     let (callee, this_value) = if !is_new {
@@ -3053,7 +3084,13 @@ fn generate_call_expression(
                 if let Some(key) = computed_key {
                     emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id_with_this(generator, &method, &super_base, &ident.name, &this_value);
+                    emit_get_by_id_with_this(
+                        generator,
+                        &method,
+                        &super_base,
+                        &arena.identifiers[*ident].name,
+                        &this_value,
+                    );
                 }
                 (method, Some(this_value))
             }
@@ -3065,7 +3102,7 @@ fn generate_call_expression(
                     let property = generate_expression_or_undefined(&data.property, generator, None);
                     emit_get_by_value(generator, &method, &obj, &property, None);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id(generator, &method, &obj, &ident.name, base_id);
+                    emit_get_by_id(generator, &method, &obj, &arena.identifiers[*ident].name, base_id);
                 } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &data.property.inner {
                     let id = generator.intern_identifier(&priv_ident.name);
                     generator.emit(Instruction::GetPrivateById {
@@ -3076,27 +3113,28 @@ fn generate_call_expression(
                 }
                 (method, Some(obj))
             }
-            ExpressionKind::Identifier(ident) if ident.is_local() => {
+            ExpressionKind::Identifier(ident) if arena.identifiers[*ident].is_local() => {
+                let id_data = &arena.identifiers[*ident];
                 // Local identifier: use the local directly, with ThrowIfTDZ
                 // if not yet initialized.
-                let local = generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
-                let needs_tdz = if ident.local_type.get() == Some(LocalType::Argument) {
-                    !generator.is_argument_initialized(ident.local_index.get())
+                let local = generator.resolve_local(id_data.local_index.get(), id_data.local_type.get().unwrap());
+                let needs_tdz = if id_data.local_type.get() == Some(LocalType::Argument) {
+                    !generator.is_argument_initialized(id_data.local_index.get())
                 } else {
-                    generator.is_local_lexically_declared(ident.local_index.get())
-                        && !generator.is_local_initialized(ident.local_index.get())
+                    generator.is_local_lexically_declared(id_data.local_index.get())
+                        && !generator.is_local_initialized(id_data.local_index.get())
                 };
                 if needs_tdz {
                     generator.emit(Instruction::ThrowIfTDZ { src: local.operand() });
                 }
                 (local, None)
             }
-            ExpressionKind::Identifier(ident) if !ident.is_global.get() => {
+            ExpressionKind::Identifier(ident) if !arena.identifiers[*ident].is_global.get() => {
                 // Non-local, non-global identifier: use GetCalleeAndThisFromEnvironment
                 // to properly handle with-statement bindings and eval.
                 let callee_reg = generator.allocate_register();
                 let this_reg = generator.allocate_register();
-                let id = generator.intern_identifier(&ident.name);
+                let id = generator.intern_identifier(&arena.identifiers[*ident].name);
                 generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
                     callee: callee_reg.operand(),
                     this_value: this_reg.operand(),
@@ -3298,9 +3336,9 @@ fn generate_update_expression(
     // so we can store back without re-evaluating.
     match &argument.inner {
         ExpressionKind::Identifier(ident) => {
-            let value = generate_identifier(ident, generator, None);
+            let value = generate_identifier(*ident, generator, None);
             let result = emit_update_op(generator, op, prefixed, &value);
-            emit_set_variable(generator, ident, &value);
+            emit_set_variable(generator, *ident, &value);
             Some(result)
         }
         ExpressionKind::Member(data) => {
@@ -3324,7 +3362,8 @@ fn generate_update_expression(
                 if let Some(ref key) = computed_key {
                     emit_get_by_value_with_this(generator, &value, &base, key, &this_value);
                 } else if let ExpressionKind::Identifier(ident) = &data.property.inner {
-                    emit_get_by_id_with_this(generator, &value, &base, &ident.name, &this_value);
+                    let arena = generator.arena.clone();
+                    emit_get_by_id_with_this(generator, &value, &base, &arena.identifiers[*ident].name, &this_value);
                 }
                 let result = emit_update_op(generator, op, prefixed, &value);
                 emit_super_put(
@@ -3350,8 +3389,10 @@ fn generate_update_expression(
                     Some(result)
                 } else if let ExpressionKind::Identifier(property_ident) = &data.property.inner {
                     let value = generator.allocate_register();
-                    emit_get_by_id(generator, &value, &base, &property_ident.name, base_id);
-                    let key = generator.intern_property_key(&property_ident.name);
+                    let arena = generator.arena.clone();
+                    let property_name = &arena.identifiers[*property_ident].name;
+                    emit_get_by_id(generator, &value, &base, property_name, base_id);
+                    let key = generator.intern_property_key(property_name);
                     let result = emit_update_op(generator, op, prefixed, &value);
                     let cache2 = generator.next_property_lookup_cache();
                     generator.emit(Instruction::PutById {
@@ -3414,20 +3455,23 @@ fn generate_assignment_expression(
     match lhs {
         AssignmentLhs::Expression(lhs_expression) => {
             // Simple assignment to identifier
-            if let ExpressionKind::Identifier(ident) = &lhs_expression.inner {
+            if let ExpressionKind::Identifier(id) = &lhs_expression.inner {
+                let id = *id;
+                let arena = generator.arena.clone();
+                let ident = &arena.identifiers[id];
                 if op == AssignmentOp::Assignment {
                     generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     generator.pending_lhs_name = None;
                     if ident.is_local() {
-                        emit_tdz_check_if_needed(generator, ident);
+                        emit_tdz_check_if_needed(generator, id);
                     }
-                    emit_set_variable(generator, ident, &rhs_val);
+                    emit_set_variable(generator, id, &rhs_val);
                     return Some(rhs_val);
                 }
 
                 // Load LHS value first (needed for both compound and logical assignments).
-                let lhs_val = generate_identifier(ident, generator, None);
+                let lhs_val = generate_identifier(id, generator, None);
                 let lhs_val = generator.copy_if_needed_to_preserve_evaluation_order(&lhs_val);
 
                 let is_logical = matches!(
@@ -3457,7 +3501,7 @@ fn generate_assignment_expression(
                     }
                     // RHS block: evaluate RHS, assign, jump to end.
                     generator.switch_to_basic_block(rhs_block);
-                    generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+                    generator.pending_lhs_name = Some(generator.intern_identifier(&arena.identifiers[id].name));
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     generator.pending_lhs_name = None;
                     // Allocate dst after RHS evaluation.
@@ -3467,7 +3511,7 @@ fn generate_assignment_expression(
                         choose_dst(generator, preferred_dst)
                     };
                     generator.emit_mov(&dst, &rhs_val);
-                    emit_set_variable(generator, ident, &dst);
+                    emit_set_variable(generator, id, &dst);
                     generator.emit(Instruction::Jump { target: end_block });
                     // LHS block: keep original value.
                     generator.switch_to_basic_block(lhs_block);
@@ -3486,7 +3530,7 @@ fn generate_assignment_expression(
                     choose_dst(generator, preferred_dst)
                 };
                 emit_compound_assignment(generator, op, &dst, &lhs_val, &rhs_val);
-                emit_set_variable(generator, ident, &dst);
+                emit_set_variable(generator, id, &dst);
                 return Some(dst);
             }
             // Member expression LHS (e.g., obj.foo = x, obj[key] = x)
@@ -3534,7 +3578,14 @@ fn generate_assignment_expression(
                     if let Some(ref key) = computed_key {
                         emit_get_by_value_with_this(generator, &old_val, &base, key, &super_this);
                     } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                        emit_get_by_id_with_this(generator, &old_val, &base, &ident.name, &super_this);
+                        let arena = generator.arena.clone();
+                        emit_get_by_id_with_this(
+                            generator,
+                            &old_val,
+                            &base,
+                            &arena.identifiers[*ident].name,
+                            &super_this,
+                        );
                     }
                     let is_logical = matches!(
                         op,
@@ -3649,7 +3700,9 @@ fn generate_assignment_expression(
                     return Some(dst);
                 } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                     let old_val = generator.allocate_register();
-                    emit_get_by_id(generator, &old_val, &base, &ident.name, base_id);
+                    let arena = generator.arena.clone();
+                    let property_name = arena.identifiers[*ident].name.clone();
+                    emit_get_by_id(generator, &old_val, &base, &property_name, base_id);
                     if is_logical {
                         let rhs_block = generator.make_block();
                         let lhs_block = generator.make_block();
@@ -3659,7 +3712,7 @@ fn generate_assignment_expression(
                         let rhs_val = generate_expression(rhs, generator, None)?;
                         let dst = choose_dst(generator, preferred_dst);
                         generator.emit_mov(&dst, &rhs_val);
-                        let key = generator.intern_property_key(&ident.name);
+                        let key = generator.intern_property_key(&property_name);
                         let cache2 = generator.next_property_lookup_cache();
                         generator.emit(Instruction::PutById {
                             base: base.operand(),
@@ -3679,7 +3732,7 @@ fn generate_assignment_expression(
                     let rhs_val = generate_expression(rhs, generator, None)?;
                     let dst = choose_dst(generator, preferred_dst);
                     emit_compound_assignment(generator, op, &dst, &old_val, &rhs_val);
-                    let key = generator.intern_property_key(&ident.name);
+                    let key = generator.intern_property_key(&property_name);
                     let cache2 = generator.next_property_lookup_cache();
                     generator.emit(Instruction::PutById {
                         base: base.operand(),
@@ -3787,7 +3840,8 @@ fn emit_super_get(
         emit_get_by_value_with_this(generator, dst, base, &property, this_value);
         Some(property)
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
-        emit_get_by_id_with_this(generator, dst, base, &ident.name, this_value);
+        let arena = generator.arena.clone();
+        emit_get_by_id_with_this(generator, dst, base, &arena.identifiers[*ident].name, this_value);
         None
     } else {
         None
@@ -3814,7 +3868,8 @@ fn emit_super_put(
         };
         emit_put_normal_by_value_with_this(generator, base, &property, this_value, value);
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
-        let key = generator.intern_property_key(&ident.name);
+        let arena = generator.arena.clone();
+        let key = generator.intern_property_key(&arena.identifiers[*ident].name);
         let cache = generator.next_property_lookup_cache();
         generator.emit(Instruction::PutByIdWithThis {
             base: base.operand(),
@@ -4141,7 +4196,9 @@ fn emit_put_by_value(
 /// Emit a ThrowIfTDZ check for a local identifier if needed. This is used
 /// before assigning to a
 /// variable to ensure TDZ semantics for let/const bindings.
-fn emit_tdz_check_if_needed(generator: &mut Generator, ident: &Identifier) {
+fn emit_tdz_check_if_needed(generator: &mut Generator, id: crate::ast::IdentifierId) {
+    let arena = generator.arena.clone();
+    let ident = &arena.identifiers[id];
     if !ident.is_local() {
         return;
     }
@@ -4161,7 +4218,9 @@ fn emit_tdz_check_if_needed(generator: &mut Generator, ident: &Identifier) {
     }
 }
 
-fn emit_set_variable(generator: &mut Generator, ident: &Identifier, value: &ScopedOperand) {
+fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, value: &ScopedOperand) {
+    let arena = generator.arena.clone();
+    let ident = &arena.identifiers[id];
     if ident.is_local() {
         if ident.declaration_kind.get() == Some(DeclarationKind::Const) {
             // The caller is responsible for emitting ThrowIfTDZ before calling
@@ -4217,7 +4276,8 @@ fn emit_put_to_member(
         let property = generate_expression_or_undefined(property, generator, None);
         emit_put_normal_by_value(generator, base, &property, value, base_id);
     } else if let ExpressionKind::Identifier(ident) = &property.inner {
-        let key = generator.intern_property_key(&ident.name);
+        let arena = generator.arena.clone();
+        let key = generator.intern_property_key(&arena.identifiers[*ident].name);
         let cache = generator.next_property_lookup_cache();
         generator.emit(Instruction::PutById {
             base: base.operand(),
@@ -4241,11 +4301,13 @@ fn emit_put_to_member(
 fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> ScopedOperand {
     match &operand.inner {
         ExpressionKind::Identifier(ident) => {
-            if ident.is_local() {
+            let arena = generator.arena.clone();
+            let identifier = &arena.identifiers[*ident];
+            if identifier.is_local() {
                 return generator.add_constant_boolean(false);
             }
             let dst = generator.allocate_register();
-            let id = generator.intern_identifier(&ident.name);
+            let id = generator.intern_identifier(&identifier.name);
             generator.emit(Instruction::DeleteVariable {
                 dst: dst.operand(),
                 identifier: id,
@@ -4293,7 +4355,8 @@ fn emit_delete_reference(generator: &mut Generator, operand: &Expression) -> Sco
                     property: key.operand(),
                 });
             } else if let ExpressionKind::Identifier(property_ident) = &data.property.inner {
-                let key = generator.intern_property_key(&property_ident.name);
+                let arena = generator.arena.clone();
+                let key = generator.intern_property_key(&arena.identifiers[*property_ident].name);
                 generator.emit(Instruction::DeleteById {
                     dst: dst.operand(),
                     base: base.operand(),
@@ -4378,7 +4441,8 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                     }
                 }
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                let key = generator.intern_property_key(&ident.name);
+                let arena = generator.arena.clone();
+                let key = generator.intern_property_key(&arena.identifiers[*ident].name);
                 let cache = generator.next_property_lookup_cache();
                 EvaluatedReference::SuperMemberId {
                     base,
@@ -4413,7 +4477,8 @@ fn emit_evaluate_member_reference(generator: &mut Generator, target: &Expression
                     }
                 }
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                let key = generator.intern_property_key(&ident.name);
+                let arena = generator.arena.clone();
+                let key = generator.intern_property_key(&arena.identifiers[*ident].name);
                 let cache = generator.next_property_lookup_cache();
                 EvaluatedReference::MemberId {
                     base,
@@ -4493,7 +4558,7 @@ fn emit_store_to_evaluated_reference(generator: &mut Generator, reference: &Eval
 fn emit_store_to_reference(generator: &mut Generator, target: &Expression, value: &ScopedOperand) {
     match &target.inner {
         ExpressionKind::Identifier(ident) => {
-            emit_set_variable(generator, ident, value);
+            emit_set_variable(generator, *ident, value);
         }
         ExpressionKind::Member(data) => {
             if matches!(data.object.inner, ExpressionKind::Super) {
@@ -4718,14 +4783,22 @@ fn generate_tagged_template_literal(
                 dst: super_base.operand(),
             });
             let method = generator.allocate_register();
+            let arena = generator.arena.clone();
             if let Some(key) = computed_key {
                 emit_get_by_value_with_this(generator, &method, &super_base, &key, &this_value);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
-                emit_get_by_id_with_this(generator, &method, &super_base, &ident.name, &this_value);
+                emit_get_by_id_with_this(
+                    generator,
+                    &method,
+                    &super_base,
+                    &arena.identifiers[*ident].name,
+                    &this_value,
+                );
             }
             (method, Some(this_value))
         }
         ExpressionKind::Member(member_data) => {
+            let arena = generator.arena.clone();
             let obj = generate_expression_or_undefined(&member_data.object, generator, None);
             let method = generator.allocate_register();
             if member_data.computed {
@@ -4733,7 +4806,7 @@ fn generate_tagged_template_literal(
                 emit_get_by_value(generator, &method, &obj, &property, None);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
-                emit_get_by_id(generator, &method, &obj, &ident.name, base_id);
+                emit_get_by_id(generator, &method, &obj, &arena.identifiers[*ident].name, base_id);
             } else if let ExpressionKind::PrivateIdentifier(priv_ident) = &member_data.property.inner {
                 let id = generator.intern_identifier(&priv_ident.name);
                 generator.emit(Instruction::GetPrivateById {
@@ -4744,7 +4817,10 @@ fn generate_tagged_template_literal(
             }
             (method, Some(obj))
         }
-        ExpressionKind::Identifier(ident) if ident.is_local() || ident.is_global.get() => {
+        ExpressionKind::Identifier(ident)
+            if generator.arena.identifiers[*ident].is_local()
+                || generator.arena.identifiers[*ident].is_global.get() =>
+        {
             let tag_val = generate_expression_or_undefined(tag, generator, None);
             (tag_val, None)
         }
@@ -4753,7 +4829,8 @@ fn generate_tagged_template_literal(
             // to properly handle with-statement bindings.
             let callee_reg = generator.allocate_register();
             let this_reg = generator.allocate_register();
-            let id = generator.intern_identifier(&ident.name);
+            let arena = generator.arena.clone();
+            let id = generator.intern_identifier(&arena.identifiers[*ident].name);
             generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
                 callee: callee_reg.operand(),
                 this_value: this_reg.operand(),
@@ -4915,10 +4992,13 @@ fn generate_switch_statement(
             // only if the scope collector approved it (name is in annexb_function_names).
             if did_create_env
                 && let StatementKind::FunctionDeclaration(ref fd) = child.inner
-                && let Some(ref name_ident) = fd.name
-                && generator.annexb_function_names.contains(name_ident.name.as_slice())
+                && let Some(name_ident_id) = fd.name
+                && generator
+                    .annexb_function_names
+                    .contains(generator.arena.identifiers[name_ident_id].name.as_slice())
             {
-                let id = generator.intern_identifier(&name_ident.name);
+                let arena = generator.arena.clone();
+                let id = generator.intern_identifier(&arena.identifiers[name_ident_id].name);
                 let value = generator.allocate_register();
                 generator.emit(Instruction::GetBinding {
                     dst: value.operand(),
@@ -4987,12 +5067,14 @@ fn emit_switch_block_declaration_instantiation(generator: &mut Generator, data: 
         {
             vd.declarations.iter().any(|declaration| {
                 let mut names = Vec::new();
-                collect_target_names(&declaration.target, &mut names);
+                collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
                 !names.is_empty()
             })
         }
         StatementKind::VariableDeclaration(_) => false,
-        StatementKind::ClassDeclaration(class_data) => class_data.name.as_ref().is_some_and(|n| !n.is_local()),
+        StatementKind::ClassDeclaration(class_data) => class_data
+            .name
+            .is_some_and(|n| !generator.arena.identifiers[n].is_local()),
         _ => false,
     });
 
@@ -5094,7 +5176,7 @@ fn generate_object_expression(
         if !effectively_computed && property.property_type != ObjectPropertyType::ProtoSetter {
             let base_name: Option<Utf16String> = match &property.key.inner {
                 ExpressionKind::StringLiteral(s) => Some((**s).clone()),
-                ExpressionKind::Identifier(ident) => Some(ident.name.to_utf16_string()),
+                ExpressionKind::Identifier(ident) => Some(generator.arena.identifiers[*ident].name.to_utf16_string()),
                 _ => None,
             };
             if let Some(name) = base_name {
@@ -5155,8 +5237,11 @@ fn generate_object_expression(
                     );
                 } else {
                     // Non-simple object: use PutOwnById instead of InitObjectLiteralProperty
+                    let arena = generator.arena.clone();
                     let property_key = match &property.key.inner {
-                        ExpressionKind::Identifier(ident) => generator.intern_property_key(&ident.name),
+                        ExpressionKind::Identifier(ident) => {
+                            generator.intern_property_key(&arena.identifiers[*ident].name)
+                        }
                         ExpressionKind::StringLiteral(s) => generator.intern_property_key(s),
                         _ => {
                             emit_object_property_set_by_key(
@@ -5244,7 +5329,8 @@ fn emit_object_property_set_by_key(
     }
     match &key.inner {
         ExpressionKind::Identifier(ident) => {
-            let property_key = generator.intern_property_key(&ident.name);
+            let arena = generator.arena.clone();
+            let property_key = generator.intern_property_key(&arena.identifiers[*ident].name);
             generator.emit(Instruction::InitObjectLiteralProperty {
                 object: object.operand(),
                 property: property_key,
@@ -5347,7 +5433,11 @@ fn emit_object_accessor_by_key(
     }
 
     match &key.inner {
-        ExpressionKind::Identifier(ident) => emit_by_id(generator, &ident.name),
+        ExpressionKind::Identifier(ident) => {
+            let arena = generator.arena.clone();
+            let name = arena.identifiers[*ident].name.clone();
+            emit_by_id(generator, &name);
+        }
         ExpressionKind::StringLiteral(s) => emit_by_id(generator, s),
         _ => emit_by_value(generator, key),
     }
@@ -5396,7 +5486,8 @@ fn generate_optional_chain_inner(
                 generator.emit_mov(current_base, &obj);
             } else if let ExpressionKind::Identifier(ident) = &member_data.property.inner {
                 let base_id = intern_base_identifier(generator, &member_data.object);
-                emit_get_by_id(generator, &val, &obj, &ident.name, base_id);
+                let arena = generator.arena.clone();
+                emit_get_by_id(generator, &val, &obj, &arena.identifiers[*ident].name, base_id);
                 generator.emit_mov(current_base, &obj);
             } else if let ExpressionKind::PrivateIdentifier(name) = &member_data.property.inner {
                 let id = generator.intern_identifier(&name.name);
@@ -5454,7 +5545,14 @@ fn generate_optional_chain_inner(
         match reference {
             OptionalChainReference::MemberReference { identifier, .. } => {
                 generator.emit_mov(current_base, current_value);
-                emit_get_by_id(generator, current_value, current_value, &identifier.name, None);
+                let arena = generator.arena.clone();
+                emit_get_by_id(
+                    generator,
+                    current_value,
+                    current_value,
+                    &arena.identifiers[*identifier].name,
+                    None,
+                );
             }
             OptionalChainReference::ComputedReference { expression, .. } => {
                 generator.emit_mov(current_base, current_value);
@@ -5578,8 +5676,8 @@ fn generate_class_expression(
     // Only emit when the class has a name, or when there's no lhs_name
     // (skip this for anonymous classes with lhs_name).
     if data.name.is_some() || lhs_name.is_none() {
-        let name = if let Some(name_ident) = &data.name {
-            name_ident.name.to_utf16_string()
+        let name = if let Some(name_ident_id) = data.name {
+            generator.arena.identifiers[name_ident_id].name.to_utf16_string()
         } else {
             Utf16String::new()
         };
@@ -5760,8 +5858,9 @@ fn generate_class_expression(
 
                     if !is_literal {
                         // Determine field name for anonymous function naming.
+                        let arena = generator.arena.clone();
                         let field_name = match &key.inner {
-                            ExpressionKind::Identifier(ident) => ident.name.to_utf16_string(),
+                            ExpressionKind::Identifier(ident) => arena.identifiers[*ident].name.to_utf16_string(),
                             ExpressionKind::StringLiteral(s) => (**s).clone(),
                             ExpressionKind::PrivateIdentifier(p) => p.name.clone(),
                             ExpressionKind::NumericLiteral(n) => super::ffi::js_number_to_utf16(*n),
@@ -5811,7 +5910,7 @@ fn generate_class_expression(
                         let key_is_private = is_private_key(key);
                         let key_name: Utf16String = match &key.inner {
                             ExpressionKind::PrivateIdentifier(ident) => ident.name.clone(),
-                            ExpressionKind::Identifier(ident) => ident.name.to_utf16_string(),
+                            ExpressionKind::Identifier(ident) => arena.identifiers[*ident].name.to_utf16_string(),
                             ExpressionKind::StringLiteral(s) => (**s).clone(),
                             ExpressionKind::NumericLiteral(n) => super::ffi::js_number_to_utf16(*n),
                             _ => Utf16String::new(),
@@ -5885,8 +5984,9 @@ fn generate_class_expression(
     let source_end = data.source_text_end as usize;
     let source_text_len = source_end - source_start;
 
+    let class_name = data.name.map(|n| generator.arena.identifiers[n].name.to_utf16_string());
     let blueprint_index = generator.register_class_blueprint(PendingClassBlueprint {
-        name: data.name.as_ref().map(|n| n.name.to_utf16_string()),
+        name: class_name,
         source_text_offset: source_start,
         source_text_length: source_text_len,
         constructor_sfd_index,
@@ -5941,7 +6041,7 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
         parser.flags.allow_super_constructor_call = true;
     }
     let program = parser.parse_program(false);
-    parser.scope_collector.analyze(false);
+    parser.scope_collector.analyze(false, &parser.arena.identifiers);
 
     assert!(!parser.has_errors(), "default constructor parse failed");
 
@@ -5995,14 +6095,14 @@ fn get_private_identifier_name(key: &Expression) -> Option<Utf16String> {
 
 /// Check if a for-in/for-of LHS is a `let`/`const` declaration with non-local identifiers,
 /// meaning we need a per-iteration lexical environment.
-fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs) -> bool {
+fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs, identifiers: &crate::ast::IdentifierArena) -> bool {
     if let ForInOfLhs::Declaration(statement) = lhs
         && let StatementKind::VariableDeclaration(vd) = &statement.inner
         && (vd.kind == DeclarationKind::Let || vd.kind == DeclarationKind::Const)
     {
         let mut names = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut names);
+            collect_target_names(&declaration.target, &mut names, identifiers);
         }
         return !names.is_empty();
     }
@@ -6010,36 +6110,47 @@ fn for_in_of_needs_lexical_env(lhs: &ForInOfLhs) -> bool {
 }
 
 /// Collect all non-local binding names from a variable declarator target.
-fn collect_target_names(target: &VariableDeclaratorTarget, names: &mut Vec<(Utf16String, bool)>) {
+fn collect_target_names(
+    target: &VariableDeclaratorTarget,
+    names: &mut Vec<(Utf16String, bool)>,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     match target {
-        VariableDeclaratorTarget::Identifier(ident) => {
+        VariableDeclaratorTarget::Identifier(id) => {
+            let ident = &identifiers[*id];
             if !ident.is_local() {
                 names.push((ident.name.to_utf16_string(), false));
             }
         }
         VariableDeclaratorTarget::BindingPattern(pattern) => {
-            collect_pattern_binding_names(pattern, names);
+            collect_pattern_binding_names(pattern, names, identifiers);
         }
     }
 }
 
 /// Collect all non-local binding names from a binding pattern (recursive).
-fn collect_pattern_binding_names(pattern: &BindingPattern, names: &mut Vec<(Utf16String, bool)>) {
+fn collect_pattern_binding_names(
+    pattern: &BindingPattern,
+    names: &mut Vec<(Utf16String, bool)>,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     for entry in &pattern.entries {
         match &entry.alias {
-            Some(BindingEntryAlias::Identifier(ident)) => {
+            Some(BindingEntryAlias::Identifier(id)) => {
+                let ident = &identifiers[*id];
                 if !ident.is_local() {
                     names.push((ident.name.to_utf16_string(), false));
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub)) => {
-                collect_pattern_binding_names(sub, names);
+                collect_pattern_binding_names(sub, names, identifiers);
             }
             None => {
-                if let Some(BindingEntryName::Identifier(ident)) = &entry.name
-                    && !ident.is_local()
-                {
-                    names.push((ident.name.to_utf16_string(), false));
+                if let Some(BindingEntryName::Identifier(id)) = &entry.name {
+                    let ident = &identifiers[*id];
+                    if !ident.is_local() {
+                        names.push((ident.name.to_utf16_string(), false));
+                    }
                 }
             }
             Some(BindingEntryAlias::MemberExpression(_)) => {}
@@ -6060,7 +6171,7 @@ fn create_for_in_of_lexical_env(generator: &mut Generator, lhs: &ForInOfLhs) -> 
     {
         is_constant = vd.kind == DeclarationKind::Const;
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut binding_names);
+            collect_target_names(&declaration.target, &mut binding_names, &generator.arena.identifiers);
         }
     }
 
@@ -6094,7 +6205,7 @@ fn enter_for_in_of_head_tdz(generator: &mut Generator, lhs: &ForInOfLhs) -> bool
     {
         let mut names = Vec::new();
         for declaration in &vd.declarations {
-            collect_target_names(&declaration.target, &mut names);
+            collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
         }
         if !names.is_empty() {
             generator.push_new_lexical_environment(0);
@@ -6153,19 +6264,20 @@ fn generate_for_in_statement(
         && let StatementKind::VariableDeclaration(vd) = &statement.inner
         && vd.kind == DeclarationKind::Var
         && let Some(declaration) = vd.declarations.first()
-        && let (VariableDeclaratorTarget::Identifier(ident), Some(init)) = (&declaration.target, &declaration.init)
+        && let (VariableDeclaratorTarget::Identifier(ident_id), Some(init)) = (&declaration.target, &declaration.init)
     {
-        generator.pending_lhs_name = Some(generator.intern_identifier(&ident.name));
+        let arena = generator.arena.clone();
+        generator.pending_lhs_name = Some(generator.intern_identifier(&arena.identifiers[*ident_id].name));
         let value = generate_expression_or_undefined(init, generator, None);
         generator.pending_lhs_name = None;
-        emit_set_variable(generator, ident, &value);
+        emit_set_variable(generator, *ident_id, &value);
     }
 
     // Create end_block and update_block first, then nullish_block and
     // continuation_block during head evaluation.
     let end_block = generator.make_block();
     let update_block = generator.make_block();
-    let needs_lexical_env = for_in_of_needs_lexical_env(lhs);
+    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.arena.identifiers);
 
     // B.3.5 Initializers in ForIn Statement Heads: evaluate initializer before RHS.
     // Create TDZ for lexical declarations before evaluating the RHS expression.
@@ -6343,7 +6455,7 @@ fn generate_for_of_statement_inner(
 
     // Create TDZ for lexical declarations before evaluating the RHS expression.
     let entered_tdz = enter_for_in_of_head_tdz(generator, lhs);
-    let needs_lexical_env = for_in_of_needs_lexical_env(lhs);
+    let needs_lexical_env = for_in_of_needs_lexical_env(lhs, &generator.arena.identifiers);
     let old_handler = generator.current_unwind_handler;
 
     // Evaluate RHS into `object`, allocate iterator registers, and emit
@@ -6780,7 +6892,7 @@ fn assign_to_for_in_of_lhs(generator: &mut Generator, lhs: &ForInOfLhs, value: &
                 };
                 match &declaration.target {
                     VariableDeclaratorTarget::Identifier(ident) => {
-                        emit_set_variable_with_mode(generator, ident, value, mode);
+                        emit_set_variable_with_mode(generator, *ident, value, mode);
                     }
                     VariableDeclaratorTarget::BindingPattern(pattern) => {
                         generate_binding_pattern_bytecode(generator, pattern, mode, value);
@@ -6811,11 +6923,12 @@ enum BindingMode {
 }
 
 fn set_pending_lhs_name_for_entry(generator: &mut Generator, entry: &BindingEntry) {
+    let arena = generator.arena.clone();
     let name = match &entry.alias {
-        Some(BindingEntryAlias::Identifier(id)) => Some(&id.name),
+        Some(BindingEntryAlias::Identifier(id)) => Some(arena.identifiers[*id].name.clone()),
         None => {
             if let Some(BindingEntryName::Identifier(id)) = &entry.name {
-                Some(&id.name)
+                Some(arena.identifiers[*id].name.clone())
             } else {
                 None
             }
@@ -6823,7 +6936,7 @@ fn set_pending_lhs_name_for_entry(generator: &mut Generator, entry: &BindingEntr
         _ => None,
     };
     if let Some(name) = name {
-        generator.pending_lhs_name = Some(generator.intern_identifier(name));
+        generator.pending_lhs_name = Some(generator.intern_identifier(&name));
     }
 }
 
@@ -6845,10 +6958,12 @@ fn generate_binding_pattern_bytecode(
 
 fn emit_set_variable_with_mode(
     generator: &mut Generator,
-    ident: &Identifier,
+    id: crate::ast::IdentifierId,
     value: &ScopedOperand,
     mode: BindingMode,
 ) {
+    let arena = generator.arena.clone();
+    let ident = &arena.identifiers[id];
     if ident.is_local() {
         let local = generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
         generator.emit_mov(&local, value);
@@ -6892,11 +7007,11 @@ fn assign_binding_entry_alias(
         None => {
             // Name IS the binding target (e.g., `{ x }` or array element).
             if let Some(BindingEntryName::Identifier(ident)) = &entry.name {
-                emit_set_variable_with_mode(generator, ident, value, mode);
+                emit_set_variable_with_mode(generator, *ident, value, mode);
             }
         }
         Some(BindingEntryAlias::Identifier(ident)) => {
-            emit_set_variable_with_mode(generator, ident, value, mode);
+            emit_set_variable_with_mode(generator, *ident, value, mode);
         }
         Some(BindingEntryAlias::BindingPattern(sub_pattern)) => {
             generate_binding_pattern_bytecode(generator, sub_pattern, mode, value);
@@ -7110,9 +7225,11 @@ fn generate_object_binding_pattern(
 
         match &entry.name {
             Some(BindingEntryName::Identifier(ident)) => {
-                emit_get_by_id(generator, &value, object, &ident.name, None);
+                let arena = generator.arena.clone();
+                let name = arena.identifiers[*ident].name.clone();
+                emit_get_by_id(generator, &value, object, &name, None);
                 if has_rest {
-                    let name_val = generator.add_constant_string(ident.name.to_utf16_string());
+                    let name_val = generator.add_constant_string(name.to_utf16_string());
                     excluded_names.push(name_val);
                 }
             }
@@ -7255,7 +7372,9 @@ fn generate_try_statement(
         let mut created_catch_scope = false;
         if let Some(parameter) = &catch.parameter {
             match parameter {
-                CatchBinding::Identifier(ident) => {
+                CatchBinding::Identifier(ident_id) => {
+                    let arena = generator.arena.clone();
+                    let ident = &arena.identifiers[*ident_id];
                     if ident.is_local() {
                         let local = generator.local(ident.local_index.get());
                         generator.emit_mov(&local, &caught_value);
@@ -7282,7 +7401,7 @@ fn generate_try_statement(
                 }
                 CatchBinding::BindingPattern(pattern) => {
                     let mut names: Vec<(Utf16String, bool)> = Vec::new();
-                    collect_pattern_binding_names(pattern, &mut names);
+                    collect_pattern_binding_names(pattern, &mut names, &generator.arena.identifiers);
 
                     if !names.is_empty() {
                         generator.push_new_lexical_environment(0);
@@ -7617,9 +7736,11 @@ pub fn emit_function_declaration_instantiation(
     let mut seen_names: HashSet<Utf16String> = HashSet::new();
     let mut has_duplicates = false;
 
+    let arena = generator.arena.clone();
     for parameter in &function_data.parameters {
         match &parameter.binding {
-            FunctionParameterBinding::Identifier(ident) => {
+            FunctionParameterBinding::Identifier(ident_id) => {
+                let ident = &arena.identifiers[*ident_id];
                 let name = ident.name.to_utf16_string();
                 let is_local = ident.is_local();
                 if !seen_names.insert(name.clone()) {
@@ -7629,7 +7750,13 @@ pub fn emit_function_declaration_instantiation(
                 }
             }
             FunctionParameterBinding::BindingPattern(pattern) => {
-                collect_binding_pattern_names(pattern, &mut parameter_names, &mut seen_names, &mut has_duplicates);
+                collect_binding_pattern_names(
+                    pattern,
+                    &mut parameter_names,
+                    &mut seen_names,
+                    &mut has_duplicates,
+                    &arena.identifiers,
+                );
             }
         }
     }
@@ -7768,7 +7895,9 @@ pub fn emit_function_declaration_instantiation(
         }
 
         match &parameter.binding {
-            FunctionParameterBinding::Identifier(ident) => {
+            FunctionParameterBinding::Identifier(ident_id) => {
+                let arena = generator.arena.clone();
+                let ident = &arena.identifiers[*ident_id];
                 if ident.is_local() {
                     let local_index = ident.local_index.get();
                     match ident.local_type.get() {
@@ -7935,7 +8064,7 @@ pub fn emit_function_declaration_instantiation(
     // --- Step 7: Lexical environment for non-local declarations ---
     // Note: this counts only let/const/class declarations (not function declarations,
     // which are var-hoisted in function bodies).
-    let lex_bindings_count = count_non_local_lexical_bindings(body_scope);
+    let lex_bindings_count = count_non_local_lexical_bindings(body_scope, &generator.arena.identifiers);
 
     if !strict && lex_bindings_count > 0 {
         generator.push_new_lexical_environment(lex_bindings_count);
@@ -7951,7 +8080,7 @@ pub fn emit_function_declaration_instantiation(
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, &generator.arena.identifiers);
                     for (name, _) in names {
                         let id = generator.intern_identifier(&name);
                         generator.emit(Instruction::CreateVariable {
@@ -7966,17 +8095,19 @@ pub fn emit_function_declaration_instantiation(
             }
             StatementKind::ClassDeclaration(class_data) => {
                 // Class declarations are lexically scoped (like const).
-                if let Some(ref name_ident) = class_data.name
-                    && !name_ident.is_local()
-                {
-                    let id = generator.intern_identifier(&name_ident.name);
-                    generator.emit(Instruction::CreateVariable {
-                        identifier: id,
-                        mode: EnvironmentMode::Lexical as u32,
-                        is_immutable: false,
-                        is_global: false,
-                        is_strict: false,
-                    });
+                if let Some(name_ident_id) = class_data.name {
+                    let arena = generator.arena.clone();
+                    let name_ident = &arena.identifiers[name_ident_id];
+                    if !name_ident.is_local() {
+                        let id = generator.intern_identifier(&name_ident.name);
+                        generator.emit(Instruction::CreateVariable {
+                            identifier: id,
+                            mode: EnvironmentMode::Lexical as u32,
+                            is_immutable: false,
+                            is_global: false,
+                            is_strict: false,
+                        });
+                    }
                 }
             }
             _ => {}
@@ -7993,7 +8124,9 @@ pub fn emit_function_declaration_instantiation(
                 let sfd_index = emit_new_function(generator, inner_function_data, None);
 
                 // Check if the function name identifier is local.
-                if let Some(name_ident) = &fd.name {
+                if let Some(name_ident_id) = fd.name {
+                    let arena = generator.arena.clone();
+                    let name_ident = &arena.identifiers[name_ident_id];
                     if name_ident.is_local() {
                         let local_index = name_ident.local_index.get();
                         let local = generator.local(local_index);
@@ -8032,7 +8165,7 @@ fn is_for_loop(statement: &Statement) -> bool {
 
 /// Check if a block needs block declaration instantiation.
 /// True when the block has function declarations or non-local let/const/class.
-fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
+fn needs_block_declaration_instantiation(scope: &ScopeData, identifiers: &crate::ast::IdentifierArena) -> bool {
     for child in &scope.children {
         match &child.inner {
             StatementKind::FunctionDeclaration(_) => {
@@ -8043,15 +8176,15 @@ fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
             {
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, identifiers);
                     if !names.is_empty() {
                         return true;
                     }
                 }
             }
             StatementKind::ClassDeclaration(class_data) => {
-                if let Some(ref name_ident) = class_data.name
-                    && !name_ident.is_local()
+                if let Some(name_ident) = class_data.name
+                    && !identifiers[name_ident].is_local()
                 {
                     return true;
                 }
@@ -8059,7 +8192,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, identifiers);
                     if !names.is_empty() {
                         return true;
                     }
@@ -8072,7 +8205,7 @@ fn needs_block_declaration_instantiation(scope: &ScopeData) -> bool {
 }
 
 /// Count non-local lexical bindings in a function body scope.
-fn count_non_local_lexical_bindings(scope: &ScopeData) -> u32 {
+fn count_non_local_lexical_bindings(scope: &ScopeData, identifiers: &crate::ast::IdentifierArena) -> u32 {
     let mut count = 0u32;
     for child in &scope.children {
         match &child.inner {
@@ -8081,11 +8214,13 @@ fn count_non_local_lexical_bindings(scope: &ScopeData) -> u32 {
             {
                 for declaration in &vd.declarations {
                     let mut names = Vec::new();
-                    collect_target_names(&declaration.target, &mut names);
+                    collect_target_names(&declaration.target, &mut names, identifiers);
                     count += u32_from_usize(names.len());
                 }
             }
-            StatementKind::ClassDeclaration(class_data) if class_data.name.as_ref().is_some_and(|n| !n.is_local()) => {
+            StatementKind::ClassDeclaration(class_data)
+                if class_data.name.is_some_and(|n| !identifiers[n].is_local()) =>
+            {
                 count += 1;
             }
             _ => {}
@@ -8105,11 +8240,13 @@ fn collect_binding_pattern_names(
     parameter_names: &mut Vec<FdiParameterName>,
     seen_names: &mut HashSet<Utf16String>,
     has_duplicates: &mut bool,
+    identifiers: &crate::ast::IdentifierArena,
 ) {
     for entry in &pattern.entries {
         // The bound name can be in the alias (for object patterns) or name (for array patterns).
         match &entry.alias {
-            Some(BindingEntryAlias::Identifier(ident)) => {
+            Some(BindingEntryAlias::Identifier(ident_id)) => {
+                let ident = &identifiers[*ident_id];
                 let name = ident.name.to_utf16_string();
                 let is_local = ident.is_local();
                 if !seen_names.insert(name.clone()) {
@@ -8119,11 +8256,12 @@ fn collect_binding_pattern_names(
                 }
             }
             Some(BindingEntryAlias::BindingPattern(sub_pattern)) => {
-                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates);
+                collect_binding_pattern_names(sub_pattern, parameter_names, seen_names, has_duplicates, identifiers);
             }
             None => {
                 // No alias — the name itself is the binding.
-                if let Some(BindingEntryName::Identifier(ident)) = &entry.name {
+                if let Some(BindingEntryName::Identifier(ident_id)) = &entry.name {
+                    let ident = &identifiers[*ident_id];
                     let name = ident.name.to_utf16_string();
                     let is_local = ident.is_local();
                     if !seen_names.insert(name.clone()) {
@@ -8172,7 +8310,7 @@ const BUILTIN_STRING_PROTOTYPE_CHAR_AT: u8 = 23;
 
 /// Detect known builtin methods from a callee expression (e.g. Math.abs).
 /// Returns the Builtin enum value as u8, matching Builtins.h ordering.
-fn get_builtin(callee: &Expression) -> Option<u8> {
+fn get_builtin(callee: &Expression, identifiers: &crate::ast::IdentifierArena) -> Option<u8> {
     let ExpressionKind::Member(member_data) = &callee.inner else {
         return None;
     };
@@ -8182,15 +8320,17 @@ fn get_builtin(callee: &Expression) -> Option<u8> {
     let ExpressionKind::Identifier(property_ident) = &member_data.property.inner else {
         return None;
     };
-    if property_ident.name == utf16!("charAt") {
+    let property_name = &identifiers[*property_ident].name;
+    if property_name == utf16!("charAt") {
         return Some(BUILTIN_STRING_PROTOTYPE_CHAR_AT);
     }
-    if property_ident.name == utf16!("charCodeAt") {
+    if property_name == utf16!("charCodeAt") {
         return Some(BUILTIN_STRING_PROTOTYPE_CHAR_CODE_AT);
     }
     let ExpressionKind::Identifier(base_ident) = &member_data.object.inner else {
         return None;
     };
+    let base_name = &identifiers[*base_ident].name;
     // Must match JS_ENUMERATE_BUILTINS order in Builtins.h.
     static BUILTINS: &[(&[u16], &[u16], u8)] = &[
         (utf16!("Math"), utf16!("abs"), BUILTIN_MATH_ABS),
@@ -8245,7 +8385,7 @@ fn get_builtin(callee: &Expression) -> Option<u8> {
         (utf16!("String"), utf16!("fromCharCode"), BUILTIN_STRING_FROM_CHAR_CODE),
     ];
     for &(base, property, id) in BUILTINS {
-        if base_ident.name == base && property_ident.name == property {
+        if base_name == base && property_name == property {
             return Some(id);
         }
     }
@@ -9078,14 +9218,15 @@ fn nanboxed_empty() -> u64 {
 /// Intern the base expression as an identifier for error messages like
 /// "Cannot access property X on null object Y".
 fn intern_base_identifier(generator: &mut Generator, base: &Expression) -> Option<IdentifierTableIndex> {
-    expression_identifier(base).map(|s| generator.intern_identifier(&s))
+    let arena = generator.arena.clone();
+    expression_identifier(base, &arena.identifiers).map(|s| generator.intern_identifier(&s))
 }
 
 /// Try to produce a human-readable name for an expression (for error messages).
 /// Returns None for expressions that have no meaningful name.
-fn expression_identifier(expression: &Expression) -> Option<Utf16String> {
+fn expression_identifier(expression: &Expression, identifiers: &crate::ast::IdentifierArena) -> Option<Utf16String> {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => Some(ident.name.to_utf16_string()),
+        ExpressionKind::Identifier(ident) => Some(identifiers[*ident].name.to_utf16_string()),
         ExpressionKind::StringLiteral(s) => {
             let mut result = Utf16String(utf16!("'").to_vec());
             result.0.extend_from_slice(s);
@@ -9096,10 +9237,10 @@ fn expression_identifier(expression: &Expression) -> Option<Utf16String> {
         ExpressionKind::This => Some(Utf16String(utf16!("this").to_vec())),
         ExpressionKind::Member(data) => {
             let mut s = Utf16String::new();
-            if let Some(obj_id) = expression_identifier(&data.object) {
+            if let Some(obj_id) = expression_identifier(&data.object, identifiers) {
                 s.0.extend_from_slice(&obj_id);
             }
-            if let Some(property_id) = expression_identifier(&data.property) {
+            if let Some(property_id) = expression_identifier(&data.property, identifiers) {
                 if data.computed {
                     s.0.extend_from_slice(utf16!("["));
                     s.0.extend_from_slice(&property_id);
@@ -9118,20 +9259,23 @@ fn expression_identifier(expression: &Expression) -> Option<Utf16String> {
 /// Produce a human-readable string for call expression error messages.
 /// Unlike expression_identifier, this always produces output for known types
 /// (using "<object>" for unrecognized sub-expressions).
-fn expression_string_approximation(expression: &Expression) -> Option<Utf16String> {
+fn expression_string_approximation(
+    expression: &Expression,
+    identifiers: &crate::ast::IdentifierArena,
+) -> Option<Utf16String> {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => Some(ident.name.to_utf16_string()),
-        ExpressionKind::Member(_) => Some(member_to_string_approximation(expression)),
+        ExpressionKind::Identifier(ident) => Some(identifiers[*ident].name.to_utf16_string()),
+        ExpressionKind::Member(_) => Some(member_to_string_approximation(expression, identifiers)),
         _ => None,
     }
 }
 
-fn member_to_string_approximation(expression: &Expression) -> Utf16String {
+fn member_to_string_approximation(expression: &Expression, identifiers: &crate::ast::IdentifierArena) -> Utf16String {
     match &expression.inner {
-        ExpressionKind::Identifier(ident) => ident.name.to_utf16_string(),
+        ExpressionKind::Identifier(ident) => identifiers[*ident].name.to_utf16_string(),
         ExpressionKind::Member(data) => {
-            let mut s = member_to_string_approximation(&data.object);
-            let property_str = member_to_string_approximation(&data.property);
+            let mut s = member_to_string_approximation(&data.object, identifiers);
+            let property_str = member_to_string_approximation(&data.property, identifiers);
             if data.computed {
                 s.0.extend_from_slice(utf16!("["));
                 s.0.extend_from_slice(&property_str);

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -1068,8 +1068,7 @@ pub fn generate_statement(
                 let arena = generator.arena.clone();
                 let name_ident = &arena.identifiers[name_ident_id];
                 if name_ident.is_local() {
-                    let local =
-                        generator.resolve_local(name_ident.local_index.get(), name_ident.local_type.get().unwrap());
+                    let local = generator.resolve_local(name_ident.local_index, name_ident.local_type.unwrap());
                     generator.emit_mov(&local, &value);
                 } else {
                     let id = generator.intern_identifier(&name_ident.name);
@@ -1751,18 +1750,18 @@ fn generate_identifier(
     let arena = generator.arena.clone();
     let ident = &arena.identifiers[id];
     if ident.is_local() {
-        let local_index = ident.local_index.get();
-        let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
+        let local_index = ident.local_index;
+        let local = generator.resolve_local(local_index, ident.local_type.unwrap());
         // Check TDZ for uninitialized bindings.
         // Arguments may need TDZ during default parameter evaluation;
         // for variable-type locals, only lexically-declared (let/const) need TDZ.
-        let needs_tdz_check = if ident.local_type.get() == Some(LocalType::Argument) {
+        let needs_tdz_check = if ident.local_type == Some(LocalType::Argument) {
             !generator.is_argument_initialized(local_index)
         } else {
             generator.is_local_lexically_declared(local_index) && !generator.is_local_initialized(local_index)
         };
         if needs_tdz_check {
-            if ident.local_type.get() == Some(LocalType::Argument) {
+            if ident.local_type == Some(LocalType::Argument) {
                 // Arguments are initialized to undefined by default, so we
                 // need to replace the value with the empty sentinel to
                 // trigger the TDZ check.
@@ -1775,14 +1774,14 @@ fn generate_identifier(
     }
 
     // OPTIMIZATION: Generate builtin constants (undefined, NaN, Infinity) directly.
-    if ident.is_global.get()
+    if ident.is_global
         && let Some(constant) = maybe_generate_builtin_constant(generator, &ident.name)
     {
         return constant;
     }
 
     let dst = choose_dst(generator, preferred_dst);
-    if ident.is_global.get() {
+    if ident.is_global {
         let id = generator.intern_identifier(&ident.name);
         let cache = generator.next_global_variable_cache();
         generator.emit(Instruction::GetGlobal {
@@ -1790,7 +1789,7 @@ fn generate_identifier(
             identifier: id,
             cache: cache as u64,
         });
-    } else if ident.declaration_kind.get() == Some(DeclarationKind::Var) {
+    } else if ident.declaration_kind == Some(DeclarationKind::Var) {
         let id = generator.intern_identifier(&ident.name);
         generator.emit(Instruction::GetInitializedBinding {
             dst: dst.operand(),
@@ -2675,7 +2674,7 @@ fn emit_lexical_declarations_for_block<'a>(
                     lhs_name: None,
                 });
                 if name_ident.is_local() {
-                    let local_index = name_ident.local_index.get();
+                    let local_index = name_ident.local_index;
                     let local = generator.local(local_index);
                     generator.emit_mov(&local, &fo);
                     generator.mark_local_initialized(local_index);
@@ -2724,8 +2723,8 @@ fn generate_variable_declaration(
         let init_dst = if kind != DeclarationKind::Var {
             if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
                 let ident = &arena.identifiers[*id];
-                if ident.is_local() && ident.local_type.get() == Some(LocalType::Variable) {
-                    Some(generator.local(ident.local_index.get()))
+                if ident.is_local() && ident.local_type == Some(LocalType::Variable) {
+                    Some(generator.local(ident.local_index))
                 } else {
                     None
                 }
@@ -2754,21 +2753,21 @@ fn generate_variable_declaration(
                 // The FDI already handles initialization for var bindings.
                 if init_value.is_none() && kind == DeclarationKind::Var {
                     if ident.is_local() {
-                        generator.mark_local_initialized(ident.local_index.get());
+                        generator.mark_local_initialized(ident.local_index);
                     }
                     continue;
                 }
                 let value = init_value.unwrap_or_else(|| generator.add_constant_undefined());
                 if ident.is_local() {
-                    let local_index = ident.local_index.get();
-                    let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
+                    let local_index = ident.local_index;
+                    let local = generator.resolve_local(local_index, ident.local_type.unwrap());
                     generator.emit_mov(&local, &value);
                     generator.mark_local_initialized(local_index);
                 } else {
                     let id = generator.intern_identifier(&ident.name);
                     match kind {
                         DeclarationKind::Var => {
-                            if ident.is_global.get() {
+                            if ident.is_global {
                                 let cache = generator.next_global_variable_cache();
                                 generator.emit(Instruction::SetGlobal {
                                     identifier: id,
@@ -3117,19 +3116,19 @@ fn generate_call_expression(
                 let id_data = &arena.identifiers[*ident];
                 // Local identifier: use the local directly, with ThrowIfTDZ
                 // if not yet initialized.
-                let local = generator.resolve_local(id_data.local_index.get(), id_data.local_type.get().unwrap());
-                let needs_tdz = if id_data.local_type.get() == Some(LocalType::Argument) {
-                    !generator.is_argument_initialized(id_data.local_index.get())
+                let local = generator.resolve_local(id_data.local_index, id_data.local_type.unwrap());
+                let needs_tdz = if id_data.local_type == Some(LocalType::Argument) {
+                    !generator.is_argument_initialized(id_data.local_index)
                 } else {
-                    generator.is_local_lexically_declared(id_data.local_index.get())
-                        && !generator.is_local_initialized(id_data.local_index.get())
+                    generator.is_local_lexically_declared(id_data.local_index)
+                        && !generator.is_local_initialized(id_data.local_index)
                 };
                 if needs_tdz {
                     generator.emit(Instruction::ThrowIfTDZ { src: local.operand() });
                 }
                 (local, None)
             }
-            ExpressionKind::Identifier(ident) if !arena.identifiers[*ident].is_global.get() => {
+            ExpressionKind::Identifier(ident) if !arena.identifiers[*ident].is_global => {
                 // Non-local, non-global identifier: use GetCalleeAndThisFromEnvironment
                 // to properly handle with-statement bindings and eval.
                 let callee_reg = generator.allocate_register();
@@ -4202,15 +4201,15 @@ fn emit_tdz_check_if_needed(generator: &mut Generator, id: crate::ast::Identifie
     if !ident.is_local() {
         return;
     }
-    let local_index = ident.local_index.get();
-    let needs_tdz_check = if ident.local_type.get() == Some(LocalType::Argument) {
+    let local_index = ident.local_index;
+    let needs_tdz_check = if ident.local_type == Some(LocalType::Argument) {
         !generator.is_argument_initialized(local_index)
     } else {
         generator.is_local_lexically_declared(local_index) && !generator.is_local_initialized(local_index)
     };
     if needs_tdz_check {
-        let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
-        if ident.local_type.get() == Some(LocalType::Argument) {
+        let local = generator.resolve_local(local_index, ident.local_type.unwrap());
+        if ident.local_type == Some(LocalType::Argument) {
             let empty = generator.add_constant_empty();
             generator.emit_mov(&local, &empty);
         }
@@ -4222,16 +4221,16 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
     let arena = generator.arena.clone();
     let ident = &arena.identifiers[id];
     if ident.is_local() {
-        if ident.declaration_kind.get() == Some(DeclarationKind::Const) {
+        if ident.declaration_kind == Some(DeclarationKind::Const) {
             // The caller is responsible for emitting ThrowIfTDZ before calling
             // emit_set_variable().
             generator.emit(Instruction::ThrowConstAssignment {});
             return;
         }
-        let local_index = ident.local_index.get();
-        let local = generator.resolve_local(local_index, ident.local_type.get().unwrap());
+        let local_index = ident.local_index;
+        let local = generator.resolve_local(local_index, ident.local_type.unwrap());
         // Skip self-move entirely.
-        let is_variable_self_move = ident.local_type.get() == Some(LocalType::Variable)
+        let is_variable_self_move = ident.local_type == Some(LocalType::Variable)
             && value.operand().is_local()
             && value.operand().index() == local_index;
         if is_variable_self_move {
@@ -4243,7 +4242,7 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
             dst: local.operand(),
             src: value.operand(),
         });
-    } else if ident.is_global.get() {
+    } else if ident.is_global {
         let id = generator.intern_identifier(&ident.name);
         let cache = generator.next_global_variable_cache();
         generator.emit(Instruction::SetGlobal {
@@ -4818,8 +4817,7 @@ fn generate_tagged_template_literal(
             (method, Some(obj))
         }
         ExpressionKind::Identifier(ident)
-            if generator.arena.identifiers[*ident].is_local()
-                || generator.arena.identifiers[*ident].is_global.get() =>
+            if generator.arena.identifiers[*ident].is_local() || generator.arena.identifiers[*ident].is_global =>
         {
             let tag_val = generate_expression_or_undefined(tag, generator, None);
             (tag_val, None)
@@ -6041,7 +6039,7 @@ fn emit_default_constructor(generator: &mut Generator, has_super: bool) -> u32 {
         parser.flags.allow_super_constructor_call = true;
     }
     let program = parser.parse_program(false);
-    parser.scope_collector.analyze(false, &parser.arena.identifiers);
+    parser.scope_collector.analyze(false, &mut parser.arena.identifiers);
 
     assert!(!parser.has_errors(), "default constructor parse failed");
 
@@ -6965,7 +6963,7 @@ fn emit_set_variable_with_mode(
     let arena = generator.arena.clone();
     let ident = &arena.identifiers[id];
     if ident.is_local() {
-        let local = generator.resolve_local(ident.local_index.get(), ident.local_type.get().unwrap());
+        let local = generator.resolve_local(ident.local_index, ident.local_type.unwrap());
         generator.emit_mov(&local, value);
     } else {
         let id = generator.intern_identifier(&ident.name);
@@ -6978,7 +6976,7 @@ fn emit_set_variable_with_mode(
                 });
             }
             BindingMode::Set => {
-                if ident.is_global.get() {
+                if ident.is_global {
                     let cache = generator.next_global_variable_cache();
                     generator.emit(Instruction::SetGlobal {
                         identifier: id,
@@ -7376,9 +7374,9 @@ fn generate_try_statement(
                     let arena = generator.arena.clone();
                     let ident = &arena.identifiers[*ident_id];
                     if ident.is_local() {
-                        let local = generator.local(ident.local_index.get());
+                        let local = generator.local(ident.local_index);
                         generator.emit_mov(&local, &caught_value);
-                        generator.mark_local_initialized(ident.local_index.get());
+                        generator.mark_local_initialized(ident.local_index);
                     } else {
                         generator.push_new_lexical_environment(0);
                         generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
@@ -7899,8 +7897,8 @@ pub fn emit_function_declaration_instantiation(
                 let arena = generator.arena.clone();
                 let ident = &arena.identifiers[*ident_id];
                 if ident.is_local() {
-                    let local_index = ident.local_index.get();
-                    match ident.local_type.get() {
+                    let local_index = ident.local_index;
+                    match ident.local_type {
                         Some(LocalType::Variable) => generator.mark_local_initialized(local_index),
                         Some(LocalType::Argument) => {
                             generator.mark_argument_initialized(local_index);
@@ -8128,7 +8126,7 @@ pub fn emit_function_declaration_instantiation(
                     let arena = generator.arena.clone();
                     let name_ident = &arena.identifiers[name_ident_id];
                     if name_ident.is_local() {
-                        let local_index = name_ident.local_index.get();
+                        let local_index = name_ident.local_index;
                         let local = generator.local(local_index);
                         generator.emit(Instruction::NewFunction {
                             dst: local.operand(),

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -322,6 +322,7 @@ pub unsafe fn create_shared_function_data(
     source_code_ptr: *const c_void,
     is_strict: bool,
     name_override: Option<&[u16]>,
+    arena: std::sync::Arc<crate::ast::AstArena>,
 ) -> *mut c_void {
     unsafe {
         use crate::ast::FunctionParameterBinding;
@@ -332,8 +333,9 @@ pub unsafe fn create_shared_function_data(
 
         let (name_ptr, name_len) = if let Some(name) = name_override {
             (name.as_ptr(), name.len())
-        } else if let Some(ref name_ident) = function_data.name {
-            (name_ident.name.as_ptr(), name_ident.name.len())
+        } else if let Some(name_ident) = function_data.name {
+            let name = &arena.identifiers[name_ident].name;
+            (name.as_ptr(), name.len())
         } else {
             (std::ptr::null(), 0)
         };
@@ -347,8 +349,8 @@ pub unsafe fn create_shared_function_data(
                 .parameters
                 .iter()
                 .map(|p| {
-                    if let FunctionParameterBinding::Identifier(ref id) = p.binding {
-                        FFIUtf16Slice::from(id.name.as_ref())
+                    if let FunctionParameterBinding::Identifier(id) = p.binding {
+                        FFIUtf16Slice::from(arena.identifiers[id].name.as_ref())
                     } else {
                         unreachable!("has_simple_parameter_list guarantees all bindings are identifiers")
                     }
@@ -369,6 +371,7 @@ pub unsafe fn create_shared_function_data(
         let payload = Box::new(crate::ast::FunctionPayload {
             data: *function_data,
             function_table: subtable,
+            arena,
         });
         let rust_ast_ptr = Box::into_raw(payload) as *mut c_void;
 
@@ -410,8 +413,9 @@ pub unsafe fn create_sfd_for_gdi(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     is_strict: bool,
+    arena: std::sync::Arc<crate::ast::AstArena>,
 ) -> *mut c_void {
-    unsafe { create_shared_function_data(function_data, subtable, vm_ptr, source_code_ptr, is_strict, None) }
+    unsafe { create_shared_function_data(function_data, subtable, vm_ptr, source_code_ptr, is_strict, None, arena) }
 }
 
 unsafe fn materialize_shared_function_data(
@@ -437,6 +441,7 @@ unsafe fn materialize_shared_function_data(
                 source_code_ptr,
                 generator.strict,
                 pending.name_override.as_ref().map(|name| name.as_slice()),
+                generator.arena.clone(),
             );
             if let Some((name, is_private)) = &pending.class_field_initializer_name {
                 rust_sfd_set_class_field_initializer_name(sfd_ptr, name.as_ptr(), name.len(), *is_private);

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -434,6 +434,7 @@ unsafe fn materialize_shared_function_data(
                 .subtable
                 .take()
                 .expect("pending shared function data subtable was already materialized");
+            let arena = pending.arena.clone().unwrap_or_else(|| generator.arena.clone());
             let sfd_ptr = create_shared_function_data(
                 function_data,
                 subtable,
@@ -441,7 +442,7 @@ unsafe fn materialize_shared_function_data(
                 source_code_ptr,
                 generator.strict,
                 pending.name_override.as_ref().map(|name| name.as_slice()),
-                generator.arena.clone(),
+                arena,
             );
             if let Some((name, is_private)) = &pending.class_field_initializer_name {
                 rust_sfd_set_class_field_initializer_name(sfd_ptr, name.as_ptr(), name.len(), *is_private);

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -334,7 +334,7 @@ pub unsafe fn create_shared_function_data(
         let (name_ptr, name_len) = if let Some(name) = name_override {
             (name.as_ptr(), name.len())
         } else if let Some(name_ident) = function_data.name {
-            let name = &arena.identifiers[name_ident].name;
+            let name = arena.name_of(name_ident);
             (name.as_ptr(), name.len())
         } else {
             (std::ptr::null(), 0)
@@ -350,7 +350,7 @@ pub unsafe fn create_shared_function_data(
                 .iter()
                 .map(|p| {
                     if let FunctionParameterBinding::Identifier(id) = p.binding {
-                        FFIUtf16Slice::from(arena.identifiers[id].name.as_ref())
+                        FFIUtf16Slice::from(arena.name_slice(id))
                     } else {
                         unreachable!("has_simple_parameter_list guarantees all bindings are identifiers")
                     }

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -642,6 +642,30 @@ impl Generator {
         property_key_table_index
     );
 
+    /// Convenience: look up a `StringId` in the AST interner and intern the
+    /// resulting slice into the bytecode identifier table.
+    pub fn intern_identifier_id(&mut self, id: crate::ast::StringId) -> IdentifierTableIndex {
+        let arena = self.arena.clone();
+        let slice = arena.strings[id].as_slice();
+        self.intern_identifier(slice)
+    }
+
+    /// Convenience: look up a `StringId` in the AST interner and intern the
+    /// resulting slice into the bytecode property key table.
+    pub fn intern_property_key_id(&mut self, id: crate::ast::StringId) -> PropertyKeyTableIndex {
+        let arena = self.arena.clone();
+        let slice = arena.strings[id].as_slice();
+        self.intern_property_key(slice)
+    }
+
+    /// Convenience: look up a `StringId` in the AST interner and intern the
+    /// resulting slice into the bytecode string table.
+    pub fn intern_string_id(&mut self, id: crate::ast::StringId) -> StringTableIndex {
+        let arena = self.arena.clone();
+        let slice = arena.strings[id].as_slice();
+        self.intern_string(slice)
+    }
+
     /// If `operand` is a constant string that is not an array index, intern it
     /// as a property key and return the index. Uses split borrows to avoid
     /// cloning the string when it is already interned (the common case).

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -17,8 +17,9 @@ use super::basic_block::{BasicBlock, SourceMapEntry};
 use super::ffi::{AbstractOperationKind, WellKnownSymbolKind};
 use super::instruction::Instruction;
 use super::operand::*;
-use crate::ast::{FunctionData, FunctionId, FunctionTable, LocalType, Position, Utf16String};
+use crate::ast::{AstArena, FunctionData, FunctionId, FunctionTable, IdentifierId, LocalType, Position, Utf16String};
 use crate::u32_from_usize;
+use std::sync::Arc;
 
 /// Identifies an operand that auto-frees its register when the last
 /// clone is dropped.
@@ -300,6 +301,20 @@ pub struct Generator {
     // Side table owning all FunctionData from the parser. Codegen
     // takes ownership of individual entries via `take()`.
     pub function_table: crate::ast::FunctionTable,
+
+    // --- AST arena ---
+    // Shared (read-only post-parse) storage for identifiers, scopes, and
+    // interned strings. Cloning is a refcount bump — multiple generators
+    // (top-level + nested IIFE + lazy children) share the same arena.
+    pub arena: Arc<AstArena>,
+}
+
+impl Generator {
+    /// Convenience: look up an identifier by ID in this generator's arena.
+    #[inline]
+    pub fn identifier(&self, id: IdentifierId) -> &crate::ast::Identifier {
+        &self.arena.identifiers[id]
+    }
 }
 
 macro_rules! singleton_constant {
@@ -425,6 +440,7 @@ impl Generator {
             source_code_ptr: std::ptr::null(),
             source_len: 0,
             function_table: crate::ast::FunctionTable::new(),
+            arena: Arc::new(AstArena::new()),
             free_register_pool,
         }
     }

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -40,6 +40,7 @@ pub(crate) struct ScopedOperandInner {
 pub struct PendingSharedFunctionData {
     pub function_data: Option<Box<FunctionData>>,
     pub subtable: Option<FunctionTable>,
+    pub arena: Option<Arc<AstArena>>,
     pub name_override: Option<Utf16String>,
     pub class_field_initializer_name: Option<(Utf16String, bool)>,
     pub should_eager_compile: bool,

--- a/Libraries/LibJS/Rust/src/fast_hash.rs
+++ b/Libraries/LibJS/Rust/src/fast_hash.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Type aliases that swap the default RandomState (SipHash) for
+//! foldhash's quality variant. Used in parser/scope-collector hot paths
+//! where keys come from lexer tokens (i.e. attacker-controlled JS
+//! source), so we keep formal HashDoS resistance while shedding
+//! SipHash's per-byte cost.
+
+pub type HashMap<K, V> = std::collections::HashMap<K, V, foldhash::quality::RandomState>;
+pub type HashSet<T> = std::collections::HashSet<T, foldhash::quality::RandomState>;
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, foldhash::quality::RandomState>;

--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -34,7 +34,7 @@
 //! type, because escaped keywords have different semantics (they can be
 //! used as identifiers in some contexts).
 
-use crate::ast::{SharedUtf16String, Utf16String};
+use crate::ast::Utf16String;
 use crate::token::{Token, TokenType};
 use crate::u32_from_usize;
 
@@ -70,8 +70,6 @@ pub struct Lexer<'a> {
     allow_html_comments: bool,
     template_states: Vec<TemplateState>,
     saved_states: Vec<SavedLexerState>,
-    short_identifier_cache: [Option<SharedUtf16String>; 128],
-    recent_identifier_cache: [Option<SharedUtf16String>; 128],
 }
 
 // Unicode constants used by the lexical grammar.
@@ -410,8 +408,6 @@ impl<'a> Lexer<'a> {
             allow_html_comments: true,
             template_states: Vec::new(),
             saved_states: Vec::new(),
-            short_identifier_cache: std::array::from_fn(|_| None),
-            recent_identifier_cache: std::array::from_fn(|_| None),
         };
         lexer.consume();
         lexer
@@ -433,42 +429,9 @@ impl<'a> Lexer<'a> {
             allow_html_comments: true,
             template_states: Vec::new(),
             saved_states: Vec::new(),
-            short_identifier_cache: std::array::from_fn(|_| None),
-            recent_identifier_cache: std::array::from_fn(|_| None),
         };
         lexer.consume();
         lexer
-    }
-
-    fn shared_identifier_from_slice(&mut self, value: &[u16]) -> Option<SharedUtf16String> {
-        if value.is_empty() {
-            return None;
-        }
-
-        let first = value[0] as usize;
-        if value.len() == 1 && first < 128 {
-            if let Some(existing) = &self.short_identifier_cache[first] {
-                return Some(existing.clone());
-            }
-            let shared = SharedUtf16String::from(value);
-            self.short_identifier_cache[first] = Some(shared.clone());
-            return Some(shared);
-        }
-
-        let slot = first % 128;
-        if let Some(existing) = &self.recent_identifier_cache[slot]
-            && existing.as_slice() == value
-        {
-            return Some(existing.clone());
-        }
-
-        let shared = SharedUtf16String::from(value);
-        self.recent_identifier_cache[slot] = Some(shared.clone());
-        Some(shared)
-    }
-
-    fn shared_identifier_from_owned(&mut self, value: &Utf16String) -> Option<SharedUtf16String> {
-        self.shared_identifier_from_slice(value.as_slice())
     }
 
     fn current_template_state(&self) -> &TemplateState {
@@ -997,7 +960,6 @@ impl<'a> Lexer<'a> {
         let did_consume_whitespace_or_comments = trivia_start != value_start;
 
         let mut identifier_value: Option<Utf16String> = None;
-        let mut shared_identifier_value: Option<SharedUtf16String> = None;
 
         if self.current_token_type == TokenType::RegexLiteral
             && !self.is_eof()
@@ -1068,11 +1030,7 @@ impl<'a> Lexer<'a> {
                 let has_escape = self.scan_identifier_body(len);
                 if has_escape {
                     let decoded = self.build_identifier_value(value_start);
-                    shared_identifier_value = self.shared_identifier_from_owned(&decoded);
                     identifier_value = Some(decoded);
-                } else {
-                    let source_slice = &self.source[value_start - 1..self.position - 1];
-                    shared_identifier_value = self.shared_identifier_from_slice(source_slice);
                 }
                 token_type = TokenType::PrivateIdentifier;
             } else {
@@ -1088,7 +1046,6 @@ impl<'a> Lexer<'a> {
                 // It is a Syntax Error if the source text matched by this production
                 // is a ReservedWord after processing unicode escape sequences.
                 let decoded = self.build_identifier_value(value_start);
-                shared_identifier_value = self.shared_identifier_from_owned(&decoded);
                 if keyword_from_str(&decoded).is_some() {
                     token_type = TokenType::EscapedKeyword;
                 } else {
@@ -1101,7 +1058,6 @@ impl<'a> Lexer<'a> {
                     token_type = kw;
                 } else {
                     token_type = TokenType::Identifier;
-                    shared_identifier_value = self.shared_identifier_from_slice(source_slice);
                 }
             }
         } else if self.is_numeric_literal_start() {
@@ -1297,7 +1253,6 @@ impl<'a> Lexer<'a> {
             offset: u32_from_usize(value_start.saturating_sub(1)),
             trivia_has_line_terminator,
             identifier_value,
-            shared_identifier_value,
             message: token_message,
         }
     }
@@ -1388,7 +1343,6 @@ impl<'a> Lexer<'a> {
             offset: u32_from_usize(value_start.saturating_sub(1)),
             trivia_has_line_terminator: false,
             identifier_value: None,
-            shared_identifier_value: None,
             message: None,
         }
     }

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -435,7 +435,7 @@ pub unsafe extern "C" fn rust_compile_program(
 
             parser
                 .scope_collector
-                .analyze(initiated_by_eval, &parser.arena.identifiers);
+                .analyze(initiated_by_eval, &mut parser.arena.identifiers);
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -502,7 +502,7 @@ pub unsafe extern "C" fn rust_parse_program(
             }
 
             if errors.is_empty() {
-                parser.scope_collector.analyze(false, &parser.arena.identifiers);
+                parser.scope_collector.analyze(false, &mut parser.arena.identifiers);
             }
 
             // Dump AST if requested (after scope analysis).
@@ -816,7 +816,7 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             }
 
-            parser.scope_collector.analyze(true, &parser.arena.identifiers);
+            parser.scope_collector.analyze(true, &mut parser.arena.identifiers);
 
             write_ast_dump_output(
                 &program,
@@ -1002,7 +1002,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // as a FunctionExpression (no Program scope for globals to bind to).
             parser
                 .scope_collector
-                .analyze_as_dynamic_function(&parser.arena.identifiers);
+                .analyze_as_dynamic_function(&mut parser.arena.identifiers);
 
             if parser.scope_collector.has_errors() {
                 if let Some(cb) = error_callback {
@@ -1112,7 +1112,7 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 panic!("Parse errors in builtin file: {}", errors.join("; "));
             }
 
-            parser.scope_collector.analyze(false, &parser.arena.identifiers);
+            parser.scope_collector.analyze(false, &mut parser.arena.identifiers);
 
             write_ast_dump_output(
                 &program,

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -184,7 +184,7 @@ fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
 unsafe fn write_ast_dump_output(
     program: &ast::Statement,
     function_table: &ast::FunctionTable,
-    identifiers: &ast::IdentifierArena,
+    arena: &ast::AstArena,
     output_ptr: *mut *mut u8,
     output_len: *mut usize,
 ) {
@@ -192,7 +192,7 @@ unsafe fn write_ast_dump_output(
         if output_ptr.is_null() || output_len.is_null() {
             return;
         }
-        let dump_string = ast_dump::dump_program_to_string(program, function_table, identifiers);
+        let dump_string = ast_dump::dump_program_to_string(program, function_table, arena);
         let mut boxed = dump_string.into_bytes().into_boxed_slice();
         *output_ptr = boxed.as_mut_ptr();
         *output_len = boxed.len();
@@ -435,7 +435,7 @@ pub unsafe extern "C" fn rust_compile_program(
 
             parser
                 .scope_collector
-                .analyze(initiated_by_eval, &mut parser.arena.identifiers);
+                .analyze(initiated_by_eval, &mut parser.arena.identifiers, &parser.arena.strings);
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -502,12 +502,14 @@ pub unsafe extern "C" fn rust_parse_program(
             }
 
             if errors.is_empty() {
-                parser.scope_collector.analyze(false, &mut parser.arena.identifiers);
+                parser
+                    .scope_collector
+                    .analyze(false, &mut parser.arena.identifiers, &parser.arena.strings);
             }
 
             // Dump AST if requested (after scope analysis).
             if dump_ast && errors.is_empty() {
-                ast_dump::dump_program(&program, use_color, &parser.function_table, &parser.arena.identifiers);
+                ast_dump::dump_program(&program, use_color, &parser.function_table, &parser.arena);
             }
 
             let (scope_ref, is_strict, has_tla) = if errors.is_empty() {
@@ -660,8 +662,7 @@ pub unsafe extern "C" fn rust_parsed_program_ast_dump(
     unsafe {
         let parsed = &mut *parsed;
         let dump = parsed.ast_dump.get_or_insert_with(|| {
-            ast_dump::dump_program_to_string(&parsed.program, &parsed.function_table, &parsed.arena.identifiers)
-                .into_bytes()
+            ast_dump::dump_program_to_string(&parsed.program, &parsed.function_table, &parsed.arena).into_bytes()
         });
         *output_ptr = dump.as_ptr();
         *output_len = dump.len();
@@ -816,12 +817,14 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             }
 
-            parser.scope_collector.analyze(true, &mut parser.arena.identifiers);
+            parser
+                .scope_collector
+                .analyze(true, &mut parser.arena.identifiers, &parser.arena.strings);
 
             write_ast_dump_output(
                 &program,
                 &parser.function_table,
-                &parser.arena.identifiers,
+                &parser.arena,
                 ast_dump_output,
                 ast_dump_output_len,
             );
@@ -1002,7 +1005,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // as a FunctionExpression (no Program scope for globals to bind to).
             parser
                 .scope_collector
-                .analyze_as_dynamic_function(&mut parser.arena.identifiers);
+                .analyze_as_dynamic_function(&mut parser.arena.identifiers, &parser.arena.strings);
 
             if parser.scope_collector.has_errors() {
                 if let Some(cb) = error_callback {
@@ -1017,7 +1020,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             write_ast_dump_output(
                 &program,
                 &parser.function_table,
-                &parser.arena.identifiers,
+                &parser.arena,
                 ast_dump_output,
                 ast_dump_output_len,
             );
@@ -1112,12 +1115,14 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 panic!("Parse errors in builtin file: {}", errors.join("; "));
             }
 
-            parser.scope_collector.analyze(false, &mut parser.arena.identifiers);
+            parser
+                .scope_collector
+                .analyze(false, &mut parser.arena.identifiers, &parser.arena.strings);
 
             write_ast_dump_output(
                 &program,
                 &parser.function_table,
-                &parser.arena.identifiers,
+                &parser.arena,
                 ast_dump_output,
                 ast_dump_output_len,
             );
@@ -1145,7 +1150,7 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                     if !sfd_ptr.is_null()
                         && let Some(name_ident) = fd.name
                     {
-                        let name = &arena.identifiers[name_ident].name;
+                        let name = arena.name_of(name_ident);
                         push_function(ctx, sfd_ptr, name.as_ptr(), name.len());
                     }
                 }
@@ -1479,7 +1484,7 @@ pub unsafe extern "C" fn rust_compile_module(
             write_ast_dump_output(
                 &parsed_ref.program,
                 &parsed_ref.function_table,
-                &parsed_ref.arena.identifiers,
+                &parsed_ref.arena,
                 ast_dump_output,
                 ast_dump_output_len,
             );
@@ -1646,7 +1651,6 @@ unsafe fn extract_module_declarations(
     function_table: &mut ast::FunctionTable,
     arena: &std::sync::Arc<ast::AstArena>,
 ) {
-    let identifiers = &arena.identifiers;
     unsafe {
         use ast::StatementKind;
 
@@ -1654,7 +1658,7 @@ unsafe fn extract_module_declarations(
 
         // Var declared names (walk all nesting levels).
         for child in &scope.children {
-            collect_module_var_names(&child.inner, ctx, cb.push_var_name, identifiers);
+            collect_module_var_names(&child.inner, ctx, cb.push_var_name, arena);
         }
 
         // Lexical bindings and functions to initialize.
@@ -1673,7 +1677,10 @@ unsafe fn extract_module_declarations(
 
             match declaration {
                 StatementKind::FunctionDeclaration(fd) => {
-                    let is_default = is_exported && fd.name.is_some_and(|n| identifiers[n].name == default_name);
+                    let is_default = is_exported
+                        && fd
+                            .name
+                            .is_some_and(|n| arena.name_of(n).as_slice() == default_name.as_slice());
 
                     let function_data = function_table.take(fd.function_id);
                     let subtable = function_table.extract_reachable(&function_data);
@@ -1691,7 +1698,7 @@ unsafe fn extract_module_declarations(
 
                     // Get the binding name from the AST (e.g., "*default*" for anonymous defaults).
                     let binding_name = if let Some(name_ident) = fd.name {
-                        identifiers[name_ident].name.to_utf16_string()
+                        arena.name_of(name_ident).clone()
                     } else {
                         continue;
                     };
@@ -1715,21 +1722,21 @@ unsafe fn extract_module_declarations(
                 }
                 StatementKind::ClassDeclaration(class_data) => {
                     if let Some(name_ident) = class_data.name {
-                        let name = &identifiers[name_ident].name;
+                        let name = arena.name_of(name_ident);
                         (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), false, -1);
                     }
                 }
                 StatementKind::VariableDeclaration(vd) if vd.kind != ast::DeclarationKind::Var => {
                     let is_constant = vd.kind == ast::DeclarationKind::Const;
                     for declaration in &vd.declarations {
-                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                        for_each_bound_name(&declaration.target, arena, &mut |name| {
                             (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), is_constant, -1);
                         });
                     }
                 }
                 StatementKind::UsingDeclaration(declarations) => {
                     for declaration in declarations.iter() {
-                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                        for_each_bound_name(&declaration.target, arena, &mut |name| {
                             (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), false, -1);
                         });
                     }
@@ -1745,25 +1752,25 @@ unsafe fn collect_module_var_names(
     statement: &ast::StatementKind,
     ctx: *mut c_void,
     push_var_name: ModuleNameCallback,
-    identifiers: &ast::IdentifierArena,
+    arena: &ast::AstArena,
 ) {
     unsafe {
         match statement {
             ast::StatementKind::VariableDeclaration(vd) if vd.kind == ast::DeclarationKind::Var => {
                 for declaration in &vd.declarations {
-                    for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                    for_each_bound_name(&declaration.target, arena, &mut |name| {
                         push_var_name(ctx, name.as_ptr(), name.len());
                     });
                 }
             }
             ast::StatementKind::Export(export_data) => {
                 if let Some(ref stmt) = export_data.statement {
-                    collect_module_var_names(&stmt.inner, ctx, push_var_name, identifiers);
+                    collect_module_var_names(&stmt.inner, ctx, push_var_name, arena);
                 }
             }
             _ => {
                 for_each_child_statement(statement, &mut |child| {
-                    collect_module_var_names(child, ctx, push_var_name, identifiers);
+                    collect_module_var_names(child, ctx, push_var_name, arena);
                 });
             }
         }
@@ -1910,18 +1917,18 @@ unsafe extern "C" {
 /// statements, excluding function/class bodies (which create new var scopes).
 fn collect_var_names_recursive(
     statement: &ast::StatementKind,
-    identifiers: &ast::IdentifierArena,
+    arena: &ast::AstArena,
     push_name: &mut dyn FnMut(&[u16]),
 ) {
     match statement {
         ast::StatementKind::VariableDeclaration(vd) if vd.kind == ast::DeclarationKind::Var => {
             for declaration in &vd.declarations {
-                for_each_bound_name(&declaration.target, identifiers, push_name);
+                for_each_bound_name(&declaration.target, arena, push_name);
             }
         }
         _ => {
             for_each_child_statement(statement, &mut |child| {
-                collect_var_names_recursive(child, identifiers, push_name);
+                collect_var_names_recursive(child, arena, push_name);
             });
         }
     }
@@ -1946,34 +1953,33 @@ fn extract_gdi_common(
     function_table: &mut ast::FunctionTable,
     arena: &std::sync::Arc<ast::AstArena>,
 ) {
-    let identifiers = &arena.identifiers;
     use ast::{DeclarationKind, StatementKind};
 
     // Var names (var declarations at any nesting level + top-level function declarations)
     for child in &scope.children {
-        collect_var_names_recursive(&child.inner, identifiers, push_var_name);
+        collect_var_names_recursive(&child.inner, arena, push_var_name);
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
             && let Some(name_ident) = fd.name
         {
-            push_var_name(&identifiers[name_ident].name);
+            push_var_name(arena.name_slice(name_ident));
         }
     }
 
     // Functions to initialize: keep the last declaration with each name
     // (ECMAScript hoisting semantics), but emit them in source order. Two
-    // forward passes; SharedUtf16String keys keep the inserts cheap.
-    let mut last_position: std::collections::HashMap<ast::SharedUtf16String, usize> = std::collections::HashMap::new();
+    // forward passes; StringId keys keep the inserts to a u32 compare.
+    let mut last_position: std::collections::HashMap<ast::StringId, usize> = std::collections::HashMap::new();
     for (i, child) in scope.children.iter().enumerate() {
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
             && let Some(name_ident) = fd.name
         {
-            last_position.insert(identifiers[name_ident].name.clone(), i);
+            last_position.insert(arena.identifiers[name_ident].name, i);
         }
     }
     for (i, child) in scope.children.iter().enumerate() {
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
             && let Some(name_ident) = fd.name
-            && last_position.get(&identifiers[name_ident].name).copied() == Some(i)
+            && last_position.get(&arena.identifiers[name_ident].name).copied() == Some(i)
         {
             let function_data = function_table.take(fd.function_id);
             let subtable = function_table.extract_reachable(&function_data);
@@ -1988,13 +1994,13 @@ fn extract_gdi_common(
                 )
             };
             assert!(!sfd_ptr.is_null(), "create_sfd_for_gdi returned null");
-            push_function(sfd_ptr, identifiers[name_ident].name.as_slice());
+            push_function(sfd_ptr, arena.name_slice(name_ident));
         }
     }
 
     // Var-scoped names (var VariableDeclaration names, excluding function declarations)
     for child in &scope.children {
-        collect_var_names_recursive(&child.inner, identifiers, push_var_scoped_name);
+        collect_var_names_recursive(&child.inner, arena, push_var_scoped_name);
     }
 
     for name in &scope.annexb_function_names {
@@ -2006,21 +2012,21 @@ fn extract_gdi_common(
             StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
-                    for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                    for_each_bound_name(&declaration.target, arena, &mut |name| {
                         push_lexical_binding(name, is_constant);
                     });
                 }
             }
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
-                    for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                    for_each_bound_name(&declaration.target, arena, &mut |name| {
                         push_lexical_binding(name, false);
                     });
                 }
             }
             StatementKind::ClassDeclaration(class_data) => {
                 if let Some(name) = class_data.name {
-                    push_lexical_binding(&identifiers[name].name, false);
+                    push_lexical_binding(arena.name_slice(name), false);
                 }
             }
             _ => {}
@@ -2076,7 +2082,6 @@ unsafe fn extract_script_gdi(
     function_table: &mut ast::FunctionTable,
     arena: &std::sync::Arc<ast::AstArena>,
 ) {
-    let identifiers = &arena.identifiers;
     unsafe {
         use ast::{DeclarationKind, StatementKind};
         use bytecode::ffi::{
@@ -2089,21 +2094,21 @@ unsafe fn extract_script_gdi(
             match &child.inner {
                 StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                     for declaration in &vd.declarations {
-                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                        for_each_bound_name(&declaration.target, arena, &mut |name| {
                             script_gdi_push_lexical_name(ctx, name.as_ptr(), name.len());
                         });
                     }
                 }
                 StatementKind::UsingDeclaration(declarations) => {
                     for declaration in declarations.iter() {
-                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
+                        for_each_bound_name(&declaration.target, arena, &mut |name| {
                             script_gdi_push_lexical_name(ctx, name.as_ptr(), name.len());
                         });
                     }
                 }
                 StatementKind::ClassDeclaration(class_data) => {
                     if let Some(name) = class_data.name {
-                        let n = &identifiers[name].name;
+                        let n = arena.name_of(name);
                         script_gdi_push_lexical_name(ctx, n.as_ptr(), n.len());
                     }
                 }
@@ -2191,34 +2196,26 @@ fn for_each_child_statement(statement: &ast::StatementKind, f: &mut dyn FnMut(&a
     }
 }
 
-fn for_each_bound_name(
-    target: &ast::VariableDeclaratorTarget,
-    identifiers: &ast::IdentifierArena,
-    f: &mut dyn FnMut(&[u16]),
-) {
+fn for_each_bound_name(target: &ast::VariableDeclaratorTarget, arena: &ast::AstArena, f: &mut dyn FnMut(&[u16])) {
     match target {
-        ast::VariableDeclaratorTarget::Identifier(id) => f(&identifiers[*id].name),
+        ast::VariableDeclaratorTarget::Identifier(id) => f(arena.name_slice(*id)),
         ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            for_each_bound_name_in_pattern(pattern, identifiers, f);
+            for_each_bound_name_in_pattern(pattern, arena, f);
         }
     }
 }
 
-fn for_each_bound_name_in_pattern(
-    pattern: &ast::BindingPattern,
-    identifiers: &ast::IdentifierArena,
-    f: &mut dyn FnMut(&[u16]),
-) {
+fn for_each_bound_name_in_pattern(pattern: &ast::BindingPattern, arena: &ast::AstArena, f: &mut dyn FnMut(&[u16])) {
     for entry in &pattern.entries {
         match &entry.alias {
             None => {
                 if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name {
-                    f(&identifiers[*id].name);
+                    f(arena.name_slice(*id));
                 }
             }
-            Some(ast::BindingEntryAlias::Identifier(id)) => f(&identifiers[*id].name),
+            Some(ast::BindingEntryAlias::Identifier(id)) => f(arena.name_slice(*id)),
             Some(ast::BindingEntryAlias::BindingPattern(inner)) => {
-                for_each_bound_name_in_pattern(inner, identifiers, f);
+                for_each_bound_name_in_pattern(inner, arena, f);
             }
             Some(ast::BindingEntryAlias::MemberExpression(_)) => {}
         }
@@ -2324,7 +2321,7 @@ fn compile_function_payload_to_bytecode(
 
     // Compute SFD metadata before codegen so the generator can optimize
     // direct `this` access when it does not need environment resolution.
-    let sfd_metadata = compute_sfd_metadata(&function_data, &arena.identifiers);
+    let sfd_metadata = compute_sfd_metadata(&function_data, &arena);
 
     let mut generator = bytecode::generator::Generator::new();
     generator.arena = arena;
@@ -2437,7 +2434,7 @@ struct BodyScopeInfo {
 /// constructor (ECMA-262 §10.2.11).
 fn compute_sfd_metadata(
     function_data: &ast::FunctionData,
-    identifiers: &ast::IdentifierArena,
+    arena: &ast::AstArena,
 ) -> bytecode::generator::FunctionSfdMetadata {
     let body_scope = match &function_data.body.inner {
         ast::StatementKind::FunctionBody { scope, .. } => Some(scope),
@@ -2500,14 +2497,14 @@ fn compute_sfd_metadata(
     for parameter in &function_data.parameters {
         match &parameter.binding {
             ast::FunctionParameterBinding::Identifier(id) => {
-                let ident = &identifiers[*id];
-                if parameter_names.insert(ident.name.to_utf16_string()) && !ident.is_local() {
+                let ident = &arena.identifiers[*id];
+                if parameter_names.insert(arena.strings[ident.name].clone()) && !ident.is_local() {
                     parameters_in_environment += 1;
                 }
             }
             ast::FunctionParameterBinding::BindingPattern(pattern) => {
-                for_each_binding_pattern_identifier(pattern, identifiers, &mut |ident| {
-                    if parameter_names.insert(ident.name.to_utf16_string()) && !ident.is_local() {
+                for_each_binding_pattern_identifier(pattern, arena, &mut |ident| {
+                    if parameter_names.insert(arena.strings[ident.name].clone()) && !ident.is_local() {
                         parameters_in_environment += 1;
                     }
                 });
@@ -2566,7 +2563,7 @@ fn compute_sfd_metadata(
             }
 
             // §10.2.11 step 30: lexical environment.
-            let non_local_lex_count = count_non_local_lex_declarations(body_scope, identifiers);
+            let non_local_lex_count = count_non_local_lex_declarations(body_scope, arena);
             if strict {
                 // Lex env == var env == function env.
                 function_environment_bindings_count += non_local_lex_count;
@@ -2588,7 +2585,7 @@ fn compute_sfd_metadata(
                 }
             }
 
-            let non_local_lex_count = count_non_local_lex_declarations(body_scope, identifiers);
+            let non_local_lex_count = count_non_local_lex_declarations(body_scope, arena);
             if strict {
                 // Lex env == var env.
                 var_environment_bindings_count += non_local_lex_count;
@@ -2641,7 +2638,7 @@ unsafe fn write_sfd_metadata(sfd_ptr: *mut c_void, metadata: &bytecode::generato
 /// Count non-local lexically-declared identifiers in a function body scope.
 /// Returns the count (used for environment sizing in the function_environment_needed
 /// computation).
-fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>, identifiers: &ast::IdentifierArena) -> usize {
+fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>, arena: &ast::AstArena) -> usize {
     let sd = scope.borrow();
     let mut count = 0;
     for child in &sd.children {
@@ -2650,18 +2647,18 @@ fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>, identif
                 use parser::DeclarationKind;
                 if vd.kind == DeclarationKind::Let || vd.kind == DeclarationKind::Const {
                     for declaration in &vd.declarations {
-                        count_non_local_names_in_target(&declaration.target, &mut count, identifiers);
+                        count_non_local_names_in_target(&declaration.target, &mut count, arena);
                     }
                 }
             }
             ast::StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
-                    count_non_local_names_in_target(&declaration.target, &mut count, identifiers);
+                    count_non_local_names_in_target(&declaration.target, &mut count, arena);
                 }
             }
             ast::StatementKind::ClassDeclaration(class_data) => {
                 if let Some(name_ident) = class_data.name
-                    && !identifiers[name_ident].is_local()
+                    && !arena.identifiers[name_ident].is_local()
                 {
                     count += 1;
                 }
@@ -2672,41 +2669,33 @@ fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>, identif
     count
 }
 
-fn count_non_local_names_in_target(
-    target: &ast::VariableDeclaratorTarget,
-    count: &mut usize,
-    identifiers: &ast::IdentifierArena,
-) {
+fn count_non_local_names_in_target(target: &ast::VariableDeclaratorTarget, count: &mut usize, arena: &ast::AstArena) {
     match target {
         ast::VariableDeclaratorTarget::Identifier(id) => {
-            if !identifiers[*id].is_local() {
+            if !arena.identifiers[*id].is_local() {
                 *count += 1;
             }
         }
         ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            count_non_local_names_in_binding_pattern(pattern, count, identifiers);
+            count_non_local_names_in_binding_pattern(pattern, count, arena);
         }
     }
 }
 
-fn count_non_local_names_in_binding_pattern(
-    pattern: &ast::BindingPattern,
-    count: &mut usize,
-    identifiers: &ast::IdentifierArena,
-) {
+fn count_non_local_names_in_binding_pattern(pattern: &ast::BindingPattern, count: &mut usize, arena: &ast::AstArena) {
     for entry in &pattern.entries {
         match &entry.alias {
             Some(ast::BindingEntryAlias::Identifier(id)) => {
-                if !identifiers[*id].is_local() {
+                if !arena.identifiers[*id].is_local() {
                     *count += 1;
                 }
             }
             Some(ast::BindingEntryAlias::BindingPattern(sub)) => {
-                count_non_local_names_in_binding_pattern(sub, count, identifiers);
+                count_non_local_names_in_binding_pattern(sub, count, arena);
             }
             None => {
                 if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name
-                    && !identifiers[*id].is_local()
+                    && !arena.identifiers[*id].is_local()
                 {
                     *count += 1;
                 }
@@ -2718,18 +2707,18 @@ fn count_non_local_names_in_binding_pattern(
 
 fn for_each_binding_pattern_identifier(
     pattern: &ast::BindingPattern,
-    identifiers: &ast::IdentifierArena,
+    arena: &ast::AstArena,
     callback: &mut dyn FnMut(&ast::Identifier),
 ) {
     for entry in &pattern.entries {
         match &entry.alias {
-            Some(ast::BindingEntryAlias::Identifier(id)) => callback(&identifiers[*id]),
+            Some(ast::BindingEntryAlias::Identifier(id)) => callback(&arena.identifiers[*id]),
             Some(ast::BindingEntryAlias::BindingPattern(sub)) => {
-                for_each_binding_pattern_identifier(sub, identifiers, callback);
+                for_each_binding_pattern_identifier(sub, arena, callback);
             }
             None => {
                 if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name {
-                    callback(&identifiers[*id]);
+                    callback(&arena.identifiers[*id]);
                 }
             }
             Some(ast::BindingEntryAlias::MemberExpression(_)) => {}

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -83,6 +83,7 @@ macro_rules! utf16 {
 pub mod ast;
 pub mod ast_dump;
 pub mod bytecode;
+pub mod fast_hash;
 pub mod lexer;
 pub mod parser;
 pub mod scope_collector;

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+// AstArena currently transitively contains `Cell<>` fields on `Identifier` (set
+// by the scope collector during parse). Once those cells are removed, the
+// arena will be naturally `Send + Sync` and this allow can go away. For now
+// we hand-wave it the same way we already do with `unsafe impl Send for
+// ParsedProgram` -- the arena is move-only-across-threads at the API layer.
+#![allow(clippy::arc_with_non_send_sync)]
+
 //! # LibJS Parser
 //!
 //! A JavaScript parser that produces an AST.
@@ -111,6 +118,7 @@ use std::rc::Rc;
 pub struct ParsedProgram {
     program: ast::Statement,
     function_table: ast::FunctionTable,
+    arena: std::sync::Arc<ast::AstArena>,
     scope_ref: Rc<RefCell<ast::ScopeData>>,
     is_strict_mode: bool,
     has_top_level_await: bool,
@@ -176,6 +184,7 @@ fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
 unsafe fn write_ast_dump_output(
     program: &ast::Statement,
     function_table: &ast::FunctionTable,
+    identifiers: &ast::IdentifierArena,
     output_ptr: *mut *mut u8,
     output_len: *mut usize,
 ) {
@@ -183,7 +192,7 @@ unsafe fn write_ast_dump_output(
         if output_ptr.is_null() || output_len.is_null() {
             return;
         }
-        let dump_string = ast_dump::dump_program_to_string(program, function_table);
+        let dump_string = ast_dump::dump_program_to_string(program, function_table, identifiers);
         let mut boxed = dump_string.into_bytes().into_boxed_slice();
         *output_ptr = boxed.as_mut_ptr();
         *output_len = boxed.len();
@@ -336,11 +345,13 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
         let payload = ast::FunctionPayload {
             data: *function_data,
             function_table: subtable,
+            arena: generator.arena.clone(),
         };
         let (function_data, precompiled) = compile_function_payload_to_bytecode(
             payload,
             generator.source_len,
             generator.builtin_abstract_operations_enabled,
+            generator.arena.clone(),
         );
 
         pending.function_data = Some(function_data);
@@ -422,7 +433,9 @@ pub unsafe extern "C" fn rust_compile_program(
                 return std::ptr::null_mut();
             }
 
-            parser.scope_collector.analyze(initiated_by_eval);
+            parser
+                .scope_collector
+                .analyze(initiated_by_eval, &parser.arena.identifiers);
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -432,6 +445,8 @@ pub unsafe extern "C" fn rust_compile_program(
 
             let mut generator = new_program_generator(starts_in_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
+            generator.arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
+            // Make a clone of the Arc so we can keep using it after generator is consumed.
             compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr)
         })
     }
@@ -487,12 +502,12 @@ pub unsafe extern "C" fn rust_parse_program(
             }
 
             if errors.is_empty() {
-                parser.scope_collector.analyze(false);
+                parser.scope_collector.analyze(false, &parser.arena.identifiers);
             }
 
             // Dump AST if requested (after scope analysis).
             if dump_ast && errors.is_empty() {
-                ast_dump::dump_program(&program, use_color, &parser.function_table);
+                ast_dump::dump_program(&program, use_color, &parser.function_table, &parser.arena.identifiers);
             }
 
             let (scope_ref, is_strict, has_tla) = if errors.is_empty() {
@@ -510,6 +525,7 @@ pub unsafe extern "C" fn rust_parse_program(
             let parsed = ParsedProgram {
                 program,
                 function_table: std::mem::take(&mut parser.function_table),
+                arena: std::sync::Arc::new(std::mem::take(&mut parser.arena)),
                 scope_ref,
                 is_strict_mode: is_strict,
                 has_top_level_await: has_tla,
@@ -584,8 +600,10 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
             }
 
             let mut parsed = Box::from_raw(parsed);
+            let arena_arc = parsed.arena.clone();
             let bytecode = if parsed.has_top_level_await {
                 let mut generator = new_module_async_generator(source_len, std::mem::take(&mut parsed.function_table));
+                generator.arena = arena_arc;
                 generator.eager_compile_direct_iifes = true;
                 let assembled = compile_module_as_async_to_bytecode(&parsed.program, &parsed.scope_ref, &mut generator);
                 precompile_eager_functions(&mut generator);
@@ -597,6 +615,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                     std::ptr::null(),
                     source_len,
                 );
+                generator.arena = arena_arc;
                 generator.eager_compile_direct_iifes = true;
                 generator.function_table = std::mem::take(&mut parsed.function_table);
                 let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, &parsed.scope_ref);
@@ -641,7 +660,8 @@ pub unsafe extern "C" fn rust_parsed_program_ast_dump(
     unsafe {
         let parsed = &mut *parsed;
         let dump = parsed.ast_dump.get_or_insert_with(|| {
-            ast_dump::dump_program_to_string(&parsed.program, &parsed.function_table).into_bytes()
+            ast_dump::dump_program_to_string(&parsed.program, &parsed.function_table, &parsed.arena.identifiers)
+                .into_bytes()
         });
         *output_ptr = dump.as_ptr();
         *output_len = dump.len();
@@ -673,6 +693,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
 
             let mut generator = new_program_generator(parsed.is_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parsed.function_table);
+            generator.arena = parsed.arena.clone();
             let exec_ptr = compile_program_body(
                 &mut generator,
                 &parsed.program,
@@ -691,6 +712,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
                 source_code_ptr,
                 gdi_context,
                 &mut generator.function_table,
+                &parsed.arena,
             );
 
             exec_ptr
@@ -735,6 +757,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_script(
                 source_code_ptr,
                 gdi_context,
                 &mut bytecode.generator.function_table,
+                &compiled.parsed.arena,
             );
 
             exec_ptr
@@ -793,9 +816,15 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             }
 
-            parser.scope_collector.analyze(true);
+            parser.scope_collector.analyze(true, &parser.arena.identifiers);
 
-            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
+            write_ast_dump_output(
+                &program,
+                &parser.function_table,
+                &parser.arena.identifiers,
+                ast_dump_output,
+                ast_dump_output_len,
+            );
 
             let (scope_ref, is_strict) = if let StatementKind::Program(ref data) = program.inner {
                 (data.scope.clone(), data.is_strict_mode)
@@ -803,8 +832,10 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             };
 
+            let arena_arc = std::sync::Arc::new(std::mem::take(&mut parser.arena));
             let mut generator = new_program_generator(is_strict, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
+            generator.arena = arena_arc.clone();
             let exec_ptr = compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr);
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
@@ -817,6 +848,7 @@ pub unsafe extern "C" fn rust_compile_eval(
                 source_code_ptr,
                 gdi_context,
                 &mut generator.function_table,
+                &arena_arc,
             );
 
             exec_ptr
@@ -968,7 +1000,9 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // Run scope analysis. Use analyze_as_dynamic_function() to suppress
             // marking identifiers as global, matching the C++ path which parses
             // as a FunctionExpression (no Program scope for globals to bind to).
-            parser.scope_collector.analyze_as_dynamic_function();
+            parser
+                .scope_collector
+                .analyze_as_dynamic_function(&parser.arena.identifiers);
 
             if parser.scope_collector.has_errors() {
                 if let Some(cb) = error_callback {
@@ -980,7 +1014,13 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
                 return std::ptr::null_mut();
             }
 
-            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
+            write_ast_dump_output(
+                &program,
+                &parser.function_table,
+                &parser.arena.identifiers,
+                ast_dump_output,
+                ast_dump_output_len,
+            );
 
             // Extract the FunctionExpression from the program.
             // The program should contain a single ExpressionStatement wrapping a FunctionExpression.
@@ -1017,8 +1057,9 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
 
             let is_strict = function_data.is_strict_mode;
             let subtable = parser.function_table.extract_reachable(&function_data);
+            let arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
 
-            bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict)
+            bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict, arena)
         })
     }
 }
@@ -1071,9 +1112,15 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 panic!("Parse errors in builtin file: {}", errors.join("; "));
             }
 
-            parser.scope_collector.analyze(false);
+            parser.scope_collector.analyze(false, &parser.arena.identifiers);
 
-            write_ast_dump_output(&program, &parser.function_table, ast_dump_output, ast_dump_output_len);
+            write_ast_dump_output(
+                &program,
+                &parser.function_table,
+                &parser.arena.identifiers,
+                ast_dump_output,
+                ast_dump_output_len,
+            );
 
             let scope_ref = if let StatementKind::Program(ref data) = program.inner {
                 data.scope.clone()
@@ -1081,6 +1128,7 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 return;
             };
 
+            let arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
             let scope = scope_ref.borrow();
             for child in &scope.children {
                 if let StatementKind::FunctionDeclaration(ref fd) = child.inner {
@@ -1092,11 +1140,13 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                         vm_ptr,
                         source_code_ptr,
                         true, // strict
+                        arena.clone(),
                     );
                     if !sfd_ptr.is_null()
-                        && let Some(name_ident) = &fd.name
+                        && let Some(name_ident) = fd.name
                     {
-                        push_function(ctx, sfd_ptr, name_ident.name.as_ptr(), name_ident.name.len());
+                        let name = &arena.identifiers[name_ident].name;
+                        push_function(ctx, sfd_ptr, name.as_ptr(), name.len());
                     }
                 }
             }
@@ -1151,6 +1201,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                 module_context,
                 cb,
                 &mut parsed.function_table,
+                &parsed.arena,
             );
 
             // 4. Compute requested modules (sorted by source offset).
@@ -1177,6 +1228,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                 }
                 let mut generator = new_program_generator(true, vm_ptr, source_code_ptr, source_len);
                 generator.function_table = std::mem::take(&mut parsed.function_table);
+                generator.arena = parsed.arena.clone();
                 compile_program_body(
                     &mut generator,
                     &parsed.program,
@@ -1228,6 +1280,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
                 module_context,
                 cb,
                 &mut bytecode.generator.function_table,
+                &compiled.parsed.arena,
             );
             extract_requested_modules(&compiled.parsed.scope_ref.borrow(), module_context, cb);
 
@@ -1422,9 +1475,11 @@ pub unsafe extern "C" fn rust_compile_module(
                 return std::ptr::null_mut();
             }
 
+            let parsed_ref = &*parsed;
             write_ast_dump_output(
-                &(*parsed).program,
-                &(*parsed).function_table,
+                &parsed_ref.program,
+                &parsed_ref.function_table,
+                &parsed_ref.arena.identifiers,
                 ast_dump_output,
                 ast_dump_output_len,
             );
@@ -1589,7 +1644,9 @@ unsafe fn extract_module_declarations(
     ctx: *mut c_void,
     cb: &ModuleCallbacks,
     function_table: &mut ast::FunctionTable,
+    arena: &std::sync::Arc<ast::AstArena>,
 ) {
+    let identifiers = &arena.identifiers;
     unsafe {
         use ast::StatementKind;
 
@@ -1597,7 +1654,7 @@ unsafe fn extract_module_declarations(
 
         // Var declared names (walk all nesting levels).
         for child in &scope.children {
-            collect_module_var_names(&child.inner, ctx, cb.push_var_name);
+            collect_module_var_names(&child.inner, ctx, cb.push_var_name, identifiers);
         }
 
         // Lexical bindings and functions to initialize.
@@ -1616,19 +1673,25 @@ unsafe fn extract_module_declarations(
 
             match declaration {
                 StatementKind::FunctionDeclaration(fd) => {
-                    let is_default = is_exported && fd.name.as_ref().is_some_and(|n| n.name == default_name);
+                    let is_default = is_exported && fd.name.is_some_and(|n| identifiers[n].name == default_name);
 
                     let function_data = function_table.take(fd.function_id);
                     let subtable = function_table.extract_reachable(&function_data);
-                    let sfd_ptr =
-                        bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, true);
+                    let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
+                        function_data,
+                        subtable,
+                        vm_ptr,
+                        source_code_ptr,
+                        true,
+                        arena.clone(),
+                    );
                     if sfd_ptr.is_null() {
                         continue;
                     }
 
                     // Get the binding name from the AST (e.g., "*default*" for anonymous defaults).
-                    let binding_name = if let Some(name_ident) = &fd.name {
-                        name_ident.name.to_utf16_string()
+                    let binding_name = if let Some(name_ident) = fd.name {
+                        identifiers[name_ident].name.to_utf16_string()
                     } else {
                         continue;
                     };
@@ -1651,21 +1714,22 @@ unsafe fn extract_module_declarations(
                     (cb.push_lexical_binding)(ctx, binding_name.as_ptr(), binding_name.len(), false, function_index);
                 }
                 StatementKind::ClassDeclaration(class_data) => {
-                    if let Some(ref name_ident) = class_data.name {
-                        (cb.push_lexical_binding)(ctx, name_ident.name.as_ptr(), name_ident.name.len(), false, -1);
+                    if let Some(name_ident) = class_data.name {
+                        let name = &identifiers[name_ident].name;
+                        (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), false, -1);
                     }
                 }
                 StatementKind::VariableDeclaration(vd) if vd.kind != ast::DeclarationKind::Var => {
                     let is_constant = vd.kind == ast::DeclarationKind::Const;
                     for declaration in &vd.declarations {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                             (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), is_constant, -1);
                         });
                     }
                 }
                 StatementKind::UsingDeclaration(declarations) => {
                     for declaration in declarations.iter() {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                             (cb.push_lexical_binding)(ctx, name.as_ptr(), name.len(), false, -1);
                         });
                     }
@@ -1681,24 +1745,25 @@ unsafe fn collect_module_var_names(
     statement: &ast::StatementKind,
     ctx: *mut c_void,
     push_var_name: ModuleNameCallback,
+    identifiers: &ast::IdentifierArena,
 ) {
     unsafe {
         match statement {
             ast::StatementKind::VariableDeclaration(vd) if vd.kind == ast::DeclarationKind::Var => {
                 for declaration in &vd.declarations {
-                    for_each_bound_name(&declaration.target, &mut |name| {
+                    for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                         push_var_name(ctx, name.as_ptr(), name.len());
                     });
                 }
             }
             ast::StatementKind::Export(export_data) => {
                 if let Some(ref stmt) = export_data.statement {
-                    collect_module_var_names(&stmt.inner, ctx, push_var_name);
+                    collect_module_var_names(&stmt.inner, ctx, push_var_name, identifiers);
                 }
             }
             _ => {
                 for_each_child_statement(statement, &mut |child| {
-                    collect_module_var_names(child, ctx, push_var_name);
+                    collect_module_var_names(child, ctx, push_var_name, identifiers);
                 });
             }
         }
@@ -1843,16 +1908,20 @@ unsafe extern "C" {
 
 /// Recursively collect var-declared names from a statement and all nested
 /// statements, excluding function/class bodies (which create new var scopes).
-fn collect_var_names_recursive(statement: &ast::StatementKind, push_name: &mut dyn FnMut(&[u16])) {
+fn collect_var_names_recursive(
+    statement: &ast::StatementKind,
+    identifiers: &ast::IdentifierArena,
+    push_name: &mut dyn FnMut(&[u16]),
+) {
     match statement {
         ast::StatementKind::VariableDeclaration(vd) if vd.kind == ast::DeclarationKind::Var => {
             for declaration in &vd.declarations {
-                for_each_bound_name(&declaration.target, push_name);
+                for_each_bound_name(&declaration.target, identifiers, push_name);
             }
         }
         _ => {
             for_each_child_statement(statement, &mut |child| {
-                collect_var_names_recursive(child, push_name);
+                collect_var_names_recursive(child, identifiers, push_name);
             });
         }
     }
@@ -1875,16 +1944,18 @@ fn extract_gdi_common(
     push_annex_b_name: &mut dyn FnMut(&[u16]),
     push_lexical_binding: &mut dyn FnMut(&[u16], bool),
     function_table: &mut ast::FunctionTable,
+    arena: &std::sync::Arc<ast::AstArena>,
 ) {
+    let identifiers = &arena.identifiers;
     use ast::{DeclarationKind, StatementKind};
 
     // Var names (var declarations at any nesting level + top-level function declarations)
     for child in &scope.children {
-        collect_var_names_recursive(&child.inner, push_var_name);
+        collect_var_names_recursive(&child.inner, identifiers, push_var_name);
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
-            && let Some(ref name_ident) = fd.name
+            && let Some(name_ident) = fd.name
         {
-            push_var_name(&name_ident.name);
+            push_var_name(&identifiers[name_ident].name);
         }
     }
 
@@ -1894,29 +1965,36 @@ fn extract_gdi_common(
     let mut last_position: std::collections::HashMap<ast::SharedUtf16String, usize> = std::collections::HashMap::new();
     for (i, child) in scope.children.iter().enumerate() {
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
-            && let Some(ref name_ident) = fd.name
+            && let Some(name_ident) = fd.name
         {
-            last_position.insert(name_ident.name.clone(), i);
+            last_position.insert(identifiers[name_ident].name.clone(), i);
         }
     }
     for (i, child) in scope.children.iter().enumerate() {
         if let StatementKind::FunctionDeclaration(ref fd) = child.inner
-            && let Some(ref name_ident) = fd.name
-            && last_position.get(&name_ident.name).copied() == Some(i)
+            && let Some(name_ident) = fd.name
+            && last_position.get(&identifiers[name_ident].name).copied() == Some(i)
         {
             let function_data = function_table.take(fd.function_id);
             let subtable = function_table.extract_reachable(&function_data);
             let sfd_ptr = unsafe {
-                bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict)
+                bytecode::ffi::create_sfd_for_gdi(
+                    function_data,
+                    subtable,
+                    vm_ptr,
+                    source_code_ptr,
+                    is_strict,
+                    arena.clone(),
+                )
             };
             assert!(!sfd_ptr.is_null(), "create_sfd_for_gdi returned null");
-            push_function(sfd_ptr, name_ident.name.as_slice());
+            push_function(sfd_ptr, identifiers[name_ident].name.as_slice());
         }
     }
 
     // Var-scoped names (var VariableDeclaration names, excluding function declarations)
     for child in &scope.children {
-        collect_var_names_recursive(&child.inner, push_var_scoped_name);
+        collect_var_names_recursive(&child.inner, identifiers, push_var_scoped_name);
     }
 
     for name in &scope.annexb_function_names {
@@ -1928,21 +2006,21 @@ fn extract_gdi_common(
             StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                 let is_constant = vd.kind == DeclarationKind::Const;
                 for declaration in &vd.declarations {
-                    for_each_bound_name(&declaration.target, &mut |name| {
+                    for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                         push_lexical_binding(name, is_constant);
                     });
                 }
             }
             StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
-                    for_each_bound_name(&declaration.target, &mut |name| {
+                    for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                         push_lexical_binding(name, false);
                     });
                 }
             }
             StatementKind::ClassDeclaration(class_data) => {
-                if let Some(ref name) = class_data.name {
-                    push_lexical_binding(&name.name, false);
+                if let Some(name) = class_data.name {
+                    push_lexical_binding(&identifiers[name].name, false);
                 }
             }
             _ => {}
@@ -1959,6 +2037,7 @@ unsafe fn extract_eval_gdi(
     source_code_ptr: *const c_void,
     ctx: *mut c_void,
     function_table: &mut ast::FunctionTable,
+    arena: &std::sync::Arc<ast::AstArena>,
 ) {
     unsafe {
         use bytecode::ffi::{
@@ -1981,6 +2060,7 @@ unsafe fn extract_eval_gdi(
                 eval_gdi_push_lexical_binding(ctx, name.as_ptr(), name.len(), is_const);
             },
             function_table,
+            arena,
         );
     }
 }
@@ -1994,7 +2074,9 @@ unsafe fn extract_script_gdi(
     source_code_ptr: *const c_void,
     ctx: *mut c_void,
     function_table: &mut ast::FunctionTable,
+    arena: &std::sync::Arc<ast::AstArena>,
 ) {
+    let identifiers = &arena.identifiers;
     unsafe {
         use ast::{DeclarationKind, StatementKind};
         use bytecode::ffi::{
@@ -2007,21 +2089,22 @@ unsafe fn extract_script_gdi(
             match &child.inner {
                 StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                     for declaration in &vd.declarations {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                             script_gdi_push_lexical_name(ctx, name.as_ptr(), name.len());
                         });
                     }
                 }
                 StatementKind::UsingDeclaration(declarations) => {
                     for declaration in declarations.iter() {
-                        for_each_bound_name(&declaration.target, &mut |name| {
+                        for_each_bound_name(&declaration.target, identifiers, &mut |name| {
                             script_gdi_push_lexical_name(ctx, name.as_ptr(), name.len());
                         });
                     }
                 }
                 StatementKind::ClassDeclaration(class_data) => {
-                    if let Some(ref name) = class_data.name {
-                        script_gdi_push_lexical_name(ctx, name.name.as_ptr(), name.name.len());
+                    if let Some(name) = class_data.name {
+                        let n = &identifiers[name].name;
+                        script_gdi_push_lexical_name(ctx, n.as_ptr(), n.len());
                     }
                 }
                 _ => {}
@@ -2041,6 +2124,7 @@ unsafe fn extract_script_gdi(
                 script_gdi_push_lexical_binding(ctx, name.as_ptr(), name.len(), is_const);
             },
             function_table,
+            arena,
         );
     }
 }
@@ -2107,26 +2191,34 @@ fn for_each_child_statement(statement: &ast::StatementKind, f: &mut dyn FnMut(&a
     }
 }
 
-fn for_each_bound_name(target: &ast::VariableDeclaratorTarget, f: &mut dyn FnMut(&[u16])) {
+fn for_each_bound_name(
+    target: &ast::VariableDeclaratorTarget,
+    identifiers: &ast::IdentifierArena,
+    f: &mut dyn FnMut(&[u16]),
+) {
     match target {
-        ast::VariableDeclaratorTarget::Identifier(id) => f(&id.name),
+        ast::VariableDeclaratorTarget::Identifier(id) => f(&identifiers[*id].name),
         ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            for_each_bound_name_in_pattern(pattern, f);
+            for_each_bound_name_in_pattern(pattern, identifiers, f);
         }
     }
 }
 
-fn for_each_bound_name_in_pattern(pattern: &ast::BindingPattern, f: &mut dyn FnMut(&[u16])) {
+fn for_each_bound_name_in_pattern(
+    pattern: &ast::BindingPattern,
+    identifiers: &ast::IdentifierArena,
+    f: &mut dyn FnMut(&[u16]),
+) {
     for entry in &pattern.entries {
         match &entry.alias {
             None => {
                 if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name {
-                    f(&id.name);
+                    f(&identifiers[*id].name);
                 }
             }
-            Some(ast::BindingEntryAlias::Identifier(id)) => f(&id.name),
+            Some(ast::BindingEntryAlias::Identifier(id)) => f(&identifiers[*id].name),
             Some(ast::BindingEntryAlias::BindingPattern(inner)) => {
-                for_each_bound_name_in_pattern(inner, f);
+                for_each_bound_name_in_pattern(inner, identifiers, f);
             }
             Some(ast::BindingEntryAlias::MemberExpression(_)) => {}
         }
@@ -2197,8 +2289,9 @@ pub unsafe extern "C" fn rust_compile_function(
                 return std::ptr::null_mut();
             }
             let payload = Box::from_raw(rust_function_ast as *mut ast::FunctionPayload);
+            let arena = payload.arena.clone();
             let (_function_data, mut precompiled) =
-                compile_function_payload_to_bytecode(*payload, source_len, builtin_abstract_operations_enabled);
+                compile_function_payload_to_bytecode(*payload, source_len, builtin_abstract_operations_enabled, arena);
 
             precompiled.generator.vm_ptr = vm_ptr;
             precompiled.generator.source_code_ptr = source_code_ptr;
@@ -2219,6 +2312,7 @@ fn compile_function_payload_to_bytecode(
     payload: ast::FunctionPayload,
     source_len: usize,
     builtin_abstract_operations_enabled: bool,
+    arena: std::sync::Arc<ast::AstArena>,
 ) -> (Box<ast::FunctionData>, Box<bytecode::generator::PrecompiledFunction>) {
     let function_data = Box::new(payload.data);
 
@@ -2230,9 +2324,10 @@ fn compile_function_payload_to_bytecode(
 
     // Compute SFD metadata before codegen so the generator can optimize
     // direct `this` access when it does not need environment resolution.
-    let sfd_metadata = compute_sfd_metadata(&function_data);
+    let sfd_metadata = compute_sfd_metadata(&function_data, &arena.identifiers);
 
     let mut generator = bytecode::generator::Generator::new();
+    generator.arena = arena;
     generator.strict = function_data.is_strict_mode;
     generator.this_value_needs_environment_resolution = sfd_metadata.this_value_needs_environment_resolution;
     generator.builtin_abstract_operations_enabled = builtin_abstract_operations_enabled;
@@ -2340,7 +2435,10 @@ struct BodyScopeInfo {
 
 /// Compute FDI runtime metadata matching the C++ SharedFunctionInstanceData
 /// constructor (ECMA-262 §10.2.11).
-fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generator::FunctionSfdMetadata {
+fn compute_sfd_metadata(
+    function_data: &ast::FunctionData,
+    identifiers: &ast::IdentifierArena,
+) -> bytecode::generator::FunctionSfdMetadata {
     let body_scope = match &function_data.body.inner {
         ast::StatementKind::FunctionBody { scope, .. } => Some(scope),
         _ => None,
@@ -2401,13 +2499,14 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generato
     let mut parameters_in_environment: usize = 0;
     for parameter in &function_data.parameters {
         match &parameter.binding {
-            ast::FunctionParameterBinding::Identifier(ident) => {
+            ast::FunctionParameterBinding::Identifier(id) => {
+                let ident = &identifiers[*id];
                 if parameter_names.insert(ident.name.to_utf16_string()) && !ident.is_local() {
                     parameters_in_environment += 1;
                 }
             }
             ast::FunctionParameterBinding::BindingPattern(pattern) => {
-                for_each_binding_pattern_identifier(pattern, &mut |ident| {
+                for_each_binding_pattern_identifier(pattern, identifiers, &mut |ident| {
                     if parameter_names.insert(ident.name.to_utf16_string()) && !ident.is_local() {
                         parameters_in_environment += 1;
                     }
@@ -2467,7 +2566,7 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generato
             }
 
             // §10.2.11 step 30: lexical environment.
-            let non_local_lex_count = count_non_local_lex_declarations(body_scope);
+            let non_local_lex_count = count_non_local_lex_declarations(body_scope, identifiers);
             if strict {
                 // Lex env == var env == function env.
                 function_environment_bindings_count += non_local_lex_count;
@@ -2489,7 +2588,7 @@ fn compute_sfd_metadata(function_data: &ast::FunctionData) -> bytecode::generato
                 }
             }
 
-            let non_local_lex_count = count_non_local_lex_declarations(body_scope);
+            let non_local_lex_count = count_non_local_lex_declarations(body_scope, identifiers);
             if strict {
                 // Lex env == var env.
                 var_environment_bindings_count += non_local_lex_count;
@@ -2542,7 +2641,7 @@ unsafe fn write_sfd_metadata(sfd_ptr: *mut c_void, metadata: &bytecode::generato
 /// Count non-local lexically-declared identifiers in a function body scope.
 /// Returns the count (used for environment sizing in the function_environment_needed
 /// computation).
-fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>) -> usize {
+fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>, identifiers: &ast::IdentifierArena) -> usize {
     let sd = scope.borrow();
     let mut count = 0;
     for child in &sd.children {
@@ -2551,18 +2650,18 @@ fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>) -> usiz
                 use parser::DeclarationKind;
                 if vd.kind == DeclarationKind::Let || vd.kind == DeclarationKind::Const {
                     for declaration in &vd.declarations {
-                        count_non_local_names_in_target(&declaration.target, &mut count);
+                        count_non_local_names_in_target(&declaration.target, &mut count, identifiers);
                     }
                 }
             }
             ast::StatementKind::UsingDeclaration(declarations) => {
                 for declaration in declarations.iter() {
-                    count_non_local_names_in_target(&declaration.target, &mut count);
+                    count_non_local_names_in_target(&declaration.target, &mut count, identifiers);
                 }
             }
             ast::StatementKind::ClassDeclaration(class_data) => {
-                if let Some(ref name_ident) = class_data.name
-                    && !name_ident.is_local()
+                if let Some(name_ident) = class_data.name
+                    && !identifiers[name_ident].is_local()
                 {
                     count += 1;
                 }
@@ -2573,33 +2672,41 @@ fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>) -> usiz
     count
 }
 
-fn count_non_local_names_in_target(target: &ast::VariableDeclaratorTarget, count: &mut usize) {
+fn count_non_local_names_in_target(
+    target: &ast::VariableDeclaratorTarget,
+    count: &mut usize,
+    identifiers: &ast::IdentifierArena,
+) {
     match target {
-        ast::VariableDeclaratorTarget::Identifier(ident) => {
-            if !ident.is_local() {
+        ast::VariableDeclaratorTarget::Identifier(id) => {
+            if !identifiers[*id].is_local() {
                 *count += 1;
             }
         }
         ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            count_non_local_names_in_binding_pattern(pattern, count);
+            count_non_local_names_in_binding_pattern(pattern, count, identifiers);
         }
     }
 }
 
-fn count_non_local_names_in_binding_pattern(pattern: &ast::BindingPattern, count: &mut usize) {
+fn count_non_local_names_in_binding_pattern(
+    pattern: &ast::BindingPattern,
+    count: &mut usize,
+    identifiers: &ast::IdentifierArena,
+) {
     for entry in &pattern.entries {
         match &entry.alias {
-            Some(ast::BindingEntryAlias::Identifier(ident)) => {
-                if !ident.is_local() {
+            Some(ast::BindingEntryAlias::Identifier(id)) => {
+                if !identifiers[*id].is_local() {
                     *count += 1;
                 }
             }
             Some(ast::BindingEntryAlias::BindingPattern(sub)) => {
-                count_non_local_names_in_binding_pattern(sub, count);
+                count_non_local_names_in_binding_pattern(sub, count, identifiers);
             }
             None => {
-                if let Some(ast::BindingEntryName::Identifier(ident)) = &entry.name
-                    && !ident.is_local()
+                if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name
+                    && !identifiers[*id].is_local()
                 {
                     *count += 1;
                 }
@@ -2609,16 +2716,20 @@ fn count_non_local_names_in_binding_pattern(pattern: &ast::BindingPattern, count
     }
 }
 
-fn for_each_binding_pattern_identifier(pattern: &ast::BindingPattern, callback: &mut dyn FnMut(&Rc<ast::Identifier>)) {
+fn for_each_binding_pattern_identifier(
+    pattern: &ast::BindingPattern,
+    identifiers: &ast::IdentifierArena,
+    callback: &mut dyn FnMut(&ast::Identifier),
+) {
     for entry in &pattern.entries {
         match &entry.alias {
-            Some(ast::BindingEntryAlias::Identifier(ident)) => callback(ident),
+            Some(ast::BindingEntryAlias::Identifier(id)) => callback(&identifiers[*id]),
             Some(ast::BindingEntryAlias::BindingPattern(sub)) => {
-                for_each_binding_pattern_identifier(sub, callback);
+                for_each_binding_pattern_identifier(sub, identifiers, callback);
             }
             None => {
-                if let Some(ast::BindingEntryName::Identifier(ident)) = &entry.name {
-                    callback(ident);
+                if let Some(ast::BindingEntryName::Identifier(id)) = &entry.name {
+                    callback(&identifiers[*id]);
                 }
             }
             Some(ast::BindingEntryAlias::MemberExpression(_)) => {}

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-// AstArena currently transitively contains `Cell<>` fields on `Identifier` (set
-// by the scope collector during parse). Once those cells are removed, the
-// arena will be naturally `Send + Sync` and this allow can go away. For now
-// we hand-wave it the same way we already do with `unsafe impl Send for
-// ParsedProgram` -- the arena is move-only-across-threads at the API layer.
-#![allow(clippy::arc_with_non_send_sync)]
-
 //! # LibJS Parser
 //!
 //! A JavaScript parser that produces an AST.
@@ -103,11 +96,18 @@ pub(crate) fn u32_from_usize(value: usize) -> u32 {
 
 use ast::StatementKind;
 use parser::{ParseError, Parser, ProgramType};
-use std::cell::RefCell;
 use std::collections::HashSet;
 use std::ffi::c_void;
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::rc::Rc;
+
+// Compile-time assertion: `ParsedProgram` travels between the parse worker
+// thread and the main thread, so it must be `Send`. After the StringId and
+// ScopeId arena migrations the AST itself contains no `Rc`/`Cell`/`RefCell`
+// values, so this is naturally satisfied without `unsafe impl Send`.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<ParsedProgram>();
+};
 
 // =============================================================================
 // ParsedProgram: GC-free parse result for off-thread parsing
@@ -119,15 +119,12 @@ pub struct ParsedProgram {
     program: ast::Statement,
     function_table: ast::FunctionTable,
     arena: std::sync::Arc<ast::AstArena>,
-    scope_ref: Rc<RefCell<ast::ScopeData>>,
+    scope_ref: ast::ScopeId,
     is_strict_mode: bool,
     has_top_level_await: bool,
     errors: Vec<ParseError>,
     ast_dump: Option<Vec<u8>>,
 }
-
-// SAFETY: Full ownership transfer between threads, never concurrent access.
-unsafe impl Send for ParsedProgram {}
 
 pub struct CompiledProgram {
     parsed: ParsedProgram,
@@ -144,9 +141,9 @@ struct CompiledBytecode {
     assembled: bytecode::generator::AssembledBytecode,
 }
 
-// SAFETY: This handle owns its parser and bytecode-generator state, and C++ treats it as a move-only handoff object.
-// The Rc/RefCell values inside are only ever touched by one thread at a time: the worker creates the handle, then the
-// main thread consumes or frees it after the event-loop hop.
+// SAFETY: `CompiledProgram` owns codegen state that uses `Rc`/`RefCell` and
+// raw VM pointers; it is created on the parse-worker thread and consumed (or
+// freed) on the main thread, never accessed concurrently.
 unsafe impl Send for CompiledProgram {}
 
 // =============================================================================
@@ -296,9 +293,10 @@ fn new_program_generator(
 fn compile_program_body_to_bytecode(
     generator: &mut bytecode::generator::Generator,
     program: &ast::Statement,
-    scope_ref: &Rc<RefCell<ast::ScopeData>>,
+    scope_id: ast::ScopeId,
 ) -> bytecode::generator::AssembledBytecode {
-    generator.local_variables = convert_local_variables(&scope_ref.borrow());
+    let arena_clone = generator.arena.clone();
+    generator.local_variables = convert_local_variables(&arena_clone.scopes[scope_id]);
 
     let entry_block = generator.make_block();
     generator.switch_to_basic_block(entry_block);
@@ -342,16 +340,17 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
             .subtable
             .take()
             .expect("pending eager function subtable was already materialized");
+        let arena = pending.arena.clone().unwrap_or_else(|| generator.arena.clone());
         let payload = ast::FunctionPayload {
             data: *function_data,
             function_table: subtable,
-            arena: generator.arena.clone(),
+            arena: arena.clone(),
         };
         let (function_data, precompiled) = compile_function_payload_to_bytecode(
             payload,
             generator.source_len,
             generator.builtin_abstract_operations_enabled,
-            generator.arena.clone(),
+            arena,
         );
 
         pending.function_data = Some(function_data);
@@ -369,11 +368,11 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
 unsafe fn compile_program_body(
     generator: &mut bytecode::generator::Generator,
     program: &ast::Statement,
-    scope_ref: &Rc<RefCell<ast::ScopeData>>,
+    scope_id: ast::ScopeId,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
 ) -> *mut c_void {
-    let assembled = compile_program_body_to_bytecode(generator, program, scope_ref);
+    let assembled = compile_program_body_to_bytecode(generator, program, scope_id);
     unsafe { bytecode::ffi::create_executable(generator, &assembled, vm_ptr, source_code_ptr) }
 }
 
@@ -433,12 +432,15 @@ pub unsafe extern "C" fn rust_compile_program(
                 return std::ptr::null_mut();
             }
 
-            parser
-                .scope_collector
-                .analyze(initiated_by_eval, &mut parser.arena.identifiers, &parser.arena.strings);
+            parser.scope_collector.analyze(
+                initiated_by_eval,
+                &mut parser.arena.identifiers,
+                &parser.arena.strings,
+                &mut parser.arena.scopes,
+            );
 
-            let scope_ref = if let StatementKind::Program(ref data) = program.inner {
-                data.scope.clone()
+            let scope_id = if let StatementKind::Program(ref data) = program.inner {
+                data.scope
             } else {
                 return std::ptr::null_mut();
             };
@@ -447,7 +449,7 @@ pub unsafe extern "C" fn rust_compile_program(
             generator.function_table = std::mem::take(&mut parser.function_table);
             generator.arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
             // Make a clone of the Arc so we can keep using it after generator is consumed.
-            compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr)
+            compile_program_body(&mut generator, &program, scope_id, vm_ptr, source_code_ptr)
         })
     }
 }
@@ -502,9 +504,12 @@ pub unsafe extern "C" fn rust_parse_program(
             }
 
             if errors.is_empty() {
-                parser
-                    .scope_collector
-                    .analyze(false, &mut parser.arena.identifiers, &parser.arena.strings);
+                parser.scope_collector.analyze(
+                    false,
+                    &mut parser.arena.identifiers,
+                    &parser.arena.strings,
+                    &mut parser.arena.scopes,
+                );
             }
 
             // Dump AST if requested (after scope analysis).
@@ -512,16 +517,12 @@ pub unsafe extern "C" fn rust_parse_program(
                 ast_dump::dump_program(&program, use_color, &parser.function_table, &parser.arena);
             }
 
-            let (scope_ref, is_strict, has_tla) = if errors.is_empty() {
-                if let StatementKind::Program(ref data) = program.inner {
-                    (data.scope.clone(), data.is_strict_mode, data.has_top_level_await)
-                } else {
-                    let scope = Rc::new(RefCell::new(ast::ScopeData::default()));
-                    (scope, false, false)
-                }
+            let (scope_ref, is_strict, has_tla) = if errors.is_empty()
+                && let StatementKind::Program(ref data) = program.inner
+            {
+                (data.scope, data.is_strict_mode, data.has_top_level_await)
             } else {
-                let scope = Rc::new(RefCell::new(ast::ScopeData::default()));
-                (scope, false, false)
+                (parser.arena.scopes.insert(ast::ScopeData::default()), false, false)
             };
 
             let parsed = ParsedProgram {
@@ -607,7 +608,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                 let mut generator = new_module_async_generator(source_len, std::mem::take(&mut parsed.function_table));
                 generator.arena = arena_arc;
                 generator.eager_compile_direct_iifes = true;
-                let assembled = compile_module_as_async_to_bytecode(&parsed.program, &parsed.scope_ref, &mut generator);
+                let assembled = compile_module_as_async_to_bytecode(&parsed.program, parsed.scope_ref, &mut generator);
                 precompile_eager_functions(&mut generator);
                 CompiledProgramBytecode::AsyncModule(CompiledBytecode { generator, assembled })
             } else {
@@ -620,7 +621,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                 generator.arena = arena_arc;
                 generator.eager_compile_direct_iifes = true;
                 generator.function_table = std::mem::take(&mut parsed.function_table);
-                let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, &parsed.scope_ref);
+                let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, parsed.scope_ref);
                 precompile_eager_functions(&mut generator);
                 CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled })
             };
@@ -698,7 +699,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
             let exec_ptr = compile_program_body(
                 &mut generator,
                 &parsed.program,
-                &parsed.scope_ref,
+                parsed.scope_ref,
                 vm_ptr,
                 source_code_ptr,
             );
@@ -707,7 +708,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
             }
 
             extract_script_gdi(
-                &parsed.scope_ref.borrow(),
+                &parsed.arena.scopes[parsed.scope_ref],
                 parsed.is_strict_mode,
                 vm_ptr,
                 source_code_ptr,
@@ -752,7 +753,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_script(
             }
 
             extract_script_gdi(
-                &compiled.parsed.scope_ref.borrow(),
+                &compiled.parsed.arena.scopes[compiled.parsed.scope_ref],
                 compiled.parsed.is_strict_mode,
                 vm_ptr,
                 source_code_ptr,
@@ -817,9 +818,12 @@ pub unsafe extern "C" fn rust_compile_eval(
                 return std::ptr::null_mut();
             }
 
-            parser
-                .scope_collector
-                .analyze(true, &mut parser.arena.identifiers, &parser.arena.strings);
+            parser.scope_collector.analyze(
+                true,
+                &mut parser.arena.identifiers,
+                &parser.arena.strings,
+                &mut parser.arena.scopes,
+            );
 
             write_ast_dump_output(
                 &program,
@@ -829,8 +833,8 @@ pub unsafe extern "C" fn rust_compile_eval(
                 ast_dump_output_len,
             );
 
-            let (scope_ref, is_strict) = if let StatementKind::Program(ref data) = program.inner {
-                (data.scope.clone(), data.is_strict_mode)
+            let (scope_id, is_strict) = if let StatementKind::Program(ref data) = program.inner {
+                (data.scope, data.is_strict_mode)
             } else {
                 return std::ptr::null_mut();
             };
@@ -839,13 +843,13 @@ pub unsafe extern "C" fn rust_compile_eval(
             let mut generator = new_program_generator(is_strict, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
             generator.arena = arena_arc.clone();
-            let exec_ptr = compile_program_body(&mut generator, &program, &scope_ref, vm_ptr, source_code_ptr);
+            let exec_ptr = compile_program_body(&mut generator, &program, scope_id, vm_ptr, source_code_ptr);
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
             }
 
             extract_eval_gdi(
-                &scope_ref.borrow(),
+                &arena_arc.scopes[scope_id],
                 is_strict,
                 vm_ptr,
                 source_code_ptr,
@@ -1003,9 +1007,11 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // Run scope analysis. Use analyze_as_dynamic_function() to suppress
             // marking identifiers as global, matching the C++ path which parses
             // as a FunctionExpression (no Program scope for globals to bind to).
-            parser
-                .scope_collector
-                .analyze_as_dynamic_function(&mut parser.arena.identifiers, &parser.arena.strings);
+            parser.scope_collector.analyze_as_dynamic_function(
+                &mut parser.arena.identifiers,
+                &parser.arena.strings,
+                &mut parser.arena.scopes,
+            );
 
             if parser.scope_collector.has_errors() {
                 if let Some(cb) = error_callback {
@@ -1028,7 +1034,7 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             // Extract the FunctionExpression from the program.
             // The program should contain a single ExpressionStatement wrapping a FunctionExpression.
             let function_id = if let StatementKind::Program(ref data) = program.inner {
-                let scope = data.scope.borrow();
+                let scope = &parser.arena.scopes[data.scope];
                 scope.children.iter().find_map(|child| match &child.inner {
                     StatementKind::FunctionDeclaration(fd) => Some(fd.function_id),
                     StatementKind::Expression(expression) => {
@@ -1059,7 +1065,9 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
             function_data.parsing_insights.might_need_arguments_object = true;
 
             let is_strict = function_data.is_strict_mode;
-            let subtable = parser.function_table.extract_reachable(&function_data);
+            let subtable = parser
+                .function_table
+                .extract_reachable(&function_data, &parser.arena.scopes);
             let arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
 
             bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict, arena)
@@ -1115,9 +1123,12 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 panic!("Parse errors in builtin file: {}", errors.join("; "));
             }
 
-            parser
-                .scope_collector
-                .analyze(false, &mut parser.arena.identifiers, &parser.arena.strings);
+            parser.scope_collector.analyze(
+                false,
+                &mut parser.arena.identifiers,
+                &parser.arena.strings,
+                &mut parser.arena.scopes,
+            );
 
             write_ast_dump_output(
                 &program,
@@ -1127,18 +1138,18 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                 ast_dump_output_len,
             );
 
-            let scope_ref = if let StatementKind::Program(ref data) = program.inner {
-                data.scope.clone()
+            let scope_id = if let StatementKind::Program(ref data) = program.inner {
+                data.scope
             } else {
                 return;
             };
 
             let arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
-            let scope = scope_ref.borrow();
+            let scope = &arena.scopes[scope_id];
             for child in &scope.children {
                 if let StatementKind::FunctionDeclaration(ref fd) = child.inner {
                     let function_data = parser.function_table.take(fd.function_id);
-                    let subtable = parser.function_table.extract_reachable(&function_data);
+                    let subtable = parser.function_table.extract_reachable(&function_data, &arena.scopes);
                     let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
                         function_data,
                         subtable,
@@ -1196,11 +1207,11 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
             (cb.set_has_top_level_await)(module_context, parsed.has_top_level_await);
 
             // 2. Process imports and exports.
-            extract_module_metadata(&parsed.scope_ref.borrow(), module_context, cb);
+            extract_module_metadata(&parsed.arena.scopes[parsed.scope_ref], module_context, cb);
 
             // 3. Extract var declared names and lexical bindings.
             extract_module_declarations(
-                &parsed.scope_ref.borrow(),
+                &parsed.arena.scopes[parsed.scope_ref],
                 vm_ptr,
                 source_code_ptr,
                 module_context,
@@ -1210,16 +1221,16 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
             );
 
             // 4. Compute requested modules (sorted by source offset).
-            extract_requested_modules(&parsed.scope_ref.borrow(), module_context, cb);
+            extract_requested_modules(&parsed.arena.scopes[parsed.scope_ref], module_context, cb);
 
             // 5. Compile module body.
             if parsed.has_top_level_await {
                 let exec_ptr = compile_module_as_async(
                     &parsed.program,
-                    &parsed.scope_ref,
+                    parsed.scope_ref,
+                    parsed.arena.clone(),
                     vm_ptr,
                     source_code_ptr,
-                    std::ptr::null(),
                     source_len,
                     std::mem::take(&mut parsed.function_table),
                 );
@@ -1237,7 +1248,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                 compile_program_body(
                     &mut generator,
                     &parsed.program,
-                    &parsed.scope_ref,
+                    parsed.scope_ref,
                     vm_ptr,
                     source_code_ptr,
                 )
@@ -1273,13 +1284,17 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
             let cb = &*callbacks;
 
             (cb.set_has_top_level_await)(module_context, compiled.parsed.has_top_level_await);
-            extract_module_metadata(&compiled.parsed.scope_ref.borrow(), module_context, cb);
+            extract_module_metadata(
+                &compiled.parsed.arena.scopes[compiled.parsed.scope_ref],
+                module_context,
+                cb,
+            );
 
             let bytecode = match &mut compiled.bytecode {
                 CompiledProgramBytecode::Program(bytecode) | CompiledProgramBytecode::AsyncModule(bytecode) => bytecode,
             };
             extract_module_declarations(
-                &compiled.parsed.scope_ref.borrow(),
+                &compiled.parsed.arena.scopes[compiled.parsed.scope_ref],
                 vm_ptr,
                 source_code_ptr,
                 module_context,
@@ -1287,7 +1302,11 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
                 &mut bytecode.generator.function_table,
                 &compiled.parsed.arena,
             );
-            extract_requested_modules(&compiled.parsed.scope_ref.borrow(), module_context, cb);
+            extract_requested_modules(
+                &compiled.parsed.arena.scopes[compiled.parsed.scope_ref],
+                module_context,
+                cb,
+            );
 
             match &mut compiled.bytecode {
                 CompiledProgramBytecode::AsyncModule(bytecode) => {
@@ -1683,7 +1702,7 @@ unsafe fn extract_module_declarations(
                             .is_some_and(|n| arena.name_of(n).as_slice() == default_name.as_slice());
 
                     let function_data = function_table.take(fd.function_id);
-                    let subtable = function_table.extract_reachable(&function_data);
+                    let subtable = function_table.extract_reachable(&function_data, &arena.scopes);
                     let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
                         function_data,
                         subtable,
@@ -1769,7 +1788,7 @@ unsafe fn collect_module_var_names(
                 }
             }
             _ => {
-                for_each_child_statement(statement, &mut |child| {
+                for_each_child_statement(statement, arena, &mut |child| {
                     collect_module_var_names(child, ctx, push_var_name, arena);
                 });
             }
@@ -1844,16 +1863,17 @@ fn new_module_async_generator(source_len: usize, function_table: ast::FunctionTa
 
 fn compile_module_as_async_to_bytecode(
     program: &ast::Statement,
-    scope_ref: &Rc<RefCell<ast::ScopeData>>,
+    scope_id: ast::ScopeId,
     generator: &mut bytecode::generator::Generator,
 ) -> bytecode::generator::AssembledBytecode {
     use bytecode::instruction::Instruction;
 
-    let scope = scope_ref.borrow();
+    let arena_clone = generator.arena.clone();
+    let scope = &arena_clone.scopes[scope_id];
 
     // Extract local variables from the program scope so the executable has the correct registers_and_locals_count.
     // Without this, locals are not saved across await suspension points, causing them to become undefined.
-    generator.local_variables = convert_local_variables(&scope);
+    generator.local_variables = convert_local_variables(scope);
 
     let entry_block = generator.make_block();
     generator.switch_to_basic_block(entry_block);
@@ -1888,19 +1908,20 @@ fn compile_module_as_async_to_bytecode(
 
 unsafe fn compile_module_as_async(
     program: &ast::Statement,
-    scope_ref: &Rc<RefCell<ast::ScopeData>>,
+    scope_id: ast::ScopeId,
+    arena: std::sync::Arc<ast::AstArena>,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
-    _source: *const u16,
     source_len: usize,
     function_table: ast::FunctionTable,
 ) -> *mut c_void {
     unsafe {
         let mut generator = new_module_async_generator(source_len, function_table);
+        generator.arena = arena;
         generator.vm_ptr = vm_ptr;
         generator.source_code_ptr = source_code_ptr;
 
-        let assembled = compile_module_as_async_to_bytecode(program, scope_ref, &mut generator);
+        let assembled = compile_module_as_async_to_bytecode(program, scope_id, &mut generator);
         bytecode::ffi::create_executable(&mut generator, &assembled, vm_ptr, source_code_ptr)
     }
 }
@@ -1927,7 +1948,7 @@ fn collect_var_names_recursive(
             }
         }
         _ => {
-            for_each_child_statement(statement, &mut |child| {
+            for_each_child_statement(statement, arena, &mut |child| {
                 collect_var_names_recursive(child, arena, push_name);
             });
         }
@@ -1982,7 +2003,7 @@ fn extract_gdi_common(
             && last_position.get(&arena.identifiers[name_ident].name).copied() == Some(i)
         {
             let function_data = function_table.take(fd.function_id);
-            let subtable = function_table.extract_reachable(&function_data);
+            let subtable = function_table.extract_reachable(&function_data, &arena.scopes);
             let sfd_ptr = unsafe {
                 bytecode::ffi::create_sfd_for_gdi(
                     function_data,
@@ -2136,12 +2157,16 @@ unsafe fn extract_script_gdi(
 
 /// Visit each child statement of a statement, excluding function/class bodies
 /// (which create new var scopes). This enables recursive var-declaration walking.
-fn for_each_child_statement(statement: &ast::StatementKind, f: &mut dyn FnMut(&ast::StatementKind)) {
+fn for_each_child_statement(
+    statement: &ast::StatementKind,
+    arena: &ast::AstArena,
+    f: &mut dyn FnMut(&ast::StatementKind),
+) {
     use ast::StatementKind;
 
     match statement {
         StatementKind::Block(scope) => {
-            for child in &scope.borrow().children {
+            for child in &arena.scopes[*scope].children {
                 f(&child.inner);
             }
         }
@@ -2174,7 +2199,7 @@ fn for_each_child_statement(statement: &ast::StatementKind, f: &mut dyn FnMut(&a
         }
         StatementKind::Switch(data) => {
             for case in &data.cases {
-                for child in &case.scope.borrow().children {
+                for child in &arena.scopes[case.scope].children {
                     f(&child.inner);
                 }
             }
@@ -2313,9 +2338,9 @@ fn compile_function_payload_to_bytecode(
 ) -> (Box<ast::FunctionData>, Box<bytecode::generator::PrecompiledFunction>) {
     let function_data = Box::new(payload.data);
 
-    let body_scope = match &function_data.body.inner {
-        StatementKind::FunctionBody { scope, .. } => Some(scope),
-        StatementKind::Block(scope) => Some(scope),
+    let body_scope: Option<ast::ScopeId> = match &function_data.body.inner {
+        StatementKind::FunctionBody { scope, .. } => Some(*scope),
+        StatementKind::Block(scope) => Some(*scope),
         _ => None,
     };
 
@@ -2332,8 +2357,9 @@ fn compile_function_payload_to_bytecode(
     generator.source_len = source_len;
     generator.enclosing_function_kind = function_data.kind;
 
-    if let Some(scope) = body_scope {
-        generator.local_variables = convert_local_variables(&scope.borrow());
+    if let Some(scope_id) = body_scope {
+        let arena_clone = generator.arena.clone();
+        generator.local_variables = convert_local_variables(&arena_clone.scopes[scope_id]);
     }
 
     let entry_block = generator.make_block();
@@ -2355,11 +2381,12 @@ fn compile_function_payload_to_bytecode(
 
     generator.capture_saved_lexical_environment();
 
-    if let Some(scope) = body_scope {
+    if let Some(scope_id) = body_scope {
+        let arena_clone = generator.arena.clone();
         bytecode::codegen::emit_function_declaration_instantiation(
             &mut generator,
             &function_data,
-            &scope.borrow(),
+            &arena_clone.scopes[scope_id],
             sfd_metadata.var_environment_bindings_count,
         );
     }
@@ -2436,8 +2463,8 @@ fn compute_sfd_metadata(
     function_data: &ast::FunctionData,
     arena: &ast::AstArena,
 ) -> bytecode::generator::FunctionSfdMetadata {
-    let body_scope = match &function_data.body.inner {
-        ast::StatementKind::FunctionBody { scope, .. } => Some(scope),
+    let body_scope: Option<ast::ScopeId> = match &function_data.body.inner {
+        ast::StatementKind::FunctionBody { scope, .. } => Some(*scope),
         _ => None,
     };
 
@@ -2445,8 +2472,8 @@ fn compute_sfd_metadata(
     let is_arrow = function_data.is_arrow_function;
 
     // Extract all scope analysis data in one borrow.
-    let bsi = if let Some(scope) = &body_scope {
-        let sd = scope.borrow();
+    let bsi = if let Some(scope_id) = body_scope {
+        let sd = &arena.scopes[scope_id];
         let fsd = sd.function_scope_data.as_ref();
         BodyScopeInfo {
             uses_this: sd.uses_this || function_data.parsing_insights.uses_this,
@@ -2638,8 +2665,8 @@ unsafe fn write_sfd_metadata(sfd_ptr: *mut c_void, metadata: &bytecode::generato
 /// Count non-local lexically-declared identifiers in a function body scope.
 /// Returns the count (used for environment sizing in the function_environment_needed
 /// computation).
-fn count_non_local_lex_declarations(scope: &Rc<RefCell<ast::ScopeData>>, arena: &ast::AstArena) -> usize {
-    let sd = scope.borrow();
+fn count_non_local_lex_declarations(scope_id: ast::ScopeId, arena: &ast::AstArena) -> usize {
+    let sd = &arena.scopes[scope_id];
     let mut count = 0;
     for child in &sd.children {
         match &child.inner {

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -36,8 +36,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
     AstArena, BindingPattern, Expression, ExpressionKind, FunctionData, FunctionId, FunctionParameter, FunctionTable,
-    Identifier, IdentifierId, PrivateIdentifier, ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement,
-    StatementKind, Utf16String,
+    Identifier, IdentifierId, PrivateIdentifier, ProgramData, ScopeData, SourceRange, Statement, StatementKind,
+    StringId, Utf16String,
 };
 use crate::lexer::{Lexer, ch};
 use crate::scope_collector::{ScopeCollector, ScopeCollectorState};
@@ -250,7 +250,7 @@ pub struct Parser<'a> {
     /// Caller drains this after calling parse_binding_pattern.
     /// Each entry is (name, identifier) — allows scope analysis to annotate
     /// binding pattern identifiers with local variable info.
-    pub(crate) pattern_bound_names: Vec<(SharedUtf16String, IdentifierId)>,
+    pub(crate) pattern_bound_names: Vec<(StringId, IdentifierId)>,
 
     /// Set during synthesize_binding_pattern to allow MemberExpressions as binding targets.
     allow_member_expressions: bool,
@@ -386,19 +386,31 @@ impl<'a> Parser<'a> {
         function_id
     }
 
-    pub(crate) fn make_identifier(&mut self, start: Position, name: impl Into<SharedUtf16String>) -> IdentifierId {
-        let identifier = Identifier::new(self.range_from(start), name.into());
+    pub(crate) fn make_identifier(&mut self, start: Position, name: StringId) -> IdentifierId {
+        let identifier = Identifier::new(self.range_from(start), name);
         self.arena.identifiers.insert(identifier)
     }
 
-    pub(crate) fn token_identifier_name(&self, token: &Token) -> SharedUtf16String {
-        if let Some(value) = &token.shared_identifier_value {
-            value.clone()
-        } else if let Some(value) = &token.identifier_value {
-            SharedUtf16String::from(value.clone())
-        } else {
-            SharedUtf16String::from(self.token_value(token))
+    pub(crate) fn make_identifier_from_slice(&mut self, start: Position, name: &[u16]) -> IdentifierId {
+        let id = self.arena.strings.intern(name);
+        self.make_identifier(start, id)
+    }
+
+    pub(crate) fn intern(&mut self, value: &[u16]) -> StringId {
+        self.arena.strings.intern(value)
+    }
+
+    pub(crate) fn token_identifier_name(&mut self, token: &Token) -> StringId {
+        if let Some(value) = &token.identifier_value {
+            // Cheap-clone via Vec slicing because intern needs a slice but
+            // self.arena is borrowed.
+            let owned = value.clone();
+            return self.arena.strings.intern_owned(owned);
         }
+        let start = token.value_start as usize;
+        let end = start + token.value_len as usize;
+        let slice = &self.source[start..end];
+        self.arena.strings.intern(slice)
     }
 
     pub(crate) fn register_function_parameters_with_scope(
@@ -422,11 +434,7 @@ impl<'a> Parser<'a> {
                         info_index += 1;
                         (pi.name.clone(), pi.is_rest, pi.is_from_pattern)
                     } else {
-                        (
-                            self.arena.identifiers[*id].name.to_utf16_string(),
-                            parameter.is_rest,
-                            false,
-                        )
+                        (self.arena.name_of(*id).clone(), parameter.is_rest, false)
                     };
                     entries.push(ParameterEntry {
                         name,
@@ -467,7 +475,12 @@ impl<'a> Parser<'a> {
         let Self {
             scope_collector, arena, ..
         } = self;
-        scope_collector.set_function_parameters(&entries, has_parameter_expressions, &mut arena.identifiers);
+        scope_collector.set_function_parameters(
+            &entries,
+            has_parameter_expressions,
+            &mut arena.identifiers,
+            &arena.strings,
+        );
     }
 
     // === Token access ===
@@ -897,9 +910,6 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn token_value<'b>(&'b self, token: &'b Token) -> &'b [u16] {
-        if let Some(ref value) = token.shared_identifier_value {
-            return value.as_slice();
-        }
         if let Some(ref value) = token.identifier_value {
             return value;
         }
@@ -1108,7 +1118,7 @@ impl<'a> Parser<'a> {
         // Collect all declared names at module level.
         let mut declared_names: HashSet<Utf16String> = HashSet::new();
         for child in children {
-            collect_module_declared_names(child, &mut declared_names, &self.arena.identifiers);
+            collect_module_declared_names(child, &mut declared_names, &self.arena);
         }
 
         // Check each export's local bindings.
@@ -1366,14 +1376,14 @@ fn is_use_strict(raw: &[u16]) -> bool {
 fn collect_binding_names(
     target: &crate::ast::VariableDeclaratorTarget,
     names: &mut HashSet<Utf16String>,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     match target {
         crate::ast::VariableDeclaratorTarget::Identifier(identifier) => {
-            names.insert(identifiers[*identifier].name.to_utf16_string());
+            names.insert(arena.name_of(*identifier).clone());
         }
         crate::ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            collect_binding_pattern_names(pattern, names, identifiers);
+            collect_binding_pattern_names(pattern, names, arena);
         }
     }
 }
@@ -1382,21 +1392,21 @@ fn collect_binding_names(
 fn collect_binding_pattern_names(
     pattern: &crate::ast::BindingPattern,
     names: &mut HashSet<Utf16String>,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     for entry in &pattern.entries {
         if let Some(ref alias) = entry.alias {
             match alias {
                 crate::ast::BindingEntryAlias::Identifier(identifier) => {
-                    names.insert(identifiers[*identifier].name.to_utf16_string());
+                    names.insert(arena.name_of(*identifier).clone());
                 }
                 crate::ast::BindingEntryAlias::BindingPattern(nested) => {
-                    collect_binding_pattern_names(nested, names, identifiers);
+                    collect_binding_pattern_names(nested, names, arena);
                 }
                 crate::ast::BindingEntryAlias::MemberExpression(_) => {}
             }
         } else if let Some(crate::ast::BindingEntryName::Identifier(identifier)) = &entry.name {
-            names.insert(identifiers[*identifier].name.to_utf16_string());
+            names.insert(arena.name_of(*identifier).clone());
         }
     }
 }
@@ -1408,24 +1418,24 @@ fn collect_binding_pattern_names(
 fn collect_module_declared_names(
     statement: &crate::ast::Statement,
     names: &mut HashSet<Utf16String>,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) => {
             // All top-level declarations (var, let, const) are module-scoped.
             for decl in &data.declarations {
-                collect_binding_names(&decl.target, names, identifiers);
+                collect_binding_names(&decl.target, names, arena);
             }
         }
         StatementKind::FunctionDeclaration(data) => {
             if let Some(name) = data.name {
-                names.insert(identifiers[name].name.to_utf16_string());
+                names.insert(arena.name_of(name).clone());
             }
         }
         StatementKind::ClassDeclaration(data) => {
             if let Some(name) = data.name {
-                names.insert(identifiers[name].name.to_utf16_string());
+                names.insert(arena.name_of(name).clone());
             }
         }
         StatementKind::Import(data) => {
@@ -1435,12 +1445,12 @@ fn collect_module_declared_names(
         }
         StatementKind::Export(data) => {
             if let Some(ref stmt) = data.statement {
-                collect_module_declared_names(stmt, names, identifiers);
+                collect_module_declared_names(stmt, names, arena);
             }
         }
         // For any other statement, recurse to find hoisted var declarations.
         _ => {
-            collect_var_declared_names(statement, names, identifiers);
+            collect_var_declared_names(statement, names, arena);
         }
     }
 }
@@ -1452,62 +1462,62 @@ fn collect_module_declared_names(
 fn collect_var_declared_names(
     statement: &crate::ast::Statement,
     names: &mut HashSet<Utf16String>,
-    identifiers: &crate::ast::IdentifierArena,
+    arena: &crate::ast::AstArena,
 ) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) if matches!(data.kind, DeclarationKind::Var) => {
             for decl in &data.declarations {
-                collect_binding_names(&decl.target, names, identifiers);
+                collect_binding_names(&decl.target, names, arena);
             }
         }
         StatementKind::Block(scope) => {
             for child in &scope.borrow().children {
-                collect_var_declared_names(child, names, identifiers);
+                collect_var_declared_names(child, names, arena);
             }
         }
         StatementKind::If(data) => {
-            collect_var_declared_names(&data.consequent, names, identifiers);
+            collect_var_declared_names(&data.consequent, names, arena);
             if let Some(ref alt) = data.alternate {
-                collect_var_declared_names(alt, names, identifiers);
+                collect_var_declared_names(alt, names, arena);
             }
         }
         StatementKind::While(data) | StatementKind::DoWhile(data) => {
-            collect_var_declared_names(&data.body, names, identifiers);
+            collect_var_declared_names(&data.body, names, arena);
         }
         StatementKind::With(data) => {
-            collect_var_declared_names(&data.body, names, identifiers);
+            collect_var_declared_names(&data.body, names, arena);
         }
         StatementKind::For(data) => {
             if let Some(ForInit::Declaration(ref decl)) = data.init {
-                collect_var_declared_names(decl, names, identifiers);
+                collect_var_declared_names(decl, names, arena);
             }
-            collect_var_declared_names(&data.body, names, identifiers);
+            collect_var_declared_names(&data.body, names, arena);
         }
         StatementKind::ForInOf(data) => {
             if let ForInOfLhs::Declaration(ref decl) = data.lhs {
-                collect_var_declared_names(decl, names, identifiers);
+                collect_var_declared_names(decl, names, arena);
             }
-            collect_var_declared_names(&data.body, names, identifiers);
+            collect_var_declared_names(&data.body, names, arena);
         }
         StatementKind::Switch(data) => {
             for case in &data.cases {
                 for child in &case.scope.borrow().children {
-                    collect_var_declared_names(child, names, identifiers);
+                    collect_var_declared_names(child, names, arena);
                 }
             }
         }
         StatementKind::Try(data) => {
-            collect_var_declared_names(&data.block, names, identifiers);
+            collect_var_declared_names(&data.block, names, arena);
             if let Some(ref handler) = data.handler {
-                collect_var_declared_names(&handler.body, names, identifiers);
+                collect_var_declared_names(&handler.body, names, arena);
             }
             if let Some(ref finalizer) = data.finalizer {
-                collect_var_declared_names(finalizer, names, identifiers);
+                collect_var_declared_names(finalizer, names, arena);
             }
         }
         StatementKind::Labelled(data) => {
-            collect_var_declared_names(&data.item, names, identifiers);
+            collect_var_declared_names(&data.item, names, arena);
         }
         // Don't recurse into functions (var doesn't hoist out of functions).
         // Don't recurse into let/const (they are block-scoped, not hoisted).

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -32,7 +32,7 @@
 //! save and restore the full parser state including lexer position, current
 //! token, error list, and all boolean flags.
 
-use std::collections::{HashMap, HashSet};
+use crate::fast_hash::{HashMap, HashSet};
 
 use crate::ast::{
     AstArena, BindingPattern, Expression, ExpressionKind, FunctionData, FunctionId, FunctionParameter, FunctionTable,
@@ -323,7 +323,7 @@ impl<'a> Parser<'a> {
             flags: ParserFlags::default(),
             initiated_by_eval: false,
             in_eval_function_context: false,
-            labels_in_scope: HashMap::new(),
+            labels_in_scope: HashMap::default(),
             last_inner_label_is_iteration: false,
             last_primary_was_parenthesized: false,
             last_function_name: Utf16String::default(),
@@ -340,11 +340,11 @@ impl<'a> Parser<'a> {
             for_loop_declaration_is_var: false,
             for_loop_declaration_is_pattern: false,
             scope_collector: ScopeCollector::new(),
-            exported_names: HashSet::new(),
+            exported_names: HashSet::default(),
             function_table: FunctionTable::new(),
             arena: AstArena::new(),
             function_context_stack: Vec::new(),
-            arrow_function_failed_positions: HashSet::new(),
+            arrow_function_failed_positions: HashSet::default(),
         }
     }
 
@@ -880,7 +880,7 @@ impl<'a> Parser<'a> {
     /// Check for duplicate parameter names in arrow functions.
     /// Arrow functions always reject duplicates, regardless of strict mode.
     pub(crate) fn check_arrow_duplicate_parameters(&mut self, parameter_info: &[ParamInfo]) {
-        let mut seen_names: HashSet<&[u16]> = HashSet::new();
+        let mut seen_names: HashSet<&[u16]> = HashSet::default();
         for pi in parameter_info {
             let name = &pi.name;
             if name.is_empty() {
@@ -903,7 +903,7 @@ impl<'a> Parser<'a> {
         force_strict: bool,
         _kind: FunctionKind,
     ) {
-        let mut seen_names: HashSet<&[u16]> = HashSet::new();
+        let mut seen_names: HashSet<&[u16]> = HashSet::default();
         for pi in parameter_info {
             let name = &pi.name;
             if name.is_empty() {
@@ -1124,7 +1124,7 @@ impl<'a> Parser<'a> {
         use crate::ast::*;
 
         // Collect all declared names at module level.
-        let mut declared_names: HashSet<Utf16String> = HashSet::new();
+        let mut declared_names: HashSet<Utf16String> = HashSet::default();
         for child in children {
             collect_module_declared_names(child, &mut declared_names, &self.arena);
         }

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -36,8 +36,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
     AstArena, BindingPattern, Expression, ExpressionKind, FunctionData, FunctionId, FunctionParameter, FunctionTable,
-    Identifier, IdentifierId, PrivateIdentifier, ProgramData, ScopeData, SourceRange, Statement, StatementKind,
-    StringId, Utf16String,
+    Identifier, IdentifierId, PrivateIdentifier, ProgramData, ScopeData, ScopeId, SourceRange, Statement,
+    StatementKind, StringId, Utf16String,
 };
 use crate::lexer::{Lexer, ch};
 use crate::scope_collector::{ScopeCollector, ScopeCollectorState};
@@ -396,8 +396,15 @@ impl<'a> Parser<'a> {
         self.make_identifier(start, id)
     }
 
-    pub(crate) fn intern(&mut self, value: &[u16]) -> StringId {
-        self.arena.strings.intern(value)
+    pub(crate) fn make_scope(&mut self, children: Vec<Statement>) -> ScopeId {
+        self.arena.scopes.insert(ScopeData {
+            children,
+            ..ScopeData::default()
+        })
+    }
+
+    pub(crate) fn make_empty_scope(&mut self) -> ScopeId {
+        self.arena.scopes.insert(ScopeData::default())
     }
 
     pub(crate) fn token_identifier_name(&mut self, token: &Token) -> StringId {
@@ -480,6 +487,7 @@ impl<'a> Parser<'a> {
             has_parameter_expressions,
             &mut arena.identifiers,
             &arena.strings,
+            &mut arena.scopes,
         );
     }
 
@@ -1010,10 +1018,10 @@ impl<'a> Parser<'a> {
 
         if self.program_type == ProgramType::Script {
             let (children, is_strict) = self.parse_script(starts_in_strict_mode);
-            let scope = ScopeData::shared_with_children(children);
+            let scope = self.make_scope(children);
             // Scope was opened in parse_script via open_program_scope.
             // Now close it after children are set.
-            self.scope_collector.set_scope_node(scope.clone());
+            self.scope_collector.set_scope_node(scope);
             self.scope_collector.close_scope();
             self.statement(
                 start,
@@ -1026,8 +1034,8 @@ impl<'a> Parser<'a> {
             )
         } else {
             let (children, has_top_level_await) = self.parse_module();
-            let scope = ScopeData::shared_with_children(children);
-            self.scope_collector.set_scope_node(scope.clone());
+            let scope = self.make_scope(children);
+            self.scope_collector.set_scope_node(scope);
             self.scope_collector.close_scope();
             self.statement(
                 start,
@@ -1472,7 +1480,7 @@ fn collect_var_declared_names(
             }
         }
         StatementKind::Block(scope) => {
-            for child in &scope.borrow().children {
+            for child in &arena.scopes[*scope].children {
                 collect_var_declared_names(child, names, arena);
             }
         }
@@ -1502,7 +1510,7 @@ fn collect_var_declared_names(
         }
         StatementKind::Switch(data) => {
             for case in &data.cases {
-                for child in &case.scope.borrow().children {
+                for child in &arena.scopes[case.scope].children {
                     collect_var_declared_names(child, names, arena);
                 }
             }

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -467,7 +467,7 @@ impl<'a> Parser<'a> {
         let Self {
             scope_collector, arena, ..
         } = self;
-        scope_collector.set_function_parameters(&entries, has_parameter_expressions, &arena.identifiers);
+        scope_collector.set_function_parameters(&entries, has_parameter_expressions, &mut arena.identifiers);
     }
 
     // === Token access ===

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -34,11 +34,10 @@
 
 use std::collections::{HashMap, HashSet};
 
-use std::rc::Rc;
-
 use crate::ast::{
-    BindingPattern, Expression, ExpressionKind, FunctionData, FunctionId, FunctionParameter, FunctionTable, Identifier,
-    PrivateIdentifier, ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement, StatementKind, Utf16String,
+    AstArena, BindingPattern, Expression, ExpressionKind, FunctionData, FunctionId, FunctionParameter, FunctionTable,
+    Identifier, IdentifierId, PrivateIdentifier, ProgramData, ScopeData, SharedUtf16String, SourceRange, Statement,
+    StatementKind, Utf16String,
 };
 use crate::lexer::{Lexer, ch};
 use crate::scope_collector::{ScopeCollector, ScopeCollectorState};
@@ -74,7 +73,7 @@ pub struct ParamInfo {
     pub name: Utf16String,
     pub is_rest: bool,
     pub is_from_pattern: bool,
-    pub identifier: Option<Rc<Identifier>>,
+    pub identifier: Option<IdentifierId>,
 }
 
 /// Result of parsing a property key (object literal or class element).
@@ -251,7 +250,7 @@ pub struct Parser<'a> {
     /// Caller drains this after calling parse_binding_pattern.
     /// Each entry is (name, identifier) — allows scope analysis to annotate
     /// binding pattern identifiers with local variable info.
-    pub(crate) pattern_bound_names: Vec<(SharedUtf16String, Rc<Identifier>)>,
+    pub(crate) pattern_bound_names: Vec<(SharedUtf16String, IdentifierId)>,
 
     /// Set during synthesize_binding_pattern to allow MemberExpressions as binding targets.
     allow_member_expressions: bool,
@@ -284,6 +283,10 @@ pub struct Parser<'a> {
 
     /// Side table owning all FunctionData produced during parsing.
     pub function_table: FunctionTable,
+
+    /// Bulk storage for identifiers, scopes, and interned strings. Replaces
+    /// the old per-node `Rc<Identifier>` heap allocations.
+    pub arena: AstArena,
 
     /// Stack of nested function ids discovered while parsing each active function.
     ///
@@ -339,6 +342,7 @@ impl<'a> Parser<'a> {
             scope_collector: ScopeCollector::new(),
             exported_names: HashSet::new(),
             function_table: FunctionTable::new(),
+            arena: AstArena::new(),
             function_context_stack: Vec::new(),
             arrow_function_failed_positions: HashSet::new(),
         }
@@ -382,8 +386,9 @@ impl<'a> Parser<'a> {
         function_id
     }
 
-    pub(crate) fn make_identifier(&self, start: Position, name: impl Into<SharedUtf16String>) -> Rc<Identifier> {
-        Rc::new(Identifier::new(self.range_from(start), name.into()))
+    pub(crate) fn make_identifier(&mut self, start: Position, name: impl Into<SharedUtf16String>) -> IdentifierId {
+        let identifier = Identifier::new(self.range_from(start), name.into());
+        self.arena.identifiers.insert(identifier)
     }
 
     pub(crate) fn token_identifier_name(&self, token: &Token) -> SharedUtf16String {
@@ -417,11 +422,15 @@ impl<'a> Parser<'a> {
                         info_index += 1;
                         (pi.name.clone(), pi.is_rest, pi.is_from_pattern)
                     } else {
-                        (id.name.to_utf16_string(), parameter.is_rest, false)
+                        (
+                            self.arena.identifiers[*id].name.to_utf16_string(),
+                            parameter.is_rest,
+                            false,
+                        )
                     };
                     entries.push(ParameterEntry {
                         name,
-                        identifier: Some(id.clone()),
+                        identifier: Some(*id),
                         is_rest,
                         is_from_pattern,
                         is_first_from_pattern: false,
@@ -445,7 +454,7 @@ impl<'a> Parser<'a> {
                         let pi = &parameter_info[info_index];
                         entries.push(ParameterEntry {
                             name: pi.name.clone(),
-                            identifier: pi.identifier.clone(),
+                            identifier: pi.identifier,
                             is_rest: pi.is_rest,
                             is_from_pattern: true,
                             is_first_from_pattern: false,
@@ -455,8 +464,10 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        self.scope_collector
-            .set_function_parameters(&entries, has_parameter_expressions);
+        let Self {
+            scope_collector, arena, ..
+        } = self;
+        scope_collector.set_function_parameters(&entries, has_parameter_expressions, &arena.identifiers);
     }
 
     // === Token access ===
@@ -1097,7 +1108,7 @@ impl<'a> Parser<'a> {
         // Collect all declared names at module level.
         let mut declared_names: HashSet<Utf16String> = HashSet::new();
         for child in children {
-            collect_module_declared_names(child, &mut declared_names);
+            collect_module_declared_names(child, &mut declared_names, &self.arena.identifiers);
         }
 
         // Check each export's local bindings.
@@ -1352,32 +1363,40 @@ fn is_use_strict(raw: &[u16]) -> bool {
 }
 
 /// Collect all binding names introduced by a variable declarator target.
-fn collect_binding_names(target: &crate::ast::VariableDeclaratorTarget, names: &mut HashSet<Utf16String>) {
+fn collect_binding_names(
+    target: &crate::ast::VariableDeclaratorTarget,
+    names: &mut HashSet<Utf16String>,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     match target {
         crate::ast::VariableDeclaratorTarget::Identifier(identifier) => {
-            names.insert(identifier.name.to_utf16_string());
+            names.insert(identifiers[*identifier].name.to_utf16_string());
         }
         crate::ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
-            collect_binding_pattern_names(pattern, names);
+            collect_binding_pattern_names(pattern, names, identifiers);
         }
     }
 }
 
 /// Collect all binding names from a binding pattern (object or array destructuring).
-fn collect_binding_pattern_names(pattern: &crate::ast::BindingPattern, names: &mut HashSet<Utf16String>) {
+fn collect_binding_pattern_names(
+    pattern: &crate::ast::BindingPattern,
+    names: &mut HashSet<Utf16String>,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     for entry in &pattern.entries {
         if let Some(ref alias) = entry.alias {
             match alias {
                 crate::ast::BindingEntryAlias::Identifier(identifier) => {
-                    names.insert(identifier.name.to_utf16_string());
+                    names.insert(identifiers[*identifier].name.to_utf16_string());
                 }
                 crate::ast::BindingEntryAlias::BindingPattern(nested) => {
-                    collect_binding_pattern_names(nested, names);
+                    collect_binding_pattern_names(nested, names, identifiers);
                 }
                 crate::ast::BindingEntryAlias::MemberExpression(_) => {}
             }
         } else if let Some(crate::ast::BindingEntryName::Identifier(identifier)) = &entry.name {
-            names.insert(identifier.name.to_utf16_string());
+            names.insert(identifiers[*identifier].name.to_utf16_string());
         }
     }
 }
@@ -1386,23 +1405,27 @@ fn collect_binding_pattern_names(pattern: &crate::ast::BindingPattern, names: &m
 /// This includes lexical declarations (let/const), function/class declarations, imports,
 /// and also `var` declarations which hoist to module scope even when nested inside
 /// blocks, loops, if/else, etc.
-fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut HashSet<Utf16String>) {
+fn collect_module_declared_names(
+    statement: &crate::ast::Statement,
+    names: &mut HashSet<Utf16String>,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) => {
             // All top-level declarations (var, let, const) are module-scoped.
             for decl in &data.declarations {
-                collect_binding_names(&decl.target, names);
+                collect_binding_names(&decl.target, names, identifiers);
             }
         }
         StatementKind::FunctionDeclaration(data) => {
-            if let Some(ref name) = data.name {
-                names.insert(name.name.to_utf16_string());
+            if let Some(name) = data.name {
+                names.insert(identifiers[name].name.to_utf16_string());
             }
         }
         StatementKind::ClassDeclaration(data) => {
-            if let Some(ref name) = data.name {
-                names.insert(name.name.to_utf16_string());
+            if let Some(name) = data.name {
+                names.insert(identifiers[name].name.to_utf16_string());
             }
         }
         StatementKind::Import(data) => {
@@ -1412,12 +1435,12 @@ fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut 
         }
         StatementKind::Export(data) => {
             if let Some(ref stmt) = data.statement {
-                collect_module_declared_names(stmt, names);
+                collect_module_declared_names(stmt, names, identifiers);
             }
         }
         // For any other statement, recurse to find hoisted var declarations.
         _ => {
-            collect_var_declared_names(statement, names);
+            collect_var_declared_names(statement, names, identifiers);
         }
     }
 }
@@ -1426,61 +1449,65 @@ fn collect_module_declared_names(statement: &crate::ast::Statement, names: &mut 
 /// `var` declarations are hoisted to the enclosing function/module scope,
 /// so we must walk into blocks, loops, if/else, switch, try/catch, etc.
 /// We do NOT walk into function bodies since `var` does not hoist out of functions.
-fn collect_var_declared_names(statement: &crate::ast::Statement, names: &mut HashSet<Utf16String>) {
+fn collect_var_declared_names(
+    statement: &crate::ast::Statement,
+    names: &mut HashSet<Utf16String>,
+    identifiers: &crate::ast::IdentifierArena,
+) {
     use crate::ast::*;
     match &statement.inner {
         StatementKind::VariableDeclaration(data) if matches!(data.kind, DeclarationKind::Var) => {
             for decl in &data.declarations {
-                collect_binding_names(&decl.target, names);
+                collect_binding_names(&decl.target, names, identifiers);
             }
         }
         StatementKind::Block(scope) => {
             for child in &scope.borrow().children {
-                collect_var_declared_names(child, names);
+                collect_var_declared_names(child, names, identifiers);
             }
         }
         StatementKind::If(data) => {
-            collect_var_declared_names(&data.consequent, names);
+            collect_var_declared_names(&data.consequent, names, identifiers);
             if let Some(ref alt) = data.alternate {
-                collect_var_declared_names(alt, names);
+                collect_var_declared_names(alt, names, identifiers);
             }
         }
         StatementKind::While(data) | StatementKind::DoWhile(data) => {
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, identifiers);
         }
         StatementKind::With(data) => {
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, identifiers);
         }
         StatementKind::For(data) => {
             if let Some(ForInit::Declaration(ref decl)) = data.init {
-                collect_var_declared_names(decl, names);
+                collect_var_declared_names(decl, names, identifiers);
             }
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, identifiers);
         }
         StatementKind::ForInOf(data) => {
             if let ForInOfLhs::Declaration(ref decl) = data.lhs {
-                collect_var_declared_names(decl, names);
+                collect_var_declared_names(decl, names, identifiers);
             }
-            collect_var_declared_names(&data.body, names);
+            collect_var_declared_names(&data.body, names, identifiers);
         }
         StatementKind::Switch(data) => {
             for case in &data.cases {
                 for child in &case.scope.borrow().children {
-                    collect_var_declared_names(child, names);
+                    collect_var_declared_names(child, names, identifiers);
                 }
             }
         }
         StatementKind::Try(data) => {
-            collect_var_declared_names(&data.block, names);
+            collect_var_declared_names(&data.block, names, identifiers);
             if let Some(ref handler) = data.handler {
-                collect_var_declared_names(&handler.body, names);
+                collect_var_declared_names(&handler.body, names, identifiers);
             }
             if let Some(ref finalizer) = data.finalizer {
-                collect_var_declared_names(finalizer, names);
+                collect_var_declared_names(finalizer, names, identifiers);
             }
         }
         StatementKind::Labelled(data) => {
-            collect_var_declared_names(&data.item, names);
+            collect_var_declared_names(&data.item, names, identifiers);
         }
         // Don't recurse into functions (var doesn't hoist out of functions).
         // Don't recurse into let/const (they are block-scoped, not hoisted).

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -6,7 +6,6 @@
 
 //! Declaration parsing: variables, functions, classes, imports, exports.
 
-use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::*;
@@ -160,6 +159,7 @@ impl Parser<'_> {
                         Some(DeclarationKind::Var),
                         &mut arena.identifiers,
                         &arena.strings,
+                        &mut arena.scopes,
                     );
                 } else {
                     self.scope_collector.add_lexical_declaration(
@@ -170,7 +170,13 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, Some(kind), &mut arena.identifiers, &arena.strings);
+                    scope_collector.register_identifier(
+                        id,
+                        Some(kind),
+                        &mut arena.identifiers,
+                        &arena.strings,
+                        &mut arena.scopes,
+                    );
                 }
 
                 VariableDeclaratorTarget::Identifier(id)
@@ -218,6 +224,7 @@ impl Parser<'_> {
                         None,
                         &mut arena.identifiers,
                         &arena.strings,
+                        &mut arena.scopes,
                     );
                 } else {
                     let refs: Vec<&[u16]> = name_strs.iter().map(|n| n.as_slice()).collect();
@@ -231,7 +238,13 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &mut arena.identifiers, &arena.strings);
+                        scope_collector.register_identifier(
+                            *id,
+                            None,
+                            &mut arena.identifiers,
+                            &arena.strings,
+                            &mut arena.scopes,
+                        );
                     }
                 }
 
@@ -332,7 +345,7 @@ impl Parser<'_> {
             let Self {
                 scope_collector, arena, ..
             } = self;
-            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings, &mut arena.scopes);
 
             let init = if self.match_token(TokenType::Equals) {
                 self.consume();
@@ -425,6 +438,7 @@ impl Parser<'_> {
             declaration_column,
             &mut arena.identifiers,
             &arena.strings,
+            &mut arena.scopes,
         );
 
         let fn_name_for_scope = if fn_name.is_empty() {
@@ -453,7 +467,7 @@ impl Parser<'_> {
                 function_id,
                 name: decl_name,
                 kind: decl_kind,
-                is_hoisted: Cell::new(false),
+                is_hoisted: false,
             })),
         )
     }
@@ -496,7 +510,7 @@ impl Parser<'_> {
             let Self {
                 scope_collector, arena, ..
             } = self;
-            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings, &mut arena.scopes);
         }
 
         // Open function scope (function expression name is bound within its own scope).
@@ -754,7 +768,13 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(name_ident, None, &mut arena.identifiers, &arena.strings);
+                    scope_collector.register_identifier(
+                        name_ident,
+                        None,
+                        &mut arena.identifiers,
+                        &arena.strings,
+                        &mut arena.scopes,
+                    );
                 }
                 self.statement(start, StatementKind::ClassDeclaration(data))
             }
@@ -794,10 +814,8 @@ impl Parser<'_> {
                 })),
             );
             let return_statement = self.statement(start, StatementKind::Return(Some(Box::new(super_call))));
-            let body = self.statement(
-                start,
-                StatementKind::Block(ScopeData::shared_with_children(vec![return_statement])),
-            );
+            let body_scope = self.make_scope(vec![return_statement]);
+            let body = self.statement(start, StatementKind::Block(body_scope));
 
             let arguments_binding = self
                 .arena
@@ -828,7 +846,8 @@ impl Parser<'_> {
             });
             self.expression(start, ExpressionKind::Function(function_id))
         } else {
-            let body = self.statement(start, StatementKind::Block(ScopeData::shared_with_children(Vec::new())));
+            let body_scope = self.make_scope(Vec::new());
+            let body = self.statement(start, StatementKind::Block(body_scope));
 
             let function_id = self.insert_function_data(FunctionData {
                 name: ctor_name,
@@ -887,8 +906,8 @@ impl Parser<'_> {
                     let children = self.parse_statement_list(false);
                     self.flags = saved_flags;
                     self.consume_token(TokenType::CurlyClose);
-                    let scope = ScopeData::shared_with_children(children);
-                    self.scope_collector.set_scope_node(scope.clone());
+                    let scope = self.make_scope(children);
+                    self.scope_collector.set_scope_node(scope);
                     self.scope_collector.close_scope();
                     // C++ uses rule_start (class start) for FunctionBody position.
                     let body = self.statement(
@@ -1194,8 +1213,8 @@ impl Parser<'_> {
 
         self.consume_token(TokenType::CurlyClose);
 
-        let scope = ScopeData::shared_with_children(children);
-        self.scope_collector.set_scope_node(scope.clone());
+        let scope = self.make_scope(children);
+        self.scope_collector.set_scope_node(scope);
 
         let body = self.statement(
             start,
@@ -1499,7 +1518,13 @@ impl Parser<'_> {
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                            scope_collector.register_identifier(
+                                id,
+                                None,
+                                &mut arena.identifiers,
+                                &arena.strings,
+                                &mut arena.scopes,
+                            );
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else if self.match_token(TokenType::BigIntLiteral) {
                             let token = self.consume_property_key_token();
@@ -1513,7 +1538,13 @@ impl Parser<'_> {
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                            scope_collector.register_identifier(
+                                id,
+                                None,
+                                &mut arena.identifiers,
+                                &arena.strings,
+                                &mut arena.scopes,
+                            );
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else {
                             let token = self.consume_property_key_token();
@@ -1523,7 +1554,13 @@ impl Parser<'_> {
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                            scope_collector.register_identifier(
+                                id,
+                                None,
+                                &mut arena.identifiers,
+                                &arena.strings,
+                                &mut arena.scopes,
+                            );
                             entry_name = Some(BindingEntryName::Identifier(id));
                         }
                     } else if self.match_token(TokenType::BracketOpen) {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -25,12 +25,12 @@ fn expression_into_identifier(expression: Expression) -> IdentifierId {
 }
 
 /// Extract bound names from a declaration for export statements.
-fn get_declaration_export_names(statement: &Statement, identifiers: &IdentifierArena) -> Vec<Utf16String> {
+fn get_declaration_export_names(statement: &Statement, arena: &AstArena) -> Vec<Utf16String> {
     match &statement.inner {
         StatementKind::VariableDeclaration(vd) => {
             let mut names = Vec::new();
             for declaration in &vd.declarations {
-                collect_declarator_names(&declaration.target, &mut names, identifiers);
+                collect_declarator_names(&declaration.target, &mut names, arena);
             }
             names
         }
@@ -38,21 +38,21 @@ fn get_declaration_export_names(statement: &Statement, identifiers: &IdentifierA
             let mut names = Vec::new();
             for declaration in declarations.iter() {
                 if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
-                    names.push(identifiers[*id].name.to_utf16_string());
+                    names.push(arena.name_of(*id).clone());
                 }
             }
             names
         }
         StatementKind::FunctionDeclaration(fd) => {
             if let Some(name) = fd.name {
-                vec![identifiers[name].name.to_utf16_string()]
+                vec![arena.name_of(name).clone()]
             } else {
                 Vec::new()
             }
         }
         StatementKind::ClassDeclaration(class) => {
             if let Some(name) = class.name {
-                vec![identifiers[name].name.to_utf16_string()]
+                vec![arena.name_of(name).clone()]
             } else {
                 Vec::new()
             }
@@ -61,28 +61,24 @@ fn get_declaration_export_names(statement: &Statement, identifiers: &IdentifierA
     }
 }
 
-fn collect_declarator_names(
-    target: &VariableDeclaratorTarget,
-    names: &mut Vec<Utf16String>,
-    identifiers: &IdentifierArena,
-) {
+fn collect_declarator_names(target: &VariableDeclaratorTarget, names: &mut Vec<Utf16String>, arena: &AstArena) {
     match target {
-        VariableDeclaratorTarget::Identifier(id) => names.push(identifiers[*id].name.to_utf16_string()),
-        VariableDeclaratorTarget::BindingPattern(pat) => collect_pattern_names(pat, names, identifiers),
+        VariableDeclaratorTarget::Identifier(id) => names.push(arena.name_of(*id).clone()),
+        VariableDeclaratorTarget::BindingPattern(pat) => collect_pattern_names(pat, names, arena),
     }
 }
 
-fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>, identifiers: &IdentifierArena) {
+fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>, arena: &AstArena) {
     for entry in &pat.entries {
         match &entry.alias {
-            Some(BindingEntryAlias::Identifier(id)) => names.push(identifiers[*id].name.to_utf16_string()),
-            Some(BindingEntryAlias::BindingPattern(nested)) => collect_pattern_names(nested, names, identifiers),
+            Some(BindingEntryAlias::Identifier(id)) => names.push(arena.name_of(*id).clone()),
+            Some(BindingEntryAlias::BindingPattern(nested)) => collect_pattern_names(nested, names, arena),
             _ => {}
         }
         if entry.alias.is_none()
             && let Some(BindingEntryName::Identifier(id)) = &entry.name
         {
-            names.push(identifiers[*id].name.to_utf16_string());
+            names.push(arena.name_of(*id).clone());
         }
     }
 }
@@ -146,42 +142,49 @@ impl Parser<'_> {
             let target = if self.match_identifier() {
                 let token = self.consume();
                 let name = self.token_identifier_name(&token);
-                self.check_identifier_name_for_assignment_validity(&name, false);
-                if kind != DeclarationKind::Var && *name == *utf16!("let") {
+                let name_str = self.arena.strings[name].clone();
+                self.check_identifier_name_for_assignment_validity(name_str.as_slice(), false);
+                if kind != DeclarationKind::Var && name_str.as_slice() == utf16!("let") {
                     self.syntax_error("Lexical binding may not be called 'let'");
                 }
-                let id = self.make_identifier(declaration_start, name.clone());
+                let id = self.make_identifier(declaration_start, name);
 
                 if kind == DeclarationKind::Var {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
                     scope_collector.add_var_declaration(
-                        &[(name.as_slice(), Some(id))],
+                        &[(name_str.as_slice(), Some(id))],
                         declaration_line,
                         declaration_column,
                         Some(DeclarationKind::Var),
                         &mut arena.identifiers,
+                        &arena.strings,
                     );
                 } else {
                     self.scope_collector.add_lexical_declaration(
-                        &[name.as_slice()],
+                        &[name_str.as_slice()],
                         declaration_line,
                         declaration_column,
                     );
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, Some(kind), &mut arena.identifiers);
+                    scope_collector.register_identifier(id, Some(kind), &mut arena.identifiers, &arena.strings);
                 }
 
                 VariableDeclaratorTarget::Identifier(id)
             } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 let pat = self.parse_binding_pattern();
                 let bound_names = std::mem::take(&mut self.pattern_bound_names);
+                // Materialize slices for scope-collector calls (which key on Utf16String).
+                let name_strs: Vec<Utf16String> = bound_names
+                    .iter()
+                    .map(|(n, _)| self.arena.strings[*n].clone())
+                    .collect();
 
-                for (name, _) in &bound_names {
-                    self.check_identifier_name_for_assignment_validity(name, false);
+                for name in &name_strs {
+                    self.check_identifier_name_for_assignment_validity(name.as_slice(), false);
                     if kind != DeclarationKind::Var && name.as_slice() == utf16!("let") {
                         self.syntax_error("Lexical binding may not be called 'let'");
                     }
@@ -189,7 +192,7 @@ impl Parser<'_> {
 
                 if kind != DeclarationKind::Var {
                     let mut seen: HashSet<&[u16]> = HashSet::new();
-                    for (name, _) in &bound_names {
+                    for name in &name_strs {
                         if !seen.insert(name.as_slice()) {
                             self.syntax_error("Duplicate parameter names in bindings");
                         }
@@ -198,8 +201,11 @@ impl Parser<'_> {
 
                 // Register bound names with scope collector.
                 if kind == DeclarationKind::Var {
-                    let entries: Vec<(&[u16], Option<IdentifierId>)> =
-                        bound_names.iter().map(|(n, id)| (n.as_slice(), Some(*id))).collect();
+                    let entries: Vec<(&[u16], Option<IdentifierId>)> = name_strs
+                        .iter()
+                        .zip(bound_names.iter())
+                        .map(|(n, (_, id))| (n.as_slice(), Some(*id)))
+                        .collect();
                     // NOTE: Binding pattern identifiers don't get declaration_kind,
                     // matching C++ behavior where only simple identifiers do.
                     let Self {
@@ -211,9 +217,10 @@ impl Parser<'_> {
                         declaration_column,
                         None,
                         &mut arena.identifiers,
+                        &arena.strings,
                     );
                 } else {
-                    let refs: Vec<&[u16]> = bound_names.iter().map(|(n, _)| n.as_slice()).collect();
+                    let refs: Vec<&[u16]> = name_strs.iter().map(|n| n.as_slice()).collect();
                     self.scope_collector
                         .add_lexical_declaration(&refs, declaration_line, declaration_column);
                     // Register each binding pattern identifier for scope analysis
@@ -224,7 +231,7 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &mut arena.identifiers);
+                        scope_collector.register_identifier(*id, None, &mut arena.identifiers, &arena.strings);
                     }
                 }
 
@@ -232,7 +239,8 @@ impl Parser<'_> {
             } else {
                 self.expected("identifier or a binding pattern");
                 self.consume();
-                let id = self.make_identifier(declaration_start, Vec::new());
+                let empty = self.arena.strings.intern(&[]);
+                let id = self.make_identifier(declaration_start, empty);
                 VariableDeclaratorTarget::Identifier(id)
             };
 
@@ -308,22 +316,23 @@ impl Parser<'_> {
             }
             let token = self.consume();
             let name = self.token_identifier_name(&token);
+            let name_str = self.arena.strings[name].clone();
 
-            self.check_identifier_name_for_assignment_validity(&name, false);
-            if *name == *utf16!("let") {
+            self.check_identifier_name_for_assignment_validity(name_str.as_slice(), false);
+            if name_str.as_slice() == utf16!("let") {
                 self.syntax_error("Lexical binding may not be called 'let'");
             }
 
-            let id = self.make_identifier(declaration_start, name.clone());
+            let id = self.make_identifier(declaration_start, name);
 
             self.scope_collector
-                .add_lexical_declaration(&[name.as_slice()], declaration_line, declaration_column);
+                .add_lexical_declaration(&[name_str.as_slice()], declaration_line, declaration_column);
             // C++ calls parse_lexical_binding() without declaration_kind for using,
             // so we pass None to match.
             let Self {
                 scope_collector, arena, ..
             } = self;
-            scope_collector.register_identifier(id, None, &mut arena.identifiers);
+            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
 
             let init = if self.match_token(TokenType::Equals) {
                 self.consume();
@@ -387,12 +396,15 @@ impl Parser<'_> {
         let (name, fn_name) = if self.has_default_export_name && !self.match_identifier() {
             let default_name = Utf16String::from(utf16!("*default*"));
             self.last_function_name = default_name.clone();
-            (Some(self.make_identifier(start, default_name.clone())), default_name)
+            (
+                Some(self.make_identifier_from_slice(start, default_name.as_slice())),
+                default_name,
+            )
         } else if self.match_identifier() {
             let token = self.consume();
             let value = Utf16String::from(self.token_value(&token));
             self.last_function_name = value.clone();
-            (Some(self.make_identifier(start, value.clone())), value)
+            (Some(self.make_identifier_from_slice(start, value.as_slice())), value)
         } else {
             self.last_function_name.0.clear();
             (None, Utf16String::default())
@@ -412,6 +424,7 @@ impl Parser<'_> {
             declaration_line,
             declaration_column,
             &mut arena.identifiers,
+            &arena.strings,
         );
 
         let fn_name_for_scope = if fn_name.is_empty() {
@@ -464,13 +477,13 @@ impl Parser<'_> {
         let name = if self.match_identifier() {
             let token = self.consume();
             fn_name_value = Utf16String::from(self.token_value(&token));
-            Some(self.make_identifier(start, fn_name_value.clone()))
+            Some(self.make_identifier_from_slice(start, fn_name_value.as_slice()))
         } else if self.match_token(TokenType::Yield) || self.match_token(TokenType::Await) {
             // C++ explicitly allows yield/await as function expression names
             // even inside generator/async contexts, then validates after.
             let token = self.consume();
             fn_name_value = Utf16String::from(self.token_value(&token));
-            Some(self.make_identifier(start, fn_name_value.clone()))
+            Some(self.make_identifier_from_slice(start, fn_name_value.as_slice()))
         } else {
             None
         };
@@ -483,7 +496,7 @@ impl Parser<'_> {
             let Self {
                 scope_collector, arena, ..
             } = self;
-            scope_collector.register_identifier(id, None, &mut arena.identifiers);
+            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
         }
 
         // Open function scope (function expression name is bound within its own scope).
@@ -615,7 +628,7 @@ impl Parser<'_> {
                 let token = self.consume();
                 let value = Utf16String::from(self.token_value(&token));
                 self.last_class_name = value.clone();
-                (Some(self.make_identifier(start, value.clone())), value)
+                (Some(self.make_identifier_from_slice(start, value.as_slice())), value)
             } else if expect_name {
                 self.expected("class name");
                 self.last_class_name.0.clear();
@@ -735,13 +748,13 @@ impl Parser<'_> {
                 // binds the name for self-reference. The outer scope needs the name
                 // registered as a lexical declaration so it's visible to sibling code.
                 if let Some(name_ident) = data.name {
-                    let name_slice = self.arena.identifiers[name_ident].name.clone();
+                    let name_slice = self.arena.name_of(name_ident).clone();
                     self.scope_collector
                         .add_lexical_declaration(&[name_slice.as_slice()], start.line, start.column);
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(name_ident, None, &mut arena.identifiers);
+                    scope_collector.register_identifier(name_ident, None, &mut arena.identifiers, &arena.strings);
                 }
                 self.statement(start, StatementKind::ClassDeclaration(data))
             }
@@ -755,7 +768,7 @@ impl Parser<'_> {
     //   - Derived class: constructor(...arguments) { super(...arguments); }
     fn synthesize_default_constructor(&mut self, start: Position, class_name: &[u16], has_super: bool) -> Expression {
         let ctor_name = if !class_name.is_empty() {
-            Some(self.make_identifier(start, Utf16String::from(class_name)))
+            Some(self.make_identifier_from_slice(start, class_name))
         } else {
             None
         };
@@ -764,12 +777,10 @@ impl Parser<'_> {
         // is stored in the SFD and compiled lazily — scope analysis runs at that point.
 
         if has_super {
-            let arguments_name = Utf16String::from(utf16!("args"));
+            let arguments_name_id = self.arena.strings.intern(utf16!("args"));
+            let range = self.range_from(start);
 
-            let arguments_ref = self
-                .arena
-                .identifiers
-                .insert(Identifier::new(self.range_from(start), arguments_name.clone().into()));
+            let arguments_ref = self.arena.identifiers.insert(Identifier::new(range, arguments_name_id));
             let arguments_expression = self.expression(start, ExpressionKind::Identifier(arguments_ref));
 
             let super_call = self.expression(
@@ -791,7 +802,7 @@ impl Parser<'_> {
             let arguments_binding = self
                 .arena
                 .identifiers
-                .insert(Identifier::new(self.range_from(start), arguments_name.into()));
+                .insert(Identifier::new(self.range_from(start), arguments_name_id));
             let parameters = vec![FunctionParameter {
                 binding: FunctionParameterBinding::Identifier(arguments_binding),
                 default_value: None,
@@ -1289,9 +1300,11 @@ impl Parser<'_> {
                 (FunctionParameterBinding::Identifier(id), false)
             } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 let pat = self.parse_binding_pattern();
-                for (n, id) in std::mem::take(&mut self.pattern_bound_names) {
+                let bound_names = std::mem::take(&mut self.pattern_bound_names);
+                for (n, id) in bound_names {
+                    let name = self.arena.strings[n].clone();
                     parameter_info.push(ParamInfo {
-                        name: n.to_utf16_string(),
+                        name,
                         is_rest: rest,
                         is_from_pattern: true,
                         identifier: Some(id),
@@ -1301,10 +1314,11 @@ impl Parser<'_> {
             } else {
                 self.expected("parameter name");
                 self.consume();
-                let id = self.arena.identifiers.insert(Identifier::new(
-                    self.range_from(parameter_start),
-                    Utf16String::default().into(),
-                ));
+                let empty = self.arena.strings.intern(&[]);
+                let id = self
+                    .arena
+                    .identifiers
+                    .insert(Identifier::new(self.range_from(parameter_start), empty));
                 (FunctionParameterBinding::Identifier(id), false)
             };
 
@@ -1459,7 +1473,7 @@ impl Parser<'_> {
                     }
                 } else {
                     let mut needs_alias = false;
-                    let mut entry_name_value = SharedUtf16String::default();
+                    let mut entry_name_value: Option<StringId> = None;
                     let mut entry_is_keyword = false;
 
                     if self.match_identifier_name()
@@ -1481,35 +1495,35 @@ impl Parser<'_> {
                         if self.match_token(TokenType::StringLiteral) {
                             let token = self.consume_property_key_token();
                             let (value, _has_octal) = self.parse_string_value(&token);
-                            let id = self.make_identifier(entry_start, value);
+                            let id = self.make_identifier_from_slice(entry_start, value.as_slice());
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else if self.match_token(TokenType::BigIntLiteral) {
                             let token = self.consume_property_key_token();
                             let value = self.token_value(&token);
-                            let name_value = if value.last() == Some(&ch(b'n')) {
+                            let name_value: Vec<u16> = if value.last() == Some(&ch(b'n')) {
                                 value[..value.len() - 1].to_vec()
                             } else {
                                 value.to_vec()
                             };
-                            let id = self.make_identifier(entry_start, name_value);
+                            let id = self.make_identifier_from_slice(entry_start, &name_value);
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else {
                             let token = self.consume_property_key_token();
                             let name = self.token_identifier_name(&token);
-                            entry_name_value = name.clone();
+                            entry_name_value = Some(name);
                             let id = self.make_identifier(entry_start, name);
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                            scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         }
                     } else if self.match_token(TokenType::BracketOpen) {
@@ -1550,7 +1564,7 @@ impl Parser<'_> {
                             let alias_start = self.position();
                             let token = self.consume();
                             let name = self.token_identifier_name(&token);
-                            let id = self.make_identifier(alias_start, name.clone());
+                            let id = self.make_identifier(alias_start, name);
                             self.pattern_bound_names.push((name, id));
                             entry_alias = Some(BindingEntryAlias::Identifier(id));
                         } else {
@@ -1560,13 +1574,13 @@ impl Parser<'_> {
                     } else if needs_alias {
                         self.expected("alias for string or numeric literal name");
                         break;
-                    } else if !entry_name_value.is_empty() {
+                    } else if let Some(name_id) = entry_name_value {
                         // Shorthand: name is the bound identifier.
                         if entry_is_keyword {
                             self.syntax_error("Binding pattern target may not be a reserved word");
                         }
                         if let Some(BindingEntryName::Identifier(id)) = entry_name {
-                            self.pattern_bound_names.push((entry_name_value, id));
+                            self.pattern_bound_names.push((name_id, id));
                         }
                     }
                 }
@@ -1584,7 +1598,7 @@ impl Parser<'_> {
                     entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
                 } else if Self::is_identifier(&expression) {
                     let id = expression_into_identifier(expression);
-                    let name = self.arena.identifiers[id].name.clone();
+                    let name = self.arena.identifiers[id].name;
                     self.pattern_bound_names.push((name, id));
                     entry_alias = Some(BindingEntryAlias::Identifier(id));
                 } else {
@@ -1598,7 +1612,7 @@ impl Parser<'_> {
                 let alias_start = self.position();
                 let token = self.consume();
                 let name = self.token_identifier_name(&token);
-                let id = self.make_identifier(alias_start, name.clone());
+                let id = self.make_identifier(alias_start, name);
                 self.pattern_bound_names.push((name, id));
                 entry_alias = Some(BindingEntryAlias::Identifier(id));
             } else {
@@ -1842,7 +1856,7 @@ impl Parser<'_> {
                     && let StatementKind::FunctionDeclaration(ref fd) = declaration.inner
                     && let Some(name_id) = fd.name
                 {
-                    local_name = Some(self.arena.identifiers[name_id].name.to_utf16_string());
+                    local_name = Some(self.arena.name_of(name_id).clone());
                 }
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Class) {
@@ -1852,7 +1866,7 @@ impl Parser<'_> {
                     if let StatementKind::ClassDeclaration(ref class) = declaration.inner
                         && let Some(name_id) = class.name
                     {
-                        local_name = Some(self.arena.identifiers[name_id].name.to_utf16_string());
+                        local_name = Some(self.arena.name_of(name_id).clone());
                     }
                     statement = Some(Box::new(declaration));
                 } else {
@@ -1925,7 +1939,7 @@ impl Parser<'_> {
                 check_for_from = FromSpecifier::Required;
             } else if self.match_declaration() {
                 let declaration = self.parse_declaration();
-                let names = get_declaration_export_names(&declaration, &self.arena.identifiers);
+                let names = get_declaration_export_names(&declaration, &self.arena);
                 for name in &names {
                     entries.push(ExportEntry {
                         kind: ExportEntryKind::NamedExport,
@@ -1936,7 +1950,7 @@ impl Parser<'_> {
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Var) {
                 let var_declaration = self.parse_variable_declaration(false);
-                let names = get_declaration_export_names(&var_declaration, &self.arena.identifiers);
+                let names = get_declaration_export_names(&var_declaration, &self.arena);
                 for name in &names {
                     entries.push(ExportEntry {
                         kind: ExportEntryKind::NamedExport,

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -6,7 +6,7 @@
 
 //! Declaration parsing: variables, functions, classes, imports, exports.
 
-use std::collections::{HashMap, HashSet};
+use crate::fast_hash::{HashMap, HashSet};
 
 use crate::ast::*;
 use crate::lexer::ch;
@@ -197,7 +197,7 @@ impl Parser<'_> {
                 }
 
                 if kind != DeclarationKind::Var {
-                    let mut seen: HashSet<&[u16]> = HashSet::new();
+                    let mut seen: HashSet<&[u16]> = HashSet::default();
                     for name in &name_strs {
                         if !seen.insert(name.as_slice()) {
                             self.syntax_error("Duplicate parameter names in bindings");
@@ -682,9 +682,9 @@ impl Parser<'_> {
         self.consume_token(TokenType::CurlyOpen);
         let mut elements: Vec<Node<ClassElement>> = Vec::new();
         let mut constructor: Option<Expression> = None;
-        let mut found_private_names: HashMap<Utf16String, (Option<ClassMethodKind>, bool)> = HashMap::new();
+        let mut found_private_names: HashMap<Utf16String, (Option<ClassMethodKind>, bool)> = HashMap::default();
 
-        self.referenced_private_names_stack.push(HashSet::new());
+        self.referenced_private_names_stack.push(HashSet::default());
 
         let saved_class_has_super = self.class_has_super_class;
         self.class_has_super_class = super_class.is_some();
@@ -1379,7 +1379,7 @@ impl Parser<'_> {
 
         // Validate duplicates after parsing so we can use borrowed name slices
         // from `parameter_info` without cloning each entry into the HashSet.
-        let mut seen_parameter_names: HashSet<&[u16]> = HashSet::new();
+        let mut seen_parameter_names: HashSet<&[u16]> = HashSet::default();
         let mut has_seen_non_simple = false;
         for (start, end, parameter_is_non_simple) in parameter_info_ranges {
             for info in &parameter_info[start..end] {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -161,7 +161,7 @@ impl Parser<'_> {
                         declaration_line,
                         declaration_column,
                         Some(DeclarationKind::Var),
-                        &arena.identifiers,
+                        &mut arena.identifiers,
                     );
                 } else {
                     self.scope_collector.add_lexical_declaration(
@@ -172,7 +172,7 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, Some(kind), &arena.identifiers);
+                    scope_collector.register_identifier(id, Some(kind), &mut arena.identifiers);
                 }
 
                 VariableDeclaratorTarget::Identifier(id)
@@ -210,7 +210,7 @@ impl Parser<'_> {
                         declaration_line,
                         declaration_column,
                         None,
-                        &arena.identifiers,
+                        &mut arena.identifiers,
                     );
                 } else {
                     let refs: Vec<&[u16]> = bound_names.iter().map(|(n, _)| n.as_slice()).collect();
@@ -224,7 +224,7 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &arena.identifiers);
+                        scope_collector.register_identifier(*id, None, &mut arena.identifiers);
                     }
                 }
 
@@ -323,7 +323,7 @@ impl Parser<'_> {
             let Self {
                 scope_collector, arena, ..
             } = self;
-            scope_collector.register_identifier(id, None, &arena.identifiers);
+            scope_collector.register_identifier(id, None, &mut arena.identifiers);
 
             let init = if self.match_token(TokenType::Equals) {
                 self.consume();
@@ -411,7 +411,7 @@ impl Parser<'_> {
             strict,
             declaration_line,
             declaration_column,
-            &arena.identifiers,
+            &mut arena.identifiers,
         );
 
         let fn_name_for_scope = if fn_name.is_empty() {
@@ -483,7 +483,7 @@ impl Parser<'_> {
             let Self {
                 scope_collector, arena, ..
             } = self;
-            scope_collector.register_identifier(id, None, &arena.identifiers);
+            scope_collector.register_identifier(id, None, &mut arena.identifiers);
         }
 
         // Open function scope (function expression name is bound within its own scope).
@@ -741,7 +741,7 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(name_ident, None, &arena.identifiers);
+                    scope_collector.register_identifier(name_ident, None, &mut arena.identifiers);
                 }
                 self.statement(start, StatementKind::ClassDeclaration(data))
             }
@@ -1485,7 +1485,7 @@ impl Parser<'_> {
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &arena.identifiers);
+                            scope_collector.register_identifier(id, None, &mut arena.identifiers);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else if self.match_token(TokenType::BigIntLiteral) {
                             let token = self.consume_property_key_token();
@@ -1499,7 +1499,7 @@ impl Parser<'_> {
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &arena.identifiers);
+                            scope_collector.register_identifier(id, None, &mut arena.identifiers);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else {
                             let token = self.consume_property_key_token();
@@ -1509,7 +1509,7 @@ impl Parser<'_> {
                             let Self {
                                 scope_collector, arena, ..
                             } = self;
-                            scope_collector.register_identifier(id, None, &arena.identifiers);
+                            scope_collector.register_identifier(id, None, &mut arena.identifiers);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         }
                     } else if self.match_token(TokenType::BracketOpen) {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -8,7 +8,6 @@
 
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
 
 use crate::ast::*;
 use crate::lexer::ch;
@@ -18,7 +17,7 @@ use crate::parser::{
 };
 use crate::token::TokenType;
 
-fn expression_into_identifier(expression: Expression) -> Rc<Identifier> {
+fn expression_into_identifier(expression: Expression) -> IdentifierId {
     match expression.inner {
         ExpressionKind::Identifier(id) => id,
         _ => unreachable!("expected Identifier expression"),
@@ -26,12 +25,12 @@ fn expression_into_identifier(expression: Expression) -> Rc<Identifier> {
 }
 
 /// Extract bound names from a declaration for export statements.
-fn get_declaration_export_names(statement: &Statement) -> Vec<Utf16String> {
+fn get_declaration_export_names(statement: &Statement, identifiers: &IdentifierArena) -> Vec<Utf16String> {
     match &statement.inner {
         StatementKind::VariableDeclaration(vd) => {
             let mut names = Vec::new();
             for declaration in &vd.declarations {
-                collect_declarator_names(&declaration.target, &mut names);
+                collect_declarator_names(&declaration.target, &mut names, identifiers);
             }
             names
         }
@@ -39,21 +38,21 @@ fn get_declaration_export_names(statement: &Statement) -> Vec<Utf16String> {
             let mut names = Vec::new();
             for declaration in declarations.iter() {
                 if let VariableDeclaratorTarget::Identifier(id) = &declaration.target {
-                    names.push(id.name.to_utf16_string());
+                    names.push(identifiers[*id].name.to_utf16_string());
                 }
             }
             names
         }
         StatementKind::FunctionDeclaration(fd) => {
-            if let Some(ref name) = fd.name {
-                vec![name.name.to_utf16_string()]
+            if let Some(name) = fd.name {
+                vec![identifiers[name].name.to_utf16_string()]
             } else {
                 Vec::new()
             }
         }
         StatementKind::ClassDeclaration(class) => {
-            if let Some(ref name) = class.name {
-                vec![name.name.to_utf16_string()]
+            if let Some(name) = class.name {
+                vec![identifiers[name].name.to_utf16_string()]
             } else {
                 Vec::new()
             }
@@ -62,24 +61,28 @@ fn get_declaration_export_names(statement: &Statement) -> Vec<Utf16String> {
     }
 }
 
-fn collect_declarator_names(target: &VariableDeclaratorTarget, names: &mut Vec<Utf16String>) {
+fn collect_declarator_names(
+    target: &VariableDeclaratorTarget,
+    names: &mut Vec<Utf16String>,
+    identifiers: &IdentifierArena,
+) {
     match target {
-        VariableDeclaratorTarget::Identifier(id) => names.push(id.name.to_utf16_string()),
-        VariableDeclaratorTarget::BindingPattern(pat) => collect_pattern_names(pat, names),
+        VariableDeclaratorTarget::Identifier(id) => names.push(identifiers[*id].name.to_utf16_string()),
+        VariableDeclaratorTarget::BindingPattern(pat) => collect_pattern_names(pat, names, identifiers),
     }
 }
 
-fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>) {
+fn collect_pattern_names(pat: &BindingPattern, names: &mut Vec<Utf16String>, identifiers: &IdentifierArena) {
     for entry in &pat.entries {
         match &entry.alias {
-            Some(BindingEntryAlias::Identifier(id)) => names.push(id.name.to_utf16_string()),
-            Some(BindingEntryAlias::BindingPattern(nested)) => collect_pattern_names(nested, names),
+            Some(BindingEntryAlias::Identifier(id)) => names.push(identifiers[*id].name.to_utf16_string()),
+            Some(BindingEntryAlias::BindingPattern(nested)) => collect_pattern_names(nested, names, identifiers),
             _ => {}
         }
         if entry.alias.is_none()
             && let Some(BindingEntryName::Identifier(id)) = &entry.name
         {
-            names.push(id.name.to_utf16_string());
+            names.push(identifiers[*id].name.to_utf16_string());
         }
     }
 }
@@ -150,11 +153,15 @@ impl Parser<'_> {
                 let id = self.make_identifier(declaration_start, name.clone());
 
                 if kind == DeclarationKind::Var {
-                    self.scope_collector.add_var_declaration(
-                        &[(name.as_slice(), Some(id.clone()))],
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    scope_collector.add_var_declaration(
+                        &[(name.as_slice(), Some(id))],
                         declaration_line,
                         declaration_column,
                         Some(DeclarationKind::Var),
+                        &arena.identifiers,
                     );
                 } else {
                     self.scope_collector.add_lexical_declaration(
@@ -162,7 +169,10 @@ impl Parser<'_> {
                         declaration_line,
                         declaration_column,
                     );
-                    self.scope_collector.register_identifier(id.clone(), Some(kind));
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    scope_collector.register_identifier(id, Some(kind), &arena.identifiers);
                 }
 
                 VariableDeclaratorTarget::Identifier(id)
@@ -188,14 +198,20 @@ impl Parser<'_> {
 
                 // Register bound names with scope collector.
                 if kind == DeclarationKind::Var {
-                    let entries: Vec<(&[u16], Option<Rc<Identifier>>)> = bound_names
-                        .iter()
-                        .map(|(n, id)| (n.as_slice(), Some(id.clone())))
-                        .collect();
+                    let entries: Vec<(&[u16], Option<IdentifierId>)> =
+                        bound_names.iter().map(|(n, id)| (n.as_slice(), Some(*id))).collect();
                     // NOTE: Binding pattern identifiers don't get declaration_kind,
                     // matching C++ behavior where only simple identifiers do.
-                    self.scope_collector
-                        .add_var_declaration(&entries, declaration_line, declaration_column, None);
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    scope_collector.add_var_declaration(
+                        &entries,
+                        declaration_line,
+                        declaration_column,
+                        None,
+                        &arena.identifiers,
+                    );
                 } else {
                     let refs: Vec<&[u16]> = bound_names.iter().map(|(n, _)| n.as_slice()).collect();
                     self.scope_collector
@@ -204,8 +220,11 @@ impl Parser<'_> {
                     // so they get is_local() annotations.
                     // NOTE: C++ does not pass declaration_kind for binding pattern identifiers,
                     // only for simple identifier declarations.
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
                     for (_name, id) in &bound_names {
-                        self.scope_collector.register_identifier(id.clone(), None);
+                        scope_collector.register_identifier(*id, None, &arena.identifiers);
                     }
                 }
 
@@ -301,7 +320,10 @@ impl Parser<'_> {
                 .add_lexical_declaration(&[name.as_slice()], declaration_line, declaration_column);
             // C++ calls parse_lexical_binding() without declaration_kind for using,
             // so we pass None to match.
-            self.scope_collector.register_identifier(id.clone(), None);
+            let Self {
+                scope_collector, arena, ..
+            } = self;
+            scope_collector.register_identifier(id, None, &arena.identifiers);
 
             let init = if self.match_token(TokenType::Equals) {
                 self.consume();
@@ -378,13 +400,18 @@ impl Parser<'_> {
         self.last_function_kind = kind;
 
         // Register function declaration in parent scope (before opening function scope).
-        self.scope_collector.add_function_declaration(
+        let strict = self.flags.strict_mode;
+        let Self {
+            scope_collector, arena, ..
+        } = self;
+        scope_collector.add_function_declaration(
             &fn_name,
-            name.clone(),
+            name,
             kind,
-            self.flags.strict_mode,
+            strict,
             declaration_line,
             declaration_column,
+            &arena.identifiers,
         );
 
         let fn_name_for_scope = if fn_name.is_empty() {
@@ -404,7 +431,7 @@ impl Parser<'_> {
             start,
             saved_might_need_arguments,
         );
-        let decl_name = fd.name.clone();
+        let decl_name = fd.name;
         let decl_kind = fd.kind;
         let function_id = self.insert_function_data(fd);
         self.statement(
@@ -452,8 +479,11 @@ impl Parser<'_> {
         // This must happen before open_function_scope so that the identifier group
         // exists with declaration_kind=None, preventing later var declarations
         // with the same name from setting a spurious declaration_kind.
-        if let Some(ref id) = name {
-            self.scope_collector.register_identifier(id.clone(), None);
+        if let Some(id) = name {
+            let Self {
+                scope_collector, arena, ..
+            } = self;
+            scope_collector.register_identifier(id, None, &arena.identifiers);
         }
 
         // Open function scope (function expression name is bound within its own scope).
@@ -482,7 +512,7 @@ impl Parser<'_> {
     #[allow(clippy::too_many_arguments)]
     fn parse_function_common(
         &mut self,
-        name: Option<Rc<Identifier>>,
+        name: Option<IdentifierId>,
         fn_name: &[u16],
         kind: FunctionKind,
         is_async: bool,
@@ -704,13 +734,14 @@ impl Parser<'_> {
                 // The inner class scope (opened/closed inside parse_class_expression)
                 // binds the name for self-reference. The outer scope needs the name
                 // registered as a lexical declaration so it's visible to sibling code.
-                if let Some(ref name_ident) = data.name {
-                    self.scope_collector.add_lexical_declaration(
-                        &[&name_ident.name as &[u16]],
-                        start.line,
-                        start.column,
-                    );
-                    self.scope_collector.register_identifier(name_ident.clone(), None);
+                if let Some(name_ident) = data.name {
+                    let name_slice = self.arena.identifiers[name_ident].name.clone();
+                    self.scope_collector
+                        .add_lexical_declaration(&[name_slice.as_slice()], start.line, start.column);
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    scope_collector.register_identifier(name_ident, None, &arena.identifiers);
                 }
                 self.statement(start, StatementKind::ClassDeclaration(data))
             }
@@ -735,7 +766,10 @@ impl Parser<'_> {
         if has_super {
             let arguments_name = Utf16String::from(utf16!("args"));
 
-            let arguments_ref = Rc::new(Identifier::new(self.range_from(start), arguments_name.clone().into()));
+            let arguments_ref = self
+                .arena
+                .identifiers
+                .insert(Identifier::new(self.range_from(start), arguments_name.clone().into()));
             let arguments_expression = self.expression(start, ExpressionKind::Identifier(arguments_ref));
 
             let super_call = self.expression(
@@ -754,7 +788,10 @@ impl Parser<'_> {
                 StatementKind::Block(ScopeData::shared_with_children(vec![return_statement])),
             );
 
-            let arguments_binding = Rc::new(Identifier::new(self.range_from(start), arguments_name.into()));
+            let arguments_binding = self
+                .arena
+                .identifiers
+                .insert(Identifier::new(self.range_from(start), arguments_name.into()));
             let parameters = vec![FunctionParameter {
                 binding: FunctionParameterBinding::Identifier(arguments_binding),
                 default_value: None,
@@ -1238,15 +1275,16 @@ impl Parser<'_> {
                 if !is_arrow {
                     self.check_identifier_name_for_assignment_validity(&value, false);
                 }
-                let id = Rc::new(Identifier::new(
-                    self.range_from(formal_parameters_start),
-                    self.token_identifier_name(&token),
-                ));
+                let name = self.token_identifier_name(&token);
+                let id = self
+                    .arena
+                    .identifiers
+                    .insert(Identifier::new(self.range_from(formal_parameters_start), name));
                 parameter_info.push(ParamInfo {
                     name: value,
                     is_rest: rest,
                     is_from_pattern: false,
-                    identifier: Some(id.clone()),
+                    identifier: Some(id),
                 });
                 (FunctionParameterBinding::Identifier(id), false)
             } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
@@ -1263,7 +1301,7 @@ impl Parser<'_> {
             } else {
                 self.expected("parameter name");
                 self.consume();
-                let id = Rc::new(Identifier::new(
+                let id = self.arena.identifiers.insert(Identifier::new(
                     self.range_from(parameter_start),
                     Utf16String::default().into(),
                 ));
@@ -1444,7 +1482,10 @@ impl Parser<'_> {
                             let token = self.consume_property_key_token();
                             let (value, _has_octal) = self.parse_string_value(&token);
                             let id = self.make_identifier(entry_start, value);
-                            self.scope_collector.register_identifier(id.clone(), None);
+                            let Self {
+                                scope_collector, arena, ..
+                            } = self;
+                            scope_collector.register_identifier(id, None, &arena.identifiers);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else if self.match_token(TokenType::BigIntLiteral) {
                             let token = self.consume_property_key_token();
@@ -1455,14 +1496,20 @@ impl Parser<'_> {
                                 value.to_vec()
                             };
                             let id = self.make_identifier(entry_start, name_value);
-                            self.scope_collector.register_identifier(id.clone(), None);
+                            let Self {
+                                scope_collector, arena, ..
+                            } = self;
+                            scope_collector.register_identifier(id, None, &arena.identifiers);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         } else {
                             let token = self.consume_property_key_token();
                             let name = self.token_identifier_name(&token);
                             entry_name_value = name.clone();
                             let id = self.make_identifier(entry_start, name);
-                            self.scope_collector.register_identifier(id.clone(), None);
+                            let Self {
+                                scope_collector, arena, ..
+                            } = self;
+                            scope_collector.register_identifier(id, None, &arena.identifiers);
                             entry_name = Some(BindingEntryName::Identifier(id));
                         }
                     } else if self.match_token(TokenType::BracketOpen) {
@@ -1504,7 +1551,7 @@ impl Parser<'_> {
                             let token = self.consume();
                             let name = self.token_identifier_name(&token);
                             let id = self.make_identifier(alias_start, name.clone());
-                            self.pattern_bound_names.push((name, id.clone()));
+                            self.pattern_bound_names.push((name, id));
                             entry_alias = Some(BindingEntryAlias::Identifier(id));
                         } else {
                             self.expected("identifier or binding pattern");
@@ -1518,8 +1565,8 @@ impl Parser<'_> {
                         if entry_is_keyword {
                             self.syntax_error("Binding pattern target may not be a reserved word");
                         }
-                        if let Some(BindingEntryName::Identifier(ref id)) = entry_name {
-                            self.pattern_bound_names.push((entry_name_value, id.clone()));
+                        if let Some(BindingEntryName::Identifier(id)) = entry_name {
+                            self.pattern_bound_names.push((entry_name_value, id));
                         }
                     }
                 }
@@ -1537,7 +1584,8 @@ impl Parser<'_> {
                     entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
                 } else if Self::is_identifier(&expression) {
                     let id = expression_into_identifier(expression);
-                    self.pattern_bound_names.push((id.name.clone(), id.clone()));
+                    let name = self.arena.identifiers[id].name.clone();
+                    self.pattern_bound_names.push((name, id));
                     entry_alias = Some(BindingEntryAlias::Identifier(id));
                 } else {
                     self.syntax_error("Invalid destructuring assignment target");
@@ -1551,7 +1599,7 @@ impl Parser<'_> {
                 let token = self.consume();
                 let name = self.token_identifier_name(&token);
                 let id = self.make_identifier(alias_start, name.clone());
-                self.pattern_bound_names.push((name, id.clone()));
+                self.pattern_bound_names.push((name, id));
                 entry_alias = Some(BindingEntryAlias::Identifier(id));
             } else {
                 self.expected("identifier or binding pattern");
@@ -1792,9 +1840,9 @@ impl Parser<'_> {
                 let declaration = self.parse_function_declaration_for_export(has_default_name);
                 if !has_default_name
                     && let StatementKind::FunctionDeclaration(ref fd) = declaration.inner
-                    && let Some(ref name_id) = fd.name
+                    && let Some(name_id) = fd.name
                 {
-                    local_name = Some(name_id.name.to_utf16_string());
+                    local_name = Some(self.arena.identifiers[name_id].name.to_utf16_string());
                 }
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Class) {
@@ -1802,9 +1850,9 @@ impl Parser<'_> {
                 if next.token_type != TokenType::CurlyOpen && next.token_type != TokenType::Extends {
                     let declaration = self.parse_class_declaration();
                     if let StatementKind::ClassDeclaration(ref class) = declaration.inner
-                        && let Some(ref name_id) = class.name
+                        && let Some(name_id) = class.name
                     {
-                        local_name = Some(name_id.name.to_utf16_string());
+                        local_name = Some(self.arena.identifiers[name_id].name.to_utf16_string());
                     }
                     statement = Some(Box::new(declaration));
                 } else {
@@ -1877,7 +1925,7 @@ impl Parser<'_> {
                 check_for_from = FromSpecifier::Required;
             } else if self.match_declaration() {
                 let declaration = self.parse_declaration();
-                let names = get_declaration_export_names(&declaration);
+                let names = get_declaration_export_names(&declaration, &self.arena.identifiers);
                 for name in &names {
                     entries.push(ExportEntry {
                         kind: ExportEntryKind::NamedExport,
@@ -1888,7 +1936,7 @@ impl Parser<'_> {
                 statement = Some(Box::new(declaration));
             } else if self.match_token(TokenType::Var) {
                 let var_declaration = self.parse_variable_declaration(false);
-                let names = get_declaration_export_names(&var_declaration);
+                let names = get_declaration_export_names(&var_declaration, &self.arena.identifiers);
                 for name in &names {
                     entries.push(ExportEntry {
                         kind: ExportEntryKind::NamedExport,

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -8,6 +8,7 @@
 //! precedence climbing.
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::ast::*;
 use crate::lexer::ch;
@@ -615,10 +616,10 @@ impl Parser<'_> {
         };
         self.validate_regex_flags(&flags);
         let compiled_regex = match crate::bytecode::ffi::compile_regex(&pattern, &flags) {
-            Ok(handle) => Rc::new(CompiledRegex::new(handle)),
+            Ok(handle) => Arc::new(CompiledRegex::new(handle)),
             Err(msg) => {
                 self.syntax_error_at_position(&msg, start);
-                Rc::new(CompiledRegex::new(std::ptr::null_mut()))
+                Arc::new(CompiledRegex::new(std::ptr::null_mut()))
             }
         };
         self.expression(

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -454,7 +454,7 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers);
                 (self.expression(start, ExpressionKind::Identifier(id)), true)
             }
 
@@ -594,7 +594,7 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, None, &arena.identifiers);
+                    scope_collector.register_identifier(id, None, &mut arena.identifiers);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else if self.match_token(TokenType::EscapedKeyword) {
                     self.syntax_error("Keyword must not contain escaped characters");
@@ -604,7 +604,7 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, None, &arena.identifiers);
+                    scope_collector.register_identifier(id, None, &mut arena.identifiers);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else {
                     self.expected("primary expression");
@@ -822,7 +822,7 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &arena.identifiers);
+                        scope_collector.register_identifier(*id, None, &mut arena.identifiers);
                     }
                     self.pattern_bound_names = saved_bound_names;
                     self.consume();
@@ -1624,7 +1624,7 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers);
             }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             self.consume(); // consume '='
@@ -1660,7 +1660,7 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers);
             }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             return ObjectProperty {

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -454,7 +454,13 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                scope_collector.register_identifier(
+                    id,
+                    None,
+                    &mut arena.identifiers,
+                    &arena.strings,
+                    &mut arena.scopes,
+                );
                 (self.expression(start, ExpressionKind::Identifier(id)), true)
             }
 
@@ -594,7 +600,13 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                    scope_collector.register_identifier(
+                        id,
+                        None,
+                        &mut arena.identifiers,
+                        &arena.strings,
+                        &mut arena.scopes,
+                    );
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else if self.match_token(TokenType::EscapedKeyword) {
                     self.syntax_error("Keyword must not contain escaped characters");
@@ -604,7 +616,13 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                    scope_collector.register_identifier(
+                        id,
+                        None,
+                        &mut arena.identifiers,
+                        &arena.strings,
+                        &mut arena.scopes,
+                    );
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else {
                     self.expected("primary expression");
@@ -823,7 +841,13 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &mut arena.identifiers, &arena.strings);
+                        scope_collector.register_identifier(
+                            *id,
+                            None,
+                            &mut arena.identifiers,
+                            &arena.strings,
+                            &mut arena.scopes,
+                        );
                     }
                     self.pattern_bound_names = saved_bound_names;
                     self.consume();
@@ -1628,7 +1652,13 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                scope_collector.register_identifier(
+                    id,
+                    None,
+                    &mut arena.identifiers,
+                    &arena.strings,
+                    &mut arena.scopes,
+                );
             }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             self.consume(); // consume '='
@@ -1664,7 +1694,13 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                scope_collector.register_identifier(
+                    id,
+                    None,
+                    &mut arena.identifiers,
+                    &arena.strings,
+                    &mut arena.scopes,
+                );
             }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             return ObjectProperty {
@@ -2368,8 +2404,8 @@ impl Parser<'_> {
                 self.range_from(start),
                 StatementKind::Return(Some(Box::new(expression))),
             );
-            let scope = ScopeData::shared_with_children(vec![return_statement]);
-            self.scope_collector.set_scope_node(scope.clone());
+            let scope = self.make_scope(vec![return_statement]);
+            self.scope_collector.set_scope_node(scope);
             let body = Statement::new(
                 self.range_from(start),
                 StatementKind::FunctionBody {

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -7,7 +7,6 @@
 //! Expression parsing: primary, secondary (binary/postfix), unary, and
 //! precedence climbing.
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::ast::*;
@@ -178,16 +177,19 @@ impl Parser<'_> {
         // C++ checks for freestanding `arguments` references here (after
         // parse_primary_expression), NOT during consume(). This avoids
         // falsely flagging parameter names like `function f(arguments)`.
-        if let ExpressionKind::Identifier(ref id) = expression.inner
-            && id.name == utf16!("arguments")
+        if let ExpressionKind::Identifier(id) = expression.inner
+            && self.arena.identifiers[id].name == utf16!("arguments")
         {
             // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
             // It is a Syntax Error if ContainsArguments of ClassStaticBlockBody is true.
             if self.flags.in_class_static_init_block {
                 self.syntax_error("'arguments' is not allowed in class static initialization blocks");
-            } else if !self.flags.strict_mode && !self.scope_collector.has_declaration_in_current_function(&id.name) {
-                self.scope_collector
-                    .set_contains_access_to_arguments_object_in_non_strict_mode();
+            } else {
+                let name = self.arena.identifiers[id].name.clone();
+                if !self.flags.strict_mode && !self.scope_collector.has_declaration_in_current_function(&name) {
+                    self.scope_collector
+                        .set_contains_access_to_arguments_object_in_non_strict_mode();
+                }
             }
         }
 
@@ -447,8 +449,12 @@ impl Parser<'_> {
                     return (arrow, false);
                 }
                 let token = self.consume_and_check_identifier();
-                let id = self.make_identifier(start, self.token_identifier_name(&token));
-                self.scope_collector.register_identifier(id.clone(), None);
+                let name = self.token_identifier_name(&token);
+                let id = self.make_identifier(start, name);
+                let Self {
+                    scope_collector, arena, ..
+                } = self;
+                scope_collector.register_identifier(id, None, &arena.identifiers);
                 (self.expression(start, ExpressionKind::Identifier(id)), true)
             }
 
@@ -583,14 +589,22 @@ impl Parser<'_> {
                         self.syntax_error("'yield' is not allowed as an identifier in this context");
                     }
                     let token = self.consume_and_check_identifier();
-                    let id = self.make_identifier(start, self.token_identifier_name(&token));
-                    self.scope_collector.register_identifier(id.clone(), None);
+                    let name = self.token_identifier_name(&token);
+                    let id = self.make_identifier(start, name);
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    scope_collector.register_identifier(id, None, &arena.identifiers);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else if self.match_token(TokenType::EscapedKeyword) {
                     self.syntax_error("Keyword must not contain escaped characters");
                     let token = self.consume_and_check_identifier();
-                    let id = self.make_identifier(start, self.token_identifier_name(&token));
-                    self.scope_collector.register_identifier(id.clone(), None);
+                    let name = self.token_identifier_name(&token);
+                    let id = self.make_identifier(start, name);
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    scope_collector.register_identifier(id, None, &arena.identifiers);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else {
                     self.expected("primary expression");
@@ -801,9 +815,14 @@ impl Parser<'_> {
                     // Register synthesized identifiers with the scope collector so
                     // they get resolved as locals during analyze().
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();
-                    for (name, id) in &bound_names {
+                    for (name, _id) in &bound_names {
                         self.check_identifier_name_for_assignment_validity(name, false);
-                        self.scope_collector.register_identifier(id.clone(), None);
+                    }
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    for (_name, id) in &bound_names {
+                        scope_collector.register_identifier(*id, None, &arena.identifiers);
                     }
                     self.pattern_bound_names = saved_bound_names;
                     self.consume();
@@ -829,8 +848,9 @@ impl Parser<'_> {
                 if !Self::is_simple_assignment_target(&lhs, allow_call, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in assignment");
                 }
-                if let ExpressionKind::Identifier(ref id) = lhs.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                if let ExpressionKind::Identifier(id) = lhs.inner {
+                    let name = self.arena.identifiers[id].name.clone();
+                    self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.consume();
                 let rhs = self.parse_expression(min_precedence, Associativity::Right, forbidden);
@@ -966,8 +986,9 @@ impl Parser<'_> {
                 if !Self::is_simple_assignment_target(&lhs, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
-                if let ExpressionKind::Identifier(ref id) = lhs.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                if let ExpressionKind::Identifier(id) = lhs.inner {
+                    let name = self.arena.identifiers[id].name.clone();
+                    self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.consume();
                 (
@@ -986,8 +1007,9 @@ impl Parser<'_> {
                 if !Self::is_simple_assignment_target(&lhs, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
-                if let ExpressionKind::Identifier(ref id) = lhs.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                if let ExpressionKind::Identifier(id) = lhs.inner {
+                    let name = self.arena.identifiers[id].name.clone();
+                    self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.consume();
                 (
@@ -1021,8 +1043,9 @@ impl Parser<'_> {
                 if !Self::is_simple_assignment_target(&expression, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
-                if let ExpressionKind::Identifier(ref id) = expression.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                if let ExpressionKind::Identifier(id) = expression.inner {
+                    let name = self.arena.identifiers[id].name.clone();
+                    self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.expression(
                     start,
@@ -1039,8 +1062,9 @@ impl Parser<'_> {
                 if !Self::is_simple_assignment_target(&expression, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
-                if let ExpressionKind::Identifier(ref id) = expression.inner {
-                    self.check_identifier_name_for_assignment_validity(&id.name, false);
+                if let ExpressionKind::Identifier(id) = expression.inner {
+                    let name = self.arena.identifiers[id].name.clone();
+                    self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.expression(
                     start,
@@ -1188,8 +1212,8 @@ impl Parser<'_> {
         let arguments = self.parse_arguments();
         // Check the actual callee expression kind, matching C++ which does
         // is<Identifier>(callee) && callee.string() == "eval".
-        if let ExpressionKind::Identifier(ref id) = callee.inner
-            && id.name == utf16!("eval")
+        if let ExpressionKind::Identifier(id) = callee.inner
+            && self.arena.identifiers[id].name == utf16!("eval")
         {
             self.scope_collector.set_contains_direct_call_to_eval();
             self.scope_collector.set_uses_this();
@@ -1596,7 +1620,12 @@ impl Parser<'_> {
             && let Some(kv) = &key_value
         {
             let id = self.make_identifier(obj_start, kv.clone());
-            self.scope_collector.register_identifier(id.clone(), None);
+            {
+                let Self {
+                    scope_collector, arena, ..
+                } = self;
+                scope_collector.register_identifier(id, None, &arena.identifiers);
+            }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             self.consume(); // consume '='
             // NB: Add a syntax error for CoverInitializedName. This error will
@@ -1627,7 +1656,12 @@ impl Parser<'_> {
                 self.syntax_error(&format!("'{name_str}' is a reserved keyword"));
             }
             let id = self.make_identifier(obj_start, kv);
-            self.scope_collector.register_identifier(id.clone(), None);
+            {
+                let Self {
+                    scope_collector, arena, ..
+                } = self;
+                scope_collector.register_identifier(id, None, &arena.identifiers);
+            }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             return ObjectProperty {
                 range: self.range_from(obj_start),
@@ -2230,10 +2264,13 @@ impl Parser<'_> {
                 self.syntax_error("'await' is a reserved identifier in async functions");
             }
             // C++ uses rule_start (arrow function start, which is `async` for async arrows).
-            let binding = Rc::new(Identifier::new(self.range_from(start), value.clone().into()));
+            let binding = self
+                .arena
+                .identifiers
+                .insert(Identifier::new(self.range_from(start), value.clone().into()));
             parsed = ParsedParameters {
                 parameters: vec![FunctionParameter {
-                    binding: FunctionParameterBinding::Identifier(binding.clone()),
+                    binding: FunctionParameterBinding::Identifier(binding),
                     default_value: None,
                     is_rest: false,
                 }],

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -178,14 +178,14 @@ impl Parser<'_> {
         // parse_primary_expression), NOT during consume(). This avoids
         // falsely flagging parameter names like `function f(arguments)`.
         if let ExpressionKind::Identifier(id) = expression.inner
-            && self.arena.identifiers[id].name == utf16!("arguments")
+            && self.arena.name_of(id).as_slice() == utf16!("arguments")
         {
             // https://tc39.es/ecma262/#sec-class-static-initialization-blocks
             // It is a Syntax Error if ContainsArguments of ClassStaticBlockBody is true.
             if self.flags.in_class_static_init_block {
                 self.syntax_error("'arguments' is not allowed in class static initialization blocks");
             } else {
-                let name = self.arena.identifiers[id].name.clone();
+                let name = self.arena.name_of(id).clone();
                 if !self.flags.strict_mode && !self.scope_collector.has_declaration_in_current_function(&name) {
                     self.scope_collector
                         .set_contains_access_to_arguments_object_in_non_strict_mode();
@@ -454,7 +454,7 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                 (self.expression(start, ExpressionKind::Identifier(id)), true)
             }
 
@@ -594,7 +594,7 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                    scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else if self.match_token(TokenType::EscapedKeyword) {
                     self.syntax_error("Keyword must not contain escaped characters");
@@ -604,7 +604,7 @@ impl Parser<'_> {
                     let Self {
                         scope_collector, arena, ..
                     } = self;
-                    scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                    scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                     (self.expression(start, ExpressionKind::Identifier(id)), true)
                 } else {
                     self.expected("primary expression");
@@ -816,13 +816,14 @@ impl Parser<'_> {
                     // they get resolved as locals during analyze().
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();
                     for (name, _id) in &bound_names {
-                        self.check_identifier_name_for_assignment_validity(name, false);
+                        let name_str = self.arena.strings[*name].clone();
+                        self.check_identifier_name_for_assignment_validity(name_str.as_slice(), false);
                     }
                     let Self {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &mut arena.identifiers);
+                        scope_collector.register_identifier(*id, None, &mut arena.identifiers, &arena.strings);
                     }
                     self.pattern_bound_names = saved_bound_names;
                     self.consume();
@@ -849,7 +850,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in assignment");
                 }
                 if let ExpressionKind::Identifier(id) = lhs.inner {
-                    let name = self.arena.identifiers[id].name.clone();
+                    let name = self.arena.name_of(id).clone();
                     self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.consume();
@@ -913,7 +914,8 @@ impl Parser<'_> {
                 } else if self.match_identifier_name() {
                     let property_start = self.position();
                     let token = self.consume();
-                    let property_identifier = self.make_identifier(property_start, self.token_identifier_name(&token));
+                    let property_name = self.token_identifier_name(&token);
+                    let property_identifier = self.make_identifier(property_start, property_name);
                     let property = self.expression(property_start, ExpressionKind::Identifier(property_identifier));
                     (
                         self.expression(
@@ -987,7 +989,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
                 if let ExpressionKind::Identifier(id) = lhs.inner {
-                    let name = self.arena.identifiers[id].name.clone();
+                    let name = self.arena.name_of(id).clone();
                     self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.consume();
@@ -1008,7 +1010,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
                 if let ExpressionKind::Identifier(id) = lhs.inner {
-                    let name = self.arena.identifiers[id].name.clone();
+                    let name = self.arena.name_of(id).clone();
                     self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.consume();
@@ -1044,7 +1046,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
                 if let ExpressionKind::Identifier(id) = expression.inner {
-                    let name = self.arena.identifiers[id].name.clone();
+                    let name = self.arena.name_of(id).clone();
                     self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.expression(
@@ -1063,7 +1065,7 @@ impl Parser<'_> {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
                 if let ExpressionKind::Identifier(id) = expression.inner {
-                    let name = self.arena.identifiers[id].name.clone();
+                    let name = self.arena.name_of(id).clone();
                     self.check_identifier_name_for_assignment_validity(&name, false);
                 }
                 self.expression(
@@ -1213,7 +1215,7 @@ impl Parser<'_> {
         // Check the actual callee expression kind, matching C++ which does
         // is<Identifier>(callee) && callee.string() == "eval".
         if let ExpressionKind::Identifier(id) = callee.inner
-            && self.arena.identifiers[id].name == utf16!("eval")
+            && self.arena.name_of(id).as_slice() == utf16!("eval")
         {
             self.scope_collector.set_contains_direct_call_to_eval();
             self.scope_collector.set_uses_this();
@@ -1301,8 +1303,9 @@ impl Parser<'_> {
                         if self.match_identifier_name() {
                             let property_start = self.position();
                             let token = self.consume();
+                            let name = self.token_identifier_name(&token);
                             references.push(OptionalChainReference::MemberReference {
-                                identifier: self.make_identifier(property_start, self.token_identifier_name(&token)),
+                                identifier: self.make_identifier(property_start, name),
                                 mode: OptionalChainMode::Optional,
                             });
                         } else {
@@ -1329,8 +1332,9 @@ impl Parser<'_> {
                 } else if self.match_identifier_name() {
                     let property_start = self.position();
                     let token = self.consume();
+                    let name = self.token_identifier_name(&token);
                     references.push(OptionalChainReference::MemberReference {
-                        identifier: self.make_identifier(property_start, self.token_identifier_name(&token)),
+                        identifier: self.make_identifier(property_start, name),
                         mode: OptionalChainMode::NotOptional,
                     });
                 } else {
@@ -1619,12 +1623,12 @@ impl Parser<'_> {
             && is_identifier
             && let Some(kv) = &key_value
         {
-            let id = self.make_identifier(obj_start, kv.clone());
+            let id = self.make_identifier_from_slice(obj_start, kv.as_slice());
             {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
             }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             self.consume(); // consume '='
@@ -1655,12 +1659,12 @@ impl Parser<'_> {
                 let name_str = String::from_utf16_lossy(&kv);
                 self.syntax_error(&format!("'{name_str}' is a reserved keyword"));
             }
-            let id = self.make_identifier(obj_start, kv);
+            let id = self.make_identifier_from_slice(obj_start, kv.as_slice());
             {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
             }
             let value = self.expression(obj_start, ExpressionKind::Identifier(id));
             return ObjectProperty {
@@ -2264,10 +2268,11 @@ impl Parser<'_> {
                 self.syntax_error("'await' is a reserved identifier in async functions");
             }
             // C++ uses rule_start (arrow function start, which is `async` for async arrows).
+            let value_id = self.arena.strings.intern(&value);
             let binding = self
                 .arena
                 .identifiers
-                .insert(Identifier::new(self.range_from(start), value.clone().into()));
+                .insert(Identifier::new(self.range_from(start), value_id));
             parsed = ParsedParameters {
                 parameters: vec![FunctionParameter {
                     binding: FunctionParameterBinding::Identifier(binding),

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -739,7 +739,7 @@ impl Parser<'_> {
                     scope_collector, arena, ..
                 } = self;
                 for id in pattern_bound_ids {
-                    scope_collector.register_identifier(id, None, &arena.identifiers);
+                    scope_collector.register_identifier(id, None, &mut arena.identifiers);
                 }
                 Some(CatchBinding::BindingPattern(pattern))
             } else if self.match_identifier() {
@@ -755,7 +755,7 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers);
                 scope_collector.add_catch_parameter_identifier(&value, id);
                 Some(CatchBinding::Identifier(id))
             } else {
@@ -1003,7 +1003,7 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &arena.identifiers);
+                        scope_collector.register_identifier(*id, None, &mut arena.identifiers);
                     }
                     ForInOfLhs::Pattern(pattern)
                 } else {

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -6,7 +6,7 @@
 
 //! Statement parsing: if, for, while, switch, try, etc.
 
-use std::collections::HashSet;
+use crate::fast_hash::HashSet;
 
 use crate::ast::*;
 use crate::parser::{Associativity, ForbiddenTokens, PRECEDENCE_COMMA, Parser, Position};
@@ -723,7 +723,7 @@ impl Parser<'_> {
                 // It is a Syntax Error if BoundNames of CatchParameter
                 // contains any duplicate elements.
                 {
-                    let mut seen: HashSet<&[u16]> = HashSet::new();
+                    let mut seen: HashSet<&[u16]> = HashSet::default();
                     for name in &names_to_check {
                         if !seen.insert(name.as_slice()) {
                             let name_str = String::from_utf16_lossy(name);

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -463,7 +463,7 @@ impl Parser<'_> {
                     if init_starts_with_async_keyword
                         && let LocalForInit::Expression(ref expression) = init
                         && let ExpressionKind::Identifier(ident) = expression.inner
-                        && self.arena.identifiers[ident].name == utf16!("async")
+                        && self.arena.name_of(ident).as_slice() == utf16!("async")
                     {
                         self.syntax_error("for-of statement may not use 'async' as the left-hand side");
                     }
@@ -471,7 +471,7 @@ impl Parser<'_> {
                     if let LocalForInit::Expression(ref expression) = init
                         && let ExpressionKind::Member(ref data) = expression.inner
                         && let ExpressionKind::Identifier(ident) = data.object.inner
-                        && self.arena.identifiers[ident].name == utf16!("let")
+                        && self.arena.name_of(ident).as_slice() == utf16!("let")
                     {
                         self.syntax_error("For of statement may not start with let.");
                     }
@@ -713,8 +713,12 @@ impl Parser<'_> {
             let parameter = if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 self.pattern_bound_names.clear();
                 let pattern = self.parse_binding_pattern();
-                let names_to_check: Vec<SharedUtf16String> =
-                    self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect();
+                // Materialize Utf16Strings for slice-based scope-collector calls.
+                let names_to_check: Vec<Utf16String> = self
+                    .pattern_bound_names
+                    .iter()
+                    .map(|(n, _)| self.arena.strings[*n].clone())
+                    .collect();
                 // https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors
                 // It is a Syntax Error if BoundNames of CatchParameter
                 // contains any duplicate elements.
@@ -728,9 +732,9 @@ impl Parser<'_> {
                     }
                 }
                 for name in &names_to_check {
-                    self.check_identifier_name_for_assignment_validity(name, false);
+                    self.check_identifier_name_for_assignment_validity(name.as_slice(), false);
                 }
-                let bound_names: Vec<&[u16]> = self.pattern_bound_names.iter().map(|(n, _)| n.as_slice()).collect();
+                let bound_names: Vec<&[u16]> = names_to_check.iter().map(|n| n.as_slice()).collect();
                 self.scope_collector.add_catch_parameter_pattern(&bound_names);
                 // Register each binding pattern identifier for scope analysis
                 // so they get is_local() annotations (matching variable declarations).
@@ -739,7 +743,7 @@ impl Parser<'_> {
                     scope_collector, arena, ..
                 } = self;
                 for id in pattern_bound_ids {
-                    scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                    scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                 }
                 Some(CatchBinding::BindingPattern(pattern))
             } else if self.match_identifier() {
@@ -755,7 +759,7 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers);
+                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
                 scope_collector.add_catch_parameter_identifier(&value, id);
                 Some(CatchBinding::Identifier(id))
             } else {
@@ -768,10 +772,10 @@ impl Parser<'_> {
             None
         };
 
-        // Collect catch parameter names for post-body validation.
-        let catch_names: Vec<SharedUtf16String> = match &parameter {
-            Some(CatchBinding::Identifier(id)) => vec![self.arena.identifiers[*id].name.clone()],
-            Some(CatchBinding::BindingPattern(_)) => self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect(),
+        // Collect catch parameter names (as StringIds) for post-body validation.
+        let catch_names: Vec<StringId> = match &parameter {
+            Some(CatchBinding::Identifier(id)) => vec![self.arena.identifiers[*id].name],
+            Some(CatchBinding::BindingPattern(_)) => self.pattern_bound_names.iter().map(|(n, _)| *n).collect(),
             None => Vec::new(),
         };
 
@@ -788,10 +792,10 @@ impl Parser<'_> {
                     StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                         for decl in &vd.declarations {
                             if let VariableDeclaratorTarget::Identifier(id) = decl.target {
-                                let id_name = self.arena.identifiers[id].name.clone();
+                                let id_name = self.arena.identifiers[id].name;
                                 for cn in &catch_names {
-                                    if cn.as_slice() == id_name.as_slice() {
-                                        let n = String::from_utf16_lossy(cn);
+                                    if *cn == id_name {
+                                        let n = String::from_utf16_lossy(self.arena.strings[*cn].as_slice());
                                         self.syntax_error(&format!(
                                             "Identifier '{n}' already declared as catch parameter"
                                         ));
@@ -802,20 +806,20 @@ impl Parser<'_> {
                     }
                     StatementKind::FunctionDeclaration(fd) if fd.name.is_some() => {
                         let id = fd.name.unwrap();
-                        let id_name = self.arena.identifiers[id].name.clone();
+                        let id_name = self.arena.identifiers[id].name;
                         for cn in &catch_names {
-                            if cn.as_slice() == id_name.as_slice() {
-                                let n = String::from_utf16_lossy(cn);
+                            if *cn == id_name {
+                                let n = String::from_utf16_lossy(self.arena.strings[*cn].as_slice());
                                 self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                             }
                         }
                     }
                     StatementKind::ClassDeclaration(data) => {
                         if let Some(id) = data.name {
-                            let id_name = self.arena.identifiers[id].name.clone();
+                            let id_name = self.arena.identifiers[id].name;
                             for cn in &catch_names {
-                                if cn.as_slice() == id_name.as_slice() {
-                                    let n = String::from_utf16_lossy(cn);
+                                if *cn == id_name {
+                                    let n = String::from_utf16_lossy(self.arena.strings[*cn].as_slice());
                                     self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                                 }
                             }
@@ -997,13 +1001,14 @@ impl Parser<'_> {
 
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();
                     for (name, _id) in &bound_names {
-                        self.check_identifier_name_for_assignment_validity(name, false);
+                        let name_str = self.arena.strings[*name].clone();
+                        self.check_identifier_name_for_assignment_validity(name_str.as_slice(), false);
                     }
                     let Self {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &mut arena.identifiers);
+                        scope_collector.register_identifier(*id, None, &mut arena.identifiers, &arena.strings);
                     }
                     ForInOfLhs::Pattern(pattern)
                 } else {

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -7,7 +7,6 @@
 //! Statement parsing: if, for, while, switch, try, etc.
 
 use std::collections::HashSet;
-use std::rc::Rc;
 
 use crate::ast::*;
 use crate::parser::{Associativity, ForbiddenTokens, PRECEDENCE_COMMA, Parser, Position};
@@ -463,16 +462,16 @@ impl Parser<'_> {
                     // are still valid here.
                     if init_starts_with_async_keyword
                         && let LocalForInit::Expression(ref expression) = init
-                        && let ExpressionKind::Identifier(ref ident) = expression.inner
-                        && ident.name == utf16!("async")
+                        && let ExpressionKind::Identifier(ident) = expression.inner
+                        && self.arena.identifiers[ident].name == utf16!("async")
                     {
                         self.syntax_error("for-of statement may not use 'async' as the left-hand side");
                     }
                     // https://tc39.es/ecma262/#sec-for-in-and-for-of-statements
                     if let LocalForInit::Expression(ref expression) = init
                         && let ExpressionKind::Member(ref data) = expression.inner
-                        && let ExpressionKind::Identifier(ref ident) = data.object.inner
-                        && ident.name == utf16!("let")
+                        && let ExpressionKind::Identifier(ident) = data.object.inner
+                        && self.arena.identifiers[ident].name == utf16!("let")
                     {
                         self.syntax_error("For of statement may not start with let.");
                     }
@@ -735,8 +734,12 @@ impl Parser<'_> {
                 self.scope_collector.add_catch_parameter_pattern(&bound_names);
                 // Register each binding pattern identifier for scope analysis
                 // so they get is_local() annotations (matching variable declarations).
-                for (_name, id) in &self.pattern_bound_names {
-                    self.scope_collector.register_identifier(id.clone(), None);
+                let pattern_bound_ids: Vec<IdentifierId> = self.pattern_bound_names.iter().map(|(_, id)| *id).collect();
+                let Self {
+                    scope_collector, arena, ..
+                } = self;
+                for id in pattern_bound_ids {
+                    scope_collector.register_identifier(id, None, &arena.identifiers);
                 }
                 Some(CatchBinding::BindingPattern(pattern))
             } else if self.match_identifier() {
@@ -744,12 +747,16 @@ impl Parser<'_> {
                 let token = self.consume();
                 let value = self.token_value(&token).to_vec();
                 self.check_identifier_name_for_assignment_validity(&value, false);
-                let id = Rc::new(Identifier::new(
-                    self.range_from(parameter_start),
-                    self.token_identifier_name(&token),
-                ));
-                self.scope_collector.register_identifier(id.clone(), None);
-                self.scope_collector.add_catch_parameter_identifier(&value, id.clone());
+                let name = self.token_identifier_name(&token);
+                let id = self
+                    .arena
+                    .identifiers
+                    .insert(Identifier::new(self.range_from(parameter_start), name));
+                let Self {
+                    scope_collector, arena, ..
+                } = self;
+                scope_collector.register_identifier(id, None, &arena.identifiers);
+                scope_collector.add_catch_parameter_identifier(&value, id);
                 Some(CatchBinding::Identifier(id))
             } else {
                 self.expected("catch parameter");
@@ -763,7 +770,7 @@ impl Parser<'_> {
 
         // Collect catch parameter names for post-body validation.
         let catch_names: Vec<SharedUtf16String> = match &parameter {
-            Some(CatchBinding::Identifier(id)) => vec![id.name.clone()],
+            Some(CatchBinding::Identifier(id)) => vec![self.arena.identifiers[*id].name.clone()],
             Some(CatchBinding::BindingPattern(_)) => self.pattern_bound_names.iter().map(|(n, _)| n.clone()).collect(),
             None => Vec::new(),
         };
@@ -780,9 +787,10 @@ impl Parser<'_> {
                 match &child.inner {
                     StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                         for decl in &vd.declarations {
-                            if let VariableDeclaratorTarget::Identifier(ref id) = decl.target {
+                            if let VariableDeclaratorTarget::Identifier(id) = decl.target {
+                                let id_name = self.arena.identifiers[id].name.clone();
                                 for cn in &catch_names {
-                                    if cn.as_slice() == id.name.as_slice() {
+                                    if cn.as_slice() == id_name.as_slice() {
                                         let n = String::from_utf16_lossy(cn);
                                         self.syntax_error(&format!(
                                             "Identifier '{n}' already declared as catch parameter"
@@ -793,18 +801,20 @@ impl Parser<'_> {
                         }
                     }
                     StatementKind::FunctionDeclaration(fd) if fd.name.is_some() => {
-                        let id = fd.name.as_ref().unwrap();
+                        let id = fd.name.unwrap();
+                        let id_name = self.arena.identifiers[id].name.clone();
                         for cn in &catch_names {
-                            if cn.as_slice() == id.name.as_slice() {
+                            if cn.as_slice() == id_name.as_slice() {
                                 let n = String::from_utf16_lossy(cn);
                                 self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                             }
                         }
                     }
                     StatementKind::ClassDeclaration(data) => {
-                        if let Some(ref id) = data.name {
+                        if let Some(id) = data.name {
+                            let id_name = self.arena.identifiers[id].name.clone();
                             for cn in &catch_names {
-                                if cn.as_slice() == id.name.as_slice() {
+                                if cn.as_slice() == id_name.as_slice() {
                                     let n = String::from_utf16_lossy(cn);
                                     self.syntax_error(&format!("Identifier '{n}' already declared as catch parameter"));
                                 }
@@ -986,9 +996,14 @@ impl Parser<'_> {
                     let pattern = self.synthesize_binding_pattern(init_start);
 
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();
-                    for (name, id) in &bound_names {
+                    for (name, _id) in &bound_names {
                         self.check_identifier_name_for_assignment_validity(name, false);
-                        self.scope_collector.register_identifier(id.clone(), None);
+                    }
+                    let Self {
+                        scope_collector, arena, ..
+                    } = self;
+                    for (_name, id) in &bound_names {
+                        scope_collector.register_identifier(*id, None, &arena.identifiers);
                     }
                     ForInOfLhs::Pattern(pattern)
                 } else {

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -89,8 +89,8 @@ impl Parser<'_> {
         }
 
         self.consume_token(TokenType::CurlyClose);
-        let scope = ScopeData::shared_with_children(children);
-        self.scope_collector.set_scope_node(scope.clone());
+        let scope = self.make_scope(children);
+        self.scope_collector.set_scope_node(scope);
         self.scope_collector.close_scope();
         self.statement(start, StatementKind::Block(scope))
     }
@@ -289,8 +289,8 @@ impl Parser<'_> {
         let start = if_start;
         self.scope_collector.open_block_scope(None);
         let declaration = self.parse_function_declaration();
-        let scope = ScopeData::shared_with_children(vec![declaration]);
-        self.scope_collector.set_scope_node(scope.clone());
+        let scope = self.make_scope(vec![declaration]);
+        self.scope_collector.set_scope_node(scope);
         self.scope_collector.close_scope();
         self.statement(start, StatementKind::Block(scope))
     }
@@ -524,8 +524,8 @@ impl Parser<'_> {
     /// Close the for-loop scope and wrap the for-loop statement in a Block
     /// with scope data.
     fn close_for_loop_scope(&mut self, start: Position, inner: Statement) -> Statement {
-        let scope = ScopeData::shared_with_children(vec![inner]);
-        self.scope_collector.set_scope_node(scope.clone());
+        let scope = self.make_scope(vec![inner]);
+        self.scope_collector.set_scope_node(scope);
         self.scope_collector.close_scope();
         self.statement(start, StatementKind::Block(scope))
     }
@@ -611,8 +611,8 @@ impl Parser<'_> {
 
         self.consume_token(TokenType::CurlyClose);
 
-        let scope = ScopeData::new_shared();
-        self.scope_collector.set_scope_node(scope.clone());
+        let scope = self.make_empty_scope();
+        self.scope_collector.set_scope_node(scope);
         self.scope_collector.close_scope();
 
         self.statement(
@@ -655,7 +655,7 @@ impl Parser<'_> {
 
         SwitchCase {
             range: self.range_from(start),
-            scope: ScopeData::shared_with_children(children),
+            scope: self.make_scope(children),
             test,
         }
     }
@@ -743,7 +743,13 @@ impl Parser<'_> {
                     scope_collector, arena, ..
                 } = self;
                 for id in pattern_bound_ids {
-                    scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                    scope_collector.register_identifier(
+                        id,
+                        None,
+                        &mut arena.identifiers,
+                        &arena.strings,
+                        &mut arena.scopes,
+                    );
                 }
                 Some(CatchBinding::BindingPattern(pattern))
             } else if self.match_identifier() {
@@ -759,7 +765,13 @@ impl Parser<'_> {
                 let Self {
                     scope_collector, arena, ..
                 } = self;
-                scope_collector.register_identifier(id, None, &mut arena.identifiers, &arena.strings);
+                scope_collector.register_identifier(
+                    id,
+                    None,
+                    &mut arena.identifiers,
+                    &arena.strings,
+                    &mut arena.scopes,
+                );
                 scope_collector.add_catch_parameter_identifier(&value, id);
                 Some(CatchBinding::Identifier(id))
             } else {
@@ -785,9 +797,9 @@ impl Parser<'_> {
         // It is a Syntax Error if any element of the BoundNames of
         // CatchParameter also occurs in the LexicallyDeclaredNames of Block.
         if !catch_names.is_empty()
-            && let StatementKind::Block(ref scope) = body.inner
+            && let StatementKind::Block(scope_id) = body.inner
         {
-            for child in &scope.borrow().children {
+            for child in &self.arena.scopes[scope_id].children.clone() {
                 match &child.inner {
                     StatementKind::VariableDeclaration(vd) if vd.kind != DeclarationKind::Var => {
                         for decl in &vd.declarations {
@@ -1008,7 +1020,13 @@ impl Parser<'_> {
                         scope_collector, arena, ..
                     } = self;
                     for (_name, id) in &bound_names {
-                        scope_collector.register_identifier(*id, None, &mut arena.identifiers, &arena.strings);
+                        scope_collector.register_identifier(
+                            *id,
+                            None,
+                            &mut arena.identifiers,
+                            &arena.strings,
+                            &mut arena.scopes,
+                        );
                     }
                     ForInOfLhs::Pattern(pattern)
                 } else {

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -529,7 +529,7 @@ impl ScopeCollector {
         declaration_line: u32,
         declaration_column: u32,
         declaration_kind: Option<DeclarationKind>,
-        identifiers: &IdentifierArena,
+        identifiers: &mut IdentifierArena,
     ) {
         let index = self.current.expect("no current scope");
 
@@ -572,7 +572,7 @@ impl ScopeCollector {
         strict_mode: bool,
         declaration_line: u32,
         declaration_column: u32,
-        identifiers: &IdentifierArena,
+        identifiers: &mut IdentifierArena,
     ) {
         let index = self.current.expect("no current scope");
         let scope_level = self.records[index].scope_level;
@@ -644,7 +644,7 @@ impl ScopeCollector {
         &mut self,
         id: IdentifierId,
         declaration_kind: Option<DeclarationKind>,
-        identifiers: &IdentifierArena,
+        identifiers: &mut IdentifierArena,
     ) {
         let index = self.current.expect("no current scope");
         let name = identifiers[id].name.clone();
@@ -671,7 +671,7 @@ impl ScopeCollector {
         &mut self,
         entries: &[ParameterEntry],
         has_parameter_expressions: bool,
-        identifiers: &IdentifierArena,
+        identifiers: &mut IdentifierArena,
     ) {
         let index = self.current.expect("no current scope");
         self.records[index].has_function_parameters = true;
@@ -859,7 +859,7 @@ impl ScopeCollector {
 
     // === Post-parse analysis ===
 
-    pub fn analyze(&mut self, initiated_by_eval: bool, identifiers: &IdentifierArena) {
+    pub fn analyze(&mut self, initiated_by_eval: bool, identifiers: &mut IdentifierArena) {
         self.analyze_inner(initiated_by_eval, false, identifiers);
     }
 
@@ -867,11 +867,11 @@ impl ScopeCollector {
     /// Used for dynamic functions (new Function(...)) where the source is
     /// parsed as a Script but identifiers must not use GetGlobal/SetGlobal,
     /// matching the C++ path which parses as a FunctionExpression.
-    pub fn analyze_as_dynamic_function(&mut self, identifiers: &IdentifierArena) {
+    pub fn analyze_as_dynamic_function(&mut self, identifiers: &mut IdentifierArena) {
         self.analyze_inner(false, true, identifiers);
     }
 
-    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool, identifiers: &IdentifierArena) {
+    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool, identifiers: &mut IdentifierArena) {
         if !self.records.is_empty() {
             self.analyze_recursive(0, initiated_by_eval, suppress_globals, identifiers);
         }
@@ -885,7 +885,7 @@ impl ScopeCollector {
         index: usize,
         initiated_by_eval: bool,
         suppress_globals: bool,
-        identifiers: &IdentifierArena,
+        identifiers: &mut IdentifierArena,
     ) {
         // Process children first (bottom-up traversal).
         let children = std::mem::take(&mut self.records[index].children);
@@ -962,7 +962,7 @@ impl ScopeCollector {
         index: usize,
         initiated_by_eval: bool,
         suppress_globals: bool,
-        identifiers: &IdentifierArena,
+        identifiers: &mut IdentifierArena,
     ) {
         // identifier_groups is an IndexMap, so iteration is in source order
         // of first reference. Local variable indices follow that order.
@@ -973,7 +973,7 @@ impl ScopeCollector {
             // so the bytecode generator knows how to handle TDZ checks, etc.
             if let Some(dk) = group.declaration_kind {
                 for id in &group.identifiers {
-                    identifiers[*id].declaration_kind.set(Some(dk));
+                    identifiers[*id].declaration_kind = Some(dk);
                 }
             }
 
@@ -1050,7 +1050,7 @@ impl ScopeCollector {
                 && var_flags.intersects(VarFlags::BOUND)
             {
                 for id in &group.identifiers {
-                    identifiers[*id].is_inside_scope_with_eval.set(true);
+                    identifiers[*id].is_inside_scope_with_eval = true;
                 }
             }
 
@@ -1078,9 +1078,9 @@ impl ScopeCollector {
                 let can_use_global = !(suppress_globals || group.used_inside_with_statement || initiated_by_eval);
                 if can_use_global {
                     for id in &group.identifiers {
-                        let identifier = &identifiers[*id];
-                        if !identifier.is_inside_scope_with_eval.get() {
-                            identifier.is_global.set(true);
+                        let identifier = &mut identifiers[*id];
+                        if !identifier.is_inside_scope_with_eval {
+                            identifier.is_global = true;
                         }
                     }
                 }
@@ -1133,9 +1133,9 @@ impl ScopeCollector {
                             let argument_index = records[ls].get_parameter_index(&name);
                             if let Some(ai) = argument_index {
                                 for id in &group.identifiers {
-                                    let identifier = &identifiers[*id];
-                                    identifier.local_index.set(ai);
-                                    identifier.local_type.set(Some(crate::ast::LocalType::Argument));
+                                    let identifier = &mut identifiers[*id];
+                                    identifier.local_index = ai;
+                                    identifier.local_type = Some(crate::ast::LocalType::Argument);
                                 }
                             } else {
                                 let lvi = u32_from_usize(sd.local_variables.len());
@@ -1144,9 +1144,9 @@ impl ScopeCollector {
                                     kind: LocalVarKind::Var,
                                 });
                                 for id in &group.identifiers {
-                                    let identifier = &identifiers[*id];
-                                    identifier.local_index.set(lvi);
-                                    identifier.local_type.set(Some(crate::ast::LocalType::Variable));
+                                    let identifier = &mut identifiers[*id];
+                                    identifier.local_index = lvi;
+                                    identifier.local_type = Some(crate::ast::LocalType::Variable);
                                 }
                             }
                         } else {
@@ -1157,9 +1157,9 @@ impl ScopeCollector {
                                 kind,
                             });
                             for id in &group.identifiers {
-                                let identifier = &identifiers[*id];
-                                identifier.local_index.set(lvi);
-                                identifier.local_type.set(Some(crate::ast::LocalType::Variable));
+                                let identifier = &mut identifiers[*id];
+                                identifier.local_index = lvi;
+                                identifier.local_type = Some(crate::ast::LocalType::Variable);
                             }
                         }
                     }
@@ -1178,7 +1178,7 @@ impl ScopeCollector {
 
                 if records[index].eval_in_current_function {
                     for id in &group.identifiers {
-                        identifiers[*id].is_inside_scope_with_eval.set(true);
+                        identifiers[*id].is_inside_scope_with_eval = true;
                     }
                 }
 
@@ -1208,7 +1208,7 @@ impl ScopeCollector {
     // - vars_to_initialize: var-declared names and their local variable indices
     // - functions_to_initialize: function declarations to instantiate (in reverse order)
     // - arguments object metadata (has_argument_parameter, has_function_named_arguments, etc.)
-    fn build_function_scope_data(records: &[ScopeRecord], index: usize, identifiers: &IdentifierArena) {
+    fn build_function_scope_data(records: &[ScopeRecord], index: usize, identifiers: &mut IdentifierArena) {
         let record = &records[index];
         let Some(ref scope_data) = record.scope_data else {
             return;
@@ -1267,8 +1267,8 @@ impl ScopeCollector {
                 let ident = &identifiers[ident_id];
                 if ident.is_local() {
                     Some(LocalBinding {
-                        local_type: ident.local_type.get().expect("is_local() implies local_type is Some"),
-                        index: ident.local_index.get(),
+                        local_type: ident.local_type.expect("is_local() implies local_type is Some"),
+                        index: ident.local_index,
                     })
                 } else {
                     None
@@ -1348,7 +1348,7 @@ impl ScopeCollector {
     /// The function propagates upward through block scopes until it reaches
     /// a function/program scope (top level) or is blocked by an existing
     /// lexical or function declaration with the same name.
-    fn hoist_functions(records: &mut [ScopeRecord], index: usize, identifiers: &IdentifierArena) {
+    fn hoist_functions(records: &mut [ScopeRecord], index: usize, identifiers: &mut IdentifierArena) {
         let functions = std::mem::take(&mut records[index].functions_to_hoist);
 
         for function in functions {

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -55,8 +55,8 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ast::{
-    FunctionScopeData, Identifier, LocalBinding, LocalVarKind, LocalVariable, ScopeData, SharedUtf16String,
-    Utf16String, VarToInit,
+    FunctionScopeData, IdentifierArena, IdentifierId, LocalBinding, LocalVarKind, LocalVariable, ScopeData,
+    SharedUtf16String, Utf16String, VarToInit,
 };
 use crate::parser::{DeclarationKind, FunctionKind, ParseError, ProgramType};
 use crate::u32_from_usize;
@@ -139,7 +139,7 @@ struct ScopeVariable {
     flags: VarFlags,
     /// The Identifier AST node for the `var` declaration (used to build
     /// FunctionScopeData). None if not a var.
-    var_identifier: Option<Rc<Identifier>>,
+    var_identifier: Option<IdentifierId>,
 }
 
 /// Groups all Identifier AST nodes that share the same name within a scope.
@@ -154,7 +154,7 @@ struct IdentifierGroup {
     /// (prevents local variable optimization since `with` can shadow anything).
     used_inside_with_statement: bool,
     /// All Identifier AST nodes with this name in this scope.
-    identifiers: Vec<Rc<Identifier>>,
+    identifiers: Vec<IdentifierId>,
     /// If this name was declared (var/let/const), tracks the declaration kind
     /// so we can annotate each Identifier AST node.
     declaration_kind: Option<DeclarationKind>,
@@ -178,7 +178,7 @@ struct ParameterName {
 /// Entry describing a single parameter binding for scope analysis.
 pub struct ParameterEntry {
     pub name: Utf16String,
-    pub identifier: Option<Rc<Identifier>>,
+    pub identifier: Option<IdentifierId>,
     pub is_rest: bool,
     pub is_from_pattern: bool,
     pub is_first_from_pattern: bool,
@@ -525,17 +525,18 @@ impl ScopeCollector {
     // class static initializer).
     pub fn add_var_declaration(
         &mut self,
-        bound_names: &[(&[u16], Option<Rc<Identifier>>)],
+        bound_names: &[(&[u16], Option<IdentifierId>)],
         declaration_line: u32,
         declaration_column: u32,
         declaration_kind: Option<DeclarationKind>,
+        identifiers: &IdentifierArena,
     ) {
         let index = self.current.expect("no current scope");
 
         for (name, identifier) in bound_names {
             // Register the declaration identifier so it participates in scope analysis.
             if let Some(id) = identifier {
-                self.register_identifier(id.clone(), declaration_kind);
+                self.register_identifier(*id, declaration_kind, identifiers);
             }
 
             let mut scope_index = index;
@@ -546,7 +547,7 @@ impl ScopeCollector {
                 }
                 let var = self.records[scope_index].variable(name);
                 var.flags |= VarFlags::VAR;
-                var.var_identifier = identifier.clone();
+                var.var_identifier = *identifier;
                 if self.records[scope_index].is_top_level() {
                     break;
                 }
@@ -562,21 +563,23 @@ impl ScopeCollector {
     // a `var` binding to the enclosing function scope.
     // In strict mode (or for async/generator functions), block-scoped function
     // declarations are treated as lexical bindings and are NOT Annex-B hoisted.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_function_declaration(
         &mut self,
         name: &[u16],
-        name_identifier: Option<Rc<Identifier>>,
+        name_identifier: Option<IdentifierId>,
         function_kind: FunctionKind,
         strict_mode: bool,
         declaration_line: u32,
         declaration_column: u32,
+        identifiers: &IdentifierArena,
     ) {
         let index = self.current.expect("no current scope");
         let scope_level = self.records[index].scope_level;
 
         // Register the name identifier so it participates in scope analysis.
-        if let Some(ref id) = name_identifier {
-            self.register_identifier(id.clone(), None);
+        if let Some(id) = name_identifier {
+            self.register_identifier(id, None, identifiers);
         }
 
         if scope_level != ScopeLevel::NotTopLevel && scope_level != ScopeLevel::ModuleTopLevel {
@@ -628,7 +631,7 @@ impl ScopeCollector {
         }
     }
 
-    pub fn add_catch_parameter_identifier(&mut self, name: &[u16], identifier: Rc<Identifier>) {
+    pub fn add_catch_parameter_identifier(&mut self, name: &[u16], identifier: IdentifierId) {
         let index = self.current.expect("no current scope");
         let var = self.records[index].variable(name);
         var.flags |= VarFlags::VAR | VarFlags::BOUND | VarFlags::CATCH_PARAMETER;
@@ -637,13 +640,19 @@ impl ScopeCollector {
 
     // === Identifier registration ===
 
-    pub fn register_identifier(&mut self, id: Rc<Identifier>, declaration_kind: Option<DeclarationKind>) {
+    pub fn register_identifier(
+        &mut self,
+        id: IdentifierId,
+        declaration_kind: Option<DeclarationKind>,
+        identifiers: &IdentifierArena,
+    ) {
         let index = self.current.expect("no current scope");
+        let name = identifiers[id].name.clone();
         self.records[index]
             .identifier_groups
-            .entry(id.name.clone())
+            .entry(name)
             .and_modify(|group| {
-                group.identifiers.push(id.clone());
+                group.identifiers.push(id);
                 if declaration_kind.is_some() && group.declaration_kind.is_none() {
                     group.declaration_kind = declaration_kind;
                 }
@@ -658,7 +667,12 @@ impl ScopeCollector {
 
     // === Function parameters ===
 
-    pub fn set_function_parameters(&mut self, entries: &[ParameterEntry], has_parameter_expressions: bool) {
+    pub fn set_function_parameters(
+        &mut self,
+        entries: &[ParameterEntry],
+        has_parameter_expressions: bool,
+        identifiers: &IdentifierArena,
+    ) {
         let index = self.current.expect("no current scope");
         self.records[index].has_function_parameters = true;
         self.records[index].has_parameter_expressions = has_parameter_expressions;
@@ -681,8 +695,8 @@ impl ScopeCollector {
                     is_rest: entry.is_rest,
                 });
             }
-            if let Some(ref id) = entry.identifier {
-                self.register_identifier(id.clone(), None);
+            if let Some(id) = entry.identifier {
+                self.register_identifier(id, None, identifiers);
             }
             let var = self.records[index].variables.entry(entry.name.clone()).or_default();
             var.flags |= VarFlags::PARAMETER_CANDIDATE | VarFlags::FORBIDDEN_LEXICAL;
@@ -845,32 +859,38 @@ impl ScopeCollector {
 
     // === Post-parse analysis ===
 
-    pub fn analyze(&mut self, initiated_by_eval: bool) {
-        self.analyze_inner(initiated_by_eval, false);
+    pub fn analyze(&mut self, initiated_by_eval: bool, identifiers: &IdentifierArena) {
+        self.analyze_inner(initiated_by_eval, false, identifiers);
     }
 
     /// Like analyze(), but suppresses marking identifiers as global.
     /// Used for dynamic functions (new Function(...)) where the source is
     /// parsed as a Script but identifiers must not use GetGlobal/SetGlobal,
     /// matching the C++ path which parses as a FunctionExpression.
-    pub fn analyze_as_dynamic_function(&mut self) {
-        self.analyze_inner(false, true);
+    pub fn analyze_as_dynamic_function(&mut self, identifiers: &IdentifierArena) {
+        self.analyze_inner(false, true, identifiers);
     }
 
-    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool) {
+    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool, identifiers: &IdentifierArena) {
         if !self.records.is_empty() {
-            self.analyze_recursive(0, initiated_by_eval, suppress_globals);
+            self.analyze_recursive(0, initiated_by_eval, suppress_globals, identifiers);
         }
     }
 
     /// Analyze a scope and all its descendants, bottom-up.
     /// Children are analyzed first so that unresolved identifiers bubble up
     /// to their parent, and eval poisoning propagates outward.
-    fn analyze_recursive(&mut self, index: usize, initiated_by_eval: bool, suppress_globals: bool) {
+    fn analyze_recursive(
+        &mut self,
+        index: usize,
+        initiated_by_eval: bool,
+        suppress_globals: bool,
+        identifiers: &IdentifierArena,
+    ) {
         // Process children first (bottom-up traversal).
         let children = std::mem::take(&mut self.records[index].children);
         for child_index in children {
-            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals);
+            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals, identifiers);
         }
 
         // Steps 1-3 must run even for scopes without scope_data (e.g. catch
@@ -881,9 +901,15 @@ impl ScopeCollector {
         // 1. Propagate eval() flags from children to parent.
         Self::propagate_eval_poisoning(&mut self.records, index);
         // 2. Match identifier references to declarations; optimize as locals.
-        Self::resolve_identifiers(&mut self.records, index, initiated_by_eval, suppress_globals);
+        Self::resolve_identifiers(
+            &mut self.records,
+            index,
+            initiated_by_eval,
+            suppress_globals,
+            identifiers,
+        );
         // 3. Annex B: hoist block-scoped functions to enclosing function scope.
-        Self::hoist_functions(&mut self.records, index);
+        Self::hoist_functions(&mut self.records, index, identifiers);
 
         // 4. For function-like scopes, build the var declaration list that
         //    the bytecode generator uses to initialize function-scoped variables.
@@ -893,7 +919,7 @@ impl ScopeCollector {
                 || st == ScopeType::ClassStaticInit
                 || st == ScopeType::ClassField;
             if needs_fsd {
-                Self::build_function_scope_data(&self.records, index);
+                Self::build_function_scope_data(&self.records, index, identifiers);
             }
         }
     }
@@ -931,7 +957,13 @@ impl ScopeCollector {
     /// - It's NOT captured by a nested function
     /// - It's NOT used inside a `with` statement
     /// - The scope chain is NOT poisoned by `eval()`
-    fn resolve_identifiers(records: &mut [ScopeRecord], index: usize, initiated_by_eval: bool, suppress_globals: bool) {
+    fn resolve_identifiers(
+        records: &mut [ScopeRecord],
+        index: usize,
+        initiated_by_eval: bool,
+        suppress_globals: bool,
+        identifiers: &IdentifierArena,
+    ) {
         // identifier_groups is an IndexMap, so iteration is in source order
         // of first reference. Local variable indices follow that order.
         let groups = std::mem::take(&mut records[index].identifier_groups);
@@ -941,7 +973,7 @@ impl ScopeCollector {
             // so the bytecode generator knows how to handle TDZ checks, etc.
             if let Some(dk) = group.declaration_kind {
                 for id in &group.identifiers {
-                    id.declaration_kind.set(Some(dk));
+                    identifiers[*id].declaration_kind.set(Some(dk));
                 }
             }
 
@@ -1018,7 +1050,7 @@ impl ScopeCollector {
                 && var_flags.intersects(VarFlags::BOUND)
             {
                 for id in &group.identifiers {
-                    id.is_inside_scope_with_eval.set(true);
+                    identifiers[*id].is_inside_scope_with_eval.set(true);
                 }
             }
 
@@ -1046,8 +1078,9 @@ impl ScopeCollector {
                 let can_use_global = !(suppress_globals || group.used_inside_with_statement || initiated_by_eval);
                 if can_use_global {
                     for id in &group.identifiers {
-                        if !id.is_inside_scope_with_eval.get() {
-                            id.is_global.set(true);
+                        let identifier = &identifiers[*id];
+                        if !identifier.is_inside_scope_with_eval.get() {
+                            identifier.is_global.set(true);
                         }
                     }
                 }
@@ -1100,8 +1133,9 @@ impl ScopeCollector {
                             let argument_index = records[ls].get_parameter_index(&name);
                             if let Some(ai) = argument_index {
                                 for id in &group.identifiers {
-                                    id.local_index.set(ai);
-                                    id.local_type.set(Some(crate::ast::LocalType::Argument));
+                                    let identifier = &identifiers[*id];
+                                    identifier.local_index.set(ai);
+                                    identifier.local_type.set(Some(crate::ast::LocalType::Argument));
                                 }
                             } else {
                                 let lvi = u32_from_usize(sd.local_variables.len());
@@ -1110,8 +1144,9 @@ impl ScopeCollector {
                                     kind: LocalVarKind::Var,
                                 });
                                 for id in &group.identifiers {
-                                    id.local_index.set(lvi);
-                                    id.local_type.set(Some(crate::ast::LocalType::Variable));
+                                    let identifier = &identifiers[*id];
+                                    identifier.local_index.set(lvi);
+                                    identifier.local_type.set(Some(crate::ast::LocalType::Variable));
                                 }
                             }
                         } else {
@@ -1122,8 +1157,9 @@ impl ScopeCollector {
                                 kind,
                             });
                             for id in &group.identifiers {
-                                id.local_index.set(lvi);
-                                id.local_type.set(Some(crate::ast::LocalType::Variable));
+                                let identifier = &identifiers[*id];
+                                identifier.local_index.set(lvi);
+                                identifier.local_type.set(Some(crate::ast::LocalType::Variable));
                             }
                         }
                     }
@@ -1142,7 +1178,7 @@ impl ScopeCollector {
 
                 if records[index].eval_in_current_function {
                     for id in &group.identifiers {
-                        id.is_inside_scope_with_eval.set(true);
+                        identifiers[*id].is_inside_scope_with_eval.set(true);
                     }
                 }
 
@@ -1172,7 +1208,7 @@ impl ScopeCollector {
     // - vars_to_initialize: var-declared names and their local variable indices
     // - functions_to_initialize: function declarations to instantiate (in reverse order)
     // - arguments object metadata (has_argument_parameter, has_function_named_arguments, etc.)
-    fn build_function_scope_data(records: &[ScopeRecord], index: usize) {
+    fn build_function_scope_data(records: &[ScopeRecord], index: usize, identifiers: &IdentifierArena) {
         let record = &records[index];
         let Some(ref scope_data) = record.scope_data else {
             return;
@@ -1202,15 +1238,15 @@ impl ScopeCollector {
             let sd = scope_data.borrow();
             for (i, child) in sd.children.iter().enumerate() {
                 if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
-                    && let Some(ref name_ident) = fd.name
+                    && let Some(name_ident) = fd.name
                 {
-                    last_position.insert(name_ident.name.clone(), i);
+                    last_position.insert(identifiers[name_ident].name.clone(), i);
                 }
             }
             for (i, child) in sd.children.iter().enumerate() {
                 if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
-                    && let Some(ref name_ident) = fd.name
-                    && last_position.get(&name_ident.name).copied() == Some(i)
+                    && let Some(name_ident) = fd.name
+                    && last_position.get(&identifiers[name_ident].name).copied() == Some(i)
                 {
                     functions_to_initialize.push(crate::ast::FunctionToInit { child_index: i });
                 }
@@ -1227,7 +1263,8 @@ impl ScopeCollector {
             let is_parameter = var.flags.intersects(VarFlags::FORBIDDEN_LEXICAL);
             let is_function_name = last_position.contains_key(name.as_slice());
 
-            let local_info = if let Some(ref ident) = var.var_identifier {
+            let local_info = if let Some(ident_id) = var.var_identifier {
+                let ident = &identifiers[ident_id];
                 if ident.is_local() {
                     Some(LocalBinding {
                         local_type: ident.local_type.get().expect("is_local() implies local_type is Some"),
@@ -1311,7 +1348,7 @@ impl ScopeCollector {
     /// The function propagates upward through block scopes until it reaches
     /// a function/program scope (top level) or is blocked by an existing
     /// lexical or function declaration with the same name.
-    fn hoist_functions(records: &mut [ScopeRecord], index: usize) {
+    fn hoist_functions(records: &mut [ScopeRecord], index: usize, identifiers: &IdentifierArena) {
         let functions = std::mem::take(&mut records[index].functions_to_hoist);
 
         for function in functions {
@@ -1346,7 +1383,7 @@ impl ScopeCollector {
                     let bs = block_scope.borrow();
                     for child in &bs.children {
                         if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
-                            && fd.name.as_ref().is_some_and(|n| n.name == function.name)
+                            && fd.name.is_some_and(|n| identifiers[n].name == function.name)
                         {
                             fd.is_hoisted.set(true);
                         }

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -50,12 +50,10 @@
 //!   name within one scope (multiple `foo` refs are grouped together)
 
 use indexmap::IndexMap;
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use crate::ast::{
-    FunctionScopeData, IdentifierArena, IdentifierId, LocalBinding, LocalVarKind, LocalVariable, ScopeData, StringId,
+    FunctionScopeData, IdentifierArena, IdentifierId, LocalBinding, LocalVarKind, LocalVariable, ScopeId, StringId,
     Utf16String, VarToInit,
 };
 use crate::parser::{DeclarationKind, FunctionKind, ParseError, ProgramType};
@@ -166,7 +164,7 @@ struct HoistableFunction {
     name: Utf16String,
     /// Reference to the block ScopeData that contains the function declaration.
     /// Used to set `is_hoisted = true` on the FunctionData when it's hoisted.
-    block_scope_data: Option<Rc<RefCell<ScopeData>>>,
+    block_scope_data: Option<ScopeId>,
 }
 
 #[derive(Debug)]
@@ -188,7 +186,7 @@ pub struct ParameterEntry {
 struct ScopeRecord {
     scope_type: ScopeType,
     scope_level: ScopeLevel,
-    scope_data: Option<Rc<RefCell<ScopeData>>>,
+    scope_data: Option<ScopeId>,
 
     variables: IndexMap<Utf16String, ScopeVariable>,
     identifier_groups: IndexMap<Utf16String, IdentifierGroup>,
@@ -217,7 +215,7 @@ struct ScopeRecord {
 }
 
 impl ScopeRecord {
-    fn new(scope_type: ScopeType, scope_level: ScopeLevel, scope_data: Option<Rc<RefCell<ScopeData>>>) -> Self {
+    fn new(scope_type: ScopeType, scope_level: ScopeLevel, scope_data: Option<ScopeId>) -> Self {
         Self {
             scope_type,
             scope_level,
@@ -397,12 +395,7 @@ impl ScopeCollector {
 
     // === Open/close scopes ===
 
-    fn open_scope(
-        &mut self,
-        scope_type: ScopeType,
-        scope_data: Option<Rc<RefCell<ScopeData>>>,
-        scope_level: ScopeLevel,
-    ) {
+    fn open_scope(&mut self, scope_type: ScopeType, scope_data: Option<ScopeId>, scope_level: ScopeLevel) {
         let index = self.records.len();
         let mut record = ScopeRecord::new(scope_type, scope_level, scope_data);
         record.parent = self.current;
@@ -411,7 +404,7 @@ impl ScopeCollector {
             && record.scope_data.is_none()
             && let Some(parent_index) = self.current
         {
-            record.scope_data = self.records[parent_index].scope_data.clone();
+            record.scope_data = self.records[parent_index].scope_data;
         }
 
         if scope_level == ScopeLevel::NotTopLevel {
@@ -464,11 +457,11 @@ impl ScopeCollector {
         }
     }
 
-    pub fn open_block_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
+    pub fn open_block_scope(&mut self, scope_data: Option<ScopeId>) {
         self.open_scope(ScopeType::Block, scope_data, ScopeLevel::NotTopLevel);
     }
 
-    pub fn open_for_loop_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
+    pub fn open_for_loop_scope(&mut self, scope_data: Option<ScopeId>) {
         self.open_scope(ScopeType::ForLoop, scope_data, ScopeLevel::NotTopLevel);
     }
 
@@ -476,7 +469,7 @@ impl ScopeCollector {
     // The `with` statement creates an object environment record that intercepts
     // identifier lookups, preventing any local variable optimization for
     // identifiers used within its scope.
-    pub fn open_with_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
+    pub fn open_with_scope(&mut self, scope_data: Option<ScopeId>) {
         self.open_scope(ScopeType::With, scope_data, ScopeLevel::NotTopLevel);
     }
 
@@ -484,11 +477,11 @@ impl ScopeCollector {
         self.open_scope(ScopeType::Catch, None, ScopeLevel::NotTopLevel);
     }
 
-    pub fn open_static_init_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
+    pub fn open_static_init_scope(&mut self, scope_data: Option<ScopeId>) {
         self.open_scope(ScopeType::ClassStaticInit, scope_data, ScopeLevel::StaticInitTopLevel);
     }
 
-    pub fn open_class_field_scope(&mut self, scope_data: Option<Rc<RefCell<ScopeData>>>) {
+    pub fn open_class_field_scope(&mut self, scope_data: Option<ScopeId>) {
         self.open_scope(ScopeType::ClassField, scope_data, ScopeLevel::NotTopLevel);
     }
 
@@ -523,6 +516,7 @@ impl ScopeCollector {
     // They walk the scope chain upward, registering in every scope along
     // the way until reaching a top-level scope (function, program, or
     // class static initializer).
+    #[allow(clippy::too_many_arguments)]
     pub fn add_var_declaration(
         &mut self,
         bound_names: &[(&[u16], Option<IdentifierId>)],
@@ -531,13 +525,14 @@ impl ScopeCollector {
         declaration_kind: Option<DeclarationKind>,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         let index = self.current.expect("no current scope");
 
         for (name, identifier) in bound_names {
             // Register the declaration identifier so it participates in scope analysis.
             if let Some(id) = identifier {
-                self.register_identifier(*id, declaration_kind, identifiers, strings);
+                self.register_identifier(*id, declaration_kind, identifiers, strings, scopes);
             }
 
             let mut scope_index = index;
@@ -575,13 +570,14 @@ impl ScopeCollector {
         declaration_column: u32,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         let index = self.current.expect("no current scope");
         let scope_level = self.records[index].scope_level;
 
         // Register the name identifier so it participates in scope analysis.
         if let Some(id) = name_identifier {
-            self.register_identifier(id, None, identifiers, strings);
+            self.register_identifier(id, None, identifiers, strings, scopes);
         }
 
         if scope_level != ScopeLevel::NotTopLevel && scope_level != ScopeLevel::ModuleTopLevel {
@@ -609,7 +605,7 @@ impl ScopeCollector {
             }
 
             if !existing_flags.intersects(VarFlags::LEXICAL) {
-                let block_scope = self.records[index].scope_data.clone();
+                let block_scope = self.records[index].scope_data;
                 self.records[index].functions_to_hoist.push(HoistableFunction {
                     name: Utf16String::from(name),
                     block_scope_data: block_scope,
@@ -648,6 +644,7 @@ impl ScopeCollector {
         declaration_kind: Option<DeclarationKind>,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        _scopes: &mut crate::ast::ScopeArena,
     ) {
         let index = self.current.expect("no current scope");
         let name = strings[identifiers[id].name].clone();
@@ -676,6 +673,7 @@ impl ScopeCollector {
         has_parameter_expressions: bool,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         let index = self.current.expect("no current scope");
         self.records[index].has_function_parameters = true;
@@ -700,7 +698,7 @@ impl ScopeCollector {
                 });
             }
             if let Some(id) = entry.identifier {
-                self.register_identifier(id, None, identifiers, strings);
+                self.register_identifier(id, None, identifiers, strings, scopes);
             }
             let var = self.records[index].variables.entry(entry.name.clone()).or_default();
             var.flags |= VarFlags::PARAMETER_CANDIDATE | VarFlags::FORBIDDEN_LEXICAL;
@@ -725,14 +723,14 @@ impl ScopeCollector {
 
     // === Scope node ===
 
-    pub fn set_scope_node(&mut self, scope_data: Rc<RefCell<ScopeData>>) {
+    pub fn set_scope_node(&mut self, scope_data: ScopeId) {
         let index = self.current.expect("no current scope");
-        self.records[index].scope_data = Some(scope_data.clone());
+        self.records[index].scope_data = Some(scope_data);
         // Update block_scope_data for any pending functions_to_hoist that
         // were registered before the ScopeData was created.
         for function in &mut self.records[index].functions_to_hoist {
             if function.block_scope_data.is_none() {
-                function.block_scope_data = Some(scope_data.clone());
+                function.block_scope_data = Some(scope_data);
             }
         }
     }
@@ -868,8 +866,9 @@ impl ScopeCollector {
         initiated_by_eval: bool,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
-        self.analyze_inner(initiated_by_eval, false, identifiers, strings);
+        self.analyze_inner(initiated_by_eval, false, identifiers, strings, scopes);
     }
 
     /// Like analyze(), but suppresses marking identifiers as global.
@@ -880,8 +879,9 @@ impl ScopeCollector {
         &mut self,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
-        self.analyze_inner(false, true, identifiers, strings);
+        self.analyze_inner(false, true, identifiers, strings, scopes);
     }
 
     fn analyze_inner(
@@ -890,9 +890,10 @@ impl ScopeCollector {
         suppress_globals: bool,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         if !self.records.is_empty() {
-            self.analyze_recursive(0, initiated_by_eval, suppress_globals, identifiers, strings);
+            self.analyze_recursive(0, initiated_by_eval, suppress_globals, identifiers, strings, scopes);
         }
     }
 
@@ -906,11 +907,19 @@ impl ScopeCollector {
         suppress_globals: bool,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         // Process children first (bottom-up traversal).
         let children = std::mem::take(&mut self.records[index].children);
         for child_index in children {
-            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals, identifiers, strings);
+            self.analyze_recursive(
+                child_index,
+                initiated_by_eval,
+                suppress_globals,
+                identifiers,
+                strings,
+                scopes,
+            );
         }
 
         // Steps 1-3 must run even for scopes without scope_data (e.g. catch
@@ -928,9 +937,10 @@ impl ScopeCollector {
             suppress_globals,
             identifiers,
             strings,
+            scopes,
         );
         // 3. Annex B: hoist block-scoped functions to enclosing function scope.
-        Self::hoist_functions(&mut self.records, index, identifiers, strings);
+        Self::hoist_functions(&mut self.records, index, identifiers, strings, scopes);
 
         // 4. For function-like scopes, build the var declaration list that
         //    the bytecode generator uses to initialize function-scoped variables.
@@ -940,7 +950,7 @@ impl ScopeCollector {
                 || st == ScopeType::ClassStaticInit
                 || st == ScopeType::ClassField;
             if needs_fsd {
-                Self::build_function_scope_data(&self.records, index, identifiers, strings);
+                Self::build_function_scope_data(&self.records, index, identifiers, strings, scopes);
             }
         }
     }
@@ -985,6 +995,7 @@ impl ScopeCollector {
         suppress_globals: bool,
         identifiers: &mut IdentifierArena,
         _strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         // identifier_groups is an IndexMap, so iteration is in source order
         // of first reference. Local variable indices follow that order.
@@ -1147,9 +1158,9 @@ impl ScopeCollector {
                     }
 
                     if let Some(ls) = local_scope
-                        && let Some(ref scope_data) = records[ls].scope_data
+                        && let Some(scope_id) = records[ls].scope_data
                     {
-                        let mut sd = scope_data.borrow_mut();
+                        let sd = &mut scopes[scope_id];
 
                         if is_function_parameter {
                             let argument_index = records[ls].get_parameter_index(&name);
@@ -1235,9 +1246,10 @@ impl ScopeCollector {
         index: usize,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         let record = &records[index];
-        let Some(ref scope_data) = record.scope_data else {
+        let Some(scope_id) = record.scope_data else {
             return;
         };
 
@@ -1263,7 +1275,7 @@ impl ScopeCollector {
         let mut last_position: HashMap<StringId, usize> = HashMap::new();
         let mut last_position_by_slice: HashMap<Utf16String, usize> = HashMap::new();
         {
-            let sd = scope_data.borrow();
+            let sd = &scopes[scope_id];
             for (i, child) in sd.children.iter().enumerate() {
                 if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
                     && let Some(name_ident) = fd.name
@@ -1349,7 +1361,7 @@ impl ScopeCollector {
         };
 
         {
-            let mut sd = scope_data.borrow_mut();
+            let sd = &mut scopes[scope_id];
             sd.function_scope_data = Some(Box::new(fsd));
 
             // Write scope analysis insights to ScopeData so they can be read
@@ -1383,6 +1395,7 @@ impl ScopeCollector {
         index: usize,
         identifiers: &mut IdentifierArena,
         strings: &crate::ast::StringInterner,
+        scopes: &mut crate::ast::ScopeArena,
     ) {
         let functions = std::mem::take(&mut records[index].functions_to_hoist);
 
@@ -1406,23 +1419,23 @@ impl ScopeCollector {
                     continue;
                 }
                 // Reached function/program scope — register the hoisted function name.
-                if let Some(ref scope_data) = records[index].scope_data {
-                    let mut sd = scope_data.borrow_mut();
+                if let Some(scope_id) = records[index].scope_data {
+                    let sd = &mut scopes[scope_id];
                     if !sd.annexb_function_names.contains(&function.name) {
                         sd.annexb_function_names.push(function.name.clone());
                     }
                 }
                 // Mark all function declarations with this name in the block
                 // as hoisted, so they emit GetBinding + SetVariableBinding.
-                if let Some(ref block_scope) = function.block_scope_data {
-                    let bs = block_scope.borrow();
-                    for child in &bs.children {
-                        if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
+                if let Some(block_scope_id) = function.block_scope_data {
+                    let bs = &mut scopes[block_scope_id];
+                    for child in &mut bs.children {
+                        if let crate::ast::StatementKind::FunctionDeclaration(ref mut fd) = child.inner
                             && fd
                                 .name
                                 .is_some_and(|n| strings[identifiers[n].name].as_slice() == function.name.as_slice())
                         {
-                            fd.is_hoisted.set(true);
+                            fd.is_hoisted = true;
                         }
                     }
                 }

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -55,8 +55,8 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::ast::{
-    FunctionScopeData, IdentifierArena, IdentifierId, LocalBinding, LocalVarKind, LocalVariable, ScopeData,
-    SharedUtf16String, Utf16String, VarToInit,
+    FunctionScopeData, IdentifierArena, IdentifierId, LocalBinding, LocalVarKind, LocalVariable, ScopeData, StringId,
+    Utf16String, VarToInit,
 };
 use crate::parser::{DeclarationKind, FunctionKind, ParseError, ProgramType};
 use crate::u32_from_usize;
@@ -191,7 +191,7 @@ struct ScopeRecord {
     scope_data: Option<Rc<RefCell<ScopeData>>>,
 
     variables: IndexMap<Utf16String, ScopeVariable>,
-    identifier_groups: IndexMap<SharedUtf16String, IdentifierGroup>,
+    identifier_groups: IndexMap<Utf16String, IdentifierGroup>,
     functions_to_hoist: Vec<HoistableFunction>,
 
     // Parameter tracking
@@ -530,13 +530,14 @@ impl ScopeCollector {
         declaration_column: u32,
         declaration_kind: Option<DeclarationKind>,
         identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
     ) {
         let index = self.current.expect("no current scope");
 
         for (name, identifier) in bound_names {
             // Register the declaration identifier so it participates in scope analysis.
             if let Some(id) = identifier {
-                self.register_identifier(*id, declaration_kind, identifiers);
+                self.register_identifier(*id, declaration_kind, identifiers, strings);
             }
 
             let mut scope_index = index;
@@ -573,13 +574,14 @@ impl ScopeCollector {
         declaration_line: u32,
         declaration_column: u32,
         identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
     ) {
         let index = self.current.expect("no current scope");
         let scope_level = self.records[index].scope_level;
 
         // Register the name identifier so it participates in scope analysis.
         if let Some(id) = name_identifier {
-            self.register_identifier(id, None, identifiers);
+            self.register_identifier(id, None, identifiers, strings);
         }
 
         if scope_level != ScopeLevel::NotTopLevel && scope_level != ScopeLevel::ModuleTopLevel {
@@ -645,9 +647,10 @@ impl ScopeCollector {
         id: IdentifierId,
         declaration_kind: Option<DeclarationKind>,
         identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
     ) {
         let index = self.current.expect("no current scope");
-        let name = identifiers[id].name.clone();
+        let name = strings[identifiers[id].name].clone();
         self.records[index]
             .identifier_groups
             .entry(name)
@@ -672,6 +675,7 @@ impl ScopeCollector {
         entries: &[ParameterEntry],
         has_parameter_expressions: bool,
         identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
     ) {
         let index = self.current.expect("no current scope");
         self.records[index].has_function_parameters = true;
@@ -696,7 +700,7 @@ impl ScopeCollector {
                 });
             }
             if let Some(id) = entry.identifier {
-                self.register_identifier(id, None, identifiers);
+                self.register_identifier(id, None, identifiers, strings);
             }
             let var = self.records[index].variables.entry(entry.name.clone()).or_default();
             var.flags |= VarFlags::PARAMETER_CANDIDATE | VarFlags::FORBIDDEN_LEXICAL;
@@ -707,14 +711,14 @@ impl ScopeCollector {
         // declares the same name, it must not be optimized to a local, since the
         // default expression needs to resolve it from the outer scope.
         if has_parameter_expressions {
-            let names_to_mark: Vec<SharedUtf16String> = self.records[index]
+            let names_to_mark: Vec<Utf16String> = self.records[index]
                 .identifier_groups
                 .keys()
-                .filter(|name| !self.records[index].has_flag(name, VarFlags::FORBIDDEN_LEXICAL))
+                .filter(|name| !self.records[index].has_flag(name.as_slice(), VarFlags::FORBIDDEN_LEXICAL))
                 .cloned()
                 .collect();
             for name in names_to_mark {
-                self.records[index].variable(&name).flags |= VarFlags::REFERENCED_IN_FORMAL_PARAMETERS;
+                self.records[index].variable(name.as_slice()).flags |= VarFlags::REFERENCED_IN_FORMAL_PARAMETERS;
             }
         }
     }
@@ -859,21 +863,36 @@ impl ScopeCollector {
 
     // === Post-parse analysis ===
 
-    pub fn analyze(&mut self, initiated_by_eval: bool, identifiers: &mut IdentifierArena) {
-        self.analyze_inner(initiated_by_eval, false, identifiers);
+    pub fn analyze(
+        &mut self,
+        initiated_by_eval: bool,
+        identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
+    ) {
+        self.analyze_inner(initiated_by_eval, false, identifiers, strings);
     }
 
     /// Like analyze(), but suppresses marking identifiers as global.
     /// Used for dynamic functions (new Function(...)) where the source is
     /// parsed as a Script but identifiers must not use GetGlobal/SetGlobal,
     /// matching the C++ path which parses as a FunctionExpression.
-    pub fn analyze_as_dynamic_function(&mut self, identifiers: &mut IdentifierArena) {
-        self.analyze_inner(false, true, identifiers);
+    pub fn analyze_as_dynamic_function(
+        &mut self,
+        identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
+    ) {
+        self.analyze_inner(false, true, identifiers, strings);
     }
 
-    fn analyze_inner(&mut self, initiated_by_eval: bool, suppress_globals: bool, identifiers: &mut IdentifierArena) {
+    fn analyze_inner(
+        &mut self,
+        initiated_by_eval: bool,
+        suppress_globals: bool,
+        identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
+    ) {
         if !self.records.is_empty() {
-            self.analyze_recursive(0, initiated_by_eval, suppress_globals, identifiers);
+            self.analyze_recursive(0, initiated_by_eval, suppress_globals, identifiers, strings);
         }
     }
 
@@ -886,11 +905,12 @@ impl ScopeCollector {
         initiated_by_eval: bool,
         suppress_globals: bool,
         identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
     ) {
         // Process children first (bottom-up traversal).
         let children = std::mem::take(&mut self.records[index].children);
         for child_index in children {
-            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals, identifiers);
+            self.analyze_recursive(child_index, initiated_by_eval, suppress_globals, identifiers, strings);
         }
 
         // Steps 1-3 must run even for scopes without scope_data (e.g. catch
@@ -907,9 +927,10 @@ impl ScopeCollector {
             initiated_by_eval,
             suppress_globals,
             identifiers,
+            strings,
         );
         // 3. Annex B: hoist block-scoped functions to enclosing function scope.
-        Self::hoist_functions(&mut self.records, index, identifiers);
+        Self::hoist_functions(&mut self.records, index, identifiers, strings);
 
         // 4. For function-like scopes, build the var declaration list that
         //    the bytecode generator uses to initialize function-scoped variables.
@@ -919,7 +940,7 @@ impl ScopeCollector {
                 || st == ScopeType::ClassStaticInit
                 || st == ScopeType::ClassField;
             if needs_fsd {
-                Self::build_function_scope_data(&self.records, index, identifiers);
+                Self::build_function_scope_data(&self.records, index, identifiers, strings);
             }
         }
     }
@@ -963,11 +984,12 @@ impl ScopeCollector {
         initiated_by_eval: bool,
         suppress_globals: bool,
         identifiers: &mut IdentifierArena,
+        _strings: &crate::ast::StringInterner,
     ) {
         // identifier_groups is an IndexMap, so iteration is in source order
         // of first reference. Local variable indices follow that order.
         let groups = std::mem::take(&mut records[index].identifier_groups);
-        let mut propagate_to_parent: Vec<(SharedUtf16String, IdentifierGroup)> = Vec::new();
+        let mut propagate_to_parent: Vec<(Utf16String, IdentifierGroup)> = Vec::new();
         for (name, mut group) in groups {
             // Annotate each Identifier AST node with its declaration kind,
             // so the bytecode generator knows how to handle TDZ checks, etc.
@@ -1140,7 +1162,7 @@ impl ScopeCollector {
                             } else {
                                 let lvi = u32_from_usize(sd.local_variables.len());
                                 sd.local_variables.push(LocalVariable {
-                                    name: name.to_utf16_string(),
+                                    name: name.clone(),
                                     kind: LocalVarKind::Var,
                                 });
                                 for id in &group.identifiers {
@@ -1153,7 +1175,7 @@ impl ScopeCollector {
                             let kind = local_var_kind.expect("local_var_kind must be set for local variables");
                             let lvi = u32_from_usize(sd.local_variables.len());
                             sd.local_variables.push(LocalVariable {
-                                name: name.to_utf16_string(),
+                                name: name.clone(),
                                 kind,
                             });
                             for id in &group.identifiers {
@@ -1208,7 +1230,12 @@ impl ScopeCollector {
     // - vars_to_initialize: var-declared names and their local variable indices
     // - functions_to_initialize: function declarations to instantiate (in reverse order)
     // - arguments object metadata (has_argument_parameter, has_function_named_arguments, etc.)
-    fn build_function_scope_data(records: &[ScopeRecord], index: usize, identifiers: &mut IdentifierArena) {
+    fn build_function_scope_data(
+        records: &[ScopeRecord],
+        index: usize,
+        identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
+    ) {
         let record = &records[index];
         let Some(ref scope_data) = record.scope_data else {
             return;
@@ -1233,14 +1260,17 @@ impl ScopeCollector {
         // position matches. Keys are SharedUtf16String so each insert is a cheap
         // Rc bump rather than a deep clone of the name.
         let mut functions_to_initialize: Vec<crate::ast::FunctionToInit> = Vec::new();
-        let mut last_position: HashMap<SharedUtf16String, usize> = HashMap::new();
+        let mut last_position: HashMap<StringId, usize> = HashMap::new();
+        let mut last_position_by_slice: HashMap<Utf16String, usize> = HashMap::new();
         {
             let sd = scope_data.borrow();
             for (i, child) in sd.children.iter().enumerate() {
                 if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
                     && let Some(name_ident) = fd.name
                 {
-                    last_position.insert(identifiers[name_ident].name.clone(), i);
+                    let name_id = identifiers[name_ident].name;
+                    last_position.insert(name_id, i);
+                    last_position_by_slice.insert(strings[name_id].clone(), i);
                 }
             }
             for (i, child) in sd.children.iter().enumerate() {
@@ -1261,7 +1291,7 @@ impl ScopeCollector {
             var_names.push(name.clone());
 
             let is_parameter = var.flags.intersects(VarFlags::FORBIDDEN_LEXICAL);
-            let is_function_name = last_position.contains_key(name.as_slice());
+            let is_function_name = last_position_by_slice.contains_key(name.as_slice());
 
             let local_info = if let Some(ident_id) = var.var_identifier {
                 let ident = &identifiers[ident_id];
@@ -1295,7 +1325,7 @@ impl ScopeCollector {
         // vars_to_initialize and var_names follow source order via the
         // insertion order of `record.variables`, which is now an IndexMap.
 
-        if last_position.contains_key(utf16!("arguments") as &[u16]) {
+        if last_position_by_slice.contains_key(utf16!("arguments") as &[u16]) {
             has_function_named_arguments = true;
         }
 
@@ -1348,7 +1378,12 @@ impl ScopeCollector {
     /// The function propagates upward through block scopes until it reaches
     /// a function/program scope (top level) or is blocked by an existing
     /// lexical or function declaration with the same name.
-    fn hoist_functions(records: &mut [ScopeRecord], index: usize, identifiers: &mut IdentifierArena) {
+    fn hoist_functions(
+        records: &mut [ScopeRecord],
+        index: usize,
+        identifiers: &mut IdentifierArena,
+        strings: &crate::ast::StringInterner,
+    ) {
         let functions = std::mem::take(&mut records[index].functions_to_hoist);
 
         for function in functions {
@@ -1383,7 +1418,9 @@ impl ScopeCollector {
                     let bs = block_scope.borrow();
                     for child in &bs.children {
                         if let crate::ast::StatementKind::FunctionDeclaration(ref fd) = child.inner
-                            && fd.name.is_some_and(|n| identifiers[n].name == function.name)
+                            && fd
+                                .name
+                                .is_some_and(|n| strings[identifiers[n].name].as_slice() == function.name.as_slice())
                         {
                             fd.is_hoisted.set(true);
                         }

--- a/Libraries/LibJS/Rust/src/scope_collector.rs
+++ b/Libraries/LibJS/Rust/src/scope_collector.rs
@@ -49,8 +49,7 @@
 //! - `IdentifierGroup` — a set of identifier references with the same
 //!   name within one scope (multiple `foo` refs are grouped together)
 
-use indexmap::IndexMap;
-use std::collections::HashMap;
+use crate::fast_hash::{HashMap, IndexMap};
 
 use crate::ast::{
     FunctionScopeData, IdentifierArena, IdentifierId, LocalBinding, LocalVarKind, LocalVariable, ScopeId, StringId,
@@ -220,8 +219,8 @@ impl ScopeRecord {
             scope_type,
             scope_level,
             scope_data,
-            variables: IndexMap::new(),
-            identifier_groups: IndexMap::new(),
+            variables: IndexMap::default(),
+            identifier_groups: IndexMap::default(),
             functions_to_hoist: Vec::new(),
             has_function_parameters: false,
             parameter_names: Vec::new(),
@@ -1272,8 +1271,8 @@ impl ScopeCollector {
         // position matches. Keys are SharedUtf16String so each insert is a cheap
         // Rc bump rather than a deep clone of the name.
         let mut functions_to_initialize: Vec<crate::ast::FunctionToInit> = Vec::new();
-        let mut last_position: HashMap<StringId, usize> = HashMap::new();
-        let mut last_position_by_slice: HashMap<Utf16String, usize> = HashMap::new();
+        let mut last_position: HashMap<StringId, usize> = HashMap::default();
+        let mut last_position_by_slice: HashMap<Utf16String, usize> = HashMap::default();
         {
             let sd = &scopes[scope_id];
             for (i, child) in sd.children.iter().enumerate() {

--- a/Libraries/LibJS/Rust/src/token.rs
+++ b/Libraries/LibJS/Rust/src/token.rs
@@ -196,8 +196,6 @@ pub struct Token {
     /// Decoded identifier value, set when the identifier contains unicode
     /// escape sequences (e.g. `l\u0065t` → `let`).
     pub identifier_value: Option<crate::ast::Utf16String>,
-    /// Shared identifier spelling supplied by the lexer for identifier-like tokens.
-    pub shared_identifier_value: Option<crate::ast::SharedUtf16String>,
     /// Error message for Invalid tokens (e.g. "Unterminated multi-line comment").
     pub message: Option<String>,
 }
@@ -215,7 +213,6 @@ impl Token {
             offset: 0,
             trivia_has_line_terminator: false,
             identifier_value: None,
-            shared_identifier_value: None,
             message: None,
         }
     }

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1267,6 +1267,14 @@ if(NOT BUILD_SHARED_LIBS)
         COMMENT "Merging Rust archive into LibWeb"
     )
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
+
+    # POST_BUILD steps don't track inputs, so when libweb_rust.a changes
+    # ninja leaves liblagom-web.a alone and the merged archive ends up with
+    # stale Rust objects. Force the C++ FFI bridge file to depend on the
+    # Rust archive: when it changes, RustTokenizer.cpp recompiles, LibWeb
+    # re-archives, and POST_BUILD re-merges the fresh Rust objects.
+    get_target_property(_libweb_rust_lib libweb_rust IMPORTED_LOCATION)
+    set_property(SOURCE CSS/Parser/RustTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
 endif()
 
 if (HAS_FONTCONFIG)


### PR DESCRIPTION
The AST moves off `Rc<Identifier>` / `Rc<RefCell<ScopeData>>` onto contiguous arenas with `Copy` index handles, all on `AstArena` shared via `Arc<AstArena>`. `ParsedProgram: Send` is now compile-time verified instead of `unsafe impl Send`, so codegen workers can clone the arc and run their own `Generator` locally.

Hot parse-time `Utf16String`-keyed hash maps move from SipHash to `foldhash::quality::RandomState`.

Bonus fix: a static-link build hole where the `POST_BUILD` Rust-archive merge into `liblagom-{js,web}.a` wasn't tracking the Rust crate as an input, leaving the merged archive stale on Rust-only edits.

JS parser benchmarks are happy:

```
Suite          Test                            Speedup    Old (Mean ± Range)     New (Mean ± Range)     Max RSS (mean)
-------------  ------------------------------  ---------  ---------------------  ---------------------  ------------------
WebsitesParse  discord-web-2026-04-03.js       1.201      1.199 ± 1.041 … 1.358  0.999 ± 0.999 … 0.999  -7.5% (-52.6 MB)
WebsitesParse  google-docs-2026-04-03.js       1.287      2.745 ± 2.698 … 2.792  2.132 ± 2.128 … 2.136  -10.5% (-114.0 MB)
WebsitesParse  instagram-main-2026-04-03.js    1.058      0.550 ± 0.548 … 0.552  0.520 ± 0.515 … 0.525  -8.8% (-34.2 MB)
WebsitesParse  vscode-workbench-2026-04-03.js  1.053      1.159 ± 1.157 … 1.161  1.100 ± 1.099 … 1.101  -7.9% (-65.1 MB)
WebsitesParse  Total                           1.190      5.653                  4.751                  -8.8% (-265.9 MB)
```