### PR TITLE
LibWebView+WebContent: Enable async scrolling by default

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -237,8 +237,8 @@ static void set_or_append_scroll_offset(Vector<AsyncScrollOffset>& scroll_offset
 
 Vector<AsyncScrollOffset> AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID node_id, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot& scroll_state_snapshot)
 {
-    // The compositor can advance only the scroll offsets it owns in this snapshot. When a target reaches an edge,
-    // the remaining wheel delta is handed to the nearest scrollable ancestor from the same immutable tree.
+    // The compositor can advance only the scroll offsets it owns in this snapshot. Hit testing already selects an
+    // ancestor when the target cannot scroll in the wheel direction at all, so once a node moves it consumes the event.
     Vector<AsyncScrollOffset> scroll_offsets;
     auto remaining_delta = delta;
     for (size_t remaining_handoffs = m_scroll_nodes.size(); remaining_handoffs > 0 && has_non_zero_scroll_delta(remaining_delta); --remaining_handoffs) {
@@ -248,10 +248,10 @@ Vector<AsyncScrollOffset> AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID 
 
         auto delta_before_scroll = remaining_delta;
         remaining_delta = apply_scroll_delta_to_node(*node, remaining_delta, scroll_state_snapshot);
-        if (remaining_delta != delta_before_scroll)
+        if (remaining_delta != delta_before_scroll) {
             set_or_append_scroll_offset(scroll_offsets, *node, scroll_offset_for_node(*node, scroll_state_snapshot));
-        if (!has_non_zero_scroll_delta(remaining_delta))
             break;
+        }
 
         auto ancestor_node_id = scrollable_ancestor_for_node(node_id, scroll_state_snapshot, remaining_delta);
         if (!ancestor_node_id.has_value())

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -169,7 +169,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
     bool disable_scrollbar_painting = false;
-    bool enable_async_scrolling = false;
+    bool disable_async_scrolling = false;
     bool file_scheme_urls_have_tuple_origins = false;
     Optional<u64> style_invalidation_counter_dump_interval;
 
@@ -241,7 +241,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation", 'g');
     args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical scrollbars on the main viewport", "disable-scrollbar-painting");
-    args_parser.add_option(enable_async_scrolling, "Enable experimental async scrolling", "enable-async-scrolling");
+    args_parser.add_option(disable_async_scrolling, "Disable async scrolling", "disable-async-scrolling");
     args_parser.add_option(dns_server_address, "Set the DNS server address", "dns-server", 0, "host|address");
     args_parser.add_option(dns_server_port, "Set the DNS server port", "dns-port", 0, "port (default: 53 or 853 if --dot)");
     args_parser.add_option(use_dns_over_tls, "Use DNS over TLS", "dot");
@@ -369,7 +369,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
         .enable_autoplay = enable_autoplay ? EnableAutoplay::Yes : EnableAutoplay::No,
         .collect_garbage_on_every_allocation = collect_garbage_on_every_allocation ? CollectGarbageOnEveryAllocation::Yes : CollectGarbageOnEveryAllocation::No,
         .paint_viewport_scrollbars = disable_scrollbar_painting ? PaintViewportScrollbars::No : PaintViewportScrollbars::Yes,
-        .enable_async_scrolling = enable_async_scrolling ? EnableAsyncScrolling::Yes : EnableAsyncScrolling::No,
+        .enable_async_scrolling = disable_async_scrolling ? EnableAsyncScrolling::No : EnableAsyncScrolling::Yes,
         .file_scheme_urls_have_tuple_origins = file_scheme_urls_have_tuple_origins ? FileSchemeUrlsHaveTupleOrigins::Yes : FileSchemeUrlsHaveTupleOrigins::No,
         .default_time_zone = default_time_zone,
         .style_invalidation_counter_dump_interval = style_invalidation_counter_dump_interval,

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -118,8 +118,8 @@ static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_proc
         arguments.append("--collect-garbage-on-every-allocation"sv);
     if (web_content_options.paint_viewport_scrollbars == PaintViewportScrollbars::No)
         arguments.append("--disable-scrollbar-painting"sv);
-    if (web_content_options.enable_async_scrolling == EnableAsyncScrolling::Yes)
-        arguments.append("--enable-async-scrolling"sv);
+    if (web_content_options.enable_async_scrolling == EnableAsyncScrolling::No)
+        arguments.append("--disable-async-scrolling"sv);
     if (web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)
         arguments.append("--tuple-file-origins"sv);
 

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -188,7 +188,7 @@ struct WebContentOptions {
     CollectGarbageOnEveryAllocation collect_garbage_on_every_allocation { CollectGarbageOnEveryAllocation::No };
     Optional<u16> echo_server_port {};
     PaintViewportScrollbars paint_viewport_scrollbars { PaintViewportScrollbars::Yes };
-    EnableAsyncScrolling enable_async_scrolling { EnableAsyncScrolling::No };
+    EnableAsyncScrolling enable_async_scrolling { EnableAsyncScrolling::Yes };
     FileSchemeUrlsHaveTupleOrigins file_scheme_urls_have_tuple_origins { FileSchemeUrlsHaveTupleOrigins::No };
     Optional<StringView> default_time_zone {};
     Optional<u64> style_invalidation_counter_dump_interval {};

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -148,7 +148,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool collect_garbage_on_every_allocation = false;
     bool is_headless = false;
     bool disable_scrollbar_painting = false;
-    bool enable_async_scrolling = false;
+    bool disable_async_scrolling = false;
     StringView echo_server_port_string_view {};
     StringView default_time_zone {};
     StringView style_invalidation_counter_dump_interval {};
@@ -170,7 +170,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation");
     args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical viewport scrollbars", "disable-scrollbar-painting");
-    args_parser.add_option(enable_async_scrolling, "Enable experimental async scrolling", "enable-async-scrolling");
+    args_parser.add_option(disable_async_scrolling, "Disable async scrolling", "disable-async-scrolling");
     args_parser.add_option(echo_server_port_string_view, "Echo server port used in test internals", "echo-server-port", 0, "echo_server_port");
     args_parser.add_option(is_headless, "Report that the browser is running in headless mode", "headless");
     args_parser.add_option(default_time_zone, "Default time zone", "default-time-zone", 0, "time-zone-id");
@@ -221,7 +221,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         Web::Fetch::Fetching::set_http_memory_cache_enabled(true);
 
     Web::Painting::set_paint_viewport_scrollbars(!disable_scrollbar_painting);
-    WebContent::PageClient::set_async_scrolling_enabled(enable_async_scrolling);
+    WebContent::PageClient::set_async_scrolling_enabled(!disable_async_scrolling);
 
     if (!echo_server_port_string_view.is_empty()) {
         if (auto maybe_echo_server_port = echo_server_port_string_view.to_number<u16>(); maybe_echo_server_port.has_value())


### PR DESCRIPTION
Async scrolling is now correct enough to run by default, so keep it enabled in normal browsing and test coverage to catch the remaining issues.