### PR TITLE
LibWeb+LibWebView+WebContent: Support primary pasting with middle mouse

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -378,6 +378,16 @@
                             Scroll pages by pressing the middle mouse button and moving the mouse.
                         </p>
                     </div>
+                    <hr />
+                    <div class="card-group">
+                        <div class="inline-container">
+                            <label for="enable-primary-paste">Enable primary pasting</label>
+                            <input id="enable-primary-paste" type="checkbox" switch />
+                        </div>
+                        <p class="description">
+                            Paste text from the clipboard when the middle mouse button is clicked.
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/Base/res/ladybird/about-pages/settings/browsing-behavior.js
+++ b/Base/res/ladybird/about-pages/settings/browsing-behavior.js
@@ -1,4 +1,5 @@
 const enableAutoscroll = document.querySelector("#enable-autoscroll");
+const enablePrimaryPaste = document.querySelector("#enable-primary-paste");
 
 let BROWSING_BEHAVIOR = {};
 
@@ -6,12 +7,18 @@ const loadSettings = settings => {
     BROWSING_BEHAVIOR = settings.browsingBehavior || {};
 
     enableAutoscroll.checked = !!BROWSING_BEHAVIOR.enableAutoscroll;
+    enablePrimaryPaste.checked = !!BROWSING_BEHAVIOR.enablePrimaryPaste;
 };
 
-enableAutoscroll.addEventListener("change", () => {
-    BROWSING_BEHAVIOR.enableAutoscroll = enableAutoscroll.checked;
-    ladybird.sendMessage("setBrowsingBehavior", BROWSING_BEHAVIOR);
-});
+function addChangeHandler(input, name) {
+    input.addEventListener("change", () => {
+        BROWSING_BEHAVIOR[name] = input.checked;
+        ladybird.sendMessage("setBrowsingBehavior", BROWSING_BEHAVIOR);
+    });
+}
+
+addChangeHandler(enableAutoscroll, "enableAutoscroll");
+addChangeHandler(enablePrimaryPaste, "enablePrimaryPaste");
 
 document.addEventListener("WebUIMessage", event => {
     if (event.detail.name === "loadSettings") {

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1501,6 +1501,10 @@ static bool is_middle_click_paste_target(DOM::Node const& node)
 
 bool EventHandler::maybe_request_paste_for_middle_click(DOM::Document& document, CSSPixelPoint visual_viewport_position)
 {
+    auto& page = m_navigable->page();
+    if (!page.enable_primary_paste())
+        return false;
+
     auto cursor_hit = paint_root()->hit_test(visual_viewport_position, Painting::HitTestType::TextCursor);
     if (!cursor_hit.has_value())
         return false;
@@ -1519,7 +1523,7 @@ bool EventHandler::maybe_request_paste_for_middle_click(DOM::Document& document,
         return false;
 
     target->set_selection_anchor(*hit_node, cursor_hit->index_in_node);
-    m_navigable->page().client().page_did_request_paste();
+    page.client().page_did_request_paste();
     return true;
 }
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -28,7 +28,9 @@
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
+#include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Navigator.h>
@@ -465,7 +467,10 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
         if (fire_click_events(*node, coordinates, screen_position, button, buttons, modifiers, click_count)
             && !chrome_widget) {
             // NB: Event dispatches above may have run JS that invalidated layout.
-            m_navigable->active_document()->update_layout(DOM::UpdateLayoutReason::EventHandlerRunActivationBehavior);
+            document->update_layout(DOM::UpdateLayoutReason::EventHandlerRunActivationBehavior);
+
+            if (button == UIEvents::MouseButton::Middle && maybe_request_paste_for_middle_click(*document, visual_viewport_position))
+                return EventResult::Handled;
 
             // FIXME: Currently cannot spawn a new top-level browsing context for new tab operations, because the
             //        new top-level browsing context would be in another process. To fix this, there needs to be
@@ -1323,7 +1328,7 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
             return;
 
         for (GC::Ptr<DOM::Node const> node = hit->paintable->dom_node(); node; node = node->parent_or_shadow_host_node()) {
-            if (is<HTML::FormAssociatedTextControlElement>(*node))
+            if (node->is_editable_or_editing_host() || is<HTML::FormAssociatedTextControlElement>(*node))
                 return;
             if (auto const* anchor = as_if<HTML::HTMLAnchorElement>(*node); anchor && anchor->has_attribute(HTML::AttributeNames::href))
                 return;
@@ -1480,6 +1485,42 @@ void EventHandler::maybe_show_context_menu(GC::Ref<DOM::Node> node, MouseEventCo
             m_navigable->page().client().page_did_request_context_menu(top_level_viewport_position, for_input_events_target);
         }
     }
+}
+
+static bool is_middle_click_paste_target(DOM::Node const& node)
+{
+    if (node.is_editable_or_editing_host())
+        return true;
+
+    return node.find_in_shadow_including_ancestry([](DOM::Node const& node) {
+        if (auto const* input_element = as_if<HTML::HTMLInputElement>(node))
+            return input_element->has_selectable_text();
+        return is<HTML::HTMLTextAreaElement>(node);
+    }) != nullptr;
+}
+
+bool EventHandler::maybe_request_paste_for_middle_click(DOM::Document& document, CSSPixelPoint visual_viewport_position)
+{
+    auto cursor_hit = paint_root()->hit_test(visual_viewport_position, Painting::HitTestType::TextCursor);
+    if (!cursor_hit.has_value())
+        return false;
+
+    auto hit_node = cursor_hit->paintable->dom_node();
+    if (!hit_node || !is_middle_click_paste_target(*hit_node))
+        return false;
+
+    if (auto focus_candidate = focus_candidate_for_position(visual_viewport_position))
+        HTML::run_focusing_steps(focus_candidate, nullptr, HTML::FocusTrigger::Click);
+    else if (auto editing_host = hit_node->editing_host())
+        HTML::run_focusing_steps(editing_host, nullptr, HTML::FocusTrigger::Click);
+
+    auto* target = document.active_input_events_target(hit_node);
+    if (!target)
+        return false;
+
+    target->set_selection_anchor(*hit_node, cursor_hit->index_in_node);
+    m_navigable->page().client().page_did_request_paste();
+    return true;
 }
 
 // https://drafts.csswg.org/css-ui/#propdef-user-select

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -100,7 +100,9 @@ private:
 
     void run_mousedown_default_actions(DOM::Document&, CSSPixelPoint visual_viewport_position, CSSPixelPoint viewport_position, unsigned button, unsigned modifiers, int click_count);
     void run_activation_behavior(GC::Ref<DOM::Node>, unsigned button, unsigned modifiers);
+
     void maybe_show_context_menu(GC::Ref<DOM::Node>, MouseEventCoordinates const&, CSSPixelPoint screen_position, CSSPixelPoint viewport_position, unsigned buttons, unsigned modifiers);
+    bool maybe_request_paste_for_middle_click(DOM::Document&, CSSPixelPoint visual_viewport_position);
 
     bool initiate_character_selection(DOM::Document&, Painting::HitTestResult const&, CSS::UserSelect, bool shift_held);
     bool initiate_word_selection(DOM::Document&, Painting::HitTestResult const&, CSS::UserSelect);

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -476,6 +476,7 @@ public:
 
     virtual void page_did_insert_clipboard_entry(Clipboard::SystemClipboardRepresentation const&, [[maybe_unused]] StringView presentation_style) { }
     virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }
+    virtual void page_did_request_paste() { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -132,6 +132,9 @@ public:
     bool enable_autoscroll() const { return m_enable_autoscroll; }
     void set_enable_autoscroll(bool b) { m_enable_autoscroll = b; }
 
+    bool enable_primary_paste() const { return m_enable_primary_paste; }
+    void set_enable_primary_paste(bool b) { m_enable_primary_paste = b; }
+
     bool async_scrolling_enabled() const { return m_async_scrolling_enabled; }
     void set_async_scrolling_enabled(bool b) { m_async_scrolling_enabled = b; }
     u64 wheel_event_listener_state_generation() const { return m_wheel_event_listener_state_generation; }
@@ -295,6 +298,7 @@ private:
     bool m_is_scripting_enabled { true };
     bool m_should_block_pop_ups { true };
     bool m_enable_autoscroll { true };
+    bool m_enable_primary_paste { true };
     bool m_async_scrolling_enabled { false };
     u64 m_wheel_event_listener_state_generation { 0 };
 

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -35,6 +35,7 @@ static auto DEFAULT_LANGUAGE = "en"_string;
 
 static constexpr auto BROWSING_BEHAVIOR_KEY = "browsingBehavior"sv;
 static constexpr auto ENABLE_AUTOSCROLL_KEY = "enableAutoscroll"sv;
+static constexpr auto ENABLE_PRIMARY_PASTE_KEY = "enablePrimaryPaste"sv;
 
 static constexpr auto SEARCH_ENGINE_KEY = "searchEngine"sv;
 static constexpr auto SEARCH_ENGINE_CUSTOM_KEY = "custom"sv;
@@ -182,6 +183,7 @@ JsonValue Settings::serialize_json() const
 
     JsonObject browsing_behavior;
     browsing_behavior.set(ENABLE_AUTOSCROLL_KEY, m_browsing_behavior.enable_autoscroll);
+    browsing_behavior.set(ENABLE_PRIMARY_PASTE_KEY, m_browsing_behavior.enable_primary_paste);
     settings.set(BROWSING_BEHAVIOR_KEY, move(browsing_behavior));
 
     JsonArray custom_search_engines;
@@ -355,6 +357,8 @@ BrowsingBehavior Settings::parse_browsing_behavior(JsonValue const& settings)
 
     if (auto enable_autoscroll = settings.as_object().get_bool(ENABLE_AUTOSCROLL_KEY); enable_autoscroll.has_value())
         browsing_behavior.enable_autoscroll = *enable_autoscroll;
+    if (auto enable_primary_paste = settings.as_object().get_bool(ENABLE_PRIMARY_PASTE_KEY); enable_primary_paste.has_value())
+        browsing_behavior.enable_primary_paste = *enable_primary_paste;
 
     return browsing_behavior;
 }
@@ -609,6 +613,7 @@ template<>
 ErrorOr<void> encode(Encoder& encoder, WebView::BrowsingBehavior const& browsing_behavior)
 {
     TRY(encoder.encode(browsing_behavior.enable_autoscroll));
+    TRY(encoder.encode(browsing_behavior.enable_primary_paste));
 
     return {};
 }
@@ -617,8 +622,9 @@ template<>
 ErrorOr<WebView::BrowsingBehavior> decode(Decoder& decoder)
 {
     auto enable_autoscroll = TRY(decoder.decode<bool>());
+    auto enable_primary_paste = TRY(decoder.decode<bool>());
 
-    return WebView::BrowsingBehavior { enable_autoscroll };
+    return WebView::BrowsingBehavior { enable_autoscroll, enable_primary_paste };
 }
 
 }

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -23,6 +23,7 @@ namespace WebView {
 
 struct BrowsingBehavior {
     bool enable_autoscroll { true };
+    bool enable_primary_paste { true };
 };
 
 struct SiteSetting {

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -945,6 +945,12 @@ void WebContentClient::did_request_clipboard_entries(u64 page_id, u64 request_id
     }
 }
 
+void WebContentClient::did_request_paste(u64 page_id)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->paste_text_from_clipboard();
+}
+
 void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -159,6 +159,7 @@ private:
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation, String presentation_style) override;
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
+    virtual void did_request_paste(u64 page_id) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent(u64 page_id, Web::Bindings::AgentType worker_type) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1283,8 +1283,10 @@ void ConnectionFromClient::set_preferred_languages(u64, Vector<String> preferred
 
 void ConnectionFromClient::set_browsing_behavior(u64 page_id, WebView::BrowsingBehavior browsing_behavior)
 {
-    if (auto page = this->page(page_id); page.has_value())
+    if (auto page = this->page(page_id); page.has_value()) {
         page->page().set_enable_autoscroll(browsing_behavior.enable_autoscroll);
+        page->page().set_enable_primary_paste(browsing_behavior.enable_primary_paste);
+    }
 }
 
 void ConnectionFromClient::set_enable_global_privacy_control(u64, bool enable)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -733,6 +733,11 @@ void PageClient::page_did_request_clipboard_entries(u64 request_id)
     client().async_did_request_clipboard_entries(m_id, request_id);
 }
 
+void PageClient::page_did_request_paste()
+{
+    client().async_did_request_paste(m_id);
+}
+
 void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play_state)
 {
     client().async_did_change_audio_play_state(m_id, play_state);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -187,6 +187,7 @@ private:
     virtual void page_did_change_theme_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
+    virtual void page_did_request_paste() override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual WorkerAgentResponse request_worker_agent(Web::Bindings::AgentType) override;
     virtual void page_did_mutate_dom(FlyString const& type, Web::DOM::Node const& target, Web::DOM::NodeList& added_nodes, Web::DOM::NodeList& removed_nodes, GC::Ptr<Web::DOM::Node> previous_sibling, GC::Ptr<Web::DOM::Node> next_sibling, Optional<String> const& attribute_name) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -113,6 +113,7 @@ endpoint WebContentClient
 
     did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style) =|
     did_request_clipboard_entries(u64 page_id, u64 request_id) =|
+    did_request_paste(u64 page_id) =|
 
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
 


### PR DESCRIPTION
When the middle mouse button is clicked on a text input control or `contenteditable` node, we now request the UI process to paste text into that node.

Fixes #9398