### PR TITLE
LibJS: Fix var and func declarations in direct eval inside catch blocks

### DIFF
--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -353,6 +353,7 @@ op CreateLexicalEnvironment < Instruction
     m_dst: Operand
     m_parent: Operand
     m_capacity: u32
+    m_is_catch_environment: bool
 endop
 
 op CreateImmutableBinding < Instruction

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -2473,6 +2473,7 @@ void CreateLexicalEnvironment::execute_impl(VM& vm) const
     auto& parent = as<Environment>(vm.get(m_parent).as_cell());
     auto environment = new_declarative_environment(parent);
     environment->ensure_capacity(m_capacity);
+    environment->set_is_catch_environment(m_is_catch_environment);
     vm.set(m_dst, environment);
     vm.running_execution_context().lexical_environment = environment;
 }

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -820,11 +820,16 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, EvalDeclarationDa
                 for (auto const& name : data.var_names) {
                     // a. If ! thisEnv.HasBinding(name) is true, then
                     if (MUST(this_environment->has_binding(name))) {
-                        // i. Throw a SyntaxError exception.
-                        return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, name);
-
-                        // FIXME: ii. NOTE: Annex B.3.4 defines alternate semantics for the above step.
-                        // In particular it only throw the syntax error if it is not an environment from a catchclause.
+                        // B.3.4 Changes to EvalDeclarationInstantiation, https://tc39.es/ecma262/#sec-evaldeclarationinstantiation
+                        // i. Normative Optional
+                        //     If the host is a web browser or otherwise supports VariableStatements in Catch Blocks, then
+                        //         i. If thisEnv is not the Environment Record for a Catch clause, throw a SyntaxError exception.
+                        // ii. Else,
+                        //     i. Throw a SyntaxError exception.
+                        // AD-HOC: We are a web browser, so we only implement the web browser branch.
+                        if (!this_environment->is_catch_environment()) {
+                            return vm.throw_completion<SyntaxError>(ErrorType::EvalVarHoistingConflict, name);
+                        }
                     }
                     // b. NOTE: A direct eval will not hoist var declaration over a like-named lexical declaration.
                 }

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -32,6 +32,9 @@ class JS_API DeclarativeEnvironment : public Environment {
 public:
     virtual ~DeclarativeEnvironment() override = default;
 
+    virtual bool is_catch_environment() const override { return m_is_catch_environment; }
+    void set_is_catch_environment(bool value) { m_is_catch_environment = value; }
+
     virtual ThrowCompletionOr<bool> has_binding(Utf16FlyString const& name, Optional<size_t>* = nullptr) const override final;
     virtual ThrowCompletionOr<void> create_mutable_binding(VM&, Utf16FlyString const& name, bool can_be_deleted) override final;
     virtual ThrowCompletionOr<void> create_immutable_binding(VM&, Utf16FlyString const& name, bool strict) override final;
@@ -128,6 +131,7 @@ private:
     DisposeCapability m_dispose_capability;
 
     u64 m_environment_serial_number { 0 };
+    bool m_is_catch_environment { false };
 };
 
 inline ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value_direct(VM& vm, size_t index) const

--- a/Libraries/LibJS/Runtime/Environment.h
+++ b/Libraries/LibJS/Runtime/Environment.h
@@ -50,6 +50,7 @@ public:
     [[nodiscard]] bool is_declarative_environment() const { return m_declarative; }
     virtual bool is_global_environment() const { return false; }
     virtual bool is_function_environment() const { return false; }
+    virtual bool is_catch_environment() const { return false; }
 
     template<typename T>
     bool fast_is() const = delete;

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -286,6 +286,7 @@
     M(ToObjectNullOrUndefinedWithProperty, "Cannot access property \"{}\" on {} object")                                            \
     M(ToObjectNullOrUndefinedWithPropertyAndName, "Cannot access property \"{}\" on {} object \"{}\"")                              \
     M(TopLevelVariableAlreadyDeclared, "Redeclaration of top level variable '{}'")                                                  \
+    M(EvalVarHoistingConflict, "Cannot declare var '{}': there is already a lexical declaration with that name in scope")           \
     M(ToPrimitiveReturnedObject, "Can't convert {} to primitive with hint \"{}\", its @@toPrimitive method returned an object")     \
     M(TypedArrayContentTypeMismatch, "Can't create {} from {}")                                                                     \
     M(TypedArrayInvalidBufferLength, "Invalid buffer length for {}: must be a multiple of {}, got {}")                              \

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -536,6 +536,7 @@ fn generate_function_expression(
             dst: new_env.operand(),
             parent: parent.operand(),
             capacity: 0,
+            is_catch_environment: false,
         });
         generator.lexical_environment_register_stack.push(new_env);
 
@@ -5655,6 +5656,7 @@ fn generate_class_expression(
         dst: class_env.operand(),
         parent: parent_env.operand(),
         capacity: 0,
+        is_catch_environment: false,
     });
     generator.lexical_environment_register_stack.push(class_env.clone());
 
@@ -7370,7 +7372,7 @@ fn generate_try_statement(
                         generator.emit_mov(&local, &caught_value);
                         generator.mark_local_initialized(ident.local_index);
                     } else {
-                        generator.push_new_lexical_environment(0);
+                        generator.push_new_catch_lexical_environment(0);
                         generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
                         created_catch_scope = true;
 
@@ -7394,7 +7396,7 @@ fn generate_try_statement(
                     collect_pattern_binding_names(pattern, &mut names, &generator.arena);
 
                     if !names.is_empty() {
-                        generator.push_new_lexical_environment(0);
+                        generator.push_new_catch_lexical_environment(0);
                         generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
                         created_catch_scope = true;
 

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -954,12 +954,21 @@ impl Generator {
     }
 
     pub fn push_new_lexical_environment(&mut self, capacity: u32) -> ScopedOperand {
+        self.push_new_lexical_environment_impl(capacity, false)
+    }
+
+    pub fn push_new_catch_lexical_environment(&mut self, capacity: u32) -> ScopedOperand {
+        self.push_new_lexical_environment_impl(capacity, true)
+    }
+
+    fn push_new_lexical_environment_impl(&mut self, capacity: u32, is_catch_environment: bool) -> ScopedOperand {
         let parent = self.current_lexical_environment();
         let new_env = self.allocate_register();
         self.emit(Instruction::CreateLexicalEnvironment {
             dst: new_env.operand(),
             parent: parent.operand(),
             capacity,
+            is_catch_environment,
         });
         self.lexical_environment_register_stack.push(new_env.clone());
         new_env

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -20,7 +20,7 @@ block0:
   [ 140] End value:reg7
 
 
-annexBFunctionInIf$f4b6a259 annex-b-function-in-if.js:2:5
+annexBFunctionInIf$f1f2b149 annex-b-function-in-if.js:2:5
   Registers: 8
   Blocks:    4
   Constants:
@@ -33,28 +33,28 @@ block0:
   [  30] JumpFalse condition:arg0, target:block2
 
 block1:
-  [  40] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  50] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [  60] NewFunction dst:reg6, shared_function_data_index:0
-  [  78] InitializeLexicalBinding `inner`, src:reg6
-  [  90] GetBinding dst:reg6, `inner`
-  [  a8] SetVariableBinding `inner`, src:reg6
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] Jump target:block3
+  [  40] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  58] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [  68] NewFunction dst:reg6, shared_function_data_index:0
+  [  80] InitializeLexicalBinding `inner`, src:reg6
+  [  98] GetBinding dst:reg6, `inner`
+  [  b0] SetVariableBinding `inner`, src:reg6
+  [  c8] SetLexicalEnvironment environment:reg4
+  [  d0] Jump target:block3
 
 block2:
-  [  d0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  e0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [  f0] NewFunction dst:reg6, shared_function_data_index:1
-  [ 108] InitializeLexicalBinding `inner`, src:reg6
-  [ 120] GetBinding dst:reg6, `inner`
-  [ 138] SetVariableBinding `inner`, src:reg6
-  [ 150] SetLexicalEnvironment environment:reg4
+  [  d8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  f0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [ 100] NewFunction dst:reg6, shared_function_data_index:1
+  [ 118] InitializeLexicalBinding `inner`, src:reg6
+  [ 130] GetBinding dst:reg6, `inner`
+  [ 148] SetVariableBinding `inner`, src:reg6
+  [ 160] SetLexicalEnvironment environment:reg4
 
 block3:
-  [ 158] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [ 170] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [ 190] Return value:reg5
+  [ 168] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [ 180] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [ 1a0] Return value:reg5
 
 
 inner$b5b8e95a annex-b-function-in-if.js:4:13

--- a/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-test$8422248c annexb-function-existing-var.js:2:5
+test$02c02c04 annexb-function-existing-var.js:2:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -23,12 +23,12 @@ block0:
   [   8] CreateVariable `f`, is_immutable:false, is_global:false, is_strict:false
   [  18] InitializeVariableBinding `f`, src:Undefined
   [  30] SetLexicalBinding `f`, src:Int32(123)
-  [  48] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  58] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
-  [  68] NewFunction dst:reg6, shared_function_data_index:0
-  [  80] InitializeLexicalBinding `f`, src:reg6
-  [  98] GetBinding dst:reg6, `f`
-  [  b0] SetVariableBinding `f`, src:reg6
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] GetInitializedBinding dst:reg5, `f`
-  [  e8] Return value:reg5
+  [  48] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  60] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
+  [  70] NewFunction dst:reg6, shared_function_data_index:0
+  [  88] InitializeLexicalBinding `f`, src:reg6
+  [  a0] GetBinding dst:reg6, `f`
+  [  b8] SetVariableBinding `f`, src:reg6
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] GetInitializedBinding dst:reg5, `f`
+  [  f0] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
+++ b/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
@@ -1,4 +1,4 @@
-$ae8c96e2 block-function-declaration-order.js:1:1
+$2a66ad4a block-function-declaration-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,16 +6,16 @@ $ae8c96e2 block-function-declaration-order.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateMutableBinding environment:reg5, `f1`, can_be_deleted:false
-  [  28] NewFunction dst:reg6, shared_function_data_index:0
-  [  40] InitializeLexicalBinding `f1`, src:reg6
-  [  58] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
-  [  68] NewFunction dst:reg6, shared_function_data_index:1
-  [  80] InitializeLexicalBinding `f2`, src:reg6
-  [  98] GetBinding dst:reg6, `f1`
-  [  b0] SetVariableBinding `f1`, src:reg6
-  [  c8] GetBinding dst:reg6, `f2`
-  [  e0] SetVariableBinding `f2`, src:reg6
-  [  f8] SetLexicalEnvironment environment:reg4
-  [ 100] End value:Undefined
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateMutableBinding environment:reg5, `f1`, can_be_deleted:false
+  [  30] NewFunction dst:reg6, shared_function_data_index:0
+  [  48] InitializeLexicalBinding `f1`, src:reg6
+  [  60] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
+  [  70] NewFunction dst:reg6, shared_function_data_index:1
+  [  88] InitializeLexicalBinding `f2`, src:reg6
+  [  a0] GetBinding dst:reg6, `f1`
+  [  b8] SetVariableBinding `f1`, src:reg6
+  [  d0] GetBinding dst:reg6, `f2`
+  [  e8] SetVariableBinding `f2`, src:reg6
+  [ 100] SetLexicalEnvironment environment:reg4
+  [ 108] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
@@ -11,7 +11,7 @@ block0:
   [  38] End value:reg5
 
 
-test$65d0907d block-scoped-function-no-tdz.js:3:5
+test$e46e97f5 block-scoped-function-no-tdz.js:3:5
   Registers: 7
   Blocks:    1
   Locals:    foo~0, result~1
@@ -21,13 +21,13 @@ test$65d0907d block-scoped-function-no-tdz.js:3:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] Mov dst:result~1, src:Undefined
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  28] NewFunction dst:reg6, shared_function_data_index:0
-  [  40] Mov dst:foo~0, src:reg6
-  [  50] Call dst:reg6, callee:foo~0, this_value:Undefined, foo
-  [  70] Mov dst:result~1, src:reg6
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Return value:result~1
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] NewFunction dst:reg6, shared_function_data_index:0
+  [  48] Mov dst:foo~0, src:reg6
+  [  58] Call dst:reg6, callee:foo~0, this_value:Undefined, foo
+  [  78] Mov dst:result~1, src:reg6
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Return value:result~1
 
 
 foo$f46a9b04 block-scoped-function-no-tdz.js:5:26

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -18,7 +18,7 @@ block0:
   [ 130] End value:reg7
 
 
-closureOverBlockScope$61104af2 block-scoping.js:2:15
+closureOverBlockScope$5e4c59e2 block-scoping.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    fns~0
@@ -30,28 +30,28 @@ closureOverBlockScope$61104af2 block-scoping.js:2:15
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] NewArray dst:fns~0
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  28] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  38] InitializeLexicalBinding `x`, src:Int32(1)
-  [  50] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  70] Mov dst:reg8, src:fns~0
-  [  80] NewFunction dst:reg9, shared_function_data_index:0
-  [  98] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  d8] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
-  [  e8] InitializeLexicalBinding `y`, src:Int32(2)
-  [ 100] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [ 120] Mov dst:reg8, src:fns~0
-  [ 130] NewFunction dst:reg9, shared_function_data_index:1
-  [ 148] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 170] SetLexicalEnvironment environment:reg4
-  [ 178] GetByValue dst:reg6, base:fns~0, property:Int32(0)
-  [ 190] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
-  [ 1b0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
-  [ 1c8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
-  [ 1e8] Add dst:reg7, lhs:reg5, rhs:reg6
-  [ 1f8] Return value:reg7
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
+  [  40] InitializeLexicalBinding `x`, src:Int32(1)
+  [  58] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  78] Mov dst:reg8, src:fns~0
+  [  88] NewFunction dst:reg9, shared_function_data_index:0
+  [  a0] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [  c8] SetLexicalEnvironment environment:reg4
+  [  d0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  e8] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
+  [  f8] InitializeLexicalBinding `y`, src:Int32(2)
+  [ 110] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [ 130] Mov dst:reg8, src:fns~0
+  [ 140] NewFunction dst:reg9, shared_function_data_index:1
+  [ 158] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 180] SetLexicalEnvironment environment:reg4
+  [ 188] GetByValue dst:reg6, base:fns~0, property:Int32(0)
+  [ 1a0] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
+  [ 1c0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
+  [ 1d8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
+  [ 1f8] Add dst:reg7, lhs:reg5, rhs:reg6
+  [ 208] Return value:reg7
 
 
 $4bcefff2 block-scoping.js:5:18
@@ -72,7 +72,7 @@ block0:
   [  18] Return value:reg5
 
 
-breakThroughBlockScopes$bb8ff62f block-scoping.js:16:5
+breakThroughBlockScopes$3fb5dfc7 block-scoping.js:16:5
   Registers: 8
   Blocks:    7
   Locals:    f~0, i~1, result~2
@@ -88,31 +88,31 @@ block0:
   [  20] Jump target:block3
 
 block1:
-  [  28] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  38] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  48] InitializeLexicalBinding `x`, src:i~1
-  [  60] NewFunction dst:f~0, shared_function_data_index:0 (f)
-  [  78] GetBinding dst:reg6, `x`
-  [  90] JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:block5, false_target:block6
+  [  28] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  40] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
+  [  50] InitializeLexicalBinding `x`, src:i~1
+  [  68] NewFunction dst:f~0, shared_function_data_index:0 (f)
+  [  80] GetBinding dst:reg6, `x`
+  [  98] JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:block5, false_target:block6
 
 block2:
-  [  a8] PostfixIncrement dst:reg5, src:i~1
+  [  b0] PostfixIncrement dst:reg5, src:i~1
 
 block3:
-  [  b8] JumpLessThan lhs:i~1, rhs:Int32(3), true_target:block1, false_target:block4
+  [  c0] JumpLessThan lhs:i~1, rhs:Int32(3), true_target:block1, false_target:block4
 
 block4:
-  [  d0] Call dst:reg5, callee:result~2, this_value:Undefined, result
-  [  f0] Return value:reg5
+  [  d8] Call dst:reg5, callee:result~2, this_value:Undefined, result
+  [  f8] Return value:reg5
 
 block5:
-  [  f8] Mov dst:result~2, src:f~0
-  [ 108] SetLexicalEnvironment environment:reg4
-  [ 110] Jump target:block4
+  [ 100] Mov dst:result~2, src:f~0
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Jump target:block4
 
 block6:
-  [ 118] SetLexicalEnvironment environment:reg4
-  [ 120] Jump target:block2
+  [ 120] SetLexicalEnvironment environment:reg4
+  [ 128] Jump target:block2
 
 
 f$e7dc110a block-scoping.js:20:21

--- a/Tests/LibJS/Bytecode/expected/captured-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/captured-variables.txt
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-outer$e7583c0c captured-variables.js:5:5
+outer$65f64384 captured-variables.js:5:5
   Registers: 7
   Blocks:    1
   Locals:    inner~0
@@ -21,12 +21,12 @@ outer$e7583c0c captured-variables.js:5:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] Mov dst:inner~0, src:Undefined
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1
-  [  28] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
-  [  38] NewFunction dst:inner~0, shared_function_data_index:0
-  [  50] InitializeLexicalBinding `captured`, src:Int32(1)
-  [  68] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
-  [  88] Return value:reg6
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  30] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
+  [  40] NewFunction dst:inner~0, shared_function_data_index:0
+  [  58] InitializeLexicalBinding `captured`, src:Int32(1)
+  [  70] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
+  [  90] Return value:reg6
 
 
 inner$e471f8e5 captured-variables.js:7:9

--- a/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
@@ -1,4 +1,4 @@
-$00cee19d class-computed-field-lhs-name.js:1:1
+$87b8bc45 class-computed-field-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -9,13 +9,13 @@ $00cee19d class-computed-field-lhs-name.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (C), element_keys:[element_keys:Int32(3)]
-  [  48] SetGlobal `C`, src:reg6
-  [  60] GetGlobal dst:reg5, `C`
-  [  78] CallConstruct dst:reg6, callee:reg5, C
-  [  90] End value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (C), element_keys:[element_keys:Int32(3)]
+  [  50] SetGlobal `C`, src:reg6
+  [  68] GetGlobal dst:reg5, `C`
+  [  80] CallConstruct dst:reg6, callee:reg5, C
+  [  98] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/class-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-key.txt
@@ -10,16 +10,16 @@ block0:
   [  38] End value:reg5
 
 
-f$88b2a512 class-computed-key.js:4:5
+f$01c8ca6a class-computed-key.js:4:5
   Registers: 8
   Blocks:    1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable ``, is_immutable:true, is_global:false, is_strict:false
-  [  28] GetGlobal dst:reg6, `Symbol`
-  [  40] GetById dst:reg7, base:reg6, `iterator` (Symbol.iterator)
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:reg7]
-  [  90] Return value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable ``, is_immutable:true, is_global:false, is_strict:false
+  [  30] GetGlobal dst:reg6, `Symbol`
+  [  48] GetById dst:reg7, base:reg6, `iterator` (Symbol.iterator)
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:reg7]
+  [  98] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/class-environment.txt
+++ b/Tests/LibJS/Bytecode/expected/class-environment.txt
@@ -13,7 +13,7 @@ block0:
   [  98] End value:reg5
 
 
-classWithName$155d62f1 class-environment.js:2:13
+classWithName$99834c89 class-environment.js:2:13
   Registers: 8
   Blocks:    1
   Locals:    C~0
@@ -23,15 +23,15 @@ classWithName$155d62f1 class-environment.js:2:13
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:C~0, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  58] CallConstruct dst:reg6, callee:C~0, C
-  [  70] GetById dst:reg7, base:reg6, `method`
-  [  90] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
-  [  b0] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
-  [  c0] Return value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:C~0, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
+  [  60] CallConstruct dst:reg6, callee:C~0, C
+  [  78] GetById dst:reg7, base:reg6, `method`
+  [  98] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
+  [  b8] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
+  [  c8] Return value:reg7
 
 
 Foo$534d924b

--- a/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
+++ b/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
@@ -1,4 +1,4 @@
-$e7eb680d class-lhs-name-no-createvariable.js:1:1
+$63c57e75 class-lhs-name-no-createvariable.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $e7eb680d class-lhs-name-no-createvariable.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (x), element_keys:[element_keys:String("method")]
-  [  48] SetGlobal `x`, src:reg6
-  [  60] End value:Undefined
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (x), element_keys:[element_keys:String("method")]
+  [  50] SetGlobal `x`, src:reg6
+  [  68] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
+++ b/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
@@ -26,7 +26,7 @@ block0:
   [ 210] End value:reg5
 
 
-test$7bd6515c class-literal-fields.js:2:5
+test$fa7458d4 class-literal-fields.js:2:5
   Registers: 7
   Blocks:    1
   Locals:    A~0
@@ -41,14 +41,14 @@ test$7bd6515c class-literal-fields.js:2:5
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("x"), element_keys:String("y"), element_keys:String("z"), element_keys:String("w"), element_keys:String("s"), element_keys:String("computed")]
-  [  68] Mov dst:A~0, src:reg6
-  [  78] ThrowIfTDZ src:A~0
-  [  80] CallConstruct dst:reg6, callee:A~0, A
-  [  98] Return value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("x"), element_keys:String("y"), element_keys:String("z"), element_keys:String("w"), element_keys:String("s"), element_keys:String("computed")]
+  [  70] Mov dst:A~0, src:reg6
+  [  80] ThrowIfTDZ src:A~0
+  [  88] CallConstruct dst:reg6, callee:A~0, A
+  [  a0] Return value:reg6
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -1,4 +1,4 @@
-$67bc40cb delete-super-eval-order.js:4:1
+$e91e3953 delete-super-eval-order.js:4:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -8,30 +8,30 @@ $67bc40cb delete-super-eval-order.js:4:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("m")]
-  [  58] InitializeLexicalBinding `A`, src:reg6
-  [  70] Jump target:block2
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("m")]
+  [  60] InitializeLexicalBinding `A`, src:reg6
+  [  78] Jump target:block2
 
 block1:
-  [  78] Catch dst:reg6
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov2 dst1:reg5, src1:Undefined, dst2:reg7, src2:reg5
-  [  a0] End value:reg5
+  [  80] Catch dst:reg6
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Mov2 dst1:reg5, src1:Undefined, dst2:reg7, src2:reg5
+  [  a8] End value:reg5
 
 block2:
-  [  a8] Mov dst:reg6, src:Undefined
-  [  b8] GetGlobal dst:reg9, `A`
-  [  d0] CallConstruct dst:reg8, callee:reg9, A
-  [  e8] GetById dst:reg9, base:reg8, `m`
-  [ 108] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
-  [ 130] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
-  [ 148] End value:reg5
+  [  b0] Mov dst:reg6, src:Undefined
+  [  c0] GetGlobal dst:reg9, `A`
+  [  d8] CallConstruct dst:reg8, callee:reg9, A
+  [  f0] GetById dst:reg9, base:reg8, `m`
+  [ 110] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
+  [ 138] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 150] End value:reg5
 
 Exception handlers:
-  [  a8 ..  150] => handler block1
+  [  b0 ..  158] => handler block1
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -1,4 +1,4 @@
-$752dc5b7 delete-super-property.js:1:1
+$f107dc1f delete-super-property.js:1:1
   Registers: 11
   Blocks:    6
   Locals:    e~0, e~1
@@ -9,48 +9,48 @@ $752dc5b7 delete-super-property.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("foo"), element_keys:String("baz")]
-  [  58] InitializeLexicalBinding `A`, src:reg6
-  [  70] Jump target:block3
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("foo"), element_keys:String("baz")]
+  [  60] InitializeLexicalBinding `A`, src:reg6
+  [  78] Jump target:block3
 
 block1:
-  [  78] Catch dst:reg6
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] Mov3 dst1:e~0, src1:reg6, dst2:reg5, src2:Undefined, dst3:reg7, src3:reg5
+  [  80] Catch dst:reg6
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] Mov3 dst1:e~0, src1:reg6, dst2:reg5, src2:Undefined, dst3:reg7, src3:reg5
 
 block2:
-  [  a8] Jump target:block5
+  [  b0] Jump target:block5
 
 block3:
-  [  b0] Mov dst:reg6, src:Undefined
-  [  c0] GetGlobal dst:reg9, `A`
-  [  d8] CallConstruct dst:reg8, callee:reg9, A
-  [  f0] GetById dst:reg9, base:reg8, `foo`
-  [ 110] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
-  [ 130] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
-  [ 148] Jump target:block2
+  [  b8] Mov dst:reg6, src:Undefined
+  [  c8] GetGlobal dst:reg9, `A`
+  [  e0] CallConstruct dst:reg8, callee:reg9, A
+  [  f8] GetById dst:reg9, base:reg8, `foo`
+  [ 118] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
+  [ 138] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 150] Jump target:block2
 
 block4:
-  [ 150] Catch dst:reg6
-  [ 158] SetLexicalEnvironment environment:reg4
-  [ 160] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
-  [ 180] End value:reg7
+  [ 158] Catch dst:reg6
+  [ 160] SetLexicalEnvironment environment:reg4
+  [ 168] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
+  [ 188] End value:reg7
 
 block5:
-  [ 188] Mov dst:reg6, src:Undefined
-  [ 198] GetGlobal dst:reg10, `A`
-  [ 1b0] CallConstruct dst:reg8, callee:reg10, A
-  [ 1c8] GetById dst:reg10, base:reg8, `baz`
-  [ 1e8] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
-  [ 208] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
-  [ 220] End value:reg7
+  [ 190] Mov dst:reg6, src:Undefined
+  [ 1a0] GetGlobal dst:reg10, `A`
+  [ 1b8] CallConstruct dst:reg8, callee:reg10, A
+  [ 1d0] GetById dst:reg10, base:reg8, `baz`
+  [ 1f0] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
+  [ 210] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
+  [ 228] End value:reg7
 
 Exception handlers:
-  [  b0 ..  150] => handler block1
-  [ 188 ..  228] => handler block4
+  [  b8 ..  158] => handler block1
+  [ 190 ..  230] => handler block4
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
@@ -14,7 +14,7 @@ block0:
   [  a8] End value:reg5
 
 
-array_destructuring_with_class_default$28ef14a9 destructuring-assignment.js:6:10
+array_destructuring_with_class_default$a4c92b11 destructuring-assignment.js:6:10
   Registers: 13
   Blocks:    7
   Locals:    x~0
@@ -39,22 +39,22 @@ block2:
   [  98] JumpUndefined condition:reg10, true_target:block3, false_target:block4
 
 block3:
-  [  a8] CreateLexicalEnvironment dst:reg11, parent:reg4, capacity:0
-  [  b8] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] NewClass dst:reg12, class_environment:reg11, class_blueprint_index:0
-  [  f0] Mov dst:reg10, src:reg12
+  [  a8] CreateLexicalEnvironment dst:reg11, parent:reg4, capacity:0, is_catch_environment:false
+  [  c0] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] NewClass dst:reg12, class_environment:reg11, class_blueprint_index:0
+  [  f8] Mov dst:reg10, src:reg12
 
 block4:
-  [ 100] Mov dst:x~0, src:reg10
-  [ 110] JumpFalse condition:reg6, target:block6
+  [ 108] Mov dst:x~0, src:reg10
+  [ 118] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 120] Return value:x~0
+  [ 128] Return value:x~0
 
 block6:
-  [ 128] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 140] Return value:x~0
+  [ 130] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 148] Return value:x~0
 
 
 object_destructuring_with_function_default$497a8092 destructuring-assignment.js:12:12

--- a/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
@@ -12,7 +12,7 @@ block0:
   [  70] End value:reg6
 
 
-with_eval$361b5eed eval-prevents-locals.js:6:5
+with_eval$b4b96665 eval-prevents-locals.js:6:5
   Registers: 9
   Blocks:    1
   Constants:
@@ -22,13 +22,13 @@ with_eval$361b5eed eval-prevents-locals.js:6:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateArguments is_immutable:false
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1
-  [  28] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  38] InitializeLexicalBinding `x`, src:Int32(1)
-  [  50] GetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
-  [  68] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
-  [  90] GetBinding dst:reg6, `x`
-  [  a8] Return value:reg6
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  30] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  40] InitializeLexicalBinding `x`, src:Int32(1)
+  [  58] GetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
+  [  70] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
+  [  98] GetBinding dst:reg6, `x`
+  [  b0] Return value:reg6
 
 
 eval$b72141f3

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$3122836b for-in-lexical-scope.js:1:12
+$b80c5e13 for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:
@@ -7,39 +7,39 @@ $3122836b for-in-lexical-scope.js:1:12
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  28] NewObject dst:reg6
-  [  38] InitObjectLiteralProperty object:reg6, `i`, src:Int32(0), shape_cache_index:0, property_slot:0
-  [  50] CacheObjectShape object:reg6
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] JumpNullish condition:reg6, true_target:block3, false_target:block4
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  30] NewObject dst:reg6
+  [  40] InitObjectLiteralProperty object:reg6, `i`, src:Int32(0), shape_cache_index:0, property_slot:0
+  [  58] CacheObjectShape object:reg6
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] JumpNullish condition:reg6, true_target:block3, false_target:block4
 
 block1:
-  [  78] End value:reg6
+  [  80] End value:reg6
 
 block2:
-  [  80] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg5
-  [  90] JumpIf condition:reg8, true_target:block1, false_target:block5
+  [  88] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg5
+  [  98] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  a0] End value:reg6
+  [  a8] End value:reg6
 
 block4:
-  [  a8] GetObjectPropertyIterator dst_iterator:reg5, object:reg6
-  [  c0] Mov dst:reg6, src:Undefined
-  [  d0] Jump target:block2
+  [  b0] GetObjectPropertyIterator dst_iterator:reg5, object:reg6
+  [  c8] Mov dst:reg6, src:Undefined
+  [  d8] Jump target:block2
 
 block5:
-  [  d8] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0
-  [  e8] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  f8] InitializeLexicalBinding `x`, src:reg7
-  [ 110] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0
-  [ 120] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
-  [ 130] NewFunction dst:reg11, shared_function_data_index:0
-  [ 148] InitializeLexicalBinding `probeDecl`, src:reg11
-  [ 160] GetBinding dst:reg11, `probeDecl`
-  [ 178] SetVariableBinding `probeDecl`, src:reg11
-  [ 190] SetLexicalEnvironment environment:reg9
-  [ 198] SetLexicalEnvironment environment:reg4
-  [ 1a0] Jump target:block2
+  [  e0] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
+  [  f8] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [ 108] InitializeLexicalBinding `x`, src:reg7
+  [ 120] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
+  [ 138] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
+  [ 148] NewFunction dst:reg11, shared_function_data_index:0
+  [ 160] InitializeLexicalBinding `probeDecl`, src:reg11
+  [ 178] GetBinding dst:reg11, `probeDecl`
+  [ 190] SetVariableBinding `probeDecl`, src:reg11
+  [ 1a8] SetLexicalEnvironment environment:reg9
+  [ 1b0] SetLexicalEnvironment environment:reg4
+  [ 1b8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -13,7 +13,7 @@ block0:
   [  98] End value:reg5
 
 
-forLetClosure$9d2e257d for-loop-scoping.js:2:15
+forLetClosure$24180025 for-loop-scoping.js:2:15
   Registers: 10
   Blocks:    4
   Locals:    fns~0
@@ -24,41 +24,41 @@ forLetClosure$9d2e257d for-loop-scoping.js:2:15
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] NewArray dst:fns~0
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  28] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  38] InitializeLexicalBinding `i`, src:Int32(0)
-  [  50] GetBinding dst:reg6, `i`
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  80] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  90] InitializeLexicalBinding `i`, src:reg6
-  [  a8] Jump target:block2
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [  40] InitializeLexicalBinding `i`, src:Int32(0)
+  [  58] GetBinding dst:reg6, `i`
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  90] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [  a0] InitializeLexicalBinding `i`, src:reg6
+  [  b8] Jump target:block2
 
 block1:
-  [  b0] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  d0] Mov dst:reg8, src:fns~0
-  [  e0] NewFunction dst:reg9, shared_function_data_index:0
-  [  f8] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 120] GetBinding dst:reg6, `i`
-  [ 138] SetLexicalEnvironment environment:reg4
-  [ 140] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [ 150] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [ 160] InitializeLexicalBinding `i`, src:reg6
-  [ 178] GetBinding dst:reg7, `i`
-  [ 190] PostfixIncrement dst:reg6, src:reg7
-  [ 1a0] SetLexicalBinding `i`, src:reg7
+  [  c0] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  e0] Mov dst:reg8, src:fns~0
+  [  f0] NewFunction dst:reg9, shared_function_data_index:0
+  [ 108] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 130] GetBinding dst:reg6, `i`
+  [ 148] SetLexicalEnvironment environment:reg4
+  [ 150] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [ 168] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [ 178] InitializeLexicalBinding `i`, src:reg6
+  [ 190] GetBinding dst:reg7, `i`
+  [ 1a8] PostfixIncrement dst:reg6, src:reg7
+  [ 1b8] SetLexicalBinding `i`, src:reg7
 
 block2:
-  [ 1b8] GetBinding dst:reg6, `i`
-  [ 1d0] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
+  [ 1d0] GetBinding dst:reg6, `i`
+  [ 1e8] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
 
 block3:
-  [ 1e8] SetLexicalEnvironment environment:reg4
-  [ 1f0] GetById dst:reg6, base:fns~0, `map` (fns.map)
-  [ 210] Mov dst:reg7, src:fns~0
-  [ 220] NewFunction dst:reg8, shared_function_data_index:1
-  [ 238] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
-  [ 260] Return value:reg5
+  [ 200] SetLexicalEnvironment environment:reg4
+  [ 208] GetById dst:reg6, base:fns~0, `map` (fns.map)
+  [ 228] Mov dst:reg7, src:fns~0
+  [ 238] NewFunction dst:reg8, shared_function_data_index:1
+  [ 250] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
+  [ 278] Return value:reg5
 
 
 $617ce76f for-loop-scoping.js:6:20

--- a/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
@@ -11,7 +11,7 @@ block0:
   [  50] End value:reg5
 
 
-f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
+f$a9a62cb8 for-of-continue-with-block-scope.js:2:15
   Registers: 18
   Blocks:    11
   Locals:    o~0, t~1
@@ -23,62 +23,62 @@ f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] NewArray dst:t~1
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  28] CreateVariable `r`, is_immutable:false, is_global:false, is_strict:false
-  [  38] SetLexicalEnvironment environment:reg4
-  [  40] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, iterable:arg0
-  [  58] Jump target:block2
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] CreateVariable `r`, is_immutable:false, is_global:false, is_strict:false
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg6, dst_iterator_done:reg7, iterable:arg0
+  [  60] Jump target:block2
 
 block1:
-  [  60] Return value:t~1
+  [  68] Return value:t~1
 
 block2:
-  [  68] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
-  [  80] JumpIf condition:reg11, true_target:block1, false_target:block4
+  [  70] IteratorNextUnpack dst_value:reg10, dst_done:reg11, iterator_object:reg5, iterator_next:reg6, iterator_done:reg7
+  [  88] JumpIf condition:reg11, true_target:block1, false_target:block4
 
 block3:
-  [  90] Catch dst:reg9
-  [  98] SetLexicalEnvironment environment:reg4
-  [  a0] Mov dst:reg8, src:Int32(1)
-  [  b0] JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:block7, false_target:block8
+  [  98] Catch dst:reg9
+  [  a0] SetLexicalEnvironment environment:reg4
+  [  a8] Mov dst:reg8, src:Int32(1)
+  [  b8] JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:block7, false_target:block8
 
 block4:
-  [  c8] CreateLexicalEnvironment dst:reg12, parent:reg4, capacity:0
-  [  d8] CreateVariable `r`, is_immutable:true, is_global:false, is_strict:true
-  [  e8] InitializeLexicalBinding `r`, src:reg10
-  [ 100] GetBinding dst:reg14, `r`
-  [ 118] Not dst:reg13, src:reg14
-  [ 128] JumpFalse condition:reg13, target:block6
+  [  d0] CreateLexicalEnvironment dst:reg12, parent:reg4, capacity:0, is_catch_environment:false
+  [  e8] CreateVariable `r`, is_immutable:true, is_global:false, is_strict:true
+  [  f8] InitializeLexicalBinding `r`, src:reg10
+  [ 110] GetBinding dst:reg14, `r`
+  [ 128] Not dst:reg13, src:reg14
+  [ 138] JumpFalse condition:reg13, target:block6
 
 block5:
-  [ 138] GetById dst:reg15, base:t~1, `push` (t.push)
-  [ 158] Mov dst:reg16, src:t~1
-  [ 168] GetBinding dst:reg17, `r`
-  [ 180] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
-  [ 1a8] SetLexicalEnvironment environment:reg4
-  [ 1b0] Jump target:block2
+  [ 148] GetById dst:reg15, base:t~1, `push` (t.push)
+  [ 168] Mov dst:reg16, src:t~1
+  [ 178] GetBinding dst:reg17, `r`
+  [ 190] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
+  [ 1b8] SetLexicalEnvironment environment:reg4
+  [ 1c0] Jump target:block2
 
 block6:
-  [ 1b8] GetById dst:reg13, base:t~1, `find` (t.find)
-  [ 1d8] Mov dst:reg14, src:t~1
-  [ 1e8] NewFunction dst:reg15, shared_function_data_index:0
-  [ 200] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
-  [ 228] SetLexicalEnvironment environment:reg4
-  [ 230] Jump target:block2
+  [ 1c8] GetById dst:reg13, base:t~1, `find` (t.find)
+  [ 1e8] Mov dst:reg14, src:t~1
+  [ 1f8] NewFunction dst:reg15, shared_function_data_index:0
+  [ 210] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
+  [ 238] SetLexicalEnvironment environment:reg4
+  [ 240] Jump target:block2
 
 block7:
-  [ 238] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
-  [ 250] Throw src:reg9
+  [ 248] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
+  [ 260] Throw src:reg9
 
 block8:
-  [ 258] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
-  [ 270] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
+  [ 268] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
+  [ 280] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
 
 block9:
-  [ 288] Return value:reg9
+  [ 298] Return value:reg9
 
 block10:
-  [ 290] Throw src:reg9
+  [ 2a0] Throw src:reg9
 
 Exception handlers:
-  [  c8 ..  238] => handler block3
+  [  d0 ..  248] => handler block3

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -1,4 +1,4 @@
-$b319ee85 lexical-env-teardown.js:13:1
+$31b7f5fd lexical-env-teardown.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -31,21 +31,21 @@ block0:
   [ 2a0] GetGlobal dst:reg10, `catchTeardown`
   [ 2b8] Call dst:reg9, callee:reg10, this_value:Undefined, catchTeardown
   [ 2d8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 300] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0
-  [ 310] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
-  [ 320] NewFunction dst:reg6, shared_function_data_index:0
-  [ 338] InitializeLexicalBinding `myName`, src:reg6
-  [ 350] SetLexicalEnvironment environment:reg4
-  [ 358] SetGlobal `namedFn`, src:reg6
-  [ 370] GetGlobal dst:reg7, `console`
-  [ 388] GetById dst:reg8, base:reg7, `log` (console.log)
-  [ 3a8] GetGlobal dst:reg10, `namedFn`
-  [ 3c0] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
-  [ 3e0] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 408] End value:reg6
+  [ 300] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
+  [ 318] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
+  [ 328] NewFunction dst:reg6, shared_function_data_index:0
+  [ 340] InitializeLexicalBinding `myName`, src:reg6
+  [ 358] SetLexicalEnvironment environment:reg4
+  [ 360] SetGlobal `namedFn`, src:reg6
+  [ 378] GetGlobal dst:reg7, `console`
+  [ 390] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 3b0] GetGlobal dst:reg10, `namedFn`
+  [ 3c8] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
+  [ 3e8] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 410] End value:reg6
 
 
-withTeardown$f8b3e64d lexical-env-teardown.js:7:5
+withTeardown$7751edc5 lexical-env-teardown.js:7:5
   Registers: 10
   Blocks:    1
   Locals:    inner~0
@@ -56,19 +56,19 @@ withTeardown$f8b3e64d lexical-env-teardown.js:7:5
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1
-  [  18] CreateVariable `outer`, is_immutable:false, is_global:false, is_strict:false
-  [  28] InitializeLexicalBinding `outer`, src:Int32(1)
-  [  40] NewObject dst:reg6
-  [  50] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
-  [  68] CacheObjectShape object:reg6
-  [  78] EnterObjectEnvironment dst:reg7, object:reg6
-  [  88] GetBinding dst:reg8, `x`
-  [  a0] GetBinding dst:reg9, `outer`
-  [  b8] Add dst:inner~0, lhs:reg8, rhs:reg9
-  [  c8] SetLexicalEnvironment environment:reg5
-  [  d0] GetBinding dst:reg6, `outer`
-  [  e8] Return value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  20] CreateVariable `outer`, is_immutable:false, is_global:false, is_strict:false
+  [  30] InitializeLexicalBinding `outer`, src:Int32(1)
+  [  48] NewObject dst:reg6
+  [  58] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
+  [  70] CacheObjectShape object:reg6
+  [  80] EnterObjectEnvironment dst:reg7, object:reg6
+  [  90] GetBinding dst:reg8, `x`
+  [  a8] GetBinding dst:reg9, `outer`
+  [  c0] Add dst:inner~0, lhs:reg8, rhs:reg9
+  [  d0] SetLexicalEnvironment environment:reg5
+  [  d8] GetBinding dst:reg6, `outer`
+  [  f0] Return value:reg6
 
 
 blockTeardown$b6f5c4f0 lexical-env-teardown.js:17:5

--- a/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
+++ b/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
@@ -1,4 +1,4 @@
-$b15087f2 named-class-expression-no-lhs-name-leak.js:1:1
+$221ada1a named-class-expression-no-lhs-name-leak.js:1:1
   Registers: 13
   Blocks:    7
   Constants:
@@ -21,19 +21,19 @@ block2:
   [  80] JumpUndefined condition:reg10, true_target:block3, false_target:block4
 
 block3:
-  [  90] CreateLexicalEnvironment dst:reg11, parent:reg4, capacity:0
-  [  a0] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] NewClass dst:reg12, class_environment:reg11, class_blueprint_index:0
-  [  d8] Mov dst:reg10, src:reg12
+  [  90] CreateLexicalEnvironment dst:reg11, parent:reg4, capacity:0, is_catch_environment:false
+  [  a8] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] NewClass dst:reg12, class_environment:reg11, class_blueprint_index:0
+  [  e0] Mov dst:reg10, src:reg12
 
 block4:
-  [  e8] SetGlobal `C`, src:reg10
-  [ 100] JumpFalse condition:reg6, target:block6
+  [  f0] SetGlobal `C`, src:reg10
+  [ 108] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 110] End value:Undefined
+  [ 118] End value:Undefined
 
 block6:
-  [ 118] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 130] Jump target:block5
+  [ 120] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 138] Jump target:block5

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,15 +1,15 @@
-$642030ef named-function-expression.js:4:6
+$cf62a0f7 named-function-expression.js:4:6
   Registers: 8
   Blocks:    1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `Oops`, is_immutable:true, is_global:false, is_strict:false
-  [  28] NewFunction dst:reg6, shared_function_data_index:0
-  [  40] InitializeLexicalBinding `Oops`, src:reg6
-  [  58] SetLexicalEnvironment environment:reg4
-  [  60] SetGlobal `Oops`, src:reg6
-  [  78] GetGlobal dst:reg5, `Oops`
-  [  90] GetById dst:reg7, base:reg5, `x` (Oops.x)
-  [  b0] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `Oops`, is_immutable:true, is_global:false, is_strict:false
+  [  30] NewFunction dst:reg6, shared_function_data_index:0
+  [  48] InitializeLexicalBinding `Oops`, src:reg6
+  [  60] SetLexicalEnvironment environment:reg4
+  [  68] SetGlobal `Oops`, src:reg6
+  [  80] GetGlobal dst:reg5, `Oops`
+  [  98] GetById dst:reg7, base:reg5, `x` (Oops.x)
+  [  b8] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
@@ -1,4 +1,4 @@
-$7ca8f805 numeric-class-field-name.js:1:1
+$fe0af08d numeric-class-field-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,16 +7,16 @@ $7ca8f805 numeric-class-field-name.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
-  [  58] InitializeLexicalBinding `C`, src:reg6
-  [  70] GetGlobal dst:reg5, `C`
-  [  88] CallConstruct dst:reg6, callee:reg5, C
-  [  a0] GetByValue dst:reg5, base:reg6, property:Int32(42)
-  [  b8] GetById dst:reg6, base:reg5, `name` ([42].name)
-  [  d8] End value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
+  [  60] InitializeLexicalBinding `C`, src:reg6
+  [  78] GetGlobal dst:reg5, `C`
+  [  90] CallConstruct dst:reg6, callee:reg5, C
+  [  a8] GetByValue dst:reg5, base:reg6, property:Int32(42)
+  [  c0] GetById dst:reg6, base:reg5, `name` ([42].name)
+  [  e0] End value:reg6
 
 
 C$e7b179de
@@ -29,13 +29,13 @@ block0:
   [   0] End value:Undefined
 
 
-field$2db660f7 numeric-class-field-name.js:2:10
+field$b1dc4a8f numeric-class-field-name.js:2:10
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] SetLexicalEnvironment environment:reg4
-  [  20] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (42)
-  [  40] Return value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] SetLexicalEnvironment environment:reg4
+  [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (42)
+  [  48] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
@@ -1,4 +1,4 @@
-$2d2a9e5a postfix-increment-private-member.js:1:1
+$ae8c96e2 postfix-increment-private-member.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,19 +7,19 @@ $2d2a9e5a postfix-increment-private-member.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] CreatePrivateEnvironment
-  [  30] AddPrivateName `#c`
-  [  38] SetLexicalEnvironment environment:reg4
-  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("nextId")]
-  [  68] LeavePrivateEnvironment
-  [  70] InitializeLexicalBinding `C`, src:reg6
-  [  88] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg5, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg5, `nextId`
-  [  d8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
-  [  f8] End value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] CreatePrivateEnvironment
+  [  38] AddPrivateName `#c`
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("nextId")]
+  [  70] LeavePrivateEnvironment
+  [  78] InitializeLexicalBinding `C`, src:reg6
+  [  90] GetGlobal dst:reg7, `C`
+  [  a8] CallConstruct dst:reg5, callee:reg7, C
+  [  c0] GetById dst:reg7, base:reg5, `nextId`
+  [  e0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
+  [ 100] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
+++ b/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
@@ -1,4 +1,4 @@
-$7f6ce915 private-identifier-access-patterns.js:1:1
+$00cee19d private-identifier-access-patterns.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,12 +7,12 @@ $7f6ce915 private-identifier-access-patterns.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] CreatePrivateEnvironment
-  [  30] AddPrivateName `#x`
-  [  38] SetLexicalEnvironment environment:reg4
-  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  68] LeavePrivateEnvironment
-  [  70] InitializeLexicalBinding `C`, src:reg6
-  [  88] End value:Undefined
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] CreatePrivateEnvironment
+  [  38] AddPrivateName `#x`
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
+  [  70] LeavePrivateEnvironment
+  [  78] InitializeLexicalBinding `C`, src:reg6
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
@@ -1,4 +1,4 @@
-$2d2a9e5a private-logical-assignment-register-order.js:1:1
+$ae8c96e2 private-logical-assignment-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,19 +7,19 @@ $2d2a9e5a private-logical-assignment-register-order.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] CreatePrivateEnvironment
-  [  30] AddPrivateName `#x`
-  [  38] SetLexicalEnvironment environment:reg4
-  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("f")]
-  [  68] LeavePrivateEnvironment
-  [  70] InitializeLexicalBinding `C`, src:reg6
-  [  88] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg5, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg5, `f`
-  [  d8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
-  [  f8] End value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] CreatePrivateEnvironment
+  [  38] AddPrivateName `#x`
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("f")]
+  [  70] LeavePrivateEnvironment
+  [  78] InitializeLexicalBinding `C`, src:reg6
+  [  90] GetGlobal dst:reg7, `C`
+  [  a8] CallConstruct dst:reg5, callee:reg7, C
+  [  c0] GetById dst:reg7, base:reg5, `f`
+  [  e0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
+  [ 100] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
+++ b/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
@@ -1,4 +1,4 @@
-$2d2a9e5a private-method-call-description.js:1:1
+$ae8c96e2 private-method-call-description.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,19 +7,19 @@ $2d2a9e5a private-method-call-description.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] CreatePrivateEnvironment
-  [  30] AddPrivateName `#m`
-  [  38] SetLexicalEnvironment environment:reg4
-  [  40] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("call")]
-  [  68] LeavePrivateEnvironment
-  [  70] InitializeLexicalBinding `C`, src:reg6
-  [  88] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg5, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg5, `call`
-  [  d8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
-  [  f8] End value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] CreatePrivateEnvironment
+  [  38] AddPrivateName `#m`
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("call")]
+  [  70] LeavePrivateEnvironment
+  [  78] InitializeLexicalBinding `C`, src:reg6
+  [  90] GetGlobal dst:reg7, `C`
+  [  a8] CallConstruct dst:reg5, callee:reg7, C
+  [  c0] GetById dst:reg7, base:reg5, `call`
+  [  e0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
+  [ 100] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$0656c3bd super-call-spread-register-order.js:1:1
+$772115e5 super-call-spread-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,15 +6,15 @@ $0656c3bd super-call-spread-register-order.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] GetGlobal dst:reg6, `Object`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  68] InitializeLexicalBinding `C`, src:reg7
-  [  80] GetGlobal dst:reg5, `C`
-  [  98] CallConstruct dst:reg7, callee:reg5, C
-  [  b0] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] GetGlobal dst:reg6, `Object`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
+  [  70] InitializeLexicalBinding `C`, src:reg7
+  [  88] GetGlobal dst:reg5, `C`
+  [  a0] CallConstruct dst:reg7, callee:reg5, C
+  [  b8] End value:reg7
 
 
 C$c11ea3e3 super-call-spread-register-order.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
@@ -1,4 +1,4 @@
-$27a2bc3a super-computed-eval-order.js:1:1
+$24decb2a super-computed-eval-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,22 +7,22 @@ $27a2bc3a super-computed-eval-order.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  50] InitializeLexicalBinding `Base`, src:reg6
-  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
-  [  78] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
-  [  88] GetGlobal dst:reg5, `Base`
-  [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
-  [  d0] InitializeLexicalBinding `Derived`, src:reg7
-  [  e8] GetGlobal dst:reg5, `Derived`
-  [ 100] CallConstruct dst:reg6, callee:reg5, Derived
-  [ 118] GetById dst:reg5, base:reg6, `test`
-  [ 138] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
-  [ 158] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
+  [  58] InitializeLexicalBinding `Base`, src:reg6
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
+  [  98] GetGlobal dst:reg5, `Base`
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
+  [  e0] InitializeLexicalBinding `Derived`, src:reg7
+  [  f8] GetGlobal dst:reg5, `Derived`
+  [ 110] CallConstruct dst:reg6, callee:reg5, Derived
+  [ 128] GetById dst:reg5, base:reg6, `test`
+  [ 148] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
+  [ 168] End value:reg7
 
 
 Derived$730ebf72 super-computed-eval-order.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
@@ -1,4 +1,4 @@
-$0656c3bd super-computed-string-to-id.js:1:1
+$772115e5 super-computed-string-to-id.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,15 +6,15 @@ $0656c3bd super-computed-string-to-id.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] GetGlobal dst:reg6, `Object`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  68] InitializeLexicalBinding `C`, src:reg7
-  [  80] GetGlobal dst:reg5, `C`
-  [  98] CallConstruct dst:reg7, callee:reg5, C
-  [  b0] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] GetGlobal dst:reg6, `Object`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
+  [  70] InitializeLexicalBinding `C`, src:reg7
+  [  88] GetGlobal dst:reg5, `C`
+  [  a0] CallConstruct dst:reg7, callee:reg5, C
+  [  b8] End value:reg7
 
 
 C$be5ab2d3 super-computed-string-to-id.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
+++ b/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
@@ -1,4 +1,4 @@
-$32b2807a super-constructor-call.js:1:1
+$2fee8f6a super-constructor-call.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,20 +7,20 @@ $32b2807a super-constructor-call.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  50] InitializeLexicalBinding `Base`, src:reg6
-  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
-  [  78] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
-  [  88] GetGlobal dst:reg5, `Base`
-  [  a0] SetLexicalEnvironment environment:reg4
-  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
-  [  c8] InitializeLexicalBinding `Derived`, src:reg7
-  [  e0] GetGlobal dst:reg6, `Derived`
-  [  f8] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
-  [ 118] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
+  [  58] InitializeLexicalBinding `Base`, src:reg6
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
+  [  98] GetGlobal dst:reg5, `Base`
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
+  [  d8] InitializeLexicalBinding `Derived`, src:reg7
+  [  f0] GetGlobal dst:reg6, `Derived`
+  [ 108] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
+  [ 128] End value:reg7
 
 
 Derived$eee8d5da super-constructor-call.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -1,4 +1,4 @@
-$bf243d42 super-evaluation-order.js:1:1
+$3afe53aa super-evaluation-order.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -9,25 +9,25 @@ $bf243d42 super-evaluation-order.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
-  [  28] GetGlobal dst:reg6, `Object`
-  [  40] SetLexicalEnvironment environment:reg4
-  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
-  [  78] InitializeLexicalBinding `A`, src:reg7
-  [  90] GetGlobal dst:reg6, `A`
-  [  a8] CallConstruct dst:reg5, callee:reg6, A
-  [  c0] GetById dst:reg6, base:reg5, `read`
-  [  e0] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
-  [ 100] GetGlobal dst:reg8, `A`
-  [ 118] CallConstruct dst:reg5, callee:reg8, A
-  [ 130] GetById dst:reg8, base:reg5, `write`
-  [ 150] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
-  [ 170] GetGlobal dst:reg5, `A`
-  [ 188] CallConstruct dst:reg8, callee:reg5, A
-  [ 1a0] GetById dst:reg5, base:reg8, `update`
-  [ 1c0] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
-  [ 1e0] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
+  [  30] GetGlobal dst:reg6, `Object`
+  [  48] SetLexicalEnvironment environment:reg4
+  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
+  [  80] InitializeLexicalBinding `A`, src:reg7
+  [  98] GetGlobal dst:reg6, `A`
+  [  b0] CallConstruct dst:reg5, callee:reg6, A
+  [  c8] GetById dst:reg6, base:reg5, `read`
+  [  e8] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
+  [ 108] GetGlobal dst:reg8, `A`
+  [ 120] CallConstruct dst:reg5, callee:reg8, A
+  [ 138] GetById dst:reg8, base:reg5, `write`
+  [ 158] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
+  [ 178] GetGlobal dst:reg5, `A`
+  [ 190] CallConstruct dst:reg8, callee:reg5, A
+  [ 1a8] GetById dst:reg5, base:reg8, `update`
+  [ 1c8] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
+  [ 1e8] End value:reg7
 
 
 A$3d02c59c super-evaluation-order.js:1:1

--- a/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
@@ -1,4 +1,4 @@
-$87b8bc45 super-for-of-resolve-order.js:1:1
+$091ab4cd super-for-of-resolve-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,14 +6,14 @@ $87b8bc45 super-for-of-resolve-order.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  50] InitializeLexicalBinding `C`, src:reg6
-  [  68] GetGlobal dst:reg5, `C`
-  [  80] CallConstruct dst:reg6, callee:reg5, C
-  [  98] End value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
+  [  58] InitializeLexicalBinding `C`, src:reg6
+  [  70] GetGlobal dst:reg5, `C`
+  [  88] CallConstruct dst:reg6, callee:reg5, C
+  [  a0] End value:reg6
 
 
 C$9d8b2466 super-for-of-resolve-order.js:3:28

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -1,4 +1,4 @@
-$663d1da4 super-length-access.js:3:1
+$63792c94 super-length-access.js:3:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -8,22 +8,22 @@ $663d1da4 super-length-access.js:3:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("length")]
-  [  58] InitializeLexicalBinding `A`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
-  [  80] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:false
-  [  90] GetGlobal dst:reg5, `A`
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
-  [  d8] InitializeLexicalBinding `B`, src:reg7
-  [  f0] GetGlobal dst:reg5, `B`
-  [ 108] CallConstruct dst:reg6, callee:reg5, B
-  [ 120] GetById dst:reg5, base:reg6, `m`
-  [ 140] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
-  [ 160] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("length")]
+  [  60] InitializeLexicalBinding `A`, src:reg6
+  [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  90] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:false
+  [  a0] GetGlobal dst:reg5, `A`
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
+  [  e8] InitializeLexicalBinding `B`, src:reg7
+  [ 100] GetGlobal dst:reg5, `B`
+  [ 118] CallConstruct dst:reg6, callee:reg5, B
+  [ 130] GetById dst:reg5, base:reg6, `m`
+  [ 150] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
+  [ 170] End value:reg7
 
 
 B$cbd8a311 super-length-access.js:7:1

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -1,4 +1,4 @@
-$a904b4c2 super-optional-call-this.js:1:1
+$a640c3b2 super-optional-call-this.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,22 +7,22 @@ $a904b4c2 super-optional-call-this.js:1:1
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
-  [  28] SetLexicalEnvironment environment:reg4
-  [  30] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  58] InitializeLexicalBinding `Base`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0
-  [  80] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
-  [  90] GetGlobal dst:reg5, `Base`
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
-  [  d8] InitializeLexicalBinding `Foo`, src:reg7
-  [  f0] GetGlobal dst:reg5, `Foo`
-  [ 108] CallConstruct dst:reg6, callee:reg5, Foo
-  [ 120] GetById dst:reg5, base:reg6, `method`
-  [ 140] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
-  [ 160] End value:reg7
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
+  [  30] SetLexicalEnvironment environment:reg4
+  [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
+  [  60] InitializeLexicalBinding `Base`, src:reg6
+  [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  90] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
+  [  a0] GetGlobal dst:reg5, `Base`
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
+  [  e8] InitializeLexicalBinding `Foo`, src:reg7
+  [ 100] GetGlobal dst:reg5, `Foo`
+  [ 118] CallConstruct dst:reg6, callee:reg5, Foo
+  [ 130] GetById dst:reg5, base:reg6, `method`
+  [ 150] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
+  [ 170] End value:reg7
 
 
 Foo$f8ebe2ee super-optional-call-this.js:4:1

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -20,7 +20,7 @@ block0:
   [ 140] End value:reg7
 
 
-switchWithBlockDecl$4f465f02 switch-scoping.js:2:5
+switchWithBlockDecl$ba88cf0a switch-scoping.js:2:5
   Registers: 7
   Blocks:    6
   Locals:    result~0
@@ -34,32 +34,32 @@ switchWithBlockDecl$4f465f02 switch-scoping.js:2:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] Mov dst:result~0, src:Undefined
-  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  28] CreateMutableBinding environment:reg5, `a`, can_be_deleted:false
-  [  38] CreateMutableBinding environment:reg5, `b`, can_be_deleted:false
-  [  48] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
+  [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  30] CreateMutableBinding environment:reg5, `a`, can_be_deleted:false
+  [  40] CreateMutableBinding environment:reg5, `b`, can_be_deleted:false
+  [  50] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
 
 block1:
-  [  60] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
+  [  68] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
 
 block2:
-  [  78] Jump target:block5
+  [  80] Jump target:block5
 
 block3:
-  [  80] InitializeLexicalBinding `a`, src:String("one")
-  [  98] NewFunction dst:reg6, shared_function_data_index:0 (result)
-  [  b0] Mov dst:result~0, src:reg6
-  [  c0] Jump target:block5
+  [  88] InitializeLexicalBinding `a`, src:String("one")
+  [  a0] NewFunction dst:reg6, shared_function_data_index:0 (result)
+  [  b8] Mov dst:result~0, src:reg6
+  [  c8] Jump target:block5
 
 block4:
-  [  c8] InitializeLexicalBinding `b`, src:String("two")
-  [  e0] NewFunction dst:reg6, shared_function_data_index:1 (result)
-  [  f8] Mov dst:result~0, src:reg6
+  [  d0] InitializeLexicalBinding `b`, src:String("two")
+  [  e8] NewFunction dst:reg6, shared_function_data_index:1 (result)
+  [ 100] Mov dst:result~0, src:reg6
 
 block5:
-  [ 108] SetLexicalEnvironment environment:reg4
-  [ 110] Call dst:reg5, callee:result~0, this_value:Undefined, result
-  [ 130] Return value:reg5
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Call dst:reg5, callee:result~0, this_value:Undefined, result
+  [ 138] Return value:reg5
 
 
 result$38b0d48c switch-scoping.js:6:22

--- a/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$055cd79c switch-with-block-scope-return.js:2:5
+f$83fadf14 switch-with-block-scope-return.js:2:5
   Registers: 8
   Blocks:    7
   Constants:
@@ -24,31 +24,31 @@ f$055cd79c switch-with-block-scope-return.js:2:5
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateImmutableBinding environment:reg5, `y`, strict_binding:true
-  [  28] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateImmutableBinding environment:reg5, `y`, strict_binding:true
+  [  30] JumpStrictlyEquals lhs:Int32(1), rhs:arg0, true_target:block3, false_target:block1
 
 block1:
-  [  40] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
+  [  48] JumpStrictlyEquals lhs:Int32(2), rhs:arg0, true_target:block4, false_target:block2
 
 block2:
-  [  58] Jump target:block5
+  [  60] Jump target:block5
 
 block3:
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] Return value:String("one")
+  [  68] SetLexicalEnvironment environment:reg4
+  [  70] Return value:String("one")
 
 block4:
-  [  70] InitializeLexicalBinding `y`, src:String("two")
-  [  88] NewFunction dst:reg7, shared_function_data_index:0
-  [  a0] Call dst:reg6, callee:reg7, this_value:Undefined
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] Return value:reg6
+  [  78] InitializeLexicalBinding `y`, src:String("two")
+  [  90] NewFunction dst:reg7, shared_function_data_index:0
+  [  a8] Call dst:reg6, callee:reg7, this_value:Undefined
+  [  c8] SetLexicalEnvironment environment:reg4
+  [  d0] Return value:reg6
 
 block5:
-  [  d0] SetLexicalEnvironment environment:reg4
-  [  d8] Return value:String("other")
+  [  d8] SetLexicalEnvironment environment:reg4
+  [  e0] Return value:String("other")
 
 block6:
-  [  e0] SetLexicalEnvironment environment:reg4
-  [  e8] End value:Undefined
+  [  e8] SetLexicalEnvironment environment:reg4
+  [  f0] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
+++ b/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
@@ -26,7 +26,7 @@ Exception handlers:
   [  48 ..   b0] => handler block1
 
 
-$e58540c1 using-declaration-non-local-env.js:1:21
+$66e73949 using-declaration-non-local-env.js:1:21
   Registers: 8
   Blocks:    2
   Constants:
@@ -34,14 +34,14 @@ $e58540c1 using-declaration-non-local-env.js:1:21
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateImmutableBinding environment:reg5, `x`, strict_binding:true
-  [  28] NewTypeError dst:reg6, TODO: UsingDeclaration
-  [  38] SetLexicalEnvironment environment:reg4
-  [  40] Throw src:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateImmutableBinding environment:reg5, `x`, strict_binding:true
+  [  30] NewTypeError dst:reg6, TODO: UsingDeclaration
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] Throw src:reg6
 
 block1:
-  [  48] NewFunction dst:reg7, shared_function_data_index:0
-  [  60] Call dst:reg6, callee:reg7, this_value:Undefined
-  [  80] SetLexicalEnvironment environment:reg4
-  [  88] End value:Undefined
+  [  50] NewFunction dst:reg7, shared_function_data_index:0
+  [  68] Call dst:reg6, callee:reg7, this_value:Undefined
+  [  88] SetLexicalEnvironment environment:reg4
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-binding-access.txt
+++ b/Tests/LibJS/Bytecode/expected/var-binding-access.txt
@@ -28,7 +28,7 @@ block0:
   [  70] Return value:reg5
 
 
-let_access$c5263a88 var-binding-access.js:14:5
+let_access$6d3f61f0 var-binding-access.js:14:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -36,9 +36,9 @@ let_access$c5263a88 var-binding-access.js:14:5
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1
-  [  18] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  28] InitializeLexicalBinding `x`, src:Int32(1)
-  [  40] NewFunction dst:reg6, shared_function_data_index:0
-  [  58] GetBinding dst:reg6, `x`
-  [  70] Return value:reg6
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
+  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  30] InitializeLexicalBinding `x`, src:Int32(1)
+  [  48] NewFunction dst:reg6, shared_function_data_index:0
+  [  60] GetBinding dst:reg6, `x`
+  [  78] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$20dcebd6 var-env-capacity-with-param-expressions.js:3:9
+f$a23ee45e var-env-capacity-with-param-expressions.js:3:9
   Registers: 10
   Blocks:    3
   Constants:
@@ -20,30 +20,30 @@ f$20dcebd6 var-env-capacity-with-param-expressions.js:3:9
 
 block0:
   [   0] GetLexicalEnvironment dst:reg4
-  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-  [  18] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  28] CreateArguments is_immutable:false
-  [  38] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  30] CreateArguments is_immutable:false
+  [  40] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  48] Mov dst:arg0, src:Int32(1)
+  [  50] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  58] InitializeLexicalBinding `x`, src:arg0
-  [  70] CreateVariableEnvironment capacity:3
-  [  78] GetLexicalEnvironment dst:reg6
-  [  80] Mov dst:reg7, src:Undefined
-  [  90] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
-  [  a0] InitializeVariableBinding `a`, src:reg7
-  [  b8] Mov dst:reg7, src:Undefined
-  [  c8] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
-  [  d8] InitializeVariableBinding `b`, src:reg7
-  [  f0] Mov dst:reg7, src:Undefined
-  [ 100] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [ 110] InitializeVariableBinding `c`, src:reg7
-  [ 128] GetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
-  [ 140] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
-  [ 168] End value:Undefined
+  [  60] InitializeLexicalBinding `x`, src:arg0
+  [  78] CreateVariableEnvironment capacity:3
+  [  80] GetLexicalEnvironment dst:reg6
+  [  88] Mov dst:reg7, src:Undefined
+  [  98] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
+  [  a8] InitializeVariableBinding `a`, src:reg7
+  [  c0] Mov dst:reg7, src:Undefined
+  [  d0] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
+  [  e0] InitializeVariableBinding `b`, src:reg7
+  [  f8] Mov dst:reg7, src:Undefined
+  [ 108] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
+  [ 118] InitializeVariableBinding `c`, src:reg7
+  [ 130] GetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
+  [ 148] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
+  [ 170] End value:Undefined
 
 
 eval$b72141f3

--- a/Tests/LibJS/Runtime/eval-catch-redeclare.js
+++ b/Tests/LibJS/Runtime/eval-catch-redeclare.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * https://github.com/tc39/test262/blob/main/test/annexB/language/eval-code/direct/var-env-lower-lex-catch-non-strict.js
+ */
+
+describe("eval catch block redeclaration", () => {
+    test("eval function declaration in catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("function err() {}");
+        }
+    });
+
+    test("eval function* declaration in catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("function* err() {}");
+        }
+    });
+
+    test("eval async function declaration in catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("async function err() {}");
+        }
+    });
+
+    test("eval async function* declaration in catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("async function* err() {}");
+        }
+    });
+
+    test("eval var declaration in catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("var err;");
+        }
+    });
+
+    test("eval var in for statement inside catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("for (var err; false; ) {}");
+        }
+    });
+
+    test("eval var in for-in inside catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("for (var err in {}) {}");
+        }
+    });
+
+    test("eval var in for-of inside catch block does not throw", () => {
+        try {
+            throw null;
+        } catch (err) {
+            eval("for (var err of []) {}");
+        }
+    });
+});


### PR DESCRIPTION
This PR implements support for Annex B.3.4 of the ECMAScript specification, allowing `eval`-declared `var` and function bindings to be redeclared in catch blocks.

See: https://github.com/tc39/test262/blob/main/test/annexB/language/eval-code/direct/var-env-lower-lex-catch-non-strict.js

By the way, this was the last failing test from Annex B - `eval_code` 🥳 

<img width="980" height="490" alt="image" src="https://github.com/user-attachments/assets/0ebd87c1-aa1f-42ca-bf67-f1b2975af2be" />
