### PR TITLE
AK: Fix UTF-16 StringBuilder corruption after non-ASCII clear/reuse

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -362,6 +362,8 @@ Utf16View StringBuilder::utf16_string_view() const
 void StringBuilder::clear()
 {
     m_buffer.resize(string_builder_prefix_size(m_mode));
+    if (m_mode == Mode::UTF16)
+        m_utf16_builder_is_ascii = true;
 }
 
 ErrorOr<void> StringBuilder::try_append_code_point(u32 code_point)

--- a/Tests/AK/TestUtf16String.cpp
+++ b/Tests/AK/TestUtf16String.cpp
@@ -1326,3 +1326,29 @@ TEST_CASE(optional)
     EXPECT(!string.has_value());
     EXPECT_EQ(released, u"well 😀 hello"sv);
 }
+
+TEST_CASE(utf16_builder_clear_resets_ascii_flag)
+{
+    // Regression test: StringBuilder(UTF16) must reset m_utf16_builder_is_ascii
+    // on clear(). Without this, a builder that previously held non-ASCII content
+    // stores subsequent ASCII as char16_t, and to_utf16_string() corrupts the
+    // first code unit via placement-new overlap in from_string_builder().
+    StringBuilder builder(StringBuilder::Mode::UTF16);
+
+    // 1. Append a non-ASCII code point to force m_utf16_builder_is_ascii = false.
+    builder.append_code_point(0x00D7); // U+00D7 MULTIPLICATION SIGN (×)
+    auto first = builder.to_utf16_string();
+    EXPECT_EQ(first.length_in_code_units(), 1u);
+    EXPECT_EQ(first.code_unit_at(0), 0x00D7);
+
+    // 2. Clear and reuse for ASCII content.
+    builder.clear();
+    builder.append_code_point('\n');
+    for (int i = 0; i < 100; ++i)
+        builder.append_code_point(' ');
+
+    auto second = builder.to_utf16_string();
+    EXPECT_EQ(second.length_in_code_units(), 101u);
+    EXPECT_EQ(second.code_unit_at(0), 0x000A); // Must be newline, not null.
+    EXPECT_EQ(second.code_unit_at(1), 0x0020);
+}


### PR DESCRIPTION
Fix two related bugs in `StringBuilder` / `Utf16StringData` that caused the first code unit of a `Utf16String` to be corrupted to null after the builder processed a non-ASCII character.

- `StringBuilder::clear()` did not reset `m_utf16_builder_is_ascii`, so a reused builder stored subsequent ASCII as char16_t and hit the placement-new overlap in `from_string_builder()`
- `Utf16StringData` has `sizeof=32` but `offsetof(m_ascii_data)=30`, leaving 2 bytes of tail padding that overlap string storage; placement-new construction could zero those bytes

The HTML parser reuses a single `m_character_insertion_builder` across all text nodes. When a non-ASCII character (e.g. `&times;`) appeared before a `<script>` tag, the script text node's first code unit was zeroed, causing a JS parse failure.

Closes #9324