### PR TITLE
AK: Keep `Utf16StringData` trailing storage out of tail padding

### DIFF
--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -151,7 +151,7 @@ private:
 
     mutable bool m_is_fly_string { false };
 
-    union {
+    union alignas(8) {
         char m_ascii_data[0];
         char16_t m_utf16_data[0];
     };

--- a/Tests/AK/TestUtf16String.cpp
+++ b/Tests/AK/TestUtf16String.cpp
@@ -445,6 +445,25 @@ TEST_CASE(from_string_builder)
     EXPECT_EQ(string, "ab😀𐀀🍕cd"sv);
 }
 
+TEST_CASE(from_string_builder_alignment)
+{
+    StringBuilder builder(StringBuilder::Mode::UTF16);
+    builder.append("\u00a0"sv);
+    builder.append(R"~~(
+<script>
+    const containsValidURL = input => {
+        return input.value.length !== 0 && input.checkValidity();
+    };
+</script>
+)~~"sv);
+
+    auto string1 = builder.to_utf16_string();
+    auto string2 = string1.to_utf8();
+
+    EXPECT_EQ(string1.code_unit_at(0), 0x00a0);
+    EXPECT_EQ(string2.bytes_as_string_view().substring_view(0, 2), "\u00a0"sv);
+}
+
 TEST_CASE(from_ipc_stream)
 {
     {


### PR DESCRIPTION
GCC 16 can clobber the first bytes of `Utf16StringData` payload when a `StringBuilder` buffer is reused for string construction. The trailing ASCII/UTF-16 storage previously started before `sizeof(Utf16StringData)`, inside tail padding, so placement-new of the header could zero the first code unit.

This patch aligns the trailing storage union so payload begins after the full header.

Fixes #9311