### PR TITLE
LibWeb: Skip `BlockContainer` children when sizing inline paintables

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -570,7 +570,7 @@ void LayoutState::commit(Box& root)
             if (paintable.line_index() != line_index)
                 return TraversalDecision::Continue;
             if (is<BlockContainer>(paintable.layout_node()))
-                return TraversalDecision::Continue;
+                return TraversalDecision::SkipChildrenAndContinue;
 
             auto const* used_values = try_get(paintable.layout_node_with_style_and_box_metrics());
             if (&paintable != paintable_with_lines && used_values)

--- a/Tests/LibWeb/Text/expected/hit_testing/inline-element-with-inline-block-child.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/inline-element-with-inline-block-child.txt
@@ -1,0 +1,1 @@
+<a> rect matches <i> rect: true

--- a/Tests/LibWeb/Text/input/hit_testing/inline-element-with-inline-block-child.html
+++ b/Tests/LibWeb/Text/input/hit_testing/inline-element-with-inline-block-child.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    i { display: inline-block; }
+    i::before { content: "X"; }
+</style>
+<a><i></i></a>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const a = document.querySelector("a");
+        const i = document.querySelector("i");
+        const a_rect = a.getBoundingClientRect();
+        const i_rect = i.getBoundingClientRect();
+        println(`<a> rect matches <i> rect: ${a_rect.x === i_rect.x && a_rect.width === i_rect.width}`);
+    });
+</script>


### PR DESCRIPTION
Inline paintables are sized by walking their paintable subtree. The traversal already ignored `BlockContainer` paintables, but it still visited their children, so an inline element could include internal fragments from an inline-block child when computing its own geometry. We now skip the entire `BlockContainer` subtree, so widths are not double counted and offsets are not pulled from a different containing block.

This fixes an issue where links could not be clicked on https://jakubsteplow.ski/. This bug can be seen in the latest [monthly update video](https://www.youtube.com/watch?v=tISi7BXWQFk&t=1651s).