### PR TITLE
AK: Constrain FixedPoint underlying type to integrals

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -26,9 +26,9 @@
 namespace AK {
 
 // FIXME: this always uses round to nearest break-tie to even
-// FIXME: use the Integral concept to constrain Underlying
 template<size_t precision, typename Underlying>
 class FixedPoint {
+    static_assert(IsIntegral<Underlying>, "Underlying type must be integral");
     using This = FixedPoint<precision, Underlying>;
     constexpr static Underlying radix_mask = (static_cast<Underlying>(1) << precision) - 1;
 


### PR DESCRIPTION
This PR addresses a FIXME in `AK/FixedPoint.h`:
`// FIXME: use the Integral concept to constrain Underlying`
for the FixedPoint class:
```cpp
template<size_t precision, typename Underlying>
class FixedPoint
```

`static_assert` was used instead of using the concept like `template<size_t precision, Integral Underlying>` in order to prevent the circular dependency errors caused by including `<AK/Concepts.h>`

Verified by manually confirming something like `FixedPoint<4, float>` does not compile.