### PR TITLE
Base: Add gui framework info to about:version

### DIFF
--- a/Base/res/ladybird/about-pages/version.html
+++ b/Base/res/ladybird/about-pages/version.html
@@ -135,6 +135,10 @@
                     <div id="platform-name" class="detail-value"></div>
                 </div>
                 <div class="detail-row">
+                    <div class="detail-label">GUI Framework</div>
+                    <div id="gui-framework" class="detail-value"></div>
+                </div>
+                <div class="detail-row">
                     <div class="detail-label">User Agent</div>
                     <div id="user-agent" class="detail-value"></div>
                 </div>
@@ -162,6 +166,7 @@
             const userAgent = document.querySelector("#user-agent");
             const commandLine = document.querySelector("#command-line");
             const executablePath = document.querySelector("#executable-path");
+            const guiFramework = document.querySelector("#gui-framework");
 
             function renderVersionInfo(versionInfo) {
                 document.title = `About ${versionInfo?.browserName}`;
@@ -173,6 +178,7 @@
                 userAgent.innerText = navigator.userAgent;
                 commandLine.innerText = versionInfo?.commandLine;
                 executablePath.innerText = versionInfo?.executablePath;
+                guiFramework.innerText = versionInfo?.guiFramework;
             }
 
             document.addEventListener("WebUILoaded", () => {

--- a/Libraries/LibWebView/WebUI/VersionUI.cpp
+++ b/Libraries/LibWebView/WebUI/VersionUI.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/WebUI/VersionUI.h>
+#include <UI/UI.h>
 
 namespace WebView {
 
@@ -28,6 +29,7 @@ void VersionUI::load_version_info()
     static auto& platform_name = *new String(String::from_utf8_without_validation({ OS_STRING, __builtin_strlen(OS_STRING) }));
     static auto& command_line = *new String(MUST(String::join(' ', Application::the().command_line_arguments().strings)));
     static auto& executable_path = *new String(MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))));
+     static auto& gui_framework = *new String(String::from_utf8_without_validation({ LADYBIRD_GUI_FRAMEWORK, __builtin_strlen(LADYBIRD_GUI_FRAMEWORK) }));
 
     JsonObject version_info;
     version_info.set("browserName"_string, browser_name);
@@ -36,6 +38,7 @@ void VersionUI::load_version_info()
     version_info.set("platformName"_string, platform_name);
     version_info.set("commandLine"_string, command_line);
     version_info.set("executablePath"_string, executable_path);
+    version_info.set("guiFramework"_string, gui_framework);
 
     async_send_message("renderVersionInfo"sv, version_info);
 }

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -59,6 +59,8 @@ else()
     set(LADYBIRD_TARGET ladybird PRIVATE)
 endif()
 
+configure_file(UI.h.in UI.h @ONLY)
+
 set(LADYBIRD_LIBS AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibRequests LibSync LibURL)
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE ${LADYBIRD_LIBS})
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE OpenSSL::Crypto OpenSSL::SSL)

--- a/UI/UI.h.in
+++ b/UI/UI.h.in
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#ifndef LADYBIRD_GUI_FRAMEWORK
+#    cmakedefine LADYBIRD_GUI_FRAMEWORK "@LADYBIRD_GUI_FRAMEWORK@"
+#endif


### PR DESCRIPTION
I am not sure if that is the right place for that info, and if it is even required, but I saw that multiple GUI frameworks are supported, so the "Build Details" overview seems to be a good place to tell the user that. (even if Qt / Gtk don't look that similar and to someone who knows the difference it is blatantly obvious)

It might also help in cases of (GUI) bug reports from users, that don't know the difference, the can just look it up there 😄 

I am not sure what the project idiomatic way of supplying the GUI framework string to the C++ code is, so I used `configure_file`, if I should do it in another way, feel free to tell me 😄 

A screenshot from the new `about:version`

<img width="858" height="477" alt="grafik" src="https://github.com/user-attachments/assets/0426f2cc-be3b-4bfe-8df5-ab597c0e8a31" />
