### PR TITLE
LibWeb: Let internals.wheel await async scroll adoption

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -20,6 +20,8 @@
 
 namespace Web::Compositor {
 
+using AsyncScrollOperationID = u64;
+
 // Stable identifier for a scroll frame in a document; the frame index alone is not unique across nested documents.
 struct AsyncScrollNodeID {
     UniqueNodeID document_id;

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -66,6 +66,7 @@ struct AsyncScrollByCommand {
     Gfx::FloatPoint delta_in_device_pixels;
     Gfx::IntRect viewport_rect;
     AsyncScrollNodeID scroll_target;
+    Optional<AsyncScrollOperationID> operation_id;
 };
 
 struct ViewportScrollbarDragCommand {
@@ -355,12 +356,13 @@ public:
             m_frame_completed.wait();
     }
 
-    Vector<AsyncScrollOffset> take_pending_async_scroll_offsets()
+    CompositorThread::PendingAsyncScrollUpdates take_pending_async_scroll_updates()
     {
         Sync::MutexLocker const locker { m_mutex };
-        Vector<AsyncScrollOffset> scroll_offsets;
-        AK::swap(scroll_offsets, m_pending_async_scroll_offsets);
-        return scroll_offsets;
+        CompositorThread::PendingAsyncScrollUpdates updates;
+        AK::swap(updates.scroll_offsets, m_pending_async_scroll_offsets);
+        AK::swap(updates.completed_operation_ids, m_completed_async_scroll_operation_ids);
+        return updates;
     }
 
     bool should_defer_async_scroll_offset_adoption() const
@@ -403,8 +405,8 @@ public:
         };
     }
 
-    bool enqueue_async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
-        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect)
+    CompositorThread::AsyncScrollEnqueueResult enqueue_async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, CompositorThread::AsyncScrollOperationTracking operation_tracking)
     {
         if (!m_can_accept_async_wheel_events.load()) {
             auto wheel_routing_admission = [this] {
@@ -413,34 +415,37 @@ public:
             }();
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: compositor cannot accept async wheel events ({})",
                 wheel_routing_admission_to_string(wheel_routing_admission));
-            return false;
+            return {};
         }
         auto scroll_target = hit_test_scroll_node_for_wheel(position, delta_in_device_pixels);
         if (scroll_target.blocked_by_main_thread_region) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: main-thread wheel region at {},{} device delta {},{}",
                 position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
-            return false;
+            return {};
         }
         if (scroll_target.blocked_by_wheel_event_region) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: blocking wheel event region at {},{} device delta {},{}",
                 position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
-            return false;
+            return {};
         }
         if (!scroll_target.node_id.has_value()) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: no wheel target at {},{} for device delta {},{}",
                 position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
-            return false;
+            return {};
         }
         if (scroll_target.node_id->document_id != expected_document_id) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: stale wheel target at {},{} for current document",
                 position.x(), position.y());
-            return false;
+            return {};
         }
 
+        Optional<AsyncScrollOperationID> operation_id;
+        if (operation_tracking == CompositorThread::AsyncScrollOperationTracking::Yes)
+            operation_id = next_async_scroll_operation_id();
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted main-thread async scroll enqueue at {},{} device delta {},{} for scroll node {} viewport={}x{} at {},{}",
             position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), scroll_target.node_id->scroll_frame_index.value(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id });
-        return true;
+        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, operation_id });
+        return { true, operation_id };
     }
 
     bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
@@ -478,7 +483,7 @@ public:
 
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted async scroll enqueue at {},{} device delta {},{} for scroll node {} viewport={}x{} at {},{}",
             position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), scroll_target.node_id->scroll_frame_index.value(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id });
+        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
         return true;
     }
 
@@ -707,13 +712,16 @@ public:
                             scroll_offsets = m_async_scroll_tree.apply_scroll_delta(cmd.scroll_target, cmd.delta_in_device_pixels, m_cached_scroll_state_snapshot);
                             if (scroll_offsets.is_empty()) {
                                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping async scroll command: scroll tree consumed no delta");
+                                // The operation produced no scroll offset (e.g. already at the scroll boundary), so it
+                                // cannot be reported through the pending-offset path; report its completion separately.
+                                complete_async_scroll_operation(cmd.operation_id);
                                 return;
                             }
                             m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
                         }
                         if (auto viewport_scroll_offset = viewport_scroll_offset_from(scroll_offsets); viewport_scroll_offset.has_value())
                             async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-                        store_pending_async_scroll_offsets(scroll_offsets);
+                        store_pending_async_scroll_offsets(scroll_offsets, cmd.operation_id);
                         {
                             Sync::MutexLocker const locker { m_mutex };
                             m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
@@ -842,11 +850,50 @@ private:
         return m_presented_bitmap_id_awaiting_ack.has_value();
     }
 
-    void store_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const& scroll_offsets)
+    AsyncScrollOperationID next_async_scroll_operation_id()
+    {
+        return m_next_async_scroll_operation_id.fetch_add(1) + 1;
+    }
+
+    void complete_async_scroll_operation(Optional<AsyncScrollOperationID> operation_id)
+    {
+        if (!operation_id.has_value())
+            return;
+
+        {
+            Sync::MutexLocker const locker { m_mutex };
+            m_completed_async_scroll_operation_ids.append(*operation_id);
+        }
+
+        // No scroll offset was produced, so nothing else will wake the main thread; schedule a rendering update so it
+        // drains the completed operation and resolves the awaiting promise.
+        invoke_on_main_thread([] {
+            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
+        });
+    }
+
+    void queue_rendering_update_if_async_scroll_updates_pending()
+    {
+        auto has_pending_updates = [this] {
+            Sync::MutexLocker const locker { m_mutex };
+            return !m_pending_async_scroll_offsets.is_empty()
+                || !m_completed_async_scroll_operation_ids.is_empty();
+        }();
+        if (!has_pending_updates)
+            return;
+
+        invoke_on_main_thread([] {
+            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
+        });
+    }
+
+    void store_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const& scroll_offsets, Optional<AsyncScrollOperationID> operation_id = {})
     {
         Sync::MutexLocker const locker { m_mutex };
         for (auto const& scroll_offset : scroll_offsets)
             set_or_append_pending_scroll_offset(m_pending_async_scroll_offsets, scroll_offset);
+        if (operation_id.has_value())
+            m_completed_async_scroll_operation_ids.append(*operation_id);
     }
 
     Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const& pending_scroll_offsets)
@@ -1060,6 +1107,8 @@ private:
 
         if (presenting_frame_id.has_value())
             mark_frame_complete(*presenting_frame_id);
+
+        queue_rendering_update_if_async_scroll_updates_pending();
     }
 
     void initialize_skia_player(DisplayListPlayerType display_list_player_type)
@@ -1159,6 +1208,8 @@ private:
     u64 m_completed_frame_id { 0 };
     mutable Sync::ConditionVariable m_frame_completed { m_mutex };
     Vector<AsyncScrollOffset> m_pending_async_scroll_offsets;
+    Vector<AsyncScrollOperationID> m_completed_async_scroll_operation_ids;
+    Atomic<AsyncScrollOperationID> m_next_async_scroll_operation_id { 0 };
     Gfx::IntRect m_async_scrolling_viewport_rect;
     Atomic<bool> m_has_async_scrolling_state { false };
     Atomic<bool> m_can_accept_async_wheel_events { false };
@@ -1461,10 +1512,10 @@ void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)
     m_thread_data->invalidate_wheel_event_listener_state(generation);
 }
 
-bool CompositorThread::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
-    Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect)
+CompositorThread::AsyncScrollEnqueueResult CompositorThread::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+    Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
 {
-    return m_thread_data->enqueue_async_scroll_by(expected_document_id, position, delta_in_device_pixels, viewport_rect);
+    return m_thread_data->enqueue_async_scroll_by(expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
 bool CompositorThread::should_defer_async_scroll_offset_adoption() const
@@ -1477,9 +1528,9 @@ bool CompositorThread::should_defer_main_thread_present_for_async_scroll() const
     return m_thread_data->should_defer_main_thread_present_for_async_scroll();
 }
 
-Vector<AsyncScrollOffset> CompositorThread::take_pending_async_scroll_offsets()
+CompositorThread::PendingAsyncScrollUpdates CompositorThread::take_pending_async_scroll_updates()
 {
-    return m_thread_data->take_pending_async_scroll_offsets();
+    return m_thread_data->take_pending_async_scroll_updates();
 }
 
 void CompositorThread::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -39,6 +39,18 @@ public:
 
     using BackingStorePresentationCallback = Function<void(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage, i32 back_bitmap_id, Gfx::SharedImage)>;
     using FramePresentationCallback = Function<void(u64 page_id, Gfx::IntRect const&, i32 bitmap_id)>;
+    struct PendingAsyncScrollUpdates {
+        Vector<AsyncScrollOffset> scroll_offsets;
+        Vector<AsyncScrollOperationID> completed_operation_ids;
+    };
+    struct AsyncScrollEnqueueResult {
+        bool accepted { false };
+        Optional<AsyncScrollOperationID> operation_id;
+    };
+    enum class AsyncScrollOperationTracking {
+        No,
+        Yes,
+    };
     struct PresentToUI {
     };
     struct PublishToExternalContent {
@@ -62,11 +74,11 @@ public:
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&);
     void update_scroll_state(Painting::ScrollStateSnapshot&&);
     void invalidate_wheel_event_listener_state(u64 generation);
-    bool async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
-        Gfx::IntRect viewport_rect);
+    AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
+        Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
     bool should_defer_async_scroll_offset_adoption() const;
     bool should_defer_main_thread_present_for_async_scroll() const;
-    Vector<AsyncScrollOffset> take_pending_async_scroll_offsets();
+    PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void update_backing_stores(Gfx::IntSize, i32 front_id, i32 back_id);
     u64 present_frame(Gfx::IntRect);
     void wait_for_frame(u64 frame_id);

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -18,6 +18,7 @@
 
 namespace Web {
 
+struct AsyncScrollOperation;
 class AutoScrollHandler;
 class CSSPixels;
 class DisplayListRecordingContext;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/BrowsingContextGroup.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/History.h>
@@ -61,6 +62,7 @@
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/InputTypes.h>
+#include <LibWeb/WebIDL/Promise.h>
 #include <LibWeb/XHR/FormData.h>
 
 #include <AK/Debug.h>
@@ -297,10 +299,13 @@ Navigable::~Navigable() = default;
 void Navigable::set_has_been_destroyed()
 {
     m_has_been_destroyed = true;
+    resolve_all_pending_async_scroll_operations();
 }
 
 void Navigable::remove_from_all_navigables()
 {
+    resolve_all_pending_async_scroll_operations();
+
     if (m_active_document)
         m_active_document->set_navigable(nullptr);
     all_navigables().remove(*this);
@@ -325,6 +330,9 @@ void Navigable::visit_edges(Cell::Visitor& visitor)
     for (auto& navigation_params : m_pending_navigations) {
         navigation_params.visit_edges(visitor);
     }
+
+    for (auto& async_scroll_operation : m_pending_async_scroll_operations)
+        visitor.visit(async_scroll_operation.promise);
 }
 
 void Navigable::NavigateParams::visit_edges(Cell::Visitor& visitor)
@@ -2962,6 +2970,48 @@ static bool adopt_async_element_scroll_offset(DOM::Document& document, Composito
     return true;
 }
 
+static void queue_async_scroll_operation_promise_resolution(GC::Ref<WebIDL::Promise> promise)
+{
+    auto& realm = promise->promise()->shape().realm();
+    HTML::queue_a_microtask(nullptr, GC::create_function(realm.heap(), [promise] {
+        auto& realm = promise->promise()->shape().realm();
+        HTML::TemporaryExecutionContext execution_context {
+            realm,
+            HTML::TemporaryExecutionContext::CallbacksEnabled::Yes
+        };
+        WebIDL::resolve_promise(realm, promise);
+    }));
+}
+
+void Navigable::wait_for_async_scroll_operation(Compositor::AsyncScrollOperationID operation_id, GC::Ref<WebIDL::Promise> promise)
+{
+    if (has_been_destroyed() || !all_navigables().contains(*this)) {
+        queue_async_scroll_operation_promise_resolution(promise);
+        return;
+    }
+
+    m_pending_async_scroll_operations.append({ operation_id, promise });
+}
+
+void Navigable::resolve_async_scroll_operation(Compositor::AsyncScrollOperationID operation_id)
+{
+    m_pending_async_scroll_operations.remove_first_matching([&](auto const& pending) {
+        if (pending.operation_id != operation_id)
+            return false;
+
+        queue_async_scroll_operation_promise_resolution(pending.promise);
+        return true;
+    });
+}
+
+void Navigable::resolve_all_pending_async_scroll_operations()
+{
+    while (!m_pending_async_scroll_operations.is_empty()) {
+        auto pending = m_pending_async_scroll_operations.take_last();
+        queue_async_scroll_operation_promise_resolution(pending.promise);
+    }
+}
+
 void Navigable::adopt_pending_async_scroll_offsets()
 {
     if (!page().async_scrolling_enabled())
@@ -2974,16 +3024,19 @@ void Navigable::adopt_pending_async_scroll_offsets()
         return;
     }
 
-    auto async_scroll_offsets = m_rendering_thread.take_pending_async_scroll_offsets();
-    if (async_scroll_offsets.is_empty())
+    auto async_scroll_updates = m_rendering_thread.take_pending_async_scroll_updates();
+    if (async_scroll_updates.scroll_offsets.is_empty() && async_scroll_updates.completed_operation_ids.is_empty())
         return;
 
     auto document = active_document();
-    if (!document)
+    if (!document) {
+        for (auto operation_id : async_scroll_updates.completed_operation_ids)
+            resolve_async_scroll_operation(operation_id);
         return;
+    }
 
     auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
-    for (auto const& async_scroll_offset : async_scroll_offsets) {
+    for (auto const& async_scroll_offset : async_scroll_updates.scroll_offsets) {
         auto css_scroll_offset = async_scroll_offset_to_css_pixels(async_scroll_offset.scroll_offset, device_pixels_per_css_pixel);
         if (async_scroll_offset.stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
             if (async_scroll_offset.stable_node_id.node_id != document->unique_id())
@@ -2999,6 +3052,9 @@ void Navigable::adopt_pending_async_scroll_offsets()
                 async_scroll_offset.scroll_offset.x(), async_scroll_offset.scroll_offset.y());
         }
     }
+
+    for (auto operation_id : async_scroll_updates.completed_operation_ids)
+        resolve_async_scroll_operation(operation_id);
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -197,6 +197,7 @@ public:
     void set_viewport_size(CSSPixelSize, InvalidateDisplayList = InvalidateDisplayList::No);
     void perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position);
     void adopt_pending_async_scroll_offsets();
+    void wait_for_async_scroll_operation(Compositor::AsyncScrollOperationID, GC::Ref<WebIDL::Promise>);
     void clamp_viewport_scroll_offset();
 
     Painting::BackingStoreManager& backing_store_manager() { return *m_backing_store_manager; }
@@ -280,6 +281,8 @@ private:
     void scroll_offset_did_change();
 
     void inform_the_navigation_api_about_aborting_navigation();
+    void resolve_async_scroll_operation(Compositor::AsyncScrollOperationID);
+    void resolve_all_pending_async_scroll_operations();
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-id
     String m_id;
@@ -333,6 +336,12 @@ private:
     GC::Ref<Painting::BackingStoreManager> m_backing_store_manager;
     Compositor::CompositorThread m_rendering_thread;
     RefPtr<Painting::ExternalContentSource> m_external_content_source;
+
+    struct PendingAsyncScrollOperation {
+        Compositor::AsyncScrollOperationID operation_id { 0 };
+        GC::Ref<WebIDL::Promise> promise;
+    };
+    Vector<PendingAsyncScrollOperation> m_pending_async_scroll_operations;
 };
 
 struct PopulateSessionHistoryEntryDocumentOutput final : public JS::Cell {

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -37,6 +37,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Internals/InternalGamepad.h>
 #include <LibWeb/Internals/Internals.h>
+#include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/PaintableBox.h>
@@ -331,12 +332,23 @@ void Internals::click_and_hold(double x, double y, WebIDL::UnsignedShort click_c
     page.handle_mousedown(position, position, mouse_button, 0, modifiers, click_count);
 }
 
-void Internals::wheel(double x, double y, double delta_x, double delta_y)
+GC::Ref<WebIDL::Promise> Internals::wheel(double x, double y, double delta_x, double delta_y)
 {
+    auto& realm = this->realm();
+    auto promise = WebIDL::create_promise(realm);
     auto& page = this->page();
 
     auto position = page.css_to_device_point({ x, y });
-    page.handle_mousewheel(position, position, 0, 0, 0, delta_x, delta_y);
+    Optional<AsyncScrollOperation> async_scroll_operation;
+    page.handle_mousewheel(position, position, 0, 0, 0, delta_x, delta_y, false, &async_scroll_operation);
+
+    if (async_scroll_operation.has_value() && async_scroll_operation->navigable) {
+        async_scroll_operation->navigable->wait_for_async_scroll_operation(async_scroll_operation->operation_id, promise);
+        return promise;
+    }
+
+    WebIDL::resolve_promise(realm, promise);
+    return promise;
 }
 
 void Internals::pinch(double x, double y, double scale_delta)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -57,7 +57,7 @@ public:
     // High-level mouse conveniences
     void click(double x, double y, WebIDL::UnsignedShort click_count, WebIDL::UnsignedShort button, WebIDL::UnsignedShort modifiers);
     void click_and_hold(double x, double y, WebIDL::UnsignedShort click_count, WebIDL::UnsignedShort button, WebIDL::UnsignedShort modifiers);
-    void wheel(double x, double y, double delta_x, double delta_y);
+    GC::Ref<WebIDL::Promise> wheel(double x, double y, double delta_x, double delta_y);
     void pinch(double x, double y, double scale_delta);
 
     String current_cursor();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -36,7 +36,7 @@ interface Internals {
     // High-level mouse conveniences
     undefined click(double x, double y, optional unsigned short clickCount = 1, optional unsigned short button = 0, optional unsigned short modifiers = 0);
     undefined clickAndHold(double x, double y, optional unsigned short clickCount = 1, optional unsigned short button = 0, optional unsigned short modifiers = 0);
-    undefined wheel(double x, double y, double deltaX, double deltaY);
+    Promise<undefined> wheel(double x, double y, double deltaX, double deltaY);
     undefined pinch(double x, double y, double scaleDelta);
 
     DOMString currentCursor();

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -502,7 +502,7 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
     return offset;
 }
 
-EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action)
+EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action, Optional<AsyncScrollOperation>* async_scroll_operation)
 {
     if (should_ignore_device_input_event())
         return EventResult::Dropped;
@@ -540,8 +540,14 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             auto async_scroll_position = Gfx::FloatPoint { static_cast<float>(device_position.x().value()), static_cast<float>(device_position.y().value()) };
             auto device_pixels_per_css_pixel = static_cast<float>(m_navigable->page().client().device_pixels_per_css_pixel());
             auto async_scroll_delta_in_device_pixels = async_scroll_delta.scaled(device_pixels_per_css_pixel);
-            async_scroll_performed_default_action = m_navigable->rendering_thread().async_scroll_by(
-                document->unique_id(), async_scroll_position, async_scroll_delta_in_device_pixels, viewport_rect);
+            auto operation_tracking = async_scroll_operation
+                ? Compositor::CompositorThread::AsyncScrollOperationTracking::Yes
+                : Compositor::CompositorThread::AsyncScrollOperationTracking::No;
+            auto enqueue_result = m_navigable->rendering_thread().async_scroll_by(
+                document->unique_id(), async_scroll_position, async_scroll_delta_in_device_pixels, viewport_rect, operation_tracking);
+            async_scroll_performed_default_action = enqueue_result.accepted;
+            if (enqueue_result.operation_id.has_value() && async_scroll_operation)
+                *async_scroll_operation = AsyncScrollOperation { m_navigable, *enqueue_result.operation_id };
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] {} wheel async scroll at {},{} with device delta {},{}",
                 async_scroll_performed_default_action ? "Enqueued"sv : "Could not enqueue"sv,
                 async_scroll_position.x(), async_scroll_position.y(),
@@ -593,8 +599,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
         };
 
         if (auto node = dom_node_for_event_dispatch(*paintable)) {
-            if (auto result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
-                    return event_handler.handle_mousewheel(position, screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action);
+            if (auto result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation](EventHandler& event_handler, CSSPixelPoint position) -> EventResult {
+                    return event_handler.handle_mousewheel(position, screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation);
                 });
                 result.has_value()) {
                 if (result.value() == EventResult::Handled || result.value() == EventResult::Cancelled)

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -16,6 +16,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibUnicode/Forward.h>
 #include <LibWeb/CSS/Enums.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Gamepad/SDLGamepadForward.h>
@@ -26,6 +27,11 @@
 #include <LibWeb/UIEvents/KeyCode.h>
 
 namespace Web {
+
+struct AsyncScrollOperation {
+    GC::Ptr<HTML::Navigable> navigable;
+    Compositor::AsyncScrollOperationID operation_id { 0 };
+};
 
 class WEB_API EventHandler {
     friend class AutoScrollHandler;
@@ -39,7 +45,7 @@ public:
     EventResult handle_mousedown(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     EventResult handle_mousemove(CSSPixelPoint, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult handle_mouseup(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
-    EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false);
+    EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
     EventResult handle_mouseleave();
 
     EventResult handle_keydown(UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -267,9 +267,9 @@ EventResult Page::handle_mouseleave()
     return top_level_traversable()->event_handler().handle_mouseleave();
 }
 
-EventResult Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action)
+EventResult Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action, Optional<AsyncScrollOperation>* async_scroll_operation)
 {
-    return top_level_traversable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action);
+    return top_level_traversable()->event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y, async_scroll_performed_default_action, async_scroll_operation);
 }
 
 EventResult Page::handle_drag_and_drop_event(DragEvent::Type type, DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -106,7 +106,7 @@ public:
     EventResult handle_mousedown(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int click_count);
     EventResult handle_mousemove(DevicePixelPoint, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult handle_mouseleave();
-    EventResult handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false);
+    EventResult handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
 
     EventResult handle_drag_and_drop_event(DragEvent::Type, DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);
     EventResult handle_pinch_event(DevicePixelPoint point, double scale);

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-removed-during-wheel.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-removed-during-wheel.txt
@@ -1,0 +1,4 @@
+wheel promise: resolved
+wheel event count: 1
+wheel event cancelable: false
+frame removed: true

--- a/Tests/LibWeb/Text/input/async-scrolling/covered-sibling-scroller-wheel-target.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/covered-sibling-scroller-wheel-target.html
@@ -45,8 +45,7 @@
         println(`covered scroller with pointer-events none wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
         overlay.style.pointerEvents = "auto";
 
-        internals.wheel(50, 50, 0, 100);
-        await animationFrame();
+        await internals.wheel(50, 50, 0, 100);
 
         println(`scroller scrollTop after covered wheel: ${scroller.scrollTop}`);
         println(`window scrollY after covered wheel: ${window.scrollY}`);

--- a/Tests/LibWeb/Text/input/async-scrolling/intersection-observer-nested-scrollable-boxes.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/intersection-observer-nested-scrollable-boxes.html
@@ -101,10 +101,7 @@
         println(`wheel scroll admission: ${internals.asyncScrollingStateWheelScrollAdmissionAt(60, 60, 0, 100)}`);
         println(`downward wheel target before wheel: ${internals.asyncScrollingStateWheelTargetAt(60, 60, 0, 100)}`);
 
-        internals.wheel(60, 60, 0, 100);
-
-        await animationFrame();
-        await animationFrame();
+        await internals.wheel(60, 60, 0, 100);
 
         const scrolledEntry = await nextIntersectionEntry();
         println(`scrolled isIntersecting: ${scrolledEntry.isIntersecting}`);

--- a/Tests/LibWeb/Text/input/async-scrolling/nested-navigable-removed-during-wheel.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/nested-navigable-removed-during-wheel.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    iframe {
+        display: block;
+        width: 160px;
+        height: 120px;
+        border: 0;
+    }
+</style>
+<iframe id="iframe" srcdoc="<!DOCTYPE html><body style='height: 1000px; margin: 0'>iframe</body>"></iframe>
+<script>
+    promiseTest(async () => {
+        const iframe = document.getElementById("iframe");
+        await new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+
+        let wheelEventCount = 0;
+        let wheelEventWasCancelable = null;
+        iframe.contentWindow.addEventListener("wheel", event => {
+            wheelEventCount++;
+            wheelEventWasCancelable = event.cancelable;
+            iframe.remove();
+        }, { passive: true });
+
+        await animationFrame();
+        await animationFrame();
+
+        const result = await Promise.race([
+            internals.wheel(50, 50, 0, 100).then(() => "resolved"),
+            timeout(500).then(() => "timed out"),
+        ]);
+
+        println(`wheel promise: ${result}`);
+        println(`wheel event count: ${wheelEventCount}`);
+        println(`wheel event cancelable: ${wheelEventWasCancelable}`);
+        println(`frame removed: ${iframe.parentNode === null}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/nested-scroller-keeps-sync-wheel.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/nested-scroller-keeps-sync-wheel.html
@@ -34,9 +34,7 @@
         await animationFrame();
         await animationFrame();
 
-        internals.wheel(50, 50, 0, 100);
-        await animationFrame();
-        await animationFrame();
+        await internals.wheel(50, 50, 0, 100);
 
         printOutputAndDisplayList([
             `scroller scrollTop: ${scroller.scrollTop}`,

--- a/Tests/LibWeb/Text/input/async-scrolling/nested-scroller-wheel-prevent-default.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/nested-scroller-wheel-prevent-default.html
@@ -36,8 +36,7 @@
 
         println(`async can scroll before wheel: ${internals.asyncScrollingStateCanWheelScrollAt(50, 50, 0, 100, false)}`);
 
-        internals.wheel(50, 50, 0, 100);
-        await animationFrame();
+        await internals.wheel(50, 50, 0, 100);
 
         println(`wheel event count: ${wheelEventCount}`);
         println(`wheel event cancelable: ${wheelEventWasCancelable}`);

--- a/Tests/LibWeb/Text/input/async-scrolling/pseudo-element-wheel-scroll.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/pseudo-element-wheel-scroll.html
@@ -43,11 +43,7 @@
         println(`wheel scroll admission: ${internals.asyncScrollingStateWheelScrollAdmissionAt(50, 50, 0, 100)}`);
         println(`downward wheel target before wheel: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
 
-        internals.wheel(50, 50, 0, 100);
-
-        // The compositor scroll offset is adopted during a rendering update.
-        await animationFrame();
-        await animationFrame();
+        await internals.wheel(50, 50, 0, 100);
 
         println(`scroll event count: ${scrollEventCount}`);
         println(`host scrollTop: ${host.scrollTop}`);

--- a/Tests/LibWeb/Text/input/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body-2.html
+++ b/Tests/LibWeb/Text/input/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body-2.html
@@ -25,9 +25,7 @@
 <script src="include.js"></script>
 <script>
     promiseTest(async () => {
-        internals.wheel(10, 10, 0, 1000);
-        await animationFrame();
-        await animationFrame();
+        await internals.wheel(10, 10, 0, 1000);
 
         const scrollable = document.getElementById("scrollable");
         println("scrollable.scrollTop: " + scrollable.scrollTop);

--- a/Tests/LibWeb/Text/input/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body.html
+++ b/Tests/LibWeb/Text/input/wheel-events-consumed-by-scrollable-should-not-be-propagated-to-body.html
@@ -24,9 +24,7 @@
 <div id="scrollable"><div id="content"></div></div>
 <script>
     promiseTest(async () => {
-        internals.wheel(10, 10, 0, 1000);
-        await animationFrame();
-        await animationFrame();
+        await internals.wheel(10, 10, 0, 1000);
 
         const scrollable = document.getElementById("scrollable");
         println("scrollable.scrollTop: " + scrollable.scrollTop);

--- a/Tests/LibWeb/Text/input/wheel-scroll-over-iframe-at-boundary-falls-back-to-parent.html
+++ b/Tests/LibWeb/Text/input/wheel-scroll-over-iframe-at-boundary-falls-back-to-parent.html
@@ -45,9 +45,7 @@
         println(`iframe.scrollHeight: ${scrollingElement.scrollHeight}`);
         println(`iframe.clientHeight: ${scrollingElement.clientHeight}`);
 
-        internals.wheel(50, 50, 0, 100);
-        await animationFrame();
-        await animationFrame();
+        await internals.wheel(50, 50, 0, 100);
 
         println(`window.scrollY: ${window.scrollY}`);
         println(`iframe.scrollTop after wheel: ${scrollingElement.scrollTop}`);

--- a/Tests/LibWeb/Text/input/wheel-scroll-over-iframe-falls-back-to-parent.html
+++ b/Tests/LibWeb/Text/input/wheel-scroll-over-iframe-falls-back-to-parent.html
@@ -25,8 +25,7 @@
 
         await new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
 
-        internals.wheel(50, 50, 0, 100);
-        await animationFrame();
+        await internals.wheel(50, 50, 0, 100);
 
         println(`window.scrollY: ${window.scrollY}`);
         println(`iframe.scrollY: ${iframe.contentWindow.scrollY}`);


### PR DESCRIPTION
Async scrolling tests used requestAnimationFrame() as a proxy for the compositor thread to return pending scroll updates to the main thread. That waited for a rendering opportunity, so tests could observe stale DOM scroll offsets when the compositor update had not been adopted yet.

Make internals.wheel() return a promise that resolves after a tracked async scroll operation has been applied by Navigable. Tracking is opt-in from the internals test API, so regular page wheel input and compositor IPC keep the boolean async-scroll path without allocating operation IDs. Tracked test scrolls are the only operations that record completions.

Update async scrolling and wheel propagation tests to await the wheel promise directly instead of relying on animation frame timing in tests.