### PR TITLE
LibWeb: Avoid GC::Root churn in wheel listener checks

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -237,15 +237,6 @@ static void record_viewport_scrollbar_state(Painting::PaintableBox const& painta
     }
 }
 
-static bool has_blocking_wheel_event_listener(DOM::EventTarget const& event_target)
-{
-    for (auto listener : event_target.event_listener_list()) {
-        if (AK::first_is_one_of(listener->type, "wheel"sv, "mousewheel"sv) && listener->passive != true)
-            return true;
-    }
-    return false;
-}
-
 static bool is_root_wheel_event_target(DOM::Node const& node)
 {
     auto& document = node.document();
@@ -261,7 +252,7 @@ static void collect_root_blocking_wheel_event_regions(AsyncScrollingState& async
         document.body(),
     };
     for (auto* target : roots) {
-        if (target && has_blocking_wheel_event_listener(*target)) {
+        if (target && target->has_blocking_wheel_event_listener()) {
             async_scrolling_state.has_blocking_wheel_event_listeners = true;
             async_scrolling_state.has_blocking_wheel_event_region_covering_viewport = true;
             return;
@@ -291,7 +282,7 @@ void record_async_scrolling_metadata_for_paintable(Painting::PaintableBox const&
     record_wheel_hit_test_target(paintable_box, context);
 
     if (!context.has_blocking_wheel_event_region_covering_viewport()) {
-        if (auto node = paintable_box.dom_node(); node && !is_root_wheel_event_target(*node) && has_blocking_wheel_event_listener(*node)) {
+        if (auto node = paintable_box.dom_node(); node && !is_root_wheel_event_target(*node) && node->has_blocking_wheel_event_listener()) {
             context.set_has_blocking_wheel_event_listeners(true);
             recorder.compositor_blocking_wheel_event_region({
                 .rect = css_rect_to_device_rect(paintable_box.absolute_united_border_box_rect(), device_pixels_per_css_pixel),

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -906,6 +906,11 @@ bool EventTarget::has_event_listener(FlyString const& type) const
     return m_data && m_data->event_listener_list.contains([&type](auto listener) { return listener->type == type; });
 }
 
+bool EventTarget::has_blocking_wheel_event_listener() const
+{
+    return m_data && m_data->event_listener_list.contains(is_blocking_wheel_event_listener);
+}
+
 bool EventTarget::has_event_listeners() const
 {
     return m_data && !m_data->event_listener_list.is_empty();

--- a/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Libraries/LibWeb/DOM/EventTarget.h
@@ -58,6 +58,7 @@ public:
     void set_event_handler_attribute(FlyString const& name, WebIDL::CallbackType*);
 
     bool has_event_listener(FlyString const& type) const;
+    bool has_blocking_wheel_event_listener() const;
     bool has_event_listeners() const;
 
     virtual bool is_universal_global_scope_mixin() const { return false; }


### PR DESCRIPTION
Async scrolling metadata recording checks many paintable nodes for blocking wheel listeners while building a display list. The helper used EventTarget::event_listener_list(), which returns a snapshot backed by GC::Root entries, so the hot paint path allocated and destroyed roots just to answer a boolean query.

Add a non-allocating EventTarget predicate that scans the stored listener references directly, and use it from async scrolling metadata recording. Event dispatch still uses event_listener_list() so it keeps the required snapshot semantics.