### PR TITLE
Base+LibWebView+UI: Support for about:history page

### DIFF
--- a/Base/res/ladybird/about-pages/history.html
+++ b/Base/res/ladybird/about-pages/history.html
@@ -1,0 +1,603 @@
+<!doctype html>
+<html>
+    <head>
+        <title>History</title>
+        <link rel="stylesheet" type="text/css" href="resource://ladybird/ladybird.css" />
+        <link rel="stylesheet" type="text/css" href="resource://ladybird/about-pages/webui.css" />
+        <style>
+            @media (prefers-color-scheme: light) {
+                :root {
+                    --tree-hover-color: #e8e8e8;
+                    --tree-selected-color: #d8d8f8;
+                    --empty-text-color: #888;
+                    --url-text-color: #666;
+                    --meta-text-color: #999;
+                    --delete-color: #999;
+                    --delete-hover-color: #e53935;
+                }
+            }
+
+            @media (prefers-color-scheme: dark) {
+                :root {
+                    --tree-hover-color: #2e2e2e;
+                    --tree-selected-color: #35355a;
+                    --empty-text-color: #777;
+                    --url-text-color: #999;
+                    --meta-text-color: #666;
+                    --delete-color: #666;
+                    --delete-hover-color: #ef5350;
+                }
+            }
+
+            .tree-empty {
+                color: var(--empty-text-color);
+
+                padding: 40px 20px;
+
+                text-align: center;
+                font-size: 14px;
+            }
+
+            .tree-item-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+
+                padding: 14px 12px;
+                border-radius: 6px;
+
+                font-size: 14px;
+            }
+
+            .tree-item-row:hover {
+                background-color: var(--tree-hover-color);
+            }
+
+            .item-icon {
+                display: flex;
+                flex-shrink: 0;
+                align-items: center;
+            }
+
+            .item-icon img,
+            .item-icon svg {
+                width: 32px;
+                height: 32px;
+            }
+
+            .item-info {
+                display: flex;
+                flex-direction: column;
+                gap: 2px;
+
+                flex-grow: 1;
+                min-width: 0;
+            }
+
+            .item-title {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                min-width: 0;
+            }
+
+            .item-title a {
+                color: inherit;
+                text-decoration: none;
+            }
+
+            .item-title a:hover {
+                text-decoration: underline;
+            }
+
+            .item-url {
+                color: var(--url-text-color);
+
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+
+                font-size: 12px;
+                min-width: 0;
+            }
+
+            .item-actions {
+                display: flex;
+                align-items: center;
+                flex-shrink: 0;
+                gap: 0;
+                position: relative;
+                padding-left: 24px;
+            }
+
+            .item-actions::before {
+                content: "";
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                width: 24px;
+                background: linear-gradient(to right, transparent, var(--card-background-color));
+                pointer-events: none;
+            }
+
+            .tree-item-row:hover .item-actions::before {
+                background: linear-gradient(to right, transparent, var(--tree-hover-color));
+            }
+
+            .item-meta {
+                color: var(--meta-text-color);
+                font-size: 12px;
+                white-space: nowrap;
+                transition: transform 0.2s ease;
+            }
+
+            .tree-item-row:hover .item-meta {
+                transform: translateX(-12px);
+            }
+
+            .item-delete {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                width: 28px;
+                height: 28px;
+
+                color: var(--delete-color);
+                background: none;
+                border: none;
+                border-radius: 4px;
+
+                cursor: pointer;
+                opacity: 0;
+                transform: translateX(0);
+                transition:
+                    opacity 0.2s ease,
+                    transform 0.2s ease;
+            }
+
+            .tree-item-row:hover .item-delete {
+                opacity: 1;
+            }
+
+            .item-delete:hover {
+                color: var(--delete-hover-color);
+                background-color: var(--tree-hover-color);
+            }
+
+            .item-delete svg {
+                width: 14px;
+                height: 14px;
+            }
+
+            .search-container {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+
+                max-width: 65%;
+                margin: 0 auto 24px auto;
+                padding: 0px 12px;
+
+                background-color: var(--tree-hover-color);
+                border: none;
+                border-radius: 8px;
+            }
+
+            .search-icon {
+                flex-shrink: 0;
+                width: 16px;
+                height: 16px;
+                color: var(--empty-text-color);
+            }
+
+            .search-input {
+                flex-grow: 1;
+                min-width: 0;
+                font-size: 13px;
+                color: inherit;
+
+                background: none;
+                border: none;
+                outline: none;
+                padding: 0;
+            }
+
+            .search-input::placeholder {
+                color: var(--empty-text-color);
+            }
+
+            .search-highlight {
+                color: inherit;
+                background-color: var(--tree-selected-color);
+                border-radius: 2px;
+            }
+
+            .search-no-results {
+                color: var(--empty-text-color);
+
+                padding: 40px 20px;
+
+                text-align: center;
+                font-size: 14px;
+            }
+
+            .pagination-bar {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 16px;
+
+                margin-top: 16px;
+                padding: 12px 16px;
+
+                font-size: 13px;
+                color: var(--meta-text-color);
+            }
+
+            .pagination-bar.hidden {
+                display: none;
+            }
+
+            .pagination-btn {
+                padding: 6px 14px;
+
+                font-size: 13px;
+                color: inherit;
+                background-color: var(--tree-hover-color);
+                border: none;
+                border-radius: 6px;
+
+                cursor: pointer;
+            }
+
+            .pagination-btn:hover:not(:disabled) {
+                background-color: var(--tree-selected-color);
+            }
+
+            .pagination-btn:disabled {
+                opacity: 0.4;
+                cursor: default;
+            }
+
+            .date-header {
+                padding: 10px 12px 6px;
+                font-size: 13px;
+                font-weight: 600;
+                color: var(--meta-text-color);
+                border-bottom: 1px solid var(--tree-hover-color);
+                margin-top: 8px;
+            }
+
+            .date-header:first-child {
+                margin-top: 0;
+            }
+
+            .pagination-select {
+                padding: 4px 8px;
+
+                font-size: 13px;
+                color: inherit;
+                background-color: var(--tree-hover-color);
+                border: none;
+                border-radius: 4px;
+
+                cursor: pointer;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <picture>
+                <source srcset="resource://icons/128x128/app-browser.png" media="(prefers-color-scheme: dark)" />
+                <img src="resource://icons/128x128/app-browser-dark.png" />
+            </picture>
+            <h1>History</h1>
+        </header>
+
+        <div class="search-container">
+            <svg
+                class="search-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+            >
+                <circle cx="11" cy="11" r="7" />
+                <line x1="16" y1="16" x2="22" y2="22" />
+            </svg>
+            <input type="text" class="search-input" id="search-input" placeholder="Search history" />
+        </div>
+
+        <div class="card">
+            <div class="card-body" id="history-list"></div>
+        </div>
+
+        <div class="pagination-bar hidden" id="pagination-bar">
+            <button class="pagination-btn" id="prev-btn">Previous</button>
+            <span id="page-indicator"></span>
+            <button class="pagination-btn" id="next-btn">Next</button>
+            <span>Items per page:</span>
+            <select class="pagination-select" id="page-size-select">
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+                <option value="200">200</option>
+            </select>
+        </div>
+
+        <script type="module">
+            const GLOBE_SVG = `
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2"/>
+                    <ellipse cx="12" cy="12" rx="4" ry="10" fill="none" stroke="currentColor" stroke-width="1.5"/>
+                    <line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="1.5"/>
+                </svg>`;
+
+            const TRASH_SVG = `
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <polyline points="3 6 5 6 21 6"/>
+                    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                    <path d="M10 11v6"/>
+                    <path d="M14 11v6"/>
+                    <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                </svg>`;
+
+            let HISTORY_ENTRIES = [];
+            let SEARCH_QUERY = "";
+            let currentPage = 0;
+            let itemsPerPage = 25;
+
+            const historyList = document.getElementById("history-list");
+            const searchInput = document.getElementById("search-input");
+            const paginationBar = document.getElementById("pagination-bar");
+            const prevBtn = document.getElementById("prev-btn");
+            const nextBtn = document.getElementById("next-btn");
+            const pageIndicator = document.getElementById("page-indicator");
+            const pageSizeSelect = document.getElementById("page-size-select");
+
+            function createElement(tagName, properties = {}, children = []) {
+                const element = document.createElement(tagName);
+                Object.assign(element, properties);
+                element.append(...children);
+                return element;
+            }
+
+            function createFaviconIcon(favicon) {
+                if (!favicon) {
+                    return createElement("span", { className: "item-icon", innerHTML: GLOBE_SVG });
+                }
+                return createElement("span", { className: "item-icon" }, [
+                    createElement("img", { src: `data:image/png;base64,${favicon}` }),
+                ]);
+            }
+
+            function getDateGroup(timestamp) {
+                const now = new Date();
+                const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+                const entryDate = new Date(timestamp);
+                const entryDay = new Date(entryDate.getFullYear(), entryDate.getMonth(), entryDate.getDate());
+                const diffDays = Math.round((today - entryDay) / 86400000);
+
+                if (diffDays === 0) return { key: "today", label: "Today" };
+                if (diffDays === 1) return { key: "yesterday", label: "Yesterday" };
+                if (diffDays < 7) {
+                    const dayName = entryDate.toLocaleDateString(undefined, { weekday: "long" });
+                    return { key: `day-${diffDays}`, label: dayName };
+                }
+                if (diffDays < 14) return { key: "last-week", label: "Last Week" };
+
+                const entryMonth = entryDate.getMonth();
+                const entryYear = entryDate.getFullYear();
+
+                if (entryYear === now.getFullYear() && entryMonth === now.getMonth()) {
+                    return { key: "earlier-this-month", label: "Earlier This Month" };
+                }
+
+                const monthLabel = entryDate.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+                return { key: `${entryYear}-${entryMonth}`, label: monthLabel };
+            }
+
+            function formatTime(timestamp) {
+                const date = new Date(timestamp);
+                return date.toLocaleTimeString(undefined, {
+                    hour: "numeric",
+                    minute: "2-digit",
+                });
+            }
+
+            function highlightText(text, query) {
+                if (!query) {
+                    return [document.createTextNode(text)];
+                }
+
+                const lowerText = text.toLowerCase();
+                const lowerQuery = query.toLowerCase();
+                const fragments = [];
+                let lastIndex = 0;
+                let matchIndex = lowerText.indexOf(lowerQuery, lastIndex);
+
+                for (; matchIndex !== -1; matchIndex = lowerText.indexOf(lowerQuery, lastIndex)) {
+                    if (matchIndex > lastIndex) {
+                        fragments.push(document.createTextNode(text.slice(lastIndex, matchIndex)));
+                    }
+
+                    const mark = createElement("mark", {
+                        className: "search-highlight",
+                        textContent: text.slice(matchIndex, matchIndex + query.length),
+                    });
+                    fragments.push(mark);
+
+                    lastIndex = matchIndex + query.length;
+                }
+
+                if (lastIndex < text.length) {
+                    fragments.push(document.createTextNode(text.slice(lastIndex)));
+                }
+
+                return fragments.length > 0 ? fragments : [document.createTextNode(text)];
+            }
+
+            function filterEntries(entries, query) {
+                if (!query) {
+                    return entries;
+                }
+
+                const lowerQuery = query.toLowerCase();
+                return entries.filter(entry => {
+                    if (!entry) return false;
+                    const title = (entry.title || "").toLowerCase();
+                    const url = (entry.url || "").toLowerCase();
+                    return title.includes(lowerQuery) || url.includes(lowerQuery);
+                });
+            }
+
+            function deleteEntry(url) {
+                ladybird.sendMessage("deleteHistoryEntry", { url });
+                HISTORY_ENTRIES = HISTORY_ENTRIES.filter(entry => entry.url !== url);
+                renderList();
+            }
+
+            function renderList() {
+                historyList.innerHTML = "";
+
+                if (HISTORY_ENTRIES.length === 0) {
+                    historyList.appendChild(
+                        createElement("div", {
+                            className: "tree-empty",
+                            textContent: "No history yet.",
+                        })
+                    );
+                    renderPagination(0);
+                    return;
+                }
+
+                const filtered = filterEntries(HISTORY_ENTRIES, SEARCH_QUERY);
+
+                if (filtered.length === 0) {
+                    historyList.appendChild(
+                        createElement("div", {
+                            className: "search-no-results",
+                            textContent: "No history matching your search.",
+                        })
+                    );
+                    renderPagination(0);
+                    return;
+                }
+
+                const totalPages = Math.ceil(filtered.length / itemsPerPage);
+                if (currentPage >= totalPages) {
+                    currentPage = totalPages - 1;
+                }
+
+                const start = currentPage * itemsPerPage;
+                const pageEntries = filtered.slice(start, start + itemsPerPage);
+
+                let lastGroupKey = null;
+
+                for (const entry of pageEntries) {
+                    if (entry === null) {
+                        continue;
+                    }
+
+                    const group = getDateGroup(entry.dateVisited);
+                    if (group.key !== lastGroupKey) {
+                        lastGroupKey = group.key;
+                        historyList.appendChild(
+                            createElement("div", {
+                                className: "date-header",
+                                textContent: group.label,
+                            })
+                        );
+                    }
+
+                    const row = createElement("div", { className: "tree-item-row" });
+
+                    row.appendChild(createFaviconIcon(entry.favicon));
+
+                    const link = createElement("a", { href: entry.url });
+                    link.append(...highlightText(entry.title || entry.url, SEARCH_QUERY));
+                    const title = createElement("span", { className: "item-title" }, [link]);
+
+                    const url = createElement("span", { className: "item-url" });
+                    url.append(...highlightText(entry.url, SEARCH_QUERY));
+
+                    row.appendChild(createElement("span", { className: "item-info" }, [title, url]));
+
+                    const meta = createElement("span", {
+                        className: "item-meta",
+                        textContent: formatTime(entry.dateVisited),
+                    });
+
+                    const deleteBtn = createElement("button", {
+                        className: "item-delete",
+                        innerHTML: TRASH_SVG,
+                        title: "Remove from history",
+                    });
+                    deleteBtn.addEventListener("click", event => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        deleteEntry(entry.url);
+                    });
+
+                    row.appendChild(createElement("span", { className: "item-actions" }, [meta, deleteBtn]));
+
+                    historyList.appendChild(row);
+                }
+
+                renderPagination(filtered.length);
+            }
+
+            function renderPagination(totalItems) {
+                if (totalItems === 0) {
+                    paginationBar.classList.add("hidden");
+                    return;
+                }
+
+                paginationBar.classList.remove("hidden");
+
+                const totalPages = Math.ceil(totalItems / itemsPerPage);
+                pageIndicator.textContent = `Page ${currentPage + 1} of ${totalPages}`;
+                prevBtn.disabled = currentPage === 0;
+                nextBtn.disabled = currentPage >= totalPages - 1;
+            }
+
+            prevBtn.addEventListener("click", () => {
+                if (currentPage > 0) {
+                    currentPage--;
+                    renderList();
+                }
+            });
+
+            nextBtn.addEventListener("click", () => {
+                currentPage++;
+                renderList();
+            });
+
+            pageSizeSelect.addEventListener("change", () => {
+                itemsPerPage = parseInt(pageSizeSelect.value, 10);
+                currentPage = 0;
+                renderList();
+            });
+
+            searchInput.addEventListener("input", () => {
+                SEARCH_QUERY = searchInput.value.trim();
+                currentPage = 0;
+                renderList();
+            });
+
+            document.addEventListener("WebUILoaded", () => {
+                ladybird.sendMessage("loadHistory");
+            });
+
+            document.addEventListener("WebUIMessage", event => {
+                if (event.detail.name === "loadHistory") {
+                    HISTORY_ENTRIES = event.detail.data;
+                    renderList();
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -219,13 +219,14 @@ inline URL about_srcdoc() { return URL::about("srcdoc"_string); }
 inline URL about_error() { return URL::about("error"_string); }
 inline URL about_newtab() { return URL::about("newtab"_string); }
 inline URL about_bookmarks() { return URL::about("bookmarks"_string); }
+inline URL about_history() { return URL::about("history"_string); }
 inline URL about_processes() { return URL::about("processes"_string); }
 inline URL about_settings() { return URL::about("settings"_string); }
 inline URL about_version() { return URL::about("version"_string); }
 
 inline bool is_webui_url(URL const& url)
 {
-    return first_is_one_of(url, about_bookmarks(), about_processes(), about_settings(), about_version());
+    return first_is_one_of(url, about_bookmarks(), about_history(), about_processes(), about_settings(), about_version());
 }
 
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1391,11 +1391,11 @@ void Application::initialize_actions()
     update_vertical_tabs_action();
 
     m_history_menu = Menu::create("History"sv);
-    m_history_menu->add_action(Action::create("Manage History"sv, ActionID::ManageHistory, [this](){
+    m_history_menu->add_action(Action::create("Manage History"sv, ActionID::ManageHistory, [this]() {
         open_url_in_new_tab(URL::about_history(), Web::HTML::ActivateTab::Yes);
     }));
     m_history_menu->add_separator();
-    m_history_menu->add_action(Action::create("Clear History"sv, ActionID::ClearHistory, [this](){
+    m_history_menu->add_action(Action::create("Clear History"sv, ActionID::ClearHistory, [this]() {
         clear_history();
     }));
     m_history_menu->add_action(reload_action());

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -22,7 +22,9 @@
 #include <LibDevTools/DevToolsServer.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibImageDecoderClient/Client.h>
+#include <LibURL/URL.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWebView/Application.h>
@@ -1387,6 +1389,16 @@ void Application::initialize_actions()
         m_settings.set_tab_settings(tab_settings);
     });
     update_vertical_tabs_action();
+
+    m_history_menu = Menu::create("History"sv);
+    m_history_menu->add_action(Action::create("Manage History"sv, ActionID::ManageHistory, [this](){
+        open_url_in_new_tab(URL::about_history(), Web::HTML::ActivateTab::Yes);
+    }));
+    m_history_menu->add_separator();
+    m_history_menu->add_action(Action::create("Clear History"sv, ActionID::ClearHistory, [this](){
+        clear_history();
+    }));
+    m_history_menu->add_action(reload_action());
 
     m_bookmarks_menu = Menu::create("Bookmarks"sv);
     m_bookmarks_menu->add_action(Action::create("Manage Bookmarks"sv, ActionID::ManageBookmarks, [this]() {

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -179,6 +179,7 @@ public:
     Menu& color_scheme_menu() { return *m_color_scheme_menu; }
     Menu& contrast_menu() { return *m_contrast_menu; }
     Menu& motion_menu() { return *m_motion_menu; }
+    Menu& history_menu() { return *m_history_menu; }
 
     Action& toggle_vertical_tabs_expanded_action() { return *m_toggle_vertical_tabs_expanded_action; }
 
@@ -377,6 +378,8 @@ private:
     Web::CSS::PreferredMotion m_motion { Web::CSS::PreferredMotion::Auto };
 
     RefPtr<Action> m_toggle_vertical_tabs_expanded_action;
+
+    RefPtr<Menu> m_history_menu;
 
     RefPtr<Menu> m_bookmarks_menu;
     RefPtr<Action> m_toggle_bookmark_action;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     WorkerProcessManager.cpp
     WebUI.cpp
     WebUI/BookmarksUI.cpp
+    WebUI/HistoryUI.cpp
     WebUI/ProcessesUI.cpp
     WebUI/SettingsUI.cpp
     WebUI/VersionUI.cpp

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -647,10 +647,6 @@ Vector<HistoryEntry> HistoryStore::TransientStorage::list_all_entries() const
 Vector<HistoryEntry> HistoryStore::PersistedStorage::list_all_entries() const
 {
     Vector<HistoryEntry> entries;
-    // database query should look something like this
-    // for now I am not very concerned about performance as this will
-    // just run when loading the about:history page
-    // : SELECT * FROM History ORDER BY last_visited_time DESC
 
     m_database.execute_statement(
         m_statements.list_all_entries,

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -5,7 +5,10 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
 #include <AK/QuickSort.h>
+#include <AK/String.h>
 #include <AK/Utf8View.h>
 #include <LibDatabase/Database.h>
 #include <LibURL/Parser.h>
@@ -216,6 +219,12 @@ ErrorOr<NonnullOwnPtr<HistoryStore>> HistoryStore::create(Database::Database& da
     )#"sv));
     statements.clear_entries = TRY(database.prepare_statement("DELETE FROM History;"sv));
     statements.delete_entries_accessed_since = TRY(database.prepare_statement("DELETE FROM History WHERE last_visited_time >= ?;"sv));
+    statements.delete_entry_by_url = TRY(database.prepare_statement("DELETE FROM History WHERE url = ?;"sv));
+    statements.list_all_entries = TRY(database.prepare_statement(R"#(
+        SELECT url, title, visit_count, last_visited_time, COALESCE(favicon, '')
+        FROM History
+        ORDER BY last_visited_time DESC;
+    )#"sv));
 
     return adopt_own(*new HistoryStore { adopt_own<StorageImpl>(*new PersistedStorage { database, move(statements) }) });
 }
@@ -616,6 +625,51 @@ Vector<HistoryEntry> HistoryStore::PersistedStorage::autocomplete_entries(String
     return entries;
 }
 
+Vector<HistoryEntry> HistoryStore::list_all_entries() const
+{
+    if (m_is_disabled)
+        return {};
+
+    return m_storage->list_all_entries();
+}
+
+Vector<HistoryEntry> HistoryStore::TransientStorage::list_all_entries() const
+{
+    Vector<HistoryEntry> entries;
+
+    for (auto const& [_, entry] : m_entries) {
+        entries.append(entry);
+    }
+
+    return entries;
+}
+
+Vector<HistoryEntry> HistoryStore::PersistedStorage::list_all_entries() const
+{
+    Vector<HistoryEntry> entries;
+    // database query should look something like this
+    // for now I am not very concerned about performance as this will
+    // just run when loading the about:history page
+    // : SELECT * FROM History ORDER BY last_visited_time DESC
+
+    m_database.execute_statement(
+        m_statements.list_all_entries,
+        [&](auto statement_id) {
+            auto title = m_database.result_column<String>(statement_id, 1);
+            auto favicon = m_database.result_column<String>(statement_id, 4);
+
+            entries.append(HistoryEntry {
+                .url = m_database.result_column<String>(statement_id, 0),
+                .title = title.is_empty() ? Optional<String> {} : Optional<String> { move(title) },
+                .favicon_base64_png = favicon.is_empty() ? Optional<String> {} : Optional<String> { move(favicon) },
+                .visit_count = m_database.result_column<u64>(statement_id, 2),
+                .last_visited_time = m_database.result_column<UnixDateTime>(statement_id, 3),
+            });
+        });
+
+    return entries;
+}
+
 void HistoryStore::PersistedStorage::clear()
 {
     m_database.execute_statement(m_statements.clear_entries, {});
@@ -624,6 +678,24 @@ void HistoryStore::PersistedStorage::clear()
 void HistoryStore::PersistedStorage::remove_entries_accessed_since(UnixDateTime since)
 {
     m_database.execute_statement(m_statements.delete_entries_accessed_since, {}, since);
+}
+
+void HistoryStore::remove_entry_by_url(String const& url)
+{
+    if (m_is_disabled)
+        return;
+
+    m_storage->remove_entry_by_url(url);
+}
+
+void HistoryStore::TransientStorage::remove_entry_by_url(String const& url)
+{
+    m_entries.remove(url);
+}
+
+void HistoryStore::PersistedStorage::remove_entry_by_url(String const& url)
+{
+    m_database.execute_statement(m_statements.delete_entry_by_url, {}, url);
 }
 
 }

--- a/Libraries/LibWebView/HistoryStore.h
+++ b/Libraries/LibWebView/HistoryStore.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <AK/JsonValue.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
@@ -57,9 +58,11 @@ public:
 
     Optional<HistoryEntry> entry_for_url(URL::URL const&);
     Vector<HistoryEntry> autocomplete_entries(StringView query, size_t limit = 8);
+    Vector<HistoryEntry> list_all_entries() const;
 
     void clear();
     void remove_entries_accessed_since(UnixDateTime since);
+    void remove_entry_by_url(String const& url);
 
 private:
     struct Statements {
@@ -70,6 +73,8 @@ private:
         Database::StatementID search_entries { 0 };
         Database::StatementID clear_entries { 0 };
         Database::StatementID delete_entries_accessed_since { 0 };
+        Database::StatementID delete_entry_by_url { 0 };
+        Database::StatementID list_all_entries { 0 };
     };
 
     class StorageImpl {
@@ -84,9 +89,11 @@ private:
 
         virtual Optional<HistoryEntry> entry_for_url(String const& url) = 0;
         virtual Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit) = 0;
+        virtual Vector<HistoryEntry> list_all_entries() const = 0;
 
         virtual void clear() = 0;
         virtual void remove_entries_accessed_since(UnixDateTime since) = 0;
+        virtual void remove_entry_by_url(String const& url) = 0;
     };
 
     class TransientStorage : public StorageImpl {
@@ -101,9 +108,11 @@ private:
 
         virtual Optional<HistoryEntry> entry_for_url(String const& url) override;
         virtual Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit) override;
+        virtual Vector<HistoryEntry> list_all_entries() const override;
 
         virtual void clear() override;
         virtual void remove_entries_accessed_since(UnixDateTime since) override;
+        virtual void remove_entry_by_url(String const& url) override;
 
     private:
         HashMap<String, HistoryEntry> m_entries;
@@ -122,9 +131,11 @@ private:
 
         virtual Optional<HistoryEntry> entry_for_url(String const& url) override;
         virtual Vector<HistoryEntry> autocomplete_entries(StringView title_query, StringView url_query, size_t limit) override;
+        virtual Vector<HistoryEntry> list_all_entries() const override;
 
         virtual void clear() override;
         virtual void remove_entries_accessed_since(UnixDateTime since) override;
+        virtual void remove_entry_by_url(String const& url) override;
 
     private:
         Database::Database& m_database;

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -40,6 +40,9 @@ enum class ActionID {
 
     ToggleVerticalTabsExpanded,
 
+    ManageHistory,
+    ClearHistory,
+
     ManageBookmarks,
     ToggleBookmark,
     ToggleBookmarkViaToolbar,

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -42,6 +42,7 @@
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/HistoryStore.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/Settings.h>
 #include <LibWebView/WebContentClient.h>

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -348,7 +348,11 @@ void WebContentClient::maybe_record_history_visit_for_current_load(u64 page_id, 
     if (!normalized_url.has_value())
         return;
 
-    if (auto recorded_url = m_history_recorded_urls_for_current_load.get(page_id); recorded_url.has_value() && *recorded_url == *normalized_url) {
+    auto recorded_url = m_history_recorded_urls_for_current_load.get(page_id);
+    // This is arguably not a bug. But if the history for a url is cleared
+    // and a currently open tab is reloaded, then this if guarantees that it is reloaded
+    // I think that the real fix would be for the history clear to send some signal
+    if (WebView::Application::history_store().entry_for_url(url).has_value() && recorded_url.has_value() && *recorded_url == *normalized_url) {
         dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Visit for page {} at '{}' was already recorded during this load before {}", page_id, *normalized_url, reason);
         return;
     }

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -9,6 +9,7 @@
 #include <LibWebView/WebContentClient.h>
 #include <LibWebView/WebUI.h>
 #include <LibWebView/WebUI/BookmarksUI.h>
+#include <LibWebView/WebUI/HistoryUI.h>
 #include <LibWebView/WebUI/ProcessesUI.h>
 #include <LibWebView/WebUI/SettingsUI.h>
 #include <LibWebView/WebUI/VersionUI.h>
@@ -35,6 +36,8 @@ ErrorOr<RefPtr<WebUI>> WebUI::create(WebContentClient& client, u64 page_id, Stri
 
     if (host == "bookmarks"sv)
         web_ui = TRY(create_web_ui<BookmarksUI>(client, page_id, move(host)));
+    else if (host == "history"sv)
+        web_ui = TRY(create_web_ui<HistoryUI>(client, page_id, move(host)));
     else if (host == "processes"sv)
         web_ui = TRY(create_web_ui<ProcessesUI>(client, page_id, move(host)));
     else if (host == "settings"sv)

--- a/Libraries/LibWebView/WebUI/HistoryUI.cpp
+++ b/Libraries/LibWebView/WebUI/HistoryUI.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, Jorge Pais <jorge27pais@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/Application.h>
+#include <LibWebView/HistoryStore.h>
+#include <LibWebView/WebUI/HistoryUI.h>
+
+namespace WebView {
+
+static constexpr auto URL_KEY = "url"sv;
+static constexpr auto TITLE_KEY = "title"sv;
+static constexpr auto FAVICON_KEY = "favicon"sv;
+static constexpr auto DATE_VISITED_KEY = "dateVisited"sv;
+static constexpr auto TIMES_VISITED_KEY = "timesVisited"sv;
+
+static JsonObject serialize_history_entry(HistoryEntry const& entry)
+{
+    JsonObject object;
+
+    object.set(URL_KEY, entry.url);
+    object.set(DATE_VISITED_KEY, entry.last_visited_time.milliseconds_since_epoch());
+    object.set(TIMES_VISITED_KEY, entry.visit_count);
+    if (entry.title.has_value())
+        object.set(TITLE_KEY, entry.title.value());
+    if (entry.favicon_base64_png.has_value())
+        object.set(FAVICON_KEY, entry.favicon_base64_png.value());
+
+    return object;
+}
+
+static JsonValue serialize_history_list(Vector<HistoryEntry> const& list)
+{
+    JsonArray items;
+    items.ensure_capacity(list.size());
+
+    for (auto const& entry : list) {
+        items.must_append(serialize_history_entry(entry));
+    }
+
+    return items;
+}
+
+void HistoryUI::register_interfaces()
+{
+    register_interface("loadHistory"sv, [this](auto&&) { load_history(); });
+    register_interface("deleteHistoryEntry"sv, [this](auto const& data) { delete_history_entry(data); });
+}
+
+void HistoryUI::load_history()
+{
+    auto history = Application::history_store().list_all_entries();
+    async_send_message("loadHistory"sv, serialize_history_list(history));
+}
+
+void HistoryUI::delete_history_entry(JsonValue const& data)
+{
+    if (!data.is_object())
+        return;
+
+    auto url = data.as_object().get_string(URL_KEY);
+    if (!url.has_value())
+        return;
+
+    Application::history_store().remove_entry_by_url(url.value());
+}
+
+}

--- a/Libraries/LibWebView/WebUI/HistoryUI.h
+++ b/Libraries/LibWebView/WebUI/HistoryUI.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, Jorge Pais <jorge27pais@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWebView/HistoryStore.h>
+#include <LibWebView/WebUI.h>
+
+namespace WebView {
+
+class HistoryUI final : public WebUI {
+    WEB_UI(HistoryUI);
+
+private:
+    virtual void register_interfaces() override;
+
+    void load_history();
+    void delete_history_entry(JsonValue const& data);
+};
+
+}

--- a/Tests/LibWebView/TestHistoryStore.cpp
+++ b/Tests/LibWebView/TestHistoryStore.cpp
@@ -271,15 +271,214 @@ TEST_CASE(history_autocomplete_entries_include_metadata)
     expect_history_autocomplete_entries_include_metadata(*store);
 }
 
-TEST_CASE(non_browsable_urls_are_not_recorded)
+TEST_CASE(remove_entry_by_url)
+{
+    auto store = WebView::HistoryStore::create();
+    auto keep_url = parse_url("https://keep.example.com/"sv);
+    auto remove_url = parse_url("https://remove.example.com/"sv);
+
+    store->record_visit(keep_url, "Keep"_string, UnixDateTime::from_seconds_since_epoch(10));
+    store->record_visit(remove_url, "Remove"_string, UnixDateTime::from_seconds_since_epoch(20));
+
+    store->remove_entry_by_url("https://remove.example.com/"_string);
+
+    EXPECT(store->entry_for_url(keep_url).has_value());
+    EXPECT(!store->entry_for_url(remove_url).has_value());
+}
+
+TEST_CASE(list_all_entries)
 {
     auto store = WebView::HistoryStore::create();
 
-    store->record_visit(parse_url("about:blank"sv));
-    store->record_visit(parse_url("data:text/plain,hello"sv));
+    store->record_visit(parse_url("https://alpha.example.com/"sv), "Alpha"_string, UnixDateTime::from_seconds_since_epoch(10));
+    store->record_visit(parse_url("https://beta.example.com/"sv), "Beta"_string, UnixDateTime::from_seconds_since_epoch(20));
+    store->record_visit(parse_url("https://gamma.example.com/"sv), "Gamma"_string, UnixDateTime::from_seconds_since_epoch(30));
 
-    EXPECT(!store->entry_for_url(parse_url("about:blank"sv)).has_value());
-    EXPECT(!store->entry_for_url(parse_url("data:text/plain,hello"sv)).has_value());
+    auto entries = store->list_all_entries();
+    EXPECT_EQ(entries.size(), 3u);
+
+    bool found_alpha = false;
+    bool found_beta = false;
+    bool found_gamma = false;
+    for (auto const& entry : entries) {
+        if (entry.url == "https://alpha.example.com/"_string)
+            found_alpha = true;
+        else if (entry.url == "https://beta.example.com/"_string)
+            found_beta = true;
+        else if (entry.url == "https://gamma.example.com/"_string)
+            found_gamma = true;
+    }
+    EXPECT(found_alpha);
+    EXPECT(found_beta);
+    EXPECT(found_gamma);
+}
+
+TEST_CASE(update_title_updates_existing_entry)
+{
+    auto store = WebView::HistoryStore::create();
+    auto url = parse_url("https://example.com/"sv);
+
+    store->record_visit(url, "Original"_string, UnixDateTime::from_seconds_since_epoch(10));
+    store->update_title(url, "Updated"_string);
+
+    auto entry = store->entry_for_url(url);
+    VERIFY(entry.has_value());
+    EXPECT_EQ(entry->title, Optional<String> { "Updated"_string });
+}
+
+TEST_CASE(update_title_ignores_empty_string)
+{
+    auto store = WebView::HistoryStore::create();
+    auto url = parse_url("https://example.com/"sv);
+
+    store->record_visit(url, "Original"_string, UnixDateTime::from_seconds_since_epoch(10));
+    store->update_title(url, String {});
+
+    auto entry = store->entry_for_url(url);
+    VERIFY(entry.has_value());
+    EXPECT_EQ(entry->title, Optional<String> { "Original"_string });
+}
+
+TEST_CASE(update_title_ignores_nonexistent_entry)
+{
+    auto store = WebView::HistoryStore::create();
+    auto url = parse_url("https://nonexistent.example.com/"sv);
+
+    store->update_title(url, "Title"_string);
+
+    EXPECT(!store->entry_for_url(url).has_value());
+}
+
+TEST_CASE(update_favicon_ignores_nonexistent_entry)
+{
+    auto store = WebView::HistoryStore::create();
+    auto url = parse_url("https://nonexistent.example.com/"sv);
+
+    store->update_favicon(url, "Zm9v"_string);
+
+    EXPECT(!store->entry_for_url(url).has_value());
+}
+
+TEST_CASE(record_closed_window_ignores_empty_urls)
+{
+    auto store = WebView::HistoryStore::create();
+
+    store->record_closed_window({}, 0, UnixDateTime::from_seconds_since_epoch(10));
+
+    EXPECT(!store->has_recently_closed_entries());
+}
+
+TEST_CASE(record_closed_window_clamps_active_tab_index)
+{
+    auto store = WebView::HistoryStore::create();
+    auto first_url = parse_url("https://first.example.com/"sv);
+    auto second_url = parse_url("https://second.example.com/"sv);
+
+    store->record_closed_window({ first_url, second_url }, 99, UnixDateTime::from_seconds_since_epoch(10));
+
+    auto entry = store->pop_most_recently_closed_entry();
+    VERIFY(entry.has_value());
+    EXPECT_EQ(entry->active_tab_index, 1u);
+}
+
+TEST_CASE(autocomplete_returns_empty_for_blank_query)
+{
+    auto store = WebView::HistoryStore::create();
+
+    store->record_visit(parse_url("https://example.com/"sv), "Example"_string, UnixDateTime::from_seconds_since_epoch(10));
+
+    EXPECT(store->autocomplete_entries(""sv, 8).is_empty());
+    EXPECT(store->autocomplete_entries("   "sv, 8).is_empty());
+}
+
+TEST_CASE(autocomplete_respects_limit)
+{
+    auto store = WebView::HistoryStore::create();
+
+    store->record_visit(parse_url("https://test1.example.com/"sv), "Test 1"_string, UnixDateTime::from_seconds_since_epoch(10));
+    store->record_visit(parse_url("https://test2.example.com/"sv), "Test 2"_string, UnixDateTime::from_seconds_since_epoch(20));
+    store->record_visit(parse_url("https://test3.example.com/"sv), "Test 3"_string, UnixDateTime::from_seconds_since_epoch(30));
+
+    auto entries = store->autocomplete_entries("test"sv, 2);
+    EXPECT_EQ(entries.size(), 2u);
+}
+
+TEST_CASE(disabled_store_ignores_list_remove_and_favicon)
+{
+    auto store = WebView::HistoryStore::create_disabled();
+    auto url = parse_url("https://example.com/"sv);
+
+    store->record_visit(url, "Example"_string, UnixDateTime::from_seconds_since_epoch(10));
+    store->update_favicon(url, "Zm9v"_string);
+
+    EXPECT(store->list_all_entries().is_empty());
+
+    store->remove_entry_by_url("https://example.com/"_string);
+    EXPECT(store->list_all_entries().is_empty());
+}
+
+TEST_CASE(persisted_remove_entry_by_url)
+{
+    auto database_directory = ByteString::formatted(
+        "{}/ladybird-history-store-remove-by-url-test-{}",
+        Core::StandardPaths::tempfile_directory(),
+        generate_random_uuid());
+    TRY_OR_FAIL(Core::Directory::create(database_directory, Core::Directory::CreateDirectories::Yes));
+
+    auto cleanup = ScopeGuard([&] {
+        MUST(FileSystem::remove(database_directory, FileSystem::RecursionMode::Allowed));
+    });
+
+    auto keep_url = parse_url("https://keep.example.com/"sv);
+    auto remove_url = parse_url("https://remove.example.com/"sv);
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
+        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        store->record_visit(keep_url, "Keep"_string, UnixDateTime::from_seconds_since_epoch(10));
+        store->record_visit(remove_url, "Remove"_string, UnixDateTime::from_seconds_since_epoch(20));
+        store->remove_entry_by_url("https://remove.example.com/"_string);
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
+        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+
+        EXPECT(store->entry_for_url(keep_url).has_value());
+        EXPECT(!store->entry_for_url(remove_url).has_value());
+    }
+}
+
+TEST_CASE(persisted_list_all_entries)
+{
+    auto database_directory = ByteString::formatted(
+        "{}/ladybird-history-store-list-all-test-{}",
+        Core::StandardPaths::tempfile_directory(),
+        generate_random_uuid());
+    TRY_OR_FAIL(Core::Directory::create(database_directory, Core::Directory::CreateDirectories::Yes));
+
+    auto cleanup = ScopeGuard([&] {
+        MUST(FileSystem::remove(database_directory, FileSystem::RecursionMode::Allowed));
+    });
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
+        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+        store->record_visit(parse_url("https://alpha.example.com/"sv), "Alpha"_string, UnixDateTime::from_seconds_since_epoch(10));
+        store->record_visit(parse_url("https://beta.example.com/"sv), "Beta"_string, UnixDateTime::from_seconds_since_epoch(20));
+    }
+
+    {
+        auto database = TRY_OR_FAIL(Database::Database::create(database_directory, "HistoryStore"sv));
+        auto store = TRY_OR_FAIL(WebView::HistoryStore::create(*database));
+
+        auto entries = store->list_all_entries();
+        EXPECT_EQ(entries.size(), 2u);
+
+        // Persisted list_all_entries orders by last_visited_time DESC.
+        EXPECT_EQ(entries[0].url, "https://beta.example.com/"_string);
+        EXPECT_EQ(entries[1].url, "https://alpha.example.com/"_string);
+    }
 }
 
 TEST_CASE(disabled_history_store_ignores_updates)

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -24,6 +24,7 @@
 @property (nonatomic, weak) Tab* active_tab;
 
 @property (nonatomic, strong) NSMenu* bookmarks_menu;
+@property (nonatomic, strong) NSMenu* history_menu;
 
 @property (nonatomic, strong) InfoBar* info_bar;
 
@@ -354,17 +355,9 @@
 {
     auto* menu = [[NSMenuItem alloc] init];
 
-    auto* submenu = [[NSMenu alloc] initWithTitle:@"History"];
-    [submenu setAutoenablesItems:NO];
+    self.history_menu = Ladybird::create_application_menu(WebView::Application::the().history_menu());
+    [menu setSubmenu:self.history_menu];
 
-    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().reload_action())];
-    [submenu addItem:[NSMenuItem separatorItem]];
-
-    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Clear History"
-                                                action:@selector(clearHistory:)
-                                         keyEquivalent:@""]];
-
-    [menu setSubmenu:submenu];
     return menu;
 }
 

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -247,6 +247,7 @@ static void initialize_native_icon(WebView::Action& action, id control)
         set_control_image(control, @"magnifyingglass");
         break;
 
+    case WebView::ActionID::ManageHistory:
     case WebView::ActionID::ManageBookmarks:
         set_control_image(control, @"bookmark");
         break;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -371,6 +371,10 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         Settings::the()->set_show_menubar(checked);
     });
 
+    m_history_menu = create_application_menu(*this, Application::the().history_menu());
+    m_hamburger_menu->addMenu(m_history_menu);
+    menuBar()->addMenu(m_history_menu);
+
     m_bookmarks_menu = create_application_menu(*this, Application::the().bookmarks_menu());
     m_hamburger_menu->addMenu(m_bookmarks_menu);
     menuBar()->addMenu(m_bookmarks_menu);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -204,6 +204,7 @@ private:
     DevToolsBanner* m_devtools_banner { nullptr };
 
     QMenu* m_hamburger_menu { nullptr };
+    QMenu* m_history_menu { nullptr };
     QMenu* m_bookmarks_menu { nullptr };
     QWidget* m_menu_bar_window_controls { nullptr };
     QToolButton* m_menu_bar_minimize_window_button { nullptr };

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -32,6 +32,7 @@ list(TRANSFORM INTERNAL_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladyb
 set(ABOUT_PAGES
     about.html
     bookmarks.html
+    history.html
     newtab.html
     processes.html
     settings.html


### PR DESCRIPTION
- Add about page for viewing history
- Add `HistoryUI` class for `loadHistory` and `deleteEntry` interfaces
- Add `list_all_entries` and `remove_entry_by_url` method to `HistoryStore`
- Add new unit tests for `HistoryStore` 
- Update AppKit+Qt global menu with history page
