### PR TITLE
LibTextCodec: Fix ISO-2022-JP encoder escape sequence on unencodable error

### DIFF
--- a/Libraries/LibTextCodec/Encoder.cpp
+++ b/Libraries/LibTextCodec/Encoder.cpp
@@ -281,7 +281,7 @@ ErrorOr<ISO2022JPEncoder::State> ISO2022JPEncoder::process_item(u32 item, State 
         if (state == State::jis0208) {
             TRY(on_byte(0x1B));
             TRY(on_byte(0x28));
-            TRY(on_byte(0x4A));
+            TRY(on_byte(0x42));
             return process_item(item, State::ASCII, on_byte, on_error);
         }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Form submission using ISO-2022-JP correctly replaces unencodables

--- a/Tests/LibWeb/Text/input/wpt-import/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.html
+++ b/Tests/LibWeb/Text/input/wpt-import/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Encoding: ISO-2022-JP unencodable replacement in form submission</title>
+<link rel="help" href="https://encoding.spec.whatwg.org/#iso-2022-jp-encoder">
+<link rel="author" title="Benjamin C. Wiley Sittler"
+      href="mailto:bsittler@chromium.org">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+promise_test(async testCase => {
+  const target = Object.assign(document.createElement('iframe'), {
+    name: 'target',
+  });
+  if (document.readyState !== 'complete') {
+    await new Promise(resolve => addEventListener('load', resolve));
+  }
+  document.body.insertBefore(target, document.body.firstChild);
+  const form = Object.assign(document.createElement('form'), {
+    acceptCharset: 'iso-2022-jp',
+    // NOTE: This uses escape and unescape rather than
+    // encodeURI/encodeURIComponent and decodeURI/decodeURIComponent
+    // intentionally, because:
+    //
+    // - escape() is required because encodeURI{,Component} encodes
+    //   using UTF-8, and would falsely imply that non-ASCII
+    //   characters are expected to work here -- which they won't, as
+    //   the data URI has ISO-2022-JP charset; likewise
+    //
+    // - unescape() is required because the encoded byte sequence
+    //   we're trying to decode and verify represents ISO-2022-JP data
+    //   rather than the UTF-8 expected by decodeURI{,Component}
+    //
+    // The resulting document inside the IFRAME will look like:
+    // <body onload="..."><plaintext>?utf16=...
+    action: 'data:text/html;charset=iso-2022-jp,' + escape(
+            '<body onload="(' +
+            (() => parent.postMessage({
+              utf16: document.body.innerText.split('=').pop(),
+              iso2022jp: unescape(location.href.split('=').pop()),
+            }, '*')) +
+            ')()"><plaintext>'),
+    target: target.name,
+  });
+  form.appendChild(Object.assign(document.createElement('input'), {
+    name: 'utf16',
+    value: 'ABC~¤•★星🌟星★•¤~XYZ',
+  }));
+  document.body.insertBefore(form, document.body.firstChild);
+  const {iso2022jp, utf16} = await new Promise(resolve => {
+    addEventListener('message', ({data}) => resolve(data));
+    form.submit();
+  });
+  assert_equals(utf16, 'ABC~&#164;&#8226;★星&#127775;星★&#8226;&#164;~XYZ');
+  assert_equals(
+      iso2022jp,
+      'ABC~&#164;&#8226;\x1b$B!z@1\x1b(B&#127775;\x1b$B@1!z\x1b(B&#8226;&#164;~XYZ');
+}, 'Form submission using ISO-2022-JP correctly replaces unencodables');
+
+</script>


### PR DESCRIPTION
This PR updates the ISO-2022-JP encoder implementation and adds the [related Web Platform Test](https://wpt.fyi/results/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.html) (WPT) to improve conformance and test coverage.

The only code change is the fix of a copy-paste typo in the encoder to use the correct escape sequence for switching to ASCII mode.

By the way, this fixes the last failing test in [`iso-2022-jp`](https://wpt.fyi/results/encoding/legacy-mb-japanese/iso-2022-jp?product=ladybird) and therefore in [`legacy-mb-japanese`](https://wpt.fyi/results/encoding/legacy-mb-japanese?product=ladybird) coming from [`encoding`](https://wpt.fyi/results/encoding?product=ladybird) 🥳 

<img width="987" height="703" alt="image" src="https://github.com/user-attachments/assets/ded52eb7-1703-4b09-ac0a-5c561e6b0562" />
