### PR TITLE
Tests+CI: Preserve LibWeb failure diagnostics

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -221,7 +221,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang_plugins }}
-          path: ${{ github.workspace }}/Build/Tests/LibWeb/test-web/test-dumps/
+          path: |
+            Build/Tests/LibWeb/test-web/test-dumps/
+            Build/**/asan.log.*
+            Build/**/ubsan.log.*
           retention-days: 0
           if-no-files-found: ignore
 
@@ -229,7 +232,7 @@ jobs:
         if: ${{ !cancelled() && inputs.os_name != 'Windows' && inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: |
-          log_output=$(find . -maxdepth 1 \( -name 'asan.log.*' -o -name 'ubsan.log.*' \) -exec cat {} \; )
+          log_output=$(find Build \( -name 'asan.log.*' -o -name 'ubsan.log.*' \) -exec cat {} \; )
           if [ -z "$log_output" ]; then
             echo "No sanitizer issues found."
           else

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/NeverDestroyed.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibIPC/Transport.h>
@@ -33,7 +34,7 @@ class CompositorConnectionToServer final
 public:
     CompositorConnectionToServer(WebContentClient& web_content_client, NonnullOwnPtr<IPC::Transport> transport)
         : IPC::ConnectionToServer<CompositorClientEndpoint, CompositorServerEndpoint>(*this, move(transport))
-        , m_web_content_client(web_content_client)
+        , m_web_content_client(web_content_client.make_weak_ptr<WebContentClient>())
     {
     }
 
@@ -42,15 +43,17 @@ private:
 
     virtual void did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) override
     {
-        m_web_content_client.did_present_backing_stores(page_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+        if (auto web_content_client = m_web_content_client.strong_ref())
+            web_content_client->did_present_backing_stores(page_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
     }
 
     virtual void did_paint(u64 page_id, Gfx::IntRect content_rect, i32 bitmap_id) override
     {
-        m_web_content_client.did_present_bitmap(page_id, content_rect, bitmap_id);
+        if (auto web_content_client = m_web_content_client.strong_ref())
+            web_content_client->did_present_bitmap(page_id, content_rect, bitmap_id);
     }
 
-    WebContentClient& m_web_content_client;
+    WeakPtr<WebContentClient> m_web_content_client;
 };
 
 static HashMap<WebContentClient*, NonnullRefPtr<CompositorConnectionToServer>>& compositor_connections()

--- a/Tests/LibWeb/test-web/TestRunCapture.cpp
+++ b/Tests/LibWeb/test-web/TestRunCapture.cpp
@@ -190,7 +190,13 @@ void TestRunCapture::write_test_output(TestWebView const& view)
 bool TestRunCapture::write_helper_process_output()
 {
     restore_stderr();
-    return m_helper_output.transfer_to_output_file().value_or(false);
+
+    auto result = m_helper_output.transfer_to_output_file();
+    if (result.is_error()) {
+        warnln("Failed to write helper process logs: {}", result.error());
+        return false;
+    }
+    return result.value();
 }
 
 void TestRunCapture::restore_stderr()

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -231,6 +231,53 @@ static void log_active_test_views(StringView reason)
     outln();
 }
 
+static ErrorOr<void> write_harness_status(StringView reason)
+{
+    auto& app = Application::the();
+    auto& display = Display::the();
+    auto status_path = LexicalPath::join(app.results_directory, "harness-status.txt"sv).string();
+    auto status_file = TRY(Core::File::open(status_path, Core::File::OpenMode::Write | Core::File::OpenMode::Truncate));
+
+    TRY(status_file->write_formatted("reason: {}\n", reason));
+    TRY(status_file->write_formatted("completed: {}/{}\n", display.completed_tests, total_tests()));
+    TRY(status_file->write_formatted("pass: {}\n", display.pass_count));
+    TRY(status_file->write_formatted("fail: {}\n", display.fail_count));
+    TRY(status_file->write_formatted("timeout: {}\n", display.timeout_count));
+    TRY(status_file->write_formatted("crashed: {}\n", display.crashed_count));
+    TRY(status_file->write_formatted("skipped: {}\n", display.skipped_count));
+    if (s_run_context)
+        TRY(status_file->write_formatted("remaining: {}\n", s_run_context->tests_remaining));
+
+    TRY(status_file->write_until_depleted("active views:\n"sv.bytes()));
+
+    auto now = UnixDateTime::now();
+    WebView::ViewImplementation::for_each_view([&](WebView::ViewImplementation const& view) {
+        pid_t pid = 0;
+        if (auto view_index = s_view_index_by_view.get(&view); view_index.has_value() && *view_index < s_view_display_states.size())
+            pid = s_view_display_states[*view_index].pid;
+
+        (void)status_file->write_formatted("  - View {} (pid {}): ", view.view_id(), pid);
+
+        auto maybe_index = s_current_test_index_by_view.get(&view);
+        if (maybe_index.has_value() && s_run_context) {
+            auto const& test = s_run_context->tests[*maybe_index];
+            (void)status_file->write_formatted("{} (duration: {})\n", test.relative_path, human_readable_time(now - test.start_time));
+        } else {
+            (void)status_file->write_formatted("{} (no active test)\n", view.url());
+        }
+
+        return IterationDecision::Continue;
+    });
+
+    return {};
+}
+
+static void try_write_harness_status(StringView reason)
+{
+    if (auto result = write_harness_status(reason); result.is_error())
+        warnln("Failed to write test-web harness status: {}", result.error());
+}
+
 static ErrorOr<void> collect_screenshot_tests(Application const& app, Vector<Test>& tests, StringView path, StringView trail)
 {
     Core::DirIterator it(ByteString::formatted("{}/input/{}", path, trail), Core::DirIterator::Flags::SkipDots);
@@ -1294,6 +1341,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
 
             // Mark this view as active (for variant wake-up tracking)
             display.on_test_started(view_id, test, view->web_content_pid());
+            try_write_harness_status(ByteString::formatted("running {}", test.relative_path));
 
             // Reset promise and attach completion callback
             view->reset_test_promise();
@@ -1320,11 +1368,13 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
                     non_passing_tests.append(result);
 
                 Display::the().on_test_finished(view_id, test, result.result);
+                try_write_harness_status(ByteString::formatted("finished {}: {}", test.relative_path, test_result_to_string(result.result)));
 
                 if (app.fail_fast && !fail_fast_triggered && should_trigger_fail_fast) {
                     fail_fast_triggered = true;
                     auto const pid = view->web_content_pid();
                     Display::the().on_fail_fast(test, result.result, pid);
+                    try_write_harness_status(ByteString::formatted("fail-fast after {}: {}", test.relative_path, test_result_to_string(result.result)));
 
                     if (s_all_tests_complete)
                         s_all_tests_complete->reject(Error::from_string_literal("Fail-fast"));
@@ -1372,12 +1422,20 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         = s_all_tests_complete->await();
     display.clear_live_display();
 
-    if (result_or_rejection.is_error())
-        log_active_test_views(ByteString::formatted("test run stopped early: {}", result_or_rejection.error()));
-    else if (tests_remaining > 0)
-        log_active_test_views(ByteString::formatted("event loop stopped with {} unfinished tests", tests_remaining));
+    bool const test_run_stopped_early = result_or_rejection.is_error() || tests_remaining > 0;
+    if (result_or_rejection.is_error()) {
+        auto reason = ByteString::formatted("test run stopped early: {}", result_or_rejection.error());
+        log_active_test_views(reason);
+        try_write_harness_status(reason);
+    } else if (tests_remaining > 0) {
+        auto reason = ByteString::formatted("event loop stopped with {} unfinished tests", tests_remaining);
+        log_active_test_views(reason);
+        try_write_harness_status(reason);
+    } else {
+        try_write_harness_status("completed"sv);
+    }
 
-    display.print_run_complete(tests, non_passing_tests, result_or_rejection.is_error() ? tests_remaining : 0);
+    display.print_run_complete(tests, non_passing_tests, tests_remaining);
 
     if (app.dump_gc_graph) {
         for (auto& view : views) {
@@ -1393,7 +1451,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     bool has_helper_output = test_run_capture.write_helper_process_output();
 
     // Generate result files (JSON data and HTML index)
-    if (app.quiet || app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT || !non_passing_tests.is_empty() || has_helper_output) {
+    if (app.quiet || app.verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT || !non_passing_tests.is_empty() || has_helper_output || test_run_stopped_early) {
         if (auto result = generate_result_files(tests, non_passing_tests); result.is_error())
             warnln("Failed to generate result files: {}", result.error());
         else
@@ -1419,6 +1477,7 @@ static void handle_signal(int signal)
         log_active_test_views(signal_name);
     else
         log_active_test_views(ByteString::formatted("signal {} received", signal));
+    try_write_harness_status(signal_name);
 
     // Stop running tests
     if (signal == SIGINT)


### PR DESCRIPTION
Keep test-web writing a small harness-status.txt file as it runs, so abrupt exits still leave behind the last known test counts and active views.

Also make helper-process log write failures visible, and write sanitizer logs to absolute workspace paths so CI can print and upload them even when CTest runs tests from a subdirectory.