### PR TITLE
LibWeb: Implement name-only `@container` queries

### DIFF
--- a/Libraries/LibWeb/CSS/BooleanExpression.cpp
+++ b/Libraries/LibWeb/CSS/BooleanExpression.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::CSS {
 
-bool BooleanExpression::evaluate_to_boolean(DOM::Document const* document) const
+bool BooleanExpression::evaluate_to_boolean(BooleanExpressionEvaluationContext const& context) const
 {
-    return evaluate(document) == MatchResult::True;
+    return evaluate(context) == MatchResult::True;
 }
 
 void BooleanExpression::indent(StringBuilder& builder, int levels)
@@ -25,11 +25,11 @@ void GeneralEnclosed::dump(StringBuilder& builder, int indent_levels) const
     builder.appendff("GeneralEnclosed: {}\n", to_string());
 }
 
-MatchResult BooleanNotExpression::evaluate(DOM::Document const* document) const
+MatchResult BooleanNotExpression::evaluate(BooleanExpressionEvaluationContext const& context) const
 {
     // https://drafts.csswg.org/css-values-5/#boolean-logic
     // `not test` evaluates to true if its contained test is false, false if it’s true, and unknown if it’s unknown.
-    switch (m_child->evaluate(document)) {
+    switch (m_child->evaluate(context)) {
     case MatchResult::False:
         return MatchResult::True;
     case MatchResult::True:
@@ -52,9 +52,9 @@ void BooleanNotExpression::dump(StringBuilder& builder, int indent_levels) const
     m_child->dump(builder, indent_levels + 1);
 }
 
-MatchResult BooleanExpressionInParens::evaluate(DOM::Document const* document) const
+MatchResult BooleanExpressionInParens::evaluate(BooleanExpressionEvaluationContext const& context) const
 {
-    return m_child->evaluate(document);
+    return m_child->evaluate(context);
 }
 
 String BooleanExpressionInParens::to_string() const
@@ -71,14 +71,14 @@ void BooleanExpressionInParens::dump(StringBuilder& builder, int indent_levels) 
     builder.append(")\n"sv);
 }
 
-MatchResult BooleanAndExpression::evaluate(DOM::Document const* document) const
+MatchResult BooleanAndExpression::evaluate(BooleanExpressionEvaluationContext const& context) const
 {
     // https://drafts.csswg.org/css-values-5/#boolean-logic
     // Multiple tests connected with `and` evaluate to true if all of those tests are true, false if any of them are
     // false, and unknown otherwise (i.e. if at least one unknown, but no false).
     size_t true_results = 0;
     for (auto const& child : m_children) {
-        auto child_match = child->evaluate(document);
+        auto child_match = child->evaluate(context);
         if (child_match == MatchResult::False)
             return MatchResult::False;
         if (child_match == MatchResult::True)
@@ -102,14 +102,14 @@ void BooleanAndExpression::dump(StringBuilder& builder, int indent_levels) const
         child->dump(builder, indent_levels + 1);
 }
 
-MatchResult BooleanOrExpression::evaluate(DOM::Document const* document) const
+MatchResult BooleanOrExpression::evaluate(BooleanExpressionEvaluationContext const& context) const
 {
     // https://drafts.csswg.org/css-values-5/#boolean-logic
     // Multiple tests connected with `or` evaluate to true if any of those tests are true, false if all of them are
     // false, and unknown otherwise (i.e. at least one unknown, but no true).
     size_t false_results = 0;
     for (auto const& child : m_children) {
-        auto child_match = child->evaluate(document);
+        auto child_match = child->evaluate(context);
         if (child_match == MatchResult::True)
             return MatchResult::True;
         if (child_match == MatchResult::False)

--- a/Libraries/LibWeb/CSS/BooleanExpression.cpp
+++ b/Libraries/LibWeb/CSS/BooleanExpression.cpp
@@ -19,6 +19,11 @@ void BooleanExpression::indent(StringBuilder& builder, int levels)
     builder.append_repeated("  "sv, levels);
 }
 
+void GeneralEnclosed::collect_container_query_feature_requirements(ContainerQueryFeatureRequirements& requirements) const
+{
+    requirements.has_unknown_or_unsupported_feature = true;
+}
+
 void GeneralEnclosed::dump(StringBuilder& builder, int indent_levels) const
 {
     indent(builder, indent_levels);
@@ -40,6 +45,11 @@ MatchResult BooleanNotExpression::evaluate(BooleanExpressionEvaluationContext co
     VERIFY_NOT_REACHED();
 }
 
+void BooleanNotExpression::collect_container_query_feature_requirements(ContainerQueryFeatureRequirements& requirements) const
+{
+    m_child->collect_container_query_feature_requirements(requirements);
+}
+
 String BooleanNotExpression::to_string() const
 {
     return MUST(String::formatted("not {}", m_child->to_string()));
@@ -55,6 +65,11 @@ void BooleanNotExpression::dump(StringBuilder& builder, int indent_levels) const
 MatchResult BooleanExpressionInParens::evaluate(BooleanExpressionEvaluationContext const& context) const
 {
     return m_child->evaluate(context);
+}
+
+void BooleanExpressionInParens::collect_container_query_feature_requirements(ContainerQueryFeatureRequirements& requirements) const
+{
+    m_child->collect_container_query_feature_requirements(requirements);
 }
 
 String BooleanExpressionInParens::to_string() const
@@ -89,6 +104,12 @@ MatchResult BooleanAndExpression::evaluate(BooleanExpressionEvaluationContext co
     return MatchResult::Unknown;
 }
 
+void BooleanAndExpression::collect_container_query_feature_requirements(ContainerQueryFeatureRequirements& requirements) const
+{
+    for (auto const& child : m_children)
+        child->collect_container_query_feature_requirements(requirements);
+}
+
 String BooleanAndExpression::to_string() const
 {
     return MUST(String::join(" and "sv, m_children));
@@ -118,6 +139,12 @@ MatchResult BooleanOrExpression::evaluate(BooleanExpressionEvaluationContext con
     if (false_results == m_children.size())
         return MatchResult::False;
     return MatchResult::Unknown;
+}
+
+void BooleanOrExpression::collect_container_query_feature_requirements(ContainerQueryFeatureRequirements& requirements) const
+{
+    for (auto const& child : m_children)
+        child->collect_container_query_feature_requirements(requirements);
 }
 
 String BooleanOrExpression::to_string() const

--- a/Libraries/LibWeb/CSS/BooleanExpression.h
+++ b/Libraries/LibWeb/CSS/BooleanExpression.h
@@ -81,6 +81,15 @@ struct BooleanExpressionEvaluationContext {
     GC::Ptr<DOM::Element const> query_container { nullptr };
 };
 
+struct ContainerQueryFeatureRequirements {
+    bool requires_size_container : 1 { false };
+    bool requires_inline_size_container : 1 { false };
+    bool requires_block_size_container : 1 { false };
+    bool requires_style_container : 1 { false };
+    bool requires_scroll_state_container : 1 { false };
+    bool has_unknown_or_unsupported_feature : 1 { false };
+};
+
 // The contents of this file implement the `<boolean-expr>` concept.
 // https://drafts.csswg.org/css-values-5/#typedef-boolean-expr
 class BooleanExpression {
@@ -91,6 +100,7 @@ public:
     static void indent(StringBuilder& builder, int levels);
 
     virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const = 0;
+    virtual void collect_container_query_feature_requirements(ContainerQueryFeatureRequirements&) const { }
     virtual String to_string() const = 0;
     virtual void dump(StringBuilder&, int indent_levels = 0) const = 0;
 };
@@ -105,6 +115,7 @@ public:
     virtual ~GeneralEnclosed() override = default;
 
     virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override { return m_matches; }
+    virtual void collect_container_query_feature_requirements(ContainerQueryFeatureRequirements&) const override;
     virtual String to_string() const override { return m_serialized_contents; }
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -128,6 +139,7 @@ public:
     virtual ~BooleanNotExpression() override = default;
 
     virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
+    virtual void collect_container_query_feature_requirements(ContainerQueryFeatureRequirements&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -149,6 +161,7 @@ public:
     virtual ~BooleanExpressionInParens() override = default;
 
     virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
+    virtual void collect_container_query_feature_requirements(ContainerQueryFeatureRequirements&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -170,6 +183,7 @@ public:
     virtual ~BooleanAndExpression() override = default;
 
     virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
+    virtual void collect_container_query_feature_requirements(ContainerQueryFeatureRequirements&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -191,6 +205,7 @@ public:
     virtual ~BooleanOrExpression() override = default;
 
     virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
+    virtual void collect_container_query_feature_requirements(ContainerQueryFeatureRequirements&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 

--- a/Libraries/LibWeb/CSS/BooleanExpression.h
+++ b/Libraries/LibWeb/CSS/BooleanExpression.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2021-2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +9,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -75,16 +76,21 @@ constexpr StringView to_string(MatchResult result)
     VERIFY_NOT_REACHED();
 }
 
+struct BooleanExpressionEvaluationContext {
+    GC::Ptr<DOM::Document const> document { nullptr };
+    GC::Ptr<DOM::Element const> query_container { nullptr };
+};
+
 // The contents of this file implement the `<boolean-expr>` concept.
 // https://drafts.csswg.org/css-values-5/#typedef-boolean-expr
 class BooleanExpression {
 public:
     virtual ~BooleanExpression() = default;
 
-    bool evaluate_to_boolean(DOM::Document const*) const;
+    bool evaluate_to_boolean(BooleanExpressionEvaluationContext const&) const;
     static void indent(StringBuilder& builder, int levels);
 
-    virtual MatchResult evaluate(DOM::Document const*) const = 0;
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const = 0;
     virtual String to_string() const = 0;
     virtual void dump(StringBuilder&, int indent_levels = 0) const = 0;
 };
@@ -98,7 +104,7 @@ public:
     }
     virtual ~GeneralEnclosed() override = default;
 
-    virtual MatchResult evaluate(DOM::Document const*) const override { return m_matches; }
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override { return m_matches; }
     virtual String to_string() const override { return m_serialized_contents; }
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -121,7 +127,7 @@ public:
     }
     virtual ~BooleanNotExpression() override = default;
 
-    virtual MatchResult evaluate(DOM::Document const*) const override;
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -142,7 +148,7 @@ public:
     }
     virtual ~BooleanExpressionInParens() override = default;
 
-    virtual MatchResult evaluate(DOM::Document const*) const override;
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -163,7 +169,7 @@ public:
     }
     virtual ~BooleanAndExpression() override = default;
 
-    virtual MatchResult evaluate(DOM::Document const*) const override;
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -184,7 +190,7 @@ public:
     }
     virtual ~BooleanOrExpression() override = default;
 
-    virtual MatchResult evaluate(DOM::Document const*) const override;
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -205,7 +211,7 @@ public:
     }
     virtual ~ConstantBooleanExpression() override = default;
 
-    virtual MatchResult evaluate(DOM::Document const*) const override { return m_value; }
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override { return m_value; }
     virtual String to_string() const override { return MUST(String::from_utf8(CSS::to_string(m_value))); }
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 

--- a/Libraries/LibWeb/CSS/CSSContainerRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSContainerRule.cpp
@@ -34,6 +34,19 @@ void CSSContainerRule::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
+void CSSContainerRule::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_cached_parent_container_rule);
+}
+
+void CSSContainerRule::clear_caches()
+{
+    Base::clear_caches();
+    m_cached_parent_container_rule = nullptr;
+    m_parent_container_rule_cache_valid = false;
+}
+
 // https://drafts.csswg.org/css-conditional-5/#the-csscontainerrule-interface
 String CSSContainerRule::condition_text() const
 {
@@ -80,6 +93,23 @@ bool CSSContainerRule::condition_matches() const
 {
     // NB: @container is processed differently from other CSSConditionRules. As such this is never called.
     VERIFY_NOT_REACHED();
+}
+
+CSSContainerRule const* CSSContainerRule::find_parent_container_rule() const
+{
+    if (m_parent_container_rule_cache_valid)
+        return m_cached_parent_container_rule.ptr();
+
+    m_cached_parent_container_rule = nullptr;
+    for (auto const* rule = parent_rule(); rule; rule = rule->parent_rule()) {
+        if (auto const* container_rule = as_if<CSSContainerRule>(*rule)) {
+            m_cached_parent_container_rule = container_rule;
+            break;
+        }
+    }
+    m_parent_container_rule_cache_valid = true;
+
+    return m_cached_parent_container_rule.ptr();
 }
 
 // https://drafts.csswg.org/cssom-1/#serialize-a-css-rule

--- a/Libraries/LibWeb/CSS/CSSContainerRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSContainerRule.cpp
@@ -10,6 +10,8 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/ContainerQuery.h>
 #include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/DOM/AbstractElement.h>
+#include <LibWeb/DOM/Element.h>
 
 namespace Web::CSS {
 
@@ -95,6 +97,33 @@ bool CSSContainerRule::condition_matches() const
     VERIFY_NOT_REACHED();
 }
 
+static bool has_ancestor_container_with_name(DOM::AbstractElement const& element, FlyString const& container_name)
+{
+    Optional<FlyString> optional_container_name { container_name };
+    for (auto* container = element.element().flat_tree_parent_element(); container; container = container->flat_tree_parent_element()) {
+        if (container_name_matches(*container, optional_container_name))
+            return true;
+    }
+
+    return false;
+}
+
+bool CSSContainerRule::conditions_match(DOM::AbstractElement const& element) const
+{
+    for (auto const& condition : m_conditions) {
+        if (condition.container_query) {
+            if (condition.container_query->evaluate(element, condition.container_name) == MatchResult::True)
+                return true;
+            continue;
+        }
+
+        if (condition.container_name.has_value() && has_ancestor_container_with_name(element, *condition.container_name))
+            return true;
+    }
+
+    return false;
+}
+
 CSSContainerRule const* CSSContainerRule::find_parent_container_rule() const
 {
     if (m_parent_container_rule_cache_valid)
@@ -110,6 +139,17 @@ CSSContainerRule const* CSSContainerRule::find_parent_container_rule() const
     m_parent_container_rule_cache_valid = true;
 
     return m_cached_parent_container_rule.ptr();
+}
+
+bool CSSContainerRule::matches(DOM::AbstractElement const& element) const
+{
+    if (!conditions_match(element))
+        return false;
+
+    if (auto const* parent_container_rule = find_parent_container_rule())
+        return parent_container_rule->matches(element);
+
+    return true;
 }
 
 // https://drafts.csswg.org/cssom-1/#serialize-a-css-rule
@@ -213,47 +253,10 @@ void CSSContainerRule::for_each_effective_rule(TraversalOrder order, Function<vo
     // https://drafts.csswg.org/css-conditional-5/#container-rule
     // Global, name-defining at-rules such as @keyframes or @font-face or @layer that are defined inside container
     // queries are not constrained by the container query conditions.
-
-    // NB: Due to how @container queries are applied to an element instead of globally, this method only treats those
-    //     global, name-defining at-rules as effective.
-    // FIXME: Is this right?
-    for (auto const& rule : css_rules()) {
-        switch (rule->type()) {
-            // These are not valid inside @container.
-        case Type::Import:
-        case Type::FunctionDeclarations:
-        case Type::Namespace:
-        case Type::Keyframe:
-            break;
-
-            // These are effective if the container rule is effective, which is not handled in this method.
-        case Type::Container:
-        case Type::Media:
-        case Type::NestedDeclarations:
-        case Type::Style:
-        case Type::Supports:
-            break;
-
-            // These are global and always effective.
-        case Type::CounterStyle:
-        case Type::FontFace:
-        case Type::FontFeatureValues:
-        case Type::Function:
-        case Type::Keyframes:
-        case Type::LayerBlock:
-        case Type::LayerStatement:
-        case Type::Margin:
-        case Type::Page:
-        case Type::Property:
-            if (order == TraversalOrder::Preorder)
-                callback(rule);
-            if (auto* grouping_rule = as_if<CSSGroupingRule>(*rule))
-                grouping_rule->for_each_effective_rule(order, callback);
-            if (order == TraversalOrder::Postorder)
-                callback(rule);
-            break;
-        }
-    }
+    //
+    // NB: For other rules, we always treat them as effective now, and reject them later when our @container conditions
+    //     are evaluated.
+    CSSGroupingRule::for_each_effective_rule(order, callback);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSContainerRule.h
+++ b/Libraries/LibWeb/CSS/CSSContainerRule.h
@@ -47,9 +47,14 @@ private:
     CSSContainerRule(JS::Realm&, Vector<Condition>&&, CSSRuleList&);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
+    virtual void clear_caches() override;
     virtual String serialized() const override;
+    CSSContainerRule const* find_parent_container_rule() const;
 
     Vector<Condition> m_conditions;
+    mutable GC::Ptr<CSSContainerRule const> m_cached_parent_container_rule;
+    mutable bool m_parent_container_rule_cache_valid { false };
 };
 
 template<>

--- a/Libraries/LibWeb/CSS/CSSContainerRule.h
+++ b/Libraries/LibWeb/CSS/CSSContainerRule.h
@@ -9,6 +9,7 @@
 #include <AK/FlyString.h>
 #include <AK/Optional.h>
 #include <LibWeb/CSS/CSSConditionRule.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
@@ -34,6 +35,7 @@ public:
 
     virtual String condition_text() const override;
     virtual bool condition_matches() const override;
+    bool matches(DOM::AbstractElement const&) const;
 
     String container_name() const;
     String container_query() const;
@@ -51,6 +53,8 @@ private:
     virtual void clear_caches() override;
     virtual String serialized() const override;
     CSSContainerRule const* find_parent_container_rule() const;
+
+    bool conditions_match(DOM::AbstractElement const&) const;
 
     Vector<Condition> m_conditions;
     mutable GC::Ptr<CSSContainerRule const> m_cached_parent_container_rule;

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -18,7 +18,7 @@ NonnullRefPtr<ContainerQuery> ContainerQuery::create(NonnullOwnPtr<BooleanExpres
 
 ContainerQuery::ContainerQuery(NonnullOwnPtr<BooleanExpression>&& condition)
     : m_condition(move(condition))
-    , m_matches(m_condition->evaluate_to_boolean(nullptr))
+    , m_matches(m_condition->evaluate_to_boolean({}))
 {
 }
 

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -7,6 +7,9 @@
 #include "ContainerQuery.h"
 #include <AK/NonnullRefPtr.h>
 #include <LibWeb/CSS/BooleanExpression.h>
+#include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/DOM/AbstractElement.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/Dump.h>
 
 namespace Web::CSS {
@@ -20,13 +23,62 @@ ContainerQuery::ContainerQuery(NonnullOwnPtr<BooleanExpression>&& condition)
     : m_condition(move(condition))
     , m_matches(m_condition->evaluate_to_boolean({}))
 {
+    m_condition->collect_container_query_feature_requirements(m_feature_requirements);
 }
 
-ContainerQueryFeatureRequirements ContainerQuery::collect_feature_requirements() const
+static bool container_satisfies_requirements(DOM::Element const& element, ContainerQueryFeatureRequirements const& requirements)
 {
-    ContainerQueryFeatureRequirements requirements;
-    m_condition->collect_container_query_feature_requirements(requirements);
-    return requirements;
+    auto style = element.computed_properties();
+    if (!style)
+        return false;
+
+    auto container_type = style->container_type();
+
+    if (requirements.requires_size_container && !container_type.is_size_container)
+        return false;
+
+    if (requirements.requires_inline_size_container && !(container_type.is_size_container || container_type.is_inline_size_container))
+        return false;
+
+    if (requirements.requires_block_size_container && !container_type.is_size_container)
+        return false;
+
+    if (requirements.requires_scroll_state_container && !container_type.is_scroll_state_container)
+        return false;
+
+    return true;
+}
+
+// https://drafts.csswg.org/css-conditional-5/#container-rule
+MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Optional<FlyString> const& container_name) const
+{
+    // If the <container-query> contains unknown or unsupported container features, no query container will be selected
+    // for that <container-condition>.
+    if (m_feature_requirements.has_unknown_or_unsupported_feature)
+        return MatchResult::Unknown;
+
+    // For each element, the query container to be queried is selected from among the element’s ancestor query
+    // containers that are established as a valid query container for all the container features in the
+    // <container-query>.
+    for (auto const* container = element.element().flat_tree_parent_element(); container; container = container->flat_tree_parent_element()) {
+        // The <container-name> filters the set of query containers considered to just those with a matching query
+        // container name.
+        if (!container_name_matches(*container, container_name))
+            continue;
+
+        if (!container_satisfies_requirements(*container, m_feature_requirements))
+            continue;
+
+        // Once an eligible query container has been selected for an element, each container feature in the
+        // <container-query> is evaluated against that query container.
+        return m_condition->evaluate({
+            .document = &element.document(),
+            .query_container = container,
+        });
+    }
+
+    // If no ancestor is an eligible query container, then the container query is unknown for that element.
+    return MatchResult::Unknown;
 }
 
 String ContainerQuery::to_string() const
@@ -39,6 +91,17 @@ void ContainerQuery::dump(StringBuilder& builder, int indent_levels) const
     dump_indent(builder, indent_levels);
     builder.appendff("Container query: (matches = {})\n", m_matches);
     m_condition->dump(builder, indent_levels + 1);
+}
+
+bool container_name_matches(DOM::Element const& element, Optional<FlyString> const& container_name)
+{
+    if (!container_name.has_value())
+        return true;
+
+    if (auto style = element.computed_properties())
+        return style->container_name().contains_slow(*container_name);
+
+    return false;
 }
 
 }

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -22,6 +22,13 @@ ContainerQuery::ContainerQuery(NonnullOwnPtr<BooleanExpression>&& condition)
 {
 }
 
+ContainerQueryFeatureRequirements ContainerQuery::collect_feature_requirements() const
+{
+    ContainerQueryFeatureRequirements requirements;
+    m_condition->collect_container_query_feature_requirements(requirements);
+    return requirements;
+}
+
 String ContainerQuery::to_string() const
 {
     return m_condition->to_string();

--- a/Libraries/LibWeb/CSS/ContainerQuery.h
+++ b/Libraries/LibWeb/CSS/ContainerQuery.h
@@ -18,6 +18,7 @@ public:
     static NonnullRefPtr<ContainerQuery> create(NonnullOwnPtr<BooleanExpression>&&);
 
     bool matches() const { return m_matches; }
+    ContainerQueryFeatureRequirements collect_feature_requirements() const;
     String to_string() const;
 
     void dump(StringBuilder&, int indent_levels = 0) const;

--- a/Libraries/LibWeb/CSS/ContainerQuery.h
+++ b/Libraries/LibWeb/CSS/ContainerQuery.h
@@ -18,7 +18,8 @@ public:
     static NonnullRefPtr<ContainerQuery> create(NonnullOwnPtr<BooleanExpression>&&);
 
     bool matches() const { return m_matches; }
-    ContainerQueryFeatureRequirements collect_feature_requirements() const;
+    ContainerQueryFeatureRequirements const& feature_requirements() const { return m_feature_requirements; }
+    MatchResult evaluate(DOM::AbstractElement const&, Optional<FlyString> const& container_name) const;
     String to_string() const;
 
     void dump(StringBuilder&, int indent_levels = 0) const;
@@ -27,7 +28,10 @@ private:
     explicit ContainerQuery(NonnullOwnPtr<BooleanExpression>&&);
 
     NonnullOwnPtr<BooleanExpression> m_condition;
+    ContainerQueryFeatureRequirements m_feature_requirements;
     bool m_matches { false };
 };
+
+bool container_name_matches(DOM::Element const&, Optional<FlyString> const& container_name);
 
 }

--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -80,8 +80,9 @@ String MediaFeature::to_string() const
     VERIFY_NOT_REACHED();
 }
 
-MatchResult MediaFeature::evaluate(DOM::Document const* document) const
+MatchResult MediaFeature::evaluate(BooleanExpressionEvaluationContext const& context) const
 {
+    auto const& document = context.document;
     VERIFY(document);
 
     // FIXME: In some cases (e.g. when parsing HTML using DOMParser::parse_from_string()) a document may not be associated with a window -
@@ -293,7 +294,7 @@ bool MediaQuery::evaluate(DOM::Document const& document)
     MatchResult result = matches_media(m_media_type);
 
     if ((result != MatchResult::False) && m_media_condition)
-        result = result && m_media_condition->evaluate(&document);
+        result = result && m_media_condition->evaluate({ .document = document });
 
     if (m_negated)
         result = negate(result);

--- a/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Libraries/LibWeb/CSS/MediaQuery.h
@@ -144,7 +144,7 @@ public:
             }));
     }
 
-    virtual MatchResult evaluate(DOM::Document const*) const override;
+    virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
     virtual String to_string() const override;
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 

--- a/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
@@ -347,7 +347,7 @@ static Vector<ComponentValue> replace_an_if_function(DOM::AbstractElement& eleme
         //    evaluates to false.
         //    If the result of condition is false, continue.
         // FIXME: Implement the above behavior once we support style queries.
-        auto condition_evaluation_result = maybe_parsed_if_condition->evaluate(&element.element().document());
+        auto condition_evaluation_result = maybe_parsed_if_condition->evaluate({ .document = element.element().document() });
 
         if (condition_evaluation_result == MatchResult::False)
             continue;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2100,7 +2100,7 @@ NonnullRefPtr<StyleValue const> Parser::parse_as_sizes_attribute(DOM::Element co
         // "If the result of any of the above productions is used in any
         // context that expects a two-valued boolean, 'unknown' must be
         // converted to 'false'."
-        if (m_document && !media_condition->evaluate_to_boolean(m_document))
+        if (m_document && !media_condition->evaluate_to_boolean({ .document = m_document }))
             continue;
 
         // 5. If size is not auto, then return size. Otherwise, continue.

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -844,7 +844,7 @@ template<typename NestedDeclarationsRule>
 GC::Ptr<CSSContainerRule> Parser::convert_to_container_rule(AtRule const& rule, Nested nested)
 {
     // @container <container-condition># {
-    //   <block-contents>
+    //   <rule-list>
     // }
     // <container-condition> = [ <container-name>? <container-query>? ]!
     // <container-name> = <custom-ident>

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 #include <LibWeb/CSS/CSSAnimation.h>
+#include <LibWeb/CSS/CSSContainerRule.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSLayerBlockRule.h>
 #include <LibWeb/CSS/CSSLayerStatementRule.h>
@@ -276,6 +277,9 @@ Vector<StyleComputer::ScopedMatchingRule> StyleComputer::collect_matching_rules(
             || (shadow_root && !rule_root && shadow_root->uses_document_style_sheets());
 
         if (!rule_is_relevant_for_current_scope)
+            return;
+
+        if (rule_to_run.container_rule && !rule_to_run.container_rule->matches(abstract_element))
             return;
 
         auto const& selector = rule_to_run.selector;

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -95,6 +95,9 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
         return invalidation;
     }
 
+    if (AK::first_is_one_of(property_id, CSS::PropertyID::ContainerName, CSS::PropertyID::ContainerType))
+        invalidation.recompute_descendant_styles = true;
+
     // OPTIMIZATION: Special handling for CSS `visibility`:
     if (property_id == CSS::PropertyID::Visibility) {
         // We don't need to relayout if the visibility changes from visible to hidden or vice versa. Only collapse requires relayout.

--- a/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -16,6 +16,8 @@ struct RequiredInvalidationAfterStyleChange {
     bool relayout : 1 { false };
     bool rebuild_layout_tree : 1 { false };
     bool rebuild_accumulated_visual_contexts : 1 { false };
+    // The element's change affects rule matching for descendants, without necessarily changing inherited style.
+    bool recompute_descendant_styles : 1 { false };
 
     void operator|=(RequiredInvalidationAfterStyleChange const& other)
     {
@@ -24,9 +26,10 @@ struct RequiredInvalidationAfterStyleChange {
         relayout |= other.relayout;
         rebuild_layout_tree |= other.rebuild_layout_tree;
         rebuild_accumulated_visual_contexts |= other.rebuild_accumulated_visual_contexts;
+        recompute_descendant_styles |= other.recompute_descendant_styles;
     }
 
-    [[nodiscard]] bool is_none() const { return !repaint && !rebuild_stacking_context_tree && !relayout && !rebuild_layout_tree && !rebuild_accumulated_visual_contexts; }
+    [[nodiscard]] bool is_none() const { return !repaint && !rebuild_stacking_context_tree && !relayout && !rebuild_layout_tree && !rebuild_accumulated_visual_contexts && !recompute_descendant_styles; }
     [[nodiscard]] bool is_full() const { return repaint && rebuild_stacking_context_tree && relayout && rebuild_layout_tree; }
     static RequiredInvalidationAfterStyleChange full() { return { true, true, true, true, false }; }
 };

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -6,6 +6,9 @@
  */
 
 #include <LibCore/ReportTime.h>
+#include <LibWeb/CSS/CSSConditionRule.h>
+#include <LibWeb/CSS/CSSContainerRule.h>
+#include <LibWeb/CSS/CSSGroupingRule.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSLayerBlockRule.h>
@@ -73,6 +76,7 @@ void MatchingRule::visit_edges(GC::Cell::Visitor& visitor)
 {
     visitor.visit(rule);
     visitor.visit(sheet);
+    visitor.visit(container_rule);
 }
 
 void RuleCache::visit_edges(GC::Cell::Visitor& visitor)
@@ -214,6 +218,89 @@ static CSSStyleSheet& svg_stylesheet()
     return *sheet;
 }
 
+static GC::Ptr<CSSContainerRule const> current_container_rule(Vector<GC::Ptr<CSSContainerRule const>> const& container_rule_stack)
+{
+    if (container_rule_stack.is_empty())
+        return nullptr;
+    return container_rule_stack.last();
+}
+
+using RuleCacheStyleRuleCallback = Function<void(CSSRule const&, GC::Ptr<CSSContainerRule const>)>;
+
+static void for_each_style_producing_rule_for_rule_cache(
+    CSSRuleList const& rule_list,
+    Vector<GC::Ptr<CSSContainerRule const>>& container_rule_stack,
+    RuleCacheStyleRuleCallback const& callback);
+
+static void for_each_style_producing_rule_for_rule_cache(
+    CSSStyleSheet const& sheet,
+    Vector<GC::Ptr<CSSContainerRule const>>& container_rule_stack,
+    RuleCacheStyleRuleCallback const& callback)
+{
+    if (!sheet.media()->matches())
+        return;
+    for_each_style_producing_rule_for_rule_cache(sheet.rules(), container_rule_stack, callback);
+}
+
+static void for_each_style_producing_rule_for_rule_cache(
+    CSSRuleList const& rule_list,
+    Vector<GC::Ptr<CSSContainerRule const>>& container_rule_stack,
+    RuleCacheStyleRuleCallback const& callback)
+{
+    for (auto const& rule : rule_list) {
+        switch (rule->type()) {
+        case CSSRule::Type::Import: {
+            auto const& import_rule = as<CSSImportRule>(*rule);
+            if (import_rule.loaded_style_sheet())
+                for_each_style_producing_rule_for_rule_cache(*import_rule.loaded_style_sheet(), container_rule_stack, callback);
+            break;
+        }
+
+        case CSSRule::Type::Container: {
+            auto const& container_rule = as<CSSContainerRule>(*rule);
+            // @container conditions are element-dependent, so keep their style rules and evaluate the container later.
+            container_rule_stack.append(&container_rule);
+            for_each_style_producing_rule_for_rule_cache(container_rule.css_rules(), container_rule_stack, callback);
+            container_rule_stack.take_last();
+            break;
+        }
+
+        case CSSRule::Type::Media:
+        case CSSRule::Type::Supports:
+            if (as<CSSConditionRule>(*rule).condition_matches())
+                for_each_style_producing_rule_for_rule_cache(as<CSSGroupingRule>(*rule).css_rules(), container_rule_stack, callback);
+            break;
+
+        case CSSRule::Type::LayerBlock:
+        case CSSRule::Type::Page:
+            for_each_style_producing_rule_for_rule_cache(as<CSSGroupingRule>(*rule).css_rules(), container_rule_stack, callback);
+            break;
+
+        case CSSRule::Type::Style:
+            callback(*rule, current_container_rule(container_rule_stack));
+            for_each_style_producing_rule_for_rule_cache(as<CSSGroupingRule>(*rule).css_rules(), container_rule_stack, callback);
+            break;
+
+        case CSSRule::Type::NestedDeclarations:
+            callback(*rule, current_container_rule(container_rule_stack));
+            break;
+
+        case CSSRule::Type::CounterStyle:
+        case CSSRule::Type::FontFace:
+        case CSSRule::Type::FontFeatureValues:
+        case CSSRule::Type::Function:
+        case CSSRule::Type::FunctionDeclarations:
+        case CSSRule::Type::Keyframe:
+        case CSSRule::Type::Keyframes:
+        case CSSRule::Type::LayerStatement:
+        case CSSRule::Type::Margin:
+        case CSSRule::Type::Namespace:
+        case CSSRule::Type::Property:
+            break;
+        }
+    }
+}
+
 void StyleScope::for_each_stylesheet(CascadeOrigin cascade_origin, Function<void(CSS::CSSStyleSheet&)> const& callback) const
 {
     if (cascade_origin == CascadeOrigin::UserAgent) {
@@ -253,7 +340,8 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
         }();
 
         size_t rule_index = 0;
-        sheet.for_each_effective_style_producing_rule([&](auto const& rule) {
+        Vector<GC::Ptr<CSSContainerRule const>> container_rule_stack;
+        for_each_style_producing_rule_for_rule_cache(sheet, container_rule_stack, [&](auto const& rule, auto container_rule) {
             SelectorList const& absolutized_selectors = [&]() {
                 if (rule.type() == CSSRule::Type::Style)
                     return static_cast<CSSStyleRule const&>(rule).absolutized_selectors();
@@ -270,6 +358,7 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                 MatchingRule matching_rule {
                     .rule = &rule,
                     .sheet = sheet,
+                    .container_rule = container_rule,
                     .default_namespace = sheet.default_namespace(),
                     .selector = selector,
                     .style_sheet_index = style_sheet_index,

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -30,6 +30,7 @@ class StyleScope;
 struct MatchingRule {
     GC::Ptr<CSSRule const> rule; // Either CSSStyleRule or CSSNestedDeclarations
     GC::Ptr<CSSStyleSheet const> sheet;
+    GC::Ptr<CSSContainerRule const> container_rule;
     Optional<FlyString> default_namespace;
     Selector const& selector;
     size_t style_sheet_index { 0 };

--- a/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Libraries/LibWeb/CSS/Supports.cpp
@@ -14,10 +14,10 @@ namespace Web::CSS {
 Supports::Supports(NonnullOwnPtr<BooleanExpression>&& condition)
     : m_condition(move(condition))
 {
-    m_matches = m_condition->evaluate_to_boolean(nullptr);
+    m_matches = m_condition->evaluate_to_boolean({});
 }
 
-MatchResult Supports::Declaration::evaluate(DOM::Document const*) const
+MatchResult Supports::Declaration::evaluate(BooleanExpressionEvaluationContext const&) const
 {
     return as_match_result(m_matches);
 }
@@ -33,7 +33,7 @@ void Supports::Declaration::dump(StringBuilder& builder, int indent_levels) cons
     builder.appendff("Declaration: `{}`, matches={}\n", m_declaration, m_matches);
 }
 
-MatchResult Supports::Selector::evaluate(DOM::Document const*) const
+MatchResult Supports::Selector::evaluate(BooleanExpressionEvaluationContext const&) const
 {
     return as_match_result(m_matches);
 }
@@ -49,7 +49,7 @@ void Supports::Selector::dump(StringBuilder& builder, int indent_levels) const
     builder.appendff("Selector: `{}` matches={}\n", m_selector, m_matches);
 }
 
-MatchResult Supports::FontTech::evaluate(DOM::Document const*) const
+MatchResult Supports::FontTech::evaluate(BooleanExpressionEvaluationContext const&) const
 {
     return as_match_result(m_matches);
 }
@@ -65,7 +65,7 @@ void Supports::FontTech::dump(StringBuilder& builder, int indent_levels) const
     builder.appendff("FontTech: `{}` matches={}\n", m_tech, m_matches);
 }
 
-MatchResult Supports::FontFormat::evaluate(DOM::Document const*) const
+MatchResult Supports::FontFormat::evaluate(BooleanExpressionEvaluationContext const&) const
 {
     return as_match_result(m_matches);
 }
@@ -81,7 +81,7 @@ void Supports::FontFormat::dump(StringBuilder& builder, int indent_levels) const
     builder.appendff("FontFormat: `{}` matches={}\n", m_format, m_matches);
 }
 
-MatchResult Supports::Env::evaluate(DOM::Document const*) const
+MatchResult Supports::Env::evaluate(BooleanExpressionEvaluationContext const&) const
 {
     return as_match_result(m_matches);
 }

--- a/Libraries/LibWeb/CSS/Supports.h
+++ b/Libraries/LibWeb/CSS/Supports.h
@@ -26,7 +26,7 @@ public:
         }
         virtual ~Declaration() override = default;
 
-        virtual MatchResult evaluate(DOM::Document const*) const override;
+        virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
         virtual String to_string() const override;
         virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -48,7 +48,7 @@ public:
         }
         virtual ~Selector() override = default;
 
-        virtual MatchResult evaluate(DOM::Document const*) const override;
+        virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
         virtual String to_string() const override;
         virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -70,7 +70,7 @@ public:
         }
         virtual ~FontTech() override = default;
 
-        virtual MatchResult evaluate(DOM::Document const*) const override;
+        virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
         virtual String to_string() const override;
         virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -92,7 +92,7 @@ public:
         }
         virtual ~FontFormat() override = default;
 
-        virtual MatchResult evaluate(DOM::Document const*) const override;
+        virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
         virtual String to_string() const override;
         virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
@@ -114,7 +114,7 @@ public:
         }
         virtual ~Env() override = default;
 
-        virtual MatchResult evaluate(DOM::Document const*) const override;
+        virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
         virtual String to_string() const override;
         virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1805,7 +1805,13 @@ bool Document::layout_is_up_to_date() const
         && m_svg_roots_needing_relayout.is_empty();
 }
 
-[[nodiscard]] static CSS::RequiredInvalidationAfterStyleChange update_style_recursively(Node& node, CSS::StyleComputer& style_computer, bool needs_inherited_style_update, bool recompute_elements_depending_on_custom_properties, bool parent_display_changed)
+[[nodiscard]] static CSS::RequiredInvalidationAfterStyleChange update_style_recursively(
+    Node& node,
+    CSS::StyleComputer& style_computer,
+    bool needs_inherited_style_update,
+    bool recompute_elements_depending_on_custom_properties,
+    bool parent_display_changed,
+    bool ancestor_needs_descendant_style_recompute)
 {
     bool const needs_full_style_update = node.document().needs_full_style_update();
     CSS::RequiredInvalidationAfterStyleChange invalidation;
@@ -1827,7 +1833,12 @@ bool Document::layout_is_up_to_date() const
         //        include media conditions, or b) the data used to resolve media queries hasn't changed.
         bool const needs_style_update_due_to_if_media = element.style_uses_if_css_function();
 
-        if (needs_full_style_update || node.needs_style_update() || parent_display_changed || (recompute_elements_depending_on_custom_properties && (element.style_uses_var_css_function() || element.style_uses_inherit_css_function())) || needs_style_update_due_to_if_media) {
+        if (needs_full_style_update
+            || node.needs_style_update()
+            || parent_display_changed
+            || ancestor_needs_descendant_style_recompute
+            || (recompute_elements_depending_on_custom_properties && (element.style_uses_var_css_function() || element.style_uses_inherit_css_function()))
+            || needs_style_update_due_to_if_media) {
             node_invalidation = element.recompute_style(did_change_custom_properties);
         } else if (needs_inherited_style_update) {
             node_invalidation = element.recompute_inherited_style();
@@ -1859,11 +1870,29 @@ bool Document::layout_is_up_to_date() const
     // NB: When display changes to/from flex/grid/contents, children may need to be blockified or un-blockified.
     //     This requires a full style recompute, not just inherited style update.
     bool children_need_full_style_recompute = node_invalidation.rebuild_layout_tree;
-    if (needs_full_style_update || node.child_needs_style_update() || children_need_inherited_style_update || recompute_elements_depending_on_custom_properties || children_need_full_style_recompute) {
+    bool descendant_style_recompute_needed = ancestor_needs_descendant_style_recompute || node_invalidation.recompute_descendant_styles;
+    if (needs_full_style_update
+        || node.child_needs_style_update()
+        || children_need_inherited_style_update
+        || recompute_elements_depending_on_custom_properties
+        || children_need_full_style_recompute
+        || descendant_style_recompute_needed) {
         if (node.is_element()) {
             if (auto shadow_root = static_cast<DOM::Element&>(node).shadow_root()) {
-                if (needs_full_style_update || shadow_root->needs_style_update() || shadow_root->child_needs_style_update()) {
-                    auto subtree_invalidation = update_style_recursively(*shadow_root, style_computer, children_need_inherited_style_update, recompute_elements_depending_on_custom_properties, children_need_full_style_recompute);
+                if (needs_full_style_update
+                    || shadow_root->needs_style_update()
+                    || shadow_root->child_needs_style_update()
+                    || children_need_inherited_style_update
+                    || recompute_elements_depending_on_custom_properties
+                    || children_need_full_style_recompute
+                    || descendant_style_recompute_needed) {
+                    auto subtree_invalidation = update_style_recursively(
+                        *shadow_root,
+                        style_computer,
+                        children_need_inherited_style_update,
+                        recompute_elements_depending_on_custom_properties,
+                        children_need_full_style_recompute,
+                        descendant_style_recompute_needed);
                     if (!is_display_none)
                         invalidation |= subtree_invalidation;
                 }
@@ -1871,8 +1900,20 @@ bool Document::layout_is_up_to_date() const
         }
 
         node.for_each_child([&](auto& child) {
-            if (needs_full_style_update || child.needs_style_update() || children_need_inherited_style_update || child.child_needs_style_update() || recompute_elements_depending_on_custom_properties || children_need_full_style_recompute) {
-                auto subtree_invalidation = update_style_recursively(child, style_computer, children_need_inherited_style_update, recompute_elements_depending_on_custom_properties, children_need_full_style_recompute);
+            if (needs_full_style_update
+                || child.needs_style_update()
+                || children_need_inherited_style_update
+                || child.child_needs_style_update()
+                || recompute_elements_depending_on_custom_properties
+                || children_need_full_style_recompute
+                || descendant_style_recompute_needed) {
+                auto subtree_invalidation = update_style_recursively(
+                    child,
+                    style_computer,
+                    children_need_inherited_style_update,
+                    recompute_elements_depending_on_custom_properties,
+                    children_need_full_style_recompute,
+                    descendant_style_recompute_needed);
                 if (!is_display_none)
                     invalidation |= subtree_invalidation;
             }
@@ -1929,7 +1970,7 @@ void Document::update_style()
 
     build_registered_properties_cache();
 
-    auto invalidation = update_style_recursively(*this, style_computer(), false, false, false);
+    auto invalidation = update_style_recursively(*this, style_computer(), false, false, false, false);
     if (!invalidation.is_none())
         invalidate_display_list();
 

--- a/Tests/LibWeb/Text/expected/css/container-rule-matching.txt
+++ b/Tests/LibWeb/Text/expected/css/container-rule-matching.txt
@@ -1,0 +1,8 @@
+matching-child color: rgb(0, 128, 0)
+matching-child background-color: rgb(255, 255, 255)
+non-matching-child color: rgb(0, 0, 0)
+non-matching-child background-color: rgb(255, 255, 255)
+nested-child color: rgb(0, 128, 0)
+nested-child background-color: rgb(255, 255, 255)
+outer-missing-inner-matching-child color: rgb(0, 128, 0)
+outer-missing-inner-matching-child background-color: rgb(255, 255, 255)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+1 Pass
+2 Fail
+Fail	Initially selects #couter as --foo container, both match
+Pass	Remove #couter --foo container-name, none match
+Fail	Make #cinner a --foo container, #inner starts matching

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.txt
@@ -4,6 +4,6 @@ Found 3 tests
 
 1 Pass
 2 Fail
-Fail	Initially selects #couter as --foo container, both match
-Pass	Remove #couter --foo container-name, none match
+Pass	Initially selects #couter as --foo container, both match
+Fail	Remove #couter --foo container-name, none match
 Fail	Make #cinner a --foo container, #inner starts matching

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-1 Pass
-2 Fail
+3 Pass
 Pass	Initially selects #couter as --foo container, both match
-Fail	Remove #couter --foo container-name, none match
-Fail	Make #cinner a --foo container, #inner starts matching
+Pass	Remove #couter --foo container-name, none match
+Pass	Make #cinner a --foo container, #inner starts matching

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+1 Pass
+4 Fail
+Fail	match closest named container
+Fail	match ancestor named container
+Pass	no match for unused container name
+Fail	match named container in shadow
+Fail	match named container in outer scope

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/query-container-name.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-1 Pass
-4 Fail
-Fail	match closest named container
-Fail	match ancestor named container
+5 Pass
+Pass	match closest named container
+Pass	match ancestor named container
 Pass	no match for unused container name
-Fail	match named container in shadow
-Fail	match named container in outer scope
+Pass	match named container in shadow
+Pass	match named container in outer scope

--- a/Tests/LibWeb/Text/input/css/container-rule-matching.html
+++ b/Tests/LibWeb/Text/input/css/container-rule-matching.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+.target {
+    background-color: white;
+    color: black;
+}
+
+#matching-container {
+    container-name: matching;
+}
+
+#non-matching-container {
+    container-name: other;
+}
+
+#outer-container {
+    container-name: outer;
+}
+
+#inner-container {
+    container-name: inner;
+}
+
+@container matching {
+    #matching-child {
+        color: green;
+    }
+
+    #non-matching-child {
+        color: red;
+    }
+}
+
+@container outer {
+    @container inner {
+        #nested-child {
+            color: green;
+        }
+    }
+}
+
+@container inner {
+    #outer-missing-inner-matching-child {
+        color: green;
+    }
+}
+
+@container missing {
+    @container inner {
+        #nested-child {
+            background-color: red;
+        }
+
+        #outer-missing-inner-matching-child {
+            color: red;
+        }
+    }
+}
+</style>
+<div id="matching-container">
+    <div id="matching-child" class="target"></div>
+</div>
+<div id="non-matching-container">
+    <div id="non-matching-child" class="target"></div>
+</div>
+<div id="outer-container">
+    <div id="inner-container">
+        <div id="nested-child" class="target"></div>
+        <div id="outer-missing-inner-matching-child" class="target"></div>
+    </div>
+</div>
+<script>
+test(() => {
+    for (const id of ["matching-child", "non-matching-child", "nested-child", "outer-missing-inner-matching-child"]) {
+        const style = getComputedStyle(document.getElementById(id));
+        println(`${id} color: ${style.color}`);
+        println(`${id} background-color: ${style.backgroundColor}`);
+    }
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/container-queries/query-container-name-dynamic.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>@container: query container name, dynamic changes</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#container-rule">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+  .container { container-name: --foo; }
+  #inner { --match-inner: no; }
+  #outer { --match-outer: no; }
+  @container --foo { #inner { --match-inner: yes; } }
+  @container --foo { #outer { --match-outer: yes; } }
+</style>
+<div id="couter" class="container">
+  <div id="outer">
+    <div id="cinner">
+      <div id="inner"></div>
+    </div>
+  </div>
+</div>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(inner).getPropertyValue("--match-inner"), "yes", "#inner target");
+    assert_equals(getComputedStyle(outer).getPropertyValue("--match-outer"), "yes", "#outer target");
+  }, "Initially selects #couter as --foo container, both match");
+
+  test(() => {
+    couter.classList.toggle("container");
+    assert_equals(getComputedStyle(inner).getPropertyValue("--match-inner"), "no", "#inner target");
+    assert_equals(getComputedStyle(outer).getPropertyValue("--match-outer"), "no", "#outer target");
+  }, "Remove #couter --foo container-name, none match");
+
+  test(() => {
+    cinner.classList.toggle("container");
+    assert_equals(getComputedStyle(inner).getPropertyValue("--match-inner"), "yes", "#inner target");
+    assert_equals(getComputedStyle(outer).getPropertyValue("--match-outer"), "no", "#outer target");
+  }, "Make #cinner a --foo container, #inner starts matching");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/container-queries/query-container-name.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/container-queries/query-container-name.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>@container: query container name, no query part</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#container-rule">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+  #inner { container-name: --foo }
+  #outer { container-name: --bar }
+  #target {
+    --match-foo: no;
+    --match-bar: no;
+    --match-baz: no;
+  }
+  @container --foo { #target { --match-foo: yes; } }
+  @container --bar { #target { --match-bar: yes; } }
+  @container --baz { #target { --match-baz: yes; } }
+</style>
+<div id="outer">
+  <div id="inner">
+    <div id="target"></div>
+  </div>
+</div>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(target).getPropertyValue("--match-foo"), "yes");
+  }, "match closest named container");
+
+  test(() => {
+    assert_equals(getComputedStyle(target).getPropertyValue("--match-bar"), "yes");
+  }, "match ancestor named container");
+
+  test(() => {
+    assert_equals(getComputedStyle(target).getPropertyValue("--match-baz"), "no");
+  }, "no match for unused container name");
+</script>
+
+<style>
+  @container --in-shadow {
+    #slotted { --match-in-shadow: yes; }
+  }
+</style>
+<div id="host" style="container-name: --for-host">
+  <template shadowrootmode="open">
+    <style>
+      @container --for-host {
+        #in-shadow { --match-for-host: yes; }
+      }
+    </style>
+    <div style="container-name: --in-shadow">
+      <div id="in-shadow"></div>
+      <slot></slot>
+    </div>
+  </template>
+  <div id="slotted"></div>
+</div>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(slotted).getPropertyValue("--match-in-shadow"), "yes");
+  }, "match named container in shadow");
+
+  test(() => {
+    assert_equals(getComputedStyle(host.shadowRoot.querySelector("#in-shadow")).getPropertyValue("--match-for-host"), "yes");
+  }, "match named container in outer scope");
+</script>


### PR DESCRIPTION
These are the simplest type to start with: Just a name, no conditions. But they are technically container queries!

Implementing the conditions will come in subsequent PRs.