### PR TITLE
LibGfx: Don't load the same font file multiple times in PathFontProvider

### DIFF
--- a/Libraries/LibGfx/Font/PathFontProvider.cpp
+++ b/Libraries/LibGfx/Font/PathFontProvider.cpp
@@ -54,7 +54,15 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
     root->for_each_descendant_file([this](Core::Resource const& resource) -> IterationDecision {
         auto uri = resource.uri();
         auto path = LexicalPath(uri.bytes_as_string_view());
-        if (path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv)) {
+        auto is_truetype = path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv);
+        auto is_woff = path.has_extension(".woff"sv);
+        if (!is_truetype && !is_woff)
+            return IterationDecision::Continue;
+
+        if (m_loaded_paths.set(resource.filesystem_path(), AK::HashSetExistingEntryBehavior::Keep) != AK::HashSetResult::InsertedNewEntry)
+            return IterationDecision::Continue;
+
+        if (is_truetype) {
             auto font_count = number_of_fonts_in_ttc(resource.data());
             for (u32 ttc_index = 0; ttc_index < font_count; ++ttc_index) {
                 if (auto font_or_error = Typeface::try_load_from_resource(resource, ttc_index); !font_or_error.is_error()) {
@@ -65,7 +73,7 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
                     family.append(font);
                 }
             }
-        } else if (path.has_extension(".woff"sv)) {
+        } else {
             if (auto font_or_error = WOFF::try_load_from_resource(resource); !font_or_error.is_error()) {
                 auto font = font_or_error.release_value();
                 auto& family = m_typeface_by_family.ensure(font->family(), [] {

--- a/Libraries/LibGfx/Font/PathFontProvider.h
+++ b/Libraries/LibGfx/Font/PathFontProvider.h
@@ -9,6 +9,7 @@
 #include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
+#include <AK/HashTable.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/Typeface.h>
 
@@ -32,6 +33,12 @@ public:
 
 private:
     HashMap<FlyString, Vector<NonnullRefPtr<Typeface>>, AK::ASCIICaseInsensitiveFlyStringTraits> m_typeface_by_family;
+
+    // Tracks files we've already loaded, to avoid mmap'ing the same .ttf/.otf/.ttc
+    // multiple times when overlapping font directories are walked (fontconfig commonly
+    // returns nested entries like /usr/share/fonts and /usr/share/fonts/truetype).
+    HashTable<String> m_loaded_paths;
+
     String m_name { "Path"_string };
 };
 


### PR DESCRIPTION
fontconfig's font directory list may contain overlapping entries (e.g. both `/usr/share/fonts` and `/usr/share/fonts/truetype/msttcorefonts`) and our recursive walk was visiting each `.ttf`/`.otf`/`.ttc` several times and `mmap`'ing it once per visit. On a typical Linux system this resulted in 2-3 mappings per file before any actual rendering.

Track each font's filesystem path and skip files we've already loaded. Drops WebContent's font-file VMA count from ~7400 to ~2500 on my box.