### PR TITLE
LibWeb: Drop display list ellipse commands

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -202,8 +202,6 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
         else HANDLE_COMMAND(FillRectWithRoundedCorners, fill_rect_with_rounded_corners)
         else HANDLE_COMMAND(FillPath, fill_path)
         else HANDLE_COMMAND(StrokePath, stroke_path)
-        else HANDLE_COMMAND(DrawEllipse, draw_ellipse)
-        else HANDLE_COMMAND(FillEllipse, fill_ellipse)
         else HANDLE_COMMAND(DrawLine, draw_line)
         else HANDLE_COMMAND(ApplyBackdropFilter, apply_backdrop_filter)
         else HANDLE_COMMAND(DrawRect, draw_rect)

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -53,8 +53,6 @@ private:
     virtual void fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) = 0;
     virtual void fill_path(FillPath const&) = 0;
     virtual void stroke_path(StrokePath const&) = 0;
-    virtual void draw_ellipse(DrawEllipse const&) = 0;
-    virtual void fill_ellipse(FillEllipse const&) = 0;
     virtual void draw_line(DrawLine const&) = 0;
     virtual void apply_backdrop_filter(ApplyBackdropFilter const&) = 0;
     virtual void draw_rect(DrawRect const&) = 0;

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -121,16 +121,6 @@ void StrokePath::dump(StringBuilder&) const
 {
 }
 
-void DrawEllipse::dump(StringBuilder& builder) const
-{
-    builder.appendff(" rect={} color={} thickness={}", rect, color, thickness);
-}
-
-void FillEllipse::dump(StringBuilder& builder) const
-{
-    builder.appendff(" rect={} color={}", rect, color);
-}
-
 void DrawLine::dump(StringBuilder& builder) const
 {
     builder.appendff(" from={} to={} color={} thickness={}", from, to, color, thickness);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -250,29 +250,6 @@ struct StrokePath {
     void dump(StringBuilder&) const;
 };
 
-struct DrawEllipse {
-    static constexpr StringView command_name = "DrawEllipse"sv;
-
-    Gfx::IntRect rect;
-    Color color;
-    int thickness;
-
-    [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
-
-    void dump(StringBuilder&) const;
-};
-
-struct FillEllipse {
-    static constexpr StringView command_name = "FillEllipse"sv;
-
-    Gfx::IntRect rect;
-    Color color;
-
-    [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
-
-    void dump(StringBuilder&) const;
-};
-
 struct DrawLine {
     static constexpr StringView command_name = "DrawLine"sv;
 
@@ -407,8 +384,6 @@ using DisplayListCommand = Variant<
     FillRectWithRoundedCorners,
     FillPath,
     StrokePath,
-    DrawEllipse,
-    FillEllipse,
     DrawLine,
     ApplyBackdropFilter,
     DrawRect,

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -611,28 +611,6 @@ void DisplayListPlayerSkia::stroke_path(StrokePath const& command)
     surface().canvas().drawPath(path, paint);
 }
 
-void DisplayListPlayerSkia::draw_ellipse(DrawEllipse const& command)
-{
-    auto const& rect = command.rect;
-    auto& canvas = surface().canvas();
-    SkPaint paint;
-    paint.setAntiAlias(true);
-    paint.setStyle(SkPaint::kStroke_Style);
-    paint.setStrokeWidth(command.thickness);
-    paint.setColor(to_skia_color(command.color));
-    canvas.drawOval(to_skia_rect(rect), paint);
-}
-
-void DisplayListPlayerSkia::fill_ellipse(FillEllipse const& command)
-{
-    auto const& rect = command.rect;
-    auto& canvas = surface().canvas();
-    SkPaint paint;
-    paint.setAntiAlias(true);
-    paint.setColor(to_skia_color(command.color));
-    canvas.drawOval(to_skia_rect(rect), paint);
-}
-
 void DisplayListPlayerSkia::draw_line(DrawLine const& command)
 {
     auto from = to_skia_point(command.from);

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -42,8 +42,6 @@ private:
     void fill_rect_with_rounded_corners(FillRectWithRoundedCorners const&) override;
     void fill_path(FillPath const&) override;
     void stroke_path(StrokePath const&) override;
-    void draw_ellipse(DrawEllipse const&) override;
-    void fill_ellipse(FillEllipse const&) override;
     void draw_line(DrawLine const&) override;
     void apply_backdrop_filter(ApplyBackdropFilter const&) override;
     void draw_rect(DrawRect const&) override;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -11,6 +11,26 @@
 
 namespace Web::Painting {
 
+static Gfx::Path path_for_ellipse(Gfx::IntRect const& rect)
+{
+    auto left = static_cast<float>(rect.left());
+    auto right = static_cast<float>(rect.right());
+    auto top = static_cast<float>(rect.top());
+    auto bottom = static_cast<float>(rect.bottom());
+    auto center_x = (left + right) / 2.0f;
+    auto center_y = (top + bottom) / 2.0f;
+    Gfx::FloatSize radii { (right - left) / 2.0f, (bottom - top) / 2.0f };
+
+    Gfx::Path path;
+    path.move_to({ right, center_y });
+    path.elliptical_arc_to({ center_x, bottom }, radii, 0.0f, false, true);
+    path.elliptical_arc_to({ left, center_y }, radii, 0.0f, false, true);
+    path.elliptical_arc_to({ center_x, top }, radii, 0.0f, false, true);
+    path.elliptical_arc_to({ right, center_y }, radii, 0.0f, false, true);
+    path.close();
+    return path;
+}
+
 DisplayListRecorder::DisplayListRecorder(DisplayList& command_list)
     : m_display_list(command_list)
 {
@@ -180,10 +200,16 @@ void DisplayListRecorder::draw_ellipse(Gfx::IntRect const& a_rect, Color color, 
 {
     if (a_rect.is_empty() || color.alpha() == 0 || !thickness)
         return;
-    APPEND(DrawEllipse {
-        .rect = a_rect,
-        .color = color,
-        .thickness = thickness,
+
+    stroke_path({
+        .cap_style = Gfx::Path::CapStyle::Butt,
+        .join_style = Gfx::Path::JoinStyle::Miter,
+        .miter_limit = 4.0f,
+        .dash_array = {},
+        .dash_offset = 0,
+        .path = path_for_ellipse(a_rect),
+        .paint_style_or_color = color,
+        .thickness = static_cast<float>(thickness),
     });
 }
 
@@ -191,7 +217,12 @@ void DisplayListRecorder::fill_ellipse(Gfx::IntRect const& a_rect, Color color)
 {
     if (a_rect.is_empty() || color.alpha() == 0)
         return;
-    APPEND(FillEllipse { a_rect, color });
+
+    fill_path({
+        .path = path_for_ellipse(a_rect),
+        .paint_style_or_color = color,
+        .winding_rule = Gfx::WindingRule::EvenOdd,
+    });
 }
 
 void DisplayListRecorder::fill_rect_with_linear_gradient(Gfx::IntRect const& gradient_rect, LinearGradientData const& data)

--- a/Tests/LibWeb/Text/expected/display_list/list-marker-ellipse-paths.txt
+++ b/Tests/LibWeb/Text/expected/display_list/list-marker-ellipse-paths.txt
@@ -1,0 +1,11 @@
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  DrawGlyphRun@1 rect=[40,0 39x23] translation=[40,17.5] color=rgb(0, 0, 0)
+  FillPath@1 path_bounding_rect=[23,7 8x9]
+  DrawGlyphRun@1 rect=[40,24 56x23] translation=[40,41.5] color=rgb(0, 0, 0)
+  StrokePath@1
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/list-marker-ellipse-paths.html
+++ b/Tests/LibWeb/Text/input/display_list/list-marker-ellipse-paths.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    ul {
+        font: 20px Arial;
+        margin: 0;
+        padding-left: 40px;
+    }
+
+    li {
+        height: 24px;
+    }
+
+    .disc {
+        list-style-type: disc;
+    }
+
+    .circle {
+        list-style-type: circle;
+    }
+</style>
+<ul>
+    <li class="disc">disc</li>
+    <li class="circle">circle</li>
+</ul>
+<script>
+    test(() => {
+        println(internals.dumpDisplayList());
+    });
+</script>


### PR DESCRIPTION
Use path painting commands instead. Reduces display list commands set.