### PR TITLE
LibWeb: Avoid temporary stream chunks for fetch bytes

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -7,8 +7,6 @@
 
 #include <LibGC/Function.h>
 #include <LibHTTP/Cache/MemoryCache.h>
-#include <LibJS/Runtime/ArrayBuffer.h>
-#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Fetch/Fetching/FetchedDataReceiver.h>
 #include <LibWeb/Fetch/Infrastructure/FetchParams.h>
@@ -123,12 +121,10 @@ void FetchedDataReceiver::enqueue_into_stream(ReadonlyBytes bytes)
 
     // 1. Pull from bytes buffer into stream.
     auto byte_buffer = MUST(ByteBuffer::copy(bytes));
-    auto array_buffer = JS::ArrayBuffer::create(realm, move(byte_buffer));
-    auto view = JS::Uint8Array::create(realm, array_buffer->byte_length(), *array_buffer);
 
     auto& controller = m_stream->controller()->get<GC::Ref<Streams::ReadableByteStreamController>>();
 
-    if (auto result = Streams::readable_byte_stream_controller_enqueue(*controller, view); result.is_error()) {
+    if (auto result = Streams::readable_byte_stream_controller_enqueue_native_bytes(*controller, move(byte_buffer)); result.is_error()) {
         auto throw_completion = Bindings::exception_to_throw_completion(realm.vm(), result.release_error());
         // 2. If stream is errored, then terminate fetchParams’s controller.
         Streams::readable_byte_stream_controller_error(*controller, throw_completion.value());

--- a/Libraries/LibWeb/Streams/ReadableStreamOperations.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamOperations.cpp
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <AK/GenericShorthands.h>
+#include <AK/NumericLimits.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DataViewConstructor.h>
@@ -1802,40 +1804,11 @@ JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm
     return MUST(JS::construct(vm, *pull_into_descriptor.view_constructor, buffer, JS::Value(pull_into_descriptor.byte_offset), JS::Value(bytes_filled / element_size)));
 }
 
-// https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue
-WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk)
+static WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_transferred_buffer(ReadableByteStreamController& controller, GC::Ref<JS::ArrayBuffer> transferred_buffer, u32 byte_offset, u32 byte_length)
 {
     auto& realm = controller.realm();
     auto& vm = realm.vm();
-
-    // 1. Let stream be controller.[[stream]].
     auto stream = controller.stream();
-
-    // 2. If controller.[[closeRequested]] is true or stream.[[state]] is not "readable", return.
-    if (controller.close_requested() || stream->state() != ReadableStream::State::Readable)
-        return {};
-
-    // 3. Let buffer be chunk.[[ViewedArrayBuffer]].
-    auto* typed_array = TRY(JS::typed_array_from(vm, chunk));
-    auto* buffer = typed_array->viewed_array_buffer();
-
-    // 4. Let byteOffset be chunk.[[ByteOffset]].
-    auto byte_offset = typed_array->byte_offset();
-
-    // 6. If ! IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    // FIXME: The streams spec has not been updated for resizable ArrayBuffer objects. We must perform step 6 before
-    //        invoking TypedArrayByteLength in step 5. We also must check if the array is out-of-bounds, rather than
-    //        just detached.
-    auto typed_array_record = JS::make_typed_array_with_buffer_witness_record(*typed_array, JS::ArrayBuffer::Order::SeqCst);
-
-    if (JS::is_typed_array_out_of_bounds(typed_array_record))
-        return vm.throw_completion<JS::TypeError>(JS::ErrorType::BufferOutOfBounds, "TypedArray"sv);
-
-    // 5. Let byteLength be chunk.[[ByteLength]].
-    auto byte_length = JS::typed_array_byte_length(typed_array_record);
-
-    // 7. Let transferredBuffer be ? TransferArrayBuffer(buffer).
-    auto transferred_buffer = TRY(transfer_array_buffer(realm, *buffer));
 
     // 8. If controller.[[pendingPullIntos]] is not empty,
     if (!controller.pending_pull_intos().is_empty()) {
@@ -1918,6 +1891,61 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteSt
     readable_byte_stream_controller_call_pull_if_needed(controller);
 
     return {};
+}
+
+// https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk)
+{
+    auto& realm = controller.realm();
+    auto& vm = realm.vm();
+
+    // 1. Let stream be controller.[[stream]].
+    auto stream = controller.stream();
+
+    // 2. If controller.[[closeRequested]] is true or stream.[[state]] is not "readable", return.
+    if (controller.close_requested() || stream->state() != ReadableStream::State::Readable)
+        return {};
+
+    // 3. Let buffer be chunk.[[ViewedArrayBuffer]].
+    auto* typed_array = TRY(JS::typed_array_from(vm, chunk));
+    auto* buffer = typed_array->viewed_array_buffer();
+
+    // 4. Let byteOffset be chunk.[[ByteOffset]].
+    auto byte_offset = typed_array->byte_offset();
+
+    // 6. If ! IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+    // FIXME: The streams spec has not been updated for resizable ArrayBuffer objects. We must perform step 6 before
+    //        invoking TypedArrayByteLength in step 5. We also must check if the array is out-of-bounds, rather than
+    //        just detached.
+    auto typed_array_record = JS::make_typed_array_with_buffer_witness_record(*typed_array, JS::ArrayBuffer::Order::SeqCst);
+
+    if (JS::is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<JS::TypeError>(JS::ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 5. Let byteLength be chunk.[[ByteLength]].
+    auto byte_length = JS::typed_array_byte_length(typed_array_record);
+
+    // 7. Let transferredBuffer be ? TransferArrayBuffer(buffer).
+    auto transferred_buffer = TRY(transfer_array_buffer(realm, *buffer));
+
+    return readable_byte_stream_controller_enqueue_transferred_buffer(controller, transferred_buffer, byte_offset, byte_length);
+}
+
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_native_bytes(ReadableByteStreamController& controller, ByteBuffer bytes)
+{
+    auto& realm = controller.realm();
+
+    auto stream = controller.stream();
+    if (controller.close_requested() || stream->state() != ReadableStream::State::Readable)
+        return {};
+
+    VERIFY(bytes.size() <= NumericLimits<u32>::max());
+    auto byte_length = static_cast<u32>(bytes.size());
+
+    // OPTIMIZATION: Native byte producers have no observable chunk object to detach, so enter the enqueue algorithm after
+    // the TransferArrayBuffer step with an already-owned ArrayBuffer.
+    auto transferred_buffer = JS::ArrayBuffer::create(realm, move(bytes));
+    return readable_byte_stream_controller_enqueue_transferred_buffer(controller, transferred_buffer, 0, byte_length);
 }
 
 // https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue-chunk-to-queue

--- a/Libraries/LibWeb/Streams/ReadableStreamOperations.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamOperations.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Streams/Algorithms.h>
@@ -83,6 +84,7 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_close(ReadableByteStre
 void readable_byte_stream_controller_commit_pull_into_descriptor(ReadableStream&, PullIntoDescriptor const&);
 JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm&, PullIntoDescriptor const&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_native_bytes(ReadableByteStreamController& controller, ByteBuffer bytes);
 void readable_byte_stream_controller_enqueue_chunk_to_queue(ReadableByteStreamController& controller, GC::Ref<JS::ArrayBuffer> buffer, u32 byte_offset, u32 byte_length);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_cloned_chunk_to_queue(ReadableByteStreamController& controller, JS::ArrayBuffer& buffer, u64 byte_offset, u64 byte_length);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_detached_pull_into_to_queue(ReadableByteStreamController& controller, PullIntoDescriptor& pull_into_descriptor);


### PR DESCRIPTION
Teach readable byte stream enqueueing about native byte producers by sharing the post-transfer part of the spec algorithm. This lets fetch hand owned network bytes directly to the byte stream controller instead of first wrapping them in an unobservable `Uint8Array` and then transferring its buffer back into another `ArrayBuffer`.

Keep the public `nqueue(chunk)` path spec-shaped and make the native path rejoin after the `TransferArrayBuffer` step, so observable chunks are still created by the shared reader and queue handling code.

This reduces GC churn while playing YouTube videos.