### PR TITLE
LibWeb: Improve SVG and replaced max-content sizing

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -42,8 +42,26 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
     if (!box.is_replaced_box() || (is_width ? natural_size.has_width() : natural_size.has_height()))
         return {};
 
-    // For the max-content size:
+    // SVG Integration says that a non-top-level <svg> starts with auto width/height, and that with a viewBox, missing
+    // width/height attributes "keep" their auto value. The resulting width, height, and aspect ratio are then
+    // "used in CSS sizing as intrinsic element size properties".
+    //
+    // CSS Sizing defines max-content as the size the box would have "if it was a float" with an auto preferred size.
+    // CSS2 replaced sizing then resolves auto width from "(used height) * (intrinsic ratio)", and auto height from
+    // "(used width) / (intrinsic ratio)". Keep this SVG specific bridge before falling through to CSS Sizing's fallback
+    // for replaced elements without natural sizes.
+    //  - https://svgwg.org/specs/integration/#svg-css-sizing
+    //  - https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
+    //  - https://drafts.csswg.org/css2/#inline-replaced-width
+    //  - https://drafts.csswg.org/css2/#inline-replaced-height
+    if (box.is_svg_svg_box() && natural_size.has_aspect_ratio()) {
+        if (is_width && natural_size.has_height())
+            return natural_size.height.value() * natural_size.aspect_ratio.value();
+        if (!is_width && natural_size.has_width())
+            return natural_size.width.value() / natural_size.aspect_ratio.value();
+    }
 
+    // For the max-content size:
     // If it has a preferred aspect ratio:
     if (natural_size.has_aspect_ratio()) {
         // If the available space is definite in the inline axis, use the stretch fit into that size for the inline size

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -29,6 +29,79 @@
 
 namespace Web::Layout {
 
+enum class SizeDimension {
+    Width,
+    Height,
+};
+
+// https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
+static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural_size(Box const& box, CSS::SizeWithAspectRatio const& natural_size, SizeDimension dimension)
+{
+    // the intrinsic sizes of replaced elements without natural sizes are defined below:
+    auto is_width = dimension == SizeDimension::Width;
+    if (!box.is_replaced_box() || (is_width ? natural_size.has_width() : natural_size.has_height()))
+        return {};
+
+    // For the max-content size:
+
+    // If it has a preferred aspect ratio:
+    if (natural_size.has_aspect_ratio()) {
+        // If the available space is definite in the inline axis, use the stretch fit into that size for the inline size
+        // and calculate the block size using the aspect ratio.
+        //
+        // NB: This helper is only for the max-content size, which has no definite available inline size.
+
+        // Otherwise if the box has a <length> as its computed value for min-width or min-height, use that size and
+        // calculate the other dimension using the aspect ratio; if both dimensions have a <length> minimum, choose the
+        // one that results in the larger overall size.
+        //
+        // NOTE: This case was previous calculated from a 300x150 default size, rather than the box’s min size. This is
+        //       believed to be a better behavior, and likely to be Web-compatible, but please send feedback to the CSSWG
+        //       if there are any problems.
+        auto aspect_ratio = natural_size.aspect_ratio.value();
+
+        Optional<CSSPixels> size_from_min_width;
+        auto const& min_width = box.computed_values().min_width();
+        if (min_width.is_length()) {
+            auto inline_size = min_width.to_px(box, 0);
+            size_from_min_width = is_width ? inline_size : inline_size / aspect_ratio;
+        }
+
+        Optional<CSSPixels> size_from_min_height;
+        auto const& min_height = box.computed_values().min_height();
+        if (min_height.is_length()) {
+            auto block_size = min_height.to_px(box, 0);
+            size_from_min_height = is_width ? block_size * aspect_ratio : block_size;
+        }
+
+        if (size_from_min_width.has_value() && size_from_min_height.has_value())
+            return max(size_from_min_width.value(), size_from_min_height.value());
+        if (size_from_min_width.has_value())
+            return size_from_min_width.value();
+        if (size_from_min_height.has_value())
+            return size_from_min_height.value();
+
+        // Otherwise use an inline size matching the corresponding dimension of the initial containing block and calculate
+        // the other dimension using the aspect ratio.
+        //
+        // NOTE: This author-controllable behavior is made possible by the new auto value for the min size properties.
+        //       This is believed to be a better behavior, but it is not yet clear if it is Web-compatible, so please
+        //       send feedback to the CSSWG if there are any problems.
+        auto inline_size = box.document().viewport_rect().width();
+        return is_width ? inline_size : inline_size / aspect_ratio;
+    }
+
+    // If it has no preferred aspect ratio:
+    // For both the min-content size and max-content size:
+    // If the box has a <length> as its computed minimum size (min-width/min-height) in that dimension, use that size.
+    auto const& min_size = is_width ? box.computed_values().min_width() : box.computed_values().min_height();
+    if (min_size.is_length())
+        return min_size.to_px(box, 0);
+
+    // Otherwise, use 300px for the width and/or 150px for the height as needed.
+    return is_width ? CSSPixels(300) : CSSPixels(150);
+}
+
 FormattingContext::FormattingContext(Type type, LayoutMode layout_mode, LayoutState& state, Box const& context_box, FormattingContext* parent)
     : m_type(type)
     , m_layout_mode(layout_mode)
@@ -1957,9 +2030,10 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
 CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box) const
 {
-
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_width())
         return auto_size.width.value();
+    if (auto max_content_width = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), SizeDimension::Width); max_content_width.has_value())
+        return max_content_width.value();
 
     // Boxes with no children have zero intrinsic width.
     if (!box.has_children())
@@ -2043,6 +2117,8 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_height())
         return auto_size.height.value();
+    if (auto max_content_height = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), SizeDimension::Height); max_content_height.has_value())
+        return max_content_height.value();
 
     // Boxes with no children have zero intrinsic height.
     if (!box.has_children())

--- a/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-height-and-viewbox-contributes-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-height-and-viewbox-contributes-width.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+      Box <div.row> at [0,0] flex-container(row) [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [FFC] children: not-inline
+        SVGSVGBox <svg> at [0,0] flex-item [0+0+0 190.53125 0+0+0] [0+0+0 24 0+0+0] [SVG] children: not-inline
+          SVGGeometryBox <rect> at [0,0] [0+0+0 190.53125 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+        BlockContainer <div.sibling> at [190.53125,0] flex-item [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,24] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x24]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x24]
+      PaintableBox (Box<DIV>.row) [0,0 800x24]
+        SVGSVGPaintable (SVGSVGBox<svg>) [0,0 190.53125x24]
+          SVGPathPaintable (SVGGeometryBox<rect>) [0,0 190.53125x24]
+        PaintableWithLines (BlockContainer<DIV>.sibling) [190.53125,0 20x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,24 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x24] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/svg-height-viewbox-centered-flex-item-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/svg-height-viewbox-centered-flex-item-width.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+      Box <div.row> at [0,0] flex-container(row) [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [FFC] children: not-inline
+        Box <div.logo> at [0,0] flex-container(column) flex-item [0+0+0 190.53125 0+0+0] [0+0+0 24 0+0+0] [FFC] children: not-inline
+          SVGSVGBox <svg> at [0,0] flex-item [0+0+0 190.53125 0+0+0] [0+0+0 24 0+0+0] [SVG] children: not-inline
+            SVGGeometryBox <rect> at [0,0] [0+0+0 190.53125 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+        BlockContainer <div.sibling> at [190.53125,0] flex-item [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,24] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x24]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x24]
+      PaintableBox (Box<DIV>.row) [0,0 800x24]
+        PaintableBox (Box<DIV>.logo) [0,0 190.53125x24]
+          SVGSVGPaintable (SVGSVGBox<svg>) [0,0 190.53125x24]
+            SVGPathPaintable (SVGGeometryBox<rect>) [0,0 190.53125x24]
+        PaintableWithLines (BlockContainer<DIV>.sibling) [190.53125,0 20x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,24 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x24] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/svg-flex-item-with-height-and-viewbox-contributes-width.html
+++ b/Tests/LibWeb/Layout/input/flex/svg-flex-item-with-height-and-viewbox-contributes-width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+}
+
+.row {
+    display: flex;
+}
+
+.sibling {
+    width: 20px;
+    height: 20px;
+    background: blue;
+}
+</style>
+<div class="row"><svg height="24" viewBox="0 0 262 33"><rect width="262" height="33"></rect></svg><div class="sibling"></div></div>

--- a/Tests/LibWeb/Layout/input/flex/svg-height-viewbox-centered-flex-item-width.html
+++ b/Tests/LibWeb/Layout/input/flex/svg-height-viewbox-centered-flex-item-width.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+body { margin: 0; }
+.row { display: flex; }
+.logo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.sibling {
+    width: 20px;
+    height: 20px;
+    background: blue;
+}
+svg { background: lime; }
+</style>
+<div class="row"><div class="logo"><svg height="24" viewBox="0 0 262 33"><rect width="262" height="33"></rect></svg></div><div class="sibling"></div></div>


### PR DESCRIPTION
Fixes the layout of logos on polar.sh

Before:
<img width="1866" height="1239" alt="image" src="https://github.com/user-attachments/assets/7cef34e0-307d-44b2-b676-e32b499ef17b" />

After:

<img width="1866" height="1239" alt="image" src="https://github.com/user-attachments/assets/fdbcf6af-40d7-47b9-a1f6-bbd71485eabe" />


