### PR TITLE
Tests/LibGfx: Remove stale Skia include from CMakeLists

### DIFF
--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(skia)
-
 set(TEST_SOURCES
     BenchmarkJPEGLoader.cpp
     TestBitmapExport.cpp


### PR DESCRIPTION
This unbreaks the build on current `master` on ed9984930b3d4b185973a08bb5d6a0916a36c983

ee4f9ef82ce added a reference to a file (`skia.cmake`) that was removed by 1d83e8c8963 when skia dependency setup moved into `check_for_dependencies.cmake`. 

This line is no longer needed since `skia` is now a globally-defined ALIAS target.