### PR TITLE
UI/Qt: Copy window size and maximized state for new windows

### DIFF
--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -120,11 +120,10 @@ NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
     return event_loop;
 }
 
-BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, BrowserWindow::IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& configuration, BrowserWindow::IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
 {
     auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
     set_active_window(*window);
-    window->show();
     if (initial_urls.is_empty()) {
         auto* tab = window->current_tab();
         if (tab) {
@@ -132,6 +131,13 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Bro
             tab->focus_location_editor();
         }
     }
+
+    window->set_window_rect(configuration.x, configuration.y, configuration.width, configuration.height);
+    if (configuration.maximized == true)
+        window->showMaximized();
+    else
+        window->show();
+
     window->activateWindow();
     window->raise();
     return *window;

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -15,6 +15,14 @@
 
 namespace Ladybird {
 
+struct WindowConfiguration {
+    Optional<Web::DevicePixels> x {};
+    Optional<Web::DevicePixels> y {};
+    Optional<Web::DevicePixels> width {};
+    Optional<Web::DevicePixels> height {};
+    Optional<bool> maximized {};
+};
+
 class Application : public WebView::Application {
     WEB_VIEW_APPLICATION(Application)
 
@@ -22,8 +30,7 @@ public:
     virtual ~Application() override;
 
     Function<void(URL::URL)> on_open_file;
-
-    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WindowConfiguration const& = {}, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     BrowserWindow& active_window() const { return *m_active_window; }
     void set_active_window(BrowserWindow& w) { m_active_window = &w; }

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -326,7 +326,13 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         tab.focus_location_editor();
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [] {
-        (void)Application::the().new_window({ WebView::Application::settings().new_tab_page_url() });
+        auto const& previous_active_window = Application::the().active_window();
+        WindowConfiguration configuration {
+            .width = previous_active_window.width(),
+            .height = previous_active_window.height(),
+            .maximized = previous_active_window.isMaximized(),
+        };
+        Application::the().new_window({ WebView::Application::settings().new_tab_page_url() }, configuration);
     });
     QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
 
@@ -491,8 +497,13 @@ void BrowserWindow::initialize_tab(Tab* tab)
 
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {
         if (hints.popup) {
-            auto& window = Application::the().new_window({}, IsPopupWindow::Yes, tab, AK::move(page_index));
-            window.set_window_rect(hints.screen_x, hints.screen_y, hints.width, hints.height);
+            WindowConfiguration configuration {
+                .x = hints.screen_x,
+                .y = hints.screen_y,
+                .width = hints.width,
+                .height = hints.height,
+            };
+            auto& window = Application::the().new_window({}, configuration, IsPopupWindow::Yes, tab, AK::move(page_index));
             return window.current_tab()->view().handle();
         }
         auto& new_tab = new_child_tab(activate_tab, *tab, page_index);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -110,6 +110,8 @@ public:
     void on_devtools_enabled();
     void on_devtools_disabled();
 
+    void set_window_rect(Optional<Web::DevicePixels> x, Optional<Web::DevicePixels> y, Optional<Web::DevicePixels> width, Optional<Web::DevicePixels> height);
+
 public slots:
     void device_pixel_ratio_changed(qreal dpi);
     void refresh_rate_changed(qreal refresh_rate);
@@ -155,8 +157,6 @@ private:
     QIcon icon_for_page_mute_state(Tab&) const;
     QString tool_tip_for_page_mute_state(Tab&) const;
     QTabBar::ButtonPosition audio_button_position_for_tab(int tab_index) const;
-
-    void set_window_rect(Optional<Web::DevicePixels> x, Optional<Web::DevicePixels> y, Optional<Web::DevicePixels> width, Optional<Web::DevicePixels> height);
 
     QScreen* m_current_screen { nullptr };
     double m_device_pixel_ratio { 0 };

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -74,22 +74,27 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         };
 
         browser_process.on_new_window = [&](auto const& urls) {
-            app->new_window(urls);
+            auto const& previous_active_window = app->active_window();
+            Ladybird::WindowConfiguration configuration {
+                .width = previous_active_window.width(),
+                .height = previous_active_window.height(),
+                .maximized = previous_active_window.isMaximized(),
+            };
+            app->new_window(urls, configuration);
         };
 
-        auto& window = app->new_window(browser_options.urls);
-        window.setWindowTitle("Ladybird");
-
-        if (Ladybird::Settings::the()->is_maximized()) {
-            window.showMaximized();
-        } else {
-            auto last_position = Ladybird::Settings::the()->last_position();
-            if (last_position.has_value())
-                window.move(last_position.value());
-            window.resize(Ladybird::Settings::the()->last_size());
+        auto last_size = Ladybird::Settings::the()->last_size();
+        Ladybird::WindowConfiguration configuration {
+            .width = last_size.width(),
+            .height = last_size.height(),
+            .maximized = Ladybird::Settings::the()->is_maximized(),
+        };
+        if (auto last_position = Ladybird::Settings::the()->last_position(); last_position.has_value()) {
+            configuration.x = last_position->x();
+            configuration.y = last_position->y();
         }
-
-        window.show();
+        auto& window = app->new_window(browser_options.urls, configuration);
+        window.setWindowTitle("Ladybird");
     }
 
     return app->execute();


### PR DESCRIPTION
Create new windows with the size of the previously active window, and maximized if it was maximized. This matches the behaviour of other browsers, and solves an annoying issue where new windows would always be tiny.