### PR TITLE
LibWeb: Stop spinning the rendering pipeline for paused media

### DIFF
--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -147,6 +147,10 @@ void MediaControls::set_up_event_listeners()
     add_event_listener(realm, media_element, HTML::EventNames::play, [this]() {
         update_play_pause_icon();
         update_placeholder_visibility();
+        if (m_request_animation_frame_callback && m_request_animation_frame_id == 0) {
+            auto& window = as<HTML::Window>(m_media_element->realm().global_object());
+            m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
+        }
         return true;
     });
     add_event_listener(realm, media_element, HTML::EventNames::pause, [this] {
@@ -416,19 +420,25 @@ void MediaControls::set_up_event_listeners()
     });
 
     // Use requestAnimationFrame to update the timeline, since timeupdate only fires every 250ms.
+    // Only keep the loop running while the media element is potentially playing, so paused
+    // videos don't keep the rendering pipeline busy.
     auto request_animation_frame_callback_function = JS::NativeFunction::create(
         realm, [this](JS::VM&) {
+            m_request_animation_frame_id = 0;
             update_timeline();
 
-            auto& realm = m_media_element->realm();
-            auto& window = as<HTML::Window>(realm.global_object());
-            m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
+            if (m_media_element && m_media_element->potentially_playing()) {
+                auto& realm = m_media_element->realm();
+                auto& window = as<HTML::Window>(realm.global_object());
+                m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
+            }
 
             return JS::js_undefined();
         },
         0, Utf16FlyString {}, &realm);
     m_request_animation_frame_callback = realm.heap().allocate<WebIDL::CallbackType>(request_animation_frame_callback_function, realm);
-    m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
+    if (media_element.potentially_playing())
+        m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
 }
 
 void MediaControls::toggle_playback()

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -559,7 +559,8 @@ void Page::update_all_media_element_video_sinks()
     bool should_request_another_frame = false;
     for_each_media_element([&](auto& media_element) {
         media_element.update_video_frame_and_timeline();
-        should_request_another_frame = true;
+        if (media_element.potentially_playing())
+            should_request_another_frame = true;
     });
 
     if (should_request_another_frame)


### PR DESCRIPTION
Two spots in the media element machinery were keeping the "update the rendering" steps running at full vsync rate even when nothing was playing.

`Page::update_all_media_element_video_sinks()` requested another frame after every rendering opportunity as long as any media element existed on the page, regardless of playback state. It now only requests another frame when at least one media element is `potentially_playing()`, so paused videos no longer keep the rendering pipeline busy.

The media controls also ran a self-perpetuating `requestAnimationFrame` to update the timeline at vsync rate (since `timeupdate` only fires every 250ms), and the callback re-registered itself unconditionally. It now only re-registers while the media element is potentially playing, and the loop is (re)started from the play event listener.

This fixes an issue with continuous high CPU usage after pausing media playback.