### PR TITLE
LibJS+LibWeb: Cache JavaScript bytecode on disk

### DIFF
--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -159,6 +159,15 @@ ErrorOr<void> mkdir(StringView path, mode_t)
     return {};
 }
 
+ErrorOr<void> rename(StringView old_path, StringView new_path)
+{
+    ByteString old_path_string = old_path;
+    ByteString new_path_string = new_path;
+    if (!MoveFileExA(old_path_string.characters(), new_path_string.characters(), MOVEFILE_REPLACE_EXISTING))
+        return Error::from_windows_error();
+    return {};
+}
+
 ErrorOr<int> openat(int, StringView, int, mode_t)
 {
     dbgln("Core::System::openat() is not implemented");

--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -89,6 +89,8 @@ void CacheEntry::remove()
         return;
 
     (void)FileSystem::remove(m_path->string(), FileSystem::RecursionMode::Disallowed);
+    for (auto associated_data : CACHE_ENTRY_ASSOCIATED_DATA_TYPES)
+        (void)FileSystem::remove(path_for_cache_entry_associated_data(m_disk_cache.cache_directory(), m_cache_key, m_vary_key, associated_data).string(), FileSystem::RecursionMode::Disallowed);
     m_index.remove_entry(m_cache_key, m_vary_key);
 }
 
@@ -202,6 +204,11 @@ ErrorOr<void> CacheEntryWriter::flush(NonnullRefPtr<HeaderList> request_headers,
 
         return result.release_error();
     }
+
+    // Drop any sidecars left over from an older entry at the same (cache_key, vary_key). They are tied to the previous
+    // response body, so reusing them with the freshly written one would mismatch the source they were generated for.
+    for (auto associated_data : CACHE_ENTRY_ASSOCIATED_DATA_TYPES)
+        (void)FileSystem::remove(path_for_cache_entry_associated_data(m_disk_cache.cache_directory(), m_cache_key, m_vary_key, associated_data).string(), FileSystem::RecursionMode::Disallowed);
 
     if (auto result = m_index.create_entry(m_cache_key, m_vary_key, m_url, move(request_headers), move(response_headers), m_cache_footer.data_size, m_request_time, m_response_time); result.is_error()) {
         dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[31;1mUnable to flush cache entry for\033[0m {} ({} bytes): {}", m_url, m_cache_footer.data_size, result.error());

--- a/Libraries/LibHTTP/Cache/CacheIndex.cpp
+++ b/Libraries/LibHTTP/Cache/CacheIndex.cpp
@@ -88,6 +88,7 @@ ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath
             request_headers BLOB,
             response_headers BLOB,
             data_size INTEGER,
+            associated_data_size INTEGER,
             request_time INTEGER,
             response_time INTEGER,
             last_access_time INTEGER,
@@ -97,19 +98,20 @@ ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath
     database.execute_statement(create_cache_index_table, {});
 
     Statements statements {};
-    statements.insert_entry = TRY(database.prepare_statement("INSERT OR REPLACE INTO CacheIndex VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
+    statements.insert_entry = TRY(database.prepare_statement("INSERT OR REPLACE INTO CacheIndex VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);"sv));
     statements.remove_entry = TRY(database.prepare_statement(R"#(
         DELETE FROM CacheIndex
         WHERE cache_key = ? AND vary_key = ?
-        RETURNING data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
+        RETURNING data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
     )#"sv));
     statements.remove_entries_accessed_since = TRY(database.prepare_statement(R"#(
         DELETE FROM CacheIndex
         WHERE last_access_time >= ?
-        RETURNING cache_key, vary_key, data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
+        RETURNING cache_key, vary_key, data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
     )#"sv));
     statements.select_entries = TRY(database.prepare_statement("SELECT * FROM CacheIndex WHERE cache_key = ?;"sv));
     statements.update_response_headers = TRY(database.prepare_statement("UPDATE CacheIndex SET response_headers = ? WHERE cache_key = ? AND vary_key = ?;"sv));
+    statements.update_associated_data_size = TRY(database.prepare_statement("UPDATE CacheIndex SET associated_data_size = ? WHERE cache_key = ? AND vary_key = ?;"sv));
     statements.update_last_access_time = TRY(database.prepare_statement("UPDATE CacheIndex SET last_access_time = ? WHERE cache_key = ? AND vary_key = ?;"sv));
 
     statements.remove_entries_exceeding_cache_limit = TRY(database.prepare_statement(R"#(
@@ -117,7 +119,7 @@ ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath
             SELECT
                 cache_key,
                 vary_key,
-                SUM(data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers))
+                SUM(data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers))
                     OVER (ORDER BY last_access_time DESC)
                     AS cumulative_estimated_size
             FROM CacheIndex
@@ -128,17 +130,17 @@ ErrorOr<CacheIndex> CacheIndex::create(Database::Database& database, LexicalPath
             FROM RankedCacheIndex
             WHERE cumulative_estimated_size > ?
         )
-        RETURNING cache_key, vary_key, data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
+        RETURNING cache_key, vary_key, data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers);
     )#"sv));
 
     statements.estimate_cache_size_accessed_since = TRY(database.prepare_statement(R"#(
-        SELECT COALESCE(SUM(data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers)), 0)
+        SELECT COALESCE(SUM(data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers)), 0)
         FROM CacheIndex
         WHERE last_access_time >= ?;
     )#"sv));
 
     statements.select_total_estimated_size = TRY(database.prepare_statement(R"#(
-        SELECT COALESCE(SUM(data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers)), 0)
+        SELECT COALESCE(SUM(data_size + associated_data_size + OCTET_LENGTH(request_headers) + OCTET_LENGTH(response_headers)), 0)
         FROM CacheIndex;
     )#"sv));
 
@@ -189,6 +191,7 @@ ErrorOr<void> CacheIndex::create_entry(u64 cache_key, u64 vary_key, String url, 
         .request_headers = move(request_headers),
         .response_headers = move(response_headers),
         .data_size = data_size,
+        .associated_data_size = 0,
         .serialized_request_headers_size = static_cast<u64>(serialized_request_headers.length()),
         .serialized_response_headers_size = static_cast<u64>(serialized_response_headers.length()),
         .request_time = request_time,
@@ -214,7 +217,7 @@ ErrorOr<void> CacheIndex::create_entry(u64 cache_key, u64 vary_key, String url, 
         return existing_entry.vary_key == vary_key;
     });
 
-    m_database->execute_statement(m_statements.insert_entry, {}, cache_key, vary_key, entry.url, serialized_request_headers, serialized_response_headers, entry.data_size, entry.request_time, entry.response_time, entry.last_access_time);
+    m_database->execute_statement(m_statements.insert_entry, {}, cache_key, vary_key, entry.url, serialized_request_headers, serialized_response_headers, entry.data_size, entry.associated_data_size, entry.request_time, entry.response_time, entry.last_access_time);
 
     if (existing_entry_index.has_value())
         entries[*existing_entry_index] = move(entry);
@@ -294,6 +297,19 @@ void CacheIndex::update_response_headers(u64 cache_key, u64 vary_key, NonnullRef
     entry->serialized_response_headers_size = serialized_response_headers_size;
 }
 
+void CacheIndex::update_associated_data_size(u64 cache_key, u64 vary_key, u64 associated_data_size)
+{
+    auto entry = get_entry(cache_key, vary_key);
+    if (!entry.has_value())
+        return;
+
+    m_database->execute_statement(m_statements.update_associated_data_size, {}, associated_data_size, cache_key, vary_key);
+
+    m_total_estimated_size -= entry->associated_data_size;
+    m_total_estimated_size += associated_data_size;
+    entry->associated_data_size = associated_data_size;
+}
+
 void CacheIndex::update_last_access_time(u64 cache_key, u64 vary_key)
 {
     auto entry = get_entry(cache_key, vary_key);
@@ -321,11 +337,12 @@ Optional<CacheIndex::Entry const&> CacheIndex::find_entry(u64 cache_key, HeaderL
                 auto request_headers = m_database->result_column<ByteString>(statement_id, column++);
                 auto response_headers = m_database->result_column<ByteString>(statement_id, column++);
                 auto data_size = m_database->result_column<u64>(statement_id, column++);
+                auto associated_data_size = m_database->result_column<u64>(statement_id, column++);
                 auto request_time = m_database->result_column<UnixDateTime>(statement_id, column++);
                 auto response_time = m_database->result_column<UnixDateTime>(statement_id, column++);
                 auto last_access_time = m_database->result_column<UnixDateTime>(statement_id, column++);
 
-                entries.empend(vary_key, move(url), deserialize_headers(request_headers), deserialize_headers(response_headers), data_size, request_headers.length(), response_headers.length(), request_time, response_time, last_access_time);
+                entries.empend(vary_key, move(url), deserialize_headers(request_headers), deserialize_headers(response_headers), data_size, associated_data_size, request_headers.length(), response_headers.length(), request_time, response_time, last_access_time);
             },
             cache_key);
 

--- a/Libraries/LibHTTP/Cache/CacheIndex.cpp
+++ b/Libraries/LibHTTP/Cache/CacheIndex.cpp
@@ -354,6 +354,11 @@ Optional<CacheIndex::Entry const&> CacheIndex::find_entry(u64 cache_key, HeaderL
     });
 }
 
+bool CacheIndex::has_entry(u64 cache_key, u64 vary_key)
+{
+    return get_entry(cache_key, vary_key).has_value();
+}
+
 Optional<CacheIndex::Entry&> CacheIndex::get_entry(u64 cache_key, u64 vary_key)
 {
     auto entries = m_entries.get(cache_key);

--- a/Libraries/LibHTTP/Cache/CacheIndex.h
+++ b/Libraries/LibHTTP/Cache/CacheIndex.h
@@ -27,6 +27,7 @@ class CacheIndex {
         NonnullRefPtr<HeaderList> request_headers;
         NonnullRefPtr<HeaderList> response_headers;
         u64 data_size { 0 };
+        u64 associated_data_size { 0 };
         u64 serialized_request_headers_size { 0 };
         u64 serialized_response_headers_size { 0 };
 
@@ -36,7 +37,7 @@ class CacheIndex {
 
         u64 estimated_size() const
         {
-            return data_size + serialized_request_headers_size + serialized_response_headers_size;
+            return data_size + associated_data_size + serialized_request_headers_size + serialized_response_headers_size;
         }
     };
 
@@ -51,6 +52,7 @@ public:
     Optional<Entry const&> find_entry(u64 cache_key, HeaderList const& request_headers);
 
     void update_response_headers(u64 cache_key, u64 vary_key, NonnullRefPtr<HeaderList>);
+    void update_associated_data_size(u64 cache_key, u64 vary_key, u64 associated_data_size);
     void update_last_access_time(u64 cache_key, u64 vary_key);
 
     Requests::CacheSizes estimate_cache_size_accessed_since(UnixDateTime since);
@@ -65,6 +67,7 @@ private:
         Database::StatementID remove_entries_accessed_since { 0 };
         Database::StatementID select_entries { 0 };
         Database::StatementID update_response_headers { 0 };
+        Database::StatementID update_associated_data_size { 0 };
         Database::StatementID update_last_access_time { 0 };
         Database::StatementID estimate_cache_size_accessed_since { 0 };
         Database::StatementID select_total_estimated_size { 0 };

--- a/Libraries/LibHTTP/Cache/CacheIndex.h
+++ b/Libraries/LibHTTP/Cache/CacheIndex.h
@@ -50,6 +50,7 @@ public:
     void remove_entries_accessed_since(UnixDateTime, Function<void(u64 cache_key, u64 vary_key)> on_entry_removed);
 
     Optional<Entry const&> find_entry(u64 cache_key, HeaderList const& request_headers);
+    bool has_entry(u64 cache_key, u64 vary_key);
 
     void update_response_headers(u64 cache_key, u64 vary_key, NonnullRefPtr<HeaderList>);
     void update_associated_data_size(u64 cache_key, u64 vary_key, u64 associated_data_size);

--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -223,18 +223,24 @@ Variant<Optional<CacheEntryReader&>, DiskCache::CacheHasOpenEntry> DiskCache::op
     return Optional<CacheEntryReader&> { *cache_entry_pointer };
 }
 
-ErrorOr<bool> DiskCache::store_associated_data(URL::URL const& url, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData associated_data, ReadonlyBytes data)
+ErrorOr<bool> DiskCache::store_associated_data(URL::URL const& url, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData associated_data, ReadonlyBytes data)
 {
     if (!is_cacheable(method, request_headers))
         return false;
 
     auto serialized_url = serialize_url_for_cache_storage(url);
     auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
-    auto index_entry = m_index.find_entry(cache_key, request_headers);
-    if (!index_entry.has_value())
+    if (!vary_key.has_value()) {
+        auto index_entry = m_index.find_entry(cache_key, request_headers);
+        if (!index_entry.has_value())
+            return false;
+        vary_key = index_entry->vary_key;
+    }
+
+    if (!m_index.has_entry(cache_key, *vary_key))
         return false;
 
-    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, index_entry->vary_key, associated_data);
+    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, *vary_key, associated_data);
     auto temporary_path = LexicalPath::join(m_cache_directory.string(), ByteString::formatted("{}.tmp", path.basename()));
     ArmedScopeGuard remove_temporary_file = [&]() {
         (void)FileSystem::remove(temporary_path.string(), FileSystem::RecursionMode::Disallowed);
@@ -247,23 +253,29 @@ ErrorOr<bool> DiskCache::store_associated_data(URL::URL const& url, StringView m
 
     TRY(Core::System::rename(temporary_path.string(), path.string()));
     remove_temporary_file.disarm();
-    m_index.update_associated_data_size(cache_key, index_entry->vary_key, TRY(compute_associated_data_size(m_cache_directory, cache_key, index_entry->vary_key)));
+    m_index.update_associated_data_size(cache_key, *vary_key, TRY(compute_associated_data_size(m_cache_directory, cache_key, *vary_key)));
     remove_entries_exceeding_cache_limit();
-    return m_index.find_entry(cache_key, request_headers).has_value();
+    return m_index.has_entry(cache_key, *vary_key);
 }
 
-ErrorOr<Optional<ByteBuffer>> DiskCache::retrieve_associated_data(URL::URL const& url, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData associated_data)
+ErrorOr<Optional<ByteBuffer>> DiskCache::retrieve_associated_data(URL::URL const& url, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData associated_data)
 {
     if (!is_cacheable(method, request_headers))
         return Optional<ByteBuffer> {};
 
     auto serialized_url = serialize_url_for_cache_storage(url);
     auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
-    auto index_entry = m_index.find_entry(cache_key, request_headers);
-    if (!index_entry.has_value())
+    if (!vary_key.has_value()) {
+        auto index_entry = m_index.find_entry(cache_key, request_headers);
+        if (!index_entry.has_value())
+            return Optional<ByteBuffer> {};
+        vary_key = index_entry->vary_key;
+    }
+
+    if (!m_index.has_entry(cache_key, *vary_key))
         return Optional<ByteBuffer> {};
 
-    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, index_entry->vary_key, associated_data);
+    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, *vary_key, associated_data);
     auto file = Core::File::open(path.string(), Core::File::OpenMode::Read);
     if (file.is_error()) {
         if (file.error().is_errno() && file.error().code() == ENOENT)

--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -5,8 +5,10 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/ScopeGuard.h>
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
@@ -18,6 +20,25 @@
 namespace HTTP {
 
 static constexpr auto INDEX_DATABASE = "INDEX"sv;
+
+static ErrorOr<u64> compute_associated_data_size(LexicalPath const& cache_directory, u64 cache_key, u64 vary_key)
+{
+    u64 associated_data_size = 0;
+    for (auto associated_data : CACHE_ENTRY_ASSOCIATED_DATA_TYPES) {
+        auto path = path_for_cache_entry_associated_data(cache_directory, cache_key, vary_key, associated_data);
+        auto size = FileSystem::size_from_stat(path.string());
+        if (size.is_error()) {
+            if (size.error().is_errno() && size.error().code() == ENOENT)
+                continue;
+            return size.release_error();
+        }
+
+        if (size.value() < 0)
+            return Error::from_errno(EINVAL);
+        associated_data_size += static_cast<u64>(size.value());
+    }
+    return associated_data_size;
+}
 
 static constexpr StringView cache_directory_for_mode(DiskCache::Mode mode)
 {
@@ -202,6 +223,57 @@ Variant<Optional<CacheEntryReader&>, DiskCache::CacheHasOpenEntry> DiskCache::op
     return Optional<CacheEntryReader&> { *cache_entry_pointer };
 }
 
+ErrorOr<bool> DiskCache::store_associated_data(URL::URL const& url, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData associated_data, ReadonlyBytes data)
+{
+    if (!is_cacheable(method, request_headers))
+        return false;
+
+    auto serialized_url = serialize_url_for_cache_storage(url);
+    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto index_entry = m_index.find_entry(cache_key, request_headers);
+    if (!index_entry.has_value())
+        return false;
+
+    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, index_entry->vary_key, associated_data);
+    auto temporary_path = LexicalPath::join(m_cache_directory.string(), ByteString::formatted("{}.tmp", path.basename()));
+    ArmedScopeGuard remove_temporary_file = [&]() {
+        (void)FileSystem::remove(temporary_path.string(), FileSystem::RecursionMode::Disallowed);
+    };
+
+    {
+        auto file = TRY(Core::File::open(temporary_path.string(), Core::File::OpenMode::Write));
+        TRY(file->write_until_depleted(data));
+    }
+
+    TRY(Core::System::rename(temporary_path.string(), path.string()));
+    remove_temporary_file.disarm();
+    m_index.update_associated_data_size(cache_key, index_entry->vary_key, TRY(compute_associated_data_size(m_cache_directory, cache_key, index_entry->vary_key)));
+    remove_entries_exceeding_cache_limit();
+    return m_index.find_entry(cache_key, request_headers).has_value();
+}
+
+ErrorOr<Optional<ByteBuffer>> DiskCache::retrieve_associated_data(URL::URL const& url, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData associated_data)
+{
+    if (!is_cacheable(method, request_headers))
+        return Optional<ByteBuffer> {};
+
+    auto serialized_url = serialize_url_for_cache_storage(url);
+    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto index_entry = m_index.find_entry(cache_key, request_headers);
+    if (!index_entry.has_value())
+        return Optional<ByteBuffer> {};
+
+    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, index_entry->vary_key, associated_data);
+    auto file = Core::File::open(path.string(), Core::File::OpenMode::Read);
+    if (file.is_error()) {
+        if (file.error().is_errno() && file.error().code() == ENOENT)
+            return Optional<ByteBuffer> {};
+        return file.release_error();
+    }
+
+    return TRY(file.value()->read_until_eof());
+}
+
 bool DiskCache::check_if_cache_has_open_entry(CacheRequest& request, u64 cache_key, URL::URL const& url, CheckReaderEntries check_reader_entries)
 {
     // FIXME: We purposefully do not use the vary key here, as we do not yet have it when creating a CacheEntryWriter
@@ -294,6 +366,8 @@ void DiskCache::delete_entry(u64 cache_key, u64 vary_key)
 
     auto cache_path = path_for_cache_entry(m_cache_directory, cache_key, vary_key);
     (void)FileSystem::remove(cache_path.string(), FileSystem::RecursionMode::Disallowed);
+    for (auto associated_data : CACHE_ENTRY_ASSOCIATED_DATA_TYPES)
+        (void)FileSystem::remove(path_for_cache_entry_associated_data(m_cache_directory, cache_key, vary_key, associated_data).string(), FileSystem::RecursionMode::Disallowed);
 }
 
 }

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/Error.h>
 #include <AK/LexicalPath.h>
 #include <AK/Optional.h>
@@ -17,6 +18,7 @@
 #include <LibHTTP/Cache/CacheEntry.h>
 #include <LibHTTP/Cache/CacheIndex.h>
 #include <LibHTTP/Cache/CacheMode.h>
+#include <LibHTTP/Cache/Utilities.h>
 #include <LibURL/Forward.h>
 
 namespace HTTP {
@@ -51,6 +53,9 @@ public:
         Revalidate,
     };
     Variant<Optional<CacheEntryReader&>, CacheHasOpenEntry> open_entry(CacheRequest&, URL::URL const&, StringView method, HeaderList const& request_headers, CacheMode, OpenMode);
+
+    ErrorOr<bool> store_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData, ReadonlyBytes);
+    ErrorOr<Optional<ByteBuffer>> retrieve_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData);
 
     void remove_entries_exceeding_cache_limit();
     void set_maximum_disk_cache_size(u64 maximum_disk_cache_size);

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -54,8 +54,8 @@ public:
     };
     Variant<Optional<CacheEntryReader&>, CacheHasOpenEntry> open_entry(CacheRequest&, URL::URL const&, StringView method, HeaderList const& request_headers, CacheMode, OpenMode);
 
-    ErrorOr<bool> store_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData, ReadonlyBytes);
-    ErrorOr<Optional<ByteBuffer>> retrieve_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, CacheEntryAssociatedData);
+    ErrorOr<bool> store_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData, ReadonlyBytes);
+    ErrorOr<Optional<ByteBuffer>> retrieve_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData);
 
     void remove_entries_exceeding_cache_limit();
     void set_maximum_disk_cache_size(u64 maximum_disk_cache_size);

--- a/Libraries/LibHTTP/Cache/Utilities.cpp
+++ b/Libraries/LibHTTP/Cache/Utilities.cpp
@@ -111,6 +111,24 @@ LexicalPath path_for_cache_entry(LexicalPath const& cache_directory, u64 cache_k
     return cache_directory.append(file);
 }
 
+static StringView cache_entry_associated_data_suffix(CacheEntryAssociatedData associated_data)
+{
+    switch (associated_data) {
+    case CacheEntryAssociatedData::JavaScriptBytecode:
+        return "jsbc"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+LexicalPath path_for_cache_entry_associated_data(LexicalPath const& cache_directory, u64 cache_key, u64 vary_key, CacheEntryAssociatedData associated_data)
+{
+    auto file = vary_key == 0
+        ? ByteString::formatted("{:016x}.{}", cache_key, cache_entry_associated_data_suffix(associated_data))
+        : ByteString::formatted("{:016x}_{:016x}.{}", cache_key, vary_key, cache_entry_associated_data_suffix(associated_data));
+
+    return cache_directory.append(file);
+}
+
 // https://httpwg.org/specs/rfc9111.html#response.cacheability
 bool is_cacheable(StringView method, HTTP::HeaderList const& request_headers)
 {

--- a/Libraries/LibHTTP/Cache/Utilities.h
+++ b/Libraries/LibHTTP/Cache/Utilities.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/LexicalPath.h>
 #include <AK/StringView.h>
 #include <AK/Time.h>
@@ -23,6 +24,11 @@ constexpr inline auto TEST_CACHE_REQUEST_TIME_OFFSET = "X-Ladybird-Request-Time-
 
 constexpr inline u64 DEFAULT_MAXIMUM_DISK_CACHE_SIZE = 5 * GiB;
 
+enum class CacheEntryAssociatedData {
+    JavaScriptBytecode,
+};
+constexpr inline Array CACHE_ENTRY_ASSOCIATED_DATA_TYPES { CacheEntryAssociatedData::JavaScriptBytecode };
+
 u64 compute_maximum_disk_cache_size(u64 free_bytes, u64 limit_maximum_disk_cache_size = DEFAULT_MAXIMUM_DISK_CACHE_SIZE);
 u64 compute_maximum_disk_cache_entry_size(u64 maximum_disk_cache_size);
 
@@ -30,6 +36,7 @@ String serialize_url_for_cache_storage(URL::URL const&);
 u64 create_cache_key(StringView url, StringView method, Optional<String const&> extra_cache_key = {});
 u64 create_vary_key(HeaderList const& request_headers, HeaderList const& response_headers);
 LexicalPath path_for_cache_entry(LexicalPath const& cache_directory, u64 cache_key, u64 vary_key);
+LexicalPath path_for_cache_entry_associated_data(LexicalPath const& cache_directory, u64 cache_key, u64 vary_key, CacheEntryAssociatedData);
 
 bool is_cacheable(StringView method, HeaderList const&);
 bool is_cacheable(u32 status_code, HeaderList const&);

--- a/Libraries/LibHTTP/Cache/Version.h
+++ b/Libraries/LibHTTP/Cache/Version.h
@@ -11,6 +11,6 @@
 namespace HTTP {
 
 // Increment this version when a breaking change is made to the cache index or cache entry formats.
-static constexpr inline u32 CACHE_VERSION = 6u;
+static constexpr inline u32 CACHE_VERSION = 7u;
 
 }

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -236,6 +236,15 @@ pub struct FunctionTable {
     next_id: u32,
 }
 
+impl Clone for FunctionTable {
+    fn clone(&self) -> Self {
+        Self {
+            functions: self.functions.iter().map(|(id, data)| (*id, data.clone())).collect(),
+            next_id: self.next_id,
+        }
+    }
+}
+
 impl Default for FunctionTable {
     fn default() -> Self {
         Self::new()
@@ -649,6 +658,7 @@ impl FunctionTable {
 
 /// Bundles a `FunctionData` with a subtable of all nested functions
 /// reachable from its body. Stored as the raw pointer in C++ SFDs.
+#[derive(Clone)]
 pub struct FunctionPayload {
     pub data: FunctionData,
     pub function_table: FunctionTable,
@@ -990,7 +1000,7 @@ pub enum FunctionParameterBinding {
 }
 
 /// Shared data for FunctionDeclaration and FunctionExpression.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FunctionData {
     pub name: Option<IdentifierId>,
     pub source_text_start: u32,

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -491,7 +491,11 @@ unsafe fn materialize_class_blueprints(
     }
 }
 
-unsafe fn materialize_class_blueprint(
+/// Create a C++ ClassBlueprint from a pending blueprint record.
+///
+/// # Safety
+/// `vm_ptr` and `source_code_ptr` must be valid pointers.
+pub unsafe fn materialize_class_blueprint(
     blueprint: &PendingClassBlueprint,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
@@ -618,6 +622,29 @@ pub unsafe fn create_executable(
     source_code_ptr: *const c_void,
 ) -> ExecutableHandle {
     unsafe {
+        let sfd_ptrs = materialize_shared_function_data(generator, vm_ptr, source_code_ptr);
+        let bp_ptrs = materialize_class_blueprints(generator, vm_ptr, source_code_ptr);
+        create_executable_with_dependencies(generator, assembled, vm_ptr, source_code_ptr, &sfd_ptrs, &bp_ptrs)
+    }
+}
+
+/// Create a C++ Executable from already materialized dependency objects.
+///
+/// This is used by bytecode cache materialization, where the cache blob
+/// contains precompiled nested functions and class blueprints instead of
+/// AST-backed `PendingSharedFunctionData` records.
+///
+/// # Safety
+/// `vm_ptr`, `source_code_ptr`, and all dependency pointers must be valid.
+pub unsafe fn create_executable_with_dependencies(
+    generator: &Generator,
+    assembled: &AssembledBytecode,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    sfd_ptrs: &[*const c_void],
+    bp_ptrs: &[*mut c_void],
+) -> ExecutableHandle {
+    unsafe {
         // Build FFI slices for tables
         let ident_slices: Vec<FFIUtf16Slice> = generator
             .identifier_table
@@ -672,9 +699,6 @@ pub unsafe fn create_executable(
             .iter()
             .map(|v| FFIUtf16Slice::from(v.name.as_ref()))
             .collect();
-
-        let sfd_ptrs = materialize_shared_function_data(generator, vm_ptr, source_code_ptr);
-        let bp_ptrs = materialize_class_blueprints(generator, vm_ptr, source_code_ptr);
 
         let ffi_data = FFIExecutableData {
             bytecode: assembled.bytecode.as_ptr(),

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Versioned serialization for fully compiled JavaScript bytecode cache blobs.
+//!
+//! The format is expressed as small record types with `Encode`
+//! implementations. The matching decoder should mirror these records instead
+//! of growing a separate procedural parser.
+
+use crate::bytecode::ffi::ConstantTag;
+use crate::bytecode::generator::{
+    AssembledBytecode, ConstantValue, FunctionSfdMetadata, Generator, PendingClassBlueprint, PendingClassElement,
+    PendingLiteralValueKind, PendingSharedFunctionData, PrecompiledFunction,
+};
+use crate::{CompiledProgram, CompiledProgramBytecode, ast, u32_from_usize};
+
+const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
+const FORMAT_VERSION: u32 = 1;
+
+pub fn serialize_compiled_program(compiled: &CompiledProgram) -> Vec<u8> {
+    let mut encoder = Encoder::new();
+    CacheBlob { compiled }.encode(&mut encoder);
+    encoder.finish()
+}
+
+struct Encoder {
+    bytes: Vec<u8>,
+}
+
+impl Encoder {
+    fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    fn byte(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn bytes(&mut self, bytes: &[u8]) {
+        self.bytes.extend_from_slice(bytes);
+    }
+
+    fn sequence<T>(&mut self, items: &[T], mut encode_item: impl FnMut(&T, &mut Self)) {
+        u32_from_usize(items.len()).encode(self);
+        for item in items {
+            encode_item(item, self);
+        }
+    }
+}
+
+trait Encode {
+    fn encode(&self, encoder: &mut Encoder);
+}
+
+impl Encode for bool {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.byte(*self as u8);
+    }
+}
+
+impl Encode for u8 {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.byte(*self);
+    }
+}
+
+impl Encode for u32 {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl Encode for i32 {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl Encode for u64 {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl Encode for usize {
+    fn encode(&self, encoder: &mut Encoder) {
+        u64::try_from(*self).expect("usize does not fit in u64").encode(encoder);
+    }
+}
+
+impl Encode for f64 {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl<T: Encode> Encode for Option<T> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.is_some().encode(encoder);
+        if let Some(value) = self {
+            value.encode(encoder);
+        }
+    }
+}
+
+struct Bytes<'a>(&'a [u8]);
+
+impl Encode for Bytes<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        u32_from_usize(self.0.len()).encode(encoder);
+        encoder.bytes(self.0);
+    }
+}
+
+struct Utf16<'a>(&'a [u16]);
+
+impl Encode for Utf16<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        u32_from_usize(self.0.len()).encode(encoder);
+        for code_unit in self.0 {
+            encoder.bytes(&code_unit.to_le_bytes());
+        }
+    }
+}
+
+struct CacheBlob<'a> {
+    compiled: &'a CompiledProgram,
+}
+
+impl Encode for CacheBlob<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.bytes(MAGIC);
+        FORMAT_VERSION.encode(encoder);
+        self.compiled.parsed.has_top_level_await.encode(encoder);
+        self.compiled.parsed.is_strict_mode.encode(encoder);
+        ProgramRecord::from(self.compiled).encode(encoder);
+    }
+}
+
+struct ProgramRecord<'a> {
+    kind: ProgramKind,
+    executable: ExecutableRecord<'a>,
+}
+
+impl<'a> From<&'a CompiledProgram> for ProgramRecord<'a> {
+    fn from(compiled: &'a CompiledProgram) -> Self {
+        match &compiled.bytecode {
+            CompiledProgramBytecode::Program(bytecode) => Self {
+                kind: ProgramKind::ScriptOrModule,
+                executable: ExecutableRecord {
+                    generator: &bytecode.generator,
+                    assembled: &bytecode.assembled,
+                },
+            },
+            CompiledProgramBytecode::AsyncModule(bytecode) => Self {
+                kind: ProgramKind::AsyncModule,
+                executable: ExecutableRecord {
+                    generator: &bytecode.generator,
+                    assembled: &bytecode.assembled,
+                },
+            },
+        }
+    }
+}
+
+impl Encode for ProgramRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.kind.encode(encoder);
+        self.executable.encode(encoder);
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum ProgramKind {
+    ScriptOrModule = 0,
+    AsyncModule = 1,
+}
+
+impl Encode for ProgramKind {
+    fn encode(&self, encoder: &mut Encoder) {
+        (*self as u8).encode(encoder);
+    }
+}
+
+struct ExecutableRecord<'a> {
+    generator: &'a Generator,
+    assembled: &'a AssembledBytecode,
+}
+
+impl Encode for ExecutableRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.generator.strict.encode(encoder);
+        self.assembled.number_of_registers.encode(encoder);
+        self.assembled.number_of_arguments.encode(encoder);
+        CacheCounters(self.generator).encode(encoder);
+        self.generator.this_value_needs_environment_resolution.encode(encoder);
+        self.generator.length_identifier.map(|index| index.0).encode(encoder);
+
+        Bytes(&self.assembled.bytecode).encode(encoder);
+        Utf16Table(&self.generator.identifier_table).encode(encoder);
+        Utf16Table(&self.generator.property_key_table).encode(encoder);
+        Utf16Table(&self.generator.string_table).encode(encoder);
+        ConstantTable(&self.generator.constants).encode(encoder);
+        ExceptionHandlerTable(self.assembled).encode(encoder);
+        SourceMapTable(self.assembled).encode(encoder);
+        BasicBlockOffsetTable(self.assembled).encode(encoder);
+        LocalVariableTable(self.generator).encode(encoder);
+        SharedFunctionTable(self.generator).encode(encoder);
+        ClassBlueprintTable(self.generator).encode(encoder);
+    }
+}
+
+struct CacheCounters<'a>(&'a Generator);
+
+impl Encode for CacheCounters<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.0.next_property_lookup_cache.encode(encoder);
+        self.0.next_global_variable_cache.encode(encoder);
+        self.0.next_template_object_cache.encode(encoder);
+        self.0.next_object_shape_cache.encode(encoder);
+        self.0.next_object_property_iterator_cache.encode(encoder);
+    }
+}
+
+struct Utf16Table<'a>(&'a [ast::Utf16String]);
+
+impl Encode for Utf16Table<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |value, encoder| Utf16(value).encode(encoder));
+    }
+}
+
+struct ConstantTable<'a>(&'a [ConstantValue]);
+
+impl Encode for ConstantTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |constant, encoder| constant.encode(encoder));
+    }
+}
+
+impl Encode for ConstantValue {
+    fn encode(&self, encoder: &mut Encoder) {
+        match self {
+            ConstantValue::Number(value) => {
+                (ConstantTag::Number as u8).encode(encoder);
+                value.encode(encoder);
+            }
+            ConstantValue::Boolean(true) => (ConstantTag::BooleanTrue as u8).encode(encoder),
+            ConstantValue::Boolean(false) => (ConstantTag::BooleanFalse as u8).encode(encoder),
+            ConstantValue::Null => (ConstantTag::Null as u8).encode(encoder),
+            ConstantValue::Undefined => (ConstantTag::Undefined as u8).encode(encoder),
+            ConstantValue::Empty => (ConstantTag::Empty as u8).encode(encoder),
+            ConstantValue::String(value) => {
+                (ConstantTag::String as u8).encode(encoder);
+                Utf16(value).encode(encoder);
+            }
+            ConstantValue::BigInt(value) => {
+                (ConstantTag::BigInt as u8).encode(encoder);
+                Bytes(value.as_bytes()).encode(encoder);
+            }
+            ConstantValue::WellKnownSymbol(symbol) => {
+                (ConstantTag::WellKnownSymbol as u8).encode(encoder);
+                (*symbol as u8).encode(encoder);
+            }
+            ConstantValue::AbstractOperation(operation) => {
+                (ConstantTag::AbstractOperation as u8).encode(encoder);
+                (*operation as u8).encode(encoder);
+            }
+        }
+    }
+}
+
+struct ExceptionHandlerTable<'a>(&'a AssembledBytecode);
+
+impl Encode for ExceptionHandlerTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(&self.0.exception_handlers, |handler, encoder| {
+            handler.start_offset.encode(encoder);
+            handler.end_offset.encode(encoder);
+            handler.handler_offset.encode(encoder);
+        });
+    }
+}
+
+struct SourceMapTable<'a>(&'a AssembledBytecode);
+
+impl Encode for SourceMapTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(&self.0.source_map, |entry, encoder| {
+            entry.bytecode_offset.encode(encoder);
+            entry.source_start.line.encode(encoder);
+            entry.source_start.column.encode(encoder);
+            entry.source_start.offset.encode(encoder);
+            entry.source_end.line.encode(encoder);
+            entry.source_end.column.encode(encoder);
+            entry.source_end.offset.encode(encoder);
+        });
+    }
+}
+
+struct BasicBlockOffsetTable<'a>(&'a AssembledBytecode);
+
+impl Encode for BasicBlockOffsetTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(&self.0.basic_block_start_offsets, |offset, encoder| {
+            offset.encode(encoder);
+        });
+    }
+}
+
+struct LocalVariableTable<'a>(&'a Generator);
+
+impl Encode for LocalVariableTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(&self.0.local_variables, |local_variable, encoder| {
+            Utf16(&local_variable.name).encode(encoder);
+            local_variable.is_lexically_declared.encode(encoder);
+            local_variable
+                .is_initialized_during_declaration_instantiation
+                .encode(encoder);
+        });
+    }
+}
+
+struct SharedFunctionTable<'a>(&'a Generator);
+
+impl Encode for SharedFunctionTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(&self.0.shared_function_data, |shared_data, encoder| {
+            FunctionRecord {
+                shared_data,
+                arena: &self.0.arena,
+            }
+            .encode(encoder);
+        });
+    }
+}
+
+struct FunctionRecord<'a> {
+    shared_data: &'a PendingSharedFunctionData,
+    arena: &'a ast::AstArena,
+}
+
+impl Encode for FunctionRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        let function_data = self
+            .shared_data
+            .function_data
+            .as_ref()
+            .expect("bytecode cache requires function data to be retained until serialization");
+        let precompiled = self
+            .shared_data
+            .precompiled_function
+            .as_ref()
+            .expect("fully compiled bytecode cache entry is missing nested function bytecode");
+
+        self.function_name(function_data).encode(encoder);
+        function_data.source_text_start.encode(encoder);
+        function_data.source_text_end.encode(encoder);
+        function_data.function_length.encode(encoder);
+        u32_from_usize(function_data.parameters.len()).encode(encoder);
+        (function_data.kind as u8).encode(encoder);
+        function_data.is_strict_mode.encode(encoder);
+        function_data.is_arrow_function.encode(encoder);
+        SimpleParameterList {
+            function_data,
+            arena: self.function_arena(),
+        }
+        .encode(encoder);
+        function_data.parsing_insights.uses_this.encode(encoder);
+        function_data
+            .parsing_insights
+            .uses_this_from_environment
+            .encode(encoder);
+        ClassFieldInitializerName(self.shared_data).encode(encoder);
+        precompiled.metadata.encode(encoder);
+        PrecompiledFunctionRecord(precompiled).encode(encoder);
+    }
+}
+
+impl<'a> FunctionRecord<'a> {
+    fn function_name(&self, function_data: &'a ast::FunctionData) -> Option<Utf16<'a>> {
+        self.shared_data
+            .name_override
+            .as_deref()
+            .or_else(|| function_data.name.map(|name| self.function_arena().name_slice(name)))
+            .map(Utf16)
+    }
+
+    fn function_arena(&self) -> &'a ast::AstArena {
+        self.shared_data.arena.as_deref().unwrap_or(self.arena)
+    }
+}
+
+struct SimpleParameterList<'a> {
+    function_data: &'a ast::FunctionData,
+    arena: &'a ast::AstArena,
+}
+
+impl Encode for SimpleParameterList<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        let names = simple_parameter_names(self.function_data, self.arena);
+        names.is_some().encode(encoder);
+        if let Some(names) = names {
+            encoder.sequence(&names, |name, encoder| Utf16(name).encode(encoder));
+        }
+    }
+}
+
+fn simple_parameter_names<'a>(
+    function_data: &'a ast::FunctionData,
+    arena: &'a ast::AstArena,
+) -> Option<Vec<&'a [u16]>> {
+    let mut names = Vec::with_capacity(function_data.parameters.len());
+    for parameter in &function_data.parameters {
+        if parameter.is_rest || parameter.default_value.is_some() {
+            return None;
+        }
+        let ast::FunctionParameterBinding::Identifier(identifier) = &parameter.binding else {
+            return None;
+        };
+        names.push(arena.name_slice(*identifier));
+    }
+    Some(names)
+}
+
+struct ClassFieldInitializerName<'a>(&'a PendingSharedFunctionData);
+
+impl Encode for ClassFieldInitializerName<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.0
+            .class_field_initializer_name
+            .as_ref()
+            .map(|(name, is_private)| (Utf16(name.as_slice()), *is_private))
+            .encode(encoder);
+    }
+}
+
+impl Encode for (Utf16<'_>, bool) {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.0.encode(encoder);
+        self.1.encode(encoder);
+    }
+}
+
+impl Encode for FunctionSfdMetadata {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.uses_this.encode(encoder);
+        self.this_value_needs_environment_resolution.encode(encoder);
+        self.function_environment_needed.encode(encoder);
+        self.function_environment_bindings_count.encode(encoder);
+        self.var_environment_bindings_count.encode(encoder);
+        self.might_need_arguments.encode(encoder);
+        self.contains_eval.encode(encoder);
+    }
+}
+
+struct PrecompiledFunctionRecord<'a>(&'a PrecompiledFunction);
+
+impl Encode for PrecompiledFunctionRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        ExecutableRecord {
+            generator: &self.0.generator,
+            assembled: &self.0.assembled,
+        }
+        .encode(encoder);
+    }
+}
+
+struct ClassBlueprintTable<'a>(&'a Generator);
+
+impl Encode for ClassBlueprintTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(&self.0.class_blueprints, |blueprint, encoder| {
+            ClassBlueprintRecord(blueprint).encode(encoder);
+        });
+    }
+}
+
+struct ClassBlueprintRecord<'a>(&'a PendingClassBlueprint);
+
+impl Encode for ClassBlueprintRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.0.name.as_deref().map(Utf16).encode(encoder);
+        self.0.source_text_offset.encode(encoder);
+        self.0.source_text_length.encode(encoder);
+        self.0.constructor_sfd_index.encode(encoder);
+        self.0.has_super_class.encode(encoder);
+        self.0.has_name.encode(encoder);
+        encoder.sequence(&self.0.elements, |element, encoder| {
+            ClassElementRecord(element).encode(encoder);
+        });
+    }
+}
+
+struct ClassElementRecord<'a>(&'a PendingClassElement);
+
+impl Encode for ClassElementRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.0.kind.encode(encoder);
+        self.0.is_static.encode(encoder);
+        self.0.is_private.encode(encoder);
+        self.0.private_identifier.as_deref().map(Utf16).encode(encoder);
+        self.0.shared_function_data_index.encode(encoder);
+        self.0.has_initializer.encode(encoder);
+        literal_value_kind_tag(self.0.literal_value_kind).encode(encoder);
+        self.0.literal_value_number.encode(encoder);
+        self.0.literal_value_string.as_deref().map(Utf16).encode(encoder);
+    }
+}
+
+fn literal_value_kind_tag(kind: PendingLiteralValueKind) -> u8 {
+    match kind {
+        PendingLiteralValueKind::None => 0,
+        PendingLiteralValueKind::Number => 1,
+        PendingLiteralValueKind::BooleanTrue => 2,
+        PendingLiteralValueKind::BooleanFalse => 3,
+        PendingLiteralValueKind::Null => 4,
+        PendingLiteralValueKind::String => 5,
+    }
+}

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -23,16 +23,30 @@ use crate::{CompiledProgram, CompiledProgramBytecode, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
 const FORMAT_VERSION: u32 = 1;
+const SOURCE_HASH_SIZE: usize = 32;
 
-pub fn serialize_compiled_program(compiled: &CompiledProgram, program_type: ast::ProgramType) -> Vec<u8> {
+pub fn serialize_compiled_program(
+    compiled: &CompiledProgram,
+    program_type: ast::ProgramType,
+    source_hash: &[u8; SOURCE_HASH_SIZE],
+) -> Vec<u8> {
     let mut encoder = Encoder::new();
-    CacheBlob { compiled, program_type }.encode(&mut encoder);
+    CacheBlob {
+        compiled,
+        program_type,
+        source_hash,
+    }
+    .encode(&mut encoder);
     encoder.finish()
 }
 
-pub(crate) fn decode_blob(bytes: &[u8], expected_program_type: ast::ProgramType) -> Option<DecodedCacheBlob> {
+pub(crate) fn decode_blob(
+    bytes: &[u8],
+    expected_program_type: ast::ProgramType,
+    expected_source_hash: &[u8; SOURCE_HASH_SIZE],
+) -> Option<DecodedCacheBlob> {
     let mut decoder = Decoder::new(bytes);
-    let blob = CacheBlob::decode(&mut decoder, expected_program_type)?;
+    let blob = CacheBlob::decode(&mut decoder, expected_program_type, expected_source_hash)?;
     if !decoder.is_empty() {
         return None;
     }
@@ -281,6 +295,11 @@ impl Encode for Utf16<'_> {
 struct CacheBlob<'a> {
     compiled: &'a CompiledProgram,
     program_type: ast::ProgramType,
+    // Fingerprint of the decoded source text the blob was generated from. Cache writes happen asynchronously after the
+    // HTTP response has been served, so the entry on disk may have been replaced for the same (URL, vary key) by the
+    // time we go to attach the sidecar. Embedding the source hash makes a stale write harmless: a later read whose
+    // source no longer matches will reject the blob and fall through to source compilation.
+    source_hash: &'a [u8; SOURCE_HASH_SIZE],
 }
 
 impl Encode for CacheBlob<'_> {
@@ -288,6 +307,7 @@ impl Encode for CacheBlob<'_> {
         encoder.bytes(MAGIC);
         FORMAT_VERSION.encode(encoder);
         self.program_type.encode(encoder);
+        encoder.bytes(self.source_hash);
         self.compiled.parsed.has_top_level_await.encode(encoder);
         self.compiled.parsed.is_strict_mode.encode(encoder);
         DeclarationMetadataRecord {
@@ -300,11 +320,16 @@ impl Encode for CacheBlob<'_> {
 }
 
 impl CacheBlob<'_> {
-    fn decode(decoder: &mut Decoder<'_>, expected_program_type: ast::ProgramType) -> Option<DecodedCacheBlob> {
+    fn decode(
+        decoder: &mut Decoder<'_>,
+        expected_program_type: ast::ProgramType,
+        expected_source_hash: &[u8; SOURCE_HASH_SIZE],
+    ) -> Option<DecodedCacheBlob> {
         decoder.expect_bytes(MAGIC)?;
         (u32::decode(decoder)? == FORMAT_VERSION).then_some(())?;
         let program_type = ast::ProgramType::decode(decoder)?;
         (program_type == expected_program_type).then_some(())?;
+        (decoder.bytes(SOURCE_HASH_SIZE)? == expected_source_hash).then_some(())?;
         Some(DecodedCacheBlob {
             program_type,
             has_top_level_await: bool::decode(decoder)?,
@@ -2093,5 +2118,19 @@ mod tests {
 
         let mut decoder = Decoder::new(&bytes);
         assert!(decoder.sequence_values(u8::decode).is_none());
+    }
+
+    #[test]
+    fn decode_rejects_mismatched_source_hash_before_payload() {
+        let stored_source_hash = [1u8; SOURCE_HASH_SIZE];
+        let expected_source_hash = [2u8; SOURCE_HASH_SIZE];
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(MAGIC);
+        bytes.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+        bytes.push(ast::ProgramType::Script as u8);
+        bytes.extend_from_slice(&stored_source_hash);
+
+        assert!(decode_blob(&bytes, ast::ProgramType::Script, &expected_source_hash).is_none());
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -20,9 +20,9 @@ use crate::{CompiledProgram, CompiledProgramBytecode, ast, u32_from_usize};
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
 const FORMAT_VERSION: u32 = 1;
 
-pub fn serialize_compiled_program(compiled: &CompiledProgram) -> Vec<u8> {
+pub fn serialize_compiled_program(compiled: &CompiledProgram, program_type: ast::ProgramType) -> Vec<u8> {
     let mut encoder = Encoder::new();
-    CacheBlob { compiled }.encode(&mut encoder);
+    CacheBlob { compiled, program_type }.encode(&mut encoder);
     encoder.finish()
 }
 
@@ -252,12 +252,14 @@ impl Decode for IgnoredUtf16 {
 
 struct CacheBlob<'a> {
     compiled: &'a CompiledProgram,
+    program_type: ast::ProgramType,
 }
 
 impl Encode for CacheBlob<'_> {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.bytes(MAGIC);
         FORMAT_VERSION.encode(encoder);
+        self.program_type.encode(encoder);
         self.compiled.parsed.has_top_level_await.encode(encoder);
         self.compiled.parsed.is_strict_mode.encode(encoder);
         ProgramRecord::from(self.compiled).encode(encoder);
@@ -265,12 +267,29 @@ impl Encode for CacheBlob<'_> {
 }
 
 impl CacheBlob<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+    fn decode(decoder: &mut Decoder<'_>, expected_program_type: ast::ProgramType) -> Option<()> {
         decoder.expect_bytes(MAGIC)?;
         (u32::decode(decoder)? == FORMAT_VERSION).then_some(())?;
+        (ast::ProgramType::decode(decoder)? == expected_program_type).then_some(())?;
         bool::decode(decoder)?;
         bool::decode(decoder)?;
         ProgramRecord::decode(decoder)
+    }
+}
+
+impl Encode for ast::ProgramType {
+    fn encode(&self, encoder: &mut Encoder) {
+        (*self as u8).encode(encoder);
+    }
+}
+
+impl Decode for ast::ProgramType {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            0 => Some(Self::Script),
+            1 => Some(Self::Module),
+            _ => None,
+        }
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -10,6 +10,8 @@
 //! implementations. The matching decoder should mirror these records instead
 //! of growing a separate procedural parser.
 
+use std::collections::HashMap;
+
 use crate::bytecode::ffi::ConstantTag;
 use crate::bytecode::generator::{
     AssembledBytecode, ConstantValue, FunctionSfdMetadata, Generator, PendingClassBlueprint, PendingClassElement,
@@ -92,6 +94,15 @@ impl<'a> Decoder<'a> {
             decode_item(self)?;
         }
         Some(())
+    }
+
+    fn sequence_values<T>(&mut self, mut decode_item: impl FnMut(&mut Self) -> Option<T>) -> Option<Vec<T>> {
+        let length: usize = u32::decode(self)?.try_into().ok()?;
+        let mut values = Vec::with_capacity(length);
+        for _ in 0..length {
+            values.push(decode_item(self)?);
+        }
+        Some(values)
     }
 }
 
@@ -210,6 +221,18 @@ impl<T: Decode> Decode for Option<T> {
     }
 }
 
+impl Decode for ast::Utf16String {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        let length: usize = u32::decode(decoder)?.try_into().ok()?;
+        let bytes = decoder.bytes(length.checked_mul(size_of::<u16>())?)?;
+        let mut code_units = Vec::with_capacity(length);
+        for chunk in bytes.chunks_exact(size_of::<u16>()) {
+            code_units.push(u16::from_le_bytes(chunk.try_into().ok()?));
+        }
+        Some(code_units.into())
+    }
+}
+
 struct Bytes<'a>(&'a [u8]);
 
 impl Encode for Bytes<'_> {
@@ -262,6 +285,11 @@ impl Encode for CacheBlob<'_> {
         self.program_type.encode(encoder);
         self.compiled.parsed.has_top_level_await.encode(encoder);
         self.compiled.parsed.is_strict_mode.encode(encoder);
+        DeclarationMetadataRecord {
+            compiled: self.compiled,
+            program_type: self.program_type,
+        }
+        .encode(encoder);
         ProgramRecord::from(self.compiled).encode(encoder);
     }
 }
@@ -273,6 +301,7 @@ impl CacheBlob<'_> {
         (ast::ProgramType::decode(decoder)? == expected_program_type).then_some(())?;
         bool::decode(decoder)?;
         bool::decode(decoder)?;
+        DeclarationMetadataRecord::decode(decoder)?.validate();
         ProgramRecord::decode(decoder)
     }
 }
@@ -290,6 +319,837 @@ impl Decode for ast::ProgramType {
             1 => Some(Self::Module),
             _ => None,
         }
+    }
+}
+
+impl Decode for ast::ExportEntryKind {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            0 => Some(Self::NamedExport),
+            1 => Some(Self::ModuleRequestAll),
+            2 => Some(Self::ModuleRequestAllButDefault),
+            _ => None,
+        }
+    }
+}
+
+struct DeclarationMetadataRecord<'a> {
+    compiled: &'a CompiledProgram,
+    program_type: ast::ProgramType,
+}
+
+impl Encode for DeclarationMetadataRecord<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        let ast::StatementKind::Program(program) = &self.compiled.parsed.program.inner else {
+            unreachable!("bytecode cache expects a parsed program root");
+        };
+        let scope = program.scope.borrow();
+        match self.program_type {
+            ast::ProgramType::Script => ScriptDeclarationMetadata::from_scope(&scope).encode(encoder),
+            ast::ProgramType::Module => ModuleDeclarationMetadata::from_scope(&scope).encode(encoder),
+        }
+    }
+}
+
+impl DeclarationMetadataRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedDeclarationMetadata> {
+        match MetadataKind::decode(decoder)? {
+            MetadataKind::Script => {
+                ScriptDeclarationMetadata::decode_payload(decoder).map(DecodedDeclarationMetadata::Script)
+            }
+            MetadataKind::Module => {
+                ModuleDeclarationMetadata::decode_payload(decoder).map(DecodedDeclarationMetadata::Module)
+            }
+        }
+    }
+}
+
+enum DecodedDeclarationMetadata {
+    Script(ScriptDeclarationMetadata),
+    Module(ModuleDeclarationMetadata),
+}
+
+impl DecodedDeclarationMetadata {
+    fn validate(&self) {
+        match self {
+            Self::Script(metadata) => metadata.validate(),
+            Self::Module(metadata) => metadata.validate(),
+        }
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum MetadataKind {
+    Script = 0,
+    Module = 1,
+}
+
+impl Encode for MetadataKind {
+    fn encode(&self, encoder: &mut Encoder) {
+        (*self as u8).encode(encoder);
+    }
+}
+
+impl Decode for MetadataKind {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            0 => Some(Self::Script),
+            1 => Some(Self::Module),
+            _ => None,
+        }
+    }
+}
+
+struct ScriptDeclarationMetadata {
+    lexical_names: Vec<ast::Utf16String>,
+    var_names: Vec<ast::Utf16String>,
+    function_names: Vec<ast::Utf16String>,
+    var_scoped_names: Vec<ast::Utf16String>,
+    annex_b_candidate_names: Vec<ast::Utf16String>,
+    lexical_bindings: Vec<LexicalBindingRecord>,
+}
+
+impl ScriptDeclarationMetadata {
+    fn from_scope(scope: &ast::ScopeData) -> Self {
+        let mut metadata = Self {
+            lexical_names: Vec::new(),
+            var_names: Vec::new(),
+            function_names: script_function_names(scope),
+            var_scoped_names: Vec::new(),
+            annex_b_candidate_names: scope.annexb_function_names.to_vec(),
+            lexical_bindings: Vec::new(),
+        };
+
+        for child in &scope.children {
+            collect_var_names_recursive(&child.inner, &mut metadata.var_names);
+            if let ast::StatementKind::FunctionDeclaration(ref function) = child.inner
+                && let Some(ref name) = function.name
+            {
+                metadata.var_names.push(name.name.to_utf16_string());
+            }
+            collect_script_lexical_names(&child.inner, &mut metadata.lexical_names);
+            collect_script_lexical_bindings(&child.inner, &mut metadata.lexical_bindings);
+            collect_var_names_recursive(&child.inner, &mut metadata.var_scoped_names);
+        }
+
+        metadata
+    }
+
+    fn decode_payload(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(Self {
+            lexical_names: Utf16Vector::decode(decoder)?,
+            var_names: Utf16Vector::decode(decoder)?,
+            function_names: Utf16Vector::decode(decoder)?,
+            var_scoped_names: Utf16Vector::decode(decoder)?,
+            annex_b_candidate_names: Utf16Vector::decode(decoder)?,
+            lexical_bindings: LexicalBindingTable::decode(decoder)?,
+        })
+    }
+
+    fn validate(&self) {
+        let _ = self.lexical_names.len()
+            + self.var_names.len()
+            + self.function_names.len()
+            + self.var_scoped_names.len()
+            + self.annex_b_candidate_names.len()
+            + self.lexical_bindings.len();
+    }
+}
+
+impl Encode for ScriptDeclarationMetadata {
+    fn encode(&self, encoder: &mut Encoder) {
+        MetadataKind::Script.encode(encoder);
+        Utf16Vector(&self.lexical_names).encode(encoder);
+        Utf16Vector(&self.var_names).encode(encoder);
+        Utf16Vector(&self.function_names).encode(encoder);
+        Utf16Vector(&self.var_scoped_names).encode(encoder);
+        Utf16Vector(&self.annex_b_candidate_names).encode(encoder);
+        LexicalBindingTable(&self.lexical_bindings).encode(encoder);
+    }
+}
+
+struct ModuleDeclarationMetadata {
+    import_entries: Vec<ModuleImportEntryRecord>,
+    local_exports: Vec<ModuleExportEntryRecord>,
+    indirect_exports: Vec<ModuleExportEntryRecord>,
+    star_exports: Vec<ModuleExportEntryRecord>,
+    requested_modules: Vec<ModuleRequestRecord>,
+    default_export_binding_name: Option<ast::Utf16String>,
+    var_declared_names: Vec<ast::Utf16String>,
+    function_names: Vec<ast::Utf16String>,
+    lexical_bindings: Vec<ModuleLexicalBindingRecord>,
+}
+
+impl ModuleDeclarationMetadata {
+    fn from_scope(scope: &ast::ScopeData) -> Self {
+        let mut metadata = Self {
+            import_entries: Vec::new(),
+            local_exports: Vec::new(),
+            indirect_exports: Vec::new(),
+            star_exports: Vec::new(),
+            requested_modules: requested_modules(scope),
+            default_export_binding_name: None,
+            var_declared_names: Vec::new(),
+            function_names: Vec::new(),
+            lexical_bindings: Vec::new(),
+        };
+
+        collect_module_imports_and_exports(scope, &mut metadata);
+
+        let mut function_index = 0;
+        for child in &scope.children {
+            collect_module_var_names(&child.inner, &mut metadata.var_declared_names);
+
+            let (declaration, is_exported) = match &child.inner {
+                ast::StatementKind::Export(export_data) => {
+                    if let Some(ref statement) = export_data.statement {
+                        (&statement.inner, true)
+                    } else {
+                        continue;
+                    }
+                }
+                other => (other, false),
+            };
+            collect_module_declaration(declaration, is_exported, function_index, &mut metadata);
+            if matches!(declaration, ast::StatementKind::FunctionDeclaration(_)) {
+                function_index += 1;
+            }
+        }
+
+        metadata
+    }
+
+    fn decode_payload(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(Self {
+            import_entries: ModuleImportEntryTable::decode(decoder)?,
+            local_exports: ModuleExportEntryTable::decode(decoder)?,
+            indirect_exports: ModuleExportEntryTable::decode(decoder)?,
+            star_exports: ModuleExportEntryTable::decode(decoder)?,
+            requested_modules: ModuleRequestTable::decode(decoder)?,
+            default_export_binding_name: Option::<ast::Utf16String>::decode(decoder)?,
+            var_declared_names: Utf16Vector::decode(decoder)?,
+            function_names: Utf16Vector::decode(decoder)?,
+            lexical_bindings: ModuleLexicalBindingTable::decode(decoder)?,
+        })
+    }
+
+    fn validate(&self) {
+        let _ = self.import_entries.len()
+            + self.local_exports.len()
+            + self.indirect_exports.len()
+            + self.star_exports.len()
+            + self.requested_modules.len()
+            + self.var_declared_names.len()
+            + self.function_names.len()
+            + self.lexical_bindings.len();
+        let _ = self
+            .default_export_binding_name
+            .as_ref()
+            .map(|name| name.as_slice().len());
+    }
+}
+
+impl Encode for ModuleDeclarationMetadata {
+    fn encode(&self, encoder: &mut Encoder) {
+        MetadataKind::Module.encode(encoder);
+        ModuleImportEntryTable(&self.import_entries).encode(encoder);
+        ModuleExportEntryTable(&self.local_exports).encode(encoder);
+        ModuleExportEntryTable(&self.indirect_exports).encode(encoder);
+        ModuleExportEntryTable(&self.star_exports).encode(encoder);
+        ModuleRequestTable(&self.requested_modules).encode(encoder);
+        self.default_export_binding_name
+            .as_ref()
+            .map(|name| Utf16(name))
+            .encode(encoder);
+        Utf16Vector(&self.var_declared_names).encode(encoder);
+        Utf16Vector(&self.function_names).encode(encoder);
+        ModuleLexicalBindingTable(&self.lexical_bindings).encode(encoder);
+    }
+}
+
+struct Utf16Vector<'a>(&'a [ast::Utf16String]);
+
+impl Encode for Utf16Vector<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |value, encoder| Utf16(value).encode(encoder));
+    }
+}
+
+impl Utf16Vector<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ast::Utf16String>> {
+        decoder.sequence_values(ast::Utf16String::decode)
+    }
+}
+
+struct LexicalBindingRecord {
+    name: ast::Utf16String,
+    is_constant: bool,
+}
+
+impl Encode for LexicalBindingRecord {
+    fn encode(&self, encoder: &mut Encoder) {
+        Utf16(&self.name).encode(encoder);
+        self.is_constant.encode(encoder);
+    }
+}
+
+struct LexicalBindingTable<'a>(&'a [LexicalBindingRecord]);
+
+impl Encode for LexicalBindingTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |binding, encoder| binding.encode(encoder));
+    }
+}
+
+impl LexicalBindingTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<LexicalBindingRecord>> {
+        decoder.sequence_values(|decoder| {
+            Some(LexicalBindingRecord {
+                name: ast::Utf16String::decode(decoder)?,
+                is_constant: bool::decode(decoder)?,
+            })
+        })
+    }
+}
+
+struct ModuleLexicalBindingRecord {
+    name: ast::Utf16String,
+    is_constant: bool,
+    function_index: i32,
+}
+
+impl Encode for ModuleLexicalBindingRecord {
+    fn encode(&self, encoder: &mut Encoder) {
+        Utf16(&self.name).encode(encoder);
+        self.is_constant.encode(encoder);
+        self.function_index.encode(encoder);
+    }
+}
+
+struct ModuleLexicalBindingTable<'a>(&'a [ModuleLexicalBindingRecord]);
+
+impl Encode for ModuleLexicalBindingTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |binding, encoder| binding.encode(encoder));
+    }
+}
+
+impl ModuleLexicalBindingTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ModuleLexicalBindingRecord>> {
+        decoder.sequence_values(|decoder| {
+            Some(ModuleLexicalBindingRecord {
+                name: ast::Utf16String::decode(decoder)?,
+                is_constant: bool::decode(decoder)?,
+                function_index: i32::decode(decoder)?,
+            })
+        })
+    }
+}
+
+#[derive(Clone)]
+struct ModuleRequestRecord {
+    specifier: ast::Utf16String,
+    attributes: Vec<ast::ImportAttribute>,
+}
+
+impl From<&ast::ModuleRequest> for ModuleRequestRecord {
+    fn from(request: &ast::ModuleRequest) -> Self {
+        Self {
+            specifier: request.module_specifier.clone(),
+            attributes: request.attributes.clone(),
+        }
+    }
+}
+
+impl Encode for ModuleRequestRecord {
+    fn encode(&self, encoder: &mut Encoder) {
+        Utf16(&self.specifier).encode(encoder);
+        ImportAttributeTable(&self.attributes).encode(encoder);
+    }
+}
+
+impl Decode for ModuleRequestRecord {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(Self {
+            specifier: ast::Utf16String::decode(decoder)?,
+            attributes: ImportAttributeTable::decode(decoder)?,
+        })
+    }
+}
+
+struct ModuleRequestTable<'a>(&'a [ModuleRequestRecord]);
+
+impl Encode for ModuleRequestTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |request, encoder| request.encode(encoder));
+    }
+}
+
+impl ModuleRequestTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ModuleRequestRecord>> {
+        decoder.sequence_values(ModuleRequestRecord::decode)
+    }
+}
+
+struct ImportAttributeTable<'a>(&'a [ast::ImportAttribute]);
+
+impl Encode for ImportAttributeTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |attribute, encoder| {
+            Utf16(&attribute.key).encode(encoder);
+            Utf16(&attribute.value).encode(encoder);
+        });
+    }
+}
+
+impl ImportAttributeTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ast::ImportAttribute>> {
+        decoder.sequence_values(|decoder| {
+            Some(ast::ImportAttribute {
+                key: ast::Utf16String::decode(decoder)?,
+                value: ast::Utf16String::decode(decoder)?,
+            })
+        })
+    }
+}
+
+struct ModuleImportEntryRecord {
+    import_name: Option<ast::Utf16String>,
+    local_name: ast::Utf16String,
+    module_request: ModuleRequestRecord,
+}
+
+impl Encode for ModuleImportEntryRecord {
+    fn encode(&self, encoder: &mut Encoder) {
+        self.import_name.as_ref().map(|name| Utf16(name)).encode(encoder);
+        Utf16(&self.local_name).encode(encoder);
+        self.module_request.encode(encoder);
+    }
+}
+
+struct ModuleImportEntryTable<'a>(&'a [ModuleImportEntryRecord]);
+
+impl Encode for ModuleImportEntryTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |entry, encoder| entry.encode(encoder));
+    }
+}
+
+impl ModuleImportEntryTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ModuleImportEntryRecord>> {
+        decoder.sequence_values(|decoder| {
+            Some(ModuleImportEntryRecord {
+                import_name: Option::<ast::Utf16String>::decode(decoder)?,
+                local_name: ast::Utf16String::decode(decoder)?,
+                module_request: ModuleRequestRecord::decode(decoder)?,
+            })
+        })
+    }
+}
+
+struct ModuleExportEntryRecord {
+    kind: ast::ExportEntryKind,
+    export_name: Option<ast::Utf16String>,
+    local_or_import_name: Option<ast::Utf16String>,
+    module_request: Option<ModuleRequestRecord>,
+}
+
+impl Encode for ModuleExportEntryRecord {
+    fn encode(&self, encoder: &mut Encoder) {
+        (self.kind as u8).encode(encoder);
+        self.export_name.as_ref().map(|name| Utf16(name)).encode(encoder);
+        self.local_or_import_name
+            .as_ref()
+            .map(|name| Utf16(name))
+            .encode(encoder);
+        self.module_request.encode(encoder);
+    }
+}
+
+struct ModuleExportEntryTable<'a>(&'a [ModuleExportEntryRecord]);
+
+impl Encode for ModuleExportEntryTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |entry, encoder| entry.encode(encoder));
+    }
+}
+
+impl ModuleExportEntryTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ModuleExportEntryRecord>> {
+        decoder.sequence_values(|decoder| {
+            Some(ModuleExportEntryRecord {
+                kind: ast::ExportEntryKind::decode(decoder)?,
+                export_name: Option::<ast::Utf16String>::decode(decoder)?,
+                local_or_import_name: Option::<ast::Utf16String>::decode(decoder)?,
+                module_request: Option::<ModuleRequestRecord>::decode(decoder)?,
+            })
+        })
+    }
+}
+
+fn collect_script_lexical_names(statement: &ast::StatementKind, names: &mut Vec<ast::Utf16String>) {
+    match statement {
+        ast::StatementKind::VariableDeclaration(declaration) if declaration.kind != ast::DeclarationKind::Var => {
+            for declarator in &declaration.declarations {
+                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+            }
+        }
+        ast::StatementKind::UsingDeclaration(declarations) => {
+            for declarator in declarations.iter() {
+                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+            }
+        }
+        ast::StatementKind::ClassDeclaration(class_data) => {
+            if let Some(ref name) = class_data.name {
+                names.push(name.name.to_utf16_string());
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_script_lexical_bindings(statement: &ast::StatementKind, bindings: &mut Vec<LexicalBindingRecord>) {
+    match statement {
+        ast::StatementKind::VariableDeclaration(declaration) if declaration.kind != ast::DeclarationKind::Var => {
+            let is_constant = declaration.kind == ast::DeclarationKind::Const;
+            for declarator in &declaration.declarations {
+                for_each_bound_name(&declarator.target, &mut |name| {
+                    bindings.push(LexicalBindingRecord {
+                        name: name.to_vec().into(),
+                        is_constant,
+                    });
+                });
+            }
+        }
+        ast::StatementKind::UsingDeclaration(declarations) => {
+            for declarator in declarations.iter() {
+                for_each_bound_name(&declarator.target, &mut |name| {
+                    bindings.push(LexicalBindingRecord {
+                        name: name.to_vec().into(),
+                        is_constant: false,
+                    });
+                });
+            }
+        }
+        ast::StatementKind::ClassDeclaration(class_data) => {
+            if let Some(ref name) = class_data.name {
+                bindings.push(LexicalBindingRecord {
+                    name: name.name.to_utf16_string(),
+                    is_constant: false,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn script_function_names(scope: &ast::ScopeData) -> Vec<ast::Utf16String> {
+    let mut last_position = HashMap::new();
+    for (index, child) in scope.children.iter().enumerate() {
+        if let ast::StatementKind::FunctionDeclaration(ref function) = child.inner
+            && let Some(ref name) = function.name
+        {
+            last_position.insert(name.name.clone(), index);
+        }
+    }
+
+    let mut names = Vec::new();
+    for (index, child) in scope.children.iter().enumerate() {
+        if let ast::StatementKind::FunctionDeclaration(ref function) = child.inner
+            && let Some(ref name) = function.name
+            && last_position.get(&name.name).copied() == Some(index)
+        {
+            names.push(name.name.to_utf16_string());
+        }
+    }
+    names
+}
+
+fn collect_module_imports_and_exports(scope: &ast::ScopeData, metadata: &mut ModuleDeclarationMetadata) {
+    struct ImportEntryWithRequest {
+        import_name: Option<ast::Utf16String>,
+        local_name: ast::Utf16String,
+        module_request: ModuleRequestRecord,
+    }
+
+    let mut all_import_entries = Vec::new();
+
+    for child in &scope.children {
+        if let ast::StatementKind::Import(import_data) = &child.inner {
+            for entry in &import_data.entries {
+                let module_request = ModuleRequestRecord::from(&import_data.module_request);
+                metadata.import_entries.push(ModuleImportEntryRecord {
+                    import_name: entry.import_name.clone(),
+                    local_name: entry.local_name.clone(),
+                    module_request: module_request.clone(),
+                });
+                all_import_entries.push(ImportEntryWithRequest {
+                    import_name: entry.import_name.clone(),
+                    local_name: entry.local_name.clone(),
+                    module_request,
+                });
+            }
+        }
+    }
+
+    for child in &scope.children {
+        let ast::StatementKind::Export(export_data) = &child.inner else {
+            continue;
+        };
+
+        if export_data.is_default_export && export_data.entries.len() == 1 {
+            let entry = &export_data.entries[0];
+            let is_declaration = export_data.statement.as_ref().is_some_and(|statement| {
+                matches!(
+                    statement.inner,
+                    ast::StatementKind::FunctionDeclaration(_) | ast::StatementKind::ClassDeclaration(_)
+                )
+            });
+            if !is_declaration {
+                metadata.default_export_binding_name = entry.local_or_import_name.clone();
+            }
+        }
+
+        for entry in &export_data.entries {
+            if entry.kind == ast::ExportEntryKind::EmptyNamedExport {
+                break;
+            }
+
+            let has_module_request = export_data.module_request.is_some();
+            if !has_module_request {
+                let matching_import = all_import_entries
+                    .iter()
+                    .find(|import| entry.local_or_import_name.as_ref() == Some(&import.local_name));
+                if let Some(import_entry) = matching_import {
+                    if import_entry.import_name.is_none() {
+                        metadata.local_exports.push(export_record(entry, None));
+                    } else {
+                        metadata
+                            .indirect_exports
+                            .push(export_record(entry, Some(&import_entry.module_request)));
+                    }
+                } else {
+                    metadata.local_exports.push(export_record(entry, None));
+                }
+            } else if entry.kind == ast::ExportEntryKind::ModuleRequestAllButDefault {
+                let module_request = export_data.module_request.as_ref().map(ModuleRequestRecord::from);
+                metadata
+                    .star_exports
+                    .push(export_record(entry, module_request.as_ref()));
+            } else {
+                let module_request = export_data.module_request.as_ref().map(ModuleRequestRecord::from);
+                metadata
+                    .indirect_exports
+                    .push(export_record(entry, module_request.as_ref()));
+            }
+        }
+    }
+}
+
+fn export_record(entry: &ast::ExportEntry, module_request: Option<&ModuleRequestRecord>) -> ModuleExportEntryRecord {
+    ModuleExportEntryRecord {
+        kind: entry.kind,
+        export_name: entry.export_name.clone(),
+        local_or_import_name: entry.local_or_import_name.clone(),
+        module_request: module_request.cloned(),
+    }
+}
+
+fn requested_modules(scope: &ast::ScopeData) -> Vec<ModuleRequestRecord> {
+    let mut modules = Vec::new();
+    for child in &scope.children {
+        match &child.inner {
+            ast::StatementKind::Import(import_data) => {
+                modules.push((
+                    child.range.start.offset,
+                    ModuleRequestRecord::from(&import_data.module_request),
+                ));
+            }
+            ast::StatementKind::Export(export_data) => {
+                if let Some(module_request) = &export_data.module_request {
+                    modules.push((child.range.start.offset, ModuleRequestRecord::from(module_request)));
+                }
+            }
+            _ => {}
+        }
+    }
+    modules.sort_by_key(|(source_offset, _)| *source_offset);
+    modules.into_iter().map(|(_, module_request)| module_request).collect()
+}
+
+fn collect_module_declaration(
+    declaration: &ast::StatementKind,
+    is_exported: bool,
+    function_index: i32,
+    metadata: &mut ModuleDeclarationMetadata,
+) {
+    let default_name: ast::Utf16String = utf16!("*default*").into();
+    match declaration {
+        ast::StatementKind::FunctionDeclaration(function) => {
+            let Some(name) = &function.name else {
+                return;
+            };
+            let is_default = is_exported && name.name == default_name;
+            let function_name = if is_default {
+                utf16!("default").into()
+            } else {
+                name.name.to_utf16_string()
+            };
+            metadata.function_names.push(function_name);
+            metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
+                name: name.name.to_utf16_string(),
+                is_constant: false,
+                function_index,
+            });
+        }
+        ast::StatementKind::ClassDeclaration(class_data) => {
+            if let Some(ref name) = class_data.name {
+                metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
+                    name: name.name.to_utf16_string(),
+                    is_constant: false,
+                    function_index: -1,
+                });
+            }
+        }
+        ast::StatementKind::VariableDeclaration(declaration) if declaration.kind != ast::DeclarationKind::Var => {
+            let is_constant = declaration.kind == ast::DeclarationKind::Const;
+            for declarator in &declaration.declarations {
+                for_each_bound_name(&declarator.target, &mut |name| {
+                    metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
+                        name: name.to_vec().into(),
+                        is_constant,
+                        function_index: -1,
+                    });
+                });
+            }
+        }
+        ast::StatementKind::UsingDeclaration(declarations) => {
+            for declarator in declarations.iter() {
+                for_each_bound_name(&declarator.target, &mut |name| {
+                    metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
+                        name: name.to_vec().into(),
+                        is_constant: false,
+                        function_index: -1,
+                    });
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_var_names_recursive(statement: &ast::StatementKind, names: &mut Vec<ast::Utf16String>) {
+    match statement {
+        ast::StatementKind::VariableDeclaration(declaration) if declaration.kind == ast::DeclarationKind::Var => {
+            for declarator in &declaration.declarations {
+                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+            }
+        }
+        _ => {
+            for_each_child_statement(statement, &mut |child| {
+                collect_var_names_recursive(child, names);
+            });
+        }
+    }
+}
+
+fn collect_module_var_names(statement: &ast::StatementKind, names: &mut Vec<ast::Utf16String>) {
+    match statement {
+        ast::StatementKind::VariableDeclaration(declaration) if declaration.kind == ast::DeclarationKind::Var => {
+            for declarator in &declaration.declarations {
+                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+            }
+        }
+        ast::StatementKind::Export(export_data) => {
+            if let Some(ref statement) = export_data.statement {
+                collect_module_var_names(&statement.inner, names);
+            }
+        }
+        _ => {
+            for_each_child_statement(statement, &mut |child| {
+                collect_module_var_names(child, names);
+            });
+        }
+    }
+}
+
+fn for_each_bound_name(target: &ast::VariableDeclaratorTarget, callback: &mut dyn FnMut(&[u16])) {
+    match target {
+        ast::VariableDeclaratorTarget::Identifier(identifier) => callback(identifier.name.as_slice()),
+        ast::VariableDeclaratorTarget::BindingPattern(pattern) => for_each_bound_name_in_pattern(pattern, callback),
+    }
+}
+
+fn for_each_bound_name_in_pattern(pattern: &ast::BindingPattern, callback: &mut dyn FnMut(&[u16])) {
+    for entry in &pattern.entries {
+        match &entry.alias {
+            Some(ast::BindingEntryAlias::Identifier(identifier)) => callback(identifier.name.as_slice()),
+            Some(ast::BindingEntryAlias::BindingPattern(pattern)) => {
+                for_each_bound_name_in_pattern(pattern, callback);
+            }
+            Some(ast::BindingEntryAlias::MemberExpression(_)) => {}
+            None => {
+                if let Some(ast::BindingEntryName::Identifier(identifier)) = &entry.name {
+                    callback(identifier.name.as_slice());
+                }
+            }
+        }
+    }
+}
+
+fn for_each_child_statement(statement: &ast::StatementKind, callback: &mut dyn FnMut(&ast::StatementKind)) {
+    match statement {
+        ast::StatementKind::Block(scope) => {
+            for child in &scope.borrow().children {
+                callback(&child.inner);
+            }
+        }
+        ast::StatementKind::If(data) => {
+            callback(&data.consequent.inner);
+            if let Some(alternate) = &data.alternate {
+                callback(&alternate.inner);
+            }
+        }
+        ast::StatementKind::While(data) | ast::StatementKind::DoWhile(data) => {
+            callback(&data.body.inner);
+        }
+        ast::StatementKind::With(data) => callback(&data.body.inner),
+        ast::StatementKind::For(data) => {
+            if let Some(ast::ForInit::Declaration(declaration)) = &data.init {
+                callback(&declaration.inner);
+            }
+            callback(&data.body.inner);
+        }
+        ast::StatementKind::ForInOf(data) => {
+            if let ast::ForInOfLhs::Declaration(declaration) = &data.lhs {
+                callback(&declaration.inner);
+            }
+            callback(&data.body.inner);
+        }
+        ast::StatementKind::Switch(data) => {
+            for case in &data.cases {
+                for child in &case.scope.borrow().children {
+                    callback(&child.inner);
+                }
+            }
+        }
+        ast::StatementKind::Labelled(data) => callback(&data.item.inner),
+        ast::StatementKind::Try(data) => {
+            callback(&data.block.inner);
+            if let Some(catch) = &data.handler {
+                callback(&catch.body.inner);
+            }
+            if let Some(finalizer) = &data.finalizer {
+                callback(&finalizer.inner);
+            }
+        }
+        ast::StatementKind::Export(export_data) => {
+            if let Some(statement) = &export_data.statement {
+                callback(&statement.inner);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -30,6 +30,16 @@ pub fn serialize_compiled_program(compiled: &CompiledProgram, program_type: ast:
     encoder.finish()
 }
 
+pub(crate) fn decode_blob(bytes: &[u8], expected_program_type: ast::ProgramType) -> Option<DecodedCacheBlob> {
+    let mut decoder = Decoder::new(bytes);
+    let blob = CacheBlob::decode(&mut decoder, expected_program_type)?;
+    if !decoder.is_empty() {
+        return None;
+    }
+    blob.validate();
+    Some(blob)
+}
+
 struct Encoder {
     bytes: Vec<u8>,
 }
@@ -305,7 +315,7 @@ impl CacheBlob<'_> {
     }
 }
 
-struct DecodedCacheBlob {
+pub(crate) struct DecodedCacheBlob {
     program_type: ast::ProgramType,
     has_top_level_await: bool,
     is_strict_mode: bool,

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -290,15 +290,35 @@ impl Encode for CacheBlob<'_> {
 }
 
 impl CacheBlob<'_> {
-    fn decode(decoder: &mut Decoder<'_>, expected_program_type: ast::ProgramType) -> Option<()> {
+    fn decode(decoder: &mut Decoder<'_>, expected_program_type: ast::ProgramType) -> Option<DecodedCacheBlob> {
         decoder.expect_bytes(MAGIC)?;
         (u32::decode(decoder)? == FORMAT_VERSION).then_some(())?;
-        (ast::ProgramType::decode(decoder)? == expected_program_type).then_some(())?;
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        DeclarationMetadataRecord::decode(decoder)?.validate();
-        ProgramRecord::decode(decoder)?.validate();
-        Some(())
+        let program_type = ast::ProgramType::decode(decoder)?;
+        (program_type == expected_program_type).then_some(())?;
+        Some(DecodedCacheBlob {
+            program_type,
+            has_top_level_await: bool::decode(decoder)?,
+            is_strict_mode: bool::decode(decoder)?,
+            metadata: DeclarationMetadataRecord::decode(decoder)?,
+            program: ProgramRecord::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedCacheBlob {
+    program_type: ast::ProgramType,
+    has_top_level_await: bool,
+    is_strict_mode: bool,
+    metadata: DecodedDeclarationMetadata,
+    program: DecodedProgramRecord,
+}
+
+impl DecodedCacheBlob {
+    fn validate(&self) {
+        let _ = self.program_type as u8;
+        let _ = self.has_top_level_await || self.is_strict_mode;
+        self.metadata.validate();
+        self.program.validate();
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -55,13 +55,67 @@ impl Encoder {
     }
 }
 
+struct Decoder<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> Decoder<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    fn bytes(&mut self, length: usize) -> Option<&'a [u8]> {
+        if self.bytes.len() < length {
+            return None;
+        }
+
+        let (bytes, rest) = self.bytes.split_at(length);
+        self.bytes = rest;
+        Some(bytes)
+    }
+
+    fn expect_bytes(&mut self, expected: &[u8]) -> Option<()> {
+        (self.bytes(expected.len())? == expected).then_some(())
+    }
+
+    fn sequence(&mut self, mut decode_item: impl FnMut(&mut Self) -> Option<()>) -> Option<()> {
+        let length: usize = u32::decode(self)?.try_into().ok()?;
+        if length > self.bytes.len() {
+            return None;
+        }
+
+        for _ in 0..length {
+            decode_item(self)?;
+        }
+        Some(())
+    }
+}
+
 trait Encode {
     fn encode(&self, encoder: &mut Encoder);
+}
+
+trait Decode: Sized {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self>;
 }
 
 impl Encode for bool {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.byte(*self as u8);
+    }
+}
+
+impl Decode for bool {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }
     }
 }
 
@@ -71,9 +125,21 @@ impl Encode for u8 {
     }
 }
 
+impl Decode for u8 {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        decoder.bytes(1)?.first().copied()
+    }
+}
+
 impl Encode for u32 {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl Decode for u32 {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(u32::from_le_bytes(decoder.bytes(4)?.try_into().ok()?))
     }
 }
 
@@ -83,9 +149,21 @@ impl Encode for i32 {
     }
 }
 
+impl Decode for i32 {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(i32::from_le_bytes(decoder.bytes(4)?.try_into().ok()?))
+    }
+}
+
 impl Encode for u64 {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl Decode for u64 {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(u64::from_le_bytes(decoder.bytes(8)?.try_into().ok()?))
     }
 }
 
@@ -95,9 +173,21 @@ impl Encode for usize {
     }
 }
 
+impl Decode for usize {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        u64::decode(decoder)?.try_into().ok()
+    }
+}
+
 impl Encode for f64 {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.bytes(&self.to_le_bytes());
+    }
+}
+
+impl Decode for f64 {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(f64::from_le_bytes(decoder.bytes(8)?.try_into().ok()?))
     }
 }
 
@@ -110,12 +200,32 @@ impl<T: Encode> Encode for Option<T> {
     }
 }
 
+impl<T: Decode> Decode for Option<T> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        if bool::decode(decoder)? {
+            Some(Some(T::decode(decoder)?))
+        } else {
+            Some(None)
+        }
+    }
+}
+
 struct Bytes<'a>(&'a [u8]);
 
 impl Encode for Bytes<'_> {
     fn encode(&self, encoder: &mut Encoder) {
         u32_from_usize(self.0.len()).encode(encoder);
         encoder.bytes(self.0);
+    }
+}
+
+struct IgnoredBytes;
+
+impl Decode for IgnoredBytes {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        let length: usize = u32::decode(decoder)?.try_into().ok()?;
+        decoder.bytes(length)?;
+        Some(Self)
     }
 }
 
@@ -130,6 +240,16 @@ impl Encode for Utf16<'_> {
     }
 }
 
+struct IgnoredUtf16;
+
+impl Decode for IgnoredUtf16 {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        let length: usize = u32::decode(decoder)?.try_into().ok()?;
+        decoder.bytes(length.checked_mul(size_of::<u16>())?)?;
+        Some(Self)
+    }
+}
+
 struct CacheBlob<'a> {
     compiled: &'a CompiledProgram,
 }
@@ -141,6 +261,16 @@ impl Encode for CacheBlob<'_> {
         self.compiled.parsed.has_top_level_await.encode(encoder);
         self.compiled.parsed.is_strict_mode.encode(encoder);
         ProgramRecord::from(self.compiled).encode(encoder);
+    }
+}
+
+impl CacheBlob<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.expect_bytes(MAGIC)?;
+        (u32::decode(decoder)? == FORMAT_VERSION).then_some(())?;
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        ProgramRecord::decode(decoder)
     }
 }
 
@@ -177,6 +307,13 @@ impl Encode for ProgramRecord<'_> {
     }
 }
 
+impl ProgramRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        ProgramKind::decode(decoder)?;
+        ExecutableRecord::decode(decoder)
+    }
+}
+
 #[repr(u8)]
 #[derive(Clone, Copy)]
 enum ProgramKind {
@@ -187,6 +324,16 @@ enum ProgramKind {
 impl Encode for ProgramKind {
     fn encode(&self, encoder: &mut Encoder) {
         (*self as u8).encode(encoder);
+    }
+}
+
+impl Decode for ProgramKind {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            0 => Some(Self::ScriptOrModule),
+            1 => Some(Self::AsyncModule),
+            _ => None,
+        }
     }
 }
 
@@ -218,6 +365,29 @@ impl Encode for ExecutableRecord<'_> {
     }
 }
 
+impl ExecutableRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        bool::decode(decoder)?;
+        u32::decode(decoder)?;
+        u32::decode(decoder)?;
+        CacheCounters::decode(decoder)?;
+        bool::decode(decoder)?;
+        Option::<u32>::decode(decoder)?;
+
+        IgnoredBytes::decode(decoder)?;
+        Utf16Table::decode(decoder)?;
+        Utf16Table::decode(decoder)?;
+        Utf16Table::decode(decoder)?;
+        ConstantTable::decode(decoder)?;
+        ExceptionHandlerTable::decode(decoder)?;
+        SourceMapTable::decode(decoder)?;
+        BasicBlockOffsetTable::decode(decoder)?;
+        LocalVariableTable::decode(decoder)?;
+        SharedFunctionTable::decode(decoder)?;
+        ClassBlueprintTable::decode(decoder)
+    }
+}
+
 struct CacheCounters<'a>(&'a Generator);
 
 impl Encode for CacheCounters<'_> {
@@ -230,6 +400,17 @@ impl Encode for CacheCounters<'_> {
     }
 }
 
+impl CacheCounters<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        u32::decode(decoder)?;
+        u32::decode(decoder)?;
+        u32::decode(decoder)?;
+        u32::decode(decoder)?;
+        u32::decode(decoder)?;
+        Some(())
+    }
+}
+
 struct Utf16Table<'a>(&'a [ast::Utf16String]);
 
 impl Encode for Utf16Table<'_> {
@@ -238,11 +419,23 @@ impl Encode for Utf16Table<'_> {
     }
 }
 
+impl Utf16Table<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(|decoder| IgnoredUtf16::decode(decoder).map(|_| ()))
+    }
+}
+
 struct ConstantTable<'a>(&'a [ConstantValue]);
 
 impl Encode for ConstantTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.sequence(self.0, |constant, encoder| constant.encode(encoder));
+    }
+}
+
+impl ConstantTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(ConstantRecord::decode)
     }
 }
 
@@ -278,6 +471,32 @@ impl Encode for ConstantValue {
     }
 }
 
+struct ConstantRecord;
+
+impl ConstantRecord {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        match u8::decode(decoder)? {
+            tag if tag == ConstantTag::Number as u8 => f64::decode(decoder).map(|_| ()),
+            tag if tag == ConstantTag::BooleanTrue as u8 => Some(()),
+            tag if tag == ConstantTag::BooleanFalse as u8 => Some(()),
+            tag if tag == ConstantTag::Null as u8 => Some(()),
+            tag if tag == ConstantTag::Undefined as u8 => Some(()),
+            tag if tag == ConstantTag::Empty as u8 => Some(()),
+            tag if tag == ConstantTag::String as u8 => IgnoredUtf16::decode(decoder).map(|_| ()),
+            tag if tag == ConstantTag::BigInt as u8 => IgnoredBytes::decode(decoder).map(|_| ()),
+            tag if tag == ConstantTag::WellKnownSymbol as u8 => match u8::decode(decoder)? {
+                0 | 1 => Some(()),
+                _ => None,
+            },
+            tag if tag == ConstantTag::AbstractOperation as u8 => match u8::decode(decoder)? {
+                0..=4 => Some(()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
 struct ExceptionHandlerTable<'a>(&'a AssembledBytecode);
 
 impl Encode for ExceptionHandlerTable<'_> {
@@ -287,6 +506,17 @@ impl Encode for ExceptionHandlerTable<'_> {
             handler.end_offset.encode(encoder);
             handler.handler_offset.encode(encoder);
         });
+    }
+}
+
+impl ExceptionHandlerTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(|decoder| {
+            u32::decode(decoder)?;
+            u32::decode(decoder)?;
+            u32::decode(decoder)?;
+            Some(())
+        })
     }
 }
 
@@ -306,6 +536,17 @@ impl Encode for SourceMapTable<'_> {
     }
 }
 
+impl SourceMapTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(|decoder| {
+            for _ in 0..7 {
+                u32::decode(decoder)?;
+            }
+            Some(())
+        })
+    }
+}
+
 struct BasicBlockOffsetTable<'a>(&'a AssembledBytecode);
 
 impl Encode for BasicBlockOffsetTable<'_> {
@@ -313,6 +554,12 @@ impl Encode for BasicBlockOffsetTable<'_> {
         encoder.sequence(&self.0.basic_block_start_offsets, |offset, encoder| {
             offset.encode(encoder);
         });
+    }
+}
+
+impl BasicBlockOffsetTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(|decoder| usize::decode(decoder).map(|_| ()))
     }
 }
 
@@ -330,6 +577,17 @@ impl Encode for LocalVariableTable<'_> {
     }
 }
 
+impl LocalVariableTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(|decoder| {
+            IgnoredUtf16::decode(decoder)?;
+            bool::decode(decoder)?;
+            bool::decode(decoder)?;
+            Some(())
+        })
+    }
+}
+
 struct SharedFunctionTable<'a>(&'a Generator);
 
 impl Encode for SharedFunctionTable<'_> {
@@ -341,6 +599,12 @@ impl Encode for SharedFunctionTable<'_> {
             }
             .encode(encoder);
         });
+    }
+}
+
+impl SharedFunctionTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(FunctionRecord::decode)
     }
 }
 
@@ -386,6 +650,28 @@ impl Encode for FunctionRecord<'_> {
     }
 }
 
+impl FunctionRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        Option::<IgnoredUtf16>::decode(decoder)?;
+        u32::decode(decoder)?;
+        u32::decode(decoder)?;
+        i32::decode(decoder)?;
+        u32::decode(decoder)?;
+        match u8::decode(decoder)? {
+            0..=3 => {}
+            _ => return None,
+        }
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        SimpleParameterList::decode(decoder)?;
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        ClassFieldInitializerName::decode(decoder)?;
+        FunctionSfdMetadata::decode(decoder)?;
+        PrecompiledFunctionRecord::decode(decoder)
+    }
+}
+
 impl<'a> FunctionRecord<'a> {
     fn function_name(&self, function_data: &'a ast::FunctionData) -> Option<Utf16<'a>> {
         self.shared_data
@@ -412,6 +698,15 @@ impl Encode for SimpleParameterList<'_> {
         if let Some(names) = names {
             encoder.sequence(&names, |name, encoder| Utf16(name).encode(encoder));
         }
+    }
+}
+
+impl SimpleParameterList<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        if bool::decode(decoder)? {
+            decoder.sequence(|decoder| IgnoredUtf16::decode(decoder).map(|_| ()))?;
+        }
+        Some(())
     }
 }
 
@@ -444,10 +739,26 @@ impl Encode for ClassFieldInitializerName<'_> {
     }
 }
 
+impl ClassFieldInitializerName<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        if bool::decode(decoder)? {
+            IgnoredUtf16::decode(decoder)?;
+            bool::decode(decoder)?;
+        }
+        Some(())
+    }
+}
+
 impl Encode for (Utf16<'_>, bool) {
     fn encode(&self, encoder: &mut Encoder) {
         self.0.encode(encoder);
         self.1.encode(encoder);
+    }
+}
+
+impl Decode for (IgnoredUtf16, bool) {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some((IgnoredUtf16::decode(decoder)?, bool::decode(decoder)?))
     }
 }
 
@@ -463,6 +774,19 @@ impl Encode for FunctionSfdMetadata {
     }
 }
 
+impl FunctionSfdMetadata {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        usize::decode(decoder)?;
+        usize::decode(decoder)?;
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        Some(())
+    }
+}
+
 struct PrecompiledFunctionRecord<'a>(&'a PrecompiledFunction);
 
 impl Encode for PrecompiledFunctionRecord<'_> {
@@ -475,6 +799,12 @@ impl Encode for PrecompiledFunctionRecord<'_> {
     }
 }
 
+impl PrecompiledFunctionRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        ExecutableRecord::decode(decoder)
+    }
+}
+
 struct ClassBlueprintTable<'a>(&'a Generator);
 
 impl Encode for ClassBlueprintTable<'_> {
@@ -482,6 +812,12 @@ impl Encode for ClassBlueprintTable<'_> {
         encoder.sequence(&self.0.class_blueprints, |blueprint, encoder| {
             ClassBlueprintRecord(blueprint).encode(encoder);
         });
+    }
+}
+
+impl ClassBlueprintTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        decoder.sequence(ClassBlueprintRecord::decode)
     }
 }
 
@@ -501,6 +837,18 @@ impl Encode for ClassBlueprintRecord<'_> {
     }
 }
 
+impl ClassBlueprintRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        Option::<IgnoredUtf16>::decode(decoder)?;
+        usize::decode(decoder)?;
+        usize::decode(decoder)?;
+        u32::decode(decoder)?;
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        decoder.sequence(ClassElementRecord::decode)
+    }
+}
+
 struct ClassElementRecord<'a>(&'a PendingClassElement);
 
 impl Encode for ClassElementRecord<'_> {
@@ -517,6 +865,24 @@ impl Encode for ClassElementRecord<'_> {
     }
 }
 
+impl ClassElementRecord<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+        u8::decode(decoder)?;
+        bool::decode(decoder)?;
+        bool::decode(decoder)?;
+        Option::<IgnoredUtf16>::decode(decoder)?;
+        Option::<u32>::decode(decoder)?;
+        bool::decode(decoder)?;
+        match u8::decode(decoder)? {
+            0..=5 => {}
+            _ => return None,
+        }
+        f64::decode(decoder)?;
+        Option::<IgnoredUtf16>::decode(decoder)?;
+        Some(())
+    }
+}
+
 fn literal_value_kind_tag(kind: PendingLiteralValueKind) -> u8 {
     match kind {
         PendingLiteralValueKind::None => 0,
@@ -525,5 +891,28 @@ fn literal_value_kind_tag(kind: PendingLiteralValueKind) -> u8 {
         PendingLiteralValueKind::BooleanFalse => 3,
         PendingLiteralValueKind::Null => 4,
         PendingLiteralValueKind::String => 5,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sequence_decode_rejects_lengths_larger_than_remaining_bytes() {
+        let bytes = u32::MAX.to_le_bytes();
+
+        let mut decoder = Decoder::new(&bytes);
+        assert!(decoder.sequence(|_| Some(())).is_none());
+    }
+
+    #[test]
+    fn sequence_decode_rejects_truncated_items_without_large_allocation() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&4u32.to_le_bytes());
+        bytes.extend_from_slice(&[1, 2, 3]);
+
+        let mut decoder = Decoder::new(&bytes);
+        assert!(decoder.sequence(|d| u8::decode(d).map(|_| ())).is_none());
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -371,37 +371,63 @@ impl Encode for DeclarationMetadataRecord<'_> {
         let ast::StatementKind::Program(program) = &self.compiled.parsed.program.inner else {
             unreachable!("bytecode cache expects a parsed program root");
         };
-        let scope = program.scope.borrow();
+        let arena = &self.compiled.parsed.arena;
+        let scope = &arena.scopes[program.scope];
         match self.program_type {
-            ast::ProgramType::Script => ScriptDeclarationMetadata::from_scope(&scope).encode(encoder),
-            ast::ProgramType::Module => ModuleDeclarationMetadata::from_scope(&scope).encode(encoder),
+            ast::ProgramType::Script => ScriptDeclarationMetadata::from_scope(scope, arena).encode(encoder),
+            ast::ProgramType::Module => ModuleDeclarationMetadata::from_scope(scope, arena).encode(encoder),
         }
+        DeclarationFunctionTable(&self.compiled.declaration_functions).encode(encoder);
     }
 }
 
 impl DeclarationMetadataRecord<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedDeclarationMetadata> {
         match MetadataKind::decode(decoder)? {
-            MetadataKind::Script => {
-                ScriptDeclarationMetadata::decode_payload(decoder).map(DecodedDeclarationMetadata::Script)
-            }
-            MetadataKind::Module => {
-                ModuleDeclarationMetadata::decode_payload(decoder).map(DecodedDeclarationMetadata::Module)
-            }
+            MetadataKind::Script => Some(DecodedDeclarationMetadata::Script {
+                metadata: ScriptDeclarationMetadata::decode_payload(decoder)?,
+                declaration_functions: DeclarationFunctionTable::decode(decoder)?,
+            }),
+            MetadataKind::Module => Some(DecodedDeclarationMetadata::Module {
+                metadata: ModuleDeclarationMetadata::decode_payload(decoder)?,
+                declaration_functions: DeclarationFunctionTable::decode(decoder)?,
+            }),
         }
     }
 }
 
 enum DecodedDeclarationMetadata {
-    Script(ScriptDeclarationMetadata),
-    Module(ModuleDeclarationMetadata),
+    Script {
+        metadata: ScriptDeclarationMetadata,
+        declaration_functions: Vec<DecodedFunctionRecord>,
+    },
+    Module {
+        metadata: ModuleDeclarationMetadata,
+        declaration_functions: Vec<DecodedFunctionRecord>,
+    },
 }
 
 impl DecodedDeclarationMetadata {
     fn validate(&self) {
         match self {
-            Self::Script(metadata) => metadata.validate(),
-            Self::Module(metadata) => metadata.validate(),
+            Self::Script {
+                metadata,
+                declaration_functions,
+            } => {
+                metadata.validate();
+                for function in declaration_functions {
+                    function.validate();
+                }
+            }
+            Self::Module {
+                metadata,
+                declaration_functions,
+            } => {
+                metadata.validate();
+                for function in declaration_functions {
+                    function.validate();
+                }
+            }
         }
     }
 }
@@ -439,26 +465,26 @@ struct ScriptDeclarationMetadata {
 }
 
 impl ScriptDeclarationMetadata {
-    fn from_scope(scope: &ast::ScopeData) -> Self {
+    fn from_scope(scope: &ast::ScopeData, arena: &ast::AstArena) -> Self {
         let mut metadata = Self {
             lexical_names: Vec::new(),
             var_names: Vec::new(),
-            function_names: script_function_names(scope),
+            function_names: script_function_names(scope, arena),
             var_scoped_names: Vec::new(),
             annex_b_candidate_names: scope.annexb_function_names.to_vec(),
             lexical_bindings: Vec::new(),
         };
 
         for child in &scope.children {
-            collect_var_names_recursive(&child.inner, &mut metadata.var_names);
+            collect_var_names_recursive(&child.inner, arena, &mut metadata.var_names);
             if let ast::StatementKind::FunctionDeclaration(ref function) = child.inner
-                && let Some(ref name) = function.name
+                && let Some(name) = function.name
             {
-                metadata.var_names.push(name.name.to_utf16_string());
+                metadata.var_names.push(arena.name_of(name).clone());
             }
-            collect_script_lexical_names(&child.inner, &mut metadata.lexical_names);
-            collect_script_lexical_bindings(&child.inner, &mut metadata.lexical_bindings);
-            collect_var_names_recursive(&child.inner, &mut metadata.var_scoped_names);
+            collect_script_lexical_names(&child.inner, arena, &mut metadata.lexical_names);
+            collect_script_lexical_bindings(&child.inner, arena, &mut metadata.lexical_bindings);
+            collect_var_names_recursive(&child.inner, arena, &mut metadata.var_scoped_names);
         }
 
         metadata
@@ -510,7 +536,7 @@ struct ModuleDeclarationMetadata {
 }
 
 impl ModuleDeclarationMetadata {
-    fn from_scope(scope: &ast::ScopeData) -> Self {
+    fn from_scope(scope: &ast::ScopeData, arena: &ast::AstArena) -> Self {
         let mut metadata = Self {
             import_entries: Vec::new(),
             local_exports: Vec::new(),
@@ -527,7 +553,7 @@ impl ModuleDeclarationMetadata {
 
         let mut function_index = 0;
         for child in &scope.children {
-            collect_module_var_names(&child.inner, &mut metadata.var_declared_names);
+            collect_module_var_names(&child.inner, arena, &mut metadata.var_declared_names);
 
             let (declaration, is_exported) = match &child.inner {
                 ast::StatementKind::Export(export_data) => {
@@ -539,7 +565,7 @@ impl ModuleDeclarationMetadata {
                 }
                 other => (other, false),
             };
-            collect_module_declaration(declaration, is_exported, function_index, &mut metadata);
+            collect_module_declaration(declaration, is_exported, function_index, arena, &mut metadata);
             if matches!(declaration, ast::StatementKind::FunctionDeclaration(_)) {
                 function_index += 1;
             }
@@ -816,33 +842,41 @@ impl ModuleExportEntryTable<'_> {
     }
 }
 
-fn collect_script_lexical_names(statement: &ast::StatementKind, names: &mut Vec<ast::Utf16String>) {
+fn collect_script_lexical_names(
+    statement: &ast::StatementKind,
+    arena: &ast::AstArena,
+    names: &mut Vec<ast::Utf16String>,
+) {
     match statement {
         ast::StatementKind::VariableDeclaration(declaration) if declaration.kind != ast::DeclarationKind::Var => {
             for declarator in &declaration.declarations {
-                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+                for_each_bound_name(&declarator.target, arena, &mut |name| names.push(name.to_vec().into()));
             }
         }
         ast::StatementKind::UsingDeclaration(declarations) => {
             for declarator in declarations.iter() {
-                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+                for_each_bound_name(&declarator.target, arena, &mut |name| names.push(name.to_vec().into()));
             }
         }
         ast::StatementKind::ClassDeclaration(class_data) => {
-            if let Some(ref name) = class_data.name {
-                names.push(name.name.to_utf16_string());
+            if let Some(name) = class_data.name {
+                names.push(arena.name_of(name).clone());
             }
         }
         _ => {}
     }
 }
 
-fn collect_script_lexical_bindings(statement: &ast::StatementKind, bindings: &mut Vec<LexicalBindingRecord>) {
+fn collect_script_lexical_bindings(
+    statement: &ast::StatementKind,
+    arena: &ast::AstArena,
+    bindings: &mut Vec<LexicalBindingRecord>,
+) {
     match statement {
         ast::StatementKind::VariableDeclaration(declaration) if declaration.kind != ast::DeclarationKind::Var => {
             let is_constant = declaration.kind == ast::DeclarationKind::Const;
             for declarator in &declaration.declarations {
-                for_each_bound_name(&declarator.target, &mut |name| {
+                for_each_bound_name(&declarator.target, arena, &mut |name| {
                     bindings.push(LexicalBindingRecord {
                         name: name.to_vec().into(),
                         is_constant,
@@ -852,7 +886,7 @@ fn collect_script_lexical_bindings(statement: &ast::StatementKind, bindings: &mu
         }
         ast::StatementKind::UsingDeclaration(declarations) => {
             for declarator in declarations.iter() {
-                for_each_bound_name(&declarator.target, &mut |name| {
+                for_each_bound_name(&declarator.target, arena, &mut |name| {
                     bindings.push(LexicalBindingRecord {
                         name: name.to_vec().into(),
                         is_constant: false,
@@ -861,9 +895,9 @@ fn collect_script_lexical_bindings(statement: &ast::StatementKind, bindings: &mu
             }
         }
         ast::StatementKind::ClassDeclaration(class_data) => {
-            if let Some(ref name) = class_data.name {
+            if let Some(name) = class_data.name {
                 bindings.push(LexicalBindingRecord {
-                    name: name.name.to_utf16_string(),
+                    name: arena.name_of(name).clone(),
                     is_constant: false,
                 });
             }
@@ -872,23 +906,23 @@ fn collect_script_lexical_bindings(statement: &ast::StatementKind, bindings: &mu
     }
 }
 
-fn script_function_names(scope: &ast::ScopeData) -> Vec<ast::Utf16String> {
+fn script_function_names(scope: &ast::ScopeData, arena: &ast::AstArena) -> Vec<ast::Utf16String> {
     let mut last_position = HashMap::new();
     for (index, child) in scope.children.iter().enumerate() {
         if let ast::StatementKind::FunctionDeclaration(ref function) = child.inner
-            && let Some(ref name) = function.name
+            && let Some(name) = function.name
         {
-            last_position.insert(name.name.clone(), index);
+            last_position.insert(arena.identifiers[name].name, index);
         }
     }
 
     let mut names = Vec::new();
     for (index, child) in scope.children.iter().enumerate() {
         if let ast::StatementKind::FunctionDeclaration(ref function) = child.inner
-            && let Some(ref name) = function.name
-            && last_position.get(&name.name).copied() == Some(index)
+            && let Some(name) = function.name
+            && last_position.get(&arena.identifiers[name].name).copied() == Some(index)
         {
-            names.push(name.name.to_utf16_string());
+            names.push(arena.name_of(name).clone());
         }
     }
     names
@@ -1010,31 +1044,32 @@ fn collect_module_declaration(
     declaration: &ast::StatementKind,
     is_exported: bool,
     function_index: i32,
+    arena: &ast::AstArena,
     metadata: &mut ModuleDeclarationMetadata,
 ) {
     let default_name: ast::Utf16String = utf16!("*default*").into();
     match declaration {
         ast::StatementKind::FunctionDeclaration(function) => {
-            let Some(name) = &function.name else {
+            let Some(name) = function.name else {
                 return;
             };
-            let is_default = is_exported && name.name == default_name;
+            let is_default = is_exported && arena.name_slice(name) == default_name.as_slice();
             let function_name = if is_default {
                 utf16!("default").into()
             } else {
-                name.name.to_utf16_string()
+                arena.name_of(name).clone()
             };
             metadata.function_names.push(function_name);
             metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
-                name: name.name.to_utf16_string(),
+                name: arena.name_of(name).clone(),
                 is_constant: false,
                 function_index,
             });
         }
         ast::StatementKind::ClassDeclaration(class_data) => {
-            if let Some(ref name) = class_data.name {
+            if let Some(name) = class_data.name {
                 metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
-                    name: name.name.to_utf16_string(),
+                    name: arena.name_of(name).clone(),
                     is_constant: false,
                     function_index: -1,
                 });
@@ -1043,7 +1078,7 @@ fn collect_module_declaration(
         ast::StatementKind::VariableDeclaration(declaration) if declaration.kind != ast::DeclarationKind::Var => {
             let is_constant = declaration.kind == ast::DeclarationKind::Const;
             for declarator in &declaration.declarations {
-                for_each_bound_name(&declarator.target, &mut |name| {
+                for_each_bound_name(&declarator.target, arena, &mut |name| {
                     metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
                         name: name.to_vec().into(),
                         is_constant,
@@ -1054,7 +1089,7 @@ fn collect_module_declaration(
         }
         ast::StatementKind::UsingDeclaration(declarations) => {
             for declarator in declarations.iter() {
-                for_each_bound_name(&declarator.target, &mut |name| {
+                for_each_bound_name(&declarator.target, arena, &mut |name| {
                     metadata.lexical_bindings.push(ModuleLexicalBindingRecord {
                         name: name.to_vec().into(),
                         is_constant: false,
@@ -1067,69 +1102,87 @@ fn collect_module_declaration(
     }
 }
 
-fn collect_var_names_recursive(statement: &ast::StatementKind, names: &mut Vec<ast::Utf16String>) {
+fn collect_var_names_recursive(
+    statement: &ast::StatementKind,
+    arena: &ast::AstArena,
+    names: &mut Vec<ast::Utf16String>,
+) {
     match statement {
         ast::StatementKind::VariableDeclaration(declaration) if declaration.kind == ast::DeclarationKind::Var => {
             for declarator in &declaration.declarations {
-                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+                for_each_bound_name(&declarator.target, arena, &mut |name| names.push(name.to_vec().into()));
             }
         }
         _ => {
-            for_each_child_statement(statement, &mut |child| {
-                collect_var_names_recursive(child, names);
+            for_each_child_statement(statement, arena, &mut |child| {
+                collect_var_names_recursive(child, arena, names);
             });
         }
     }
 }
 
-fn collect_module_var_names(statement: &ast::StatementKind, names: &mut Vec<ast::Utf16String>) {
+fn collect_module_var_names(statement: &ast::StatementKind, arena: &ast::AstArena, names: &mut Vec<ast::Utf16String>) {
     match statement {
         ast::StatementKind::VariableDeclaration(declaration) if declaration.kind == ast::DeclarationKind::Var => {
             for declarator in &declaration.declarations {
-                for_each_bound_name(&declarator.target, &mut |name| names.push(name.to_vec().into()));
+                for_each_bound_name(&declarator.target, arena, &mut |name| names.push(name.to_vec().into()));
             }
         }
         ast::StatementKind::Export(export_data) => {
             if let Some(ref statement) = export_data.statement {
-                collect_module_var_names(&statement.inner, names);
+                collect_module_var_names(&statement.inner, arena, names);
             }
         }
         _ => {
-            for_each_child_statement(statement, &mut |child| {
-                collect_module_var_names(child, names);
+            for_each_child_statement(statement, arena, &mut |child| {
+                collect_module_var_names(child, arena, names);
             });
         }
     }
 }
 
-fn for_each_bound_name(target: &ast::VariableDeclaratorTarget, callback: &mut dyn FnMut(&[u16])) {
+fn for_each_bound_name(
+    target: &ast::VariableDeclaratorTarget,
+    arena: &ast::AstArena,
+    callback: &mut dyn FnMut(&[u16]),
+) {
     match target {
-        ast::VariableDeclaratorTarget::Identifier(identifier) => callback(identifier.name.as_slice()),
-        ast::VariableDeclaratorTarget::BindingPattern(pattern) => for_each_bound_name_in_pattern(pattern, callback),
+        ast::VariableDeclaratorTarget::Identifier(identifier) => callback(arena.name_slice(*identifier)),
+        ast::VariableDeclaratorTarget::BindingPattern(pattern) => {
+            for_each_bound_name_in_pattern(pattern, arena, callback);
+        }
     }
 }
 
-fn for_each_bound_name_in_pattern(pattern: &ast::BindingPattern, callback: &mut dyn FnMut(&[u16])) {
+fn for_each_bound_name_in_pattern(
+    pattern: &ast::BindingPattern,
+    arena: &ast::AstArena,
+    callback: &mut dyn FnMut(&[u16]),
+) {
     for entry in &pattern.entries {
         match &entry.alias {
-            Some(ast::BindingEntryAlias::Identifier(identifier)) => callback(identifier.name.as_slice()),
+            Some(ast::BindingEntryAlias::Identifier(identifier)) => callback(arena.name_slice(*identifier)),
             Some(ast::BindingEntryAlias::BindingPattern(pattern)) => {
-                for_each_bound_name_in_pattern(pattern, callback);
+                for_each_bound_name_in_pattern(pattern, arena, callback);
             }
             Some(ast::BindingEntryAlias::MemberExpression(_)) => {}
             None => {
                 if let Some(ast::BindingEntryName::Identifier(identifier)) = &entry.name {
-                    callback(identifier.name.as_slice());
+                    callback(arena.name_slice(*identifier));
                 }
             }
         }
     }
 }
 
-fn for_each_child_statement(statement: &ast::StatementKind, callback: &mut dyn FnMut(&ast::StatementKind)) {
+fn for_each_child_statement(
+    statement: &ast::StatementKind,
+    arena: &ast::AstArena,
+    callback: &mut dyn FnMut(&ast::StatementKind),
+) {
     match statement {
         ast::StatementKind::Block(scope) => {
-            for child in &scope.borrow().children {
+            for child in &arena.scopes[*scope].children {
                 callback(&child.inner);
             }
         }
@@ -1157,7 +1210,7 @@ fn for_each_child_statement(statement: &ast::StatementKind, callback: &mut dyn F
         }
         ast::StatementKind::Switch(data) => {
             for case in &data.cases {
-                for child in &case.scope.borrow().children {
+                for child in &arena.scopes[case.scope].children {
                     callback(&child.inner);
                 }
             }
@@ -1599,6 +1652,26 @@ impl Encode for SharedFunctionTable<'_> {
 }
 
 impl SharedFunctionTable<'_> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedFunctionRecord>> {
+        decoder.sequence_values(FunctionRecord::decode)
+    }
+}
+
+struct DeclarationFunctionTable<'a>(&'a [PendingSharedFunctionData]);
+
+impl Encode for DeclarationFunctionTable<'_> {
+    fn encode(&self, encoder: &mut Encoder) {
+        encoder.sequence(self.0, |shared_data, encoder| {
+            let arena = shared_data
+                .arena
+                .as_deref()
+                .expect("bytecode cache declaration function is missing its AST arena");
+            FunctionRecord { shared_data, arena }.encode(encoder);
+        });
+    }
+}
+
+impl DeclarationFunctionTable<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedFunctionRecord>> {
         decoder.sequence_values(FunctionRecord::decode)
     }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -11,19 +11,33 @@
 //! of growing a separate procedural parser.
 
 use std::collections::HashMap;
+use std::ffi::c_void;
 
 use crate::bytecode::basic_block::SourceMapEntry;
-use crate::bytecode::ffi::{AbstractOperationKind, ConstantTag, WellKnownSymbolKind};
+use crate::bytecode::ffi::{
+    AbstractOperationKind, ConstantTag, FFISharedFunctionData, FFIUtf16Slice, WellKnownSymbolKind,
+};
 use crate::bytecode::generator::{
     AssembledBytecode, ConstantValue, ExceptionHandler, FunctionSfdMetadata, Generator, LocalVariable,
     PendingClassBlueprint, PendingClassElement, PendingLiteralValueKind, PendingSharedFunctionData,
     PrecompiledFunction,
 };
-use crate::{CompiledProgram, CompiledProgramBytecode, ast, u32_from_usize};
+use crate::bytecode::operand::PropertyKeyTableIndex;
+use crate::{CompiledProgram, CompiledProgramBytecode, ModuleCallbacks, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
 const FORMAT_VERSION: u32 = 1;
 const SOURCE_HASH_SIZE: usize = 32;
+
+fn source_span_is_valid(start: u32, end: u32, source_len: usize) -> bool {
+    let start = start as usize;
+    let end = end as usize;
+    start <= end && end <= source_len
+}
+
+fn source_range_is_valid(offset: usize, length: usize, source_len: usize) -> bool {
+    offset <= source_len && length <= source_len - offset
+}
 
 pub fn serialize_compiled_program(
     compiled: &CompiledProgram,
@@ -355,6 +369,453 @@ impl DecodedCacheBlob {
         self.metadata.validate();
         self.program.validate();
     }
+
+    pub(crate) fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        self.metadata.source_ranges_are_valid(source_len)
+            && self.metadata.indices_are_valid()
+            && self.program.source_ranges_are_valid(source_len)
+            && self.program.indices_are_valid()
+    }
+
+    pub(crate) unsafe fn materialize_script(
+        self,
+        vm_ptr: *mut c_void,
+        source_code_ptr: *const c_void,
+        gdi_context: *mut c_void,
+    ) -> *mut c_void {
+        unsafe {
+            let Self {
+                program_type,
+                is_strict_mode,
+                metadata,
+                program,
+                ..
+            } = self;
+            if program_type != ast::ProgramType::Script {
+                return std::ptr::null_mut();
+            }
+            let DecodedDeclarationMetadata::Script {
+                metadata,
+                declaration_functions,
+            } = metadata
+            else {
+                return std::ptr::null_mut();
+            };
+            let ProgramKind::ScriptOrModule = program.kind else {
+                return std::ptr::null_mut();
+            };
+            if declaration_functions.len() != metadata.function_names.len() {
+                return std::ptr::null_mut();
+            }
+
+            if !materialize_script_declaration_metadata(
+                metadata,
+                declaration_functions,
+                is_strict_mode,
+                vm_ptr,
+                source_code_ptr,
+                gdi_context,
+            ) {
+                return std::ptr::null_mut();
+            }
+            materialize_executable(program.executable, vm_ptr, source_code_ptr)
+        }
+    }
+
+    pub(crate) unsafe fn materialize_module(
+        self,
+        vm_ptr: *mut c_void,
+        source_code_ptr: *const c_void,
+        module_context: *mut c_void,
+        callbacks: *const ModuleCallbacks,
+        tla_executable_out: *mut *mut c_void,
+    ) -> *mut c_void {
+        unsafe {
+            if callbacks.is_null() {
+                return std::ptr::null_mut();
+            }
+            let cb = &*callbacks;
+            let Self {
+                program_type,
+                has_top_level_await,
+                metadata,
+                program,
+                ..
+            } = self;
+            if program_type != ast::ProgramType::Module {
+                return std::ptr::null_mut();
+            }
+            let DecodedDeclarationMetadata::Module {
+                metadata,
+                declaration_functions,
+            } = metadata
+            else {
+                return std::ptr::null_mut();
+            };
+            if declaration_functions.len() != metadata.function_names.len() {
+                return std::ptr::null_mut();
+            }
+
+            (cb.set_has_top_level_await)(module_context, has_top_level_await);
+            if !materialize_module_declaration_metadata(
+                metadata,
+                declaration_functions,
+                vm_ptr,
+                source_code_ptr,
+                module_context,
+                cb,
+            ) {
+                return std::ptr::null_mut();
+            }
+
+            match program.kind {
+                ProgramKind::AsyncModule => {
+                    let exec_ptr = materialize_executable(program.executable, vm_ptr, source_code_ptr);
+                    if !tla_executable_out.is_null() {
+                        *tla_executable_out = exec_ptr;
+                    }
+                    std::ptr::null_mut()
+                }
+                ProgramKind::ScriptOrModule => {
+                    if !tla_executable_out.is_null() {
+                        *tla_executable_out = std::ptr::null_mut();
+                    }
+                    materialize_executable(program.executable, vm_ptr, source_code_ptr)
+                }
+            }
+        }
+    }
+}
+
+unsafe fn materialize_script_declaration_metadata(
+    metadata: ScriptDeclarationMetadata,
+    declaration_functions: Vec<DecodedFunctionRecord>,
+    is_strict_mode: bool,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    gdi_context: *mut c_void,
+) -> bool {
+    unsafe {
+        use crate::bytecode::ffi::{
+            script_gdi_push_annex_b_name, script_gdi_push_function, script_gdi_push_lexical_binding,
+            script_gdi_push_lexical_name, script_gdi_push_var_name, script_gdi_push_var_scoped_name,
+        };
+
+        for name in &metadata.lexical_names {
+            script_gdi_push_lexical_name(gdi_context, name.as_ptr(), name.len());
+        }
+        for name in &metadata.var_names {
+            script_gdi_push_var_name(gdi_context, name.as_ptr(), name.len());
+        }
+        for (function, name) in declaration_functions.into_iter().zip(metadata.function_names.iter()) {
+            let sfd_ptr = materialize_function(function, is_strict_mode, vm_ptr, source_code_ptr);
+            if sfd_ptr.is_null() {
+                return false;
+            }
+            script_gdi_push_function(gdi_context, sfd_ptr, name.as_ptr(), name.len());
+        }
+        for name in &metadata.var_scoped_names {
+            script_gdi_push_var_scoped_name(gdi_context, name.as_ptr(), name.len());
+        }
+        for name in &metadata.annex_b_candidate_names {
+            script_gdi_push_annex_b_name(gdi_context, name.as_ptr(), name.len());
+        }
+        for binding in &metadata.lexical_bindings {
+            script_gdi_push_lexical_binding(
+                gdi_context,
+                binding.name.as_ptr(),
+                binding.name.len(),
+                binding.is_constant,
+            );
+        }
+
+        true
+    }
+}
+
+unsafe fn materialize_module_declaration_metadata(
+    metadata: ModuleDeclarationMetadata,
+    declaration_functions: Vec<DecodedFunctionRecord>,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    module_context: *mut c_void,
+    cb: &ModuleCallbacks,
+) -> bool {
+    unsafe {
+        for entry in &metadata.import_entries {
+            let (import_name, import_name_len, is_namespace) = entry
+                .import_name
+                .as_ref()
+                .map(|name| (name.as_ptr(), name.len(), false))
+                .unwrap_or((std::ptr::null(), 0, true));
+            let attributes = import_attributes_to_ffi(&entry.module_request.attributes);
+            (cb.push_import_entry)(
+                module_context,
+                import_name,
+                import_name_len,
+                is_namespace,
+                entry.local_name.as_ptr(),
+                entry.local_name.len(),
+                entry.module_request.specifier.as_ptr(),
+                entry.module_request.specifier.len(),
+                attributes.keys.as_ptr(),
+                attributes.values.as_ptr(),
+                attributes.keys.len(),
+            );
+        }
+
+        for entry in &metadata.local_exports {
+            push_module_export_entry(module_context, cb.push_local_export, entry);
+        }
+        for entry in &metadata.indirect_exports {
+            push_module_export_entry(module_context, cb.push_indirect_export, entry);
+        }
+        for entry in &metadata.star_exports {
+            push_module_export_entry(module_context, cb.push_star_export, entry);
+        }
+        for request in &metadata.requested_modules {
+            let attributes = import_attributes_to_ffi(&request.attributes);
+            (cb.push_requested_module)(
+                module_context,
+                request.specifier.as_ptr(),
+                request.specifier.len(),
+                attributes.keys.as_ptr(),
+                attributes.values.as_ptr(),
+                attributes.keys.len(),
+            );
+        }
+        if let Some(name) = &metadata.default_export_binding_name {
+            (cb.set_default_export_binding)(module_context, name.as_ptr(), name.len());
+        }
+        for name in &metadata.var_declared_names {
+            (cb.push_var_name)(module_context, name.as_ptr(), name.len());
+        }
+        for (function, name) in declaration_functions.into_iter().zip(metadata.function_names.iter()) {
+            let sfd_ptr = materialize_function(function, true, vm_ptr, source_code_ptr);
+            if sfd_ptr.is_null() {
+                return false;
+            }
+            (cb.push_function)(module_context, sfd_ptr, name.as_ptr(), name.len());
+        }
+        for binding in &metadata.lexical_bindings {
+            (cb.push_lexical_binding)(
+                module_context,
+                binding.name.as_ptr(),
+                binding.name.len(),
+                binding.is_constant,
+                binding.function_index,
+            );
+        }
+
+        true
+    }
+}
+
+struct ImportAttributesFfi {
+    keys: Vec<FFIUtf16Slice>,
+    values: Vec<FFIUtf16Slice>,
+}
+
+fn import_attributes_to_ffi(attributes: &[ast::ImportAttribute]) -> ImportAttributesFfi {
+    ImportAttributesFfi {
+        keys: attributes
+            .iter()
+            .map(|attribute| FFIUtf16Slice::from(attribute.key.as_ref()))
+            .collect(),
+        values: attributes
+            .iter()
+            .map(|attribute| FFIUtf16Slice::from(attribute.value.as_ref()))
+            .collect(),
+    }
+}
+
+unsafe fn push_module_export_entry(
+    module_context: *mut c_void,
+    callback: crate::ModuleExportEntryCallback,
+    entry: &ModuleExportEntryRecord,
+) {
+    unsafe {
+        let (export_name, export_name_len) = entry
+            .export_name
+            .as_ref()
+            .map(|name| (name.as_ptr(), name.len()))
+            .unwrap_or((std::ptr::null(), 0));
+        let (local_or_import_name, local_or_import_name_len) = entry
+            .local_or_import_name
+            .as_ref()
+            .map(|name| (name.as_ptr(), name.len()))
+            .unwrap_or((std::ptr::null(), 0));
+        let (module_specifier, module_specifier_len, attributes) = entry
+            .module_request
+            .as_ref()
+            .map(|request| {
+                (
+                    request.specifier.as_ptr(),
+                    request.specifier.len(),
+                    import_attributes_to_ffi(&request.attributes),
+                )
+            })
+            .unwrap_or((
+                std::ptr::null(),
+                0,
+                ImportAttributesFfi {
+                    keys: Vec::new(),
+                    values: Vec::new(),
+                },
+            ));
+
+        callback(
+            module_context,
+            entry.kind as u8,
+            export_name,
+            export_name_len,
+            local_or_import_name,
+            local_or_import_name_len,
+            module_specifier,
+            module_specifier_len,
+            attributes.keys.as_ptr(),
+            attributes.values.as_ptr(),
+            attributes.keys.len(),
+        );
+    }
+}
+
+unsafe fn materialize_function(
+    function: DecodedFunctionRecord,
+    outer_strict: bool,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+) -> *mut c_void {
+    unsafe {
+        let parameter_names: Vec<FFIUtf16Slice> = function
+            .parameter_names
+            .as_ref()
+            .map(|names| names.iter().map(|name| FFIUtf16Slice::from(name.as_ref())).collect())
+            .unwrap_or_default();
+        let (name, name_len) = function
+            .name
+            .as_ref()
+            .map(|name| (name.as_ptr(), name.len()))
+            .unwrap_or((std::ptr::null(), 0));
+        let source_text_offset = function.source_text_start as usize;
+        let source_text_length = function
+            .source_text_end
+            .checked_sub(function.source_text_start)
+            .map(|length| length as usize)
+            .unwrap_or(0);
+
+        let data = FFISharedFunctionData {
+            name,
+            name_len,
+            function_kind: function.kind as u8,
+            function_length: function.function_length,
+            formal_parameter_count: function.formal_parameter_count,
+            strict: function.is_strict_mode || outer_strict,
+            is_arrow: function.is_arrow_function,
+            has_simple_parameter_list: function.parameter_names.is_some(),
+            parameter_names: parameter_names.as_ptr(),
+            parameter_name_count: parameter_names.len(),
+            source_text_offset,
+            source_text_length,
+            rust_function_ast: std::ptr::null_mut(),
+            uses_this: function.uses_this,
+            uses_this_from_environment: function.uses_this_from_environment,
+        };
+
+        let sfd_ptr = crate::bytecode::ffi::rust_create_sfd(vm_ptr, source_code_ptr, &raw const data);
+        if sfd_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        if let Some((name, is_private)) = &function.class_field_initializer_name {
+            crate::bytecode::ffi::rust_sfd_set_class_field_initializer_name(
+                sfd_ptr,
+                name.as_ptr(),
+                name.len(),
+                *is_private,
+            );
+        }
+
+        let executable_ptr = materialize_executable(function.precompiled, vm_ptr, source_code_ptr);
+        if executable_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+        crate::bytecode::ffi::rust_sfd_set_precompiled_executable(
+            sfd_ptr,
+            executable_ptr,
+            function.metadata.uses_this,
+            function.metadata.this_value_needs_environment_resolution,
+            function.metadata.function_environment_needed,
+            function.metadata.function_environment_bindings_count,
+            function.metadata.might_need_arguments,
+            function.metadata.contains_eval,
+        );
+
+        sfd_ptr
+    }
+}
+
+unsafe fn materialize_executable(
+    executable: DecodedExecutableRecord,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+) -> *mut c_void {
+    unsafe {
+        let mut generator = Generator::new();
+        generator.strict = executable.strict;
+        generator.this_value_needs_environment_resolution = executable.this_value_needs_environment_resolution;
+        generator.next_property_lookup_cache = executable.cache_counters.property_lookup_cache_count;
+        generator.next_global_variable_cache = executable.cache_counters.global_variable_cache_count;
+        generator.next_template_object_cache = executable.cache_counters.template_object_cache_count;
+        generator.next_object_shape_cache = executable.cache_counters.object_shape_cache_count;
+        generator.next_object_property_iterator_cache = executable.cache_counters.object_property_iterator_cache_count;
+        generator.identifier_table = executable.identifier_table;
+        generator.property_key_table = executable.property_key_table;
+        generator.string_table = executable.string_table;
+        generator.constants = executable.constants;
+        generator.local_variables = executable.local_variables;
+        generator.length_identifier = executable.length_identifier.map(PropertyKeyTableIndex);
+
+        let sfd_ptrs: Vec<*const c_void> = executable
+            .shared_functions
+            .into_iter()
+            .map(|function| materialize_function(function, generator.strict, vm_ptr, source_code_ptr) as *const c_void)
+            .collect();
+        if sfd_ptrs.iter().any(|ptr| ptr.is_null()) {
+            return std::ptr::null_mut();
+        }
+
+        let class_blueprints: Vec<PendingClassBlueprint> = executable
+            .class_blueprints
+            .into_iter()
+            .map(PendingClassBlueprint::from)
+            .collect();
+        let bp_ptrs: Vec<*mut c_void> = class_blueprints
+            .iter()
+            .map(|blueprint| crate::bytecode::ffi::materialize_class_blueprint(blueprint, vm_ptr, source_code_ptr))
+            .collect();
+        if bp_ptrs.iter().any(|ptr| ptr.is_null()) {
+            return std::ptr::null_mut();
+        }
+
+        let assembled = AssembledBytecode {
+            bytecode: executable.bytecode,
+            source_map: executable.source_map,
+            exception_handlers: executable.exception_handlers,
+            basic_block_start_offsets: executable.basic_block_start_offsets,
+            number_of_registers: executable.number_of_registers,
+            number_of_arguments: executable.number_of_arguments,
+        };
+
+        crate::bytecode::ffi::create_executable_with_dependencies(
+            &generator,
+            &assembled,
+            vm_ptr,
+            source_code_ptr,
+            &sfd_ptrs,
+            &bp_ptrs,
+        )
+    }
 }
 
 impl Encode for ast::ProgramType {
@@ -462,6 +923,36 @@ impl DecodedDeclarationMetadata {
                 for function in declaration_functions {
                     function.validate();
                 }
+            }
+        }
+    }
+
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        match self {
+            Self::Script {
+                declaration_functions, ..
+            }
+            | Self::Module {
+                declaration_functions, ..
+            } => declaration_functions
+                .iter()
+                .all(|function| function.source_ranges_are_valid(source_len)),
+        }
+    }
+
+    fn indices_are_valid(&self) -> bool {
+        match self {
+            Self::Script { .. } => true,
+            Self::Module {
+                metadata,
+                declaration_functions,
+            } => {
+                declaration_functions.len() == metadata.function_names.len()
+                    && metadata.lexical_bindings.iter().all(|binding| {
+                        binding.function_index < 0
+                            || usize::try_from(binding.function_index)
+                                .is_ok_and(|index| index < declaration_functions.len())
+                    })
             }
         }
     }
@@ -1321,6 +1812,14 @@ impl DecodedProgramRecord {
         let _ = self.kind as u8;
         self.executable.validate();
     }
+
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        self.executable.source_ranges_are_valid(source_len)
+    }
+
+    fn indices_are_valid(&self) -> bool {
+        self.executable.indices_are_valid()
+    }
 }
 
 #[repr(u8)]
@@ -1442,6 +1941,25 @@ impl DecodedExecutableRecord {
         for blueprint in &self.class_blueprints {
             blueprint.validate();
         }
+    }
+
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        self.shared_functions
+            .iter()
+            .all(|function| function.source_ranges_are_valid(source_len))
+            && self
+                .class_blueprints
+                .iter()
+                .all(|blueprint| blueprint.source_range_is_valid(source_len))
+    }
+
+    fn indices_are_valid(&self) -> bool {
+        self.length_identifier
+            .is_none_or(|index| (index as usize) < self.property_key_table.len())
+            && self
+                .class_blueprints
+                .iter()
+                .all(|blueprint| blueprint.indices_are_valid(self.shared_functions.len()))
     }
 }
 
@@ -1795,7 +2313,9 @@ struct DecodedFunctionRecord {
 impl DecodedFunctionRecord {
     fn validate(&self) {
         let _ = self.name.as_ref().map(|name| name.as_slice().len());
-        let _ = self.source_text_start + self.source_text_end + self.formal_parameter_count;
+        let _ = self.source_text_start;
+        let _ = self.source_text_end;
+        let _ = self.formal_parameter_count;
         let _ = self.function_length;
         let _ = self.kind as u8;
         let _ = self.is_strict_mode || self.is_arrow_function || self.uses_this || self.uses_this_from_environment;
@@ -1806,6 +2326,11 @@ impl DecodedFunctionRecord {
             .map(|(name, _)| name.as_slice().len());
         self.precompiled.validate();
         validate_function_metadata(&self.metadata);
+    }
+
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        source_span_is_valid(self.source_text_start, self.source_text_end, source_len)
+            && self.precompiled.source_ranges_are_valid(source_len)
     }
 }
 
@@ -2008,11 +2533,38 @@ struct DecodedClassBlueprintRecord {
 impl DecodedClassBlueprintRecord {
     fn validate(&self) {
         let _ = self.name.as_ref().map(|name| name.as_slice().len());
-        let _ = self.source_text_offset + self.source_text_length;
+        let _ = self.source_text_offset;
+        let _ = self.source_text_length;
         let _ = self.constructor_sfd_index;
         let _ = self.has_super_class || self.has_name;
         for element in &self.elements {
             element.validate();
+        }
+    }
+
+    fn source_range_is_valid(&self, source_len: usize) -> bool {
+        source_range_is_valid(self.source_text_offset, self.source_text_length, source_len)
+    }
+
+    fn indices_are_valid(&self, shared_function_count: usize) -> bool {
+        (self.constructor_sfd_index as usize) < shared_function_count
+            && self
+                .elements
+                .iter()
+                .all(|element| element.indices_are_valid(shared_function_count))
+    }
+}
+
+impl From<DecodedClassBlueprintRecord> for PendingClassBlueprint {
+    fn from(record: DecodedClassBlueprintRecord) -> Self {
+        Self {
+            name: record.name,
+            source_text_offset: record.source_text_offset,
+            source_text_length: record.source_text_length,
+            constructor_sfd_index: record.constructor_sfd_index,
+            has_super_class: record.has_super_class,
+            has_name: record.has_name,
+            elements: record.elements.into_iter().map(PendingClassElement::from).collect(),
         }
     }
 }
@@ -2070,6 +2622,42 @@ impl DecodedClassElementRecord {
         let _ = literal_value_kind_tag(self.literal_value_kind);
         let _ = self.literal_value_number;
         let _ = self.literal_value_string.as_ref().map(|value| value.as_slice().len());
+    }
+
+    fn indices_are_valid(&self, shared_function_count: usize) -> bool {
+        let shared_function_data_index_is_valid = || {
+            self.shared_function_data_index
+                .is_some_and(|index| (index as usize) < shared_function_count)
+        };
+
+        match self.kind {
+            0 | 1 | 2 | 4 => shared_function_data_index_is_valid(),
+            3 => {
+                if self.has_initializer && matches!(self.literal_value_kind, PendingLiteralValueKind::None) {
+                    shared_function_data_index_is_valid()
+                } else {
+                    self.shared_function_data_index
+                        .is_none_or(|index| (index as usize) < shared_function_count)
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
+impl From<DecodedClassElementRecord> for PendingClassElement {
+    fn from(record: DecodedClassElementRecord) -> Self {
+        Self {
+            kind: record.kind,
+            is_static: record.is_static,
+            is_private: record.is_private,
+            private_identifier: record.private_identifier,
+            shared_function_data_index: record.shared_function_data_index,
+            has_initializer: record.has_initializer,
+            literal_value_kind: record.literal_value_kind,
+            literal_value_number: record.literal_value_number,
+            literal_value_string: record.literal_value_string,
+        }
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -12,10 +12,12 @@
 
 use std::collections::HashMap;
 
-use crate::bytecode::ffi::ConstantTag;
+use crate::bytecode::basic_block::SourceMapEntry;
+use crate::bytecode::ffi::{AbstractOperationKind, ConstantTag, WellKnownSymbolKind};
 use crate::bytecode::generator::{
-    AssembledBytecode, ConstantValue, FunctionSfdMetadata, Generator, PendingClassBlueprint, PendingClassElement,
-    PendingLiteralValueKind, PendingSharedFunctionData, PrecompiledFunction,
+    AssembledBytecode, ConstantValue, ExceptionHandler, FunctionSfdMetadata, Generator, LocalVariable,
+    PendingClassBlueprint, PendingClassElement, PendingLiteralValueKind, PendingSharedFunctionData,
+    PrecompiledFunction,
 };
 use crate::{CompiledProgram, CompiledProgramBytecode, ast, u32_from_usize};
 
@@ -84,20 +86,14 @@ impl<'a> Decoder<'a> {
         (self.bytes(expected.len())? == expected).then_some(())
     }
 
-    fn sequence(&mut self, mut decode_item: impl FnMut(&mut Self) -> Option<()>) -> Option<()> {
+    fn sequence_values<T>(&mut self, mut decode_item: impl FnMut(&mut Self) -> Option<T>) -> Option<Vec<T>> {
         let length: usize = u32::decode(self)?.try_into().ok()?;
+        // Reject lengths that cannot fit in the remaining blob even for one-byte items, so a
+        // malformed sidecar with a four-billion element header cannot drag the allocator down.
         if length > self.bytes.len() {
             return None;
         }
 
-        for _ in 0..length {
-            decode_item(self)?;
-        }
-        Some(())
-    }
-
-    fn sequence_values<T>(&mut self, mut decode_item: impl FnMut(&mut Self) -> Option<T>) -> Option<Vec<T>> {
-        let length: usize = u32::decode(self)?.try_into().ok()?;
         let mut values = Vec::with_capacity(length);
         for _ in 0..length {
             values.push(decode_item(self)?);
@@ -202,6 +198,16 @@ impl Decode for f64 {
     }
 }
 
+impl Decode for ast::Position {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(Self {
+            line: u32::decode(decoder)?,
+            column: u32::decode(decoder)?,
+            offset: u32::decode(decoder)?,
+        })
+    }
+}
+
 impl<T: Encode> Encode for Option<T> {
     fn encode(&self, encoder: &mut Encoder) {
         self.is_some().encode(encoder);
@@ -242,13 +248,12 @@ impl Encode for Bytes<'_> {
     }
 }
 
-struct IgnoredBytes;
+struct ByteVector;
 
-impl Decode for IgnoredBytes {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+impl ByteVector {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<u8>> {
         let length: usize = u32::decode(decoder)?.try_into().ok()?;
-        decoder.bytes(length)?;
-        Some(Self)
+        Some(decoder.bytes(length)?.to_vec())
     }
 }
 
@@ -260,16 +265,6 @@ impl Encode for Utf16<'_> {
         for code_unit in self.0 {
             encoder.bytes(&code_unit.to_le_bytes());
         }
-    }
-}
-
-struct IgnoredUtf16;
-
-impl Decode for IgnoredUtf16 {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
-        let length: usize = u32::decode(decoder)?.try_into().ok()?;
-        decoder.bytes(length.checked_mul(size_of::<u16>())?)?;
-        Some(Self)
     }
 }
 
@@ -302,7 +297,8 @@ impl CacheBlob<'_> {
         bool::decode(decoder)?;
         bool::decode(decoder)?;
         DeclarationMetadataRecord::decode(decoder)?.validate();
-        ProgramRecord::decode(decoder)
+        ProgramRecord::decode(decoder)?.validate();
+        Some(())
     }
 }
 
@@ -328,6 +324,18 @@ impl Decode for ast::ExportEntryKind {
             0 => Some(Self::NamedExport),
             1 => Some(Self::ModuleRequestAll),
             2 => Some(Self::ModuleRequestAllButDefault),
+            _ => None,
+        }
+    }
+}
+
+impl Decode for ast::FunctionKind {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            0 => Some(Self::Normal),
+            1 => Some(Self::Generator),
+            2 => Some(Self::Async),
+            3 => Some(Self::AsyncGenerator),
             _ => None,
         }
     }
@@ -1187,9 +1195,23 @@ impl Encode for ProgramRecord<'_> {
 }
 
 impl ProgramRecord<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        ProgramKind::decode(decoder)?;
-        ExecutableRecord::decode(decoder)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedProgramRecord> {
+        Some(DecodedProgramRecord {
+            kind: ProgramKind::decode(decoder)?,
+            executable: ExecutableRecord::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedProgramRecord {
+    kind: ProgramKind,
+    executable: DecodedExecutableRecord,
+}
+
+impl DecodedProgramRecord {
+    fn validate(&self) {
+        let _ = self.kind as u8;
+        self.executable.validate();
     }
 }
 
@@ -1245,25 +1267,73 @@ impl Encode for ExecutableRecord<'_> {
 }
 
 impl ExecutableRecord<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        bool::decode(decoder)?;
-        u32::decode(decoder)?;
-        u32::decode(decoder)?;
-        CacheCounters::decode(decoder)?;
-        bool::decode(decoder)?;
-        Option::<u32>::decode(decoder)?;
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedExecutableRecord> {
+        Some(DecodedExecutableRecord {
+            strict: bool::decode(decoder)?,
+            number_of_registers: u32::decode(decoder)?,
+            number_of_arguments: u32::decode(decoder)?,
+            cache_counters: CacheCounters::decode(decoder)?,
+            this_value_needs_environment_resolution: bool::decode(decoder)?,
+            length_identifier: Option::<u32>::decode(decoder)?,
+            bytecode: ByteVector::decode(decoder)?,
+            identifier_table: Utf16Table::decode(decoder)?,
+            property_key_table: Utf16Table::decode(decoder)?,
+            string_table: Utf16Table::decode(decoder)?,
+            constants: ConstantTable::decode(decoder)?,
+            exception_handlers: ExceptionHandlerTable::decode(decoder)?,
+            source_map: SourceMapTable::decode(decoder)?,
+            basic_block_start_offsets: BasicBlockOffsetTable::decode(decoder)?,
+            local_variables: LocalVariableTable::decode(decoder)?,
+            shared_functions: SharedFunctionTable::decode(decoder)?,
+            class_blueprints: ClassBlueprintTable::decode(decoder)?,
+        })
+    }
+}
 
-        IgnoredBytes::decode(decoder)?;
-        Utf16Table::decode(decoder)?;
-        Utf16Table::decode(decoder)?;
-        Utf16Table::decode(decoder)?;
-        ConstantTable::decode(decoder)?;
-        ExceptionHandlerTable::decode(decoder)?;
-        SourceMapTable::decode(decoder)?;
-        BasicBlockOffsetTable::decode(decoder)?;
-        LocalVariableTable::decode(decoder)?;
-        SharedFunctionTable::decode(decoder)?;
-        ClassBlueprintTable::decode(decoder)
+struct DecodedExecutableRecord {
+    strict: bool,
+    number_of_registers: u32,
+    number_of_arguments: u32,
+    cache_counters: DecodedCacheCounters,
+    this_value_needs_environment_resolution: bool,
+    length_identifier: Option<u32>,
+    bytecode: Vec<u8>,
+    identifier_table: Vec<ast::Utf16String>,
+    property_key_table: Vec<ast::Utf16String>,
+    string_table: Vec<ast::Utf16String>,
+    constants: Vec<ConstantValue>,
+    exception_handlers: Vec<ExceptionHandler>,
+    source_map: Vec<SourceMapEntry>,
+    basic_block_start_offsets: Vec<usize>,
+    local_variables: Vec<LocalVariable>,
+    shared_functions: Vec<DecodedFunctionRecord>,
+    class_blueprints: Vec<DecodedClassBlueprintRecord>,
+}
+
+impl DecodedExecutableRecord {
+    fn validate(&self) {
+        let _ = self.strict;
+        let _ = self.number_of_registers + self.number_of_arguments;
+        self.cache_counters.validate();
+        let _ = self.this_value_needs_environment_resolution;
+        let _ = self.length_identifier;
+        let _ = self.bytecode.len()
+            + self.identifier_table.len()
+            + self.property_key_table.len()
+            + self.string_table.len()
+            + self.constants.len()
+            + self.exception_handlers.len()
+            + self.source_map.len()
+            + self.basic_block_start_offsets.len()
+            + self.local_variables.len()
+            + self.shared_functions.len()
+            + self.class_blueprints.len();
+        for function in &self.shared_functions {
+            function.validate();
+        }
+        for blueprint in &self.class_blueprints {
+            blueprint.validate();
+        }
     }
 }
 
@@ -1280,13 +1350,32 @@ impl Encode for CacheCounters<'_> {
 }
 
 impl CacheCounters<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        u32::decode(decoder)?;
-        u32::decode(decoder)?;
-        u32::decode(decoder)?;
-        u32::decode(decoder)?;
-        u32::decode(decoder)?;
-        Some(())
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedCacheCounters> {
+        Some(DecodedCacheCounters {
+            property_lookup_cache_count: u32::decode(decoder)?,
+            global_variable_cache_count: u32::decode(decoder)?,
+            template_object_cache_count: u32::decode(decoder)?,
+            object_shape_cache_count: u32::decode(decoder)?,
+            object_property_iterator_cache_count: u32::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedCacheCounters {
+    property_lookup_cache_count: u32,
+    global_variable_cache_count: u32,
+    template_object_cache_count: u32,
+    object_shape_cache_count: u32,
+    object_property_iterator_cache_count: u32,
+}
+
+impl DecodedCacheCounters {
+    fn validate(&self) {
+        let _ = self.property_lookup_cache_count
+            + self.global_variable_cache_count
+            + self.template_object_cache_count
+            + self.object_shape_cache_count
+            + self.object_property_iterator_cache_count;
     }
 }
 
@@ -1299,8 +1388,8 @@ impl Encode for Utf16Table<'_> {
 }
 
 impl Utf16Table<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(|decoder| IgnoredUtf16::decode(decoder).map(|_| ()))
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ast::Utf16String>> {
+        decoder.sequence_values(ast::Utf16String::decode)
     }
 }
 
@@ -1313,8 +1402,8 @@ impl Encode for ConstantTable<'_> {
 }
 
 impl ConstantTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(ConstantRecord::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ConstantValue>> {
+        decoder.sequence_values(ConstantValue::decode)
     }
 }
 
@@ -1350,25 +1439,30 @@ impl Encode for ConstantValue {
     }
 }
 
-struct ConstantRecord;
-
-impl ConstantRecord {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+impl Decode for ConstantValue {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
         match u8::decode(decoder)? {
-            tag if tag == ConstantTag::Number as u8 => f64::decode(decoder).map(|_| ()),
-            tag if tag == ConstantTag::BooleanTrue as u8 => Some(()),
-            tag if tag == ConstantTag::BooleanFalse as u8 => Some(()),
-            tag if tag == ConstantTag::Null as u8 => Some(()),
-            tag if tag == ConstantTag::Undefined as u8 => Some(()),
-            tag if tag == ConstantTag::Empty as u8 => Some(()),
-            tag if tag == ConstantTag::String as u8 => IgnoredUtf16::decode(decoder).map(|_| ()),
-            tag if tag == ConstantTag::BigInt as u8 => IgnoredBytes::decode(decoder).map(|_| ()),
+            tag if tag == ConstantTag::Number as u8 => Some(Self::Number(f64::decode(decoder)?)),
+            tag if tag == ConstantTag::BooleanTrue as u8 => Some(Self::Boolean(true)),
+            tag if tag == ConstantTag::BooleanFalse as u8 => Some(Self::Boolean(false)),
+            tag if tag == ConstantTag::Null as u8 => Some(Self::Null),
+            tag if tag == ConstantTag::Undefined as u8 => Some(Self::Undefined),
+            tag if tag == ConstantTag::Empty as u8 => Some(Self::Empty),
+            tag if tag == ConstantTag::String as u8 => Some(Self::String(ast::Utf16String::decode(decoder)?)),
+            tag if tag == ConstantTag::BigInt as u8 => {
+                Some(Self::BigInt(String::from_utf8(ByteVector::decode(decoder)?).ok()?))
+            }
             tag if tag == ConstantTag::WellKnownSymbol as u8 => match u8::decode(decoder)? {
-                0 | 1 => Some(()),
+                0 => Some(Self::WellKnownSymbol(WellKnownSymbolKind::SymbolIterator)),
+                1 => Some(Self::WellKnownSymbol(WellKnownSymbolKind::SymbolAsyncIterator)),
                 _ => None,
             },
             tag if tag == ConstantTag::AbstractOperation as u8 => match u8::decode(decoder)? {
-                0..=4 => Some(()),
+                0 => Some(Self::AbstractOperation(AbstractOperationKind::AsyncIteratorClose)),
+                1 => Some(Self::AbstractOperation(AbstractOperationKind::GetMethod)),
+                2 => Some(Self::AbstractOperation(AbstractOperationKind::GetIteratorDirect)),
+                3 => Some(Self::AbstractOperation(AbstractOperationKind::GetIteratorFromMethod)),
+                4 => Some(Self::AbstractOperation(AbstractOperationKind::IteratorComplete)),
                 _ => None,
             },
             _ => None,
@@ -1389,12 +1483,13 @@ impl Encode for ExceptionHandlerTable<'_> {
 }
 
 impl ExceptionHandlerTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(|decoder| {
-            u32::decode(decoder)?;
-            u32::decode(decoder)?;
-            u32::decode(decoder)?;
-            Some(())
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ExceptionHandler>> {
+        decoder.sequence_values(|decoder| {
+            Some(ExceptionHandler {
+                start_offset: u32::decode(decoder)?,
+                end_offset: u32::decode(decoder)?,
+                handler_offset: u32::decode(decoder)?,
+            })
         })
     }
 }
@@ -1416,12 +1511,13 @@ impl Encode for SourceMapTable<'_> {
 }
 
 impl SourceMapTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(|decoder| {
-            for _ in 0..7 {
-                u32::decode(decoder)?;
-            }
-            Some(())
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<SourceMapEntry>> {
+        decoder.sequence_values(|decoder| {
+            Some(SourceMapEntry {
+                bytecode_offset: u32::decode(decoder)?,
+                source_start: ast::Position::decode(decoder)?,
+                source_end: ast::Position::decode(decoder)?,
+            })
         })
     }
 }
@@ -1437,8 +1533,8 @@ impl Encode for BasicBlockOffsetTable<'_> {
 }
 
 impl BasicBlockOffsetTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(|decoder| usize::decode(decoder).map(|_| ()))
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<usize>> {
+        decoder.sequence_values(usize::decode)
     }
 }
 
@@ -1457,12 +1553,13 @@ impl Encode for LocalVariableTable<'_> {
 }
 
 impl LocalVariableTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(|decoder| {
-            IgnoredUtf16::decode(decoder)?;
-            bool::decode(decoder)?;
-            bool::decode(decoder)?;
-            Some(())
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<LocalVariable>> {
+        decoder.sequence_values(|decoder| {
+            Some(LocalVariable {
+                name: ast::Utf16String::decode(decoder)?,
+                is_lexically_declared: bool::decode(decoder)?,
+                is_initialized_during_declaration_instantiation: bool::decode(decoder)?,
+            })
         })
     }
 }
@@ -1482,8 +1579,8 @@ impl Encode for SharedFunctionTable<'_> {
 }
 
 impl SharedFunctionTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(FunctionRecord::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedFunctionRecord>> {
+        decoder.sequence_values(FunctionRecord::decode)
     }
 }
 
@@ -1530,24 +1627,57 @@ impl Encode for FunctionRecord<'_> {
 }
 
 impl FunctionRecord<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        Option::<IgnoredUtf16>::decode(decoder)?;
-        u32::decode(decoder)?;
-        u32::decode(decoder)?;
-        i32::decode(decoder)?;
-        u32::decode(decoder)?;
-        match u8::decode(decoder)? {
-            0..=3 => {}
-            _ => return None,
-        }
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        SimpleParameterList::decode(decoder)?;
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        ClassFieldInitializerName::decode(decoder)?;
-        FunctionSfdMetadata::decode(decoder)?;
-        PrecompiledFunctionRecord::decode(decoder)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedFunctionRecord> {
+        Some(DecodedFunctionRecord {
+            name: Option::<ast::Utf16String>::decode(decoder)?,
+            source_text_start: u32::decode(decoder)?,
+            source_text_end: u32::decode(decoder)?,
+            function_length: i32::decode(decoder)?,
+            formal_parameter_count: u32::decode(decoder)?,
+            kind: ast::FunctionKind::decode(decoder)?,
+            is_strict_mode: bool::decode(decoder)?,
+            is_arrow_function: bool::decode(decoder)?,
+            parameter_names: SimpleParameterList::decode(decoder)?,
+            uses_this: bool::decode(decoder)?,
+            uses_this_from_environment: bool::decode(decoder)?,
+            class_field_initializer_name: ClassFieldInitializerName::decode(decoder)?,
+            metadata: FunctionSfdMetadata::decode(decoder)?,
+            precompiled: PrecompiledFunctionRecord::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedFunctionRecord {
+    name: Option<ast::Utf16String>,
+    source_text_start: u32,
+    source_text_end: u32,
+    function_length: i32,
+    formal_parameter_count: u32,
+    kind: ast::FunctionKind,
+    is_strict_mode: bool,
+    is_arrow_function: bool,
+    parameter_names: Option<Vec<ast::Utf16String>>,
+    uses_this: bool,
+    uses_this_from_environment: bool,
+    class_field_initializer_name: Option<(ast::Utf16String, bool)>,
+    metadata: FunctionSfdMetadata,
+    precompiled: DecodedExecutableRecord,
+}
+
+impl DecodedFunctionRecord {
+    fn validate(&self) {
+        let _ = self.name.as_ref().map(|name| name.as_slice().len());
+        let _ = self.source_text_start + self.source_text_end + self.formal_parameter_count;
+        let _ = self.function_length;
+        let _ = self.kind as u8;
+        let _ = self.is_strict_mode || self.is_arrow_function || self.uses_this || self.uses_this_from_environment;
+        let _ = self.parameter_names.as_ref().map(|names| names.len());
+        let _ = self
+            .class_field_initializer_name
+            .as_ref()
+            .map(|(name, _)| name.as_slice().len());
+        self.precompiled.validate();
+        validate_function_metadata(&self.metadata);
     }
 }
 
@@ -1581,11 +1711,12 @@ impl Encode for SimpleParameterList<'_> {
 }
 
 impl SimpleParameterList<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Option<Vec<ast::Utf16String>>> {
         if bool::decode(decoder)? {
-            decoder.sequence(|decoder| IgnoredUtf16::decode(decoder).map(|_| ()))?;
+            Some(Some(decoder.sequence_values(ast::Utf16String::decode)?))
+        } else {
+            Some(None)
         }
-        Some(())
     }
 }
 
@@ -1619,12 +1750,8 @@ impl Encode for ClassFieldInitializerName<'_> {
 }
 
 impl ClassFieldInitializerName<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        if bool::decode(decoder)? {
-            IgnoredUtf16::decode(decoder)?;
-            bool::decode(decoder)?;
-        }
-        Some(())
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Option<(ast::Utf16String, bool)>> {
+        Option::<(ast::Utf16String, bool)>::decode(decoder)
     }
 }
 
@@ -1635,9 +1762,9 @@ impl Encode for (Utf16<'_>, bool) {
     }
 }
 
-impl Decode for (IgnoredUtf16, bool) {
+impl Decode for (ast::Utf16String, bool) {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
-        Some((IgnoredUtf16::decode(decoder)?, bool::decode(decoder)?))
+        Some((ast::Utf16String::decode(decoder)?, bool::decode(decoder)?))
     }
 }
 
@@ -1654,16 +1781,26 @@ impl Encode for FunctionSfdMetadata {
 }
 
 impl FunctionSfdMetadata {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        usize::decode(decoder)?;
-        usize::decode(decoder)?;
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        Some(())
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Some(Self {
+            uses_this: bool::decode(decoder)?,
+            this_value_needs_environment_resolution: bool::decode(decoder)?,
+            function_environment_needed: bool::decode(decoder)?,
+            function_environment_bindings_count: usize::decode(decoder)?,
+            var_environment_bindings_count: usize::decode(decoder)?,
+            might_need_arguments: bool::decode(decoder)?,
+            contains_eval: bool::decode(decoder)?,
+        })
     }
+}
+
+fn validate_function_metadata(metadata: &FunctionSfdMetadata) {
+    let _ = metadata.uses_this
+        || metadata.this_value_needs_environment_resolution
+        || metadata.function_environment_needed
+        || metadata.might_need_arguments
+        || metadata.contains_eval;
+    let _ = metadata.function_environment_bindings_count + metadata.var_environment_bindings_count;
 }
 
 struct PrecompiledFunctionRecord<'a>(&'a PrecompiledFunction);
@@ -1679,7 +1816,7 @@ impl Encode for PrecompiledFunctionRecord<'_> {
 }
 
 impl PrecompiledFunctionRecord<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedExecutableRecord> {
         ExecutableRecord::decode(decoder)
     }
 }
@@ -1695,8 +1832,8 @@ impl Encode for ClassBlueprintTable<'_> {
 }
 
 impl ClassBlueprintTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        decoder.sequence(ClassBlueprintRecord::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedClassBlueprintRecord>> {
+        decoder.sequence_values(ClassBlueprintRecord::decode)
     }
 }
 
@@ -1717,14 +1854,38 @@ impl Encode for ClassBlueprintRecord<'_> {
 }
 
 impl ClassBlueprintRecord<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        Option::<IgnoredUtf16>::decode(decoder)?;
-        usize::decode(decoder)?;
-        usize::decode(decoder)?;
-        u32::decode(decoder)?;
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        decoder.sequence(ClassElementRecord::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedClassBlueprintRecord> {
+        Some(DecodedClassBlueprintRecord {
+            name: Option::<ast::Utf16String>::decode(decoder)?,
+            source_text_offset: usize::decode(decoder)?,
+            source_text_length: usize::decode(decoder)?,
+            constructor_sfd_index: u32::decode(decoder)?,
+            has_super_class: bool::decode(decoder)?,
+            has_name: bool::decode(decoder)?,
+            elements: decoder.sequence_values(ClassElementRecord::decode)?,
+        })
+    }
+}
+
+struct DecodedClassBlueprintRecord {
+    name: Option<ast::Utf16String>,
+    source_text_offset: usize,
+    source_text_length: usize,
+    constructor_sfd_index: u32,
+    has_super_class: bool,
+    has_name: bool,
+    elements: Vec<DecodedClassElementRecord>,
+}
+
+impl DecodedClassBlueprintRecord {
+    fn validate(&self) {
+        let _ = self.name.as_ref().map(|name| name.as_slice().len());
+        let _ = self.source_text_offset + self.source_text_length;
+        let _ = self.constructor_sfd_index;
+        let _ = self.has_super_class || self.has_name;
+        for element in &self.elements {
+            element.validate();
+        }
     }
 }
 
@@ -1745,20 +1906,56 @@ impl Encode for ClassElementRecord<'_> {
 }
 
 impl ClassElementRecord<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<()> {
-        u8::decode(decoder)?;
-        bool::decode(decoder)?;
-        bool::decode(decoder)?;
-        Option::<IgnoredUtf16>::decode(decoder)?;
-        Option::<u32>::decode(decoder)?;
-        bool::decode(decoder)?;
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedClassElementRecord> {
+        Some(DecodedClassElementRecord {
+            kind: u8::decode(decoder)?,
+            is_static: bool::decode(decoder)?,
+            is_private: bool::decode(decoder)?,
+            private_identifier: Option::<ast::Utf16String>::decode(decoder)?,
+            shared_function_data_index: Option::<u32>::decode(decoder)?,
+            has_initializer: bool::decode(decoder)?,
+            literal_value_kind: PendingLiteralValueKind::decode(decoder)?,
+            literal_value_number: f64::decode(decoder)?,
+            literal_value_string: Option::<ast::Utf16String>::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedClassElementRecord {
+    kind: u8,
+    is_static: bool,
+    is_private: bool,
+    private_identifier: Option<ast::Utf16String>,
+    shared_function_data_index: Option<u32>,
+    has_initializer: bool,
+    literal_value_kind: PendingLiteralValueKind,
+    literal_value_number: f64,
+    literal_value_string: Option<ast::Utf16String>,
+}
+
+impl DecodedClassElementRecord {
+    fn validate(&self) {
+        let _ = self.kind;
+        let _ = self.is_static || self.is_private || self.has_initializer;
+        let _ = self.private_identifier.as_ref().map(|name| name.as_slice().len());
+        let _ = self.shared_function_data_index;
+        let _ = literal_value_kind_tag(self.literal_value_kind);
+        let _ = self.literal_value_number;
+        let _ = self.literal_value_string.as_ref().map(|value| value.as_slice().len());
+    }
+}
+
+impl Decode for PendingLiteralValueKind {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
         match u8::decode(decoder)? {
-            0..=5 => {}
-            _ => return None,
+            0 => Some(Self::None),
+            1 => Some(Self::Number),
+            2 => Some(Self::BooleanTrue),
+            3 => Some(Self::BooleanFalse),
+            4 => Some(Self::Null),
+            5 => Some(Self::String),
+            _ => None,
         }
-        f64::decode(decoder)?;
-        Option::<IgnoredUtf16>::decode(decoder)?;
-        Some(())
     }
 }
 
@@ -1782,7 +1979,7 @@ mod tests {
         let bytes = u32::MAX.to_le_bytes();
 
         let mut decoder = Decoder::new(&bytes);
-        assert!(decoder.sequence(|_| Some(())).is_none());
+        assert!(decoder.sequence_values(u8::decode).is_none());
     }
 
     #[test]
@@ -1792,6 +1989,6 @@ mod tests {
         bytes.extend_from_slice(&[1, 2, 3]);
 
         let mut decoder = Decoder::new(&bytes);
-        assert!(decoder.sequence(|d| u8::decode(d).map(|_| ())).is_none());
+        assert!(decoder.sequence_values(u8::decode).is_none());
     }
 }

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -335,9 +335,18 @@ unsafe fn create_executable_from_compiled_bytecode(
     }
 }
 
-fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
+#[derive(Clone, Copy)]
+enum FunctionPrecompileMode {
+    EagerOnly,
+    All,
+}
+
+fn precompile_functions(generator: &mut bytecode::generator::Generator, mode: FunctionPrecompileMode) {
     for pending in &mut generator.shared_function_data {
-        if !pending.should_eager_compile || pending.precompiled_function.is_some() {
+        if pending.precompiled_function.is_some() {
+            continue;
+        }
+        if matches!(mode, FunctionPrecompileMode::EagerOnly) && !pending.should_eager_compile {
             continue;
         }
 
@@ -360,6 +369,7 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
             generator.source_len,
             generator.builtin_abstract_operations_enabled,
             arena,
+            mode,
         );
 
         pending.function_data = Some(function_data);
@@ -368,41 +378,6 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
         // immediately cleared after the precompiled executable is attached.
         pending.subtable = Some(ast::FunctionTable::new());
         pending.precompiled_function = Some(precompiled);
-    }
-}
-
-fn precompile_all_functions(generator: &mut bytecode::generator::Generator) {
-    for pending in &mut generator.shared_function_data {
-        if pending.precompiled_function.is_none() {
-            let function_data = pending
-                .function_data
-                .take()
-                .expect("pending function data was already materialized");
-            let subtable = pending
-                .subtable
-                .take()
-                .expect("pending function subtable was already materialized");
-            let arena = pending.arena.clone().unwrap_or_else(|| generator.arena.clone());
-            let payload = ast::FunctionPayload {
-                data: *function_data,
-                function_table: subtable,
-                arena: arena.clone(),
-            };
-            let (function_data, precompiled) = compile_function_payload_to_bytecode(
-                payload,
-                generator.source_len,
-                generator.builtin_abstract_operations_enabled,
-                arena,
-            );
-
-            pending.function_data = Some(function_data);
-            pending.subtable = Some(ast::FunctionTable::new());
-            pending.precompiled_function = Some(precompiled);
-        }
-
-        if let Some(precompiled) = pending.precompiled_function.as_mut() {
-            precompile_all_functions(&mut precompiled.generator);
-        }
     }
 }
 
@@ -628,17 +603,10 @@ pub unsafe extern "C" fn rust_free_parsed_program(parsed: *mut ParsedProgram) {
     }
 }
 
-/// Compile a parsed program to an off-thread bytecode artifact.
-///
-/// Consumes and frees the ParsedProgram. The returned CompiledProgram still needs to be materialized on the main thread
-/// before it becomes a GC-backed Executable.
-///
-/// # Safety
-/// - `parsed` must be a valid pointer from `rust_parse_program()` with no errors.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
+fn compile_parsed_program_off_thread_impl(
     parsed: *mut ParsedProgram,
     source_len: usize,
+    function_precompile_mode: FunctionPrecompileMode,
 ) -> *mut CompiledProgram {
     unsafe {
         abort_on_panic(|| {
@@ -653,7 +621,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                 generator.arena = arena_arc;
                 generator.eager_compile_direct_iifes = true;
                 let assembled = compile_module_as_async_to_bytecode(&parsed.program, parsed.scope_ref, &mut generator);
-                precompile_eager_functions(&mut generator);
+                precompile_functions(&mut generator, function_precompile_mode);
                 CompiledProgramBytecode::AsyncModule(CompiledBytecode { generator, assembled })
             } else {
                 let mut generator = new_program_generator(
@@ -666,7 +634,7 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
                 generator.eager_compile_direct_iifes = true;
                 generator.function_table = std::mem::take(&mut parsed.function_table);
                 let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, parsed.scope_ref);
-                precompile_eager_functions(&mut generator);
+                precompile_functions(&mut generator, function_precompile_mode);
                 CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled })
             };
 
@@ -676,6 +644,36 @@ pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
             }))
         })
     }
+}
+
+/// Compile a parsed program to an off-thread bytecode artifact.
+///
+/// Consumes and frees the ParsedProgram. The returned CompiledProgram still needs to be materialized on the main thread
+/// before it becomes a GC-backed Executable.
+///
+/// # Safety
+/// - `parsed` must be a valid pointer from `rust_parse_program()` with no errors.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_compile_parsed_program_off_thread(
+    parsed: *mut ParsedProgram,
+    source_len: usize,
+) -> *mut CompiledProgram {
+    compile_parsed_program_off_thread_impl(parsed, source_len, FunctionPrecompileMode::EagerOnly)
+}
+
+/// Fully compile a parsed program to an off-thread bytecode artifact for persistence.
+///
+/// This is intended for post-handoff cache generation, not the latency-sensitive
+/// path that produces bytecode for immediate execution.
+///
+/// # Safety
+/// - `parsed` must be a valid pointer from `rust_parse_program()` with no errors.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_compile_parsed_program_fully_off_thread(
+    parsed: *mut ParsedProgram,
+    source_len: usize,
+) -> *mut CompiledProgram {
+    compile_parsed_program_off_thread_impl(parsed, source_len, FunctionPrecompileMode::All)
 }
 
 /// Free a CompiledProgram without materializing it.
@@ -2376,8 +2374,13 @@ pub unsafe extern "C" fn rust_compile_function(
             }
             let payload = Box::from_raw(rust_function_ast as *mut ast::FunctionPayload);
             let arena = payload.arena.clone();
-            let (_function_data, mut precompiled) =
-                compile_function_payload_to_bytecode(*payload, source_len, builtin_abstract_operations_enabled, arena);
+            let (_function_data, mut precompiled) = compile_function_payload_to_bytecode(
+                *payload,
+                source_len,
+                builtin_abstract_operations_enabled,
+                arena,
+                FunctionPrecompileMode::EagerOnly,
+            );
 
             precompiled.generator.vm_ptr = vm_ptr;
             precompiled.generator.source_code_ptr = source_code_ptr;
@@ -2414,9 +2417,13 @@ pub unsafe extern "C" fn rust_compile_function_off_thread(
             }
             let payload = Box::from_raw(rust_function_ast as *mut ast::FunctionPayload);
             let arena = payload.arena.clone();
-            let (_function_data, mut precompiled) =
-                compile_function_payload_to_bytecode(*payload, source_len, builtin_abstract_operations_enabled, arena);
-            precompile_all_functions(&mut precompiled.generator);
+            let (_function_data, precompiled) = compile_function_payload_to_bytecode(
+                *payload,
+                source_len,
+                builtin_abstract_operations_enabled,
+                arena,
+                FunctionPrecompileMode::All,
+            );
             Box::into_raw(Box::new(CompiledFunction { precompiled }))
         })
     }
@@ -2488,6 +2495,7 @@ fn compile_function_payload_to_bytecode(
     source_len: usize,
     builtin_abstract_operations_enabled: bool,
     arena: std::sync::Arc<ast::AstArena>,
+    precompile_mode: FunctionPrecompileMode,
 ) -> (Box<ast::FunctionData>, Box<bytecode::generator::PrecompiledFunction>) {
     let function_data = Box::new(payload.data);
 
@@ -2578,6 +2586,8 @@ fn compile_function_payload_to_bytecode(
     if generator.is_in_generator_or_async_function() {
         generator.terminate_unterminated_blocks_with_yield();
     }
+
+    precompile_functions(&mut generator, precompile_mode);
 
     let assembled = generator.assemble();
 

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -704,6 +704,7 @@ pub unsafe extern "C" fn rust_free_compiled_program(compiled: *mut CompiledProgr
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_serialize_compiled_program_for_bytecode_cache(
     compiled: *const CompiledProgram,
+    program_type: u8,
 ) -> BytecodeCacheBlob {
     unsafe {
         abort_on_panic(|| {
@@ -714,7 +715,18 @@ pub unsafe extern "C" fn rust_serialize_compiled_program_for_bytecode_cache(
                 };
             }
 
-            let bytes = bytecode_cache::serialize_compiled_program(&*compiled);
+            let program_type = match program_type {
+                0 => ast::ProgramType::Script,
+                1 => ast::ProgramType::Module,
+                _ => {
+                    return BytecodeCacheBlob {
+                        data: std::ptr::null_mut(),
+                        length: 0,
+                    };
+                }
+            };
+
+            let bytes = bytecode_cache::serialize_compiled_program(&*compiled, program_type);
             let length = bytes.len();
             let mut bytes = bytes.into_boxed_slice();
             let data = bytes.as_mut_ptr();

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -146,6 +146,10 @@ pub struct BytecodeCacheBlob {
     length: usize,
 }
 
+pub struct DecodedBytecodeCacheBlob {
+    _blob: bytecode_cache::DecodedCacheBlob,
+}
+
 enum CompiledProgramBytecode {
     Program(CompiledBytecode),
     AsyncModule(CompiledBytecode),
@@ -903,6 +907,47 @@ pub unsafe extern "C" fn rust_free_bytecode_cache_blob(data: *mut u8, length: us
                 drop(Vec::from_raw_parts(data, length, length));
             }
         });
+    }
+}
+
+/// Decode a bytecode cache blob into an owned parser-free cache handle.
+///
+/// # Safety
+/// `data` must point to `length` readable bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_decode_bytecode_cache_blob(
+    data: *const u8,
+    length: usize,
+    expected_program_type: u8,
+) -> *mut DecodedBytecodeCacheBlob {
+    unsafe {
+        abort_on_panic(|| {
+            if data.is_null() {
+                return std::ptr::null_mut();
+            }
+            let expected_program_type = match expected_program_type {
+                0 => ast::ProgramType::Script,
+                1 => ast::ProgramType::Module,
+                _ => return std::ptr::null_mut(),
+            };
+            let Some(blob) =
+                bytecode_cache::decode_blob(std::slice::from_raw_parts(data, length), expected_program_type)
+            else {
+                return std::ptr::null_mut();
+            };
+            Box::into_raw(Box::new(DecodedBytecodeCacheBlob { _blob: blob }))
+        })
+    }
+}
+
+/// Free a decoded bytecode cache blob.
+///
+/// # Safety
+/// `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_free_decoded_bytecode_cache_blob(blob: *mut DecodedBytecodeCacheBlob) {
+    unsafe {
+        drop(Box::from_raw(blob));
     }
 }
 

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -97,6 +97,7 @@ pub(crate) fn u32_from_usize(value: usize) -> u32 {
 }
 
 use ast::StatementKind;
+use bytecode::generator::PendingSharedFunctionData;
 use parser::{ParseError, Parser, ProgramType};
 use std::collections::HashSet;
 use std::ffi::c_void;
@@ -122,6 +123,7 @@ pub struct ParsedProgram {
     function_table: ast::FunctionTable,
     arena: std::sync::Arc<ast::AstArena>,
     scope_ref: ast::ScopeId,
+    program_type: ast::ProgramType,
     is_strict_mode: bool,
     has_top_level_await: bool,
     errors: Vec<ParseError>,
@@ -131,6 +133,7 @@ pub struct ParsedProgram {
 pub struct CompiledProgram {
     parsed: ParsedProgram,
     bytecode: CompiledProgramBytecode,
+    declaration_functions: Vec<PendingSharedFunctionData>,
 }
 
 pub struct CompiledFunction {
@@ -342,7 +345,7 @@ unsafe fn create_executable_from_compiled_bytecode(
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 enum FunctionPrecompileMode {
     EagerOnly,
     All,
@@ -385,6 +388,138 @@ fn precompile_functions(generator: &mut bytecode::generator::Generator, mode: Fu
         // immediately cleared after the precompiled executable is attached.
         pending.subtable = Some(ast::FunctionTable::new());
         pending.precompiled_function = Some(precompiled);
+    }
+}
+
+fn precompile_declaration_functions(
+    program_type: ast::ProgramType,
+    scope_id: ast::ScopeId,
+    generator: &mut bytecode::generator::Generator,
+    mode: FunctionPrecompileMode,
+) -> Vec<PendingSharedFunctionData> {
+    if mode != FunctionPrecompileMode::All {
+        return Vec::new();
+    }
+
+    match program_type {
+        ast::ProgramType::Script => precompile_script_declaration_functions(scope_id, generator, mode),
+        ast::ProgramType::Module => precompile_module_declaration_functions(scope_id, generator, mode),
+    }
+}
+
+fn precompile_script_declaration_functions(
+    scope_id: ast::ScopeId,
+    generator: &mut bytecode::generator::Generator,
+    mode: FunctionPrecompileMode,
+) -> Vec<PendingSharedFunctionData> {
+    use ast::StatementKind;
+
+    let arena = generator.arena.clone();
+    let scope = &arena.scopes[scope_id];
+    let mut last_position: std::collections::HashMap<ast::StringId, usize> = std::collections::HashMap::new();
+    for (index, child) in scope.children.iter().enumerate() {
+        if let StatementKind::FunctionDeclaration(ref function) = child.inner
+            && let Some(name) = function.name
+        {
+            last_position.insert(arena.identifiers[name].name, index);
+        }
+    }
+
+    let mut declaration_functions = Vec::new();
+    for (index, child) in scope.children.iter().enumerate() {
+        if let StatementKind::FunctionDeclaration(ref function) = child.inner
+            && let Some(name) = function.name
+            && last_position.get(&arena.identifiers[name].name).copied() == Some(index)
+        {
+            declaration_functions.push(precompile_declaration_function(
+                function.function_id,
+                None,
+                generator,
+                mode,
+            ));
+        }
+    }
+
+    declaration_functions
+}
+
+fn precompile_module_declaration_functions(
+    scope_id: ast::ScopeId,
+    generator: &mut bytecode::generator::Generator,
+    mode: FunctionPrecompileMode,
+) -> Vec<PendingSharedFunctionData> {
+    use ast::StatementKind;
+
+    let arena = generator.arena.clone();
+    let scope = &arena.scopes[scope_id];
+    let default_name: ast::Utf16String = utf16!("*default*").into();
+    let mut declaration_functions = Vec::new();
+    for child in &scope.children {
+        let (declaration, is_exported) = match &child.inner {
+            StatementKind::Export(export_data) => {
+                if let Some(ref statement) = export_data.statement {
+                    (&statement.inner, true)
+                } else {
+                    continue;
+                }
+            }
+            other => (other, false),
+        };
+
+        if let StatementKind::FunctionDeclaration(function) = declaration {
+            let is_default = is_exported
+                && function
+                    .name
+                    .is_some_and(|name| arena.name_slice(name) == default_name.as_slice());
+            let name_override = if is_default {
+                Some(utf16!("default").into())
+            } else {
+                None
+            };
+            declaration_functions.push(precompile_declaration_function(
+                function.function_id,
+                name_override,
+                generator,
+                mode,
+            ));
+        }
+    }
+
+    declaration_functions
+}
+
+fn precompile_declaration_function(
+    function_id: ast::FunctionId,
+    name_override: Option<ast::Utf16String>,
+    generator: &mut bytecode::generator::Generator,
+    mode: FunctionPrecompileMode,
+) -> PendingSharedFunctionData {
+    let function_data = generator.function_table.take(function_id);
+    let arena = generator.arena.clone();
+    let subtable = generator
+        .function_table
+        .extract_reachable(&function_data, &arena.scopes);
+    let payload = ast::FunctionPayload {
+        data: *function_data,
+        function_table: subtable,
+        arena: arena.clone(),
+    };
+    let (function_data, precompiled_function) = compile_function_payload_to_bytecode(
+        payload,
+        generator.source_len,
+        generator.builtin_abstract_operations_enabled,
+        arena.clone(),
+        mode,
+    );
+
+    PendingSharedFunctionData {
+        function_data: Some(function_data),
+        subtable: Some(ast::FunctionTable::new()),
+        arena: Some(arena),
+        name_override,
+        class_field_initializer_name: None,
+        should_eager_compile: false,
+        precompiled_function: Some(precompiled_function),
     }
 }
 
@@ -556,6 +691,7 @@ pub unsafe extern "C" fn rust_parse_program(
                 function_table: std::mem::take(&mut parser.function_table),
                 arena: std::sync::Arc::new(std::mem::take(&mut parser.arena)),
                 scope_ref,
+                program_type: pt,
                 is_strict_mode: is_strict,
                 has_top_level_await: has_tla,
                 errors,
@@ -623,13 +759,22 @@ fn compile_parsed_program_off_thread_impl(
 
             let mut parsed = Box::from_raw(parsed);
             let arena_arc = parsed.arena.clone();
-            let bytecode = if parsed.has_top_level_await {
+            let (bytecode, declaration_functions) = if parsed.has_top_level_await {
                 let mut generator = new_module_async_generator(source_len, std::mem::take(&mut parsed.function_table));
                 generator.arena = arena_arc;
                 generator.eager_compile_direct_iifes = true;
                 let assembled = compile_module_as_async_to_bytecode(&parsed.program, parsed.scope_ref, &mut generator);
+                let declaration_functions = precompile_declaration_functions(
+                    parsed.program_type,
+                    parsed.scope_ref,
+                    &mut generator,
+                    function_precompile_mode,
+                );
                 precompile_functions(&mut generator, function_precompile_mode);
-                CompiledProgramBytecode::AsyncModule(CompiledBytecode { generator, assembled })
+                (
+                    CompiledProgramBytecode::AsyncModule(CompiledBytecode { generator, assembled }),
+                    declaration_functions,
+                )
             } else {
                 let mut generator = new_program_generator(
                     parsed.is_strict_mode,
@@ -641,13 +786,23 @@ fn compile_parsed_program_off_thread_impl(
                 generator.eager_compile_direct_iifes = true;
                 generator.function_table = std::mem::take(&mut parsed.function_table);
                 let assembled = compile_program_body_to_bytecode(&mut generator, &parsed.program, parsed.scope_ref);
+                let declaration_functions = precompile_declaration_functions(
+                    parsed.program_type,
+                    parsed.scope_ref,
+                    &mut generator,
+                    function_precompile_mode,
+                );
                 precompile_functions(&mut generator, function_precompile_mode);
-                CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled })
+                (
+                    CompiledProgramBytecode::Program(CompiledBytecode { generator, assembled }),
+                    declaration_functions,
+                )
             };
 
             Box::into_raw(Box::new(CompiledProgram {
                 parsed: *parsed,
                 bytecode,
+                declaration_functions,
             }))
         })
     }

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -963,6 +963,68 @@ pub unsafe extern "C" fn rust_free_decoded_bytecode_cache_blob(blob: *mut Decode
     }
 }
 
+/// Materialize a decoded script bytecode cache blob. Consumes and frees the blob.
+///
+/// # Safety
+/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob()`.
+/// - `vm_ptr` must be a valid `JS::VM*`.
+/// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
+/// - `gdi_context` must be a valid pointer to a C++ ScriptGdiBuilder.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_materialize_bytecode_cache_script(
+    blob: *mut DecodedBytecodeCacheBlob,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    source_len: usize,
+    gdi_context: *mut c_void,
+) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if blob.is_null() {
+                return std::ptr::null_mut();
+            }
+            let blob = Box::from_raw(blob);
+            if !blob._blob.source_ranges_are_valid(source_len) {
+                return std::ptr::null_mut();
+            }
+            blob._blob.materialize_script(vm_ptr, source_code_ptr, gdi_context)
+        })
+    }
+}
+
+/// Materialize a decoded module bytecode cache blob. Consumes and frees the blob.
+///
+/// # Safety
+/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob()`.
+/// - `vm_ptr` must be a valid `JS::VM*`.
+/// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
+/// - `module_context` must be a valid `ModuleBuilder*`.
+/// - `callbacks` must point to a valid `ModuleCallbacks`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_materialize_bytecode_cache_module(
+    blob: *mut DecodedBytecodeCacheBlob,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    source_len: usize,
+    module_context: *mut c_void,
+    callbacks: *const ModuleCallbacks,
+    tla_executable_out: *mut *mut c_void,
+) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if blob.is_null() {
+                return std::ptr::null_mut();
+            }
+            let blob = Box::from_raw(blob);
+            if !blob._blob.source_ranges_are_valid(source_len) {
+                return std::ptr::null_mut();
+            }
+            blob._blob
+                .materialize_module(vm_ptr, source_code_ptr, module_context, callbacks, tla_executable_out)
+        })
+    }
+}
+
 /// Get the AST dump string from a ParsedProgram.
 ///
 /// Generates the dump on first call and caches it. Writes the pointer

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -864,10 +864,12 @@ pub unsafe extern "C" fn rust_free_compiled_program(compiled: *mut CompiledProgr
 pub unsafe extern "C" fn rust_serialize_compiled_program_for_bytecode_cache(
     compiled: *const CompiledProgram,
     program_type: u8,
+    source_hash: *const u8,
+    source_hash_len: usize,
 ) -> BytecodeCacheBlob {
     unsafe {
         abort_on_panic(|| {
-            if compiled.is_null() {
+            if compiled.is_null() || source_hash.is_null() || source_hash_len != 32 {
                 return BytecodeCacheBlob {
                     data: std::ptr::null_mut(),
                     length: 0,
@@ -885,7 +887,10 @@ pub unsafe extern "C" fn rust_serialize_compiled_program_for_bytecode_cache(
                 }
             };
 
-            let bytes = bytecode_cache::serialize_compiled_program(&*compiled, program_type);
+            let source_hash = std::slice::from_raw_parts(source_hash, source_hash_len)
+                .try_into()
+                .expect("source hash length was checked");
+            let bytes = bytecode_cache::serialize_compiled_program(&*compiled, program_type, source_hash);
             let length = bytes.len();
             let mut bytes = bytes.into_boxed_slice();
             let data = bytes.as_mut_ptr();
@@ -919,10 +924,12 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob(
     data: *const u8,
     length: usize,
     expected_program_type: u8,
+    expected_source_hash: *const u8,
+    expected_source_hash_len: usize,
 ) -> *mut DecodedBytecodeCacheBlob {
     unsafe {
         abort_on_panic(|| {
-            if data.is_null() {
+            if data.is_null() || expected_source_hash.is_null() || expected_source_hash_len != 32 {
                 return std::ptr::null_mut();
             }
             let expected_program_type = match expected_program_type {
@@ -930,9 +937,14 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob(
                 1 => ast::ProgramType::Module,
                 _ => return std::ptr::null_mut(),
             };
-            let Some(blob) =
-                bytecode_cache::decode_blob(std::slice::from_raw_parts(data, length), expected_program_type)
-            else {
+            let expected_source_hash = std::slice::from_raw_parts(expected_source_hash, expected_source_hash_len)
+                .try_into()
+                .expect("source hash length was checked");
+            let Some(blob) = bytecode_cache::decode_blob(
+                std::slice::from_raw_parts(data, length),
+                expected_program_type,
+                expected_source_hash,
+            ) else {
                 return std::ptr::null_mut();
             };
             Box::into_raw(Box::new(DecodedBytecodeCacheBlob { _blob: blob }))

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -132,6 +132,10 @@ pub struct CompiledProgram {
     bytecode: CompiledProgramBytecode,
 }
 
+pub struct CompiledFunction {
+    precompiled: Box<bytecode::generator::PrecompiledFunction>,
+}
+
 enum CompiledProgramBytecode {
     Program(CompiledBytecode),
     AsyncModule(CompiledBytecode),
@@ -146,6 +150,10 @@ struct CompiledBytecode {
 // raw VM pointers; it is created on the parse-worker thread and consumed (or
 // freed) on the main thread, never accessed concurrently.
 unsafe impl Send for CompiledProgram {}
+
+// SAFETY: `CompiledFunction` owns GC-free codegen state and is transferred
+// from a compile worker back to the main thread for materialization.
+unsafe impl Send for CompiledFunction {}
 
 // =============================================================================
 // Internal helpers
@@ -360,6 +368,41 @@ fn precompile_eager_functions(generator: &mut bytecode::generator::Generator) {
         // immediately cleared after the precompiled executable is attached.
         pending.subtable = Some(ast::FunctionTable::new());
         pending.precompiled_function = Some(precompiled);
+    }
+}
+
+fn precompile_all_functions(generator: &mut bytecode::generator::Generator) {
+    for pending in &mut generator.shared_function_data {
+        if pending.precompiled_function.is_none() {
+            let function_data = pending
+                .function_data
+                .take()
+                .expect("pending function data was already materialized");
+            let subtable = pending
+                .subtable
+                .take()
+                .expect("pending function subtable was already materialized");
+            let arena = pending.arena.clone().unwrap_or_else(|| generator.arena.clone());
+            let payload = ast::FunctionPayload {
+                data: *function_data,
+                function_table: subtable,
+                arena: arena.clone(),
+            };
+            let (function_data, precompiled) = compile_function_payload_to_bytecode(
+                payload,
+                generator.source_len,
+                generator.builtin_abstract_operations_enabled,
+                arena,
+            );
+
+            pending.function_data = Some(function_data);
+            pending.subtable = Some(ast::FunctionTable::new());
+            pending.precompiled_function = Some(precompiled);
+        }
+
+        if let Some(precompiled) = pending.precompiled_function.as_mut() {
+            precompile_all_functions(&mut precompiled.generator);
+        }
     }
 }
 
@@ -2270,6 +2313,26 @@ pub unsafe extern "C" fn rust_free_function_ast(ast: *mut c_void) {
     }
 }
 
+/// Clone a lazy function compilation payload.
+///
+/// The clone lets background compilation race with synchronous lazy
+/// compilation. Each path owns and eventually frees its own AST payload.
+///
+/// # Safety
+/// `ast` must be null or a valid pointer returned by `Box::into_raw(Box<FunctionPayload>)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_clone_function_ast(ast: *const c_void) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if ast.is_null() {
+                return std::ptr::null_mut();
+            }
+            let payload = &*(ast as *const ast::FunctionPayload);
+            Box::into_raw(Box::new(payload.clone())) as *mut c_void
+        })
+    }
+}
+
 /// Free a string allocated by Rust (e.g. AST dump output).
 ///
 /// # Safety
@@ -2328,6 +2391,95 @@ pub unsafe extern "C" fn rust_compile_function(
                 source_code_ptr,
             )
         })
+    }
+}
+
+/// Compile a function payload to a GC-free bytecode artifact.
+///
+/// Takes ownership of the cloned `Box<FunctionPayload>`. The result must be
+/// materialized on the main thread or freed with `rust_free_compiled_function`.
+///
+/// # Safety
+/// `rust_function_ast` must be a valid `Box<FunctionPayload>` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_compile_function_off_thread(
+    rust_function_ast: *mut c_void,
+    source_len: usize,
+    builtin_abstract_operations_enabled: bool,
+) -> *mut CompiledFunction {
+    unsafe {
+        abort_on_panic(|| {
+            if rust_function_ast.is_null() {
+                return std::ptr::null_mut();
+            }
+            let payload = Box::from_raw(rust_function_ast as *mut ast::FunctionPayload);
+            let arena = payload.arena.clone();
+            let (_function_data, mut precompiled) =
+                compile_function_payload_to_bytecode(*payload, source_len, builtin_abstract_operations_enabled, arena);
+            precompile_all_functions(&mut precompiled.generator);
+            Box::into_raw(Box::new(CompiledFunction { precompiled }))
+        })
+    }
+}
+
+/// Materialize a GC-free compiled function onto an existing SFD.
+///
+/// Consumes and frees the compiled function.
+///
+/// # Safety
+/// - `compiled` must be a valid pointer returned by `rust_compile_function_off_thread`.
+/// - `vm_ptr`, `source_code_ptr`, and `sfd_ptr` must be valid main-thread pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_materialize_compiled_function(
+    compiled: *mut CompiledFunction,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    sfd_ptr: *mut c_void,
+) {
+    unsafe {
+        abort_on_panic(|| {
+            if compiled.is_null() {
+                return;
+            }
+            let mut compiled = Box::from_raw(compiled);
+            compiled.precompiled.generator.vm_ptr = vm_ptr;
+            compiled.precompiled.generator.source_code_ptr = source_code_ptr;
+            let executable_ptr = bytecode::ffi::create_executable(
+                &mut compiled.precompiled.generator,
+                &compiled.precompiled.assembled,
+                vm_ptr,
+                source_code_ptr,
+            );
+            assert!(
+                !executable_ptr.is_null(),
+                "rust_materialize_compiled_function: executable materialization failed"
+            );
+            bytecode::ffi::rust_sfd_set_precompiled_executable(
+                sfd_ptr,
+                executable_ptr,
+                compiled.precompiled.metadata.uses_this,
+                compiled.precompiled.metadata.this_value_needs_environment_resolution,
+                compiled.precompiled.metadata.function_environment_needed,
+                compiled.precompiled.metadata.function_environment_bindings_count,
+                compiled.precompiled.metadata.might_need_arguments,
+                compiled.precompiled.metadata.contains_eval,
+            );
+        });
+    }
+}
+
+/// Free a GC-free compiled function without materializing it.
+///
+/// # Safety
+/// `compiled` must be null or a valid pointer returned by `rust_compile_function_off_thread`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_free_compiled_function(compiled: *mut CompiledFunction) {
+    unsafe {
+        abort_on_panic(|| {
+            if !compiled.is_null() {
+                drop(Box::from_raw(compiled));
+            }
+        });
     }
 }
 

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -83,6 +83,7 @@ macro_rules! utf16 {
 pub mod ast;
 pub mod ast_dump;
 pub mod bytecode;
+mod bytecode_cache;
 pub mod fast_hash;
 pub mod lexer;
 pub mod parser;
@@ -134,6 +135,12 @@ pub struct CompiledProgram {
 
 pub struct CompiledFunction {
     precompiled: Box<bytecode::generator::PrecompiledFunction>,
+}
+
+#[repr(C)]
+pub struct BytecodeCacheBlob {
+    data: *mut u8,
+    length: usize,
 }
 
 enum CompiledProgramBytecode {
@@ -684,6 +691,51 @@ pub unsafe extern "C" fn rust_compile_parsed_program_fully_off_thread(
 pub unsafe extern "C" fn rust_free_compiled_program(compiled: *mut CompiledProgram) {
     unsafe {
         drop(Box::from_raw(compiled));
+    }
+}
+
+/// Serialize a fully compiled program into a versioned bytecode cache blob.
+///
+/// The caller owns the returned bytes and must release them with
+/// `rust_free_bytecode_cache_blob()`.
+///
+/// # Safety
+/// `compiled` must be a valid pointer from `rust_compile_parsed_program_fully_off_thread()`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_serialize_compiled_program_for_bytecode_cache(
+    compiled: *const CompiledProgram,
+) -> BytecodeCacheBlob {
+    unsafe {
+        abort_on_panic(|| {
+            if compiled.is_null() {
+                return BytecodeCacheBlob {
+                    data: std::ptr::null_mut(),
+                    length: 0,
+                };
+            }
+
+            let bytes = bytecode_cache::serialize_compiled_program(&*compiled);
+            let length = bytes.len();
+            let mut bytes = bytes.into_boxed_slice();
+            let data = bytes.as_mut_ptr();
+            std::mem::forget(bytes);
+            BytecodeCacheBlob { data, length }
+        })
+    }
+}
+
+/// Free a bytecode cache blob returned by `rust_serialize_compiled_program_for_bytecode_cache()`.
+///
+/// # Safety
+/// `data` and `length` must match a blob returned by Rust.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_free_bytecode_cache_blob(data: *mut u8, length: usize) {
+    unsafe {
+        abort_on_panic(|| {
+            if !data.is_null() {
+                drop(Vec::from_raw_parts(data, length, length));
+            }
+        });
     }
 }
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -386,9 +386,9 @@ void free_compiled_program(CompiledProgram* compiled)
     rust_free_compiled_program(compiled);
 }
 
-ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& compiled)
+ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& compiled, ProgramType type)
 {
-    auto blob = rust_serialize_compiled_program_for_bytecode_cache(&compiled);
+    auto blob = rust_serialize_compiled_program_for_bytecode_cache(&compiled, static_cast<u8>(type));
     if (!blob.data || blob.length == 0)
         return {};
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -682,6 +682,27 @@ GC::Ptr<Bytecode::Executable> compile_function(VM& vm, SharedFunctionInstanceDat
     return exec;
 }
 
+void* clone_function_ast(void const* ast)
+{
+    return rust_clone_function_ast(ast);
+}
+
+CompiledFunction* compile_function_off_thread(void* function_ast, size_t length_in_code_units, bool builtin_abstract_operations_enabled)
+{
+    return rust_compile_function_off_thread(function_ast, length_in_code_units, builtin_abstract_operations_enabled);
+}
+
+void materialize_compiled_function(CompiledFunction* compiled, VM& vm, SourceCode const& source_code, SharedFunctionInstanceData& shared_data)
+{
+    GC::DeferGC defer_gc(vm.heap());
+    rust_materialize_compiled_function(compiled, &vm, &source_code, &shared_data);
+}
+
+void free_compiled_function(CompiledFunction* compiled)
+{
+    rust_free_compiled_function(compiled);
+}
+
 void free_function_ast(void* ast)
 {
     if (ast)

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -397,6 +397,16 @@ ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& 
     return bytes;
 }
 
+DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes bytes, ProgramType expected_type)
+{
+    return rust_decode_bytecode_cache_blob(bytes.data(), bytes.size(), static_cast<u8>(expected_type));
+}
+
+void free_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob)
+{
+    rust_free_decoded_bytecode_cache_blob(blob);
+}
+
 Optional<Result<ScriptResult, Vector<ParserError>>> compile_parsed_script(ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
 {
     if (!parsed)

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -386,9 +386,9 @@ void free_compiled_program(CompiledProgram* compiled)
     rust_free_compiled_program(compiled);
 }
 
-ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& compiled, ProgramType type)
+ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& compiled, ProgramType type, ReadonlyBytes source_hash)
 {
-    auto blob = rust_serialize_compiled_program_for_bytecode_cache(&compiled, static_cast<u8>(type));
+    auto blob = rust_serialize_compiled_program_for_bytecode_cache(&compiled, static_cast<u8>(type), source_hash.data(), source_hash.size());
     if (!blob.data || blob.length == 0)
         return {};
 
@@ -397,9 +397,9 @@ ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& 
     return bytes;
 }
 
-DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes bytes, ProgramType expected_type)
+DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash)
 {
-    return rust_decode_bytecode_cache_blob(bytes.data(), bytes.size(), static_cast<u8>(expected_type));
+    return rust_decode_bytecode_cache_blob(bytes.data(), bytes.size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size());
 }
 
 void free_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob)

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -386,6 +386,17 @@ void free_compiled_program(CompiledProgram* compiled)
     rust_free_compiled_program(compiled);
 }
 
+ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& compiled)
+{
+    auto blob = rust_serialize_compiled_program_for_bytecode_cache(&compiled);
+    if (!blob.data || blob.length == 0)
+        return {};
+
+    auto bytes = ByteBuffer::copy({ blob.data, blob.length }).release_value_but_fixme_should_propagate_errors();
+    rust_free_bytecode_cache_blob(blob.data, blob.length);
+    return bytes;
+}
+
 Optional<Result<ScriptResult, Vector<ParserError>>> compile_parsed_script(ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
 {
     if (!parsed)

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -366,6 +366,11 @@ CompiledProgram* compile_parsed_program_off_thread(ParsedProgram* parsed, size_t
     return rust_compile_parsed_program_off_thread(parsed, length_in_code_units);
 }
 
+CompiledProgram* compile_parsed_program_fully_off_thread(ParsedProgram* parsed, size_t length_in_code_units)
+{
+    return rust_compile_parsed_program_fully_off_thread(parsed, length_in_code_units);
+}
+
 bool parsed_program_has_errors(ParsedProgram const* parsed)
 {
     return rust_parsed_program_has_errors(const_cast<ParsedProgram*>(parsed));

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/RustIntegration.h>
 
+#include <AK/TemporaryChange.h>
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <AK/kmalloc.h>
@@ -37,6 +38,11 @@ using namespace JS::FFI;
 namespace JS::RustIntegration {
 
 // --- Shared helpers ---
+
+// Bytecode cache materialization rebuilds executables from disk, which is untrusted input. Materialization paths flip
+// this flag for the duration of their work so that the in-process bytecode validator runs even in release builds; the
+// normal Rust pipeline path leaves it off and keeps the existing debug/sanitizer-only behavior.
+static thread_local bool s_validate_materialized_bytecode_cache_executables = false;
 
 static Utf16View utf16_view_from_bytes(uint16_t const* data, size_t len)
 {
@@ -450,6 +456,24 @@ Optional<Result<ScriptResult, Vector<ParserError>>> materialize_compiled_script(
     return builder.result;
 }
 
+Optional<Result<ScriptResult, Vector<ParserError>>> materialize_bytecode_cache_script(DecodedBytecodeCacheBlob* blob, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
+{
+    if (!blob)
+        return {};
+
+    GC::DeferGC defer_gc(realm.vm().heap());
+    TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+    ScriptGdiBuilder builder;
+
+    void* exec_ptr = rust_materialize_bytecode_cache_script(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &builder);
+
+    if (!exec_ptr)
+        return Vector<ParserError> { ParserError { "Failed to materialize bytecode cache"_string, {} } };
+
+    builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
+    return builder.result;
+}
+
 Optional<Result<ScriptResult, Vector<ParserError>>> compile_script(StringView source_text, Realm& realm, StringView filename, size_t line_number_offset)
 {
     auto source_code = SourceCode::create(
@@ -584,6 +608,56 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_compiled_module(
 
     if (!exec_ptr && !tla_executable)
         return Vector<ParserError> {};
+
+    if (tla_executable) {
+        auto& vm = realm.vm();
+        auto* tla_exec = static_cast<Bytecode::Executable*>(tla_executable);
+
+        builder.result.tla_shared_data = vm.heap().allocate<SharedFunctionInstanceData>(
+            vm, FunctionKind::Async,
+            "module code with top-level await"_utf16_fly_string,
+            0, 0, true, false, true,
+            Vector<Utf16FlyString> {}, nullptr);
+        builder.result.tla_shared_data->m_is_module_wrapper = true;
+        builder.result.tla_shared_data->m_uses_this = true;
+        builder.result.tla_shared_data->m_function_environment_needed = true;
+        builder.result.tla_shared_data->update_asm_call_metadata();
+        builder.result.tla_shared_data->set_executable(tla_exec);
+    } else {
+        builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
+    }
+
+    return builder.result;
+}
+
+Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_module(DecodedBytecodeCacheBlob* blob, NonnullRefPtr<SourceCode const> source_code, Realm& realm)
+{
+    if (!blob)
+        return {};
+
+    GC::DeferGC defer_gc(realm.vm().heap());
+    TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+    ModuleBuilder builder;
+    ModuleCallbacks callbacks {
+        .set_has_top_level_await = module_set_has_top_level_await,
+        .push_import_entry = module_push_import_entry,
+        .push_local_export = module_push_local_export,
+        .push_indirect_export = module_push_indirect_export,
+        .push_star_export = module_push_star_export,
+        .push_requested_module = module_push_requested_module,
+        .set_default_export_binding = module_set_default_export_binding,
+        .push_var_name = module_push_var_name,
+        .push_function = module_push_function,
+        .push_lexical_binding = module_push_lexical_binding,
+    };
+
+    void* tla_executable = nullptr;
+
+    void* exec_ptr = rust_materialize_bytecode_cache_module(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(),
+        &builder, &callbacks, &tla_executable);
+
+    if (!exec_ptr && !tla_executable)
+        return Vector<ParserError> { ParserError { "Failed to materialize bytecode cache"_string, {} } };
 
     if (tla_executable) {
         auto& vm = realm.vm();
@@ -987,10 +1061,23 @@ extern "C" void* rust_create_executable(
         delete bp;
     }
 
+    auto const is_materializing_bytecode_cache = JS::RustIntegration::s_validate_materialized_bytecode_cache_executables;
 #if !defined(NDEBUG) || defined(HAS_ADDRESS_SANITIZER)
-    if (auto validation = JS::Bytecode::validate_bytecode(*executable, JS::Bytecode::CacheState::BeforeFixup); validation.is_error())
-        VERIFY_NOT_REACHED();
+    auto const should_validate_bytecode = true;
+#else
+    auto const should_validate_bytecode = is_materializing_bytecode_cache;
 #endif
+    if (should_validate_bytecode) {
+        if (auto validation = JS::Bytecode::validate_bytecode(*executable, JS::Bytecode::CacheState::BeforeFixup); validation.is_error()) {
+            if (is_materializing_bytecode_cache)
+                return nullptr;
+#if !defined(NDEBUG) || defined(HAS_ADDRESS_SANITIZER)
+            VERIFY_NOT_REACHED();
+#else
+            return nullptr;
+#endif
+        }
+    }
 
     executable->fixup_cache_pointers();
 

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -109,10 +109,10 @@ JS_API void free_parsed_program(FFI::ParsedProgram*);
 JS_API void free_compiled_program(FFI::CompiledProgram*);
 
 // Serialize a fully compiled program into a versioned bytecode cache blob.
-JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&, ProgramType);
+JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&, ProgramType, ReadonlyBytes source_hash);
 
 // Decode a bytecode cache blob into an owned parser-free cache handle.
-JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes, ProgramType);
+JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes, ProgramType, ReadonlyBytes source_hash);
 
 // Free a decoded bytecode cache blob.
 JS_API void free_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*);

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -94,6 +94,9 @@ JS_API FFI::ParsedProgram* parse_program(u16 const* utf16_data, size_t length_in
 // Compile a parsed program to bytecode without touching the VM or GC. Thread-safe.
 JS_API FFI::CompiledProgram* compile_parsed_program_off_thread(FFI::ParsedProgram* parsed, size_t length_in_code_units);
 
+// Fully compile a parsed program to bytecode without touching the VM or GC. Thread-safe.
+JS_API FFI::CompiledProgram* compile_parsed_program_fully_off_thread(FFI::ParsedProgram* parsed, size_t length_in_code_units);
+
 // Check if a parsed program has errors. Does not consume the program.
 JS_API bool parsed_program_has_errors(FFI::ParsedProgram const*);
 

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -108,7 +108,7 @@ JS_API void free_parsed_program(FFI::ParsedProgram*);
 JS_API void free_compiled_program(FFI::CompiledProgram*);
 
 // Serialize a fully compiled program into a versioned bytecode cache blob.
-JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&);
+JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&, ProgramType);
 
 // Compile a previously parsed script. Must be called on the main thread.
 // Consumes and frees the Rust ParsedProgram.

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -117,6 +117,14 @@ JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes, 
 // Free a decoded bytecode cache blob.
 JS_API void free_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*);
 
+// Materialize a decoded script bytecode cache blob. Must be called on the main thread.
+// Consumes and frees the decoded blob.
+JS_API Optional<Result<ScriptResult, Vector<ParserError>>> materialize_bytecode_cache_script(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&);
+
+// Materialize a decoded module bytecode cache blob. Must be called on the main thread.
+// Consumes and frees the decoded blob.
+JS_API Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_module(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&);
+
 // Compile a previously parsed script. Must be called on the main thread.
 // Consumes and frees the Rust ParsedProgram.
 // Returns nullopt if Rust is not available.

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -26,6 +26,7 @@ namespace JS::FFI {
 
 struct ParsedProgram;
 struct CompiledProgram;
+struct CompiledFunction;
 
 }
 
@@ -146,6 +147,11 @@ Optional<Vector<GC::Root<SharedFunctionInstanceData>>> compile_builtin_file(
 // Compile a function body for lazy compilation.
 // Returns nullptr if Rust is not available or the SFD doesn't use Rust compilation.
 GC::Ptr<Bytecode::Executable> compile_function(VM& vm, SharedFunctionInstanceData& shared_data, bool builtin_abstract_operations_enabled);
+
+JS_API void* clone_function_ast(void const*);
+JS_API FFI::CompiledFunction* compile_function_off_thread(void* function_ast, size_t length_in_code_units, bool builtin_abstract_operations_enabled);
+JS_API void materialize_compiled_function(FFI::CompiledFunction*, VM&, SourceCode const&, SharedFunctionInstanceData&);
+JS_API void free_compiled_function(FFI::CompiledFunction*);
 
 // Free a Rust function AST pointer. No-op if Rust is not available.
 void free_function_ast(void* ast);

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
 #include <AK/HashTable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
@@ -105,6 +106,9 @@ JS_API void free_parsed_program(FFI::ParsedProgram*);
 
 // Free a compiled program without materializing it.
 JS_API void free_compiled_program(FFI::CompiledProgram*);
+
+// Serialize a fully compiled program into a versioned bytecode cache blob.
+JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&);
 
 // Compile a previously parsed script. Must be called on the main thread.
 // Consumes and frees the Rust ParsedProgram.

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -28,6 +28,7 @@ namespace JS::FFI {
 struct ParsedProgram;
 struct CompiledProgram;
 struct CompiledFunction;
+struct DecodedBytecodeCacheBlob;
 
 }
 
@@ -109,6 +110,12 @@ JS_API void free_compiled_program(FFI::CompiledProgram*);
 
 // Serialize a fully compiled program into a versioned bytecode cache blob.
 JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&, ProgramType);
+
+// Decode a bytecode cache blob into an owned parser-free cache handle.
+JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes, ProgramType);
+
+// Free a decoded bytecode cache blob.
+JS_API void free_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*);
 
 // Compile a previously parsed script. Must be called on the main thread.
 // Consumes and frees the Rust ParsedProgram.

--- a/Libraries/LibJS/Script.cpp
+++ b/Libraries/LibJS/Script.cpp
@@ -53,6 +53,17 @@ Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_compiled(FFI::C
     return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
 }
 
+Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code, Realm& realm, HostDefined* host_defined)
+{
+    auto filename = source_code->filename();
+    auto rust_compilation = RustIntegration::materialize_bytecode_cache_script(bytecode_cache, move(source_code), realm);
+    if (!rust_compilation.has_value())
+        return Vector<ParserError> {};
+    if (rust_compilation->is_error())
+        return rust_compilation->release_error();
+    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
+}
+
 Script::Script(Realm& realm, StringView filename, RustIntegration::ScriptResult&& result, HostDefined* host_defined)
     : m_realm(realm)
     , m_executable(result.executable)

--- a/Libraries/LibJS/Script.h
+++ b/Libraries/LibJS/Script.h
@@ -24,6 +24,7 @@ namespace FFI {
 
 struct ParsedProgram;
 struct CompiledProgram;
+struct DecodedBytecodeCacheBlob;
 
 }
 
@@ -56,6 +57,7 @@ public:
     static Result<GC::Ref<Script>, Vector<ParserError>> parse(StringView source_text, Realm&, StringView filename = {}, HostDefined* = nullptr, size_t line_number_offset = 1);
     static Result<GC::Ref<Script>, Vector<ParserError>> create_from_parsed(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm&, HostDefined* = nullptr);
     static Result<GC::Ref<Script>, Vector<ParserError>> create_from_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm&, HostDefined* = nullptr);
+    static Result<GC::Ref<Script>, Vector<ParserError>> create_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, HostDefined* = nullptr);
 
     Realm& realm() { return *m_realm; }
     Vector<LoadedModuleRequest>& loaded_modules() { return m_loaded_modules; }

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -106,6 +106,29 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_f
         module_result.executable.ptr(), module_result.tla_shared_data.ptr());
 }
 
+Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Script::HostDefined* host_defined)
+{
+    auto filename = source_code->filename();
+    auto rust_result = RustIntegration::materialize_bytecode_cache_module(bytecode_cache, move(source_code), realm);
+    // Always from the Rust pipeline, so the Optional must have a value.
+    VERIFY(rust_result.has_value());
+    if (rust_result->is_error())
+        return rust_result->release_error();
+    auto& module_result = rust_result->value();
+    Vector<FunctionToInitialize> functions_to_initialize;
+    functions_to_initialize.ensure_capacity(module_result.functions_to_initialize.size());
+    for (auto& f : module_result.functions_to_initialize)
+        functions_to_initialize.append({ *f.shared_data, move(f.name) });
+    return realm.heap().allocate<SourceTextModule>(
+        realm, filename, host_defined, module_result.has_top_level_await,
+        move(module_result.requested_modules), move(module_result.import_entries),
+        move(module_result.local_export_entries), move(module_result.indirect_export_entries),
+        move(module_result.star_export_entries), move(module_result.default_export_binding_name),
+        move(module_result.var_declared_names), move(module_result.lexical_bindings),
+        move(functions_to_initialize),
+        module_result.executable.ptr(), module_result.tla_shared_data.ptr());
+}
+
 // 16.2.1.7.1 ParseModule ( sourceText, realm, hostDefined ), https://tc39.es/ecma262/#sec-parsemodule
 Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(StringView source_text, Realm& realm, StringView filename, Script::HostDefined* host_defined)
 {

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -19,6 +19,7 @@ namespace FFI {
 
 struct ParsedProgram;
 struct CompiledProgram;
+struct DecodedBytecodeCacheBlob;
 
 }
 
@@ -33,6 +34,7 @@ public:
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse(StringView source_text, Realm&, StringView filename = {}, Script::HostDefined* host_defined = nullptr);
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_pre_parsed(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_pre_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
+    static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
 
     virtual Vector<Utf16FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
     virtual ResolvedBinding resolve_export(VM& vm, Utf16FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -53,6 +53,9 @@ public:
         i32 function_index { -1 }; // index into m_functions_to_initialize, -1 if not a function
     };
 
+    Bytecode::Executable* cached_executable() const { return m_executable; }
+    SharedFunctionInstanceData* top_level_await_shared_data() const { return m_tla_shared_data; }
+
 protected:
     virtual ThrowCompletionOr<void> initialize_environment(VM& vm) override;
     virtual ThrowCompletionOr<void> execute_module(VM& vm, GC::Ptr<PromiseCapability> capability) override;

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -66,10 +66,12 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
 
     m_internal_buffered_data = make<InternalBufferedData>();
 
-    on_headers_received = [this](auto headers, auto response_code, auto const& reason_phrase) {
+    on_headers_received = [this](auto headers, auto response_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key) {
         m_internal_buffered_data->response_headers = move(headers);
         m_internal_buffered_data->response_code = move(response_code);
         m_internal_buffered_data->reason_phrase = reason_phrase;
+        m_internal_buffered_data->javascript_bytecode = move(javascript_bytecode);
+        m_internal_buffered_data->javascript_bytecode_cache_vary_key = javascript_bytecode_cache_vary_key;
     };
 
     on_finish = [this, on_buffered_request_finished = move(on_buffered_request_finished)](auto total_size, auto& timing_info, auto network_error) {
@@ -83,6 +85,8 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
             m_internal_buffered_data->response_headers,
             m_internal_buffered_data->response_code,
             m_internal_buffered_data->reason_phrase,
+            move(m_internal_buffered_data->javascript_bytecode),
+            m_internal_buffered_data->javascript_bytecode_cache_vary_key,
             output_buffer);
     };
 
@@ -109,10 +113,10 @@ void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo
         on_finish(total_size, timing_info, network_error);
 }
 
-void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase)
+void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)
 {
     if (on_headers_received)
-        on_headers_received(move(response_headers), response_code, reason_phrase);
+        on_headers_received(move(response_headers), response_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
 }
 
 void Request::did_request_certificates(Badge<RequestClient>)

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -13,6 +13,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/Notifier.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/NetworkError.h>
@@ -60,13 +61,13 @@ public:
     int fd() const { return m_fd; }
     bool stop();
 
-    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, ReadonlyBytes payload)>;
+    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, ReadonlyBytes payload)>;
 
     // Configure the request such that the entirety of the response data is buffered. The callback receives that data and
     // the response headers all at once. Using this method is mutually exclusive with `set_unbuffered_data_received_callback`.
     void set_buffered_request_finished_callback(BufferedRequestFinished);
 
-    using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase)>;
+    using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using DataReceived = Function<void(ReadonlyBytes data)>;
     using RequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> network_error)>;
 
@@ -77,7 +78,7 @@ public:
     Function<CertificateAndKey()> on_certificate_requested;
 
     void did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error);
-    void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase);
+    void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key);
     void did_request_certificates(Badge<RequestClient>);
 
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
@@ -110,6 +111,8 @@ private:
         NonnullRefPtr<HTTP::HeaderList> response_headers;
         Optional<u32> response_code;
         Optional<String> reason_phrase;
+        Optional<Core::AnonymousBuffer> javascript_bytecode;
+        Optional<u64> javascript_bytecode_cache_vary_key;
     };
 
     struct InternalStreamData {

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -65,6 +65,21 @@ RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL 
     return request;
 }
 
+ErrorOr<bool> RequestClient::store_cache_associated_data(URL::URL const& url, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData associated_data, ReadonlyBytes data)
+{
+    auto buffer = TRY(Core::AnonymousBuffer::create_with_size(data.size()));
+    memcpy(buffer.data<void>(), data.data(), data.size());
+
+    auto headers = request_headers.map([](auto const& headers) { return headers.headers(); }).value_or({});
+    return IPCProxy::store_cache_associated_data(url, method, headers, associated_data, move(buffer));
+}
+
+ErrorOr<Optional<Core::AnonymousBuffer>> RequestClient::retrieve_cache_associated_data(URL::URL const& url, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData associated_data)
+{
+    auto headers = request_headers.map([](auto const& headers) { return headers.headers(); }).value_or({});
+    return IPCProxy::retrieve_cache_associated_data(url, method, headers, associated_data);
+}
+
 bool RequestClient::stop_request(Badge<Request>, Request& request)
 {
     if (!m_requests.contains(request.id()))

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -65,19 +65,19 @@ RefPtr<Request> RequestClient::start_request(ByteString const& method, URL::URL 
     return request;
 }
 
-ErrorOr<bool> RequestClient::store_cache_associated_data(URL::URL const& url, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData associated_data, ReadonlyBytes data)
+ErrorOr<bool> RequestClient::store_cache_associated_data(URL::URL const& url, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data, ReadonlyBytes data)
 {
     auto buffer = TRY(Core::AnonymousBuffer::create_with_size(data.size()));
     memcpy(buffer.data<void>(), data.data(), data.size());
 
     auto headers = request_headers.map([](auto const& headers) { return headers.headers(); }).value_or({});
-    return IPCProxy::store_cache_associated_data(url, method, headers, associated_data, move(buffer));
+    return IPCProxy::store_cache_associated_data(url, method, headers, vary_key, associated_data, move(buffer));
 }
 
-ErrorOr<Optional<Core::AnonymousBuffer>> RequestClient::retrieve_cache_associated_data(URL::URL const& url, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData associated_data)
+ErrorOr<Optional<Core::AnonymousBuffer>> RequestClient::retrieve_cache_associated_data(URL::URL const& url, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data)
 {
     auto headers = request_headers.map([](auto const& headers) { return headers.headers(); }).value_or({});
-    return IPCProxy::retrieve_cache_associated_data(url, method, headers, associated_data);
+    return IPCProxy::retrieve_cache_associated_data(url, method, headers, vary_key, associated_data);
 }
 
 bool RequestClient::stop_request(Badge<Request>, Request& request)
@@ -138,10 +138,10 @@ void RequestClient::request_finished(u64 request_id, u64 total_size, RequestTimi
     }
 }
 
-void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase)
+void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)
 {
     if (auto request = m_requests.get(request_id); request.has_value())
-        (*request)->did_receive_headers({}, HTTP::HeaderList::create(move(response_headers)), status_code, reason_phrase);
+        (*request)->did_receive_headers({}, HTTP::HeaderList::create(move(response_headers)), status_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
     else
         warnln("Received headers for non-existent request {}", request_id);
 }

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -44,8 +44,8 @@ public:
     RefPtr<WebSocket> websocket_connect(URL::URL const&, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HTTP::HeaderList const& request_headers);
 
     NonnullRefPtr<Core::Promise<CacheSizes>> estimate_cache_size_accessed_since(UnixDateTime since);
-    ErrorOr<bool> store_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData, ReadonlyBytes);
-    ErrorOr<Optional<Core::AnonymousBuffer>> retrieve_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData);
+    ErrorOr<bool> store_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData, ReadonlyBytes);
+    ErrorOr<Optional<Core::AnonymousBuffer>> retrieve_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData);
 
     Function<String(URL::URL const&)> on_retrieve_http_cookie;
     Function<void()> on_request_server_died;
@@ -55,7 +55,7 @@ private:
 
     virtual void request_started(u64 request_id, IPC::File) override;
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
-    virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>) override;
+    virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<Core::AnonymousBuffer>, Optional<u64>) override;
 
     virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url) override;
 

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -7,7 +7,9 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibHTTP/Cache/CacheMode.h>
+#include <LibHTTP/Cache/Utilities.h>
 #include <LibHTTP/Cookie/IncludeCredentials.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibIPC/ConnectionToServer.h>
@@ -42,6 +44,8 @@ public:
     RefPtr<WebSocket> websocket_connect(URL::URL const&, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HTTP::HeaderList const& request_headers);
 
     NonnullRefPtr<Core::Promise<CacheSizes>> estimate_cache_size_accessed_since(UnixDateTime since);
+    ErrorOr<bool> store_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData, ReadonlyBytes);
+    ErrorOr<Optional<Core::AnonymousBuffer>> retrieve_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, HTTP::CacheEntryAssociatedData);
 
     Function<String(URL::URL const&)> on_retrieve_http_cookie;
     Function<void()> on_request_server_died;

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2167,7 +2167,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
     // 13. Set up stream with byte reading support with pullAlgorithm set to pullAlgorithm, cancelAlgorithm set to cancelAlgorithm.
     stream->set_up_with_byte_reading_support(pull_algorithm, cancel_algorithm);
 
-    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase) {
+    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) {
         if (pending_response->is_resolved()) {
             // RequestServer will send us the response headers twice, the second time being for HTTP trailers. This
             // fetch algorithm is not interested in trailers, so just drop them here.
@@ -2179,6 +2179,8 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
 
         if (reason_phrase.has_value())
             response->set_status_message(reason_phrase->to_byte_string());
+        response->set_javascript_bytecode_cache(move(javascript_bytecode));
+        response->set_javascript_bytecode_cache_vary_key(javascript_bytecode_cache_vary_key);
 
         (void)request;
         if constexpr (WEB_FETCH_DEBUG) {

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -180,6 +180,8 @@ GC::Ref<Response> Response::clone(JS::Realm& realm) const
     new_response->set_request_includes_credentials(m_request_includes_credentials);
     new_response->set_timing_allow_passed(m_timing_allow_passed);
     new_response->set_body_info(m_body_info);
+    new_response->set_javascript_bytecode_cache(m_javascript_bytecode_cache);
+    new_response->set_javascript_bytecode_cache_vary_key(m_javascript_bytecode_cache_vary_key);
     // FIXME: service worker timing info
 
     // 3. If response’s body is non-null, then set newResponse’s body to the result of cloning response’s body.

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -12,6 +12,7 @@
 #include <AK/Optional.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibGC/Ptr.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibJS/Forward.h>
@@ -105,6 +106,11 @@ public:
     [[nodiscard]] virtual BodyInfo const& body_info() const { return m_body_info; }
     virtual void set_body_info(BodyInfo body_info) { m_body_info = move(body_info); }
 
+    [[nodiscard]] Optional<Core::AnonymousBuffer> const& javascript_bytecode_cache() const { return m_javascript_bytecode_cache; }
+    void set_javascript_bytecode_cache(Optional<Core::AnonymousBuffer> javascript_bytecode_cache) { m_javascript_bytecode_cache = move(javascript_bytecode_cache); }
+    [[nodiscard]] Optional<u64> javascript_bytecode_cache_vary_key() const { return m_javascript_bytecode_cache_vary_key; }
+    void set_javascript_bytecode_cache_vary_key(Optional<u64> javascript_bytecode_cache_vary_key) { m_javascript_bytecode_cache_vary_key = javascript_bytecode_cache_vary_key; }
+
     [[nodiscard]] RedirectTaint redirect_taint() const { return m_redirect_taint; }
     void set_redirect_taint(RedirectTaint redirect_taint) { m_redirect_taint = redirect_taint; }
 
@@ -195,6 +201,8 @@ private:
     MonotonicTime m_monotonic_response_time;
 
     Optional<String> m_network_error_message;
+    Optional<Core::AnonymousBuffer> m_javascript_bytecode_cache;
+    Optional<u64> m_javascript_bytecode_cache_vary_key;
 
 public:
     [[nodiscard]] ByteString const& method() const { return m_method; }

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -138,6 +138,39 @@ GC::Ref<ClassicScript> ClassicScript::create_from_pre_compiled(ByteString filena
     return script;
 }
 
+GC::Ref<ClassicScript> ClassicScript::create_from_bytecode_cache(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject& settings, URL::URL base_url, JS::FFI::DecodedBytecodeCacheBlob* bytecode_cache, MutedErrors muted_errors)
+{
+    auto& realm = settings.realm();
+    auto& vm = realm.vm();
+
+    if (muted_errors == MutedErrors::Yes)
+        base_url = URL::about_blank();
+
+    auto script = vm.heap().allocate<ClassicScript>(move(base_url), move(filename), settings);
+
+    script->m_muted_errors = muted_errors;
+    script->set_parse_error(JS::js_null());
+    script->set_error_to_rethrow(JS::js_null());
+
+    auto parse_timer = Core::ElapsedTimer::start_new();
+    auto result = JS::Script::create_from_bytecode_cache(bytecode_cache, move(source_code), realm, script);
+    dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Materialized cached bytecode {} in {}ms", script->filename(), parse_timer.elapsed_milliseconds());
+
+    if (result.is_error()) {
+        auto& parse_error = result.error().first();
+        dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Failed to materialize bytecode cache: {}", parse_error.to_string());
+
+        script->set_parse_error(JS::SyntaxError::create(realm, parse_error.to_string()));
+        script->set_error_to_rethrow(script->parse_error());
+
+        return script;
+    }
+
+    script->m_script_record = *result.release_value();
+
+    return script;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script
 JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, GC::Ptr<JS::Environment> lexical_environment_override)
 {

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -28,6 +28,7 @@ public:
     static GC::Ref<ClassicScript> create(ByteString filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No);
     static GC::Ref<ClassicScript> create_from_pre_parsed(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::ParsedProgram* parsed, MutedErrors = MutedErrors::No);
     static GC::Ref<ClassicScript> create_from_pre_compiled(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::CompiledProgram* compiled, MutedErrors = MutedErrors::No);
+    static GC::Ref<ClassicScript> create_from_bytecode_cache(ByteString filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::DecodedBytecodeCacheBlob*, MutedErrors = MutedErrors::No);
 
     JS::Script* script_record() { return m_script_record; }
     JS::Script const* script_record() const { return m_script_record; }

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/Utf16String.h>
 #include <LibCore/EventLoop.h>
+#include <LibCrypto/Hash/SHA2.h>
 #include <LibGC/Function.h>
 #include <LibGC/Root.h>
 #include <LibJS/Bytecode/Executable.h>

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -16,6 +16,7 @@
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/RustIntegration.h>
 #include <LibJS/SourceCode.h>
+#include <LibRequests/RequestClient.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibThreading/ThreadPool.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -38,6 +39,7 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 
 namespace Web::HTML {
@@ -46,6 +48,76 @@ struct OffThreadCompiledProgram {
     JS::FFI::ParsedProgram* parsed { nullptr };
     JS::FFI::CompiledProgram* compiled { nullptr };
 };
+
+struct BytecodeCacheContext {
+    URL::URL url;
+    ByteString method;
+    NonnullRefPtr<HTTP::HeaderList> request_headers;
+};
+
+static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::Infrastructure::Request const& request, URL::URL const& response_url)
+{
+    if (!Fetch::Infrastructure::is_http_or_https_scheme(response_url.scheme()))
+        return {};
+
+    if (!ResourceLoader::is_initialized() || !ResourceLoader::the().request_client())
+        return {};
+
+    return BytecodeCacheContext {
+        .url = response_url,
+        .method = request.method(),
+        .request_headers = HTTP::HeaderList::create(request.header_list()->headers()),
+    };
+}
+
+static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(JS::SourceCode const& source_code)
+{
+    return ::Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code.utf16_data()), source_code.length_in_code_units() * sizeof(u16));
+}
+
+// Schedule a fresh, fully off-thread compile of the script source for the sole purpose of producing a bytecode cache
+// blob to hand to RequestServer. The execution path has already received its (latency-trimmed) compile artifact and is
+// running, so this work happens entirely on a background thread and never blocks the main thread on cache generation.
+// Reparsing here is intentional: the execution-path compile only eagerly generates top-level bytecode plus direct
+// IIFEs, while the cache wants every nested function compiled so that warm loads avoid lazy compile work entirely.
+static void schedule_bytecode_cache_generation(JS::SourceCode const& original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context)
+{
+    auto filename = original_source_code.filename();
+    auto source_code = original_source_code.code();
+    auto event_loop_weak = Core::EventLoop::current_weak();
+
+    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, cache_context = move(cache_context), event_loop_weak = move(event_loop_weak)]() mutable {
+        auto source = JS::SourceCode::create(move(filename), move(source_code));
+        auto* parsed = JS::RustIntegration::parse_program(source->utf16_data(), source->length_in_code_units(), type, line_number_offset);
+        if (!parsed)
+            return;
+
+        if (JS::RustIntegration::parsed_program_has_errors(parsed)) {
+            JS::RustIntegration::free_parsed_program(parsed);
+            return;
+        }
+
+        auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(parsed, source->length_in_code_units());
+        if (!compiled)
+            return;
+
+        auto source_hash = bytecode_cache_source_hash(*source);
+        auto blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled, type, source_hash.bytes());
+        JS::RustIntegration::free_compiled_program(compiled);
+        if (blob.is_empty())
+            return;
+
+        auto origin = event_loop_weak->take();
+        if (!origin)
+            return;
+
+        origin->deferred_invoke([cache_context = move(cache_context), blob = move(blob)]() mutable {
+            if (!ResourceLoader::is_initialized() || !ResourceLoader::the().request_client())
+                return;
+            (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, blob.bytes());
+        });
+    });
+}
 
 static void compile_remaining_functions_off_thread(JS::Bytecode::Executable& executable, NonnullRefPtr<JS::SourceCode const> source_code)
 {
@@ -484,7 +556,7 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
     // 5. Fetch request with the following processResponseConsumeBody steps given response response and null, failure,
     //    or a byte sequence bodyBytes:
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
-    fetch_algorithms_input.process_response_consume_body = [&settings_object, options = move(options), character_encoding = move(character_encoding), on_complete = move(on_complete)](auto response, auto body_bytes) {
+    fetch_algorithms_input.process_response_consume_body = [request, &settings_object, options = move(options), character_encoding = move(character_encoding), on_complete = move(on_complete)](auto response, auto body_bytes) {
         // 1. Set response to response's unsafe response.
         response = response->unsafe_response();
 
@@ -527,12 +599,15 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
             auto source_code = JS::SourceCode::create(
                 String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
                 Utf16String::from_utf8(source_text));
+            auto bytecode_cache_context = bytecode_cache_context_for_request(*request, response_url);
 
             compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Script, 1,
                 [response_url = move(response_url), response_url_string = move(response_url_string),
+                    bytecode_cache_context = move(bytecode_cache_context),
                     muted_errors, on_complete_root = move(on_complete_root),
                     settings_root = move(settings_root)](auto result, auto source_code) mutable {
                     auto source_code_for_background_compile = source_code;
+                    auto source_code_for_cache = source_code;
                     auto script = result.compiled
                         ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
                         : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
@@ -541,6 +616,8 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                             compile_remaining_functions_off_thread(*executable, move(source_code_for_background_compile));
                     }
                     on_complete_root->function()(script);
+                    if (result.compiled && bytecode_cache_context.has_value())
+                        schedule_bytecode_cache_generation(*source_code_for_cache, JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value());
                 });
         } else {
             auto script = ClassicScript::create(response_url.to_byte_string(), source_text, settings_object, response_url, 1, muted_errors);
@@ -844,7 +921,7 @@ void fetch_single_module_script(JS::Realm& realm,
     // 13. If performFetch was given, run performFetch with request, isTopLevel, and with processResponseConsumeBody as defined below.
     //     Otherwise, fetch request with processResponseConsumeBody set to processResponseConsumeBody as defined below.
     //     In both cases, let processResponseConsumeBody given response response and null, failure, or a byte sequence bodyBytes be the following algorithm:
-    auto process_response_consume_body = [&module_map, url, module_type, &settings_object, on_complete](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
+    auto process_response_consume_body = [request, &module_map, url, module_type, &settings_object, on_complete](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
         // 1. If any of the following are true:
         //    - bodyBytes is null or failure; or
         //    - response's status is not an ok status,
@@ -894,13 +971,16 @@ void fetch_single_module_script(JS::Realm& realm,
                     auto source_code = JS::SourceCode::create(
                         String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
                         Utf16String::from_utf8(source_text));
+                    auto bytecode_cache_context = bytecode_cache_context_for_request(*request, response_url);
 
                     compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Module, 0,
                         [url = move(url), url_string = move(url_string), response_url = move(response_url),
                             module_type_string = move(module_type_string),
+                            bytecode_cache_context = move(bytecode_cache_context),
                             on_complete_root = move(on_complete_root),
                             settings_root = move(settings_root)](auto result, auto source_code) mutable {
                             auto source_code_for_background_compile = source_code;
+                            auto source_code_for_cache = source_code;
                             auto module_script = result.compiled
                                 ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
                                 : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
@@ -908,6 +988,8 @@ void fetch_single_module_script(JS::Realm& realm,
                                 compile_remaining_module_functions_off_thread(*module_script, move(source_code_for_background_compile));
                             settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
                             on_complete_root->function()(module_script);
+                            if (result.compiled && bytecode_cache_context.has_value())
+                                schedule_bytecode_cache_generation(*source_code_for_cache, JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value());
                         });
                     return;
                 }

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -53,9 +53,15 @@ struct BytecodeCacheContext {
     URL::URL url;
     ByteString method;
     NonnullRefPtr<HTTP::HeaderList> request_headers;
+    u64 vary_key { 0 };
 };
 
-static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::Infrastructure::Request const& request, URL::URL const& response_url)
+static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(JS::SourceCode const& source_code)
+{
+    return ::Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code.utf16_data()), source_code.length_in_code_units() * sizeof(u16));
+}
+
+static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::Infrastructure::Request const& request, Fetch::Infrastructure::Response const& response, URL::URL const& response_url)
 {
     if (!Fetch::Infrastructure::is_http_or_https_scheme(response_url.scheme()))
         return {};
@@ -63,16 +69,16 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
     if (!ResourceLoader::is_initialized() || !ResourceLoader::the().request_client())
         return {};
 
+    auto vary_key = response.javascript_bytecode_cache_vary_key();
+    if (!vary_key.has_value())
+        return {};
+
     return BytecodeCacheContext {
         .url = response_url,
         .method = request.method(),
         .request_headers = HTTP::HeaderList::create(request.header_list()->headers()),
+        .vary_key = *vary_key,
     };
-}
-
-static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(JS::SourceCode const& source_code)
-{
-    return ::Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code.utf16_data()), source_code.length_in_code_units() * sizeof(u16));
 }
 
 // Schedule a fresh, fully off-thread compile of the script source for the sole purpose of producing a bytecode cache
@@ -114,7 +120,7 @@ static void schedule_bytecode_cache_generation(JS::SourceCode const& original_so
         origin->deferred_invoke([cache_context = move(cache_context), blob = move(blob)]() mutable {
             if (!ResourceLoader::is_initialized() || !ResourceLoader::the().request_client())
                 return;
-            (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, blob.bytes());
+            (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, cache_context.vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, blob.bytes());
         });
     });
 }
@@ -599,7 +605,22 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
             auto source_code = JS::SourceCode::create(
                 String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
                 Utf16String::from_utf8(source_text));
-            auto bytecode_cache_context = bytecode_cache_context_for_request(*request, response_url);
+            auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *response, response_url);
+            // Warm-cache fast path: a sidecar arrived with the response, decode it, and try to materialize a script
+            // straight from the cached bytecode without parsing or compiling. Pass non-moved source_code / response_url
+            // so the fallback compile path below can reuse them if decode or materialization is rejected.
+            if (auto const& bytecode = response->javascript_bytecode_cache(); bytecode.has_value()) {
+                auto source_hash = bytecode_cache_source_hash(*source_code);
+                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(bytecode->bytes(), JS::RustIntegration::ProgramType::Script, source_hash.bytes())) {
+                    auto script = ClassicScript::create_from_bytecode_cache(response_url_string, source_code, settings_object, response_url, bytecode_cache, muted_errors);
+                    // Bytecode validation runs during materialization and may reject a structurally valid blob whose
+                    // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
+                    if (script->parse_error().is_null()) {
+                        on_complete->function()(script);
+                        return;
+                    }
+                }
+            }
 
             compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Script, 1,
                 [response_url = move(response_url), response_url_string = move(response_url_string),
@@ -922,6 +943,8 @@ void fetch_single_module_script(JS::Realm& realm,
     //     Otherwise, fetch request with processResponseConsumeBody set to processResponseConsumeBody as defined below.
     //     In both cases, let processResponseConsumeBody given response response and null, failure, or a byte sequence bodyBytes be the following algorithm:
     auto process_response_consume_body = [request, &module_map, url, module_type, &settings_object, on_complete](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes) {
+        auto internal_response = response->unsafe_response();
+
         // 1. If any of the following are true:
         //    - bodyBytes is null or failure; or
         //    - response's status is not an ok status,
@@ -971,7 +994,18 @@ void fetch_single_module_script(JS::Realm& realm,
                     auto source_code = JS::SourceCode::create(
                         String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
                         Utf16String::from_utf8(source_text));
-                    auto bytecode_cache_context = bytecode_cache_context_for_request(*request, response_url);
+                    auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
+                    if (auto const& bytecode = internal_response->javascript_bytecode_cache(); bytecode.has_value()) {
+                        auto source_hash = bytecode_cache_source_hash(*source_code);
+                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(bytecode->bytes(), JS::RustIntegration::ProgramType::Module, source_hash.bytes())) {
+                            auto module_script = ModuleScript::create_from_bytecode_cache(url_string, source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
+                            if (module_script && module_script->parse_error().is_null()) {
+                                settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
+                                on_complete->function()(module_script);
+                                return;
+                            }
+                        }
+                    }
 
                     compile_off_thread(move(source_code), JS::RustIntegration::ProgramType::Module, 0,
                         [url = move(url), url_string = move(url_string), response_url = move(response_url),

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -10,7 +10,9 @@
 #include <LibCore/EventLoop.h>
 #include <LibGC/Function.h>
 #include <LibGC/Root.h>
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/ModuleRequest.h>
+#include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/RustIntegration.h>
 #include <LibJS/SourceCode.h>
 #include <LibTextCodec/Decoder.h>
@@ -43,6 +45,87 @@ struct OffThreadCompiledProgram {
     JS::FFI::ParsedProgram* parsed { nullptr };
     JS::FFI::CompiledProgram* compiled { nullptr };
 };
+
+static void compile_remaining_functions_off_thread(JS::Bytecode::Executable& executable, NonnullRefPtr<JS::SourceCode const> source_code)
+{
+    Vector<GC::Root<JS::SharedFunctionInstanceData>> shared_data_roots;
+    Vector<void*> function_asts;
+
+    for (auto& shared_data : executable.shared_function_data) {
+        if (!shared_data || shared_data->m_executable || !shared_data->m_rust_function_ast)
+            continue;
+
+        auto* cloned_ast = JS::RustIntegration::clone_function_ast(shared_data->m_rust_function_ast);
+        if (!cloned_ast)
+            continue;
+
+        shared_data_roots.append(GC::make_root(*shared_data));
+        function_asts.append(cloned_ast);
+    }
+
+    if (function_asts.is_empty())
+        return;
+
+    auto length = source_code->length_in_code_units();
+    auto* callback = new Function<void(Vector<JS::FFI::CompiledFunction*>)>(
+        [shared_data_roots = move(shared_data_roots), source_code = move(source_code)](Vector<JS::FFI::CompiledFunction*> compiled_functions) mutable {
+            VERIFY(compiled_functions.size() == shared_data_roots.size());
+            auto& vm = Bindings::main_thread_vm();
+            for (size_t i = 0; i < compiled_functions.size(); ++i) {
+                auto* compiled_function = compiled_functions[i];
+                if (!compiled_function)
+                    continue;
+
+                auto& shared_data = *shared_data_roots[i];
+                if (shared_data.m_executable) {
+                    compile_remaining_functions_off_thread(*shared_data.m_executable, source_code);
+                    JS::RustIntegration::free_compiled_function(compiled_function);
+                    continue;
+                }
+
+                JS::RustIntegration::materialize_compiled_function(compiled_function, vm, *source_code, shared_data);
+            }
+        });
+
+    auto event_loop_weak = Core::EventLoop::current_weak();
+
+    Threading::ThreadPool::the().submit([function_asts = move(function_asts), length,
+                                            callback,
+                                            event_loop_weak = move(event_loop_weak)]() mutable {
+        Vector<JS::FFI::CompiledFunction*> compiled_functions;
+        compiled_functions.ensure_capacity(function_asts.size());
+        for (auto* function_ast : function_asts)
+            compiled_functions.append(JS::RustIntegration::compile_function_off_thread(function_ast, length, false));
+
+        auto origin = event_loop_weak->take();
+        if (!origin)
+            return;
+        origin->deferred_invoke([compiled_functions = move(compiled_functions), callback]() mutable {
+            (*callback)(move(compiled_functions));
+            delete callback;
+        });
+    });
+}
+
+static void compile_remaining_module_functions_off_thread(ModuleScript& module_script, NonnullRefPtr<JS::SourceCode const> source_code)
+{
+    module_script.record().visit(
+        [](Empty) {},
+        [](GC::Ref<JS::SyntheticModule>) {},
+        [](GC::Ref<WebAssembly::WebAssemblyModule>) {},
+        [source_code = move(source_code)](GC::Ref<JS::SourceTextModule> module) mutable {
+            if (auto* executable = module->cached_executable()) {
+                compile_remaining_functions_off_thread(*executable, source_code);
+                return;
+            }
+
+            auto* top_level_await_shared_data = module->top_level_await_shared_data();
+            if (!top_level_await_shared_data || !top_level_await_shared_data->m_executable)
+                return;
+
+            compile_remaining_functions_off_thread(*top_level_await_shared_data->m_executable, source_code);
+        });
+}
 
 // Submit parsing and top-level bytecode generation to the thread pool, then bounce back to the main thread via
 // deferred_invoke once the worker is done. Syntax errors still come back as a ParsedProgram so the main thread can
@@ -448,9 +531,14 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                 [response_url = move(response_url), response_url_string = move(response_url_string),
                     muted_errors, on_complete_root = move(on_complete_root),
                     settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                    auto source_code_for_background_compile = source_code;
                     auto script = result.compiled
                         ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
                         : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
+                    if (auto* script_record = script->script_record()) {
+                        if (auto* executable = script_record->cached_executable())
+                            compile_remaining_functions_off_thread(*executable, move(source_code_for_background_compile));
+                    }
                     on_complete_root->function()(script);
                 });
         } else {
@@ -811,9 +899,12 @@ void fetch_single_module_script(JS::Realm& realm,
                             module_type_string = move(module_type_string),
                             on_complete_root = move(on_complete_root),
                             settings_root = move(settings_root)](auto result, auto source_code) mutable {
+                            auto source_code_for_background_compile = source_code;
                             auto module_script = result.compiled
                                 ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
                                 : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
+                            if (module_script)
+                                compile_remaining_module_functions_off_thread(*module_script, move(source_code_for_background_compile));
                             settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
                             on_complete_root->function()(module_script);
                         });

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -111,6 +111,27 @@ WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_pre_compile
     return script;
 }
 
+WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_from_bytecode_cache(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject& settings, URL::URL base_url, JS::FFI::DecodedBytecodeCacheBlob* bytecode_cache)
+{
+    auto& realm = settings.realm();
+    auto script = realm.create<ModuleScript>(move(base_url), filename, settings);
+
+    script->set_parse_error(JS::js_null());
+    script->set_error_to_rethrow(JS::js_null());
+
+    auto result = JS::SourceTextModule::parse_from_bytecode_cache(bytecode_cache, move(source_code), realm, script);
+
+    if (result.is_error()) {
+        auto& parse_error = result.error().first();
+        dbgln("JavaScriptModuleScript: Failed to materialize bytecode cache: {}", parse_error.to_string());
+        script->set_parse_error(JS::SyntaxError::create(realm, parse_error.to_string()));
+        return script;
+    }
+
+    script->m_record = result.value();
+    return script;
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-css-module-script
 WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> ModuleScript::create_a_css_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject& settings)
 {

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -16,6 +16,7 @@ namespace JS::FFI {
 
 struct ParsedProgram;
 struct CompiledProgram;
+struct DecodedBytecodeCacheBlob;
 
 }
 
@@ -34,6 +35,7 @@ public:
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create(ByteString const& filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_pre_parsed(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::ParsedProgram* parsed);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_pre_compiled(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::CompiledProgram* compiled);
+    static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_from_bytecode_cache(ByteString const& filename, NonnullRefPtr<JS::SourceCode const> source_code, EnvironmentSettingsObject&, URL::URL base_url, JS::FFI::DecodedBytecodeCacheBlob*);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_javascript_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_css_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&);
     static WebIDL::ExceptionOr<GC::Ptr<ModuleScript>> create_a_json_module_script(ByteString const& filename, StringView source, EnvironmentSettingsObject&);

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -368,7 +368,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete = move(on_complete), request](ReadonlyBytes data, Requests::RequestTimingInfo const& timing_info, HTTP::HeaderList const& response_headers) {
                 log_success(request);
-                on_headers_received->function()(response_headers, {}, {});
+                on_headers_received->function()(response_headers, {}, {}, {}, {});
                 on_data_received->function()(data);
                 on_complete->function()(true, timing_info, {});
             });
@@ -379,7 +379,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         handle_resource_load_request(
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
-                on_headers_received->function()(load_result.response_headers, {}, {});
+                on_headers_received->function()(load_result.response_headers, {}, {}, {}, {});
                 on_data_received->function()(load_result.data);
                 on_complete->function()(true, load_result.timing_info, {});
             },
@@ -395,7 +395,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [request, on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
                 log_success(request);
-                on_headers_received->function()(load_result.response_headers, {}, {});
+                on_headers_received->function()(load_result.response_headers, {}, {}, {}, {});
                 on_data_received->function()(load_result.data);
                 on_complete->function()(true, load_result.timing_info, {});
             },
@@ -420,13 +420,13 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         return nullptr;
     }
 
-    auto protocol_headers_received = [this, on_headers_received = move(on_headers_received), request, request_id = protocol_request->id()](auto const& response_headers, auto status_code, auto const& reason_phrase) {
+    auto protocol_headers_received = [this, on_headers_received = move(on_headers_received), request, request_id = protocol_request->id()](auto const& response_headers, auto status_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key) {
         handle_network_response_headers(request, response_headers);
 
         if (auto page = request.page())
             page->client().page_did_receive_network_response_headers(request_id, status_code.value_or(0), reason_phrase, response_headers->headers());
 
-        on_headers_received->function()(response_headers, move(status_code), reason_phrase);
+        on_headers_received->function()(response_headers, move(status_code), reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
     };
 
     auto protocol_data_received = [on_data_received = move(on_data_received), request, request_id = protocol_request->id()](auto data) {

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -10,6 +10,7 @@
 #include <AK/ByteString.h>
 #include <AK/Function.h>
 #include <AK/HashTable.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/EventReceiver.h>
 #include <LibGC/Function.h>
 #include <LibHTTP/HeaderList.h>
@@ -31,7 +32,7 @@ public:
 
     void set_client(NonnullRefPtr<Requests::RequestClient>);
 
-    using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase)>;
+    using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using OnDataReceived = GC::Function<void(ReadonlyBytes data)>;
     using OnComplete = GC::Function<void(bool success, Requests::RequestTimingInfo const& timing_info, Optional<StringView> error_message)>;
 

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -304,7 +304,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
     m_request = Application::request_server_client().start_request("GET"sv, *url);
 
     m_request->set_buffered_request_finished_callback(
-        [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, ReadonlyBytes payload) {
+        [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, ReadonlyBytes payload) {
             Core::deferred_invoke([this]() { m_request.clear(); });
 
             if (m_query != query) {

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -42,7 +42,7 @@ void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
     auto request_id = next_request_id++;
 
     request->set_buffered_request_finished_callback(
-        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, ReadonlyBytes payload) {
+        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, ReadonlyBytes payload) {
             Core::deferred_invoke([this, request_id]() { m_requests.remove(request_id); });
 
             if (network_error.has_value()) {

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -454,6 +454,43 @@ void ConnectionFromClient::remove_cache_entries_accessed_since(UnixDateTime sinc
         m_disk_cache->remove_entries_accessed_since(since);
 }
 
+Messages::RequestServer::StoreCacheAssociatedDataResponse ConnectionFromClient::store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data)
+{
+    if (!m_disk_cache.has_value() || !data.is_valid())
+        return false;
+
+    auto result = m_disk_cache->store_associated_data(url, method, *HTTP::HeaderList::create(move(request_headers)), associated_data, data.bytes());
+    if (result.is_error()) {
+        dbgln("Failed to store cache associated data for {}: {}", url, result.error());
+        return false;
+    }
+
+    return result.value();
+}
+
+Messages::RequestServer::RetrieveCacheAssociatedDataResponse ConnectionFromClient::retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data)
+{
+    if (!m_disk_cache.has_value())
+        return Optional<Core::AnonymousBuffer> {};
+
+    auto data = m_disk_cache->retrieve_associated_data(url, method, *HTTP::HeaderList::create(move(request_headers)), associated_data);
+    if (data.is_error()) {
+        dbgln("Failed to retrieve cache associated data for {}: {}", url, data.error());
+        return Optional<Core::AnonymousBuffer> {};
+    }
+    if (!data.value().has_value())
+        return Optional<Core::AnonymousBuffer> {};
+
+    auto buffer = Core::AnonymousBuffer::create_with_size(data.value()->size());
+    if (buffer.is_error()) {
+        dbgln("Failed to allocate cache associated data buffer for {}: {}", url, buffer.error());
+        return Optional<Core::AnonymousBuffer> {};
+    }
+
+    memcpy(buffer.value().data<void>(), data.value()->data(), data.value()->size());
+    return Optional<Core::AnonymousBuffer> { buffer.release_value() };
+}
+
 void ConnectionFromClient::websocket_connect(u64 websocket_id, URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, Vector<HTTP::Header> additional_request_headers)
 {
     auto host = url.serialized_host().to_byte_string();

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -454,12 +454,12 @@ void ConnectionFromClient::remove_cache_entries_accessed_since(UnixDateTime sinc
         m_disk_cache->remove_entries_accessed_since(since);
 }
 
-Messages::RequestServer::StoreCacheAssociatedDataResponse ConnectionFromClient::store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data)
+Messages::RequestServer::StoreCacheAssociatedDataResponse ConnectionFromClient::store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data)
 {
     if (!m_disk_cache.has_value() || !data.is_valid())
         return false;
 
-    auto result = m_disk_cache->store_associated_data(url, method, *HTTP::HeaderList::create(move(request_headers)), associated_data, data.bytes());
+    auto result = m_disk_cache->store_associated_data(url, method, *HTTP::HeaderList::create(move(request_headers)), vary_key, associated_data, data.bytes());
     if (result.is_error()) {
         dbgln("Failed to store cache associated data for {}: {}", url, result.error());
         return false;
@@ -468,12 +468,12 @@ Messages::RequestServer::StoreCacheAssociatedDataResponse ConnectionFromClient::
     return result.value();
 }
 
-Messages::RequestServer::RetrieveCacheAssociatedDataResponse ConnectionFromClient::retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data)
+Messages::RequestServer::RetrieveCacheAssociatedDataResponse ConnectionFromClient::retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data)
 {
     if (!m_disk_cache.has_value())
         return Optional<Core::AnonymousBuffer> {};
 
-    auto data = m_disk_cache->retrieve_associated_data(url, method, *HTTP::HeaderList::create(move(request_headers)), associated_data);
+    auto data = m_disk_cache->retrieve_associated_data(url, method, *HTTP::HeaderList::create(move(request_headers)), vary_key, associated_data);
     if (data.is_error()) {
         dbgln("Failed to retrieve cache associated data for {}: {}", url, data.error());
         return Optional<Core::AnonymousBuffer> {};

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -10,8 +10,10 @@
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/Time.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibHTTP/Cache/CacheMode.h>
 #include <LibHTTP/Cache/DiskCacheSettings.h>
+#include <LibHTTP/Cache/Utilities.h>
 #include <LibHTTP/Forward.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibRequests/WebSocket.h>
@@ -64,6 +66,8 @@ private:
 
     virtual void estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) override;
     virtual void remove_cache_entries_accessed_since(UnixDateTime since) override;
+    virtual Messages::RequestServer::StoreCacheAssociatedDataResponse store_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData, Core::AnonymousBuffer) override;
+    virtual Messages::RequestServer::RetrieveCacheAssociatedDataResponse retrieve_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData) override;
 
     virtual void websocket_connect(u64 websocket_id, URL::URL, ByteString, Vector<ByteString>, Vector<ByteString>, Vector<HTTP::Header>) override;
     virtual void websocket_send(u64 websocket_id, bool, ByteBuffer) override;

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -66,8 +66,8 @@ private:
 
     virtual void estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) override;
     virtual void remove_cache_entries_accessed_since(UnixDateTime since) override;
-    virtual Messages::RequestServer::StoreCacheAssociatedDataResponse store_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData, Core::AnonymousBuffer) override;
-    virtual Messages::RequestServer::RetrieveCacheAssociatedDataResponse retrieve_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData) override;
+    virtual Messages::RequestServer::StoreCacheAssociatedDataResponse store_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData, Core::AnonymousBuffer) override;
+    virtual Messages::RequestServer::RetrieveCacheAssociatedDataResponse retrieve_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData) override;
 
     virtual void websocket_connect(u64 websocket_id, URL::URL, ByteString, Vector<ByteString>, Vector<ByteString>, Vector<HTTP::Header>) override;
     virtual void websocket_send(u64 websocket_id, bool, ByteBuffer) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -1007,7 +1007,20 @@ void Request::handle_complete_state()
         auto timing_info = acquire_timing_info();
         transfer_headers_to_client_if_needed();
 
+        // Finalize the disk cache entry before notifying WebContent that the request is complete: WebContent may
+        // immediately fire off a JavaScript bytecode cache store against this entry, and that store needs the cache
+        // index row to already exist. If we notified first the store would race the index write and be rejected.
+        if (m_cache_entry_writer.has_value()) {
+            (void)m_cache_entry_writer->flush(m_request_headers, m_response_headers);
+            m_cache_entry_writer.clear();
+        }
+
         m_client.async_request_finished(m_request_id, m_bytes_transferred_to_client, timing_info, m_network_error);
+    }
+
+    if (m_cache_entry_writer.has_value()) {
+        (void)m_cache_entry_writer->flush(m_request_headers, m_response_headers);
+        m_cache_entry_writer.clear();
     }
 
     m_client.request_complete({}, *this);

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/GenericShorthands.h>
 #include <AK/HashMap.h>
+#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/Notifier.h>
@@ -1167,7 +1168,24 @@ void Request::transfer_headers_to_client_if_needed()
         }
     }
 
-    m_client.async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase);
+    Optional<Core::AnonymousBuffer> javascript_bytecode;
+    Optional<u64> javascript_bytecode_cache_vary_key;
+    if (m_cache_status == CacheStatus::ReadFromCache && m_disk_cache.has_value()) {
+        VERIFY(m_cache_entry_reader.has_value());
+        javascript_bytecode_cache_vary_key = m_cache_entry_reader->vary_key();
+        auto data = m_disk_cache->retrieve_associated_data(m_url, m_method, *m_request_headers, javascript_bytecode_cache_vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode);
+        if (!data.is_error() && data.value().has_value()) {
+            auto buffer = Core::AnonymousBuffer::create_with_size(data.value()->size());
+            if (!buffer.is_error()) {
+                memcpy(buffer.value().data<void>(), data.value()->data(), data.value()->size());
+                javascript_bytecode = buffer.release_value();
+            }
+        }
+    } else if (m_cache_status == CacheStatus::WrittenToCache && m_cache_entry_writer.has_value()) {
+        javascript_bytecode_cache_vary_key = m_cache_entry_writer->vary_key();
+    }
+
+    m_client.async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
 }
 
 ErrorOr<void> Request::write_queued_bytes_without_blocking()

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -1,3 +1,4 @@
+#include <LibCore/AnonymousBuffer.h>
 #include <LibHTTP/Header.h>
 #include <LibRequests/CacheSizes.h>
 #include <LibRequests/NetworkError.h>
@@ -9,7 +10,7 @@ endpoint RequestClient
 {
     request_started(u64 request_id, IPC::File fd) =|
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
-    headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase) =|
+    headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) =|
 
     retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url) =|
 

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -35,8 +35,8 @@ endpoint RequestServer
 
     estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) =|
     remove_cache_entries_accessed_since(UnixDateTime since) =|
-    store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data) => (bool stored)
-    retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data) => (Optional<Core::AnonymousBuffer> data)
+    store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data) => (bool stored)
+    retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data) => (Optional<Core::AnonymousBuffer> data)
 
     // Websocket Connection API
     websocket_connect(u64 websocket_id, URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, Vector<HTTP::Header> additional_request_headers) =|

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -1,6 +1,8 @@
+#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/Proxy.h>
 #include <LibHTTP/Cache/CacheMode.h>
 #include <LibHTTP/Cache/DiskCacheSettings.h>
+#include <LibHTTP/Cache/Utilities.h>
 #include <LibHTTP/Cookie/IncludeCredentials.h>
 #include <LibHTTP/Header.h>
 #include <LibIPC/TransportHandle.h>
@@ -33,6 +35,8 @@ endpoint RequestServer
 
     estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) =|
     remove_cache_entries_accessed_since(UnixDateTime since) =|
+    store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data) => (bool stored)
+    retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, HTTP::CacheEntryAssociatedData associated_data) => (Optional<Core::AnonymousBuffer> data)
 
     // Websocket Connection API
     websocket_connect(u64 websocket_id, URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, Vector<HTTP::Header> additional_request_headers) =|

--- a/Tests/LibHTTP/CMakeLists.txt
+++ b/Tests/LibHTTP/CMakeLists.txt
@@ -8,3 +8,4 @@ foreach(source IN LISTS TEST_SOURCES)
 endforeach()
 
 ladybird_test("TestCacheIndex.cpp" LibWeb LIBS LibHTTP LibDatabase)
+ladybird_test("TestDiskCache.cpp" LibWeb LIBS LibHTTP LibURL)

--- a/Tests/LibHTTP/TestCacheIndex.cpp
+++ b/Tests/LibHTTP/TestCacheIndex.cpp
@@ -112,3 +112,29 @@ TEST_CASE(remove_entries_exceeding_cache_limit_tolerates_replaced_unloaded_entri
     EXPECT_EQ(removed_entries.size(), 0u);
     EXPECT_EQ(reloaded_index.estimate_cache_size_accessed_since(UnixDateTime::earliest()).total, 80u);
 }
+
+TEST_CASE(associated_data_counts_toward_cache_size)
+{
+    auto state = create_cache_index();
+
+    auto request_headers = HTTP::HeaderList::create();
+    auto response_headers = HTTP::HeaderList::create();
+    auto vary_key = HTTP::create_vary_key(*request_headers, *response_headers);
+    auto now = UnixDateTime::now();
+
+    state.index.set_maximum_disk_cache_size(80);
+
+    for (u64 cache_key = 1; cache_key <= 5; ++cache_key)
+        TRY_OR_FAIL(state.index.create_entry(cache_key, vary_key, "https://example.com/script.js"_string, request_headers, response_headers, 10, now, now));
+    state.index.update_associated_data_size(1, vary_key, 50);
+
+    EXPECT_EQ(state.index.estimate_cache_size_accessed_since(UnixDateTime::earliest()).total, 100u);
+
+    Vector<u64> removed_entries;
+    state.index.remove_entries_exceeding_cache_limit([&](auto removed_cache_key, auto) {
+        removed_entries.append(removed_cache_key);
+    });
+
+    EXPECT(removed_entries.size() > 0);
+    EXPECT(state.index.estimate_cache_size_accessed_since(UnixDateTime::earliest()).total <= 80u);
+}

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <LibHTTP/Cache/CacheRequest.h>
+#include <LibHTTP/Cache/DiskCache.h>
+#include <LibHTTP/Cache/Utilities.h>
+#include <LibHTTP/HeaderList.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+
+struct TestCacheRequest final : public HTTP::CacheRequest {
+    virtual bool is_revalidation_request() const override { return false; }
+    virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override { }
+};
+
+static URL::URL parse_url(StringView url)
+{
+    return URL::Parser::basic_parse(url).release_value();
+}
+
+static NonnullRefPtr<HTTP::HeaderList> create_cacheable_request_headers()
+{
+    return HTTP::HeaderList::create({
+        { HTTP::TEST_CACHE_ENABLED_HEADER, "1"sv },
+    });
+}
+
+static NonnullRefPtr<HTTP::HeaderList> create_cacheable_response_headers()
+{
+    return HTTP::HeaderList::create({
+        { "Cache-Control"sv, "max-age=60"sv },
+    });
+}
+
+static HTTP::CacheEntryWriter& create_cache_entry(HTTP::DiskCache& disk_cache, TestCacheRequest& request, URL::URL const& url, HTTP::HeaderList const& request_headers)
+{
+    Optional<HTTP::CacheEntryWriter&> writer;
+
+    disk_cache.create_entry(request, url, "GET"sv, request_headers, UnixDateTime::now())
+        .visit(
+            [&](Optional<HTTP::CacheEntryWriter&> cache_entry_writer) {
+                writer = cache_entry_writer;
+            },
+            [](HTTP::DiskCache::CacheHasOpenEntry) {
+                FAIL("Cache entry was unexpectedly open");
+            });
+
+    VERIFY(writer.has_value());
+    return *writer;
+}
+
+TEST_CASE(associated_data_round_trips_with_cache_entry)
+{
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    TestCacheRequest request;
+
+    auto url = parse_url("https://example.com/script.js"sv);
+    auto request_headers = create_cacheable_request_headers();
+    auto response_headers = create_cacheable_response_headers();
+
+    auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+    TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+    TRY_OR_FAIL(writer.write_data("console.log('hello');"sv.bytes()));
+    TRY_OR_FAIL(writer.flush(request_headers, response_headers));
+
+    auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("bytecode"sv.bytes()));
+    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    VERIFY(retrieved_bytecode.has_value());
+    EXPECT_EQ(retrieved_bytecode->bytes(), bytecode.bytes());
+
+    disk_cache.remove_entries_accessed_since(UnixDateTime::earliest());
+
+    retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    EXPECT(!retrieved_bytecode.has_value());
+}
+
+TEST_CASE(replacing_cache_entry_removes_associated_data)
+{
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    TestCacheRequest request;
+
+    auto url = parse_url("https://example.com/script.js"sv);
+    auto request_headers = create_cacheable_request_headers();
+    auto response_headers = create_cacheable_response_headers();
+
+    auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+    TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+    TRY_OR_FAIL(writer.write_data("console.log('old');"sv.bytes()));
+    TRY_OR_FAIL(writer.flush(request_headers, response_headers));
+
+    auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("bytecode"sv.bytes()));
+    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    VERIFY(retrieved_bytecode.has_value());
+
+    auto replacement_request_headers = create_cacheable_request_headers();
+    auto replacement_response_headers = create_cacheable_response_headers();
+    auto& replacement_writer = create_cache_entry(disk_cache, request, url, *replacement_request_headers);
+    TRY_OR_FAIL(replacement_writer.write_status_and_reason(200, "OK"_string, *replacement_request_headers, *replacement_response_headers));
+    TRY_OR_FAIL(replacement_writer.write_data("console.log('new');"sv.bytes()));
+    TRY_OR_FAIL(replacement_writer.flush(replacement_request_headers, replacement_response_headers));
+
+    retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    EXPECT(!retrieved_bytecode.has_value());
+}
+
+TEST_CASE(associated_data_participates_in_cache_eviction)
+{
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    TestCacheRequest request;
+
+    auto url = parse_url("https://example.com/script.js"sv);
+    auto request_headers = create_cacheable_request_headers();
+    auto response_headers = create_cacheable_response_headers();
+
+    auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+    TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+    TRY_OR_FAIL(writer.write_data("console.log('hello');"sv.bytes()));
+    TRY_OR_FAIL(writer.flush(request_headers, response_headers));
+
+    disk_cache.set_maximum_disk_cache_size(80);
+    auto bytecode = TRY_OR_FAIL(ByteBuffer::create_zeroed(100));
+    EXPECT(!TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    EXPECT(!retrieved_bytecode.has_value());
+}

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -68,15 +68,15 @@ TEST_CASE(associated_data_round_trips_with_cache_entry)
     TRY_OR_FAIL(writer.flush(request_headers, response_headers));
 
     auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("bytecode"sv.bytes()));
-    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
 
-    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     VERIFY(retrieved_bytecode.has_value());
     EXPECT_EQ(retrieved_bytecode->bytes(), bytecode.bytes());
 
     disk_cache.remove_entries_accessed_since(UnixDateTime::earliest());
 
-    retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     EXPECT(!retrieved_bytecode.has_value());
 }
 
@@ -95,9 +95,9 @@ TEST_CASE(replacing_cache_entry_removes_associated_data)
     TRY_OR_FAIL(writer.flush(request_headers, response_headers));
 
     auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("bytecode"sv.bytes()));
-    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
 
-    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     VERIFY(retrieved_bytecode.has_value());
 
     auto replacement_request_headers = create_cacheable_request_headers();
@@ -107,8 +107,39 @@ TEST_CASE(replacing_cache_entry_removes_associated_data)
     TRY_OR_FAIL(replacement_writer.write_data("console.log('new');"sv.bytes()));
     TRY_OR_FAIL(replacement_writer.flush(replacement_request_headers, replacement_response_headers));
 
-    retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     EXPECT(!retrieved_bytecode.has_value());
+}
+
+TEST_CASE(associated_data_round_trips_with_explicit_vary_key)
+{
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    TestCacheRequest request;
+
+    auto url = parse_url("https://example.com/script.js"sv);
+    auto request_headers = HTTP::HeaderList::create({
+        { HTTP::TEST_CACHE_ENABLED_HEADER, "1"sv },
+        { "Origin"sv, "https://origin.example"sv },
+    });
+    auto mismatched_request_headers = create_cacheable_request_headers();
+    auto response_headers = HTTP::HeaderList::create({
+        { "Cache-Control"sv, "max-age=60"sv },
+        { "Vary"sv, "Origin"sv },
+    });
+    auto vary_key = HTTP::create_vary_key(*request_headers, *response_headers);
+
+    auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+    TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+    TRY_OR_FAIL(writer.write_data("console.log('hello');"sv.bytes()));
+    TRY_OR_FAIL(writer.flush(request_headers, response_headers));
+
+    auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("bytecode"sv.bytes()));
+    EXPECT(!TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *mismatched_request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+    EXPECT(TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *mismatched_request_headers, vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *mismatched_request_headers, vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    VERIFY(retrieved_bytecode.has_value());
+    EXPECT_EQ(retrieved_bytecode->bytes(), bytecode.bytes());
 }
 
 TEST_CASE(associated_data_participates_in_cache_eviction)
@@ -127,8 +158,8 @@ TEST_CASE(associated_data_participates_in_cache_eviction)
 
     disk_cache.set_maximum_disk_cache_size(80);
     auto bytecode = TRY_OR_FAIL(ByteBuffer::create_zeroed(100));
-    EXPECT(!TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
+    EXPECT(!TRY_OR_FAIL(disk_cache.store_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
 
-    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    auto retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     EXPECT(!retrieved_bytecode.has_value());
 }

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,5 +1,6 @@
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
 ladybird_test(test-primitive-string.cpp LibJS LIBS LibJS LibGC)
+ladybird_test(test-bytecode-cache.cpp LibJS LIBS LibCrypto LibGC LibJS)
 
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}")

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ScopeGuard.h>
+#include <LibCrypto/Hash/SHA2.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibJS/RustIntegration.h>
+#include <LibJS/SourceCode.h>
+#include <LibTest/TestCase.h>
+
+struct BytecodeCacheTestData {
+    NonnullRefPtr<JS::SourceCode const> source_code;
+    ByteBuffer blob;
+    Crypto::Hash::SHA256::DigestType source_hash;
+};
+
+class BytecodeCacheBlobReader {
+public:
+    explicit BytecodeCacheBlobReader(ReadonlyBytes bytes)
+        : m_bytes(bytes)
+    {
+    }
+
+    void skip(size_t length)
+    {
+        VERIFY(m_offset + length <= m_bytes.size());
+        m_offset += length;
+    }
+
+    bool read_bool()
+    {
+        return read_u8() != 0;
+    }
+
+    u8 read_u8()
+    {
+        VERIFY(m_offset < m_bytes.size());
+        return m_bytes[m_offset++];
+    }
+
+    u32 read_u32()
+    {
+        VERIFY(m_offset + sizeof(u32) <= m_bytes.size());
+        auto value = static_cast<u32>(m_bytes[m_offset])
+            | (static_cast<u32>(m_bytes[m_offset + 1]) << 8)
+            | (static_cast<u32>(m_bytes[m_offset + 2]) << 16)
+            | (static_cast<u32>(m_bytes[m_offset + 3]) << 24);
+        m_offset += sizeof(u32);
+        return value;
+    }
+
+    void skip_utf16()
+    {
+        auto length = read_u32();
+        skip(length * sizeof(u16));
+    }
+
+    void skip_utf16_vector()
+    {
+        auto length = read_u32();
+        for (u32 i = 0; i < length; ++i)
+            skip_utf16();
+    }
+
+    void skip_optional_utf16()
+    {
+        if (read_bool())
+            skip_utf16();
+    }
+
+    void skip_optional_u32()
+    {
+        if (read_bool())
+            skip(sizeof(u32));
+    }
+
+    size_t offset() const { return m_offset; }
+
+private:
+    ReadonlyBytes m_bytes;
+    size_t m_offset { 0 };
+};
+
+static void write_u32(ByteBuffer& bytes, size_t offset, u32 value)
+{
+    VERIFY(offset + sizeof(u32) <= bytes.size());
+    bytes[offset] = value & 0xff;
+    bytes[offset + 1] = (value >> 8) & 0xff;
+    bytes[offset + 2] = (value >> 16) & 0xff;
+    bytes[offset + 3] = (value >> 24) & 0xff;
+}
+
+static BytecodeCacheTestData create_bytecode_cache_blob(StringView source)
+{
+    auto source_code = JS::SourceCode::create("test.js"_string, Utf16String::from_utf8(source));
+    auto source_hash = Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code->utf16_data()), source_code->length_in_code_units() * sizeof(u16));
+
+    auto* parsed = JS::RustIntegration::parse_program(source_code->utf16_data(), source_code->length_in_code_units(), JS::RustIntegration::ProgramType::Script);
+    VERIFY(parsed);
+    ArmedScopeGuard free_parsed = [&] {
+        JS::RustIntegration::free_parsed_program(parsed);
+    };
+    EXPECT(!JS::RustIntegration::parsed_program_has_errors(parsed));
+
+    auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(parsed, source_code->length_in_code_units());
+    VERIFY(compiled);
+    free_parsed.disarm();
+    ScopeGuard free_compiled = [&] {
+        JS::RustIntegration::free_compiled_program(compiled);
+    };
+
+    auto blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled, JS::RustIntegration::ProgramType::Script, source_hash.bytes());
+    VERIFY(!blob.is_empty());
+
+    return {
+        .source_code = source_code,
+        .blob = move(blob),
+        .source_hash = source_hash,
+    };
+}
+
+static size_t first_declaration_function_bytecode_payload_offset(ReadonlyBytes blob)
+{
+    BytecodeCacheBlobReader reader { blob };
+
+    reader.skip(8);           // Magic.
+    reader.skip(sizeof(u32)); // Format version.
+    reader.skip(1);           // Program type.
+    reader.skip(32);          // Source hash.
+    reader.skip(1);           // Has top-level await.
+    reader.skip(1);           // Is strict mode.
+
+    EXPECT_EQ(reader.read_u8(), 0); // Script declaration metadata.
+    reader.skip_utf16_vector();     // Lexical names.
+    reader.skip_utf16_vector();     // Var names.
+    reader.skip_utf16_vector();     // Function names.
+    reader.skip_utf16_vector();     // Var-scoped names.
+    reader.skip_utf16_vector();     // Annex B candidate names.
+
+    auto lexical_binding_count = reader.read_u32();
+    for (u32 i = 0; i < lexical_binding_count; ++i) {
+        reader.skip_utf16();
+        reader.skip(1);
+    }
+
+    auto declaration_function_count = reader.read_u32();
+    VERIFY(declaration_function_count > 0);
+
+    reader.skip_optional_utf16(); // Function name.
+    reader.skip(sizeof(u32));     // Source text start.
+    reader.skip(sizeof(u32));     // Source text end.
+    reader.skip(sizeof(i32));     // Function length.
+    reader.skip(sizeof(u32));     // Formal parameter count.
+    reader.skip(1);               // Function kind.
+    reader.skip(1);               // Strict mode.
+    reader.skip(1);               // Arrow function.
+
+    if (reader.read_bool())
+        reader.skip_utf16_vector();
+
+    reader.skip(1); // Uses this.
+    reader.skip(1); // Uses this from environment.
+    if (reader.read_bool()) {
+        reader.skip_utf16();
+        reader.skip(1);
+    }
+
+    reader.skip(3);               // Function metadata bools.
+    reader.skip(sizeof(u64));     // Function environment bindings count.
+    reader.skip(sizeof(u64));     // Var environment bindings count.
+    reader.skip(2);               // Function metadata bools.
+    reader.skip(1);               // Executable strict mode.
+    reader.skip(sizeof(u32));     // Number of registers.
+    reader.skip(sizeof(u32));     // Number of arguments.
+    reader.skip(5 * sizeof(u32)); // Cache counters.
+    reader.skip(1);               // This value needs environment resolution.
+    reader.skip_optional_u32();   // Length identifier.
+
+    auto bytecode_length = reader.read_u32();
+    VERIFY(bytecode_length > 0);
+    return reader.offset();
+}
+
+static size_t first_declaration_function_source_text_start_offset(ReadonlyBytes blob)
+{
+    BytecodeCacheBlobReader reader { blob };
+
+    reader.skip(8);           // Magic.
+    reader.skip(sizeof(u32)); // Format version.
+    reader.skip(1);           // Program type.
+    reader.skip(32);          // Source hash.
+    reader.skip(1);           // Has top-level await.
+    reader.skip(1);           // Is strict mode.
+
+    EXPECT_EQ(reader.read_u8(), 0); // Script declaration metadata.
+    reader.skip_utf16_vector();     // Lexical names.
+    reader.skip_utf16_vector();     // Var names.
+    reader.skip_utf16_vector();     // Function names.
+    reader.skip_utf16_vector();     // Var-scoped names.
+    reader.skip_utf16_vector();     // Annex B candidate names.
+
+    auto lexical_binding_count = reader.read_u32();
+    for (u32 i = 0; i < lexical_binding_count; ++i) {
+        reader.skip_utf16();
+        reader.skip(1);
+    }
+
+    auto declaration_function_count = reader.read_u32();
+    VERIFY(declaration_function_count > 0);
+
+    reader.skip_optional_utf16(); // Function name.
+    return reader.offset();
+}
+
+TEST_CASE(bytecode_cache_materialization_failure_has_parser_error)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto test_data = create_bytecode_cache_blob("1;"sv);
+
+    auto corrupted_blob = MUST(ByteBuffer::copy(test_data.blob.bytes()));
+
+    // For this minimal script, the encoded top-level bytecode payload begins
+    // after the cache header, empty declaration metadata, and executable
+    // metadata. Corrupting the payload keeps the blob structurally decodable
+    // while causing executable validation to reject it during materialization.
+    constexpr size_t bytecode_payload_offset_for_empty_script = 112;
+    VERIFY(corrupted_blob.size() > bytecode_payload_offset_for_empty_script);
+    corrupted_blob[bytecode_payload_offset_for_empty_script] ^= 0xff;
+
+    // Structural decode still succeeds because the blob is internally well-formed; the corruption is in the bytecode
+    // payload, which is only checked by the validator that runs during materialization.
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(corrupted_blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    auto materialized = JS::RustIntegration::materialize_bytecode_cache_script(decoded_blob, test_data.source_code, realm);
+    EXPECT(materialized.has_value());
+    EXPECT(materialized->is_error());
+    EXPECT(!materialized->error().is_empty());
+    EXPECT_EQ(materialized->error().first().message, "Failed to materialize bytecode cache"_string);
+}
+
+TEST_CASE(bytecode_cache_rejects_corrupt_declaration_function)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto test_data = create_bytecode_cache_blob("function f() { return 1; } f();"_string);
+    auto corrupted_blob = MUST(ByteBuffer::copy(test_data.blob.bytes()));
+
+    auto declaration_function_bytecode_offset = first_declaration_function_bytecode_payload_offset(corrupted_blob.bytes());
+    VERIFY(declaration_function_bytecode_offset < corrupted_blob.size());
+    corrupted_blob[declaration_function_bytecode_offset] ^= 0xff;
+
+    // Structural decode still succeeds (the blob layout is intact); the corruption is in a function's bytecode payload
+    // and is only caught when the materializer asks the validator to check it.
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(corrupted_blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    auto materialized = JS::RustIntegration::materialize_bytecode_cache_script(decoded_blob, test_data.source_code, realm);
+    EXPECT(materialized.has_value());
+    EXPECT(materialized->is_error());
+    EXPECT(!materialized->error().is_empty());
+    EXPECT_EQ(materialized->error().first().message, "Failed to materialize bytecode cache"_string);
+}
+
+TEST_CASE(bytecode_cache_rejects_out_of_range_declaration_function_source_span)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto test_data = create_bytecode_cache_blob("function f() { return 1; } f();"_string);
+    auto corrupted_blob = MUST(ByteBuffer::copy(test_data.blob.bytes()));
+
+    auto source_text_start_offset = first_declaration_function_source_text_start_offset(corrupted_blob.bytes());
+    write_u32(corrupted_blob, source_text_start_offset, test_data.source_code->length_in_code_units() + 1);
+
+    // The source hash still matches and the blob layout is intact, but the cached function source span points outside
+    // the current SourceCode. Materialization should reject it as a cache miss instead of handing the range to C++.
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(corrupted_blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    auto materialized = JS::RustIntegration::materialize_bytecode_cache_script(decoded_blob, test_data.source_code, realm);
+    EXPECT(materialized.has_value());
+    EXPECT(materialized->is_error());
+    EXPECT(!materialized->error().is_empty());
+    EXPECT_EQ(materialized->error().first().message, "Failed to materialize bytecode cache"_string);
+}

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCrypto/Hash/SHA2.h>
 #include <LibJS/Bytecode/Debug.h>
 #include <LibJS/Console.h>
 #include <LibJS/Contrib/Test262/GlobalObject.h>


### PR DESCRIPTION
Add disk-backed JavaScript bytecode caching for fetched classic scripts and modules.

After the initial off-thread compile hands top-level bytecode back to the main thread, LibWeb schedules a second background job that fully compiles the remaining lazy functions and serializes the result as a LibJS bytecode cache blob. RequestServer stores that blob as HTTP disk cache sidecar data and sends it back with later cached responses, allowing script fetching to materialize bytecode directly on warm-cache hits.

The cache format includes structural validation, source fingerprint matching, program-type tagging, declaration metadata, declaration function bytecode, and parser-free materialization for scripts and modules. Corrupt or stale blobs are treated as cache misses and fall back to normal source compilation.

This greatly improves page load times across the entire web, since we no longer have to parse or compile JavaScript when it's available in our disk cache :)