### PR TITLE
Meta+LibGfx: Run a Python type checker alongside the linter

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -66,7 +66,7 @@ runs:
         if ${{ inputs.type == 'build' }} ; then
           pip3 install pyyaml requests six
         else
-          pip3 install ruff
+          pip3 install pyright ruff
         fi
 
     - name: Ensure clang-cl is available

--- a/Libraries/LibGfx/TIFFGenerator.py
+++ b/Libraries/LibGfx/TIFFGenerator.py
@@ -22,14 +22,16 @@ class EnumWithExportName(Enum):
 
 
 class TIFFType(EnumWithExportName):
+    size: int
+
     @classmethod
     def export_name(cls) -> str:
         return "Type"
 
-    def __new__(cls, *args):
+    def __new__(cls, value: int, size: int) -> "TIFFType":
         obj = object.__new__(cls)
-        obj._value_ = args[0]
-        obj.size = args[1]
+        obj._value_ = value
+        obj.size = size
         return obj
 
     # First value is the underlying u16, second one is the size in bytes

--- a/Meta/CMake/flatpak/generate-cargo-sources.py
+++ b/Meta/CMake/flatpak/generate-cargo-sources.py
@@ -9,6 +9,7 @@ import json
 import re
 
 from pathlib import Path
+from typing import Any
 
 script_dir = Path(__file__).parent
 repo_root = script_dir / ".." / ".." / ".."
@@ -23,7 +24,7 @@ for m in re.finditer(
 ):
     crates.append((m.group(1), m.group(2), m.group(3)))
 
-sources = [
+sources: list[dict[str, Any]] = [
     {
         "type": "git",
         "url": "https://github.com/corrosion-rs/corrosion.git",

--- a/Meta/Generators/generate_libwasm_spec_test.py
+++ b/Meta/Generators/generate_libwasm_spec_test.py
@@ -34,7 +34,7 @@ class GenerateException(Exception):
 @dataclass
 class WasmPrimitiveValue:
     kind: Literal["i32", "i64", "f32", "f64", "externref", "funcref"]
-    value: str
+    value: Optional[str]
 
 
 @dataclass
@@ -179,7 +179,7 @@ class Context:
     has_unclosed: bool
 
 
-def parse_value(arg: dict[str, str]) -> WasmValue:
+def parse_value(arg: dict[str, Any]) -> WasmValue:
     type_ = arg["type"]
     if type_ in ("i32", "i64", "f32", "f64"):
         return WasmPrimitiveValue(type_, arg["value"])
@@ -320,6 +320,9 @@ def gen_value_arg(value: WasmValue) -> str:
     if isinstance(value, EitherOf):
         raise AssertionError("EitherOf should not appear here")
 
+    if value.value is None:
+        raise GenerateException("Cannot generate an argument without a concrete value")
+
     def unsigned_to_signed(uint: int, bits: int) -> int:
         max_value = 2**bits
         if uint >= 2 ** (bits - 1):
@@ -344,7 +347,7 @@ def gen_value_arg(value: WasmValue) -> str:
         f = int_to_float64_bitcast(bits) if double else int_to_float_bitcast(bits)
         return str(f)
 
-    if value.value is not None and value.value.startswith("nan"):
+    if value.value.startswith("nan"):
         raise GenerateException("Should not get indeterminate nan value as an argument")
     if value.value == "inf":
         return "Infinity"
@@ -374,13 +377,15 @@ def gen_value_result(value: WasmValue) -> GeneratedValue:
     if value.kind == "funcref" and value.value is None:
         return GeneratedAnyFuncRef()
 
-    if (value.kind == "f32" or value.kind == "f64") and value.value.startswith("nan"):
-        num_bits = int(value.kind[1:])
-        if value.value == "nan:canonical":
-            return CanonicalNan(num_bits)
-        if value.value == "nan:arithmetic":
-            return ArithmeticNan(num_bits)
-        raise GenerateException(f"Unknown indeterminate nan: {value.value}")
+    if value.kind == "f32" or value.kind == "f64":
+        assert value.value is not None
+        if value.value.startswith("nan"):
+            num_bits = int(value.kind[1:])
+            if value.value == "nan:canonical":
+                return CanonicalNan(num_bits)
+            if value.value == "nan:arithmetic":
+                return ArithmeticNan(num_bits)
+            raise GenerateException(f"Unknown indeterminate nan: {value.value}")
     return gen_value_arg(value)
 
 

--- a/Meta/Generators/libjs_bytecode_def.py
+++ b/Meta/Generators/libjs_bytecode_def.py
@@ -28,8 +28,7 @@ def parse_bytecode_def(path: str) -> List[OpDef]:
         lines = f.readlines()
 
     ops: List[OpDef] = []
-    current: Optional[OpDef] = None
-    in_op = False
+    current_op: Optional[OpDef] = None
 
     for raw_line in lines:
         stripped = raw_line.strip()
@@ -39,9 +38,8 @@ def parse_bytecode_def(path: str) -> List[OpDef]:
             continue
 
         if stripped.startswith("op "):
-            if in_op:
+            if current_op is not None:
                 raise RuntimeError("Nested op blocks are not allowed")
-            in_op = True
 
             rest = stripped[len("op ") :].strip()
             if "<" in rest:
@@ -52,25 +50,24 @@ def parse_bytecode_def(path: str) -> List[OpDef]:
                 name = rest.strip()
                 base = "Instruction"
 
-            current = OpDef(name=name, base=base)
+            current_op = OpDef(name=name, base=base)
             continue
 
         if stripped == "endop":
-            if not in_op or current is None:
+            if current_op is None:
                 raise RuntimeError("endop without corresponding op")
-            ops.append(current)
-            current = None
-            in_op = False
+            ops.append(current_op)
+            current_op = None
             continue
 
-        if not in_op:
+        if current_op is None:
             continue
 
         if stripped.startswith("@"):
             if stripped == "@terminator":
-                current.is_terminator = True
+                current_op.is_terminator = True
             elif stripped == "@nothrow":
-                current.is_nothrow = True
+                current_op.is_nothrow = True
             continue
 
         if ":" not in stripped:
@@ -82,9 +79,9 @@ def parse_bytecode_def(path: str) -> List[OpDef]:
         if field_type.endswith("[]"):
             is_array = True
             field_type = field_type[:-2].strip()
-        current.fields.append(Field(name=field_name, type=field_type, is_array=is_array))
+        current_op.fields.append(Field(name=field_name, type=field_type, is_array=is_array))
 
-    if in_op or current is not None:
+    if current_op is not None:
         raise RuntimeError("Unclosed op block at end of file")
 
     return ops

--- a/Meta/Linters/lint_python.sh
+++ b/Meta/Linters/lint_python.sh
@@ -31,10 +31,17 @@ else
 fi
 
 if (( ${#files[@]} )); then
+    if ! command -v pyright >/dev/null 2>&1 ; then
+        echo "Please install pyright: pip3 install pyright"
+        exit 1
+    fi
+
     if ! command -v ruff >/dev/null 2>&1 ; then
         echo "Please install ruff: pip3 install ruff"
         exit 1
     fi
+
+    pyright "${files[@]}"
 
     if [[ ${overwrite} -eq 0 ]] ; then
         ruff check "${files[@]}"

--- a/Meta/Utils/css_dimensions.py
+++ b/Meta/Utils/css_dimensions.py
@@ -2,8 +2,9 @@ import json
 import sys
 
 from typing import Any
+from typing import Optional
 
-_css_dimensions: dict[str, Any] | None = None
+_css_dimensions: Optional[dict[str, Any]] = None
 
 
 def json_is_valid(dimensions_data: dict[str, Any], json_path: str) -> bool:

--- a/Meta/Utils/utils.py
+++ b/Meta/Utils/utils.py
@@ -21,9 +21,9 @@ def run_command(
     stdin = subprocess.PIPE if type(input) is str else None
     stdout = subprocess.PIPE if return_output else None
 
-    try:
-        # FIXME: For Windows, set the working directory so DLLs are found.
-        with subprocess.Popen(command, stdin=stdin, stdout=stdout, text=True, cwd=cwd) as process:
+    # FIXME: For Windows, set the working directory so DLLs are found.
+    with subprocess.Popen(command, stdin=stdin, stdout=stdout, text=True, cwd=cwd) as process:
+        try:
             (output, _) = process.communicate(input=input)
 
             if process.returncode != 0:
@@ -31,11 +31,11 @@ def run_command(
                     sys.exit(process.returncode)
                 return None
 
-    except KeyboardInterrupt:
-        process.send_signal(signal.SIGINT)
-        process.wait()
+        except KeyboardInterrupt:
+            process.send_signal(signal.SIGINT)
+            process.wait()
 
-        sys.exit(process.returncode)
+            sys.exit(process.returncode)
 
     if return_output:
         return output.strip()

--- a/Meta/Utils/webidl_parser.py
+++ b/Meta/Utils/webidl_parser.py
@@ -7,6 +7,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import Dict
 from typing import List
+from typing import NoReturn
 from typing import Optional
 
 from Utils.lexer import Lexer
@@ -412,7 +413,7 @@ class Parser:
         if not self.lexer.consume_specific(expected_character):
             self.raise_parse_error(f"expected '{expected_character}'")
 
-    def raise_parse_error(self, message: str) -> None:
+    def raise_parse_error(self, message: str) -> NoReturn:
         line_number = 1
         column_number = 1
 

--- a/Meta/import-wpt-test.py
+++ b/Meta/import-wpt-test.py
@@ -42,7 +42,7 @@ class TestType(Enum):
         obj._value_ = args[0]
         return obj
 
-    def __init__(self, _: str, input_path: str, expected_path: str):
+    def __init__(self, _: int, input_path: str, expected_path: str):
         self.input_path = input_path
         self.expected_path = expected_path
 
@@ -176,6 +176,7 @@ def map_to_path(
         if source.resource.startswith("/") or not is_resource:
             file_path = Path(base_directory, source.resource.lstrip("/"))
         else:
+            assert resource_path is not None
             parsed_url = urlparse(source.resource)
             if parsed_url.scheme != "":
                 print(f"Skipping '{source.resource}'. Downloading external resources is not supported.")
@@ -232,6 +233,7 @@ def modify_sources(files, resources: list[ResourceAndType]) -> None:
 
         # Look for mentions of the reference page, and update their href
         if raw_reference_path is not None:
+            assert reference_path is not None
             new_reference_path = parent_folder_path + "../../expected/wpt-import/" + reference_path[::]
             page_source = page_source.replace(raw_reference_path, new_reference_path)
 

--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -227,7 +227,11 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         if key not in echo_store:
             key = f"{method} {parsed_url.path}"
 
-        recorded_request_headers[self.path] = {header: self.headers.get_all(header) for header in self.headers.keys()}
+        headers_for_path: Dict[str, list[str]] = {}
+        for header, value in self.headers.items():
+            headers_for_path.setdefault(header, []).append(value)
+        recorded_request_headers[self.path] = headers_for_path
+
         if parsed_url.path != self.path:
             recorded_request_headers[parsed_url.path] = recorded_request_headers[self.path]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,13 @@ extend-select = [
 [tool.ruff.lint.isort]
 force-single-line = true
 lines-between-types = 1
+
+[tool.pyright]
+pythonVersion = "3.9"
+extraPaths = ["Meta"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/.*",
+    "**/lit.cfg.py",
+]


### PR DESCRIPTION
This will help us be more explicit about our Python typing, while also completely ensuring that we don't use features that are unsupported in Python 3.9. For example, it catches usage of the union operator in `css_dimensions.py` which passed CI's current Python version checking and breaks builds on macOS.