### PR TITLE
LibGC: Prefer MADV_DONTNEED over MADV_FREE for decommitted blocks

### DIFF
--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -56,18 +56,23 @@ static void madvise_block_for_decommit(void* block)
         VERIFY_NOT_REACHED();
     }
 #elif defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
+    // macOS uses the FREE_REUSABLE/FREE_REUSE paired protocol, which integrates
+    // with its RSS accounting properly.
     if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSABLE) < 0) {
         perror("madvise(MADV_FREE_REUSABLE)");
+        VERIFY_NOT_REACHED();
+    }
+#elif defined(MADV_DONTNEED)
+    // Prefer DONTNEED over FREE on Linux: FREE is lazy and only releases pages
+    // under memory pressure, which leaves freed blocks counted in RSS for
+    // arbitrarily long after a busy page goes idle.
+    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_DONTNEED) < 0) {
+        perror("madvise(MADV_DONTNEED)");
         VERIFY_NOT_REACHED();
     }
 #elif defined(MADV_FREE)
     if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE) < 0) {
         perror("madvise(MADV_FREE)");
-        VERIFY_NOT_REACHED();
-    }
-#elif defined(MADV_DONTNEED)
-    if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_DONTNEED) < 0) {
-        perror("madvise(MADV_DONTNEED)");
         VERIFY_NOT_REACHED();
     }
 #endif


### PR DESCRIPTION
`MADV_FREE` is lazy: the kernel only reclaims pages once it actually needs them. As a result, blocks freed during a transient burst of allocation continue to count toward our RSS for an arbitrarily long time after a busy page goes idle.

Switch to `MADV_DONTNEED` on Linux so freed blocks drop out of RSS immediately. macOS keeps the existing `FREE_REUSABLE`/`FREE_REUSE` paired protocol (which integrates with its RSS accounting and gives the same "eager release" behavior).

On https://cloudflare.com, some big GCs now drop ~350 MB instantly instead of accumulating into a long-lived `MADV_FREE` backlog.