### PR TITLE
LibWeb: Publish dirty canvas content before painting

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -358,10 +358,6 @@ void EventLoop::update_the_rendering()
     for (auto& document : docs)
         document->page().update_all_media_element_video_sinks();
 
-    // AD-HOC: Present all canvas element surfaces in documents' pages.
-    for (auto& document : docs)
-        document->page().present_all_canvas_element_surfaces();
-
     // FIXME: 4. Unnecessary rendering: Remove from docs any Document object doc for which all of the following are true:
 
     // FIXME: 5. Remove from docs all Document objects for which the user agent believes that it's preferable to skip updating the rendering for other reasons.
@@ -527,6 +523,11 @@ void EventLoop::update_the_rendering()
     // FIXME: 20. For each doc of docs, record rendering time for doc given unsafeStyleAndLayoutStartTime.
 
     // FIXME: 21. For each doc of docs, mark paint timing for doc.
+
+    // AD-HOC: Present all canvas element surfaces in documents' pages after callbacks
+    // have had a chance to update them, and before painting snapshots the frame.
+    for (auto& document : docs)
+        document->page().present_all_canvas_element_surfaces();
 
     // 22. For each doc of docs, update the rendering or user interface of doc and its node navigable to reflect the current state.
     for (auto& doc : docs.in_reverse()) {

--- a/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -33,13 +33,10 @@ void CanvasPaintable::paint(DisplayListRecordingContext& context, PaintPhase pha
 
         auto& canvas_element = as<HTML::HTMLCanvasElement>(*dom_node());
         if (canvas_element.surface()) {
-            // present() snapshots the surface and publishes to ExternalContentSource.
-            // FIXME: Remove this const_cast.
-            auto& mutable_canvas_element = const_cast<HTML::HTMLCanvasElement&>(canvas_element);
-            mutable_canvas_element.present();
             auto canvas_int_rect = canvas_rect.to_type<int>();
             auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(),
                 canvas_element.surface()->size(), canvas_int_rect.size());
+            auto& mutable_canvas_element = const_cast<HTML::HTMLCanvasElement&>(canvas_element);
             context.display_list_recorder().draw_external_content(canvas_int_rect,
                 mutable_canvas_element.ensure_external_content_source(), scaling_mode);
         }

--- a/Tests/LibWeb/Ref/expected/canvas-display-list-cache-update-ref.html
+++ b/Tests/LibWeb/Ref/expected/canvas-display-list-cache-update-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg height="100" width="100">
+    <rect fill="rgb(0, 255, 0)" height="100" width="100" />
+</svg>

--- a/Tests/LibWeb/Ref/input/canvas-display-list-cache-update.html
+++ b/Tests/LibWeb/Ref/input/canvas-display-list-cache-update.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/canvas-display-list-cache-update-ref.html">
+<canvas id="canvas" height="100" width="100"></canvas>
+<script>
+    const context = canvas.getContext("2d");
+    context.fillStyle = "rgb(255, 0, 0)";
+    context.fillRect(0, 0, 100, 100);
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            context.fillStyle = "rgb(0, 255, 0)";
+            context.fillRect(0, 0, 100, 100);
+
+            requestAnimationFrame(() => {
+                if (window.internals)
+                    internals.signalTestIsDone("PASS");
+                else
+                    document.documentElement.classList.remove("reftest-wait");
+            });
+        });
+    });
+</script>
+</html>


### PR DESCRIPTION
Canvas frame publishing was tied to CanvasPaintable::paint(), so cached paint commands could replay DrawExternalContent without updating the ExternalContentSource first. That made dynamic canvas content depend on whether the display list was re-recorded for the frame.

Move canvas presentation to the rendering update step after animation frame callbacks and layout, immediately before navigables paint. The canvas paintable now only records the external-content draw command, which keeps display-list replay from skipping the resource update.

Add a ref test that draws red, lets the display list cache, then draws green on a later animation frame. The final rendering must come from the updated external content source while reusing the cached draw command.