### PR TITLE
LibWeb/Painting: Skip positioned descendants earlier in traversal

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -144,6 +144,13 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
         if (child.has_stacking_context())
             return IterationDecision::Continue;
 
+        auto const& z_index = [&] { return child.computed_values().z_index(); };
+
+        // Positioned descendants at stack level 0 are painted in a separate pass.
+        // See `m_positioned_descendants_and_stacking_contexts_with_stack_level_0`.
+        if (child.is_positioned() && z_index().value_or(0) == 0)
+            return IterationDecision::Continue;
+
         if (child.is_svg_svg_paintable()) {
             paint_svg(context, static_cast<PaintableBox const&>(child), to_paint_phase(phase));
             return IterationDecision::Continue;
@@ -154,7 +161,6 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
         //       "For each one of these, treat the element as if it created a new stacking context, but any positioned
         //       descendants and descendants which actually create a new stacking context should be considered part of
         //       the parent stacking context, not this new one."
-        auto const& z_index = [&] { return child.computed_values().z_index(); };
         if (child.layout_node().is_grid_item() && !z_index().has_value()) {
             // FIXME: This may not be fully correct with respect to the paint phases.
             if (phase == StackingContextPaintPhase::Foreground)
@@ -173,9 +179,6 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
             }
             return IterationDecision::Continue;
         }
-
-        if (child.is_positioned() && z_index().value_or(0) == 0)
-            return IterationDecision::Continue;
 
         bool child_is_inline_or_replaced = child.is_inline() || is<Layout::ReplacedBox>(child.layout_node());
         switch (phase) {

--- a/Tests/LibWeb/Ref/expected/positioned-grid-item-alpha-background-ref.html
+++ b/Tests/LibWeb/Ref/expected/positioned-grid-item-alpha-background-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<style>
+.grid { display: grid; width: 200px; height: 200px; background: white; }
+.card { background-color: #ff000033; }
+</style>
+<div class="grid"><div class="card"></div></div>

--- a/Tests/LibWeb/Ref/expected/positioned-svg-root-alpha-background-ref.html
+++ b/Tests/LibWeb/Ref/expected/positioned-svg-root-alpha-background-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<style>
+.container { background: white; width: 200px; height: 200px; }
+svg { width: 200px; height: 200px; background-color: #ff000033; }
+</style>
+<div class="container"><svg></svg></div>

--- a/Tests/LibWeb/Ref/input/positioned-grid-item-alpha-background.html
+++ b/Tests/LibWeb/Ref/input/positioned-grid-item-alpha-background.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<link rel="match" href="../expected/positioned-grid-item-alpha-background-ref.html" />
+<style>
+.grid { display: grid; width: 200px; height: 200px; background: white; }
+.card { position: relative; background-color: #ff000033; }
+</style>
+<div class="grid"><div class="card"></div></div>

--- a/Tests/LibWeb/Ref/input/positioned-svg-root-alpha-background.html
+++ b/Tests/LibWeb/Ref/input/positioned-svg-root-alpha-background.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<link rel="match" href="../expected/positioned-svg-root-alpha-background-ref.html" />
+<style>
+.container { background: white; width: 200px; height: 200px; }
+svg { position: relative; width: 200px; height: 200px; background-color: #ff000033; }
+</style>
+<div class="container"><svg></svg></div>


### PR DESCRIPTION
paint_descendants already skipped positioned descendants at stack level zero so they're only painted by paint_internal's pass, but the SVG-root and grid-item branches returned before reaching the skip, making them be painted twice.

Move the skip above them to make it apply to all deferred positioned descendants uniformly.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/9277