### PR TITLE
LibWeb: Send scroll-state-only updates to the rendering thread

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1653,7 +1653,7 @@ void Document::update_layout(UpdateLayoutReason reason)
             relayout_svg_root(*svg_root);
 
         invalidate_stacking_context_tree();
-        invalidate_display_list();
+        set_needs_to_record_display_list();
 
         set_needs_accumulated_visual_contexts_update(true);
         update_paint_and_hit_testing_properties_if_needed();
@@ -1665,7 +1665,7 @@ void Document::update_layout(UpdateLayoutReason reason)
     if (m_layout_root)
         m_layout_root->invalidate_text_blocks_cache();
 
-    invalidate_display_list();
+    set_needs_to_record_display_list();
 
     auto* document_element = this->document_element();
     auto viewport_rect = navigable->viewport_rect();
@@ -1935,7 +1935,7 @@ void Document::update_style()
 
     auto invalidation = update_style_recursively(*this, style_computer(), false, false, false);
     if (!invalidation.is_none())
-        invalidate_display_list();
+        set_needs_to_record_display_list();
 
     if (invalidation.rebuild_accumulated_visual_contexts)
         set_needs_accumulated_visual_contexts_update(true);
@@ -7553,7 +7553,7 @@ void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display
         return;
 
     if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
-        invalidate_display_list();
+        set_needs_to_record_display_list();
     }
 
     if (!navigable)
@@ -7571,21 +7571,14 @@ void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display
     }
 }
 
-void Document::invalidate_display_list()
+void Document::set_needs_to_record_display_list()
 {
-    m_cached_display_list.clear();
-}
-
-RefPtr<Painting::DisplayList> Document::cached_display_list() const
-{
-    return m_cached_display_list;
+    if (auto navigable = this->navigable())
+        navigable->set_needs_to_record_display_list();
 }
 
 RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig config)
 {
-    if (m_cached_display_list && m_cached_display_list_paint_config == config)
-        return m_cached_display_list;
-
     update_paint_and_hit_testing_properties_if_needed();
     VERIFY(paintable());
 
@@ -7638,9 +7631,6 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     if (highlighted_node() && highlighted_node()->paintable()) {
         highlighted_node()->paintable()->paint_inspector_overlay(context);
     }
-
-    m_cached_display_list = display_list;
-    m_cached_display_list_paint_config = config;
 
     return display_list;
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -959,10 +959,9 @@ public:
         set_needs_repaint(should_invalidate_display_list);
     }
 
-    RefPtr<Painting::DisplayList> cached_display_list() const;
     RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig);
 
-    void invalidate_display_list();
+    void set_needs_to_record_display_list();
 
     Unicode::Segmenter& grapheme_segmenter() const;
     Unicode::Segmenter& line_segmenter() const;
@@ -1486,9 +1485,6 @@ private:
     Core::SharedVersion m_cookie_version { Core::INVALID_SHARED_VERSION };
     Optional<Core::SharedVersionIndex> m_cookie_version_index;
     String m_cookie;
-
-    Optional<HTML::PaintConfig> m_cached_display_list_paint_config;
-    RefPtr<Painting::DisplayList> m_cached_display_list;
 
     mutable OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
     mutable OwnPtr<Unicode::Segmenter> m_line_segmenter;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -470,6 +470,7 @@ void Navigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, GC::Re
         m_active_document->set_navigable(nullptr);
     m_active_document = new_document;
     new_document->set_navigable(this);
+    set_needs_to_record_display_list();
 
     // 5. Make active newDocument.
     new_document->make_active();
@@ -521,6 +522,7 @@ void Navigable::set_active_document(GC::Ptr<DOM::Document> document)
     m_active_document = document;
     if (document)
         document->set_navigable(this);
+    set_needs_to_record_display_list();
 
     VERIFY(m_active_session_history_entry);
     Optional<UniqueNodeID> document_id;
@@ -3131,14 +3133,29 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
     if (!document)
         return;
 
-    auto display_list = document->record_display_list(paint_config);
-    if (!display_list)
-        return;
+    auto should_record_display_list = m_needs_to_record_display_list
+        || !m_rendering_thread_display_list_paint_config.has_value()
+        || !(m_rendering_thread_display_list_paint_config.value() == paint_config);
 
-    auto& document_paintable = *document->paintable();
-    document_paintable.refresh_scroll_state();
+    RefPtr<Painting::DisplayList> display_list;
+    if (should_record_display_list) {
+        display_list = document->record_display_list(paint_config);
+        if (!display_list)
+            return;
+    }
 
-    m_rendering_thread.update_display_list(*display_list, Painting::ScrollStateSnapshot(document_paintable.scroll_state_snapshot()));
+    auto document_paintable = document->paintable();
+    VERIFY(document_paintable);
+    document_paintable->refresh_scroll_state();
+
+    Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
+    if (should_record_display_list) {
+        m_rendering_thread.update_display_list(*display_list, move(scroll_state_snapshot));
+        m_needs_to_record_display_list = false;
+        m_rendering_thread_display_list_paint_config = paint_config;
+    } else {
+        m_rendering_thread.update_scroll_state(move(scroll_state_snapshot));
+    }
 }
 
 void Navigable::paint_next_frame()

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/NavigationObserver.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/POSTResource.h>
+#include <LibWeb/HTML/PaintConfig.h>
 #include <LibWeb/HTML/RenderingThread.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/SourceSnapshotParams.h>
@@ -235,6 +236,7 @@ public:
 
     bool needs_repaint() const { return m_needs_repaint; }
     void set_needs_repaint() { m_needs_repaint = true; }
+    void set_needs_to_record_display_list() { m_needs_to_record_display_list = true; }
 
     [[nodiscard]] bool has_inclusive_ancestor_with_visibility_hidden() const;
 
@@ -321,8 +323,10 @@ private:
 
     bool m_is_svg_page { false };
     bool m_needs_repaint { true };
+    bool m_needs_to_record_display_list { true };
     bool m_pending_set_browser_zoom_request { false };
     bool m_should_show_line_box_borders { false };
+    Optional<PaintConfig> m_rendering_thread_display_list_paint_config;
     GC::Ref<Painting::BackingStoreManager> m_backing_store_manager;
     RenderingThread m_rendering_thread;
     RefPtr<Painting::ExternalContentSource> m_external_content_source;

--- a/Libraries/LibWeb/HTML/PaintConfig.h
+++ b/Libraries/LibWeb/HTML/PaintConfig.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <LibGfx/Rect.h>
+
 namespace Web::HTML {
 
 struct PaintConfig {

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -48,6 +48,10 @@ struct UpdateDisplayListCommand {
     Painting::ScrollStateSnapshot scroll_state_snapshot;
 };
 
+struct UpdateScrollStateCommand {
+    Painting::ScrollStateSnapshot scroll_state_snapshot;
+};
+
 struct UpdateBackingStoresCommand {
     Gfx::IntSize size;
     i32 front_bitmap_id;
@@ -60,7 +64,7 @@ struct ScreenshotCommand {
     Function<void()> callback;
 };
 
-using CompositorCommand = Variant<UpdateDisplayListCommand, UpdateBackingStoresCommand, ScreenshotCommand>;
+using CompositorCommand = Variant<UpdateDisplayListCommand, UpdateScrollStateCommand, UpdateBackingStoresCommand, ScreenshotCommand>;
 
 struct BackingStorePair {
     RefPtr<Gfx::PaintingSurface> front;
@@ -221,6 +225,9 @@ public:
                 command->visit(
                     [this](UpdateDisplayListCommand& cmd) {
                         m_cached_display_list = move(cmd.display_list);
+                        m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
+                    },
+                    [this](UpdateScrollStateCommand& cmd) {
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
                     },
                     [this](UpdateBackingStoresCommand& cmd) {
@@ -429,6 +436,11 @@ void RenderingThread::set_presentation_mode(PresentationMode mode)
 void RenderingThread::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot) });
+}
+
+void RenderingThread::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    m_thread_data->enqueue_command(UpdateScrollStateCommand { move(scroll_state_snapshot) });
 }
 
 void RenderingThread::update_backing_stores(Gfx::IntSize size, i32 front_id, i32 back_id, Function<void(i32, Gfx::SharedImage, i32, Gfx::SharedImage)>&& allocation_callback)

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -40,6 +40,7 @@ public:
     void set_presentation_mode(PresentationMode);
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&);
+    void update_scroll_state(Painting::ScrollStateSnapshot&&);
     void update_backing_stores(Gfx::IntSize, i32 front_id, i32 back_id, Function<void(i32, Gfx::SharedImage, i32, Gfx::SharedImage)>&& = {});
     u64 present_frame(Gfx::IntRect);
     void wait_for_frame(u64 frame_id);

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -27,14 +27,11 @@ static void set_command_sequence_visual_context(Bytes command_bytes, VisualConte
     }
 }
 
-DisplayListCommandSequence::DisplayListCommandSequence()
-    : m_resource_storage(DisplayListResourceStorage::create())
-{
-}
+DisplayListCommandSequence::DisplayListCommandSequence() = default;
 
 DisplayList::DisplayList(
     NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree,
-    NonnullRefPtr<DisplayListResourceStorage> resource_storage)
+    DisplayListResourceStorage resource_storage)
     : m_visual_context_tree(move(visual_context_tree))
     , m_resource_storage(move(resource_storage))
     , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
@@ -83,7 +80,7 @@ void DisplayList::append_command_sequence(DisplayListCommandSequence const& sequ
         command_bytes.append(sequence.m_command_bytes.data(), sequence.m_command_bytes.size());
 
     set_command_sequence_visual_context(command_bytes.span(), context_index);
-    m_resource_storage->append_referenced_resources_from(*sequence.m_resource_storage, command_bytes.span());
+    m_resource_storage.append_referenced_resources_from(sequence.m_resource_storage, command_bytes.span());
     VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
     VERIFY(command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
 
@@ -99,7 +96,7 @@ DisplayListCommandSequence DisplayList::copy_command_sequence_from(size_t comman
         sequence.m_command_bytes.append(
             m_command_bytes.data() + command_start_offset,
             m_command_bytes.size() - command_start_offset);
-    sequence.m_resource_storage->append_referenced_resources_from(*m_resource_storage, sequence.m_command_bytes.span());
+    sequence.m_resource_storage.append_referenced_resources_from(m_resource_storage, sequence.m_command_bytes.span());
     return sequence;
 }
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -59,7 +59,7 @@ private:
     friend class DisplayList;
     DisplayListCommandSequence();
 
-    NonnullRefPtr<DisplayListResourceStorage> m_resource_storage;
+    DisplayListResourceStorage m_resource_storage;
     Vector<u8> m_command_bytes;
 };
 
@@ -135,12 +135,12 @@ class DisplayList : public AtomicRefCounted<DisplayList> {
 public:
     static NonnullRefPtr<DisplayList> create(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
     {
-        return adopt_ref(*new DisplayList(move(visual_context_tree), DisplayListResourceStorage::create()));
+        return adopt_ref(*new DisplayList(move(visual_context_tree), DisplayListResourceStorage {}));
     }
 
     static NonnullRefPtr<DisplayList> create(
         NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree,
-        NonnullRefPtr<DisplayListResourceStorage> resource_storage)
+        DisplayListResourceStorage resource_storage)
     {
         return adopt_ref(*new DisplayList(move(visual_context_tree), move(resource_storage)));
     }
@@ -161,8 +161,8 @@ public:
     u64 id() const { return m_id; }
 
     ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
-    DisplayListResourceStorage& resource_storage() { return *m_resource_storage; }
-    DisplayListResourceStorage const& resource_storage() const { return *m_resource_storage; }
+    DisplayListResourceStorage& resource_storage() { return m_resource_storage; }
+    DisplayListResourceStorage const& resource_storage() const { return m_resource_storage; }
 
     template<typename Callback>
     static void for_each_command_header(ReadonlyBytes command_bytes, Callback callback)
@@ -183,7 +183,7 @@ public:
 private:
     explicit DisplayList(
         NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree,
-        NonnullRefPtr<DisplayListResourceStorage> resource_storage);
+        DisplayListResourceStorage resource_storage);
 
     static Optional<Gfx::IntRect> command_bounding_rectangle(auto const& command)
     {
@@ -210,7 +210,7 @@ private:
         bool is_clip);
 
     NonnullRefPtr<AccumulatedVisualContextTree const> const m_visual_context_tree;
-    NonnullRefPtr<DisplayListResourceStorage> m_resource_storage;
+    DisplayListResourceStorage m_resource_storage;
     u64 m_id { 0 };
     Vector<u8> m_command_bytes;
 };

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -6,11 +6,10 @@
 
 #pragma once
 
-#include <AK/AtomicRefCounted.h>
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
+#include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
-#include <AK/RefPtr.h>
 #include <AK/Span.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/Forward.h>
@@ -21,13 +20,12 @@
 
 namespace Web::Painting {
 
-class DisplayListResourceStorage : public AtomicRefCounted<DisplayListResourceStorage> {
-public:
-    static NonnullRefPtr<DisplayListResourceStorage> create()
-    {
-        return adopt_ref(*new DisplayListResourceStorage);
-    }
+class DisplayListResourceStorage {
+    AK_MAKE_NONCOPYABLE(DisplayListResourceStorage);
+    AK_MAKE_DEFAULT_MOVABLE(DisplayListResourceStorage);
 
+public:
+    DisplayListResourceStorage() = default;
     ~DisplayListResourceStorage();
 
     FontResourceId add_font(Gfx::Font const&);
@@ -44,8 +42,6 @@ public:
     DisplayList const& display_list(DisplayListResourceId id) const { return *m_display_lists.get(id.value()).value(); }
 
 private:
-    DisplayListResourceStorage() = default;
-
     HashMap<u64, NonnullRefPtr<Gfx::Font const>> m_fonts;
     HashMap<u64, Gfx::DecodedImageFrame> m_image_frames;
     HashMap<u64, NonnullRefPtr<ExternalContentSource const>> m_external_content_sources;


### PR DESCRIPTION
When nothing invalidates the display list between frames, push only an
updated scroll state snapshot to the rendering thread instead of
handing it the display list again.

This is preparation for moving rendering to a separate process, where
sending the display list across the process boundary on every frame
would be expensive.