### PR TITLE
LibWeb: Notify observers after compositor-only scrolls

### DIFF
--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -857,8 +857,6 @@ private:
             hovered_scrollbar_index = m_hovered_viewport_scrollbar_index;
             captured_scrollbar_index = m_captured_viewport_scrollbar_index;
         }
-        if (!hovered_scrollbar_index.has_value() && !captured_scrollbar_index.has_value())
-            return;
         paint_viewport_scrollbars(surface, scrollbars, m_cached_scroll_state_snapshot, hovered_scrollbar_index, captured_scrollbar_index);
     }
 

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/ExternalContentSource.h>
@@ -724,6 +725,9 @@ public:
                             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Stored pending async viewport offset {},{}",
                                 scroll_offset->x(), scroll_offset->y());
                         }
+                        invoke_on_main_thread([] {
+                            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
+                        });
                         {
                             Sync::MutexLocker const locker { m_mutex };
                             m_has_deferred_async_scroll_present = true;
@@ -931,6 +935,9 @@ private:
             m_has_deferred_async_scroll_present = true;
             m_deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
         }
+        invoke_on_main_thread([] {
+            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
+        });
         return true;
     }
 

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -381,8 +381,11 @@ void EventLoop::update_the_rendering()
     }
 
     // 9. For each doc of docs, run the scroll steps for doc. [CSSOMVIEW]
-    for (auto& document : docs)
+    for (auto& document : docs) {
+        if (auto navigable = document->navigable())
+            navigable->adopt_pending_async_viewport_scroll_offset();
         document->run_the_scroll_steps();
+    }
 
     // 10. For each doc of docs, evaluate media queries and report changes for doc. [CSSOMVIEW]
     for (auto& document : docs) {

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2907,6 +2907,26 @@ void Navigable::perform_scroll_of_viewport_scrolling_box(CSSPixelPoint new_posit
     HTML::main_thread_event_loop().schedule();
 }
 
+void Navigable::adopt_pending_async_viewport_scroll_offset()
+{
+    if (!page().async_scrolling_enabled())
+        return;
+
+    // The compositor thread may have already presented newer viewport scroll offsets. Adopt the latest one before
+    // running rendering-update observers so they see the same scroll position as the user.
+    if (m_rendering_thread.should_defer_async_viewport_scroll_offset_adoption()) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred async viewport offset adoption");
+    } else if (auto async_scroll_offset = m_rendering_thread.take_pending_async_viewport_scroll_offset(); async_scroll_offset.has_value()) {
+        auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async viewport offset {},{}",
+            async_scroll_offset->x(), async_scroll_offset->y());
+        perform_scroll_of_viewport_scrolling_box({
+            CSSPixels { async_scroll_offset->x() / device_pixels_per_css_pixel },
+            CSSPixels { async_scroll_offset->y() / device_pixels_per_css_pixel },
+        });
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity
 bool Navigable::has_a_rendering_opportunity() const
 {
@@ -3133,21 +3153,7 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
     if (!document)
         return;
 
-    if (page().async_scrolling_enabled()) {
-        // The compositor thread may have already presented newer viewport scroll offsets. Adopt the latest one before
-        // recording so a main-thread repaint catches up to the visible async position.
-        if (m_rendering_thread.should_defer_async_viewport_scroll_offset_adoption()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred async viewport offset adoption before recording display list");
-        } else if (auto async_scroll_offset = m_rendering_thread.take_pending_async_viewport_scroll_offset(); async_scroll_offset.has_value()) {
-            auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async viewport offset {},{} before recording display list",
-                async_scroll_offset->x(), async_scroll_offset->y());
-            perform_scroll_of_viewport_scrolling_box({
-                CSSPixels { async_scroll_offset->x() / device_pixels_per_css_pixel },
-                CSSPixels { async_scroll_offset->y() / device_pixels_per_css_pixel },
-            });
-        }
-    }
+    adopt_pending_async_viewport_scroll_offset();
 
     auto should_record_display_list = m_needs_to_record_display_list
         || !m_rendering_thread_display_list_paint_config.has_value()

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -196,6 +196,7 @@ public:
     CSSPixelSize viewport_size() const { return m_viewport_size; }
     void set_viewport_size(CSSPixelSize, InvalidateDisplayList = InvalidateDisplayList::No);
     void perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position);
+    void adopt_pending_async_viewport_scroll_offset();
     void clamp_viewport_scroll_offset();
 
     Painting::BackingStoreManager& backing_store_manager() { return *m_backing_store_manager; }


### PR DESCRIPTION
Make compositor-only async viewport scrolling notify scroll observers even when the main thread does not repaint immediately.

The compositor now reports committed async scroll offsets back through the rendering path, and Navigable adopts those offsets before running scroll observers. This keeps scroll-driven behavior in sync with viewport scrolling that was performed entirely by the compositor.

Bonus fix: keep compositor-owned viewport scrollbars visible whenever async scrolling state is available, instead of tying their visibility to hover or capture state.