### PR TITLE
LibWeb: Fix single-line flex line placement and flex item paint order

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1657,9 +1657,10 @@ void FlexFormattingContext::align_all_flex_lines()
     CSSPixels cross_size_of_flex_container = inner_cross_size(m_flex_container_state);
 
     if (is_single_line()) {
-        // For single-line flex containers, we only need to center the line along the cross axis.
+        // https://drafts.csswg.org/css-flexbox-1/#flex-lines
+        // 'align-content' does not apply to single-line flex containers, so place the line at cross-start.
         auto& flex_line = m_flex_lines[0];
-        CSSPixels center_of_line = cross_size_of_flex_container / 2;
+        CSSPixels center_of_line = flex_line.cross_size / 2;
         for (auto& item : flex_line.items) {
             item.cross_offset += center_of_line;
         }

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -182,12 +182,13 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
             return IterationDecision::Continue;
         }
 
-        // NOTE: Grid specification https://www.w3.org/TR/css-grid-2/#z-order says that grid items should be treated
-        //       the same way as CSS2 defines for inline-blocks:
+        // NOTE: Flex and grid items should be treated the same way as CSS2 defines for inline-blocks:
+        //       - https://drafts.csswg.org/css-flexbox-1/#painting
+        //       - https://www.w3.org/TR/css-grid-2/#z-order
         //       "For each one of these, treat the element as if it created a new stacking context, but any positioned
         //       descendants and descendants which actually create a new stacking context should be considered part of
         //       the parent stacking context, not this new one."
-        if (child.layout_node().is_grid_item() && !z_index().has_value()) {
+        if ((child.layout_node().is_flex_item() || child.layout_node().is_grid_item()) && !z_index().has_value()) {
             // FIXME: This may not be fully correct with respect to the paint phases.
             if (phase == StackingContextPaintPhase::Foreground)
                 paint_node_as_stacking_context(child, context);

--- a/Tests/LibWeb/Layout/expected/flex/single-line-flex-line-uses-cross-start.txt
+++ b/Tests/LibWeb/Layout/expected/flex/single-line-flex-line-uses-cross-start.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+    Box <body> at [8,8] flex-container(row) [8+0+0 100 0+0+692] [8+0+0 584 0+0+8] [FFC] children: not-inline
+      BlockContainer <div> at [8,8] flex-item [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableBox (Box<BODY>) [8,8 100x584]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 50x50]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x600] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/single-line-flex-line-uses-cross-start.html
+++ b/Tests/LibWeb/Layout/input/flex/single-line-flex-line-uses-cross-start.html
@@ -1,0 +1,14 @@
+<!DOCTYPE quirks>
+<style>
+    body {
+        width: 100px;
+        display: flex;
+    }
+
+    div {
+        background: red;
+        width: 50px;
+        height: 50px;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/flex/overflowing-text-paints-under-later-flex-item-ref.html
+++ b/Tests/LibWeb/Ref/expected/flex/overflowing-text-paints-under-later-flex-item-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    body {
+        width: 100px;
+        display: flex;
+    }
+
+    div {
+        background-color: red;
+        width: 50px;
+        height: 50px;
+    }
+
+    span {
+        width: 50px;
+        overflow: hidden;
+    }
+</style>
+<span>LoremIpsum</span>
+<div></div>

--- a/Tests/LibWeb/Ref/input/flex/overflowing-text-paints-under-later-flex-item.html
+++ b/Tests/LibWeb/Ref/input/flex/overflowing-text-paints-under-later-flex-item.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<head>
+<link rel="match" href="../../expected/flex/overflowing-text-paints-under-later-flex-item-ref.html" />
+<style>
+    body {
+        width: 100px;
+        display: flex;
+    }
+
+    div {
+        background-color: red;
+        width: 50px;
+        height: 50px;
+    }
+
+    span {
+        width: 50px;
+    }
+</style>
+</head>
+<body>
+    <span>LoremIpsum</span>
+    <div></div>
+</body>

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -15,14 +15,14 @@ SaveLayer@0
   FillRect@1 rect=[8,8 202x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 202x22]
   CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[9,9 200x20]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 196x18]
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[218,8 202x22]
   FillRect@1 rect=[218,8 202x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[218,8 202x22]
   CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[219,9 200x20]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[221,10 196x18]
   DrawGlyphRun@1 rect=[210,14 8x18] translation=[210,27.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 196x18]
   DrawGlyphRun@3 rect=[11,10 28x18] translation=[11,23.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[221,10 196x18]
   DrawGlyphRun@5 rect=[221,10 28x18] translation=[221,23.796875] color=rgb(0, 0, 0)
   FillRect@5 rect=[221,10 1x18] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[216,6 206x26]

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -15,11 +15,11 @@ SaveLayer@0
   FillPath@1 path_bounding_rect=[8,8 102x82]
   CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[9,9 150x120]
   FillRect@3 rect=[9,9 150x120] color=rgb(240, 128, 128)
+  DrawGlyphRun@3 rect=[9,9 110x18] translation=[9,22.796875] color=rgb(0, 0, 0)
   CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[130,8 102x82]
   FillPath@1 path_bounding_rect=[130,8 102x82]
   CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[131,9 150x120]
   FillRect@5 rect=[131,9 150x120] color=rgb(144, 238, 144)
-  DrawGlyphRun@3 rect=[9,9 110x18] translation=[9,22.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@5 rect=[131,9 119x18] translation=[131,22.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -19,22 +19,22 @@ SaveLayer@0
   FillPath@0 path_bounding_rect=[22,22 93x152]
   CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[23,23 200x300]
   FillRect@3 rect=[23,23 200x300] color=rgb(240, 128, 128)
+  DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0)
+  PaintScrollBar@0
+  PaintScrollBar@0
   CompositorWheelHitTestTarget@0 target_scroll_frame_index=3 rect=[125.328125,22 93.328125x152]
   CompositorScrollNode@0 scroll_frame_index=3 parent_scroll_frame_index=0 scrollport_rect=[126,23 92x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[125,22 94x152]
   CompositorWheelHitTestTarget@5 target_scroll_frame_index=3 rect=[126.328125,23 200x300]
   FillRect@5 rect=[126,23 200x300] color=rgb(144, 238, 144)
+  DrawGlyphRun@5 rect=[126,23 66x18] translation=[126.328125,36.796875] color=rgb(0, 0, 0)
+  PaintScrollBar@0
+  PaintScrollBar@0
   CompositorWheelHitTestTarget@0 target_scroll_frame_index=4 rect=[228.65625,22 93.328125x152]
   CompositorScrollNode@0 scroll_frame_index=4 parent_scroll_frame_index=0 scrollport_rect=[230,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[229,22 93x152]
   CompositorWheelHitTestTarget@7 target_scroll_frame_index=4 rect=[229.65625,23 200x300]
   FillRect@7 rect=[230,23 200x300] color=rgb(173, 216, 230)
-  DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0)
-  PaintScrollBar@0
-  PaintScrollBar@0
-  DrawGlyphRun@5 rect=[126,23 66x18] translation=[126.328125,36.796875] color=rgb(0, 0, 0)
-  PaintScrollBar@0
-  PaintScrollBar@0
   DrawGlyphRun@7 rect=[229,23 67x18] translation=[229.65625,36.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0


### PR DESCRIPTION
Fixes: https://github.com/LadybirdBrowser/ladybird/issues/2781

NB: Case 1 was working before this MR, this fixes two boogs found looking at case 2.

Not sure why #9376 was closed after I force pushed to it - this has same fix as that.