### PR TITLE
RequestServer+LibCompress: Fix invalid Content-Encoding

### DIFF
--- a/Libraries/LibCompress/CMakeLists.txt
+++ b/Libraries/LibCompress/CMakeLists.txt
@@ -4,9 +4,12 @@ set(SOURCES
     Gzip.cpp
     PackBitsDecoder.cpp
     Zlib.cpp
+    Zstd.cpp
 )
+
+find_package(zstd CONFIG REQUIRED)
 
 ladybird_lib(LibCompress compress)
 target_link_libraries(LibCompress PRIVATE LibCore LibCrypto)
 
-target_link_libraries(LibCompress PRIVATE ZLIB::ZLIB)
+target_link_libraries(LibCompress PRIVATE ZLIB::ZLIB zstd::libzstd)

--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -9,6 +9,8 @@
 #include <AK/BinarySearch.h>
 #include <LibCompress/Deflate.h>
 #include <LibCompress/DeflateTables.h>
+#include <LibCompress/Helpers.h>
+#include <LibCompress/Zlib.h>
 
 #include <zlib.h>
 

--- a/Libraries/LibCompress/Deflate.h
+++ b/Libraries/LibCompress/Deflate.h
@@ -8,8 +8,11 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/BitStream.h>
+#include <AK/OwnPtr.h>
 #include <AK/Stream.h>
+#include <AK/Vector.h>
 #include <LibCompress/GenericZlib.h>
 
 namespace Compress {
@@ -65,6 +68,32 @@ private:
         : GenericZlibDecompressor(move(buffer), move(stream), zstream)
     {
     }
+};
+
+class HTTPDeflateDecompressor final : public Stream {
+    AK_MAKE_NONCOPYABLE(HTTPDeflateDecompressor);
+
+public:
+    static ErrorOr<NonnullOwnPtr<HTTPDeflateDecompressor>> create(MaybeOwned<Stream>);
+    static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
+
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
+    virtual bool is_eof() const override;
+    virtual bool is_open() const override;
+    virtual void close() override;
+
+private:
+    class PrefixStream;
+
+    explicit HTTPDeflateDecompressor(MaybeOwned<Stream>);
+
+    ErrorOr<void> ensure_decoder();
+
+    MaybeOwned<Stream> m_stream;
+    OwnPtr<Stream> m_decoder;
+    Array<u8, 2> m_prefix_buffer {};
+    size_t m_prefix_size { 0 };
 };
 
 class DeflateCompressor final : public GenericZlibCompressor {

--- a/Libraries/LibCompress/Forward.h
+++ b/Libraries/LibCompress/Forward.h
@@ -14,5 +14,6 @@ class GzipCompressor;
 class GzipDecompressor;
 class ZlibCompressor;
 class ZlibDecompressor;
+class ZstdDecompressor;
 
 }

--- a/Libraries/LibCompress/GenericZlib.h
+++ b/Libraries/LibCompress/GenericZlib.h
@@ -9,7 +9,6 @@
 #include <AK/ByteBuffer.h>
 #include <AK/FixedArray.h>
 #include <AK/MaybeOwned.h>
-#include <AK/MemoryStream.h>
 #include <AK/Stream.h>
 
 extern "C" {
@@ -74,28 +73,5 @@ private:
 
     AK::FixedArray<u8> m_buffer;
 };
-
-template<class T>
-ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes bytes)
-{
-    auto input_stream = make<AK::FixedMemoryStream>(bytes);
-    auto deflate_stream = TRY(T::create(MaybeOwned<Stream>(move(input_stream))));
-    return TRY(deflate_stream->read_until_eof(4096));
-}
-
-template<class T>
-ErrorOr<ByteBuffer> compress_all(ReadonlyBytes bytes, GenericZlibCompressionLevel compression_level)
-{
-    auto output_stream = TRY(try_make<AllocatingMemoryStream>());
-    auto gzip_stream = TRY(T::create(MaybeOwned { *output_stream }, compression_level));
-
-    TRY(gzip_stream->write_until_depleted(bytes));
-    TRY(gzip_stream->finish());
-
-    auto buffer = TRY(ByteBuffer::create_uninitialized(output_stream->used_buffer_size()));
-    TRY(output_stream->read_until_filled(buffer.bytes()));
-
-    return buffer;
-}
 
 }

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibCompress/Gzip.h>
+#include <LibCompress/Helpers.h>
 
 #include <zlib.h>
 

--- a/Libraries/LibCompress/Helpers.h
+++ b/Libraries/LibCompress/Helpers.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/MaybeOwned.h>
+#include <AK/MemoryStream.h>
+#include <AK/StdLibExtras.h>
+#include <AK/Stream.h>
+
+namespace Compress {
+
+template<class T>
+ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes bytes)
+{
+    auto input_stream = make<AK::FixedMemoryStream>(bytes);
+    auto decompressor = TRY(T::create(MaybeOwned<Stream>(move(input_stream))));
+    return TRY(decompressor->read_until_eof(4096));
+}
+
+template<class T, class... Args>
+ErrorOr<ByteBuffer> compress_all(ReadonlyBytes bytes, Args&&... args)
+{
+    auto output_stream = TRY(try_make<AllocatingMemoryStream>());
+    auto compressor = TRY(T::create(MaybeOwned { *output_stream }, forward<Args>(args)...));
+
+    TRY(compressor->write_until_depleted(bytes));
+    TRY(compressor->finish());
+
+    auto buffer = TRY(ByteBuffer::create_uninitialized(output_stream->used_buffer_size()));
+    TRY(output_stream->read_until_filled(buffer.bytes()));
+
+    return buffer;
+}
+
+}

--- a/Libraries/LibCompress/Zlib.cpp
+++ b/Libraries/LibCompress/Zlib.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCompress/Helpers.h>
 #include <LibCompress/Zlib.h>
 
 #include <zlib.h>

--- a/Libraries/LibCompress/Zstd.cpp
+++ b/Libraries/LibCompress/Zstd.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCompress/Helpers.h>
+#include <LibCompress/Zstd.h>
+#include <zstd.h>
+
+namespace Compress {
+
+ZstdDecompressor::ZstdDecompressor(AK::FixedArray<u8> buffer, MaybeOwned<Stream> stream, ZSTD_DStream* decoder)
+    : m_stream(move(stream))
+    , m_decoder(decoder)
+    , m_buffer(move(buffer))
+{
+}
+
+ErrorOr<NonnullOwnPtr<ZstdDecompressor>> ZstdDecompressor::create(MaybeOwned<Stream> stream)
+{
+    auto buffer = TRY(AK::FixedArray<u8>::create(ZSTD_DStreamInSize()));
+    auto* decoder = ZSTD_createDStream();
+    if (!decoder)
+        return Error::from_errno(ENOMEM);
+    return adopt_nonnull_own_or_enomem(new (nothrow) ZstdDecompressor(move(buffer), move(stream), decoder));
+}
+
+ErrorOr<ByteBuffer> ZstdDecompressor::decompress_all(ReadonlyBytes bytes)
+{
+    return ::Compress::decompress_all<ZstdDecompressor>(bytes);
+}
+
+ZstdDecompressor::~ZstdDecompressor()
+{
+    ZSTD_freeDStream(m_decoder);
+}
+
+ErrorOr<Bytes> ZstdDecompressor::read_some(Bytes bytes)
+{
+    if (m_eof || bytes.is_empty())
+        return bytes.trim(0);
+
+    size_t total_output = 0;
+
+    while (total_output < bytes.size()) {
+        if (m_input_offset == m_input_size) {
+            auto input = TRY(m_stream->read_some(m_buffer.span()));
+            m_input_offset = 0;
+            m_input_size = input.size();
+
+            if (m_input_size == 0 && !m_stream->is_eof())
+                break;
+        }
+
+        ZSTD_inBuffer input {
+            .src = m_buffer.data() + m_input_offset,
+            .size = m_input_size - m_input_offset,
+            .pos = 0,
+        };
+        ZSTD_outBuffer output {
+            .dst = bytes.data() + total_output,
+            .size = bytes.size() - total_output,
+            .pos = 0,
+        };
+
+        auto result = ZSTD_decompressStream(m_decoder, &output, &input);
+        if (ZSTD_isError(result))
+            return Error::from_string_literal("Zstd data error");
+
+        m_input_offset += input.pos;
+        total_output += output.pos;
+
+        if (result == 0 && m_input_offset == m_input_size) {
+            m_eof = true;
+            break;
+        }
+
+        if (output.pos == 0 && input.pos == 0) {
+            if (m_stream->is_eof())
+                return Error::from_string_literal("Zstd stream ended before end-of-stream marker");
+            break;
+        }
+    }
+
+    return bytes.trim(total_output);
+}
+
+ErrorOr<size_t> ZstdDecompressor::write_some(ReadonlyBytes)
+{
+    return Error::from_errno(EBADF);
+}
+
+bool ZstdDecompressor::is_eof() const
+{
+    return m_eof;
+}
+
+bool ZstdDecompressor::is_open() const
+{
+    return m_stream->is_open();
+}
+
+void ZstdDecompressor::close()
+{
+}
+
+}

--- a/Libraries/LibCompress/Zstd.h
+++ b/Libraries/LibCompress/Zstd.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/FixedArray.h>
+#include <AK/MaybeOwned.h>
+#include <AK/Stream.h>
+
+extern "C" {
+typedef struct ZSTD_DCtx_s ZSTD_DStream;
+}
+
+namespace Compress {
+
+class ZstdDecompressor final : public Stream {
+    AK_MAKE_NONCOPYABLE(ZstdDecompressor);
+
+public:
+    static ErrorOr<NonnullOwnPtr<ZstdDecompressor>> create(MaybeOwned<Stream>);
+    static ErrorOr<ByteBuffer> decompress_all(ReadonlyBytes);
+
+    ~ZstdDecompressor() override;
+
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
+    virtual bool is_eof() const override;
+    virtual bool is_open() const override;
+    virtual void close() override;
+
+private:
+    ZstdDecompressor(AK::FixedArray<u8>, MaybeOwned<Stream>, ZSTD_DStream*);
+
+    MaybeOwned<Stream> m_stream;
+    ZSTD_DStream* m_decoder { nullptr };
+    AK::FixedArray<u8> m_buffer;
+    size_t m_input_offset { 0 };
+    size_t m_input_size { 0 };
+    bool m_eof { false };
+};
+
+}

--- a/Services/RequestServer/BodyDecoder.cpp
+++ b/Services/RequestServer/BodyDecoder.cpp
@@ -1,8 +1,17 @@
+/*
+ * Copyright (c) 2026, Ladybird contributors.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
 #include <AK/Array.h>
 #include <AK/MaybeOwned.h>
 #include <AK/MemoryStream.h>
 #include <AK/StringView.h>
+#include <LibCompress/Deflate.h>
 #include <LibCompress/Gzip.h>
+#include <LibCompress/Zlib.h>
+#include <LibCompress/Zstd.h>
 #include <RequestServer/BodyDecoder.h>
 
 namespace RequestServer {
@@ -36,7 +45,7 @@ static Optional<ContentEncoding> recognize_token(StringView token)
         return ContentEncoding::Brotli;
     if (token.equals_ignoring_ascii_case("zstd"sv))
         return ContentEncoding::Zstd;
-    return { };
+    return {};
 }
 
 Vector<ContentEncoding> parse_content_encoding(HTTP::HeaderList const& headers)
@@ -68,7 +77,7 @@ Vector<ContentEncoding> parse_content_encoding(HTTP::HeaderList const& headers)
     });
 
     if (invalid_token_found) {
-        return { };
+        return {};
     }
 
     return encoding_chain;
@@ -85,9 +94,8 @@ static ErrorOr<NonnullOwnPtr<Stream>> wrap_with_decoder(ContentEncoding encoding
     case ContentEncoding::Brotli:
         // TODO: Implement in LibCompress and add the decompressor here.
         return Error::from_string_literal("Brotli decompression not yet implemented");
-        case ContentEncoding::Zstd:
-        // TODO: Implement in LibCompress and add the decompressor here.
-        return Error::from_string_literal("Zstd decompression not yet implemented");
+    case ContentEncoding::Zstd:
+        return TRY(Compress::ZstdDecompressor::create(move(upstream)));
     }
     VERIFY_NOT_REACHED();
 }
@@ -129,7 +137,7 @@ ErrorOr<void> BodyDecoder::push(ReadonlyBytes wire_bytes, AllocatingMemoryStream
 {
     if (is_pass_through()) {
         TRY(out.write_until_depleted(wire_bytes));
-        return { };
+        return {};
     }
 
     TRY(m_feeder->write_until_depleted(wire_bytes));
@@ -141,13 +149,13 @@ ErrorOr<void> BodyDecoder::push(ReadonlyBytes wire_bytes, AllocatingMemoryStream
             break;
         TRY(out.write_until_depleted(decoded));
     }
-    return { };
+    return {};
 }
 
 ErrorOr<void> BodyDecoder::finish(AllocatingMemoryStream& out)
 {
     if (is_pass_through())
-        return { };
+        return {};
 
     m_feeder->mark_eof();
 
@@ -161,7 +169,7 @@ ErrorOr<void> BodyDecoder::finish(AllocatingMemoryStream& out)
         }
         TRY(out.write_until_depleted(decoded));
     }
-    return { };
+    return {};
 }
 
 }

--- a/Services/RequestServer/BodyDecoder.cpp
+++ b/Services/RequestServer/BodyDecoder.cpp
@@ -1,0 +1,167 @@
+#include <AK/Array.h>
+#include <AK/MaybeOwned.h>
+#include <AK/MemoryStream.h>
+#include <AK/StringView.h>
+#include <LibCompress/Gzip.h>
+#include <RequestServer/BodyDecoder.h>
+
+namespace RequestServer {
+
+class BodyDecoder::FeederStream : public Stream {
+public:
+    virtual ErrorOr<Bytes> read_some(Bytes bytes) override { return m_buffer.read_some(bytes); }
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_buffer.write_some(bytes); }
+    virtual bool is_eof() const override { return m_eof_marked && m_buffer.is_eof(); }
+    virtual bool is_open() const override { return !m_eof_marked; }
+    virtual void close() override { m_eof_marked = true; }
+
+    void mark_eof() { m_eof_marked = true; }
+
+private:
+    AllocatingMemoryStream m_buffer;
+    bool m_eof_marked { false };
+};
+
+static Optional<ContentEncoding> recognize_token(StringView token)
+{
+    // RFC 7231: https://www.iana.org/assignments/http-parameters/http-parameters.xhtml
+    // Chrome implements: deflate, gzip, x-gzip, br, and zstd https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/filter/filter_source_stream.cc
+    // libcurl implements the same set as Chrome
+
+    if (token.equals_ignoring_ascii_case("gzip"sv) || token.equals_ignoring_ascii_case("x-gzip"sv))
+        return ContentEncoding::Gzip;
+    if (token.equals_ignoring_ascii_case("deflate"sv))
+        return ContentEncoding::Deflate;
+    if (token.equals_ignoring_ascii_case("br"sv))
+        return ContentEncoding::Brotli;
+    if (token.equals_ignoring_ascii_case("zstd"sv))
+        return ContentEncoding::Zstd;
+    return { };
+}
+
+Vector<ContentEncoding> parse_content_encoding(HTTP::HeaderList const& headers)
+{
+    Vector<ContentEncoding> encoding_chain;
+    bool invalid_token_found = false;
+
+    headers.for_each_header_value("Content-Encoding"sv, [&](StringView value) -> IterationDecision {
+        value.for_each_split_view(","sv, SplitBehavior::Nothing, [&](StringView raw_token) -> IterationDecision {
+            auto token = raw_token.trim(" \t"sv);
+
+            // Skip empty or identity tokens
+            if (token.is_empty() || token.equals_ignoring_ascii_case("identity"sv))
+                return IterationDecision::Continue;
+
+            auto encoding = recognize_token(token);
+
+            if (!encoding.has_value()) {
+                // Unknown encoding: pass through the raw body.
+                invalid_token_found = true;
+                return IterationDecision::Break;
+            }
+
+            encoding_chain.append(*encoding);
+            return IterationDecision::Continue;
+        });
+
+        return invalid_token_found ? IterationDecision::Break : IterationDecision::Continue;
+    });
+
+    if (invalid_token_found) {
+        return { };
+    }
+
+    return encoding_chain;
+}
+
+static ErrorOr<NonnullOwnPtr<Stream>> wrap_with_decoder(ContentEncoding encoding, MaybeOwned<Stream> upstream)
+{
+    switch (encoding) {
+    case ContentEncoding::Gzip:
+        return TRY(Compress::GzipDecompressor::create(move(upstream)));
+    case ContentEncoding::Deflate:
+        // TODO: Auto-detect if raw deflate should be used or zlib-wrapped. Chrome and Firefox detects this even though the RFC 7230 says it's zlib-wrapped.
+        return TRY(Compress::ZlibDecompressor::create(move(upstream)));
+    case ContentEncoding::Brotli:
+        // TODO: Implement in LibCompress and add the decompressor here.
+        return Error::from_string_literal("Brotli decompression not yet implemented");
+        case ContentEncoding::Zstd:
+        // TODO: Implement in LibCompress and add the decompressor here.
+        return Error::from_string_literal("Zstd decompression not yet implemented");
+    }
+    VERIFY_NOT_REACHED();
+}
+
+NonnullOwnPtr<BodyDecoder> BodyDecoder::create_pass_through()
+{
+    return adopt_own(*new BodyDecoder);
+}
+
+ErrorOr<NonnullOwnPtr<BodyDecoder>> BodyDecoder::create(Vector<ContentEncoding> const& encoding_chain)
+{
+    VERIFY(!encoding_chain.is_empty());
+
+    auto feeder = TRY(adopt_nonnull_own_or_enomem(new (nothrow) FeederStream));
+
+    // Build the stream decompression pipeline in reverse header order. Per RFC 7231:
+    // Content-Encoding lists the order the encodings where applied so we need to reverse it
+    OwnPtr<Stream> current;
+    for (auto encoding : encoding_chain.in_reverse()) {
+        MaybeOwned<Stream> upstream = current
+            ? MaybeOwned<Stream>(current.release_nonnull())
+            : MaybeOwned<Stream>(*feeder);
+        current = TRY(wrap_with_decoder(encoding, move(upstream)));
+    }
+    VERIFY(current);
+
+    return adopt_nonnull_own_or_enomem(new (nothrow) BodyDecoder(move(feeder), current.release_nonnull()));
+}
+
+BodyDecoder::BodyDecoder(NonnullOwnPtr<FeederStream> feeder, NonnullOwnPtr<Stream> top)
+    : m_feeder(move(feeder))
+    , m_top(move(top))
+{
+}
+
+BodyDecoder::~BodyDecoder() = default;
+
+ErrorOr<void> BodyDecoder::push(ReadonlyBytes wire_bytes, AllocatingMemoryStream& out)
+{
+    if (is_pass_through()) {
+        TRY(out.write_until_depleted(wire_bytes));
+        return { };
+    }
+
+    TRY(m_feeder->write_until_depleted(wire_bytes));
+
+    Array<u8, 4096> scratch;
+    while (true) {
+        auto decoded = TRY(m_top->read_some(scratch.span()));
+        if (decoded.is_empty())
+            break;
+        TRY(out.write_until_depleted(decoded));
+    }
+    return { };
+}
+
+ErrorOr<void> BodyDecoder::finish(AllocatingMemoryStream& out)
+{
+    if (is_pass_through())
+        return { };
+
+    m_feeder->mark_eof();
+
+    Array<u8, 4096> scratch;
+    while (!m_top->is_eof()) {
+        auto decoded = TRY(m_top->read_some(scratch.span()));
+        if (decoded.is_empty()) {
+            if (!m_top->is_eof())
+                return Error::from_string_literal("Compressed body ended before end-of-stream marker");
+            break;
+        }
+        TRY(out.write_until_depleted(decoded));
+    }
+    return { };
+}
+
+}

--- a/Services/RequestServer/BodyDecoder.h
+++ b/Services/RequestServer/BodyDecoder.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/MemoryStream.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/Span.h>
+#include <AK/Stream.h>
+#include <AK/Vector.h>
+#include <LibHTTP/HeaderList.h>
+
+namespace RequestServer {
+
+enum class ContentEncoding : u8 {
+    Gzip,
+    Deflate,
+    Brotli,
+    Zstd,
+};
+
+// parse the Content-Encoding header and return the chain of encoding methods to be "undone"
+Vector<ContentEncoding> parse_content_encoding(HTTP::HeaderList const&);
+
+class BodyDecoder {
+public:
+    static NonnullOwnPtr<BodyDecoder> create_pass_through();
+    static ErrorOr<NonnullOwnPtr<BodyDecoder>> create(Vector<ContentEncoding> const&);
+
+    ~BodyDecoder();
+
+    ErrorOr<void> push(ReadonlyBytes wire_bytes, AllocatingMemoryStream& out);
+
+    ErrorOr<void> finish(AllocatingMemoryStream& out);
+
+    bool is_pass_through() const { return !m_top; }
+
+private:
+    class FeederStream;
+
+    BodyDecoder() = default;
+    BodyDecoder(NonnullOwnPtr<FeederStream>, NonnullOwnPtr<Stream>);
+
+    OwnPtr<FeederStream> m_feeder;
+    OwnPtr<Stream> m_top;
+};
+
+}

--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Resolver.cpp
     ResourceSubstitutionMap.cpp
     WebSocketImplCurl.cpp
+    BodyDecoder.cpp
 )
 
 set(GENERATED_SOURCES
@@ -31,7 +32,7 @@ target_include_directories(requestserverservice PRIVATE ${CMAKE_CURRENT_BINARY_D
 target_include_directories(requestserverservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/)
 
 target_link_libraries(RequestServer PRIVATE requestserverservice)
-target_link_libraries(requestserverservice PUBLIC LibCore LibDNS LibHTTP LibIPC LibMain LibRequests LibTLS LibWebSocket LibURL LibTextCodec CURL::libcurl)
+target_link_libraries(requestserverservice PUBLIC LibCore LibDNS LibHTTP LibIPC LibMain LibRequests LibTLS LibWebSocket LibURL LibTextCodec CURL::libcurl LibCompress)
 target_link_libraries(requestserverservice PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 if (WIN32)

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -952,8 +952,7 @@ void Request::handle_fetch_state()
 
     // Append the encoding methods that ladybird supports in the Accept-Encoding header
     if (!m_request_headers->contains("Accept-Encoding"sv)) {
-        // TODO: Add brotli (br) and zstd (zstd) once they are implemented in LibCompress.
-        m_request_headers->append({ "Accept-Encoding"sv, "gzip, deflate"sv });
+        m_request_headers->append({ "Accept-Encoding"sv, "gzip, deflate, zstd"sv });
     }
 
     for (auto const& header : *m_request_headers) {

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -537,6 +537,17 @@ void Request::notify_fetch_complete(Badge<ConnectionFromClient>, int result_code
 
     m_curl_result_code = result_code;
 
+    if (m_body_decoder && result_code == CURLE_OK) {
+        auto flush_result = m_body_decoder->finish(m_response_buffer);
+
+        if (flush_result.is_error()) {
+            dbgln("Request::notify_fetch_complete: Body decoder flush failed: {}", flush_result.error());
+            m_network_error = Requests::NetworkError::InvalidContentEncoding;
+            transition_to_state(State::Error);
+            return;
+        }
+    }
+
     if (m_response_buffer.is_eof())
         transition_to_state(State::Complete);
 }
@@ -904,7 +915,10 @@ void Request::handle_fetch_state()
     if (auto const& path = default_certificate_path(); !path.is_empty())
         set_option(CURLOPT_CAINFO, path.characters());
 
-    set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
+    // do not let curl perform HTTP content decoding.
+    // curl treats unknown Content-Encoding values as errors, but websites doesn't always follow the spec.
+    set_option(CURLOPT_HTTP_CONTENT_DECODING, 0L);
+
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
@@ -934,6 +948,12 @@ void Request::handle_fetch_state()
             curl_headers = curl_slist_append(curl_headers, "Content-Type:");
     } else if (m_method == "HEAD"sv) {
         set_option(CURLOPT_NOBODY, 1L);
+    }
+
+    // Append the encoding methods that ladybird supports in the Accept-Encoding header
+    if (!m_request_headers->contains("Accept-Encoding"sv)) {
+        // TODO: Add brotli (br) and zstd (zstd) once they are implemented in LibCompress.
+        m_request_headers->append({ "Accept-Encoding"sv, "gzip, deflate"sv });
     }
 
     for (auto const& header : *m_request_headers) {
@@ -1129,8 +1149,26 @@ size_t Request::on_data_received(void* buffer, size_t size, size_t nmemb, void* 
     auto total_size = size * nmemb;
     ReadonlyBytes bytes { static_cast<u8 const*>(buffer), total_size };
 
+    if (!request.m_body_decoder) {
+        auto encoding_chain = parse_content_encoding(*request.m_response_headers);
+        if (encoding_chain.is_empty()) {
+            request.m_body_decoder = BodyDecoder::create_pass_through();
+        } else {
+            auto decoder_or_error = BodyDecoder::create(encoding_chain);
+            if (decoder_or_error.is_error()) {
+                dbgln("Request::on_data_received: Failed to build body decoder: {}", decoder_or_error.error());
+                request.m_network_error = Requests::NetworkError::InvalidContentEncoding;
+                return CURL_WRITEFUNC_ERROR;
+            }
+            request.m_body_decoder = decoder_or_error.release_value();
+        }
+    }
+
     auto result = [&] -> ErrorOr<void> {
-        TRY(request.m_response_buffer.write_some(bytes));
+        if (auto push_result = request.m_body_decoder->push(bytes, request.m_response_buffer); push_result.is_error()) {
+            request.m_network_error = Requests::NetworkError::InvalidContentEncoding;
+            return push_result.release_error();
+        }
         return request.write_queued_bytes_without_blocking();
     }();
 

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -20,6 +20,7 @@
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
+#include <RequestServer/BodyDecoder.h>
 #include <RequestServer/CacheLevel.h>
 #include <RequestServer/Forward.h>
 #include <RequestServer/RequestPipe.h>
@@ -215,6 +216,8 @@ private:
     size_t m_bytes_transferred_to_client { 0 };
 
     Optional<Requests::NetworkError> m_network_error;
+
+    OwnPtr<BodyDecoder> m_body_decoder;
 };
 
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -178,7 +178,8 @@
     "vulkan",
     "vulkan-headers",
     "woff2",
-    "zlib"
+    "zlib",
+    "zstd"
   ],
   "features": {
     "gtk": {


### PR DESCRIPTION
Hi, first time contributor here.

I was looking for something to help out with, and then stumbled upon an error while trying to use the Norwegian Bank login system. Apparently the server there returns an invalid Content-Encoding `ISO-8859-1` which curl trows as an error

```
HTTP/1.1 200
Date: Tue, 05 May 2026 18:30:17 GMT
Server: web
Access-Control-Allow-Origin: https://csfe.bankid.no
Content-Encoding: ISO-8859-1 <----- This one
Content-Type: application/json
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
Referrer-Policy: no-referrer
Keep-Alive: timeout=60, max=1000
Connection: Keep-Alive
```

I got curious then and tried to figure out how chrome did this and as i suspected they just ignore these invalid encodings and flag the whole body as uncompressed bytes see: https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/filter/filter_source_stream.cc


The problem is that libcurl doesn't provide a way to do this behavior for us as discussed by @InvalidUsernameException on the libcurl github discussion page. And it doesnt seem like they're planning to implement it either.

So i did the only logical thing and tried to fix it myself. Currently the implementation disables libcurl automatic body decompression. This means we have to implement it ourselves. So i created a BodyDecoder which takes a encoding chain which is the comma seperated list in the header and streams the bytes through the decompressors using the already existing methods in `LibCompress`. But when encountering a unknown token it will treat the request as a normal uncompressed body.

There are however some missing implementation details hence why i marked the PR as a draft.

- [ ] LibCompress does not have brotli decompressor implemented and we do not have brotli as a direct dependency as far as i know.
- [x] LibCompress does not have zstd decompressor implemented and we do not have a direct dependency on zstd either as far as i know
- [ ] [Firefox](https://searchfox.org/firefox-main/rev/8352bcb6d75d53f3e2190221b71190e47afa0bfc/netwerk/streamconv/converters/nsHTTPCompressConv.cpp#810) and [chrome](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/filter/gzip_source_stream.cc) auto-detects if its zlib-wrapped deflate or just raw deflate calls which would require a wrapper around the existing deflate implementation.


The current pushed code works for loading youtube and watching videos as well as the norwegian bank login service (haven't really done much more testing than that). Since i don't want to cause any regressions by replacing libcurl's logic i would gladly like some comments on the code and implementation before committing all the way and doing the rest.