### PR TITLE
Implement time buffered ranges

### DIFF
--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BinarySearch.h>
 #include <AK/Math.h>
 #include <AK/MemoryStream.h>
 #include <AK/Stream.h>
@@ -228,11 +229,65 @@ Optional<AK::UnixDateTime> FFmpegDemuxer::start_time_realtime() const
 
 TimeRanges FFmpegDemuxer::buffered_time_ranges() const
 {
-    // FIXME: Use the format context's index to determine the buffered ranges from the underlying stream.
-    TimeRanges ranges;
-    if (!m_total_duration.is_zero())
-        ranges.add_range(AK::Duration::zero(), m_total_duration);
-    return ranges;
+    auto byte_ranges = m_stream->available_byte_ranges();
+
+    auto full_duration_range = [&]() {
+        TimeRanges ranges;
+        if (!m_total_duration.is_zero())
+            ranges.add_range(AK::Duration::zero(), m_total_duration);
+        return ranges;
+    };
+
+    if (byte_ranges.is_empty())
+        return full_duration_range();
+
+    auto is_available = [&](u64 pos) {
+        return binary_search(byte_ranges, pos, nullptr, [](u64 needle, MediaStream::ByteRange const& range) -> int {
+            if (needle < range.begin)
+                return -1;
+            if (needle >= range.end)
+                return 1;
+            return 0;
+        }) != nullptr;
+    };
+
+    if (m_track_contexts.is_empty())
+        return full_duration_range();
+
+    Optional<TimeRanges> intersection;
+    for (auto const& [track, context] : m_track_contexts) {
+        if (!context->format_context)
+            continue;
+        VERIFY(track.identifier() < context->format_context->nb_streams);
+        auto* av_stream = context->format_context->streams[track.identifier()];
+
+        int index_count = avformat_index_get_entries_count(av_stream);
+        if (index_count == 0)
+            continue;
+
+        TimeRanges track_ranges;
+        for (int i = 0; i < index_count; i++) {
+            auto const* entry = avformat_index_get_entry(av_stream, i);
+            if (entry->pos < 0 || !is_available(static_cast<u64>(entry->pos)))
+                continue;
+
+            auto start = time_units_to_duration(entry->timestamp, av_stream->time_base);
+            AK::Duration end;
+            if (auto const* next = avformat_index_get_entry(av_stream, i + 1))
+                end = time_units_to_duration(next->timestamp, av_stream->time_base);
+            else
+                end = m_total_duration;
+
+            track_ranges.add_range(start, end);
+        }
+
+        if (!intersection.has_value())
+            intersection = track_ranges;
+        else
+            intersection = intersection->intersection(track_ranges);
+    }
+
+    return intersection.value_or(full_duration_range());
 }
 
 DecoderErrorOr<AK::Duration> FFmpegDemuxer::duration_of_track(Track const& track)

--- a/Libraries/LibMedia/IncrementallyPopulatedStream.cpp
+++ b/Libraries/LibMedia/IncrementallyPopulatedStream.cpp
@@ -246,6 +246,17 @@ NonnullRefPtr<MediaStreamCursor> IncrementallyPopulatedStream::create_cursor()
     return adopt_ref(*new Cursor(NonnullRefPtr { *this }));
 }
 
+Vector<MediaStream::ByteRange> IncrementallyPopulatedStream::available_byte_ranges() const
+{
+    Sync::MutexLocker locker { m_mutex };
+    Vector<MediaStream::ByteRange> byte_ranges;
+
+    for (auto const& chunk : m_chunks)
+        MUST(byte_ranges.try_append({ chunk.offset(), chunk.end() }));
+
+    return byte_ranges;
+}
+
 IncrementallyPopulatedStream::Cursor::Cursor(NonnullRefPtr<IncrementallyPopulatedStream> const& stream)
     : m_stream(stream)
 {

--- a/Libraries/LibMedia/IncrementallyPopulatedStream.h
+++ b/Libraries/LibMedia/IncrementallyPopulatedStream.h
@@ -33,6 +33,8 @@ public:
 
     virtual NonnullRefPtr<MediaStreamCursor> create_cursor() override;
 
+    virtual Vector<MediaStream::ByteRange> available_byte_ranges() const override;
+
     // Callback invoked when data at a specific offset is needed but not available.
     // The callback receives the desired offset position and is invoked on the provided event loop.
     using DataRequestCallback = Function<void(u64 offset)>;

--- a/Libraries/LibMedia/MediaStream.h
+++ b/Libraries/LibMedia/MediaStream.h
@@ -9,6 +9,7 @@
 #include <AK/AtomicRefCounted.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Stream.h>
+#include <AK/Vector.h>
 #include <LibMedia/DecoderError.h>
 
 namespace Media {
@@ -30,9 +31,16 @@ public:
 
 class MediaStream : public AtomicRefCounted<MediaStream> {
 public:
+    struct ByteRange {
+        u64 begin;
+        u64 end;
+    };
+
     virtual ~MediaStream() = default;
 
     virtual NonnullRefPtr<MediaStreamCursor> create_cursor() = 0;
+
+    virtual Vector<ByteRange> available_byte_ranges() const { return {}; }
 };
 
 }

--- a/Tests/LibMedia/TestFFmpegDemuxer.cpp
+++ b/Tests/LibMedia/TestFFmpegDemuxer.cpp
@@ -12,6 +12,42 @@
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 
+TEST_CASE(buffered_time_ranges_no_track_contexts)
+{
+    // With no track contexts opened, buffered_time_ranges() should fall back to the full duration.
+    auto file = MUST(Core::File::open("./avc.mp4"sv, Core::File::OpenMode::Read));
+    auto file_data = MUST(file->read_until_eof());
+    auto stream = Media::IncrementallyPopulatedStream::create_from_buffer(file_data);
+
+    auto demuxer = MUST(Media::FFmpeg::FFmpegDemuxer::from_stream(stream));
+    auto total_duration = MUST(demuxer->total_duration());
+
+    auto ranges = demuxer->buffered_time_ranges();
+    EXPECT_EQ(ranges.size(), 1u);
+    EXPECT_EQ(ranges[0].start, AK::Duration::zero());
+    EXPECT_EQ(ranges[0].end, total_duration);
+}
+
+TEST_CASE(buffered_time_ranges_full_stream)
+{
+    // With all data loaded and a track context open, buffered_time_ranges() should cover the full duration.
+    auto file = MUST(Core::File::open("./avc.mp4"sv, Core::File::OpenMode::Read));
+    auto file_data = MUST(file->read_until_eof());
+    auto stream = Media::IncrementallyPopulatedStream::create_from_buffer(file_data);
+
+    auto demuxer = MUST(Media::FFmpeg::FFmpegDemuxer::from_stream(stream));
+    auto total_duration = MUST(demuxer->total_duration());
+
+    auto optional_track = MUST(demuxer->get_preferred_track_for_type(Media::TrackType::Video));
+    VERIFY(optional_track.has_value());
+    auto track = optional_track.release_value();
+    MUST(demuxer->create_context_for_track(track));
+
+    auto ranges = demuxer->buffered_time_ranges();
+    EXPECT(!ranges.is_empty());
+    EXPECT_EQ(ranges.highest_end_time(), total_duration);
+}
+
 TEST_CASE(read_after_aborted_blocking_read)
 {
     // This is a regression test for an issue that would occur when aborting a blocking read in the AVIOContext

--- a/Tests/LibMedia/TestIncrementallyPopulatedStream.cpp
+++ b/Tests/LibMedia/TestIncrementallyPopulatedStream.cpp
@@ -273,6 +273,41 @@ TEST_CASE(redundant_chunk_within_existing_chunk_at_nonzero_offset)
         EXPECT_EQ(buffer[i], static_cast<u8>(100 + i));
 }
 
+TEST_CASE(available_byte_ranges_empty_stream)
+{
+    auto stream = Media::IncrementallyPopulatedStream::create_empty();
+    auto ranges = stream->available_byte_ranges();
+    EXPECT(ranges.is_empty());
+}
+
+TEST_CASE(available_byte_ranges_single_chunk)
+{
+    auto data = make_test_data(100);
+    auto stream = Media::IncrementallyPopulatedStream::create_from_data(data.bytes());
+
+    auto ranges = stream->available_byte_ranges();
+    EXPECT_EQ(ranges.size(), 1u);
+    EXPECT_EQ(ranges[0].begin, 0u);
+    EXPECT_EQ(ranges[0].end, 100u);
+}
+
+TEST_CASE(available_byte_ranges_multiple_non_contiguous_chunks)
+{
+    auto stream = Media::IncrementallyPopulatedStream::create_empty();
+    stream->set_expected_size(300);
+
+    auto data = make_test_data(300);
+    stream->add_chunk_at(0, data.bytes().trim(100));
+    stream->add_chunk_at(200, data.bytes().slice(200));
+
+    auto ranges = stream->available_byte_ranges();
+    EXPECT_EQ(ranges.size(), 2u);
+    EXPECT_EQ(ranges[0].begin, 0u);
+    EXPECT_EQ(ranges[0].end, 100u);
+    EXPECT_EQ(ranges[1].begin, 200u);
+    EXPECT_EQ(ranges[1].end, 300u);
+}
+
 TEST_CASE(data_request_callback_invoked)
 {
     Core::EventLoop loop;


### PR DESCRIPTION
* Implement `FFmpegDemuxer::buffered_time_ranges` that maps the AVindexEntry to the current downloaded chunk
* Implement `IncrementallyPopulatedStream::available_byte_ranges()` that returns all the current available downloaded chunk byte ranges
* Add tests for both implementations
* Matroska implementation is not done yet