### PR TITLE
LibWeb: Follow paint order for async wheel hit testing

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -15,8 +15,9 @@ void AsyncScrollTree::set_state(AsyncScrollingState&& state)
 {
     m_scroll_nodes = move(state.scroll_nodes);
     m_sticky_areas = move(state.sticky_areas);
+    m_wheel_hit_test_regions = move(state.wheel_hit_test_targets);
     m_main_thread_wheel_event_regions = move(state.main_thread_wheel_event_regions);
-    m_wheel_scroll_targets.clear();
+    m_wheel_hit_test_targets.clear();
     m_main_thread_wheel_event_targets.clear();
     m_visual_context_tree = nullptr;
 }
@@ -28,6 +29,18 @@ AsyncScrollNode const* AsyncScrollTree::scroll_node_for_id(AsyncScrollNodeID nod
             return &node;
     }
     return nullptr;
+}
+
+WheelHitTestResult AsyncScrollTree::hit_test_result_for_scroll_node(AsyncScrollNodeID node_id, Gfx::FloatPoint delta) const
+{
+    auto const* node = scroll_node_for_id(node_id);
+    if (!node)
+        return {};
+    if (can_scroll_node_by_delta(*node, m_scroll_state_snapshot, delta))
+        return { node_id, false };
+    if (auto ancestor = scrollable_ancestor_for_node(node_id, m_scroll_state_snapshot, delta); ancestor.has_value())
+        return { ancestor, false };
+    return {};
 }
 
 AsyncStickyArea const* AsyncScrollTree::sticky_area_for_scroll_frame_index(Painting::ScrollFrameIndex scroll_frame_index) const
@@ -229,9 +242,9 @@ bool AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID node_id, Gfx::FloatPo
     return scrolled;
 }
 
-void AsyncScrollTree::rebuild_wheel_scroll_targets(RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+void AsyncScrollTree::rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayList> const& display_list, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
-    m_wheel_scroll_targets.clear();
+    m_wheel_hit_test_targets.clear();
     m_main_thread_wheel_event_targets.clear();
     m_visual_context_tree = nullptr;
     m_scroll_state_snapshot = scroll_state_snapshot;
@@ -241,19 +254,18 @@ void AsyncScrollTree::rebuild_wheel_scroll_targets(RefPtr<Painting::DisplayList>
     auto const& visual_context_tree = display_list->visual_context_tree();
     m_visual_context_tree = &visual_context_tree;
 
-    for (auto const& node : m_scroll_nodes) {
-        auto rect = node.scrollport_rect.to_type<float>();
-        auto viewport_rect = node.is_viewport
-            ? Gfx::FloatRect { {}, rect.size() }
-            : visual_context_tree.transform_rect_to_viewport(node.hit_test_visual_context_index, rect, scroll_state_snapshot);
-        m_wheel_scroll_targets.append({
-            .node_id = node.node_id,
-            .visual_context_index = node.hit_test_visual_context_index,
-            .rect = rect,
-            .viewport_rect = viewport_rect,
+    m_wheel_hit_test_targets.ensure_capacity(m_wheel_hit_test_regions.size());
+    for (auto const& target : m_wheel_hit_test_regions) {
+        m_wheel_hit_test_targets.append({
+            .target_node_id = target.target_node_id,
+            .visual_context_index = target.visual_context_index,
+            .rect = target.rect,
+            .corner_radii = target.corner_radii,
+            .viewport_rect = visual_context_tree.transform_rect_to_viewport(target.visual_context_index, target.rect, scroll_state_snapshot),
         });
     }
 
+    m_main_thread_wheel_event_targets.ensure_capacity(m_main_thread_wheel_event_regions.size());
     for (auto const& region : m_main_thread_wheel_event_regions) {
         m_main_thread_wheel_event_targets.append({
             .visual_context_index = region.visual_context_index,
@@ -263,11 +275,20 @@ void AsyncScrollTree::rebuild_wheel_scroll_targets(RefPtr<Painting::DisplayList>
     }
 }
 
-void AsyncScrollTree::clear_wheel_scroll_targets()
+void AsyncScrollTree::clear_wheel_hit_test_targets()
 {
-    m_wheel_scroll_targets.clear();
+    m_wheel_hit_test_targets.clear();
     m_main_thread_wheel_event_targets.clear();
     m_visual_context_tree = nullptr;
+}
+
+static bool wheel_hit_test_target_contains_point(CachedWheelHitTestTarget const& target, Gfx::FloatPoint position_in_context)
+{
+    if (!target.rect.contains(position_in_context))
+        return false;
+    if (!target.corner_radii.has_any_radius())
+        return true;
+    return target.corner_radii.contains(position_in_context.to_type<int>(), target.rect.to_type<int>());
 }
 
 Optional<Gfx::FloatPoint> AsyncScrollTree::scroll_offset_for_node(AsyncScrollNodeID node_id, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
@@ -300,24 +321,25 @@ WheelHitTestResult AsyncScrollTree::hit_test_scroll_node_for_wheel(Gfx::FloatPoi
             return { {}, true };
     }
 
-    for (auto const& target : m_wheel_scroll_targets.in_reverse()) {
+    for (auto const& target : m_wheel_hit_test_targets.in_reverse()) {
         if (!target.viewport_rect.contains(position))
             continue;
 
         auto position_in_context = m_visual_context_tree->transform_point_for_hit_test(target.visual_context_index, position, m_scroll_state_snapshot);
-        if (!position_in_context.has_value() || !target.rect.contains(*position_in_context))
+        if (!position_in_context.has_value() || !wheel_hit_test_target_contains_point(target, *position_in_context))
             continue;
-
-        auto const* node = scroll_node_for_id(target.node_id);
-        if (!node)
+        if (!target.target_node_id.has_value())
             return {};
-        if (can_scroll_node_by_delta(*node, m_scroll_state_snapshot, delta))
-            return { target.node_id, false };
-        if (auto ancestor = scrollable_ancestor_for_node(target.node_id, m_scroll_state_snapshot, delta); ancestor.has_value())
-            return { ancestor, false };
-        return {};
+        return hit_test_result_for_scroll_node(*target.target_node_id, delta);
     }
-    return {};
+
+    auto viewport_node_id = viewport_scroll_node_id();
+    if (!viewport_node_id.has_value())
+        return {};
+    auto const* viewport_node = scroll_node_for_id(*viewport_node_id);
+    if (!viewport_node || !viewport_node->scrollport_rect.to_type<float>().contains(position))
+        return {};
+    return hit_test_result_for_scroll_node(*viewport_node_id, delta);
 }
 
 bool AsyncScrollTree::scroll_node_is_viewport(AsyncScrollNodeID node_id) const

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
+#include <LibGfx/CornerRadii.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
@@ -22,15 +23,14 @@ struct WheelHitTestResult {
     bool blocked_by_main_thread_region { false };
 };
 
-// Viewport-space cache used for wheel hit-testing, rebuilt whenever scroll offsets change.
-struct WheelScrollTarget {
-    AsyncScrollNodeID node_id;
+struct CachedWheelHitTestTarget {
+    Optional<AsyncScrollNodeID> target_node_id;
     Painting::VisualContextIndex visual_context_index;
     Gfx::FloatRect rect;
+    Gfx::CornerRadii corner_radii;
     Gfx::FloatRect viewport_rect;
 };
 
-// Viewport-space cache of regions that force main-thread wheel routing.
 struct MainThreadWheelEventTarget {
     Painting::VisualContextIndex visual_context_index;
     Gfx::FloatRect rect;
@@ -43,8 +43,8 @@ class AsyncScrollTree {
 public:
     void set_state(AsyncScrollingState&&);
 
-    void rebuild_wheel_scroll_targets(RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&);
-    void clear_wheel_scroll_targets();
+    void rebuild_wheel_hit_test_targets(RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&);
+    void clear_wheel_hit_test_targets();
 
     Optional<Gfx::FloatPoint> scroll_offset_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&) const;
     Optional<AsyncScrollNodeID> viewport_scroll_node_id() const;
@@ -60,6 +60,7 @@ private:
     static bool has_non_zero_scroll_delta(Gfx::FloatPoint);
 
     AsyncScrollNode const* scroll_node_for_id(AsyncScrollNodeID) const;
+    WheelHitTestResult hit_test_result_for_scroll_node(AsyncScrollNodeID, Gfx::FloatPoint delta) const;
     AsyncStickyArea const* sticky_area_for_scroll_frame_index(Painting::ScrollFrameIndex) const;
     Optional<AsyncScrollNodeID> scrollable_ancestor_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint delta) const;
     Optional<Painting::ScrollFrameIndex> parent_scroll_frame_index(Painting::ScrollFrameIndex) const;
@@ -69,9 +70,10 @@ private:
 
     Vector<AsyncScrollNode> m_scroll_nodes;
     Vector<AsyncStickyArea> m_sticky_areas;
+    Vector<WheelHitTestTarget> m_wheel_hit_test_regions;
     Vector<MainThreadWheelEventRegion> m_main_thread_wheel_event_regions;
+    Vector<CachedWheelHitTestTarget> m_wheel_hit_test_targets;
     Vector<MainThreadWheelEventTarget> m_main_thread_wheel_event_targets;
-    Vector<WheelScrollTarget> m_wheel_scroll_targets;
     RefPtr<Painting::AccumulatedVisualContextTree const> m_visual_context_tree;
     Painting::ScrollStateSnapshot m_scroll_state_snapshot;
 };

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -104,6 +104,34 @@ static void record_main_thread_wheel_event_region(Painting::PaintableBox const& 
     });
 }
 
+static Optional<Painting::ScrollFrameIndex> wheel_hit_test_target_scroll_frame_index_for(Painting::PaintableBox const& paintable_box)
+{
+    if (paintable_box.own_scroll_frame_index().value() && paintable_box.could_be_scrolled_by_wheel_event())
+        return paintable_box.own_scroll_frame_index();
+    if (auto scrollable_ancestor = paintable_box.nearest_scrollable_ancestor())
+        return scrollable_ancestor->own_scroll_frame_index();
+    if (auto viewport_paintable = paintable_box.document().paintable(); viewport_paintable && viewport_paintable->could_be_scrolled_by_wheel_event())
+        return viewport_paintable->own_scroll_frame_index();
+    return {};
+}
+
+static void record_wheel_hit_test_target(Painting::PaintableBox const& paintable_box, DisplayListRecordingContext& context)
+{
+    if (!paintable_box.is_visible() || !paintable_box.visible_for_hit_testing())
+        return;
+
+    auto rect = css_rect_to_device_rect(paintable_box.absolute_border_box_rect(), context.device_pixels_per_css_pixel());
+    if (rect.is_empty())
+        return;
+
+    context.display_list_recorder().compositor_wheel_hit_test_target({
+        .document_id = paintable_box.document().unique_id(),
+        .target_scroll_frame_index = wheel_hit_test_target_scroll_frame_index_for(paintable_box).value_or({}),
+        .rect = rect,
+        .corner_radii = paintable_box.border_radii_data().as_corners(context.device_pixel_converter()),
+    });
+}
+
 static void record_viewport_scrollbar_state(Painting::PaintableBox const& paintable_box, DisplayListRecordingContext& context)
 {
     if (!paintable_box.is_viewport_paintable())
@@ -200,6 +228,8 @@ void record_async_scrolling_metadata_for_paintable(Painting::PaintableBox const&
     auto device_pixels_per_css_pixel = context.device_pixels_per_css_pixel();
     auto& recorder = context.display_list_recorder();
 
+    record_wheel_hit_test_target(paintable_box, context);
+
     if (!context.has_blocking_wheel_event_region_covering_viewport()) {
         if (auto node = paintable_box.dom_node(); node && !is_root_wheel_event_target(*node) && has_blocking_wheel_event_listener(*node)) {
             context.set_has_blocking_wheel_event_listeners(true);
@@ -259,6 +289,8 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
 {
     AsyncScrollingState async_scrolling_state;
     Vector<Painting::ScrollFrameIndex> parent_scroll_frame_indices;
+    Vector<Painting::ScrollFrameIndex> wheel_hit_test_target_scroll_frame_indices;
+    Vector<UniqueNodeID> wheel_hit_test_target_document_ids;
 
     if (auto const& metadata = display_list.async_scrolling_metadata(); metadata.has_value()) {
         async_scrolling_state.viewport_rect = metadata->viewport_rect;
@@ -310,6 +342,18 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
             parent_scroll_frame_indices.append(command.parent_scroll_frame_index);
             break;
         }
+        case Painting::DisplayListCommandType::CompositorWheelHitTestTarget: {
+            auto command = Painting::read_display_list_command_payload<Painting::CompositorWheelHitTestTarget>(payload);
+            async_scrolling_state.wheel_hit_test_targets.append({
+                .visual_context_index = header.context_index,
+                .rect = command.rect,
+                .corner_radii = command.corner_radii,
+                .target_node_id = {},
+            });
+            wheel_hit_test_target_scroll_frame_indices.append(command.target_scroll_frame_index);
+            wheel_hit_test_target_document_ids.append(command.document_id);
+            break;
+        }
         case Painting::DisplayListCommandType::CompositorMainThreadWheelEventRegion: {
             auto command = Painting::read_display_list_command_payload<Painting::CompositorMainThreadWheelEventRegion>(payload);
             async_scrolling_state.main_thread_wheel_event_regions.append({
@@ -346,6 +390,14 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
         auto parent_scroll_frame_index = parent_scroll_frame_indices[i];
         if (parent_scroll_frame_index.value())
             async_scrolling_state.scroll_nodes[i].parent_node_id = scroll_node_id_for(async_scrolling_state.scroll_nodes[i].node_id.document_id, parent_scroll_frame_index);
+    }
+
+    VERIFY(wheel_hit_test_target_scroll_frame_indices.size() == async_scrolling_state.wheel_hit_test_targets.size());
+    VERIFY(wheel_hit_test_target_document_ids.size() == async_scrolling_state.wheel_hit_test_targets.size());
+    for (size_t i = 0; i < async_scrolling_state.wheel_hit_test_targets.size(); ++i) {
+        auto target_scroll_frame_index = wheel_hit_test_target_scroll_frame_indices[i];
+        if (target_scroll_frame_index.value())
+            async_scrolling_state.wheel_hit_test_targets[i].target_node_id = scroll_node_id_for(wheel_hit_test_target_document_ids[i], target_scroll_frame_index);
     }
     return async_scrolling_state;
 }
@@ -412,7 +464,7 @@ static WheelHitTestResult hit_test_scroll_node_at_position(AsyncScrollingState c
     AsyncScrollTree scroll_tree;
     auto async_scrolling_state_copy = async_scrolling_state;
     scroll_tree.set_state(move(async_scrolling_state_copy));
-    scroll_tree.rebuild_wheel_scroll_targets(display_list, scroll_state_snapshot);
+    scroll_tree.rebuild_wheel_hit_test_targets(display_list, scroll_state_snapshot);
     return scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
 }
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -10,6 +10,7 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/CornerRadii.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/Forward.h>
@@ -61,6 +62,13 @@ struct BlockingWheelEventRegion {
     Gfx::FloatRect rect;
 };
 
+struct WheelHitTestTarget {
+    Painting::VisualContextIndex visual_context_index;
+    Gfx::FloatRect rect;
+    Gfx::CornerRadii corner_radii;
+    Optional<AsyncScrollNodeID> target_node_id;
+};
+
 // A region that must always use main-thread wheel routing even without a blocking listener, such as a nested navigable.
 struct MainThreadWheelEventRegion {
     Painting::VisualContextIndex visual_context_index;
@@ -85,6 +93,7 @@ struct ViewportScrollbar {
 struct AsyncScrollingState {
     Vector<AsyncScrollNode> scroll_nodes;
     Vector<AsyncStickyArea> sticky_areas;
+    Vector<WheelHitTestTarget> wheel_hit_test_targets;
     Vector<MainThreadWheelEventRegion> main_thread_wheel_event_regions;
     Vector<ViewportScrollbar> viewport_scrollbars;
 

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -678,7 +678,7 @@ public:
                                 if (auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(viewport_node->node_id, *pending_async_viewport_scroll_offset, m_cached_scroll_state_snapshot); reconciled_scroll_offset.has_value())
                                     async_scrolling_viewport_rect.set_location(reconciled_scroll_offset->to_type<int>());
                             }
-                            m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
                         }
                         {
                             Sync::MutexLocker const locker { m_mutex };
@@ -698,7 +698,7 @@ public:
                                 return;
                             }
                             scroll_offset = m_async_scroll_tree.scroll_offset_for_node(cmd.scroll_target, m_cached_scroll_state_snapshot);
-                            m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
                         }
                         if (scroll_offset.has_value()) {
                             async_scroll_viewport_rect.set_location(scroll_offset->to_type<int>());
@@ -747,7 +747,7 @@ public:
                                         reconciled_viewport_scroll_offset = m_async_scroll_tree.set_scroll_offset(*viewport_node_id, *pending_async_viewport_scroll_offset, m_cached_scroll_state_snapshot);
                                     }
                                 }
-                                m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                                m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
                             }
                             if (reconciled_viewport_scroll_offset.has_value()) {
                                 Sync::MutexLocker const mutex_locker { m_mutex };
@@ -900,7 +900,7 @@ private:
             if (!m_async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, m_cached_scroll_state_snapshot))
                 return false;
             scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
-            m_async_scroll_tree.rebuild_wheel_scroll_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+            m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
         }
 
         if (!scroll_offset.has_value())

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -754,7 +754,7 @@ String Internals::async_scrolling_state_wheel_target_at(double x, double y, doub
 
     Compositor::AsyncScrollTree scroll_tree;
     scroll_tree.set_state(move(snapshot->state));
-    scroll_tree.rebuild_wheel_scroll_targets(snapshot->display_list, snapshot->document_paintable->scroll_state_snapshot());
+    scroll_tree.rebuild_wheel_hit_test_targets(snapshot->display_list, snapshot->document_paintable->scroll_state_snapshot());
 
     auto target = scroll_tree.hit_test_scroll_node_for_wheel(
         { static_cast<float>(x), static_cast<float>(y) },

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -121,6 +121,7 @@ private:
     virtual void paint_nested_display_list(PaintNestedDisplayList const&) = 0;
     virtual void compositor_scroll_node(CompositorScrollNode const&) = 0;
     virtual void compositor_sticky_area(CompositorStickyArea const&) = 0;
+    virtual void compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&) = 0;
     virtual void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&) = 0;
     virtual void compositor_viewport_scrollbar(CompositorViewportScrollbar const&) = 0;
     virtual void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&) = 0;

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -183,6 +183,18 @@ void CompositorBlockingWheelEventRegion::dump(StringBuilder& builder) const
     builder.appendff(" rect={}", rect);
 }
 
+void CompositorWheelHitTestTarget::dump(StringBuilder& builder) const
+{
+    builder.appendff(" target_scroll_frame_index={} rect={}", target_scroll_frame_index, rect);
+    if (corner_radii.has_any_radius()) {
+        builder.appendff(" corner_radii=[{}x{},{}x{},{}x{},{}x{}]",
+            corner_radii.top_left.horizontal_radius, corner_radii.top_left.vertical_radius,
+            corner_radii.top_right.horizontal_radius, corner_radii.top_right.vertical_radius,
+            corner_radii.bottom_right.horizontal_radius, corner_radii.bottom_right.vertical_radius,
+            corner_radii.bottom_left.horizontal_radius, corner_radii.bottom_left.vertical_radius);
+    }
+}
+
 void CompositorMainThreadWheelEventRegion::dump(StringBuilder& builder) const
 {
     builder.appendff(" rect={}", rect);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -63,6 +63,7 @@ class DisplayList;
     V(PaintNestedDisplayList, paint_nested_display_list)                               \
     V(CompositorScrollNode, compositor_scroll_node)                                    \
     V(CompositorStickyArea, compositor_sticky_area)                                    \
+    V(CompositorWheelHitTestTarget, compositor_wheel_hit_test_target)                  \
     V(CompositorMainThreadWheelEventRegion, compositor_main_thread_wheel_event_region) \
     V(CompositorViewportScrollbar, compositor_viewport_scrollbar)                      \
     V(CompositorBlockingWheelEventRegion, compositor_blocking_wheel_event_region)      \
@@ -546,6 +547,18 @@ struct CompositorBlockingWheelEventRegion {
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorBlockingWheelEventRegion;
 
     Gfx::FloatRect rect;
+
+    void dump(StringBuilder&) const;
+};
+
+struct CompositorWheelHitTestTarget {
+    static constexpr StringView command_name = "CompositorWheelHitTestTarget"sv;
+    static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorWheelHitTestTarget;
+
+    UniqueNodeID document_id;
+    ScrollFrameIndex target_scroll_frame_index;
+    Gfx::FloatRect rect;
+    Gfx::CornerRadii corner_radii;
 
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -829,6 +829,10 @@ void DisplayListPlayerSkia::compositor_sticky_area(CompositorStickyArea const&)
 {
 }
 
+void DisplayListPlayerSkia::compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&)
+{
+}
+
 void DisplayListPlayerSkia::compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&)
 {
 }

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -52,6 +52,7 @@ private:
     void add_rounded_rect_clip(AddRoundedRectClip const&) override;
     void compositor_scroll_node(CompositorScrollNode const&) override;
     void compositor_sticky_area(CompositorStickyArea const&) override;
+    void compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&) override;
     void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&) override;
     void compositor_viewport_scrollbar(CompositorViewportScrollbar const&) override;
     void compositor_blocking_wheel_event_region(CompositorBlockingWheelEventRegion const&) override;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -722,6 +722,11 @@ void DisplayListRecorder::compositor_sticky_area(CompositorStickyArea const& sti
     append_command(sticky_area);
 }
 
+void DisplayListRecorder::compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const& target)
+{
+    append_command(target);
+}
+
 void DisplayListRecorder::set_async_scrolling_metadata(DisplayList::AsyncScrollingMetadata metadata)
 {
     m_display_list.set_async_scrolling_metadata(metadata);

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -142,6 +142,7 @@ public:
 
     void compositor_scroll_node(CompositorScrollNode const&);
     void compositor_sticky_area(CompositorStickyArea const&);
+    void compositor_wheel_hit_test_target(CompositorWheelHitTestTarget const&);
     void set_async_scrolling_metadata(DisplayList::AsyncScrollingMetadata);
     void compositor_main_thread_wheel_event_region(CompositorMainThreadWheelEventRegion const&);
     void compositor_viewport_scrollbar(CompositorViewportScrollbar const&);

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
@@ -12,6 +12,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x13]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[20,20 100x100]
   CompositorBlockingWheelEventRegion@2 rect=[20,20 100x100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[20,160 100x100]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[20,160 200x100]
   CompositorBlockingWheelEventRegion@4 rect=[20,160 200x100]
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
@@ -30,8 +30,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 200x200]
   CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x100]
   CompositorBlockingWheelEventRegion@3 rect=[0,0 100x100]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,100 1000x1000]
   PaintScrollBar@1
   PaintScrollBar@1
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
@@ -3,8 +3,13 @@ listener generation increased: true
 after routing admission: blocking wheel event listeners
 display list:
 AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2013]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/covered-sibling-scroller-wheel-target.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/covered-sibling-scroller-wheel-target.txt
@@ -1,0 +1,5 @@
+uncovered scroller wheel target: non-viewport
+covered scroller wheel target: viewport
+covered scroller with pointer-events none wheel target: non-viewport
+scroller scrollTop after covered wheel: 0
+window scrollY after covered wheel: 100

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
@@ -7,7 +7,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2013]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[40,40 160x120]
   CompositorMainThreadWheelEventRegion@1 rect=[40,40 160x120]
   Save@1
     AddClipRect@1 rect=[40,40 160x120]

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
@@ -3,10 +3,18 @@ window scrollY: 0
 display list:
 AccumulatedVisualContext Tree:
   [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[0,0 100x100]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 100x100]
   CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x500]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
   PaintScrollBar@1
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/rounded-overlay-wheel-target.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/rounded-overlay-wheel-target.txt
@@ -1,0 +1,2 @@
+rounded corner wheel target: non-viewport
+rounded center wheel target: viewport

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
@@ -6,12 +6,21 @@ display list:
 AccumulatedVisualContext Tree:
   [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+      [3] clip=[0,0 100x100]
+        [4] scroll_frame_id=3 (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=1 rect=[0,0 800x100]
   CompositorStickyArea@2 scroll_frame_index=2 parent_scroll_frame_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x100] scrollport_size=[800x600] containing_block_region=[0,0 800x2100] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=3 rect=[0,0 100x100]
   CompositorScrollNode@2 scroll_frame_index=3 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=3 rect=[0,0 500x500]
   PaintScrollBar@2
   PaintScrollBar@2
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
@@ -8,11 +8,19 @@ child parent is viewport: true
 display list:
 AccumulatedVisualContext Tree:
   [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[0,0 100x100]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 100x100]
   CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 500x500]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
   PaintScrollBar@1
   PaintScrollBar@1
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
@@ -14,8 +14,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1431] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2031]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2018]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,18 800x2000]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=1 rect=[0,0 800x18]
   CompositorStickyArea@2 scroll_frame_index=2 parent_scroll_frame_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x18] scrollport_size=[800x600] containing_block_region=[0,0 800x2018] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=1 rect=[0,0 800x18]
   CompositorStickyArea@3 scroll_frame_index=3 parent_scroll_frame_index=2 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x18] scrollport_size=[800x600] containing_block_region=[0,0 800x18] needs_parent_offset_adjustment=true inset_top=20 inset_right=none inset_bottom=none inset_left=none
   DrawGlyphRun@3 rect=[0,0 45x18] translation=[0,13.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
@@ -5,10 +5,18 @@ scroller wheel target: non-viewport
 display list:
 AccumulatedVisualContext Tree:
   [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[0,0 100x100]
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#scroller-spacer))
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 100x100]
   CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x500]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
   PaintScrollBar@1
 Restore@0

--- a/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
@@ -14,8 +14,15 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 200x200]
   CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x100]
   CompositorBlockingWheelEventRegion@3 rect=[0,0 100x100]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,100 1000x1000]
   PaintScrollBar@1
   PaintScrollBar@1
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[250,0 100x100]
 Restore@0

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -3,6 +3,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x39]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 27.15625x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[43.15625,8 27.640625x18]
   DrawGlyphRun@1 rect=[35,8 8x18] translation=[35.15625,21.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,8 28x18] translation=[8,21.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[8,25] to=[35,25] color=rgb(0, 0, 0) thickness=2

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -6,6 +6,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@6 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@6 rect=[8,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -5,6 +5,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@4 rect=[8,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -4,9 +4,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,613] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x1213]
   Save@1
     PaintLinearGradient@2 rect=[0,0 800x600]
   Restore@1
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,13 800x1200]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -3,8 +3,15 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x43]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x22]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x22]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 105.671875x22]
   FillRect@1 rect=[8,8 106x22] color=rgb(212, 208, 200)
   FillPath@1 path_bounding_rect=[8,8 106x22]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[13,10 95.671875x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[13,10 95.671875x18]
   DrawGlyphRun@1 rect=[13,10 96x18] translation=[13,23.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[13,27] to=[109,27] color=rgb(0, 0, 0) thickness=2
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -5,6 +5,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,13 30x18] translation=[8,26.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -16,6 +19,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,13 30x18] translation=[8,26.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -5,6 +5,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -16,6 +20,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -3,6 +3,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x41]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x20]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x20]
   FillRect@1 rect=[8,8 1x18] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 104x24]
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -4,6 +4,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 150x150]
   FillRect@2 rect=[8,13 150x150] color=rgb(128, 0, 128)
   DrawGlyphRun@2 rect=[8,13 71x18] translation=[8,26.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@2 rect=[8,31 72x18] translation=[8,44.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -10,15 +10,25 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x225]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x204]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 404x204]
   FillPath@1 path_bounding_rect=[8,8 404x204]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[10,10 195x200]
   FillPath@2 path_bounding_rect=[10,10 195x200]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[215,10 195x200]
   FillPath@2 path_bounding_rect=[215,10 195x200]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[16,16 150x80]
   FillRect@4 rect=[16,16 150x80] color=rgb(255, 0, 0)
   DrawGlyphRun@4 rect=[16,16 15x18] translation=[16,29.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[16,101 150x80]
   FillRect@5 rect=[16,101 150x80] color=rgb(0, 128, 0)
   DrawGlyphRun@5 rect=[16,101 10x18] translation=[16,114.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@7 target_scroll_frame_index=0 rect=[221,16 150x80]
   FillRect@7 rect=[221,16 150x80] color=rgb(0, 0, 255)
   DrawGlyphRun@7 rect=[221,16 11x18] translation=[221,29.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@8 target_scroll_frame_index=0 rect=[221,101 150x80]
   FillRect@8 rect=[221,101 150x80] color=rgb(255, 165, 0)
   DrawGlyphRun@8 rect=[221,101 12x18] translation=[221,114.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
@@ -3,6 +3,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x74.59375]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x53.59375]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[10,8 780x53.59375]
   Save@1
     AddClipRect@1 rect=[10,16 780x46]
     FillRect@1 rect=[10,8 780x54] color=rgb(0, 0, 255)
@@ -23,6 +27,9 @@ SaveLayer@0
     FillPath@1 path_bounding_rect=[10,16 780x1]
     FillPath@1 path_bounding_rect=[9,17 782x1]
   Restore@1
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[24,8 57.328125x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[24,31.59375 752x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[24,31.59375 752x18]
   DrawGlyphRun@1 rect=[26,8 54x18] translation=[26,21.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[24,31 63x18] translation=[24,45.390625] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -4,8 +4,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x100]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 150x50]
   FillRect@2 rect=[8,8 150x50] color=rgb(0, 128, 0)
   DrawGlyphRun@2 rect=[8,8 56x18] translation=[8,21.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[10,10 80x40]
   FillRect@0 rect=[10,10 80x40] color=rgb(255, 0, 0)
   DrawGlyphRun@0 rect=[10,10 44x18] translation=[10,23.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
@@ -3,10 +3,19 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x51]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x30]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 147x30]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 28.59375x30]
   FillRect@1 rect=[8,8 29x30] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[37.59375,8 28.59375x30]
   FillRect@1 rect=[38,8 28x30] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[67.1875,8 28.59375x30]
   FillRect@1 rect=[67,8 29x30] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[96.78125,8 28.59375x30]
   FillRect@1 rect=[97,8 28x30] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[126.375,8 28.59375x30]
   FillRect@1 rect=[126,8 29x30] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -5,8 +5,15 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x43]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x22]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x22]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 102x22]
   FillRect@1 rect=[8,8 102x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 102x22]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[9,9 100x20]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 96x18]
   DrawGlyphRun@3 rect=[11,10 37x18] translation=[11,23.796875] color=rgb(0, 0, 0)
   FillRect@3 rect=[11,10 1x18] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 106x26]

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -7,10 +7,20 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x45]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x24]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x24]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 202x22]
   FillRect@1 rect=[8,8 202x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 202x22]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[9,9 200x20]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 196x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[218,8 202x22]
   FillRect@1 rect=[218,8 202x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[218,8 202x22]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[219,9 200x20]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[221,10 196x18]
   DrawGlyphRun@1 rect=[210,14 8x18] translation=[210,27.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@3 rect=[11,10 28x18] translation=[11,23.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@5 rect=[221,10 28x18] translation=[221,23.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -6,9 +6,16 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x123]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x102]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x102]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[118,8 102x102]
   FillPath@1 path_bounding_rect=[118,8 102x102]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[119,9 150x150]
   FillRect@4 rect=[119,9 150x150] color=rgb(173, 216, 230)
   DrawGlyphRun@4 rect=[119,9 55x18] translation=[119,22.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@2 rect=[8,8 88x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -4,6 +4,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x93]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x72]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x72]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 69.625x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,26 47.0625x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,44 60x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,62 36.46875x18]
   DrawGlyphRun@1 rect=[8,8 70x18] translation=[8,21.796875] color=rgb(0, 0, 255)
   DrawLine@1 from=[8,25] to=[78,25] color=rgb(0, 0, 255) thickness=2
   DrawGlyphRun@1 rect=[8,26 48x18] translation=[8,39.796875] color=rgb(0, 0, 255)
@@ -20,6 +28,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x93]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x72]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x72]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 69.625x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,26 47.0625x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,44 60x18]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,62 36.46875x18]
   DrawGlyphRun@1 rect=[8,8 70x18] translation=[8,21.796875] color=rgb(255, 0, 0)
   DrawLine@1 from=[8,25] to=[78,25] color=rgb(255, 0, 0) thickness=2
   DrawGlyphRun@1 rect=[8,26 48x18] translation=[8,39.796875] color=rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -10,15 +10,25 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x295]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x274]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 324x274]
   FillPath@1 path_bounding_rect=[8,8 324x274]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[20,20 145x250]
   FillPath@2 path_bounding_rect=[20,20 145x250]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[175,20 145x250]
   FillPath@2 path_bounding_rect=[175,20 145x250]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[26,26 133x40]
   FillRect@4 rect=[26,26 133x40] color=rgb(255, 136, 136)
   DrawGlyphRun@4 rect=[26,26 20x18] translation=[26,39.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[26,71 133x40]
   FillRect@5 rect=[26,71 133x40] color=rgb(136, 255, 136)
   DrawGlyphRun@5 rect=[26,71 22x18] translation=[26,84.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@7 target_scroll_frame_index=0 rect=[181,26 133x40]
   FillRect@7 rect=[181,26 133x40] color=rgb(136, 136, 255)
   DrawGlyphRun@7 rect=[181,26 22x18] translation=[181,39.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@8 target_scroll_frame_index=0 rect=[181,71 133x40]
   FillRect@8 rect=[181,71 133x40] color=rgb(255, 255, 136)
   DrawGlyphRun@8 rect=[181,71 25x18] translation=[181,84.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -7,11 +7,17 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x175]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x154]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[8,8 204x154]
   CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[10,10 200x150] max_scroll_offset=[102,0] is_viewport=false
   FillPath@1 path_bounding_rect=[8,8 204x154]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=3 rect=[10,10 302x102]
   CompositorScrollNode@3 scroll_frame_index=3 parent_scroll_frame_index=2 scrollport_rect=[11,11 300x100] max_scroll_offset=[100,0] is_viewport=false
   FillRect@3 rect=[10,10 302x102] color=rgb(255, 255, 224)
   FillPath@3 path_bounding_rect=[10,10 302x102]
+  CompositorWheelHitTestTarget@5 target_scroll_frame_index=3 rect=[11,11 400x80]
   FillRect@5 rect=[11,11 400x80] color=rgb(240, 128, 128)
   DrawGlyphRun@5 rect=[11,11 178x18] translation=[11,24.796875] color=rgb(0, 0, 0)
   PaintScrollBar@3

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -5,6 +5,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 255)
   DrawGlyphRun@3 rect=[8,8 21x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -4,8 +4,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 200x200]
   FillRect@2 rect=[8,8 200x200] color=rgb(211, 211, 211)
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 200x90]
   FillRect@2 rect=[8,8 200x90] color=rgb(173, 216, 230)
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[33,33 100x50]
   FillRect@2 rect=[33,33 100x50] color=rgb(255, 127, 80)
   DrawGlyphRun@2 rect=[33,33 84x18] translation=[33,46.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -5,8 +5,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x321]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x300]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 300x300]
   FillRect@1 rect=[8,8 300x300] color=rgb(211, 211, 211)
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[13,13 100x100]
   FillRect@3 rect=[13,13 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@3 rect=[13,13 65x18] translation=[13,26.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -1,13 +1,19 @@
 AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
   [2] clip=[33,33 180x100]
     [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[20,20 204x154]
   FillRect@0 rect=[20,20 204x154] color=rgb(211, 211, 211)
   FillPath@0 path_bounding_rect=[20,20 204x154]
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=2 rect=[32,32 182x102]
   CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[33,33 180x100] max_scroll_offset=[120,100] is_viewport=false
   FillPath@0 path_bounding_rect=[32,32 182x102]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[33,33 300x200]
   FillRect@3 rect=[33,33 300x200] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[33,33 179x18] translation=[33,46.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -7,9 +7,17 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x103]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x82]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x82]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 102x82]
   FillPath@1 path_bounding_rect=[8,8 102x82]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[9,9 150x120]
   FillRect@3 rect=[9,9 150x120] color=rgb(240, 128, 128)
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[130,8 102x82]
   FillPath@1 path_bounding_rect=[130,8 102x82]
+  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[131,9 150x120]
   FillRect@5 rect=[131,9 150x120] color=rgb(144, 238, 144)
   DrawGlyphRun@3 rect=[9,9 110x18] translation=[9,22.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@5 rect=[131,9 119x18] translation=[131,22.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -1,4 +1,5 @@
 AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
   [2] clip=[23,23 91x150]
     [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
   [4] clip=[126,23 92x150]
@@ -8,16 +9,25 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[10,10 324x224]
   FillRect@0 rect=[10,10 324x224] color=rgb(211, 211, 211)
   FillPath@0 path_bounding_rect=[10,10 324x224]
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=2 rect=[22,22 93.328125x152]
   CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[23,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[22,22 93x152]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[23,23 200x300]
   FillRect@3 rect=[23,23 200x300] color=rgb(240, 128, 128)
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=3 rect=[125.328125,22 93.328125x152]
   CompositorScrollNode@0 scroll_frame_index=3 parent_scroll_frame_index=0 scrollport_rect=[126,23 92x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[125,22 94x152]
+  CompositorWheelHitTestTarget@5 target_scroll_frame_index=3 rect=[126.328125,23 200x300]
   FillRect@5 rect=[126,23 200x300] color=rgb(144, 238, 144)
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=4 rect=[228.65625,22 93.328125x152]
   CompositorScrollNode@0 scroll_frame_index=4 parent_scroll_frame_index=0 scrollport_rect=[230,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[229,22 93x152]
+  CompositorWheelHitTestTarget@7 target_scroll_frame_index=4 rect=[229.65625,23 200x300]
   FillRect@7 rect=[230,23 200x300] color=rgb(173, 216, 230)
   DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -5,8 +5,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x101]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x80]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x80]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 80x80]
   FillRect@2 rect=[8,8 80x80] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,8 15x18] translation=[8,21.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[98,8 80x80]
   FillRect@3 rect=[98,8 80x80] color=rgb(0, 0, 255)
   DrawGlyphRun@3 rect=[98,8 10x18] translation=[98,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -5,7 +5,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x125]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x104]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 204x104]
   FillPath@1 path_bounding_rect=[8,8 204x104]
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[10,10 300x150]
   FillRect@3 rect=[10,10 300x150] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[10,10 38x18] translation=[10,23.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
+++ b/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
@@ -4,6 +4,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,108 100x100]
+  CompositorWheelHitTestTarget@6 target_scroll_frame_index=0 rect=[8,108 50x50]
   FillRect@6 rect=[8,108 50x50] color=rgb(255, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -5,6 +5,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
   Save@2
     AddClipRect@2 rect=[-2,-2 119x119]
     SaveLayer@2
@@ -18,6 +23,8 @@ SaveLayer@0
   Save@2
     AddClipRect@2 rect=[-2,-2 119x119]
     SaveLayer@2
+      CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+      CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
       FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 0)
       ApplyEffects@2 opacity=1 has_filter=false
         PaintNestedDisplayList@2 rect=[-2,-2 119x119]

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -3,10 +3,17 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 300x200]
   Save@1
     AddClipRect@1 rect=[8,13 300x200]
     PaintNestedDisplayList@1 rect=[8,13 300x200]
       SaveLayer@0
+        CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 300x200]
+        CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 300x200]
         FillPath@1 path_bounding_rect=[5,0 55x56]
         FillPath@1 path_bounding_rect=[1,50 55x55]
         Save@1

--- a/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
@@ -4,6 +4,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 200x200]
   FillPath@2 path_bounding_rect=[10,10 100x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -6,6 +6,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
   FillPath@4 path_bounding_rect=[8,8 100x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
+++ b/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
@@ -3,6 +3,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x71]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x50]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x50]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 168.54688x50]
   FillRect@1 rect=[69,-17 47x100] color=rgba(61, 174, 233, 0.5)
   Save@1
     AddClipRect@1 rect=[8,-17 61x100]

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -4,8 +4,15 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x57]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x36]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x36]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 106x36]
   FillRect@1 rect=[8,8 106x36] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 106x36]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,11 100x15]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,11 100x15]
   DrawGlyphRun@2 rect=[11,11 30x15] translation=[11,22.390625] color=rgb(0, 0, 0)
   FillRect@2 rect=[11,11 1x15] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 110x40]

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -6,10 +6,17 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x81]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x60]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x60]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 60x60]
   FillRect@2 rect=[8,8 60x60] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,8 7x18] translation=[8,21.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[73,8 60x60]
   FillRect@3 rect=[73,8 60x60] color=rgb(0, 128, 0)
   DrawGlyphRun@3 rect=[73,8 9x18] translation=[73,21.796875] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[138,8 60x60]
   FillRect@4 rect=[138,8 60x60] color=rgb(0, 0, 255)
   DrawGlyphRun@4 rect=[138,8 10x18] translation=[138,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -4,6 +4,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,8 38x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -5,7 +5,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 200x200]
   FillRect@2 rect=[8,8 200x200] color=rgb(173, 216, 230)
+  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@3 rect=[8,8 52x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -6,7 +6,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x175]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x154]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 154x154]
   FillPath@1 path_bounding_rect=[8,8 154x154]
+  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[10,10 200x200]
   FillRect@4 rect=[10,10 200x200] color=rgb(144, 238, 144)
   DrawGlyphRun@4 rect=[10,10 185x18] translation=[10,23.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
+++ b/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
@@ -4,6 +4,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 50x50]
   FillRect@1 rect=[8,8 50x50] color=rgb(0, 0, 255)
 Restore@0
 
@@ -13,6 +18,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
+  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 50x50]
   FillRect@1 rect=[8,8 50x50] color=rgb(0, 0, 255)
 Restore@0
 

--- a/Tests/LibWeb/Text/input/async-scrolling/covered-sibling-scroller-wheel-target.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/covered-sibling-scroller-wheel-target.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+    }
+
+    #spacer {
+        height: 800px;
+    }
+
+    #overlay {
+        position: absolute;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+
+    #page-spacer {
+        height: 2000px;
+        margin-top: 200px;
+    }
+</style>
+<div id="scroller"><div id="spacer"></div></div>
+<div id="overlay"></div>
+<div id="page-spacer"></div>
+<script>
+    promiseTest(async () => {
+        println(`uncovered scroller wheel target: ${internals.asyncScrollingStateWheelTargetAt(150, 150, 0, 100)}`);
+        println(`covered scroller wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+
+        overlay.style.pointerEvents = "none";
+        println(`covered scroller with pointer-events none wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+        overlay.style.pointerEvents = "auto";
+
+        internals.wheel(50, 50, 0, 100);
+        await animationFrame();
+
+        println(`scroller scrollTop after covered wheel: ${scroller.scrollTop}`);
+        println(`window scrollY after covered wheel: ${window.scrollY}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/rounded-overlay-wheel-target.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/rounded-overlay-wheel-target.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+    }
+
+    #spacer {
+        height: 800px;
+    }
+
+    #overlay {
+        position: absolute;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        border-radius: 50px;
+        background-color: red;
+    }
+
+    #page-spacer {
+        height: 2000px;
+        margin-top: 200px;
+    }
+</style>
+<div id="scroller"><div id="spacer"></div></div>
+<div id="overlay"></div>
+<div id="page-spacer"></div>
+<script>
+    test(() => {
+        println(`rounded corner wheel target: ${internals.asyncScrollingStateWheelTargetAt(5, 5, 0, 100)}`);
+        println(`rounded center wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+    });
+</script>


### PR DESCRIPTION
Async wheel routing used scroll node scrollports as the hit-test surface. That works while the scrollable content is the topmost content under the pointer, but it ignores the rest of the painted scene. A sibling with a higher z-index can visually cover a nested scroller without being part of that scroller's subtree. In that case the compositor could still pick the covered scroller from its scrollport rect and consume the wheel event, even though normal hit testing would target the covering element and let the page or an ancestor handle the scroll.

Record wheel hit-test targets as display-list metadata in paint order and resolve each target to the scroll frame that should receive wheel deltas. The compositor can then walk those targets from front to back, preserve non-passive wheel regions as main-thread barriers, and only scroll the node associated with the topmost hit-testable box.