### PR TITLE
LibWeb: Reconcile async scroll snapshots and preserve wheel fractions

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -288,6 +288,15 @@ Optional<Gfx::FloatPoint> AsyncScrollTree::scroll_offset_for_node(AsyncScrollNod
     return {};
 }
 
+Optional<AsyncScrollNodeID> AsyncScrollTree::viewport_scroll_node_id() const
+{
+    for (auto const& node : m_scroll_nodes) {
+        if (node.is_viewport)
+            return node.node_id;
+    }
+    return {};
+}
+
 Optional<AsyncScrollNodeID> AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const
 {
     for (auto const& target : m_main_thread_wheel_event_targets) {
@@ -310,6 +319,18 @@ bool AsyncScrollTree::scroll_node_is_viewport(AsyncScrollNodeID node_id) const
 {
     auto const* node = scroll_node_for_id(node_id);
     return node && node->is_viewport;
+}
+
+Optional<Gfx::FloatPoint> AsyncScrollTree::set_scroll_offset(AsyncScrollNodeID node_id, Gfx::FloatPoint scroll_offset, Painting::ScrollStateSnapshot& scroll_state_snapshot)
+{
+    auto* node = scroll_node_for_id(node_id);
+    if (!node)
+        return {};
+
+    node->scroll_offset = clamp_scroll_offset_to_node(*node, scroll_offset);
+    scroll_state_snapshot.set_device_offset_for_index(node->node_id.scroll_frame_index, { -node->scroll_offset.x(), -node->scroll_offset.y() });
+    update_sticky_offsets(scroll_state_snapshot);
+    return node->scroll_offset;
 }
 
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -42,9 +42,11 @@ public:
     void clear_wheel_scroll_targets();
 
     Optional<Gfx::FloatPoint> scroll_offset_for_node(AsyncScrollNodeID) const;
+    Optional<AsyncScrollNodeID> viewport_scroll_node_id() const;
     Optional<AsyncScrollNodeID> hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const;
     bool scroll_node_is_viewport(AsyncScrollNodeID) const;
     bool apply_scroll_delta(AsyncScrollNodeID, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
+    Optional<Gfx::FloatPoint> set_scroll_offset(AsyncScrollNodeID, Gfx::FloatPoint, Painting::ScrollStateSnapshot&);
 
 private:
     static Gfx::FloatPoint clamp_scroll_offset_to_node(AsyncScrollNode const&, Gfx::FloatPoint);

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -382,6 +382,7 @@ public:
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
                         if (cmd.async_scrolling_state.has_value()) {
                             auto async_scrolling_state = cmd.async_scrolling_state.release_value();
+                            auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
                             auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
                             auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
                             {
@@ -391,7 +392,6 @@ public:
                                 else
                                     m_wheel_event_listener_state_generation = wheel_event_listener_state_generation;
                                 m_wheel_routing_admission = wheel_routing_admission;
-                                m_async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
                             }
                             m_can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
                             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor wheel routing admission: {} (scroll_nodes={}, sticky_areas={}, blocking_regions={})",
@@ -409,14 +409,16 @@ public:
                                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
                                 m_async_scroll_tree.set_state(move(async_scrolling_state));
                                 if (viewport_node.has_value() && pending_async_viewport_scroll_offset.has_value()) {
-                                    auto delta = pending_async_viewport_scroll_offset->translated(-viewport_node->scroll_offset.x(), -viewport_node->scroll_offset.y());
-                                    if (delta.x() != 0 || delta.y() != 0) {
-                                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying pending async viewport offset {},{} to display list update",
-                                            pending_async_viewport_scroll_offset->x(), pending_async_viewport_scroll_offset->y());
-                                        m_async_scroll_tree.apply_scroll_delta(viewport_node->node_id, delta, m_cached_scroll_state_snapshot);
-                                    }
+                                    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying pending async viewport offset {},{} to display list update",
+                                        pending_async_viewport_scroll_offset->x(), pending_async_viewport_scroll_offset->y());
+                                    if (auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(viewport_node->node_id, *pending_async_viewport_scroll_offset, m_cached_scroll_state_snapshot); reconciled_scroll_offset.has_value())
+                                        async_scrolling_viewport_rect.set_location(reconciled_scroll_offset->to_type<int>());
                                 }
                                 m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            }
+                            {
+                                Sync::MutexLocker const locker { m_mutex };
+                                m_async_scrolling_viewport_rect = async_scrolling_viewport_rect;
                             }
                             m_has_async_scrolling_state = true;
                         } else {
@@ -466,8 +468,29 @@ public:
                     [this](UpdateScrollStateCommand& cmd) {
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
                         if (m_has_async_scrolling_state) {
-                            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                            m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            auto pending_async_viewport_scroll_offset = [this] {
+                                Sync::MutexLocker const locker { m_mutex };
+                                return m_pending_async_viewport_scroll_offset;
+                            }();
+                            Optional<Gfx::FloatPoint> reconciled_viewport_scroll_offset;
+                            {
+                                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                                if (pending_async_viewport_scroll_offset.has_value()) {
+                                    if (auto viewport_node_id = m_async_scroll_tree.viewport_scroll_node_id(); viewport_node_id.has_value()) {
+                                        // A main-thread scroll-state update can be older than compositor-side async
+                                        // scrolling. Preserve the compositor-visible viewport offset in the fresh
+                                        // snapshot before rebuilding hit-test data from it.
+                                        reconciled_viewport_scroll_offset = m_async_scroll_tree.set_scroll_offset(*viewport_node_id, *pending_async_viewport_scroll_offset, m_cached_scroll_state_snapshot);
+                                    }
+                                }
+                                m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            }
+                            if (reconciled_viewport_scroll_offset.has_value()) {
+                                Sync::MutexLocker const mutex_locker { m_mutex };
+                                auto reconciled_viewport_rect = m_async_scrolling_viewport_rect;
+                                reconciled_viewport_rect.set_location(reconciled_viewport_scroll_offset->to_type<int>());
+                                m_async_scrolling_viewport_rect = reconciled_viewport_rect;
+                            }
                         }
                     },
                     [this](UpdateBackingStoresCommand& cmd) {

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3197,7 +3197,10 @@ void Navigable::paint_next_frame()
 
     record_display_list_and_scroll_state(paint_config);
 
-    if (page().async_scrolling_enabled() && m_rendering_thread.should_defer_main_thread_present_for_async_scroll()) {
+    viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
+    auto should_defer_main_thread_present_for_async_scroll = page().async_scrolling_enabled()
+        && m_rendering_thread.should_defer_main_thread_present_for_async_scroll();
+    if (should_defer_main_thread_present_for_async_scroll) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred present while async scroll is pending");
         return;
     }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -601,7 +601,7 @@ RefPtr<Painting::PaintableBox const> EventHandler::paint_root() const
     return m_navigable->active_document()->paintable_box();
 }
 
-EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, int wheel_delta_x, int wheel_delta_y, bool async_scroll_performed_default_action)
+EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action)
 {
     if (should_ignore_device_input_event())
         return EventResult::Dropped;
@@ -713,7 +713,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                     handled_event = EventResult::Handled;
                 } else if (could_scroll_viewport) {
                     auto viewport_scroll_position_before = CSSPixelPoint { CSSPixels(document->visual_viewport()->page_left()), CSSPixels(document->visual_viewport()->page_top()) };
-                    m_navigable->scroll_viewport_by_delta({ wheel_delta_x, wheel_delta_y });
+                    m_navigable->scroll_viewport_by_delta({ CSSPixels::nearest_value_for(wheel_delta_x), CSSPixels::nearest_value_for(wheel_delta_y) });
                     auto viewport_scroll_position_after = CSSPixelPoint { CSSPixels(document->visual_viewport()->page_left()), CSSPixels(document->visual_viewport()->page_top()) };
                     handled_event = viewport_scroll_position_before != viewport_scroll_position_after ? EventResult::Handled : EventResult::Accepted;
                 } else {

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -42,7 +42,7 @@ public:
     EventResult handle_mousedown(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     EventResult handle_mousemove(CSSPixelPoint, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult handle_mouseleave();
-    EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y, bool async_scroll_performed_default_action = false);
+    EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false);
 
     EventResult handle_drag_and_drop_event(DragEvent::Type, CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);
 

--- a/Libraries/LibWeb/Page/InputEvent.cpp
+++ b/Libraries/LibWeb/Page/InputEvent.cpp
@@ -76,8 +76,8 @@ ErrorOr<Web::MouseEvent> IPC::decode(Decoder& decoder)
     auto button = TRY(decoder.decode<Web::UIEvents::MouseButton>());
     auto buttons = TRY(decoder.decode<Web::UIEvents::MouseButton>());
     auto modifiers = TRY(decoder.decode<Web::UIEvents::KeyModifier>());
-    auto wheel_delta_x = TRY(decoder.decode<int>());
-    auto wheel_delta_y = TRY(decoder.decode<int>());
+    auto wheel_delta_x = TRY(decoder.decode<double>());
+    auto wheel_delta_y = TRY(decoder.decode<double>());
     auto click_count = TRY(decoder.decode<int>());
     auto async_scroll_performed_default_action = TRY(decoder.decode<bool>());
 

--- a/Libraries/LibWeb/Page/InputEvent.h
+++ b/Libraries/LibWeb/Page/InputEvent.h
@@ -57,8 +57,8 @@ struct WEB_API MouseEvent {
     UIEvents::MouseButton button { UIEvents::MouseButton::None };
     UIEvents::MouseButton buttons { UIEvents::MouseButton::None };
     UIEvents::KeyModifier modifiers { UIEvents::KeyModifier::Mod_None };
-    int wheel_delta_x { 0 };
-    int wheel_delta_y { 0 };
+    double wheel_delta_x { 0 };
+    double wheel_delta_y { 0 };
     int click_count { 0 };
 
     OwnPtr<BrowserInputData> browser_data;

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -267,9 +267,9 @@ EventResult Page::handle_mouseleave()
     return top_level_traversable()->event_handler().handle_mouseleave();
 }
 
-EventResult Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, DevicePixels wheel_delta_x, DevicePixels wheel_delta_y, bool async_scroll_performed_default_action)
+EventResult Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action)
 {
-    return top_level_traversable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x.value(), wheel_delta_y.value(), async_scroll_performed_default_action);
+    return top_level_traversable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action);
 }
 
 EventResult Page::handle_drag_and_drop_event(DragEvent::Type type, DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -106,7 +106,7 @@ public:
     EventResult handle_mousedown(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     EventResult handle_mousemove(DevicePixelPoint, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult handle_mouseleave();
-    EventResult handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, DevicePixels wheel_delta_x, DevicePixels wheel_delta_y, bool async_scroll_performed_default_action = false);
+    EventResult handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false);
 
     EventResult handle_drag_and_drop_event(DragEvent::Type, DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);
     EventResult handle_pinch_event(DevicePixelPoint point, double scale);

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -113,7 +113,7 @@ GC::Ptr<HTML::Navigable> Paintable::navigable() const
     return document().navigable();
 }
 
-bool Paintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int, int)
+bool Paintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, double, double)
 {
     return false;
 }

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -92,7 +92,7 @@ public:
 
     virtual bool forms_unconnected_subtree() const { return false; }
 
-    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y);
 
     Layout::Node const& layout_node() const
     {

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -253,9 +253,9 @@ PaintableBox::ScrollHandled PaintableBox::set_scroll_offset(CSSPixelPoint offset
     return ScrollHandled::Yes;
 }
 
-PaintableBox::ScrollHandled PaintableBox::scroll_by(int delta_x, int delta_y)
+PaintableBox::ScrollHandled PaintableBox::scroll_by(double delta_x, double delta_y)
 {
-    return set_scroll_offset(scroll_offset().translated(delta_x, delta_y));
+    return set_scroll_offset(scroll_offset().translated(CSSPixels::nearest_value_for(delta_x), CSSPixels::nearest_value_for(delta_y)));
 }
 
 void PaintableBox::scroll_into_view(CSSPixelRect rect)
@@ -1047,10 +1047,10 @@ NonnullRefPtr<ResizeHandle> PaintableBox::ensure_resize_handle()
     return *m_resize_handle;
 }
 
-bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
+bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, double wheel_delta_x, double wheel_delta_y)
 {
     // if none of the axes we scrolled with can be accepted by this element, don't handle scroll.
-    if ((!wheel_delta_x || !could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal)) && (!wheel_delta_y || !could_be_scrolled_by_wheel_event(ScrollDirection::Vertical))) {
+    if ((wheel_delta_x == 0 || !could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal)) && (wheel_delta_y == 0 || !could_be_scrolled_by_wheel_event(ScrollDirection::Vertical))) {
         return false;
     }
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -78,7 +78,7 @@ public:
 
     CSSPixelPoint scroll_offset() const;
     ScrollHandled set_scroll_offset(CSSPixelPoint);
-    ScrollHandled scroll_by(int delta_x, int delta_y);
+    ScrollHandled scroll_by(double delta_x, double delta_y);
     void scroll_into_view(CSSPixelRect);
 
     void set_offset(CSSPixelPoint);
@@ -156,7 +156,7 @@ public:
     [[nodiscard]] virtual TraversalDecision hit_test(CSSPixelPoint position, HitTestType type, Function<TraversalDecision(HitTestResult)> const& callback) const override;
     Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
 
-    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
+    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y) override;
 
     struct ScrollbarData {
         CSSPixelRect gutter_rect;

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -631,7 +631,7 @@ void ViewportPaintable::recompute_selection_states(DOM::Range& range)
     }
 }
 
-bool ViewportPaintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int, int)
+bool ViewportPaintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, double, double)
 {
     return false;
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -32,7 +32,7 @@ public:
     GC::Ptr<Selection::Selection> selection() const;
     void recompute_selection_states(DOM::Range&);
 
-    bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y) override;
+    bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, double wheel_delta_x, double wheel_delta_y) override;
 
     void set_needs_to_refresh_scroll_state(bool value) { m_needs_to_refresh_scroll_state = value; }
 

--- a/UI/AppKit/Interface/Event.mm
+++ b/UI/AppKit/Interface/Event.mm
@@ -46,22 +46,19 @@ Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* eve
 
     auto modifiers = ns_modifiers_to_key_modifiers(event.modifierFlags);
 
-    int wheel_delta_x = 0;
-    int wheel_delta_y = 0;
+    double wheel_delta_x = 0;
+    double wheel_delta_y = 0;
 
     if (type == Web::MouseEvent::Type::MouseWheel) {
-        CGFloat delta_x = -[event scrollingDeltaX];
-        CGFloat delta_y = -[event scrollingDeltaY];
+        wheel_delta_x = -[event scrollingDeltaX];
+        wheel_delta_y = -[event scrollingDeltaY];
 
         if (![event hasPreciseScrollingDeltas]) {
-            static constexpr CGFloat imprecise_scroll_multiplier = 40;
+            static constexpr double imprecise_scroll_multiplier = 40;
 
-            delta_x *= imprecise_scroll_multiplier;
-            delta_y *= imprecise_scroll_multiplier;
+            wheel_delta_x *= imprecise_scroll_multiplier;
+            wheel_delta_y *= imprecise_scroll_multiplier;
         }
-
-        wheel_delta_x = static_cast<int>(delta_x);
-        wheel_delta_y = static_cast<int>(delta_y);
     }
 
     int click_count = 0;

--- a/UI/Gtk/Widgets/LadybirdWebView.cpp
+++ b/UI/Gtk/Widgets/LadybirdWebView.cpp
@@ -164,20 +164,20 @@ static gboolean on_scroll(GtkEventControllerScroll* controller, gdouble dx, gdou
 
     auto device_pixel_ratio = self->impl->device_pixel_ratio();
 
-    int wheel_delta_x = 0;
-    int wheel_delta_y = 0;
+    double wheel_delta_x = 0;
+    double wheel_delta_y = 0;
 
     auto* gdk_event = gtk_event_controller_get_current_event(GTK_EVENT_CONTROLLER(controller));
     auto unit = gdk_scroll_event_get_unit(gdk_event);
 
     if (unit == GDK_SCROLL_UNIT_SURFACE) {
-        wheel_delta_x = static_cast<int>(dx * device_pixel_ratio);
-        wheel_delta_y = static_cast<int>(dy * device_pixel_ratio);
+        wheel_delta_x = dx * device_pixel_ratio;
+        wheel_delta_y = dy * device_pixel_ratio;
     } else {
         static constexpr double scroll_lines = 3.0;
         static constexpr double scroll_step_size = 40.0;
-        wheel_delta_x = static_cast<int>(dx * scroll_lines * scroll_step_size * device_pixel_ratio);
-        wheel_delta_y = static_cast<int>(dy * scroll_lines * scroll_step_size * device_pixel_ratio);
+        wheel_delta_x = dx * scroll_lines * scroll_step_size * device_pixel_ratio;
+        wheel_delta_y = dy * scroll_lines * scroll_step_size * device_pixel_ratio;
     }
 
     // GDK scroll events on Wayland do not carry reliable pointer coordinates, so we

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -808,8 +808,8 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
         return;
     }
 
-    int wheel_delta_x = 0;
-    int wheel_delta_y = 0;
+    double wheel_delta_x = 0;
+    double wheel_delta_y = 0;
 
     if (type == Web::MouseEvent::Type::MouseWheel) {
         auto const& wheel_event = static_cast<QWheelEvent const&>(event);
@@ -819,15 +819,15 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
             wheel_delta_y = pixel_delta.y();
         } else {
             auto angle_delta = -wheel_event.angleDelta();
-            float delta_x = -static_cast<float>(angle_delta.x()) / 120.0f;
-            float delta_y = static_cast<float>(angle_delta.y()) / 120.0f;
+            double delta_x = -static_cast<double>(angle_delta.x()) / 120.0;
+            double delta_y = static_cast<double>(angle_delta.y()) / 120.0;
 
-            static constexpr float scroll_step_size = 40;
-            auto step_x = delta_x * static_cast<float>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
-            auto step_y = delta_y * static_cast<float>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
+            static constexpr double scroll_step_size = 40;
+            auto step_x = delta_x * static_cast<double>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
+            auto step_y = delta_y * static_cast<double>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
 
-            wheel_delta_x = static_cast<int>(step_x * scroll_step_size);
-            wheel_delta_y = static_cast<int>(step_y * scroll_step_size);
+            wheel_delta_x = step_x * scroll_step_size;
+            wheel_delta_y = step_y * scroll_step_size;
         }
     }
 


### PR DESCRIPTION
Preserve compositor-visible async viewport offsets when fresh main-thread scroll state arrives. This prevents stale main-thread scroll snapshots from replacing the compositor snapshot with an older viewport offset after async scrolling has already presented newer positions.

Also keep wheel scroll deltas in double precision through the input and scrolling pipeline, so trackpad momentum does not lose fractional deltas at the platform boundary.