### PR TITLE
LibWeb: Keep intrinsic heights indefinite for percentage children

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -506,7 +506,8 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
     }
 
     box_state.set_content_height(height);
-    box_state.set_has_definite_height(true);
+    if (computed_height_establishes_definite_containing_block_height(computed_values.height()))
+        box_state.set_has_definite_height(true);
 }
 
 void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, FormattingContext const* box_formatting_context)

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -40,6 +40,14 @@ FormattingContext::FormattingContext(Type type, LayoutMode layout_mode, LayoutSt
 
 FormattingContext::~FormattingContext() = default;
 
+bool FormattingContext::computed_height_establishes_definite_containing_block_height(CSS::Size const& computed_height)
+{
+    // A resolved used height is not always a definite containing block height.
+    // Intrinsic sizing keywords like fit-content still depend on child layout,
+    // so percentage-height descendants must continue to treat them as indefinite.
+    return !computed_height.is_intrinsic_sizing_constraint();
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
 bool FormattingContext::creates_block_formatting_context(Box const& box)
 {
@@ -1240,7 +1248,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
-    box_state.set_has_definite_height(true);
+    if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
+        box_state.set_has_definite_height(true);
     box_state.inset_top = top.to_px_or_zero(box, height_of_containing_block);
     box_state.inset_bottom = bottom.to_px_or_zero(box, height_of_containing_block);
     box_state.margin_top = margin_top.to_px_or_zero(box, width_of_containing_block);
@@ -1643,7 +1652,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     if (is_non_auto(computed_values.inset().left()) && is_non_auto(computed_values.inset().right())) {
         box_state.set_has_definite_width(true);
     }
-    if (is_non_auto(computed_values.inset().top()) && is_non_auto(computed_values.inset().bottom())) {
+    if (is_non_auto(computed_values.inset().top()) && is_non_auto(computed_values.inset().bottom())
+        && (computed_values.height().is_auto() || computed_height_establishes_definite_containing_block_height(computed_values.height()))) {
         box_state.set_has_definite_height(true);
     }
 
@@ -1656,7 +1666,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
             && box.has_preferred_aspect_ratio()
             && box_state.has_definite_width();
         box_state.set_has_definite_width(true);
-        if (!computed_values.height().is_auto() || height_resolved_from_aspect_ratio)
+        if ((!computed_values.height().is_auto() && computed_height_establishes_definite_containing_block_height(computed_values.height())) || height_resolved_from_aspect_ratio)
             box_state.set_has_definite_height(true);
     }
 
@@ -1809,7 +1819,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
-    box_state.set_has_definite_height(true);
+    if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
+        box_state.set_has_definite_height(true);
     box_state.inset_top = to_px(top);
     box_state.inset_bottom = to_px(bottom);
     box_state.margin_top = to_px(margin_top);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -162,6 +162,8 @@ public:
 protected:
     FormattingContext(Type, LayoutMode, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 
+    [[nodiscard]] static bool computed_height_establishes_definite_containing_block_height(CSS::Size const&);
+
     [[nodiscard]] bool should_treat_width_as_auto(Box const&, AvailableSpace const&) const;
     [[nodiscard]] bool should_treat_height_as_auto(Box const&, AvailableSpace const&) const;
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/fixed-fit-content-min-height-with-percentage-height-child.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/fixed-fit-content-min-height-with-percentage-height-child.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <div.a> at [0,0] positioned [0+0+0 40 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.b> at [0,0] [0+0+0 40 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,0 14.265625x18] baseline: 13.796875
+              "A"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,18] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.c> at [0,18] [0+0+0 40 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,18 9.34375x18] baseline: 13.796875
+              "B"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,36] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>.a) [0,0 40x48]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 40x0]
+        PaintableWithLines (BlockContainer<DIV>.b) [0,0 40x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,18 40x0]
+        PaintableWithLines (BlockContainer<DIV>.c) [0,18 40x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,36 40x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] [children: 1] (z-index: auto)
+  SC for BlockContainer<DIV>.a [0,0 40x48] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/fixed-fit-content-top-and-bottom-with-percentage-height-child.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/fixed-fit-content-top-and-bottom-with-percentage-height-child.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <div.a> at [0,0] positioned [0+0+0 14.265625 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.b> at [0,0] [0+0+0 14.265625 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,0 14.265625x18] baseline: 13.796875
+              "A"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,18] [0+0+0 14.265625 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,18 9.34375x18] baseline: 13.796875
+              "B"
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>.a) [0,0 14.265625x36]
+        PaintableWithLines (BlockContainer<DIV>.b) [0,0 14.265625x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,18 14.265625x18]
+          TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] [children: 1] (z-index: auto)
+  SC for BlockContainer<DIV>.a [0,0 14.265625x36] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-height-child-in-fit-content-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-height-child-in-fit-content-height.txt
@@ -1,0 +1,36 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] children: not-inline
+      BlockContainer <div.a> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.b> at [0,0] [0+0+0 800 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,0 14.265625x18] baseline: 13.796875
+              "A"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,18] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [0,18] [0+0+0 800 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [0,18 9.34375x18] baseline: 13.796875
+              "B"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,36] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,36] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x36]
+      PaintableWithLines (BlockContainer<DIV>.a) [0,0 800x36]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+        PaintableWithLines (BlockContainer<DIV>.b) [0,0 800x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,18 800x0]
+        PaintableWithLines (BlockContainer<DIV>) [0,18 800x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,36 800x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,36 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
@@ -12,13 +12,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <(anonymous)> at [10,436] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.h.min> at [11,437] [0+1+0 778 0+1+0] [0+1+0 402 0+1+0] children: inline
-        frag 0 from ImageBox start: 0, length: 0, rect: [12,438 402x402] baseline: 404
-        ImageBox <img> at [12,438] [0+1+0 402 0+1+0] [0+1+0 402 0+1+0] children: not-inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [12,438 400x400] baseline: 402
+        ImageBox <img> at [12,438] [0+1+0 400 0+1+0] [0+1+0 400 0+1+0] children: not-inline
       BlockContainer <(anonymous)> at [10,840] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div.h.max> at [11,841] [0+1+0 778 0+1+0] [0+1+0 402 0+1+0] children: inline
-        frag 0 from ImageBox start: 0, length: 0, rect: [12,842 402x402] baseline: 404
-        ImageBox <img> at [12,842] [0+1+0 402 0+1+0] [0+1+0 402 0+1+0] children: not-inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [12,842 400x400] baseline: 402
+        ImageBox <img> at [12,842] [0+1+0 400 0+1+0] [0+1+0 400 0+1+0] children: not-inline
       BlockContainer <(anonymous)> at [10,1244] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -32,10 +32,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1254]
         ImagePaintable (ImageBox<IMG>) [11,31 404x404]
       PaintableWithLines (BlockContainer(anonymous)) [10,436 780x0]
       PaintableWithLines (BlockContainer<DIV>.h.min) [10,436 780x404]
-        ImagePaintable (ImageBox<IMG>) [11,437 404x404]
+        ImagePaintable (ImageBox<IMG>) [11,437 402x402]
       PaintableWithLines (BlockContainer(anonymous)) [10,840 780x0]
       PaintableWithLines (BlockContainer<DIV>.h.max) [10,840 780x404]
-        ImagePaintable (ImageBox<IMG>) [11,841 404x404]
+        ImagePaintable (ImageBox<IMG>) [11,841 402x402]
       PaintableWithLines (BlockContainer(anonymous)) [10,1244 780x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/fixed-fit-content-min-height-with-percentage-height-child.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/fixed-fit-content-min-height-with-percentage-height-child.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<style>
+body { margin: 0; }
+.a {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 40px;
+    height: fit-content;
+    min-height: 48px;
+}
+.b { height: 100%; background: lightblue; }
+.c { background: pink; }
+</style>
+<div class="a">
+  <div class="b">A</div>
+  <div class="c">B</div>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/fixed-fit-content-top-and-bottom-with-percentage-height-child.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/fixed-fit-content-top-and-bottom-with-percentage-height-child.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<style>
+body { margin: 0; }
+.a {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    height: fit-content;
+}
+.b { height: 100%; background: lightblue; }
+</style>
+<div class="a"><div class="b">A</div>B</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/percentage-height-child-in-fit-content-height.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/percentage-height-child-in-fit-content-height.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<style>
+body { margin: 0; }
+.a { height: fit-content; }
+.b { height: 100%; background: lightblue; }
+</style>
+<div class="a">
+  <div class="b">A</div>
+  <div style="background: pink">B</div>
+</div>


### PR DESCRIPTION
A used height computed from an intrinsic sizing keyword like fit-content does not necessarily establish a definite containing-block height for percentage descendants.

Preserve indefinite percentage-height resolution both in normal block layout and in absolutely positioned/fixed layout, including cases where non-auto top/bottom insets resolve the box’s own used height.

Fixes the layout of the header on business.google.com

Before:

<img width="1357" height="699" alt="image" src="https://github.com/user-attachments/assets/b06a59d7-36f2-43a8-b1bf-88525ac5d1de" />


After:

<img width="1357" height="699" alt="image" src="https://github.com/user-attachments/assets/ddaf8732-7a7c-44be-a257-417f7bb9adfb" />
