### PR TITLE
LibWeb: Update hovered nested navigable on mouse leave

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -228,6 +228,23 @@ static Optional<EventResult> dispatch_event_to_nested_navigable(Painting::Painta
     return {};
 }
 
+void EventHandler::update_hovered_nested_navigable(GC::Ptr<Painting::Paintable> paintable)
+{
+    GC::Ptr<HTML::Navigable> navigable;
+    if (paintable && is<Painting::NavigableContainerViewportPaintable>(*paintable)) {
+        if (auto node = dom_node_for_event_dispatch(*paintable); node)
+            navigable = as<HTML::NavigableContainer>(*node).content_navigable();
+    }
+    if (m_hovered_nested_navigable.ptr() == navigable)
+        return;
+
+    GC::Ptr<HTML::Navigable> previously_hovered_nested_navigable = m_hovered_nested_navigable.ptr();
+    m_hovered_nested_navigable = navigable;
+
+    if (previously_hovered_nested_navigable)
+        previously_hovered_nested_navigable->event_handler().handle_mouseleave();
+}
+
 // Find paragraph boundaries for triple-click selection. A paragraph is delimited by block nodes or <br> elements.
 static GC::Ref<DOM::Range> find_paragraph_range(DOM::Text& text_node, WebIDL::UnsignedLong offset)
 {
@@ -998,6 +1015,7 @@ void EventHandler::clear_per_test_input_state(Badge<Internals::Internals>)
     m_hovered_chrome_widget = nullptr;
     m_captured_chrome_widget = nullptr;
     m_effective_legacy_mouse_pointer_position = nullptr;
+    m_hovered_nested_navigable = nullptr;
     m_drag_and_drop_event_handler->reset();
     m_mousemove_previous_screen_position.clear();
 }
@@ -1437,6 +1455,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         start_index = result->index_in_node;
     }
 
+    update_hovered_nested_navigable(paintable);
     ArmedScopeGuard clear_cursor = [&] {
         update_cursor(nullptr, nullptr, nullptr);
     };
@@ -1533,6 +1552,7 @@ EventResult EventHandler::handle_mouseleave()
     if (!paint_root())
         return EventResult::Dropped;
 
+    update_hovered_nested_navigable(nullptr);
     update_hovered_chrome_widget(nullptr);
     update_cursor(nullptr, nullptr, nullptr);
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -120,6 +120,7 @@ private:
     bool fire_click_events(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
     void maybe_show_context_menu(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
+    void update_hovered_nested_navigable(GC::Ptr<Painting::Paintable>);
 
     void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
 
@@ -147,6 +148,7 @@ private:
     NonnullOwnPtr<DragAndDropEventHandler> m_drag_and_drop_event_handler;
 
     GC::Weak<DOM::Node> m_effective_legacy_mouse_pointer_position;
+    GC::Weak<HTML::Navigable> m_hovered_nested_navigable;
 
     GC::Weak<DOM::Node> m_mousedown_target;
     Optional<CSSPixelPoint> m_mousedown_visual_viewport_position;

--- a/Tests/LibWeb/Text/expected/iframe-mouseout-when-leaving-nested-navigable.txt
+++ b/Tests/LibWeb/Text/expected/iframe-mouseout-when-leaving-nested-navigable.txt
@@ -1,0 +1,1 @@
+child mouseout count: 1

--- a/Tests/LibWeb/Text/input/iframe-mouseout-when-leaving-nested-navigable.html
+++ b/Tests/LibWeb/Text/input/iframe-mouseout-when-leaving-nested-navigable.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; }
+    iframe {
+        position: absolute;
+        top: 20px;
+        left: 20px;
+        width: 120px;
+        height: 120px;
+        border: none;
+    }
+</style>
+<script src="include.js"></script>
+<script>
+    asyncTest(async done => {
+        window.childMouseOutCount = 0;
+
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                body { margin: 0; }
+                #target {
+                    width: 80px;
+                    height: 80px;
+                    background: lightblue;
+                }
+            </style>
+            <div id="target"></div>
+            <script>
+                document.addEventListener("mouseout", () => {
+                    parent.childMouseOutCount++;
+                }, { once: true });
+            <\/script>
+        `;
+        document.body.appendChild(iframe);
+
+        await new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        await animationFrame();
+
+        const rect = iframe.getBoundingClientRect();
+        internals.mouseMove(rect.left + 40, rect.top + 40);
+        await animationFrame();
+        internals.mouseMove(rect.right + 20, rect.bottom + 20);
+        await animationFrame();
+
+        println(`child mouseout count: ${window.childMouseOutCount}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
When the pointer leaves an iframe, we need to notify any hovered node. Otherwise, canvas animations that pause on mouseleave will continue, pigs will rain from the sky, the chicken will keep crossing the road, etc