### PR TITLE
LibWeb: Rebuild async scrolling from display list

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -16,18 +16,9 @@ void AsyncScrollTree::set_state(AsyncScrollingState&& state)
     m_scroll_nodes = move(state.scroll_nodes);
     m_sticky_areas = move(state.sticky_areas);
     m_main_thread_wheel_event_regions = move(state.main_thread_wheel_event_regions);
-    m_viewport_rect = state.viewport_rect;
-    m_main_thread_wheel_event_targets.clear();
     m_wheel_scroll_targets.clear();
-}
-
-AsyncScrollNode* AsyncScrollTree::scroll_node_for_id(AsyncScrollNodeID node_id)
-{
-    for (auto& node : m_scroll_nodes) {
-        if (node.node_id == node_id)
-            return &node;
-    }
-    return nullptr;
+    m_main_thread_wheel_event_targets.clear();
+    m_visual_context_tree = nullptr;
 }
 
 AsyncScrollNode const* AsyncScrollTree::scroll_node_for_id(AsyncScrollNodeID node_id) const
@@ -55,28 +46,22 @@ Gfx::FloatPoint AsyncScrollTree::clamp_scroll_offset_to_node(AsyncScrollNode con
     return scroll_offset;
 }
 
-bool AsyncScrollTree::can_scroll_node_by_delta(AsyncScrollNode const& node, Gfx::FloatPoint delta)
+Gfx::FloatPoint AsyncScrollTree::scroll_offset_for_node(AsyncScrollNode const& node, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
-    if (delta.x() < 0 && node.scroll_offset.x() > 0)
-        return true;
-    if (delta.x() > 0 && node.scroll_offset.x() < node.max_scroll_offset.x())
-        return true;
-    if (delta.y() < 0 && node.scroll_offset.y() > 0)
-        return true;
-    if (delta.y() > 0 && node.scroll_offset.y() < node.max_scroll_offset.y())
-        return true;
-    return false;
+    auto device_offset = scroll_state_snapshot.device_offset_for_index(node.node_id.scroll_frame_index);
+    return { -device_offset.x(), -device_offset.y() };
 }
 
-bool AsyncScrollTree::can_scroll_target_by_delta(WheelScrollTarget const& target, Gfx::FloatPoint delta)
+bool AsyncScrollTree::can_scroll_node_by_delta(AsyncScrollNode const& node, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint delta)
 {
-    if (delta.x() < 0 && target.can_scroll_left)
+    auto scroll_offset = scroll_offset_for_node(node, scroll_state_snapshot);
+    if (delta.x() < 0 && scroll_offset.x() > 0)
         return true;
-    if (delta.x() > 0 && target.can_scroll_right)
+    if (delta.x() > 0 && scroll_offset.x() < node.max_scroll_offset.x())
         return true;
-    if (delta.y() < 0 && target.can_scroll_up)
+    if (delta.y() < 0 && scroll_offset.y() > 0)
         return true;
-    if (delta.y() > 0 && target.can_scroll_down)
+    if (delta.y() > 0 && scroll_offset.y() < node.max_scroll_offset.y())
         return true;
     return false;
 }
@@ -86,7 +71,7 @@ bool AsyncScrollTree::has_non_zero_scroll_delta(Gfx::FloatPoint delta)
     return delta.x() != 0 || delta.y() != 0;
 }
 
-Optional<AsyncScrollNodeID> AsyncScrollTree::scrollable_ancestor_for_node(AsyncScrollNodeID node_id, Gfx::FloatPoint delta) const
+Optional<AsyncScrollNodeID> AsyncScrollTree::scrollable_ancestor_for_node(AsyncScrollNodeID node_id, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint delta) const
 {
     auto const* node = scroll_node_for_id(node_id);
     if (!node)
@@ -97,7 +82,7 @@ Optional<AsyncScrollNodeID> AsyncScrollTree::scrollable_ancestor_for_node(AsyncS
         auto const* parent_node = scroll_node_for_id(*parent_node_id);
         if (!parent_node)
             return {};
-        if (can_scroll_node_by_delta(*parent_node, delta))
+        if (can_scroll_node_by_delta(*parent_node, scroll_state_snapshot, delta))
             return *parent_node_id;
         parent_node_id = parent_node->parent_node_id;
     }
@@ -133,9 +118,9 @@ Gfx::FloatPoint AsyncScrollTree::cumulative_device_offset_for_frame(Painting::Sc
     return offset;
 }
 
-Gfx::FloatPoint AsyncScrollTree::apply_scroll_delta_to_node(AsyncScrollNode& node, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot& scroll_state_snapshot)
+Gfx::FloatPoint AsyncScrollTree::apply_scroll_delta_to_node(AsyncScrollNode const& node, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot& scroll_state_snapshot)
 {
-    auto old_scroll_offset = node.scroll_offset;
+    auto old_scroll_offset = scroll_offset_for_node(node, scroll_state_snapshot);
     auto new_scroll_offset = clamp_scroll_offset_to_node(node, old_scroll_offset.translated(delta));
     if (new_scroll_offset == old_scroll_offset) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll node {} did not move for delta {},{} (offset={},{} max={},{})",
@@ -143,7 +128,6 @@ Gfx::FloatPoint AsyncScrollTree::apply_scroll_delta_to_node(AsyncScrollNode& nod
         return delta;
     }
 
-    node.scroll_offset = new_scroll_offset;
     scroll_state_snapshot.set_device_offset_for_index(node.node_id.scroll_frame_index, { -new_scroll_offset.x(), -new_scroll_offset.y() });
 
     Gfx::FloatPoint consumed_delta {
@@ -219,7 +203,7 @@ bool AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID node_id, Gfx::FloatPo
     bool scrolled = false;
     auto remaining_delta = delta;
     for (size_t remaining_handoffs = m_scroll_nodes.size(); remaining_handoffs > 0 && has_non_zero_scroll_delta(remaining_delta); --remaining_handoffs) {
-        auto* node = scroll_node_for_id(node_id);
+        auto const* node = scroll_node_for_id(node_id);
         if (!node)
             break;
 
@@ -230,7 +214,7 @@ bool AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID node_id, Gfx::FloatPo
         if (!has_non_zero_scroll_delta(remaining_delta))
             break;
 
-        auto ancestor_node_id = scrollable_ancestor_for_node(node_id, remaining_delta);
+        auto ancestor_node_id = scrollable_ancestor_for_node(node_id, scroll_state_snapshot, remaining_delta);
         if (!ancestor_node_id.has_value())
             break;
         node_id = *ancestor_node_id;
@@ -249,27 +233,31 @@ void AsyncScrollTree::rebuild_wheel_scroll_targets(RefPtr<Painting::DisplayList>
 {
     m_wheel_scroll_targets.clear();
     m_main_thread_wheel_event_targets.clear();
+    m_visual_context_tree = nullptr;
+    m_scroll_state_snapshot = scroll_state_snapshot;
     if (!display_list)
         return;
 
     auto const& visual_context_tree = display_list->visual_context_tree();
-    for (auto const& node : m_scroll_nodes) {
-        auto viewport_rect = node.is_viewport
-            ? Gfx::FloatRect { {}, m_viewport_rect.size().to_type<float>() }
-            : visual_context_tree.transform_rect_to_viewport(node.hit_test_visual_context_index, node.scrollport_rect.to_type<float>(), scroll_state_snapshot);
+    m_visual_context_tree = &visual_context_tree;
 
+    for (auto const& node : m_scroll_nodes) {
+        auto rect = node.scrollport_rect.to_type<float>();
+        auto viewport_rect = node.is_viewport
+            ? Gfx::FloatRect { {}, rect.size() }
+            : visual_context_tree.transform_rect_to_viewport(node.hit_test_visual_context_index, rect, scroll_state_snapshot);
         m_wheel_scroll_targets.append({
             .node_id = node.node_id,
+            .visual_context_index = node.hit_test_visual_context_index,
+            .rect = rect,
             .viewport_rect = viewport_rect,
-            .can_scroll_left = node.scroll_offset.x() > 0,
-            .can_scroll_right = node.scroll_offset.x() < node.max_scroll_offset.x(),
-            .can_scroll_up = node.scroll_offset.y() > 0,
-            .can_scroll_down = node.scroll_offset.y() < node.max_scroll_offset.y(),
         });
     }
 
     for (auto const& region : m_main_thread_wheel_event_regions) {
         m_main_thread_wheel_event_targets.append({
+            .visual_context_index = region.visual_context_index,
+            .rect = region.rect,
             .viewport_rect = visual_context_tree.transform_rect_to_viewport(region.visual_context_index, region.rect, scroll_state_snapshot),
         });
     }
@@ -279,12 +267,13 @@ void AsyncScrollTree::clear_wheel_scroll_targets()
 {
     m_wheel_scroll_targets.clear();
     m_main_thread_wheel_event_targets.clear();
+    m_visual_context_tree = nullptr;
 }
 
-Optional<Gfx::FloatPoint> AsyncScrollTree::scroll_offset_for_node(AsyncScrollNodeID node_id) const
+Optional<Gfx::FloatPoint> AsyncScrollTree::scroll_offset_for_node(AsyncScrollNodeID node_id, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
 {
     if (auto const* node = scroll_node_for_id(node_id))
-        return node->scroll_offset;
+        return scroll_offset_for_node(*node, scroll_state_snapshot);
     return {};
 }
 
@@ -297,22 +286,38 @@ Optional<AsyncScrollNodeID> AsyncScrollTree::viewport_scroll_node_id() const
     return {};
 }
 
-Optional<AsyncScrollNodeID> AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const
+WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const
 {
-    for (auto const& target : m_main_thread_wheel_event_targets) {
-        if (target.viewport_rect.contains(position))
-            return {};
-    }
+    if (!m_visual_context_tree)
+        return {};
 
-    Optional<AsyncScrollNodeID> scroll_target;
-    for (auto const& target : m_wheel_scroll_targets) {
+    for (auto const& target : m_main_thread_wheel_event_targets) {
         if (!target.viewport_rect.contains(position))
             continue;
-        if (!can_scroll_target_by_delta(target, delta))
-            continue;
-        scroll_target = target.node_id;
+
+        auto position_in_context = m_visual_context_tree->transform_point_for_hit_test(target.visual_context_index, position, m_scroll_state_snapshot);
+        if (position_in_context.has_value() && target.rect.contains(*position_in_context))
+            return { {}, true };
     }
-    return scroll_target;
+
+    for (auto const& target : m_wheel_scroll_targets.in_reverse()) {
+        if (!target.viewport_rect.contains(position))
+            continue;
+
+        auto position_in_context = m_visual_context_tree->transform_point_for_hit_test(target.visual_context_index, position, m_scroll_state_snapshot);
+        if (!position_in_context.has_value() || !target.rect.contains(*position_in_context))
+            continue;
+
+        auto const* node = scroll_node_for_id(target.node_id);
+        if (!node)
+            return {};
+        if (can_scroll_node_by_delta(*node, m_scroll_state_snapshot, delta))
+            return { target.node_id, false };
+        if (auto ancestor = scrollable_ancestor_for_node(target.node_id, m_scroll_state_snapshot, delta); ancestor.has_value())
+            return { ancestor, false };
+        return {};
+    }
+    return {};
 }
 
 bool AsyncScrollTree::scroll_node_is_viewport(AsyncScrollNodeID node_id) const
@@ -323,14 +328,14 @@ bool AsyncScrollTree::scroll_node_is_viewport(AsyncScrollNodeID node_id) const
 
 Optional<Gfx::FloatPoint> AsyncScrollTree::set_scroll_offset(AsyncScrollNodeID node_id, Gfx::FloatPoint scroll_offset, Painting::ScrollStateSnapshot& scroll_state_snapshot)
 {
-    auto* node = scroll_node_for_id(node_id);
+    auto const* node = scroll_node_for_id(node_id);
     if (!node)
         return {};
 
-    node->scroll_offset = clamp_scroll_offset_to_node(*node, scroll_offset);
-    scroll_state_snapshot.set_device_offset_for_index(node->node_id.scroll_frame_index, { -node->scroll_offset.x(), -node->scroll_offset.y() });
+    auto new_scroll_offset = clamp_scroll_offset_to_node(*node, scroll_offset);
+    scroll_state_snapshot.set_device_offset_for_index(node->node_id.scroll_frame_index, { -new_scroll_offset.x(), -new_scroll_offset.y() });
     update_sticky_offsets(scroll_state_snapshot);
-    return node->scroll_offset;
+    return new_scroll_offset;
 }
 
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -17,23 +17,28 @@
 
 namespace Web::Compositor {
 
-// Viewport-space cache used for wheel hit-testing, rebuilt from AsyncScrollNode whenever scroll offsets change.
+struct WheelHitTestResult {
+    Optional<AsyncScrollNodeID> node_id;
+    bool blocked_by_main_thread_region { false };
+};
+
+// Viewport-space cache used for wheel hit-testing, rebuilt whenever scroll offsets change.
 struct WheelScrollTarget {
     AsyncScrollNodeID node_id;
+    Painting::VisualContextIndex visual_context_index;
+    Gfx::FloatRect rect;
     Gfx::FloatRect viewport_rect;
-    bool can_scroll_left { false };
-    bool can_scroll_right { false };
-    bool can_scroll_up { false };
-    bool can_scroll_down { false };
 };
 
 // Viewport-space cache of regions that force main-thread wheel routing.
 struct MainThreadWheelEventTarget {
+    Painting::VisualContextIndex visual_context_index;
+    Gfx::FloatRect rect;
     Gfx::FloatRect viewport_rect;
 };
 
-// Mutable compositor-side copy of AsyncScrollingState. The main thread owns the source snapshot; this tree owns only
-// compositor scroll offsets and derived hit-test targets.
+// Mutable compositor-side copy of AsyncScrollingState. Current scroll offsets live in ScrollStateSnapshot; this tree
+// owns scroll node geometry and derived hit-test targets.
 class AsyncScrollTree {
 public:
     void set_state(AsyncScrollingState&&);
@@ -41,26 +46,25 @@ public:
     void rebuild_wheel_scroll_targets(RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&);
     void clear_wheel_scroll_targets();
 
-    Optional<Gfx::FloatPoint> scroll_offset_for_node(AsyncScrollNodeID) const;
+    Optional<Gfx::FloatPoint> scroll_offset_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&) const;
     Optional<AsyncScrollNodeID> viewport_scroll_node_id() const;
-    Optional<AsyncScrollNodeID> hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const;
+    WheelHitTestResult hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const;
     bool scroll_node_is_viewport(AsyncScrollNodeID) const;
     bool apply_scroll_delta(AsyncScrollNodeID, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
     Optional<Gfx::FloatPoint> set_scroll_offset(AsyncScrollNodeID, Gfx::FloatPoint, Painting::ScrollStateSnapshot&);
 
 private:
     static Gfx::FloatPoint clamp_scroll_offset_to_node(AsyncScrollNode const&, Gfx::FloatPoint);
-    static bool can_scroll_node_by_delta(AsyncScrollNode const&, Gfx::FloatPoint);
-    static bool can_scroll_target_by_delta(WheelScrollTarget const&, Gfx::FloatPoint);
+    static Gfx::FloatPoint scroll_offset_for_node(AsyncScrollNode const&, Painting::ScrollStateSnapshot const&);
+    static bool can_scroll_node_by_delta(AsyncScrollNode const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint);
     static bool has_non_zero_scroll_delta(Gfx::FloatPoint);
 
-    AsyncScrollNode* scroll_node_for_id(AsyncScrollNodeID);
     AsyncScrollNode const* scroll_node_for_id(AsyncScrollNodeID) const;
     AsyncStickyArea const* sticky_area_for_scroll_frame_index(Painting::ScrollFrameIndex) const;
-    Optional<AsyncScrollNodeID> scrollable_ancestor_for_node(AsyncScrollNodeID, Gfx::FloatPoint delta) const;
+    Optional<AsyncScrollNodeID> scrollable_ancestor_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint delta) const;
     Optional<Painting::ScrollFrameIndex> parent_scroll_frame_index(Painting::ScrollFrameIndex) const;
     Gfx::FloatPoint cumulative_device_offset_for_frame(Painting::ScrollFrameIndex, Painting::ScrollStateSnapshot const&) const;
-    Gfx::FloatPoint apply_scroll_delta_to_node(AsyncScrollNode&, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
+    Gfx::FloatPoint apply_scroll_delta_to_node(AsyncScrollNode const&, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
     void update_sticky_offsets(Painting::ScrollStateSnapshot&) const;
 
     Vector<AsyncScrollNode> m_scroll_nodes;
@@ -68,7 +72,8 @@ private:
     Vector<MainThreadWheelEventRegion> m_main_thread_wheel_event_regions;
     Vector<MainThreadWheelEventTarget> m_main_thread_wheel_event_targets;
     Vector<WheelScrollTarget> m_wheel_scroll_targets;
-    Gfx::IntRect m_viewport_rect;
+    RefPtr<Painting::AccumulatedVisualContextTree const> m_visual_context_tree;
+    Painting::ScrollStateSnapshot m_scroll_state_snapshot;
 };
 
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/DOMEventListener.h>
 #include <LibWeb/DOM/Document.h>
@@ -14,11 +15,12 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ScrollState.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/PixelUnits.h>
-#include <LibWeb/TraversalDecision.h>
 
 namespace Web::Compositor {
 
@@ -46,6 +48,17 @@ static Optional<float> css_inset_to_device_inset(Optional<CSSPixels> inset, doub
     return inset->to_float() * static_cast<float>(device_pixels_per_css_pixel);
 }
 
+static AsyncScrollNodeID scroll_node_id_for(UniqueNodeID document_id, Painting::ScrollFrameIndex scroll_frame_index)
+{
+    return { .document_id = document_id, .scroll_frame_index = scroll_frame_index };
+}
+
+static bool is_nested_navigable_container(Painting::PaintableBox const& paintable_box)
+{
+    auto node = paintable_box.dom_node();
+    return node && node->is_navigable_container() && as<HTML::NavigableContainer const>(*node).content_navigable();
+}
+
 static CSSPixelPoint maximum_scroll_offset_for(Painting::PaintableBox const& paintable_box)
 {
     CSSPixelPoint max_scroll_offset;
@@ -59,32 +72,43 @@ static CSSPixelPoint maximum_scroll_offset_for(Painting::PaintableBox const& pai
     return max_scroll_offset;
 }
 
-static AsyncScrollNodeID scroll_node_id_for(UniqueNodeID document_id, Painting::ScrollFrameIndex scroll_frame_index)
+static void record_scroll_node(Painting::PaintableBox const& paintable_box, DisplayListRecordingContext& context)
 {
-    return { .document_id = document_id, .scroll_frame_index = scroll_frame_index };
+    auto parent_scroll_frame_index = Painting::ScrollFrameIndex {};
+    if (auto scrollable_ancestor = paintable_box.nearest_scrollable_ancestor())
+        parent_scroll_frame_index = scrollable_ancestor->own_scroll_frame_index();
+
+    auto scrollport_rect = paintable_box.is_viewport_paintable()
+        ? Gfx::IntRect { {}, context.device_viewport_rect().size().to_type<int>() }
+        : context.rounded_device_rect(paintable_box.absolute_padding_box_rect()).to_type<int>();
+
+    auto& recorder = context.display_list_recorder();
+    recorder.compositor_scroll_node({
+        .document_id = paintable_box.document().unique_id(),
+        .scroll_frame_index = paintable_box.own_scroll_frame_index(),
+        .parent_scroll_frame_index = parent_scroll_frame_index,
+        .scrollport_rect = scrollport_rect,
+        .max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), context.device_pixels_per_css_pixel()),
+        .is_viewport = paintable_box.is_viewport_paintable(),
+    });
 }
 
-static Optional<AsyncScrollNodeID> scroll_node_id_for_scroll_frame_index(AsyncScrollingState const& async_scrolling_state, Painting::ScrollFrameIndex scroll_frame_index)
+static void record_main_thread_wheel_event_region(Painting::PaintableBox const& paintable_box, DisplayListRecordingContext& context)
 {
-    for (auto const& scroll_node : async_scrolling_state.scroll_nodes) {
-        if (scroll_node.node_id.scroll_frame_index == scroll_frame_index)
-            return scroll_node.node_id;
-    }
-    return {};
+    auto rect = css_rect_to_device_rect(paintable_box.absolute_united_border_box_rect(), context.device_pixels_per_css_pixel());
+    if (rect.is_empty())
+        return;
+
+    context.display_list_recorder().compositor_main_thread_wheel_event_region({
+        .rect = rect,
+    });
 }
 
-static Optional<AsyncScrollNodeID> parent_scroll_node_id_for(AsyncScrollingState const& async_scrolling_state, Painting::ScrollState const& scroll_state, Painting::ScrollFrameIndex parent_scroll_frame_index)
-{
-    for (auto scroll_frame_index = parent_scroll_frame_index; scroll_frame_index.value(); scroll_frame_index = scroll_state.frame_at(scroll_frame_index).parent_index()) {
-        if (auto node_id = scroll_node_id_for_scroll_frame_index(async_scrolling_state, scroll_frame_index); node_id.has_value())
-            return node_id;
-    }
-    return {};
-}
-
-static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrolling_state, HTML::Navigable& navigable, Painting::PaintableBox const& paintable_box)
+static void record_viewport_scrollbar_state(Painting::PaintableBox const& paintable_box, DisplayListRecordingContext& context)
 {
     if (!paintable_box.is_viewport_paintable())
+        return;
+    if (!paintable_box.document().page().async_scrolling_enabled())
         return;
     if (!Painting::should_paint_viewport_scrollbars())
         return;
@@ -92,7 +116,7 @@ static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrollin
         return;
 
     auto scrollbar_colors = paintable_box.computed_values().scrollbar_color();
-    auto metrics = paintable_box.document().page().chrome_metrics();
+    auto const& metrics = context.chrome_metrics();
 
     for (auto direction : { Painting::PaintableBox::ScrollDirection::Vertical, Painting::PaintableBox::ScrollDirection::Horizontal }) {
         auto scrollbar_data = paintable_box.compute_scrollbar_data(direction, metrics, nullptr, Painting::PaintableBox::ScrollbarSizing::Regular);
@@ -101,20 +125,20 @@ static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrollin
         auto expanded_scrollbar_data = paintable_box.compute_scrollbar_data(direction, metrics, nullptr, Painting::PaintableBox::ScrollbarSizing::Enlarged);
         VERIFY(expanded_scrollbar_data.has_value());
 
-        auto gutter_rect = navigable.page().css_to_device_rect(scrollbar_data->gutter_rect).to_type<int>();
-        auto max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), navigable.page().client().device_pixels_per_css_pixel());
+        auto gutter_rect = context.rounded_device_rect(scrollbar_data->gutter_rect).to_type<int>();
+        auto max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), context.device_pixels_per_css_pixel());
         auto orientation = direction == Painting::PaintableBox::ScrollDirection::Horizontal ? Gfx::Orientation::Horizontal : Gfx::Orientation::Vertical;
         auto thumb_color = scrollbar_colors.thumb_color;
         if (gutter_rect.is_empty() && thumb_color == CSS::InitialValues::scrollbar_color().thumb_color)
             thumb_color = thumb_color.with_alpha(128);
 
-        async_scrolling_state.viewport_scrollbars.append({
-            .scroll_node_id = scroll_node_id_for(paintable_box.document().unique_id(), paintable_box.own_scroll_frame_index()),
+        context.display_list_recorder().compositor_viewport_scrollbar({
+            .document_id = paintable_box.document().unique_id(),
             .scroll_frame_index = paintable_box.own_scroll_frame_index(),
             .gutter_rect = gutter_rect,
-            .thumb_rect = navigable.page().css_to_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
-            .expanded_gutter_rect = navigable.page().css_to_device_rect(expanded_scrollbar_data->gutter_rect).to_type<int>(),
-            .expanded_thumb_rect = navigable.page().css_to_device_rect(expanded_scrollbar_data->thumb_rect).to_type<int>(),
+            .thumb_rect = context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
+            .expanded_gutter_rect = context.rounded_device_rect(expanded_scrollbar_data->gutter_rect).to_type<int>(),
+            .expanded_thumb_rect = context.rounded_device_rect(expanded_scrollbar_data->thumb_rect).to_type<int>(),
             .scroll_size = scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
             .expanded_scroll_size = expanded_scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
             .max_scroll_offset = max_scroll_offset.primary_offset_for_orientation(orientation),
@@ -125,7 +149,7 @@ static void collect_viewport_scrollbar_state(AsyncScrollingState& async_scrollin
     }
 }
 
-static bool has_blocking_wheel_event_listener(DOM::EventTarget& event_target)
+static bool has_blocking_wheel_event_listener(DOM::EventTarget const& event_target)
 {
     for (auto listener : event_target.event_listener_list()) {
         if (AK::first_is_one_of(listener->type, "wheel"sv, "mousewheel"sv) && listener->passive != true)
@@ -134,7 +158,7 @@ static bool has_blocking_wheel_event_listener(DOM::EventTarget& event_target)
     return false;
 }
 
-static bool is_root_wheel_event_target(DOM::Node& node)
+static bool is_root_wheel_event_target(DOM::Node const& node)
 {
     auto& document = node.document();
     return &node == document.document_element() || &node == document.body();
@@ -142,102 +166,187 @@ static bool is_root_wheel_event_target(DOM::Node& node)
 
 static void collect_root_blocking_wheel_event_regions(AsyncScrollingState& async_scrolling_state, DOM::Document& document)
 {
-    if (auto window = document.navigable() ? document.navigable()->active_window() : nullptr; window && has_blocking_wheel_event_listener(*window)) {
-        async_scrolling_state.has_blocking_wheel_event_listeners = true;
-        async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = true;
-    }
-    if (has_blocking_wheel_event_listener(document)) {
-        async_scrolling_state.has_blocking_wheel_event_listeners = true;
-        async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = true;
-    }
-    if (auto* document_element = document.document_element(); document_element && has_blocking_wheel_event_listener(*document_element)) {
-        async_scrolling_state.has_blocking_wheel_event_listeners = true;
-        async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = true;
-    }
-    if (auto* body = document.body(); body && has_blocking_wheel_event_listener(*body)) {
-        async_scrolling_state.has_blocking_wheel_event_listeners = true;
-        async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = true;
+    DOM::EventTarget* roots[] = {
+        document.navigable() ? document.navigable()->active_window() : nullptr,
+        &document,
+        document.document_element(),
+        document.body(),
+    };
+    for (auto* target : roots) {
+        if (target && has_blocking_wheel_event_listener(*target)) {
+            async_scrolling_state.has_blocking_wheel_event_listeners = true;
+            async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = true;
+            return;
+        }
     }
 }
 
-AsyncScrollingState collect_async_scrolling_state(HTML::Navigable& navigable, Painting::ViewportPaintable& document_paintable, Gfx::IntRect viewport_rect)
+void initialize_async_scrolling_metadata_recording(DisplayListRecordingContext& context, Painting::ViewportPaintable& document_paintable)
 {
-    auto device_pixels_per_css_pixel = navigable.page().client().device_pixels_per_css_pixel();
-    auto const& scroll_state = document_paintable.scroll_state();
-    auto document_id = document_paintable.document().unique_id();
     AsyncScrollingState async_scrolling_state;
-    Vector<Painting::ScrollFrameIndex> parent_scroll_frame_indices;
-    async_scrolling_state.viewport_rect = viewport_rect;
-    async_scrolling_state.wheel_event_listener_state_generation = navigable.page().wheel_event_listener_state_generation();
     collect_root_blocking_wheel_event_regions(async_scrolling_state, document_paintable.document());
+    context.set_async_scrolling_metadata_context(
+        document_paintable.document().unique_id(),
+        document_paintable.scroll_state(),
+        async_scrolling_state.has_blocking_wheel_event_listeners,
+        async_scrolling_state.has_blocking_wheel_event_region_covering_viewport);
+}
 
-    document_paintable.for_each_in_inclusive_subtree_of_type<Painting::PaintableBox>([&](auto& paintable_box) {
-        if (!async_scrolling_state.has_blocking_wheel_event_region_covering_viewport) {
-            if (auto node = paintable_box.dom_node(); node && !is_root_wheel_event_target(*node) && has_blocking_wheel_event_listener(*node)) {
-                async_scrolling_state.has_blocking_wheel_event_listeners = true;
-                async_scrolling_state.blocking_wheel_event_regions.append({
-                    .visual_context_index = paintable_box.accumulated_visual_context_index(),
-                    .rect = css_rect_to_device_rect(paintable_box.absolute_united_border_box_rect(), device_pixels_per_css_pixel),
-                });
-            }
-        }
+void record_async_scrolling_metadata_for_paintable(Painting::PaintableBox const& paintable_box, DisplayListRecordingContext& context)
+{
+    if (!context.is_recording_async_scrolling_metadata())
+        return;
 
-        if (auto node = paintable_box.dom_node(); node && node->is_navigable_container() && as<HTML::NavigableContainer>(*node).content_navigable()) {
-            async_scrolling_state.main_thread_wheel_event_regions.append({
-                .visual_context_index = paintable_box.accumulated_visual_context_index(),
+    auto device_pixels_per_css_pixel = context.device_pixels_per_css_pixel();
+    auto& recorder = context.display_list_recorder();
+
+    if (!context.has_blocking_wheel_event_region_covering_viewport()) {
+        if (auto node = paintable_box.dom_node(); node && !is_root_wheel_event_target(*node) && has_blocking_wheel_event_listener(*node)) {
+            context.set_has_blocking_wheel_event_listeners(true);
+            recorder.compositor_blocking_wheel_event_region({
                 .rect = css_rect_to_device_rect(paintable_box.absolute_united_border_box_rect(), device_pixels_per_css_pixel),
             });
         }
+    }
 
-        auto sticky_frame_index = paintable_box.enclosing_scroll_frame_index();
-        if (paintable_box.is_sticky_position() && sticky_frame_index.value()) {
-            auto const& frame = scroll_state.frame_at(sticky_frame_index);
-            if (frame.is_sticky() && frame.has_sticky_constraints()) {
-                auto const& constraints = frame.sticky_constraints();
-                auto const& insets = constraints.insets;
-                async_scrolling_state.sticky_areas.append({
-                    .document_id = document_id,
-                    .scroll_frame_index = sticky_frame_index,
-                    .parent_scroll_frame_index = frame.parent_index(),
-                    .nearest_scrolling_ancestor_index = scroll_state.nearest_scrolling_ancestor(sticky_frame_index),
-                    .position_relative_to_scroll_ancestor = css_point_to_device_point(constraints.position_relative_to_scroll_ancestor, device_pixels_per_css_pixel),
-                    .border_box_size = css_size_to_device_size(constraints.border_box_size, device_pixels_per_css_pixel),
-                    .scrollport_size = css_size_to_device_size(constraints.scrollport_size, device_pixels_per_css_pixel),
-                    .containing_block_region = css_rect_to_device_rect(constraints.containing_block_region, device_pixels_per_css_pixel),
-                    .needs_parent_offset_adjustment = constraints.needs_parent_offset_adjustment,
-                    .inset_top = css_inset_to_device_inset(insets.top, device_pixels_per_css_pixel),
-                    .inset_right = css_inset_to_device_inset(insets.right, device_pixels_per_css_pixel),
-                    .inset_bottom = css_inset_to_device_inset(insets.bottom, device_pixels_per_css_pixel),
-                    .inset_left = css_inset_to_device_inset(insets.left, device_pixels_per_css_pixel),
-                });
-            }
-        }
+    if (is_nested_navigable_container(paintable_box)) {
+        record_main_thread_wheel_event_region(paintable_box, context);
+    } else if (paintable_box.own_scroll_frame_index().value() && paintable_box.could_be_scrolled_by_wheel_event()) {
+        record_scroll_node(paintable_box, context);
+    }
+    record_viewport_scrollbar_state(paintable_box, context);
 
-        auto scroll_frame_index = paintable_box.own_scroll_frame_index();
-        if (scroll_frame_index.value() && paintable_box.could_be_scrolled_by_wheel_event()) {
-            auto parent_scroll_frame_index = scroll_state.frame_at(scroll_frame_index).parent_index();
-            async_scrolling_state.scroll_nodes.append({
-                .node_id = scroll_node_id_for(document_id, scroll_frame_index),
-                .parent_node_id = {},
-                .hit_test_visual_context_index = paintable_box.accumulated_visual_context_index(),
-                .scrollport_rect = navigable.page().css_to_device_rect(paintable_box.absolute_padding_box_rect()).template to_type<int>(),
-                .scroll_offset = css_point_to_device_point(paintable_box.scroll_offset(), device_pixels_per_css_pixel),
-                .max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), device_pixels_per_css_pixel),
-                .is_viewport = paintable_box.is_viewport_paintable(),
+    auto const& scroll_state = context.async_scrolling_scroll_state();
+    auto sticky_frame_index = paintable_box.enclosing_scroll_frame_index();
+    if (paintable_box.is_sticky_position() && sticky_frame_index.value()) {
+        auto const& frame = scroll_state.frame_at(sticky_frame_index);
+        if (frame.is_sticky() && frame.has_sticky_constraints()) {
+            auto const& constraints = frame.sticky_constraints();
+            auto const& insets = constraints.insets;
+            recorder.compositor_sticky_area({
+                .document_id = context.async_scrolling_document_id(),
+                .scroll_frame_index = sticky_frame_index,
+                .parent_scroll_frame_index = frame.parent_index(),
+                .nearest_scrolling_ancestor_index = scroll_state.nearest_scrolling_ancestor(sticky_frame_index),
+                .position_relative_to_scroll_ancestor = css_point_to_device_point(constraints.position_relative_to_scroll_ancestor, device_pixels_per_css_pixel),
+                .border_box_size = css_size_to_device_size(constraints.border_box_size, device_pixels_per_css_pixel),
+                .scrollport_size = css_size_to_device_size(constraints.scrollport_size, device_pixels_per_css_pixel),
+                .containing_block_region = css_rect_to_device_rect(constraints.containing_block_region, device_pixels_per_css_pixel),
+                .needs_parent_offset_adjustment = constraints.needs_parent_offset_adjustment,
+                .inset_top = css_inset_to_device_inset(insets.top, device_pixels_per_css_pixel),
+                .inset_right = css_inset_to_device_inset(insets.right, device_pixels_per_css_pixel),
+                .inset_bottom = css_inset_to_device_inset(insets.bottom, device_pixels_per_css_pixel),
+                .inset_left = css_inset_to_device_inset(insets.left, device_pixels_per_css_pixel),
             });
-            parent_scroll_frame_indices.append(parent_scroll_frame_index);
         }
+    }
+}
 
-        collect_viewport_scrollbar_state(async_scrolling_state, navigable, paintable_box);
+void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext& context, HTML::Navigable& navigable, Gfx::IntRect viewport_rect)
+{
+    if (!context.is_recording_async_scrolling_metadata())
+        return;
 
-        return TraversalDecision::Continue;
+    context.display_list_recorder().set_async_scrolling_metadata({
+        .viewport_rect = viewport_rect,
+        .wheel_event_listener_state_generation = navigable.page().wheel_event_listener_state_generation(),
+        .has_blocking_wheel_event_listeners = context.has_blocking_wheel_event_listeners(),
+        .has_blocking_wheel_event_region_covering_viewport = context.has_blocking_wheel_event_region_covering_viewport(),
+    });
+}
+
+AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const& display_list)
+{
+    AsyncScrollingState async_scrolling_state;
+    Vector<Painting::ScrollFrameIndex> parent_scroll_frame_indices;
+
+    if (auto const& metadata = display_list.async_scrolling_metadata(); metadata.has_value()) {
+        async_scrolling_state.viewport_rect = metadata->viewport_rect;
+        async_scrolling_state.wheel_event_listener_state_generation = metadata->wheel_event_listener_state_generation;
+        async_scrolling_state.has_blocking_wheel_event_listeners = metadata->has_blocking_wheel_event_listeners;
+        async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = metadata->has_blocking_wheel_event_region_covering_viewport;
+    }
+
+    display_list.for_each_command_header([&](Painting::DisplayListCommandHeader const& header, ReadonlyBytes payload) {
+        switch (header.type) {
+        case Painting::DisplayListCommandType::CompositorBlockingWheelEventRegion: {
+            auto command = Painting::read_display_list_command_payload<Painting::CompositorBlockingWheelEventRegion>(payload);
+            async_scrolling_state.has_blocking_wheel_event_listeners = true;
+            async_scrolling_state.blocking_wheel_event_regions.append({
+                .visual_context_index = header.context_index,
+                .rect = command.rect,
+            });
+            break;
+        }
+        case Painting::DisplayListCommandType::CompositorStickyArea: {
+            auto command = Painting::read_display_list_command_payload<Painting::CompositorStickyArea>(payload);
+            async_scrolling_state.sticky_areas.append({
+                .document_id = command.document_id,
+                .scroll_frame_index = command.scroll_frame_index,
+                .parent_scroll_frame_index = command.parent_scroll_frame_index,
+                .nearest_scrolling_ancestor_index = command.nearest_scrolling_ancestor_index,
+                .position_relative_to_scroll_ancestor = command.position_relative_to_scroll_ancestor,
+                .border_box_size = command.border_box_size,
+                .scrollport_size = command.scrollport_size,
+                .containing_block_region = command.containing_block_region,
+                .needs_parent_offset_adjustment = command.needs_parent_offset_adjustment,
+                .inset_top = command.inset_top,
+                .inset_right = command.inset_right,
+                .inset_bottom = command.inset_bottom,
+                .inset_left = command.inset_left,
+            });
+            break;
+        }
+        case Painting::DisplayListCommandType::CompositorScrollNode: {
+            auto command = Painting::read_display_list_command_payload<Painting::CompositorScrollNode>(payload);
+            async_scrolling_state.scroll_nodes.append({
+                .node_id = scroll_node_id_for(command.document_id, command.scroll_frame_index),
+                .parent_node_id = {},
+                .hit_test_visual_context_index = header.context_index,
+                .scrollport_rect = command.scrollport_rect,
+                .max_scroll_offset = command.max_scroll_offset,
+                .is_viewport = command.is_viewport,
+            });
+            parent_scroll_frame_indices.append(command.parent_scroll_frame_index);
+            break;
+        }
+        case Painting::DisplayListCommandType::CompositorMainThreadWheelEventRegion: {
+            auto command = Painting::read_display_list_command_payload<Painting::CompositorMainThreadWheelEventRegion>(payload);
+            async_scrolling_state.main_thread_wheel_event_regions.append({
+                .visual_context_index = header.context_index,
+                .rect = command.rect,
+            });
+            break;
+        }
+        case Painting::DisplayListCommandType::CompositorViewportScrollbar: {
+            auto command = Painting::read_display_list_command_payload<Painting::CompositorViewportScrollbar>(payload);
+            async_scrolling_state.viewport_scrollbars.append({
+                .scroll_node_id = scroll_node_id_for(command.document_id, command.scroll_frame_index),
+                .scroll_frame_index = command.scroll_frame_index,
+                .gutter_rect = command.gutter_rect,
+                .thumb_rect = command.thumb_rect,
+                .expanded_gutter_rect = command.expanded_gutter_rect,
+                .expanded_thumb_rect = command.expanded_thumb_rect,
+                .scroll_size = command.scroll_size,
+                .expanded_scroll_size = command.expanded_scroll_size,
+                .max_scroll_offset = command.max_scroll_offset,
+                .thumb_color = command.thumb_color,
+                .track_color = command.track_color,
+                .vertical = command.vertical,
+            });
+            break;
+        }
+        default:
+            break;
+        }
     });
 
     VERIFY(parent_scroll_frame_indices.size() == async_scrolling_state.scroll_nodes.size());
-    for (size_t i = 0; i < async_scrolling_state.scroll_nodes.size(); ++i)
-        async_scrolling_state.scroll_nodes[i].parent_node_id = parent_scroll_node_id_for(async_scrolling_state, scroll_state, parent_scroll_frame_indices[i]);
-
-    async_scrolling_state.blocking_wheel_event_regions_are_current = async_scrolling_state.has_blocking_wheel_event_listeners;
+    for (size_t i = 0; i < async_scrolling_state.scroll_nodes.size(); ++i) {
+        auto parent_scroll_frame_index = parent_scroll_frame_indices[i];
+        if (parent_scroll_frame_index.value())
+            async_scrolling_state.scroll_nodes[i].parent_node_id = scroll_node_id_for(async_scrolling_state.scroll_nodes[i].node_id.document_id, parent_scroll_frame_index);
+    }
     return async_scrolling_state;
 }
 
@@ -295,70 +404,34 @@ bool blocks_wheel_event_at_position(AsyncScrollingState const& async_scrolling_s
     return false;
 }
 
-bool requires_main_thread_wheel_event_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position)
-{
-    if (async_scrolling_state.main_thread_wheel_event_regions.is_empty())
-        return false;
-
-    if (!display_list)
-        return true;
-
-    auto const& visual_context_tree = display_list->visual_context_tree();
-    for (auto const& region : async_scrolling_state.main_thread_wheel_event_regions) {
-        auto position_in_context = visual_context_tree.transform_point_for_hit_test(region.visual_context_index, position, scroll_state_snapshot);
-        if (position_in_context.has_value() && region.rect.contains(*position_in_context))
-            return true;
-    }
-    return false;
-}
-
-static bool scroll_node_can_scroll_by_delta(AsyncScrollNode const& node, Gfx::FloatPoint delta)
-{
-    if (delta.x() < 0 && node.scroll_offset.x() > 0)
-        return true;
-    if (delta.x() > 0 && node.scroll_offset.x() < node.max_scroll_offset.x())
-        return true;
-    if (delta.y() < 0 && node.scroll_offset.y() > 0)
-        return true;
-    if (delta.y() > 0 && node.scroll_offset.y() < node.max_scroll_offset.y())
-        return true;
-    return false;
-}
-
-static bool has_scroll_node_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta)
+static WheelHitTestResult hit_test_scroll_node_at_position(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta)
 {
     if (!display_list)
-        return false;
+        return {};
 
-    auto const& visual_context_tree = display_list->visual_context_tree();
-    for (auto const& node : async_scrolling_state.scroll_nodes) {
-        if (!scroll_node_can_scroll_by_delta(node, delta))
-            continue;
-
-        auto scrollport_rect = node.is_viewport
-            ? Gfx::FloatRect { {}, async_scrolling_state.viewport_rect.size().to_type<float>() }
-            : visual_context_tree.transform_rect_to_viewport(node.hit_test_visual_context_index, node.scrollport_rect.to_type<float>(), scroll_state_snapshot);
-        if (scrollport_rect.contains(position))
-            return true;
-    }
-    return false;
+    AsyncScrollTree scroll_tree;
+    auto async_scrolling_state_copy = async_scrolling_state;
+    scroll_tree.set_state(move(async_scrolling_state_copy));
+    scroll_tree.rebuild_wheel_scroll_targets(display_list, scroll_state_snapshot);
+    return scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
 }
 
-WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool has_blocking_wheel_event_listeners, bool blocking_wheel_event_regions_are_current)
+WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const& async_scrolling_state, RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current)
 {
-    if (requires_main_thread_wheel_event_at_position(async_scrolling_state, display_list, scroll_state_snapshot, position))
+    auto hit_test_result = hit_test_scroll_node_at_position(async_scrolling_state, display_list, scroll_state_snapshot, position, delta);
+    if (hit_test_result.blocked_by_main_thread_region)
         return WheelScrollAdmission::BlockedByMainThreadRegion;
 
     // Async scrolling may only start when the snapshot can prove that the wheel event cannot be canceled by script
     // at this position. Stale or missing blocker information sends the event back to the main thread.
-    if (has_blocking_wheel_event_listeners) {
+    if (async_scrolling_state.has_blocking_wheel_event_listeners) {
         if (!blocking_wheel_event_regions_are_current)
             return WheelScrollAdmission::StaleBlockingWheelEventRegions;
         if (blocks_wheel_event_at_position(async_scrolling_state, display_list, scroll_state_snapshot, position))
             return WheelScrollAdmission::BlockedByWheelEventRegion;
     }
 
-    if (!has_scroll_node_at_position(async_scrolling_state, display_list, scroll_state_snapshot, position, delta))
+    if (!hit_test_result.node_id.has_value())
         return WheelScrollAdmission::NoScrollableTarget;
     return WheelScrollAdmission::Accepted;
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -33,7 +33,6 @@ struct AsyncScrollNode {
     Optional<AsyncScrollNodeID> parent_node_id;
     Painting::VisualContextIndex hit_test_visual_context_index;
     Gfx::IntRect scrollport_rect;
-    Gfx::FloatPoint scroll_offset;
     Gfx::FloatPoint max_scroll_offset;
     bool is_viewport { false };
 };
@@ -83,8 +82,6 @@ struct ViewportScrollbar {
     bool vertical { false };
 };
 
-// Snapshot of scroll-related paint data that the compositor can read without touching DOM, layout, or paintables.
-// It is immutable once collected on the main thread; AsyncScrollTree keeps the mutable compositor-side scroll offsets.
 struct AsyncScrollingState {
     Vector<AsyncScrollNode> scroll_nodes;
     Vector<AsyncStickyArea> sticky_areas;
@@ -102,7 +99,6 @@ struct AsyncScrollingState {
     // added.
     u64 wheel_event_listener_state_generation { 0 };
     bool has_blocking_wheel_event_listeners { false };
-    bool blocking_wheel_event_regions_are_current { false };
     bool has_blocking_wheel_event_region_covering_viewport { false };
 };
 
@@ -122,11 +118,13 @@ enum class WheelScrollAdmission {
     BlockedByWheelEventRegion,
 };
 
-AsyncScrollingState collect_async_scrolling_state(HTML::Navigable&, Painting::ViewportPaintable&, Gfx::IntRect viewport_rect);
+void initialize_async_scrolling_metadata_recording(DisplayListRecordingContext&, Painting::ViewportPaintable&);
+void record_async_scrolling_metadata_for_paintable(Painting::PaintableBox const&, DisplayListRecordingContext&);
+void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext&, HTML::Navigable&, Gfx::IntRect viewport_rect);
+AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const&);
 WheelRoutingAdmission wheel_routing_admission_for(AsyncScrollingState const&);
 StringView wheel_routing_admission_to_string(WheelRoutingAdmission);
 bool blocks_wheel_event_at_position(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position);
-bool requires_main_thread_wheel_event_at_position(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position);
-WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool has_blocking_wheel_event_listeners, bool blocking_wheel_event_regions_are_current);
+WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current);
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -59,7 +59,6 @@ struct BackingStoreState {
 struct UpdateDisplayListCommand {
     NonnullRefPtr<Painting::DisplayList> display_list;
     Painting::ScrollStateSnapshot scroll_state_snapshot;
-    Optional<AsyncScrollingState> async_scrolling_state;
 };
 
 struct AsyncScrollByCommand {
@@ -401,11 +400,11 @@ public:
     {
         Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
         auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
-        if (!scroll_target.has_value())
+        if (scroll_target.blocked_by_main_thread_region || !scroll_target.node_id.has_value())
             return {};
-        if (!m_async_scroll_tree.scroll_node_is_viewport(*scroll_target))
+        if (!m_async_scroll_tree.scroll_node_is_viewport(*scroll_target.node_id))
             return { {}, true };
-        return { scroll_target, false };
+        return { scroll_target.node_id, false };
     }
 
     bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect)
@@ -476,7 +475,7 @@ public:
         Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
         for (size_t i = 0; i < m_viewport_scrollbars.size(); ++i) {
             auto const& scrollbar = m_viewport_scrollbars[i];
-            auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+            auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
             if (!scroll_offset.has_value())
                 continue;
 
@@ -508,7 +507,7 @@ public:
                 Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
                 for (size_t i = 0; i < m_viewport_scrollbars.size(); ++i) {
                     auto const& scrollbar = m_viewport_scrollbars[i];
-                    auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+                    auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
                     if (!scroll_offset.has_value())
                         continue;
 
@@ -637,71 +636,55 @@ public:
                 bool should_yield_to_async_scroll_present = false;
                 command->visit(
                     [this](UpdateDisplayListCommand& cmd) {
-                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing display list update (has_async_state={}, raster_tasks={}, deferred_async_present={})",
-                            cmd.async_scrolling_state.has_value(), m_queued_rasterization_tasks.load(), m_has_deferred_async_scroll_present);
+                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing display list update (raster_tasks={}, deferred_async_present={})",
+                            m_queued_rasterization_tasks.load(), m_has_deferred_async_scroll_present);
                         m_cached_display_list = move(cmd.display_list);
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
-                        if (cmd.async_scrolling_state.has_value()) {
-                            auto async_scrolling_state = cmd.async_scrolling_state.release_value();
-                            auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
-                            auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
-                            auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
-                            {
-                                Sync::MutexLocker const locker { m_mutex };
-                                if (wheel_event_listener_state_generation < m_wheel_event_listener_state_generation)
-                                    wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
-                                else
-                                    m_wheel_event_listener_state_generation = wheel_event_listener_state_generation;
-                                m_wheel_routing_admission = wheel_routing_admission;
-                            }
-                            m_can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
-                            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor wheel routing admission: {} (scroll_nodes={}, sticky_areas={}, blocking_regions={})",
-                                wheel_routing_admission_to_string(wheel_routing_admission),
-                                async_scrolling_state.scroll_nodes.size(),
-                                async_scrolling_state.sticky_areas.size(),
-                                async_scrolling_state.blocking_wheel_event_regions.size());
-                            auto viewport_node = viewport_scroll_node(async_scrolling_state);
-                            auto pending_async_viewport_scroll_offset = [this] {
-                                Sync::MutexLocker const locker { m_mutex };
-                                return m_pending_async_viewport_scroll_offset;
-                            }();
-
-                            {
-                                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                                auto hovered_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_hovered_viewport_scrollbar_index);
-                                auto captured_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_captured_viewport_scrollbar_index);
-                                m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
-                                m_hovered_viewport_scrollbar_index = hovered_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *hovered_scrollbar_identity) : Optional<size_t> {};
-                                m_captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
-                                m_async_scroll_tree.set_state(move(async_scrolling_state));
-                                if (viewport_node.has_value() && pending_async_viewport_scroll_offset.has_value()) {
-                                    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying pending async viewport offset {},{} to display list update",
-                                        pending_async_viewport_scroll_offset->x(), pending_async_viewport_scroll_offset->y());
-                                    if (auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(viewport_node->node_id, *pending_async_viewport_scroll_offset, m_cached_scroll_state_snapshot); reconciled_scroll_offset.has_value())
-                                        async_scrolling_viewport_rect.set_location(reconciled_scroll_offset->to_type<int>());
-                                }
-                                m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
-                            }
-                            {
-                                Sync::MutexLocker const locker { m_mutex };
-                                m_async_scrolling_viewport_rect = async_scrolling_viewport_rect;
-                            }
-                            m_has_async_scrolling_state = true;
-                        } else {
-                            {
-                                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                                m_viewport_scrollbars.clear();
-                                m_hovered_viewport_scrollbar_index.clear();
-                                m_captured_viewport_scrollbar_index.clear();
-                                m_async_scroll_tree.clear_wheel_scroll_targets();
-                            }
-                            m_has_async_scrolling_state = false;
-                            m_can_accept_async_wheel_events = false;
-                            {
-                                Sync::MutexLocker const locker { m_mutex };
-                                m_wheel_routing_admission = WheelRoutingAdmission::NoAsyncScrollingState;
-                            }
+                        auto async_scrolling_state = async_scrolling_state_from_display_list(*m_cached_display_list);
+                        auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
+                        auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
+                        auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
+                        {
+                            Sync::MutexLocker const locker { m_mutex };
+                            if (wheel_event_listener_state_generation < m_wheel_event_listener_state_generation)
+                                wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
+                            else
+                                m_wheel_event_listener_state_generation = wheel_event_listener_state_generation;
+                            m_wheel_routing_admission = wheel_routing_admission;
                         }
+                        m_can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
+                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor wheel routing admission: {} (scroll_nodes={}, sticky_areas={}, blocking_regions={})",
+                            wheel_routing_admission_to_string(wheel_routing_admission),
+                            async_scrolling_state.scroll_nodes.size(),
+                            async_scrolling_state.sticky_areas.size(),
+                            async_scrolling_state.blocking_wheel_event_regions.size());
+                        auto viewport_node = viewport_scroll_node(async_scrolling_state);
+                        auto pending_async_viewport_scroll_offset = [this] {
+                            Sync::MutexLocker const locker { m_mutex };
+                            return m_pending_async_viewport_scroll_offset;
+                        }();
+
+                        {
+                            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                            auto hovered_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_hovered_viewport_scrollbar_index);
+                            auto captured_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_captured_viewport_scrollbar_index);
+                            m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
+                            m_hovered_viewport_scrollbar_index = hovered_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *hovered_scrollbar_identity) : Optional<size_t> {};
+                            m_captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
+                            m_async_scroll_tree.set_state(move(async_scrolling_state));
+                            if (viewport_node.has_value() && pending_async_viewport_scroll_offset.has_value()) {
+                                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying pending async viewport offset {},{} to display list update",
+                                    pending_async_viewport_scroll_offset->x(), pending_async_viewport_scroll_offset->y());
+                                if (auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(viewport_node->node_id, *pending_async_viewport_scroll_offset, m_cached_scroll_state_snapshot); reconciled_scroll_offset.has_value())
+                                    async_scrolling_viewport_rect.set_location(reconciled_scroll_offset->to_type<int>());
+                            }
+                            m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                        }
+                        {
+                            Sync::MutexLocker const locker { m_mutex };
+                            m_async_scrolling_viewport_rect = async_scrolling_viewport_rect;
+                        }
+                        m_has_async_scrolling_state = true;
                     },
                     [this, &should_yield_to_async_scroll_present](AsyncScrollByCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing async scroll command at {},{} device delta {},{} (raster_tasks={}, deferred_async_present={})",
@@ -714,7 +697,7 @@ public:
                                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping async scroll command: scroll tree consumed no delta");
                                 return;
                             }
-                            scroll_offset = m_async_scroll_tree.scroll_offset_for_node(cmd.scroll_target);
+                            scroll_offset = m_async_scroll_tree.scroll_offset_for_node(cmd.scroll_target, m_cached_scroll_state_snapshot);
                             m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
                         }
                         if (scroll_offset.has_value()) {
@@ -898,7 +881,7 @@ private:
             if (scroll_size == 0)
                 return false;
 
-            auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+            auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
             if (!current_scroll_offset.has_value())
                 return false;
 
@@ -916,7 +899,7 @@ private:
 
             if (!m_async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, m_cached_scroll_state_snapshot))
                 return false;
-            scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id);
+            scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
             m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
         }
 
@@ -1431,12 +1414,7 @@ void CompositorThread::stop_presenting_to_client()
 
 void CompositorThread::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot), {} });
-}
-
-void CompositorThread::update_display_list_and_async_scrolling_state(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshot&& scroll_state_snapshot, AsyncScrollingState&& async_scrolling_state)
-{
-    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot), Optional<AsyncScrollingState> { move(async_scrolling_state) } });
+    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot) });
 }
 
 void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -23,8 +23,6 @@
 
 namespace Web::Compositor {
 
-struct AsyncScrollingState;
-
 class WEB_API CompositorThread {
     AK_MAKE_NONCOPYABLE(CompositorThread);
     AK_MAKE_NONMOVABLE(CompositorThread);
@@ -61,7 +59,6 @@ public:
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&);
     void update_scroll_state(Painting::ScrollStateSnapshot&&);
-    void update_display_list_and_async_scrolling_state(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&, AsyncScrollingState&&);
     void invalidate_wheel_event_listener_state(u64 generation);
     bool async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect);
     Optional<Gfx::FloatPoint> pending_async_viewport_scroll_offset() const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -71,6 +71,7 @@
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/TransitionEvent.h>
 #include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 #include <LibWeb/ContentSecurityPolicy/Policy.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
@@ -7666,8 +7667,11 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     context.set_should_paint_overlay(config.paint_overlay);
 
     auto& viewport_paintable = *paintable();
+    viewport_paintable.refresh_scroll_state();
+    Compositor::initialize_async_scrolling_metadata_recording(context, viewport_paintable);
 
     viewport_paintable.paint_all_phases(context);
+    Compositor::finalize_async_scrolling_metadata_recording(context, *navigable(), viewport_rect.to_type<int>());
 
     if (highlighted_node() && highlighted_node()->paintable()) {
         highlighted_node()->paintable()->paint_inspector_overlay(context);

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -95,7 +95,7 @@ size_t EventTarget::external_memory_size() const
     return size;
 }
 
-Vector<GC::Root<DOMEventListener>> EventTarget::event_listener_list()
+Vector<GC::Root<DOMEventListener>> EventTarget::event_listener_list() const
 {
     Vector<GC::Root<DOMEventListener>> list;
     if (!m_data)
@@ -198,12 +198,16 @@ static void invalidate_compositor_wheel_event_listener_state(EventTarget& event_
         return;
 
     if (auto* window = as_if<HTML::Window>(event_target)) {
-        window->associated_document().page().invalidate_compositor_wheel_event_listener_state();
+        auto& document = window->associated_document();
+        document.set_needs_to_record_display_list();
+        document.page().invalidate_compositor_wheel_event_listener_state();
         return;
     }
 
-    if (auto* node = as_if<Node>(event_target))
+    if (auto* node = as_if<Node>(event_target)) {
+        node->set_needs_repaint();
         node->document().page().invalidate_compositor_wheel_event_listener_state();
+    }
 }
 
 // https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener

--- a/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Libraries/LibWeb/DOM/EventTarget.h
@@ -44,7 +44,7 @@ public:
     void add_an_event_listener(DOMEventListener&);
     void remove_an_event_listener(DOMEventListener&);
 
-    Vector<GC::Root<DOMEventListener>> event_listener_list();
+    Vector<GC::Root<DOMEventListener>> event_listener_list() const;
 
     virtual bool has_activation_behavior() const;
     virtual void activation_behavior(Event const&);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -9,7 +9,6 @@
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/VisualViewport.h>
-#include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
@@ -3172,16 +3171,7 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
-        if (page().async_scrolling_enabled()) {
-            auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
-            auto async_scrolling_state = Compositor::collect_async_scrolling_state(*this, *document_paintable, viewport_rect);
-            m_rendering_thread.update_display_list_and_async_scrolling_state(
-                *display_list,
-                move(scroll_state_snapshot),
-                move(async_scrolling_state));
-        } else {
-            m_rendering_thread.update_display_list(*display_list, move(scroll_state_snapshot));
-        }
+        m_rendering_thread.update_display_list(*display_list, move(scroll_state_snapshot));
         m_needs_to_record_display_list = false;
         m_rendering_thread_display_list_paint_config = paint_config;
     } else {

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -624,33 +624,35 @@ void Internals::reset_style_invalidation_counters()
     window().associated_document().reset_style_invalidation_counters();
 }
 
-JS::Object* Internals::async_scrolling_state()
-{
-    auto& document = window().associated_document();
-    document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
+struct AsyncScrollingStateSnapshot {
+    Compositor::AsyncScrollingState state;
+    RefPtr<Painting::DisplayList> display_list;
+    RefPtr<Painting::ViewportPaintable> document_paintable;
+};
 
-    auto object = JS::Object::create(realm(), nullptr);
+static Optional<AsyncScrollingStateSnapshot> capture_async_scrolling_state(DOM::Document& document)
+{
+    document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
     auto navigable = document.navigable();
     auto document_paintable = document.paintable();
-    if (!navigable || !document_paintable) {
-        auto scroll_nodes = MUST(JS::Array::create(realm(), 0));
-        auto sticky_areas = MUST(JS::Array::create(realm(), 0));
-        object->define_direct_property("scrollNodeCount"_utf16_fly_string, JS::Value(0), JS::default_attributes);
-        object->define_direct_property("scrollNodes"_utf16_fly_string, scroll_nodes, JS::default_attributes);
-        object->define_direct_property("stickyAreaCount"_utf16_fly_string, JS::Value(0), JS::default_attributes);
-        object->define_direct_property("stickyAreas"_utf16_fly_string, sticky_areas, JS::default_attributes);
-        object->define_direct_property("hasBlockingWheelEventListeners"_utf16_fly_string, JS::Value(false), JS::default_attributes);
-        object->define_direct_property("blockingWheelEventRegionCount"_utf16_fly_string, JS::Value(0), JS::default_attributes);
-        object->define_direct_property("mainThreadWheelEventRegionCount"_utf16_fly_string, JS::Value(0), JS::default_attributes);
-        object->define_direct_property("wheelEventListenerStateGeneration"_utf16_fly_string, JS::Value(0), JS::default_attributes);
-        object->define_direct_property("blockingWheelEventRegionsAreCurrent"_utf16_fly_string, JS::Value(false), JS::default_attributes);
-        object->define_direct_property("hasBlockingWheelEventRegionCoveringViewport"_utf16_fly_string, JS::Value(false), JS::default_attributes);
-        return object;
-    }
+    if (!navigable || !document_paintable)
+        return {};
+    auto display_list = document.record_display_list(HTML::PaintConfig {});
+    if (!display_list)
+        return {};
+    return AsyncScrollingStateSnapshot {
+        .state = Compositor::async_scrolling_state_from_display_list(*display_list),
+        .display_list = display_list,
+        .document_paintable = document_paintable,
+    };
+}
 
-    document_paintable->refresh_scroll_state();
-    auto viewport_rect = page().css_to_device_rect(navigable->viewport_rect()).to_type<int>();
-    auto state = Compositor::collect_async_scrolling_state(*navigable, *document_paintable, viewport_rect);
+JS::Object* Internals::async_scrolling_state()
+{
+    auto object = JS::Object::create(realm(), nullptr);
+    auto snapshot = capture_async_scrolling_state(window().associated_document());
+    Compositor::AsyncScrollingState empty_state;
+    auto const& state = snapshot.has_value() ? snapshot->state : empty_state;
 
     auto scroll_nodes = MUST(JS::Array::create(realm(), state.scroll_nodes.size()));
     for (size_t i = 0; i < state.scroll_nodes.size(); ++i) {
@@ -687,26 +689,17 @@ JS::Object* Internals::async_scrolling_state()
     object->define_direct_property("blockingWheelEventRegionCount"_utf16_fly_string, JS::Value(state.blocking_wheel_event_regions.size()), JS::default_attributes);
     object->define_direct_property("mainThreadWheelEventRegionCount"_utf16_fly_string, JS::Value(state.main_thread_wheel_event_regions.size()), JS::default_attributes);
     object->define_direct_property("wheelEventListenerStateGeneration"_utf16_fly_string, JS::Value(state.wheel_event_listener_state_generation), JS::default_attributes);
-    object->define_direct_property("blockingWheelEventRegionsAreCurrent"_utf16_fly_string, JS::Value(state.blocking_wheel_event_regions_are_current), JS::default_attributes);
+    object->define_direct_property("blockingWheelEventRegionsAreCurrent"_utf16_fly_string, JS::Value(state.has_blocking_wheel_event_listeners), JS::default_attributes);
     object->define_direct_property("hasBlockingWheelEventRegionCoveringViewport"_utf16_fly_string, JS::Value(state.has_blocking_wheel_event_region_covering_viewport), JS::default_attributes);
     return object;
 }
 
 bool Internals::async_scrolling_state_blocks_wheel_event_at(double x, double y)
 {
-    auto& document = window().associated_document();
-    document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
-
-    auto navigable = document.navigable();
-    auto document_paintable = document.paintable();
-    if (!navigable || !document_paintable)
+    auto snapshot = capture_async_scrolling_state(window().associated_document());
+    if (!snapshot.has_value())
         return false;
-
-    auto display_list = document.record_display_list(HTML::PaintConfig {});
-    document_paintable->refresh_scroll_state();
-    auto viewport_rect = page().css_to_device_rect(navigable->viewport_rect()).to_type<int>();
-    auto state = Compositor::collect_async_scrolling_state(*navigable, *document_paintable, viewport_rect);
-    return Compositor::blocks_wheel_event_at_position(state, display_list, document_paintable->scroll_state_snapshot(), { static_cast<float>(x), static_cast<float>(y) });
+    return Compositor::blocks_wheel_event_at_position(snapshot->state, snapshot->display_list, snapshot->document_paintable->scroll_state_snapshot(), { static_cast<float>(x), static_cast<float>(y) });
 }
 
 bool Internals::async_scrolling_state_can_wheel_scroll_at(double x, double y, double delta_x, double delta_y, bool force_stale_wheel_event_regions)
@@ -716,20 +709,9 @@ bool Internals::async_scrolling_state_can_wheel_scroll_at(double x, double y, do
 
 String Internals::async_scrolling_state_wheel_routing_admission()
 {
-    auto& document = window().associated_document();
-    document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
-
-    auto navigable = document.navigable();
-    auto document_paintable = document.paintable();
-    if (!navigable || !document_paintable)
-        return String::from_utf8_without_validation(
-            Compositor::wheel_routing_admission_to_string(Compositor::WheelRoutingAdmission::NoAsyncScrollingState).bytes());
-
-    document_paintable->refresh_scroll_state();
-    auto viewport_rect = page().css_to_device_rect(navigable->viewport_rect()).to_type<int>();
-    auto state = Compositor::collect_async_scrolling_state(*navigable, *document_paintable, viewport_rect);
-    return String::from_utf8_without_validation(
-        Compositor::wheel_routing_admission_to_string(Compositor::wheel_routing_admission_for(state)).bytes());
+    auto snapshot = capture_async_scrolling_state(window().associated_document());
+    auto admission = snapshot.has_value() ? Compositor::wheel_routing_admission_for(snapshot->state) : Compositor::WheelRoutingAdmission::NoAsyncScrollingState;
+    return String::from_utf8_without_validation(Compositor::wheel_routing_admission_to_string(admission).bytes());
 }
 
 static String wheel_scroll_admission_to_string(Compositor::WheelScrollAdmission admission)
@@ -751,55 +733,35 @@ static String wheel_scroll_admission_to_string(Compositor::WheelScrollAdmission 
 
 String Internals::async_scrolling_state_wheel_scroll_admission_at(double x, double y, double delta_x, double delta_y, bool force_stale_wheel_event_regions)
 {
-    auto& document = window().associated_document();
-    document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
-
-    auto navigable = document.navigable();
-    auto document_paintable = document.paintable();
-    if (!navigable || !document_paintable)
+    auto snapshot = capture_async_scrolling_state(window().associated_document());
+    if (!snapshot.has_value())
         return "no-scrollable-target"_string;
-
-    auto display_list = document.record_display_list(HTML::PaintConfig {});
-    document_paintable->refresh_scroll_state();
-    auto viewport_rect = page().css_to_device_rect(navigable->viewport_rect()).to_type<int>();
-    auto state = Compositor::collect_async_scrolling_state(*navigable, *document_paintable, viewport_rect);
     auto admission = Compositor::admit_wheel_scroll(
-        state,
-        display_list,
-        document_paintable->scroll_state_snapshot(),
+        snapshot->state,
+        snapshot->display_list,
+        snapshot->document_paintable->scroll_state_snapshot(),
         { static_cast<float>(x), static_cast<float>(y) },
         { static_cast<float>(delta_x), static_cast<float>(delta_y) },
-        state.has_blocking_wheel_event_listeners,
-        state.blocking_wheel_event_regions_are_current && !force_stale_wheel_event_regions);
+        snapshot->state.has_blocking_wheel_event_listeners && !force_stale_wheel_event_regions);
     return wheel_scroll_admission_to_string(admission);
 }
 
 String Internals::async_scrolling_state_wheel_target_at(double x, double y, double delta_x, double delta_y)
 {
-    auto& document = window().associated_document();
-    document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
-
-    auto navigable = document.navigable();
-    auto document_paintable = document.paintable();
-    if (!navigable || !document_paintable)
+    auto snapshot = capture_async_scrolling_state(window().associated_document());
+    if (!snapshot.has_value())
         return "none"_string;
 
-    auto display_list = document.record_display_list(HTML::PaintConfig {});
-    document_paintable->refresh_scroll_state();
-    auto scroll_state_snapshot = document_paintable->scroll_state_snapshot();
-    auto viewport_rect = page().css_to_device_rect(navigable->viewport_rect()).to_type<int>();
-    auto state = Compositor::collect_async_scrolling_state(*navigable, *document_paintable, viewport_rect);
-
     Compositor::AsyncScrollTree scroll_tree;
-    scroll_tree.set_state(move(state));
-    scroll_tree.rebuild_wheel_scroll_targets(display_list, scroll_state_snapshot);
+    scroll_tree.set_state(move(snapshot->state));
+    scroll_tree.rebuild_wheel_scroll_targets(snapshot->display_list, snapshot->document_paintable->scroll_state_snapshot());
 
     auto target = scroll_tree.hit_test_scroll_node_for_wheel(
         { static_cast<float>(x), static_cast<float>(y) },
         { static_cast<float>(delta_x), static_cast<float>(delta_y) });
-    if (!target.has_value())
+    if (target.blocked_by_main_thread_region || !target.node_id.has_value())
         return "none"_string;
-    if (scroll_tree.scroll_node_is_viewport(*target))
+    if (scroll_tree.scroll_node_is_viewport(*target.node_id))
         return "viewport"_string;
     return "non-viewport"_string;
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -13,7 +13,6 @@
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/Bindings/InputEvent.h>
 #include <LibWeb/CSS/VisualViewport.h>
-#include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/EditingHostManager.h>
 #include <LibWeb/DOM/Element.h>
@@ -105,39 +104,6 @@ static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, GC
         node = layout_node->dom_node();
     }
     return node && layout_node;
-}
-
-static bool async_scrolling_state_has_scrollable_viewport_node(Compositor::AsyncScrollingState const& async_scrolling_state, Gfx::FloatPoint delta, Optional<Gfx::FloatPoint> pending_async_viewport_scroll_offset)
-{
-    for (auto const& node : async_scrolling_state.scroll_nodes) {
-        if (!node.is_viewport)
-            continue;
-
-        auto scroll_offset = pending_async_viewport_scroll_offset.value_or(node.scroll_offset);
-        if (delta.x() < 0 && scroll_offset.x() > 0)
-            return true;
-        if (delta.x() > 0 && scroll_offset.x() < node.max_scroll_offset.x())
-            return true;
-        if (delta.y() < 0 && scroll_offset.y() > 0)
-            return true;
-        if (delta.y() > 0 && scroll_offset.y() < node.max_scroll_offset.y())
-            return true;
-    }
-    return false;
-}
-
-static bool target_is_inside_non_viewport_wheel_scrollable_box(Painting::Paintable const& target)
-{
-    for (RefPtr<Painting::Paintable const> paintable = target; paintable; paintable = paintable->containing_block()) {
-        auto const* paintable_box = as_if<Painting::PaintableBox const>(*paintable);
-        if (!paintable_box)
-            continue;
-        if (paintable_box->is_viewport_paintable())
-            return false;
-        if (paintable_box->could_be_scrolled_by_wheel_event())
-            return true;
-    }
-    return false;
 }
 
 static Gfx::Cursor css_to_gfx_cursor(CSS::CursorPredefined css_cursor)
@@ -612,7 +578,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     if (!document->is_fully_active())
         return EventResult::Dropped;
 
-    auto viewport_position = document->visual_viewport()->map_to_layout_viewport(visual_viewport_position);
+    auto visual_viewport = document->visual_viewport();
+    auto viewport_position = visual_viewport->map_to_layout_viewport(visual_viewport_position);
 
     document->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseWheel);
 
@@ -628,22 +595,12 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
 
     if (m_navigable->page().async_scrolling_enabled() && async_scroll_performed_default_action) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: default action already performed");
+    } else if (m_navigable->page().async_scrolling_enabled() && visual_viewport->scale() != 1.0) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: visual viewport is scaled");
     } else if (m_navigable->page().async_scrolling_enabled()) {
-        auto& document_paintable = *document->paintable();
-        document_paintable.refresh_scroll_state();
-        auto viewport_rect = m_navigable->page().css_to_device_rect(m_navigable->viewport_rect()).to_type<int>();
-        auto async_scrolling_state = Compositor::collect_async_scrolling_state(*m_navigable, document_paintable, viewport_rect);
-        auto async_scroll_delta = Gfx::FloatPoint { static_cast<float>(wheel_delta_x), static_cast<float>(wheel_delta_y) };
-        auto pending_async_viewport_scroll_offset = m_navigable->rendering_thread().pending_async_viewport_scroll_offset();
-        // Non-passive wheel listeners can cancel the default scroll action, so the first live async path only handles
-        // pages where the current snapshot proves that no such listener exists anywhere in this page. Everything else
-        // stays on the synchronous path.
-        auto can_try_async_viewport_scroll = paintable
-            && !is<Painting::NavigableContainerViewportPaintable>(*paintable)
-            && !target_is_inside_non_viewport_wheel_scrollable_box(*paintable)
-            && !async_scrolling_state.has_blocking_wheel_event_listeners
-            && async_scrolling_state_has_scrollable_viewport_node(async_scrolling_state, async_scroll_delta, pending_async_viewport_scroll_offset);
-        if (can_try_async_viewport_scroll) {
+        if (paintable) {
+            auto viewport_rect = m_navigable->page().css_to_device_rect(m_navigable->viewport_rect()).to_type<int>();
+            auto async_scroll_delta = Gfx::FloatPoint { static_cast<float>(wheel_delta_x), static_cast<float>(wheel_delta_y) };
             auto device_position = m_navigable->page().css_to_device_point(visual_viewport_position);
             auto async_scroll_position = Gfx::FloatPoint { static_cast<float>(device_position.x().value()), static_cast<float>(device_position.y().value()) };
             auto device_pixels_per_css_pixel = static_cast<float>(m_navigable->page().client().device_pixels_per_css_pixel());
@@ -655,15 +612,6 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 async_scroll_delta_in_device_pixels.x(), async_scroll_delta_in_device_pixels.y());
         } else if (!paintable) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: no paintable target");
-        } else if (is<Painting::NavigableContainerViewportPaintable>(*paintable)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: target is a nested navigable");
-        } else if (target_is_inside_non_viewport_wheel_scrollable_box(*paintable)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: target is inside a nested scroll container");
-        } else if (async_scrolling_state.has_blocking_wheel_event_listeners) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: blocking wheel event listeners exist");
-        } else {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: viewport cannot scroll by delta {},{}",
-                async_scroll_delta.x(), async_scroll_delta.y());
         }
     }
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -119,6 +119,11 @@ private:
     virtual void draw_rect(DrawRect const&) = 0;
     virtual void add_rounded_rect_clip(AddRoundedRectClip const&) = 0;
     virtual void paint_nested_display_list(PaintNestedDisplayList const&) = 0;
+    virtual void compositor_scroll_node(CompositorScrollNode const&) = 0;
+    virtual void compositor_sticky_area(CompositorStickyArea const&) = 0;
+    virtual void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&) = 0;
+    virtual void compositor_viewport_scrollbar(CompositorViewportScrollbar const&) = 0;
+    virtual void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&) = 0;
     virtual void paint_scrollbar(PaintScrollBar const&) = 0;
     virtual void apply_effects(ApplyEffects const&, Gfx::Filter const* = nullptr) = 0;
     virtual void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) = 0;
@@ -133,6 +138,13 @@ private:
 
 class DisplayList : public AtomicRefCounted<DisplayList> {
 public:
+    struct AsyncScrollingMetadata {
+        Gfx::IntRect viewport_rect;
+        u64 wheel_event_listener_state_generation { 0 };
+        bool has_blocking_wheel_event_listeners { false };
+        bool has_blocking_wheel_event_region_covering_viewport { false };
+    };
+
     static NonnullRefPtr<DisplayList> create(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
     {
         return adopt_ref(*new DisplayList(move(visual_context_tree), DisplayListResourceStorage {}));
@@ -163,6 +175,8 @@ public:
     ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
     DisplayListResourceStorage& resource_storage() { return m_resource_storage; }
     DisplayListResourceStorage const& resource_storage() const { return m_resource_storage; }
+    void set_async_scrolling_metadata(AsyncScrollingMetadata metadata) { m_async_scrolling_metadata = metadata; }
+    Optional<AsyncScrollingMetadata> const& async_scrolling_metadata() const { return m_async_scrolling_metadata; }
 
     template<typename Callback>
     static void for_each_command_header(ReadonlyBytes command_bytes, Callback callback)
@@ -213,6 +227,7 @@ private:
     DisplayListResourceStorage m_resource_storage;
     u64 m_id { 0 };
     ByteBuffer m_command_bytes;
+    Optional<AsyncScrollingMetadata> m_async_scrolling_metadata;
 };
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -151,6 +151,49 @@ void PaintNestedDisplayList::dump(StringBuilder& builder) const
     builder.appendff(" rect={}", rect);
 }
 
+void CompositorScrollNode::dump(StringBuilder& builder) const
+{
+    builder.appendff(" scroll_frame_index={} parent_scroll_frame_index={} scrollport_rect={} max_scroll_offset={} is_viewport={}",
+        scroll_frame_index, parent_scroll_frame_index, scrollport_rect, max_scroll_offset, is_viewport);
+}
+
+static void dump_optional_float(StringBuilder& builder, Optional<float> value)
+{
+    if (value.has_value())
+        builder.appendff("{}", *value);
+    else
+        builder.append("none"sv);
+}
+
+void CompositorStickyArea::dump(StringBuilder& builder) const
+{
+    builder.appendff(" scroll_frame_index={} parent_scroll_frame_index={} nearest_scrolling_ancestor_index={} position_relative_to_scroll_ancestor={} border_box_size={} scrollport_size={} containing_block_region={} needs_parent_offset_adjustment={} inset_top=",
+        scroll_frame_index, parent_scroll_frame_index, nearest_scrolling_ancestor_index, position_relative_to_scroll_ancestor, border_box_size, scrollport_size, containing_block_region, needs_parent_offset_adjustment);
+    dump_optional_float(builder, inset_top);
+    builder.append(" inset_right="sv);
+    dump_optional_float(builder, inset_right);
+    builder.append(" inset_bottom="sv);
+    dump_optional_float(builder, inset_bottom);
+    builder.append(" inset_left="sv);
+    dump_optional_float(builder, inset_left);
+}
+
+void CompositorBlockingWheelEventRegion::dump(StringBuilder& builder) const
+{
+    builder.appendff(" rect={}", rect);
+}
+
+void CompositorMainThreadWheelEventRegion::dump(StringBuilder& builder) const
+{
+    builder.appendff(" rect={}", rect);
+}
+
+void CompositorViewportScrollbar::dump(StringBuilder& builder) const
+{
+    builder.appendff(" scroll_frame_index={} gutter_rect={} thumb_rect={} expanded_gutter_rect={} expanded_thumb_rect={} scroll_size={} expanded_scroll_size={} max_scroll_offset={} thumb_color={} track_color={} vertical={}",
+        scroll_frame_index, gutter_rect, thumb_rect, expanded_gutter_rect, expanded_thumb_rect, scroll_size, expanded_scroll_size, max_scroll_offset, thumb_color, track_color, vertical);
+}
+
 void PaintScrollBar::dump(StringBuilder&) const
 {
 }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -24,6 +24,7 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 #include <LibWeb/Painting/ScrollState.h>
@@ -32,35 +33,40 @@ namespace Web::Painting {
 
 class DisplayList;
 
-#define ENUMERATE_DISPLAY_LIST_COMMANDS(V)                              \
-    V(DrawGlyphRun, draw_glyph_run)                                     \
-    V(FillRect, fill_rect)                                              \
-    V(DrawScaledDecodedImageFrame, draw_scaled_decoded_image_frame)     \
-    V(DrawRepeatedDecodedImageFrame, draw_repeated_decoded_image_frame) \
-    V(DrawExternalContent, draw_external_content)                       \
-    V(DrawVideoFrameSource, draw_video_frame_source)                    \
-    V(Save, save)                                                       \
-    V(SaveLayer, save_layer)                                            \
-    V(Restore, restore)                                                 \
-    V(Translate, translate)                                             \
-    V(AddClipRect, add_clip_rect)                                       \
-    V(PaintLinearGradient, paint_linear_gradient)                       \
-    V(PaintRadialGradient, paint_radial_gradient)                       \
-    V(PaintConicGradient, paint_conic_gradient)                         \
-    V(PaintOuterBoxShadow, paint_outer_box_shadow)                      \
-    V(PaintInnerBoxShadow, paint_inner_box_shadow)                      \
-    V(PaintTextShadow, paint_text_shadow)                               \
-    V(FillRectWithRoundedCorners, fill_rect_with_rounded_corners)       \
-    V(FillPath, fill_path)                                              \
-    V(StrokePath, stroke_path)                                          \
-    V(DrawEllipse, draw_ellipse)                                        \
-    V(FillEllipse, fill_ellipse)                                        \
-    V(DrawLine, draw_line)                                              \
-    V(ApplyBackdropFilter, apply_backdrop_filter)                       \
-    V(DrawRect, draw_rect)                                              \
-    V(AddRoundedRectClip, add_rounded_rect_clip)                        \
-    V(PaintNestedDisplayList, paint_nested_display_list)                \
-    V(PaintScrollBar, paint_scrollbar)                                  \
+#define ENUMERATE_DISPLAY_LIST_COMMANDS(V)                                             \
+    V(DrawGlyphRun, draw_glyph_run)                                                    \
+    V(FillRect, fill_rect)                                                             \
+    V(DrawScaledDecodedImageFrame, draw_scaled_decoded_image_frame)                    \
+    V(DrawRepeatedDecodedImageFrame, draw_repeated_decoded_image_frame)                \
+    V(DrawExternalContent, draw_external_content)                                      \
+    V(DrawVideoFrameSource, draw_video_frame_source)                                   \
+    V(Save, save)                                                                      \
+    V(SaveLayer, save_layer)                                                           \
+    V(Restore, restore)                                                                \
+    V(Translate, translate)                                                            \
+    V(AddClipRect, add_clip_rect)                                                      \
+    V(PaintLinearGradient, paint_linear_gradient)                                      \
+    V(PaintRadialGradient, paint_radial_gradient)                                      \
+    V(PaintConicGradient, paint_conic_gradient)                                        \
+    V(PaintOuterBoxShadow, paint_outer_box_shadow)                                     \
+    V(PaintInnerBoxShadow, paint_inner_box_shadow)                                     \
+    V(PaintTextShadow, paint_text_shadow)                                              \
+    V(FillRectWithRoundedCorners, fill_rect_with_rounded_corners)                      \
+    V(FillPath, fill_path)                                                             \
+    V(StrokePath, stroke_path)                                                         \
+    V(DrawEllipse, draw_ellipse)                                                       \
+    V(FillEllipse, fill_ellipse)                                                       \
+    V(DrawLine, draw_line)                                                             \
+    V(ApplyBackdropFilter, apply_backdrop_filter)                                      \
+    V(DrawRect, draw_rect)                                                             \
+    V(AddRoundedRectClip, add_rounded_rect_clip)                                       \
+    V(PaintNestedDisplayList, paint_nested_display_list)                               \
+    V(CompositorScrollNode, compositor_scroll_node)                                    \
+    V(CompositorStickyArea, compositor_sticky_area)                                    \
+    V(CompositorMainThreadWheelEventRegion, compositor_main_thread_wheel_event_region) \
+    V(CompositorViewportScrollbar, compositor_viewport_scrollbar)                      \
+    V(CompositorBlockingWheelEventRegion, compositor_blocking_wheel_event_region)      \
+    V(PaintScrollBar, paint_scrollbar)                                                 \
     V(ApplyEffects, apply_effects)
 
 enum class DisplayListCommandType : u8 {
@@ -496,6 +502,79 @@ struct PaintNestedDisplayList {
     Gfx::IntRect rect;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
+
+    void dump(StringBuilder&) const;
+};
+
+struct CompositorScrollNode {
+    static constexpr StringView command_name = "CompositorScrollNode"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorScrollNode;
+
+    UniqueNodeID document_id;
+    ScrollFrameIndex scroll_frame_index;
+    ScrollFrameIndex parent_scroll_frame_index;
+    Gfx::IntRect scrollport_rect;
+    Gfx::FloatPoint max_scroll_offset;
+    bool is_viewport { false };
+
+    void dump(StringBuilder&) const;
+};
+
+struct CompositorStickyArea {
+    static constexpr StringView command_name = "CompositorStickyArea"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorStickyArea;
+
+    UniqueNodeID document_id;
+    ScrollFrameIndex scroll_frame_index;
+    ScrollFrameIndex parent_scroll_frame_index;
+    ScrollFrameIndex nearest_scrolling_ancestor_index;
+    Gfx::FloatPoint position_relative_to_scroll_ancestor;
+    Gfx::FloatSize border_box_size;
+    Gfx::FloatSize scrollport_size;
+    Gfx::FloatRect containing_block_region;
+    bool needs_parent_offset_adjustment { false };
+    Optional<float> inset_top;
+    Optional<float> inset_right;
+    Optional<float> inset_bottom;
+    Optional<float> inset_left;
+
+    void dump(StringBuilder&) const;
+};
+
+struct CompositorBlockingWheelEventRegion {
+    static constexpr StringView command_name = "CompositorBlockingWheelEventRegion"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorBlockingWheelEventRegion;
+
+    Gfx::FloatRect rect;
+
+    void dump(StringBuilder&) const;
+};
+
+struct CompositorMainThreadWheelEventRegion {
+    static constexpr StringView command_name = "CompositorMainThreadWheelEventRegion"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorMainThreadWheelEventRegion;
+
+    Gfx::FloatRect rect;
+
+    void dump(StringBuilder&) const;
+};
+
+struct CompositorViewportScrollbar {
+    static constexpr StringView command_name = "CompositorViewportScrollbar"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorViewportScrollbar;
+
+    UniqueNodeID document_id;
+    ScrollFrameIndex scroll_frame_index;
+    Gfx::IntRect gutter_rect;
+    Gfx::IntRect thumb_rect;
+    Gfx::IntRect expanded_gutter_rect;
+    Gfx::IntRect expanded_thumb_rect;
+    double scroll_size { 0 };
+    double expanded_scroll_size { 0 };
+    float max_scroll_offset { 0 };
+    Color thumb_color;
+    Color track_color;
+    bool vertical { false };
 
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -821,6 +821,26 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
     execute_nested_display_list(nested_display_list, scroll_state_snapshot, command_bytes);
 }
 
+void DisplayListPlayerSkia::compositor_scroll_node(CompositorScrollNode const&)
+{
+}
+
+void DisplayListPlayerSkia::compositor_sticky_area(CompositorStickyArea const&)
+{
+}
+
+void DisplayListPlayerSkia::compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&)
+{
+}
+
+void DisplayListPlayerSkia::compositor_viewport_scrollbar(CompositorViewportScrollbar const&)
+{
+}
+
+void DisplayListPlayerSkia::compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&)
+{
+}
+
 void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
 {
     auto gutter_rect = to_skia_rect(command.gutter_rect);

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -50,6 +50,11 @@ private:
     void paint_radial_gradient(PaintRadialGradient const&) override;
     void paint_conic_gradient(PaintConicGradient const&) override;
     void add_rounded_rect_clip(AddRoundedRectClip const&) override;
+    void compositor_scroll_node(CompositorScrollNode const&) override;
+    void compositor_sticky_area(CompositorStickyArea const&) override;
+    void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&) override;
+    void compositor_viewport_scrollbar(CompositorViewportScrollbar const&) override;
+    void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&) override;
     void paint_scrollbar(PaintScrollBar const&) override;
     void paint_nested_display_list(PaintNestedDisplayList const&) override;
     void apply_effects(ApplyEffects const&, Gfx::Filter const*) override;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -712,6 +712,36 @@ void DisplayListRecorder::paint_scrollbar(ScrollFrameIndex scroll_frame_index, G
         .vertical = vertical });
 }
 
+void DisplayListRecorder::compositor_scroll_node(CompositorScrollNode const& scroll_node)
+{
+    append_command(scroll_node);
+}
+
+void DisplayListRecorder::compositor_sticky_area(CompositorStickyArea const& sticky_area)
+{
+    append_command(sticky_area);
+}
+
+void DisplayListRecorder::set_async_scrolling_metadata(DisplayList::AsyncScrollingMetadata metadata)
+{
+    m_display_list.set_async_scrolling_metadata(metadata);
+}
+
+void DisplayListRecorder::compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const& region)
+{
+    append_command(region);
+}
+
+void DisplayListRecorder::compositor_viewport_scrollbar(CompositorViewportScrollbar const& scrollbar)
+{
+    append_command(scrollbar);
+}
+
+void DisplayListRecorder::compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const& region)
+{
+    append_command(region);
+}
+
 void DisplayListRecorder::apply_effects(float opacity, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Optional<Gfx::Filter> filter, Optional<Gfx::MaskKind> mask_kind)
 {
     CommandPayloadBuilder<ApplyEffects> payload_builder(m_display_list);

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -140,6 +140,13 @@ public:
 
     void paint_scrollbar(ScrollFrameIndex scroll_frame_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical);
 
+    void compositor_scroll_node(CompositorScrollNode const&);
+    void compositor_sticky_area(CompositorStickyArea const&);
+    void set_async_scrolling_metadata(DisplayList::AsyncScrollingMetadata);
+    void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&);
+    void compositor_viewport_scrollbar(CompositorViewportScrollbar const&);
+    void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&);
+
     void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {}, Optional<Gfx::MaskKind> mask_kind = {});
 
     DisplayListRecorder(DisplayList&);

--- a/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
@@ -17,6 +17,12 @@
 #include <LibWeb/Painting/DevicePixelConverter.h>
 #include <LibWeb/PixelUnits.h>
 
+namespace Web::Painting {
+
+class ScrollState;
+
+}
+
 namespace Web {
 
 class WEB_API DisplayListRecordingContext {
@@ -84,6 +90,25 @@ public:
     ChromeMetrics const& chrome_metrics() const { return m_chrome_metrics; }
     u64 paint_generation_id() const { return m_paint_generation_id; }
 
+    void set_async_scrolling_metadata_context(
+        UniqueNodeID document_id,
+        Painting::ScrollState const& scroll_state,
+        bool has_blocking_wheel_event_listeners,
+        bool has_blocking_wheel_event_region_covering_viewport)
+    {
+        m_async_scrolling_document_id = document_id;
+        m_async_scrolling_scroll_state = &scroll_state;
+        m_has_blocking_wheel_event_listeners = has_blocking_wheel_event_listeners;
+        m_has_blocking_wheel_event_region_covering_viewport = has_blocking_wheel_event_region_covering_viewport;
+    }
+
+    bool is_recording_async_scrolling_metadata() const { return m_async_scrolling_scroll_state != nullptr; }
+    UniqueNodeID async_scrolling_document_id() const { return m_async_scrolling_document_id; }
+    Painting::ScrollState const& async_scrolling_scroll_state() const { return *m_async_scrolling_scroll_state; }
+    bool has_blocking_wheel_event_listeners() const { return m_has_blocking_wheel_event_listeners; }
+    void set_has_blocking_wheel_event_listeners(bool value) { m_has_blocking_wheel_event_listeners = value; }
+    bool has_blocking_wheel_event_region_covering_viewport() const { return m_has_blocking_wheel_event_region_covering_viewport; }
+
 private:
     Painting::DisplayListRecorder& m_display_list_recorder;
     Palette m_palette;
@@ -95,6 +120,10 @@ private:
     bool m_draw_svg_geometry_for_clip_path { false };
     Gfx::AffineTransform m_svg_transform;
     u64 m_paint_generation_id { 0 };
+    UniqueNodeID m_async_scrolling_document_id {};
+    Painting::ScrollState const* m_async_scrolling_scroll_state { nullptr };
+    bool m_has_blocking_wheel_event_listeners { false };
+    bool m_has_blocking_wheel_event_region_covering_viewport { false };
 };
 
 }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -11,6 +11,7 @@
 #include <LibGfx/Font/Font.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/Navigable.h>
@@ -637,6 +638,9 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
 
 void PaintableBox::paint(DisplayListRecordingContext& context, PaintPhase phase) const
 {
+    if (phase == PaintPhase::Background)
+        Compositor::record_async_scrolling_metadata_for_paintable(*this, context);
+
     if (!is_visible())
         return;
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
@@ -3,3 +3,15 @@ transformed visual inside: true
 transformed original position: false
 clipped visible inside: true
 clipped overflow outside clip: false
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] transform=[1,0,0,1,100,0] origin=(20,20) (PaintableWithLines(BlockContainer<DIV>#transformed))
+    [3] clip=[20,160 100x100]
+      [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+
+DisplayList:
+SaveLayer@0
+  CompositorBlockingWheelEventRegion@2 rect=[20,20 100x100]
+  CompositorBlockingWheelEventRegion@4 rect=[20,160 200x100]
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
@@ -22,3 +22,16 @@ removed window listener:
   regions current: false
   viewport blocked: false
   blocking regions: 0
+display list after blocking element listener:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[0,0 200x200]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
+  CompositorBlockingWheelEventRegion@3 rect=[0,0 100x100]
+  PaintScrollBar@1
+  PaintScrollBar@1
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
@@ -1,3 +1,10 @@
 before routing admission: accepted
 listener generation increased: true
 after routing admission: blocking wheel event listeners
+display list:
+AccumulatedVisualContext Tree:
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
@@ -1,3 +1,16 @@
 main thread regions: 1
 over iframe: blocked-by-main-thread-region
 outside iframe: accepted
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
+  CompositorMainThreadWheelEventRegion@1 rect=[40,40 160x120]
+  Save@1
+    AddClipRect@1 rect=[40,40 160x120]
+    DrawExternalContent@1 dst_rect=[40,40 160x120]
+  Restore@1
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
@@ -1,2 +1,12 @@
 scroller scrollTop: 100
 window scrollY: 0
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  PaintScrollBar@1
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-metadata-cache-replay.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-metadata-cache-replay.txt
@@ -1,0 +1,7 @@
+window scrollY: 1000
+scroller scrollTop: 80
+wheel target near viewport top: viewport
+upward wheel target over scroller: non-viewport
+scroll metadata:
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,2501] is_viewport=true
+  CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
@@ -2,3 +2,16 @@ scroll nodes: 2
 child nodes: 1
 dangling parent nodes: 0
 child parent is viewport: true
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorStickyArea@2 scroll_frame_index=2 parent_scroll_frame_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x100] scrollport_size=[800x600] containing_block_region=[0,0 800x2100] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
+  CompositorScrollNode@2 scroll_frame_index=3 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
+  PaintScrollBar@2
+  PaintScrollBar@2
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
@@ -5,3 +5,14 @@ viewport parent: 0
 child nodes: 1
 child has same document as viewport: true
 child parent is viewport: true
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
+  PaintScrollBar@1
+  PaintScrollBar@1
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
@@ -6,3 +6,16 @@ outer ancestor is viewport: true
 inner ancestor is viewport: true
 outer has top inset only: true
 inner has top inset only: true
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+      [3] scroll_frame_id=3 (sticky) (PaintableWithLines(BlockContainer<DIV>#inner))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1431] is_viewport=true
+  CompositorStickyArea@2 scroll_frame_index=2 parent_scroll_frame_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x18] scrollport_size=[800x600] containing_block_region=[0,0 800x2018] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
+  CompositorStickyArea@3 scroll_frame_index=3 parent_scroll_frame_index=2 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x18] scrollport_size=[800x600] containing_block_region=[0,0 800x18] needs_parent_offset_adjustment=true inset_top=20 inset_right=none inset_bottom=none inset_left=none
+  DrawGlyphRun@3 rect=[0,0 45x18] translation=[0,13.796875] color=rgb(0, 0, 0)
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
@@ -2,3 +2,13 @@ scroll nodes: 2
 wheel routing admission: accepted
 viewport wheel target: viewport
 scroller wheel target: non-viewport
+display list:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  PaintScrollBar@1
+Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
@@ -6,3 +6,16 @@ blocking element listener outside: true
 stale blocking element regions: false
 blocking window listener: false
 stale blocking window regions: false
+display list after blocking element listener:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[0,0 200x200]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+
+DisplayList:
+SaveLayer@0
+  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
+  CompositorBlockingWheelEventRegion@3 rect=[0,0 100x100]
+  PaintScrollBar@1
+  PaintScrollBar@1
+Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -4,6 +4,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,613] is_viewport=true
   Save@1
     PaintLinearGradient@2 rect=[0,0 800x600]
   Restore@1

--- a/Tests/LibWeb/Text/expected/display_list/blocking-wheel-listener-cache-replay.txt
+++ b/Tests/LibWeb/Text/expected/display_list/blocking-wheel-listener-cache-replay.txt
@@ -1,0 +1,1 @@
+  CompositorBlockingWheelEventRegion@1 rect=[8,8 100x100]

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -7,7 +7,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[10,10 200x150] max_scroll_offset=[102,0] is_viewport=false
   FillPath@1 path_bounding_rect=[8,8 204x154]
+  CompositorScrollNode@3 scroll_frame_index=3 parent_scroll_frame_index=2 scrollport_rect=[11,11 300x100] max_scroll_offset=[100,0] is_viewport=false
   FillRect@3 rect=[10,10 302x102] color=rgb(255, 255, 224)
   FillPath@3 path_bounding_rect=[10,10 302x102]
   FillRect@5 rect=[11,11 400x80] color=rgb(240, 128, 128)

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -6,6 +6,7 @@ DisplayList:
 SaveLayer@0
   FillRect@0 rect=[20,20 204x154] color=rgb(211, 211, 211)
   FillPath@0 path_bounding_rect=[20,20 204x154]
+  CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[33,33 180x100] max_scroll_offset=[120,100] is_viewport=false
   FillPath@0 path_bounding_rect=[32,32 182x102]
   FillRect@3 rect=[33,33 300x200] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[33,33 179x18] translation=[33,46.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -10,10 +10,13 @@ DisplayList:
 SaveLayer@0
   FillRect@0 rect=[10,10 324x224] color=rgb(211, 211, 211)
   FillPath@0 path_bounding_rect=[10,10 324x224]
+  CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[23,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[22,22 93x152]
   FillRect@3 rect=[23,23 200x300] color=rgb(240, 128, 128)
+  CompositorScrollNode@0 scroll_frame_index=3 parent_scroll_frame_index=0 scrollport_rect=[126,23 92x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[125,22 94x152]
   FillRect@5 rect=[126,23 200x300] color=rgb(144, 238, 144)
+  CompositorScrollNode@0 scroll_frame_index=4 parent_scroll_frame_index=0 scrollport_rect=[230,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[229,22 93x152]
   FillRect@7 rect=[230,23 200x300] color=rgb(173, 216, 230)
   DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-event-region-hit-testing.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-event-region-hit-testing.html
@@ -34,18 +34,28 @@
     <div id="clipped-target"></div>
 </div>
 <script>
-    function dump(label, x, y) {
-        println(`${label}: ${internals.asyncScrollingStateBlocksWheelEventAt(x, y)}`);
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
+    function dump(output, label, x, y) {
+        output.push(`${label}: ${internals.asyncScrollingStateBlocksWheelEventAt(x, y)}`);
     }
 
     test(() => {
+        const output = [];
         transformed.addEventListener("wheel", event => {}, { passive: false });
         document.getElementById("clipped-target").addEventListener("wheel", event => {}, { passive: false });
 
-        println(`blocking regions: ${internals.asyncScrollingState().blockingWheelEventRegionCount}`);
-        dump("transformed visual inside", 130, 30);
-        dump("transformed original position", 30, 30);
-        dump("clipped visible inside", 30, 170);
-        dump("clipped overflow outside clip", 150, 170);
+        output.push(`blocking regions: ${internals.asyncScrollingState().blockingWheelEventRegionCount}`);
+        dump(output, "transformed visual inside", 130, 30);
+        dump(output, "transformed original position", 30, 30);
+        dump(output, "clipped visible inside", 30, 170);
+        dump(output, "clipped overflow outside clip", 150, 170);
+        printOutputAndDisplayList(output);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-event-regions.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-event-regions.html
@@ -26,33 +26,43 @@
     <div id="spacer"></div>
 </div>
 <script>
-    function dump(label) {
+    function printOutputAndDisplayList(output, displayList, label = "display list:") {
+        for (const line of output)
+            println(line);
+        println(label);
+        println(displayList);
+    }
+
+    function dump(output, label) {
         const state = internals.asyncScrollingState();
-        println(`${label}:`);
-        println(`  regions current: ${state.blockingWheelEventRegionsAreCurrent}`);
-        println(`  viewport blocked: ${state.hasBlockingWheelEventRegionCoveringViewport}`);
-        println(`  blocking regions: ${state.blockingWheelEventRegionCount}`);
+        output.push(`${label}:`);
+        output.push(`  regions current: ${state.blockingWheelEventRegionsAreCurrent}`);
+        output.push(`  viewport blocked: ${state.hasBlockingWheelEventRegionCoveringViewport}`);
+        output.push(`  blocking regions: ${state.blockingWheelEventRegionCount}`);
     }
 
     test(() => {
-        dump("initial");
+        const output = [];
+        dump(output, "initial");
 
         const passiveElementListener = event => {};
         target.addEventListener("wheel", passiveElementListener, { passive: true });
-        dump("passive element listener");
+        dump(output, "passive element listener");
 
         const blockingElementListener = event => {};
         target.addEventListener("wheel", blockingElementListener, { passive: false });
-        dump("blocking element listener");
+        dump(output, "blocking element listener");
+        const displayList = internals.dumpDisplayList();
 
         target.removeEventListener("wheel", blockingElementListener);
-        dump("removed element listener");
+        dump(output, "removed element listener");
 
         const blockingWindowListener = event => {};
         window.addEventListener("wheel", blockingWindowListener, { passive: false });
-        dump("blocking window listener");
+        dump(output, "blocking window listener");
 
         window.removeEventListener("wheel", blockingWindowListener);
-        dump("removed window listener");
+        dump(output, "removed window listener");
+        printOutputAndDisplayList(output, displayList, "display list after blocking element listener:");
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-listener-invalidation.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/blocking-wheel-listener-invalidation.html
@@ -11,14 +11,24 @@
 </style>
 <div id="spacer"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     test(() => {
+        const output = [];
         const before = internals.asyncScrollingState();
-        println(`before routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`);
+        output.push(`before routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`);
 
         document.addEventListener("wheel", event => event.preventDefault(), { passive: false });
 
         const after = internals.asyncScrollingState();
-        println(`listener generation increased: ${after.wheelEventListenerStateGeneration > before.wheelEventListenerStateGeneration}`);
-        println(`after routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`);
+        output.push(`listener generation increased: ${after.wheelEventListenerStateGeneration > before.wheelEventListenerStateGeneration}`);
+        output.push(`after routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`);
+        printOutputAndDisplayList(output);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/nested-navigable-wheel-admission.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/nested-navigable-wheel-admission.html
@@ -21,6 +21,14 @@
 <iframe id="frame" srcdoc="<body style='height: 1000px'></body>"></iframe>
 <div id="spacer"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     promiseTest(async () => {
         await new Promise(resolve => {
             if (frame.contentDocument && frame.contentDocument.readyState === "complete") {
@@ -32,8 +40,11 @@
         await animationFrame();
 
         const state = internals.asyncScrollingState();
-        println(`main thread regions: ${state.mainThreadWheelEventRegionCount}`);
-        println(`over iframe: ${internals.asyncScrollingStateWheelScrollAdmissionAt(60, 60, 0, 100)}`);
-        println(`outside iframe: ${internals.asyncScrollingStateWheelScrollAdmissionAt(250, 60, 0, 100)}`);
+        const output = [
+            `main thread regions: ${state.mainThreadWheelEventRegionCount}`,
+            `over iframe: ${internals.asyncScrollingStateWheelScrollAdmissionAt(60, 60, 0, 100)}`,
+            `outside iframe: ${internals.asyncScrollingStateWheelScrollAdmissionAt(250, 60, 0, 100)}`,
+        ];
+        printOutputAndDisplayList(output);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/nested-scroller-keeps-sync-wheel.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/nested-scroller-keeps-sync-wheel.html
@@ -22,11 +22,21 @@
 <div id="scroller"><div id="spacer"></div></div>
 <div id="page-spacer"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     promiseTest(async () => {
         internals.wheel(50, 50, 0, 100);
         await animationFrame();
 
-        println(`scroller scrollTop: ${scroller.scrollTop}`);
-        println(`window scrollY: ${window.scrollY}`);
+        printOutputAndDisplayList([
+            `scroller scrollTop: ${scroller.scrollTop}`,
+            `window scrollY: ${window.scrollY}`,
+        ]);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-node-metadata-cache-replay.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-node-metadata-cache-replay.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        overflow: scroll;
+    }
+
+    #scroller-content {
+        height: 500px;
+    }
+
+    #page-spacer {
+        height: 3000px;
+    }
+</style>
+<div id="scroller"><div id="scroller-content"></div></div>
+<div id="page-spacer"></div>
+<script>
+    function compositorScrollLines(displayList) {
+        return displayList
+            .split("\n")
+            .filter(line => line.includes("CompositorScrollNode"))
+            .join("\n");
+    }
+
+    test(() => {
+        internals.dumpDisplayList();
+
+        window.scrollTo(0, 1000);
+        scroller.scrollTop = 80;
+
+        println(`window scrollY: ${window.scrollY}`);
+        println(`scroller scrollTop: ${scroller.scrollTop}`);
+        println(`wheel target near viewport top: ${internals.asyncScrollingStateWheelTargetAt(150, 50, 0, 100)}`);
+        println(`upward wheel target over scroller: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, -100)}`);
+        println("scroll metadata:");
+        println(compositorScrollLines(internals.dumpDisplayList()));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-parent-nodes.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-parent-nodes.html
@@ -26,6 +26,14 @@
 </div>
 <div style="height: 2000px"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     test(() => {
         const state = internals.asyncScrollingState();
         const scrollNodeIDs = new Set(state.scrollNodes.map(node => `${node.documentID}:${node.scrollFrameIndex}`));
@@ -33,10 +41,13 @@
         const childNodes = state.scrollNodes.filter(node => !node.isViewport);
         const danglingParentNodes = state.scrollNodes.filter(node => node.parentScrollFrameIndex !== 0 && !scrollNodeIDs.has(`${node.parentDocumentID}:${node.parentScrollFrameIndex}`));
 
-        println(`scroll nodes: ${state.scrollNodes.length}`);
-        println(`child nodes: ${childNodes.length}`);
-        println(`dangling parent nodes: ${danglingParentNodes.length}`);
+        const output = [
+            `scroll nodes: ${state.scrollNodes.length}`,
+            `child nodes: ${childNodes.length}`,
+            `dangling parent nodes: ${danglingParentNodes.length}`,
+        ];
         for (const node of childNodes)
-            println(`child parent is viewport: ${node.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
+            output.push(`child parent is viewport: ${node.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
+        printOutputAndDisplayList(output);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-shape.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-shape.html
@@ -19,20 +19,31 @@
 <div id="scroller"><div id="spacer"></div></div>
 <div style="height: 2000px"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     test(() => {
         const state = internals.asyncScrollingState();
-        println(`scroll node count: ${state.scrollNodeCount}`);
-        println(`scroll nodes: ${state.scrollNodes.length}`);
+        const output = [
+            `scroll node count: ${state.scrollNodeCount}`,
+            `scroll nodes: ${state.scrollNodes.length}`,
+        ];
 
         const viewportNode = state.scrollNodes.find(node => node.isViewport);
-        println(`has viewport node: ${!!viewportNode}`);
-        println(`viewport parent: ${viewportNode?.parentScrollFrameIndex ?? "missing"}`);
+        output.push(`has viewport node: ${!!viewportNode}`);
+        output.push(`viewport parent: ${viewportNode?.parentScrollFrameIndex ?? "missing"}`);
 
         const childNodes = state.scrollNodes.filter(node => !node.isViewport);
-        println(`child nodes: ${childNodes.length}`);
+        output.push(`child nodes: ${childNodes.length}`);
         for (const node of childNodes) {
-            println(`child has same document as viewport: ${node.documentID === viewportNode.documentID}`);
-            println(`child parent is viewport: ${node.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
+            output.push(`child has same document as viewport: ${node.documentID === viewportNode.documentID}`);
+            output.push(`child parent is viewport: ${node.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
         }
+        printOutputAndDisplayList(output);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/sticky-areas.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/sticky-areas.html
@@ -24,19 +24,29 @@
 </div>
 <div id="spacer"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     test(() => {
         const state = internals.asyncScrollingState();
         const viewportNode = state.scrollNodes.find(node => node.isViewport);
         const outerArea = state.stickyAreas.find(area => area.parentScrollFrameIndex === viewportNode.scrollFrameIndex);
         const innerArea = state.stickyAreas.find(area => area.parentScrollFrameIndex === outerArea.scrollFrameIndex);
 
-        println(`scroll nodes: ${state.scrollNodeCount}`);
-        println(`sticky areas: ${state.stickyAreaCount}`);
-        println(`outer parent is viewport: ${outerArea.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
-        println(`inner parent is outer: ${innerArea.parentScrollFrameIndex === outerArea.scrollFrameIndex}`);
-        println(`outer ancestor is viewport: ${outerArea.nearestScrollingAncestorIndex === viewportNode.scrollFrameIndex}`);
-        println(`inner ancestor is viewport: ${innerArea.nearestScrollingAncestorIndex === viewportNode.scrollFrameIndex}`);
-        println(`outer has top inset only: ${outerArea.hasTopInset && !outerArea.hasRightInset && !outerArea.hasBottomInset && !outerArea.hasLeftInset}`);
-        println(`inner has top inset only: ${innerArea.hasTopInset && !innerArea.hasRightInset && !innerArea.hasBottomInset && !innerArea.hasLeftInset}`);
+        printOutputAndDisplayList([
+            `scroll nodes: ${state.scrollNodeCount}`,
+            `sticky areas: ${state.stickyAreaCount}`,
+            `outer parent is viewport: ${outerArea.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`,
+            `inner parent is outer: ${innerArea.parentScrollFrameIndex === outerArea.scrollFrameIndex}`,
+            `outer ancestor is viewport: ${outerArea.nearestScrollingAncestorIndex === viewportNode.scrollFrameIndex}`,
+            `inner ancestor is viewport: ${innerArea.nearestScrollingAncestorIndex === viewportNode.scrollFrameIndex}`,
+            `outer has top inset only: ${outerArea.hasTopInset && !outerArea.hasRightInset && !outerArea.hasBottomInset && !outerArea.hasLeftInset}`,
+            `inner has top inset only: ${innerArea.hasTopInset && !innerArea.hasRightInset && !innerArea.hasBottomInset && !innerArea.hasLeftInset}`,
+        ]);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/viewport-wheel-with-nested-scroller.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/viewport-wheel-with-nested-scroller.html
@@ -22,12 +22,22 @@
 <div id="scroller"><div id="scroller-spacer"></div></div>
 <div id="page-spacer"></div>
 <script>
+    function printOutputAndDisplayList(output) {
+        const displayList = internals.dumpDisplayList();
+        for (const line of output)
+            println(line);
+        println("display list:");
+        println(displayList);
+    }
+
     test(() => {
         const state = internals.asyncScrollingState();
 
-        println(`scroll nodes: ${state.scrollNodeCount}`);
-        println(`wheel routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`);
-        println(`viewport wheel target: ${internals.asyncScrollingStateWheelTargetAt(150, 150, 0, 100)}`);
-        println(`scroller wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+        printOutputAndDisplayList([
+            `scroll nodes: ${state.scrollNodeCount}`,
+            `wheel routing admission: ${internals.asyncScrollingStateWheelRoutingAdmission()}`,
+            `viewport wheel target: ${internals.asyncScrollingStateWheelTargetAt(150, 150, 0, 100)}`,
+            `scroller wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`,
+        ]);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/wheel-scroll-admission.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/wheel-scroll-admission.html
@@ -35,28 +35,38 @@
 </div>
 <div id="not-scrollable"></div>
 <script>
-    function canWheel(label, x, y, forceStaleWheelEventRegions = false) {
+    function printOutputAndDisplayList(output, displayList, label = "display list:") {
+        for (const line of output)
+            println(line);
+        println(label);
+        println(displayList);
+    }
+
+    function canWheel(output, label, x, y, forceStaleWheelEventRegions = false) {
         const canScroll = internals.asyncScrollingStateCanWheelScrollAt(x, y, 0, 100, forceStaleWheelEventRegions);
-        println(`${label}: ${canScroll}`);
+        output.push(`${label}: ${canScroll}`);
     }
 
     test(() => {
-        canWheel("no listener over scroller", 150, 150);
-        canWheel("no scrollable target", 275, 50);
+        const output = [];
+        canWheel(output, "no listener over scroller", 150, 150);
+        canWheel(output, "no scrollable target", 275, 50);
 
         target.addEventListener("wheel", event => {}, { passive: true });
-        canWheel("passive listener over target", 50, 50);
+        canWheel(output, "passive listener over target", 50, 50);
 
         const blockingElementListener = event => {};
         target.addEventListener("wheel", blockingElementListener, { passive: false });
-        canWheel("blocking element listener inside", 50, 50);
-        canWheel("blocking element listener outside", 150, 150);
-        canWheel("stale blocking element regions", 150, 150, true);
+        canWheel(output, "blocking element listener inside", 50, 50);
+        canWheel(output, "blocking element listener outside", 150, 150);
+        canWheel(output, "stale blocking element regions", 150, 150, true);
+        const displayList = internals.dumpDisplayList();
 
         target.removeEventListener("wheel", blockingElementListener);
         const blockingWindowListener = event => {};
         window.addEventListener("wheel", blockingWindowListener, { passive: false });
-        canWheel("blocking window listener", 150, 150);
-        canWheel("stale blocking window regions", 150, 150, true);
+        canWheel(output, "blocking window listener", 150, 150);
+        canWheel(output, "stale blocking window regions", 150, 150, true);
+        printOutputAndDisplayList(output, displayList, "display list after blocking element listener:");
     });
 </script>

--- a/Tests/LibWeb/Text/input/display_list/blocking-wheel-listener-cache-replay.html
+++ b/Tests/LibWeb/Text/input/display_list/blocking-wheel-listener-cache-replay.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="target"></div>
+<script>
+    function compositorBlockingWheelEventRegionLines(displayListDump) {
+        return displayListDump
+            .split("\n")
+            .filter(line => line.includes("CompositorBlockingWheelEventRegion"))
+            .join("\n");
+    }
+
+    test(() => {
+        internals.dumpDisplayList();
+        target.addEventListener("wheel", () => {}, { passive: false });
+        println(compositorBlockingWheelEventRegionLines(internals.dumpDisplayList()));
+    });
+</script>


### PR DESCRIPTION
Use compositor hit-test commands in the display list to rebuild async wheel targets, and serialize the async scroll metadata needed to reconstruct AsyncScrollingState from the same display-list snapshot.

Driving the async scroll tree off the display list rather than a separately collected tree has a few benefits:

- No additional full paintable tree traversal is required, since the information needed by the compositor is gathered while recording the display list.
- The display list is already serializable, so the async scroll tree no longer needs its own serialization path.
- It is more debuggable, as the existing display list dump now also covers the data used to reconstruct the async scroll tree.
- In the future we will want to include other areas that can interfere with hit-testing; recording them during display list construction makes it straightforward to preserve a hit-testing order that matches painting order.