### PR TITLE
LibJS: Remove unused Rust function 

### DIFF
--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -243,11 +243,6 @@ pub type ParseErrorCallback = Option<
     unsafe extern "C" fn(ctx: *mut c_void, message: *const u8, message_len: usize, line: u32, column: u32) -> (),
 >;
 
-/// Log parser and scope collector errors, returning true if any were found.
-fn check_errors(parser: &mut Parser) -> bool {
-    check_errors_with_callback(parser, std::ptr::null_mut(), None)
-}
-
 /// Check for errors, optionally reporting them via a C++ callback.
 fn check_errors_with_callback(
     parser: &mut Parser,

--- a/Meta/CMake/rust_crate.cmake
+++ b/Meta/CMake/rust_crate.cmake
@@ -192,6 +192,7 @@ function(_rust_crate_common_setup)
         ${cargo_profile_flag}
         --
         -Cdefault-linker-libraries=yes
+        -D warnings
         --emit=dep-info
     )
 

--- a/Meta/CMake/rust_crate.cmake
+++ b/Meta/CMake/rust_crate.cmake
@@ -9,7 +9,6 @@
 function(import_rust_crate)
     cmake_parse_arguments(PARSE_ARGV 0 ARG "" "MANIFEST_PATH;CRATE_NAME;FFI_OUTPUT_DIR;FFI_HEADER" "FEATURES")
 
-    set(ARG_MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_MANIFEST_PATH}")
     if (NOT ARG_FFI_OUTPUT_DIR)
         set(ARG_FFI_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
@@ -17,44 +16,17 @@ function(import_rust_crate)
         set(ffi_output "${ARG_FFI_OUTPUT_DIR}/${ARG_FFI_HEADER}")
     endif()
 
-    # Find the workspace Cargo.lock to track as a dependency.
-    get_filename_component(workspace_dir "${ARG_MANIFEST_PATH}" DIRECTORY)
-    while(NOT EXISTS "${workspace_dir}/Cargo.lock")
-        get_filename_component(workspace_dir "${workspace_dir}" DIRECTORY)
-    endwhile()
-
-    # Detect the Rust toolchain.
-    find_program(RUST_CARGO cargo REQUIRED)
-    find_program(RUST_RUSTC rustc REQUIRED)
-    if (NOT DEFINED CACHE{RUST_TARGET_TRIPLE})
-        execute_process(COMMAND "${RUST_RUSTC}" -vV OUTPUT_VARIABLE rustc_verbose)
-        string(REGEX MATCH "host: ([^\n]+)" _ "${rustc_verbose}")
-        string(STRIP "${CMAKE_MATCH_1}" host_triple)
-        set(RUST_TARGET_TRIPLE "${host_triple}" CACHE INTERNAL "Rust target triple")
-    endif()
-
-    # Build the uppercased and underscored variants of the target triple.
-    string(REPLACE "-" "_" target_underscore "${RUST_TARGET_TRIPLE}")
-    string(TOUPPER "${target_underscore}" target_upper)
+    _rust_crate_common_setup(
+        MANIFEST_PATH "${ARG_MANIFEST_PATH}"
+        CRATE_NAME ${ARG_CRATE_NAME}
+        FFI_OUTPUT_DIR "${ARG_FFI_OUTPUT_DIR}"
+    )
 
     set(cargo_feature_flags "")
     if (ARG_FEATURES)
         list(JOIN ARG_FEATURES "," cargo_features)
         list(APPEND cargo_feature_flags "--features=${cargo_features}")
     endif()
-
-    # Determine the cargo profile and output directory name.
-    string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
-    if (build_type_upper STREQUAL "DEBUG")
-        set(cargo_profile_flag "")
-        set(cargo_profile_dir "debug")
-    else()
-        set(cargo_profile_flag "--release")
-        set(cargo_profile_dir "release")
-    endif()
-
-    set(cargo_target_dir "${CMAKE_BINARY_DIR}/cargo/build")
-    set(cargo_output_dir "${cargo_target_dir}/${RUST_TARGET_TRIPLE}/${cargo_profile_dir}")
 
     if (WIN32)
         set(output_lib "${cargo_output_dir}/${ARG_CRATE_NAME}.lib")
@@ -64,27 +36,6 @@ function(import_rust_crate)
         set(depfile "${cargo_output_dir}/lib${ARG_CRATE_NAME}.d")
     endif()
 
-    # Build environment variables for cargo.
-    set(cargo_env
-        "CC_${target_underscore}=${CMAKE_C_COMPILER}"
-        "CXX_${target_underscore}=${CMAKE_CXX_COMPILER}"
-        "CARGO_BUILD_RUSTC=${RUST_RUSTC}"
-        "FFI_OUTPUT_DIR=${ARG_FFI_OUTPUT_DIR}"
-    )
-
-    # On Windows, rustc invokes the linker directly with MSVC-style flags, so we must not override it with a
-    # compiler driver like clang-cl.
-    if (NOT WIN32)
-        list(APPEND cargo_env
-            "CARGO_TARGET_${target_upper}_LINKER=${CMAKE_C_COMPILER}"
-            "AR_${target_underscore}=${CMAKE_AR}"
-        )
-    endif()
-
-    if (APPLE AND CMAKE_OSX_SYSROOT)
-        list(APPEND cargo_env "SDKROOT=${CMAKE_OSX_SYSROOT}")
-    endif()
-
     add_custom_command(
         OUTPUT "${output_lib}" ${ffi_output}
         COMMAND
@@ -92,15 +43,8 @@ function(import_rust_crate)
             "${RUST_CARGO}"
                 rustc
                 --lib
-                "--target=${RUST_TARGET_TRIPLE}"
-                --package ${ARG_CRATE_NAME}
-                --manifest-path "${ARG_MANIFEST_PATH}"
-                --target-dir "${cargo_target_dir}"
                 ${cargo_feature_flags}
-                ${cargo_profile_flag}
-                --
-                -Cdefault-linker-libraries=yes
-                --emit=dep-info
+                ${cargo_common_flags}
         COMMAND
             ${CMAKE_COMMAND}
                 -DCARGO_BUILD_SCRIPT_DIR=${cargo_output_dir}/build
@@ -108,7 +52,7 @@ function(import_rust_crate)
                 -DFFI_HEADER=${ARG_FFI_HEADER}
                 -DFFI_OUTPUT_DIR=${ARG_FFI_OUTPUT_DIR}
                 -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/sync_rust_ffi_header.cmake"
-        DEPENDS "${ARG_MANIFEST_PATH}"
+        DEPENDS "${manifest_path}"
             "${workspace_dir}/Cargo.lock" "${workspace_dir}/Cargo.toml"
         DEPFILE "${depfile}"
         COMMENT "Building Rust crate ${ARG_CRATE_NAME}"
@@ -143,10 +87,48 @@ function(build_rust_binary)
         set(ARG_OUTPUT_NAME "${ARG_BINARY_NAME}")
     endif()
 
-    set(ARG_MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_MANIFEST_PATH}")
+    _rust_crate_common_setup(
+        MANIFEST_PATH "${ARG_MANIFEST_PATH}"
+        CRATE_NAME ${ARG_CRATE_NAME}
+        FFI_OUTPUT_DIR "${ARG_FFI_OUTPUT_DIR}"
+    )
+
+    set(cargo_binary "${cargo_output_dir}/${ARG_BINARY_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+    set(depfile "${cargo_output_dir}/${ARG_BINARY_NAME}.d")
+    set(output_binary "${CMAKE_BINARY_DIR}/bin/${ARG_OUTPUT_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+
+    add_custom_command(
+        OUTPUT "${output_binary}"
+        COMMAND
+            ${CMAKE_COMMAND} -E env ${cargo_env}
+            "${RUST_CARGO}"
+                rustc
+                --bin ${ARG_BINARY_NAME}
+                ${cargo_common_flags}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${cargo_binary}" "${output_binary}"
+        DEPENDS "${manifest_path}"
+            "${workspace_dir}/Cargo.lock" "${workspace_dir}/Cargo.toml"
+        DEPFILE "${depfile}"
+        COMMENT "Building Rust binary ${ARG_BINARY_NAME}"
+        USES_TERMINAL
+        COMMAND_EXPAND_LISTS
+    )
+
+    add_custom_target(${ARG_BINARY_NAME}-build DEPENDS "${output_binary}")
+
+    if (ARG_OUTPUT_PATH_VAR)
+        set(${ARG_OUTPUT_PATH_VAR} "${output_binary}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Shared cargo setup for import_rust_crate() and build_rust_binary().
+function(_rust_crate_common_setup)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "MANIFEST_PATH;CRATE_NAME;FFI_OUTPUT_DIR" "")
+
+    set(manifest_path "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_MANIFEST_PATH}")
 
     # Find the workspace Cargo.lock to track as a dependency.
-    get_filename_component(workspace_dir "${ARG_MANIFEST_PATH}" DIRECTORY)
+    get_filename_component(workspace_dir "${manifest_path}" DIRECTORY)
     while(NOT EXISTS "${workspace_dir}/Cargo.lock")
         get_filename_component(workspace_dir "${workspace_dir}" DIRECTORY)
     endwhile()
@@ -177,9 +159,6 @@ function(build_rust_binary)
 
     set(cargo_target_dir "${CMAKE_BINARY_DIR}/cargo/build")
     set(cargo_output_dir "${cargo_target_dir}/${RUST_TARGET_TRIPLE}/${cargo_profile_dir}")
-    set(cargo_binary "${cargo_output_dir}/${ARG_BINARY_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
-    set(depfile "${cargo_output_dir}/${ARG_BINARY_NAME}.d")
-    set(output_binary "${CMAKE_BINARY_DIR}/bin/${ARG_OUTPUT_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
 
     # Build environment variables for cargo.
     set(cargo_env
@@ -192,6 +171,8 @@ function(build_rust_binary)
         list(APPEND cargo_env "FFI_OUTPUT_DIR=${ARG_FFI_OUTPUT_DIR}")
     endif()
 
+    # On Windows, rustc invokes the linker directly with MSVC-style flags, so we must not override it with a
+    # compiler driver like clang-cl.
     if (NOT WIN32)
         list(APPEND cargo_env
             "CARGO_TARGET_${target_upper}_LINKER=${CMAKE_C_COMPILER}"
@@ -203,33 +184,23 @@ function(build_rust_binary)
         list(APPEND cargo_env "SDKROOT=${CMAKE_OSX_SYSROOT}")
     endif()
 
-    add_custom_command(
-        OUTPUT "${output_binary}"
-        COMMAND
-            ${CMAKE_COMMAND} -E env ${cargo_env}
-            "${RUST_CARGO}"
-                rustc
-                --bin ${ARG_BINARY_NAME}
-                "--target=${RUST_TARGET_TRIPLE}"
-                --package ${ARG_CRATE_NAME}
-                --manifest-path "${ARG_MANIFEST_PATH}"
-                --target-dir "${cargo_target_dir}"
-                ${cargo_profile_flag}
-                --
-                -Cdefault-linker-libraries=yes
-                --emit=dep-info
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different "${cargo_binary}" "${output_binary}"
-        DEPENDS "${ARG_MANIFEST_PATH}"
-            "${workspace_dir}/Cargo.lock" "${workspace_dir}/Cargo.toml"
-        DEPFILE "${depfile}"
-        COMMENT "Building Rust binary ${ARG_BINARY_NAME}"
-        USES_TERMINAL
-        COMMAND_EXPAND_LISTS
+    set(cargo_common_flags
+        "--target=${RUST_TARGET_TRIPLE}"
+        --package ${ARG_CRATE_NAME}
+        --manifest-path "${manifest_path}"
+        --target-dir "${cargo_target_dir}"
+        ${cargo_profile_flag}
+        --
+        -Cdefault-linker-libraries=yes
+        --emit=dep-info
     )
 
-    add_custom_target(${ARG_BINARY_NAME}-build DEPENDS "${output_binary}")
+    # Populate the variable names used by the public helpers below.
+    set(RUST_CARGO "${RUST_CARGO}" PARENT_SCOPE)
 
-    if (ARG_OUTPUT_PATH_VAR)
-        set(${ARG_OUTPUT_PATH_VAR} "${output_binary}" PARENT_SCOPE)
-    endif()
+    set(cargo_common_flags "${cargo_common_flags}" PARENT_SCOPE)
+    set(cargo_env "${cargo_env}" PARENT_SCOPE)
+    set(cargo_output_dir "${cargo_output_dir}" PARENT_SCOPE)
+    set(manifest_path "${manifest_path}" PARENT_SCOPE)
+    set(workspace_dir "${workspace_dir}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
This became unused after 87493f056d3043b770a6768f20c83946f49814d7, and we now see a warning during the build.

We will also now treat warnings as errors.