### PR TITLE
LibWeb+LibWebView: Feed async scroll deltas in device pixels

### DIFF
--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -58,7 +58,7 @@ struct UpdateDisplayListCommand {
 
 struct AsyncScrollByCommand {
     Gfx::FloatPoint position;
-    Gfx::FloatPoint delta;
+    Gfx::FloatPoint delta_in_device_pixels;
     Gfx::IntRect viewport_rect;
     AsyncScrollNodeID scroll_target;
 };
@@ -280,7 +280,7 @@ public:
         return { scroll_target, false };
     }
 
-    bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect)
+    bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect)
     {
         if (!m_can_accept_async_wheel_events.load()) {
             auto wheel_routing_admission = [this] {
@@ -291,25 +291,25 @@ public:
                 wheel_routing_admission_to_string(wheel_routing_admission));
             return false;
         }
-        auto scroll_target = hit_test_viewport_scroll_node_for_wheel(position, delta);
+        auto scroll_target = hit_test_viewport_scroll_node_for_wheel(position, delta_in_device_pixels);
         if (scroll_target.rejected_non_viewport_target) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: non-viewport target at {},{} delta {},{}",
-                position.x(), position.y(), delta.x(), delta.y());
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: non-viewport target at {},{} device delta {},{}",
+                position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
             return false;
         }
         if (!scroll_target.node_id.has_value()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: no wheel target at {},{} for delta {},{}",
-                position.x(), position.y(), delta.x(), delta.y());
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: no wheel target at {},{} for device delta {},{}",
+                position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
             return false;
         }
 
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted main-thread async scroll enqueue at {},{} delta {},{} viewport={}x{} at {},{}",
-            position.x(), position.y(), delta.x(), delta.y(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(AsyncScrollByCommand { position, delta, viewport_rect, *scroll_target.node_id });
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted main-thread async scroll enqueue at {},{} device delta {},{} viewport={}x{} at {},{}",
+            position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
+        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id });
         return true;
     }
 
-    bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta)
+    bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
     {
         if (!m_can_accept_async_wheel_events.load()) {
             auto wheel_routing_admission = [this] {
@@ -325,21 +325,21 @@ public:
             Sync::MutexLocker const locker { m_mutex };
             return m_async_scrolling_viewport_rect;
         }();
-        auto scroll_target = hit_test_viewport_scroll_node_for_wheel(position, delta);
+        auto scroll_target = hit_test_viewport_scroll_node_for_wheel(position, delta_in_device_pixels);
         if (scroll_target.rejected_non_viewport_target) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: non-viewport target at {},{} delta {},{}",
-                position.x(), position.y(), delta.x(), delta.y());
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: non-viewport target at {},{} device delta {},{}",
+                position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
             return false;
         }
         if (!scroll_target.node_id.has_value()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: no wheel target at {},{} for delta {},{}",
-                position.x(), position.y(), delta.x(), delta.y());
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: no wheel target at {},{} for device delta {},{}",
+                position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
             return false;
         }
 
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted async scroll enqueue at {},{} delta {},{} viewport={}x{} at {},{}",
-            position.x(), position.y(), delta.x(), delta.y(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(AsyncScrollByCommand { position, delta, viewport_rect, *scroll_target.node_id });
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted async scroll enqueue at {},{} device delta {},{} viewport={}x{} at {},{}",
+            position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
+        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id });
         return true;
     }
 
@@ -433,13 +433,13 @@ public:
                         }
                     },
                     [this, &should_yield_to_async_scroll_present](AsyncScrollByCommand& cmd) {
-                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing async scroll command at {},{} delta {},{} (raster_tasks={}, deferred_async_present={})",
-                            cmd.position.x(), cmd.position.y(), cmd.delta.x(), cmd.delta.y(), m_queued_rasterization_tasks.load(), m_has_deferred_async_scroll_present);
+                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing async scroll command at {},{} device delta {},{} (raster_tasks={}, deferred_async_present={})",
+                            cmd.position.x(), cmd.position.y(), cmd.delta_in_device_pixels.x(), cmd.delta_in_device_pixels.y(), m_queued_rasterization_tasks.load(), m_has_deferred_async_scroll_present);
                         auto async_scroll_viewport_rect = cmd.viewport_rect;
                         Optional<Gfx::FloatPoint> scroll_offset;
                         {
                             Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                            if (!m_async_scroll_tree.apply_scroll_delta(cmd.scroll_target, cmd.delta, m_cached_scroll_state_snapshot)) {
+                            if (!m_async_scroll_tree.apply_scroll_delta(cmd.scroll_target, cmd.delta_in_device_pixels, m_cached_scroll_state_snapshot)) {
                                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping async scroll command: scroll tree consumed no delta");
                                 return;
                             }
@@ -973,7 +973,7 @@ void CompositorThread::presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_i
     thread_data->decrement_queued_tasks(bitmap_id);
 }
 
-bool CompositorThread::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta)
+bool CompositorThread::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
     RefPtr<ThreadData> thread_data;
     {
@@ -985,7 +985,7 @@ bool CompositorThread::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gf
         }
         thread_data = compositor->value;
     }
-    return thread_data->enqueue_async_scroll_by(position, delta);
+    return thread_data->enqueue_async_scroll_by(position, delta_in_device_pixels);
 }
 
 void CompositorThread::start(DisplayListPlayerType display_list_player_type)
@@ -1024,9 +1024,9 @@ void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)
     m_thread_data->invalidate_wheel_event_listener_state(generation);
 }
 
-bool CompositorThread::async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect)
+bool CompositorThread::async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect)
 {
-    return m_thread_data->enqueue_async_scroll_by(position, delta, viewport_rect);
+    return m_thread_data->enqueue_async_scroll_by(position, delta_in_device_pixels, viewport_rect);
 }
 
 Optional<Gfx::FloatPoint> CompositorThread::pending_async_viewport_scroll_offset() const

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -51,7 +51,7 @@ public:
     static void set_frame_presentation_callbacks(NonnullRefPtr<Core::WeakEventLoopReference>, BackingStorePresentationCallback, FramePresentationCallback);
     static void clear_frame_presentation_callbacks();
     static void presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
-    static bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta);
+    static bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
 
     void start(DisplayListPlayerType);
     void stop_presenting_to_client();
@@ -61,7 +61,7 @@ public:
     void update_scroll_state(Painting::ScrollStateSnapshot&&);
     void update_display_list_and_async_scrolling_state(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&, AsyncScrollingState&&);
     void invalidate_wheel_event_listener_state(u64 generation);
-    bool async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect);
+    bool async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect);
     Optional<Gfx::FloatPoint> pending_async_viewport_scroll_offset() const;
     bool should_defer_async_viewport_scroll_offset_adoption() const;
     bool should_defer_main_thread_present_for_async_scroll() const;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -646,11 +646,13 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
         if (can_try_async_viewport_scroll) {
             auto device_position = m_navigable->page().css_to_device_point(visual_viewport_position);
             auto async_scroll_position = Gfx::FloatPoint { static_cast<float>(device_position.x().value()), static_cast<float>(device_position.y().value()) };
-            async_scroll_performed_default_action = m_navigable->rendering_thread().async_scroll_by(async_scroll_position, async_scroll_delta, viewport_rect);
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] {} wheel async scroll for viewport at {},{} with delta {},{}",
+            auto device_pixels_per_css_pixel = static_cast<float>(m_navigable->page().client().device_pixels_per_css_pixel());
+            auto async_scroll_delta_in_device_pixels = async_scroll_delta.scaled(device_pixels_per_css_pixel);
+            async_scroll_performed_default_action = m_navigable->rendering_thread().async_scroll_by(async_scroll_position, async_scroll_delta_in_device_pixels, viewport_rect);
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] {} wheel async scroll for viewport at {},{} with device delta {},{}",
                 async_scroll_performed_default_action ? "Enqueued"sv : "Could not enqueue"sv,
                 async_scroll_position.x(), async_scroll_position.y(),
-                async_scroll_delta.x(), async_scroll_delta.y());
+                async_scroll_delta_in_device_pixels.x(), async_scroll_delta_in_device_pixels.y());
         } else if (!paintable) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: no paintable target");
         } else if (is<Painting::NavigableContainerViewportPaintable>(*paintable)) {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -258,9 +258,20 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
         && m_client_state.has_usable_bitmap
         && mouse_event
         && mouse_event->type == Web::MouseEvent::Type::MouseWheel) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI attempting compositor wheel bypass for page {} at {},{} delta {},{}",
-            m_client_state.page_index, mouse_event->position.x().value(), mouse_event->position.y().value(), mouse_event->wheel_delta_x, mouse_event->wheel_delta_y);
-        if (client().send_mouse_event_to_compositor(m_client_state.page_index, *mouse_event))
+        auto wheel_delta_x = mouse_event->wheel_delta_x;
+        auto wheel_delta_y = mouse_event->wheel_delta_y;
+        if (mouse_event->modifiers & Web::UIEvents::KeyModifier::Mod_Shift)
+            swap(wheel_delta_x, wheel_delta_y);
+
+        auto device_pixels_per_css_pixel = static_cast<float>(device_pixel_ratio() * zoom_level());
+        auto position = Gfx::FloatPoint {
+            static_cast<float>(mouse_event->position.x().value()),
+            static_cast<float>(mouse_event->position.y().value()),
+        };
+        auto delta_in_device_pixels = Gfx::FloatPoint { wheel_delta_x, wheel_delta_y }.scaled(device_pixels_per_css_pixel);
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI attempting compositor wheel bypass for page {} at {},{} device delta {},{}",
+            m_client_state.page_index, position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
+        if (client().send_async_scroll_to_compositor(m_client_state.page_index, position, delta_in_device_pixels))
             mouse_event->async_scroll_performed_default_action = true;
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor wheel bypass result for page {}: {}",
             m_client_state.page_index, mouse_event->async_scroll_performed_default_action ? "accepted"sv : "rejected"sv);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -158,7 +158,7 @@ void WebContentClient::notify_all_views_of_crash()
     }
 }
 
-bool WebContentClient::send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const& event)
+bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
     auto connection = compositor_connections().get(this);
     if (!connection.has_value() || !connection.value()->is_open()) {
@@ -168,8 +168,8 @@ bool WebContentClient::send_mouse_event_to_compositor(u64 page_id, Web::MouseEve
     }
 
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
-    auto handled = connection.value()->mouse_event(page_id, event.clone_without_browser_data());
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC mouse_event page {} returned {} in {} us",
+    auto handled = connection.value()->async_scroll_by(page_id, position, delta_in_device_pixels);
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC async_scroll_by page {} returned {} in {} us",
         page_id, handled, timer.elapsed_time().to_microseconds());
     return handled;
 }

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -12,6 +12,7 @@
 #include <AK/SourceLocation.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <LibGfx/Point.h>
 #include <LibGfx/SharedImage.h>
 #include <LibHTTP/Header.h>
 #include <LibIPC/ConnectionToServer.h>
@@ -60,7 +61,7 @@ public:
     bool has_views() const { return !m_views.is_empty(); }
 
     void notify_all_views_of_crash();
-    bool send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const&);
+    bool send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     void did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
     void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);

--- a/Services/WebContent/CompositorServer.ipc
+++ b/Services/WebContent/CompositorServer.ipc
@@ -1,7 +1,7 @@
-#include <LibWeb/Page/InputEvent.h>
+#include <LibGfx/Point.h>
 
 endpoint CompositorServer
 {
-    mouse_event(u64 page_id, Web::MouseEvent event) => (bool handled)
+    async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) => (bool handled)
     ready_to_paint(u64 page_id, i32 bitmap_id) =|
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -89,29 +89,13 @@ private:
     {
     }
 
-    virtual Messages::CompositorServer::MouseEventResponse mouse_event(u64 page_id, Web::MouseEvent event) override
+    virtual Messages::CompositorServer::AsyncScrollByResponse async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override
     {
-        if (event.type != Web::MouseEvent::Type::MouseWheel) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC rejected non-wheel mouse event for page {}", page_id);
-            return false;
-        }
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC received async scroll for page {} at {},{} device delta {},{}",
+            page_id, position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
 
-        if (event.modifiers & Web::UIEvents::KeyModifier::Mod_Shift)
-            swap(event.wheel_delta_x, event.wheel_delta_y);
-
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC received wheel for page {} at {},{} delta {},{}",
-            page_id, event.position.x().value(), event.position.y().value(), event.wheel_delta_x, event.wheel_delta_y);
-
-        auto position = Gfx::FloatPoint {
-            static_cast<float>(event.position.x().value()),
-            static_cast<float>(event.position.y().value()),
-        };
-        auto delta = Gfx::FloatPoint {
-            static_cast<float>(event.wheel_delta_x),
-            static_cast<float>(event.wheel_delta_y),
-        };
-        auto handled = Web::Compositor::CompositorThread::async_scroll_by(page_id, position, delta);
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC wheel for page {} returned {}", page_id, handled);
+        auto handled = Web::Compositor::CompositorThread::async_scroll_by(page_id, position, delta_in_device_pixels);
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC async scroll for page {} returned {}", page_id, handled);
         return handled;
     }
 


### PR DESCRIPTION
The synchronous wheel path treats wheel deltas as CSS-pixel scroll distances, while the async compositor scroll tree mutates scroll state stored in device pixels. Passing the same unscaled delta into the compositor made async scrolling advance too little whenever device pixels per CSSPixel was greater than 1, so scrolling felt slower than with async scrolling disabled.

Convert wheel deltas before crossing the compositor boundary and make the compositor IPC carry only the device-pixel position and delta it needs. This keeps AsyncScrollTree device-pixel native and makes async viewport scrolling match the synchronous path across high-DPI displays and page zoom levels.