### PR TITLE
LibGC: Add a Variant `visit` overload and add tests for Visitor

### DIFF
--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -193,6 +193,16 @@ public:
 
         void visit(NanBoxedValue const& value);
 
+        template<typename... Ts>
+        void visit(Variant<Ts...> const& variant)
+        requires((IsVisitable<Ts>::value || ...))
+        {
+            variant.visit([&](auto const& value) {
+                if constexpr (requires { visit(value); })
+                    visit(value);
+            });
+        }
+
         // Allow explicitly ignoring a GC-allocated member in a visit_edges implementation instead
         // of just not using it.
         template<typename T>

--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -19,6 +19,9 @@
 
 namespace GC {
 
+template<typename T>
+struct IsVisitable;
+
 // This instrumentation tells analysis tooling to ignore a potentially mis-wrapped GC-allocated member variable
 // It should only be used when the lifetime of the GC-allocated member is always longer than the object
 #if defined(AK_COMPILER_CLANG)
@@ -99,6 +102,7 @@ public:
 
         template<typename T>
         void visit(ReadonlySpan<T> span)
+        requires(!IsBaseOf<NanBoxedValue, T> && IsVisitable<T>::value)
         {
             for (auto& value : span)
                 visit(value);
@@ -113,6 +117,7 @@ public:
 
         template<typename T>
         void visit(Span<T> span)
+        requires(!IsBaseOf<NanBoxedValue, T> && IsVisitable<T>::value)
         {
             for (auto& value : span)
                 visit(value);
@@ -127,6 +132,7 @@ public:
 
         template<typename T, size_t inline_capacity>
         void visit(Vector<T, inline_capacity> const& vector)
+        requires(!IsBaseOf<NanBoxedValue, T> && IsVisitable<T>::value)
         {
             for (auto& value : vector)
                 visit(value);
@@ -141,6 +147,7 @@ public:
 
         template<typename T>
         void visit(HashTable<T> const& table)
+        requires(IsVisitable<T>::value)
         {
             for (auto& value : table)
                 visit(value);
@@ -148,6 +155,7 @@ public:
 
         template<typename T>
         void visit(OrderedHashTable<T> const& table)
+        requires(IsVisitable<T>::value)
         {
             for (auto& value : table)
                 visit(value);
@@ -177,6 +185,7 @@ public:
 
         template<typename T>
         void visit(Optional<T> const& optional)
+        requires(IsVisitable<T>::value)
         {
             if (optional.has_value())
                 visit(optional.value());
@@ -219,6 +228,11 @@ protected:
 private:
     bool m_mark { false };
     State m_state { State::Live };
+};
+
+template<typename T>
+struct IsVisitable {
+    static constexpr bool value = requires(Cell::Visitor& visitor, T const& value) { visitor.visit(value); };
 };
 
 }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -297,14 +297,7 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
 
     if (m_class_data) {
         for (auto& field : m_class_data->fields) {
-            field.initializer.visit(
-                [&visitor](GC::Ref<ECMAScriptFunctionObject>& initializer) {
-                    visitor.visit(initializer);
-                },
-                [&visitor](Value initializer) {
-                    visitor.visit(initializer);
-                },
-                [](Empty) {});
+            visitor.visit(field.initializer);
             if (auto* property_key_ptr = field.name.get_pointer<PropertyKey>(); property_key_ptr && property_key_ptr->is_symbol())
                 visitor.visit(property_key_ptr->as_symbol());
         }
@@ -313,11 +306,7 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
             visitor.visit(private_element.value);
     }
 
-    m_script_or_module.visit(
-        [](Empty) {},
-        [&](auto& script_or_module) {
-            visitor.visit(script_or_module);
-        });
+    visitor.visit(m_script_or_module);
 }
 
 // 10.2.7 MakeMethod ( F, homeObject ), https://tc39.es/ecma262/#sec-makemethod

--- a/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -135,11 +135,7 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(this_value);
     visitor.visit(executable);
     visitor.visit(registers_and_constants_and_locals_and_arguments_span());
-    script_or_module.visit(
-        [](Empty) {},
-        [&](auto& script_or_module) {
-            visitor.visit(script_or_module);
-        });
+    visitor.visit(script_or_module);
 }
 
 }

--- a/Libraries/LibWeb/Animations/AnimationPlaybackEvent.cpp
+++ b/Libraries/LibWeb/Animations/AnimationPlaybackEvent.cpp
@@ -49,14 +49,8 @@ void AnimationPlaybackEvent::initialize(JS::Realm& realm)
 void AnimationPlaybackEvent::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-
-    auto visit_numberish_internal = [&](auto& numberish_internal) {
-        numberish_internal.visit(
-            [&](GC::Ref<CSS::CSSNumericValue> const& numeric) { visitor.visit(numeric); },
-            [](auto const&) {});
-    };
-    visit_numberish_internal(m_current_time);
-    visit_numberish_internal(m_timeline_time);
+    visitor.visit(m_current_time);
+    visitor.visit(m_timeline_time);
 }
 
 NullableCSSNumberish AnimationPlaybackEvent::to_nullable_numberish(CSSNumberishInternal const& numberish)

--- a/Libraries/LibWeb/CSS/CSSPerspective.cpp
+++ b/Libraries/LibWeb/CSS/CSSPerspective.cpp
@@ -80,7 +80,7 @@ void CSSPerspective::initialize(JS::Realm& realm)
 void CSSPerspective::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_length.visit([&visitor](auto const& it) { visitor.visit(it); });
+    visitor.visit(m_length);
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssperspective

--- a/Libraries/LibWeb/DOM/Slot.cpp
+++ b/Libraries/LibWeb/DOM/Slot.cpp
@@ -14,8 +14,7 @@ Slot::~Slot() = default;
 
 void Slot::visit_edges(JS::Cell::Visitor& visitor)
 {
-    for (auto const& node : m_assigned_nodes)
-        node.visit([&](auto const& slottable) { visitor.visit(slottable); });
+    visitor.visit(m_assigned_nodes);
 }
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchParams.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchParams.cpp
@@ -52,10 +52,8 @@ void FetchParams::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_algorithms);
     visitor.visit(m_controller);
     visitor.visit(m_timing_info);
-    if (m_task_destination.has<GC::Ref<JS::Object>>())
-        visitor.visit(m_task_destination.get<GC::Ref<JS::Object>>());
-    if (m_preloaded_response_candidate.has<GC::Ref<Response>>())
-        visitor.visit(m_preloaded_response_candidate.get<GC::Ref<Response>>());
+    visitor.visit(m_task_destination);
+    visitor.visit(m_preloaded_response_candidate);
 }
 
 // https://fetch.spec.whatwg.org/#fetch-params-aborted

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -35,18 +35,11 @@ void Request::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_client);
-    m_body.visit(
-        [&](GC::Ref<Body>& body) { visitor.visit(body); },
-        [](auto&) {});
+    visitor.visit(m_body);
     visitor.visit(m_reserved_client);
-    m_traversable_for_user_prompts.visit(
-        [&](GC::Ptr<HTML::EnvironmentSettingsObject> const& value) { visitor.visit(value); },
-        [&](GC::Ptr<HTML::TraversableNavigable> const& value) { visitor.visit(value); },
-        [](auto const&) {});
+    visitor.visit(m_traversable_for_user_prompts);
     visitor.visit(m_pending_responses);
-    m_policy_container.visit(
-        [&](GC::Ref<HTML::PolicyContainer> const& policy_container) { visitor.visit(policy_container); },
-        [](auto const&) {});
+    visitor.visit(m_policy_container);
 }
 
 // https://fetch.spec.whatwg.org/#concept-request-url

--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -74,10 +74,7 @@ public:
 
         void visit_edges(GC::Cell::Visitor& visitor)
         {
-            m_fill_or_stroke_style.visit([&](Gfx::Color) {},
-                [&](auto& handle) {
-                    visitor.visit(handle);
-                });
+            visitor.visit(m_fill_or_stroke_style);
         }
 
     private:

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -61,18 +61,7 @@ void HTMLCanvasElement::finalize()
 void HTMLCanvasElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_context.visit(
-        [&](GC::Ref<CanvasRenderingContext2D>& context) {
-            visitor.visit(context);
-        },
-        [&](GC::Ref<WebGL::WebGLRenderingContext>& context) {
-            visitor.visit(context);
-        },
-        [&](GC::Ref<WebGL::WebGL2RenderingContext>& context) {
-            visitor.visit(context);
-        },
-        [](Empty) {
-        });
+    visitor.visit(m_context);
 }
 
 bool HTMLCanvasElement::is_presentational_hint(FlyString const& name) const

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -34,9 +34,7 @@ void HTMLSlotElement::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     Slot::visit_edges(visitor);
-
-    for (auto const& node : m_manually_assigned_nodes)
-        node.visit([&](auto const& slottable) { visitor.visit(slottable); });
+    visitor.visit(m_manually_assigned_nodes);
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#dom-slot-assignednodes

--- a/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -62,9 +62,7 @@ void MessageEvent::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_data);
     visitor.visit(m_ports_array);
     visitor.visit(m_ports);
-    m_source.visit(
-        [](Empty) {},
-        [&](auto const& ref) { visitor.visit(ref); });
+    visitor.visit(m_source);
 }
 
 // https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -175,10 +175,7 @@ private:
     virtual void visit_edges(Cell::Visitor& visitor) override
     {
         Base::visit_edges(visitor);
-        navigation_params.visit(
-            [](auto const&) {},
-            [&](GC::Ref<NavigationParams> const& p) { visitor.visit(p); },
-            [&](GC::Ref<NonFetchSchemeNavigationParams> const& p) { visitor.visit(p); });
+        visitor.visit(navigation_params);
     }
 };
 
@@ -238,10 +235,7 @@ void PopulateSessionHistoryEntryDocumentOutput::visit_edges(Cell::Visitor& visit
 {
     Base::visit_edges(visitor);
     visitor.visit(document);
-    navigation_params.visit(
-        [](auto const&) {},
-        [&](GC::Ref<NavigationParams> const& p) { visitor.visit(p); },
-        [&](GC::Ref<NonFetchSchemeNavigationParams> const& p) { visitor.visit(p); });
+    visitor.visit(navigation_params);
 }
 
 HashTable<GC::RawRef<Navigable>>& all_navigables()

--- a/Libraries/LibWeb/HTML/OffscreenCanvas.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvas.cpp
@@ -378,18 +378,7 @@ void OffscreenCanvas::initialize(JS::Realm& realm)
 void OffscreenCanvas::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_context.visit(
-        [&](GC::Ref<OffscreenCanvasRenderingContext2D>& context) {
-            visitor.visit(context);
-        },
-        [&](GC::Ref<WebGL::WebGLRenderingContext>& context) {
-            visitor.visit(context);
-        },
-        [&](GC::Ref<WebGL::WebGL2RenderingContext>& context) {
-            visitor.visit(context);
-        },
-        [](Empty) {
-        });
+    visitor.visit(m_context);
 }
 
 JS::ThrowCompletionOr<OffscreenCanvas::HasOrCreatedContext> OffscreenCanvas::create_2d_context(JS::Value options)

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -317,9 +317,7 @@ WebIDL::Promise* ModuleScript::run(PreventErrorReporting prevent_error_reporting
 void ModuleScript::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_record.visit(
-        [&](Empty) {},
-        [&](auto record) { visitor.visit(record); });
+    visitor.visit(m_record);
 }
 
 }

--- a/Libraries/LibWeb/HTML/TrackEvent.cpp
+++ b/Libraries/LibWeb/HTML/TrackEvent.cpp
@@ -48,9 +48,7 @@ void TrackEvent::initialize(JS::Realm& realm)
 void TrackEvent::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_track.visit(
-        [](Empty) {},
-        [&](auto const& ref) { visitor.visit(ref); });
+    visitor.visit(m_track);
 }
 
 NullableTrackType TrackEvent::track() const

--- a/Libraries/LibWeb/IndexedDB/IDBRequest.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBRequest.cpp
@@ -45,11 +45,7 @@ void IDBRequest::visit_edges(Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_result);
     visitor.visit(m_transaction);
-
-    m_source.visit(
-        [&](Empty) {},
-        [&](auto const& object) { visitor.visit(object); });
-
+    visitor.visit(m_source);
     visitor.visit(m_error);
 }
 

--- a/Libraries/LibWeb/Streams/ReadableStreamTee.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamTee.cpp
@@ -174,7 +174,7 @@ void ReadableByteStreamTeeParams::visit_edges(Visitor& visitor)
     visitor.visit(branch2);
     visitor.visit(pull1_algorithm);
     visitor.visit(pull2_algorithm);
-    reader.visit([&](auto underlying_reader) { visitor.visit(underlying_reader); });
+    visitor.visit(reader);
 }
 
 // https://streams.spec.whatwg.org/#ref-for-read-request④

--- a/Libraries/LibWeb/WebIDL/Buffers.cpp
+++ b/Libraries/LibWeb/WebIDL/Buffers.cpp
@@ -100,7 +100,7 @@ bool BufferableObjectBase::is_array_buffer() const
 void BufferableObjectBase::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_bufferable_object.visit([&](auto& obj) { visitor.visit(obj); });
+    visitor.visit(m_bufferable_object);
 }
 
 ArrayBufferView::~ArrayBufferView() = default;

--- a/Libraries/LibWeb/XHR/FormData.cpp
+++ b/Libraries/LibWeb/XHR/FormData.cpp
@@ -92,10 +92,8 @@ void FormData::initialize(JS::Realm& realm)
 void FormData::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    for (auto const& entry : m_entry_list) {
-        entry.value.visit([&](GC::Ref<FileAPI::File> const& file) { visitor.visit(file); },
-            [&](auto const&) {});
-    }
+    for (auto const& entry : m_entry_list)
+        visitor.visit(entry.value);
 }
 
 // https://xhr.spec.whatwg.org/#dom-formdata-append

--- a/Tests/LibGC/CMakeLists.txt
+++ b/Tests/LibGC/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestGCContainers.cpp
+    TestGCVisitor.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibGC/TestGCVisitor.cpp
+++ b/Tests/LibGC/TestGCVisitor.cpp
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/BitCast.h>
+#include <AK/HashMap.h>
+#include <AK/HashTable.h>
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+#include <LibGC/Cell.h>
+#include <LibGC/CellAllocator.h>
+#include <LibGC/Heap.h>
+#include <LibGC/NanBoxedValue.h>
+#include <LibGC/Ptr.h>
+#include <LibTest/TestCase.h>
+
+class TestCell : public GC::Cell {
+    GC_CELL(TestCell, GC::Cell);
+    GC_DECLARE_ALLOCATOR(TestCell);
+
+    u8 m_padding[16] {};
+};
+
+GC_DEFINE_ALLOCATOR(TestCell);
+
+static GC::Heap& test_heap()
+{
+    static GC::Heap heap([](auto&) { });
+    return heap;
+}
+
+class TestVisitor : public GC::Cell::Visitor {
+    virtual void visit_impl(GC::Cell& cell) override { visited_cells.set(&cell); }
+    virtual void visit_impl(ReadonlySpan<GC::NanBoxedValue> span) override { last_nan_span_size = span.size(); }
+    virtual void visit_possible_values(ReadonlyBytes) override { }
+
+public:
+    HashTable<GC::Cell*> visited_cells;
+    Optional<size_t> last_nan_span_size;
+};
+
+class TestNanBox : public GC::NanBoxedValue {
+public:
+    static TestNanBox from_cell(GC::Cell* cell)
+    {
+        TestNanBox box;
+        box.m_value.encoded = GC::SHIFTED_IS_CELL_PATTERN | (bit_cast<u64>(cell) & 0x0000FFFFFFFFFFFFULL);
+        return box;
+    }
+
+    static TestNanBox from_double(double value)
+    {
+        TestNanBox box;
+        box.m_value.as_double = value;
+        return box;
+    }
+};
+
+TEST_CASE(visit_cell_pointer_traces_cell)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    TestVisitor visitor;
+    visitor.visit(static_cast<GC::Cell*>(cell.ptr()));
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_null_cell_pointer_traces_nothing)
+{
+    TestVisitor visitor;
+    visitor.visit(static_cast<GC::Cell*>(nullptr));
+
+    EXPECT_EQ(visitor.visited_cells.size(), 0u);
+}
+
+TEST_CASE(visit_cell_reference_traces_cell)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    TestVisitor visitor;
+    visitor.visit(static_cast<GC::Cell&>(*cell));
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_const_cell_pointer_traces_cell)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    TestVisitor visitor;
+    visitor.visit(static_cast<GC::Cell const*>(cell.ptr()));
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_const_cell_reference_traces_cell)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    TestVisitor visitor;
+    visitor.visit(static_cast<GC::Cell const&>(*cell));
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_ptr_traces_cell)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+    GC::Ptr<TestCell> ptr { cell };
+
+    TestVisitor visitor;
+    visitor.visit(ptr);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_null_ptr_traces_nothing)
+{
+    GC::Ptr<TestCell> ptr;
+
+    TestVisitor visitor;
+    visitor.visit(ptr);
+
+    EXPECT_EQ(visitor.visited_cells.size(), 0u);
+}
+
+TEST_CASE(visit_ref_traces_cell)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+    GC::Ref<TestCell> ref { cell };
+
+    TestVisitor visitor;
+    visitor.visit(ref);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_span_traces_cell_elements)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    Vector<GC::Ref<TestCell>> elements;
+    elements.append(cell);
+
+    TestVisitor visitor;
+    visitor.visit(elements.span());
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_readonly_span_traces_cell_elements)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    Vector<GC::Ref<TestCell>> elements;
+    elements.append(cell);
+
+    TestVisitor visitor;
+    visitor.visit(static_cast<ReadonlySpan<GC::Ref<TestCell>>>(elements.span()));
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_vector_traces_cell_elements)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    Vector<GC::Ref<TestCell>> vector;
+    vector.append(cell);
+
+    TestVisitor visitor;
+    visitor.visit(vector);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_hash_table_traces_cell_elements)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    HashTable<GC::Ref<TestCell>> table;
+    table.set(cell);
+
+    TestVisitor visitor;
+    visitor.visit(table);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_ordered_hash_table_traces_cell_elements)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    OrderedHashTable<GC::Ref<TestCell>> table;
+    table.set(cell);
+
+    TestVisitor visitor;
+    visitor.visit(table);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_hash_map_traces_cell_value)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    HashMap<int, GC::Ref<TestCell>> map;
+    map.set(7, cell);
+
+    TestVisitor visitor;
+    visitor.visit(map);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_hash_map_traces_cell_key)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    HashMap<GC::Ref<TestCell>, int> map;
+    map.set(cell, 7);
+
+    TestVisitor visitor;
+    visitor.visit(map);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_ordered_hash_map_traces_cell_value)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+
+    OrderedHashMap<int, GC::Ref<TestCell>> map;
+    map.set(7, cell);
+
+    TestVisitor visitor;
+    visitor.visit(map);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_optional_traces_cell_value)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+    Optional<GC::Ref<TestCell>> optional { cell };
+
+    TestVisitor visitor;
+    visitor.visit(optional);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_empty_optional_traces_nothing)
+{
+    Optional<GC::Ref<TestCell>> optional;
+
+    TestVisitor visitor;
+    visitor.visit(optional);
+
+    EXPECT_EQ(visitor.visited_cells.size(), 0u);
+}
+
+TEST_CASE(visit_nan_boxed_value_traces_cell_when_cell_held)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+    auto value = TestNanBox::from_cell(cell.ptr());
+
+    TestVisitor visitor;
+    visitor.visit(value);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_nan_boxed_value_traces_nothing_when_not_cell)
+{
+    auto value = TestNanBox::from_double(3.14);
+
+    TestVisitor visitor;
+    visitor.visit(value);
+
+    EXPECT_EQ(visitor.visited_cells.size(), 0u);
+}
+
+TEST_CASE(visit_readonly_span_of_nan_boxed_values_routes_to_visit_impl)
+{
+    Vector<TestNanBox> values;
+    values.append(TestNanBox::from_double(1.0));
+    values.append(TestNanBox::from_double(2.0));
+    values.append(TestNanBox::from_double(3.0));
+
+    TestVisitor visitor;
+    visitor.visit(static_cast<ReadonlySpan<TestNanBox>>(values.span()));
+
+    EXPECT_EQ(visitor.last_nan_span_size, 3u);
+}
+
+TEST_CASE(visit_span_of_nan_boxed_values_routes_to_visit_impl)
+{
+    Vector<TestNanBox> values;
+    values.append(TestNanBox::from_double(1.0));
+    values.append(TestNanBox::from_double(2.0));
+
+    TestVisitor visitor;
+    visitor.visit(values.span());
+
+    EXPECT_EQ(visitor.last_nan_span_size, 2u);
+}
+
+TEST_CASE(visit_vector_of_nan_boxed_values_routes_to_visit_impl)
+{
+    Vector<TestNanBox> values;
+    values.append(TestNanBox::from_double(1.0));
+    values.append(TestNanBox::from_double(2.0));
+    values.append(TestNanBox::from_double(3.0));
+    values.append(TestNanBox::from_double(4.0));
+
+    TestVisitor visitor;
+    visitor.visit(values);
+
+    EXPECT_EQ(visitor.last_nan_span_size, 4u);
+}
+
+static_assert(GC::IsVisitable<Vector<GC::Ref<TestCell>>>::value);
+static_assert(GC::IsVisitable<Span<GC::Ref<TestCell>>>::value);
+static_assert(GC::IsVisitable<ReadonlySpan<GC::Ref<TestCell>>>::value);
+static_assert(GC::IsVisitable<HashTable<GC::Ref<TestCell>>>::value);
+static_assert(GC::IsVisitable<OrderedHashTable<GC::Ref<TestCell>>>::value);
+static_assert(GC::IsVisitable<Optional<GC::Ref<TestCell>>>::value);
+
+static_assert(GC::IsVisitable<Vector<Vector<GC::Ref<TestCell>>>>::value);
+
+static_assert(!GC::IsVisitable<Vector<int>>::value);
+static_assert(!GC::IsVisitable<Span<int>>::value);
+static_assert(!GC::IsVisitable<ReadonlySpan<int>>::value);
+static_assert(!GC::IsVisitable<HashTable<int>>::value);
+static_assert(!GC::IsVisitable<OrderedHashTable<int>>::value);
+static_assert(!GC::IsVisitable<Optional<int>>::value);

--- a/Tests/LibGC/TestGCVisitor.cpp
+++ b/Tests/LibGC/TestGCVisitor.cpp
@@ -8,6 +8,7 @@
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/Optional.h>
+#include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGC/Cell.h>
 #include <LibGC/CellAllocator.h>
@@ -339,6 +340,31 @@ TEST_CASE(visit_vector_of_nan_boxed_values_routes_to_visit_impl)
     EXPECT_EQ(visitor.last_nan_span_size, 4u);
 }
 
+TEST_CASE(visit_variant_traces_active_cell_alternative)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+    Variant<GC::Ref<TestCell>, int> variant { GC::Ref<TestCell>(cell) };
+
+    TestVisitor visitor;
+    visitor.visit(variant);
+
+    EXPECT(visitor.visited_cells.contains(cell.ptr()));
+}
+
+TEST_CASE(visit_variant_skips_untraced_alternative)
+{
+    auto& heap = test_heap();
+    auto cell = heap.allocate<TestCell>();
+    Variant<GC::Ref<TestCell>, int> variant { 42 };
+
+    TestVisitor visitor;
+    visitor.visit(variant);
+
+    EXPECT_EQ(visitor.visited_cells.size(), 0u);
+    EXPECT(!visitor.visited_cells.contains(cell.ptr()));
+}
+
 static_assert(GC::IsVisitable<Vector<GC::Ref<TestCell>>>::value);
 static_assert(GC::IsVisitable<Span<GC::Ref<TestCell>>>::value);
 static_assert(GC::IsVisitable<ReadonlySpan<GC::Ref<TestCell>>>::value);
@@ -354,3 +380,6 @@ static_assert(!GC::IsVisitable<ReadonlySpan<int>>::value);
 static_assert(!GC::IsVisitable<HashTable<int>>::value);
 static_assert(!GC::IsVisitable<OrderedHashTable<int>>::value);
 static_assert(!GC::IsVisitable<Optional<int>>::value);
+
+static_assert(GC::IsVisitable<Variant<GC::Ref<TestCell>, int>>::value);
+static_assert(!GC::IsVisitable<Variant<int, double>>::value);


### PR DESCRIPTION
This is part 2 of a rough 18 part series. See part 1: https://github.com/LadybirdBrowser/ladybird/pull/9282

This adds test for Visitor, then a Variant helper overload and uses it where appropriate.