### PR TITLE
LibWeb: Move viewport scrollbars onto the compositor

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -95,9 +95,11 @@ static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrollin
     auto metrics = paintable_box.document().page().chrome_metrics();
 
     for (auto direction : { Painting::PaintableBox::ScrollDirection::Vertical, Painting::PaintableBox::ScrollDirection::Horizontal }) {
-        auto scrollbar_data = paintable_box.compute_scrollbar_data(direction, metrics);
+        auto scrollbar_data = paintable_box.compute_scrollbar_data(direction, metrics, nullptr, Painting::PaintableBox::ScrollbarSizing::Regular);
         if (!scrollbar_data.has_value())
             continue;
+        auto expanded_scrollbar_data = paintable_box.compute_scrollbar_data(direction, metrics, nullptr, Painting::PaintableBox::ScrollbarSizing::Enlarged);
+        VERIFY(expanded_scrollbar_data.has_value());
 
         auto gutter_rect = navigable.page().css_to_device_rect(scrollbar_data->gutter_rect).to_type<int>();
         auto max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), navigable.page().client().device_pixels_per_css_pixel());
@@ -111,7 +113,10 @@ static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrollin
             .scroll_frame_index = paintable_box.own_scroll_frame_index(),
             .gutter_rect = gutter_rect,
             .thumb_rect = navigable.page().css_to_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
+            .expanded_gutter_rect = navigable.page().css_to_device_rect(expanded_scrollbar_data->gutter_rect).to_type<int>(),
+            .expanded_thumb_rect = navigable.page().css_to_device_rect(expanded_scrollbar_data->thumb_rect).to_type<int>(),
             .scroll_size = scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
+            .expanded_scroll_size = expanded_scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
             .max_scroll_offset = max_scroll_offset.primary_offset_for_orientation(orientation),
             .thumb_color = thumb_color,
             .track_color = scrollbar_colors.track_color,

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -100,15 +100,19 @@ static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrollin
             continue;
 
         auto gutter_rect = navigable.page().css_to_device_rect(scrollbar_data->gutter_rect).to_type<int>();
+        auto max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), navigable.page().client().device_pixels_per_css_pixel());
+        auto orientation = direction == Painting::PaintableBox::ScrollDirection::Horizontal ? Gfx::Orientation::Horizontal : Gfx::Orientation::Vertical;
         auto thumb_color = scrollbar_colors.thumb_color;
         if (gutter_rect.is_empty() && thumb_color == CSS::InitialValues::scrollbar_color().thumb_color)
             thumb_color = thumb_color.with_alpha(128);
 
         async_scrolling_state.viewport_scrollbars.append({
+            .scroll_node_id = scroll_node_id_for(paintable_box.document().unique_id(), paintable_box.own_scroll_frame_index()),
             .scroll_frame_index = paintable_box.own_scroll_frame_index(),
             .gutter_rect = gutter_rect,
             .thumb_rect = navigable.page().css_to_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
             .scroll_size = scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
+            .max_scroll_offset = max_scroll_offset.primary_offset_for_orientation(orientation),
             .thumb_color = thumb_color,
             .track_color = scrollbar_colors.track_color,
             .vertical = direction == Painting::PaintableBox::ScrollDirection::Vertical,

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/DOMEventListener.h>
 #include <LibWeb/DOM/Document.h>
@@ -79,6 +80,40 @@ static Optional<AsyncScrollNodeID> parent_scroll_node_id_for(AsyncScrollingState
             return node_id;
     }
     return {};
+}
+
+static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrolling_state, HTML::Navigable& navigable, Painting::PaintableBox const& paintable_box)
+{
+    if (!paintable_box.is_viewport_paintable())
+        return;
+    if (!Painting::should_paint_viewport_scrollbars())
+        return;
+    if (paintable_box.computed_values().scrollbar_width() == CSS::ScrollbarWidth::None)
+        return;
+
+    auto scrollbar_colors = paintable_box.computed_values().scrollbar_color();
+    auto metrics = paintable_box.document().page().chrome_metrics();
+
+    for (auto direction : { Painting::PaintableBox::ScrollDirection::Vertical, Painting::PaintableBox::ScrollDirection::Horizontal }) {
+        auto scrollbar_data = paintable_box.compute_scrollbar_data(direction, metrics);
+        if (!scrollbar_data.has_value())
+            continue;
+
+        auto gutter_rect = navigable.page().css_to_device_rect(scrollbar_data->gutter_rect).to_type<int>();
+        auto thumb_color = scrollbar_colors.thumb_color;
+        if (gutter_rect.is_empty() && thumb_color == CSS::InitialValues::scrollbar_color().thumb_color)
+            thumb_color = thumb_color.with_alpha(128);
+
+        async_scrolling_state.viewport_scrollbars.append({
+            .scroll_frame_index = paintable_box.own_scroll_frame_index(),
+            .gutter_rect = gutter_rect,
+            .thumb_rect = navigable.page().css_to_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
+            .scroll_size = scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
+            .thumb_color = thumb_color,
+            .track_color = scrollbar_colors.track_color,
+            .vertical = direction == Painting::PaintableBox::ScrollDirection::Vertical,
+        });
+    }
 }
 
 static bool has_blocking_wheel_event_listener(DOM::EventTarget& event_target)
@@ -183,6 +218,8 @@ AsyncScrollingState collect_async_scrolling_state(HTML::Navigable& navigable, Pa
             });
             parent_scroll_frame_indices.append(parent_scroll_frame_index);
         }
+
+        collect_viewport_scrollbar_state(async_scrolling_state, navigable, paintable_box);
 
         return TraversalDecision::Continue;
     });

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -73,7 +73,10 @@ struct ViewportScrollbar {
     Painting::ScrollFrameIndex scroll_frame_index;
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
+    Gfx::IntRect expanded_gutter_rect;
+    Gfx::IntRect expanded_thumb_rect;
     double scroll_size { 0 };
+    double expanded_scroll_size { 0 };
     float max_scroll_offset { 0 };
     Color thumb_color;
     Color track_color;

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -69,10 +69,12 @@ struct MainThreadWheelEventRegion {
 };
 
 struct ViewportScrollbar {
+    AsyncScrollNodeID scroll_node_id;
     Painting::ScrollFrameIndex scroll_frame_index;
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
     double scroll_size { 0 };
+    float max_scroll_offset { 0 };
     Color thumb_color;
     Color track_color;
     bool vertical { false };

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/Forward.h>
@@ -67,12 +68,23 @@ struct MainThreadWheelEventRegion {
     Gfx::FloatRect rect;
 };
 
+struct ViewportScrollbar {
+    Painting::ScrollFrameIndex scroll_frame_index;
+    Gfx::IntRect gutter_rect;
+    Gfx::IntRect thumb_rect;
+    double scroll_size { 0 };
+    Color thumb_color;
+    Color track_color;
+    bool vertical { false };
+};
+
 // Snapshot of scroll-related paint data that the compositor can read without touching DOM, layout, or paintables.
 // It is immutable once collected on the main thread; AsyncScrollTree keeps the mutable compositor-side scroll offsets.
 struct AsyncScrollingState {
     Vector<AsyncScrollNode> scroll_nodes;
     Vector<AsyncStickyArea> sticky_areas;
     Vector<MainThreadWheelEventRegion> main_thread_wheel_event_regions;
+    Vector<ViewportScrollbar> viewport_scrollbars;
 
     // Non-passive wheel listeners can cancel scrolling, so async scrolling must treat them as hard barriers.
     // Viewport-wide barriers cover listeners on the root targets; element regions let input hit-testing accept

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/SharedImage.h>
 #include <LibGfx/SharedImageBuffer.h>
 #include <LibGfx/SkiaBackendContext.h>
+#include <LibGfx/SkiaUtils.h>
 #include <LibThreading/Thread.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
@@ -30,6 +31,8 @@
 
 #include <core/SkCanvas.h>
 #include <core/SkColor.h>
+#include <core/SkPaint.h>
+#include <core/SkRRect.h>
 
 #include <LibCore/Platform/ScopedAutoreleasePool.h>
 
@@ -87,6 +90,55 @@ static Optional<AsyncScrollNode> viewport_scroll_node(AsyncScrollingState const&
             return node;
     }
     return {};
+}
+
+static SkRect to_skia_rect(Gfx::IntRect const& rect)
+{
+    return SkRect::MakeXYWH(rect.x(), rect.y(), rect.width(), rect.height());
+}
+
+static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+{
+    auto thumb_rect = scrollbar.thumb_rect;
+    auto device_offset = scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_frame_index);
+    if (scrollbar.vertical)
+        thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * scrollbar.scroll_size));
+    else
+        thumb_rect.translate_by(static_cast<int>(-device_offset.x() * scrollbar.scroll_size), 0);
+
+    auto& canvas = surface.canvas();
+
+    SkPaint gutter_fill_paint;
+    gutter_fill_paint.setColor(to_skia_color(scrollbar.track_color));
+    canvas.drawRect(to_skia_rect(scrollbar.gutter_rect), gutter_fill_paint);
+
+    auto skia_thumb_rect = to_skia_rect(thumb_rect);
+    auto radius = skia_thumb_rect.width() / 2;
+    auto thumb_rrect = SkRRect::MakeRectXY(skia_thumb_rect, radius, radius);
+
+    SkPaint thumb_fill_paint;
+    thumb_fill_paint.setColor(to_skia_color(scrollbar.thumb_color));
+    canvas.drawRRect(thumb_rrect, thumb_fill_paint);
+
+    SkPaint stroke_paint;
+    stroke_paint.setStroke(true);
+    stroke_paint.setStrokeWidth(1);
+    stroke_paint.setAntiAlias(true);
+    stroke_paint.setColor(to_skia_color(scrollbar.thumb_color.lightened()));
+    canvas.drawRRect(thumb_rrect, stroke_paint);
+}
+
+static void paint_viewport_scrollbars(Gfx::PaintingSurface& surface, ReadonlySpan<ViewportScrollbar> scrollbars, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+{
+    for (auto const& scrollbar : scrollbars)
+        paint_viewport_scrollbar(surface, scrollbar, scroll_state_snapshot);
+}
+
+static void flush_surface(Gfx::PaintingSurface& surface)
+{
+    if (auto context = surface.skia_backend_context())
+        context->flush_and_submit(&surface.sk_surface());
+    surface.flush();
 }
 
 struct BackingStorePair {
@@ -385,6 +437,7 @@ public:
                             auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
                             auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
                             auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
+                            m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
                             {
                                 Sync::MutexLocker const locker { m_mutex };
                                 if (wheel_event_listener_state_generation < m_wheel_event_listener_state_generation)
@@ -422,6 +475,7 @@ public:
                             }
                             m_has_async_scrolling_state = true;
                         } else {
+                            m_viewport_scrollbars.clear();
                             {
                                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
                                 m_async_scroll_tree.clear_wheel_scroll_targets();
@@ -506,6 +560,8 @@ public:
                         if (!m_cached_display_list)
                             return;
                         m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *cmd.target_surface);
+                        paint_viewport_scrollbars(*cmd.target_surface, m_viewport_scrollbars, m_cached_scroll_state_snapshot);
+                        flush_surface(*cmd.target_surface);
                         if (cmd.callback) {
                             invoke_on_main_thread([callback = move(cmd.callback)]() mutable {
                                 callback();
@@ -611,6 +667,8 @@ private:
                 m_backing_stores.back_store->canvas().clear(SK_ColorTRANSPARENT);
             }
             m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *m_backing_stores.back_store);
+            paint_viewport_scrollbars(*m_backing_stores.back_store, m_viewport_scrollbars, m_cached_scroll_state_snapshot);
+            flush_surface(*m_backing_stores.back_store);
             i32 rendered_bitmap_id = m_backing_stores.back_bitmap_id;
             m_backing_stores.swap();
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Finished {} display-list replay into bitmap {}",
@@ -731,6 +789,7 @@ private:
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
     RefPtr<Painting::DisplayList> m_cached_display_list;
     Painting::ScrollStateSnapshot m_cached_scroll_state_snapshot;
+    Vector<ViewportScrollbar> m_viewport_scrollbars;
     mutable Sync::Mutex m_async_scroll_tree_mutex;
     AsyncScrollTree m_async_scroll_tree;
     BackingStoreState m_backing_stores;

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -23,6 +23,7 @@
 #include <AK/HashMap.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/Queue.h>
+#include <AK/Time.h>
 
 #ifdef USE_VULKAN_DMABUF_IMAGES
 #    include <AK/Array.h>
@@ -135,25 +136,56 @@ static Optional<size_t> find_viewport_scrollbar_index(ReadonlySpan<ViewportScrol
     return {};
 }
 
-static Gfx::IntRect translated_thumb_rect(ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+static Gfx::IntRect scrollbar_gutter_rect(ViewportScrollbar const& scrollbar, bool expanded)
 {
-    auto thumb_rect = scrollbar.thumb_rect;
+    return expanded ? scrollbar.expanded_gutter_rect : scrollbar.gutter_rect;
+}
+
+static double scrollbar_scroll_size(ViewportScrollbar const& scrollbar, bool expanded)
+{
+    return expanded ? scrollbar.expanded_scroll_size : scrollbar.scroll_size;
+}
+
+static Gfx::IntRect translated_thumb_rect(ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot, bool expanded)
+{
+    auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
+    auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);
     auto device_offset = scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_frame_index);
     if (scrollbar.vertical)
-        thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * scrollbar.scroll_size));
+        thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * scroll_size));
     else
-        thumb_rect.translate_by(static_cast<int>(-device_offset.x() * scrollbar.scroll_size), 0);
+        thumb_rect.translate_by(static_cast<int>(-device_offset.x() * scroll_size), 0);
     return thumb_rect;
 }
 
-static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+static Gfx::IntRect translated_thumb_rect(ViewportScrollbar const& scrollbar, Gfx::FloatPoint scroll_offset, bool expanded)
 {
-    auto thumb_rect = translated_thumb_rect(scrollbar, scroll_state_snapshot);
+    auto orientation = orientation_for_scrollbar(scrollbar);
+    auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
+    thumb_rect.translate_primary_offset_for_orientation(orientation, static_cast<int>(scroll_offset.primary_offset_for_orientation(orientation) * scrollbar_scroll_size(scrollbar, expanded)));
+    return thumb_rect;
+}
+
+static Gfx::IntRect scrollbar_hit_rect(ViewportScrollbar const& scrollbar, Gfx::FloatPoint scroll_offset)
+{
+    static constexpr int scrollbar_hit_slop = 4;
+
+    auto rect = translated_thumb_rect(scrollbar, scroll_offset, false).united(translated_thumb_rect(scrollbar, scroll_offset, true));
+    auto expanded_gutter_rect = scrollbar_gutter_rect(scrollbar, true);
+    if (!expanded_gutter_rect.is_empty())
+        rect.unite(expanded_gutter_rect);
+    rect.inflate(scrollbar_hit_slop, scrollbar_hit_slop);
+    return rect;
+}
+
+static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot, bool expanded)
+{
+    auto thumb_rect = translated_thumb_rect(scrollbar, scroll_state_snapshot, expanded);
     auto& canvas = surface.canvas();
 
     SkPaint gutter_fill_paint;
     gutter_fill_paint.setColor(to_skia_color(scrollbar.track_color));
-    canvas.drawRect(to_skia_rect(scrollbar.gutter_rect), gutter_fill_paint);
+    canvas.drawRect(to_skia_rect(scrollbar_gutter_rect(scrollbar, expanded)), gutter_fill_paint);
 
     auto skia_thumb_rect = to_skia_rect(thumb_rect);
     auto radius = skia_thumb_rect.width() / 2;
@@ -171,10 +203,10 @@ static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScro
     canvas.drawRRect(thumb_rrect, stroke_paint);
 }
 
-static void paint_viewport_scrollbars(Gfx::PaintingSurface& surface, ReadonlySpan<ViewportScrollbar> scrollbars, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+static void paint_viewport_scrollbars(Gfx::PaintingSurface& surface, ReadonlySpan<ViewportScrollbar> scrollbars, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Optional<size_t> hovered_scrollbar_index, Optional<size_t> captured_scrollbar_index)
 {
-    for (auto const& scrollbar : scrollbars)
-        paint_viewport_scrollbar(surface, scrollbar, scroll_state_snapshot);
+    for (size_t i = 0; i < scrollbars.size(); ++i)
+        paint_viewport_scrollbar(surface, scrollbars[i], scroll_state_snapshot, hovered_scrollbar_index == i || captured_scrollbar_index == i);
 }
 
 static void flush_surface(Gfx::PaintingSurface& surface)
@@ -447,14 +479,7 @@ public:
             if (!scroll_offset.has_value())
                 continue;
 
-            auto thumb_rect = scrollbar.thumb_rect;
-            if (scrollbar.vertical)
-                thumb_rect.translate_by(0, static_cast<int>(scroll_offset->y() * scrollbar.scroll_size));
-            else
-                thumb_rect.translate_by(static_cast<int>(scroll_offset->x() * scrollbar.scroll_size), 0);
-            if (thumb_rect.to_type<float>().contains(position))
-                return i;
-            if (!scrollbar.gutter_rect.is_empty() && scrollbar.gutter_rect.to_type<float>().contains(position))
+            if (scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position))
                 return i;
         }
         return {};
@@ -486,19 +511,20 @@ public:
                     if (!scroll_offset.has_value())
                         continue;
 
+                    auto expanded = m_hovered_viewport_scrollbar_index == i || m_captured_viewport_scrollbar_index == i;
                     auto orientation = orientation_for_scrollbar(scrollbar);
-                    auto thumb_rect = scrollbar.thumb_rect;
-                    thumb_rect.translate_primary_offset_for_orientation(orientation, static_cast<int>(scroll_offset->primary_offset_for_orientation(orientation) * scrollbar.scroll_size));
+                    auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
                     primary_position = primary_position_for_scrollbar(scrollbar);
                     if (thumb_rect.to_type<float>().contains(position)) {
                         thumb_grab_position = primary_position - static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
                         scrollbar_index = i;
                         break;
                     }
-                    if (!scrollbar.gutter_rect.is_empty() && scrollbar.gutter_rect.to_type<float>().contains(position)) {
+                    if (scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position)) {
+                        auto gutter_rect = scrollbar_gutter_rect(scrollbar, true);
                         auto thumb_size = static_cast<float>(thumb_rect.primary_size_for_orientation(orientation));
-                        auto gutter_start = static_cast<float>(scrollbar.gutter_rect.primary_offset_for_orientation(orientation));
-                        auto gutter_size = static_cast<float>(scrollbar.gutter_rect.primary_size_for_orientation(orientation));
+                        auto gutter_start = static_cast<float>(gutter_rect.primary_offset_for_orientation(orientation));
+                        auto gutter_size = static_cast<float>(gutter_rect.primary_size_for_orientation(orientation));
                         auto offset_relative_to_gutter = primary_position - gutter_start;
                         thumb_grab_position = max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
                         scrollbar_index = i;
@@ -510,9 +536,11 @@ public:
                     return false;
 
                 m_captured_viewport_scrollbar_index = *scrollbar_index;
+                m_hovered_viewport_scrollbar_index = *scrollbar_index;
                 m_viewport_scrollbar_thumb_grab_position = thumb_grab_position;
             }
 
+            schedule_viewport_scrollbar_present();
             enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
             return true;
         }
@@ -536,7 +564,9 @@ public:
                 enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
                 return true;
             }
-            return hit_test_viewport_scrollbar(position).has_value();
+            auto hovered_scrollbar_index = hit_test_viewport_scrollbar(position);
+            set_hovered_viewport_scrollbar(hovered_scrollbar_index);
+            return hovered_scrollbar_index.has_value();
         }
         case MouseEvent::Type::MouseUp: {
             Optional<size_t> scrollbar_index;
@@ -555,12 +585,17 @@ public:
                 primary_position = primary_position_for_scrollbar(m_viewport_scrollbars[*scrollbar_index]);
                 m_captured_viewport_scrollbar_index.clear();
             }
+            schedule_viewport_scrollbar_present();
             enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseLeave: {
-            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-            return m_captured_viewport_scrollbar_index.has_value();
+            auto has_capture = [this] {
+                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                return m_captured_viewport_scrollbar_index.has_value();
+            }();
+            set_hovered_viewport_scrollbar({});
+            return has_capture;
         }
         case MouseEvent::Type::MouseWheel:
             return false;
@@ -632,8 +667,10 @@ public:
 
                             {
                                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                                auto hovered_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_hovered_viewport_scrollbar_index);
                                 auto captured_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_captured_viewport_scrollbar_index);
                                 m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
+                                m_hovered_viewport_scrollbar_index = hovered_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *hovered_scrollbar_identity) : Optional<size_t> {};
                                 m_captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
                                 m_async_scroll_tree.set_state(move(async_scrolling_state));
                                 if (viewport_node.has_value() && pending_async_viewport_scroll_offset.has_value()) {
@@ -653,6 +690,7 @@ public:
                             {
                                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
                                 m_viewport_scrollbars.clear();
+                                m_hovered_viewport_scrollbar_index.clear();
                                 m_captured_viewport_scrollbar_index.clear();
                                 m_async_scroll_tree.clear_wheel_scroll_targets();
                             }
@@ -745,7 +783,7 @@ public:
                         if (!m_cached_display_list)
                             return;
                         m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *cmd.target_surface);
-                        paint_viewport_scrollbars(*cmd.target_surface, m_viewport_scrollbars, m_cached_scroll_state_snapshot);
+                        paint_viewport_scrollbar_overlay(*cmd.target_surface);
                         flush_surface(*cmd.target_surface);
                         if (cmd.callback) {
                             invoke_on_main_thread([callback = move(cmd.callback)]() mutable {
@@ -804,6 +842,46 @@ private:
         AsyncScroll,
     };
 
+    void paint_viewport_scrollbar_overlay(Gfx::PaintingSurface& surface)
+    {
+        Vector<ViewportScrollbar> scrollbars;
+        Optional<size_t> hovered_scrollbar_index;
+        Optional<size_t> captured_scrollbar_index;
+        {
+            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+            scrollbars = m_viewport_scrollbars;
+            hovered_scrollbar_index = m_hovered_viewport_scrollbar_index;
+            captured_scrollbar_index = m_captured_viewport_scrollbar_index;
+        }
+        if (!hovered_scrollbar_index.has_value() && !captured_scrollbar_index.has_value())
+            return;
+        paint_viewport_scrollbars(surface, scrollbars, m_cached_scroll_state_snapshot, hovered_scrollbar_index, captured_scrollbar_index);
+    }
+
+    void schedule_viewport_scrollbar_present()
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        if (m_async_scrolling_viewport_rect.is_empty())
+            return;
+        m_has_deferred_async_scroll_present = true;
+        m_deferred_async_scroll_present_viewport_rect = m_async_scrolling_viewport_rect;
+        m_command_ready.signal();
+    }
+
+    void set_hovered_viewport_scrollbar(Optional<size_t> scrollbar_index)
+    {
+        bool changed = false;
+        {
+            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+            if (m_hovered_viewport_scrollbar_index == scrollbar_index)
+                return;
+            changed = true;
+            m_hovered_viewport_scrollbar_index = scrollbar_index;
+        }
+        if (changed)
+            schedule_viewport_scrollbar_present();
+    }
+
     bool apply_viewport_scrollbar_drag(size_t scrollbar_index, float primary_position, float thumb_grab_position)
     {
         Optional<Gfx::FloatPoint> scroll_offset;
@@ -813,7 +891,9 @@ private:
                 return false;
 
             auto const& scrollbar = m_viewport_scrollbars[scrollbar_index];
-            if (scrollbar.scroll_size == 0)
+            auto expanded = m_hovered_viewport_scrollbar_index == scrollbar_index || m_captured_viewport_scrollbar_index == scrollbar_index;
+            auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);
+            if (scroll_size == 0)
                 return false;
 
             auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
@@ -821,10 +901,11 @@ private:
                 return false;
 
             auto orientation = orientation_for_scrollbar(scrollbar);
-            auto min_thumb_position = static_cast<float>(scrollbar.thumb_rect.primary_offset_for_orientation(orientation));
-            auto max_thumb_position = min_thumb_position + scrollbar.max_scroll_offset * static_cast<float>(scrollbar.scroll_size);
+            auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
+            auto min_thumb_position = static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
+            auto max_thumb_position = min_thumb_position + scrollbar.max_scroll_offset * static_cast<float>(scroll_size);
             auto target_thumb_position = AK::clamp(primary_position - thumb_grab_position, min_thumb_position, max_thumb_position);
-            auto target_scroll_offset = (target_thumb_position - min_thumb_position) / static_cast<float>(scrollbar.scroll_size);
+            auto target_scroll_offset = (target_thumb_position - min_thumb_position) / static_cast<float>(scroll_size);
 
             Gfx::FloatPoint delta;
             delta.set_primary_offset_for_orientation(orientation, target_scroll_offset - current_scroll_offset->primary_offset_for_orientation(orientation));
@@ -901,7 +982,7 @@ private:
                 m_backing_stores.back_store->canvas().clear(SK_ColorTRANSPARENT);
             }
             m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *m_backing_stores.back_store);
-            paint_viewport_scrollbars(*m_backing_stores.back_store, m_viewport_scrollbars, m_cached_scroll_state_snapshot);
+            paint_viewport_scrollbar_overlay(*m_backing_stores.back_store);
             flush_surface(*m_backing_stores.back_store);
             i32 rendered_bitmap_id = m_backing_stores.back_bitmap_id;
             m_backing_stores.swap();
@@ -1024,6 +1105,7 @@ private:
     RefPtr<Painting::DisplayList> m_cached_display_list;
     Painting::ScrollStateSnapshot m_cached_scroll_state_snapshot;
     Vector<ViewportScrollbar> m_viewport_scrollbars;
+    Optional<size_t> m_hovered_viewport_scrollbar_index;
     Optional<size_t> m_captured_viewport_scrollbar_index;
     float m_viewport_scrollbar_thumb_grab_position { 0 };
     mutable Sync::Mutex m_async_scroll_tree_mutex;

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/ExternalContentSource.h>
 
@@ -66,6 +67,12 @@ struct AsyncScrollByCommand {
     AsyncScrollNodeID scroll_target;
 };
 
+struct ViewportScrollbarDragCommand {
+    size_t scrollbar_index { 0 };
+    float primary_position { 0 };
+    float thumb_grab_position { 0 };
+};
+
 struct UpdateScrollStateCommand {
     Painting::ScrollStateSnapshot scroll_state_snapshot;
 };
@@ -81,7 +88,7 @@ struct ScreenshotCommand {
     Function<void()> callback;
 };
 
-using CompositorCommand = Variant<UpdateDisplayListCommand, AsyncScrollByCommand, UpdateScrollStateCommand, UpdateBackingStoresCommand, ScreenshotCommand>;
+using CompositorCommand = Variant<UpdateDisplayListCommand, AsyncScrollByCommand, ViewportScrollbarDragCommand, UpdateScrollStateCommand, UpdateBackingStoresCommand, ScreenshotCommand>;
 
 static Optional<AsyncScrollNode> viewport_scroll_node(AsyncScrollingState const& state)
 {
@@ -97,7 +104,38 @@ static SkRect to_skia_rect(Gfx::IntRect const& rect)
     return SkRect::MakeXYWH(rect.x(), rect.y(), rect.width(), rect.height());
 }
 
-static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+static Gfx::Orientation orientation_for_scrollbar(ViewportScrollbar const& scrollbar)
+{
+    return scrollbar.vertical ? Gfx::Orientation::Vertical : Gfx::Orientation::Horizontal;
+}
+
+struct ViewportScrollbarIdentity {
+    AsyncScrollNodeID scroll_node_id;
+    bool vertical { false };
+};
+
+static ViewportScrollbarIdentity viewport_scrollbar_identity(ViewportScrollbar const& scrollbar)
+{
+    return { scrollbar.scroll_node_id, scrollbar.vertical };
+}
+
+static Optional<ViewportScrollbarIdentity> viewport_scrollbar_identity_at(ReadonlySpan<ViewportScrollbar> scrollbars, Optional<size_t> scrollbar_index)
+{
+    if (!scrollbar_index.has_value() || *scrollbar_index >= scrollbars.size())
+        return {};
+    return viewport_scrollbar_identity(scrollbars[*scrollbar_index]);
+}
+
+static Optional<size_t> find_viewport_scrollbar_index(ReadonlySpan<ViewportScrollbar> scrollbars, ViewportScrollbarIdentity identity)
+{
+    for (size_t i = 0; i < scrollbars.size(); ++i) {
+        if (scrollbars[i].scroll_node_id == identity.scroll_node_id && scrollbars[i].vertical == identity.vertical)
+            return i;
+    }
+    return {};
+}
+
+static Gfx::IntRect translated_thumb_rect(ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
     auto thumb_rect = scrollbar.thumb_rect;
     auto device_offset = scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_frame_index);
@@ -105,7 +143,12 @@ static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScro
         thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * scrollbar.scroll_size));
     else
         thumb_rect.translate_by(static_cast<int>(-device_offset.x() * scrollbar.scroll_size), 0);
+    return thumb_rect;
+}
 
+static void paint_viewport_scrollbar(Gfx::PaintingSurface& surface, ViewportScrollbar const& scrollbar, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+{
+    auto thumb_rect = translated_thumb_rect(scrollbar, scroll_state_snapshot);
     auto& canvas = surface.canvas();
 
     SkPaint gutter_fill_paint;
@@ -395,6 +438,136 @@ public:
         return true;
     }
 
+    Optional<size_t> hit_test_viewport_scrollbar(Gfx::FloatPoint position) const
+    {
+        Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+        for (size_t i = 0; i < m_viewport_scrollbars.size(); ++i) {
+            auto const& scrollbar = m_viewport_scrollbars[i];
+            auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+            if (!scroll_offset.has_value())
+                continue;
+
+            auto thumb_rect = scrollbar.thumb_rect;
+            if (scrollbar.vertical)
+                thumb_rect.translate_by(0, static_cast<int>(scroll_offset->y() * scrollbar.scroll_size));
+            else
+                thumb_rect.translate_by(static_cast<int>(scroll_offset->x() * scrollbar.scroll_size), 0);
+            if (thumb_rect.to_type<float>().contains(position))
+                return i;
+            if (!scrollbar.gutter_rect.is_empty() && scrollbar.gutter_rect.to_type<float>().contains(position))
+                return i;
+        }
+        return {};
+    }
+
+    bool handle_viewport_scrollbar_mouse_event(MouseEvent const& event)
+    {
+        auto position = Gfx::FloatPoint {
+            static_cast<float>(event.position.x().value()),
+            static_cast<float>(event.position.y().value()),
+        };
+        auto primary_position_for_scrollbar = [&](ViewportScrollbar const& scrollbar) {
+            return position.primary_offset_for_orientation(orientation_for_scrollbar(scrollbar));
+        };
+
+        switch (event.type) {
+        case MouseEvent::Type::MouseDown: {
+            if (event.button != UIEvents::MouseButton::Primary)
+                return false;
+
+            Optional<size_t> scrollbar_index;
+            float thumb_grab_position = 0;
+            float primary_position = 0;
+            {
+                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                for (size_t i = 0; i < m_viewport_scrollbars.size(); ++i) {
+                    auto const& scrollbar = m_viewport_scrollbars[i];
+                    auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+                    if (!scroll_offset.has_value())
+                        continue;
+
+                    auto orientation = orientation_for_scrollbar(scrollbar);
+                    auto thumb_rect = scrollbar.thumb_rect;
+                    thumb_rect.translate_primary_offset_for_orientation(orientation, static_cast<int>(scroll_offset->primary_offset_for_orientation(orientation) * scrollbar.scroll_size));
+                    primary_position = primary_position_for_scrollbar(scrollbar);
+                    if (thumb_rect.to_type<float>().contains(position)) {
+                        thumb_grab_position = primary_position - static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
+                        scrollbar_index = i;
+                        break;
+                    }
+                    if (!scrollbar.gutter_rect.is_empty() && scrollbar.gutter_rect.to_type<float>().contains(position)) {
+                        auto thumb_size = static_cast<float>(thumb_rect.primary_size_for_orientation(orientation));
+                        auto gutter_start = static_cast<float>(scrollbar.gutter_rect.primary_offset_for_orientation(orientation));
+                        auto gutter_size = static_cast<float>(scrollbar.gutter_rect.primary_size_for_orientation(orientation));
+                        auto offset_relative_to_gutter = primary_position - gutter_start;
+                        thumb_grab_position = max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
+                        scrollbar_index = i;
+                        break;
+                    }
+                }
+
+                if (!scrollbar_index.has_value())
+                    return false;
+
+                m_captured_viewport_scrollbar_index = *scrollbar_index;
+                m_viewport_scrollbar_thumb_grab_position = thumb_grab_position;
+            }
+
+            enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+            return true;
+        }
+        case MouseEvent::Type::MouseMove: {
+            Optional<size_t> scrollbar_index;
+            float thumb_grab_position = 0;
+            float primary_position = 0;
+            {
+                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                if (m_captured_viewport_scrollbar_index.has_value()) {
+                    scrollbar_index = *m_captured_viewport_scrollbar_index;
+                    thumb_grab_position = m_viewport_scrollbar_thumb_grab_position;
+                    if (*scrollbar_index >= m_viewport_scrollbars.size()) {
+                        m_captured_viewport_scrollbar_index.clear();
+                        return false;
+                    }
+                    primary_position = primary_position_for_scrollbar(m_viewport_scrollbars[*scrollbar_index]);
+                }
+            }
+            if (scrollbar_index.has_value()) {
+                enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+                return true;
+            }
+            return hit_test_viewport_scrollbar(position).has_value();
+        }
+        case MouseEvent::Type::MouseUp: {
+            Optional<size_t> scrollbar_index;
+            float thumb_grab_position = 0;
+            float primary_position = 0;
+            {
+                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                if (!m_captured_viewport_scrollbar_index.has_value())
+                    return false;
+                scrollbar_index = *m_captured_viewport_scrollbar_index;
+                thumb_grab_position = m_viewport_scrollbar_thumb_grab_position;
+                if (*scrollbar_index >= m_viewport_scrollbars.size()) {
+                    m_captured_viewport_scrollbar_index.clear();
+                    return false;
+                }
+                primary_position = primary_position_for_scrollbar(m_viewport_scrollbars[*scrollbar_index]);
+                m_captured_viewport_scrollbar_index.clear();
+            }
+            enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+            return true;
+        }
+        case MouseEvent::Type::MouseLeave: {
+            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+            return m_captured_viewport_scrollbar_index.has_value();
+        }
+        case MouseEvent::Type::MouseWheel:
+            return false;
+        }
+        VERIFY_NOT_REACHED();
+    }
+
     void compositor_loop(DisplayListPlayerType display_list_player_type)
     {
         initialize_skia_player(display_list_player_type);
@@ -437,7 +610,6 @@ public:
                             auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
                             auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
                             auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
-                            m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
                             {
                                 Sync::MutexLocker const locker { m_mutex };
                                 if (wheel_event_listener_state_generation < m_wheel_event_listener_state_generation)
@@ -460,6 +632,9 @@ public:
 
                             {
                                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                                auto captured_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_captured_viewport_scrollbar_index);
+                                m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
+                                m_captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
                                 m_async_scroll_tree.set_state(move(async_scrolling_state));
                                 if (viewport_node.has_value() && pending_async_viewport_scroll_offset.has_value()) {
                                     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying pending async viewport offset {},{} to display list update",
@@ -475,9 +650,10 @@ public:
                             }
                             m_has_async_scrolling_state = true;
                         } else {
-                            m_viewport_scrollbars.clear();
                             {
                                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                                m_viewport_scrollbars.clear();
+                                m_captured_viewport_scrollbar_index.clear();
                                 m_async_scroll_tree.clear_wheel_scroll_targets();
                             }
                             m_has_async_scrolling_state = false;
@@ -518,6 +694,15 @@ public:
                         should_yield_to_async_scroll_present = can_present_deferred_async_scroll();
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor async scroll command complete (yield_to_present={}, raster_tasks={})",
                             should_yield_to_async_scroll_present, m_queued_rasterization_tasks.load());
+                    },
+                    [this, &should_yield_to_async_scroll_present](ViewportScrollbarDragCommand& cmd) {
+                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing viewport scrollbar drag (index={}, position={}, grab={})",
+                            cmd.scrollbar_index, cmd.primary_position, cmd.thumb_grab_position);
+                        if (apply_viewport_scrollbar_drag(cmd.scrollbar_index, cmd.primary_position, cmd.thumb_grab_position)) {
+                            should_yield_to_async_scroll_present = can_present_deferred_async_scroll();
+                            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor viewport scrollbar drag complete (yield_to_present={}, raster_tasks={})",
+                                should_yield_to_async_scroll_present, m_queued_rasterization_tasks.load());
+                        }
                     },
                     [this](UpdateScrollStateCommand& cmd) {
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
@@ -618,6 +803,55 @@ private:
         MainThread,
         AsyncScroll,
     };
+
+    bool apply_viewport_scrollbar_drag(size_t scrollbar_index, float primary_position, float thumb_grab_position)
+    {
+        Optional<Gfx::FloatPoint> scroll_offset;
+        {
+            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+            if (scrollbar_index >= m_viewport_scrollbars.size())
+                return false;
+
+            auto const& scrollbar = m_viewport_scrollbars[scrollbar_index];
+            if (scrollbar.scroll_size == 0)
+                return false;
+
+            auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+            if (!current_scroll_offset.has_value())
+                return false;
+
+            auto orientation = orientation_for_scrollbar(scrollbar);
+            auto min_thumb_position = static_cast<float>(scrollbar.thumb_rect.primary_offset_for_orientation(orientation));
+            auto max_thumb_position = min_thumb_position + scrollbar.max_scroll_offset * static_cast<float>(scrollbar.scroll_size);
+            auto target_thumb_position = AK::clamp(primary_position - thumb_grab_position, min_thumb_position, max_thumb_position);
+            auto target_scroll_offset = (target_thumb_position - min_thumb_position) / static_cast<float>(scrollbar.scroll_size);
+
+            Gfx::FloatPoint delta;
+            delta.set_primary_offset_for_orientation(orientation, target_scroll_offset - current_scroll_offset->primary_offset_for_orientation(orientation));
+            if (delta.x() == 0 && delta.y() == 0)
+                return false;
+
+            if (!m_async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, m_cached_scroll_state_snapshot))
+                return false;
+            scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+            m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+        }
+
+        if (!scroll_offset.has_value())
+            return false;
+
+        Gfx::IntRect async_scroll_viewport_rect;
+        {
+            Sync::MutexLocker const locker { m_mutex };
+            async_scroll_viewport_rect = m_async_scrolling_viewport_rect;
+            async_scroll_viewport_rect.set_location(scroll_offset->to_type<int>());
+            m_pending_async_viewport_scroll_offset = *scroll_offset;
+            m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
+            m_has_deferred_async_scroll_present = true;
+            m_deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
+        }
+        return true;
+    }
 
     bool has_presentable_work() const
     {
@@ -790,6 +1024,8 @@ private:
     RefPtr<Painting::DisplayList> m_cached_display_list;
     Painting::ScrollStateSnapshot m_cached_scroll_state_snapshot;
     Vector<ViewportScrollbar> m_viewport_scrollbars;
+    Optional<size_t> m_captured_viewport_scrollbar_index;
+    float m_viewport_scrollbar_thumb_grab_position { 0 };
     mutable Sync::Mutex m_async_scroll_tree_mutex;
     AsyncScrollTree m_async_scroll_tree;
     BackingStoreState m_backing_stores;
@@ -1068,6 +1304,21 @@ bool CompositorThread::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gf
         thread_data = compositor->value;
     }
     return thread_data->enqueue_async_scroll_by(position, delta_in_device_pixels);
+}
+
+bool CompositorThread::handle_mouse_event(u64 page_id, MouseEvent const& event)
+{
+    RefPtr<ThreadData> thread_data;
+    {
+        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
+        auto compositor = page_compositors().find(page_id);
+        if (compositor == page_compositors().end()) {
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Viewport scrollbar mouse event cannot be handled for page {}: no compositor registered", page_id);
+            return false;
+        }
+        thread_data = compositor->value;
+    }
+    return thread_data->handle_viewport_scrollbar_mouse_event(event);
 }
 
 void CompositorThread::start(DisplayListPlayerType display_list_player_type)

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -18,6 +18,7 @@
 #include <LibThreading/Forward.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
 
 namespace Web::Compositor {
@@ -52,6 +53,7 @@ public:
     static void clear_frame_presentation_callbacks();
     static void presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     static bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
+    static bool handle_mouse_event(u64 page_id, MouseEvent const&);
 
     void start(DisplayListPlayerType);
     void stop_presenting_to_client();

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -43,6 +43,11 @@ void set_paint_viewport_scrollbars(bool const enabled)
     g_paint_viewport_scrollbars = enabled;
 }
 
+bool should_paint_viewport_scrollbars()
+{
+    return g_paint_viewport_scrollbars;
+}
+
 ResolvedCSSFilter resolve_css_filter(CSS::Filter const& computed_filter, PaintableBox const& paintable_box)
 {
     auto const& computed_values = paintable_box.computed_values();
@@ -674,7 +679,7 @@ void PaintableBox::paint(DisplayListRecordingContext& context, PaintPhase phase)
     if (phase == PaintPhase::Overlay) {
         ChromeMetrics const& metrics = context.chrome_metrics();
 
-        if ((g_paint_viewport_scrollbars || !is_viewport_paintable())
+        if (((g_paint_viewport_scrollbars && !document().page().async_scrolling_enabled()) || !is_viewport_paintable())
             && computed_values().scrollbar_width() != CSS::ScrollbarWidth::None) {
             auto scrollbar_colors = computed_values().scrollbar_color();
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -567,7 +567,7 @@ Optional<CSSPixelRect> PaintableBox::absolute_scrollbar_rect(ScrollDirection dir
     return scrollbar_rect;
 }
 
-Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(ScrollDirection direction, ChromeMetrics const& metrics, ScrollStateSnapshot const* scroll_state_snapshot) const
+Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(ScrollDirection direction, ChromeMetrics const& metrics, ScrollStateSnapshot const* scroll_state_snapshot, ScrollbarSizing scrollbar_sizing) const
 {
     bool is_horizontal = direction == ScrollDirection::Horizontal;
     auto orientation = is_horizontal ? Gfx::Orientation::Horizontal : Gfx::Orientation::Vertical;
@@ -585,7 +585,17 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
         return {};
 
     auto const& scrollbar = is_horizontal ? m_horizontal_scrollbar : m_vertical_scrollbar;
-    bool with_gutter = scrollbar && scrollbar->is_enlarged();
+    bool with_gutter = [&] {
+        switch (scrollbar_sizing) {
+        case ScrollbarSizing::Current:
+            return scrollbar && scrollbar->is_enlarged();
+        case ScrollbarSizing::Regular:
+            return false;
+        case ScrollbarSizing::Enlarged:
+            return true;
+        }
+        VERIFY_NOT_REACHED();
+    }();
     auto scrollbar_rect = absolute_scrollbar_rect(direction, with_gutter, metrics);
     if (!scrollbar_rect.has_value())
         return {};

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -168,11 +168,17 @@ public:
         Horizontal,
         Vertical,
     };
+    enum class ScrollbarSizing {
+        Current,
+        Regular,
+        Enlarged,
+    };
 
     Optional<ScrollbarData> compute_scrollbar_data(
         ScrollDirection direction,
         ChromeMetrics const& chrome_metrics,
-        ScrollStateSnapshot const* = nullptr) const;
+        ScrollStateSnapshot const* = nullptr,
+        ScrollbarSizing = ScrollbarSizing::Current) const;
     Optional<CSSPixelRect> absolute_scrollbar_rect(ScrollDirection direction, bool with_gutter, ChromeMetrics const& chrome_metrics) const;
 
     RefPtr<Scrollbar> scrollbar(ScrollDirection) const;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -31,6 +31,7 @@ class ResizeHandle;
 class Scrollbar;
 
 WEB_API void set_paint_viewport_scrollbars(bool enabled);
+bool should_paint_viewport_scrollbars();
 ResolvedCSSFilter resolve_css_filter(CSS::Filter const& computed_filter, PaintableBox const& paintable_box);
 
 class WEB_API PaintableBox : public Paintable {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -256,25 +256,30 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
     if (auto* mouse_event = event.get_pointer<Web::MouseEvent>();
         Application::web_content_options().enable_async_scrolling == EnableAsyncScrolling::Yes
         && m_client_state.has_usable_bitmap
-        && mouse_event
-        && mouse_event->type == Web::MouseEvent::Type::MouseWheel) {
-        auto wheel_delta_x = mouse_event->wheel_delta_x;
-        auto wheel_delta_y = mouse_event->wheel_delta_y;
-        if (mouse_event->modifiers & Web::UIEvents::KeyModifier::Mod_Shift)
-            swap(wheel_delta_x, wheel_delta_y);
+        && mouse_event) {
+        if (mouse_event->type == Web::MouseEvent::Type::MouseWheel) {
+            auto wheel_delta_x = mouse_event->wheel_delta_x;
+            auto wheel_delta_y = mouse_event->wheel_delta_y;
+            if (mouse_event->modifiers & Web::UIEvents::KeyModifier::Mod_Shift)
+                swap(wheel_delta_x, wheel_delta_y);
 
-        auto device_pixels_per_css_pixel = static_cast<float>(device_pixel_ratio() * zoom_level());
-        auto position = Gfx::FloatPoint {
-            static_cast<float>(mouse_event->position.x().value()),
-            static_cast<float>(mouse_event->position.y().value()),
-        };
-        auto delta_in_device_pixels = Gfx::FloatPoint { wheel_delta_x, wheel_delta_y }.scaled(device_pixels_per_css_pixel);
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI attempting compositor wheel bypass for page {} at {},{} device delta {},{}",
-            m_client_state.page_index, position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
-        if (client().send_async_scroll_to_compositor(m_client_state.page_index, position, delta_in_device_pixels))
-            mouse_event->async_scroll_performed_default_action = true;
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor wheel bypass result for page {}: {}",
-            m_client_state.page_index, mouse_event->async_scroll_performed_default_action ? "accepted"sv : "rejected"sv);
+            auto device_pixels_per_css_pixel = static_cast<float>(device_pixel_ratio() * zoom_level());
+            auto position = Gfx::FloatPoint {
+                static_cast<float>(mouse_event->position.x().value()),
+                static_cast<float>(mouse_event->position.y().value()),
+            };
+            auto delta_in_device_pixels = Gfx::FloatPoint { wheel_delta_x, wheel_delta_y }.scaled(device_pixels_per_css_pixel);
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI attempting compositor wheel bypass for page {} at {},{} device delta {},{}",
+                m_client_state.page_index, position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
+            if (client().send_async_scroll_to_compositor(m_client_state.page_index, position, delta_in_device_pixels))
+                mouse_event->async_scroll_performed_default_action = true;
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor wheel bypass result for page {}: {}",
+                m_client_state.page_index, mouse_event->async_scroll_performed_default_action ? "accepted"sv : "rejected"sv);
+        } else if (client().send_mouse_event_to_compositor(m_client_state.page_index, *mouse_event)) {
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor handled mouse event for page {} at {},{}",
+                m_client_state.page_index, mouse_event->position.x().value(), mouse_event->position.y().value());
+            return;
+        }
     }
 
     // Send the next event over to the WebContent to be handled by JS. We'll later get a message to say whether JS

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -10,6 +10,7 @@
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibIPC/Transport.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibWeb/Page/InputEvent.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/HelperProcess.h>
@@ -170,6 +171,22 @@ bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPo
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
     auto handled = connection.value()->async_scroll_by(page_id, position, delta_in_device_pixels);
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC async_scroll_by page {} returned {} in {} us",
+        page_id, handled, timer.elapsed_time().to_microseconds());
+    return handled;
+}
+
+bool WebContentClient::send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const& event)
+{
+    auto connection = compositor_connections().get(this);
+    if (!connection.has_value() || !connection.value()->is_open()) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC unavailable for page {} (connection={}, open={})",
+            page_id, connection.has_value(), connection.has_value() && connection.value()->is_open());
+        return false;
+    }
+
+    auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
+    auto handled = connection.value()->mouse_event(page_id, event.clone_without_browser_data());
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC mouse_event page {} returned {} in {} us",
         page_id, handled, timer.elapsed_time().to_microseconds());
     return handled;
 }

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -21,6 +21,7 @@
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -62,6 +63,7 @@ public:
 
     void notify_all_views_of_crash();
     bool send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
+    bool send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const&);
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     void did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
     void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);

--- a/Services/WebContent/CompositorServer.ipc
+++ b/Services/WebContent/CompositorServer.ipc
@@ -1,7 +1,9 @@
 #include <LibGfx/Point.h>
+#include <LibWeb/Page/InputEvent.h>
 
 endpoint CompositorServer
 {
     async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) => (bool handled)
+    mouse_event(u64 page_id, Web::MouseEvent event) => (bool handled)
     ready_to_paint(u64 page_id, i32 bitmap_id) =|
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -99,6 +99,13 @@ private:
         return handled;
     }
 
+    virtual Messages::CompositorServer::MouseEventResponse mouse_event(u64 page_id, Web::MouseEvent event) override
+    {
+        auto handled = Web::Compositor::CompositorThread::handle_mouse_event(page_id, event);
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC mouse event for page {} returned {}", page_id, handled);
+        return handled;
+    }
+
     virtual void ready_to_paint(u64 page_id, i32 bitmap_id) override
     {
         Web::Compositor::CompositorThread::presented_bitmap_ready_to_paint(page_id, bitmap_id);


### PR DESCRIPTION
Move viewport scrollbar painting and interaction into the compositor when async scrolling is enabled.

The main thread now exports viewport scrollbar geometry with the async scrolling state and skips painting those scrollbars into the display list. Mouse input for viewport scrollbar hover and drag is routed to the compositor, where drag deltas update the async scroll tree directly.

The compositor keeps viewport scrollbars visible during wheel scrolling and dragging, preserves hover and capture state across async scrolling state updates, and fades compositor-owned scrollbars after interaction.
