### PR TITLE
LibWebView + UI/Qt: Add reopening of recently closed tabs and windows

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -839,6 +839,8 @@ NonnullRefPtr<Core::Promise<Application::BrowsingDataSizes>> Application::estima
 
 void Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
 {
+    bool did_change_history = false;
+
     if (options.delete_cached_files == ClearBrowsingDataOptions::Delete::Yes) {
         m_request_server_client->async_remove_cache_entries_accessed_since(options.since);
 
@@ -851,13 +853,18 @@ void Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
         });
     }
 
-    if (options.delete_history == ClearBrowsingDataOptions::Delete::Yes)
+    if (options.delete_history == ClearBrowsingDataOptions::Delete::Yes) {
         m_history_store->remove_entries_accessed_since(options.since);
+        did_change_history = true;
+    }
 
     if (options.delete_site_data == ClearBrowsingDataOptions::Delete::Yes) {
         m_cookie_jar->expire_cookies_accessed_since(options.since);
         m_storage_jar->remove_items_accessed_since(options.since);
     }
+
+    if (did_change_history)
+        on_recently_closed_entries_changed();
 }
 
 void Application::clear_history()
@@ -865,6 +872,7 @@ void Application::clear_history()
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Clearing browsing history");
 
     m_history_store->clear();
+    on_recently_closed_entries_changed();
 }
 
 void Application::initialize_actions()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -180,6 +180,7 @@ protected:
 
     virtual void rebuild_bookmarks_menu() const { }
     virtual void update_bookmarks_bar_display([[maybe_unused]] bool show_bookmarks_bar) const { }
+    virtual void on_recently_closed_entries_changed() const { }
 
     struct BookmarkID {
         String id;

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -216,25 +216,25 @@ ErrorOr<NonnullOwnPtr<HistoryStore>> HistoryStore::create(Database::Database& da
     statements.clear_entries = TRY(database.prepare_statement("DELETE FROM History;"sv));
     statements.delete_entries_accessed_since = TRY(database.prepare_statement("DELETE FROM History WHERE last_visited_time >= ?;"sv));
 
-    return adopt_own(*new HistoryStore { PersistedStorage { database, statements } });
+    return adopt_own(*new HistoryStore { adopt_own<StorageImpl>(*new PersistedStorage { database, move(statements) }) });
 }
 
 NonnullOwnPtr<HistoryStore> HistoryStore::create()
 {
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Opening transient history store");
 
-    return adopt_own(*new HistoryStore { OptionalNone {} });
+    return adopt_own(*new HistoryStore { adopt_own<StorageImpl>(*new TransientStorage {}) });
 }
 
 NonnullOwnPtr<HistoryStore> HistoryStore::create_disabled()
 {
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Opening disabled history store");
 
-    return adopt_own(*new HistoryStore { OptionalNone {}, true });
+    return adopt_own(*new HistoryStore { adopt_own<StorageImpl>(*new TransientStorage {}), true });
 }
 
-HistoryStore::HistoryStore(Optional<PersistedStorage> persisted_storage, bool is_disabled)
-    : m_persisted_storage(move(persisted_storage))
+HistoryStore::HistoryStore(NonnullOwnPtr<StorageImpl>&& storage, bool is_disabled)
+    : m_storage(move(storage))
     , m_is_disabled(is_disabled)
 {
 }
@@ -272,15 +272,12 @@ void HistoryStore::record_visit(URL::URL const& url, Optional<String> title, Uni
         return;
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Recording visit in {} store: url='{}' title='{}' visited_at={}",
-        m_persisted_storage.has_value() ? "SQL"sv : "transient"sv,
+        m_storage->name(),
         *normalized_url,
         title.has_value() ? title->bytes_as_string_view() : "<none>"sv,
         visited_at.seconds_since_epoch());
 
-    if (m_persisted_storage.has_value())
-        m_persisted_storage->record_visit(*normalized_url, title, visited_at);
-    else
-        m_transient_storage.record_visit(normalized_url.release_value(), move(title), visited_at);
+    m_storage->record_visit(*normalized_url, title, visited_at);
 }
 
 void HistoryStore::update_title(URL::URL const& url, String const& title)
@@ -298,14 +295,11 @@ void HistoryStore::update_title(URL::URL const& url, String const& title)
         return;
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Updating history title in {} store: url='{}' title='{}'",
-        m_persisted_storage.has_value() ? "SQL"sv : "transient"sv,
+        m_storage->name(),
         *normalized_url,
         title);
 
-    if (m_persisted_storage.has_value())
-        m_persisted_storage->update_title(*normalized_url, title);
-    else
-        m_transient_storage.update_title(*normalized_url, title);
+    m_storage->update_title(*normalized_url, title);
 }
 
 void HistoryStore::update_favicon(URL::URL const& url, String const& favicon_base64_png)
@@ -320,14 +314,11 @@ void HistoryStore::update_favicon(URL::URL const& url, String const& favicon_bas
         return;
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Updating history favicon in {} store: url='{}' bytes={}",
-        m_persisted_storage.has_value() ? "SQL"sv : "transient"sv,
+        m_storage->name(),
         *normalized_url,
         favicon_base64_png.bytes().size());
 
-    if (m_persisted_storage.has_value())
-        m_persisted_storage->update_favicon(*normalized_url, favicon_base64_png);
-    else
-        m_transient_storage.update_favicon(*normalized_url, favicon_base64_png);
+    m_storage->update_favicon(*normalized_url, favicon_base64_png);
 }
 
 Optional<HistoryEntry> HistoryStore::entry_for_url(URL::URL const& url)
@@ -339,9 +330,7 @@ Optional<HistoryEntry> HistoryStore::entry_for_url(URL::URL const& url)
     if (!normalized_url.has_value())
         return {};
 
-    auto entry = m_persisted_storage.has_value()
-        ? m_persisted_storage->entry_for_url(*normalized_url)
-        : m_transient_storage.entry_for_url(*normalized_url);
+    auto entry = m_storage->entry_for_url(*normalized_url);
 
     if (entry.has_value()) {
         dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Found history entry for '{}': title='{}' visits={} last_visited={} has_favicon={}",
@@ -371,12 +360,10 @@ Vector<HistoryEntry> HistoryStore::autocomplete_entries(StringView query, size_t
     auto title_query = autocomplete_title_query(trimmed_query);
     auto url_query = autocomplete_url_query(trimmed_query);
 
-    auto entries = m_persisted_storage.has_value()
-        ? m_persisted_storage->autocomplete_entries(title_query, url_query, limit)
-        : m_transient_storage.autocomplete_entries(title_query, url_query, limit);
+    auto entries = m_storage->autocomplete_entries(title_query, url_query, limit);
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] {} history autocomplete suggestions for '{}' (title_query='{}', url_query='{}', limit={}): {}",
-        m_persisted_storage.has_value() ? "SQL"sv : "Transient"sv,
+        m_storage->name(),
         trimmed_query,
         title_query,
         url_query,
@@ -391,11 +378,8 @@ void HistoryStore::clear()
     if (m_is_disabled)
         return;
 
-    dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Clearing {} history store", m_persisted_storage.has_value() ? "SQL"sv : "transient"sv);
-    if (m_persisted_storage.has_value())
-        m_persisted_storage->clear();
-    else
-        m_transient_storage.clear();
+    dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Clearing {} history store", m_storage->name());
+    m_storage->clear();
 }
 
 void HistoryStore::remove_entries_accessed_since(UnixDateTime since)
@@ -404,15 +388,12 @@ void HistoryStore::remove_entries_accessed_since(UnixDateTime since)
         return;
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Removing {} history entries accessed since {}",
-        m_persisted_storage.has_value() ? "SQL"sv : "transient"sv,
+        m_storage->name(),
         since.seconds_since_epoch());
-    if (m_persisted_storage.has_value())
-        m_persisted_storage->remove_entries_accessed_since(since);
-    else
-        m_transient_storage.remove_entries_accessed_since(since);
+    m_storage->remove_entries_accessed_since(since);
 }
 
-void HistoryStore::TransientStorage::record_visit(String url, Optional<String> title, UnixDateTime visited_at)
+void HistoryStore::TransientStorage::record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at)
 {
     auto entry = m_entries.find(url);
     if (entry == m_entries.end()) {
@@ -435,7 +416,7 @@ void HistoryStore::TransientStorage::record_visit(String url, Optional<String> t
         entry->value.title = move(title);
 }
 
-void HistoryStore::TransientStorage::update_title(String const& url, String title)
+void HistoryStore::TransientStorage::update_title(String const& url, String const& title)
 {
     auto entry = m_entries.find(url);
     if (entry == m_entries.end())
@@ -444,7 +425,7 @@ void HistoryStore::TransientStorage::update_title(String const& url, String titl
     entry->value.title = move(title);
 }
 
-void HistoryStore::TransientStorage::update_favicon(String const& url, String favicon_base64_png)
+void HistoryStore::TransientStorage::update_favicon(String const& url, String const& favicon_base64_png)
 {
     auto entry = m_entries.find(url);
     if (entry == m_entries.end())
@@ -494,10 +475,18 @@ void HistoryStore::TransientStorage::remove_entries_accessed_since(UnixDateTime 
     });
 }
 
+HistoryStore::PersistedStorage::PersistedStorage(Database::Database& database, Statements&& statements)
+    : m_database(database)
+    , m_statements(move(statements))
+{
+}
+
+HistoryStore::PersistedStorage::~PersistedStorage() = default;
+
 void HistoryStore::PersistedStorage::record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at)
 {
-    database.execute_statement(
-        statements.upsert_entry,
+    m_database.execute_statement(
+        m_statements.upsert_entry,
         {},
         url,
         title.value_or(String {}),
@@ -506,8 +495,8 @@ void HistoryStore::PersistedStorage::record_visit(String const& url, Optional<St
 
 void HistoryStore::PersistedStorage::update_title(String const& url, String const& title)
 {
-    database.execute_statement(
-        statements.update_title,
+    m_database.execute_statement(
+        m_statements.update_title,
         {},
         title,
         url);
@@ -515,8 +504,8 @@ void HistoryStore::PersistedStorage::update_title(String const& url, String cons
 
 void HistoryStore::PersistedStorage::update_favicon(String const& url, String const& favicon_base64_png)
 {
-    database.execute_statement(
-        statements.update_favicon,
+    m_database.execute_statement(
+        m_statements.update_favicon,
         {},
         favicon_base64_png,
         url);
@@ -526,18 +515,18 @@ Optional<HistoryEntry> HistoryStore::PersistedStorage::entry_for_url(String cons
 {
     Optional<HistoryEntry> entry;
 
-    database.execute_statement(
-        statements.get_entry,
+    m_database.execute_statement(
+        m_statements.get_entry,
         [&](auto statement_id) {
-            auto title = database.result_column<String>(statement_id, 0);
-            auto favicon = database.result_column<String>(statement_id, 3);
+            auto title = m_database.result_column<String>(statement_id, 0);
+            auto favicon = m_database.result_column<String>(statement_id, 3);
 
             entry = HistoryEntry {
                 .url = url,
                 .title = title.is_empty() ? Optional<String> {} : Optional<String> { move(title) },
                 .favicon_base64_png = favicon.is_empty() ? Optional<String> {} : Optional<String> { move(favicon) },
-                .visit_count = database.result_column<u64>(statement_id, 1),
-                .last_visited_time = database.result_column<UnixDateTime>(statement_id, 2),
+                .visit_count = m_database.result_column<u64>(statement_id, 1),
+                .last_visited_time = m_database.result_column<UnixDateTime>(statement_id, 2),
             };
         },
         url);
@@ -553,18 +542,18 @@ Vector<HistoryEntry> HistoryStore::PersistedStorage::autocomplete_entries(String
     auto title_query_string = MUST(String::from_utf8(title_query));
     auto url_contains_query_string = MUST(String::from_utf8(autocomplete_url_contains_query(url_query)));
 
-    database.execute_statement(
-        statements.search_entries,
+    m_database.execute_statement(
+        m_statements.search_entries,
         [&](auto statement_id) {
-            auto title = database.result_column<String>(statement_id, 1);
-            auto favicon = database.result_column<String>(statement_id, 4);
+            auto title = m_database.result_column<String>(statement_id, 1);
+            auto favicon = m_database.result_column<String>(statement_id, 4);
 
             entries.append(HistoryEntry {
-                .url = database.result_column<String>(statement_id, 0),
+                .url = m_database.result_column<String>(statement_id, 0),
                 .title = title.is_empty() ? Optional<String> {} : Optional<String> { move(title) },
                 .favicon_base64_png = favicon.is_empty() ? Optional<String> {} : Optional<String> { move(favicon) },
-                .visit_count = database.result_column<u64>(statement_id, 2),
-                .last_visited_time = database.result_column<UnixDateTime>(statement_id, 3),
+                .visit_count = m_database.result_column<u64>(statement_id, 2),
+                .last_visited_time = m_database.result_column<UnixDateTime>(statement_id, 3),
             });
         },
         url_query_string,
@@ -577,12 +566,12 @@ Vector<HistoryEntry> HistoryStore::PersistedStorage::autocomplete_entries(String
 
 void HistoryStore::PersistedStorage::clear()
 {
-    database.execute_statement(statements.clear_entries, {});
+    m_database.execute_statement(m_statements.clear_entries, {});
 }
 
 void HistoryStore::PersistedStorage::remove_entries_accessed_since(UnixDateTime since)
 {
-    database.execute_statement(statements.delete_entries_accessed_since, {}, since);
+    m_database.execute_statement(m_statements.delete_entries_accessed_since, {}, since);
 }
 
 }

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -8,6 +8,7 @@
 #include <AK/QuickSort.h>
 #include <AK/Utf8View.h>
 #include <LibDatabase/Database.h>
+#include <LibURL/Parser.h>
 #include <LibURL/URL.h>
 #include <LibWebView/HistoryDebug.h>
 #include <LibWebView/HistoryStore.h>
@@ -321,6 +322,53 @@ void HistoryStore::update_favicon(URL::URL const& url, String const& favicon_bas
     m_storage->update_favicon(*normalized_url, favicon_base64_png);
 }
 
+void HistoryStore::record_closed_tab(URL::URL const& url, UnixDateTime closed_at)
+{
+    m_recently_closed_entries.empend(RecentlyClosedEntry {
+        .urls = { url },
+        .was_window = false,
+        .active_tab_index = 0,
+        .closed_time = closed_at,
+    });
+}
+
+void HistoryStore::record_closed_window(Vector<URL::URL> urls, size_t active_tab_index, UnixDateTime closed_at)
+{
+    if (urls.is_empty())
+        return;
+
+    m_recently_closed_entries.empend(RecentlyClosedEntry {
+        .urls = move(urls),
+        .was_window = true,
+        .active_tab_index = 0,
+        .closed_time = closed_at,
+    });
+
+    auto& entry = m_recently_closed_entries.last();
+    entry.active_tab_index = active_tab_index < entry.urls.size() ? active_tab_index : entry.urls.size() - 1;
+}
+
+bool HistoryStore::has_recently_closed_entries() const
+{
+    return !m_recently_closed_entries.is_empty();
+}
+
+Optional<RecentlyClosedEntry const&> HistoryStore::most_recently_closed_entry() const
+{
+    if (m_recently_closed_entries.is_empty())
+        return {};
+
+    return m_recently_closed_entries.last();
+}
+
+Optional<RecentlyClosedEntry> HistoryStore::pop_most_recently_closed_entry()
+{
+    if (m_recently_closed_entries.is_empty())
+        return {};
+
+    return m_recently_closed_entries.take_last();
+}
+
 Optional<HistoryEntry> HistoryStore::entry_for_url(URL::URL const& url)
 {
     if (m_is_disabled)
@@ -380,6 +428,7 @@ void HistoryStore::clear()
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Clearing {} history store", m_storage->name());
     m_storage->clear();
+    m_recently_closed_entries.clear();
 }
 
 void HistoryStore::remove_entries_accessed_since(UnixDateTime since)
@@ -391,6 +440,9 @@ void HistoryStore::remove_entries_accessed_since(UnixDateTime since)
         m_storage->name(),
         since.seconds_since_epoch());
     m_storage->remove_entries_accessed_since(since);
+    m_recently_closed_entries.remove_all_matching([&](auto const& entry) {
+        return entry.closed_time >= since;
+    });
 }
 
 void HistoryStore::TransientStorage::record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at)

--- a/Libraries/LibWebView/HistoryStore.h
+++ b/Libraries/LibWebView/HistoryStore.h
@@ -11,8 +11,9 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Time.h>
+#include <AK/Vector.h>
 #include <LibDatabase/Forward.h>
-#include <LibURL/Forward.h>
+#include <LibURL/URL.h>
 #include <LibWebView/Export.h>
 
 namespace WebView {
@@ -23,6 +24,13 @@ struct WEBVIEW_API HistoryEntry {
     Optional<String> favicon_base64_png;
     u64 visit_count { 0 };
     UnixDateTime last_visited_time;
+};
+
+struct WEBVIEW_API RecentlyClosedEntry {
+    Vector<URL::URL> urls;
+    bool was_window { false };
+    size_t active_tab_index { 0 };
+    UnixDateTime closed_time;
 };
 
 class WEBVIEW_API HistoryStore {
@@ -40,6 +48,12 @@ public:
     void record_visit(URL::URL const&, Optional<String> title = {}, UnixDateTime visited_at = UnixDateTime::now());
     void update_title(URL::URL const&, String const& title);
     void update_favicon(URL::URL const&, String const& favicon_base64_png);
+
+    void record_closed_tab(URL::URL const&, UnixDateTime closed_at = UnixDateTime::now());
+    void record_closed_window(Vector<URL::URL>, size_t active_tab_index, UnixDateTime closed_at = UnixDateTime::now());
+    bool has_recently_closed_entries() const;
+    Optional<RecentlyClosedEntry const&> most_recently_closed_entry() const;
+    Optional<RecentlyClosedEntry> pop_most_recently_closed_entry();
 
     Optional<HistoryEntry> entry_for_url(URL::URL const&);
     Vector<HistoryEntry> autocomplete_entries(StringView query, size_t limit = 8);
@@ -120,6 +134,7 @@ private:
     explicit HistoryStore(NonnullOwnPtr<StorageImpl>&&, bool is_disabled = false);
 
     NonnullOwnPtr<StorageImpl> m_storage;
+    Vector<RecentlyClosedEntry> m_recently_closed_entries;
     bool m_is_disabled { false };
 };
 

--- a/Libraries/LibWebView/HistoryStore.h
+++ b/Libraries/LibWebView/HistoryStore.h
@@ -58,41 +58,68 @@ private:
         Database::StatementID delete_entries_accessed_since { 0 };
     };
 
-    class TransientStorage {
+    class StorageImpl {
     public:
-        void record_visit(String url, Optional<String> title, UnixDateTime visited_at);
-        void update_title(String const& url, String title);
-        void update_favicon(String const& url, String favicon_base64_png);
+        virtual ~StorageImpl() = default;
 
-        Optional<HistoryEntry> entry_for_url(String const& url);
-        Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit);
+        virtual StringView name() = 0;
 
-        void clear();
-        void remove_entries_accessed_since(UnixDateTime since);
+        virtual void record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at) = 0;
+        virtual void update_title(String const& url, String const& title) = 0;
+        virtual void update_favicon(String const& url, String const& favicon_base64_png) = 0;
+
+        virtual Optional<HistoryEntry> entry_for_url(String const& url) = 0;
+        virtual Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit) = 0;
+
+        virtual void clear() = 0;
+        virtual void remove_entries_accessed_since(UnixDateTime since) = 0;
+    };
+
+    class TransientStorage : public StorageImpl {
+    public:
+        virtual ~TransientStorage() override = default;
+
+        virtual StringView name() override { return "transient"sv; }
+
+        virtual void record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at) override;
+        virtual void update_title(String const& url, String const& title) override;
+        virtual void update_favicon(String const& url, String const& favicon_base64_png) override;
+
+        virtual Optional<HistoryEntry> entry_for_url(String const& url) override;
+        virtual Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit) override;
+
+        virtual void clear() override;
+        virtual void remove_entries_accessed_since(UnixDateTime since) override;
 
     private:
         HashMap<String, HistoryEntry> m_entries;
     };
 
-    struct PersistedStorage {
-        void record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at);
-        void update_title(String const& url, String const& title);
-        void update_favicon(String const& url, String const& favicon_base64_png);
+    class PersistedStorage : public StorageImpl {
+    public:
+        PersistedStorage(Database::Database&, Statements&&);
+        virtual ~PersistedStorage() override;
 
-        Optional<HistoryEntry> entry_for_url(String const& url);
-        Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit);
+        virtual StringView name() override { return "SQL"sv; }
 
-        void clear();
-        void remove_entries_accessed_since(UnixDateTime since);
+        virtual void record_visit(String const& url, Optional<String> const& title, UnixDateTime visited_at) override;
+        virtual void update_title(String const& url, String const& title) override;
+        virtual void update_favicon(String const& url, String const& favicon_base64_png) override;
 
-        Database::Database& database;
-        Statements statements;
+        virtual Optional<HistoryEntry> entry_for_url(String const& url) override;
+        virtual Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit) override;
+
+        virtual void clear() override;
+        virtual void remove_entries_accessed_since(UnixDateTime since) override;
+
+    private:
+        Database::Database& m_database;
+        Statements m_statements;
     };
 
-    explicit HistoryStore(Optional<PersistedStorage>, bool is_disabled = false);
+    explicit HistoryStore(NonnullOwnPtr<StorageImpl>&&, bool is_disabled = false);
 
-    Optional<PersistedStorage> m_persisted_storage;
-    TransientStorage m_transient_storage;
+    NonnullOwnPtr<StorageImpl> m_storage;
     bool m_is_disabled { false };
 };
 

--- a/Tests/LibWebView/TestHistoryStore.cpp
+++ b/Tests/LibWebView/TestHistoryStore.cpp
@@ -177,6 +177,94 @@ TEST_CASE(history_favicon_updates_entry)
     EXPECT_EQ(entry->favicon_base64_png, Optional<String> { "Zm9v"_string });
 }
 
+TEST_CASE(recently_closed_entries_are_reopened_in_lifo_order)
+{
+    auto store = WebView::HistoryStore::create();
+    auto first_url = parse_url("https://first.example.com/"sv);
+    auto second_url = parse_url("https://second.example.com/"sv);
+    auto third_url = parse_url("https://third.example.com/"sv);
+
+    EXPECT(!store->has_recently_closed_entries());
+
+    store->record_closed_tab(first_url, UnixDateTime::from_seconds_since_epoch(10));
+    store->record_closed_window({ second_url, third_url }, 1, UnixDateTime::from_seconds_since_epoch(20));
+
+    EXPECT(store->has_recently_closed_entries());
+
+    auto recently_closed_entry = store->pop_most_recently_closed_entry();
+    VERIFY(recently_closed_entry.has_value());
+    EXPECT(recently_closed_entry->was_window);
+    EXPECT_EQ(recently_closed_entry->active_tab_index, 1u);
+    EXPECT_EQ(recently_closed_entry->urls.size(), 2u);
+    EXPECT_EQ(recently_closed_entry->urls[0], second_url);
+    EXPECT_EQ(recently_closed_entry->urls[1], third_url);
+    EXPECT(store->has_recently_closed_entries());
+
+    recently_closed_entry = store->pop_most_recently_closed_entry();
+    VERIFY(recently_closed_entry.has_value());
+    EXPECT(!recently_closed_entry->was_window);
+    EXPECT_EQ(recently_closed_entry->active_tab_index, 0u);
+    EXPECT_EQ(recently_closed_entry->urls.size(), 1u);
+    EXPECT_EQ(recently_closed_entry->urls[0], first_url);
+    EXPECT(!store->has_recently_closed_entries());
+
+    EXPECT(!store->pop_most_recently_closed_entry().has_value());
+}
+
+TEST_CASE(recently_closed_entries_accessed_since_can_be_removed)
+{
+    auto store = WebView::HistoryStore::create();
+    auto older_url = parse_url("https://older.example.com/"sv);
+    auto newer_url = parse_url("https://newer.example.com/"sv);
+    auto newest_url = parse_url("https://newest.example.com/"sv);
+
+    store->record_closed_tab(older_url, UnixDateTime::from_seconds_since_epoch(10));
+    store->record_closed_window({ newer_url, newest_url }, 0, UnixDateTime::from_seconds_since_epoch(20));
+
+    store->remove_entries_accessed_since(UnixDateTime::from_seconds_since_epoch(15));
+
+    EXPECT(store->has_recently_closed_entries());
+
+    auto recently_closed_entry = store->pop_most_recently_closed_entry();
+    VERIFY(recently_closed_entry.has_value());
+    EXPECT_EQ(recently_closed_entry->urls.size(), 1u);
+    EXPECT_EQ(recently_closed_entry->urls[0], older_url);
+    EXPECT(!store->has_recently_closed_entries());
+}
+
+TEST_CASE(recently_closed_entries_can_be_peeked_without_popping)
+{
+    auto store = WebView::HistoryStore::create();
+    auto first_url = parse_url("https://peek.example.com/"sv);
+    auto second_url = parse_url("https://peek-two.example.com/"sv);
+
+    store->record_closed_window({ first_url, second_url }, 0, UnixDateTime::from_seconds_since_epoch(10));
+
+    auto recently_closed_entry = store->most_recently_closed_entry();
+    VERIFY(recently_closed_entry.has_value());
+    EXPECT(recently_closed_entry->was_window);
+    EXPECT_EQ(recently_closed_entry->urls.size(), 2u);
+    EXPECT_EQ(recently_closed_entry->urls[0], first_url);
+    EXPECT_EQ(recently_closed_entry->urls[1], second_url);
+    EXPECT(store->has_recently_closed_entries());
+}
+
+TEST_CASE(recently_closed_entries_are_cleared_with_history)
+{
+    auto store = WebView::HistoryStore::create();
+    auto first_url = parse_url("https://clear.example.com/"sv);
+    auto second_url = parse_url("https://clear-two.example.com/"sv);
+
+    store->record_closed_tab(first_url, UnixDateTime::from_seconds_since_epoch(10));
+    store->record_closed_window({ second_url }, 0, UnixDateTime::from_seconds_since_epoch(20));
+
+    store->clear();
+
+    EXPECT(!store->has_recently_closed_entries());
+    EXPECT(!store->most_recently_closed_entry().has_value());
+    EXPECT(!store->pop_most_recently_closed_entry().has_value());
+}
+
 TEST_CASE(history_autocomplete_entries_include_metadata)
 {
     auto store = WebView::HistoryStore::create();

--- a/Tests/LibWebView/TestHistoryStore.cpp
+++ b/Tests/LibWebView/TestHistoryStore.cpp
@@ -199,13 +199,22 @@ TEST_CASE(disabled_history_store_ignores_updates)
     auto store = WebView::HistoryStore::create_disabled();
     auto url = parse_url("https://example.com/"sv);
 
-    store->record_visit(url, "Example"_string, UnixDateTime::from_seconds_since_epoch(10));
-    store->update_title(url, "Example title"_string);
-    store->remove_entries_accessed_since(UnixDateTime::from_seconds_since_epoch(0));
-    store->clear();
+    auto check_is_empty = [&] {
+        EXPECT(!store->entry_for_url(url).has_value());
+        EXPECT(store->autocomplete_entries("example"sv, 8).is_empty());
+    };
 
-    EXPECT(!store->entry_for_url(url).has_value());
-    EXPECT(store->autocomplete_entries("example"sv, 8).is_empty());
+    store->record_visit(url, "Example"_string, UnixDateTime::from_seconds_since_epoch(10));
+    check_is_empty();
+
+    store->update_title(url, "Example title"_string);
+    check_is_empty();
+
+    store->remove_entries_accessed_since(UnixDateTime::from_seconds_since_epoch(0));
+    check_is_empty();
+
+    store->clear();
+    check_is_empty();
 }
 
 TEST_CASE(history_entries_accessed_since_can_be_removed)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -249,6 +249,14 @@ void Application::update_bookmarks_bar_display(bool show_bookmarks_bar) const
     }
 }
 
+void Application::update_reopen_recently_closed_actions() const
+{
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (auto* window = as_if<BrowserWindow>(widget))
+            window->update_reopen_recently_closed_action();
+    }
+}
+
 void Application::show_bookmark_context_menu(Gfx::IntPoint content_position, Optional<WebView::BookmarkItem const&> item, Optional<String const&> target_folder_id)
 {
     if (auto* active_tab = this->active_tab()) {
@@ -416,6 +424,11 @@ void Application::on_devtools_disabled() const
 
     if (m_active_window)
         m_active_window->on_devtools_disabled();
+}
+
+void Application::on_recently_closed_entries_changed() const
+{
+    update_reopen_recently_closed_actions();
 }
 
 }

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -29,6 +29,7 @@ public:
     void set_active_window(BrowserWindow& w) { m_active_window = &w; }
 
     Tab* active_tab() const { return m_active_window ? m_active_window->current_tab() : nullptr; }
+    void update_reopen_recently_closed_actions() const;
 
 private:
     explicit Application();
@@ -58,6 +59,7 @@ private:
 
     virtual void on_devtools_enabled() const override;
     virtual void on_devtools_disabled() const override;
+    virtual void on_recently_closed_entries_changed() const override;
 
     OwnPtr<QApplication> m_application;
     BrowserWindow* m_active_window { nullptr };

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -3,7 +3,7 @@
  * Copyright (c) 2022, Matthew Costa <ucosty@gmail.com>
  * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  * Copyright (c) 2023, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2024-2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024-2026, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2025, Simon Farre <simon.farre.cx@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,6 +12,7 @@
 #include <AK/RefPtr.h>
 #include <AK/TypeCasts.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/HistoryStore.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Icon.h>
@@ -41,6 +42,25 @@
 #include <QWindow>
 
 namespace Ladybird {
+
+static QString reopen_recently_closed_action_text(Optional<WebView::RecentlyClosedEntry const&> entry)
+{
+    if (entry.has_value() && entry->was_window)
+        return "&Reopen Recently Closed Window";
+
+    return "&Reopen Recently Closed Tab";
+}
+
+static Vector<URL::URL> recently_closed_urls_for_window(TabWidget const& tabs_container)
+{
+    Vector<URL::URL> urls;
+    urls.ensure_capacity(tabs_container.count());
+
+    for (int index = 0; index < tabs_container.count(); ++index)
+        urls.append(tabs_container.tab(index)->view().url());
+
+    return urls;
+}
 
 FullscreenMode::FullscreenMode(BrowserWindow* window, ExitFullscreenButton* exit_button)
     : QObject(window)
@@ -216,6 +236,12 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     m_hamburger_menu->addAction(m_new_window_action);
     file_menu->addAction(m_new_window_action);
 
+    m_reopen_recently_closed_tab_action = new QAction("&Reopen Recently Closed Tab", this);
+    m_reopen_recently_closed_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_T));
+    m_hamburger_menu->addAction(m_reopen_recently_closed_tab_action);
+    file_menu->addAction(m_reopen_recently_closed_tab_action);
+    update_reopen_recently_closed_action();
+
     auto* close_current_tab_action = new QAction("&Close Current Tab", this);
     close_current_tab_action->setIcon(load_icon_from_uri("resource://icons/16x16/close-tab.png"sv));
     close_current_tab_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Close));
@@ -326,6 +352,18 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [] {
         (void)Application::the().new_window({ WebView::Application::settings().new_tab_page_url() });
+    });
+    QObject::connect(m_reopen_recently_closed_tab_action, &QAction::triggered, this, [this] {
+        auto recently_closed_entry = Application::history_store().pop_most_recently_closed_entry();
+        if (recently_closed_entry.has_value()) {
+            if (recently_closed_entry->was_window) {
+                auto& window = Application::the().new_window(recently_closed_entry->urls);
+                window.activate_tab(static_cast<int>(recently_closed_entry->active_tab_index));
+            } else if (!recently_closed_entry->urls.is_empty()) {
+                new_tab_from_url(recently_closed_entry->urls[0], Web::HTML::ActivateTab::Yes);
+            }
+        }
+        Application::the().update_reopen_recently_closed_actions();
     });
     QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
 
@@ -519,11 +557,26 @@ void BrowserWindow::activate_tab(int index)
 void BrowserWindow::definitely_close_tab(int index)
 {
     auto* tab = m_tabs_container->tab(index);
+    auto url = tab->view().url();
     m_tabs_container->remove_tab(index);
+    Application::history_store().record_closed_tab(url);
+    Application::the().update_reopen_recently_closed_actions();
     tab->deleteLater();
 
-    if (m_tabs_container->count() == 0)
+    if (m_tabs_container->count() == 0) {
+        m_should_record_closed_window_on_close = false;
         close();
+    }
+}
+
+void BrowserWindow::update_reopen_recently_closed_action()
+{
+    if (!m_reopen_recently_closed_tab_action)
+        return;
+
+    auto recently_closed_entry = Application::history_store().most_recently_closed_entry();
+    m_reopen_recently_closed_tab_action->setText(reopen_recently_closed_action_text(recently_closed_entry));
+    m_reopen_recently_closed_tab_action->setEnabled(recently_closed_entry.has_value());
 }
 
 void BrowserWindow::move_tab(int old_index, int new_index)
@@ -801,6 +854,13 @@ void BrowserWindow::wheelEvent(QWheelEvent* event)
 
 void BrowserWindow::closeEvent(QCloseEvent* event)
 {
+    Optional<Vector<URL::URL>> recently_closed_window_urls;
+    size_t recently_closed_window_active_tab_index { 0 };
+    if (m_should_record_closed_window_on_close && m_tabs_container->count() > 0) {
+        recently_closed_window_urls = recently_closed_urls_for_window(*m_tabs_container);
+        recently_closed_window_active_tab_index = static_cast<size_t>(m_tabs_container->current_index());
+    }
+
     if (m_is_popup_window == IsPopupWindow::No) {
         Settings::the()->set_last_position(pos());
         Settings::the()->set_last_size(size());
@@ -810,6 +870,11 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     QObject::deleteLater();
 
     QMainWindow::closeEvent(event);
+
+    if (event->isAccepted() && recently_closed_window_urls.has_value()) {
+        Application::history_store().record_closed_window(recently_closed_window_urls.release_value(), recently_closed_window_active_tab_index);
+        Application::the().update_reopen_recently_closed_actions();
+    }
 }
 
 }

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -104,6 +104,7 @@ public:
 
     void rebuild_bookmarks_menu();
     void update_bookmarks_bar_display(bool show_bookmarks_bar);
+    void update_reopen_recently_closed_action();
 
     double refresh_rate() const { return m_refresh_rate; }
 
@@ -170,6 +171,7 @@ private:
 
     QAction* m_new_tab_action { nullptr };
     QAction* m_new_window_action { nullptr };
+    QAction* m_reopen_recently_closed_tab_action { nullptr };
     QAction* m_find_in_page_action { nullptr };
 
     IsPopupWindow m_is_popup_window { IsPopupWindow::No };
@@ -178,6 +180,7 @@ private:
     FullscreenMode* m_fullscreen_mode { nullptr };
     // Determine if window should restore to maximized or normal, when exiting fullscreen.
     bool m_restore_to_maximized { false };
+    bool m_should_record_closed_window_on_close { true };
 };
 
 }


### PR DESCRIPTION
I kept trying to do this with Ctrl+Shift+T, so now it works! :tada:

First commits are some adjustments to HistoryStore, namely to only have a single *Storage object instead of either one or two, when we only ever use one of them. And then an adjustment to a test that wasn't actually testing what it claimed to.

For the main event: Closed tabs and windows are stored on the HistoryStore, as a stack. (Well, actually a Vector because AK::Stack is fixed-size, which is a bit annoying.) We keep track of whether there's anything on that stack, and whether the top entry is for a tab or a window, so that the menu item changes description and gets disabled when it should.

For now it's quite simple: we store the URLs, and then for windows we store which tab was selected. That means you don't get the "it's as if you never closed the page" experience of other browsers.

Only Qt is implemented. I tried AppKit too, but Codex had a lot of trouble distinguishing between tab and window closures and I'm not convinced what it came up with is any good. You can view those changes on [this branch](https://github.com/AtkinsSJ/ladybird/tree/reopen-recent-tabs-appkit). The first commit there worked and was for an earlier version that only saved individual tabs; the second is the diff to support window closure and it technically does work but it also seems quite cursed and I don't know ObjC or AppKit well enough to know. I have a strong feeling that someone who knows what they're doing won't find it hard to do.

cc: @trflynn89