### PR TITLE
LibJS: Fix FinalizationRegistry cleanup liveness

### DIFF
--- a/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -51,6 +51,15 @@ bool FinalizationRegistry::remove_by_token(Cell& unregister_token)
     return removed;
 }
 
+bool FinalizationRegistry::has_empty_cells() const
+{
+    for (auto& record : m_records) {
+        if (!record.target)
+            return true;
+    }
+    return false;
+}
+
 void FinalizationRegistry::remove_dead_cells(Badge<GC::Heap>)
 {
     auto any_cells_were_removed = false;

--- a/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -62,7 +62,6 @@ void FinalizationRegistry::remove_dead_cells(Badge<GC::Heap>)
             continue;
         record.target = nullptr;
         any_cells_were_removed = true;
-        break;
     }
     if (any_cells_were_removed) {
         // NOTE: We make a GC::Root here to ensure that the FinalizationRegistry stays alive

--- a/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -30,6 +30,7 @@ public:
     void add_finalization_record(Cell& target, Value held_value, Cell* unregister_token);
     bool remove_by_token(Cell& unregister_token);
     ThrowCompletionOr<void> cleanup(GC::Ptr<JobCallback> = {});
+    bool has_empty_cells() const;
 
     virtual Cell const& owner_cell(Badge<GC::Heap>) const override { return *this; }
     virtual void remove_dead_cells(Badge<GC::Heap>) override;

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -488,7 +488,9 @@ void VM::run_queued_finalization_registry_cleanup_jobs()
     while (!m_finalization_registry_cleanup_jobs.is_empty()) {
         auto registry = m_finalization_registry_cleanup_jobs.take_last();
         // FIXME: Handle any uncatched exceptions here.
-        (void)registry->cleanup();
+        auto result = registry->cleanup();
+        if (result.is_error() && registry->has_empty_cells())
+            m_finalization_registry_cleanup_jobs.append(registry);
     }
 }
 

--- a/Tests/LibJS/Runtime/builtins/FinalizationRegistry/FinalizationRegistry.cleanup.js
+++ b/Tests/LibJS/Runtime/builtins/FinalizationRegistry/FinalizationRegistry.cleanup.js
@@ -70,6 +70,26 @@ test("cleanup can process multiple dead records from one garbage collection", ()
     expect(heldValues).toEqual(["first", "second"]);
 });
 
+test("automatic cleanup continues after a callback throws", () => {
+    var heldValues = [];
+    var registry = new FinalizationRegistry(value => {
+        heldValues.push(value);
+        if (value === "first") throw new Error("expected abrupt completion");
+    });
+
+    evaluateSource("var __finalizationRegistryCleanupAfterThrowTarget1 = {};");
+    evaluateSource("var __finalizationRegistryCleanupAfterThrowTarget2 = {};");
+    registry.register(globalThis.__finalizationRegistryCleanupAfterThrowTarget1, "first");
+    registry.register(globalThis.__finalizationRegistryCleanupAfterThrowTarget2, "second");
+    markAsGarbage("__finalizationRegistryCleanupAfterThrowTarget1");
+    markAsGarbage("__finalizationRegistryCleanupAfterThrowTarget2");
+    gc();
+
+    runQueuedFinalizationRegistryCleanupJobs();
+
+    expect(heldValues).toEqual(["first", "second"]);
+});
+
 test("cleanup helper errors", () => {
     var registry = new FinalizationRegistry(() => {});
 

--- a/Tests/LibJS/Runtime/builtins/FinalizationRegistry/FinalizationRegistry.cleanup.js
+++ b/Tests/LibJS/Runtime/builtins/FinalizationRegistry/FinalizationRegistry.cleanup.js
@@ -2,13 +2,7 @@ test("cleanupSome is not exposed", () => {
     expect(FinalizationRegistry.prototype.cleanupSome).toBeUndefined();
 });
 
-function registerInDifferentScope(registry) {
-    const target = {};
-    registry.register(target, {});
-    return target;
-}
-
-test.xfail("basic functionality", () => {
+test("basic functionality", () => {
     var registry = new FinalizationRegistry(() => {});
 
     var count = 0;
@@ -20,8 +14,9 @@ test.xfail("basic functionality", () => {
 
     expect(count).toBe(0);
 
-    const target = registerInDifferentScope(registry);
-    markAsGarbage("target");
+    evaluateSource("var __finalizationRegistryTarget = {};");
+    registry.register(globalThis.__finalizationRegistryTarget, {});
+    markAsGarbage("__finalizationRegistryTarget");
     gc();
 
     cleanupFinalizationRegistry(registry, increment);
@@ -68,6 +63,39 @@ test("cleanup can process multiple dead records from one garbage collection", ()
     cleanupFinalizationRegistry(registry);
 
     expect(heldValues).toEqual(["first", "second"]);
+});
+
+test("held values are kept alive until cleanup", () => {
+    var heldValue;
+    var registry = new FinalizationRegistry(value => {
+        heldValue = value;
+    });
+
+    evaluateSource("var __finalizationRegistryHeldValueTarget = {};");
+    evaluateSource("var __finalizationRegistryHeldValue = { marker: 1 };");
+    registry.register(globalThis.__finalizationRegistryHeldValueTarget, globalThis.__finalizationRegistryHeldValue);
+    markAsGarbage("__finalizationRegistryHeldValueTarget");
+    markAsGarbage("__finalizationRegistryHeldValue");
+    gc();
+
+    cleanupFinalizationRegistry(registry);
+
+    expect(heldValue.marker).toBe(1);
+});
+
+test.xfail("unregister tokens are kept alive", () => {
+    var registry = new FinalizationRegistry(() => {});
+    var target = {};
+    evaluateSource("var __finalizationRegistryUnregisterToken = {};");
+    var tokenRef = new WeakRef(globalThis.__finalizationRegistryUnregisterToken);
+
+    registry.register(target, "held value", globalThis.__finalizationRegistryUnregisterToken);
+    markAsGarbage("__finalizationRegistryUnregisterToken");
+    clearKeptObjects();
+    gc();
+
+    expect(tokenRef.deref()).not.toBe(undefined);
+    expect(registry.unregister(tokenRef.deref())).toBeTrue();
 });
 
 test("automatic cleanup continues after a callback throws", () => {

--- a/Tests/LibJS/Runtime/builtins/FinalizationRegistry/FinalizationRegistry.cleanup.js
+++ b/Tests/LibJS/Runtime/builtins/FinalizationRegistry/FinalizationRegistry.cleanup.js
@@ -51,6 +51,25 @@ test("callback can unregister the next record after the current record dies", ()
     expect(registry.unregister(token2)).toBeFalse();
 });
 
+test("cleanup can process multiple dead records from one garbage collection", () => {
+    var heldValues = [];
+    var registry = new FinalizationRegistry(value => {
+        heldValues.push(value);
+    });
+
+    evaluateSource("var __finalizationRegistryCleanupTarget1 = {};");
+    evaluateSource("var __finalizationRegistryCleanupTarget2 = {};");
+    registry.register(globalThis.__finalizationRegistryCleanupTarget1, "first");
+    registry.register(globalThis.__finalizationRegistryCleanupTarget2, "second");
+    markAsGarbage("__finalizationRegistryCleanupTarget1");
+    markAsGarbage("__finalizationRegistryCleanupTarget2");
+    gc();
+
+    cleanupFinalizationRegistry(registry);
+
+    expect(heldValues).toEqual(["first", "second"]);
+});
+
 test("cleanup helper errors", () => {
     var registry = new FinalizationRegistry(() => {});
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -53,6 +53,12 @@ TESTJS_GLOBAL_FUNCTION(run_queued_promise_jobs, runQueuedPromiseJobs)
     return JS::js_undefined();
 }
 
+TESTJS_GLOBAL_FUNCTION(run_queued_finalization_registry_cleanup_jobs, runQueuedFinalizationRegistryCleanupJobs)
+{
+    vm.run_queued_finalization_registry_cleanup_jobs();
+    return JS::js_undefined();
+}
+
 TESTJS_GLOBAL_FUNCTION(get_weak_set_size, getWeakSetSize)
 {
     auto object = TRY(vm.argument(0).to_object(vm));

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -53,6 +53,12 @@ TESTJS_GLOBAL_FUNCTION(run_queued_promise_jobs, runQueuedPromiseJobs)
     return JS::js_undefined();
 }
 
+TESTJS_GLOBAL_FUNCTION(clear_kept_objects, clearKeptObjects)
+{
+    vm.finish_execution_generation();
+    return JS::js_undefined();
+}
+
 TESTJS_GLOBAL_FUNCTION(run_queued_finalization_registry_cleanup_jobs, runQueuedFinalizationRegistryCleanupJobs)
 {
     vm.run_queued_finalization_registry_cleanup_jobs();
@@ -99,8 +105,9 @@ TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)
     if (!can_be_held_weakly(value))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::CannotBeHeldWeakly, ByteString::formatted("Variable with name {}", variable_name.utf8_string_view()));
 
+    TRY(reference.put_value(vm, JS::js_undefined()));
+    (void)TRY(reference.delete_(vm));
     vm.heap().uproot_cell(&value.as_cell());
-    TRY(reference.delete_(vm));
 
     return JS::js_undefined();
 }


### PR DESCRIPTION
Fix a pair of `FinalizationRegistry` cleanup issues found while tightening GC coverage.

The weak-container pass now clears every dead target in a registry instead of stopping after the first one. Otherwise later dead records can keep raw target pointers around, and block reuse can make those stale addresses look alive in a later collection.

Automatic cleanup now also requeues the registry when a cleanup callback throws after some dead records remain. This prevents later held values from being stranded until another registered target dies.

The branch also adds deterministic coverage for cleanup delivery, multiple dead records, cleanup after throwing callbacks, held-value liveness, and the unregister-token liveness behavior that is still expected-failing here.