### PR TITLE
LibJS: Store Shape metadata in compact descriptor arrays

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1447,11 +1447,12 @@ struct FastPropertyNameIteratorData {
 
 static bool shape_has_enumerable_string_property(Shape const& shape)
 {
-    for (auto const& [property_key, metadata] : shape.property_table()) {
+    bool has_enumerable_string_property = false;
+    shape.for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
         if (property_key.is_string() && metadata.attributes.is_enumerable())
-            return true;
-    }
-    return false;
+            has_enumerable_string_property = true;
+    });
+    return has_enumerable_string_property;
 }
 
 static bool property_name_iterator_fast_path_is_still_eligible(Object& object, PropertyNameIterator::FastPath fast_path, u32 indexed_property_count)
@@ -1550,10 +1551,10 @@ static ThrowCompletionOr<Optional<FastPropertyNameIteratorData>> try_get_fast_pr
         // Common case: only the receiver contributes enumerable string keys, so
         // we can copy them straight from the shape without any shadowing work.
         result.properties.ensure_capacity(object.shape().property_count());
-        for (auto const& [property_key, metadata] : object.shape().property_table()) {
+        object.shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
             if (property_key.is_string() && metadata.attributes.is_enumerable())
                 result.properties.append(property_key);
-        }
+        });
         return result;
     }
 
@@ -1583,25 +1584,25 @@ static ThrowCompletionOr<Optional<FastPropertyNameIteratorData>> try_get_fast_pr
         if (object_to_check->has_magical_length_property())
             seen_non_enumerable_properties.set(vm.names.length);
 
-        for (auto const& [property_key, metadata] : object_to_check->shape().property_table()) {
+        object_to_check->shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
             if (!property_key.is_string())
-                continue;
+                return;
 
             bool enumerable = metadata.attributes.is_enumerable();
             if (!enumerable)
                 seen_non_enumerable_properties.set(property_key);
             if (in_prototype_chain && enumerable) {
                 if (seen_non_enumerable_properties.contains(property_key))
-                    continue;
+                    return;
                 ensure_seen_properties();
                 if (seen_properties->contains(property_key))
-                    continue;
+                    return;
             }
             if (enumerable)
                 result.properties.append(property_key);
             if (seen_properties.has_value())
                 seen_properties->set(property_key);
-        }
+        });
         in_prototype_chain = true;
     }
 

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCES
     Runtime/DataView.cpp
     Runtime/DataViewConstructor.cpp
     Runtime/DataViewPrototype.cpp
+    Runtime/DescriptorArray.cpp
     Runtime/Date.cpp
     Runtime/DateConstructor.cpp
     Runtime/DatePrototype.cpp

--- a/Libraries/LibJS/Runtime/DescriptorArray.cpp
+++ b/Libraries/LibJS/Runtime/DescriptorArray.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NumericLimits.h>
+#include <AK/QuickSort.h>
+#include <LibJS/Runtime/DescriptorArray.h>
+#include <LibJS/Runtime/ExternalMemory.h>
+
+namespace JS {
+
+GC_DEFINE_ALLOCATOR(DescriptorArray);
+
+static u32 property_key_hash(PropertyKey const& property_key)
+{
+    return AK::Traits<PropertyKey>::hash(property_key);
+}
+
+DescriptorArray::DescriptorArray(DescriptorArray const& other, u32 descriptor_count)
+{
+    VERIFY(descriptor_count <= max_descriptor_count);
+    m_entries.ensure_capacity(descriptor_count);
+    other.for_each_in_insertion_order([&](auto const& property_key, auto const& metadata) {
+        set(property_key, metadata, m_entries.size());
+    },
+        descriptor_count);
+}
+
+Optional<PropertyMetadata> DescriptorArray::lookup(PropertyKey const& property_key, u32 descriptor_count) const
+{
+    auto index = find(property_key, descriptor_count);
+    if (!index.has_value())
+        return {};
+    return m_entries[*index].metadata();
+}
+
+void DescriptorArray::set(PropertyKey const& property_key, PropertyMetadata metadata, u32 enum_index)
+{
+    VERIFY(enum_index < max_descriptor_count);
+    if (auto existing_index = find(property_key, enum_index + 1); existing_index.has_value()) {
+        auto& entry = m_entries[*existing_index];
+        entry.offset = metadata.offset;
+        entry.attributes = metadata.attributes.bits();
+        return;
+    }
+
+    auto insertion_index = find_insertion_index(property_key);
+    m_entries.insert(insertion_index, { property_key, metadata.offset, metadata.attributes.bits(), static_cast<u16>(enum_index) });
+}
+
+void DescriptorArray::set_attributes(PropertyKey const& property_key, PropertyAttributes attributes, u32 descriptor_count)
+{
+    auto index = find(property_key, descriptor_count);
+    VERIFY(index.has_value());
+    m_entries[*index].attributes = attributes.bits();
+}
+
+void DescriptorArray::remove(PropertyKey const& property_key, u32 descriptor_count)
+{
+    auto index = find(property_key, descriptor_count);
+    VERIFY(index.has_value());
+
+    auto removed_offset = m_entries[*index].offset;
+    auto removed_enum_index = m_entries[*index].enum_index;
+    m_entries.remove(*index);
+
+    for (auto& entry : m_entries) {
+        if (entry.enum_index >= descriptor_count)
+            continue;
+        if (entry.offset > removed_offset)
+            --entry.offset;
+        if (entry.enum_index > removed_enum_index)
+            --entry.enum_index;
+    }
+}
+
+void DescriptorArray::for_each_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback, u32 descriptor_count) const
+{
+    Vector<Entry const*, 32> entries;
+    entries.ensure_capacity(descriptor_count);
+    for (auto const& entry : m_entries) {
+        if (entry.enum_index < descriptor_count)
+            entries.unchecked_append(&entry);
+    }
+
+    quick_sort(entries, [](auto const* lhs, auto const* rhs) {
+        return lhs->enum_index < rhs->enum_index;
+    });
+
+    for (auto const* entry : entries) {
+        auto metadata = entry->metadata();
+        callback(entry->property_key, metadata);
+    }
+}
+
+void DescriptorArray::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto const& entry : m_entries)
+        entry.property_key.visit_edges(visitor);
+}
+
+size_t DescriptorArray::external_memory_size() const
+{
+    return vector_external_memory_size(m_entries);
+}
+
+Optional<size_t> DescriptorArray::find(PropertyKey const& property_key, u32 descriptor_count) const
+{
+    if (m_entries.size() <= 16) {
+        for (size_t i = 0; i < m_entries.size(); ++i) {
+            auto const& entry = m_entries[i];
+            if (entry.enum_index < descriptor_count && entry.property_key == property_key)
+                return i;
+        }
+        return {};
+    }
+
+    auto hash = property_key_hash(property_key);
+    size_t low = 0;
+    size_t high = m_entries.size();
+    while (low < high) {
+        auto middle = low + (high - low) / 2;
+        if (property_key_hash(m_entries[middle].property_key) < hash)
+            low = middle + 1;
+        else
+            high = middle;
+    }
+
+    for (auto i = low; i < m_entries.size() && property_key_hash(m_entries[i].property_key) == hash; ++i) {
+        auto const& entry = m_entries[i];
+        if (entry.enum_index < descriptor_count && entry.property_key == property_key)
+            return i;
+    }
+    return {};
+}
+
+size_t DescriptorArray::find_insertion_index(PropertyKey const& property_key) const
+{
+    auto hash = property_key_hash(property_key);
+    size_t low = 0;
+    size_t high = m_entries.size();
+    while (low < high) {
+        auto middle = low + (high - low) / 2;
+        if (property_key_hash(m_entries[middle].property_key) <= hash)
+            low = middle + 1;
+        else
+            high = middle;
+    }
+    return low;
+}
+
+}

--- a/Libraries/LibJS/Runtime/DescriptorArray.cpp
+++ b/Libraries/LibJS/Runtime/DescriptorArray.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/NumericLimits.h>
-#include <AK/QuickSort.h>
 #include <LibJS/Runtime/DescriptorArray.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 
@@ -22,6 +21,7 @@ DescriptorArray::DescriptorArray(DescriptorArray const& other, u32 descriptor_co
 {
     VERIFY(descriptor_count <= max_descriptor_count);
     m_entries.ensure_capacity(descriptor_count);
+    m_entry_indices_by_enum_index.ensure_capacity(descriptor_count);
     other.for_each_in_insertion_order([&](auto const& property_key, auto const& metadata) {
         set(property_key, metadata, m_entries.size());
     },
@@ -47,7 +47,14 @@ void DescriptorArray::set(PropertyKey const& property_key, PropertyMetadata meta
     }
 
     auto insertion_index = find_insertion_index(property_key);
+    VERIFY(insertion_index <= NumericLimits<u32>::max());
+    VERIFY(enum_index == m_entry_indices_by_enum_index.size());
+    for (auto& entry_index : m_entry_indices_by_enum_index) {
+        if (entry_index >= insertion_index)
+            ++entry_index;
+    }
     m_entries.insert(insertion_index, { property_key, metadata.offset, metadata.attributes.bits(), static_cast<u16>(enum_index) });
+    m_entry_indices_by_enum_index.append(static_cast<u32>(insertion_index));
 }
 
 void DescriptorArray::set_attributes(PropertyKey const& property_key, PropertyAttributes attributes, u32 descriptor_count)
@@ -65,6 +72,11 @@ void DescriptorArray::remove(PropertyKey const& property_key, u32 descriptor_cou
     auto removed_offset = m_entries[*index].offset;
     auto removed_enum_index = m_entries[*index].enum_index;
     m_entries.remove(*index);
+    m_entry_indices_by_enum_index.remove(removed_enum_index);
+    for (auto& entry_index : m_entry_indices_by_enum_index) {
+        if (entry_index > *index)
+            --entry_index;
+    }
 
     for (auto& entry : m_entries) {
         if (entry.enum_index >= descriptor_count)
@@ -78,20 +90,12 @@ void DescriptorArray::remove(PropertyKey const& property_key, u32 descriptor_cou
 
 void DescriptorArray::for_each_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback, u32 descriptor_count) const
 {
-    Vector<Entry const*, 32> entries;
-    entries.ensure_capacity(descriptor_count);
-    for (auto const& entry : m_entries) {
-        if (entry.enum_index < descriptor_count)
-            entries.unchecked_append(&entry);
-    }
-
-    quick_sort(entries, [](auto const* lhs, auto const* rhs) {
-        return lhs->enum_index < rhs->enum_index;
-    });
-
-    for (auto const* entry : entries) {
-        auto metadata = entry->metadata();
-        callback(entry->property_key, metadata);
+    VERIFY(descriptor_count <= m_entry_indices_by_enum_index.size());
+    for (u32 enum_index = 0; enum_index < descriptor_count; ++enum_index) {
+        auto const& entry = m_entries[m_entry_indices_by_enum_index[enum_index]];
+        VERIFY(entry.enum_index == enum_index);
+        auto metadata = entry.metadata();
+        callback(entry.property_key, metadata);
     }
 }
 
@@ -104,7 +108,7 @@ void DescriptorArray::visit_edges(Visitor& visitor)
 
 size_t DescriptorArray::external_memory_size() const
 {
-    return vector_external_memory_size(m_entries);
+    return vector_external_memory_size(m_entries) + vector_external_memory_size(m_entry_indices_by_enum_index);
 }
 
 Optional<size_t> DescriptorArray::find(PropertyKey const& property_key, u32 descriptor_count) const

--- a/Libraries/LibJS/Runtime/DescriptorArray.h
+++ b/Libraries/LibJS/Runtime/DescriptorArray.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/NumericLimits.h>
+#include <AK/Vector.h>
+#include <LibJS/Export.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/PropertyAttributes.h>
+#include <LibJS/Runtime/PropertyKey.h>
+
+namespace JS {
+
+struct PropertyMetadata {
+    u32 offset { 0 };
+    PropertyAttributes attributes { 0 };
+};
+
+class JS_API DescriptorArray final : public Cell {
+    GC_CELL(DescriptorArray, Cell);
+    GC_DECLARE_ALLOCATOR(DescriptorArray);
+
+public:
+    struct Entry {
+        PropertyKey property_key;
+        u32 offset { 0 };
+        u16 attributes { 0 };
+        u16 enum_index { 0 };
+
+        PropertyMetadata metadata() const
+        {
+            return { offset, static_cast<u8>(attributes) };
+        }
+    };
+
+    static constexpr u32 max_descriptor_count = NumericLimits<u16>::max() + 1;
+
+    DescriptorArray() = default;
+    explicit DescriptorArray(DescriptorArray const&, u32 descriptor_count);
+    virtual ~DescriptorArray() override = default;
+
+    [[nodiscard]] u32 size() const { return m_entries.size(); }
+    [[nodiscard]] Optional<PropertyMetadata> lookup(PropertyKey const&, u32 descriptor_count) const;
+
+    void set(PropertyKey const&, PropertyMetadata, u32 enum_index);
+    void set_attributes(PropertyKey const&, PropertyAttributes, u32 descriptor_count);
+    void remove(PropertyKey const&, u32 descriptor_count);
+
+    void for_each_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const&, u32 descriptor_count) const;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+    virtual size_t external_memory_size() const override;
+
+    [[nodiscard]] Optional<size_t> find(PropertyKey const&, u32 descriptor_count) const;
+    [[nodiscard]] size_t find_insertion_index(PropertyKey const&) const;
+
+    Vector<Entry> m_entries;
+};
+
+static_assert(sizeof(DescriptorArray::Entry) == 16);
+
+}

--- a/Libraries/LibJS/Runtime/DescriptorArray.h
+++ b/Libraries/LibJS/Runtime/DescriptorArray.h
@@ -61,6 +61,7 @@ private:
     [[nodiscard]] size_t find_insertion_index(PropertyKey const&) const;
 
     Vector<Entry> m_entries;
+    Vector<u32> m_entry_indices_by_enum_index;
 };
 
 static_assert(sizeof(DescriptorArray::Entry) == 16);

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1242,20 +1242,20 @@ ThrowCompletionOr<GC::RootVector<Value>> Object::internal_own_property_keys() co
     }
 
     // 3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
-    for (auto& it : shape().property_table()) {
-        if (it.key.is_string()) {
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_string()) {
             // a. Add P as the last element of keys.
-            keys.append(it.key.to_value(vm));
+            keys.append(property_key.to_value(vm));
         }
-    }
+    });
 
     // 4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
-    for (auto& it : shape().property_table()) {
-        if (it.key.is_symbol()) {
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_symbol()) {
             // a. Add P as the last element of keys.
-            keys.append(it.key.to_value(vm));
+            keys.append(property_key.to_value(vm));
         }
-    }
+    });
 
     // 5. Return keys.
     return { move(keys) };
@@ -1486,11 +1486,11 @@ ThrowCompletionOr<void> Object::for_each_own_property_with_enumerability(Functio
         if (has_magical_length_property())
             keys.unchecked_append({ PropertyKey(vm.names.length), false });
 
-        for (auto const& [property_key, metadata] : shape().property_table()) {
+        shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
             if (!property_key.is_string())
-                continue;
+                return;
             keys.unchecked_append({ property_key, metadata.attributes.is_enumerable() });
-        }
+        });
 
         for (auto& key : keys)
             TRY(callback(key.property_key, key.enumerable));
@@ -1512,7 +1512,7 @@ ThrowCompletionOr<void> Object::for_each_own_property_with_enumerability(Functio
 
 size_t Object::own_properties_count() const
 {
-    return indexed_real_size() + shape().property_table().size() + (has_magical_length_property() ? 1 : 0);
+    return indexed_real_size() + shape().property_count() + (has_magical_length_property() ? 1 : 0);
 }
 
 // Simple side-effect free property lookup, following the prototype chain. Non-standard.

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -89,7 +89,7 @@ GC::Ref<Shape> Shape::create_dictionary_transition()
 
 GC::Ptr<Shape> Shape::get_or_prune_cached_forward_transition(TransitionKey const& key)
 {
-    if (m_is_prototype_shape)
+    if (is_prototype_shape())
         return nullptr;
     if (!m_forward_transitions)
         return nullptr;
@@ -106,7 +106,7 @@ GC::Ptr<Shape> Shape::get_or_prune_cached_forward_transition(TransitionKey const
 
 GC::Ptr<Shape> Shape::get_or_prune_cached_delete_transition(PropertyKey const& key)
 {
-    if (m_is_prototype_shape)
+    if (is_prototype_shape())
         return nullptr;
     if (!m_delete_transitions)
         return nullptr;
@@ -123,7 +123,7 @@ GC::Ptr<Shape> Shape::get_or_prune_cached_delete_transition(PropertyKey const& k
 
 GC::Ptr<Shape> Shape::get_or_prune_cached_prototype_transition(Object* prototype)
 {
-    if (m_is_prototype_shape)
+    if (is_prototype_shape())
         return nullptr;
     if (!m_prototype_transitions)
         return nullptr;
@@ -153,7 +153,7 @@ GC::Ref<Shape> Shape::create_put_transition(PropertyKey const& property_key, Pro
         new_shape->descriptors()->set(property_key, { m_property_count, attributes }, m_property_count);
     }
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
-    if (!m_is_prototype_shape) {
+    if (!is_prototype_shape()) {
         if (!m_forward_transitions)
             m_forward_transitions = make<HashMap<TransitionKey, GC::Weak<Shape>>>();
         m_forward_transitions->set(key, new_shape);
@@ -170,7 +170,7 @@ GC::Ref<Shape> Shape::create_configure_transition(PropertyKey const& property_ke
     new_shape->set_descriptors(copy_descriptors());
     new_shape->descriptors()->set_attributes(property_key, attributes, m_property_count);
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
-    if (!m_is_prototype_shape) {
+    if (!is_prototype_shape()) {
         if (!m_forward_transitions)
             m_forward_transitions = make<HashMap<TransitionKey, GC::Weak<Shape>>>();
         m_forward_transitions->set(key, new_shape.ptr());
@@ -194,7 +194,7 @@ GC::Ref<Shape> Shape::create_prototype_transition(Object* new_prototype)
         new_shape->set_descriptors(descriptors());
     }
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
-    if (!m_is_prototype_shape) {
+    if (!is_prototype_shape()) {
         if (!m_prototype_transitions)
             m_prototype_transitions = make<HashMap<GC::Ptr<Object>, GC::Weak<Shape>>>();
         m_prototype_transitions->set(new_prototype, new_shape.ptr());
@@ -390,10 +390,9 @@ void Shape::remove_property_without_transition(PropertyKey const& property_key, 
 
 GC::Ref<Shape> Shape::clone_for_prototype()
 {
-    VERIFY(!m_is_prototype_shape);
+    VERIFY(!is_prototype_shape());
     VERIFY(!m_prototype_chain_validity);
     auto new_shape = heap().allocate<Shape>(m_realm);
-    new_shape->m_is_prototype_shape = true;
     new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
@@ -418,8 +417,7 @@ void Shape::set_prototype_without_transition(Object* new_prototype)
 
 void Shape::set_prototype_shape()
 {
-    VERIFY(!m_is_prototype_shape);
-    m_is_prototype_shape = true;
+    VERIFY(!is_prototype_shape());
     m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();
     if (m_prototype)
         m_prototype->shape().add_child_prototype_shape(*this);
@@ -427,8 +425,8 @@ void Shape::set_prototype_shape()
 
 void Shape::add_child_prototype_shape(GC::Ref<Shape> child)
 {
-    VERIFY(m_is_prototype_shape);
-    VERIFY(child->m_is_prototype_shape);
+    VERIFY(is_prototype_shape());
+    VERIFY(child->is_prototype_shape());
     if (!m_child_prototype_shapes)
         m_child_prototype_shapes = make<Vector<GC::Weak<Shape>>>();
     m_child_prototype_shapes->append(GC::Weak<Shape> { *child });
@@ -436,7 +434,7 @@ void Shape::add_child_prototype_shape(GC::Ref<Shape> child)
 
 void Shape::invalidate_prototype_if_needed_for_new_prototype(GC::Ref<Shape> new_prototype_shape)
 {
-    if (!m_is_prototype_shape)
+    if (!is_prototype_shape())
         return;
     new_prototype_shape->set_prototype_shape();
     m_prototype_chain_validity->set_valid(false);
@@ -450,7 +448,7 @@ void Shape::invalidate_prototype_if_needed_for_new_prototype(GC::Ref<Shape> new_
 
 void Shape::invalidate_prototype_if_needed_for_change_without_transition()
 {
-    if (!m_is_prototype_shape)
+    if (!is_prototype_shape())
         return;
     m_prototype_chain_validity->set_valid(false);
     m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -38,24 +38,33 @@ void Shape::set_descriptors(GC::Ptr<DescriptorArray> descriptors)
     m_property_storage.descriptors = descriptors;
 }
 
-Shape::PropertyTablePtr& Shape::property_table() const
+Shape::PropertyTable& Shape::property_table()
 {
     VERIFY(m_dictionary);
-    return m_property_storage.property_table;
+    VERIFY(m_property_storage.property_table);
+    return *m_property_storage.property_table;
+}
+
+Shape::PropertyTable const& Shape::property_table() const
+{
+    VERIFY(m_dictionary);
+    VERIFY(m_property_storage.property_table);
+    return *m_property_storage.property_table;
 }
 
 void Shape::become_dictionary_shape()
 {
     VERIFY(!m_dictionary);
     new (&m_property_storage.property_table) PropertyTablePtr();
+    m_property_storage.property_table = make<PropertyTable>();
     m_dictionary = true;
 }
 
 size_t Shape::external_memory_size() const
 {
     size_t size = 0;
-    if (m_dictionary && property_table())
-        size += hash_map_external_memory_size(*property_table());
+    if (m_dictionary)
+        size += hash_map_external_memory_size(property_table());
     if (m_forward_transitions)
         size += hash_map_external_memory_size(*m_forward_transitions);
     if (m_prototype_transitions)
@@ -254,8 +263,8 @@ void Shape::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_prototype_chain_validity);
 
     // Descriptor arrays mark their own keys; dictionary tables are not cells, so Shape marks their keys directly.
-    if (m_dictionary && property_table()) {
-        for (auto& it : *property_table())
+    if (m_dictionary) {
+        for (auto& it : property_table())
             it.key.visit_edges(visitor);
     }
 }
@@ -265,8 +274,7 @@ Optional<PropertyMetadata> Shape::lookup(PropertyKey const& property_key) const
     if (m_property_count == 0)
         return {};
     if (m_dictionary) {
-        ensure_property_table();
-        auto property = property_table()->get(property_key);
+        auto property = property_table().get(property_key);
         if (!property.has_value())
             return {};
         return property;
@@ -279,22 +287,13 @@ Optional<PropertyMetadata> Shape::lookup(PropertyKey const& property_key) const
 void Shape::for_each_property_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback) const
 {
     if (m_dictionary) {
-        ensure_property_table();
-        for (auto const& [property_key, metadata] : *property_table())
+        for (auto const& [property_key, metadata] : property_table())
             callback(property_key, metadata);
         return;
     }
     if (!descriptors())
         return;
     descriptors()->for_each_in_insertion_order(callback, m_property_count);
-}
-
-void Shape::ensure_property_table() const
-{
-    VERIFY(m_dictionary);
-    if (property_table())
-        return;
-    property_table() = make<PropertyTable>();
 }
 
 void Shape::ensure_descriptor_array()
@@ -321,11 +320,10 @@ GC::Ref<DescriptorArray> Shape::copy_descriptors() const
 void Shape::copy_properties_to_dictionary_shape(Shape& shape) const
 {
     VERIFY(shape.m_dictionary);
-    shape.ensure_property_table();
     for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
-        shape.property_table()->set(property_key, metadata);
+        shape.property_table().set(property_key, metadata);
     });
-    shape.m_property_count = shape.property_table()->size();
+    shape.m_property_count = shape.property_table().size();
 }
 
 GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
@@ -346,8 +344,7 @@ void Shape::add_property_without_transition(PropertyKey const& property_key, Pro
 {
     invalidate_prototype_if_needed_for_change_without_transition();
     if (m_dictionary) {
-        ensure_property_table();
-        if (property_table()->set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
+        if (property_table().set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
             VERIFY(m_property_count < NumericLimits<u32>::max());
             ++m_property_count;
             ++m_dictionary_generation;
@@ -370,11 +367,10 @@ void Shape::set_property_attributes_without_transition(PropertyKey const& proper
 {
     invalidate_prototype_if_needed_for_change_without_transition();
     VERIFY(is_dictionary());
-    VERIFY(property_table());
-    auto it = property_table()->find(property_key);
-    VERIFY(it != property_table()->end());
+    auto it = property_table().find(property_key);
+    VERIFY(it != property_table().end());
     it->value.attributes = attributes;
-    property_table()->set(property_key, it->value);
+    property_table().set(property_key, it->value);
     ++m_dictionary_generation;
 }
 
@@ -382,10 +378,9 @@ void Shape::remove_property_without_transition(PropertyKey const& property_key, 
 {
     invalidate_prototype_if_needed_for_change_without_transition();
     VERIFY(is_dictionary());
-    VERIFY(property_table());
-    if (property_table()->remove(property_key))
+    if (property_table().remove(property_key))
         --m_property_count;
-    for (auto& it : *property_table()) {
+    for (auto& it : property_table()) {
         VERIFY(it.value.offset != offset);
         if (it.value.offset > offset)
             --it.value.offset;

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -19,11 +19,43 @@ GC_DEFINE_ALLOCATOR(PrototypeChainValidity);
 
 Shape::~Shape() = default;
 
+void Shape::finalize()
+{
+    Base::finalize();
+    if (m_dictionary)
+        m_property_storage.property_table.~PropertyTablePtr();
+}
+
+GC::Ptr<DescriptorArray> Shape::descriptors() const
+{
+    VERIFY(!m_dictionary);
+    return m_property_storage.descriptors;
+}
+
+void Shape::set_descriptors(GC::Ptr<DescriptorArray> descriptors)
+{
+    VERIFY(!m_dictionary);
+    m_property_storage.descriptors = descriptors;
+}
+
+Shape::PropertyTablePtr& Shape::property_table() const
+{
+    VERIFY(m_dictionary);
+    return m_property_storage.property_table;
+}
+
+void Shape::become_dictionary_shape()
+{
+    VERIFY(!m_dictionary);
+    new (&m_property_storage.property_table) PropertyTablePtr();
+    m_dictionary = true;
+}
+
 size_t Shape::external_memory_size() const
 {
     size_t size = 0;
-    if (m_dictionary && m_property_table)
-        size += hash_map_external_memory_size(*m_property_table);
+    if (m_dictionary && property_table())
+        size += hash_map_external_memory_size(*property_table());
     if (m_forward_transitions)
         size += hash_map_external_memory_size(*m_forward_transitions);
     if (m_prototype_transitions)
@@ -38,7 +70,7 @@ size_t Shape::external_memory_size() const
 GC::Ref<Shape> Shape::create_dictionary_transition()
 {
     auto new_shape = heap().allocate<Shape>(m_realm);
-    new_shape->m_dictionary = true;
+    new_shape->become_dictionary_shape();
     new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
@@ -104,14 +136,13 @@ GC::Ref<Shape> Shape::create_put_transition(PropertyKey const& property_key, Pro
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Put);
 
-    if (m_descriptors && m_descriptors->size() == m_own_descriptor_count) {
-        m_descriptors->set(property_key, { m_property_count, attributes }, m_own_descriptor_count);
-        new_shape->m_descriptors = m_descriptors;
+    if (descriptors() && descriptors()->size() == m_property_count) {
+        descriptors()->set(property_key, { m_property_count, attributes }, m_property_count);
+        new_shape->set_descriptors(descriptors());
     } else {
-        new_shape->m_descriptors = copy_descriptors();
-        new_shape->m_descriptors->set(property_key, { m_property_count, attributes }, m_property_count);
+        new_shape->set_descriptors(copy_descriptors());
+        new_shape->descriptors()->set(property_key, { m_property_count, attributes }, m_property_count);
     }
-    new_shape->m_own_descriptor_count = new_shape->m_property_count;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
         if (!m_forward_transitions)
@@ -127,9 +158,8 @@ GC::Ref<Shape> Shape::create_configure_transition(PropertyKey const& property_ke
     if (auto existing_shape = get_or_prune_cached_forward_transition(key))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Configure);
-    new_shape->m_descriptors = copy_descriptors();
-    new_shape->m_descriptors->set_attributes(property_key, attributes, m_own_descriptor_count);
-    new_shape->m_own_descriptor_count = new_shape->m_property_count;
+    new_shape->set_descriptors(copy_descriptors());
+    new_shape->descriptors()->set_attributes(property_key, attributes, m_property_count);
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
         if (!m_forward_transitions)
@@ -147,14 +177,12 @@ GC::Ref<Shape> Shape::create_prototype_transition(Object* new_prototype)
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, new_prototype);
     if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
-        new_shape->m_dictionary = true;
+        new_shape->become_dictionary_shape();
         copy_properties_to_dictionary_shape(*new_shape);
     } else if (m_dictionary) {
-        new_shape->m_descriptors = copy_descriptors();
-        new_shape->m_own_descriptor_count = new_shape->m_property_count;
+        new_shape->set_descriptors(copy_descriptors());
     } else {
-        new_shape->m_descriptors = m_descriptors;
-        new_shape->m_own_descriptor_count = m_own_descriptor_count;
+        new_shape->set_descriptors(descriptors());
     }
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
@@ -179,7 +207,6 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAtt
     , m_property_key(property_key)
     , m_prototype(previous_shape.m_prototype)
     , m_property_count(transition_type == TransitionType::Put ? previous_shape.m_property_count + 1 : previous_shape.m_property_count)
-    , m_own_descriptor_count(m_property_count)
 {
 }
 
@@ -191,7 +218,6 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionT
     , m_property_key(property_key)
     , m_prototype(previous_shape.m_prototype)
     , m_property_count(previous_shape.m_property_count - 1)
-    , m_own_descriptor_count(m_property_count)
 {
     VERIFY(transition_type == TransitionType::Delete);
 }
@@ -203,7 +229,6 @@ Shape::Shape(Shape& previous_shape, Object* new_prototype)
     , m_previous(&previous_shape)
     , m_prototype(new_prototype)
     , m_property_count(previous_shape.m_property_count)
-    , m_own_descriptor_count(m_property_count)
 {
 }
 
@@ -211,7 +236,8 @@ void Shape::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_realm);
-    visitor.visit(m_descriptors);
+    if (!m_dictionary)
+        visitor.visit(m_property_storage.descriptors);
     visitor.visit(m_prototype);
     visitor.visit(m_previous);
     if (m_property_key.has_value())
@@ -236,23 +262,9 @@ void Shape::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_prototype_chain_validity);
 
-    // Only dictionary shapes actually need us to mark the keys in m_property_table.
-    //
-    // For non-dictionary shapes, m_property_table is a lazily-built cache of the
-    // transition chain: every key it contains was originally inserted into some
-    // ancestor's m_property_key, and that ancestor is kept alive by m_previous
-    // (which we already visit above). So those keys are guaranteed to be marked
-    // transitively via the chain, and re-marking them here is pure overhead.
-    //
-    // The exception used to be the handful of intrinsic shapes populated via
-    // add_property_without_transition() in Intrinsics.cpp (iterator-result,
-    // function, arguments, regexp-exec-array, ...). Those shapes are not
-    // dictionaries and have no m_previous to reach their property keys through.
-    // However, every key they hold is a vm.names.* string or a well-known
-    // symbol, both of which are strongly rooted by the VM for its entire
-    // lifetime, so skipping them here is safe.
-    if (m_dictionary && m_property_table) {
-        for (auto& it : *m_property_table)
+    // Descriptor arrays mark their own keys; dictionary tables are not cells, so Shape marks their keys directly.
+    if (m_dictionary && property_table()) {
+        for (auto& it : *property_table())
             it.key.visit_edges(visitor);
     }
 }
@@ -263,50 +275,50 @@ Optional<PropertyMetadata> Shape::lookup(PropertyKey const& property_key) const
         return {};
     if (m_dictionary) {
         ensure_property_table();
-        auto property = m_property_table->get(property_key);
+        auto property = property_table()->get(property_key);
         if (!property.has_value())
             return {};
         return property;
     }
-    if (!m_descriptors)
+    if (!descriptors())
         return {};
-    return m_descriptors->lookup(property_key, m_own_descriptor_count);
+    return descriptors()->lookup(property_key, m_property_count);
 }
 
 void Shape::for_each_property_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback) const
 {
     if (m_dictionary) {
         ensure_property_table();
-        for (auto const& [property_key, metadata] : *m_property_table)
+        for (auto const& [property_key, metadata] : *property_table())
             callback(property_key, metadata);
         return;
     }
-    if (!m_descriptors)
+    if (!descriptors())
         return;
-    m_descriptors->for_each_in_insertion_order(callback, m_own_descriptor_count);
+    descriptors()->for_each_in_insertion_order(callback, m_property_count);
 }
 
 void Shape::ensure_property_table() const
 {
     VERIFY(m_dictionary);
-    if (m_property_table)
+    if (property_table())
         return;
-    m_property_table = make<OrderedHashMap<PropertyKey, PropertyMetadata>>();
+    property_table() = make<PropertyTable>();
 }
 
 void Shape::ensure_descriptor_array()
 {
     VERIFY(!m_dictionary);
-    if (m_descriptors)
+    if (descriptors())
         return;
-    m_descriptors = heap().allocate<DescriptorArray>();
+    set_descriptors(heap().allocate<DescriptorArray>());
 }
 
 GC::Ref<DescriptorArray> Shape::copy_descriptors() const
 {
     VERIFY(m_property_count <= DescriptorArray::max_descriptor_count);
-    if (!m_dictionary && m_descriptors)
-        return heap().allocate<DescriptorArray>(*m_descriptors, m_own_descriptor_count);
+    if (!m_dictionary && descriptors())
+        return heap().allocate<DescriptorArray>(*descriptors(), m_property_count);
 
     auto descriptors = heap().allocate<DescriptorArray>();
     for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
@@ -320,9 +332,9 @@ void Shape::copy_properties_to_dictionary_shape(Shape& shape) const
     VERIFY(shape.m_dictionary);
     shape.ensure_property_table();
     for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
-        shape.m_property_table->set(property_key, metadata);
+        shape.property_table()->set(property_key, metadata);
     });
-    shape.m_property_count = shape.m_property_table->size();
+    shape.m_property_count = shape.property_table()->size();
 }
 
 GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
@@ -330,9 +342,8 @@ GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
     if (auto existing_shape = get_or_prune_cached_delete_transition(property_key))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, TransitionType::Delete);
-    new_shape->m_descriptors = copy_descriptors();
-    new_shape->m_descriptors->remove(property_key, m_own_descriptor_count);
-    new_shape->m_own_descriptor_count = new_shape->m_property_count;
+    new_shape->set_descriptors(copy_descriptors());
+    new_shape->descriptors()->remove(property_key, m_property_count);
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_delete_transitions)
         m_delete_transitions = make<HashMap<PropertyKey, GC::Weak<Shape>>>();
@@ -345,7 +356,7 @@ void Shape::add_property_without_transition(PropertyKey const& property_key, Pro
     invalidate_prototype_if_needed_for_change_without_transition();
     if (m_dictionary) {
         ensure_property_table();
-        if (m_property_table->set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
+        if (property_table()->set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
             VERIFY(m_property_count < NumericLimits<u32>::max());
             ++m_property_count;
             ++m_dictionary_generation;
@@ -354,26 +365,25 @@ void Shape::add_property_without_transition(PropertyKey const& property_key, Pro
     }
 
     ensure_descriptor_array();
-    if (!m_descriptors->lookup(property_key, m_own_descriptor_count).has_value()) {
+    if (!descriptors()->lookup(property_key, m_property_count).has_value()) {
         VERIFY(m_property_count < NumericLimits<u32>::max());
-        m_descriptors->set(property_key, { m_property_count, attributes }, m_own_descriptor_count);
+        descriptors()->set(property_key, { m_property_count, attributes }, m_property_count);
         ++m_property_count;
-        ++m_own_descriptor_count;
         ++m_dictionary_generation;
         return;
     }
-    m_descriptors->set(property_key, { m_property_count, attributes }, m_own_descriptor_count);
+    descriptors()->set(property_key, { m_property_count, attributes }, m_property_count);
 }
 
 void Shape::set_property_attributes_without_transition(PropertyKey const& property_key, PropertyAttributes attributes)
 {
     invalidate_prototype_if_needed_for_change_without_transition();
     VERIFY(is_dictionary());
-    VERIFY(m_property_table);
-    auto it = m_property_table->find(property_key);
-    VERIFY(it != m_property_table->end());
+    VERIFY(property_table());
+    auto it = property_table()->find(property_key);
+    VERIFY(it != property_table()->end());
     it->value.attributes = attributes;
-    m_property_table->set(property_key, it->value);
+    property_table()->set(property_key, it->value);
     ++m_dictionary_generation;
 }
 
@@ -381,10 +391,10 @@ void Shape::remove_property_without_transition(PropertyKey const& property_key, 
 {
     invalidate_prototype_if_needed_for_change_without_transition();
     VERIFY(is_dictionary());
-    VERIFY(m_property_table);
-    if (m_property_table->remove(property_key))
+    VERIFY(property_table());
+    if (property_table()->remove(property_key))
         --m_property_count;
-    for (auto& it : *m_property_table) {
+    for (auto& it : *property_table()) {
         VERIFY(it.value.offset != offset);
         if (it.value.offset > offset)
             --it.value.offset;
@@ -401,12 +411,11 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
-        new_shape->m_dictionary = true;
+        new_shape->become_dictionary_shape();
         copy_properties_to_dictionary_shape(*new_shape);
     } else {
-        new_shape->m_descriptors = copy_descriptors();
+        new_shape->set_descriptors(copy_descriptors());
         new_shape->m_property_count = m_property_count;
-        new_shape->m_own_descriptor_count = m_property_count;
     }
     new_shape->m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();
     if (new_shape->m_prototype)

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGC/DeferGC.h>
+#include <LibJS/Runtime/DescriptorArray.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/Shape.h>
@@ -21,7 +22,7 @@ Shape::~Shape() = default;
 size_t Shape::external_memory_size() const
 {
     size_t size = 0;
-    if (m_property_table)
+    if (m_dictionary && m_property_table)
         size += hash_map_external_memory_size(*m_property_table);
     if (m_forward_transitions)
         size += hash_map_external_memory_size(*m_forward_transitions);
@@ -41,10 +42,7 @@ GC::Ref<Shape> Shape::create_dictionary_transition()
     new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
-    ensure_property_table();
-    new_shape->ensure_property_table();
-    (*new_shape->m_property_table) = *m_property_table;
-    new_shape->m_property_count = new_shape->m_property_table->size();
+    copy_properties_to_dictionary_shape(*new_shape);
     return new_shape;
 }
 
@@ -105,6 +103,9 @@ GC::Ref<Shape> Shape::create_put_transition(PropertyKey const& property_key, Pro
     if (auto existing_shape = get_or_prune_cached_forward_transition(key))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Put);
+    new_shape->m_descriptors = copy_descriptors();
+    new_shape->m_descriptors->set(property_key, { m_property_count, attributes }, m_property_count);
+    new_shape->m_own_descriptor_count = new_shape->m_property_count;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
         if (!m_forward_transitions)
@@ -120,6 +121,9 @@ GC::Ref<Shape> Shape::create_configure_transition(PropertyKey const& property_ke
     if (auto existing_shape = get_or_prune_cached_forward_transition(key))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Configure);
+    new_shape->m_descriptors = copy_descriptors();
+    new_shape->m_descriptors->set_attributes(property_key, attributes, m_own_descriptor_count);
+    new_shape->m_own_descriptor_count = new_shape->m_property_count;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
         if (!m_forward_transitions)
@@ -136,6 +140,13 @@ GC::Ref<Shape> Shape::create_prototype_transition(Object* new_prototype)
     if (auto existing_shape = get_or_prune_cached_prototype_transition(new_prototype))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, new_prototype);
+    if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
+        new_shape->m_dictionary = true;
+        copy_properties_to_dictionary_shape(*new_shape);
+    } else {
+        new_shape->m_descriptors = copy_descriptors();
+        new_shape->m_own_descriptor_count = new_shape->m_property_count;
+    }
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
         if (!m_prototype_transitions)
@@ -159,6 +170,7 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAtt
     , m_property_key(property_key)
     , m_prototype(previous_shape.m_prototype)
     , m_property_count(transition_type == TransitionType::Put ? previous_shape.m_property_count + 1 : previous_shape.m_property_count)
+    , m_own_descriptor_count(m_property_count)
 {
 }
 
@@ -170,6 +182,7 @@ Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionT
     , m_property_key(property_key)
     , m_prototype(previous_shape.m_prototype)
     , m_property_count(previous_shape.m_property_count - 1)
+    , m_own_descriptor_count(m_property_count)
 {
     VERIFY(transition_type == TransitionType::Delete);
 }
@@ -181,6 +194,7 @@ Shape::Shape(Shape& previous_shape, Object* new_prototype)
     , m_previous(&previous_shape)
     , m_prototype(new_prototype)
     , m_property_count(previous_shape.m_property_count)
+    , m_own_descriptor_count(m_property_count)
 {
 }
 
@@ -188,6 +202,7 @@ void Shape::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_realm);
+    visitor.visit(m_descriptors);
     visitor.visit(m_prototype);
     visitor.visit(m_previous);
     if (m_property_key.has_value())
@@ -237,60 +252,68 @@ Optional<PropertyMetadata> Shape::lookup(PropertyKey const& property_key) const
 {
     if (m_property_count == 0)
         return {};
-    auto property = property_table().get(property_key);
-    if (!property.has_value())
+    if (m_dictionary) {
+        ensure_property_table();
+        auto property = m_property_table->get(property_key);
+        if (!property.has_value())
+            return {};
+        return property;
+    }
+    if (!m_descriptors)
         return {};
-    return property;
+    return m_descriptors->lookup(property_key, m_own_descriptor_count);
 }
 
-FLATTEN OrderedHashMap<PropertyKey, PropertyMetadata> const& Shape::property_table() const
+void Shape::for_each_property_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const& callback) const
 {
-    ensure_property_table();
-    return *m_property_table;
+    if (m_dictionary) {
+        ensure_property_table();
+        for (auto const& [property_key, metadata] : *m_property_table)
+            callback(property_key, metadata);
+        return;
+    }
+    if (!m_descriptors)
+        return;
+    m_descriptors->for_each_in_insertion_order(callback, m_own_descriptor_count);
 }
 
 void Shape::ensure_property_table() const
 {
+    VERIFY(m_dictionary);
     if (m_property_table)
         return;
     m_property_table = make<OrderedHashMap<PropertyKey, PropertyMetadata>>();
+}
 
-    u32 next_offset = 0;
+void Shape::ensure_descriptor_array()
+{
+    VERIFY(!m_dictionary);
+    if (m_descriptors)
+        return;
+    m_descriptors = heap().allocate<DescriptorArray>();
+}
 
-    Vector<Shape const&, 64> transition_chain;
-    transition_chain.append(*this);
-    for (auto shape = m_previous; shape; shape = shape->m_previous) {
-        if (shape->m_property_table) {
-            *m_property_table = *shape->m_property_table;
-            next_offset = shape->m_property_count;
-            break;
-        }
-        transition_chain.append(*shape);
-    }
+GC::Ref<DescriptorArray> Shape::copy_descriptors() const
+{
+    VERIFY(m_property_count <= DescriptorArray::max_descriptor_count);
+    if (!m_dictionary && m_descriptors)
+        return heap().allocate<DescriptorArray>(*m_descriptors, m_own_descriptor_count);
 
-    for (auto const& shape : transition_chain.in_reverse()) {
-        if (!shape.m_property_key.has_value()) {
-            // Ignore prototype transitions as they don't affect the key map.
-            continue;
-        }
-        if (shape.m_transition_type == TransitionType::Put) {
-            m_property_table->set(*shape.m_property_key, { next_offset++, shape.m_attributes });
-        } else if (shape.m_transition_type == TransitionType::Configure) {
-            auto it = m_property_table->find(*shape.m_property_key);
-            VERIFY(it != m_property_table->end());
-            it->value.attributes = shape.m_attributes;
-        } else if (shape.m_transition_type == TransitionType::Delete) {
-            auto remove_it = m_property_table->find(*shape.m_property_key);
-            VERIFY(remove_it != m_property_table->end());
-            auto removed_offset = remove_it->value.offset;
-            m_property_table->remove(remove_it);
-            for (auto& it : *m_property_table) {
-                if (it.value.offset > removed_offset)
-                    --it.value.offset;
-            }
-            --next_offset;
-        }
-    }
+    auto descriptors = heap().allocate<DescriptorArray>();
+    for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
+        descriptors->set(property_key, metadata, descriptors->size());
+    });
+    return descriptors;
+}
+
+void Shape::copy_properties_to_dictionary_shape(Shape& shape) const
+{
+    VERIFY(shape.m_dictionary);
+    shape.ensure_property_table();
+    for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
+        shape.m_property_table->set(property_key, metadata);
+    });
+    shape.m_property_count = shape.m_property_table->size();
 }
 
 GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
@@ -298,6 +321,9 @@ GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
     if (auto existing_shape = get_or_prune_cached_delete_transition(property_key))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, TransitionType::Delete);
+    new_shape->m_descriptors = copy_descriptors();
+    new_shape->m_descriptors->remove(property_key, m_own_descriptor_count);
+    new_shape->m_own_descriptor_count = new_shape->m_property_count;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_delete_transitions)
         m_delete_transitions = make<HashMap<PropertyKey, GC::Weak<Shape>>>();
@@ -308,12 +334,26 @@ GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
 void Shape::add_property_without_transition(PropertyKey const& property_key, PropertyAttributes attributes)
 {
     invalidate_prototype_if_needed_for_change_without_transition();
-    ensure_property_table();
-    if (m_property_table->set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
-        VERIFY(m_property_count < NumericLimits<u32>::max());
-        ++m_property_count;
-        ++m_dictionary_generation;
+    if (m_dictionary) {
+        ensure_property_table();
+        if (m_property_table->set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
+            VERIFY(m_property_count < NumericLimits<u32>::max());
+            ++m_property_count;
+            ++m_dictionary_generation;
+        }
+        return;
     }
+
+    ensure_descriptor_array();
+    if (!m_descriptors->lookup(property_key, m_own_descriptor_count).has_value()) {
+        VERIFY(m_property_count < NumericLimits<u32>::max());
+        m_descriptors->set(property_key, { m_property_count, attributes }, m_own_descriptor_count);
+        ++m_property_count;
+        ++m_own_descriptor_count;
+        ++m_dictionary_generation;
+        return;
+    }
+    m_descriptors->set(property_key, { m_property_count, attributes }, m_own_descriptor_count);
 }
 
 void Shape::set_property_attributes_without_transition(PropertyKey const& property_key, PropertyAttributes attributes)
@@ -351,10 +391,14 @@ GC::Ref<Shape> Shape::clone_for_prototype()
     new_shape->m_is_prototype_shape = true;
     new_shape->m_has_parameter_map = m_has_parameter_map;
     new_shape->m_prototype = m_prototype;
-    ensure_property_table();
-    new_shape->ensure_property_table();
-    (*new_shape->m_property_table) = *m_property_table;
-    new_shape->m_property_count = new_shape->m_property_table->size();
+    if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
+        new_shape->m_dictionary = true;
+        copy_properties_to_dictionary_shape(*new_shape);
+    } else {
+        new_shape->m_descriptors = copy_descriptors();
+        new_shape->m_property_count = m_property_count;
+        new_shape->m_own_descriptor_count = m_property_count;
+    }
     new_shape->m_prototype_chain_validity = heap().allocate<PrototypeChainValidity>();
     if (new_shape->m_prototype)
         new_shape->m_prototype->shape().add_child_prototype_shape(*new_shape);

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -103,8 +103,14 @@ GC::Ref<Shape> Shape::create_put_transition(PropertyKey const& property_key, Pro
     if (auto existing_shape = get_or_prune_cached_forward_transition(key))
         return *existing_shape;
     auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Put);
-    new_shape->m_descriptors = copy_descriptors();
-    new_shape->m_descriptors->set(property_key, { m_property_count, attributes }, m_property_count);
+
+    if (m_descriptors && m_descriptors->size() == m_own_descriptor_count) {
+        m_descriptors->set(property_key, { m_property_count, attributes }, m_own_descriptor_count);
+        new_shape->m_descriptors = m_descriptors;
+    } else {
+        new_shape->m_descriptors = copy_descriptors();
+        new_shape->m_descriptors->set(property_key, { m_property_count, attributes }, m_property_count);
+    }
     new_shape->m_own_descriptor_count = new_shape->m_property_count;
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {
@@ -143,9 +149,12 @@ GC::Ref<Shape> Shape::create_prototype_transition(Object* new_prototype)
     if (m_dictionary && m_property_count > DescriptorArray::max_descriptor_count) {
         new_shape->m_dictionary = true;
         copy_properties_to_dictionary_shape(*new_shape);
-    } else {
+    } else if (m_dictionary) {
         new_shape->m_descriptors = copy_descriptors();
         new_shape->m_own_descriptor_count = new_shape->m_property_count;
+    } else {
+        new_shape->m_descriptors = m_descriptors;
+        new_shape->m_own_descriptor_count = m_own_descriptor_count;
     }
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
     if (!m_is_prototype_shape) {

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -134,7 +134,7 @@ GC::Ref<Shape> Shape::create_put_transition(PropertyKey const& property_key, Pro
     TransitionKey key { property_key, attributes };
     if (auto existing_shape = get_or_prune_cached_forward_transition(key))
         return *existing_shape;
-    auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Put);
+    auto new_shape = heap().allocate<Shape>(*this, PropertyCountChange::Increment);
 
     if (descriptors() && descriptors()->size() == m_property_count) {
         descriptors()->set(property_key, { m_property_count, attributes }, m_property_count);
@@ -157,7 +157,7 @@ GC::Ref<Shape> Shape::create_configure_transition(PropertyKey const& property_ke
     TransitionKey key { property_key, attributes };
     if (auto existing_shape = get_or_prune_cached_forward_transition(key))
         return *existing_shape;
-    auto new_shape = heap().allocate<Shape>(*this, property_key, attributes, TransitionType::Configure);
+    auto new_shape = heap().allocate<Shape>(*this, PropertyCountChange::Preserve);
     new_shape->set_descriptors(copy_descriptors());
     new_shape->descriptors()->set_attributes(property_key, attributes, m_property_count);
     invalidate_prototype_if_needed_for_new_prototype(new_shape);
@@ -198,35 +198,29 @@ Shape::Shape(Realm& realm)
 {
 }
 
-Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAttributes attributes, TransitionType transition_type)
-    : m_attributes(attributes)
-    , m_transition_type(transition_type)
-    , m_has_parameter_map(previous_shape.m_has_parameter_map)
+Shape::Shape(Shape& previous_shape, PropertyCountChange property_count_change)
+    : m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
-    , m_previous(&previous_shape)
-    , m_property_key(property_key)
     , m_prototype(previous_shape.m_prototype)
-    , m_property_count(transition_type == TransitionType::Put ? previous_shape.m_property_count + 1 : previous_shape.m_property_count)
+    , m_property_count(previous_shape.m_property_count)
 {
-}
-
-Shape::Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionType transition_type)
-    : m_transition_type(transition_type)
-    , m_has_parameter_map(previous_shape.m_has_parameter_map)
-    , m_realm(previous_shape.m_realm)
-    , m_previous(&previous_shape)
-    , m_property_key(property_key)
-    , m_prototype(previous_shape.m_prototype)
-    , m_property_count(previous_shape.m_property_count - 1)
-{
-    VERIFY(transition_type == TransitionType::Delete);
+    switch (property_count_change) {
+    case PropertyCountChange::Preserve:
+        break;
+    case PropertyCountChange::Increment:
+        VERIFY(m_property_count < NumericLimits<u32>::max());
+        ++m_property_count;
+        break;
+    case PropertyCountChange::Decrement:
+        VERIFY(m_property_count > 0);
+        --m_property_count;
+        break;
+    }
 }
 
 Shape::Shape(Shape& previous_shape, Object* new_prototype)
-    : m_transition_type(TransitionType::Prototype)
-    , m_has_parameter_map(previous_shape.m_has_parameter_map)
+    : m_has_parameter_map(previous_shape.m_has_parameter_map)
     , m_realm(previous_shape.m_realm)
-    , m_previous(&previous_shape)
     , m_prototype(new_prototype)
     , m_property_count(previous_shape.m_property_count)
 {
@@ -239,9 +233,6 @@ void Shape::visit_edges(Cell::Visitor& visitor)
     if (!m_dictionary)
         visitor.visit(m_property_storage.descriptors);
     visitor.visit(m_prototype);
-    visitor.visit(m_previous);
-    if (m_property_key.has_value())
-        m_property_key->visit_edges(visitor);
 
     visitor.ignore(m_prototype_transitions);
 
@@ -341,7 +332,7 @@ GC::Ref<Shape> Shape::create_delete_transition(PropertyKey const& property_key)
 {
     if (auto existing_shape = get_or_prune_cached_delete_transition(property_key))
         return *existing_shape;
-    auto new_shape = heap().allocate<Shape>(*this, property_key, TransitionType::Delete);
+    auto new_shape = heap().allocate<Shape>(*this, PropertyCountChange::Decrement);
     new_shape->set_descriptors(copy_descriptors());
     new_shape->descriptors()->remove(property_key, m_property_count);
     invalidate_prototype_if_needed_for_new_prototype(new_shape);

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -120,7 +120,6 @@ private:
     [[nodiscard]] GC::Ptr<Shape> get_or_prune_cached_prototype_transition(Object* prototype);
     [[nodiscard]] GC::Ptr<Shape> get_or_prune_cached_delete_transition(PropertyKey const&);
 
-    void ensure_property_table() const;
     void ensure_descriptor_array();
     [[nodiscard]] GC::Ref<DescriptorArray> copy_descriptors() const;
     void copy_properties_to_dictionary_shape(Shape&) const;
@@ -132,7 +131,8 @@ private:
 
     GC::Ptr<DescriptorArray> descriptors() const;
     void set_descriptors(GC::Ptr<DescriptorArray>);
-    PropertyTablePtr& property_table() const;
+    PropertyTable& property_table();
+    PropertyTable const& property_table() const;
     void become_dictionary_shape();
 
     union PropertyStorage {
@@ -153,7 +153,7 @@ private:
 
     GC::Ref<Realm> m_realm;
 
-    mutable PropertyStorage m_property_storage;
+    PropertyStorage m_property_storage;
 
     OwnPtr<HashMap<TransitionKey, GC::Weak<Shape>>> m_forward_transitions;
     OwnPtr<HashMap<GC::Ptr<Object>, GC::Weak<Shape>>> m_prototype_transitions;

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -62,16 +62,6 @@ public:
     virtual ~Shape() override;
     virtual void finalize() override;
 
-    enum class TransitionType : u8 {
-        Invalid,
-        Put,
-        Configure,
-        Prototype,
-        Delete,
-        CacheableDictionary,
-        UncacheableDictionary,
-    };
-
     [[nodiscard]] GC::Ref<Shape> create_put_transition(PropertyKey const&, PropertyAttributes attributes);
     [[nodiscard]] GC::Ref<Shape> create_configure_transition(PropertyKey const&, PropertyAttributes attributes);
     [[nodiscard]] GC::Ref<Shape> create_prototype_transition(Object* new_prototype);
@@ -107,9 +97,14 @@ public:
     void set_prototype_without_transition(Object* new_prototype);
 
 private:
+    enum class PropertyCountChange : u8 {
+        Preserve,
+        Increment,
+        Decrement,
+    };
+
     explicit Shape(Realm&);
-    Shape(Shape& previous_shape, PropertyKey const& property_key, PropertyAttributes attributes, TransitionType);
-    Shape(Shape& previous_shape, PropertyKey const& property_key, TransitionType);
+    Shape(Shape& previous_shape, PropertyCountChange);
     Shape(Shape& previous_shape, Object* new_prototype);
 
     void invalidate_prototype_if_needed_for_new_prototype(GC::Ref<Shape> new_prototype_shape);
@@ -152,9 +147,6 @@ private:
         PropertyTablePtr property_table;
     };
 
-    PropertyAttributes m_attributes { 0 };
-    TransitionType m_transition_type { TransitionType::Invalid };
-
     bool m_dictionary : 1 { false };
     bool m_is_prototype_shape : 1 { false };
     bool m_has_parameter_map : 1 { false };
@@ -166,8 +158,6 @@ private:
     OwnPtr<HashMap<TransitionKey, GC::Weak<Shape>>> m_forward_transitions;
     OwnPtr<HashMap<GC::Ptr<Object>, GC::Weak<Shape>>> m_prototype_transitions;
     OwnPtr<HashMap<PropertyKey, GC::Weak<Shape>>> m_delete_transitions;
-    GC::Ptr<Shape> m_previous;
-    Optional<PropertyKey> m_property_key;
     GC::Ptr<Object> m_prototype;
 
     // The following two are only populated for prototype shapes.
@@ -180,7 +170,7 @@ private:
 };
 
 #if !defined(AK_OS_WINDOWS)
-static_assert(sizeof(Shape) == 104, "Keep the size of JS::Shape down!");
+static_assert(sizeof(Shape) == 88, "Keep the size of JS::Shape down!");
 #endif
 
 }

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -57,7 +57,10 @@ class JS_API Shape final : public Cell {
     GC_DECLARE_ALLOCATOR(Shape);
 
 public:
+    static constexpr bool OVERRIDES_FINALIZE = true;
+
     virtual ~Shape() override;
+    virtual void finalize() override;
 
     enum class TransitionType : u8 {
         Invalid,
@@ -127,6 +130,28 @@ private:
     [[nodiscard]] GC::Ref<DescriptorArray> copy_descriptors() const;
     void copy_properties_to_dictionary_shape(Shape&) const;
 
+    using PropertyTable = OrderedHashMap<PropertyKey, PropertyMetadata>;
+    using PropertyTablePtr = OwnPtr<PropertyTable>;
+
+    static_assert(IsTriviallyDestructible<GC::Ptr<DescriptorArray>>);
+
+    GC::Ptr<DescriptorArray> descriptors() const;
+    void set_descriptors(GC::Ptr<DescriptorArray>);
+    PropertyTablePtr& property_table() const;
+    void become_dictionary_shape();
+
+    union PropertyStorage {
+        PropertyStorage()
+            : descriptors(nullptr)
+        {
+        }
+
+        ~PropertyStorage() { }
+
+        GC::Ptr<DescriptorArray> descriptors;
+        PropertyTablePtr property_table;
+    };
+
     PropertyAttributes m_attributes { 0 };
     TransitionType m_transition_type { TransitionType::Invalid };
 
@@ -136,8 +161,7 @@ private:
 
     GC::Ref<Realm> m_realm;
 
-    mutable OwnPtr<OrderedHashMap<PropertyKey, PropertyMetadata>> m_property_table;
-    GC::Ptr<DescriptorArray> m_descriptors;
+    mutable PropertyStorage m_property_storage;
 
     OwnPtr<HashMap<TransitionKey, GC::Weak<Shape>>> m_forward_transitions;
     OwnPtr<HashMap<GC::Ptr<Object>, GC::Weak<Shape>>> m_prototype_transitions;
@@ -152,12 +176,11 @@ private:
     OwnPtr<Vector<GC::Weak<Shape>>> m_child_prototype_shapes;
 
     u32 m_property_count { 0 };
-    u32 m_own_descriptor_count { 0 };
     u32 m_dictionary_generation { 0 };
 };
 
 #if !defined(AK_OS_WINDOWS)
-static_assert(sizeof(Shape) == 120, "Keep the size of JS::Shape down!");
+static_assert(sizeof(Shape) == 104, "Keep the size of JS::Shape down!");
 #endif
 
 }

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -17,16 +17,12 @@
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/DescriptorArray.h>
 #include <LibJS/Runtime/PropertyAttributes.h>
 #include <LibJS/Runtime/PropertyKey.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS {
-
-struct PropertyMetadata {
-    u32 offset { 0 };
-    PropertyAttributes attributes { 0 };
-};
 
 struct TransitionKey {
     PropertyKey property_key;
@@ -102,7 +98,7 @@ public:
     Object const* prototype() const { return m_prototype; }
 
     Optional<PropertyMetadata> lookup(PropertyKey const&) const;
-    OrderedHashMap<PropertyKey, PropertyMetadata> const& property_table() const;
+    void for_each_property_in_insertion_order(Function<void(PropertyKey const&, PropertyMetadata const&)> const&) const;
     u32 property_count() const { return m_property_count; }
 
     void set_prototype_without_transition(Object* new_prototype);
@@ -127,6 +123,9 @@ private:
     [[nodiscard]] GC::Ptr<Shape> get_or_prune_cached_delete_transition(PropertyKey const&);
 
     void ensure_property_table() const;
+    void ensure_descriptor_array();
+    [[nodiscard]] GC::Ref<DescriptorArray> copy_descriptors() const;
+    void copy_properties_to_dictionary_shape(Shape&) const;
 
     PropertyAttributes m_attributes { 0 };
     TransitionType m_transition_type { TransitionType::Invalid };
@@ -138,6 +137,7 @@ private:
     GC::Ref<Realm> m_realm;
 
     mutable OwnPtr<OrderedHashMap<PropertyKey, PropertyMetadata>> m_property_table;
+    GC::Ptr<DescriptorArray> m_descriptors;
 
     OwnPtr<HashMap<TransitionKey, GC::Weak<Shape>>> m_forward_transitions;
     OwnPtr<HashMap<GC::Ptr<Object>, GC::Weak<Shape>>> m_prototype_transitions;
@@ -152,11 +152,12 @@ private:
     OwnPtr<Vector<GC::Weak<Shape>>> m_child_prototype_shapes;
 
     u32 m_property_count { 0 };
+    u32 m_own_descriptor_count { 0 };
     u32 m_dictionary_generation { 0 };
 };
 
 #if !defined(AK_OS_WINDOWS)
-static_assert(sizeof(Shape) == 104, "Keep the size of JS::Shape down!");
+static_assert(sizeof(Shape) == 120, "Keep the size of JS::Shape down!");
 #endif
 
 }

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -80,7 +80,7 @@ public:
 
     [[nodiscard]] u32 dictionary_generation() const { return m_dictionary_generation; }
 
-    [[nodiscard]] bool is_prototype_shape() const { return m_is_prototype_shape; }
+    [[nodiscard]] bool is_prototype_shape() const { return m_prototype_chain_validity; }
     void set_prototype_shape();
 
     GC::Ptr<PrototypeChainValidity> prototype_chain_validity() const { return m_prototype_chain_validity; }
@@ -148,7 +148,6 @@ private:
     };
 
     bool m_dictionary : 1 { false };
-    bool m_is_prototype_shape : 1 { false };
     bool m_has_parameter_map : 1 { false };
 
     GC::Ref<Realm> m_realm;
@@ -160,9 +159,8 @@ private:
     OwnPtr<HashMap<PropertyKey, GC::Weak<Shape>>> m_delete_transitions;
     GC::Ptr<Object> m_prototype;
 
-    // The following two are only populated for prototype shapes.
+    // A non-null validity cell marks this as a prototype shape. Child shape references only exist for prototype shapes.
     GC::Ptr<PrototypeChainValidity> m_prototype_chain_validity;
-    // Prototype shapes whose immediate [[Prototype]] is the object that owns this shape.
     OwnPtr<Vector<GC::Weak<Shape>>> m_child_prototype_shapes;
 
     u32 m_property_count { 0 };

--- a/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Libraries/LibJS/Runtime/StringObject.cpp
@@ -159,20 +159,20 @@ ThrowCompletionOr<GC::RootVector<Value>> StringObject::internal_own_property_key
     }
 
     // 7. For each own property key P of O such that P is a String and P is not an array index, in ascending chronological order of property creation, do
-    for (auto& it : shape().property_table()) {
-        if (it.key.is_string()) {
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_string()) {
             // a. Add P as the last element of keys.
-            keys.append(it.key.to_value(vm));
+            keys.append(property_key.to_value(vm));
         }
-    }
+    });
 
     // 8. For each own property key P of O such that P is a Symbol, in ascending chronological order of property creation, do
-    for (auto& it : shape().property_table()) {
-        if (it.key.is_symbol()) {
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_symbol()) {
             // a. Add P as the last element of keys.
-            keys.append(it.key.to_value(vm));
+            keys.append(property_key.to_value(vm));
         }
-    }
+    });
 
     // 9. Return keys.
     return { move(keys) };

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -477,20 +477,20 @@ public:
         }
 
         // 4. For each own property key P of O such that P is a String and P is not an integer index, in ascending chronological order of property creation, do
-        for (auto& it : shape().property_table()) {
-            if (it.key.is_string()) {
+        shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+            if (property_key.is_string()) {
                 // a. Append P to keys.
-                keys.append(it.key.to_value(vm));
+                keys.append(property_key.to_value(vm));
             }
-        }
+        });
 
         // 5. For each own property key P of O such that P is a Symbol, in ascending chronological order of property creation, do
-        for (auto& it : shape().property_table()) {
-            if (it.key.is_symbol()) {
+        shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+            if (property_key.is_symbol()) {
                 // a. Append P to keys.
-                keys.append(it.key.to_value(vm));
+                keys.append(property_key.to_value(vm));
             }
-        }
+        });
 
         // 6. Return keys.
         return { move(keys) };

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -432,16 +432,16 @@ JS::ThrowCompletionOr<GC::RootVector<JS::Value>> PlatformObject::internal_own_pr
 
     // 4. For each P of O’s own property keys that is a String, in ascending chronological order of property creation, append P to keys.
     // NB: A PropertyKey containing a number is a String (it can only be a String or a Symbol, the number representation is an optimization).
-    for (auto& it : shape().property_table()) {
-        if (it.key.is_string() || it.key.is_number())
-            keys.append(it.key.to_value(vm));
-    }
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_string() || property_key.is_number())
+            keys.append(property_key.to_value(vm));
+    });
 
     // 5. For each P of O’s own property keys that is a Symbol, in ascending chronological order of property creation, append P to keys.
-    for (auto& it : shape().property_table()) {
-        if (it.key.is_symbol())
-            keys.append(it.key.to_value(vm));
-    }
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_symbol())
+            keys.append(property_key.to_value(vm));
+    });
 
     // FIXME: 6. Assert: keys has no duplicate items.
 

--- a/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
@@ -85,7 +85,11 @@ WebIDL::ExceptionOr<ImportMap> parse_import_map_string(JS::Realm& realm, ByteStr
     }
 
     // 9. If parsed's keys contains any items besides "imports", "scopes", or "integrity", then the user agent should report a warning to the console indicating that an invalid top-level key was present in the import map.
-    for (auto& key : parsed_object.shape().property_table().keys()) {
+    Vector<JS::PropertyKey> parsed_keys;
+    parsed_object.shape().for_each_property_in_insertion_order([&](auto const& key, auto const&) {
+        parsed_keys.append(key);
+    });
+    for (auto& key : parsed_keys) {
         if (key.as_string().is_one_of("imports"sv, "scopes"sv, "integrity"sv))
             continue;
 
@@ -132,7 +136,11 @@ WebIDL::ExceptionOr<ModuleSpecifierMap> sort_and_normalise_module_specifier_map(
     ModuleSpecifierMap normalized;
 
     // 2. For each specifierKey → value of originalMap:
-    for (auto& specifier_key : original_map.shape().property_table().keys()) {
+    Vector<JS::PropertyKey> specifier_keys;
+    original_map.shape().for_each_property_in_insertion_order([&](auto const& specifier_key, auto const&) {
+        specifier_keys.append(specifier_key);
+    });
+    for (auto& specifier_key : specifier_keys) {
         auto value = TRY(original_map.get(specifier_key.as_string()));
 
         // 1. Let normalizedSpecifierKey be the result of normalizing a specifier key given specifierKey and baseURL.
@@ -200,7 +208,11 @@ WebIDL::ExceptionOr<HashMap<URL::URL, ModuleSpecifierMap>> sort_and_normalise_sc
     HashMap<URL::URL, ModuleSpecifierMap> normalized;
 
     // 2. For each scopePrefix → potentialSpecifierMap of originalMap:
-    for (auto& scope_prefix : original_map.shape().property_table().keys()) {
+    Vector<JS::PropertyKey> scope_prefixes;
+    original_map.shape().for_each_property_in_insertion_order([&](auto const& scope_prefix, auto const&) {
+        scope_prefixes.append(scope_prefix);
+    });
+    for (auto& scope_prefix : scope_prefixes) {
         auto potential_specifier_map = TRY(original_map.get(scope_prefix.as_string()));
 
         // 1. If potentialSpecifierMap is not an ordered map, then throw a TypeError indicating that the value of the scope with prefix scopePrefix needs to be a JSON object.
@@ -237,7 +249,11 @@ WebIDL::ExceptionOr<ModuleIntegrityMap> normalize_module_integrity_map(JS::Realm
     ModuleIntegrityMap normalized;
 
     // 2. For each key → value of originalMap:
-    for (auto& key : original_map.shape().property_table().keys()) {
+    Vector<JS::PropertyKey> keys;
+    original_map.shape().for_each_property_in_insertion_order([&](auto const& key, auto const&) {
+        keys.append(key);
+    });
+    for (auto& key : keys) {
         auto value = TRY(original_map.get(key.as_string()));
 
         // 1. Let resolvedURL be the result of resolving a URL-like module specifier given key and baseURL.

--- a/Tests/LibJS/Runtime/dictionary-shape-stress.js
+++ b/Tests/LibJS/Runtime/dictionary-shape-stress.js
@@ -387,6 +387,21 @@ describe("Object.defineProperty on dictionaries", () => {
 });
 
 describe("dictionary objects with prototype chain", () => {
+    test("setting prototype of a very large dictionary object", () => {
+        const obj = {};
+        const propertyCount = 65537;
+        for (let i = 0; i < propertyCount; ++i) {
+            obj["p" + i] = i;
+        }
+
+        const proto = { inherited: "value" };
+        Object.setPrototypeOf(obj, proto);
+
+        expect(obj.p0).toBe(0);
+        expect(obj.p65536).toBe(65536);
+        expect(obj.inherited).toBe("value");
+    });
+
     test("dictionary object inheriting from prototype", () => {
         const proto = { inherited: 42 };
         const obj = Object.create(proto);

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -174,15 +174,15 @@ TESTJS_GLOBAL_FUNCTION(parse_webassembly_module, parseWebAssemblyModule)
     HashMap<Wasm::Linker::Name, Wasm::ExternValue> imports;
     auto import_value = vm.argument(1);
     if (auto import_object = import_value.template as_if<JS::Object>()) {
-        for (auto const& property : import_object->shape().property_table()) {
-            auto module_object = import_object->get_without_side_effects(property.key).as_if<WebAssemblyModule>();
+        import_object->shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+            auto module_object = import_object->get_without_side_effects(property_key).template as_if<WebAssemblyModule>();
             if (!module_object)
-                continue;
+                return;
             for (auto& entry : module_object->module_instance().exports()) {
                 // FIXME: Don't pretend that everything is a function
-                imports.set({ property.key.as_string().to_utf16_string().to_byte_string(), entry.name(), Wasm::TypeIndex(0) }, entry.value());
+                imports.set({ property_key.as_string().to_utf16_string().to_byte_string(), entry.name(), Wasm::TypeIndex(0) }, entry.value());
             }
-        }
+        });
     }
 
     return JS::Value(TRY(WebAssemblyModule::create(realm, result.release_value(), imports)));

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -789,11 +789,11 @@ static ErrorOr<int> run_repl(bool gc_on_every_allocation, bool syntax_highlight)
         Vector<Line::CompletionSuggestion> results;
 
         Function<void(JS::Shape const&, Utf16FlyString const&)> list_all_properties = [&results, &list_all_properties](JS::Shape const& shape, Utf16FlyString const& property_pattern) {
-            for (auto const& descriptor : shape.property_table()) {
-                if (!descriptor.key.is_string())
-                    continue;
+            shape.for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+                if (!property_key.is_string())
+                    return;
 
-                auto key = descriptor.key.as_string().to_utf16_string();
+                auto key = property_key.as_string().to_utf16_string();
 
                 if (key.starts_with(property_pattern.view())) {
                     Line::CompletionSuggestion completion { key.to_utf8_but_should_be_ported_to_utf16(), Line::CompletionSuggestion::ForSearch };
@@ -802,7 +802,7 @@ static ErrorOr<int> run_repl(bool gc_on_every_allocation, bool syntax_highlight)
                         results.last().invariant_offset = property_pattern.length_in_code_units();
                     }
                 }
-            }
+            });
             if (auto const* prototype = shape.prototype()) {
                 list_all_properties(prototype->shape(), property_pattern);
             }


### PR DESCRIPTION
Replace the lazy non-dictionary `Shape` property table with a compact `DescriptorArray`. Descriptor arrays store entries in hash order for lookup and keep a separate insertion-order index for enumeration.

Dictionary shapes stay on the mutable `OrderedHashMap` path, including oversized shapes that cannot fit in the compact descriptor representation.

This also shares descriptor arrays across compatible transitions, packs descriptor and dictionary storage into one Shape union, removes the old transition-chain payload from Shape, eagerly allocates dictionary tables, derives prototype-shape status from the validity cell, and reduces Shape from 104 to 88 bytes.

This reduces the memory footprint of WebContent by 63 MiB on https://x.com/awesomekling

JS benchmarks look neutral/good with a minor reduction in memory usage:
```
Suite           Test                                            Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  ----------------------------------------------  ---------  ---------------------------------  ---------------------------------  -----------------
LongSpider      3d-cube.js                                      1.004      4.914 ± 4.893 … 4.935              4.894 ± 4.776 … 5.012              +0.2% (+0.1 MB)
LongSpider      3d-morph.js                                     1.005      1.505 ± 1.500 … 1.509              1.497 ± 1.475 … 1.518              +0.0% (+0.0 MB)
LongSpider      3d-raytrace.js                                  1.044      2.880 ± 2.873 … 2.888              2.758 ± 2.754 … 2.762              -0.7% (-0.3 MB)
LongSpider      access-binary-trees.js                          1.053      7.790 ± 7.732 … 7.849              7.397 ± 7.373 … 7.422              +16.3% (+24.9 MB)
LongSpider      access-fannkuch.js                              0.990      1.709 ± 1.672 … 1.745              1.726 ± 1.710 … 1.743              +0.0% (+0.0 MB)
LongSpider      access-nbody.js                                 1.010      4.143 ± 4.140 … 4.147              4.103 ± 3.886 … 4.319              +0.0% (+0.0 MB)
LongSpider      access-nsieve.js                                1.026      0.950 ± 0.947 … 0.954              0.926 ± 0.922 … 0.930              +0.0% (+0.0 MB)
LongSpider      bitops-3bit-bits-in-byte.js                     1.004      0.440 ± 0.439 … 0.441              0.438 ± 0.436 … 0.441              +0.0% (+0.0 MB)
LongSpider      bitops-bits-in-byte.js                          1.064      0.770 ± 0.769 … 0.770              0.723 ± 0.700 … 0.746              +0.0% (+0.0 MB)
LongSpider      bitops-nsieve-bits.js                           1.174      2.499 ± 2.129 … 2.869              2.129 ± 1.990 … 2.268              -0.3% (-0.1 MB)
LongSpider      controlflow-recursive.js                        1.004      1.787 ± 1.784 … 1.790              1.780 ± 1.776 … 1.784              +0.0% (+0.0 MB)
LongSpider      crypto-aes.js                                   1.008      4.498 ± 4.381 … 4.616              4.461 ± 4.438 … 4.483              -0.2% (-0.1 MB)
LongSpider      crypto-md5.js                                   0.995      4.572 ± 4.571 … 4.573              4.593 ± 4.568 … 4.619              -0.1% (-0.1 MB)
LongSpider      crypto-sha1.js                                  1.006      8.780 ± 8.624 … 8.935              8.727 ± 8.589 … 8.864              -0.2% (-0.1 MB)
LongSpider      date-format-tofte.js                            0.999      3.837 ± 3.836 … 3.839              3.839 ± 3.823 … 3.856              +0.4% (+0.2 MB)
LongSpider      date-format-xparb.js                            0.938      4.161 ± 4.153 … 4.169              4.438 ± 4.376 … 4.499              +0.1% (+0.0 MB)
LongSpider      hash-map.js                                     0.994      0.988 ± 0.976 … 1.000              0.994 ± 0.986 … 1.002              -0.1% (-0.1 MB)
LongSpider      math-cordic.js                                  1.005      5.248 ± 5.246 … 5.250              5.221 ± 5.218 … 5.225              +0.0% (+0.0 MB)
LongSpider      math-partial-sums.js                            0.998      0.801 ± 0.800 … 0.802              0.803 ± 0.801 … 0.805              +0.0% (+0.0 MB)
LongSpider      math-spectral-norm.js                           1.024      4.698 ± 4.593 … 4.804              4.589 ± 4.584 … 4.594              +0.0% (+0.0 MB)
LongSpider      string-base64.js                                0.991      1.300 ± 1.285 … 1.315              1.312 ± 1.307 … 1.316              +10.0% (+31.1 MB)
LongSpider      string-fasta.js                                 1.014      1.582 ± 1.565 … 1.600              1.561 ± 1.557 … 1.566              +0.1% (+0.0 MB)
LongSpider      string-tagcloud.js                              1.019      0.742 ± 0.737 … 0.748              0.729 ± 0.725 … 0.732              +1.9% (+1.5 MB)
Kraken          ai-astar.js                                     1.044      0.676 ± 0.643 … 0.708              0.647 ± 0.640 … 0.654              -0.2% (-0.1 MB)
Kraken          audio-beat-detection.js                         1.030      0.513 ± 0.512 … 0.514              0.498 ± 0.495 … 0.500              -0.2% (-0.2 MB)
Kraken          audio-dft.js                                    1.052      0.367 ± 0.359 … 0.375              0.349 ± 0.342 … 0.356              -10.3% (-5.2 MB)
Kraken          audio-fft.js                                    1.020      0.437 ± 0.425 … 0.449              0.429 ± 0.423 … 0.434              +0.4% (+0.3 MB)
Kraken          audio-oscillator.js                             1.049      0.366 ± 0.355 … 0.377              0.349 ± 0.349 … 0.349              +0.1% (+0.1 MB)
Kraken          imaging-darkroom.js                             0.987      0.545 ± 0.541 … 0.550              0.552 ± 0.543 … 0.562              -0.1% (-0.1 MB)
Kraken          imaging-desaturate.js                           0.995      0.594 ± 0.593 … 0.596              0.598 ± 0.597 … 0.598              +0.3% (+0.2 MB)
Kraken          imaging-gaussian-blur.js                        0.997      2.636 ± 2.561 … 2.712              2.643 ± 2.642 … 2.644              +0.3% (+0.2 MB)
Kraken          json-parse-financial.js                         1.170      0.063 ± 0.054 … 0.072              0.054 ± 0.054 … 0.054              +0.0% (+0.0 MB)
Kraken          json-stringify-tinderbox.js                     1.012      0.052 ± 0.050 … 0.055              0.052 ± 0.051 … 0.052              +5.5% (+2.1 MB)
Kraken          stanford-crypto-aes.js                          1.034      0.222 ± 0.221 … 0.223              0.214 ± 0.214 … 0.215              -0.0% (-0.0 MB)
Kraken          stanford-crypto-ccm.js                          1.023      0.173 ± 0.170 … 0.176              0.169 ± 0.169 … 0.169              -0.5% (-0.3 MB)
Kraken          stanford-crypto-pbkdf2.js                       1.007      0.380 ± 0.376 … 0.385              0.378 ± 0.371 … 0.385              -4.2% (-1.8 MB)
Kraken          stanford-crypto-sha256-iterative.js             1.018      0.133 ± 0.131 … 0.135              0.130 ± 0.130 … 0.131              -5.2% (-2.0 MB)
Octane          box2d.js                                        1.008      8555.500 ± 8539.000 … 8572.000     8627.500 ± 8623.000 … 8632.000     -5.3% (-3.2 MB)
Octane          code-load.js                                    1.006      21792.000 ± 21779.000 … 21805.000  21922.500 ± 21847.000 … 21998.000  -1.7% (-21.6 MB)
Octane          crypto.js                                       1.012      2779.000 ± 2718.000 … 2840.000     2813.500 ± 2773.000 … 2854.000     -5.1% (-2.2 MB)
Octane          deltablue.js                                    1.002      2347.000 ± 2316.000 … 2378.000     2351.500 ± 2347.000 … 2356.000     -0.4% (-0.2 MB)
Octane          earley-boyer.js                                 1.012      4564.500 ± 4557.000 … 4572.000     4617.500 ± 4617.000 … 4618.000     -0.4% (-0.3 MB)
Octane          gbemu.js                                        0.996      16729.000 ± 16714.000 … 16744.000  16668.500 ± 16638.000 … 16699.000  +0.3% (+0.3 MB)
Octane          mandreel.js                                     1.003      16454.500 ± 16292.000 … 16617.000  16509.000 ± 16345.000 … 16673.000  +1.0% (+3.1 MB)
Octane          navier-stokes.js                                0.985      5318.500 ± 5048.000 … 5589.000     5238.000 ± 4937.000 … 5539.000     -7.2% (-1.9 MB)
Octane          pdfjs.js                                        0.996      8272.500 ± 8261.000 … 8284.000     8242.500 ± 8224.000 … 8261.000     -4.6% (-5.8 MB)
Octane          raytrace.js                                     1.008      3520.000 ± 3520.000 … 3520.000     3546.500 ± 3517.000 … 3576.000     +1.1% (+0.5 MB)
Octane          regexp.js                                       1.029      2058.000 ± 2056.000 … 2060.000     2117.500 ± 2104.000 … 2131.000     -0.1% (-0.1 MB)
Octane          richards.js                                     0.993      2481.500 ± 2471.000 … 2492.000     2463.000 ± 2436.000 … 2490.000     +1.7% (+0.5 MB)
Octane          splay.js                                        0.990      7969.500 ± 7930.000 … 8009.000     7887.000 ± 7852.000 … 7922.000     -0.0% (-0.1 MB)
Octane          typescript.js                                   1.012      22127.000 ± 22056.000 … 22198.000  22389.000 ± 22385.000 … 22393.000  -2.0% (-7.0 MB)
Octane          zlib.js                                         1.013      5437.500 ± 5289.000 … 5586.000     5510.000 ± 5460.000 … 5560.000     -0.0% (-0.1 MB)
JetStream       bigfib.cpp.js                                   1.083      5.075 ± 5.026 … 5.124              4.686 ± 4.679 … 4.694              +0.1% (+0.1 MB)
JetStream       cdjs.js                                         1.020      2.004 ± 2.002 … 2.006              1.965 ± 1.961 … 1.969              -0.4% (-0.2 MB)
JetStream       container.cpp.js                                1.015      21.688 ± 21.578 … 21.798           21.367 ± 21.304 … 21.429           -3.1% (-4.0 MB)
JetStream       dry.c.js                                        1.180      12.386 ± 11.785 … 12.987           10.494 ± 10.437 … 10.551           -0.0% (-0.0 MB)
JetStream       float-mm.c.js                                   0.998      13.062 ± 12.508 … 13.616           13.087 ± 12.561 … 13.613           +0.1% (+0.0 MB)
JetStream       gcc-loops.cpp.js                                0.977      70.116 ± 69.884 … 70.348           71.786 ± 70.370 … 73.203           -1.8% (-2.3 MB)
JetStream       hash-map.js                                     0.988      1.004 ± 0.998 … 1.011              1.016 ± 0.990 … 1.042              -0.0% (-0.0 MB)
JetStream       n-body.c.js                                     1.026      17.444 ± 17.189 … 17.699           17.003 ± 16.354 … 17.652           -3.9% (-1.9 MB)
JetStream       quicksort.c.js                                  1.135      3.063 ± 3.010 … 3.117              2.700 ± 2.677 … 2.722              -0.1% (-0.0 MB)
JetStream       towers.c.js                                     1.124      3.436 ± 3.328 … 3.544              3.058 ± 2.979 … 3.138              -3.8% (-1.8 MB)
JetStream3      js-tokens.js                                    1.037      0.286 ± 0.280 … 0.293              0.276 ± 0.273 … 0.279              -5.2% (-2.2 MB)
JetStream3      lazy-collections.js                             1.022      0.810 ± 0.806 … 0.814              0.793 ± 0.788 … 0.797              +0.8% (+0.4 MB)
JetStream3      raytrace-private-class-fields.js                1.004      3.596 ± 3.588 … 3.604              3.583 ± 3.563 … 3.604              -0.2% (-0.1 MB)
JetStream3      raytrace-public-class-fields.js                 1.040      2.599 ± 2.598 … 2.601              2.500 ± 2.490 … 2.511              -2.9% (-1.1 MB)
JetStream3      sync-file-system.js                             1.010      1.792 ± 1.787 … 1.797              1.774 ± 1.762 … 1.785              -3.2% (-1.2 MB)
AsyncBench      async-call-return.js                            1.001      0.251 ± 0.241 … 0.262              0.251 ± 0.243 … 0.259              -4.8% (-2.1 MB)
AsyncBench      async-class-method.js                           1.023      0.271 ± 0.266 … 0.277              0.265 ± 0.262 … 0.268              -4.7% (-2.1 MB)
AsyncBench      async-fan-out.js                                1.019      0.178 ± 0.176 … 0.181              0.175 ± 0.175 … 0.175              -0.2% (-0.1 MB)
AsyncBench      async-generator.js                              1.025      0.236 ± 0.236 … 0.236              0.230 ± 0.230 … 0.231              -0.6% (-0.2 MB)
AsyncBench      async-iife.js                                   0.958      0.340 ± 0.340 … 0.340              0.355 ± 0.352 … 0.358              +0.4% (+0.2 MB)
AsyncBench      async-nested-calls.js                           0.975      0.402 ± 0.400 … 0.404              0.412 ± 0.409 … 0.416              -4.7% (-2.0 MB)
AsyncBench      async-pipeline.js                               1.019      0.396 ± 0.393 … 0.399              0.389 ± 0.389 … 0.389              -0.1% (-0.0 MB)
AsyncBench      async-sequential-awaits.js                      1.029      0.114 ± 0.112 … 0.116              0.110 ± 0.109 … 0.112              -3.4% (-1.9 MB)
AsyncBench      async-try-catch-reject.js                       0.984      0.532 ± 0.531 … 0.532              0.540 ± 0.528 … 0.553              -4.1% (-1.7 MB)
AsyncBench      await-primitive.js                              1.024      0.045 ± 0.043 … 0.048              0.044 ± 0.044 … 0.044              +0.2% (+0.1 MB)
AsyncBench      await-resolved-promise.js                       0.989      0.333 ± 0.332 … 0.334              0.337 ± 0.332 … 0.341              +0.2% (+0.1 MB)
AsyncBench      await-thenable.js                               1.044      0.035 ± 0.033 … 0.037              0.033 ± 0.033 … 0.034              +0.1% (+0.1 MB)
AsyncBench      promise-all.js                                  0.995      0.488 ± 0.486 … 0.491              0.491 ± 0.490 … 0.492              +0.2% (+0.1 MB)
AsyncBench      promise-allSettled.js                           1.007      0.563 ± 0.561 … 0.565              0.559 ± 0.557 … 0.561              +0.2% (+0.1 MB)
AsyncBench      promise-chain.js                                1.011      0.209 ± 0.208 … 0.210              0.207 ± 0.207 … 0.207              +0.1% (+0.1 MB)
AsyncBench      promise-new-resolve.js                          1.036      0.247 ± 0.244 … 0.250              0.239 ± 0.238 … 0.239              +0.2% (+0.1 MB)
AsyncBench      promise-race.js                                 0.994      0.505 ± 0.502 … 0.507              0.508 ± 0.506 … 0.509              +0.2% (+0.1 MB)
ARES-6          Air.js                                          0.989      1.751 ± 1.747 … 1.755              1.770 ± 1.758 … 1.781              +0.0% (+0.0 MB)
ARES-6          Babylon.js                                      0.994      1.011 ± 1.003 … 1.019              1.017 ± 1.009 … 1.026              +1.1% (+0.6 MB)
ARES-6          Basic.js                                        1.001      1.397 ± 1.389 … 1.405              1.396 ± 1.374 … 1.417              -0.4% (-0.2 MB)
ARES-6          ML.js                                           0.998      1.519 ± 1.518 … 1.519              1.522 ± 1.521 … 1.524              -2.1% (-1.2 MB)
JetStreamExtra  FlightPlanner.js                                1.023      0.913 ± 0.908 … 0.918              0.892 ± 0.885 … 0.899              -0.2% (-1.0 MB)
JetStreamExtra  OfflineAssembler.js                             1.007      1.087 ± 1.086 … 1.089              1.080 ± 1.074 … 1.086              -4.1% (-2.7 MB)
JetStreamExtra  UniPoker.js                                     1.020      1.262 ± 1.242 … 1.282              1.238 ± 1.232 … 1.243              +0.2% (+0.1 MB)
JetStreamExtra  async-fs.js                                     1.007      1.704 ± 1.699 … 1.708              1.693 ± 1.691 … 1.694              -0.5% (-0.2 MB)
JetStreamExtra  babylonjs-startup-es5.js                        1.008      0.862 ± 0.859 … 0.865              0.855 ± 0.852 … 0.858              -2.0% (-13.5 MB)
JetStreamExtra  babylonjs-startup-es6.js                        1.008      1.052 ± 1.044 … 1.060              1.043 ± 1.043 … 1.043              -4.3% (-34.7 MB)
JetStreamExtra  bigint-bigdenary.js                             0.995      1.926 ± 1.917 … 1.934              1.935 ± 1.929 … 1.941              +1.0% (+0.5 MB)
JetStreamExtra  bigint-noble-bls12-381.js                       0.990      2.084 ± 2.083 … 2.085              2.104 ± 2.100 … 2.107              +0.2% (+0.1 MB)
JetStreamExtra  bigint-noble-ed25519.js                         1.009      2.093 ± 2.093 … 2.094              2.076 ± 2.074 … 2.077              -0.6% (-0.6 MB)
JetStreamExtra  bigint-noble-secp256k1.js                       1.002      1.938 ± 1.936 … 1.940              1.935 ± 1.934 … 1.935              -2.9% (-2.7 MB)
JetStreamExtra  bigint-paillier.js                              1.013      2.032 ± 2.020 … 2.044              2.006 ± 1.998 … 2.015              -0.1% (-0.1 MB)
JetStreamExtra  doxbee-async.js                                 0.959      1.740 ± 1.739 … 1.741              1.813 ± 1.793 … 1.834              +3.0% (+1.9 MB)
JetStreamExtra  doxbee-promise.js                               1.008      1.415 ± 1.414 … 1.415              1.404 ± 1.401 … 1.406              -1.9% (-0.9 MB)
JetStreamExtra  first-inspector-code-load.js                    1.002      1.723 ± 1.709 … 1.736              1.719 ± 1.716 … 1.723              +0.4% (+6.1 MB)
JetStreamExtra  jsdom-d3-startup.js                             0.989      1.279 ± 1.275 … 1.283              1.294 ± 1.291 … 1.297              -1.0% (-4.3 MB)
JetStreamExtra  json-parse-inspector.js                         0.963      1.062 ± 1.039 … 1.085              1.103 ± 1.048 … 1.157              +0.1% (+0.4 MB)
JetStreamExtra  json-stringify-inspector.js                     0.999      0.945 ± 0.929 … 0.961              0.946 ± 0.945 … 0.946              -4.4% (-15.8 MB)
JetStreamExtra  mobx-startup.js                                 1.009      1.445 ± 1.440 … 1.449              1.432 ± 1.431 … 1.433              -0.7% (-0.5 MB)
JetStreamExtra  multi-inspector-code-load.js                    1.000      1.719 ± 1.718 … 1.720              1.719 ± 1.718 … 1.720              -0.1% (-1.2 MB)
JetStreamExtra  prismjs-startup-es5.js                          1.005      1.748 ± 1.727 … 1.770              1.740 ± 1.738 … 1.742              -2.0% (-1.5 MB)
JetStreamExtra  prismjs-startup-es6.js                          1.005      1.746 ± 1.730 … 1.761              1.736 ± 1.736 … 1.737              -4.4% (-3.2 MB)
JetStreamExtra  proxy-mobx.js                                   0.997      1.306 ± 1.296 … 1.315              1.309 ± 1.304 … 1.315              -0.6% (-0.3 MB)
JetStreamExtra  proxy-vue.js                                    1.019      1.232 ± 1.207 … 1.256              1.208 ± 1.171 … 1.245              -3.0% (-2.0 MB)
JetStreamExtra  threejs.js                                      0.911      1.501 ± 1.500 … 1.501              1.647 ± 1.643 … 1.650              -4.7% (-22.1 MB)
JetStreamExtra  typescript-lib.js                               1.034      0.576 ± 0.555 … 0.596              0.557 ± 0.554 … 0.560              -2.9% (-8.8 MB)
JetStreamExtra  validatorjs.js                                  1.020      1.562 ± 1.558 … 1.566              1.531 ± 1.528 … 1.534              -4.2% (-2.8 MB)
JetStreamExtra  web-ssr.js                                      1.005      1.578 ± 1.574 … 1.582              1.569 ± 1.558 … 1.580              +1.6% (+7.8 MB)
GarBench        array-of-objects.js                             1.007      0.803 ± 0.794 … 0.813              0.798 ± 0.797 … 0.799              -0.0% (-0.0 MB)
GarBench        closures.js                                     1.010      1.039 ± 1.034 … 1.043              1.028 ± 1.025 … 1.031              -0.2% (-1.9 MB)
GarBench        cyclic-graph.js                                 0.999      1.217 ± 1.211 … 1.223              1.218 ± 1.215 … 1.221              +1.0% (+2.3 MB)
GarBench        deep-linked-list.js                             1.023      0.863 ± 0.853 … 0.874              0.844 ± 0.842 … 0.845              -0.4% (-2.1 MB)
GarBench        finalization.js                                 1.017      0.868 ± 0.853 … 0.883              0.853 ± 0.850 … 0.856              -1.4% (-6.3 MB)
GarBench        many-properties.js                              0.951      2.370 ± 2.364 … 2.375              2.491 ± 2.472 … 2.510              +0.1% (+0.9 MB)
GarBench        marking-stress.js                               0.839      0.970 ± 0.970 … 0.970              1.156 ± 0.951 … 1.361              -1.8% (-9.7 MB)
GarBench        mixed-sizes.js                                  1.032      1.064 ± 1.058 … 1.070              1.031 ± 1.030 … 1.032              -0.0% (-0.1 MB)
GarBench        sparse-arrays.js                                1.051      2.144 ± 2.144 … 2.144              2.039 ± 2.037 … 2.041              +0.1% (+0.8 MB)
GarBench        string-heavy.js                                 1.012      1.395 ± 1.394 … 1.395              1.379 ± 1.375 … 1.382              -0.0% (-0.2 MB)
GarBench        wide-tree.js                                    0.985      1.378 ± 1.375 … 1.381              1.399 ± 1.396 … 1.401              +0.5% (+4.3 MB)
MicroBench      array-destructuring-assignment-rest.js          1.028      0.316 ± 0.308 … 0.324              0.307 ± 0.305 … 0.309              +0.2% (+0.1 MB)
MicroBench      array-destructuring-assignment.js               1.001      2.886 ± 2.879 … 2.894              2.883 ± 2.848 … 2.918              -0.2% (-4.8 MB)
MicroBench      array-prototype-map.js                          1.009      1.214 ± 1.203 … 1.224              1.203 ± 1.200 … 1.206              +0.1% (+0.2 MB)
MicroBench      array-prototype-shift.js                        1.247      0.010 ± 0.008 … 0.011              0.008 ± 0.008 … 0.008              +0.2% (+0.1 MB)
MicroBench      bound-call-00-args.js                           1.000      1.437 ± 1.435 … 1.440              1.437 ± 1.431 … 1.443              +0.2% (+0.1 MB)
MicroBench      bound-call-04-args.js                           0.990      1.545 ± 1.543 … 1.547              1.560 ± 1.550 … 1.570              +0.2% (+0.1 MB)
MicroBench      bound-call-16-args.js                           0.998      1.741 ± 1.740 … 1.741              1.743 ± 1.738 … 1.749              +0.2% (+0.1 MB)
MicroBench      call-00-args.js                                 1.023      0.468 ± 0.460 … 0.476              0.457 ± 0.456 … 0.459              +0.2% (+0.1 MB)
MicroBench      call-01-args.js                                 1.010      0.457 ± 0.452 … 0.462              0.452 ± 0.451 … 0.453              +0.2% (+0.1 MB)
MicroBench      call-02-args.js                                 1.011      0.478 ± 0.471 … 0.485              0.473 ± 0.468 … 0.477              +0.2% (+0.1 MB)
MicroBench      call-03-args.js                                 1.007      0.522 ± 0.519 … 0.525              0.518 ± 0.517 … 0.519              +0.2% (+0.1 MB)
MicroBench      call-04-args.js                                 1.007      0.517 ± 0.515 … 0.518              0.513 ± 0.510 … 0.516              +0.2% (+0.1 MB)
MicroBench      call-16-args.js                                 1.001      0.681 ± 0.679 … 0.683              0.680 ± 0.679 … 0.682              +0.2% (+0.1 MB)
MicroBench      call-32-args.js                                 1.033      0.910 ± 0.896 … 0.924              0.880 ± 0.873 … 0.888              +0.2% (+0.1 MB)
MicroBench      call-with-function-environment-2.js             1.008      0.936 ± 0.932 … 0.941              0.929 ± 0.929 … 0.929              +0.3% (+0.2 MB)
MicroBench      call-with-function-environment-captured-var.js  1.010      0.989 ± 0.985 … 0.993              0.979 ± 0.979 … 0.979              +0.5% (+0.3 MB)
MicroBench      call-with-function-environment.js               0.994      0.466 ± 0.465 … 0.467              0.468 ± 0.467 … 0.470              +0.2% (+0.1 MB)
MicroBench      for-in-indexed-properties.js                    1.028      0.228 ± 0.223 … 0.232              0.222 ± 0.221 … 0.222              -0.3% (-0.6 MB)
MicroBench      for-in-named-properties.js                      1.019      0.172 ± 0.171 … 0.174              0.169 ± 0.169 … 0.169              +0.2% (+0.1 MB)
MicroBench      for-of.js                                       1.061      0.541 ± 0.512 … 0.570              0.510 ± 0.488 … 0.532              +0.2% (+0.1 MB)
MicroBench      function-prototype-call.js                      1.069      0.418 ± 0.378 … 0.458              0.392 ± 0.374 … 0.409              +0.2% (+0.1 MB)
MicroBench      object-keys.js                                  0.950      1.311 ± 1.277 … 1.345              1.380 ± 1.380 … 1.380              +0.2% (+0.4 MB)
MicroBench      object-set-with-rope-strings.js                 1.032      0.521 ± 0.520 … 0.523              0.505 ± 0.499 … 0.512              +0.2% (+0.1 MB)
MicroBench      pic-add-own.js                                  0.987      0.415 ± 0.411 … 0.418              0.420 ± 0.418 … 0.423              +0.2% (+0.1 MB)
MicroBench      pic-get-own.js                                  1.013      0.492 ± 0.491 … 0.493              0.485 ± 0.484 … 0.486              +0.2% (+0.1 MB)
MicroBench      pic-get-pchain.js                               1.001      0.530 ± 0.529 … 0.530              0.530 ± 0.529 … 0.530              +0.2% (+0.1 MB)
MicroBench      pic-put-own.js                                  0.751      0.517 ± 0.515 … 0.518              0.688 ± 0.517 … 0.859              +0.2% (+0.1 MB)
MicroBench      pic-put-pchain.js                               1.004      1.889 ± 1.884 … 1.895              1.883 ± 1.878 … 1.887              +0.2% (+0.1 MB)
MicroBench      setter-in-prototype-chain.js                    0.970      1.927 ± 1.911 … 1.942              1.986 ± 1.878 … 2.093              +0.2% (+0.1 MB)
MicroBench      strictly-equals-object.js                       1.002      0.727 ± 0.725 … 0.729              0.726 ± 0.725 … 0.726              +0.2% (+0.1 MB)
LongSpider      Total                                           1.014      70.595                             69.638                             +3.3% (+57.0 MB)
Kraken          Total                                           1.014      7.158                              7.062                              -0.8% (-6.7 MB)
Octane          Total                                           1.004      130406.000                         130903.500                         -1.2% (-38.0 MB)
JetStream       Total                                           1.014      149.279                            147.162                            -1.2% (-10.1 MB)
JetStream3      Total                                           1.018      9.084                              8.926                              -2.1% (-4.2 MB)
AsyncBench      Total                                           1.000      5.146                              5.145                              -1.0% (-9.3 MB)
ARES-6          Total                                           0.995      5.678                              5.705                              -0.3% (-0.8 MB)
JetStreamExtra  Total                                           0.999      39.528                             39.585                             -1.2% (-102.0 MB)
GarBench        Total                                           0.991      14.110                             14.235                             -0.1% (-12.1 MB)
MicroBench      Total                                           0.995      25.259                             25.387                             -0.0% (-2.2 MB)
All Suites      Total                                           1.009      391.120                            387.588                            -0.4% (-128.4 MB)
```

Gratuitous mermaid diagram of new data layout :)

```mermaid
  flowchart LR
      subgraph Shape["JS::Shape"]
          ShapeBits["bit flags<br/>m_dictionary<br/>m_has_parameter_map"]
          ShapeRealm["m_realm"]
          ShapeStorage["m_property_storage union"]
          ShapeTransitions["transition caches"]
          ShapePrototype["m_prototype<br/>m_prototype_chain_validity<br/>m_child_prototype_shapes"]
          ShapeCounts["m_property_count<br/>m_dictionary_generation"]
      end

      subgraph Storage["Shape::PropertyStorage"]
          DescriptorArm["descriptor arm<br/>GC::Ptr&lt;DescriptorArray&gt;"]
          DictionaryArm["dictionary arm<br/>OwnPtr&lt;OrderedHashMap&lt;PropertyKey, PropertyMetadata&gt;&gt;"]
      end

      ShapeStorage --> Storage

      DescriptorArm --> DescriptorArray["DescriptorArray"]

      subgraph DescriptorArray["JS::DescriptorArray"]
          Entries["m_entries<br/>Vector&lt;Entry&gt;<br/>sorted by PropertyKey hash"]
          EnumMap["m_entry_indices_by_enum_index<br/>Vector&lt;u32&gt;<br/>enum index to m_entries index"]
      end

      subgraph Entry["DescriptorArray::Entry, 16 bytes"]
          EntryKey["PropertyKey property_key"]
          EntryOffset["u32 offset"]
          EntryAttrs["u16 attributes"]
          EntryEnum["u16 enum_index"]
      end

      Entries --> Entry

      ShapeCounts --> VisiblePrefix["m_property_count selects visible descriptors"]
      VisiblePrefix --> Entries
      VisiblePrefix --> EnumMap

      EnumMap --> Enum0["enum index 0"]
      EnumMap --> Enum1["enum index 1"]
      EnumMap --> EnumN["enum index N"]
      Enum0 --> EntryByIndex0["m_entries[index]"]
      Enum1 --> EntryByIndex1["m_entries[index]"]
      EnumN --> EntryByIndexN["m_entries[index]"]

      EntryOffset --> ObjectStorage["Object::m_named_properties[offset]"]

      DictionaryArm --> PropertyTable["dictionary shapes only<br/>property key to metadata"]
      PropertyTable --> ObjectStorage

```