### PR TITLE
Tests/LibJS: Remove tests that assume WeakRef will be garbage collected

### DIFF
--- a/Tests/LibJS/Runtime/builtins/WeakRef/WeakRef.prototype.deref.js
+++ b/Tests/LibJS/Runtime/builtins/WeakRef/WeakRef.prototype.deref.js
@@ -35,27 +35,3 @@ test("symbol kept alive for current synchronous execution sequence", () => {
     // This is fine 🔥
     expect(weakRef.deref()).not.toBe(undefined);
 });
-
-test("returned WeakRef target is no longer kept alive after an inline return", () => {
-    function createWeakRef() {
-        return new WeakRef({});
-    }
-
-    var weakRef = createWeakRef();
-    gc();
-
-    expect(weakRef.deref()).toBe(undefined);
-});
-
-test("assigned WeakRef target is no longer kept alive after an inline end", () => {
-    var weakRef;
-
-    function createWeakRef() {
-        weakRef = new WeakRef({});
-    }
-
-    createWeakRef();
-    gc();
-
-    expect(weakRef.deref()).toBe(undefined);
-});


### PR DESCRIPTION
The marking phase of our garbage collection will potentially find stale pointers to GC cells or random data that looks like a pointer in either the active stack or CPU registers, which means that this test is flaky until we find a way to do precise stack scans. Remove the tests since it is unlikely that we'll have that in the short term.