### PR TITLE
LibUnicode: Update icu4x's calendar module to 2.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_calendar"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf"
+checksum = "a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",

--- a/Libraries/LibUnicode/Rust/Cargo.toml
+++ b/Libraries/LibUnicode/Rust/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "rlib"]
 #   python3 Meta/CMake/flatpak/generate-cargo-sources.py
 [dependencies]
 calendrical_calculations = "=0.2.4"
-icu_calendar = { version = "=2.2.0", features = ["compiled_data"] }
+icu_calendar = { version = "=2.2.1", features = ["compiled_data"] }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/Meta/CMake/flatpak/cargo-sources.json
+++ b/Meta/CMake/flatpak/cargo-sources.json
@@ -183,9 +183,9 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/icu_calendar/icu_calendar-2.2.0.crate",
-        "sha256": "baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf",
-        "dest": "cargo/vendor/icu_calendar-2.2.0"
+        "url": "https://static.crates.io/crates/icu_calendar/icu_calendar-2.2.1.crate",
+        "sha256": "a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45",
+        "dest": "cargo/vendor/icu_calendar-2.2.1"
     },
     {
         "type": "archive",
@@ -733,7 +733,7 @@
             "echo '{\"files\": {}, \"package\": \"9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1\"}' > cargo/vendor/hashbrown-0.15.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100\"}' > cargo/vendor/hashbrown-0.16.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\"}' > cargo/vendor/heck-0.5.0/.cargo-checksum.json",
-            "echo '{\"files\": {}, \"package\": \"baf11bd83ebd0cd319e23a9a9c9a25b564a1fadc3bbc93069b8abc9d8df812bf\"}' > cargo/vendor/icu_calendar-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45\"}' > cargo/vendor/icu_calendar-2.2.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d\"}' > cargo/vendor/icu_calendar_data-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c\"}' > cargo/vendor/icu_collections-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26\"}' > cargo/vendor/icu_locale-2.2.0/.cargo-checksum.json",


### PR DESCRIPTION
This pull request updates the `icu_calendar` Rust crate from version 2.2.0 to 2.2.1.

The [2.2.1 version](https://github.com/unicode-org/icu4x/blob/162257d91c3d37e7babe3b01855d059a9bf0a8a0/CHANGELOG.md#icu-22x) fixed year calculations in Gregorian-like and Coptic-like calendars (implemented in https://github.com/unicode-org/icu4x/pull/7849)