### PR TITLE
Meta+LibWeb: Support more CSS grammar features for code generation

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -319,8 +319,10 @@ public:
         if (style_value->is_value_list()) {
             auto const& values = style_value->as_value_list().values();
 
-            if (values.size() == 1)
-                return { values[0]->as_url().url(), {} };
+            VERIFY(values.size() == 2);
+
+            if (values[1]->is_empty_optional())
+                return values[0]->as_url().url();
 
             return { values[0]->as_url().url(), values[1]->to_color(color_resolution_context) };
         }

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -435,7 +435,6 @@ private:
     RefPtr<AbstractImageStyleValue const> parse_image_value(TokenStream<ComponentValue>&);
     RefPtr<AbstractImageStyleValue const> parse_image_value(TokenStream<ComponentValue>&, AllowImageSet);
     RefPtr<ImageSetStyleValue const> parse_image_set_function(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue const> parse_paint_value(TokenStream<ComponentValue>&);
     enum class PositionParsingMode {
         Normal,
         BackgroundPosition,

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2783,56 +2783,6 @@ RefPtr<AbstractImageStyleValue const> Parser::parse_image_value(TokenStream<Comp
     return nullptr;
 }
 
-// https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
-RefPtr<StyleValue const> Parser::parse_paint_value(TokenStream<ComponentValue>& tokens)
-{
-    // `<paint> = none | <color> | <url> [none | <color>]? | context-fill | context-stroke`
-
-    auto parse_color_or_none = [&]() -> Optional<RefPtr<StyleValue const>> {
-        if (auto color = parse_color_value(tokens))
-            return color;
-
-        // NOTE: <color> also accepts identifiers, so we do this identifier check last.
-        if (tokens.next_token().is(Token::Type::Ident)) {
-            auto maybe_keyword = keyword_from_string(tokens.next_token().token().ident());
-            if (maybe_keyword.has_value()) {
-                // FIXME: Accept `context-fill` and `context-stroke`
-                switch (*maybe_keyword) {
-                case Keyword::None:
-                    tokens.discard_a_token();
-                    return KeywordStyleValue::create(*maybe_keyword);
-                default:
-                    return nullptr;
-                }
-            }
-        }
-
-        return OptionalNone {};
-    };
-
-    // FIXME: Allow context-fill/context-stroke here
-    if (auto color_or_none = parse_color_or_none(); color_or_none.has_value())
-        return *color_or_none;
-
-    if (auto url = parse_url_value(tokens)) {
-        tokens.discard_whitespace();
-
-        StyleValueVector values;
-        values.ensure_capacity(2);
-        values.unchecked_append(url.release_nonnull());
-
-        if (auto color_or_none = parse_color_or_none(); color_or_none == nullptr) {
-            // Fail to parse if the fallback is invalid, but otherwise ignore it.
-            return nullptr;
-        } else if (color_or_none.has_value() && *color_or_none && (*color_or_none)->has_color()) {
-            values.unchecked_append(color_or_none->release_nonnull());
-        }
-        return StyleValueList::create(move(values), StyleValueList::Separator::Space, StyleValueList::Collapsible::No);
-    }
-
-    return nullptr;
-}
-
 // https://www.w3.org/TR/css-values-4/#position
 RefPtr<PositionStyleValue const> Parser::parse_position_value(TokenStream<ComponentValue>& tokens, PositionParsingMode position_parsing_mode)
 {

--- a/Libraries/LibWeb/CSS/StyleValues/EmptyOptionalStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EmptyOptionalStyleValue.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, Callum Law <callumlaw1709@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/StyleValues/StyleValue.h>
+
+namespace Web::CSS {
+
+class EmptyOptionalStyleValue final : public StyleValueWithDefaultOperators<EmptyOptionalStyleValue> {
+public:
+    static ValueComparingNonnullRefPtr<EmptyOptionalStyleValue> create()
+    {
+        auto static const instance = adopt_ref(*new (nothrow) EmptyOptionalStyleValue());
+        return instance;
+    }
+
+    virtual ~EmptyOptionalStyleValue() override = default;
+
+    // NB: This style is used to represent a missing optional value, it should only appear within a StyleValueList which
+    //     will skip serializing/tokenizing it and the relevant separator so it should never be serialized/tokenized.
+    virtual void serialize(StringBuilder&, SerializationMode) const override { VERIFY_NOT_REACHED(); }
+    virtual Vector<Parser::ComponentValue> tokenize() const override { VERIFY_NOT_REACHED(); }
+
+    bool properties_equal(EmptyOptionalStyleValue const&) const { return true; }
+
+    virtual bool is_computationally_independent() const override { return true; }
+
+private:
+    EmptyOptionalStyleValue()
+        : StyleValueWithDefaultOperators(Type::EmptyOptional)
+    {
+    }
+};
+
+}

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -37,6 +37,7 @@
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/EmptyOptionalStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FlexStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FontSourceStyleValue.h>

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -56,6 +56,7 @@ namespace Web::CSS {
     __ENUMERATE_CSS_STYLE_VALUE_TYPE(Display, display, DisplayStyleValue)                                                      \
     __ENUMERATE_CSS_STYLE_VALUE_TYPE(Easing, easing, EasingStyleValue)                                                         \
     __ENUMERATE_CSS_STYLE_VALUE_TYPE(Edge, edge, EdgeStyleValue)                                                               \
+    __ENUMERATE_CSS_STYLE_VALUE_TYPE(EmptyOptional, empty_optional, EmptyOptionalStyleValue)                                   \
     __ENUMERATE_CSS_STYLE_VALUE_TYPE(FilterValueList, filter_value_list, FilterValueListStyleValue)                            \
     __ENUMERATE_CSS_STYLE_VALUE_TYPE(Function, function, FunctionStyleValue)                                                   \
     __ENUMERATE_CSS_STYLE_VALUE_TYPE(Flex, flex, FlexStyleValue)                                                               \

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -59,15 +59,22 @@ void StyleValueList::serialize(StringBuilder& builder, SerializationMode mode) c
     }
 
     auto first_value = m_properties.values.first();
-    if (all_of(m_properties.values, [&](auto const& property) { return property == first_value; }) && m_properties.separator != Separator::Comma && m_properties.collapsible == Collapsible::Yes) {
+    if (all_of(m_properties.values, [&](auto const& property) { return property == first_value; }) && m_properties.separator != Separator::Comma && m_properties.collapsible == Collapsible::Yes && !first_value->is_empty_optional()) {
         first_value->serialize(builder, mode);
         return;
     }
 
+    bool first = true;
+
     for (size_t i = 0; i < m_properties.values.size(); ++i) {
-        m_properties.values[i]->serialize(builder, mode);
-        if (i != m_properties.values.size() - 1)
+        if (m_properties.values[i]->is_empty_optional())
+            continue;
+
+        if (!first)
             builder.append(separator);
+
+        first = false;
+        m_properties.values[i]->serialize(builder, mode);
     }
 }
 
@@ -83,6 +90,8 @@ Vector<Parser::ComponentValue> StyleValueList::tokenize() const
     Vector<Parser::ComponentValue> component_values;
     bool first = true;
     for (auto const& value : m_properties.values) {
+        if (value->is_empty_optional())
+            continue;
         if (first) {
             first = false;
         } else {

--- a/Libraries/LibWeb/CSS/ValueTypes.json
+++ b/Libraries/LibWeb/CSS/ValueTypes.json
@@ -3,6 +3,11 @@
         "spec": "https://drafts.csswg.org/css-fonts-4/#font-weight-absolute-values",
         "grammar": "[ normal | bold | <number [1,1000]> ]"
     },
+    "<paint>": {
+        "spec": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+        "grammar": "none | <color> | <url> [none | <color>]?",
+        "__comment": "FIXME: Support context-fill and context-stroke values here"
+    },
     "<symbol>": {
         "spec": "https://drafts.csswg.org/css-counter-styles-3/#typedef-symbol",
         "grammar": "<string> | <custom-ident>",

--- a/Libraries/LibWeb/CSS/ValueTypes.json
+++ b/Libraries/LibWeb/CSS/ValueTypes.json
@@ -1,8 +1,7 @@
 {
     "<font-weight-absolute>": {
         "spec": "https://drafts.csswg.org/css-fonts-4/#font-weight-absolute-values",
-        "grammar": "normal | bold | <number [1,1000]>",
-        "__comment": "FIXME: The spec defines this wrapped in a group i.e. '[ normal | bold | <number [1,1000]> ]' but our CSS grammar parser doesn't currently know how to handle that"
+        "grammar": "[ normal | bold | <number [1,1000]> ]"
     },
     "<symbol>": {
         "spec": "https://drafts.csswg.org/css-counter-styles-3/#typedef-symbol",

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -313,6 +313,7 @@ class Display;
 class DisplayStyleValue;
 class EasingStyleValue;
 class EdgeStyleValue;
+class EmptyOptionalStyleValue;
 class ExplicitGridTrack;
 class FilterValueListStyleValue;
 class Flex;

--- a/Meta/Generators/generate_libweb_css_value_types_parsing.py
+++ b/Meta/Generators/generate_libweb_css_value_types_parsing.py
@@ -96,6 +96,8 @@ def generate_implementation_file(out: TextIO, value_type_data: dict[str, Any]) -
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EmptyOptionalStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
+#include <LibWeb/CSS/StyleValues/StyleValueList.h>
+#include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 
 namespace Web::CSS::Parser {
 

--- a/Meta/Generators/generate_libweb_css_value_types_parsing.py
+++ b/Meta/Generators/generate_libweb_css_value_types_parsing.py
@@ -94,6 +94,7 @@ def generate_implementation_file(out: TextIO, value_type_data: dict[str, Any]) -
 #include <LibWeb/CSS/Parser/Parser.h>
 
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/EmptyOptionalStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
 
 namespace Web::CSS::Parser {

--- a/Meta/Utils/CSSGrammar/Parser/grammar_node.py
+++ b/Meta/Utils/CSSGrammar/Parser/grammar_node.py
@@ -19,6 +19,10 @@ class ComponentValueGrammarNode(GrammarNode):
 
 
 class CombinatorType(Enum):
+    # https://drafts.csswg.org/css-values-4/#component-combinators
+    # Juxtaposing components means that all of them must occur, in the given order.
+    JUXTAPOSITION = "Juxtaposition"
+
     # https://drafts.csswg.org/css-values-4/#comb-one
     # A bar (|) separates two or more alternatives: exactly one of them must occur.
     ALTERNATIVES = "Alternatives"

--- a/Meta/Utils/CSSGrammar/Parser/grammar_node.py
+++ b/Meta/Utils/CSSGrammar/Parser/grammar_node.py
@@ -37,3 +37,11 @@ class CombinatorGrammarNode(GrammarNode):
             output += child.dump(indent + 2)
 
         return output
+
+
+@dataclass(frozen=True)
+class GroupGrammarNode(GrammarNode):
+    child: GrammarNode
+
+    def dump(self, indent: int = 0) -> str:
+        return f"{'': >{indent}}Group:\n" + self.child.dump(indent + 2)

--- a/Meta/Utils/CSSGrammar/Parser/grammar_node.py
+++ b/Meta/Utils/CSSGrammar/Parser/grammar_node.py
@@ -45,3 +45,11 @@ class GroupGrammarNode(GrammarNode):
 
     def dump(self, indent: int = 0) -> str:
         return f"{'': >{indent}}Group:\n" + self.child.dump(indent + 2)
+
+
+@dataclass(frozen=True)
+class OptionalGrammarNode(GrammarNode):
+    child: GrammarNode
+
+    def dump(self, indent: int = 0) -> str:
+        return f"{'': >{indent}}Optional:\n" + self.child.dump(indent + 2)

--- a/Meta/Utils/CSSGrammar/Parser/parser.py
+++ b/Meta/Utils/CSSGrammar/Parser/parser.py
@@ -2,6 +2,7 @@ from Utils.CSSGrammar.Parser.grammar_node import CombinatorGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import CombinatorType
 from Utils.CSSGrammar.Parser.grammar_node import ComponentValueGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GrammarNode
+from Utils.CSSGrammar.Parser.grammar_node import GroupGrammarNode
 from Utils.CSSGrammar.Parser.token import Token
 from Utils.CSSGrammar.Parser.token import TokenType
 from Utils.CSSGrammar.Parser.tokenizer import Tokenizer
@@ -38,6 +39,17 @@ class Parser:
     def parse_component_value(self) -> GrammarNode:
         # https://drafts.csswg.org/css-values-4/#component-multipliers
         # FIXME: Support component multipliers
+
+        if self.peek().is_token_type(TokenType.OPEN_SQUARE_BRACKET):
+            self.consume()
+            group = self.parse_alternatives()
+
+            if not self.peek().is_token_type(TokenType.CLOSE_SQUARE_BRACKET):
+                raise SyntaxError("CSSGrammar::Parser: Expected ']'")
+
+            # FIXME: Support required groups (e.g. [ <foo>? ]!)
+            self.consume()
+            return GroupGrammarNode(group)
 
         if not self.peek().is_token_type(TokenType.COMPONENT_VALUE):
             raise SyntaxError("CSSGrammar::Parser: Expected a component value")

--- a/Meta/Utils/CSSGrammar/Parser/parser.py
+++ b/Meta/Utils/CSSGrammar/Parser/parser.py
@@ -3,6 +3,7 @@ from Utils.CSSGrammar.Parser.grammar_node import CombinatorType
 from Utils.CSSGrammar.Parser.grammar_node import ComponentValueGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GroupGrammarNode
+from Utils.CSSGrammar.Parser.grammar_node import OptionalGrammarNode
 from Utils.CSSGrammar.Parser.token import Token
 from Utils.CSSGrammar.Parser.token import TokenType
 from Utils.CSSGrammar.Parser.tokenizer import Tokenizer
@@ -40,7 +41,10 @@ class Parser:
         # https://drafts.csswg.org/css-values-4/#component-multipliers
         # FIXME: Support component multipliers
 
-        if self.peek().is_token_type(TokenType.OPEN_SQUARE_BRACKET):
+        peeked = self.peek()
+        component_value = None
+
+        if peeked.is_token_type(TokenType.OPEN_SQUARE_BRACKET):
             self.consume()
             group = self.parse_alternatives()
 
@@ -49,12 +53,19 @@ class Parser:
 
             # FIXME: Support required groups (e.g. [ <foo>? ]!)
             self.consume()
-            return GroupGrammarNode(group)
+            component_value = GroupGrammarNode(group)
 
-        if not self.peek().is_token_type(TokenType.COMPONENT_VALUE):
+        if peeked.is_token_type(TokenType.COMPONENT_VALUE):
+            component_value = ComponentValueGrammarNode(self.consume().component_value())
+
+        if component_value is None:
             raise SyntaxError("CSSGrammar::Parser: Expected a component value")
 
-        return ComponentValueGrammarNode(self.consume().component_value())
+        if self.peek().is_token_type(TokenType.QUESTION_MARK):
+            self.consume()
+            component_value = OptionalGrammarNode(component_value)
+
+        return component_value
 
     def peek(self, offset: int = 0) -> Token:
         index = min(self.index + offset, len(self.tokens) - 1)

--- a/Meta/Utils/CSSGrammar/Parser/parser.py
+++ b/Meta/Utils/CSSGrammar/Parser/parser.py
@@ -26,16 +26,27 @@ class Parser:
         return value
 
     def parse_alternatives(self) -> GrammarNode:
-        children = [self.parse_component_value()]
+        children = [self.parse_juxtaposition()]
 
         while self.peek().is_token_type(TokenType.SINGLE_BAR):
             self.consume()
-            children.append(self.parse_component_value())
+            children.append(self.parse_juxtaposition())
 
         if len(children) == 1:
             return children[0]
 
         return CombinatorGrammarNode(CombinatorType.ALTERNATIVES, children)
+
+    def parse_juxtaposition(self) -> GrammarNode:
+        children = [self.parse_component_value()]
+
+        while self.next_token_starts_component_value():
+            children.append(self.parse_component_value())
+
+        if len(children) == 1:
+            return children[0]
+
+        return CombinatorGrammarNode(CombinatorType.JUXTAPOSITION, children)
 
     def parse_component_value(self) -> GrammarNode:
         # https://drafts.csswg.org/css-values-4/#component-multipliers
@@ -66,6 +77,12 @@ class Parser:
             component_value = OptionalGrammarNode(component_value)
 
         return component_value
+
+    def next_token_starts_component_value(self) -> bool:
+        return self.peek().token_type in (
+            TokenType.OPEN_SQUARE_BRACKET,
+            TokenType.COMPONENT_VALUE,
+        )
 
     def peek(self, offset: int = 0) -> Token:
         index = min(self.index + offset, len(self.tokens) - 1)

--- a/Meta/Utils/CSSGrammar/Parser/token.py
+++ b/Meta/Utils/CSSGrammar/Parser/token.py
@@ -8,6 +8,8 @@ from Utils.CSSGrammar.Parser.component_values import ComponentValue
 class TokenType(Enum):
     END_OF_FILE = "end-of-file"
     SINGLE_BAR = "single-bar"
+    OPEN_SQUARE_BRACKET = "open-square-bracket"
+    CLOSE_SQUARE_BRACKET = "close-square-bracket"
     COMPONENT_VALUE = "component-value"
 
 

--- a/Meta/Utils/CSSGrammar/Parser/token.py
+++ b/Meta/Utils/CSSGrammar/Parser/token.py
@@ -10,6 +10,7 @@ class TokenType(Enum):
     SINGLE_BAR = "single-bar"
     OPEN_SQUARE_BRACKET = "open-square-bracket"
     CLOSE_SQUARE_BRACKET = "close-square-bracket"
+    QUESTION_MARK = "question-mark"
     COMPONENT_VALUE = "component-value"
 
 

--- a/Meta/Utils/CSSGrammar/Parser/tokenizer.py
+++ b/Meta/Utils/CSSGrammar/Parser/tokenizer.py
@@ -51,6 +51,9 @@ class Tokenizer:
         if peeked == "]":
             self.lexer.consume()
             return Token.create(TokenType.CLOSE_SQUARE_BRACKET)
+        if peeked == "?":
+            self.lexer.consume()
+            return Token.create(TokenType.QUESTION_MARK)
         if peeked == "<":
             return self.consume_a_non_terminal_token()
 

--- a/Meta/Utils/CSSGrammar/Parser/tokenizer.py
+++ b/Meta/Utils/CSSGrammar/Parser/tokenizer.py
@@ -45,6 +45,12 @@ class Tokenizer:
         if peeked == "|":
             self.lexer.consume()
             return Token.create(TokenType.SINGLE_BAR)
+        if peeked == "[":
+            self.lexer.consume()
+            return Token.create(TokenType.OPEN_SQUARE_BRACKET)
+        if peeked == "]":
+            self.lexer.consume()
+            return Token.create(TokenType.CLOSE_SQUARE_BRACKET)
         if peeked == "<":
             return self.consume_a_non_terminal_token()
 

--- a/Meta/Utils/CSSGrammar/generator.py
+++ b/Meta/Utils/CSSGrammar/generator.py
@@ -9,6 +9,7 @@ from Utils.CSSGrammar.Parser.grammar_node import CombinatorType
 from Utils.CSSGrammar.Parser.grammar_node import ComponentValueGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GroupGrammarNode
+from Utils.CSSGrammar.Parser.grammar_node import OptionalGrammarNode
 from Utils.CSSGrammar.Parser.parser import parse_value_definition_grammar
 from Utils.utils import snake_casify
 from Utils.utils import title_casify
@@ -101,12 +102,28 @@ def generate_css_parser_expression_for_group_grammar_node(
     generate_css_parser_expression_for_grammar_node(out, cpp_name, grammar_node.child)
 
 
+def generate_css_parser_expression_for_optional_grammar_node(
+    out: TextIO, cpp_name: str, grammar_node: OptionalGrammarNode
+) -> None:
+    out.write(f"""RefPtr<StyleValue const> {cpp_name} = EmptyOptionalStyleValue::create();
+""")
+
+    generate_css_parser_expression_for_grammar_node(out, f"maybe_{cpp_name}", grammar_node.child)
+
+    out.write(f"""if (maybe_{cpp_name})
+        {cpp_name} = maybe_{cpp_name};
+""")
+
+
 def generate_css_parser_expression_for_grammar_node(out: TextIO, cpp_name: str, grammar_node: GrammarNode) -> None:
     if isinstance(grammar_node, ComponentValueGrammarNode):
         generate_css_parser_expression_for_component_value_grammar_node(out, cpp_name, grammar_node)
         return
     if isinstance(grammar_node, GroupGrammarNode):
         generate_css_parser_expression_for_group_grammar_node(out, cpp_name, grammar_node)
+        return
+    if isinstance(grammar_node, OptionalGrammarNode):
+        generate_css_parser_expression_for_optional_grammar_node(out, cpp_name, grammar_node)
         return
     if isinstance(grammar_node, CombinatorGrammarNode):
         generate_css_parser_expression_for_combinator_grammar_node(out, cpp_name, grammar_node)

--- a/Meta/Utils/CSSGrammar/generator.py
+++ b/Meta/Utils/CSSGrammar/generator.py
@@ -8,6 +8,7 @@ from Utils.CSSGrammar.Parser.grammar_node import CombinatorGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import CombinatorType
 from Utils.CSSGrammar.Parser.grammar_node import ComponentValueGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GrammarNode
+from Utils.CSSGrammar.Parser.grammar_node import GroupGrammarNode
 from Utils.CSSGrammar.Parser.parser import parse_value_definition_grammar
 from Utils.utils import snake_casify
 from Utils.utils import title_casify
@@ -94,9 +95,18 @@ def generate_css_parser_expression_for_combinator_grammar_node(
     raise TypeError(f"Unhandled combinator type: {grammar_node.combinator_type}")
 
 
+def generate_css_parser_expression_for_group_grammar_node(
+    out: TextIO, cpp_name: str, grammar_node: GroupGrammarNode
+) -> None:
+    generate_css_parser_expression_for_grammar_node(out, cpp_name, grammar_node.child)
+
+
 def generate_css_parser_expression_for_grammar_node(out: TextIO, cpp_name: str, grammar_node: GrammarNode) -> None:
     if isinstance(grammar_node, ComponentValueGrammarNode):
         generate_css_parser_expression_for_component_value_grammar_node(out, cpp_name, grammar_node)
+        return
+    if isinstance(grammar_node, GroupGrammarNode):
+        generate_css_parser_expression_for_group_grammar_node(out, cpp_name, grammar_node)
         return
     if isinstance(grammar_node, CombinatorGrammarNode):
         generate_css_parser_expression_for_combinator_grammar_node(out, cpp_name, grammar_node)

--- a/Meta/Utils/CSSGrammar/generator.py
+++ b/Meta/Utils/CSSGrammar/generator.py
@@ -86,9 +86,38 @@ auto {cpp_name} = parse_{cpp_name}_alternatives();
 """)
 
 
+def generate_css_parser_expression_for_juxtaposition(out: TextIO, cpp_name: str, children: list[GrammarNode]) -> None:
+    out.write(f"""auto const parse_{cpp_name}_juxtaposition = [&]() -> RefPtr<StyleValue const> {{
+auto {cpp_name}_transaction = tokens.begin_transaction();
+StyleValueVector {cpp_name}_values;
+{cpp_name}_values.ensure_capacity({len(children)});
+
+""")
+
+    for i, component in enumerate(children):
+        component_name = f"{cpp_name}_component_{i}"
+        generate_css_parser_expression_for_grammar_node(out, component_name, component)
+        out.write(f"""if (!{component_name})
+    return nullptr;
+
+{cpp_name}_values.append({component_name}.release_nonnull());
+""")
+
+    out.write(f"""{cpp_name}_transaction.commit();
+return StyleValueList::create(move({cpp_name}_values), StyleValueList::Separator::Space, StyleValueList::Collapsible::No);
+}};
+
+auto {cpp_name} = parse_{cpp_name}_juxtaposition();
+""")
+
+
 def generate_css_parser_expression_for_combinator_grammar_node(
     out: TextIO, cpp_name: str, grammar_node: CombinatorGrammarNode
 ) -> None:
+    if grammar_node.combinator_type == CombinatorType.JUXTAPOSITION:
+        generate_css_parser_expression_for_juxtaposition(out, cpp_name, grammar_node.children)
+        return
+
     if grammar_node.combinator_type == CombinatorType.ALTERNATIVES:
         generate_css_parser_expression_for_alternatives(out, cpp_name, grammar_node.children)
         return

--- a/Tests/Meta/test-css-grammar-parser.py
+++ b/Tests/Meta/test-css-grammar-parser.py
@@ -157,6 +157,30 @@ class TestCSSGrammarParser(unittest.TestCase):
 """,
         )
 
+    def test_parse_optional_type_reference(self) -> None:
+        syntax = parse_value_definition_grammar("<foo>?")
+        self.assertEqual(
+            syntax.dump(),
+            """Optional:
+  ComponentValue
+    Type: foo
+""",
+        )
+
+    def test_parse_optional_group(self) -> None:
+        syntax = parse_value_definition_grammar("[ auto | none ]?")
+        self.assertEqual(
+            syntax.dump(),
+            """Optional:
+  Group:
+    Combinator(Alternatives):
+      ComponentValue
+        Keyword: auto
+      ComponentValue
+        Keyword: none
+""",
+        )
+
     def test_parse_ignores_whitespace_around_tokens(self) -> None:
         syntax = parse_value_definition_grammar("  <foo>\t|\n<bar>  ")
         self.assertEqual(
@@ -180,6 +204,16 @@ class TestCSSGrammarParser(unittest.TestCase):
     def test_reject_trailing_bar(self) -> None:
         with self.assertRaises(SyntaxError):
             parse_value_definition_grammar("<foo> |")
+
+    def test_reject_invalid_optional(self) -> None:
+        for value in (
+            "?",
+            "<foo>??",
+            "[ <foo> ]??",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(SyntaxError):
+                    parse_value_definition_grammar(value)
 
     def test_reject_invalid_group(self) -> None:
         for value in (

--- a/Tests/Meta/test-css-grammar-parser.py
+++ b/Tests/Meta/test-css-grammar-parser.py
@@ -116,6 +116,47 @@ class TestCSSGrammarParser(unittest.TestCase):
 """,
         )
 
+    def test_parse_group(self) -> None:
+        syntax = parse_value_definition_grammar("[ <length> ]")
+        self.assertEqual(
+            syntax.dump(),
+            """Group:
+  ComponentValue
+    Type: length [-∞,∞]
+""",
+        )
+
+    def test_parse_grouped_alternatives(self) -> None:
+        syntax = parse_value_definition_grammar("[ auto | none | <length> ]")
+        self.assertEqual(
+            syntax.dump(),
+            """Group:
+  Combinator(Alternatives):
+    ComponentValue
+      Keyword: auto
+    ComponentValue
+      Keyword: none
+    ComponentValue
+      Type: length [-∞,∞]
+""",
+        )
+
+    def test_parse_groups_as_alternative(self) -> None:
+        syntax = parse_value_definition_grammar("[ auto | none ] | <length>")
+        self.assertEqual(
+            syntax.dump(),
+            """Combinator(Alternatives):
+  Group:
+    Combinator(Alternatives):
+      ComponentValue
+        Keyword: auto
+      ComponentValue
+        Keyword: none
+  ComponentValue
+    Type: length [-∞,∞]
+""",
+        )
+
     def test_parse_ignores_whitespace_around_tokens(self) -> None:
         syntax = parse_value_definition_grammar("  <foo>\t|\n<bar>  ")
         self.assertEqual(
@@ -139,6 +180,17 @@ class TestCSSGrammarParser(unittest.TestCase):
     def test_reject_trailing_bar(self) -> None:
         with self.assertRaises(SyntaxError):
             parse_value_definition_grammar("<foo> |")
+
+    def test_reject_invalid_group(self) -> None:
+        for value in (
+            "[]",
+            "[ <foo>",
+            "<foo> ]",
+            "[ <foo> | ]",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(SyntaxError):
+                    parse_value_definition_grammar(value)
 
     def test_reject_invalid_type_reference(self) -> None:
         for value in (

--- a/Tests/Meta/test-css-grammar-parser.py
+++ b/Tests/Meta/test-css-grammar-parser.py
@@ -116,6 +116,51 @@ class TestCSSGrammarParser(unittest.TestCase):
 """,
         )
 
+    def test_parse_juxtaposition(self) -> None:
+        syntax = parse_value_definition_grammar("<foo> <bar> baz")
+        self.assertEqual(
+            syntax.dump(),
+            """Combinator(Juxtaposition):
+  ComponentValue
+    Type: foo
+  ComponentValue
+    Type: bar
+  ComponentValue
+    Keyword: baz
+""",
+        )
+
+    def test_parse_juxtaposition_has_higher_precedence_than_alternatives(self) -> None:
+        syntax = parse_value_definition_grammar("<foo> <bar> | <baz>")
+        self.assertEqual(
+            syntax.dump(),
+            """Combinator(Alternatives):
+  Combinator(Juxtaposition):
+    ComponentValue
+      Type: foo
+    ComponentValue
+      Type: bar
+  ComponentValue
+    Type: baz
+""",
+        )
+
+    def test_parse_grouped_alternatives_in_juxtaposition(self) -> None:
+        syntax = parse_value_definition_grammar("[ <foo> | <bar> ] <baz>")
+        self.assertEqual(
+            syntax.dump(),
+            """Combinator(Juxtaposition):
+  Group:
+    Combinator(Alternatives):
+      ComponentValue
+        Type: foo
+      ComponentValue
+        Type: bar
+  ComponentValue
+    Type: baz
+""",
+        )
+
     def test_parse_group(self) -> None:
         syntax = parse_value_definition_grammar("[ <length> ]")
         self.assertEqual(


### PR DESCRIPTION
This PR adds support for groups, optionals and juxtaposition and implements `<paint>` generation which uses these features.

No functional change.