### PR TITLE
LibWebView: Mark the debug process command line option mode as required

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -205,7 +205,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");
     args_parser.add_option(file_scheme_urls_have_tuple_origins, "Treat file:// URLs as having tuple origins", "tuple-file-origins");
     args_parser.add_option(Core::ArgsParser::Option {
-        .argument_mode = Core::ArgsParser::OptionArgumentMode::Optional,
+        .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
         .help_string = "Wait for a debugger to attach to the given process name (WebContent, RequestServer, etc.)",
         .long_name = "debug-process",
         .value_name = "process-name",


### PR DESCRIPTION
If this flag is present, there must be an argument provided. Commit 11f82ee3b77a34c39621f3eb0a441684f95cf25d marked this flag as optional, which then meant an equals sign was required to specify the process to be debugged.

Fixes #9314