### PR TITLE
AK+LibWeb: Add a `fast_as<T>()` method for quickly casting mixin types and use it

### DIFF
--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -38,7 +38,9 @@ ALWAYS_INLINE bool is(NonnullRefPtr<InputType> const& input)
 template<typename OutputType, typename InputType>
 ALWAYS_INLINE CopyConst<InputType, OutputType>* as_if(InputType& input)
 {
-    if constexpr (requires { input.template fast_is<RemoveCVReference<OutputType>>(); static_cast<CopyConst<InputType, OutputType>*>(&input); }) {
+    if constexpr (requires { input.template fast_as<RemoveCVReference<OutputType>>(); }) {
+        return input.template fast_as<RemoveCVReference<OutputType>>();
+    } else if constexpr (requires { input.template fast_is<RemoveCVReference<OutputType>>(); static_cast<CopyConst<InputType, OutputType>*>(&input); }) {
         if (!is<OutputType>(input))
             return nullptr;
         return static_cast<CopyConst<InputType, OutputType>*>(&input);

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -383,6 +383,11 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
+    template<typename T>
+    T* fast_as() = delete;
+    template<typename T>
+    T const* fast_as() const = delete;
+
     WebIDL::ExceptionOr<void> ensure_pre_insertion_validity(JS::Realm&, GC::Ref<Node> node, GC::Ptr<Node> child) const;
 
     bool is_host_including_inclusive_ancestor_of(Node const&) const;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1357,3 +1357,23 @@ GC::Ref<JS::Cell> FormAssociatedTextControlElement::as_cell()
 }
 
 }
+
+namespace Web::DOM {
+
+template<>
+HTML::FormAssociatedTextControlElement* Node::fast_as<HTML::FormAssociatedTextControlElement>()
+{
+    if (auto* input = as_if<HTML::HTMLInputElement>(*this))
+        return input;
+    if (auto* textarea = as_if<HTML::HTMLTextAreaElement>(*this))
+        return textarea;
+    return nullptr;
+}
+
+template<>
+HTML::FormAssociatedTextControlElement const* Node::fast_as<HTML::FormAssociatedTextControlElement>() const
+{
+    return const_cast<Node&>(*this).fast_as<HTML::FormAssociatedTextControlElement>();
+}
+
+}

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -12,6 +12,7 @@
 #include <LibGC/Weak.h>
 #include <LibWeb/Bindings/HTMLFormElement.h>
 #include <LibWeb/DOM/InputEventsTarget.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebIDL/Types.h>
@@ -307,5 +308,17 @@ private:
     // https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event
     bool m_has_scheduled_selectionchange_event { false };
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<HTML::FormAssociatedTextControlElement>() const { return is_html_input_element() || is_html_textarea_element(); }
+
+template<>
+HTML::FormAssociatedTextControlElement* Node::fast_as<HTML::FormAssociatedTextControlElement>();
+template<>
+HTML::FormAssociatedTextControlElement const* Node::fast_as<HTML::FormAssociatedTextControlElement>() const;
 
 }


### PR DESCRIPTION
This change was motivated by seeing `user_select_used_value()` show up in a profile of https://en.wikipedia.org/wiki/Holy_Roman_Empire. Every time a table of contents link was clicked we would spend ~20ms in this method. This change reduces that by ~90%.