### PR TITLE
UI: Increase mouse wheel scroll step from 24 to 40 pixels

### DIFF
--- a/UI/AppKit/Interface/Event.mm
+++ b/UI/AppKit/Interface/Event.mm
@@ -54,7 +54,7 @@ Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* eve
         CGFloat delta_y = -[event scrollingDeltaY];
 
         if (![event hasPreciseScrollingDeltas]) {
-            static constexpr CGFloat imprecise_scroll_multiplier = 24;
+            static constexpr CGFloat imprecise_scroll_multiplier = 40;
 
             delta_x *= imprecise_scroll_multiplier;
             delta_y *= imprecise_scroll_multiplier;

--- a/UI/Gtk/Widgets/LadybirdWebView.cpp
+++ b/UI/Gtk/Widgets/LadybirdWebView.cpp
@@ -175,7 +175,7 @@ static gboolean on_scroll(GtkEventControllerScroll* controller, gdouble dx, gdou
         wheel_delta_y = static_cast<int>(dy * device_pixel_ratio);
     } else {
         static constexpr double scroll_lines = 3.0;
-        static constexpr double scroll_step_size = 24.0;
+        static constexpr double scroll_step_size = 40.0;
         wheel_delta_x = static_cast<int>(dx * scroll_lines * scroll_step_size * device_pixel_ratio);
         wheel_delta_y = static_cast<int>(dy * scroll_lines * scroll_step_size * device_pixel_ratio);
     }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -822,7 +822,7 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
             float delta_x = -static_cast<float>(angle_delta.x()) / 120.0f;
             float delta_y = static_cast<float>(angle_delta.y()) / 120.0f;
 
-            static constexpr float scroll_step_size = 24;
+            static constexpr float scroll_step_size = 40;
             auto step_x = delta_x * static_cast<float>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
             auto step_y = delta_y * static_cast<float>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
 


### PR DESCRIPTION
Other engines converge on roughly 40 pixels per line as the per-line step for discrete mouse wheel input (Chrome's `kWheelDelta` of 120 over 3 lines, WebKit's `Scrollbar::pixelsPerLineStep` of 40, Chrome's macOS `kScrollbarPixelsPerCocoaTick` of 40). At a step of 24 we were scrolling about 60% as far per tick as Chrome on the same input, which made the browser feel sluggish under a regular wheel.

Bumping the constant to 40 in the Qt, Gtk, and AppKit frontends puts us at 120 pixels per discrete tick on Linux (3 lines * 40 pixels) and aligns the macOS imprecise-scroll multiplier with WebKit and Chrome. High-precision (trackpad) input is unaffected on all platforms, since those paths use pixel deltas directly without applying a multiplier.