### PR TITLE
LibWeb: Guard `HTMLCollection` weak prune against freed cells

### DIFF
--- a/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -59,12 +59,14 @@ GC::Cell const& HTMLCollection::owner_cell(Badge<GC::Heap>) const
 
 void HTMLCollection::remove_dead_cells(Badge<GC::Heap>)
 {
-    m_cached_elements.remove_all_matching([](GC::RawPtr<Element> const& element) {
-        return element->state() != GC::Cell::State::Live;
+    m_cached_elements.remove_all_matching([&](GC::RawPtr<Element> const& element) {
+        auto* block = GC::HeapBlock::from_cell(element);
+        return !heap().is_live_heap_block(block) || element->state() != Cell::State::Live || !element->is_marked();
     });
     if (m_cached_name_to_element_mappings) {
-        m_cached_name_to_element_mappings->remove_all_matching([](FlyString const&, GC::RawPtr<Element> const& element) {
-            return element->state() != GC::Cell::State::Live;
+        m_cached_name_to_element_mappings->remove_all_matching([&](FlyString const&, GC::RawPtr<Element> const& element) {
+            auto* block = GC::HeapBlock::from_cell(element);
+            return !heap().is_live_heap_block(block) || element->state() != Cell::State::Live || !element->is_marked();
         });
     }
 }

--- a/Tests/LibWeb/Crash/HTML/htmlcollection-cache-prune-after-gc.html
+++ b/Tests/LibWeb/Crash/HTML/htmlcollection-cache-prune-after-gc.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<div id="container"></div>
+<script>
+    const container = document.getElementById("container");
+    const collection   = container.getElementsByTagName("div");
+
+    for (let i = 0; i < 800; i++) {
+        container.appendChild(document.createElement("div"));
+    }
+    collection.length;
+
+    while (container.firstChild) {
+        container.removeChild(container.firstChild);
+        internals.gc();
+    }
+</script>


### PR DESCRIPTION
Check `is_live_heap_block()` before touching the cell, and also drop cached entries that survived the block but are unmarked, matching the pattern used elsewhere.

NB: The included crash test will only fail on `master` when built with the Sanitizer preset.

Fixes #9420