### PR TITLE
LibWeb: Invalidate img-element when loaded from list of available images

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -692,6 +692,9 @@ void HTMLImageElement::update_the_image_data_impl(bool restart_animations, bool 
                 // 2. Set the current request's current URL to urlString.
                 m_current_request->set_current_url(realm(), *url_string);
 
+                set_needs_style_update(true);
+                set_needs_layout_update(DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
+
                 // 3. If maybe omit events is not set or previousURL is not equal to urlString, then fire an event named load at the img element.
                 if (!maybe_omit_events || previous_url != url_string)
                     dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));

--- a/Tests/LibWeb/Ref/expected/already-loaded-image-invalidates-style-and-layout-ref.html
+++ b/Tests/LibWeb/Ref/expected/already-loaded-image-invalidates-style-and-layout-ref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<p>There should be a green square and no red!</p>
+<img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='100' height='100'><rect width='100' height='100' fill='%23008000'/></svg>" />

--- a/Tests/LibWeb/Ref/input/already-loaded-image-invalidates-style-and-layout.html
+++ b/Tests/LibWeb/Ref/input/already-loaded-image-invalidates-style-and-layout.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/already-loaded-image-invalidates-style-and-layout-ref.html" />
+
+<p>There should be a green square and no red!</p>
+<img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='100' height='100'><rect width='100' height='100' fill='%23ff0000'/></svg>"
+     data-src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='100' height='100'><rect width='100' height='100' fill='%23008000'/></svg>" />
+
+<script>
+const element = document.querySelector("img");
+const actualUrl = element.getAttribute("data-src");
+const detachedImage = new Image();
+const onLoadHandler = function() {
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      setTimeout(() => {
+        element.src = actualUrl;
+        detachedImage.removeEventListener('load', onLoadHandler);
+        document.documentElement.classList.remove("reftest-wait");
+      }, 0);
+    });
+  });
+};
+
+detachedImage.addEventListener("load", onLoadHandler);
+detachedImage.src = actualUrl;
+</script>
+</html>


### PR DESCRIPTION
As a followup to #9014, fix that many images did not become visible on https://bleepingcomputer.com/ until hovered. More details in the commit message.

There is currently another invalidation(?) bug on that site that causes the navigation menu to behave weirdly. That one seems like a recent regression that will need to be looked at separately.

Before:
<img width="1197" height="310" alt="before_1" src="https://github.com/user-attachments/assets/392dc4a9-6c46-47ed-b05d-3d31fe018e5a" />
<img width="1200" height="840" alt="before_2" src="https://github.com/user-attachments/assets/7b34237e-95ab-43e1-b77f-99e57203d4e4" />


After:
<img width="1194" height="314" alt="after_1" src="https://github.com/user-attachments/assets/f90257df-79bd-4cbf-9fc2-7e8848235786" />
<img width="1199" height="821" alt="after_2" src="https://github.com/user-attachments/assets/91cdfe17-8503-49fe-af77-6e0094e390b8" />
