### PR TITLE
AK: Use `memchr` in ASCII string `contains()` functions

### DIFF
--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -165,11 +165,7 @@ bool StringView::matches(StringView mask, CaseSensitivity case_sensitivity) cons
 
 bool StringView::contains(char needle) const
 {
-    for (char current : *this) {
-        if (current == needle)
-            return true;
-    }
-    return false;
+    return memchr(m_characters, static_cast<unsigned char>(needle), m_length) != nullptr;
 }
 
 bool StringView::contains(u32 needle) const

--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -126,18 +126,15 @@ bool Utf8View::starts_with(Utf8View const& start) const
 bool Utf8View::contains(u32 needle) const
 {
     if (needle <= 0x7f) {
-        // OPTIMIZATION: Fast path for ASCII
-        for (u8 code_point : as_string()) {
-            if (code_point == needle)
-                return true;
-        }
-    } else {
-        for (u32 code_point : *this) {
-            if (code_point == needle)
-                return true;
-        }
+        // OPTIMIZATION: An ASCII byte can only appear as itself in valid UTF-8, so memchr is safe here.
+        auto bytes = as_string();
+        return memchr(bytes.characters_without_null_termination(), needle, bytes.length()) != nullptr;
     }
 
+    for (u32 code_point : *this) {
+        if (code_point == needle)
+            return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
The libc implementation of `memchr` uses SIMD, so is significantly faster than looping over individual bytes.

On a 15 second `perf` profile of https://ubereats.com initial load 2.68% of time was taken by `Utf8View::contains()`. With this change, that time shrinks to  0.17% (representing the non-ASCII path), while `__memchr_evex` now takes 0.21% of time - for a total of 0.38%. A 7x speedup.


