### PR TITLE
LibGC: Wake decommit worker after incremental sweep

### DIFF
--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -1283,6 +1283,9 @@ void Heap::finish_incremental_sweep()
     m_incremental_sweep_active = false;
 
     stop_incremental_sweep_timer();
+
+    // Sweep is done; kick the global decommit worker so the slots we just freed get madvise()'d off the GC pause path.
+    BlockAllocator::wake_decommit_worker_async();
 }
 
 void Heap::finish_pending_incremental_sweep()


### PR DESCRIPTION
Kick the `BlockAllocator` decommit worker when incremental sweep finishes, matching the synchronous sweep path. Empty `HeapBlock` slots freed during incremental sweep otherwise remain in the freshly freed pool and avoid `madvise()` unless a later synchronous sweep wakes the worker.

Fixes an issue where we'd hold on to GC memory for much longer than necessary.