### PR TITLE
LibGC: External memory accounting + tuned thresholds

### DIFF
--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -59,6 +59,7 @@ public:
     void set_to(SignedBigInteger const& other);
 
     [[nodiscard]] size_t byte_length() const;
+    [[nodiscard]] size_t external_memory_size() const { return m_mp.alloc * sizeof(mp_digit); }
 
     [[nodiscard]] SignedBigInteger plus(SignedBigInteger const& other) const;
     [[nodiscard]] SignedBigInteger minus(SignedBigInteger const& other) const;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -69,6 +69,7 @@ public:
     [[nodiscard]] bool is_odd() const;
 
     [[nodiscard]] size_t byte_length() const;
+    [[nodiscard]] size_t external_memory_size() const { return m_mp.alloc * sizeof(mp_digit); }
 
     size_t one_based_index_of_highest_set_bit() const;
 

--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -204,6 +204,8 @@ public:
     // This will be called on unmarked objects by the garbage collector in a separate pass before destruction.
     MUST_UPCALL virtual void finalize() { }
 
+    virtual size_t external_memory_size() const { return 0; }
+
     // This allows cells to survive GC by choice, even if nothing points to them.
     // It's used to implement special rules in the web platform.
     // NOTE: Cell types must have OVERRIDES_MUST_SURVIVE_GARBAGE_COLLECTION set for this to be called.

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -38,6 +38,10 @@
 
 namespace GC {
 
+static constexpr size_t GC_MIN_BYTES_THRESHOLD { 8 * 1024 * 1024 };
+static constexpr size_t GC_HEAP_GROWTH_FACTOR_NUMERATOR { 7 };
+static constexpr size_t GC_HEAP_GROWTH_FACTOR_DENOMINATOR { 4 };
+
 static Heap* s_the;
 
 Heap& Heap::the()
@@ -49,6 +53,7 @@ Heap::Heap(AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roo
     : m_gather_embedder_roots(move(gather_embedder_roots))
 {
     s_the = this;
+    m_gc_bytes_threshold = GC_MIN_BYTES_THRESHOLD;
     static_assert(HeapBlock::min_possible_cell_size <= 32, "Heap Cell tracking uses too much data!");
     m_size_based_cell_allocators.append(make<CellAllocator>(64));
     m_size_based_cell_allocators.append(make<CellAllocator>(96));
@@ -779,7 +784,8 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
         });
     }
 
-    m_gc_bytes_threshold = live_cell_bytes > GC_MIN_BYTES_THRESHOLD ? live_cell_bytes : GC_MIN_BYTES_THRESHOLD;
+    auto next_gc_bytes_threshold = live_cell_bytes * GC_HEAP_GROWTH_FACTOR_NUMERATOR / GC_HEAP_GROWTH_FACTOR_DENOMINATOR;
+    m_gc_bytes_threshold = max(next_gc_bytes_threshold, GC_MIN_BYTES_THRESHOLD);
 
     if (print_report) {
         AK::Duration const time_spent = measurement_timer.elapsed_time();

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Badge.h>
 #include <AK/BinarySearch.h>
+#include <AK/Checked.h>
 #include <AK/Debug.h>
 #include <AK/Function.h>
 #include <AK/HashTable.h>
@@ -80,6 +81,43 @@ void Heap::will_allocate(size_t size)
     }
 
     m_allocated_bytes_since_last_gc += size;
+}
+
+void Heap::did_allocate_external_memory(size_t size)
+{
+    will_allocate(size);
+}
+
+void Heap::did_free_external_memory(size_t size)
+{
+    if (size > m_allocated_bytes_since_last_gc) {
+        m_allocated_bytes_since_last_gc = 0;
+        return;
+    }
+
+    m_allocated_bytes_since_last_gc -= size;
+}
+
+void Heap::update_gc_bytes_threshold(size_t live_cell_bytes, size_t live_external_bytes)
+{
+    Checked<size_t> live_bytes = live_cell_bytes;
+    live_bytes += live_external_bytes;
+
+    if (live_bytes.has_overflow()) {
+        m_gc_bytes_threshold = NumericLimits<size_t>::max();
+        return;
+    }
+
+    Checked<size_t> next_gc_bytes_threshold = live_bytes.value();
+    next_gc_bytes_threshold *= GC_HEAP_GROWTH_FACTOR_NUMERATOR;
+    next_gc_bytes_threshold /= GC_HEAP_GROWTH_FACTOR_DENOMINATOR;
+
+    if (next_gc_bytes_threshold.has_overflow()) {
+        m_gc_bytes_threshold = NumericLimits<size_t>::max();
+        return;
+    }
+
+    m_gc_bytes_threshold = max(next_gc_bytes_threshold.value(), GC_MIN_BYTES_THRESHOLD);
 }
 
 static void add_possible_value(HashMap<FlatPtr, HeapRoot>& possible_pointers, FlatPtr data, HeapRoot origin, FlatPtr min_block_address, FlatPtr max_block_address)
@@ -737,6 +775,7 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
     size_t live_cells = 0;
     size_t collected_cell_bytes = 0;
     size_t live_cell_bytes = 0;
+    size_t live_external_bytes = 0;
 
     for_each_block([&](auto& block) {
         bool block_has_live_cells = false;
@@ -752,6 +791,10 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
                 block_has_live_cells = true;
                 ++live_cells;
                 live_cell_bytes += block.cell_size();
+                auto cell_external_memory_size = cell->external_memory_size();
+                live_external_bytes = cell_external_memory_size > NumericLimits<size_t>::max() - live_external_bytes
+                    ? NumericLimits<size_t>::max()
+                    : live_external_bytes + cell_external_memory_size;
             }
         });
         if (!block_has_live_cells)
@@ -784,8 +827,7 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
         });
     }
 
-    auto next_gc_bytes_threshold = live_cell_bytes * GC_HEAP_GROWTH_FACTOR_NUMERATOR / GC_HEAP_GROWTH_FACTOR_DENOMINATOR;
-    m_gc_bytes_threshold = max(next_gc_bytes_threshold, GC_MIN_BYTES_THRESHOLD);
+    update_gc_bytes_threshold(live_cell_bytes, live_external_bytes);
 
     if (print_report) {
         AK::Duration const time_spent = measurement_timer.elapsed_time();
@@ -799,6 +841,7 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
         dbgln("=============================================");
         dbgln("     Time spent: {} ms", time_spent.to_milliseconds());
         dbgln("     Live cells: {} ({} bytes)", live_cells, live_cell_bytes);
+        dbgln("  Live external: {} bytes", live_external_bytes);
         dbgln("Collected cells: {} ({} bytes)", collected_cells, collected_cell_bytes);
         dbgln("    Live blocks: {} ({} bytes)", live_block_count, live_block_count * HeapBlock::BLOCK_SIZE);
         dbgln("   Freed blocks: {} ({} bytes)", empty_blocks.size(), empty_blocks.size() * HeapBlock::BLOCK_SIZE);

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -155,8 +155,7 @@ private:
         }
     }
 
-    static constexpr size_t GC_MIN_BYTES_THRESHOLD { 4 * 1024 * 1024 };
-    size_t m_gc_bytes_threshold { GC_MIN_BYTES_THRESHOLD };
+    size_t m_gc_bytes_threshold { 0 };
     size_t m_allocated_bytes_since_last_gc { 0 };
 
     bool m_should_collect_on_every_allocation { false };

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -91,6 +91,9 @@ public:
 
     WeakImpl* create_weak_impl(void*);
 
+    void did_allocate_external_memory(size_t);
+    void did_free_external_memory(size_t);
+
 private:
     friend class MarkingVisitor;
     friend class GraphConstructorVisitor;
@@ -124,6 +127,7 @@ private:
     }
 
     void will_allocate(size_t);
+    void update_gc_bytes_threshold(size_t live_cell_bytes, size_t live_external_bytes);
 
     void find_min_and_max_block_addresses(FlatPtr& min_address, FlatPtr& max_address);
     void gather_roots(HashMap<Cell*, HeapRoot>&, HashTable<HeapBlock*>& all_live_heap_blocks, Vector<StackFrameInfo>* out_stack_frames = nullptr);

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/RegexTable.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibJS/SourceCode.h>
@@ -50,6 +51,13 @@ void ObjectPropertyIteratorCacheData::visit_edges(Visitor& visitor)
     visitor.visit(m_property_values.span());
     for (auto& key : m_properties)
         key.visit_edges(visitor);
+}
+
+size_t ObjectPropertyIteratorCacheData::external_memory_size() const
+{
+    auto size = vector_external_memory_size(m_properties);
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_property_values));
+    return size;
 }
 
 Executable::Executable(
@@ -291,6 +299,33 @@ void Executable::visit_edges(Visitor& visitor)
         }
     }
     property_key_table->visit_edges(visitor);
+}
+
+size_t Executable::external_memory_size() const
+{
+    size_t size = vector_external_memory_size(bytecode);
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(property_lookup_caches));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(global_variable_caches));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(template_object_caches));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(object_shape_caches));
+    for (auto const& cache : object_shape_caches)
+        size = saturating_add_external_memory_size(size, vector_external_memory_size(cache.property_offsets));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(object_property_iterator_caches));
+    size = saturating_add_external_memory_size(size, string_table->external_memory_size());
+    size = saturating_add_external_memory_size(size, identifier_table->external_memory_size());
+    size = saturating_add_external_memory_size(size, property_key_table->external_memory_size());
+    size = saturating_add_external_memory_size(size, regex_table->external_memory_size());
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(constants));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(shared_function_data));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(class_blueprints));
+    for (auto const& blueprint : class_blueprints)
+        size = saturating_add_external_memory_size(size, vector_external_memory_size(blueprint.elements));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(exception_handlers));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(basic_block_start_offsets));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(source_map));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(local_variable_names));
+    size = saturating_add_external_memory_size(size, hash_map_external_memory_size(m_source_range_cache));
+    return size;
 }
 
 static Vector<PropertyLookupCache*>& static_property_lookup_caches()

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -120,6 +120,7 @@ public:
 
 private:
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     Vector<PropertyKey> m_properties;
     Vector<Value> m_property_values;
@@ -242,6 +243,7 @@ public:
 
 private:
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     HashMap<u32, SourceRange> m_source_range_cache;
 };

--- a/Libraries/LibJS/Bytecode/IdentifierTable.h
+++ b/Libraries/LibJS/Bytecode/IdentifierTable.h
@@ -9,6 +9,7 @@
 #include <AK/DistinctNumeric.h>
 #include <AK/Utf16FlyString.h>
 #include <AK/Vector.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 
 namespace JS::Bytecode {
 
@@ -29,6 +30,7 @@ public:
     Utf16FlyString const& get(IdentifierTableIndex) const;
     void dump() const;
     bool is_empty() const { return m_identifiers.is_empty(); }
+    size_t external_memory_size() const { return vector_external_memory_size(m_identifiers); }
 
     ReadonlySpan<Utf16FlyString const> identifiers() const { return m_identifiers; }
 

--- a/Libraries/LibJS/Bytecode/PropertyKeyTable.h
+++ b/Libraries/LibJS/Bytecode/PropertyKeyTable.h
@@ -8,6 +8,7 @@
 
 #include <AK/DistinctNumeric.h>
 #include <AK/Vector.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/PropertyKey.h>
 
 namespace JS::Bytecode {
@@ -29,6 +30,7 @@ public:
     PropertyKey const& get(PropertyKeyTableIndex) const;
     void dump() const;
     bool is_empty() const { return m_property_keys.is_empty(); }
+    size_t external_memory_size() const { return vector_external_memory_size(m_property_keys); }
 
     ReadonlySpan<PropertyKey const> property_keys() const { return m_property_keys; }
 

--- a/Libraries/LibJS/Bytecode/PropertyNameIterator.cpp
+++ b/Libraries/LibJS/Bytecode/PropertyNameIterator.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Bytecode/PropertyNameIterator.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/Shape.h>
 
@@ -191,6 +192,11 @@ void PropertyNameIterator::visit_edges(Visitor& visitor)
     visitor.visit(m_prototype_chain_validity);
     for (auto& key : m_owned_properties)
         key.visit_edges(visitor);
+}
+
+size_t PropertyNameIterator::external_memory_size() const
+{
+    return Object::external_memory_size() + vector_external_memory_size(m_owned_properties);
 }
 
 }

--- a/Libraries/LibJS/Bytecode/PropertyNameIterator.h
+++ b/Libraries/LibJS/Bytecode/PropertyNameIterator.h
@@ -43,6 +43,7 @@ private:
     void disable_fast_path();
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     GC::Ptr<Object> m_object;
     Vector<PropertyKey> m_owned_properties;

--- a/Libraries/LibJS/Bytecode/RegexTable.h
+++ b/Libraries/LibJS/Bytecode/RegexTable.h
@@ -20,6 +20,7 @@ public:
     RegexTable() = default;
 
     bool is_empty() const { return true; }
+    size_t external_memory_size() const { return 0; }
 };
 
 }

--- a/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Libraries/LibJS/Bytecode/StringTable.h
@@ -9,6 +9,7 @@
 #include <AK/DistinctNumeric.h>
 #include <AK/Utf16String.h>
 #include <AK/Vector.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 
 namespace JS::Bytecode {
 
@@ -30,6 +31,13 @@ public:
     void dump() const;
     bool is_empty() const { return m_strings.is_empty(); }
     size_t size() const { return m_strings.size(); }
+    size_t external_memory_size() const
+    {
+        size_t size = vector_external_memory_size(m_strings);
+        for (auto const& string : m_strings)
+            size = saturating_add_external_memory_size(size, utf16_string_external_memory_size(string));
+        return size;
+    }
 
 private:
     Vector<Utf16String> m_strings;

--- a/Libraries/LibJS/CyclicModule.cpp
+++ b/Libraries/LibJS/CyclicModule.cpp
@@ -8,6 +8,7 @@
 #include <AK/Debug.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/CyclicModule.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/ModuleRequest.h>
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/PromiseConstructor.h>
@@ -16,6 +17,34 @@
 namespace JS {
 
 GC_DEFINE_ALLOCATOR(CyclicModule);
+
+static size_t import_attributes_external_memory_size(Vector<ImportAttribute> const& attributes)
+{
+    size_t size = JS::vector_external_memory_size(attributes);
+    for (auto const& attribute : attributes) {
+        size = JS::saturating_add_external_memory_size(size, JS::utf16_string_external_memory_size(attribute.key));
+        size = JS::saturating_add_external_memory_size(size, JS::utf16_string_external_memory_size(attribute.value));
+    }
+    return size;
+}
+
+static size_t loaded_module_requests_external_memory_size(Vector<LoadedModuleRequest> const& requests)
+{
+    size_t size = JS::vector_external_memory_size(requests);
+    for (auto const& request : requests) {
+        size = JS::saturating_add_external_memory_size(size, JS::utf16_string_external_memory_size(request.specifier));
+        size = JS::saturating_add_external_memory_size(size, import_attributes_external_memory_size(request.attributes));
+    }
+    return size;
+}
+
+static size_t module_requests_external_memory_size(Vector<ModuleRequest> const& requests)
+{
+    size_t size = JS::vector_external_memory_size(requests);
+    for (auto const& request : requests)
+        size = JS::saturating_add_external_memory_size(size, import_attributes_external_memory_size(request.attributes));
+    return size;
+}
 
 CyclicModule::CyclicModule(Realm& realm, StringView filename, bool has_top_level_await, Vector<ModuleRequest> requested_modules, Script::HostDefined* host_defined)
     : Module(realm, filename, host_defined)
@@ -38,12 +67,26 @@ void CyclicModule::visit_edges(Cell::Visitor& visitor)
         visitor.visit(m_evaluation_error.error_value());
 }
 
+size_t CyclicModule::external_memory_size() const
+{
+    size_t size = Base::external_memory_size();
+    size = JS::saturating_add_external_memory_size(size, module_requests_external_memory_size(m_requested_modules));
+    size = JS::saturating_add_external_memory_size(size, loaded_module_requests_external_memory_size(m_loaded_modules));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_async_parent_modules));
+    return size;
+}
+
 void GraphLoadingState::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(promise_capability);
     visitor.visit(host_defined);
     visitor.visit(visited);
+}
+
+size_t GraphLoadingState::external_memory_size() const
+{
+    return JS::hash_table_external_memory_size(visited);
 }
 
 // 16.2.1.5.1 LoadRequestedModules ( [ hostDefined ] ), https://tc39.es/ecma262/#sec-LoadRequestedModules

--- a/Libraries/LibJS/CyclicModule.h
+++ b/Libraries/LibJS/CyclicModule.h
@@ -49,6 +49,7 @@ protected:
     CyclicModule(Realm& realm, StringView filename, bool has_top_level_await, Vector<ModuleRequest> requested_modules, Script::HostDefined* host_defined);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override final;
     virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override final;

--- a/Libraries/LibJS/Module.cpp
+++ b/Libraries/LibJS/Module.cpp
@@ -9,6 +9,7 @@
 #include <AK/GenericShorthands.h>
 #include <LibJS/CyclicModule.h>
 #include <LibJS/Module.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/ModuleEnvironment.h>
 #include <LibJS/Runtime/ModuleNamespaceObject.h>
 #include <LibJS/Runtime/ModuleRequest.h>
@@ -39,6 +40,11 @@ void Module::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_namespace);
     if (m_host_defined)
         m_host_defined->visit_host_defined_self(visitor);
+}
+
+size_t Module::external_memory_size() const
+{
+    return byte_string_external_memory_size(m_filename);
 }
 
 // 16.2.1.5.1 EvaluateModuleSync ( module ), https://tc39.es/ecma262/#sec-EvaluateModuleSync

--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -87,6 +87,7 @@ private:
     {
     }
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 };
 
 // 16.2.1.4 Abstract Module Records, https://tc39.es/ecma262/#sec-abstract-module-records
@@ -125,6 +126,7 @@ protected:
     Module(Realm&, ByteString filename, Script::HostDefined* host_defined = nullptr);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     void set_environment(GC::Ref<ModuleEnvironment> environment)
     {

--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -339,7 +339,7 @@ ErrorOr<void> print_set(JS::PrintContext& print_context, JS::Set const& set, Has
 ErrorOr<void> print_weak_map(JS::PrintContext& print_context, JS::WeakMap const& weak_map, HashTable<JS::Object*>&)
 {
     TRY(print_type(print_context, "WeakMap"sv));
-    TRY(js_out(print_context, " ({})", weak_map.values().size()));
+    TRY(js_out(print_context, " ({})", weak_map.weak_map_size()));
     // Note: We could tell you what's actually inside, but not in insertion order.
     return {};
 }
@@ -347,7 +347,7 @@ ErrorOr<void> print_weak_map(JS::PrintContext& print_context, JS::WeakMap const&
 ErrorOr<void> print_weak_set(JS::PrintContext& print_context, JS::WeakSet const& weak_set, HashTable<JS::Object*>&)
 {
     TRY(print_type(print_context, "WeakSet"sv));
-    TRY(js_out(print_context, " ({})", weak_set.values().size()));
+    TRY(js_out(print_context, " ({})", weak_set.weak_set_size()));
     // Note: We could tell you what's actually inside, but not in insertion order.
     return {};
 }

--- a/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/ArgumentsObject.h>
 #include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 
 namespace JS {
@@ -27,6 +28,11 @@ void ArgumentsObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_environment);
+}
+
+size_t ArgumentsObject::external_memory_size() const
+{
+    return Object::external_memory_size() + vector_external_memory_size(m_mapped_names);
 }
 
 bool ArgumentsObject::parameter_map_has(PropertyKey const& key) const

--- a/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -37,6 +37,7 @@ private:
     void delete_from_parameter_map(PropertyKey const&);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     GC::Ref<Environment> m_environment;
     Vector<Utf16FlyString> m_mapped_names;

--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/Heap.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/ArrayBufferConstructor.h>
@@ -32,7 +33,9 @@ ThrowCompletionOr<GC::Ref<ArrayBuffer>> ArrayBuffer::create(Realm& realm, size_t
 
 GC::Ref<ArrayBuffer> ArrayBuffer::create(Realm& realm, ByteBuffer buffer, DataBlock::Shared is_shared)
 {
-    return realm.create<ArrayBuffer>(move(buffer), is_shared, prototype_for_shared_state(realm, is_shared));
+    auto array_buffer = realm.create<ArrayBuffer>(move(buffer), is_shared, prototype_for_shared_state(realm, is_shared));
+    realm.vm().heap().did_allocate_external_memory(array_buffer->external_memory_size());
+    return array_buffer;
 }
 
 GC::Ref<ArrayBuffer> ArrayBuffer::create(Realm& realm, ByteBuffer* buffer, DataBlock::Shared is_shared)
@@ -52,6 +55,28 @@ ArrayBuffer::ArrayBuffer(ByteBuffer* buffer, DataBlock::Shared is_shared, Object
     , m_data_block(DataBlock { DataBlock::UnownedFixedLengthByteBuffer(buffer), is_shared })
     , m_detach_key(js_undefined())
 {
+}
+
+void ArrayBuffer::account_external_memory_change(size_t old_external_memory_size, size_t new_external_memory_size)
+{
+    if (new_external_memory_size > old_external_memory_size) {
+        heap().did_allocate_external_memory(new_external_memory_size - old_external_memory_size);
+        return;
+    }
+
+    heap().did_free_external_memory(old_external_memory_size - new_external_memory_size);
+}
+
+void ArrayBuffer::set_data_block(DataBlock block)
+{
+    auto old_external_memory_size = external_memory_size();
+    m_data_block = move(block);
+    account_external_memory_change(old_external_memory_size, external_memory_size());
+}
+
+void ArrayBuffer::did_change_data_block_capacity(size_t old_external_memory_size)
+{
+    account_external_memory_change(old_external_memory_size, external_memory_size());
 }
 
 void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
@@ -184,8 +209,10 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& co
     if (allocating_resizable_buffer) {
         // a. If it is not possible to create a Data Block block consisting of maxByteLength bytes, throw a RangeError exception.
         // b. NOTE: Resizable ArrayBuffers are designed to be implementable with in-place growth. Implementations may throw if, for example, virtual memory cannot be reserved up front.
+        auto old_external_memory_size = obj->external_memory_size();
         if (auto result = obj->buffer().try_ensure_capacity(*max_byte_length); result.is_error())
             return vm.throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, *max_byte_length);
+        obj->did_change_data_block_capacity(old_external_memory_size);
 
         // c. Set obj.[[ArrayBufferMaxByteLength]] to maxByteLength.
         obj->set_max_byte_length(*max_byte_length);
@@ -253,6 +280,7 @@ ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM& vm, ArrayBuffer
 
 void ArrayBuffer::detach_buffer()
 {
+    auto old_external_memory_size = external_memory_size();
     for (auto& cached_view : m_cached_views) {
         auto& view = static_cast<TypedArrayBase&>(cached_view);
         if (view.viewed_array_buffer() == this)
@@ -260,6 +288,7 @@ void ArrayBuffer::detach_buffer()
     }
     m_cached_views.clear();
     m_data_block.byte_buffer = Empty {};
+    account_external_memory_change(old_external_memory_size, 0);
 }
 
 ThrowCompletionOr<ByteBuffer> ArrayBuffer::detach_and_take_bytes(VM& vm)
@@ -269,11 +298,19 @@ ThrowCompletionOr<ByteBuffer> ArrayBuffer::detach_and_take_bytes(VM& vm)
     if (!same_value(detach_key(), js_undefined()))
         return vm.throw_completion<TypeError>(ErrorType::DetachKeyMismatch, js_undefined(), detach_key());
 
+    auto old_external_memory_size = external_memory_size();
     auto bytes = m_data_block.byte_buffer.visit(
         [](Empty) -> ByteBuffer { VERIFY_NOT_REACHED(); },
         [](ByteBuffer& value) -> ByteBuffer { return move(value); },
         [](DataBlock::UnownedFixedLengthByteBuffer& value) -> ByteBuffer { return MUST(ByteBuffer::copy(value.buffer->span())); });
-    detach_buffer();
+    for (auto& cached_view : m_cached_views) {
+        auto& view = static_cast<TypedArrayBase&>(cached_view);
+        if (view.viewed_array_buffer() == this)
+            view.set_cached_data_ptr(nullptr);
+    }
+    m_cached_views.clear();
+    m_data_block.byte_buffer = Empty {};
+    account_external_memory_change(old_external_memory_size, 0);
     return bytes;
 }
 

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -80,6 +80,14 @@ struct DataBlock {
             [](UnownedFixedLengthByteBuffer const& value) { return value.size; });
     }
 
+    size_t external_memory_size() const
+    {
+        return byte_buffer.visit(
+            [](Empty) -> size_t { return 0; },
+            [](ByteBuffer const& buffer) { return buffer.is_inline() ? 0 : buffer.capacity(); },
+            [](UnownedFixedLengthByteBuffer const&) -> size_t { return 0; });
+    }
+
     Variant<Empty, ByteBuffer, UnownedFixedLengthByteBuffer> byte_buffer;
     Shared is_shared = { Shared::No };
 };
@@ -96,6 +104,7 @@ public:
     virtual ~ArrayBuffer() override = default;
 
     size_t byte_length() const { return m_data_block.size(); }
+    virtual size_t external_memory_size() const override { return m_data_block.external_memory_size(); }
 
     // [[ArrayBufferData]]
     ByteBuffer& buffer() { return m_data_block.buffer(); }
@@ -111,7 +120,8 @@ public:
     void set_max_byte_length(size_t max_byte_length) { m_max_byte_length = max_byte_length; }
 
     // Used by allocate_array_buffer() to attach the data block after construction
-    void set_data_block(DataBlock block) { m_data_block = move(block); }
+    void set_data_block(DataBlock);
+    void did_change_data_block_capacity(size_t old_external_memory_size);
 
     Value detach_key() const { return m_detach_key; }
     void set_detach_key(Value detach_key) { m_detach_key = detach_key; }
@@ -179,6 +189,8 @@ private:
     virtual bool is_array_buffer() const final { return true; }
 
     virtual void visit_edges(Visitor&) override;
+
+    void account_external_memory_change(size_t old_external_memory_size, size_t new_external_memory_size);
 
     DataBlock m_data_block;
     Optional<size_t> m_max_byte_length;

--- a/Libraries/LibJS/Runtime/BigInt.cpp
+++ b/Libraries/LibJS/Runtime/BigInt.cpp
@@ -33,6 +33,11 @@ Utf16String BigInt::to_utf16_string() const
     return Utf16String::formatted("{}n", MUST(m_big_integer.to_base(10)));
 }
 
+size_t BigInt::external_memory_size() const
+{
+    return m_big_integer.external_memory_size();
+}
+
 // 21.2.1.1.1 NumberToBigInt ( number ), https://tc39.es/ecma262/#sec-numbertobigint
 ThrowCompletionOr<GC::Ref<BigInt>> number_to_bigint(VM& vm, Value number)
 {

--- a/Libraries/LibJS/Runtime/BigInt.h
+++ b/Libraries/LibJS/Runtime/BigInt.h
@@ -31,6 +31,8 @@ public:
     Utf16String to_utf16_string() const;
 
 private:
+    virtual size_t external_memory_size() const override;
+
     explicit BigInt(Crypto::SignedBigInteger);
 
     Crypto::SignedBigInteger m_big_integer;

--- a/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -7,6 +7,7 @@
 
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/BoundFunction.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 
 namespace JS {
@@ -106,6 +107,11 @@ void BoundFunction::visit_edges(Visitor& visitor)
     visitor.visit(m_bound_target_function);
     visitor.visit(m_bound_this);
     visitor.visit(m_bound_arguments);
+}
+
+size_t BoundFunction::external_memory_size() const
+{
+    return vector_external_memory_size(m_bound_arguments);
 }
 
 void BoundFunction::get_stack_frame_info(size_t& registers_and_locals_count, ReadonlySpan<Value>& constants, size_t& argument_count)

--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -37,6 +37,7 @@ private:
 
     void get_stack_frame_info(size_t& registers_and_locals_count, ReadonlySpan<Value>& constants, size_t& argument_count) override;
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     virtual bool is_bound_function() const final { return true; }
 

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Value.h>
@@ -41,6 +42,13 @@ void DeclarativeEnvironment::visit_edges(Visitor& visitor)
 
     for (auto& binding : m_bindings)
         visitor.visit(binding.value);
+}
+
+size_t DeclarativeEnvironment::external_memory_size() const
+{
+    auto size = vector_external_memory_size(m_bindings);
+    size = saturating_add_external_memory_size(size, hash_map_external_memory_size(m_bindings_assoc));
+    return size;
 }
 
 // 9.1.1.1.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-hasbinding-n

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -81,6 +81,7 @@ protected:
     DeclarativeEnvironment(Environment* parent_environment, ReadonlySpan<Binding> bindings);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     class BindingAndIndex {
     public:

--- a/Libraries/LibJS/Runtime/Error.cpp
+++ b/Libraries/LibJS/Runtime/Error.cpp
@@ -47,6 +47,11 @@ void Error::visit_edges(Visitor& visitor)
     ErrorData::visit_edges(visitor);
 }
 
+size_t Error::external_memory_size() const
+{
+    return Object::external_memory_size() + ErrorData::external_memory_size();
+}
+
 // 20.5.8.1 InstallErrorCause ( O, options ), https://tc39.es/ecma262/#sec-installerrorcause
 ThrowCompletionOr<void> Error::install_error_cause(Value options)
 {

--- a/Libraries/LibJS/Runtime/Error.h
+++ b/Libraries/LibJS/Runtime/Error.h
@@ -42,6 +42,7 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
+    virtual size_t external_memory_size() const override;
     virtual bool is_error_object() const final { return true; }
     virtual ErrorData* error_data() final { return this; }
     virtual ErrorData const* error_data() const final { return this; }

--- a/Libraries/LibJS/Runtime/ErrorData.cpp
+++ b/Libraries/LibJS/Runtime/ErrorData.cpp
@@ -8,6 +8,7 @@
 #include <AK/StringBuilder.h>
 #include <LibJS/Runtime/ErrorData.h>
 #include <LibJS/Runtime/ExecutionContext.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/VM.h>
@@ -31,6 +32,14 @@ ErrorData::ErrorData(VM& vm)
 void ErrorData::visit_edges(Cell::Visitor& visitor)
 {
     visitor.visit(m_cached_string);
+}
+
+size_t ErrorData::external_memory_size() const
+{
+    size_t size = vector_external_memory_size(m_traceback);
+    for (auto const& frame : m_traceback)
+        size = saturating_add_external_memory_size(size, utf16_string_external_memory_size(frame.function_name));
+    return size;
 }
 
 void ErrorData::populate_stack(VM& vm)

--- a/Libraries/LibJS/Runtime/ErrorData.h
+++ b/Libraries/LibJS/Runtime/ErrorData.h
@@ -42,6 +42,7 @@ public:
 
 protected:
     void visit_edges(Cell::Visitor&);
+    size_t external_memory_size() const;
 
 private:
     void populate_stack(VM&);

--- a/Libraries/LibJS/Runtime/ExternalMemory.h
+++ b/Libraries/LibJS/Runtime/ExternalMemory.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NumericLimits.h>
+#include <AK/String.h>
+#include <AK/Utf16String.h>
+#include <AK/Vector.h>
+
+namespace JS {
+
+inline size_t saturating_add_external_memory_size(size_t lhs, size_t rhs)
+{
+    if (rhs > NumericLimits<size_t>::max() - lhs)
+        return NumericLimits<size_t>::max();
+    return lhs + rhs;
+}
+
+inline size_t string_external_memory_size(String const& string)
+{
+    if (string.is_short_string())
+        return 0;
+    return string.byte_count();
+}
+
+inline size_t utf16_string_external_memory_size(Utf16String const& string)
+{
+    if (!string.has_long_storage())
+        return 0;
+
+    auto code_unit_size = string.has_ascii_storage() ? sizeof(char) : sizeof(char16_t);
+    if (string.length_in_code_units() > NumericLimits<size_t>::max() / code_unit_size)
+        return NumericLimits<size_t>::max();
+    return string.length_in_code_units() * code_unit_size;
+}
+
+template<typename T, size_t inline_capacity, FastLastAccess fast_last_access>
+size_t vector_external_memory_size(Vector<T, inline_capacity, fast_last_access> const& vector)
+{
+    if (vector.capacity() <= inline_capacity)
+        return 0;
+    return vector.capacity() * sizeof(T);
+}
+
+template<typename Map>
+size_t ordered_hash_map_external_memory_size(Map const& map)
+{
+    return map.capacity() * (sizeof(typename Map::KeyType) + sizeof(typename Map::ValueType));
+}
+
+}

--- a/Libraries/LibJS/Runtime/ExternalMemory.h
+++ b/Libraries/LibJS/Runtime/ExternalMemory.h
@@ -47,7 +47,7 @@ size_t vector_external_memory_size(Vector<T, inline_capacity, fast_last_access> 
 }
 
 template<typename Map>
-size_t ordered_hash_map_external_memory_size(Map const& map)
+size_t hash_map_external_memory_size(Map const& map)
 {
     return map.capacity() * (sizeof(typename Map::KeyType) + sizeof(typename Map::ValueType));
 }

--- a/Libraries/LibJS/Runtime/ExternalMemory.h
+++ b/Libraries/LibJS/Runtime/ExternalMemory.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
+#include <AK/HashTable.h>
 #include <AK/NumericLimits.h>
 #include <AK/String.h>
 #include <AK/Utf16String.h>
@@ -25,6 +27,13 @@ inline size_t string_external_memory_size(String const& string)
     if (string.is_short_string())
         return 0;
     return string.byte_count();
+}
+
+inline size_t byte_string_external_memory_size(ByteString const& string)
+{
+    if (string.is_empty())
+        return 0;
+    return AK::allocation_size_for_stringimpl(string.length());
 }
 
 inline size_t utf16_string_external_memory_size(Utf16String const& string)
@@ -50,6 +59,12 @@ template<typename Map>
 size_t hash_map_external_memory_size(Map const& map)
 {
     return map.capacity() * (sizeof(typename Map::KeyType) + sizeof(typename Map::ValueType));
+}
+
+template<typename T, typename TraitsForT, bool is_ordered>
+size_t hash_table_external_memory_size(HashTable<T, TraitsForT, is_ordered> const& table)
+{
+    return table.capacity() * sizeof(T);
 }
 
 }

--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -51,6 +51,11 @@ public:
 
     HashMap<u32, ValueAndAttributes> const& sparse_elements() const { return m_sparse_elements; }
 
+    size_t external_memory_size() const
+    {
+        return m_sparse_elements.capacity() * (sizeof(u32) + sizeof(ValueAndAttributes));
+    }
+
 private:
     size_t m_array_size { 0 };
     HashMap<u32, ValueAndAttributes> m_sparse_elements;

--- a/Libraries/LibJS/Runtime/IteratorHelper.cpp
+++ b/Libraries/LibJS/Runtime/IteratorHelper.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Iterator.h>
 #include <LibJS/Runtime/IteratorHelper.h>
@@ -32,6 +33,11 @@ void IteratorHelper::visit_edges(Visitor& visitor)
     visitor.visit(m_underlying_iterators);
     visitor.visit(m_closure);
     visitor.visit(m_abrupt_closure);
+}
+
+size_t IteratorHelper::external_memory_size() const
+{
+    return GeneratorObject::external_memory_size() + vector_external_memory_size(m_underlying_iterators);
 }
 
 ThrowCompletionOr<IteratorHelper::IterationResult> IteratorHelper::execute(VM& vm, JS::Completion const& completion)

--- a/Libraries/LibJS/Runtime/IteratorHelper.h
+++ b/Libraries/LibJS/Runtime/IteratorHelper.h
@@ -33,6 +33,7 @@ private:
     IteratorHelper(Realm&, Object& prototype, ReadonlySpan<GC::Ref<IteratorRecord>>, GC::Ref<Closure>, GC::Ptr<AbruptClosure>);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
     virtual ThrowCompletionOr<IterationResult> execute(VM&, JS::Completion const& completion) override;
 
     Vector<GC::Ref<IteratorRecord>> m_underlying_iterators; // [[UnderlyingIterators]]

--- a/Libraries/LibJS/Runtime/Map.cpp
+++ b/Libraries/LibJS/Runtime/Map.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Map.h>
 
 namespace JS {
@@ -23,8 +24,10 @@ Map::Map(Object& prototype)
 // 24.1.3.1 Map.prototype.clear ( ), https://tc39.es/ecma262/#sec-map.prototype.clear
 void Map::map_clear()
 {
+    auto old_external_memory_size = external_memory_size();
     m_keys.clear();
     m_entries.clear();
+    account_external_memory_change(old_external_memory_size);
 }
 
 // 24.1.3.3 Map.prototype.delete ( key ), https://tc39.es/ecma262/#sec-map.prototype.delete
@@ -42,8 +45,10 @@ bool Map::map_remove(Value const& key)
     if (!index.has_value())
         return false;
 
+    auto old_external_memory_size = external_memory_size();
     m_keys.remove(*index);
     m_entries.remove(key);
+    account_external_memory_change(old_external_memory_size);
     return true;
 }
 
@@ -68,15 +73,42 @@ void Map::map_set(Value const& key, Value value)
     if (it != m_entries.end()) {
         it->value = value;
     } else {
+        auto old_external_memory_size = external_memory_size();
         auto index = m_next_insertion_id++;
         m_keys.insert(index, key);
         m_entries.set(key, value);
+        account_external_memory_change(old_external_memory_size);
     }
 }
 
 size_t Map::map_size() const
 {
     return m_keys.size();
+}
+
+static size_t map_key_tree_external_memory_size(RedBlackTree<size_t, Value> const& keys)
+{
+    constexpr auto approximate_node_size = sizeof(AK::BaseRedBlackTree<size_t>::Node) + sizeof(Value);
+    if (keys.size() > NumericLimits<size_t>::max() / approximate_node_size)
+        return NumericLimits<size_t>::max();
+    return keys.size() * approximate_node_size;
+}
+
+size_t Map::external_memory_size() const
+{
+    auto size = Object::external_memory_size();
+    size = saturating_add_external_memory_size(size, map_key_tree_external_memory_size(m_keys));
+    size = saturating_add_external_memory_size(size, hash_map_external_memory_size(m_entries));
+    return size;
+}
+
+void Map::account_external_memory_change(size_t old_external_memory_size)
+{
+    auto new_external_memory_size = external_memory_size();
+    if (new_external_memory_size > old_external_memory_size)
+        heap().did_allocate_external_memory(new_external_memory_size - old_external_memory_size);
+    else if (old_external_memory_size > new_external_memory_size)
+        heap().did_free_external_memory(old_external_memory_size - new_external_memory_size);
 }
 
 void Map::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Runtime/Map.h
+++ b/Libraries/LibJS/Runtime/Map.h
@@ -34,6 +34,8 @@ public:
     void map_set(Value const&, Value);
     size_t map_size() const;
 
+    virtual size_t external_memory_size() const override;
+
     struct EndIterator {
     };
 
@@ -117,6 +119,8 @@ public:
 private:
     explicit Map(Object& prototype);
     virtual void visit_edges(Visitor& visitor) override;
+
+    void account_external_memory_change(size_t old_external_memory_size);
 
     size_t m_next_insertion_id { 0 };
     RedBlackTree<size_t, Value> m_keys;

--- a/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/ModuleEnvironment.h>
 #include <LibJS/Runtime/VM.h>
@@ -125,6 +126,13 @@ Optional<ModuleEnvironment::BindingAndIndex> ModuleEnvironment::find_binding_and
     }
 
     return DeclarativeEnvironment::find_binding_and_index(name);
+}
+
+size_t ModuleEnvironment::external_memory_size() const
+{
+    auto size = DeclarativeEnvironment::external_memory_size();
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_indirect_bindings));
+    return size;
 }
 
 void ModuleEnvironment::visit_edges(Visitor& visitor)

--- a/Libraries/LibJS/Runtime/ModuleEnvironment.h
+++ b/Libraries/LibJS/Runtime/ModuleEnvironment.h
@@ -32,6 +32,7 @@ private:
     explicit ModuleEnvironment(Environment* outer_environment);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     struct IndirectBinding {
         Utf16FlyString name;

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/QuickSort.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/ModuleEnvironment.h>
 #include <LibJS/Runtime/ModuleNamespaceObject.h>
@@ -30,6 +31,11 @@ void ModuleNamespaceObject::initialize(Realm& realm)
 
     // 28.3.1 @@toStringTag, https://tc39.es/ecma262/#sec-@@tostringtag
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Module"_string), 0);
+}
+
+size_t ModuleNamespaceObject::external_memory_size() const
+{
+    return Object::external_memory_size() + vector_external_memory_size(m_exports);
 }
 
 // 10.4.6.1 [[GetPrototypeOf]] ( ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-getprototypeof

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -38,6 +38,7 @@ private:
     ModuleNamespaceObject(Realm&, Module* module, Vector<Utf16FlyString> exports);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     GC::Ptr<Module> m_module;         // [[Module]]
     Vector<Utf16FlyString> m_exports; // [[Exports]]

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -62,6 +62,13 @@ static u32 heap_named_storage_capacity(Value* storage)
     return *reinterpret_cast<u32*>(reinterpret_cast<u8*>(storage) - HEAP_STORAGE_HEADER_SIZE);
 }
 
+size_t Object::named_storage_external_memory_size() const
+{
+    if (named_storage_is_inline())
+        return 0;
+    return HEAP_STORAGE_HEADER_SIZE + heap_named_storage_capacity(m_named_properties) * sizeof(Value);
+}
+
 void Object::ensure_named_storage_capacity(u32 needed)
 {
     bool is_inline = named_storage_is_inline();
@@ -1660,6 +1667,15 @@ void Object::visit_edges(Cell::Visitor& visitor)
     }
 }
 
+size_t Object::external_memory_size() const
+{
+    size_t size = named_storage_external_memory_size();
+    size += indexed_storage_external_memory_size();
+    if (m_private_elements)
+        size += m_private_elements->capacity() * sizeof(PrivateElement);
+    return size;
+}
+
 // 7.1.1.1 OrdinaryToPrimitive ( O, hint ), https://tc39.es/ecma262/#sec-ordinarytoprimitive
 ThrowCompletionOr<Value> Object::ordinary_to_primitive(Value::PreferredType preferred_type) const
 {
@@ -1720,6 +1736,20 @@ u32 Object::indexed_elements_capacity() const
     VERIFY(m_indexed_storage_kind == IndexedStorageKind::Packed || m_indexed_storage_kind == IndexedStorageKind::Holey);
     // Capacity is stored as a u32 at (m_indexed_elements - sizeof(u64))
     return *reinterpret_cast<u32 const*>(reinterpret_cast<u8 const*>(m_indexed_elements) - sizeof(u64));
+}
+
+size_t Object::indexed_storage_external_memory_size() const
+{
+    switch (m_indexed_storage_kind) {
+    case IndexedStorageKind::None:
+        return 0;
+    case IndexedStorageKind::Packed:
+    case IndexedStorageKind::Holey:
+        return sizeof(u64) + indexed_elements_capacity() * sizeof(Value);
+    case IndexedStorageKind::Dictionary:
+        return sizeof(GenericIndexedPropertyStorage) + indexed_dictionary()->external_memory_size();
+    }
+    VERIFY_NOT_REACHED();
 }
 
 static Value* allocate_indexed_elements(u32 capacity)

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -292,6 +292,7 @@ public:
     bool has_parameter_map() const { return shape().has_parameter_map(); }
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     Value get_direct(size_t index) const { return m_named_properties[index]; }
     void put_direct(size_t index, Value value) { m_named_properties[index] = value; }
@@ -399,6 +400,8 @@ private:
     void free_indexed_elements();
     void ensure_named_storage_capacity(u32 needed);
     bool named_storage_is_inline() const { return m_named_properties == const_cast<Object*>(this)->m_inline_named_storage; }
+    size_t named_storage_external_memory_size() const;
+    size_t indexed_storage_external_memory_size() const;
 
 public:
     static constexpr u32 INLINE_NAMED_PROPERTY_CAPACITY = 2;

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -8,6 +8,7 @@
 #include <AK/Array.h>
 #include <AK/CharacterTypes.h>
 #include <AK/FlyString.h>
+#include <AK/NumericLimits.h>
 #include <AK/StringBuilder.h>
 #include <AK/UnicodeUtils.h>
 #include <AK/Utf16FlyString.h>
@@ -228,6 +229,38 @@ PrimitiveString::PrimitiveString(String string)
 }
 
 PrimitiveString::~PrimitiveString() = default;
+
+static size_t string_external_memory_size(String const& string)
+{
+    if (string.is_short_string())
+        return 0;
+    return string.byte_count();
+}
+
+static size_t utf16_string_external_memory_size(Utf16String const& string)
+{
+    if (!string.has_long_storage())
+        return 0;
+
+    auto code_unit_size = string.has_ascii_storage() ? sizeof(char) : sizeof(char16_t);
+    if (string.length_in_code_units() > NumericLimits<size_t>::max() / code_unit_size)
+        return NumericLimits<size_t>::max();
+    return string.length_in_code_units() * code_unit_size;
+}
+
+size_t PrimitiveString::external_memory_size() const
+{
+    size_t size = 0;
+    if (m_utf8_string.has_value())
+        size += string_external_memory_size(*m_utf8_string);
+    if (m_utf16_string.has_value()) {
+        auto utf16_size = utf16_string_external_memory_size(*m_utf16_string);
+        size = utf16_size > NumericLimits<size_t>::max() - size
+            ? NumericLimits<size_t>::max()
+            : size + utf16_size;
+    }
+    return size;
+}
 
 void PrimitiveString::finalize()
 {

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -8,13 +8,13 @@
 #include <AK/Array.h>
 #include <AK/CharacterTypes.h>
 #include <AK/FlyString.h>
-#include <AK/NumericLimits.h>
 #include <AK/StringBuilder.h>
 #include <AK/UnicodeUtils.h>
 #include <AK/Utf16FlyString.h>
 #include <AK/Utf16View.h>
 #include <AK/Utf8View.h>
 #include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/PropertyKey.h>
@@ -230,35 +230,13 @@ PrimitiveString::PrimitiveString(String string)
 
 PrimitiveString::~PrimitiveString() = default;
 
-static size_t string_external_memory_size(String const& string)
-{
-    if (string.is_short_string())
-        return 0;
-    return string.byte_count();
-}
-
-static size_t utf16_string_external_memory_size(Utf16String const& string)
-{
-    if (!string.has_long_storage())
-        return 0;
-
-    auto code_unit_size = string.has_ascii_storage() ? sizeof(char) : sizeof(char16_t);
-    if (string.length_in_code_units() > NumericLimits<size_t>::max() / code_unit_size)
-        return NumericLimits<size_t>::max();
-    return string.length_in_code_units() * code_unit_size;
-}
-
 size_t PrimitiveString::external_memory_size() const
 {
     size_t size = 0;
     if (m_utf8_string.has_value())
         size += string_external_memory_size(*m_utf8_string);
-    if (m_utf16_string.has_value()) {
-        auto utf16_size = utf16_string_external_memory_size(*m_utf16_string);
-        size = utf16_size > NumericLimits<size_t>::max() - size
-            ? NumericLimits<size_t>::max()
-            : size + utf16_size;
-    }
+    if (m_utf16_string.has_value())
+        size = saturating_add_external_memory_size(size, utf16_string_external_memory_size(*m_utf16_string));
     return size;
 }
 

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -91,6 +91,7 @@ private:
     friend class Substring;
 
     virtual void finalize() override;
+    virtual size_t external_memory_size() const override;
 
     explicit PrimitiveString(Utf16String);
     explicit PrimitiveString(String);

--- a/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/PrivateEnvironment.h>
 
 namespace JS {
@@ -51,6 +52,11 @@ void PrivateEnvironment::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_outer_environment);
+}
+
+size_t PrivateEnvironment::external_memory_size() const
+{
+    return vector_external_memory_size(m_private_names);
 }
 
 }

--- a/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -44,6 +44,7 @@ private:
     explicit PrivateEnvironment(PrivateEnvironment* parent);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     auto find_private_name(Utf16FlyString const& description) const
     {

--- a/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Libraries/LibJS/Runtime/Promise.cpp
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/JobCallback.h>
 #include <LibJS/Runtime/Promise.h>
@@ -404,6 +405,13 @@ void Promise::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_result);
     visitor.visit(m_fulfill_reactions);
     visitor.visit(m_reject_reactions);
+}
+
+size_t Promise::external_memory_size() const
+{
+    auto size = vector_external_memory_size(m_fulfill_reactions);
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_reject_reactions));
+    return size;
 }
 
 }

--- a/Libraries/LibJS/Runtime/Promise.h
+++ b/Libraries/LibJS/Runtime/Promise.h
@@ -56,6 +56,7 @@ protected:
     explicit Promise(Object& prototype);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
 private:
     virtual bool is_promise() const override { return true; }

--- a/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/AggregateError.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/PromiseResolvingElementFunctions.h>
@@ -25,6 +26,11 @@ void PromiseValueList::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_values);
+}
+
+size_t PromiseValueList::external_memory_size() const
+{
+    return vector_external_memory_size(m_values);
 }
 
 PromiseResolvingElementFunction::PromiseResolvingElementFunction(size_t index, PromiseValueList& values, GC::Ref<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)

--- a/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -39,6 +39,7 @@ private:
     PromiseValueList() = default;
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     Vector<Value> m_values;
 };

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGC/DeferGC.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/Shape.h>
 #include <LibJS/Runtime/VM.h>
@@ -16,12 +17,6 @@ GC_DEFINE_ALLOCATOR(Shape);
 GC_DEFINE_ALLOCATOR(PrototypeChainValidity);
 
 Shape::~Shape() = default;
-
-template<typename Map>
-static size_t ordered_hash_map_external_memory_size(Map const& map)
-{
-    return map.capacity() * (sizeof(typename Map::KeyType) + sizeof(typename Map::ValueType));
-}
 
 size_t Shape::external_memory_size() const
 {
@@ -35,7 +30,7 @@ size_t Shape::external_memory_size() const
     if (m_delete_transitions)
         size += ordered_hash_map_external_memory_size(*m_delete_transitions);
     if (m_child_prototype_shapes)
-        size += m_child_prototype_shapes->capacity() * sizeof(GC::Weak<Shape>);
+        size += vector_external_memory_size(*m_child_prototype_shapes);
     return size;
 }
 

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -17,6 +17,28 @@ GC_DEFINE_ALLOCATOR(PrototypeChainValidity);
 
 Shape::~Shape() = default;
 
+template<typename Map>
+static size_t ordered_hash_map_external_memory_size(Map const& map)
+{
+    return map.capacity() * (sizeof(typename Map::KeyType) + sizeof(typename Map::ValueType));
+}
+
+size_t Shape::external_memory_size() const
+{
+    size_t size = 0;
+    if (m_property_table)
+        size += ordered_hash_map_external_memory_size(*m_property_table);
+    if (m_forward_transitions)
+        size += ordered_hash_map_external_memory_size(*m_forward_transitions);
+    if (m_prototype_transitions)
+        size += ordered_hash_map_external_memory_size(*m_prototype_transitions);
+    if (m_delete_transitions)
+        size += ordered_hash_map_external_memory_size(*m_delete_transitions);
+    if (m_child_prototype_shapes)
+        size += m_child_prototype_shapes->capacity() * sizeof(GC::Weak<Shape>);
+    return size;
+}
+
 GC::Ref<Shape> Shape::create_dictionary_transition()
 {
     auto new_shape = heap().allocate<Shape>(m_realm);

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -22,13 +22,13 @@ size_t Shape::external_memory_size() const
 {
     size_t size = 0;
     if (m_property_table)
-        size += ordered_hash_map_external_memory_size(*m_property_table);
+        size += hash_map_external_memory_size(*m_property_table);
     if (m_forward_transitions)
-        size += ordered_hash_map_external_memory_size(*m_forward_transitions);
+        size += hash_map_external_memory_size(*m_forward_transitions);
     if (m_prototype_transitions)
-        size += ordered_hash_map_external_memory_size(*m_prototype_transitions);
+        size += hash_map_external_memory_size(*m_prototype_transitions);
     if (m_delete_transitions)
-        size += ordered_hash_map_external_memory_size(*m_delete_transitions);
+        size += hash_map_external_memory_size(*m_delete_transitions);
     if (m_child_prototype_shapes)
         size += vector_external_memory_size(*m_child_prototype_shapes);
     return size;

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -120,6 +120,7 @@ private:
     void add_child_prototype_shape(GC::Ref<Shape>);
 
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     [[nodiscard]] GC::Ptr<Shape> get_or_prune_cached_forward_transition(TransitionKey const&);
     [[nodiscard]] GC::Ptr<Shape> get_or_prune_cached_prototype_transition(Object* prototype);

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/RustIntegration.h>
 
@@ -50,6 +51,19 @@ void SharedFunctionInstanceData::visit_edges(Visitor& visitor)
     for (auto& function : m_functions_to_initialize)
         visitor.visit(function.shared_data);
     m_class_field_initializer_name.visit([&](PropertyKey const& key) { key.visit_edges(visitor); }, [](auto&) {});
+}
+
+size_t SharedFunctionInstanceData::external_memory_size() const
+{
+    size_t size = utf16_string_external_memory_size(m_source_text_owner);
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_local_variables_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_parameter_names_for_mapped_arguments));
+    size = saturating_add_external_memory_size(size, hash_map_external_memory_size(m_parameter_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_functions_to_initialize));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_var_names_to_initialize_binding));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_function_names_to_initialize_binding));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_lexical_bindings));
+    return size;
 }
 
 SharedFunctionInstanceData::~SharedFunctionInstanceData() = default;

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
@@ -153,6 +153,7 @@ public:
 
 private:
     virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
     void update_can_inline_call();
 
     bool m_can_inline_call { false };

--- a/Libraries/LibJS/Runtime/Symbol.cpp
+++ b/Libraries/LibJS/Runtime/Symbol.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGC/Heap.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Symbol.h>
 #include <LibJS/Runtime/VM.h>
 
@@ -50,6 +51,13 @@ Optional<Utf16String> Symbol::key() const
     // 2. Assert: GlobalSymbolRegistry does not currently contain an entry for sym.
     // 3. Return undefined.
     return {};
+}
+
+size_t Symbol::external_memory_size() const
+{
+    if (!m_description.has_value())
+        return 0;
+    return utf16_string_external_memory_size(*m_description);
 }
 
 }

--- a/Libraries/LibJS/Runtime/Symbol.h
+++ b/Libraries/LibJS/Runtime/Symbol.h
@@ -30,6 +30,8 @@ public:
     Optional<Utf16String> key() const;
 
 private:
+    virtual size_t external_memory_size() const override;
+
     Symbol(Optional<Utf16String>, bool);
 
     Optional<Utf16String> m_description;

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -14,6 +14,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibGC/Heap.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
@@ -192,8 +193,10 @@ VM::VM(ErrorMessages error_messages)
 
         // The default implementation of HostResizeArrayBuffer is to return NormalCompletion(unhandled).
 
+        auto old_external_memory_size = buffer.external_memory_size();
         if (auto result = buffer.buffer().try_resize(new_byte_length, ByteBuffer::ZeroFillNewElements::Yes); result.is_error())
             return throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, new_byte_length);
+        buffer.did_change_data_block_capacity(old_external_memory_size);
 
         return HandledByHost::Handled;
     };

--- a/Libraries/LibJS/Runtime/WeakMap.cpp
+++ b/Libraries/LibJS/Runtime/WeakMap.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/WeakMap.h>
 
 namespace JS {
@@ -21,11 +22,53 @@ WeakMap::WeakMap(Object& prototype)
 {
 }
 
+Optional<Value> WeakMap::weak_map_get(GC::Ptr<Cell> key) const
+{
+    if (auto it = m_values.find(key); it != m_values.end())
+        return it->value;
+    return {};
+}
+
+bool WeakMap::weak_map_has(GC::Ptr<Cell> key) const
+{
+    return m_values.contains(key);
+}
+
+void WeakMap::weak_map_set(GC::Ptr<Cell> key, Value value)
+{
+    auto old_external_memory_size = external_memory_size();
+    m_values.set(key, value);
+    account_external_memory_change(old_external_memory_size);
+}
+
+bool WeakMap::weak_map_remove(GC::Ptr<Cell> key)
+{
+    auto old_external_memory_size = external_memory_size();
+    auto did_remove = m_values.remove(key);
+    if (did_remove)
+        account_external_memory_change(old_external_memory_size);
+    return did_remove;
+}
+
 void WeakMap::remove_dead_cells(Badge<GC::Heap>)
 {
     m_values.remove_all_matching([](Cell* key, Value) {
         return key->state() != Cell::State::Live;
     });
+}
+
+size_t WeakMap::external_memory_size() const
+{
+    return saturating_add_external_memory_size(Object::external_memory_size(), hash_map_external_memory_size(m_values));
+}
+
+void WeakMap::account_external_memory_change(size_t old_external_memory_size)
+{
+    auto new_external_memory_size = external_memory_size();
+    if (new_external_memory_size > old_external_memory_size)
+        heap().did_allocate_external_memory(new_external_memory_size - old_external_memory_size);
+    else if (old_external_memory_size > new_external_memory_size)
+        heap().did_free_external_memory(old_external_memory_size - new_external_memory_size);
 }
 
 void WeakMap::visit_edges(Visitor& visitor)

--- a/Libraries/LibJS/Runtime/WeakMap.h
+++ b/Libraries/LibJS/Runtime/WeakMap.h
@@ -25,16 +25,22 @@ public:
 
     virtual ~WeakMap() override = default;
 
-    HashMap<GC::Ptr<Cell>, Value> const& values() const { return m_values; }
-    HashMap<GC::Ptr<Cell>, Value>& values() { return m_values; }
+    Optional<Value> weak_map_get(GC::Ptr<Cell>) const;
+    bool weak_map_has(GC::Ptr<Cell>) const;
+    void weak_map_set(GC::Ptr<Cell>, Value);
+    bool weak_map_remove(GC::Ptr<Cell>);
+    size_t weak_map_size() const { return m_values.size(); }
 
     virtual void remove_dead_cells(Badge<GC::Heap>) override;
+    virtual size_t external_memory_size() const override;
 
 private:
     explicit WeakMap(Object& prototype);
 
     virtual bool is_weak_map() const final { return true; }
     void visit_edges(Visitor&) override;
+
+    void account_external_memory_change(size_t old_external_memory_size);
 
     HashMap<GC::Ptr<Cell>, Value> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };

--- a/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
+++ b/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/HashTable.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/WeakMapPrototype.h>
@@ -54,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::delete_)
     //         ii. Set p.[[Value]] to empty.
     //         iii. Return true.
     // 5. Return false.
-    return Value(weak_map->values().remove(&key.as_cell()));
+    return Value(weak_map->weak_map_remove(&key.as_cell()));
 }
 
 // 24.3.3.3 WeakMap.prototype.get ( key ), https://tc39.es/ecma262/#sec-weakmap.prototype.get
@@ -72,10 +71,8 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::get)
 
     // 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
     //     a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-    auto& values = weak_map->values();
-    auto result = values.find(&key.as_cell());
-    if (result != values.end())
-        return result->value;
+    if (auto result = weak_map->weak_map_get(&key.as_cell()); result.has_value())
+        return *result;
 
     // 5. Return undefined.
     return js_undefined();
@@ -95,17 +92,15 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::get_or_insert)
     if (!can_be_held_weakly(key))
         return vm.throw_completion<TypeError>(ErrorType::CannotBeHeldWeakly, key);
 
-    auto& values = weak_map->values();
-
     // 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
-    if (auto result = values.find(&key.as_cell()); result != values.end()) {
+    if (auto result = weak_map->weak_map_get(&key.as_cell()); result.has_value()) {
         // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-        return result->value;
+        return *result;
     }
 
     // 5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
     // 6. Append p to M.[[WeakMapData]].
-    values.set(&key.as_cell(), value);
+    weak_map->weak_map_set(&key.as_cell(), value);
 
     // 7. Return value.
     return value;
@@ -129,12 +124,10 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::get_or_insert_computed)
     if (!callback.is_function())
         return vm.throw_completion<TypeError>(ErrorType::NotAFunction, callback);
 
-    auto& values = weak_map->values();
-
     // 5. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
-    if (auto result = values.find(&key.as_cell()); result != values.end()) {
+    if (auto result = weak_map->weak_map_get(&key.as_cell()); result.has_value()) {
         // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return p.[[Value]].
-        return result->value;
+        return *result;
     }
 
     // 6. Let value be ? Call(callback, undefined, « key »).
@@ -148,7 +141,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::get_or_insert_computed)
     //         ii. Return value.
     // 9. Let p be the Record { [[Key]]: key, [[Value]]: value }.
     // 10. Append p to M.[[WeakMapData]].
-    values.set(&key.as_cell(), value);
+    weak_map->weak_map_set(&key.as_cell(), value);
 
     // 11. Return value.
     return value;
@@ -169,9 +162,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::has)
 
     // 4. For each Record { [[Key]], [[Value]] } p of M.[[WeakMapData]], do
     //     a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, return true.
-    auto& values = weak_map->values();
-    auto result = values.find(&key.as_cell());
-    if (result != values.end())
+    if (weak_map->weak_map_has(&key.as_cell()))
         return Value(true);
 
     // 5. Return false.
@@ -198,7 +189,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::set)
     //        ii. Return M.
     // 5. Let p be the Record { [[Key]]: key, [[Value]]: value }.
     // 6. Append p to M.[[WeakMapData]].
-    weak_map->values().set(&key.as_cell(), value);
+    weak_map->weak_map_set(&key.as_cell(), value);
 
     // 7. Return M.
     return weak_map;

--- a/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/WeakSet.h>
 
 namespace JS {
@@ -21,11 +22,46 @@ WeakSet::WeakSet(Object& prototype)
 {
 }
 
+bool WeakSet::weak_set_has(GC::Ptr<Cell> value) const
+{
+    return m_values.contains(value);
+}
+
+void WeakSet::weak_set_add(GC::Ptr<Cell> value)
+{
+    auto old_external_memory_size = external_memory_size();
+    m_values.set(value, AK::HashSetExistingEntryBehavior::Keep);
+    account_external_memory_change(old_external_memory_size);
+}
+
+bool WeakSet::weak_set_remove(GC::Ptr<Cell> value)
+{
+    auto old_external_memory_size = external_memory_size();
+    auto did_remove = m_values.remove(value);
+    if (did_remove)
+        account_external_memory_change(old_external_memory_size);
+    return did_remove;
+}
+
 void WeakSet::remove_dead_cells(Badge<GC::Heap>)
 {
     m_values.remove_all_matching([](Cell* cell) {
         return cell->state() != Cell::State::Live;
     });
+}
+
+size_t WeakSet::external_memory_size() const
+{
+    return saturating_add_external_memory_size(Object::external_memory_size(), hash_table_external_memory_size(m_values));
+}
+
+void WeakSet::account_external_memory_change(size_t old_external_memory_size)
+{
+    auto new_external_memory_size = external_memory_size();
+    if (new_external_memory_size > old_external_memory_size)
+        heap().did_allocate_external_memory(new_external_memory_size - old_external_memory_size);
+    else if (old_external_memory_size > new_external_memory_size)
+        heap().did_free_external_memory(old_external_memory_size - new_external_memory_size);
 }
 
 }

--- a/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Libraries/LibJS/Runtime/WeakSet.h
@@ -25,13 +25,18 @@ public:
 
     virtual ~WeakSet() override = default;
 
-    HashTable<GC::Ptr<Cell>> const& values() const { return m_values; }
-    HashTable<GC::Ptr<Cell>>& values() { return m_values; }
+    bool weak_set_has(GC::Ptr<Cell>) const;
+    void weak_set_add(GC::Ptr<Cell>);
+    bool weak_set_remove(GC::Ptr<Cell>);
+    size_t weak_set_size() const { return m_values.size(); }
 
     virtual void remove_dead_cells(Badge<GC::Heap>) override;
+    virtual size_t external_memory_size() const override;
 
 private:
     explicit WeakSet(Object& prototype);
+
+    void account_external_memory_change(size_t old_external_memory_size);
 
     HashTable<GC::RawPtr<Cell>> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };

--- a/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/HashTable.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/WeakSetPrototype.h>
@@ -49,7 +48,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::add)
     //     a. If e is not empty and SameValue(e, value) is true, then
     //         i. Return S.
     // 5. Append value to S.[[WeakSetData]].
-    weak_set->values().set(&value.as_cell(), AK::HashSetExistingEntryBehavior::Keep);
+    weak_set->weak_set_add(&value.as_cell());
 
     // 6. Return S.
     return weak_set;
@@ -73,7 +72,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::delete_)
     //         i. Replace the element of S.[[WeakSetData]] whose value is e with an element whose value is empty.
     //         ii. Return true.
     // 5. Return false.
-    return Value(weak_set->values().remove(&value.as_cell()));
+    return Value(weak_set->weak_set_remove(&value.as_cell()));
 }
 
 // 24.4.3.4 WeakSet.prototype.has ( value ), https://tc39.es/ecma262/#sec-weakset.prototype.has
@@ -91,9 +90,7 @@ JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::has)
 
     // 4. For each element e of S.[[WeakSetData]], do
     //     a. If e is not empty and SameValue(e, value) is true, return true.
-    auto& values = weak_set->values();
-    auto result = values.find(&value.as_cell());
-    if (result != values.end())
+    if (weak_set->weak_set_has(&value.as_cell()))
         return Value(true);
 
     // 5. Return false.

--- a/Libraries/LibJS/Script.cpp
+++ b/Libraries/LibJS/Script.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/Runtime/VM.h>
@@ -228,6 +229,19 @@ void Script::visit_edges(Cell::Visitor& visitor)
         m_host_defined->visit_host_defined_self(visitor);
     for (auto const& loaded_module : m_loaded_modules)
         visitor.visit(loaded_module.module);
+}
+
+size_t Script::external_memory_size() const
+{
+    size_t size = vector_external_memory_size(m_loaded_modules);
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_lexical_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_var_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_functions_to_initialize));
+    size = saturating_add_external_memory_size(size, m_declared_function_names.capacity() * sizeof(Utf16FlyString));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_var_scoped_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_annex_b_candidate_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_lexical_bindings));
+    return size;
 }
 
 }

--- a/Libraries/LibJS/Script.h
+++ b/Libraries/LibJS/Script.h
@@ -86,6 +86,7 @@ private:
     Script(Realm&, StringView filename, RustIntegration::ScriptResult&&, HostDefined*);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     GC::Ptr<Realm> m_realm;                       // [[Realm]]
     Vector<LoadedModuleRequest> m_loaded_modules; // [[LoadedModules]]

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -10,6 +10,7 @@
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/AsyncFunctionDriverWrapper.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/ModuleEnvironment.h>
 #include <LibJS/Runtime/PromiseCapability.h>
@@ -23,6 +24,39 @@
 namespace JS {
 
 GC_DEFINE_ALLOCATOR(SourceTextModule);
+
+static size_t import_attributes_external_memory_size(Vector<ImportAttribute> const& attributes)
+{
+    size_t size = vector_external_memory_size(attributes);
+    for (auto const& attribute : attributes) {
+        size = saturating_add_external_memory_size(size, utf16_string_external_memory_size(attribute.key));
+        size = saturating_add_external_memory_size(size, utf16_string_external_memory_size(attribute.value));
+    }
+    return size;
+}
+
+static size_t module_request_external_memory_size(Optional<ModuleRequest> const& request)
+{
+    if (!request.has_value())
+        return 0;
+    return import_attributes_external_memory_size(request->attributes);
+}
+
+static size_t import_entries_external_memory_size(Vector<ImportEntry> const& entries)
+{
+    size_t size = vector_external_memory_size(entries);
+    for (auto const& entry : entries)
+        size = saturating_add_external_memory_size(size, module_request_external_memory_size(entry.m_module_request));
+    return size;
+}
+
+static size_t export_entries_external_memory_size(Vector<ExportEntry> const& entries)
+{
+    size_t size = vector_external_memory_size(entries);
+    for (auto const& entry : entries)
+        size = saturating_add_external_memory_size(size, module_request_external_memory_size(entry.m_module_request));
+    return size;
+}
 
 SourceTextModule::SourceTextModule(Realm& realm, StringView filename, Script::HostDefined* host_defined, bool has_top_level_await,
     Vector<ModuleRequest> requested_modules, Vector<ImportEntry> import_entries,
@@ -58,6 +92,19 @@ void SourceTextModule::visit_edges(Cell::Visitor& visitor)
         visitor.visit(function.shared_data);
     visitor.visit(m_executable);
     visitor.visit(m_tla_shared_data);
+}
+
+size_t SourceTextModule::external_memory_size() const
+{
+    size_t size = Base::external_memory_size();
+    size = saturating_add_external_memory_size(size, import_entries_external_memory_size(m_import_entries));
+    size = saturating_add_external_memory_size(size, export_entries_external_memory_size(m_local_export_entries));
+    size = saturating_add_external_memory_size(size, export_entries_external_memory_size(m_indirect_export_entries));
+    size = saturating_add_external_memory_size(size, export_entries_external_memory_size(m_star_export_entries));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_var_declared_names));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_lexical_bindings));
+    size = saturating_add_external_memory_size(size, vector_external_memory_size(m_functions_to_initialize));
+    return size;
 }
 
 Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_from_pre_parsed(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Script::HostDefined* host_defined)

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -66,6 +66,7 @@ private:
     SourceTextModule(Realm&, StringView filename, Script::HostDefined* host_defined, bool has_top_level_await, Vector<ModuleRequest> requested_modules, Vector<ImportEntry> import_entries, Vector<ExportEntry> local_export_entries, Vector<ExportEntry> indirect_export_entries, Vector<ExportEntry> star_export_entries, Optional<Utf16FlyString> default_export_binding_name, Vector<Utf16FlyString> var_declared_names, Vector<LexicalBinding> lexical_bindings, Vector<FunctionToInitialize> functions_to_initialize, GC::Ptr<Bytecode::Executable> executable, GC::Ptr<SharedFunctionInstanceData> tla_shared_data);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     NonnullOwnPtr<ExecutionContext> m_execution_context; // [[Context]]
     GC::Ptr<Object> m_import_meta;                       // [[ImportMeta]]

--- a/Libraries/LibJS/SyntheticModule.cpp
+++ b/Libraries/LibJS/SyntheticModule.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/ModuleEnvironment.h>
@@ -29,6 +30,11 @@ void SyntheticModule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_evaluation_steps);
+}
+
+size_t SyntheticModule::external_memory_size() const
+{
+    return saturating_add_external_memory_size(Base::external_memory_size(), vector_external_memory_size(m_export_names));
 }
 
 // 16.2.1.8.1 CreateDefaultExportSyntheticModule ( defaultExport ), https://tc39.es/ecma262/#sec-create-default-export-synthetic-module

--- a/Libraries/LibJS/SyntheticModule.h
+++ b/Libraries/LibJS/SyntheticModule.h
@@ -34,6 +34,7 @@ private:
     SyntheticModule(Realm& realm, Vector<Utf16FlyString> export_names, EvaluationFunction evaluation_steps, ByteString filename);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     Vector<Utf16FlyString> m_export_names; // [[ExportNames]]
     EvaluationFunction m_evaluation_steps; // [[EvaluationSteps]]

--- a/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/CSSRuleList.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSContainerRule.h>
@@ -51,6 +52,11 @@ void CSSRuleList::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_rules);
     visitor.visit(m_owner_rule);
+}
+
+size_t CSSRuleList::external_memory_size() const
+{
+    return JS::saturating_add_external_memory_size(Base::external_memory_size(), JS::vector_external_memory_size(m_rules));
 }
 
 // AD-HOC: The spec doesn't include a declared_namespaces parameter, but we need it to handle parsing of namespaced selectors.

--- a/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -74,6 +74,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     Vector<Parser::RuleContext> rule_context() const;
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/CSSStyleProperties.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
@@ -125,6 +126,14 @@ void CSSStyleProperties::visit_edges(Visitor& visitor)
     for (auto& property : m_properties) {
         property.value->visit_edges(visitor);
     }
+}
+
+size_t CSSStyleProperties::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_properties));
+    size = JS::saturating_add_external_memory_size(size, JS::hash_map_external_memory_size(m_custom_properties));
+    return size;
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-length

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -75,6 +75,7 @@ private:
     static Vector<StyleProperty> convert_declarations_to_specified_order(Vector<StyleProperty>&);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     RefPtr<StyleValue const> style_value_for_computed_property(Layout::NodeWithStyle const&, PropertyID) const;
     Optional<StyleProperty> get_property_internal(PropertyNameAndID const&) const;

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/Bindings/CSSStyleSheet.h>
 #include <LibWeb/Bindings/Intrinsics.h>
@@ -142,6 +143,19 @@ void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
         m_shared_single_constructed_sheet_style_cache->visit_edges(visitor);
     for (auto& subresource : m_critical_subresources)
         subresource.visit_edges(visitor);
+}
+
+size_t CSSStyleSheet::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    if (m_source_text.has_value())
+        size = JS::saturating_add_external_memory_size(size, JS::string_external_memory_size(*m_source_text));
+    size = JS::saturating_add_external_memory_size(size, JS::hash_map_external_memory_size(m_namespace_rules));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_import_rules));
+    size = JS::saturating_add_external_memory_size(size, JS::hash_table_external_memory_size(m_owning_documents_or_shadow_roots));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_critical_subresources));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_pending_image_values));
+    return size;
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-insertrule

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -137,6 +137,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     void recalculate_rule_caches();
     void invalidate_shared_style_cache();

--- a/Libraries/LibWeb/CSS/StyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheet.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/StyleSheet.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/StyleSheet.h>
@@ -25,6 +26,14 @@ void StyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_owner_node);
     visitor.visit(m_parent_style_sheet);
     visitor.visit(m_media);
+}
+
+size_t StyleSheet::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    size = JS::saturating_add_external_memory_size(size, JS::string_external_memory_size(m_title));
+    size = JS::saturating_add_external_memory_size(size, JS::string_external_memory_size(m_type_string));
+    return size;
 }
 
 Optional<String> StyleSheet::href() const

--- a/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Libraries/LibWeb/CSS/StyleSheet.h
@@ -62,6 +62,7 @@ public:
 protected:
     explicit StyleSheet(JS::Realm&, MediaList& media);
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     GC::Ref<MediaList> m_media;
 

--- a/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/AbortSignal.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/AbortSignal.h>
@@ -131,6 +132,15 @@ void AbortSignal::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_abort_algorithms);
     visitor.visit(m_source_signals);
     visitor.visit(m_dependent_signals);
+}
+
+size_t AbortSignal::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    size = JS::saturating_add_external_memory_size(size, JS::hash_map_external_memory_size(m_abort_algorithms));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_source_signals));
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_dependent_signals));
+    return size;
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-abort

--- a/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Libraries/LibWeb/DOM/AbortSignal.h
@@ -57,6 +57,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     bool dependent() const { return m_dependent; }
     void set_dependent(bool dependent) { m_dependent = dependent; }

--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/Bindings/CharacterData.h>
 #include <LibWeb/CSS/Invalidation/LanguageInvalidator.h>
@@ -30,6 +31,11 @@ void CharacterData::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(CharacterData);
     Base::initialize(realm);
+}
+
+size_t CharacterData::external_memory_size() const
+{
+    return Node::external_memory_size() + JS::utf16_string_external_memory_size(m_data);
 }
 
 // https://dom.spec.whatwg.org/#dom-characterdata-data

--- a/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Libraries/LibWeb/DOM/CharacterData.h
@@ -48,6 +48,8 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
 private:
+    virtual size_t external_memory_size() const override;
+
     Utf16String m_data;
 
     mutable OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;

--- a/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/DOMTokenList.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
@@ -90,6 +91,15 @@ void DOMTokenList::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_associated_element);
+}
+
+size_t DOMTokenList::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_token_set));
+    for (auto const& token : m_token_set)
+        size = JS::saturating_add_external_memory_size(size, JS::string_external_memory_size(token));
+    return size;
 }
 
 // https://dom.spec.whatwg.org/#ref-for-domtokenlist%E2%91%A0%E2%91%A1

--- a/Libraries/LibWeb/DOM/DOMTokenList.h
+++ b/Libraries/LibWeb/DOM/DOMTokenList.h
@@ -48,6 +48,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     WebIDL::ExceptionOr<void> validate_token(StringView token) const;
     WebIDL::ExceptionOr<void> validate_token_not_empty(StringView token) const;

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -11,6 +11,7 @@
 #include <AK/StringBuilder.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/ObjectEnvironment.h>
@@ -80,6 +81,17 @@ void EventTarget::visit_edges(Cell::Visitor& visitor)
         visitor.visit(data->event_listener_list);
         visitor.visit(data->event_handler_map);
     }
+}
+
+size_t EventTarget::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    if (!m_data)
+        return size;
+
+    size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(m_data->event_listener_list));
+    size = JS::saturating_add_external_memory_size(size, JS::hash_map_external_memory_size(m_data->event_handler_map));
+    return size;
 }
 
 Vector<GC::Root<DOMEventListener>> EventTarget::event_listener_list()

--- a/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Libraries/LibWeb/DOM/EventTarget.h
@@ -69,6 +69,7 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
 private:
     // ^JS::Object

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -14,6 +14,7 @@
 #include <LibGC/DeferGC.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -137,6 +138,14 @@ void Node::visit_edges(Cell::Visitor& visitor)
     if (m_registered_observer_list) {
         visitor.visit(*m_registered_observer_list);
     }
+}
+
+size_t Node::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    if (m_registered_observer_list)
+        size = JS::saturating_add_external_memory_size(size, JS::vector_external_memory_size(*m_registered_observer_list));
+    return size;
 }
 
 // https://dom.spec.whatwg.org/#dom-node-baseuri

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -494,6 +494,7 @@ protected:
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
+    virtual size_t external_memory_size() const override;
 
     GC::Ptr<Document> m_document;
     GC::Ptr<Layout::Node> m_layout_node;

--- a/Libraries/LibWeb/DOM/StaticNodeList.cpp
+++ b/Libraries/LibWeb/DOM/StaticNodeList.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGC/Heap.h>
 #include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/StaticNodeList.h>
 
@@ -31,6 +32,11 @@ void StaticNodeList::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_static_nodes);
+}
+
+size_t StaticNodeList::external_memory_size() const
+{
+    return Base::external_memory_size() + JS::vector_external_memory_size(m_static_nodes);
 }
 
 // https://dom.spec.whatwg.org/#dom-nodelist-length

--- a/Libraries/LibWeb/DOM/StaticNodeList.h
+++ b/Libraries/LibWeb/DOM/StaticNodeList.h
@@ -26,6 +26,7 @@ private:
     StaticNodeList(JS::Realm&, Vector<GC::Root<Node>>);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     Vector<GC::Ref<Node>> m_static_nodes;
 };

--- a/Libraries/LibWeb/HTML/AnimatedDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/AnimatedDecodedImageData.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGC/Heap.h>
 #include <LibGfx/Bitmap.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/HTML/AnimatedDecodedImageData.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
@@ -99,6 +100,16 @@ AnimatedDecodedImageData::AnimatedDecodedImageData(
 }
 
 AnimatedDecodedImageData::~AnimatedDecodedImageData() = default;
+
+size_t AnimatedDecodedImageData::external_memory_size() const
+{
+    size_t size = JS::vector_external_memory_size(m_durations);
+    for (auto const& slot : m_buffer_slots) {
+        if (slot.frame)
+            size = JS::saturating_add_external_memory_size(size, slot.frame->bitmap().data_size());
+    }
+    return size;
+}
 
 void AnimatedDecodedImageData::finalize()
 {

--- a/Libraries/LibWeb/HTML/AnimatedDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/AnimatedDecodedImageData.h
@@ -79,6 +79,8 @@ private:
         Gfx::ColorSpace,
         Vector<u32> durations);
 
+    virtual size_t external_memory_size() const override;
+
     BufferSlot const* find_slot(u32 frame_index) const;
     BufferSlot& evict_oldest_slot();
     void maybe_request_more_frames(size_t current_frame_index);

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <LibGC/Heap.h>
+#include <LibGfx/Bitmap.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/HTML/BitmapDecodedImageData.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
@@ -27,6 +29,16 @@ BitmapDecodedImageData::BitmapDecodedImageData(Vector<Frame>&& frames, size_t lo
 }
 
 BitmapDecodedImageData::~BitmapDecodedImageData() = default;
+
+size_t BitmapDecodedImageData::external_memory_size() const
+{
+    size_t size = JS::vector_external_memory_size(m_frames);
+    for (auto const& frame : m_frames) {
+        if (frame.frame)
+            size = JS::saturating_add_external_memory_size(size, frame.frame->bitmap().data_size());
+    }
+    return size;
+}
 
 RefPtr<Gfx::DecodedImageFrame> BitmapDecodedImageData::frame(size_t frame_index, Gfx::IntSize) const
 {

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
@@ -42,6 +42,8 @@ public:
 private:
     BitmapDecodedImageData(Vector<Frame>&&, size_t loop_count, bool animated);
 
+    virtual size_t external_memory_size() const override;
+
     Vector<Frame> m_frames;
     size_t m_loop_count { 0 };
     bool m_animated { false };

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -9,12 +9,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
+#include <AK/NumericLimits.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/CompositingAndBlendingOperator.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/PainterSkia.h>
 #include <LibGfx/Rect.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibUnicode/Segmenter.h>
@@ -72,6 +75,24 @@ void CanvasRenderingContext2D::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     CanvasState::visit_edges(visitor);
     visitor.visit(m_element);
+}
+
+size_t CanvasRenderingContext2D::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    if (!m_surface)
+        return size;
+
+    auto surface_size = m_surface->size();
+    if (surface_size.is_empty())
+        return size;
+
+    Checked<size_t> pixel_size = static_cast<size_t>(surface_size.width());
+    pixel_size *= static_cast<size_t>(surface_size.height());
+    pixel_size *= sizeof(u32);
+    if (pixel_size.has_overflow())
+        return NumericLimits<size_t>::max();
+    return JS::saturating_add_external_memory_size(size, pixel_size.value());
 }
 
 HTMLCanvasElement& CanvasRenderingContext2D::canvas_element()

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -138,6 +138,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     virtual Gfx::Painter* painter_for_canvas_state() override { return painter(); }
     virtual Gfx::Path& path_for_canvas_state() override { return path(); }

--- a/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/ImageBitmap.h>
 #include <LibWeb/HTML/ImageBitmap.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
@@ -70,6 +71,14 @@ void ImageBitmap::initialize(JS::Realm& realm)
 void ImageBitmap::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+}
+
+size_t ImageBitmap::external_memory_size() const
+{
+    auto size = Base::external_memory_size();
+    if (m_bitmap)
+        size = JS::saturating_add_external_memory_size(size, m_bitmap->data_size());
+    return size;
 }
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#the-imagebitmap-interface:serialization-steps

--- a/Libraries/LibWeb/HTML/ImageBitmap.h
+++ b/Libraries/LibWeb/HTML/ImageBitmap.h
@@ -65,6 +65,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     WebIDL::UnsignedLong m_width = 0;
     WebIDL::UnsignedLong m_height = 0;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
+#include <AK/NumericLimits.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/DecodedImageFrame.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/DOM/Document.h>
@@ -100,6 +104,34 @@ void SVGDecodedImageData::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document);
     visitor.visit(m_page_client);
     visitor.visit(m_root_element);
+}
+
+static size_t surface_external_memory_size(Gfx::PaintingSurface const& surface)
+{
+    auto surface_size = surface.size();
+    if (surface_size.is_empty())
+        return 0;
+
+    Checked<size_t> pixel_size = static_cast<size_t>(surface_size.width());
+    pixel_size *= static_cast<size_t>(surface_size.height());
+    pixel_size *= sizeof(u32);
+    if (pixel_size.has_overflow())
+        return NumericLimits<size_t>::max();
+    return pixel_size.value();
+}
+
+size_t SVGDecodedImageData::external_memory_size() const
+{
+    size_t size = Base::external_memory_size();
+    size = JS::saturating_add_external_memory_size(size, JS::hash_map_external_memory_size(m_cached_rendered_frames));
+    for (auto const& cached_frame : m_cached_rendered_frames)
+        size = JS::saturating_add_external_memory_size(size, cached_frame.value->bitmap().data_size());
+
+    size = JS::saturating_add_external_memory_size(size, JS::hash_map_external_memory_size(m_cached_rendered_surfaces));
+    for (auto const& cached_surface : m_cached_rendered_surfaces)
+        size = JS::saturating_add_external_memory_size(size, surface_external_memory_size(*cached_surface.value));
+
+    return size;
 }
 
 RefPtr<Painting::DisplayList> SVGDecodedImageData::record_display_list(Gfx::IntSize size) const

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -36,6 +36,7 @@ public:
     DOM::Document const& svg_document() const { return *m_document; }
 
     virtual void visit_edges(Cell::Visitor& visitor) override;
+    virtual size_t external_memory_size() const override;
 
     virtual Optional<Gfx::IntRect> frame_rect(size_t frame_index) const override;
     virtual void paint(DisplayListRecordingContext&, size_t frame_index, Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::ScalingMode scaling_mode) const override;

--- a/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/VM.h>
@@ -152,6 +153,11 @@ void AudioBuffer::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_channels);
+}
+
+size_t AudioBuffer::external_memory_size() const
+{
+    return JS::saturating_add_external_memory_size(Base::external_memory_size(), JS::vector_external_memory_size(m_channels));
 }
 
 }

--- a/Libraries/LibWeb/WebAudio/AudioBuffer.h
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.h
@@ -45,6 +45,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual size_t external_memory_size() const override;
 
     // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-number-of-channels-slot
     // The number of audio channels for this AudioBuffer, which is an unsigned long.

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -58,7 +58,7 @@ TESTJS_GLOBAL_FUNCTION(get_weak_set_size, getWeakSetSize)
     if (!is<JS::WeakSet>(*object))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "WeakSet");
     auto& weak_set = static_cast<JS::WeakSet&>(*object);
-    return JS::Value(weak_set.values().size());
+    return JS::Value(weak_set.weak_set_size());
 }
 
 TESTJS_GLOBAL_FUNCTION(get_weak_map_size, getWeakMapSize)
@@ -67,7 +67,7 @@ TESTJS_GLOBAL_FUNCTION(get_weak_map_size, getWeakMapSize)
     if (!is<JS::WeakMap>(*object))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "WeakMap");
     auto& weak_map = static_cast<JS::WeakMap&>(*object);
-    return JS::Value(weak_map.values().size());
+    return JS::Value(weak_map.weak_map_size());
 }
 
 TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)


### PR DESCRIPTION
LibGC was sizing the heap based only on cell allocations, ignoring everything held in external buffers (`BigInt` limbs, `ArrayBuffer` payloads, DOM text and image data, stylesheets, media cache, module storage, keyed collections, etc, etc...).

This branch teaches `Cell` to report its external footprint so collection, thresholds reflect actual memory pressure, then retunes the threshold floor (4 MiB → 8 MiB) and growth factor (1.0× → 1.75×) on top of the new accounting.

The retune comes from a sweep of 13 `(min, growth)` pairs across Speedometer 2/3, Octane, GarBench.

Comparing Speedometer 2 & 3 on master vs this PR:

|                | Speedo 2 master | Speedo 2 PR    | Speedo 3 master | Speedo 3 PR    |                                                                
|----------------|-----------------|----------------|-----------------|----------------|
| score          | 50.1            | 52.0 (+3.8%)   | 2.97            | 3.15 (+6.1%)   |                                                                
| WebContent RSS | 1438 MB         | 1647 MB (+15%) | 2083 MB         | 2473 MB (+19%) |
| GC count       | 158             | 47 (−70%)      | 95              | 28 (−70%)      |                                                                
| total GC time  | 1.65 s          | 1.09 s (−34%)  | 1.65 s          | 1.21 s (−27%)  |
| max GC pause   | 38 ms           | 76 ms          | 97 ms           | 139 ms         |          

Aggregate time in GC drops 27-34%, so the user spends less total wall-clock waiting on collection. The tradeoff is that the remaining pauses are bigger: many small sub-perception pauses get traded for fewer larger ones, with +15-19% steady-state RSS as the GC legitimately lets the heap grow longer between collections.

The +RSS isn't free; it's the cost of letting the heap reflect actual pressure. More aggressive growth factors (2.5×, 3.0×) score slightly higher but pay 30–40% RSS, and 3.0× actually introduces a 223 ms worst-case pause despite running fewer GCs. 1.75× is the cleanest tradeoff: best max pause among non-trivial growth factors, modest RSS, ~80% of the score win that 2.5× delivers.

