### PR TITLE
LibWeb: Use cached hash for InvalidationSet equality

### DIFF
--- a/Libraries/LibWeb/CSS/InvalidationSet.cpp
+++ b/Libraries/LibWeb/CSS/InvalidationSet.cpp
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/QuickSort.h>
 #include <LibWeb/CSS/InvalidationSet.h>
 
 namespace Web::CSS {
 
 bool InvalidationSet::operator==(InvalidationSet const& other) const
 {
+    if (hash() != other.hash())
+        return false;
     if (m_needs_invalidate_self != other.m_needs_invalidate_self)
         return false;
     if (m_needs_invalidate_whole_subtree != other.m_needs_invalidate_whole_subtree)
@@ -30,6 +33,7 @@ void InvalidationSet::include_all_from(InvalidationSet const& other)
     m_needs_invalidate_whole_subtree |= other.m_needs_invalidate_whole_subtree;
     for (auto const& property : other.m_properties)
         m_properties.set(property);
+    m_hash = {};
 }
 
 bool InvalidationSet::is_empty() const
@@ -51,6 +55,28 @@ void InvalidationSet::for_each_property(Function<IterationDecision(Property cons
         if (callback(property) == IterationDecision::Break)
             return;
     }
+}
+
+u32 InvalidationSet::hash() const
+{
+    if (m_hash.has_value())
+        return *m_hash;
+
+    u32 hash = 0;
+    hash = pair_int_hash(hash, m_needs_invalidate_self);
+    hash = pair_int_hash(hash, m_needs_invalidate_whole_subtree);
+
+    Vector<u32> property_hashes;
+    property_hashes.ensure_capacity(m_properties.size());
+    for (auto const& property : m_properties)
+        property_hashes.unchecked_append(AK::Traits<Property>::hash(property));
+    quick_sort(property_hashes);
+
+    for (auto property_hash : property_hashes)
+        hash = pair_int_hash(hash, property_hash);
+
+    m_hash = hash;
+    return hash;
 }
 
 }

--- a/Libraries/LibWeb/CSS/InvalidationSet.h
+++ b/Libraries/LibWeb/CSS/InvalidationSet.h
@@ -39,27 +39,58 @@ public:
     void include_all_from(InvalidationSet const& other);
 
     bool needs_invalidate_self() const { return m_needs_invalidate_self; }
-    void set_needs_invalidate_self() { m_needs_invalidate_self = true; }
+    void set_needs_invalidate_self()
+    {
+        m_needs_invalidate_self = true;
+        m_hash = {};
+    }
 
     bool needs_invalidate_whole_subtree() const { return m_needs_invalidate_whole_subtree; }
-    void set_needs_invalidate_whole_subtree() { m_needs_invalidate_whole_subtree = true; }
+    void set_needs_invalidate_whole_subtree()
+    {
+        m_needs_invalidate_whole_subtree = true;
+        m_hash = {};
+    }
 
     bool operator==(InvalidationSet const& other) const;
 
-    void set_needs_invalidate_class(FlyString const& name) { m_properties.set({ Property::Type::Class, name }); }
-    void set_needs_invalidate_id(FlyString const& name) { m_properties.set({ Property::Type::Id, name }); }
-    void set_needs_invalidate_tag_name(FlyString const& name) { m_properties.set({ Property::Type::TagName, name }); }
-    void set_needs_invalidate_attribute(FlyString const& name) { m_properties.set({ Property::Type::Attribute, name }); }
-    void set_needs_invalidate_pseudo_class(PseudoClass pseudo_class) { m_properties.set({ Property::Type::PseudoClass, pseudo_class }); }
+    void set_needs_invalidate_class(FlyString const& name)
+    {
+        m_properties.set({ Property::Type::Class, name });
+        m_hash = {};
+    }
+    void set_needs_invalidate_id(FlyString const& name)
+    {
+        m_properties.set({ Property::Type::Id, name });
+        m_hash = {};
+    }
+    void set_needs_invalidate_tag_name(FlyString const& name)
+    {
+        m_properties.set({ Property::Type::TagName, name });
+        m_hash = {};
+    }
+    void set_needs_invalidate_attribute(FlyString const& name)
+    {
+        m_properties.set({ Property::Type::Attribute, name });
+        m_hash = {};
+    }
+    void set_needs_invalidate_pseudo_class(PseudoClass pseudo_class)
+    {
+        m_properties.set({ Property::Type::PseudoClass, pseudo_class });
+        m_hash = {};
+    }
 
     bool is_empty() const;
     bool has_properties() const { return !m_properties.is_empty(); }
     void for_each_property(Function<IterationDecision(Property const&)> const& callback) const;
 
+    u32 hash() const;
+
 private:
     bool m_needs_invalidate_self { false };
     bool m_needs_invalidate_whole_subtree { false };
     HashTable<Property> m_properties;
+    mutable Optional<u32> m_hash;
 };
 
 }


### PR DESCRIPTION
Reduces time spent in the two hottest functions on a profile of https://perftest.netlify.app/stylebench/
`InvalidationSet::operator==`: 16% -> 3.6%
`Traits<InvalidationSet::Property::>hash`: 9.6% -> 0.57%

And the resulting runs/minute: 3.99 -> 5.73 (both +- 0.046)