### PR TITLE
Tests: Resync idlharness.js with WPT and fix worker IDL loading

### DIFF
--- a/Tests/LibWeb/Text/input/wpt-import/resources/idlharness.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/idlharness.js
@@ -783,6 +783,10 @@ IdlArray.prototype.merge_partials = function()
         }
         testedPartials.set(parsed_idl.name, partialTestCount);
 
+        if (!self.shouldRunSubTest(partialTestName)) {
+            return;
+        }
+
         if (!parsed_idl.untested) {
             test(function () {
                 assert_true(originalExists, `Original ${parsed_idl.type} should be defined`);
@@ -871,6 +875,7 @@ IdlArray.prototype.merge_mixins = function()
     {
         const lhs = parsed_idl.target;
         const rhs = parsed_idl.includes;
+        const testName = lhs + " includes " + rhs + ": member names are unique";
 
         var errStr = lhs + " includes " + rhs + ", but ";
         if (!(lhs in this.members)) throw errStr + lhs + " is undefined.";
@@ -878,7 +883,7 @@ IdlArray.prototype.merge_mixins = function()
         if (!(rhs in this.members)) throw errStr + rhs + " is undefined.";
         if (!(this.members[rhs] instanceof IdlInterface)) throw errStr + rhs + " is not an interface.";
 
-        if (this.members[rhs].members.length) {
+        if (this.members[rhs].members.length && self.shouldRunSubTest(testName)) {
             test(function () {
                 var clash = this.members[rhs].members.find(function(member) {
                     return this.members[lhs].members.find(function(m) {
@@ -892,7 +897,7 @@ IdlArray.prototype.merge_mixins = function()
                     this.members[lhs].members.push(new IdlInterfaceMember(member));
                 }.bind(this));
                 assert_true(!clash, "member " + (clash && clash.name) + " is unique");
-            }.bind(this), lhs + " includes " + rhs + ": member names are unique");
+            }.bind(this), testName);
         }
     }
     this.includes = [];
@@ -1393,7 +1398,7 @@ IdlInterface.prototype.default_to_json_operation = function() {
         if (I.has_default_to_json_regular_operation()) {
             isDefault = true;
             for (const m of I.members) {
-                if (m.special !== "static" && m.type == "attribute" && I.array.is_json_type(m.idlType)) {
+                if (!m.untested && m.special !== "static" && m.type == "attribute" && I.array.is_json_type(m.idlType)) {
                     map.set(m.name, m.idlType);
                 }
             }
@@ -3557,12 +3562,7 @@ globalThis.idl_test = idl_test;
  * Note: ShadowRealm-specific implementation in testharness-shadowrealm-inner.js
  */
 function fetch_spec(spec) {
-    const url_parts = window.location.href.split("/");
-
-    while (url_parts[url_parts.length - 1] != "wpt-import")
-        url_parts.pop();
-
-    var url = url_parts.join("/") + '/interfaces/' + spec + '.idl';
+    var url = '/interfaces/' + spec + '.idl';
     return fetch(url).then(function (r) {
         if (!r.ok) {
             throw new IdlHarnessError("Error fetching " + url + ".");


### PR DESCRIPTION
Sync our local copy of `idlharness.js` with upstream WPT changes.

This also fixes worker IDL harness tests by replacing the local `window.location` based URL handling in `fetch_spec()`. Worker globals do not expose `window`, so worker IDL tests could fail during setup before any interface checks ran.

The local `window.location` logic was originally needed for `file://` execution, but this is no longer needed as our IDL tests are now served over HTTP.