### PR TITLE
LibJS: Shrink bytecode source maps

### DIFF
--- a/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -45,7 +45,10 @@ public:
     BasicBlock const* handler() const { return m_handler; }
 
     auto const& source_map() const { return m_source_map; }
-    void add_source_map_entry(u32 bytecode_offset, SourceRecord const& source_record) { m_source_map.append({ bytecode_offset, source_record }); }
+    void add_source_map_entry(u32 bytecode_offset, Position source_start)
+    {
+        m_source_map.append({ bytecode_offset, source_start.line, source_start.column });
+    }
 
     [[nodiscard]] bool has_resolved_this() const { return m_has_resolved_this; }
     void set_has_resolved_this() { m_has_resolved_this = true; }

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -405,19 +405,24 @@ Optional<SourceRange> Executable::source_range_at(size_t offset) const
 {
     if (offset >= bytecode.size())
         return {};
-    auto* entry = binary_search(source_map, offset, nullptr, [](size_t needle, SourceMapEntry const& entry) -> int {
-        if (needle < entry.bytecode_offset)
-            return -1;
-        if (needle > entry.bytecode_offset)
-            return 1;
-        return 0;
-    });
-    if (!entry)
+    if (source_map.is_empty())
         return {};
+    size_t low = 0;
+    size_t high = source_map.size();
+    while (low < high) {
+        auto middle = low + (high - low) / 2;
+        if (source_map[middle].bytecode_offset <= offset)
+            low = middle + 1;
+        else
+            high = middle;
+    }
+    if (low == 0)
+        return {};
+    auto& entry = source_map[low - 1];
     return SourceRange {
         .code = source_code,
-        .start = entry->source_record.start,
-        .end = entry->source_record.end,
+        .start = entry.source_record.start,
+        .end = entry.source_record.end,
     };
 }
 

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -112,36 +112,46 @@ void Executable::fixup_cache_pointers()
     }
 }
 
+static SourceMapEntry const* first_real_source_map_entry(Executable const& executable)
+{
+    SourceMapEntry const* first_entry = nullptr;
+    for (auto const& entry : executable.source_map) {
+        if (entry.line == 0 && entry.column == 0)
+            continue;
+        if (!first_entry || entry.line < first_entry->line || (entry.line == first_entry->line && entry.column < first_entry->column))
+            first_entry = &entry;
+    }
+    return first_entry;
+}
+
 static void dump_header(StringBuilder& output, Executable const& executable, bool use_color)
 {
     auto const white_bold = use_color ? "\033[37;1m"sv : ""sv;
     auto const reset = use_color ? "\033[0m"sv : ""sv;
-
-    // Generate a stable hash from the source text for identification.
-    // We hash source code rather than bytecode so the ID is stable
-    // across changes to bytecode generation.
-    // Find the overall source range covered by this executable.
-    u32 source_start = NumericLimits<u32>::max();
-    u32 source_end = 0;
-    Optional<Position> first_position;
-    for (auto const& entry : executable.source_map) {
-        if (entry.source_record.start.offset < entry.source_record.end.offset) {
-            source_start = min(source_start, entry.source_record.start.offset);
-            source_end = max(source_end, entry.source_record.end.offset);
-            if (!first_position.has_value() || entry.source_record.start.offset < first_position->offset)
-                first_position = entry.source_record.start;
-        }
-    }
+    auto const* first_source_map_entry = first_real_source_map_entry(executable);
 
     u32 hash = 2166136261u; // FNV-1a offset basis
-    auto code_view = executable.source_code->code_view();
-    for (auto i = source_start; i < source_end && i < code_view.length_in_code_units(); ++i) {
-        auto code_unit = code_view.code_unit_at(i);
+    auto update_hash = [&](u32 value) {
+        for (size_t i = 0; i < sizeof(value); ++i) {
+            hash ^= (value >> (i * 8)) & 0xFF;
+            hash *= 16777619u;
+        }
+    };
+    auto update_hash_with_code_unit = [&](u16 code_unit) {
         hash ^= code_unit & 0xFF;
         hash *= 16777619u;
         hash ^= (code_unit >> 8) & 0xFF;
         hash *= 16777619u;
+    };
+
+    auto name_view = executable.name.view();
+    for (size_t i = 0; i < name_view.length_in_code_units(); ++i)
+        update_hash_with_code_unit(name_view.code_unit_at(i));
+    if (first_source_map_entry) {
+        update_hash(first_source_map_entry->line);
+        update_hash(first_source_map_entry->column);
     }
+    update_hash(static_cast<u32>(min(executable.bytecode.size(), static_cast<size_t>(NumericLimits<u32>::max()))));
 
     if (executable.name.is_empty())
         output.appendff("{}${:08x}{}", white_bold, hash, reset);
@@ -149,16 +159,16 @@ static void dump_header(StringBuilder& output, Executable const& executable, boo
         output.appendff("{}{}${:08x}{}", white_bold, executable.name, hash, reset);
 
     // Show source location if available.
-    if (source_start < source_end && first_position.has_value()) {
+    if (first_source_map_entry) {
         auto filename = executable.source_code->filename();
         if (!filename.is_empty()) {
             // Show just the basename to keep output portable across machines.
             auto last_slash = filename.bytes_as_string_view().find_last('/');
             if (last_slash.has_value())
                 filename = MUST(filename.substring_from_byte_offset(last_slash.value() + 1));
-            output.appendff(" {}:{}:{}", filename, first_position->line, first_position->column);
+            output.appendff(" {}:{}:{}", filename, first_source_map_entry->line, first_source_map_entry->column);
         } else {
-            output.appendff(" line {}, column {}", first_position->line, first_position->column);
+            output.appendff(" line {}, column {}", first_source_map_entry->line, first_source_map_entry->column);
         }
     }
     output.append('\n');
@@ -421,8 +431,7 @@ Optional<SourceRange> Executable::source_range_at(size_t offset) const
     auto& entry = source_map[low - 1];
     return SourceRange {
         .code = source_code,
-        .start = entry.source_record.start,
-        .end = entry.source_record.end,
+        .start = { .line = entry.line, .column = entry.column },
     };
 }
 
@@ -431,7 +440,7 @@ SourceRange const& Executable::get_source_range(u32 program_counter)
     return m_source_range_cache.ensure(program_counter, [&] {
         if (auto source_range = source_range_at(program_counter); source_range.has_value())
             return *source_range;
-        static SourceRange dummy { SourceCode::create({}, {}), {}, {} };
+        static SourceRange dummy { SourceCode::create({}, {}), {} };
         return dummy;
     });
 }

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -137,14 +137,10 @@ struct ObjectPropertyIteratorCache {
     GC::Ptr<Object> reusable_property_name_iterator;
 };
 
-struct SourceRecord {
-    Position start {};
-    Position end {};
-};
-
 struct SourceMapEntry {
     u32 bytecode_offset {};
-    SourceRecord source_record {};
+    u32 line {};
+    u32 column {};
 };
 
 class JS_API Executable final

--- a/Libraries/LibJS/Position.h
+++ b/Libraries/LibJS/Position.h
@@ -13,7 +13,6 @@ namespace JS {
 struct Position {
     u32 line { 0 };
     u32 column { 0 };
-    u32 offset { 0 };
 };
 
 }

--- a/Libraries/LibJS/Runtime/ErrorData.cpp
+++ b/Libraries/LibJS/Runtime/ErrorData.cpp
@@ -15,7 +15,7 @@
 
 namespace JS {
 
-static SourceRange dummy_source_range { SourceCode::create({}, {}), {}, {} };
+static SourceRange dummy_source_range { SourceCode::create({}, {}), {} };
 
 SourceRange const& TracebackFrame::source_range() const
 {
@@ -67,7 +67,7 @@ Utf16String ErrorData::stack_string(CompactTraceback compact) const
         auto const& function_name = frame.function_name;
         auto const& source_range = frame.source_range();
         // Note: Since we don't know whether we have a valid SourceRange here we just check for some default values.
-        if (!source_range.filename().is_empty() || source_range.start.offset != 0 || source_range.end.offset != 0) {
+        if (!source_range.filename().is_empty() || source_range.start.line != 0 || source_range.start.column != 0) {
 
             if (function_name.is_empty())
                 stack_string_builder.appendff("    at {}:{}:{}\n", source_range.filename(), source_range.start.line, source_range.start.column);

--- a/Libraries/LibJS/Rust/src/ast.rs
+++ b/Libraries/LibJS/Rust/src/ast.rs
@@ -759,7 +759,7 @@ impl Utf16String {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Position {
     pub line: u32,
     pub column: u32,

--- a/Libraries/LibJS/Rust/src/bytecode/basic_block.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/basic_block.rs
@@ -6,14 +6,13 @@
 
 use super::instruction::Instruction;
 use super::operand::Label;
-use crate::ast::Position;
 
-/// A source map entry mapping a bytecode offset to a source range.
+/// A source map entry mapping a bytecode offset to a source position.
 #[derive(Debug, Clone, Copy)]
 pub struct SourceMapEntry {
     pub bytecode_offset: u32,
-    pub source_start: Position,
-    pub source_end: Position,
+    pub line: u32,
+    pub column: u32,
 }
 
 /// A basic block in the bytecode generator.

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -40,16 +40,12 @@ pub struct FFIExceptionHandler {
     pub handler_offset: u32,
 }
 
-/// Source map entry mapping bytecode offset to source range.
+/// Source map entry mapping bytecode offset to source position.
 #[repr(C)]
 pub struct FFISourceMapEntry {
     pub bytecode_offset: u32,
     pub source_start_line: u32,
     pub source_start_column: u32,
-    pub source_start_offset: u32,
-    pub source_end_line: u32,
-    pub source_end_column: u32,
-    pub source_end_offset: u32,
 }
 
 /// A borrowed UTF-16 string slice for passing across FFI.
@@ -702,12 +698,8 @@ pub unsafe fn create_executable_with_dependencies(
             .iter()
             .map(|e| FFISourceMapEntry {
                 bytecode_offset: e.bytecode_offset,
-                source_start_line: e.source_start.line,
-                source_start_column: e.source_start.column,
-                source_start_offset: e.source_start.offset,
-                source_end_line: e.source_end.line,
-                source_end_column: e.source_end.column,
-                source_end_offset: e.source_end.offset,
+                source_start_line: e.line,
+                source_start_column: e.column,
             })
             .collect();
 

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -785,8 +785,8 @@ impl Generator {
         }
         let source_map = SourceMapEntry {
             bytecode_offset: 0, // filled during flattening
-            source_start: self.current_source_start,
-            source_end: self.current_source_end,
+            line: self.current_source_start.line,
+            column: self.current_source_start.column,
         };
         let block = &mut self.basic_blocks[self.current_block_index.basic_block_index()];
         block.append(instruction, source_map);
@@ -1646,9 +1646,9 @@ impl Generator {
         let mut source_map: Vec<SourceMapEntry> = Vec::new();
         let mut exception_handlers: Vec<ExceptionHandler> = Vec::new();
         fn push_source_map_entry(source_map: &mut Vec<SourceMapEntry>, entry: SourceMapEntry) {
-            let should_push = source_map.last().is_none_or(|previous| {
-                previous.source_start != entry.source_start || previous.source_end != entry.source_end
-            });
+            let should_push = source_map
+                .last()
+                .is_none_or(|previous| previous.line != entry.line || previous.column != entry.column);
             if should_push {
                 source_map.push(entry);
             }
@@ -1679,8 +1679,8 @@ impl Generator {
                             &mut source_map,
                             SourceMapEntry {
                                 bytecode_offset: u32_from_usize(instruction_offset),
-                                source_start: sm.source_start,
-                                source_end: sm.source_end,
+                                line: sm.line,
+                                column: sm.column,
                             },
                         );
                         instruction.encode(self.strict, &mut bytecode);
@@ -1691,8 +1691,8 @@ impl Generator {
                             &mut source_map,
                             SourceMapEntry {
                                 bytecode_offset: u32_from_usize(instruction_offset),
-                                source_start: sm.source_start,
-                                source_end: sm.source_end,
+                                line: sm.line,
+                                column: sm.column,
                             },
                         );
                         let replacement = Instruction::Return { value };
@@ -1704,8 +1704,8 @@ impl Generator {
                             &mut source_map,
                             SourceMapEntry {
                                 bytecode_offset: u32_from_usize(instruction_offset),
-                                source_start: sm.source_start,
-                                source_end: sm.source_end,
+                                line: sm.line,
+                                column: sm.column,
                             },
                         );
                         let replacement = Instruction::End { value };
@@ -1720,8 +1720,8 @@ impl Generator {
                             &mut source_map,
                             SourceMapEntry {
                                 bytecode_offset: u32_from_usize(instruction_offset),
-                                source_start: sm.source_start,
-                                source_end: sm.source_end,
+                                line: sm.line,
+                                column: sm.column,
                             },
                         );
                         let replacement = Instruction::JumpFalse { condition, target };
@@ -1735,8 +1735,8 @@ impl Generator {
                             &mut source_map,
                             SourceMapEntry {
                                 bytecode_offset: u32_from_usize(instruction_offset),
-                                source_start: sm.source_start,
-                                source_end: sm.source_end,
+                                line: sm.line,
+                                column: sm.column,
                             },
                         );
                         let replacement = Instruction::JumpTrue { condition, target };
@@ -1755,16 +1755,8 @@ impl Generator {
                     &mut source_map,
                     SourceMapEntry {
                         bytecode_offset: u32_from_usize(instruction_offset),
-                        source_start: Position {
-                            line: 0,
-                            column: 0,
-                            offset: 0,
-                        },
-                        source_end: Position {
-                            line: 0,
-                            column: 0,
-                            offset: 0,
-                        },
+                        line: 0,
+                        column: 0,
                     },
                 );
                 end_instruction.encode(self.strict, &mut bytecode);

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -1645,6 +1645,15 @@ impl Generator {
         let mut bytecode: Vec<u8> = Vec::with_capacity(offset);
         let mut source_map: Vec<SourceMapEntry> = Vec::new();
         let mut exception_handlers: Vec<ExceptionHandler> = Vec::new();
+        fn push_source_map_entry(source_map: &mut Vec<SourceMapEntry>, entry: SourceMapEntry) {
+            let should_push = source_map.last().is_none_or(|previous| {
+                previous.source_start != entry.source_start || previous.source_end != entry.source_end
+            });
+            if should_push {
+                source_map.push(entry);
+            }
+        }
+
         // Track which blocks actually produced instructions.
         let mut basic_block_start_offsets: Vec<usize> = Vec::with_capacity(num_blocks);
 
@@ -1666,30 +1675,39 @@ impl Generator {
                     }
                     InstAction::Emit => {
                         let instruction_offset = bytecode.len();
-                        source_map.push(SourceMapEntry {
-                            bytecode_offset: u32_from_usize(instruction_offset),
-                            source_start: sm.source_start,
-                            source_end: sm.source_end,
-                        });
+                        push_source_map_entry(
+                            &mut source_map,
+                            SourceMapEntry {
+                                bytecode_offset: u32_from_usize(instruction_offset),
+                                source_start: sm.source_start,
+                                source_end: sm.source_end,
+                            },
+                        );
                         instruction.encode(self.strict, &mut bytecode);
                     }
                     InstAction::JumpToReturn(value) => {
                         let instruction_offset = bytecode.len();
-                        source_map.push(SourceMapEntry {
-                            bytecode_offset: u32_from_usize(instruction_offset),
-                            source_start: sm.source_start,
-                            source_end: sm.source_end,
-                        });
+                        push_source_map_entry(
+                            &mut source_map,
+                            SourceMapEntry {
+                                bytecode_offset: u32_from_usize(instruction_offset),
+                                source_start: sm.source_start,
+                                source_end: sm.source_end,
+                            },
+                        );
                         let replacement = Instruction::Return { value };
                         replacement.encode(self.strict, &mut bytecode);
                     }
                     InstAction::JumpToEnd(value) => {
                         let instruction_offset = bytecode.len();
-                        source_map.push(SourceMapEntry {
-                            bytecode_offset: u32_from_usize(instruction_offset),
-                            source_start: sm.source_start,
-                            source_end: sm.source_end,
-                        });
+                        push_source_map_entry(
+                            &mut source_map,
+                            SourceMapEntry {
+                                bytecode_offset: u32_from_usize(instruction_offset),
+                                source_start: sm.source_start,
+                                source_end: sm.source_end,
+                            },
+                        );
                         let replacement = Instruction::End { value };
                         replacement.encode(self.strict, &mut bytecode);
                     }
@@ -1698,11 +1716,14 @@ impl Generator {
                         let target_block = target.0 as usize;
                         target.0 = u32_from_usize(block_offsets[target_block]);
                         let instruction_offset = bytecode.len();
-                        source_map.push(SourceMapEntry {
-                            bytecode_offset: u32_from_usize(instruction_offset),
-                            source_start: sm.source_start,
-                            source_end: sm.source_end,
-                        });
+                        push_source_map_entry(
+                            &mut source_map,
+                            SourceMapEntry {
+                                bytecode_offset: u32_from_usize(instruction_offset),
+                                source_start: sm.source_start,
+                                source_end: sm.source_end,
+                            },
+                        );
                         let replacement = Instruction::JumpFalse { condition, target };
                         replacement.encode(self.strict, &mut bytecode);
                     }
@@ -1710,11 +1731,14 @@ impl Generator {
                         let target_block = target.0 as usize;
                         target.0 = u32_from_usize(block_offsets[target_block]);
                         let instruction_offset = bytecode.len();
-                        source_map.push(SourceMapEntry {
-                            bytecode_offset: u32_from_usize(instruction_offset),
-                            source_start: sm.source_start,
-                            source_end: sm.source_end,
-                        });
+                        push_source_map_entry(
+                            &mut source_map,
+                            SourceMapEntry {
+                                bytecode_offset: u32_from_usize(instruction_offset),
+                                source_start: sm.source_start,
+                                source_end: sm.source_end,
+                            },
+                        );
                         let replacement = Instruction::JumpTrue { condition, target };
                         replacement.encode(self.strict, &mut bytecode);
                     }
@@ -1727,19 +1751,22 @@ impl Generator {
                 undef_rewritten.offset_index_by(number_of_registers + number_of_locals);
                 let end_instruction = Instruction::End { value: undef_rewritten };
                 let instruction_offset = bytecode.len();
-                source_map.push(SourceMapEntry {
-                    bytecode_offset: u32_from_usize(instruction_offset),
-                    source_start: Position {
-                        line: 0,
-                        column: 0,
-                        offset: 0,
+                push_source_map_entry(
+                    &mut source_map,
+                    SourceMapEntry {
+                        bytecode_offset: u32_from_usize(instruction_offset),
+                        source_start: Position {
+                            line: 0,
+                            column: 0,
+                            offset: 0,
+                        },
+                        source_end: Position {
+                            line: 0,
+                            column: 0,
+                            offset: 0,
+                        },
                     },
-                    source_end: Position {
-                        line: 0,
-                        column: 0,
-                        offset: 0,
-                    },
-                });
+                );
                 end_instruction.encode(self.strict, &mut bytecode);
             }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -29,7 +29,7 @@ use crate::bytecode::validator::{
 use crate::{CompiledProgram, CompiledProgramBytecode, ModuleCallbacks, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 2;
+const FORMAT_VERSION: u32 = 4;
 const SOURCE_HASH_SIZE: usize = 32;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;
 const ITERATOR_HINT_VARIANT_COUNT: u32 = 2;
@@ -2209,12 +2209,8 @@ impl Encode for SourceMapTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
         encoder.sequence(&self.0.source_map, |entry, encoder| {
             entry.bytecode_offset.encode(encoder);
-            entry.source_start.line.encode(encoder);
-            entry.source_start.column.encode(encoder);
-            entry.source_start.offset.encode(encoder);
-            entry.source_end.line.encode(encoder);
-            entry.source_end.column.encode(encoder);
-            entry.source_end.offset.encode(encoder);
+            entry.line.encode(encoder);
+            entry.column.encode(encoder);
         });
     }
 }
@@ -2224,8 +2220,8 @@ impl SourceMapTable<'_> {
         decoder.sequence_values(|decoder| {
             Some(SourceMapEntry {
                 bytecode_offset: u32::decode(decoder)?,
-                source_start: ast::Position::decode(decoder)?,
-                source_end: ast::Position::decode(decoder)?,
+                line: u32::decode(decoder)?,
+                column: u32::decode(decoder)?,
             })
         })
     }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -78,7 +78,7 @@ static void collect_parse_errors(void* ctx, uint8_t const* message, size_t messa
     auto& errors = *static_cast<Vector<ParserError>*>(ctx);
     errors.append({
         MUST(String::from_utf8({ message, message_len })),
-        Position { line, column, 0 },
+        Position { line, column },
     });
 }
 
@@ -1041,18 +1041,8 @@ extern "C" void* rust_create_executable(
     for (size_t i = 0; i < data->source_map_count; ++i) {
         executable->source_map.append({
             data->source_map[i].bytecode_offset,
-            {
-                .start = {
-                    .line = data->source_map[i].source_start_line,
-                    .column = data->source_map[i].source_start_column,
-                    .offset = data->source_map[i].source_start_offset,
-                },
-                .end = {
-                    .line = data->source_map[i].source_end_line,
-                    .column = data->source_map[i].source_end_column,
-                    .offset = data->source_map[i].source_end_offset,
-                },
-            },
+            data->source_map[i].source_start_line,
+            data->source_map[i].source_start_column,
         });
     }
 

--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -54,7 +54,7 @@ void SourceCode::fill_position_cache() const
     u32 offset_of_last_starting_point = 0;
 
     m_cached_positions.ensure_capacity(predicted_minimum_cached_positions + (m_code.length_in_code_units() / maximum_distance_between_cached_positions));
-    m_cached_positions.append({ .line = 1, .column = 1, .offset = 0 });
+    m_cached_positions.append({ .position = { .line = 1, .column = 1 }, .offset = 0 });
 
     auto view = m_code.utf16_view();
 
@@ -69,7 +69,7 @@ void SourceCode::fill_position_cache() const
         auto distance_between_cached_position = offset - offset_of_last_starting_point;
 
         if ((distance_between_cached_position >= minimum_distance_between_cached_positions && is_nonempty_line) || distance_between_cached_position >= maximum_distance_between_cached_positions) {
-            m_cached_positions.append({ .line = line, .column = column, .offset = static_cast<u32>(offset) });
+            m_cached_positions.append({ .position = { .line = line, .column = column }, .offset = static_cast<u32>(offset) });
             offset_of_last_starting_point = offset;
         }
 
@@ -84,19 +84,19 @@ void SourceCode::fill_position_cache() const
     }
 }
 
-SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) const
+SourceRange SourceCode::range_from_offsets(u32 start_offset, [[maybe_unused]] u32 end_offset) const
 {
-    // If the underlying code is an empty string, the range is 1,1 - 1,1 no matter what.
+    // If the underlying code is an empty string, the range is 1,1 no matter what.
     if (m_code.is_empty())
-        return { *this, { .line = 1, .column = 1, .offset = 0 }, { .line = 1, .column = 1, .offset = 0 } };
+        return { *this, { .line = 1, .column = 1 } };
 
     if (m_cached_positions.is_empty())
         fill_position_cache();
 
-    Position current { .line = 1, .column = 1, .offset = 0 };
+    CachedPosition current { .position = { .line = 1, .column = 1 }, .offset = 0 };
 
     if (!m_cached_positions.is_empty()) {
-        Position const dummy;
+        CachedPosition const dummy;
         size_t nearest_index = 0;
         binary_search(m_cached_positions, dummy, &nearest_index,
             [&](auto&, auto& starting_point) {
@@ -107,7 +107,6 @@ SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) con
     }
 
     Optional<Position> start;
-    Optional<Position> end;
 
     u32 previous_code_point = 0;
 
@@ -117,20 +116,9 @@ SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) con
         // If we're on or after the start offset, this is the start position.
         if (!start.has_value() && view.iterator_offset(it) >= start_offset) {
             start = Position {
-                .line = current.line,
-                .column = current.column,
-                .offset = start_offset,
+                .line = current.position.line,
+                .column = current.position.column,
             };
-        }
-
-        // If we're on or after the end offset, this is the end position.
-        if (!end.has_value() && view.iterator_offset(it) >= end_offset) {
-            end = Position {
-                .line = current.line,
-                .column = current.column,
-                .offset = end_offset,
-            };
-            break;
         }
 
         u32 code_point = *it;
@@ -139,20 +127,20 @@ SourceRange SourceCode::range_from_offsets(u32 start_offset, u32 end_offset) con
         previous_code_point = code_point;
 
         if (is_line_terminator) {
-            current.line += 1;
-            current.column = 1;
+            current.position.line += 1;
+            current.position.column = 1;
             continue;
         }
 
-        current.column += 1;
+        current.position.column += 1;
     }
 
-    // If we didn't find both a start and end position, just return 1,1-1,1.
+    // If we didn't find a start position, just return 1,1.
     // FIXME: This is a hack. Find a way to return the nicest possible values here.
-    if (!start.has_value() || !end.has_value())
-        return SourceRange { *this, { .line = 1, .column = 1 }, { .line = 1, .column = 1 } };
+    if (!start.has_value())
+        return SourceRange { *this, { .line = 1, .column = 1 } };
 
-    return SourceRange { *this, *start, *end };
+    return SourceRange { *this, *start };
 }
 
 }

--- a/Libraries/LibJS/SourceCode.h
+++ b/Libraries/LibJS/SourceCode.h
@@ -40,7 +40,11 @@ private:
     // starting points (with byte offsets into the source string) and which
     // line:column they map to. This can then be binary-searched.
     void fill_position_cache() const;
-    Vector<Position> mutable m_cached_positions;
+    struct CachedPosition {
+        Position position;
+        u32 offset { 0 };
+    };
+    Vector<CachedPosition> mutable m_cached_positions;
 
     // Cached UTF-16 widening of ASCII source data, lazily populated by
     // utf16_data() for use by the Rust compilation pipeline.

--- a/Libraries/LibJS/SourceRange.h
+++ b/Libraries/LibJS/SourceRange.h
@@ -18,11 +18,8 @@
 namespace JS {
 
 struct JS_API SourceRange {
-    [[nodiscard]] bool contains(Position const& position) const { return position.offset <= end.offset && position.offset >= start.offset; }
-
     NonnullRefPtr<SourceCode const> code;
     Position start;
-    Position end;
 
     ByteString filename() const { return code->filename().to_byte_string(); }
 };

--- a/Services/WebContent/DevToolsConsoleClient.cpp
+++ b/Services/WebContent/DevToolsConsoleClient.cpp
@@ -112,7 +112,7 @@ void DevToolsConsoleClient::report_exception(String const& name, String const& m
         if (!frame.function_name.is_empty())
             stack_frame.function = frame.function_name.to_utf8();
 
-        if (!source_range.filename().is_empty() || source_range.start.offset != 0 || source_range.end.offset != 0) {
+        if (!source_range.filename().is_empty() || source_range.start.line != 0 || source_range.start.column != 0) {
             stack_frame.file = String::from_utf8_with_replacement_character(source_range.filename());
             stack_frame.line = source_range.start.line;
             stack_frame.column = source_range.start.column;

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -1,4 +1,4 @@
-$64717e3f annex-b-function-in-if.js:13:1
+$eeeaa256 annex-b-function-in-if.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -20,7 +20,7 @@ block0:
   [ 140] End value:reg7
 
 
-annexBFunctionInIf$cf6b2161 annex-b-function-in-if.js:2:5
+annexBFunctionInIf$f4b6a259 annex-b-function-in-if.js:2:5
   Registers: 8
   Blocks:    4
   Constants:
@@ -57,7 +57,7 @@ block3:
   [ 190] Return value:reg5
 
 
-inner$b8316a64 annex-b-function-in-if.js:4:13
+inner$b5b8e95a annex-b-function-in-if.js:4:13
   Registers: 5
   Blocks:    1
   Constants:
@@ -67,7 +67,7 @@ block0:
   [   0] Return value:String("true branch")
 
 
-inner$1f25fd67 annex-b-function-in-if.js:8:13
+inner$8980a116 annex-b-function-in-if.js:8:13
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
@@ -1,4 +1,4 @@
-$d99dc022 annexb-function-existing-var.js:10:1
+$d36729be annexb-function-existing-var.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-test$de75bc07 annexb-function-existing-var.js:2:5
+test$8422248c annexb-function-existing-var.js:2:5
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/argument-postfix-self-move.txt
+++ b/Tests/LibJS/Bytecode/expected/argument-postfix-self-move.txt
@@ -1,4 +1,4 @@
-$b08b32bb argument-postfix-self-move.js:5:1
+$9431c529 argument-postfix-self-move.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$bfdb0dbf argument-postfix-self-move.js:2:6
+f$833b82e7 argument-postfix-self-move.js:2:6
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/argument-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/argument-variables.txt
@@ -1,4 +1,4 @@
-$e3bb9811 argument-variables.js:12:1
+$3b8b4350 argument-variables.js:12:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  80] End value:reg6
 
 
-identity$7176ad76 argument-variables.js:5:5
+identity$753f961b argument-variables.js:5:5
   Registers: 5
   Blocks:    1
 
@@ -22,7 +22,7 @@ block0:
   [   0] Return value:arg0
 
 
-swap$0ff1f8d6 argument-variables.js:9:5
+swap$556fb42c argument-variables.js:9:5
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
+++ b/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
@@ -1,4 +1,4 @@
-$69cce752 arguments-with-arguments-fn.js:4:1
+$2b997e90 arguments-with-arguments-fn.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$811c9dc5
+f$6cd6eab3
   Registers: 6
   Blocks:    3
   Locals:    arguments~0

--- a/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
@@ -1,4 +1,4 @@
-$a49ec34a assign-to-argument-no-tdz.js:11:1
+$393b7f47 assign-to-argument-no-tdz.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$71204352 assign-to-argument-no-tdz.js:6:5
+f$44906188 assign-to-argument-no-tdz.js:6:5
   Registers: 5
   Blocks:    1
   Locals:    y~0

--- a/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
@@ -1,4 +1,4 @@
-$3dab9a19 assign-to-let-variable-tdz.js:12:1
+$bced3bd8 assign-to-let-variable-tdz.js:12:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  78] End value:reg5
 
 
-f$08c437ee assign-to-let-variable-tdz.js:7:5
+f$7105e5e6 assign-to-let-variable-tdz.js:7:5
   Registers: 10
   Blocks:    3
   Locals:    a~0
@@ -45,7 +45,7 @@ block2:
   [ 100] Return value:a~0
 
 
-g$15d4d90c assign-to-let-variable-tdz.js:4:17
+g$f452072f assign-to-let-variable-tdz.js:4:17
   Registers: 5
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/assign-to-parameter.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-parameter.txt
@@ -1,4 +1,4 @@
-$b05eae7c assign-to-parameter.js:8:1
+$162ec0dc assign-to-parameter.js:8:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-isect$96caa89c assign-to-parameter.js:5:9
+isect$41c8d351 assign-to-parameter.js:5:9
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/async-await-in-try-catch.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await-in-try-catch.txt
@@ -1,4 +1,4 @@
-$0b8784bc async-await-in-try-catch.js:9:1
+$793f2555 async-await-in-try-catch.js:9:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  50] End value:reg5
 
 
-f$9cd82caf async-await-in-try-catch.js:2:5
+f$8982c134 async-await-in-try-catch.js:2:5
   Registers: 10
   Blocks:    8
   Locals:    e~0

--- a/Tests/LibJS/Bytecode/expected/async-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await.txt
@@ -1,4 +1,4 @@
-$69cce752 async-await.js:9:1
+$fd650eed async-await.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$c9505126 async-await.js:7:5
+f$efa3ed5e async-await.js:7:5
   Registers: 10
   Blocks:    8
   Constants:

--- a/Tests/LibJS/Bytecode/expected/async-generator-yield-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-generator-yield-await.txt
@@ -1,4 +1,4 @@
-$bfb1383b async-generator-yield-await.js:6:1
+$6a33dffa async-generator-yield-await.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$12f73db2 async-generator-yield-await.js:4:5
+f$7363bd74 async-generator-yield-await.js:4:5
   Registers: 12
   Blocks:    19
   Constants:

--- a/Tests/LibJS/Bytecode/expected/async-generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/async-generator-yield.txt
@@ -1,4 +1,4 @@
-$bfb1383b async-generator-yield.js:7:1
+$516a2e0b async-generator-yield.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$a4f936a8 async-generator-yield.js:5:5
+f$aa186530 async-generator-yield.js:5:5
   Registers: 10
   Blocks:    16
   Constants:

--- a/Tests/LibJS/Bytecode/expected/async-return-bare.txt
+++ b/Tests/LibJS/Bytecode/expected/async-return-bare.txt
@@ -1,4 +1,4 @@
-$69cce752 async-return-bare.js:4:1
+$2b997e90 async-return-bare.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$e646074e async-return-bare.js:2:5
+f$e16999cc async-return-bare.js:2:5
   Registers: 5
   Blocks:    2
   Constants:

--- a/Tests/LibJS/Bytecode/expected/baseline.txt
+++ b/Tests/LibJS/Bytecode/expected/baseline.txt
@@ -1,4 +1,4 @@
-$52070826 baseline.js:5:1
+$8ea9e309 baseline.js:5:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  a0] End value:reg5
 
 
-add$782c0096 baseline.js:2:5
+add$9f351e1b baseline.js:2:5
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/bigint-binary-literal-fold.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-binary-literal-fold.txt
@@ -1,4 +1,4 @@
-$811c9dc5
+$ccf7ed9d
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/bigint-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-constant-folding.txt
@@ -1,4 +1,4 @@
-$ab928610 bigint-constant-folding.js:1:1
+$7ca8f805 bigint-constant-folding.js:1:1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
@@ -1,4 +1,4 @@
-$66877791 bigint-large-constant-folding.js:2:1
+$343fb726 bigint-large-constant-folding.js:2:1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
@@ -1,4 +1,4 @@
-$a2397124 bigint-truthiness.js:2:1
+$266c01d6 bigint-truthiness.js:2:1
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/bitwise-numeric-preconvert.txt
+++ b/Tests/LibJS/Bytecode/expected/bitwise-numeric-preconvert.txt
@@ -1,4 +1,4 @@
-$3063fdab bitwise-numeric-preconvert.js:4:1
+$acfb7718 bitwise-numeric-preconvert.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-test$355d3f01 bitwise-numeric-preconvert.js:2:5
+test$e718c164 bitwise-numeric-preconvert.js:2:5
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
+++ b/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
@@ -1,4 +1,4 @@
-$7ec14918 block-function-declaration-order.js:1:1
+$ae8c96e2 block-function-declaration-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
@@ -1,4 +1,4 @@
-$d99dc022 block-scoped-function-no-tdz.js:10:1
+$d36729be block-scoped-function-no-tdz.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  38] End value:reg5
 
 
-test$8f4c6018 block-scoped-function-no-tdz.js:3:5
+test$65d0907d block-scoped-function-no-tdz.js:3:5
   Registers: 7
   Blocks:    1
   Locals:    foo~0, result~1
@@ -30,7 +30,7 @@ block0:
   [  88] Return value:result~1
 
 
-foo$48752efa block-scoped-function-no-tdz.js:5:26
+foo$f46a9b04 block-scoped-function-no-tdz.js:5:26
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -1,4 +1,4 @@
-$975f41e0 block-scoping.js:13:1
+$fcbe57a6 block-scoping.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [ 130] End value:reg7
 
 
-closureOverBlockScope$4f0633f8 block-scoping.js:2:15
+closureOverBlockScope$61104af2 block-scoping.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    fns~0
@@ -54,7 +54,7 @@ block0:
   [ 1f8] Return value:reg7
 
 
-$551734f7 block-scoping.js:5:18
+$4bcefff2 block-scoping.js:5:18
   Registers: 6
   Blocks:    1
 
@@ -63,7 +63,7 @@ block0:
   [  18] Return value:reg5
 
 
-$2f14ba8e block-scoping.js:9:18
+$3664423e block-scoping.js:9:18
   Registers: 6
   Blocks:    1
 
@@ -72,7 +72,7 @@ block0:
   [  18] Return value:reg5
 
 
-breakThroughBlockScopes$c915ba4a block-scoping.js:16:5
+breakThroughBlockScopes$bb8ff62f block-scoping.js:16:5
   Registers: 8
   Blocks:    7
   Locals:    f~0, i~1, result~2
@@ -115,7 +115,7 @@ block6:
   [ 120] Jump target:block2
 
 
-f$551734f7 block-scoping.js:20:21
+f$e7dc110a block-scoping.js:20:21
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$da4d2529 call-spread-register-order.js:2:1
+$973653fe call-spread-register-order.js:2:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  80] End value:reg5
 
 
-f$811c9dc5
+f$7aaaa003
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/captured-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/captured-variables.txt
@@ -1,4 +1,4 @@
-$6cc1cfb5 captured-variables.js:12:1
+$c7fd0018 captured-variables.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-outer$0300a3f9 captured-variables.js:5:5
+outer$e7583c0c captured-variables.js:5:5
   Registers: 7
   Blocks:    1
   Locals:    inner~0
@@ -29,7 +29,7 @@ block0:
   [  88] Return value:reg6
 
 
-inner$f798183e captured-variables.js:7:9
+inner$e471f8e5 captured-variables.js:7:9
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
+++ b/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
@@ -1,4 +1,4 @@
-$b00b92b3 catch-scope-boundary.js:14:1
+$3a6e508d catch-scope-boundary.js:14:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [ 130] End value:reg7
 
 
-throwInCatch$ff1cead7 catch-scope-boundary.js:2:5
+throwInCatch$94c0d746 catch-scope-boundary.js:2:5
   Registers: 7
   Blocks:    7
   Locals:    e2~0, e~1, result~2
@@ -61,7 +61,7 @@ Exception handlers:
   [  88 ..   90] => handler block1
 
 
-throwInCatchWithLocals$a73f2041 catch-scope-boundary.js:17:5
+throwInCatchWithLocals$35b0d9e9 catch-scope-boundary.js:17:5
   Registers: 9
   Blocks:    5
   Locals:    inner~0, catchLocal~1, e~2, outerVar~3

--- a/Tests/LibJS/Bytecode/expected/chained-member-call.txt
+++ b/Tests/LibJS/Bytecode/expected/chained-member-call.txt
@@ -1,4 +1,4 @@
-$c0e94b43 chained-member-call.js:12:1
+$82bdc9cb chained-member-call.js:12:1
   Registers: 10
   Blocks:    7
   Constants:
@@ -44,7 +44,7 @@ Exception handlers:
   [  e8 ..  158] => handler block4
 
 
-chained_computed_call$df45ff7f chained-member-call.js:5:5
+chained_computed_call$78bf026a chained-member-call.js:5:5
   Registers: 8
   Blocks:    1
 
@@ -57,7 +57,7 @@ block0:
   [  80] Return value:reg5
 
 
-chained_dot_call$9501e458 chained-member-call.js:9:5
+chained_dot_call$4ef00940 chained-member-call.js:9:5
   Registers: 8
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
@@ -1,4 +1,4 @@
-$91a5a724 class-computed-field-lhs-name.js:1:1
+$00cee19d class-computed-field-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [  90] End value:reg6
 
 
-C$811c9dc5
+C$e7b179de
   Registers: 5
   Blocks:    1
   Constants:
@@ -28,7 +28,7 @@ block0:
   [   0] End value:Undefined
 
 
-field$d817cc70 class-computed-field-lhs-name.js:2:15
+field$e1b95ffa class-computed-field-lhs-name.js:2:15
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/class-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-key.txt
@@ -1,4 +1,4 @@
-$69cce752 class-computed-key.js:10:1
+$d36729be class-computed-key.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$7455d328 class-computed-key.js:4:5
+f$88b2a512 class-computed-key.js:4:5
   Registers: 8
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/class-environment.txt
+++ b/Tests/LibJS/Bytecode/expected/class-environment.txt
@@ -1,4 +1,4 @@
-$5f9e2ffb class-environment.js:9:1
+$241c3dcd class-environment.js:9:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -13,7 +13,7 @@ block0:
   [  98] End value:reg5
 
 
-classWithName$8829de8e class-environment.js:2:13
+classWithName$155d62f1 class-environment.js:2:13
   Registers: 8
   Blocks:    1
   Locals:    C~0
@@ -34,7 +34,7 @@ block0:
   [  c0] Return value:reg7
 
 
-Foo$811c9dc5
+Foo$534d924b
   Registers: 5
   Blocks:    1
   Constants:
@@ -44,7 +44,7 @@ block0:
   [   0] End value:Undefined
 
 
-method$e3fa2040 class-environment.js:4:13
+method$f198ceab class-environment.js:4:13
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
+++ b/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
@@ -1,4 +1,4 @@
-$e092f884 class-lhs-name-no-createvariable.js:1:1
+$e7eb680d class-lhs-name-no-createvariable.js:1:1
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
+++ b/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
@@ -1,4 +1,4 @@
-$b4f9525c class-literal-fields.js:12:1
+$ccb44156 class-literal-fields.js:12:1
   Registers: 15
   Blocks:    1
   Constants:
@@ -26,7 +26,7 @@ block0:
   [ 210] End value:reg5
 
 
-test$657cc1d3 class-literal-fields.js:2:5
+test$7bd6515c class-literal-fields.js:2:5
   Registers: 7
   Blocks:    1
   Locals:    A~0
@@ -51,7 +51,7 @@ block0:
   [  98] Return value:reg6
 
 
-A$811c9dc5
+A$ef0589ec
   Registers: 5
   Blocks:    1
   Constants:
@@ -61,7 +61,7 @@ block0:
   [   0] End value:Undefined
 
 
-field$4297853c class-literal-fields.js:8:22
+field$d016a301 class-literal-fields.js:8:22
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
@@ -1,4 +1,4 @@
-$17c08991 computed-compound-assign-register-reuse.js:9:1
+$9d326325 computed-compound-assign-register-reuse.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -12,7 +12,7 @@ block0:
   [  80] End value:reg5
 
 
-subVector$1525553e computed-compound-assign-register-reuse.js:5:13
+subVector$3599dc10 computed-compound-assign-register-reuse.js:5:13
   Registers: 9
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/computed-member-access.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-access.txt
@@ -1,4 +1,4 @@
-$d6bbce15 computed-member-access.js:12:1
+$3e4f3460 computed-member-access.js:12:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  b0] End value:reg6
 
 
-computed_read$a6f67e31 computed-member-access.js:5:5
+computed_read$f0ef6ac1 computed-member-access.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -27,7 +27,7 @@ block0:
   [  28] Return value:reg6
 
 
-computed_read_expression$adb2a228 computed-member-access.js:9:5
+computed_read_expression$c18fd380 computed-member-access.js:9:5
   Registers: 7
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
@@ -1,4 +1,4 @@
-$b23ddabf computed-member-compound-assign.js:15:1
+$7fc74e7b computed-member-compound-assign.js:15:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [  c8] End value:reg6
 
 
-compound_computed$3d35f992 computed-member-compound-assign.js:7:14
+compound_computed$811bdddb computed-member-compound-assign.js:7:14
   Registers: 8
   Blocks:    1
   Constants:
@@ -33,7 +33,7 @@ block0:
   [  50] End value:Undefined
 
 
-compound_then_assign$fda157e3 computed-member-compound-assign.js:11:13
+compound_then_assign$aead8c3c computed-member-compound-assign.js:11:13
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/computed-string-object-literal.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-string-object-literal.txt
@@ -1,4 +1,4 @@
-$2d41d92c computed-string-object-literal.js:15:1
+$f8dd73d3 computed-string-object-literal.js:15:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  b0] End value:reg5
 
 
-simple_computed$4b41b515 computed-string-object-literal.js:6:5
+simple_computed$ee1d99de computed-string-object-literal.js:6:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -28,7 +28,7 @@ block0:
   [  38] Return value:reg5
 
 
-mixed$5c18a76a computed-string-object-literal.js:9:5
+mixed$9f3e333c computed-string-object-literal.js:9:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -43,7 +43,7 @@ block0:
   [  50] Return value:reg5
 
 
-dynamic$ae7fe9ae computed-string-object-literal.js:12:5
+dynamic$fd0d2731 computed-string-object-literal.js:12:5
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/computed-string-to-ById.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-string-to-ById.txt
@@ -1,4 +1,4 @@
-$90ad3082 computed-string-to-ById.js:17:1
+$dc43d5b2 computed-string-to-ById.js:17:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -20,7 +20,7 @@ block0:
   [ 140] End value:reg6
 
 
-get_string_prop$fa843635 computed-string-to-ById.js:5:5
+get_string_prop$d6b42da3 computed-string-to-ById.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -32,7 +32,7 @@ block0:
   [  30] Return value:reg6
 
 
-set_string_prop$5b793bae computed-string-to-ById.js:8:16
+set_string_prop$592a21c7 computed-string-to-ById.js:8:16
   Registers: 6
   Blocks:    1
   Constants:
@@ -46,7 +46,7 @@ block0:
   [  38] End value:Undefined
 
 
-get_index_prop$f6a04ecf computed-string-to-ById.js:11:5
+get_index_prop$a54df54e computed-string-to-ById.js:11:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -58,7 +58,7 @@ block0:
   [  28] Return value:reg6
 
 
-get_length_prop$2983fb9b computed-string-to-ById.js:14:5
+get_length_prop$813e14f1 computed-string-to-ById.js:14:5
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
@@ -1,4 +1,4 @@
-$b70081a4 computed-update-register-order.js:8:1
+$9790b964 computed-update-register-order.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  70] End value:reg5
 
 
-test$c6be6338 computed-update-register-order.js:5:9
+test$7becb49f computed-update-register-order.js:5:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -28,7 +28,7 @@ block0:
   [  90] End value:Undefined
 
 
-foo$7176ad76 computed-update-register-order.js:2:5
+foo$93622fcc computed-update-register-order.js:2:5
   Registers: 5
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
+++ b/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
@@ -1,4 +1,4 @@
-$4a68760f condition-dead-code-elim.js:141:1
+$ec8fc79b condition-dead-code-elim.js:141:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -31,7 +31,7 @@ block0:
   [ 270] End value:reg5
 
 
-ternary_true$adbcc261 condition-dead-code-elim.js:9:5
+ternary_true$cd62d477 condition-dead-code-elim.js:9:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -42,7 +42,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-ternary_truthy$8671fdc6 condition-dead-code-elim.js:12:5
+ternary_truthy$8c4636c2 condition-dead-code-elim.js:12:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -52,7 +52,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-ternary_false$1fde34b2 condition-dead-code-elim.js:15:5
+ternary_false$0ff09522 condition-dead-code-elim.js:15:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -63,7 +63,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-ternary_falsey$1c25e5ad condition-dead-code-elim.js:18:5
+ternary_falsey$47046b1e condition-dead-code-elim.js:18:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -74,7 +74,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-while_falsey$5d6360eb condition-dead-code-elim.js:33:5
+while_falsey$17590e95 condition-dead-code-elim.js:33:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -88,7 +88,7 @@ block0:
   [  38] End value:Undefined
 
 
-alive$57b46309 condition-dead-code-elim.js:2:5
+alive$dfea904d condition-dead-code-elim.js:2:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -98,7 +98,7 @@ block0:
   [   0] Return value:String("alive")
 
 
-do_while_falsey$799dde23 condition-dead-code-elim.js:37:9
+do_while_falsey$2b22dba1 condition-dead-code-elim.js:37:9
   Registers: 7
   Blocks:    4
   Constants:
@@ -124,7 +124,7 @@ block3:
   [  e0] End value:Undefined
 
 
-if_falsely$5d6360eb condition-dead-code-elim.js:62:5
+if_falsely$537336d6 condition-dead-code-elim.js:62:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -138,7 +138,7 @@ block0:
   [  38] End value:Undefined
 
 
-if_truthy$ac929a95 condition-dead-code-elim.js:66:9
+if_truthy$a6783770 condition-dead-code-elim.js:66:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -159,7 +159,7 @@ block0:
   [  e0] End value:Undefined
 
 
-if_exhausted$80f20e23 condition-dead-code-elim.js:90:9
+if_exhausted$9d4f2301 condition-dead-code-elim.js:90:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -177,7 +177,7 @@ block0:
   [  a8] End value:Undefined
 
 
-for_false$2883f85d condition-dead-code-elim.js:109:5
+for_false$23671fdc condition-dead-code-elim.js:109:5
   Registers: 7
   Blocks:    9
   Locals:    x~0
@@ -218,7 +218,7 @@ block8:
   [  b0] End value:Undefined
 
 
-call_this$77eb3a07 condition-dead-code-elim.js:105:5
+call_this$7cdf005a condition-dead-code-elim.js:105:5
   Registers: 5
   Blocks:    1
   Constants:
@@ -228,7 +228,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-for_true$81dd51ad condition-dead-code-elim.js:128:5
+for_true$e3e30115 condition-dead-code-elim.js:128:5
   Registers: 7
   Blocks:    11
   Constants:

--- a/Tests/LibJS/Bytecode/expected/conditional-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/conditional-register-order.txt
@@ -1,4 +1,4 @@
-$e6445d4a conditional-register-order.js:4:1
+$2b997e90 conditional-register-order.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-foo$3dbe5650 conditional-register-order.js:2:5
+foo$1d0ffb84 conditional-register-order.js:2:5
   Registers: 6
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
@@ -1,4 +1,4 @@
-$5904f18d const-assignment-no-extra-tdz.js:5:1
+$0a83f971 const-assignment-no-extra-tdz.js:5:1
   Registers: 9
   Blocks:    4
   Locals:    e~0
@@ -28,7 +28,7 @@ Exception handlers:
   [  48 ..   b0] => handler block1
 
 
-f$22fe0a32 const-assignment-no-extra-tdz.js:2:5
+f$e16999cc const-assignment-no-extra-tdz.js:2:5
   Registers: 5
   Blocks:    1
   Locals:    x~0

--- a/Tests/LibJS/Bytecode/expected/const-fold-exponentiation.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-exponentiation.txt
@@ -1,4 +1,4 @@
-$68a257fc const-fold-exponentiation.js:1:1
+$e7eb680d const-fold-exponentiation.js:1:1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -1,4 +1,4 @@
-$dc4cd9dd const-fold-template-literals.js:20:1
+$5034494e const-fold-template-literals.js:20:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -42,7 +42,7 @@ block0:
   [ 2d0] End value:Undefined
 
 
-prefix$f72ec249 const-fold-template-literals.js:2:5
+prefix$722bd91a const-fold-template-literals.js:2:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -54,7 +54,7 @@ block0:
   [  20] Return value:reg5
 
 
-suffix$5b9fba3e const-fold-template-literals.js:5:5
+suffix$a92a9be2 const-fold-template-literals.js:5:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -66,7 +66,7 @@ block0:
   [  20] Return value:reg5
 
 
-tostring$1567fc7c const-fold-template-literals.js:8:5
+tostring$ba142bc6 const-fold-template-literals.js:8:5
   Registers: 6
   Blocks:    1
 
@@ -75,7 +75,7 @@ block0:
   [  10] Return value:reg5
 
 
-multi$f3ef7824 const-fold-template-literals.js:11:5
+multi$05431102 const-fold-template-literals.js:11:5
   Registers: 6
   Blocks:    1
 
@@ -86,7 +86,7 @@ block0:
   [  30] Return value:reg5
 
 
-literal$c7e85f9e const-fold-template-literals.js:14:5
+literal$12c5c655 const-fold-template-literals.js:14:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -96,7 +96,7 @@ block0:
   [   0] Return value:String("hello world")
 
 
-empty$93602216 const-fold-template-literals.js:17:5
+empty$4890c274 const-fold-template-literals.js:17:5
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/constant-fold-large-string-to-number.txt
+++ b/Tests/LibJS/Bytecode/expected/constant-fold-large-string-to-number.txt
@@ -1,4 +1,4 @@
-$8ea0b7a6 constant-fold-large-string-to-number.js:1:1
+$e7eb680d constant-fold-large-string-to-number.js:1:1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/constant-fold-string-to-number.txt
+++ b/Tests/LibJS/Bytecode/expected/constant-fold-string-to-number.txt
@@ -1,4 +1,4 @@
-$199ac30a constant-fold-string-to-number.js:1:1
+$e7eb680d constant-fold-string-to-number.js:1:1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/default-param-self-reference.txt
+++ b/Tests/LibJS/Bytecode/expected/default-param-self-reference.txt
@@ -1,4 +1,4 @@
-$bfb1383b default-param-self-reference.js:2:1
+$b865a0be default-param-self-reference.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$e162c485 default-param-self-reference.js:1:16
+f$d753a0ea default-param-self-reference.js:1:16
   Registers: 5
   Blocks:    3
   Constants:

--- a/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
@@ -1,4 +1,4 @@
-$bfb1383b delete-expression-register.js:6:1
+$6a33dffa delete-expression-register.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$2bc22ddd delete-expression-register.js:3:7
+f$04c49ea7 delete-expression-register.js:3:7
   Registers: 7
   Blocks:    3
   Locals:    x~0, arguments~1

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -1,4 +1,4 @@
-$7867793e delete-super-eval-order.js:4:1
+$67bc40cb delete-super-eval-order.js:4:1
   Registers: 10
   Blocks:    4
   Constants:
@@ -36,7 +36,7 @@ Exception handlers:
   [  a8 ..  150] => handler block1
 
 
-A$811c9dc5
+A$ef0589ec
   Registers: 5
   Blocks:    1
   Constants:
@@ -46,7 +46,7 @@ block0:
   [   0] End value:Undefined
 
 
-m$0f0a711c delete-super-eval-order.js:6:9
+m$0f7c4977 delete-super-eval-order.js:6:9
   Registers: 7
   Blocks:    2
   Constants:

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -1,4 +1,4 @@
-$2915e894 delete-super-property.js:1:1
+$752dc5b7 delete-super-property.js:1:1
   Registers: 11
   Blocks:    7
   Locals:    e~0, e~1
@@ -55,7 +55,7 @@ Exception handlers:
   [ 188 ..  228] => handler block4
 
 
-A$811c9dc5
+A$ef0589ec
   Registers: 5
   Blocks:    1
   Constants:
@@ -65,7 +65,7 @@ block0:
   [   0] End value:Undefined
 
 
-foo$7dff3f72 delete-super-property.js:3:9
+foo$7707d509 delete-super-property.js:3:9
   Registers: 7
   Blocks:    2
   Constants:
@@ -81,7 +81,7 @@ block1:
   [  28] End value:Undefined
 
 
-baz$cb4e52e2 delete-super-property.js:6:9
+baz$8acb3acb delete-super-property.js:6:9
   Registers: 7
   Blocks:    2
   Constants:

--- a/Tests/LibJS/Bytecode/expected/destructure-array-rest.txt
+++ b/Tests/LibJS/Bytecode/expected/destructure-array-rest.txt
@@ -1,4 +1,4 @@
-$69cce752 destructure-array-rest.js:9:1
+$fd650eed destructure-array-rest.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$e318a32c destructure-array-rest.js:6:5
+f$88fef6f3 destructure-array-rest.js:6:5
   Registers: 12
   Blocks:    6
   Locals:    a~0, b~1

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
@@ -1,4 +1,4 @@
-$490efcb5 destructuring-assignment-in-logical-and.js:5:1
+$9431c529 destructuring-assignment-in-logical-and.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -12,7 +12,7 @@ block0:
   [  40] End value:reg5
 
 
-f$c5d7e0b7 destructuring-assignment-in-logical-and.js:2:5
+f$bd59b03f destructuring-assignment-in-logical-and.js:2:5
   Registers: 12
   Blocks:    10
   Locals:    a~0, b~1

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
@@ -1,4 +1,4 @@
-$6b0803e2 destructuring-assignment.js:28:1
+$f2f04dd8 destructuring-assignment.js:28:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  a8] End value:reg5
 
 
-array_destructuring_with_class_default$c0397068 destructuring-assignment.js:6:10
+array_destructuring_with_class_default$28ef14a9 destructuring-assignment.js:6:10
   Registers: 13
   Blocks:    7
   Locals:    x~0
@@ -57,7 +57,7 @@ block6:
   [ 140] Return value:x~0
 
 
-object_destructuring_with_function_default$544c1fbd destructuring-assignment.js:12:12
+object_destructuring_with_function_default$497a8092 destructuring-assignment.js:12:12
   Registers: 8
   Blocks:    3
   Locals:    x~0
@@ -80,7 +80,7 @@ block2:
   [  90] Return value:x~0
 
 
-setter_parameter_resolution$75109441 destructuring-assignment.js:19:9
+setter_parameter_resolution$2898cc06 destructuring-assignment.js:19:9
   Registers: 12
   Blocks:    5
   Constants:
@@ -116,7 +116,7 @@ block4:
   [ 168] Jump target:block3
 
 
-set y$f36f0033 destructuring-assignment.js:21:26
+set y$72954fa9 destructuring-assignment.js:21:26
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
@@ -1,4 +1,4 @@
-$59a926ae destructuring-let-compound-assign.js:5:1
+$99b9a749 destructuring-let-compound-assign.js:5:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -12,7 +12,7 @@ block0:
   [  60] End value:reg5
 
 
-f$0c16b60f destructuring-let-compound-assign.js:2:5
+f$fa4d135c destructuring-let-compound-assign.js:2:5
   Registers: 8
   Blocks:    1
   Locals:    a~0

--- a/Tests/LibJS/Bytecode/expected/destructuring-no-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-no-base-identifier.txt
@@ -1,4 +1,4 @@
-$7861a666 destructuring-no-base-identifier.js:1:1
+$32b2807a destructuring-no-base-identifier.js:1:1
   Registers: 12
   Blocks:    5
   Constants:

--- a/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
@@ -1,4 +1,4 @@
-$34849cbe destructuring-param-no-param-expressions.js:10:1
+$2e11f366 destructuring-param-no-param-expressions.js:10:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -16,7 +16,7 @@ block0:
   [  90] End value:reg5
 
 
-f$84013cfc destructuring-param-no-param-expressions.js:7:5
+f$41e63819 destructuring-param-no-param-expressions.js:7:5
   Registers: 6
   Blocks:    1
   Locals:    local~0

--- a/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
+++ b/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
@@ -1,4 +1,4 @@
-$d99dc022 do-while-register-allocation.js:15:1
+$6c6bb70b do-while-register-allocation.js:15:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-test$21b235ef do-while-register-allocation.js:9:5
+test$e414328f do-while-register-allocation.js:9:5
   Registers: 9
   Blocks:    4
   Locals:    i~0
@@ -38,7 +38,7 @@ block3:
   [  e0] End value:Undefined
 
 
-foo$7176ad76 do-while-register-allocation.js:2:5
+foo$93622fcc do-while-register-allocation.js:2:5
   Registers: 5
   Blocks:    1
 
@@ -46,7 +46,7 @@ block0:
   [   0] Return value:arg0
 
 
-bar$7176ad76 do-while-register-allocation.js:5:5
+bar$cbf37924 do-while-register-allocation.js:5:5
   Registers: 5
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/double-constant-deduplication.txt
+++ b/Tests/LibJS/Bytecode/expected/double-constant-deduplication.txt
@@ -1,4 +1,4 @@
-$e6445d4a double-constant-deduplication.js:8:1
+$162ec0dc double-constant-deduplication.js:8:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-foo$afa1fb9c double-constant-deduplication.js:2:5
+foo$9e71f40c double-constant-deduplication.js:2:5
   Registers: 7
   Blocks:    1
   Locals:    a~0, b~1, c~2

--- a/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
@@ -1,4 +1,4 @@
-$2de61f8f eval-prevents-locals.js:22:1
+$a036f1fa eval-prevents-locals.js:22:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -12,7 +12,7 @@ block0:
   [  70] End value:reg6
 
 
-with_eval$28a6eab0 eval-prevents-locals.js:6:5
+with_eval$361b5eed eval-prevents-locals.js:6:5
   Registers: 9
   Blocks:    1
   Constants:
@@ -31,7 +31,7 @@ block0:
   [  a8] Return value:reg6
 
 
-eval$811c9dc5
+eval$b72141f3
   Registers: 5
   Blocks:    1
   Constants:
@@ -41,7 +41,7 @@ block0:
   [   0] End value:Undefined
 
 
-outer_eval$85fe2dd2 eval-prevents-locals.js:14:9
+outer_eval$6785167a eval-prevents-locals.js:14:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -61,7 +61,7 @@ block0:
   [  e0] Return value:reg5
 
 
-eval$811c9dc5
+eval$b72141f3
   Registers: 5
   Blocks:    1
   Constants:
@@ -71,7 +71,7 @@ block0:
   [   0] End value:Undefined
 
 
-inner$cbedf31d eval-prevents-locals.js:16:9
+inner$1897993a eval-prevents-locals.js:16:9
   Registers: 5
   Blocks:    1
   Locals:    y~0

--- a/Tests/LibJS/Bytecode/expected/eval-same-function.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-same-function.txt
@@ -1,4 +1,4 @@
-$e6445d4a eval-same-function.js:10:1
+$d36729be eval-same-function.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-foo$a4ff2c4f eval-same-function.js:6:9
+foo$c25bdd1c eval-same-function.js:6:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -27,7 +27,7 @@ block0:
   [  88] Return value:reg5
 
 
-eval$3c61584c line 1, column 1
+eval$6295ffeb line 1, column 1
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
@@ -1,4 +1,4 @@
-$6cc1cfb5 eval-scope-optimization.js:12:1
+$c7fd0018 eval-scope-optimization.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-outer$6201e926 eval-scope-optimization.js:9:5
+outer$2f7d7ac8 eval-scope-optimization.js:9:5
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/expression-identifier-number-format.txt
+++ b/Tests/LibJS/Bytecode/expected/expression-identifier-number-format.txt
@@ -1,4 +1,4 @@
-$169c53c3 expression-identifier-number-format.js:1:1
+$f8830e6d expression-identifier-number-format.js:1:1
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
@@ -1,4 +1,4 @@
-$1faa0c14 for-in-block-order.js:5:1
+$916dd419 for-in-block-order.js:5:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  50] End value:reg5
 
 
-foo$ad9db83a for-in-block-order.js:2:16
+foo$3b347bf9 for-in-block-order.js:2:16
   Registers: 8
   Blocks:    6
   Locals:    k~0

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$6f3aad7a for-in-lexical-scope.js:1:12
+$3122836b for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
@@ -1,4 +1,4 @@
-$5af00ff4 for-in-object-property-iterator-next.js:8:1
+$298a584c for-in-object-property-iterator-next.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -21,7 +21,7 @@ block0:
   [  c8] End value:reg5
 
 
-collect$4195dbe6 for-in-object-property-iterator-next.js:2:18
+collect$a74ca55b for-in-object-property-iterator-next.js:2:18
   Registers: 12
   Blocks:    6
   Locals:    key~0, keys~1

--- a/Tests/LibJS/Bytecode/expected/for-in-of-lhs-patterns.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-of-lhs-patterns.txt
@@ -1,4 +1,4 @@
-$811c9dc5
+$ccf7ed9d
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
@@ -1,4 +1,4 @@
-$0d42cfa1 for-in-register-lifetime.js:1:1
+$ee43eb0f for-in-register-lifetime.js:1:1
   Registers: 14
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
@@ -1,4 +1,4 @@
-$a37f24d4 for-in-var-function-lhs-name.js:7:1
+$d0083583 for-in-var-function-lhs-name.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-fn$a115675f for-in-var-function-lhs-name.js:4:19
+fn$4477295a for-in-var-function-lhs-name.js:4:19
   Registers: 8
   Blocks:    6
   Locals:    f~0

--- a/Tests/LibJS/Bytecode/expected/for-loop-break-after-if-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-break-after-if-continue.txt
@@ -1,4 +1,4 @@
-$1eaa9a1f for-loop-break-after-if-continue.js:11:1
+$393b7f47 for-loop-break-after-if-continue.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-bok$e37018c9 for-loop-break-after-if-continue.js:6:9
+bok$3c12db64 for-loop-break-after-if-continue.js:6:9
   Registers: 5
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -1,4 +1,4 @@
-$5198286f for-loop-scoping.js:8:1
+$3ce5efbc for-loop-scoping.js:8:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -13,7 +13,7 @@ block0:
   [  98] End value:reg5
 
 
-forLetClosure$ab480781 for-loop-scoping.js:2:15
+forLetClosure$9d2e257d for-loop-scoping.js:2:15
   Registers: 10
   Blocks:    5
   Locals:    fns~0
@@ -63,7 +63,7 @@ block4:
   [ 260] Return value:reg5
 
 
-$a78bf47f for-loop-scoping.js:6:20
+$617ce76f for-loop-scoping.js:6:20
   Registers: 6
   Blocks:    1
   Constants:
@@ -74,7 +74,7 @@ block0:
   [  20] Return value:reg5
 
 
-$ceed13fe for-loop-scoping.js:4:18
+$732f8c03 for-loop-scoping.js:4:18
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
@@ -1,4 +1,4 @@
-$9cd3e64e for-of-cond-rhs-block-order.js:6:1
+$6a33dffa for-of-cond-rhs-block-order.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$0adf9089 for-of-cond-rhs-block-order.js:2:21
+f$567c3f32 for-of-cond-rhs-block-order.js:2:21
   Registers: 17
   Blocks:    20
   Locals:    r~0, n~1

--- a/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
@@ -1,4 +1,4 @@
-$90bea1bc for-of-continue-with-block-scope.js:13:1
+$2b0d6491 for-of-continue-with-block-scope.js:13:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  50] End value:reg5
 
 
-f$cb6e0975 for-of-continue-with-block-scope.js:2:15
+f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
   Registers: 18
   Blocks:    12
   Locals:    o~0, t~1

--- a/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
@@ -1,4 +1,4 @@
-$abb2d42c for-of-iteration-env-capacity.js:1:14
+$0a509d5d for-of-iteration-env-capacity.js:1:14
   Registers: 13
   Blocks:    10
   Locals:    x~0

--- a/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
@@ -1,4 +1,4 @@
-$d21ee499 for-of-iterator-close.js:6:1
+$04795212 for-of-iterator-close.js:6:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  d8] End value:reg5
 
 
-forOfBreak$0cb6b2e2 for-of-iterator-close.js:2:18
+forOfBreak$0dacb993 for-of-iterator-close.js:2:18
   Registers: 13
   Blocks:    13
   Locals:    x~0
@@ -79,7 +79,7 @@ Exception handlers:
   [  b8 ..  108] => handler block3
 
 
-forOfReturn$1ac7c5b6 for-of-iterator-close.js:9:18
+forOfReturn$3e676e69 for-of-iterator-close.js:9:18
   Registers: 12
   Blocks:    10
   Locals:    x~0
@@ -133,7 +133,7 @@ Exception handlers:
   [  b8 ..   f0] => handler block3
 
 
-forAwaitOfBreak$1ffc670e for-of-iterator-close.js:16:24
+forAwaitOfBreak$0834dde7 for-of-iterator-close.js:16:24
   Registers: 18
   Blocks:    30
   Locals:    x~0

--- a/Tests/LibJS/Bytecode/expected/for-of-rhs-precedence.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-rhs-precedence.txt
@@ -1,4 +1,4 @@
-$811c9dc5
+$ccf7ed9d
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
@@ -1,4 +1,4 @@
-$7e6e32fd for-try-finally-continue.js:1:1
+$6ce1f287 for-try-finally-continue.js:1:1
   Registers: 11
   Blocks:    16
   Locals:    e~0

--- a/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
@@ -1,4 +1,4 @@
-$ae1c0998 function-decl-source-order.js:17:1
+$7ed51afa function-decl-source-order.js:17:1
   Registers: 14
   Blocks:    1
   Constants:
@@ -21,7 +21,7 @@ block0:
   [ 188] End value:reg5
 
 
-alpha$3b8324cd function-decl-source-order.js:5:20
+alpha$29e24060 function-decl-source-order.js:5:20
   Registers: 5
   Blocks:    1
   Constants:
@@ -31,7 +31,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-beta$d739d7c6 function-decl-source-order.js:7:19
+beta$565e177b function-decl-source-order.js:7:19
   Registers: 5
   Blocks:    1
   Constants:
@@ -41,7 +41,7 @@ block0:
   [   0] Return value:Int32(2)
 
 
-gamma$09aead7f function-decl-source-order.js:11:20
+gamma$03071905 function-decl-source-order.js:11:20
   Registers: 5
   Blocks:    1
   Constants:
@@ -51,7 +51,7 @@ block0:
   [   0] Return value:Int32(3)
 
 
-delta$240367f0 function-decl-source-order.js:15:20
+delta$3c1404ee function-decl-source-order.js:15:20
   Registers: 5
   Blocks:    1
   Constants:
@@ -61,7 +61,7 @@ block0:
   [   0] Return value:Int32(4)
 
 
-dup$510f266c function-decl-source-order.js:13:18
+dup$7c6f066b function-decl-source-order.js:13:18
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
@@ -1,4 +1,4 @@
-$115d56d4 generator-yield-call.js:9:1
+$9ff65435 generator-yield-call.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [  b0] End value:reg5
 
 
-f$21b59c1e generator-yield-call.js:6:5
+f$914aca23 generator-yield-call.js:6:5
   Registers: 11
   Blocks:    12
   Constants:

--- a/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
@@ -1,4 +1,4 @@
-$69cce752 generator-yield-finally.js:11:1
+$ba9d77cf generator-yield-finally.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$f2967315 generator-yield-finally.js:4:5
+f$6b17ea44 generator-yield-finally.js:4:5
   Registers: 13
   Blocks:    24
   Constants:

--- a/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
@@ -1,4 +1,4 @@
-$1522c0b3 generator-yield-star.js:6:1
+$6fbbc21a generator-yield-star.js:6:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  60] End value:reg5
 
 
-f$c2e40832 generator-yield-star.js:4:5
+f$289ca507 generator-yield-star.js:4:5
   Registers: 22
   Blocks:    19
   Constants:

--- a/Tests/LibJS/Bytecode/expected/generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield.txt
@@ -1,4 +1,4 @@
-$9403c830 generator-yield.js:11:1
+$ef4507bc generator-yield.js:11:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -17,7 +17,7 @@ block0:
   [ 100] End value:reg7
 
 
-multi_yield$617e06b7 generator-yield.js:7:5
+multi_yield$7e2d183f generator-yield.js:7:5
   Registers: 10
   Blocks:    12
   Constants:

--- a/Tests/LibJS/Bytecode/expected/global-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/global-variables.txt
@@ -1,4 +1,4 @@
-$df0fe8a9 global-variables.js:4:1
+$9f27c1c8 global-variables.js:4:1
   Registers: 9
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
@@ -1,4 +1,4 @@
-$93c13d35 if-else-register-lifetime.js:11:1
+$c02559ef if-else-register-lifetime.js:11:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  58] End value:reg5
 
 
-test$c1ed08de if-else-register-lifetime.js:2:5
+test$5f5e45da if-else-register-lifetime.js:2:5
   Registers: 13
   Blocks:    12
   Locals:    a~0, i~1, j~2

--- a/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
+++ b/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
@@ -1,4 +1,4 @@
-$01a3b494 indexed-append-guards.js:16:1
+$40a540f0 indexed-append-guards.js:16:1
   Registers: 11
   Blocks:    7
   Constants:
@@ -75,7 +75,7 @@ block6:
   [ 430] End value:reg5
 
 
-expect_type_error$f42c6af9 indexed-append-guards.js:4:5
+expect_type_error$f9cd6888 indexed-append-guards.js:4:5
   Registers: 9
   Blocks:    8
   Locals:    error~0, did_throw~1
@@ -125,7 +125,7 @@ Exception handlers:
   [  c0 ..   e8] => handler block1
 
 
-$58e01468 indexed-append-guards.js:18:5
+$6dd371fa indexed-append-guards.js:18:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -139,7 +139,7 @@ block0:
   [  30] End value:Undefined
 
 
-$19fab4ff indexed-append-guards.js:26:5
+$f99f4d22 indexed-append-guards.js:26:5
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
@@ -1,4 +1,4 @@
-$b4733eed invalid-lhs-assignment-no-dead-code.js:8:1
+$aaec50d4 invalid-lhs-assignment-no-dead-code.js:8:1
   Registers: 10
   Blocks:    4
   Constants:
@@ -28,7 +28,7 @@ Exception handlers:
   [  40 ..   c8] => handler block1
 
 
-f$36570247 invalid-lhs-assignment-no-dead-code.js:5:6
+f$36958900 invalid-lhs-assignment-no-dead-code.js:5:6
   Registers: 6
   Blocks:    1
   Constants:
@@ -40,7 +40,7 @@ block0:
   [  30] Throw src:reg5
 
 
-$811c9dc5
+$ccf7ed9d
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
@@ -1,4 +1,4 @@
-$fa0f7b9b invalid-lhs-forin-no-dead-code.js:6:6
+$03b9f5e5 invalid-lhs-forin-no-dead-code.js:6:6
   Registers: 11
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -1,4 +1,4 @@
-$6c97fa3b lexical-env-teardown.js:13:1
+$b319ee85 lexical-env-teardown.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -45,7 +45,7 @@ block0:
   [ 408] End value:reg6
 
 
-withTeardown$27bad413 lexical-env-teardown.js:7:5
+withTeardown$f8b3e64d lexical-env-teardown.js:7:5
   Registers: 10
   Blocks:    1
   Locals:    inner~0
@@ -71,7 +71,7 @@ block0:
   [  e8] Return value:reg6
 
 
-blockTeardown$7cd4b5cf lexical-env-teardown.js:17:5
+blockTeardown$b6f5c4f0 lexical-env-teardown.js:17:5
   Registers: 5
   Blocks:    1
   Locals:    inner~0, outer~1
@@ -84,7 +84,7 @@ block0:
   [  18] Return value:outer~1
 
 
-forInTeardown$e8d7ea8e lexical-env-teardown.js:28:5
+forInTeardown$00ab80a8 lexical-env-teardown.js:28:5
   Registers: 8
   Blocks:    6
   Locals:    k~0, outer~1
@@ -121,7 +121,7 @@ block5:
   [  d8] Jump target:block2
 
 
-forOfTeardown$b603f5d2 lexical-env-teardown.js:38:5
+forOfTeardown$94a2ae97 lexical-env-teardown.js:38:5
   Registers: 12
   Blocks:    10
   Locals:    v~0, outer~1
@@ -176,7 +176,7 @@ Exception handlers:
   [  c0 ..   e0] => handler block3
 
 
-catchTeardown$ece08ab5 lexical-env-teardown.js:48:5
+catchTeardown$ea214605 lexical-env-teardown.js:48:5
   Registers: 7
   Blocks:    4
   Locals:    e~0, outer~1
@@ -207,7 +207,7 @@ Exception handlers:
   [  48 ..   88] => handler block1
 
 
-myName$bf13a37c lexical-env-teardown.js:60:5
+myName$b54e4267 lexical-env-teardown.js:60:5
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/local-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/local-source-order.txt
@@ -1,4 +1,4 @@
-$da832d31 local-source-order.js:12:1
+$c7fd0018 local-source-order.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-source_order_locals$7988cb5f local-source-order.js:6:5
+source_order_locals$4b1aeb83 local-source-order.js:6:5
   Registers: 7
   Blocks:    1
   Locals:    zebra~0, yak~1, aardvark~2

--- a/Tests/LibJS/Bytecode/expected/local-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/local-variables.txt
@@ -1,4 +1,4 @@
-$3230d765 local-variables.js:20:1
+$568ccc50 local-variables.js:20:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  a8] End value:reg5
 
 
-simple_let$92bdb436 local-variables.js:5:5
+simple_let$40478631 local-variables.js:5:5
   Registers: 5
   Blocks:    1
   Locals:    x~0
@@ -26,7 +26,7 @@ block0:
   [  10] Return value:x~0
 
 
-simple_const$0a9e10fd local-variables.js:10:5
+simple_const$80d5d79e local-variables.js:10:5
   Registers: 5
   Blocks:    1
   Locals:    y~0
@@ -38,7 +38,7 @@ block0:
   [  10] Return value:y~0
 
 
-multiple_locals$37fee39e local-variables.js:15:5
+multiple_locals$77559ec6 local-variables.js:15:5
   Registers: 6
   Blocks:    1
   Locals:    a~0, b~1

--- a/Tests/LibJS/Bytecode/expected/logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-assignment-register-order.txt
@@ -1,4 +1,4 @@
-$a061729d logical-assignment-register-order.js:2:7
+$932d2a38 logical-assignment-register-order.js:2:7
   Registers: 8
   Blocks:    4
 

--- a/Tests/LibJS/Bytecode/expected/logical-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-constant-folding.txt
@@ -1,4 +1,4 @@
-$66fad71b logical-constant-folding.js:1:1
+$84f4cb35 logical-constant-folding.js:1:1
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/logical-or-in-if-condition.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-or-in-if-condition.txt
@@ -1,4 +1,4 @@
-$2e768d79 logical-or-in-if-condition.js:12:1
+$469b0790 logical-or-in-if-condition.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-blocked$d90bf4bd logical-or-in-if-condition.js:7:9
+blocked$f2600453 logical-or-in-if-condition.js:7:9
   Registers: 6
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/logical-or-preferred-dst.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-or-preferred-dst.txt
@@ -1,4 +1,4 @@
-$2e768d79 logical-or-preferred-dst.js:11:1
+$393b7f47 logical-or-preferred-dst.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-blocked$3d17db43 logical-or-preferred-dst.js:6:9
+blocked$0b29b642 logical-or-preferred-dst.js:6:9
   Registers: 6
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/mov-merging.txt
+++ b/Tests/LibJS/Bytecode/expected/mov-merging.txt
@@ -1,4 +1,4 @@
-$3add7786 mov-merging.js:14:1
+$3a6e508d mov-merging.js:14:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [ 130] End value:reg7
 
 
-twoLocals$37fee39e mov-merging.js:2:5
+twoLocals$848f6408 mov-merging.js:2:5
   Registers: 6
   Blocks:    1
   Locals:    a~0, b~1
@@ -32,7 +32,7 @@ block0:
   [  28] Return value:reg5
 
 
-threeLocals$ddb137e7 mov-merging.js:8:5
+threeLocals$f4c3fc48 mov-merging.js:8:5
   Registers: 7
   Blocks:    1
   Locals:    a~0, b~1, c~2

--- a/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
+++ b/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
@@ -1,4 +1,4 @@
-$ddd7ff5c named-class-expression-no-lhs-name-leak.js:1:1
+$b15087f2 named-class-expression-no-lhs-name-leak.js:1:1
   Registers: 13
   Blocks:    7
   Constants:

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,4 +1,4 @@
-$46e6a760 named-function-expression.js:4:6
+$642030ef named-function-expression.js:4:6
   Registers: 8
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
@@ -1,4 +1,4 @@
-$9814d5bc nested-for-loop-completion.js:4:1
+$700813fb nested-for-loop-completion.js:4:1
   Registers: 9
   Blocks:    8
   Constants:

--- a/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
@@ -1,4 +1,4 @@
-$54f8ba98 nested-function-decl-source-order.js:15:1
+$06b12923 nested-function-decl-source-order.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -16,7 +16,7 @@ block0:
   [  e0] End value:reg5
 
 
-outer$541206d9 nested-function-decl-source-order.js:12:5
+outer$f608465a nested-function-decl-source-order.js:12:5
   Registers: 11
   Blocks:    1
   Locals:    alpha~0, beta~1, dup~2, gamma~3, delta~4
@@ -40,7 +40,7 @@ block0:
   [ 178] Return value:reg10
 
 
-alpha$3b8324cd nested-function-decl-source-order.js:6:24
+alpha$ddf1e99f nested-function-decl-source-order.js:6:24
   Registers: 5
   Blocks:    1
   Constants:
@@ -50,7 +50,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-beta$d739d7c6 nested-function-decl-source-order.js:7:23
+beta$cbe393ff nested-function-decl-source-order.js:7:23
   Registers: 5
   Blocks:    1
   Constants:
@@ -60,7 +60,7 @@ block0:
   [   0] Return value:Int32(2)
 
 
-gamma$09aead7f nested-function-decl-source-order.js:9:24
+gamma$4c5374eb nested-function-decl-source-order.js:9:24
   Registers: 5
   Blocks:    1
   Constants:
@@ -70,7 +70,7 @@ block0:
   [   0] Return value:Int32(3)
 
 
-delta$240367f0 nested-function-decl-source-order.js:11:24
+delta$fd075126 nested-function-decl-source-order.js:11:24
   Registers: 5
   Blocks:    1
   Constants:
@@ -80,7 +80,7 @@ block0:
   [   0] Return value:Int32(4)
 
 
-dup$510f266c nested-function-decl-source-order.js:10:22
+dup$5f4e2278 nested-function-decl-source-order.js:10:22
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/nested-member-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-member-base-identifier.txt
@@ -1,4 +1,4 @@
-$4b4a3d70 nested-member-base-identifier.js:9:1
+$9a6e7215 nested-member-base-identifier.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  90] End value:reg5
 
 
-assign_nested$ab9ddddc nested-member-base-identifier.js:6:8
+assign_nested$126a4010 nested-member-base-identifier.js:6:8
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
@@ -1,4 +1,4 @@
-$058cd786 nested-try-finally-continue.js:14:1
+$853568fa nested-try-finally-continue.js:14:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-nestedTryFinallyContinue$f4bfe0d3 nested-try-finally-continue.js:2:5
+nestedTryFinallyContinue$4f168066 nested-try-finally-continue.js:2:5
   Registers: 13
   Blocks:    24
   Locals:    i~0

--- a/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
@@ -1,4 +1,4 @@
-$dffca61b numeric-class-field-name.js:1:1
+$7ca8f805 numeric-class-field-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -19,7 +19,7 @@ block0:
   [  d8] End value:reg6
 
 
-C$811c9dc5
+C$e7b179de
   Registers: 5
   Blocks:    1
   Constants:
@@ -29,7 +29,7 @@ block0:
   [   0] End value:Undefined
 
 
-field$a798f2fd numeric-class-field-name.js:2:10
+field$2db660f7 numeric-class-field-name.js:2:10
   Registers: 7
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/numeric-getter-no-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-getter-no-lhs-name.txt
@@ -1,4 +1,4 @@
-$d8d3a626 numeric-getter-no-lhs-name.js:1:1
+$87b8bc45 numeric-getter-no-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -15,7 +15,7 @@ block0:
   [  98] End value:reg6
 
 
-get 0$52a40bc0 numeric-getter-no-lhs-name.js:3:9
+get 0$4c2eeb71 numeric-getter-no-lhs-name.js:3:9
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/numeric-index-object-literal.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-index-object-literal.txt
@@ -1,4 +1,4 @@
-$d99dc022 numeric-index-object-literal.js:4:1
+$2b997e90 numeric-index-object-literal.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-test$9f6ed6e2 numeric-index-object-literal.js:2:5
+test$7e9a426c numeric-index-object-literal.js:2:5
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
@@ -1,4 +1,4 @@
-$87cdcfb6 numeric-property-key.js:4:1
+$aa378608 numeric-property-key.js:4:1
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/object-rest-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/object-rest-computed-key.txt
@@ -1,4 +1,4 @@
-$28c626df object-rest-computed-key.js:1:1
+$fb46ff7d object-rest-computed-key.js:1:1
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
@@ -1,4 +1,4 @@
-$5b93d13b optional-chain-base-identifier.js:1:1
+$a37cd2a2 optional-chain-base-identifier.js:1:1
   Registers: 9
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/optional-chain.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain.txt
@@ -1,4 +1,4 @@
-$b53b3a59 optional-chain.js:25:1
+$9712b2ea optional-chain.js:25:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -21,7 +21,7 @@ block0:
   [ 180] End value:reg6
 
 
-member$f8fa6898 optional-chain.js:7:5
+member$b5894147 optional-chain.js:7:5
   Registers: 7
   Blocks:    4
   Constants:
@@ -43,7 +43,7 @@ block3:
   [  70] Return value:reg6
 
 
-nested_member$1108ab88 optional-chain.js:10:5
+nested_member$830d1888 optional-chain.js:10:5
   Registers: 7
   Blocks:    5
   Constants:
@@ -70,7 +70,7 @@ block4:
   [  b0] Return value:reg6
 
 
-call_no_args$4730b337 optional-chain.js:13:5
+call_no_args$f2028fc1 optional-chain.js:13:5
   Registers: 8
   Blocks:    4
   Constants:
@@ -95,7 +95,7 @@ block3:
   [  a8] Return value:reg6
 
 
-call_with_args$880276bf optional-chain.js:16:5
+call_with_args$339c1d87 optional-chain.js:16:5
   Registers: 11
   Blocks:    4
   Constants:
@@ -124,7 +124,7 @@ block3:
   [  d8] Return value:reg6
 
 
-computed$ae9e607c optional-chain.js:19:5
+computed$1d9658d2 optional-chain.js:19:5
   Registers: 7
   Blocks:    4
   Constants:
@@ -147,7 +147,7 @@ block3:
   [  70] Return value:reg6
 
 
-member_then_call$4f64d681 optional-chain.js:22:5
+member_then_call$adb462b3 optional-chain.js:22:5
   Registers: 8
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
+++ b/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
@@ -1,4 +1,4 @@
-$6ef6ff9a parameter-createvariable-order.js:7:1
+$cd444473 parameter-createvariable-order.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -13,7 +13,7 @@ block0:
   [  48] End value:reg5
 
 
-f$40c96172 parameter-createvariable-order.js:2:5
+f$8982c134 parameter-createvariable-order.js:2:5
   Registers: 6
   Blocks:    1
   Locals:    inner~0
@@ -34,7 +34,7 @@ block0:
   [  d0] Return value:reg5
 
 
-inner$350d7dbe parameter-createvariable-order.js:3:9
+inner$9e8c0b51 parameter-createvariable-order.js:3:9
   Registers: 8
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
@@ -1,4 +1,4 @@
-$c73348dc postfix-increment-private-member.js:1:1
+$2d2a9e5a postfix-increment-private-member.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -22,7 +22,7 @@ block0:
   [  f8] End value:reg6
 
 
-C$811c9dc5
+C$e7b179de
   Registers: 5
   Blocks:    1
   Constants:
@@ -32,7 +32,7 @@ block0:
   [   0] End value:Undefined
 
 
-nextId$b6db6eed postfix-increment-private-member.js:4:9
+nextId$ab917a32 postfix-increment-private-member.js:4:9
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
@@ -1,4 +1,4 @@
-$e8ebe331 postfix-update-in-logical-and.js:4:1
+$acfb7718 postfix-update-in-logical-and.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-postfixInLogicalAnd$34f13720 postfix-update-in-logical-and.js:2:5
+postfixInLogicalAnd$ff9880b2 postfix-update-in-logical-and.js:2:5
   Registers: 8
   Blocks:    3
   Constants:

--- a/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
+++ b/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
@@ -1,4 +1,4 @@
-$ae8c532d private-identifier-access-patterns.js:1:1
+$7f6ce915 private-identifier-access-patterns.js:1:1
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
@@ -1,4 +1,4 @@
-$1ca3d2f9 private-logical-assignment-register-order.js:1:1
+$2d2a9e5a private-logical-assignment-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -22,7 +22,7 @@ block0:
   [  f8] End value:reg6
 
 
-C$811c9dc5
+C$e7b179de
   Registers: 5
   Blocks:    1
   Constants:
@@ -32,7 +32,7 @@ block0:
   [   0] End value:Undefined
 
 
-f$cce54051 private-logical-assignment-register-order.js:3:19
+f$2cb7734b private-logical-assignment-register-order.js:3:19
   Registers: 7
   Blocks:    4
   Constants:

--- a/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
+++ b/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
@@ -1,4 +1,4 @@
-$15b7a0d0 private-method-call-description.js:1:1
+$2d2a9e5a private-method-call-description.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -22,7 +22,7 @@ block0:
   [  f8] End value:reg6
 
 
-C$811c9dc5
+C$e7b179de
   Registers: 5
   Blocks:    1
   Constants:
@@ -32,7 +32,7 @@ block0:
   [   0] End value:Undefined
 
 
-call$f617ed01 private-method-call-description.js:6:9
+call$c4371728 private-method-call-description.js:6:9
   Registers: 7
   Blocks:    1
 
@@ -42,7 +42,7 @@ block0:
   [  30] Return value:reg5
 
 
-#m$52a40bc0 private-method-call-description.js:3:9
+#m$a16f05d1 private-method-call-description.js:3:9
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/regex-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/regex-literals.txt
@@ -1,4 +1,4 @@
-$b46fb5c4 regex-literals.js:2:1
+$a7cdfa5e regex-literals.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -19,7 +19,7 @@ block0:
   [  e0] End value:reg6
 
 
-matchDigits$4cca49e8 regex-literals.js:8:5
+matchDigits$5149c62f regex-literals.js:8:5
   Registers: 9
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/resolve-this-caching.txt
+++ b/Tests/LibJS/Bytecode/expected/resolve-this-caching.txt
@@ -1,4 +1,4 @@
-$e6445d4a resolve-this-caching.js:4:1
+$2b997e90 resolve-this-caching.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-foo$2256967e resolve-this-caching.js:2:5
+foo$1d0ffb84 resolve-this-caching.js:2:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -22,7 +22,7 @@ block0:
   [  38] Return value:reg5
 
 
-$c9429add resolve-this-caching.js:2:13
+$9bf17e5a resolve-this-caching.js:2:13
   Registers: 8
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/right-shift-by-zero.txt
+++ b/Tests/LibJS/Bytecode/expected/right-shift-by-zero.txt
@@ -1,4 +1,4 @@
-$a08063d8 right-shift-by-zero.js:5:1
+$9431c529 right-shift-by-zero.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-foo$197906fe right-shift-by-zero.js:2:5
+foo$962620dc right-shift-by-zero.js:2:5
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
+++ b/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
@@ -1,4 +1,4 @@
-$d96d9efb sequential-try-blocks.js:17:1
+$b56ffb15 sequential-try-blocks.js:17:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -13,7 +13,7 @@ block0:
   [  98] End value:reg5
 
 
-sequentialTryCatch$4bff3490 sequential-try-blocks.js:2:5
+sequentialTryCatch$0a8456ee sequential-try-blocks.js:2:5
   Registers: 8
   Blocks:    7
   Locals:    e~0, e~1, result~2

--- a/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
@@ -1,4 +1,4 @@
-$bc2d85a0 string-from-char-code-builtin.js:3:1
+$8130931f string-from-char-code-builtin.js:3:1
   Registers: 9
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/string-prototype-char-at-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-prototype-char-at-builtin.txt
@@ -1,4 +1,4 @@
-$a11ba3a7 string-prototype-char-at-builtin.js:4:13
+$ffb83754 string-prototype-char-at-builtin.js:4:13
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$477d99c6 super-call-spread-register-order.js:1:1
+$0656c3bd super-call-spread-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -17,7 +17,7 @@ block0:
   [  b0] End value:reg7
 
 
-C$0ec9c92d super-call-spread-register-order.js:3:14
+C$c11ea3e3 super-call-spread-register-order.js:3:14
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
@@ -1,4 +1,4 @@
-$b88eb0a5 super-computed-eval-order.js:1:1
+$27a2bc3a super-computed-eval-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -25,7 +25,7 @@ block0:
   [ 158] End value:reg7
 
 
-Derived$1c41db7c super-computed-eval-order.js:4:14
+Derived$730ebf72 super-computed-eval-order.js:4:14
   Registers: 7
   Blocks:    1
   Constants:
@@ -37,7 +37,7 @@ block0:
   [  20] End value:Undefined
 
 
-Base$811c9dc5
+Base$a461b108
   Registers: 5
   Blocks:    1
   Constants:
@@ -47,7 +47,7 @@ block0:
   [   0] End value:Undefined
 
 
-test$fd5f6781 super-computed-eval-order.js:7:9
+test$37ca7115 super-computed-eval-order.js:7:9
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
@@ -1,4 +1,4 @@
-$dda9a222 super-computed-string-to-id.js:1:1
+$0656c3bd super-computed-string-to-id.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -17,7 +17,7 @@ block0:
   [  b0] End value:reg7
 
 
-C$851d2148 super-computed-string-to-id.js:3:14
+C$be5ab2d3 super-computed-string-to-id.js:3:14
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
+++ b/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
@@ -1,4 +1,4 @@
-$e065c380 super-constructor-call.js:1:1
+$32b2807a super-constructor-call.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -23,7 +23,7 @@ block0:
   [ 118] End value:reg7
 
 
-Derived$3808ea25 super-constructor-call.js:4:14
+Derived$eee8d5da super-constructor-call.js:4:14
   Registers: 7
   Blocks:    1
   Constants:
@@ -36,7 +36,7 @@ block0:
   [  38] End value:Undefined
 
 
-Base$811c9dc5
+Base$a461b108
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -1,4 +1,4 @@
-$781e423f super-evaluation-order.js:1:1
+$bf243d42 super-evaluation-order.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -30,7 +30,7 @@ block0:
   [ 1e0] End value:reg7
 
 
-A$3f156142 super-evaluation-order.js:1:1
+A$3d02c59c super-evaluation-order.js:1:1
   Registers: 7
   Blocks:    1
 
@@ -43,7 +43,7 @@ block0:
   [  60] Return value:reg6
 
 
-read$2a1a7339 super-evaluation-order.js:3:9
+read$df25c2bd super-evaluation-order.js:3:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -56,7 +56,7 @@ block0:
   [  30] Return value:reg6
 
 
-write$5b793bae super-evaluation-order.js:6:20
+write$7ede70d2 super-evaluation-order.js:6:20
   Registers: 6
   Blocks:    1
   Constants:
@@ -71,7 +71,7 @@ block0:
   [  30] End value:Undefined
 
 
-update$8ce50e3d super-evaluation-order.js:9:16
+update$044d6445 super-evaluation-order.js:9:16
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
@@ -1,4 +1,4 @@
-$7dae70db super-for-of-resolve-order.js:1:1
+$87b8bc45 super-for-of-resolve-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -16,7 +16,7 @@ block0:
   [  98] End value:reg6
 
 
-C$f4d17d48 super-for-of-resolve-order.js:3:28
+C$9d8b2466 super-for-of-resolve-order.js:3:28
   Registers: 13
   Blocks:    10
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -1,4 +1,4 @@
-$452aea0d super-length-access.js:3:1
+$663d1da4 super-length-access.js:3:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -26,7 +26,7 @@ block0:
   [ 160] End value:reg7
 
 
-B$ea587383 super-length-access.js:7:1
+B$cbd8a311 super-length-access.js:7:1
   Registers: 7
   Blocks:    1
 
@@ -39,7 +39,7 @@ block0:
   [  60] Return value:reg6
 
 
-A$811c9dc5
+A$ef0589ec
   Registers: 5
   Blocks:    1
   Constants:
@@ -49,7 +49,7 @@ block0:
   [   0] End value:Undefined
 
 
-m$15d709a5 super-length-access.js:9:9
+m$6cadcac8 super-length-access.js:9:9
   Registers: 7
   Blocks:    1
 
@@ -60,7 +60,7 @@ block0:
   [  28] Return value:reg6
 
 
-get length$48752efa super-length-access.js:4:20
+get length$e8de8dcf super-length-access.js:4:20
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
@@ -1,4 +1,4 @@
-$bc802664 super-method-call-order.js:1:1
+$0463738f super-method-call-order.js:1:1
   Registers: 9
   Blocks:    1
 
@@ -29,7 +29,7 @@ block0:
   [ 278] End value:reg5
 
 
-test$6b58e3e5 super-method-call-order.js:5:9
+test$70dcf05f super-method-call-order.js:5:9
   Registers: 8
   Blocks:    1
 
@@ -41,7 +41,7 @@ block0:
   [  50] Return value:reg5
 
 
-m$811c9dc5
+m$685877e0
   Registers: 5
   Blocks:    1
   Constants:
@@ -51,7 +51,7 @@ block0:
   [   0] End value:Undefined
 
 
-get x$6b58e3e5 super-method-call-order.js:8:9
+get x$97875862 super-method-call-order.js:8:9
   Registers: 8
   Blocks:    1
 
@@ -63,7 +63,7 @@ block0:
   [  50] Return value:reg5
 
 
-test2$d17f9e3d super-method-call-order.js:11:9
+test2$5d2fb73b super-method-call-order.js:11:9
   Registers: 8
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -1,4 +1,4 @@
-$aea521ec super-optional-call-this.js:1:1
+$a904b4c2 super-optional-call-this.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -25,7 +25,7 @@ block0:
   [ 160] End value:reg7
 
 
-Foo$4b66ae80 super-optional-call-this.js:4:1
+Foo$f8ebe2ee super-optional-call-this.js:4:1
   Registers: 7
   Blocks:    1
 
@@ -38,7 +38,7 @@ block0:
   [  60] Return value:reg6
 
 
-Base$811c9dc5
+Base$a461b108
   Registers: 5
   Blocks:    1
   Constants:
@@ -48,7 +48,7 @@ block0:
   [   0] End value:Undefined
 
 
-method$e17748b6 super-optional-call-this.js:6:9
+method$994e3bed super-optional-call-this.js:6:9
   Registers: 9
   Blocks:    4
   Constants:
@@ -75,7 +75,7 @@ block3:
   [  b8] Return value:reg6
 
 
-method$811c9dc5
+method$6c22ae6a
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
@@ -1,4 +1,4 @@
-$bb1bc930 switch-completion-value.js:1:1
+$bf243d42 switch-completion-value.js:1:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -26,7 +26,7 @@ block0:
   [ 1e0] End value:reg5
 
 
-eval$802caa65 line 1, column 1
+eval$6559f0fb line 1, column 1
   Registers: 7
   Blocks:    5
   Locals:    x~0
@@ -51,7 +51,7 @@ block4:
   [  48] End value:reg5
 
 
-eval$e4733afc line 1, column 1
+eval$6559f0fb line 1, column 1
   Registers: 7
   Blocks:    5
   Constants:
@@ -76,7 +76,7 @@ block4:
   [  48] End value:reg5
 
 
-eval$94daef6a line 1, column 1
+eval$6da5c42b line 1, column 1
   Registers: 7
   Blocks:    6
   Constants:

--- a/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
@@ -1,4 +1,4 @@
-$a1c3db73 switch-local-only-let.js:15:1
+$c7ca75d8 switch-local-only-let.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -26,7 +26,7 @@ block0:
   [ 1e0] End value:reg5
 
 
-switchLocalOnly$c70bcd58 switch-local-only-let.js:4:5
+switchLocalOnly$fc47fb27 switch-local-only-let.js:4:5
   Registers: 6
   Blocks:    7
   Locals:    a~0, b~1

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -1,4 +1,4 @@
-$fc23251f switch-scoping.js:15:1
+$ac230b38 switch-scoping.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -20,7 +20,7 @@ block0:
   [ 140] End value:reg7
 
 
-switchWithBlockDecl$2b5ecfcd switch-scoping.js:2:5
+switchWithBlockDecl$4f465f02 switch-scoping.js:2:5
   Registers: 7
   Blocks:    7
   Locals:    result~0
@@ -64,7 +64,7 @@ block6:
   [ 130] Return value:reg5
 
 
-result$9ed940b6 switch-scoping.js:6:22
+result$38b0d48c switch-scoping.js:6:22
   Registers: 6
   Blocks:    1
 
@@ -73,7 +73,7 @@ block0:
   [  18] Return value:reg5
 
 
-result$78d6c64d switch-scoping.js:10:22
+result$ff741ac0 switch-scoping.js:10:22
   Registers: 6
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
@@ -1,4 +1,4 @@
-$bfb1383b switch-with-block-scope-return.js:12:1
+$469b0790 switch-with-block-scope-return.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ block0:
   [  40] End value:reg5
 
 
-f$bb4b08d4 switch-with-block-scope-return.js:2:5
+f$055cd79c switch-with-block-scope-return.js:2:5
   Registers: 8
   Blocks:    8
   Constants:

--- a/Tests/LibJS/Bytecode/expected/tagged-template-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-base-identifier.txt
@@ -1,4 +1,4 @@
-$fe3e9770 tagged-template-base-identifier.js:1:1
+$79e506f5 tagged-template-base-identifier.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -17,7 +17,7 @@ block0:
   [  e8] End value:reg8
 
 
-f$53c26a58 tagged-template-base-identifier.js:3:9
+f$eef94cf9 tagged-template-base-identifier.js:3:9
   Registers: 5
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -1,4 +1,4 @@
-$400d186a tagged-template-if-register-order.js:2:1
+$54bb0ec1 tagged-template-if-register-order.js:2:1
   Registers: 10
   Blocks:    3
   Constants:

--- a/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
@@ -1,4 +1,4 @@
-$3a924082 this-base-identifier.js:16:1
+$80aea387 this-base-identifier.js:16:1
   Registers: 10
   Blocks:    4
   Constants:
@@ -31,7 +31,7 @@ Exception handlers:
   [  b0 ..  118] => handler block1
 
 
-get_from_this$4bb390c8 this-base-identifier.js:5:5
+get_from_this$7b4d6173 this-base-identifier.js:5:5
   Registers: 6
   Blocks:    1
 
@@ -40,7 +40,7 @@ block0:
   [  20] Return value:reg5
 
 
-set_on_this$453a2d11 this-base-identifier.js:9:14
+set_on_this$1818839f this-base-identifier.js:9:14
   Registers: 5
   Blocks:    1
   Constants:
@@ -52,7 +52,7 @@ block0:
   [  28] End value:Undefined
 
 
-chained_this_access$48ebed63 this-base-identifier.js:13:5
+chained_this_access$4d4a3dab this-base-identifier.js:13:5
   Registers: 7
   Blocks:    1
 

--- a/Tests/LibJS/Bytecode/expected/try-catch-completion-ordering.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-completion-ordering.txt
@@ -1,4 +1,4 @@
-$f0f9cdaa try-catch-completion-ordering.js:1:1
+$63c57e75 try-catch-completion-ordering.js:1:1
   Registers: 8
   Blocks:    4
   Locals:    e~0

--- a/Tests/LibJS/Bytecode/expected/try-catch-finally-register.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-finally-register.txt
@@ -1,4 +1,4 @@
-$3a9dde7d try-catch-finally-register.js:1:1
+$abc8a5d2 try-catch-finally-register.js:1:1
   Registers: 10
   Blocks:    9
   Locals:    e~0

--- a/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
@@ -1,4 +1,4 @@
-$2bdd3a63 try-catch-scoping.js:11:1
+$3bff7057 try-catch-scoping.js:11:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -12,7 +12,7 @@ block0:
   [  70] End value:reg6
 
 
-tryCatchWithBlocks$5efa7757 try-catch-scoping.js:2:5
+tryCatchWithBlocks$fc7f9ac0 try-catch-scoping.js:2:5
   Registers: 11
   Blocks:    4
   Locals:    y~0, z~1, e~2, x~3
@@ -48,7 +48,7 @@ Exception handlers:
   [  d0 ..   e8] => handler block1
 
 
-tryCatchFinallyWithBlocks$3ef115ff try-catch-scoping.js:14:5
+tryCatchFinallyWithBlocks$b3c419da try-catch-scoping.js:14:5
   Registers: 12
   Blocks:    9
   Locals:    y~0, e~1, z~2, x~3

--- a/Tests/LibJS/Bytecode/expected/try-catch-terminated.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-terminated.txt
@@ -1,4 +1,4 @@
-$31ad76ee try-catch-terminated.js:12:1
+$c7fd0018 try-catch-terminated.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-try_return$21828749 try-catch-terminated.js:5:5
+try_return$6825fe97 try-catch-terminated.js:5:5
   Registers: 6
   Blocks:    3
   Locals:    e~0

--- a/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
@@ -1,4 +1,4 @@
-$e54891d8 try-finally-continue.js:13:1
+$fcbe57a6 try-finally-continue.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -18,7 +18,7 @@ block0:
   [ 130] End value:reg7
 
 
-continueThroughFinally$8372c35a try-finally-continue.js:2:5
+continueThroughFinally$49ed363e try-finally-continue.js:2:5
   Registers: 9
   Blocks:    15
   Locals:    i~0, result~1
@@ -90,7 +90,7 @@ Exception handlers:
   [  c8 ..  138] => handler block5
 
 
-breakThroughFinally$9e814d0d try-finally-continue.js:16:5
+breakThroughFinally$d975d962 try-finally-continue.js:16:5
   Registers: 9
   Blocks:    15
   Locals:    i~0, result~1

--- a/Tests/LibJS/Bytecode/expected/try-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally.txt
@@ -1,4 +1,4 @@
-$3522b97e try-finally.js:8:1
+$3a21feac try-finally.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  a8] End value:reg5
 
 
-basicTryFinally$06bcb6b7 try-finally.js:2:5
+basicTryFinally$280b5166 try-finally.js:2:5
   Registers: 10
   Blocks:    8
   Constants:
@@ -59,7 +59,7 @@ Exception handlers:
   [  a8 ..   c8] => handler block1
 
 
-breakThroughFinally$a2a426c4 try-finally.js:11:5
+breakThroughFinally$8a0e33e1 try-finally.js:11:5
   Registers: 11
   Blocks:    15
   Locals:    i~0
@@ -131,7 +131,7 @@ Exception handlers:
   [ 100 ..  148] => handler block5
 
 
-nestedTryFinallyWithBreak$aa8999b1 try-finally.js:22:12
+nestedTryFinallyWithBreak$a67b40bb try-finally.js:22:12
   Registers: 12
   Blocks:    21
   Locals:    i~0

--- a/Tests/LibJS/Bytecode/expected/update-member-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/update-member-expression.txt
@@ -1,4 +1,4 @@
-$0c699965 update-member-expression.js:13:1
+$28497381 update-member-expression.js:13:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  a0] End value:reg6
 
 
-postfix_increment$8ce50e3d update-member-expression.js:6:14
+postfix_increment$43f18c4c update-member-expression.js:6:14
   Registers: 7
   Blocks:    1
   Constants:
@@ -27,7 +27,7 @@ block0:
   [  58] End value:Undefined
 
 
-prefix_decrement$41bc97a7 update-member-expression.js:10:5
+prefix_decrement$f522dc02 update-member-expression.js:10:5
   Registers: 6
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
+++ b/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
@@ -1,4 +1,4 @@
-$97607366 using-declaration-non-local-env.js:1:1
+$84f4cb35 using-declaration-non-local-env.js:1:1
   Registers: 9
   Blocks:    4
   Locals:    e~0
@@ -28,7 +28,7 @@ Exception handlers:
   [  48 ..   b0] => handler block1
 
 
-$21ba43fc using-declaration-non-local-env.js:1:21
+$e58540c1 using-declaration-non-local-env.js:1:21
   Registers: 8
   Blocks:    2
   Constants:

--- a/Tests/LibJS/Bytecode/expected/var-binding-access.txt
+++ b/Tests/LibJS/Bytecode/expected/var-binding-access.txt
@@ -1,4 +1,4 @@
-$12ff989c var-binding-access.js:22:1
+$a036f1fa var-binding-access.js:22:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -12,7 +12,7 @@ block0:
   [  70] End value:reg6
 
 
-var_access$84869239 var-binding-access.js:5:5
+var_access$52e19afb var-binding-access.js:5:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -28,7 +28,7 @@ block0:
   [  70] Return value:reg5
 
 
-let_access$a0a01ad1 var-binding-access.js:14:5
+let_access$c5263a88 var-binding-access.js:14:5
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
@@ -1,4 +1,4 @@
-$69cce752 var-env-capacity-with-param-expressions.js:5:1
+$12cfcca1 var-env-capacity-with-param-expressions.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$c585851c var-env-capacity-with-param-expressions.js:3:9
+f$20dcebd6 var-env-capacity-with-param-expressions.js:3:9
   Registers: 10
   Blocks:    3
   Constants:
@@ -46,7 +46,7 @@ block2:
   [ 168] End value:Undefined
 
 
-eval$811c9dc5
+eval$b72141f3
   Registers: 5
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
@@ -1,4 +1,4 @@
-$b05eae7c var-hoisting-tdz.js:9:1
+$fd650eed var-hoisting-tdz.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-isect$3b32d4d0 var-hoisting-tdz.js:5:5
+isect$63c4d7d5 var-hoisting-tdz.js:5:5
   Registers: 6
   Blocks:    7
   Locals:    i~0

--- a/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
@@ -1,4 +1,4 @@
-$69cce752 var-init-in-param-body-scope.js:4:1
+$2b997e90 var-init-in-param-body-scope.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-f$811c9dc5
+f$6f9adbc3
   Registers: 6
   Blocks:    3
   Locals:    x~0

--- a/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
@@ -1,4 +1,4 @@
-$b1c0097f var-shadow-in-default-param.js:7:1
+$d85408b3 var-shadow-in-default-param.js:7:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  88] End value:reg6
 
 
-shadow_in_default$8b450421 var-shadow-in-default-param.js:8:32
+shadow_in_default$adf74487 var-shadow-in-default-param.js:8:32
   Registers: 7
   Blocks:    3
   Constants:
@@ -38,7 +38,7 @@ block2:
   [  98] Return value:arg0
 
 
-no_conflict$0d2d606f var-shadow-in-default-param.js:17:5
+no_conflict$f0c5f291 var-shadow-in-default-param.js:17:5
   Registers: 6
   Blocks:    3
   Locals:    y~0

--- a/Tests/LibJS/Bytecode/expected/with-return.txt
+++ b/Tests/LibJS/Bytecode/expected/with-return.txt
@@ -1,4 +1,4 @@
-$e9ab2da1 with-return.js:10:1
+$b237dcfe with-return.js:10:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ block0:
   [  78] End value:reg5
 
 
-with_return$a3013274 with-return.js:5:5
+with_return$d690ef5a with-return.js:5:5
   Registers: 7
   Blocks:    1
   Constants:

--- a/Tests/LibJS/Bytecode/expected/with-statement.txt
+++ b/Tests/LibJS/Bytecode/expected/with-statement.txt
@@ -1,4 +1,4 @@
-$d60f48d7 with-statement.js:7:1
+$d0083583 with-statement.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,7 +10,7 @@ block0:
   [  38] End value:reg5
 
 
-withBlock$86b35e99 with-statement.js:2:15
+withBlock$8fb7b75b with-statement.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    obj~0


### PR DESCRIPTION
Reduce bytecode source map memory use by deduplicating adjacent entries and storing only the data runtime consumers need: bytecode offset, line, and column.

Source lookup now returns the closest preceding source map entry so runs of bytecode can share one location without changing stack trace behavior. The bytecode cache format is bumped for the slimmer serialized entry shape.

This reduces WebContent memory footprint by 84 MiB on https://x.com/awesomekling