### PR TITLE
LibWeb: Avoid unhandled rejection when reporting module script errors

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -301,10 +301,9 @@ WebIDL::Promise* ModuleScript::run(PreventErrorReporting prevent_error_reporting
     // 8. If preventErrorReporting is false, then upon rejection of evaluationPromise with reason, report the exception given by reason for script.
     if (prevent_error_reporting == PreventErrorReporting::No) {
         HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
-        evaluation_promise = WebIDL::upon_rejection(*evaluation_promise, GC::create_function(realm.heap(), [&realm](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
-            auto& window_or_worker = as<WindowOrWorkerGlobalScopeMixin>(realm.global_object());
-            window_or_worker.report_an_exception(reason);
-            return throw_completion(reason);
+        WebIDL::upon_rejection(*evaluation_promise, GC::create_function(realm.heap(), [&realm](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
+            as<WindowOrWorkerGlobalScopeMixin>(realm.global_object()).report_an_exception(reason);
+            return JS::js_undefined();
         }));
     }
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -97,6 +97,7 @@ Text/input/wpt-import/html/semantics/forms/the-input-element/show-picker-disable
 Text/input/wpt-import/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic.html
 Text/input/wpt-import/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic.html
 Text/input/wpt-import/html/semantics/scripting-1/the-script-element/json-module/module.html
+Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.html
 Text/input/wpt-import/wasm/webapi/esm-integration/wasm-import.tentative.html
 
 ; Unable to fetch the test resources JSON with CORS error.

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Module script queueing a microtask then throwing an exception

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.js
@@ -1,0 +1,5 @@
+// META: global=dedicatedworker-module,sharedworker-module
+// META: script=./resources/evaluation-order-setup.js
+
+import './resources/evaluation-order-2-setup.js';
+import './resources/evaluation-order-2.1.mjs';

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../../../../../resources/testharness.js"></script>
+<script src="../../../../../resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+fetch_tests_from_worker(new Worker("/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.js", { type: "module" }));
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.worker-module.js
@@ -1,0 +1,10 @@
+
+self.GLOBAL = {
+  isWindow: function() { return false; },
+  isWorker: function() { return true; },
+  isShadowRealm: function() { return false; },
+};
+import "/resources/testharness.js";
+import "./resources/evaluation-order-setup.js";
+import "/html/semantics/scripting-1/the-script-element/microtasks/evaluation-order-2.any.js";
+done();

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-2-setup.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-2-setup.js
@@ -1,0 +1,10 @@
+// Spec: https://html.spec.whatwg.org/C/#run-a-module-script
+setupTest("Module script queueing a microtask then throwing an exception", [
+  "step-2.2-1", "step-2.2-2", // Step 6.
+  "microtask-2.2",            // "Clean up after running script" at Step 8.
+  "global-error",             // "Clean up after running script" at Step 8,
+    // because `evaluationPromise` is synchronously rejected and the rejection
+    // is processed in the microtask checkpoint here (See also Step 7).
+    // As `evaluationPromise` is rejected after the microtask queued during
+    // evaluation, "global-error" occurs after "microtask".
+]);

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-2.1.mjs
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-2.1.mjs
@@ -1,0 +1,8 @@
+globalThis.log.push("step-2.1-1");
+queueMicrotask(() => globalThis.log.push("microtask-2.1"));
+globalThis.log.push("step-2.1-2");
+
+// import is evaluated first.
+import "./evaluation-order-2.2.mjs";
+
+globalThis.log.push("step-2.1-3");

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-2.2.mjs
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-2.2.mjs
@@ -1,0 +1,7 @@
+globalThis.log.push("step-2.2-1");
+queueMicrotask(() => globalThis.log.push("microtask-2.2"));
+globalThis.log.push("step-2.2-2");
+
+globalThis.test_load.step_timeout(() => globalThis.testDone(), 0);
+
+throw new Error("error");

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-setup.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/microtasks/resources/evaluation-order-setup.js
@@ -1,0 +1,30 @@
+globalThis.setup({allow_uncaught_exception: true});
+
+// Must be called after previous tests are completed.
+globalThis.setupTest = (description, expectedLog) => {
+  globalThis.log = [];
+  globalThis.onerror = message => {
+      globalThis.log.push("global-error");
+      return true;
+  };
+  globalThis.onunhandledrejection =
+      () => globalThis.log.push('unhandled-promise-rejection');
+
+  globalThis.unreachable = () => globalThis.log.push("unreachable");
+
+  globalThis.test_load = async_test(description);
+  globalThis.testDone = globalThis.test_load.step_func_done(() => {
+    assert_array_equals(globalThis.log, expectedLog);
+  });
+
+  if (!('Window' in globalThis && globalThis instanceof Window)) {
+    // In workers, there are no <script> load event, so scheduling `testDone()`
+    // here, assuming the target script is loaded and evaluated soon.
+    globalThis.test_load.step_timeout(() => globalThis.testDone(), 1000);
+
+    // In workers, call `done()` here because the auto-generated `done()` calls
+    // by `any.js` etc. are at the end of main script and thus are not
+    // evaluated when the target script throws an exception.
+    done();
+  }
+};


### PR DESCRIPTION
Report module script evaluation failures without replacing the returned evaluation promise or rethrowing from the reporting reaction. This avoids surfacing the same failure as both a script error and an unhandled promise rejection.