### PR TITLE
LibGC: Allocate HeapBlocks from 2 MiB chunks + defer decommit to a worker

### DIFF
--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -8,7 +8,6 @@
 #include <AK/Assertions.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/Platform.h>
-#include <AK/Random.h>
 #include <AK/Vector.h>
 #include <LibGC/BlockAllocator.h>
 #include <LibGC/HeapBlock.h>
@@ -252,11 +251,9 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
         // decommit payoff -- hot recycle skips both MADV_FREE_REUSABLE
         // and MADV_FREE_REUSE.
         if (!m_freshly_freed.is_empty()) {
-            size_t random_index = get_random_uniform(m_freshly_freed.size());
-            block = m_freshly_freed.unstable_take(random_index);
+            block = m_freshly_freed.take_last();
         } else if (!m_blocks.is_empty()) {
-            size_t random_index = get_random_uniform(m_blocks.size());
-            block = m_blocks.unstable_take(random_index);
+            block = m_blocks.take_last();
             needs_madvise_reuse = true;
         }
     }
@@ -303,8 +300,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
         Threading::MutexLocker locker(m_mutex);
         for (size_t i = 0; i < BLOCKS_PER_CHUNK; ++i)
             m_blocks.append(static_cast<u8*>(chunk_base) + i * HeapBlock::BLOCK_SIZE);
-        size_t random_index = get_random_uniform(m_blocks.size());
-        block = m_blocks.unstable_take(random_index);
+        block = m_blocks.take_last();
         needs_madvise_reuse = true;
     }
 

--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -6,11 +6,13 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/NeverDestroyed.h>
 #include <AK/Platform.h>
 #include <AK/Random.h>
 #include <AK/Vector.h>
 #include <LibGC/BlockAllocator.h>
 #include <LibGC/HeapBlock.h>
+#include <LibThreading/Thread.h>
 #include <sys/mman.h>
 
 #if defined(AK_OS_MACOS)
@@ -26,30 +28,241 @@
 #if defined(AK_OS_WINDOWS)
 #    include <AK/Windows.h>
 #    include <memoryapi.h>
+#else
+#    include <sched.h>
+#    include <unistd.h>
 #endif
 
 namespace GC {
 
 // Each BlockAllocator carves its 16 KiB HeapBlock slots out of 2 MiB
-// chunks, so the kernel sees one mmap per 128 blocks instead of one per
-// block. Chunks are owned exclusively by a single BlockAllocator and are
-// never released back to the OS or shared across allocators -- that's how
-// we keep the heap's VM permanently type-isolated, where a virtual address
-// used for a cell of type T is never reused for any other type.
+// chunks. Chunks are owned exclusively by a single BlockAllocator and are
+// never released back to the OS or shared across allocators -- the heap's
+// VM is permanently type-isolated.
 //
-// We do not hint MADV_HUGEPAGE: per-block madvise() in deallocate_block
-// would split any THP backing the chunk anyway. Per-block memory return
-// matches what V8, SpiderMonkey, and WebKit's libpas all do.
+// Per-block madvise() is deferred to a single global background "decommit
+// worker" so it never costs us GC pause time, and slots that are recycled
+// before the worker sees them skip the madvise pair entirely.
 static constexpr size_t CHUNK_SIZE = 2 * MiB;
 static constexpr size_t BLOCKS_PER_CHUNK = CHUNK_SIZE / HeapBlock::BLOCK_SIZE;
 static_assert(CHUNK_SIZE % HeapBlock::BLOCK_SIZE == 0);
 static_assert(BLOCKS_PER_CHUNK == 128);
 
-BlockAllocator::~BlockAllocator() = default;
+static void madvise_block_for_decommit(void* block)
+{
+#if defined(AK_OS_WINDOWS)
+    DWORD ret = DiscardVirtualMemory(block, HeapBlock::BLOCK_SIZE);
+    if (ret != ERROR_SUCCESS) {
+        warnln("{}", Error::from_windows_error(ret));
+        VERIFY_NOT_REACHED();
+    }
+#elif defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
+    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSABLE) < 0) {
+        perror("madvise(MADV_FREE_REUSABLE)");
+        VERIFY_NOT_REACHED();
+    }
+#elif defined(MADV_FREE)
+    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE) < 0) {
+        perror("madvise(MADV_FREE)");
+        VERIFY_NOT_REACHED();
+    }
+#elif defined(MADV_DONTNEED)
+    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_DONTNEED) < 0) {
+        perror("madvise(MADV_DONTNEED)");
+        VERIFY_NOT_REACHED();
+    }
+#endif
+}
+
+static void sleep_before_decommit()
+{
+#if defined(AK_OS_WINDOWS)
+    Sleep(50);
+#else
+    usleep(50 * 1000);
+#endif
+}
+
+static void yield_during_decommit()
+{
+#if defined(AK_OS_WINDOWS)
+    Sleep(0);
+#else
+    sched_yield();
+#endif
+}
+
+class DecommitWorker {
+public:
+    static DecommitWorker& the();
+
+    void register_pending(BlockAllocator&);
+    void deregister(BlockAllocator&);
+    void kick();
+
+    DecommitWorker();
+
+private:
+    void run();
+    void process_one(BlockAllocator&);
+
+    Threading::Mutex m_mutex;
+    Threading::ConditionVariable m_cv { m_mutex };
+    RefPtr<Threading::Thread> m_thread;
+    Vector<BlockAllocator*> m_pending;
+    bool m_kicked { false };
+};
+
+DecommitWorker& DecommitWorker::the()
+{
+    static AK::NeverDestroyed<DecommitWorker> instance;
+    return *instance;
+}
+
+DecommitWorker::DecommitWorker()
+{
+    m_thread = Threading::Thread::construct("DecommitWorker"sv, [this] {
+        run();
+        return static_cast<intptr_t>(0);
+    });
+    m_thread->start();
+    m_thread->detach();
+}
+
+void DecommitWorker::register_pending(BlockAllocator& a)
+{
+    Threading::MutexLocker locker(m_mutex);
+    m_pending.append(&a);
+}
+
+void DecommitWorker::deregister(BlockAllocator& a)
+{
+    Threading::MutexLocker locker(m_mutex);
+    m_pending.remove_first_matching([&](auto* p) { return p == &a; });
+}
+
+void DecommitWorker::kick()
+{
+    {
+        Threading::MutexLocker locker(m_mutex);
+        m_kicked = true;
+    }
+    m_cv.signal();
+}
+
+void DecommitWorker::run()
+{
+    while (true) {
+        Vector<BlockAllocator*> snapshot;
+        {
+            Threading::MutexLocker locker(m_mutex);
+            while (!m_kicked)
+                m_cv.wait();
+            m_kicked = false;
+            snapshot = move(m_pending);
+            // Pin every allocator we're about to process so destructors
+            // block until we drop our reference.
+            for (auto* a : snapshot)
+                a->m_worker_refcount.fetch_add(1);
+        }
+
+        if (snapshot.is_empty())
+            continue;
+
+        // Stagger: give the JS thread some breathing room after the kick
+        // (typically right after sweep ends) before we consume CPU and
+        // syscall bandwidth.
+        sleep_before_decommit();
+
+        for (auto* a : snapshot) {
+            process_one(*a);
+            int prev_refcount = a->m_worker_refcount.fetch_sub(1);
+            if (prev_refcount == 1) {
+                Threading::MutexLocker locker(a->m_mutex);
+                a->m_worker_cv.broadcast();
+            }
+        }
+    }
+}
+
+void DecommitWorker::process_one(BlockAllocator& a)
+{
+    Vector<void*> to_process;
+    {
+        Threading::MutexLocker locker(a.m_mutex);
+        a.m_in_decommit_registry = false;
+        to_process = move(a.m_freshly_freed);
+    }
+
+    // Madvise each slot outside the per-allocator lock so the JS thread can
+    // continue to allocate/free; yield every 64 slots to avoid hogging the
+    // kernel's mm subsystem.
+    constexpr size_t BATCH = 64;
+    for (size_t i = 0; i < to_process.size(); ++i) {
+        madvise_block_for_decommit(to_process[i]);
+        if ((i + 1) % BATCH == 0)
+            yield_during_decommit();
+    }
+
+    {
+        Threading::MutexLocker locker(a.m_mutex);
+        for (auto* slot : to_process)
+            a.m_blocks.append(slot);
+    }
+}
+
+void BlockAllocator::wake_decommit_worker_async()
+{
+    DecommitWorker::the().kick();
+}
+
+BlockAllocator::BlockAllocator()
+    : m_worker_cv(m_mutex)
+{
+}
+
+BlockAllocator::~BlockAllocator()
+{
+    // Chunks are permanent -- we never tear them down. The destructor only
+    // exists to make sure the global decommit worker has finished any
+    // in-flight processing of *this before our storage goes away.
+    DecommitWorker::the().deregister(*this);
+
+    Threading::MutexLocker locker(m_mutex);
+    while (m_worker_refcount.load() != 0)
+        m_worker_cv.wait();
+}
+
+size_t BlockAllocator::block_count()
+{
+    Threading::MutexLocker locker(m_mutex);
+    return m_blocks.size();
+}
 
 void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
 {
-    if (m_blocks.is_empty()) {
+    void* block = nullptr;
+    bool needs_madvise_reuse = false;
+
+    {
+        Threading::MutexLocker locker(m_mutex);
+
+        // Prefer m_freshly_freed: those slots were never madvised, so we
+        // can hand them back out with zero syscalls. This is the deferred-
+        // decommit payoff -- hot recycle skips both MADV_FREE_REUSABLE
+        // and MADV_FREE_REUSE.
+        if (!m_freshly_freed.is_empty()) {
+            size_t random_index = get_random_uniform(m_freshly_freed.size());
+            block = m_freshly_freed.unstable_take(random_index);
+        } else if (!m_blocks.is_empty()) {
+            size_t random_index = get_random_uniform(m_blocks.size());
+            block = m_blocks.unstable_take(random_index);
+            needs_madvise_reuse = true;
+        }
+    }
+
+    if (block == nullptr) {
+        // Both pools empty: allocate a fresh 2 MiB chunk and slice it.
         void* chunk_base = nullptr;
 #if defined(AK_OS_MACOS)
         mach_vm_address_t address = 0;
@@ -77,7 +290,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
 
 #if defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
         // Mark the whole chunk reusable upfront so MADV_FREE_REUSE pairs
-        // symmetrically when slots are popped from m_blocks below. (Linux
+        // symmetrically when slots are popped from m_blocks later. (Linux
         // and Windows fall through with no-op.)
         if (madvise(chunk_base, CHUNK_SIZE, MADV_FREE_REUSABLE) < 0) {
             perror("madvise(MADV_FREE_REUSABLE)");
@@ -86,21 +299,26 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
 #endif
 
         ASAN_POISON_MEMORY_REGION(chunk_base, CHUNK_SIZE);
+
+        Threading::MutexLocker locker(m_mutex);
         for (size_t i = 0; i < BLOCKS_PER_CHUNK; ++i)
             m_blocks.append(static_cast<u8*>(chunk_base) + i * HeapBlock::BLOCK_SIZE);
+        size_t random_index = get_random_uniform(m_blocks.size());
+        block = m_blocks.unstable_take(random_index);
+        needs_madvise_reuse = true;
     }
-
-    // Random pick to preserve the previous anti-predictability behavior.
-    size_t random_index = get_random_uniform(m_blocks.size());
-    auto* block = m_blocks.unstable_take(random_index);
 
     ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
     LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
 #if defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
-    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSE) < 0) {
-        perror("madvise(MADV_FREE_REUSE)");
-        VERIFY_NOT_REACHED();
+    if (needs_madvise_reuse) {
+        if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSE) < 0) {
+            perror("madvise(MADV_FREE_REUSE)");
+            VERIFY_NOT_REACHED();
+        }
     }
+#else
+    (void)needs_madvise_reuse;
 #endif
     return block;
 }
@@ -109,35 +327,22 @@ void BlockAllocator::deallocate_block(void* block)
 {
     VERIFY(block);
 
-    // Tell the kernel it can reclaim physical pages backing this 16 KiB
-    // slot. The slot stays in m_blocks for reuse by this same
-    // BlockAllocator -- never seen by a different cell type.
-#if defined(AK_OS_WINDOWS)
-    DWORD ret = DiscardVirtualMemory(block, HeapBlock::BLOCK_SIZE);
-    if (ret != ERROR_SUCCESS) {
-        warnln("{}", Error::from_windows_error(ret));
-        VERIFY_NOT_REACHED();
-    }
-#elif defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
-    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSABLE) < 0) {
-        perror("madvise(MADV_FREE_REUSABLE)");
-        VERIFY_NOT_REACHED();
-    }
-#elif defined(MADV_FREE)
-    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE) < 0) {
-        perror("madvise(MADV_FREE)");
-        VERIFY_NOT_REACHED();
-    }
-#elif defined(MADV_DONTNEED)
-    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_DONTNEED) < 0) {
-        perror("madvise(MADV_DONTNEED)");
-        VERIFY_NOT_REACHED();
-    }
-#endif
-
+    // Fast path: bookkeep only. The actual madvise is deferred to the
+    // global decommit worker, which the GC kicks at the end of sweep.
     ASAN_POISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
     LSAN_UNREGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
-    m_blocks.append(block);
+
+    bool need_to_register = false;
+    {
+        Threading::MutexLocker locker(m_mutex);
+        m_freshly_freed.append(block);
+        if (!m_in_decommit_registry) {
+            m_in_decommit_registry = true;
+            need_to_register = true;
+        }
+    }
+    if (need_to_register)
+        DecommitWorker::the().register_pending(*this);
 }
 
 }

--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -30,66 +30,78 @@
 
 namespace GC {
 
-BlockAllocator::~BlockAllocator()
-{
-    for (auto* block : m_blocks) {
-        ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
-#if defined(AK_OS_MACOS)
-        kern_return_t kr = mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(block), HeapBlock::BLOCK_SIZE);
-        VERIFY(kr == KERN_SUCCESS);
-#elif defined(AK_OS_WINDOWS)
-        if (!VirtualFree(block, 0, MEM_RELEASE)) {
-            warnln("{}", Error::from_windows_error());
-            VERIFY_NOT_REACHED();
-        }
-#else
-        free(block);
-#endif
-    }
-}
+// Each BlockAllocator carves its 16 KiB HeapBlock slots out of 2 MiB
+// chunks, so the kernel sees one mmap per 128 blocks instead of one per
+// block. Chunks are owned exclusively by a single BlockAllocator and are
+// never released back to the OS or shared across allocators -- that's how
+// we keep the heap's VM permanently type-isolated, where a virtual address
+// used for a cell of type T is never reused for any other type.
+//
+// We do not hint MADV_HUGEPAGE: per-block madvise() in deallocate_block
+// would split any THP backing the chunk anyway. Per-block memory return
+// matches what V8, SpiderMonkey, and WebKit's libpas all do.
+static constexpr size_t CHUNK_SIZE = 2 * MiB;
+static constexpr size_t BLOCKS_PER_CHUNK = CHUNK_SIZE / HeapBlock::BLOCK_SIZE;
+static_assert(CHUNK_SIZE % HeapBlock::BLOCK_SIZE == 0);
+static_assert(BLOCKS_PER_CHUNK == 128);
+
+BlockAllocator::~BlockAllocator() = default;
 
 void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
 {
-    if (!m_blocks.is_empty()) {
-        // To reduce predictability, take a random block from the cache.
-        size_t random_index = get_random_uniform(m_blocks.size());
-        auto* block = m_blocks.unstable_take(random_index);
-        ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
-        LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+    if (m_blocks.is_empty()) {
+        void* chunk_base = nullptr;
+#if defined(AK_OS_MACOS)
+        mach_vm_address_t address = 0;
+        kern_return_t kr = mach_vm_map(
+            mach_task_self(),
+            &address,
+            CHUNK_SIZE,
+            CHUNK_SIZE - 1,
+            VM_FLAGS_ANYWHERE,
+            MEMORY_OBJECT_NULL,
+            0,
+            false,
+            VM_PROT_READ | VM_PROT_WRITE,
+            VM_PROT_READ | VM_PROT_WRITE,
+            VM_INHERIT_DEFAULT);
+        VERIFY(kr == KERN_SUCCESS);
+        chunk_base = reinterpret_cast<void*>(address);
+#elif defined(AK_OS_WINDOWS)
+        chunk_base = VirtualAlloc(nullptr, CHUNK_SIZE, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        VERIFY(chunk_base);
+#else
+        auto rc = posix_memalign(&chunk_base, CHUNK_SIZE, CHUNK_SIZE);
+        VERIFY(rc == 0);
+#endif
+
 #if defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
-        if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSE) < 0) {
-            perror("madvise(MADV_FREE_REUSE)");
+        // Mark the whole chunk reusable upfront so MADV_FREE_REUSE pairs
+        // symmetrically when slots are popped from m_blocks below. (Linux
+        // and Windows fall through with no-op.)
+        if (madvise(chunk_base, CHUNK_SIZE, MADV_FREE_REUSABLE) < 0) {
+            perror("madvise(MADV_FREE_REUSABLE)");
             VERIFY_NOT_REACHED();
         }
 #endif
-        return block;
+
+        ASAN_POISON_MEMORY_REGION(chunk_base, CHUNK_SIZE);
+        for (size_t i = 0; i < BLOCKS_PER_CHUNK; ++i)
+            m_blocks.append(static_cast<u8*>(chunk_base) + i * HeapBlock::BLOCK_SIZE);
     }
 
-#if defined(AK_OS_MACOS)
-    mach_vm_address_t address = 0;
-    kern_return_t kr = mach_vm_map(
-        mach_task_self(),
-        &address,
-        HeapBlock::BLOCK_SIZE,
-        HeapBlock::BLOCK_SIZE - 1,
-        VM_FLAGS_ANYWHERE,
-        MEMORY_OBJECT_NULL,
-        0,
-        false,
-        VM_PROT_READ | VM_PROT_WRITE,
-        VM_PROT_READ | VM_PROT_WRITE,
-        VM_INHERIT_DEFAULT);
-    VERIFY(kr == KERN_SUCCESS);
-    auto* block = reinterpret_cast<void*>(address);
-#elif defined(AK_OS_WINDOWS)
-    auto* block = VirtualAlloc(NULL, HeapBlock::BLOCK_SIZE, MEM_COMMIT, PAGE_READWRITE);
-    VERIFY(block);
-#else
-    void* block = nullptr;
-    auto rc = posix_memalign(&block, HeapBlock::BLOCK_SIZE, HeapBlock::BLOCK_SIZE);
-    VERIFY(rc == 0);
-#endif
+    // Random pick to preserve the previous anti-predictability behavior.
+    size_t random_index = get_random_uniform(m_blocks.size());
+    auto* block = m_blocks.unstable_take(random_index);
+
+    ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
     LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+#if defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
+    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSE) < 0) {
+        perror("madvise(MADV_FREE_REUSE)");
+        VERIFY_NOT_REACHED();
+    }
+#endif
     return block;
 }
 
@@ -97,6 +109,9 @@ void BlockAllocator::deallocate_block(void* block)
 {
     VERIFY(block);
 
+    // Tell the kernel it can reclaim physical pages backing this 16 KiB
+    // slot. The slot stays in m_blocks for reuse by this same
+    // BlockAllocator -- never seen by a different cell type.
 #if defined(AK_OS_WINDOWS)
     DWORD ret = DiscardVirtualMemory(block, HeapBlock::BLOCK_SIZE);
     if (ret != ERROR_SUCCESS) {

--- a/Libraries/LibGC/BlockAllocator.h
+++ b/Libraries/LibGC/BlockAllocator.h
@@ -6,23 +6,56 @@
 
 #pragma once
 
+#include <AK/Atomic.h>
 #include <AK/Vector.h>
 #include <LibGC/Forward.h>
+#include <LibThreading/ConditionVariable.h>
+#include <LibThreading/Mutex.h>
 
 namespace GC {
 
+class DecommitWorker;
+
 class GC_API BlockAllocator {
 public:
-    BlockAllocator() = default;
+    BlockAllocator();
     ~BlockAllocator();
 
     void* allocate_block(char const* name);
     void deallocate_block(void*);
 
-    auto const& blocks() const { return m_blocks; }
+    size_t block_count();
+
+    // Wake the global decommit worker so it processes any deferred madvise
+    // work that's piled up. Call this at the end of a GC sweep.
+    static void wake_decommit_worker_async();
 
 private:
+    friend class DecommitWorker;
+
+    // Slots in "ready to reuse" state -- have been MADV_FREE_REUSABLE'd by
+    // the worker (Darwin) so allocate_block pairs them with MADV_FREE_REUSE.
     Vector<void*> m_blocks;
+
+    // Slots freed by deallocate_block but not yet madvised. allocate_block
+    // pops directly from here to skip the madvise round-trip on hot recycle
+    // paths -- this is the main payoff of deferring decommit.
+    Vector<void*> m_freshly_freed;
+
+    // Protects m_blocks, m_freshly_freed, and m_in_decommit_registry. Held
+    // briefly on the alloc/dealloc hot path; uncontended in the common case.
+    Threading::Mutex m_mutex;
+
+    // Refcount the decommit worker bumps while it has a reference to this
+    // allocator. The destructor waits on m_worker_cv until it hits zero so
+    // we never let our storage go away while the worker is still running.
+    AK::Atomic<int> m_worker_refcount { 0 };
+    Threading::ConditionVariable m_worker_cv;
+
+    // True iff this allocator is currently in the worker's pending list.
+    // Avoids re-registering on every dealloc; cleared by the worker at the
+    // start of process_one, set by deallocate_block under m_mutex.
+    bool m_in_decommit_registry { false };
 };
 
 }

--- a/Libraries/LibGC/CMakeLists.txt
+++ b/Libraries/LibGC/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
 
 ladybird_lib(LibGC gc EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibGC PRIVATE LibCore)
+target_link_libraries(LibGC PUBLIC LibThreading)
 
 if(cpptrace_FOUND AND LADYBIRD_ENABLE_CPPTRACE)
     target_link_libraries(LibGC PRIVATE cpptrace::cpptrace)

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -21,6 +21,7 @@
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/File.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGC/BlockAllocator.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Heap.h>
 #include <LibGC/HeapBlock.h>
@@ -424,7 +425,7 @@ void Heap::dump_allocators()
         builder.appendff(" x {}", total_live_cells);
 
         size_t cost = blocks.size() * HeapBlock::BLOCK_SIZE / KiB;
-        size_t reserved = allocator.block_allocator().blocks().size() * HeapBlock::BLOCK_SIZE / KiB;
+        size_t reserved = allocator.block_allocator().block_count() * HeapBlock::BLOCK_SIZE / KiB;
         builder.appendff(", cost: {} KiB, reserved: {} KiB", cost, reserved);
 
         size_t total_dead_bytes = ((blocks.size() * cell_count) - total_live_cells) * allocator.cell_size();
@@ -847,6 +848,10 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
         dbgln("   Freed blocks: {} ({} bytes)", empty_blocks.size(), empty_blocks.size() * HeapBlock::BLOCK_SIZE);
         dbgln("=============================================");
     }
+
+    // Sweep is done; kick the global decommit worker so the slots we just
+    // freed get madvise()'d off the GC pause path.
+    BlockAllocator::wake_decommit_worker_async();
 }
 
 void Heap::defer_gc()

--- a/Libraries/LibTest/CMakeLists.txt
+++ b/Libraries/LibTest/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(LibTestMain OBJECT TestMain.cpp AssertionHandler.cpp)
 target_link_libraries(LibTestMain PUBLIC GenericClangPlugin)
 
 add_library(JavaScriptTestRunnerMain OBJECT JavaScriptTestRunnerMain.cpp)
+target_link_libraries(JavaScriptTestRunnerMain PRIVATE LibJS LibGC)
 
 set(SOURCES
     TestSuite.cpp


### PR DESCRIPTION
This reworks `BlockAllocator` to stop churning kernel VMAs and to stop spending GC pause time on `madvise()`.
                                                                                                                                                                   
Each `BlockAllocator` now carves its 16 KiB `HeapBlock` slots out of 2 MiB chunks (128 slots/chunk) instead of doing one `posix_memalign` / `mach_vm_map` / `VirtualAlloc` per block.

The kernel sees one mapping per 128 blocks, which keeps the internal mm data structures from ballooning on non-trivial heaps. Chunks are owned exclusively by a single `BlockAllocator` and are never torn down. That preserves our type-isolated VM invariant (a VA used for cell type `T` is never reused for any other type).                              
                                                                                                                                                                   
`deallocate_block` no longer calls `MADV_FREE_REUSABLE` / `MADV_FREE` / `MADV_DONTNEED` inline. Freed slots are pushed onto a per-allocator `m_freshly_freed` queue, and a single global `DecommitWorker` thread drains them outside the GC pause. `Heap::sweep_dead_cells` kicks the worker at the end of sweep; the worker sleeps 50 ms (giving the JS thread breathing room) then `madvise`s in batches of 64 with `sched_yield` between batches.
                                                                                                                                                                   
`allocate_block` prefers `m_freshly_freed` over `m_blocks`, so a slot that's recycled before the worker gets to it skips the `REUSABLE`/`REUSE` syscall pair entirely. This is a nice side effect of deferring the work. :^)

JS benchmarks look happy (and note how we are way better at giving memory back to the OS now):
```
Suite           Test                                            Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  ----------------------------------------------  ---------  ---------------------------------  ---------------------------------  -------------------
LongSpider      3d-cube.js                                      1.041      4.772 ± 4.704 … 4.841              4.585 ± 4.419 … 4.750              -3.0% (-1.3 MB)
LongSpider      3d-morph.js                                     0.996      1.489 ± 1.482 … 1.495              1.494 ± 1.494 … 1.495              +0.0% (+0.0 MB)
LongSpider      3d-raytrace.js                                  1.098      3.156 ± 3.146 … 3.166              2.875 ± 2.867 … 2.883              -4.5% (-1.9 MB)
LongSpider      access-binary-trees.js                          1.087      7.835 ± 7.736 … 7.935              7.209 ± 7.064 … 7.354              -13.8% (-32.8 MB)
LongSpider      access-fannkuch.js                              0.964      1.713 ± 1.664 … 1.762              1.777 ± 1.769 … 1.786              +0.0% (+0.0 MB)
LongSpider      access-nbody.js                                 1.029      3.985 ± 3.970 … 4.001              3.872 ± 3.868 … 3.876              +0.0% (+0.0 MB)
LongSpider      access-nsieve.js                                1.007      0.940 ± 0.913 … 0.967              0.934 ± 0.929 … 0.938              -0.0% (-0.1 MB)
LongSpider      bitops-3bit-bits-in-byte.js                     1.001      0.446 ± 0.445 … 0.447              0.445 ± 0.445 … 0.446              +0.0% (+0.0 MB)
LongSpider      bitops-bits-in-byte.js                          0.985      0.695 ± 0.670 … 0.719              0.705 ± 0.680 … 0.730              +0.0% (+0.0 MB)
LongSpider      bitops-nsieve-bits.js                           1.020      1.970 ± 1.887 … 2.054              1.932 ± 1.819 … 2.046              -0.0% (-0.0 MB)
LongSpider      controlflow-recursive.js                        1.000      1.785 ± 1.784 … 1.785              1.785 ± 1.782 … 1.789              +0.0% (+0.0 MB)
LongSpider      crypto-aes.js                                   0.976      4.570 ± 4.516 … 4.624              4.684 ± 4.615 … 4.753              -4.2% (-1.7 MB)
LongSpider      crypto-md5.js                                   1.009      4.462 ± 4.418 … 4.507              4.423 ± 4.418 … 4.429              +0.1% (+0.1 MB)
LongSpider      crypto-sha1.js                                  0.963      8.662 ± 8.639 … 8.686              8.991 ± 8.813 … 9.169              -0.1% (-0.1 MB)
LongSpider      date-format-tofte.js                            1.029      3.708 ± 3.706 … 3.711              3.604 ± 3.583 … 3.624              -3.4% (-1.4 MB)
LongSpider      date-format-xparb.js                            1.031      4.228 ± 4.227 … 4.229              4.102 ± 4.098 … 4.107              -5.4% (-1.9 MB)
LongSpider      hash-map.js                                     1.019      1.006 ± 0.998 … 1.015              0.988 ± 0.987 … 0.989              -12.3% (-13.9 MB)
LongSpider      math-cordic.js                                  1.000      5.251 ± 5.247 … 5.254              5.250 ± 5.242 … 5.257              +0.0% (+0.0 MB)
LongSpider      math-partial-sums.js                            0.987      0.799 ± 0.798 … 0.799              0.809 ± 0.809 … 0.809              +0.0% (+0.0 MB)
LongSpider      math-spectral-norm.js                           1.002      4.604 ± 4.599 … 4.608              4.597 ± 4.593 … 4.600              +0.0% (+0.0 MB)
LongSpider      string-base64.js                                1.103      1.347 ± 1.343 … 1.351              1.222 ± 1.221 … 1.222              -21.8% (-99.3 MB)
LongSpider      string-fasta.js                                 1.061      1.620 ± 1.618 … 1.622              1.527 ± 1.524 … 1.531              -9.5% (-4.6 MB)
LongSpider      string-tagcloud.js                              1.030      0.754 ± 0.746 … 0.763              0.732 ± 0.731 … 0.733              -3.8% (-2.8 MB)
Kraken          ai-astar.js                                     1.007      0.625 ± 0.598 … 0.653              0.621 ± 0.605 … 0.637              -2.2% (-1.1 MB)
Kraken          audio-beat-detection.js                         1.012      0.517 ± 0.516 … 0.518              0.511 ± 0.508 … 0.513              -0.6% (-0.4 MB)
Kraken          audio-dft.js                                    1.022      0.356 ± 0.353 … 0.359              0.348 ± 0.346 … 0.351              -0.7% (-0.3 MB)
Kraken          audio-fft.js                                    0.974      0.426 ± 0.421 … 0.431              0.437 ± 0.429 … 0.446              +0.1% (+0.1 MB)
Kraken          audio-oscillator.js                             1.009      0.350 ± 0.348 … 0.351              0.347 ± 0.345 … 0.348              -0.2% (-0.2 MB)
Kraken          imaging-darkroom.js                             1.030      0.550 ± 0.543 … 0.557              0.534 ± 0.530 … 0.538              -0.2% (-0.1 MB)
Kraken          imaging-desaturate.js                           1.020      0.584 ± 0.573 … 0.595              0.573 ± 0.567 … 0.578              +8.7% (+6.2 MB)
Kraken          imaging-gaussian-blur.js                        1.012      2.641 ± 2.588 … 2.694              2.610 ± 2.541 … 2.679              +8.6% (+6.2 MB)
Kraken          json-parse-financial.js                         1.099      0.060 ± 0.054 … 0.065              0.054 ± 0.053 … 0.055              -7.9% (-2.7 MB)
Kraken          json-stringify-tinderbox.js                     1.045      0.052 ± 0.051 … 0.054              0.050 ± 0.050 … 0.050              -0.2% (-0.1 MB)
Kraken          stanford-crypto-aes.js                          1.004      0.216 ± 0.212 … 0.220              0.215 ± 0.213 … 0.217              -3.8% (-2.1 MB)
Kraken          stanford-crypto-ccm.js                          1.033      0.169 ± 0.168 … 0.171              0.164 ± 0.164 … 0.164              -2.3% (-1.3 MB)
Kraken          stanford-crypto-pbkdf2.js                       1.032      0.376 ± 0.373 … 0.378              0.364 ± 0.364 … 0.365              -4.8% (-2.1 MB)
Kraken          stanford-crypto-sha256-iterative.js             0.998      0.135 ± 0.134 … 0.136              0.135 ± 0.135 … 0.136              -5.0% (-2.0 MB)
Octane          box2d.js                                        1.012      8493.000 ± 8464.000 … 8522.000     8593.500 ± 8564.000 … 8623.000     -6.0% (-3.9 MB)
Octane          code-load.js                                    1.012      21954.000 ± 21942.000 … 21966.000  22210.000 ± 22173.000 … 22247.000  -2.6% (-35.7 MB)
Octane          crypto.js                                       1.051      2768.500 ± 2757.000 … 2780.000     2910.500 ± 2869.000 … 2952.000     -5.9% (-2.6 MB)
Octane          deltablue.js                                    1.013      2317.500 ± 2294.000 … 2341.000     2348.000 ± 2345.000 … 2351.000     -5.2% (-2.2 MB)
Octane          earley-boyer.js                                 1.077      4488.500 ± 4485.000 … 4492.000     4832.000 ± 4815.000 … 4849.000     -12.5% (-9.3 MB)
Octane          gbemu.js                                        0.989      17046.500 ± 17007.000 … 17086.000  16867.500 ± 16759.000 … 16976.000  -10.1% (-9.3 MB)
Octane          mandreel.js                                     1.000      16453.000 ± 16399.000 … 16507.000  16455.500 ± 16238.000 … 16673.000  +0.7% (+2.4 MB)
Octane          navier-stokes.js                                0.951      5293.000 ± 4923.000 … 5663.000     5031.500 ± 5001.000 … 5062.000     +3.4% (+0.8 MB)
Octane          pdfjs.js                                        1.058      8099.500 ± 8004.000 … 8195.000     8572.000 ± 8564.000 … 8580.000     -10.3% (-15.1 MB)
Octane          raytrace.js                                     1.039      3453.500 ± 3394.000 … 3513.000     3588.500 ± 3558.000 … 3619.000     -4.3% (-1.9 MB)
Octane          regexp.js                                       1.040      2015.500 ± 1967.000 … 2064.000     2095.500 ± 2091.000 … 2100.000     -4.3% (-2.7 MB)
Octane          richards.js                                     0.989      2485.500 ± 2461.000 … 2510.000     2457.500 ± 2437.000 … 2478.000     -5.8% (-1.7 MB)
Octane          splay.js                                        1.187      5410.500 ± 5374.000 … 5447.000     6422.000 ± 6415.000 … 6429.000     -24.9% (-134.5 MB)
Octane          typescript.js                                   1.013      22836.500 ± 22781.000 … 22892.000  23128.500 ± 23036.000 … 23221.000  -14.9% (-74.8 MB)
Octane          zlib.js                                         0.983      5471.500 ± 5367.000 … 5576.000     5381.000 ± 5336.000 … 5426.000     +1.0% (+1.8 MB)
JetStream       bigfib.cpp.js                                   1.056      5.173 ± 4.960 … 5.386              4.898 ± 4.860 … 4.937              +0.9% (+1.9 MB)
JetStream       cdjs.js                                         1.015      1.967 ± 1.964 … 1.971              1.939 ± 1.933 … 1.945              -6.6% (-2.9 MB)
JetStream       container.cpp.js                                1.026      21.851 ± 21.570 … 22.132           21.296 ± 21.151 … 21.441           +1.1% (+1.3 MB)
JetStream       dry.c.js                                        1.045      11.721 ± 11.045 … 12.397           11.218 ± 10.596 … 11.840           +3.2% (+1.7 MB)
JetStream       float-mm.c.js                                   0.920      12.627 ± 12.104 … 13.150           13.717 ± 13.645 … 13.790           +4.2% (+2.0 MB)
JetStream       gcc-loops.cpp.js                                1.003      75.712 ± 74.258 … 77.166           75.517 ± 72.354 … 78.679           +0.8% (+1.0 MB)
JetStream       hash-map.js                                     1.000      1.010 ± 1.007 … 1.013              1.010 ± 1.004 … 1.016              -12.4% (-14.0 MB)
JetStream       n-body.c.js                                     0.999      17.032 ± 16.917 … 17.146           17.052 ± 16.677 … 17.427           +4.2% (+2.0 MB)
JetStream       quicksort.c.js                                  0.945      2.911 ± 2.871 … 2.951              3.079 ± 2.944 … 3.215              +4.4% (+2.1 MB)
JetStream       towers.c.js                                     1.059      3.390 ± 3.348 … 3.431              3.200 ± 3.074 … 3.327              +4.2% (+2.0 MB)
JetStream3      js-tokens.js                                    1.041      0.279 ± 0.276 … 0.282              0.268 ± 0.267 … 0.269              -5.6% (-2.2 MB)
JetStream3      lazy-collections.js                             1.054      0.791 ± 0.791 … 0.792              0.751 ± 0.750 … 0.752              -3.5% (-1.4 MB)
JetStream3      raytrace-private-class-fields.js                1.050      3.669 ± 3.663 … 3.676              3.494 ± 3.483 … 3.504              -3.7% (-1.4 MB)
JetStream3      raytrace-public-class-fields.js                 1.057      2.640 ± 2.614 … 2.666              2.497 ± 2.489 … 2.504              -6.1% (-2.1 MB)
JetStream3      sync-file-system.js                             1.018      1.784 ± 1.774 … 1.793              1.751 ± 1.749 … 1.753              +4.1% (+1.4 MB)
AsyncBench      async-call-return.js                            1.145      0.234 ± 0.227 … 0.241              0.205 ± 0.199 … 0.210              +9.8% (+3.8 MB)
AsyncBench      async-class-method.js                           1.154      0.265 ± 0.253 … 0.278              0.230 ± 0.229 … 0.231              +10.8% (+4.2 MB)
AsyncBench      async-fan-out.js                                1.150      0.179 ± 0.179 … 0.179              0.155 ± 0.155 … 0.156              -0.4% (-0.1 MB)
AsyncBench      async-generator.js                              1.107      0.251 ± 0.249 … 0.252              0.226 ± 0.226 … 0.227              -6.3% (-2.0 MB)
AsyncBench      async-iife.js                                   1.124      0.352 ± 0.348 … 0.356              0.313 ± 0.312 … 0.314              +5.7% (+2.1 MB)
AsyncBench      async-nested-calls.js                           1.085      0.380 ± 0.377 … 0.383              0.350 ± 0.348 … 0.353              +11.2% (+4.4 MB)
AsyncBench      async-pipeline.js                               1.099      0.380 ± 0.377 … 0.383              0.345 ± 0.340 … 0.350              +3.1% (+1.2 MB)
AsyncBench      async-sequential-awaits.js                      1.077      0.115 ± 0.115 … 0.116              0.107 ± 0.106 … 0.108              +8.7% (+4.5 MB)
AsyncBench      async-try-catch-reject.js                       1.021      0.530 ± 0.514 … 0.545              0.519 ± 0.519 … 0.519              +2.8% (+1.1 MB)
AsyncBench      await-primitive.js                              1.005      0.046 ± 0.045 … 0.048              0.046 ± 0.045 … 0.047              -0.0% (-0.0 MB)
AsyncBench      await-resolved-promise.js                       1.108      0.356 ± 0.354 … 0.358              0.321 ± 0.316 … 0.326              -0.0% (-0.0 MB)
AsyncBench      await-thenable.js                               1.096      0.038 ± 0.035 … 0.040              0.034 ± 0.034 … 0.035              -3.7% (-2.1 MB)
AsyncBench      promise-all.js                                  1.136      0.488 ± 0.484 … 0.492              0.429 ± 0.429 … 0.429              -0.0% (-0.0 MB)
AsyncBench      promise-allSettled.js                           1.112      0.561 ± 0.558 … 0.563              0.504 ± 0.501 … 0.508              -0.0% (-0.0 MB)
AsyncBench      promise-chain.js                                1.202      0.236 ± 0.232 … 0.240              0.197 ± 0.195 … 0.198              -27.4% (-78.5 MB)
AsyncBench      promise-new-resolve.js                          1.128      0.258 ± 0.257 … 0.259              0.229 ± 0.228 … 0.230              -0.0% (-0.0 MB)
AsyncBench      promise-race.js                                 1.089      0.494 ± 0.489 … 0.499              0.454 ± 0.446 … 0.461              -0.0% (-0.0 MB)
ARES-6          Air.js                                          1.057      1.753 ± 1.743 … 1.763              1.658 ± 1.654 … 1.661              -7.0% (-6.8 MB)
ARES-6          Babylon.js                                      1.029      0.996 ± 0.994 … 0.998              0.968 ± 0.966 … 0.970              -7.5% (-4.1 MB)
ARES-6          Basic.js                                        0.995      1.381 ± 1.377 … 1.385              1.388 ± 1.369 … 1.408              -0.0% (-0.0 MB)
ARES-6          ML.js                                           1.002      1.515 ± 1.510 … 1.519              1.511 ± 1.496 … 1.526              -5.3% (-3.0 MB)
JetStreamExtra  FlightPlanner.js                                1.028      0.814 ± 0.806 … 0.823              0.793 ± 0.785 … 0.800              -0.6% (-3.1 MB)
JetStreamExtra  OfflineAssembler.js                             1.012      1.564 ± 1.558 … 1.569              1.545 ± 1.542 … 1.547              -12.4% (-8.4 MB)
JetStreamExtra  UniPoker.js                                     1.014      1.238 ± 1.229 … 1.248              1.221 ± 1.220 … 1.221              -0.0% (-0.0 MB)
JetStreamExtra  async-fs.js                                     1.086      1.717 ± 1.716 … 1.718              1.581 ± 1.579 … 1.582              -0.0% (-0.0 MB)
JetStreamExtra  babylonjs-startup-es5.js                        1.008      0.863 ± 0.860 … 0.866              0.856 ± 0.855 … 0.857              +2.0% (+13.4 MB)
JetStreamExtra  babylonjs-startup-es6.js                        1.015      1.062 ± 1.058 … 1.065              1.046 ± 1.044 … 1.048              -2.1% (-17.7 MB)
JetStreamExtra  bigint-bigdenary.js                             1.018      1.856 ± 1.851 … 1.861              1.822 ± 1.817 … 1.828              -0.0% (-0.0 MB)
JetStreamExtra  bigint-noble-bls12-381.js                       1.003      2.010 ± 2.007 … 2.014              2.004 ± 1.999 … 2.009              +5.7% (+3.4 MB)
JetStreamExtra  bigint-noble-ed25519.js                         1.022      2.053 ± 2.044 … 2.063              2.010 ± 2.007 … 2.013              +3.2% (+2.9 MB)
JetStreamExtra  bigint-noble-secp256k1.js                       1.007      1.888 ± 1.887 … 1.889              1.876 ± 1.875 … 1.876              +2.6% (+2.2 MB)
JetStreamExtra  bigint-paillier.js                              0.957      1.905 ± 1.893 … 1.917              1.989 ± 1.986 … 1.992              +5.3% (+3.8 MB)
JetStreamExtra  doxbee-async.js                                 1.089      1.804 ± 1.777 … 1.832              1.658 ± 1.649 … 1.666              -7.5% (-5.0 MB)
JetStreamExtra  doxbee-promise.js                               1.119      1.492 ± 1.483 … 1.502              1.333 ± 1.329 … 1.338              -16.3% (-10.0 MB)
JetStreamExtra  first-inspector-code-load.js                    1.004      1.717 ± 1.714 … 1.720              1.710 ± 1.709 … 1.711              +0.0% (+0.1 MB)
JetStreamExtra  jsdom-d3-startup.js                             1.052      1.342 ± 1.317 … 1.367              1.276 ± 1.276 … 1.276              -13.9% (-72.8 MB)
JetStreamExtra  json-parse-inspector.js                         0.997      1.066 ± 1.064 … 1.068              1.070 ± 1.042 … 1.098              -9.7% (-40.8 MB)
JetStreamExtra  json-stringify-inspector.js                     1.026      0.949 ± 0.941 … 0.957              0.926 ± 0.924 … 0.927              -1.5% (-5.6 MB)
JetStreamExtra  mobx-startup.js                                 1.008      1.404 ± 1.402 … 1.407              1.393 ± 1.391 … 1.394              -9.2% (-7.1 MB)
JetStreamExtra  multi-inspector-code-load.js                    1.004      1.717 ± 1.714 … 1.721              1.710 ± 1.707 … 1.713              -0.1% (-1.1 MB)
JetStreamExtra  prismjs-startup-es5.js                          1.031      1.719 ± 1.709 … 1.729              1.668 ± 1.664 … 1.672              -7.4% (-4.9 MB)
JetStreamExtra  prismjs-startup-es6.js                          1.028      1.715 ± 1.705 … 1.725              1.669 ± 1.666 … 1.672              -8.8% (-6.0 MB)
JetStreamExtra  proxy-mobx.js                                   1.018      1.291 ± 1.290 … 1.293              1.268 ± 1.267 … 1.270              -0.9% (-0.5 MB)
JetStreamExtra  proxy-vue.js                                    0.967      1.186 ± 1.120 … 1.253              1.226 ± 1.161 … 1.291              -2.8% (-2.0 MB)
JetStreamExtra  threejs.js                                      1.051      1.598 ± 1.564 … 1.632              1.521 ± 1.516 … 1.526              -13.4% (-69.1 MB)
JetStreamExtra  typescript-lib.js                               1.050      0.581 ± 0.560 … 0.602              0.553 ± 0.552 … 0.555              -5.5% (-19.1 MB)
JetStreamExtra  validatorjs.js                                  1.031      1.521 ± 1.513 … 1.529              1.475 ± 1.473 … 1.476              -6.4% (-4.4 MB)
JetStreamExtra  web-ssr.js                                      1.017      1.542 ± 1.541 … 1.542              1.515 ± 1.510 … 1.521              -8.0% (-37.8 MB)
GarBench        array-of-objects.js                             1.124      0.782 ± 0.779 … 0.784              0.696 ± 0.694 … 0.697              -19.9% (-204.3 MB)
GarBench        closures.js                                     1.141      1.091 ± 1.085 … 1.097              0.956 ± 0.955 … 0.958              -21.8% (-307.7 MB)
GarBench        cyclic-graph.js                                 1.029      1.242 ± 1.210 … 1.274              1.207 ± 1.172 … 1.242              -17.6% (-47.9 MB)
GarBench        deep-linked-list.js                             1.130      0.887 ± 0.881 … 0.892              0.785 ± 0.785 … 0.785              -31.9% (-252.8 MB)
GarBench        finalization.js                                 1.068      0.863 ± 0.850 … 0.876              0.808 ± 0.806 … 0.810              -8.0% (-42.5 MB)
GarBench        many-properties.js                              1.031      2.332 ± 2.323 … 2.341              2.262 ± 2.218 … 2.305              -16.7% (-214.4 MB)
GarBench        marking-stress.js                               1.306      1.314 ± 1.117 … 1.511              1.006 ± 0.999 … 1.013              -19.7% (-133.3 MB)
GarBench        mixed-sizes.js                                  1.048      1.110 ± 1.108 … 1.113              1.059 ± 1.059 … 1.060              -16.7% (-121.2 MB)
GarBench        sparse-arrays.js                                1.125      2.379 ± 2.166 … 2.591              2.115 ± 2.075 … 2.155              -16.3% (-173.7 MB)
GarBench        string-heavy.js                                 1.117      1.480 ± 1.480 … 1.481              1.326 ± 1.325 … 1.326              -31.4% (-357.3 MB)
GarBench        wide-tree.js                                    1.136      1.426 ± 1.426 … 1.427              1.256 ± 1.253 … 1.258              -30.9% (-330.3 MB)
MicroBench      array-destructuring-assignment-rest.js          1.085      0.323 ± 0.316 … 0.331              0.298 ± 0.297 … 0.300              -0.0% (-0.0 MB)
MicroBench      array-destructuring-assignment.js               1.153      2.741 ± 2.736 … 2.746              2.376 ± 2.373 … 2.380              -23.8% (-874.6 MB)
MicroBench      array-prototype-map.js                          1.010      1.213 ± 1.205 … 1.221              1.201 ± 1.198 … 1.205              -0.6% (-2.0 MB)
MicroBench      array-prototype-shift.js                        1.240      0.010 ± 0.008 … 0.011              0.008 ± 0.008 … 0.008              -0.0% (-0.0 MB)
MicroBench      bound-call-00-args.js                           1.001      1.439 ± 1.437 … 1.441              1.437 ± 1.436 … 1.438              -0.0% (-0.0 MB)
MicroBench      bound-call-04-args.js                           0.952      1.568 ± 1.554 … 1.582              1.647 ± 1.546 … 1.749              -0.0% (-0.0 MB)
MicroBench      bound-call-16-args.js                           0.995      1.738 ± 1.736 … 1.740              1.747 ± 1.726 … 1.768              -0.0% (-0.0 MB)
MicroBench      call-00-args.js                                 1.022      0.460 ± 0.448 … 0.472              0.450 ± 0.449 … 0.452              -0.0% (-0.0 MB)
MicroBench      call-01-args.js                                 1.006      0.468 ± 0.462 … 0.473              0.465 ± 0.462 … 0.468              -0.0% (-0.0 MB)
MicroBench      call-02-args.js                                 1.001      0.505 ± 0.503 … 0.506              0.504 ± 0.502 … 0.507              -0.0% (-0.0 MB)
MicroBench      call-03-args.js                                 1.003      0.522 ± 0.520 … 0.524              0.520 ± 0.519 … 0.521              -0.0% (-0.0 MB)
MicroBench      call-04-args.js                                 1.007      0.513 ± 0.513 … 0.513              0.509 ± 0.506 … 0.512              -0.0% (-0.0 MB)
MicroBench      call-16-args.js                                 1.005      0.688 ± 0.686 … 0.689              0.685 ± 0.682 … 0.687              -0.0% (-0.0 MB)
MicroBench      call-32-args.js                                 1.022      0.926 ± 0.904 … 0.948              0.906 ± 0.906 … 0.907              -0.0% (-0.0 MB)
MicroBench      call-with-function-environment-2.js             1.080      1.043 ± 1.018 … 1.068              0.966 ± 0.871 … 1.061              -2.2% (-1.3 MB)
MicroBench      call-with-function-environment-captured-var.js  1.148      1.070 ± 1.067 … 1.073              0.932 ± 0.931 … 0.932              -1.4% (-0.8 MB)
MicroBench      call-with-function-environment.js               1.018      0.476 ± 0.469 … 0.482              0.467 ± 0.465 … 0.469              -0.0% (-0.0 MB)
MicroBench      for-in-indexed-properties.js                    1.030      0.230 ± 0.228 … 0.232              0.223 ± 0.222 … 0.224              -10.8% (-20.0 MB)
MicroBench      for-in-named-properties.js                      1.029      0.176 ± 0.175 … 0.178              0.171 ± 0.171 … 0.172              -0.0% (-0.0 MB)
MicroBench      for-of.js                                       0.944      0.506 ± 0.503 … 0.508              0.536 ± 0.508 … 0.564              -0.0% (-0.0 MB)
MicroBench      function-prototype-call.js                      1.002      0.379 ± 0.378 … 0.380              0.378 ± 0.377 … 0.379              -0.0% (-0.0 MB)
MicroBench      object-keys.js                                  1.015      1.276 ± 1.273 … 1.280              1.258 ± 1.257 … 1.260              +15.1% (+29.2 MB)
MicroBench      object-set-with-rope-strings.js                 0.996      0.528 ± 0.521 … 0.534              0.530 ± 0.524 … 0.535              -0.0% (-0.0 MB)
MicroBench      pic-add-own.js                                  1.162      0.459 ± 0.450 … 0.469              0.395 ± 0.393 … 0.398              -0.0% (-0.0 MB)
MicroBench      pic-get-own.js                                  0.998      0.489 ± 0.487 … 0.491              0.490 ± 0.482 … 0.498              -0.0% (-0.0 MB)
MicroBench      pic-get-pchain.js                               0.991      0.536 ± 0.535 … 0.538              0.541 ± 0.536 … 0.546              -0.0% (-0.0 MB)
MicroBench      pic-put-own.js                                  1.004      0.517 ± 0.515 … 0.518              0.514 ± 0.514 … 0.515              -0.0% (-0.0 MB)
MicroBench      pic-put-pchain.js                               0.970      1.894 ± 1.880 … 1.907              1.953 ± 1.900 … 2.006              -0.0% (-0.0 MB)
MicroBench      setter-in-prototype-chain.js                    1.039      1.982 ± 1.970 … 1.994              1.908 ± 1.893 … 1.923              -0.0% (-0.0 MB)
MicroBench      strictly-equals-object.js                       1.000      0.731 ± 0.731 … 0.731              0.731 ± 0.730 … 0.732              -0.0% (-0.0 MB)
LongSpider      Total                                           1.018      69.800                             68.543                             -8.3% (-161.7 MB)
Kraken          Total                                           1.013      7.057                              6.964                              -0.0% (-0.0 MB)
Octane          Total                                           1.018      128586.500                         130893.500                         -8.1% (-288.5 MB)
JetStream       Total                                           1.003      153.394                            152.927                            -0.3% (-2.8 MB)
JetStream3      Total                                           1.046      9.164                              8.761                              -3.0% (-5.8 MB)
AsyncBench      Total                                           1.107      5.163                              4.666                              -6.2% (-61.5 MB)
ARES-6          Total                                           1.022      5.645                              5.525                              -5.4% (-13.9 MB)
JetStreamExtra  Total                                           1.023      39.616                             38.712                             -3.2% (-289.8 MB)
GarBench        Total                                           1.106      14.906                             13.475                             -21.9% (-2185.4 MB)
MicroBench      Total                                           1.027      25.406                             24.749                             -15.3% (-869.7 MB)
All Suites      Total                                           1.015      395.064                            389.276                            -11.6% (-3879.1 MB)
```

Speedometer 2 & 3 both see a small progression as well:

```
Benchmark     Old Score     New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  52.70 ± 1.14  53.70 ± 0.52                1.019  9.59 ± 0.10            9.47 ± 0.08                1.013
Speedometer3  3.24 ± 0.07   3.30 ± 0.07                 1.018  8.32 ± 0.18            8.03 ± 0.20                1.037
```