### PR TITLE
LibWeb: Preserve auto duration for scroll animations

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -2001,12 +2001,9 @@ Vector<ComputedProperties::AnimationProperties> ComputedProperties::animations(D
         auto duration = [&] -> Variant<double, String> {
             // auto
             if (animation_duration_style_value->to_keyword() == Keyword::Auto) {
-                // For time-driven animations, equivalent to 0s.
-                return 0;
-
-                // FIXME: For scroll-driven animations, equivalent to the duration necessary to fill the timeline in
-                //        consideration of animation-range, animation-delay, and animation-iteration-count. See
-                //        Scroll-driven Animations § 4.1 Finite Timeline Calculations.
+                // Preserve auto until the animation effect is associated with its timeline. Time-driven animations
+                // will resolve this to 0s, while scroll-driven animations fill the progress-based timeline.
+                return "auto"_string;
             }
 
             // <time [0s,∞]>

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -313,7 +313,7 @@
     "affects-layout": false,
     "animation-type": "none",
     "inherited": false,
-    "initial": "0s",
+    "initial": "auto",
     "multiplicity": "coordinating-list",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
+#include <LibWeb/CSS/StyleValues/TimeStyleValue.h>
 
 namespace Web::CSS {
 
@@ -69,7 +70,12 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
         return;
     }
 
-    auto const coordinating_value_list_shorthand_serialize = [&](StringView entry_when_all_longhands_initial, Vector<PropertyID> const& required_longhands = {}, Vector<PropertyID> const& reset_only_longhands = {}) {
+    enum class AllowResolvedZeroDurationAsInitial {
+        No,
+        Yes,
+    };
+
+    auto const coordinating_value_list_shorthand_serialize = [&](StringView entry_when_all_longhands_initial, Vector<PropertyID> const& required_longhands = {}, Vector<PropertyID> const& reset_only_longhands = {}, AllowResolvedZeroDurationAsInitial allow_resolved_zero_duration_as_initial = AllowResolvedZeroDurationAsInitial::No) {
         for (auto reset_only_longhand : reset_only_longhands) {
             if (!longhand(reset_only_longhand)->equals(property_initial_value(reset_only_longhand)))
                 return;
@@ -87,6 +93,17 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
         if (any_of(m_properties.sub_properties, [&](auto longhand_id) { return !reset_only_longhands.contains_slow(longhand_id) && longhand(longhand_id)->as_value_list().size() != entry_count; }))
             return;
 
+        auto longhand_value_is_initial = [&](PropertyID longhand_id, StyleValue const& value) {
+            if (allow_resolved_zero_duration_as_initial == AllowResolvedZeroDurationAsInitial::Yes
+                && longhand_id == PropertyID::AnimationDuration
+                && value.is_time()
+                && value.as_time().time().to_seconds() == 0) {
+                return true;
+            }
+
+            return value.equals(*property_initial_value(longhand_id)->as_value_list().values()[0]);
+        };
+
         // We should serialize a longhand if it is not a reset-only longhand and one of the following is true:
         // - The longhand is required
         // - The value is not the initial value
@@ -102,7 +119,7 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
 
             auto longhand_value = longhand(longhand_id)->as_value_list().values()[entry_index];
 
-            if (!longhand_value->equals(property_initial_value(longhand_id)->as_value_list().values()[0]))
+            if (!longhand_value_is_initial(longhand_id, *longhand_value))
                 return true;
 
             for (size_t other_longhand_index = longhand_index + 1; other_longhand_index < m_properties.sub_properties.size(); other_longhand_index++) {
@@ -114,7 +131,7 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
                 auto other_longhand_value = longhand(other_longhand_id)->as_value_list().values()[entry_index];
 
                 // FIXME: This should really account for the other longhand being included in the serialization for any reason, not just because it is not the initial value.
-                if (other_longhand_value->equals(property_initial_value(other_longhand_id)->as_value_list().values()[0]))
+                if (longhand_value_is_initial(other_longhand_id, *other_longhand_value))
                     continue;
 
                 if (parse_css_value(Parser::ParsingParams {}, other_longhand_value->to_string(mode), longhand_id))
@@ -192,7 +209,7 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
         return;
     }
     case PropertyID::Animation:
-        coordinating_value_list_shorthand_serialize("none"sv, {}, { PropertyID::AnimationTimeline });
+        coordinating_value_list_shorthand_serialize("none"sv, {}, { PropertyID::AnimationTimeline }, AllowResolvedZeroDurationAsInitial::Yes);
         return;
     case PropertyID::Background: {
         auto color = longhand(PropertyID::BackgroundColor);

--- a/Tests/LibWeb/Text/expected/css/scroll-timeline-auto-duration-progress.txt
+++ b/Tests/LibWeb/Text/expected/css/scroll-timeline-auto-duration-progress.txt
@@ -1,0 +1,2 @@
+animation duration: auto
+scale at 25% scroll: 0.25

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-shorthand.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 36 tests
 
-28 Pass
-8 Fail
+30 Pass
+6 Fail
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
@@ -18,7 +18,7 @@ Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
 Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
 Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
 Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-fill-mode
 Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-iteration-count
 Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-name
@@ -30,7 +30,7 @@ Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, 
 Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
 Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-delay
 Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-direction
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-duration
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-duration
 Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-fill-mode
 Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-iteration-count
 Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-name

--- a/Tests/LibWeb/Text/input/css/scroll-timeline-auto-duration-progress.html
+++ b/Tests/LibWeb/Text/input/css/scroll-timeline-auto-duration-progress.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<style>
+    html {
+        min-height: 100vh;
+        padding-bottom: 100px;
+    }
+
+    body {
+        margin: 0;
+    }
+
+    #bar {
+        animation: grow linear;
+        animation-timeline: scroll(root block);
+        background: red;
+        height: 10px;
+        transform-origin: 0 50%;
+        width: 100px;
+    }
+
+    @keyframes grow {
+        from {
+            transform: scaleX(0);
+        }
+
+        to {
+            transform: scaleX(1);
+        }
+    }
+</style>
+<body>
+    <div id="bar"></div>
+    <script src="../include.js"></script>
+    <script>
+        function scaleX(element) {
+            const transform = getComputedStyle(element).transform;
+            const match = transform.match(/^matrix\(([^,]+)/);
+            return match ? Number.parseFloat(match[1]).toFixed(2) : transform;
+        }
+
+        promiseTest(async () => {
+            await animationFrame();
+
+            document.scrollingElement.scrollTop = 25;
+            await animationFrame();
+
+            println(`animation duration: ${getComputedStyle(bar).animationDuration}`);
+            println(`scale at 25% scroll: ${scaleX(bar)}`);
+
+            document.scrollingElement.scrollTop = 0;
+        });
+    </script>
+</body>


### PR DESCRIPTION
CSS Animations Level 2 makes animation-duration default to auto. We still initialized it to 0s and converted auto to zero while collecting CSS animation properties, before the animation effect had its scroll timeline. Scroll-driven animations with an omitted duration therefore behaved like zero-duration animations, so scroll(root) progress bars did not track the scroll position.

Make animation-duration initialize to auto and carry that value into the effect timing normalization. Time-driven animations still resolve auto to 0s there, while progress-based timelines resolve it against the timeline duration.