### PR TITLE
LibWeb: Propagate line box borders debug toggle to child navigables

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -419,6 +419,8 @@ void Navigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state
 
     // 5. Set navigable's parent to parent.
     m_parent = parent;
+    if (parent)
+        m_should_show_line_box_borders = parent->m_should_show_line_box_borders;
     if (parent && !m_is_svg_page) {
         m_external_content_source = Painting::ExternalContentSource::create();
         m_rendering_thread.set_presentation_mode(RenderingThread::PublishToExternalContent { external_content_source() });
@@ -3092,6 +3094,15 @@ NonnullRefPtr<Painting::ExternalContentSource> Navigable::external_content_sourc
 {
     VERIFY(m_external_content_source);
     return *m_external_content_source;
+}
+
+void Navigable::set_should_show_line_box_borders(bool value)
+{
+    m_should_show_line_box_borders = value;
+    set_needs_repaint();
+
+    for (auto const& child_navigable : child_navigables())
+        child_navigable->set_should_show_line_box_borders(value);
 }
 
 void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -244,7 +244,7 @@ public:
     void set_pending_set_browser_zoom_request(bool value) { m_pending_set_browser_zoom_request = value; }
     bool pending_set_browser_zoom_request() const { return m_pending_set_browser_zoom_request; }
 
-    void set_should_show_line_box_borders(bool value) { m_should_show_line_box_borders = value; }
+    void set_should_show_line_box_borders(bool);
 
     bool is_svg_page() const { return m_is_svg_page; }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -399,7 +399,6 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         bool state = argument == "on";
         auto traversable = page->page().top_level_traversable();
         traversable->set_should_show_line_box_borders(state);
-        traversable->set_needs_repaint();
         return;
     }
 


### PR DESCRIPTION
Only the top navigable received this setting; existing and new descendant navigables never showed these debug boxes.

| Before | After |
|--|--|
| <img width="3680" height="2392" alt="debug-before" src="https://github.com/user-attachments/assets/5442d31f-7add-499f-b08c-0665ddb848ba" /> | <img width="3680" height="2392" alt="debug-after" src="https://github.com/user-attachments/assets/2ae32304-689c-4db0-9a11-9ba37fa178b1" /> |