### PR TITLE
LibWeb/DOM: Prefix inline event handler source text with "on" 

### DIFF
--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -448,12 +448,12 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
         if (name == HTML::EventNames::error && is<HTML::Window>(this)) {
             //  -> If name is onerror and eventTarget is a Window object
             //      Let the function have five arguments, named event, source, lineno, colno, and error.
-            source_builder.appendff("function {}(event, source, lineno, colno, error) {{\n{}\n}}", name, body);
+            source_builder.appendff("function on{}(event, source, lineno, colno, error) {{\n{}\n}}", name, body);
             parameters_string = "event, source, lineno, colno, error"sv;
         } else {
             //  -> Otherwise
             //      Let the function have a single argument called event.
-            source_builder.appendff("function {}(event) {{\n{}\n}}", name, body);
+            source_builder.appendff("function on{}(event) {{\n{}\n}}", name, body);
             parameters_string = "event"sv;
         }
 

--- a/Libraries/LibWeb/HTML/EventNames.h
+++ b/Libraries/LibWeb/HTML/EventNames.h
@@ -22,6 +22,7 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(audioend)                 \
     __ENUMERATE_HTML_EVENT(audioprocess)             \
     __ENUMERATE_HTML_EVENT(audiostart)               \
+    __ENUMERATE_HTML_EVENT(begin)                    \
     __ENUMERATE_HTML_EVENT(beforeinput)              \
     __ENUMERATE_HTML_EVENT(beforematch)              \
     __ENUMERATE_HTML_EVENT(beforeprint)              \
@@ -110,6 +111,7 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(rejectionhandled)         \
     __ENUMERATE_HTML_EVENT(remove)                   \
     __ENUMERATE_HTML_EVENT(removetrack)              \
+    __ENUMERATE_HTML_EVENT(repeat)                   \
     __ENUMERATE_HTML_EVENT(reset)                    \
     __ENUMERATE_HTML_EVENT(resize)                   \
     __ENUMERATE_HTML_EVENT(result)                   \

--- a/Libraries/LibWeb/SVG/SVGAnimationElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGAnimationElement.cpp
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGAnimationElement.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/Layout/Node.h>
 
 namespace Web::SVG {
@@ -23,6 +24,42 @@ void SVGAnimationElement::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGAnimationElement);
     Base::initialize(realm);
+}
+
+// https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onbegin
+void SVGAnimationElement::set_onbegin(GC::Ptr<WebIDL::CallbackType> value)
+{
+    set_event_handler_attribute(HTML::EventNames::begin, value);
+}
+
+// https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onbegin
+GC::Ptr<WebIDL::CallbackType> SVGAnimationElement::onbegin()
+{
+    return event_handler_attribute(HTML::EventNames::begin);
+}
+
+// https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onend
+void SVGAnimationElement::set_onend(GC::Ptr<WebIDL::CallbackType> value)
+{
+    set_event_handler_attribute(HTML::EventNames::end, value);
+}
+
+// https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onend
+GC::Ptr<WebIDL::CallbackType> SVGAnimationElement::onend()
+{
+    return event_handler_attribute(HTML::EventNames::error);
+}
+
+// https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onrepeat
+void SVGAnimationElement::set_onrepeat(GC::Ptr<WebIDL::CallbackType> value)
+{
+    set_event_handler_attribute(HTML::EventNames::end, value);
+}
+
+// https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onrepeat
+GC::Ptr<WebIDL::CallbackType> SVGAnimationElement::onrepeat()
+{
+    return event_handler_attribute(HTML::EventNames::repeat);
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGAnimationElement.h
+++ b/Libraries/LibWeb/SVG/SVGAnimationElement.h
@@ -17,6 +17,15 @@ class SVGAnimationElement final : public SVGElement {
     WEB_PLATFORM_OBJECT(SVGAnimationElement, SVGElement);
     GC_DECLARE_ALLOCATOR(SVGAnimationElement);
 
+    void set_onbegin(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onbegin();
+
+    void set_onend(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onend();
+
+    void set_onrepeat(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onrepeat();
+
 private:
     SVGAnimationElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/SVG/SVGAnimationElement.idl
+++ b/Libraries/LibWeb/SVG/SVGAnimationElement.idl
@@ -4,9 +4,9 @@ interface SVGAnimationElement : SVGElement {
 
     [FIXME] readonly attribute SVGElement? targetElement;
 
-    [FIXME] attribute EventHandler onbegin;
-    [FIXME] attribute EventHandler onend;
-    [FIXME] attribute EventHandler onrepeat;
+    attribute EventHandler onbegin;
+    attribute EventHandler onend;
+    attribute EventHandler onrepeat;
 
     [FIXME] float getStartTime();
     [FIXME] float getCurrentTime();

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/events/event-handler-sourcetext.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/events/event-handler-sourcetext.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	non-error event handler
+Pass	error event handler not on body
+Pass	error event handler on disconnected body
+Pass	error event handler on disconnected frameset
+Pass	error event handler on connected body, reflected to Window

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 1780 tests
 
-1098 Pass
-682 Fail
+1101 Pass
+679 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Document: original interface defined
@@ -1644,9 +1644,9 @@ Pass	SVGAnimationElement interface: existence and properties of interface protot
 Pass	SVGAnimationElement interface: existence and properties of interface prototype object's "constructor" property
 Pass	SVGAnimationElement interface: existence and properties of interface prototype object's @@unscopables property
 Fail	SVGAnimationElement interface: attribute targetElement
-Fail	SVGAnimationElement interface: attribute onbegin
-Fail	SVGAnimationElement interface: attribute onend
-Fail	SVGAnimationElement interface: attribute onrepeat
+Pass	SVGAnimationElement interface: attribute onbegin
+Pass	SVGAnimationElement interface: attribute onend
+Pass	SVGAnimationElement interface: attribute onrepeat
 Fail	SVGAnimationElement interface: operation getStartTime()
 Fail	SVGAnimationElement interface: operation getCurrentTime()
 Fail	SVGAnimationElement interface: operation getSimpleDuration()

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/events/event-handler-sourcetext.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/events/event-handler-sourcetext.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test the sourceText of event handlers</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/5500">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<body>
+<script>
+"use strict";
+
+test(() => {
+  const el = document.createElement("div");
+  el.setAttribute("onclick", "foo");
+  assert_equals(el.onclick.toString(), "function onclick(event) {\nfoo\n}");
+}, "non-error event handler");
+
+test(() => {
+  const el = document.createElement("div");
+  el.setAttribute("onerror", "foo");
+  assert_equals(el.onerror.toString(), "function onerror(event) {\nfoo\n}");
+}, "error event handler not on body");
+
+test(() => {
+  const el = document.createElement("body");
+  el.setAttribute("onerror", "foo");
+  assert_equals(el.onerror.toString(), "function onerror(event, source, lineno, colno, error) {\nfoo\n}");
+}, "error event handler on disconnected body");
+
+test(() => {
+  const el = document.createElement("frameset");
+  el.setAttribute("onerror", "foo");
+  assert_equals(el.onerror.toString(), "function onerror(event, source, lineno, colno, error) {\nfoo\n}");
+}, "error event handler on disconnected frameset");
+
+test(() => {
+  document.body.setAttribute("onerror", "foo");
+  assert_equals(window.onerror.toString(), "function onerror(event, source, lineno, colno, error) {\nfoo\n}");
+}, "error event handler on connected body, reflected to Window");
+</script>


### PR DESCRIPTION
Alongside implementing some EventHandler bindings I noticed in logs when running the test.
