### PR TITLE
LibWeb: Rebase pending async scrolls over main-thread state

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -221,17 +221,19 @@ void AsyncScrollTree::update_sticky_offsets(Painting::ScrollStateSnapshot& scrol
     }
 }
 
-static void set_or_append_scroll_offset(Vector<AsyncScrollOffset>& scroll_offsets, AsyncScrollNode const& node, Gfx::FloatPoint scroll_offset)
+static void set_or_append_scroll_offset(Vector<AsyncScrollOffset>& scroll_offsets, AsyncScrollNode const& node, Gfx::FloatPoint compositor_scroll_offset, Gfx::FloatPoint unadopted_scroll_delta)
 {
     for (auto& existing : scroll_offsets) {
         if (existing.stable_node_id == node.stable_node_id) {
-            existing.scroll_offset = scroll_offset;
+            existing.compositor_scroll_offset = compositor_scroll_offset;
+            existing.unadopted_scroll_delta.translate_by(unadopted_scroll_delta);
             return;
         }
     }
     scroll_offsets.append({
         .stable_node_id = node.stable_node_id,
-        .scroll_offset = scroll_offset,
+        .compositor_scroll_offset = compositor_scroll_offset,
+        .unadopted_scroll_delta = unadopted_scroll_delta,
     });
 }
 
@@ -249,7 +251,11 @@ Vector<AsyncScrollOffset> AsyncScrollTree::apply_scroll_delta(AsyncScrollNodeID 
         auto delta_before_scroll = remaining_delta;
         remaining_delta = apply_scroll_delta_to_node(*node, remaining_delta, scroll_state_snapshot);
         if (remaining_delta != delta_before_scroll) {
-            set_or_append_scroll_offset(scroll_offsets, *node, scroll_offset_for_node(*node, scroll_state_snapshot));
+            Gfx::FloatPoint consumed_delta {
+                delta_before_scroll.x() - remaining_delta.x(),
+                delta_before_scroll.y() - remaining_delta.y(),
+            };
+            set_or_append_scroll_offset(scroll_offsets, *node, scroll_offset_for_node(*node, scroll_state_snapshot), consumed_delta);
             break;
         }
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -47,7 +47,8 @@ struct AsyncScrollNodeStableID {
 
 struct AsyncScrollOffset {
     AsyncScrollNodeStableID stable_node_id;
-    Gfx::FloatPoint scroll_offset;
+    Gfx::FloatPoint compositor_scroll_offset;
+    Gfx::FloatPoint unadopted_scroll_delta;
 };
 
 // One scrollable area from the paint snapshot. Non-viewport scrollports are stored in hit_test_visual_context_index

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -132,7 +132,8 @@ static void set_or_append_pending_scroll_offset(Vector<AsyncScrollOffset>& pendi
 {
     for (auto& existing : pending_scroll_offsets) {
         if (existing.stable_node_id == scroll_offset.stable_node_id) {
-            existing.scroll_offset = scroll_offset.scroll_offset;
+            existing.compositor_scroll_offset = scroll_offset.compositor_scroll_offset;
+            existing.unadopted_scroll_delta.translate_by(scroll_offset.unadopted_scroll_delta);
             return;
         }
     }
@@ -903,7 +904,10 @@ private:
             auto node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(pending_scroll_offset.stable_node_id);
             if (!node_id.has_value())
                 continue;
-            auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(*node_id, pending_scroll_offset.scroll_offset, m_cached_scroll_state_snapshot);
+            auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(*node_id, m_cached_scroll_state_snapshot);
+            if (!current_scroll_offset.has_value())
+                continue;
+            auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(*node_id, current_scroll_offset->translated(pending_scroll_offset.unadopted_scroll_delta), m_cached_scroll_state_snapshot);
             if (reconciled_scroll_offset.has_value() && m_async_scroll_tree.scroll_node_is_viewport(*node_id))
                 viewport_scroll_offset = *reconciled_scroll_offset;
         }
@@ -914,7 +918,7 @@ private:
     {
         for (auto const& scroll_offset : scroll_offsets) {
             if (scroll_offset.stable_node_id.kind == AsyncScrollNodeKind::Viewport)
-                return scroll_offset.scroll_offset;
+                return scroll_offset.compositor_scroll_offset;
         }
         return {};
     }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2937,7 +2937,7 @@ static DOM::Element* element_for_async_scroll_node_stable_id(DOM::Document& docu
     return element;
 }
 
-static bool adopt_async_element_scroll_offset(DOM::Document& document, Compositor::AsyncScrollNodeStableID const& stable_id, CSSPixelPoint scroll_offset)
+static bool adopt_async_element_scroll_delta(DOM::Document& document, Compositor::AsyncScrollNodeStableID const& stable_id, CSSPixelPoint scroll_delta)
 {
     auto* element = element_for_async_scroll_node_stable_id(document, stable_id);
     if (!element)
@@ -2958,6 +2958,8 @@ static bool adopt_async_element_scroll_offset(DOM::Document& document, Composito
         break;
     }
 
+    auto scroll_offset = element->scroll_offset(pseudo_element);
+    scroll_offset.translate_by(scroll_delta);
     if (element->scroll_offset(pseudo_element) == scroll_offset)
         return false;
 
@@ -3012,6 +3014,16 @@ void Navigable::resolve_all_pending_async_scroll_operations()
     }
 }
 
+static bool adopt_async_viewport_scroll_delta(Navigable& navigable, CSSPixelPoint scroll_delta)
+{
+    auto scroll_offset = navigable.viewport_scroll_offset();
+    scroll_offset.translate_by(scroll_delta);
+    if (scroll_offset == navigable.viewport_scroll_offset())
+        return false;
+    navigable.perform_scroll_of_viewport_scrolling_box(scroll_offset);
+    return true;
+}
+
 void Navigable::adopt_pending_async_scroll_offsets()
 {
     if (!page().async_scrolling_enabled())
@@ -3037,19 +3049,20 @@ void Navigable::adopt_pending_async_scroll_offsets()
 
     auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
     for (auto const& async_scroll_offset : async_scroll_updates.scroll_offsets) {
-        auto css_scroll_offset = async_scroll_offset_to_css_pixels(async_scroll_offset.scroll_offset, device_pixels_per_css_pixel);
+        auto css_scroll_delta = async_scroll_offset_to_css_pixels(async_scroll_offset.unadopted_scroll_delta, device_pixels_per_css_pixel);
         if (async_scroll_offset.stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
             if (async_scroll_offset.stable_node_id.node_id != document->unique_id())
                 continue;
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async viewport offset {},{}",
-                async_scroll_offset.scroll_offset.x(), async_scroll_offset.scroll_offset.y());
-            perform_scroll_of_viewport_scrolling_box(css_scroll_offset);
+            if (adopt_async_viewport_scroll_delta(*this, css_scroll_delta)) {
+                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async viewport delta {},{}",
+                    async_scroll_offset.unadopted_scroll_delta.x(), async_scroll_offset.unadopted_scroll_delta.y());
+            }
             continue;
         }
 
-        if (adopt_async_element_scroll_offset(*document, async_scroll_offset.stable_node_id, css_scroll_offset)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async element offset {},{}",
-                async_scroll_offset.scroll_offset.x(), async_scroll_offset.scroll_offset.y());
+        if (adopt_async_element_scroll_delta(*document, async_scroll_offset.stable_node_id, css_scroll_delta)) {
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async element delta {},{}",
+                async_scroll_offset.unadopted_scroll_delta.x(), async_scroll_offset.unadopted_scroll_delta.y());
         }
     }
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/main-thread-scroll-rebase.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/main-thread-scroll-rebase.txt
@@ -1,0 +1,2 @@
+script scrollTop: 200
+final scrollTop: 300

--- a/Tests/LibWeb/Text/input/async-scrolling/main-thread-scroll-rebase.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/main-thread-scroll-rebase.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        width: 100px;
+        height: 100px;
+        overflow: scroll;
+    }
+
+    #spacer {
+        height: 600px;
+    }
+</style>
+<div id="scroller"><div id="spacer"></div></div>
+<script>
+    promiseTest(async () => {
+        await animationFrame();
+        await animationFrame();
+
+        const wheelPromise = internals.wheel(50, 50, 0, 100);
+        scroller.scrollTop = 200;
+        println(`script scrollTop: ${scroller.scrollTop}`);
+        scroller.appendChild(document.createElement("div"));
+
+        await wheelPromise;
+
+        println(`final scrollTop: ${scroller.scrollTop}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/pseudo-element-wheel-scroll.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/pseudo-element-wheel-scroll.html
@@ -44,6 +44,7 @@
         println(`downward wheel target before wheel: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
 
         await internals.wheel(50, 50, 0, 100);
+        await animationFrame();
 
         println(`scroll event count: ${scrollEventCount}`);
         println(`host scrollTop: ${host.scrollTop}`);


### PR DESCRIPTION
Async scrolling kept only the compositor-visible absolute scroll offset for pending scrolls. If script changed the same scrolling box before the main thread adopted the pending offset, adoption could write the stale absolute compositor offset back to the DOM and lose the script update.

Track the unadopted compositor delta alongside the absolute offset used for compositor presentation. When fresh scroll state reaches the compositor, and when the main thread adopts pending async scrolls, apply that delta on top of the current main-thread offset instead of assigning the old absolute value.

Adoption can run during the event-loop scroll steps, before the later rendering-update layout pass has made paintables safe to query. Keep element adoption on the stored DOM scroll offset and apply viewport deltas through the navigable, so a dirty layout tree does not trip the paintable freshness invariant.

The async scrolling text test covers the script-scroll race and also dirties layout before adoption. The old paintable-box adoption path crashed in that case.