### PR TITLE
LibGC: Remove lagacy size-based allocator support

### DIFF
--- a/Libraries/LibGC/CellAllocator.h
+++ b/Libraries/LibGC/CellAllocator.h
@@ -20,13 +20,6 @@
 #define GC_DEFINE_ALLOCATOR(ClassName) \
     GC::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator { #ClassName##sv, ClassName::OVERRIDES_MUST_SURVIVE_GARBAGE_COLLECTION, ClassName::OVERRIDES_FINALIZE }
 
-// The size-based allocator, which isolates different Cell types based on their size instead of their concrete type.
-// This should only be used if it's not possible or undesirable to use a type-isolated cell allocator.
-// Different Cell types can use the same blocks if they happen to have the same size, which allows type confusion
-// to occur if a Cell is used after it's freed.
-#define GC_DECLARE_SIZE_BASED_ALLOCATOR(ClassName) \
-    using gc_allocator_marker = ClassName
-
 namespace GC {
 
 class GC_API CellAllocator {

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -57,13 +57,6 @@ Heap::Heap(AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roo
     s_the = this;
     m_gc_bytes_threshold = GC_MIN_BYTES_THRESHOLD;
     static_assert(HeapBlock::min_possible_cell_size <= 32, "Heap Cell tracking uses too much data!");
-    m_size_based_cell_allocators.append(make<CellAllocator>(64));
-    m_size_based_cell_allocators.append(make<CellAllocator>(96));
-    m_size_based_cell_allocators.append(make<CellAllocator>(128));
-    m_size_based_cell_allocators.append(make<CellAllocator>(256));
-    m_size_based_cell_allocators.append(make<CellAllocator>(512));
-    m_size_based_cell_allocators.append(make<CellAllocator>(1024));
-    m_size_based_cell_allocators.append(make<CellAllocator>(3072));
 }
 
 Heap::~Heap()

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -105,25 +105,14 @@ private:
     void dump_allocators();
 
     template<typename T>
-    static consteval bool has_own_gc_allocator_marker()
-    {
-        if constexpr (requires { typename T::gc_allocator_marker; })
-            return IsSame<typename T::gc_allocator_marker, T>;
-        return false;
-    }
-
-    template<typename T>
     Cell* allocate_cell()
     {
-        static_assert(has_own_gc_allocator_marker<T>(), "Cell type must declare its own allocator with either GC_DECLARE_ALLOCATOR (for type-isolated allocation) or GC_DECLARE_SIZE_BASED_ALLOCATOR (for size-based allocation)");
+        static_assert(requires { T::cell_allocator.allocator.get().allocate_cell(*this); }, "GC cell type must declare its own allocator using GC_DECLARE_ALLOCATOR(ClassName)");
+        static_assert(IsSame<T, typename decltype(T::cell_allocator)::CellType>,
+            "GC cell allocator type mismatch");
 
         will_allocate(sizeof(T));
-        if constexpr (requires { T::cell_allocator.allocator.get().allocate_cell(*this); }) {
-            if constexpr (IsSame<T, typename decltype(T::cell_allocator)::CellType>) {
-                return T::cell_allocator.allocator.get().allocate_cell(*this);
-            }
-        }
-        return allocator_for_size(sizeof(T)).allocate_cell(*this);
+        return T::cell_allocator.allocator.get().allocate_cell(*this);
     }
 
     void will_allocate(size_t);
@@ -139,17 +128,6 @@ private:
     void sweep_weak_blocks();
     void run_post_gc_tasks();
 
-    ALWAYS_INLINE CellAllocator& allocator_for_size(size_t cell_size)
-    {
-        // FIXME: Use binary search?
-        for (auto& allocator : m_size_based_cell_allocators) {
-            if (allocator->cell_size() >= cell_size)
-                return *allocator;
-        }
-        dbgln("Cannot get CellAllocator for cell size {}, largest available is {}!", cell_size, m_size_based_cell_allocators.last()->cell_size());
-        VERIFY_NOT_REACHED();
-    }
-
     template<typename Callback>
     void for_each_block(Callback callback)
     {
@@ -164,7 +142,6 @@ private:
 
     bool m_should_collect_on_every_allocation { false };
 
-    Vector<NonnullOwnPtr<CellAllocator>> m_size_based_cell_allocators;
     CellAllocator::List m_all_cell_allocators;
 
     RootImpl::List m_roots;


### PR DESCRIPTION
#### Description

As the size-based allocators are never used anymore, this PR removes the `allocator_for_size` API and the associated size-based cell allocator from `LibGC`.

#### Changes

- Removed `Heap::allocator_for_size(size_t)` and the `m_size_based_cell_allocators` vector in class `Heap`.
- Removed the `GC_DECLARE_SIZE_BASED_ALLOCATOR` macro from `CellAllocator.h`.
- Added `static_assert` in `Heap::allocate_cell<T>` to check type-isolated allocators at compile-time .
- Removed the initialization of legacy size-based allocators in `Heap` constructor.
