### PR TITLE
LibWeb: Remove replaced animations per effect target

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6141,15 +6141,21 @@ void Document::remove_replaced_animations()
     });
 
     // Lower value = higher priority
-    HashMap<CSS::PropertyID, size_t> highest_property_composite_orders;
+    HashMap<DOM::AbstractElement, HashTable<CSS::PropertyID>> highest_priority_properties_by_target;
     for (int i = replaceable_animations.size() - 1; i >= 0; i--) {
         auto animation = replaceable_animations[i];
+        auto& keyframe_effect = static_cast<Animations::KeyframeEffect&>(*animation->effect());
+        auto target = keyframe_effect.target_abstract_element();
+        if (!target.has_value())
+            continue;
+
+        auto& highest_priority_properties = highest_priority_properties_by_target.ensure(target.value());
         bool has_any_highest_priority_property = false;
 
         for (auto const& property : animation->effect()->target_properties()) {
-            if (!highest_property_composite_orders.contains(property)) {
+            if (!highest_priority_properties.contains(property)) {
                 has_any_highest_priority_property = true;
-                highest_property_composite_orders.set(property, i);
+                highest_priority_properties.set(property);
             }
         }
 

--- a/Tests/LibWeb/Text/expected/WebAnimations/animation-methods/finished-fill-forwards-animations-on-different-elements-are-not-replaced.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/animation-methods/finished-fill-forwards-animations-on-different-elements-are-not-replaced.txt
@@ -1,0 +1,4 @@
+first animations after timeout: 1
+first opacity after timeout: 0
+second animations after timeout: 1
+second opacity after timeout: 0

--- a/Tests/LibWeb/Text/input/WebAnimations/animation-methods/finished-fill-forwards-animations-on-different-elements-are-not-replaced.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/animation-methods/finished-fill-forwards-animations-on-different-elements-are-not-replaced.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<div id="first"></div>
+<div id="second"></div>
+<script src="../../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const first = document.getElementById("first");
+        const second = document.getElementById("second");
+
+        first.animate([{ opacity: 1 }, { opacity: 0 }], {
+            duration: 300,
+            fill: "forwards",
+        }).finish();
+
+        second.animate([{ opacity: 1 }, { opacity: 0 }], {
+            duration: 300,
+            fill: "forwards",
+        }).finish();
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        println(`first animations after timeout: ${first.getAnimations().length}`);
+        println(`first opacity after timeout: ${getComputedStyle(first).opacity}`);
+        println(`second animations after timeout: ${second.getAnimations().length}`);
+        println(`second opacity after timeout: ${getComputedStyle(second).opacity}`);
+    });
+</script>


### PR DESCRIPTION
Finished replaceable animations should only be replaced by newer animations that target the same effect target and property.

The previous bookkeeping was global per CSS property. This let a finished opacity animation on one element replace a finished opacity animation on another element, dropping the older animation's fill-forwards result. On Duolingo this made the hidden drawer backdrop fall back to its base visible opacity and tint the whole page.

<img width="1280" height="480" alt="duolingo-before-after-comparison" src="https://github.com/user-attachments/assets/43dd31ad-558e-48db-ad0c-da92128b56ca" />
