### PR TITLE
LibWeb: Only invalidate style for relevant links on navigation

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -393,6 +393,8 @@ void StyleScope::collect_selector_insights(Selector const& selector, SelectorIns
     for (auto const& compound_selector : selector.compound_selectors()) {
         for (auto const& simple_selector : compound_selector.simple_selectors) {
             if (simple_selector.type == Selector::SimpleSelector::Type::PseudoClass) {
+                if (simple_selector.pseudo_class().type == PseudoClass::LocalLink)
+                    insights.has_local_link_selectors = true;
                 if (simple_selector.pseudo_class().type == PseudoClass::Has) {
                     insights.has_has_selectors = true;
                     for (auto const& argument_selector : simple_selector.pseudo_class().argument_selector_list) {
@@ -822,6 +824,12 @@ bool StyleScope::have_has_selectors_with_relative_selector_that_has_sibling_comb
 {
     build_rule_cache_if_needed();
     return m_rule_cache->selector_insights.has_has_selectors_with_relative_selector_that_has_sibling_combinator;
+}
+
+bool StyleScope::have_local_link_selectors() const
+{
+    build_rule_cache_if_needed();
+    return m_rule_cache->selector_insights.has_local_link_selectors;
 }
 
 DOM::Document& StyleScope::document() const

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -78,6 +78,7 @@ struct RuleCaches {
 struct SelectorInsights {
     bool has_has_selectors { false };
     bool has_has_selectors_with_relative_selector_that_has_sibling_combinator { false };
+    bool has_local_link_selectors { false };
 };
 
 struct StyleCache : public RefCounted<StyleCache> {
@@ -139,6 +140,7 @@ public:
     [[nodiscard]] bool have_has_selectors() const;
     [[nodiscard]] bool may_have_has_selectors_with_relative_selector_that_has_sibling_combinator() const;
     [[nodiscard]] bool have_has_selectors_with_relative_selector_that_has_sibling_combinator() const;
+    [[nodiscard]] bool have_local_link_selectors() const;
 
     void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)> const& callback) const;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1353,6 +1353,26 @@ void Document::respond_to_base_url_changes(URL::URL const& old_document_url, URL
     // FIXME: Update those UI elements.
 
     // 2. Ensure that the CSS :link/:visited/etc. pseudo-classes are updated appropriately.
+    // FIXME: When we track which links have been visited, then :link and :visited will also depend on the new URL and
+    //        and this early return will need to be replaced with something that identifies which links will be
+    //        affected by the URL change.
+    auto any_scope_has_local_link = style_scope().have_local_link_selectors();
+    if (!any_scope_has_local_link) {
+        for_each_shadow_including_descendant([&](Node& node) {
+            auto* element = as_if<Element>(node);
+            if (!element)
+                return TraversalDecision::Continue;
+            auto shadow_root = element->shadow_root();
+            if (shadow_root && shadow_root->style_scope().have_local_link_selectors()) {
+                any_scope_has_local_link = true;
+                return TraversalDecision::Break;
+            }
+            return TraversalDecision::Continue;
+        });
+    }
+    if (!any_scope_has_local_link)
+        return;
+
     auto const& new_document_url = m_url;
     auto new_base_url = base_url();
     bool const base_url_unchanged = (old_base_url == new_base_url);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -54,6 +54,7 @@
 #include <LibWeb/CSS/Invalidation/PseudoClassInvalidator.h>
 #include <LibWeb/CSS/Invalidation/SlotInvalidator.h>
 #include <LibWeb/CSS/Invalidation/StyleInvalidator.h>
+#include <LibWeb/CSS/InvalidationSet.h>
 #include <LibWeb/CSS/MediaQueryList.h>
 #include <LibWeb/CSS/MediaQueryListEvent.h>
 #include <LibWeb/CSS/Parser/Parser.h>
@@ -1341,7 +1342,7 @@ GC::Ptr<HTML::HTMLBaseElement> Document::first_base_element_with_target_in_tree_
 }
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#respond-to-base-url-changes
-void Document::respond_to_base_url_changes()
+void Document::respond_to_base_url_changes(URL::URL const& old_document_url, URL::URL const& old_base_url)
 {
     // To respond to base URL changes for a Document document:
 
@@ -1352,7 +1353,39 @@ void Document::respond_to_base_url_changes()
     // FIXME: Update those UI elements.
 
     // 2. Ensure that the CSS :link/:visited/etc. pseudo-classes are updated appropriately.
-    invalidate_style(StyleInvalidationReason::BaseURLChanged);
+    auto const& new_document_url = m_url;
+    auto new_base_url = base_url();
+    bool const base_url_unchanged = (old_base_url == new_base_url);
+    if (base_url_unchanged && old_document_url == new_document_url)
+        return;
+
+    auto encoding = encoding_or_default();
+    auto local_link_match = [&](Optional<URL::URL> const& target_url, URL::URL const& document_url) {
+        if (!target_url.has_value())
+            return false;
+        if (target_url->fragment().has_value())
+            return document_url.equals(*target_url, URL::ExcludeFragment::No);
+        return document_url.equals(*target_url, URL::ExcludeFragment::Yes);
+    };
+
+    for_each_shadow_including_descendant([&](Node& node) {
+        auto* element = as_if<Element>(node);
+        if (!element || !element->matches_link_pseudo_class())
+            return TraversalDecision::Continue;
+
+        auto href = element->get_attribute_value(HTML::AttributeNames::href);
+        auto old_target_url = DOMURL::parse(href, old_base_url, encoding);
+        auto new_target_url = base_url_unchanged ? old_target_url : DOMURL::parse(href, new_base_url, encoding);
+
+        if (local_link_match(old_target_url, old_document_url) != local_link_match(new_target_url, new_document_url)) {
+            element->invalidate_style(
+                StyleInvalidationReason::BaseURLChanged,
+                { { .type = CSS::InvalidationSet::Property::Type::PseudoClass, .value = CSS::PseudoClass::LocalLink } },
+                {});
+        }
+
+        return TraversalDecision::Continue;
+    });
 
     // FIXME: 3. For each descendant of document's shadow-including descendants:
     //        ...
@@ -1369,13 +1402,16 @@ void Document::set_url(URL::URL const& url)
 
     ensure_cookie_version_index(url, m_url);
 
+    auto old_document_url = m_url;
+    auto old_base_url = base_url();
+
     // To set the URL for a Document document to a URL record url:
 
     // 1. Set document's URL to url.
     m_url = url;
 
     // 2. Respond to base URL changes given document.
-    respond_to_base_url_changes();
+    respond_to_base_url_changes(old_document_url, old_base_url);
 }
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fallback-base-url

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -268,7 +268,7 @@ public:
     void update_base_element(Badge<HTML::HTMLBaseElement>);
     GC::Ptr<HTML::HTMLBaseElement> first_base_element_with_href_in_tree_order() const;
     GC::Ptr<HTML::HTMLBaseElement> first_base_element_with_target_in_tree_order() const;
-    void respond_to_base_url_changes();
+    void respond_to_base_url_changes(URL::URL const& old_document_url, URL::URL const& old_base_url);
 
     String url_string() const { return m_url.to_string(); }
     String document_uri() const { return url_string(); }

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -30,6 +30,7 @@ void HTMLBaseElement::inserted()
 {
     HTMLElement::inserted();
 
+    auto old_base_url = document().base_url();
     document().update_base_element({});
 
     // The frozen base URL must be immediately set for an element whenever any of the following situations occur:
@@ -38,20 +39,21 @@ void HTMLBaseElement::inserted()
     // NOTE: inserted() is called after this element has been inserted into the document.
     auto first_base_element_with_href_in_document = document().first_base_element_with_href_in_tree_order();
     if (first_base_element_with_href_in_document.ptr() == this)
-        set_the_frozen_base_url();
+        set_the_frozen_base_url(old_base_url);
 }
 
 void HTMLBaseElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor, Node& old_root)
 {
     HTMLElement::removed_from(is_subtree_root, old_ancestor, old_root);
     auto old_first_base_element_with_href_in_tree_order = document().first_base_element_with_href_in_tree_order();
+    auto old_base_url = document().base_url();
     document().update_base_element({});
 
     // The frozen base URL must be immediately set for an element whenever any of the following situations occur:
     // - The base element becomes the first base element in tree order with an href content attribute in its Document.
     auto first_base_element_with_href_in_document = document().first_base_element_with_href_in_tree_order();
     if (first_base_element_with_href_in_document && first_base_element_with_href_in_document != old_first_base_element_with_href_in_tree_order)
-        first_base_element_with_href_in_document->set_the_frozen_base_url();
+        first_base_element_with_href_in_document->set_the_frozen_base_url(old_base_url);
 }
 
 void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
@@ -63,15 +65,16 @@ void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<String> 
     if (name != AttributeNames::href)
         return;
 
+    auto old_base_url = document().base_url();
     document().update_base_element({});
 
     auto first_base_element_with_href_in_document = document().first_base_element_with_href_in_tree_order();
     if (first_base_element_with_href_in_document.ptr() == this)
-        set_the_frozen_base_url();
+        set_the_frozen_base_url(old_base_url);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url
-void HTMLBaseElement::set_the_frozen_base_url()
+void HTMLBaseElement::set_the_frozen_base_url(URL::URL const& old_base_url)
 {
     // 1. Let document be element's node document.
     auto& document = this->document();
@@ -97,7 +100,7 @@ void HTMLBaseElement::set_the_frozen_base_url()
     m_frozen_base_url = url_record.release_value();
 
     // 5. Respond to base URL changes given document.
-    document.respond_to_base_url_changes();
+    document.respond_to_base_url_changes(document.url(), old_base_url);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -36,7 +36,7 @@ private:
     // A base element that is the first base element with an href content attribute in a document tree has a frozen base URL.
     URL::URL m_frozen_base_url;
 
-    void set_the_frozen_base_url();
+    void set_the_frozen_base_url(URL::URL const& old_base_url);
 };
 
 }

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/url-change-skips-full-document-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/url-change-skips-full-document-invalidation.txt
@@ -1,0 +1,3 @@
+no :local-link rule: fullStyleInvalidations=0, styleInvalidations=0, elementStyleRecomputations=0
+:local-link rule, anchor flips: fullStyleInvalidations=0, styleInvalidations=1, elementStyleRecomputations=1
+shadow-only :local-link rule, shadow anchor flips: fullStyleInvalidations=0, styleInvalidations=1, elementStyleRecomputations=1

--- a/Tests/LibWeb/Text/input/css/style-invalidation/url-change-skips-full-document-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/url-change-skips-full-document-invalidation.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script src="structural-matrix.js"></script>
+<script>
+    test(() => {
+        // Verifies that updating the document URL doesn't trigger a full document style invalidation. Links whose
+        // :local-link match state actually flipped should be recomputed.
+
+        const NUM_LINKS = 50;
+        for (let i = 0; i < NUM_LINKS; i++) {
+            document.body.appendChild(makeElement("a", { attributes: { href: `https://example.com/page${i}` } }));
+        }
+        document.body.appendChild(makeElement("a", { id: "same-doc", attributes: { href: "#target" } }));
+        document.body.offsetWidth;
+
+        const printCounters = label => {
+            const counters = internals.getStyleInvalidationCounters();
+            println(`${label}: fullStyleInvalidations=${counters.fullStyleInvalidations}, styleInvalidations=${counters.styleInvalidations}, elementStyleRecomputations=${counters.elementStyleRecomputations}`);
+        };
+
+        // Without any :local-link rule, a URL change should produce no invalidation work at all.
+        resetStyleCounters();
+        history.pushState({}, "", "#initial");
+        document.body.offsetWidth;
+        printCounters("no :local-link rule");
+
+        const documentStyle = addStyle(document.head, `a:local-link { color: rgb(0, 128, 0); }`);
+        document.body.offsetWidth;
+
+        // With a :local-link rule, navigating to the targeted fragment must restyle only the matching anchor, the
+        // other 50 anchors and the rest of the document are untouched.
+        resetStyleCounters();
+        history.pushState({}, "", "#target");
+        document.body.offsetWidth;
+        printCounters(":local-link rule, anchor flips");
+
+        // A :local-link rule that lives only inside a shadow root must still trigger invalidation for shadow
+        // anchors when their match state flips on URL change.
+        documentStyle.remove();
+        const host = makeElement("div");
+        document.body.appendChild(host);
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        addStyle(shadowRoot, `a:local-link { color: rgb(0, 0, 128); }`);
+        shadowRoot.appendChild(makeElement("a", { id: "shadow-anchor", attributes: { href: "#shadow-target" } }));
+        document.body.offsetWidth;
+
+        resetStyleCounters();
+        history.pushState({}, "", "#shadow-target");
+        document.body.offsetWidth;
+        printCounters("shadow-only :local-link rule, shadow anchor flips");
+    });
+</script>


### PR DESCRIPTION
Previously, updating the document URL, by clicking a href, for example, would call `respond_to_base_url_changes()` which unconditionally invalidated style on the entire document, in order to update the style of any elements with pseudo classes that respond to changes in URL.

Currently, :link and :visited pseudo classes do not respond to URL changes, so I've added an early escape for now, so these do not invalidate style. We now also walk over all the links in the document and figure out which one's may have changed before invalidating their style. This will obviously need to be updated when we start tracking visited URLs.

This speedup can be seen on https://en.wikipedia.org/wiki/Holy_Roman_Empire, where the time taken to navigate to a given section after clicking on a table of contents link dropped from 1.05s to 750ms on average on my machine.