### PR TITLE
RequestServer: Fix set_certificate crash and wire client certs via cURL

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -403,12 +403,10 @@ Messages::RequestServer::StopRequestResponse ConnectionFromClient::stop_request(
     return true;
 }
 
-Messages::RequestServer::SetCertificateResponse ConnectionFromClient::set_certificate(u64 request_id, ByteString certificate, ByteString key)
+Messages::RequestServer::SetCertificateResponse ConnectionFromClient::set_certificate(u64, ByteString, ByteString)
 {
-    (void)request_id;
-    (void)certificate;
-    (void)key;
-    TODO();
+    // FIXME: Store client certificate and pass to cURL for mTLS support (https://github.com/LadybirdBrowser/ladybird/issues/8343).
+    return false;
 }
 
 void ConnectionFromClient::ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level)
@@ -584,15 +582,10 @@ void ConnectionFromClient::websocket_close(u64 websocket_id, u16 code, ByteStrin
         connection->close(code, reason);
 }
 
-Messages::RequestServer::WebsocketSetCertificateResponse ConnectionFromClient::websocket_set_certificate(u64 websocket_id, ByteString, ByteString)
+Messages::RequestServer::WebsocketSetCertificateResponse ConnectionFromClient::websocket_set_certificate(u64, ByteString, ByteString)
 {
-    auto success = false;
-    if (auto* connection = m_websockets.get(websocket_id).value_or({}); connection) {
-        // NO OP here
-        // connection->set_certificate(certificate, key);
-        success = true;
-    }
-    return success;
+    // FIXME: Store client certificate and pass to cURL for mTLS support (https://github.com/LadybirdBrowser/ladybird/issues/8343).
+    return false;
 }
 
 }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -403,10 +403,16 @@ Messages::RequestServer::StopRequestResponse ConnectionFromClient::stop_request(
     return true;
 }
 
-Messages::RequestServer::SetCertificateResponse ConnectionFromClient::set_certificate(u64, ByteString, ByteString)
+Messages::RequestServer::SetCertificateResponse ConnectionFromClient::set_certificate(u64 request_id, ByteString certificate, ByteString key)
 {
-    // FIXME: Store client certificate and pass to cURL for mTLS support (https://github.com/LadybirdBrowser/ladybird/issues/8343).
-    return false;
+    auto request = m_active_requests.get(request_id);
+    if (!request.has_value()) {
+        dbgln("SetCertificate: Request ID {} not found", request_id);
+        return false;
+    }
+
+    (*request)->set_client_certificate({}, move(certificate), move(key));
+    return true;
 }
 
 void ConnectionFromClient::ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level)

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -59,7 +59,7 @@ private:
     virtual void set_use_system_dns() override;
     virtual void start_request(u64 request_id, ByteString, URL::URL, Vector<HTTP::Header>, ByteBuffer, HTTP::CacheMode, HTTP::Cookie::IncludeCredentials, Core::ProxyData) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(u64 request_id) override;
-    virtual Messages::RequestServer::SetCertificateResponse set_certificate(u64 request_id, ByteString, ByteString) override;
+    virtual Messages::RequestServer::SetCertificateResponse set_certificate(u64 request_id, ByteString certificate, ByteString key) override;
     virtual void ensure_connection(u64 request_id, URL::URL url, ::RequestServer::CacheLevel cache_level) override;
 
     virtual void retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, String cookie) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -511,6 +511,16 @@ void Request::notify_retrieved_http_cookie(Badge<ConnectionFromClient>, StringVi
     transition_to_state(State::Fetch);
 }
 
+void Request::set_client_certificate(Badge<ConnectionFromClient>, ByteString certificate, ByteString key)
+{
+    if (certificate.is_empty() && !key.is_empty()) {
+        dbgln("Request: Client key provided without certificate, dropping");
+        return;
+    }
+    m_client_certificate = move(certificate);
+    m_client_key = move(key);
+}
+
 void Request::notify_fetch_complete(Badge<ConnectionFromClient>, int result_code)
 {
     mark_lifecycle_event(this, &WireStats::complete_observed_at);
@@ -884,6 +894,21 @@ void Request::handle_fetch_state()
 
     if (auto const& path = default_certificate_path(); !path.is_empty())
         set_option(CURLOPT_CAINFO, path.characters());
+
+    // Apply client certificate for mTLS if provided. The certificate blob is required;
+    // the key blob is optional (the cert blob may contain the private key, e.g. combined PEM;
+    // future PKCS#12 support needs explicit type/passphrase plumbing).
+    // NOTE: const_cast is needed because curl_blob::data is void*, but CURL_BLOB_COPY ensures cURL
+    //       copies the data, so the source is not modified.
+    if (!m_client_certificate.is_empty()) {
+        curl_blob cert_blob { const_cast<char*>(m_client_certificate.characters()), m_client_certificate.length(), CURL_BLOB_COPY };
+        set_option(CURLOPT_SSLCERT_BLOB, &cert_blob);
+
+        if (!m_client_key.is_empty()) {
+            curl_blob key_blob { const_cast<char*>(m_client_key.characters()), m_client_key.length(), CURL_BLOB_COPY };
+            set_option(CURLOPT_SSLKEY_BLOB, &key_blob);
+        }
+    }
 
     set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -77,6 +77,7 @@ public:
     virtual void notify_request_unblocked(Badge<HTTP::DiskCache>) override;
     void notify_retrieved_http_cookie(Badge<ConnectionFromClient>, StringView cookie);
     void notify_fetch_complete(Badge<ConnectionFromClient>, int result_code);
+    void set_client_certificate(Badge<ConnectionFromClient>, ByteString certificate, ByteString key);
 
 private:
     enum class State : u8 {
@@ -202,6 +203,9 @@ private:
 
     ByteString m_alt_svc_cache_path;
     Core::ProxyData m_proxy_data;
+
+    ByteString m_client_certificate;
+    ByteString m_client_key;
 
     Optional<u32> m_status_code;
     Optional<String> m_reason_phrase;


### PR DESCRIPTION
`set_certificate()` and `websocket_set_certificate()` are leftover IPC handlers
from the pre-cURL LibTLS era. `set_certificate()` unconditionally hit `TODO()`,
crashing RequestServer if ever invoked; the websocket variant returned success
without storing anything.

Replace both with working stubs, then wire `set_certificate()` to look up the
request by ID, store the provided certificate and key on it, and pass them to
cURL via `CURLOPT_SSLCERT_BLOB` / `CURLOPT_SSLKEY_BLOB` during
`handle_fetch_state()`.

The `certificate_requested` IPC is not yet sent, so this code path is not
reachable end-to-end. Adding a `RequestClientCertificate` state to the request
state machine is the next step (tracked in #8343).