### PR TITLE
LibCrypto: Add SecureStore for encrypted blob storage

### DIFF
--- a/Libraries/LibCrypto/CMakeLists.txt
+++ b/Libraries/LibCrypto/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     Curves/EdwardsCurve.cpp
     Curves/SECPxxxr1.cpp
     KeyProvider.cpp
+    SecureStore.cpp
     Hash/Argon2.cpp
     Hash/SHAKE.cpp
     Hash/BLAKE2b.cpp

--- a/Libraries/LibCrypto/CMakeLists.txt
+++ b/Libraries/LibCrypto/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     Cipher/ChaCha.cpp
     Curves/EdwardsCurve.cpp
     Curves/SECPxxxr1.cpp
+    KeyProvider.cpp
     Hash/Argon2.cpp
     Hash/SHAKE.cpp
     Hash/BLAKE2b.cpp

--- a/Libraries/LibCrypto/KeyProvider.cpp
+++ b/Libraries/LibCrypto/KeyProvider.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Memory.h>
+#include <AK/ScopeGuard.h>
+#include <LibCrypto/Hash/Argon2.h>
+#include <LibCrypto/KeyProvider.h>
+
+namespace Crypto {
+
+ErrorOr<NonnullOwnPtr<PasswordKeyProvider>> PasswordKeyProvider::create(StringView password, Parameters params)
+{
+    auto password_buf = TRY(SecureByteBuffer::copy(password.bytes()));
+    return adopt_own(*new PasswordKeyProvider(move(password_buf), params));
+}
+
+PasswordKeyProvider::PasswordKeyProvider(SecureByteBuffer password, Parameters params)
+    : m_password(move(password))
+    , m_params(params)
+{
+}
+
+ErrorOr<SecureByteBuffer> PasswordKeyProvider::derive_key(ReadonlyBytes salt)
+{
+    Hash::Argon2 argon2(Hash::Argon2Type::Argon2id);
+
+    auto key = TRY(argon2.derive_key(
+        m_password.bytes(),
+        salt,
+        m_params.parallelism,
+        m_params.memory_kib,
+        m_params.iterations,
+        0x13, // Argon2 version 1.3 (RFC 9106)
+        Optional<ReadonlyBytes> { },
+        Optional<ReadonlyBytes> { },
+        32)); // 256-bit output
+
+    ScopeGuard const zero_key = [&] { secure_zero(key.data(), key.size()); };
+    return SecureByteBuffer::copy(key.bytes());
+}
+
+}

--- a/Libraries/LibCrypto/KeyProvider.h
+++ b/Libraries/LibCrypto/KeyProvider.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StringView.h>
+#include <LibCrypto/SecureByteBuffer.h>
+
+namespace Crypto {
+
+// Interface for pluggable master-key derivation strategies.
+// Implementations derive a 256-bit encryption key from a secret
+// (password, hardware token, etc.) and a per-store salt.
+class KeyProvider {
+public:
+    virtual ~KeyProvider() = default;
+    virtual ErrorOr<SecureByteBuffer> derive_key(ReadonlyBytes salt) = 0;
+    virtual StringView name() const = 0;
+};
+
+struct PasswordKeyProviderParameters {
+    u32 memory_kib { 19456 }; // 19 MiB (OWASP 2024 recommendation)
+    u32 iterations { 2 };     // OWASP minimum for interactive use
+    u32 parallelism { 1 };
+};
+
+// Derives a 256-bit key from a password using Argon2id (RFC 9106).
+class PasswordKeyProvider final : public KeyProvider {
+public:
+    using Parameters = PasswordKeyProviderParameters;
+
+    static ErrorOr<NonnullOwnPtr<PasswordKeyProvider>> create(StringView password, Parameters = { });
+
+    ErrorOr<SecureByteBuffer> derive_key(ReadonlyBytes salt) override;
+    StringView name() const override { return "password"sv; }
+
+private:
+    PasswordKeyProvider(SecureByteBuffer password, Parameters);
+
+    SecureByteBuffer m_password;
+    Parameters m_params;
+};
+
+}

--- a/Libraries/LibCrypto/SecureByteBuffer.h
+++ b/Libraries/LibCrypto/SecureByteBuffer.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Memory.h>
+#include <AK/Noncopyable.h>
+
+namespace Crypto {
+
+// A ByteBuffer wrapper that securely zeros its contents on destruction.
+// Use for key material, passwords, and other secrets that must not persist
+// in memory after use.
+class SecureByteBuffer {
+    AK_MAKE_NONCOPYABLE(SecureByteBuffer);
+
+public:
+    SecureByteBuffer() = default;
+
+    static ErrorOr<SecureByteBuffer> create_uninitialized(size_t size)
+    {
+        SecureByteBuffer buf;
+        buf.m_buffer = TRY(ByteBuffer::create_uninitialized(size));
+        return buf;
+    }
+
+    static ErrorOr<SecureByteBuffer> copy(ReadonlyBytes bytes)
+    {
+        SecureByteBuffer buf;
+        if (bytes.size() > 0) {
+            buf.m_buffer = TRY(ByteBuffer::create_uninitialized(bytes.size()));
+            __builtin_memcpy(buf.m_buffer.data(), bytes.data(), bytes.size());
+        }
+        return buf;
+    }
+
+    SecureByteBuffer(SecureByteBuffer&& other)
+        : m_buffer(move(other.m_buffer))
+    {
+        // ByteBuffer::move_from() memcpy's inline data, leaving the stale
+        // secret in the moved-from inline buffer (m_size=0, m_inline=true).
+        // Zero the full inline capacity. Safe for outline buffers too —
+        // the pointer was transferred and the inline area is irrelevant.
+        secure_zero(other.m_buffer.data(), other.m_buffer.capacity());
+    }
+
+    SecureByteBuffer& operator=(SecureByteBuffer&& other)
+    {
+        if (this != &other) {
+            secure_clear();
+            m_buffer = move(other.m_buffer);
+            secure_zero(other.m_buffer.data(), other.m_buffer.capacity());
+        }
+        return *this;
+    }
+
+    ~SecureByteBuffer()
+    {
+        secure_clear();
+    }
+
+    [[nodiscard]] u8* data() { return m_buffer.data(); }
+    [[nodiscard]] u8 const* data() const { return m_buffer.data(); }
+    [[nodiscard]] size_t size() const { return m_buffer.size(); }
+    [[nodiscard]] bool is_empty() const { return m_buffer.is_empty(); }
+
+    [[nodiscard]] ReadonlyBytes bytes() const { return m_buffer.bytes(); }
+    [[nodiscard]] Bytes bytes() { return m_buffer.bytes(); }
+
+    operator ReadonlyBytes() const { return bytes(); }
+
+private:
+    void secure_clear()
+    {
+        if (m_buffer.size() > 0)
+            secure_zero(m_buffer.data(), m_buffer.size());
+    }
+
+    ByteBuffer m_buffer;
+};
+
+}

--- a/Libraries/LibCrypto/SecureStore.cpp
+++ b/Libraries/LibCrypto/SecureStore.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Memory.h>
+#include <AK/Random.h>
+#include <AK/ScopeGuard.h>
+#include <LibCrypto/Cipher/AES.h>
+#include <LibCrypto/SecureStore.h>
+
+namespace Crypto {
+
+SecureStore::SecureStore(NonnullOwnPtr<KeyProvider> provider)
+    : m_provider(move(provider))
+{
+}
+
+SecureStore::~SecureStore()
+{
+    lock();
+}
+
+SecureStore::SecureStore(SecureStore&& other)
+    : m_provider(move(other.m_provider))
+    , m_key(move(other.m_key))
+{
+}
+
+SecureStore& SecureStore::operator=(SecureStore&& other)
+{
+    if (this != &other) {
+        lock();
+        m_provider = move(other.m_provider);
+        m_key = move(other.m_key);
+    }
+    return *this;
+}
+
+ErrorOr<void> SecureStore::unlock(ReadonlyBytes salt)
+{
+    lock();
+    auto key = TRY(m_provider->derive_key(salt));
+    if (key.size() != key_size)
+        return Error::from_string_literal("KeyProvider returned wrong key size (expected 32 bytes)");
+    m_key = move(key);
+    return { };
+}
+
+void SecureStore::lock()
+{
+    m_key.clear();
+}
+
+bool SecureStore::is_unlocked() const
+{
+    return m_key.has_value();
+}
+
+ErrorOr<ByteBuffer> SecureStore::encrypt(ReadonlyBytes plaintext, ReadonlyBytes aad) const
+{
+    if (!is_unlocked())
+        return Error::from_string_literal("SecureStore is locked");
+
+    u8 nonce_bytes[nonce_size];
+    fill_with_random({ nonce_bytes, nonce_size });
+
+    Cipher::AESGCMCipher cipher(m_key->bytes());
+    auto [ciphertext, tag] = TRY(cipher.encrypt(
+        plaintext,
+        ReadonlyBytes { nonce_bytes, nonce_size },
+        aad,
+        tag_size));
+
+    auto blob = TRY(ByteBuffer::create_uninitialized(
+        nonce_size + ciphertext.size() + tag.size()));
+    blob.overwrite(0, nonce_bytes, nonce_size);
+    blob.overwrite(nonce_size, ciphertext.data(), ciphertext.size());
+    blob.overwrite(nonce_size + ciphertext.size(), tag.data(), tag.size());
+
+    return blob;
+}
+
+ErrorOr<SecureByteBuffer> SecureStore::decrypt(ReadonlyBytes blob, ReadonlyBytes aad) const
+{
+    if (!is_unlocked())
+        return Error::from_string_literal("SecureStore is locked");
+
+    if (blob.size() < overhead)
+        return Error::from_string_literal("Encrypted blob is too small");
+
+    auto nonce = blob.slice(0, nonce_size);
+    auto ciphertext = blob.slice(nonce_size, blob.size() - overhead);
+    auto tag = blob.slice(blob.size() - tag_size, tag_size);
+
+    Cipher::AESGCMCipher cipher(m_key->bytes());
+    auto plaintext = TRY(cipher.decrypt(ciphertext, nonce, aad, tag));
+    ScopeGuard const zero_plaintext = [&] { secure_zero(plaintext.data(), plaintext.size()); };
+
+    return SecureByteBuffer::copy(plaintext.bytes());
+}
+
+ErrorOr<ByteBuffer> SecureStore::generate_salt()
+{
+    auto salt = TRY(ByteBuffer::create_uninitialized(salt_size));
+    fill_with_random(salt.bytes());
+    return salt;
+}
+
+}

--- a/Libraries/LibCrypto/SecureStore.h
+++ b/Libraries/LibCrypto/SecureStore.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <LibCrypto/KeyProvider.h>
+#include <LibCrypto/SecureByteBuffer.h>
+
+namespace Crypto {
+
+// Storage-independent encrypted blob helper.
+//
+// Encrypts/decrypts blobs using AES-256-GCM with per-blob random nonces.
+// Requires a KeyProvider for master key derivation. The derived key is
+// held in memory only while unlocked and securely wiped on lock().
+//
+// Blob wire format: [12-byte nonce][ciphertext][16-byte tag]
+//
+// Callers are responsible for persistence. SecureStore only transforms
+// plaintext <-> encrypted blobs.
+class SecureStore {
+    AK_MAKE_NONCOPYABLE(SecureStore);
+
+public:
+    static constexpr size_t nonce_size = 12;
+    static constexpr size_t tag_size = 16;
+    static constexpr size_t key_size = 32;
+    static constexpr size_t salt_size = 16;
+    static constexpr size_t overhead = nonce_size + tag_size;
+
+    explicit SecureStore(NonnullOwnPtr<KeyProvider>);
+    ~SecureStore();
+
+    SecureStore(SecureStore&&);
+    SecureStore& operator=(SecureStore&&);
+
+    // Derive the master key from the provider using the given salt.
+    // The salt should be generated once per store and persisted alongside
+    // the encrypted data.
+    ErrorOr<void> unlock(ReadonlyBytes salt);
+
+    // Securely wipe the master key from memory. The provider retains
+    // its secret (e.g. password) so unlock() can re-derive without
+    // re-prompting the user. To wipe all secrets, destroy the store.
+    void lock();
+
+    [[nodiscard]] bool is_unlocked() const;
+
+    // Encrypt plaintext into a self-contained blob (nonce || ct || tag).
+    // Optional AAD binds metadata (e.g. entry ID) to the ciphertext.
+    ErrorOr<ByteBuffer> encrypt(ReadonlyBytes plaintext,
+        ReadonlyBytes aad = { }) const;
+
+    // Decrypt a blob produced by encrypt(). AAD must match what was
+    // used during encryption or decryption will fail.
+    ErrorOr<SecureByteBuffer> decrypt(ReadonlyBytes blob,
+        ReadonlyBytes aad = { }) const;
+
+    // Generate a random salt suitable for unlock().
+    static ErrorOr<ByteBuffer> generate_salt();
+
+private:
+    NonnullOwnPtr<KeyProvider> m_provider;
+    Optional<SecureByteBuffer> m_key;
+};
+
+}

--- a/Tests/LibCrypto/CMakeLists.txt
+++ b/Tests/LibCrypto/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     TestPBKDF2.cpp
     TestPSS.cpp
     TestRSA.cpp
+    TestSecureByteBuffer.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibCrypto/CMakeLists.txt
+++ b/Tests/LibCrypto/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCES
     TestPSS.cpp
     TestRSA.cpp
     TestSecureByteBuffer.cpp
+    TestSecureStore.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibCrypto/TestSecureByteBuffer.cpp
+++ b/Tests/LibCrypto/TestSecureByteBuffer.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCrypto/SecureByteBuffer.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(test_secure_byte_buffer_copy_and_verify)
+{
+    u8 const secret[] = { 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe };
+    auto buf = TRY_OR_FAIL(Crypto::SecureByteBuffer::copy(ReadonlyBytes { secret, sizeof(secret) }));
+
+    EXPECT_EQ(buf.size(), sizeof(secret));
+    EXPECT_EQ(buf.bytes(), ReadonlyBytes(secret));
+}
+
+TEST_CASE(test_secure_byte_buffer_move_constructor)
+{
+    u8 const secret[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto original = TRY_OR_FAIL(Crypto::SecureByteBuffer::copy(ReadonlyBytes { secret, sizeof(secret) }));
+
+    auto moved = move(original);
+
+    EXPECT_EQ(moved.size(), sizeof(secret));
+    EXPECT_EQ(moved.bytes(), ReadonlyBytes(secret));
+    EXPECT(original.is_empty());
+}
+
+TEST_CASE(test_secure_byte_buffer_move_assignment)
+{
+    u8 const first[] = { 0xaa, 0xbb };
+    u8 const second[] = { 0xcc, 0xdd, 0xee };
+
+    auto buf_a = TRY_OR_FAIL(Crypto::SecureByteBuffer::copy(ReadonlyBytes { first, sizeof(first) }));
+    auto buf_b = TRY_OR_FAIL(Crypto::SecureByteBuffer::copy(ReadonlyBytes { second, sizeof(second) }));
+
+    buf_a = move(buf_b);
+
+    EXPECT_EQ(buf_a.size(), sizeof(second));
+    EXPECT_EQ(buf_a.bytes(), ReadonlyBytes(second));
+    EXPECT(buf_b.is_empty());
+}
+
+TEST_CASE(test_secure_byte_buffer_empty_default)
+{
+    Crypto::SecureByteBuffer buf;
+    EXPECT(buf.is_empty());
+    EXPECT_EQ(buf.size(), 0u);
+}
+
+TEST_CASE(test_secure_byte_buffer_create_uninitialized)
+{
+    auto buf = TRY_OR_FAIL(Crypto::SecureByteBuffer::create_uninitialized(64));
+    EXPECT_EQ(buf.size(), 64u);
+    EXPECT(!buf.is_empty());
+}
+
+TEST_CASE(test_secure_byte_buffer_copy_empty_span)
+{
+    auto buf = TRY_OR_FAIL(Crypto::SecureByteBuffer::copy(ReadonlyBytes { }));
+    EXPECT(buf.is_empty());
+    EXPECT_EQ(buf.size(), 0u);
+}

--- a/Tests/LibCrypto/TestSecureStore.cpp
+++ b/Tests/LibCrypto/TestSecureStore.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, Kevin Bortis
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCrypto/SecureStore.h>
+#include <LibTest/TestCase.h>
+
+// Use minimal Argon2 parameters for test speed. These are cryptographically
+// weak but sufficient for verifying correctness.
+static Crypto::PasswordKeyProviderParameters const s_fast_params { 32, 1, 1 };
+
+static ErrorOr<Crypto::SecureStore> create_unlocked_store(StringView password = "test-password"sv)
+{
+    auto provider = TRY(Crypto::PasswordKeyProvider::create(password, s_fast_params));
+    auto store = Crypto::SecureStore(move(provider));
+    auto salt = TRY(Crypto::SecureStore::generate_salt());
+    TRY(store.unlock(salt.bytes()));
+    return store;
+}
+
+TEST_CASE(test_encrypt_decrypt_round_trip)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    auto plaintext = "Hello, SecureStore!"sv.bytes();
+    auto blob = TRY_OR_FAIL(store.encrypt(plaintext));
+    auto decrypted = TRY_OR_FAIL(store.decrypt(blob.bytes()));
+
+    EXPECT_EQ(decrypted.bytes(), plaintext);
+}
+
+TEST_CASE(test_encrypt_decrypt_with_aad)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    auto plaintext = "secret data"sv.bytes();
+    auto aad = "entry-42"sv.bytes();
+    auto blob = TRY_OR_FAIL(store.encrypt(plaintext, aad));
+    auto decrypted = TRY_OR_FAIL(store.decrypt(blob.bytes(), aad));
+
+    EXPECT_EQ(decrypted.bytes(), plaintext);
+}
+
+TEST_CASE(test_decrypt_wrong_aad_fails)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    auto blob = TRY_OR_FAIL(store.encrypt("data"sv.bytes(), "correct-aad"sv.bytes()));
+    auto result = store.decrypt(blob.bytes(), "wrong-aad"sv.bytes());
+
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_decrypt_wrong_key_fails)
+{
+    auto provider_a = TRY_OR_FAIL(Crypto::PasswordKeyProvider::create("password-A"sv, s_fast_params));
+    auto store_a = Crypto::SecureStore(move(provider_a));
+    auto salt = TRY_OR_FAIL(Crypto::SecureStore::generate_salt());
+    TRY_OR_FAIL(store_a.unlock(salt.bytes()));
+
+    auto blob = TRY_OR_FAIL(store_a.encrypt("secret"sv.bytes()));
+
+    auto provider_b = TRY_OR_FAIL(Crypto::PasswordKeyProvider::create("password-B"sv, s_fast_params));
+    auto store_b = Crypto::SecureStore(move(provider_b));
+    TRY_OR_FAIL(store_b.unlock(salt.bytes()));
+
+    auto result = store_b.decrypt(blob.bytes());
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_encrypt_while_locked_fails)
+{
+    auto provider = TRY_OR_FAIL(Crypto::PasswordKeyProvider::create("pw"sv, s_fast_params));
+    auto store = Crypto::SecureStore(move(provider));
+
+    auto result = store.encrypt("data"sv.bytes());
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_decrypt_while_locked_fails)
+{
+    auto provider = TRY_OR_FAIL(Crypto::PasswordKeyProvider::create("pw"sv, s_fast_params));
+    auto store = Crypto::SecureStore(move(provider));
+
+    u8 dummy[32] { };
+    auto result = store.decrypt(ReadonlyBytes { dummy, sizeof(dummy) });
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_lock_wipes_and_prevents_use)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+    EXPECT(store.is_unlocked());
+
+    store.lock();
+    EXPECT(!store.is_unlocked());
+
+    auto result = store.encrypt("data"sv.bytes());
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_encrypt_decrypt_empty_plaintext)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    auto blob = TRY_OR_FAIL(store.encrypt(ReadonlyBytes { }));
+    EXPECT_EQ(blob.size(), Crypto::SecureStore::overhead);
+
+    auto decrypted = TRY_OR_FAIL(store.decrypt(blob.bytes()));
+    EXPECT(decrypted.is_empty());
+}
+
+TEST_CASE(test_blob_overhead_size)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    u8 data[100];
+    auto blob = TRY_OR_FAIL(store.encrypt(ReadonlyBytes { data, sizeof(data) }));
+    EXPECT_EQ(blob.size(), sizeof(data) + Crypto::SecureStore::overhead);
+}
+
+TEST_CASE(test_truncated_blob_fails)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    u8 short_blob[20] { };
+    auto result = store.decrypt(ReadonlyBytes { short_blob, sizeof(short_blob) });
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_corrupted_blob_fails)
+{
+    auto store = TRY_OR_FAIL(create_unlocked_store());
+
+    auto blob = TRY_OR_FAIL(store.encrypt("important data"sv.bytes()));
+    // Flip a bit in the ciphertext area (after the 12-byte nonce).
+    blob[Crypto::SecureStore::nonce_size] ^= 0x01;
+
+    auto result = store.decrypt(blob.bytes());
+    EXPECT(result.is_error());
+}
+
+TEST_CASE(test_generate_salt_length)
+{
+    auto salt = TRY_OR_FAIL(Crypto::SecureStore::generate_salt());
+    EXPECT_EQ(salt.size(), Crypto::SecureStore::salt_size);
+}
+
+TEST_CASE(test_password_key_provider_deterministic)
+{
+    auto salt = TRY_OR_FAIL(Crypto::SecureStore::generate_salt());
+
+    auto provider_1 = TRY_OR_FAIL(Crypto::PasswordKeyProvider::create("same-password"sv, s_fast_params));
+    auto key_1 = TRY_OR_FAIL(provider_1->derive_key(salt.bytes()));
+
+    auto provider_2 = TRY_OR_FAIL(Crypto::PasswordKeyProvider::create("same-password"sv, s_fast_params));
+    auto key_2 = TRY_OR_FAIL(provider_2->derive_key(salt.bytes()));
+
+    EXPECT_EQ(key_1.bytes(), key_2.bytes());
+}


### PR DESCRIPTION
Adds reusable encrypted blob storage primitives to LibCrypto:

SecureByteBuffer is a ByteBuffer wrapper that securely zeros contents on destruction via AK::secure_zero(). Move-only to prevent accidental duplication of secrets. Zeroes moved-from inline storage after move.

KeyProvider is a pluggable key derivation interface. PasswordKeyProvider derives a 256-bit key using Argon2id v1.3 (RFC 9106) with OWASP 2024 recommended parameters.

SecureStore encrypts and decrypts blobs using AES-256-GCM with per-blob random nonces. Lock/unlock lifecycle keeps the derived key in memory only while unlocked. Validates 32-byte key size from the provider. Blob format: nonce(12) || ciphertext || tag(16). Callers handle persistence; SecureStore only transforms plaintext to/from blobs.

Intermediate sensitive buffers are wiped via ScopeGuard so cleanup runs even on error paths.

This is groundwork for browser-managed certificate storage (#8343) and not yet used by any active module. May also be used to implement other managers for storing secrets.