### PR TITLE
LibJS+RequestServer: Keep cached resources (downloads & bytecode) file-backed

### DIFF
--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     EventLoopImplementation.cpp
     EventReceiver.cpp
     File.cpp
+    ImmutableBytes.cpp
     MappedFile.cpp
     MimeData.cpp
     Notifier.cpp

--- a/Libraries/LibCore/ImmutableBytes.cpp
+++ b/Libraries/LibCore/ImmutableBytes.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ImmutableBytes.h>
+
+namespace Core {
+
+ErrorOr<ImmutableBytes> ImmutableBytes::copy(ReadonlyBytes bytes)
+{
+    return adopt(TRY(ByteBuffer::copy(bytes)));
+}
+
+ImmutableBytes ImmutableBytes::adopt(ByteBuffer bytes)
+{
+    return ImmutableBytes { adopt_ref(*new Impl(move(bytes))) };
+}
+
+ImmutableBytes ImmutableBytes::adopt_mapped_file(NonnullOwnPtr<MappedFile> mapped_file)
+{
+    return ImmutableBytes { adopt_ref(*new Impl(move(mapped_file))) };
+}
+
+ErrorOr<ImmutableBytes> ImmutableBytes::map_from_fd_range_and_close(int fd, StringView path, off_t offset, size_t size)
+{
+    return adopt_mapped_file(TRY(MappedFile::map_from_fd_range_and_close(fd, path, offset, size)));
+}
+
+bool ImmutableBytes::is_file_backed() const
+{
+    return m_impl && m_impl->is_file_backed();
+}
+
+ReadonlyBytes ImmutableBytes::bytes() const
+{
+    if (!m_impl)
+        return {};
+    return m_impl->bytes();
+}
+
+ErrorOr<ByteBuffer> ImmutableBytes::copy_to_byte_buffer() const
+{
+    return ByteBuffer::copy(bytes());
+}
+
+ImmutableBytes::ImmutableBytes(NonnullRefPtr<Impl> impl)
+    : m_impl(move(impl))
+{
+}
+
+ImmutableBytes::Impl::Impl(ByteBuffer bytes)
+    : m_storage(move(bytes))
+{
+}
+
+ImmutableBytes::Impl::Impl(NonnullOwnPtr<MappedFile> mapped_file)
+    : m_storage(move(mapped_file))
+{
+}
+
+bool ImmutableBytes::Impl::is_file_backed() const
+{
+    return m_storage.has<NonnullOwnPtr<MappedFile>>();
+}
+
+ReadonlyBytes ImmutableBytes::Impl::bytes() const
+{
+    return m_storage.visit(
+        [](ByteBuffer const& bytes) -> ReadonlyBytes {
+            return bytes.bytes();
+        },
+        [](NonnullOwnPtr<MappedFile> const& mapped_file) -> ReadonlyBytes {
+            return mapped_file->bytes();
+        });
+}
+
+}

--- a/Libraries/LibCore/ImmutableBytes.h
+++ b/Libraries/LibCore/ImmutableBytes.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/Variant.h>
+#include <LibCore/Export.h>
+#include <LibCore/MappedFile.h>
+
+namespace Core {
+
+class CORE_API ImmutableBytes {
+public:
+    static ErrorOr<ImmutableBytes> copy(ReadonlyBytes);
+    static ImmutableBytes adopt(ByteBuffer);
+    static ImmutableBytes adopt_mapped_file(NonnullOwnPtr<MappedFile>);
+    static ErrorOr<ImmutableBytes> map_from_fd_range_and_close(int fd, StringView path, off_t offset, size_t size);
+
+    ImmutableBytes() = default;
+
+    [[nodiscard]] bool is_empty() const { return size() == 0; }
+    [[nodiscard]] bool is_valid() const { return m_impl; }
+    [[nodiscard]] bool is_file_backed() const;
+
+    [[nodiscard]] size_t size() const { return bytes().size(); }
+    [[nodiscard]] ReadonlyBytes bytes() const LIFETIME_BOUND;
+    [[nodiscard]] ErrorOr<ByteBuffer> copy_to_byte_buffer() const;
+
+private:
+    class Impl final : public RefCounted<Impl> {
+    public:
+        explicit Impl(ByteBuffer);
+        explicit Impl(NonnullOwnPtr<MappedFile>);
+
+        [[nodiscard]] bool is_file_backed() const;
+        [[nodiscard]] ReadonlyBytes bytes() const LIFETIME_BOUND;
+
+    private:
+        Variant<ByteBuffer, NonnullOwnPtr<MappedFile>> m_storage;
+    };
+
+    explicit ImmutableBytes(NonnullRefPtr<Impl>);
+
+    RefPtr<Impl> m_impl;
+};
+
+}

--- a/Libraries/LibCore/MappedFile.cpp
+++ b/Libraries/LibCore/MappedFile.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
@@ -27,12 +28,35 @@ ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core:
 
 ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] StringView path, Mode mode)
 {
-    ScopeGuard fd_close_guard = [fd] {
+    ArmedScopeGuard fd_close_guard = [fd] {
         (void)System::close(fd);
     };
 
     auto stat = TRY(Core::System::fstat(fd));
-    auto size = stat.st_size;
+    if (stat.st_size < 0)
+        return Error::from_errno(EINVAL);
+
+    fd_close_guard.disarm();
+    return map_from_fd_range_and_close(fd, path, 0, static_cast<size_t>(stat.st_size), mode);
+}
+
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_range_and_close(int fd, [[maybe_unused]] StringView path, off_t offset, size_t size, Mode mode)
+{
+    ScopeGuard fd_close_guard = [fd] {
+        (void)System::close(fd);
+    };
+
+    if (offset < 0 || !AK::is_within_range<size_t>(offset))
+        return Error::from_errno(EINVAL);
+
+    auto stat = TRY(Core::System::fstat(fd));
+    if (stat.st_size < 0 || !AK::is_within_range<size_t>(stat.st_size))
+        return Error::from_errno(EINVAL);
+
+    auto file_size = static_cast<size_t>(stat.st_size);
+    auto requested_offset = static_cast<size_t>(offset);
+    if (requested_offset > file_size || size > file_size - requested_offset)
+        return Error::from_errno(EINVAL);
 
     int protection;
     int flags;
@@ -48,23 +72,40 @@ ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[m
         break;
     }
 
-    auto* ptr = TRY(Core::System::mmap(nullptr, size, protection, flags, fd, 0, 0, path));
+    if (size == 0)
+        return adopt_own(*new MappedFile(nullptr, 0, nullptr, 0, mode));
 
-    return adopt_own(*new MappedFile(ptr, size, mode));
+    auto page_aligned_offset = align_down_to(requested_offset, PAGE_SIZE);
+    auto offset_in_mapping = requested_offset - page_aligned_offset;
+
+    Checked<size_t> mapping_size = offset_in_mapping;
+    mapping_size += size;
+    if (mapping_size.has_overflow())
+        return Error::from_errno(EOVERFLOW);
+
+    auto* mapping = TRY(Core::System::mmap(nullptr, mapping_size.value(), protection, flags, fd, page_aligned_offset, 0, path));
+    auto* data = reinterpret_cast<u8*>(mapping) + offset_in_mapping;
+
+    return adopt_own(*new MappedFile(mapping, mapping_size.value(), data, size, mode));
 }
 
-MappedFile::MappedFile(void* ptr, size_t size, Mode mode)
-    : FixedMemoryStream(Bytes { ptr, size }, mode)
-    , m_data(ptr)
+MappedFile::MappedFile(void* mapping, size_t mapping_size, void* data, size_t size, Mode mode)
+    : FixedMemoryStream(Bytes { data, size }, mode)
+    , m_mapping(mapping)
+    , m_mapping_size(mapping_size)
+    , m_data(data)
     , m_size(size)
 {
 }
 
 MappedFile::~MappedFile()
 {
-    auto res = Core::System::munmap(m_data, m_size);
+    if (!m_mapping)
+        return;
+
+    auto res = Core::System::munmap(m_mapping, m_mapping_size);
     if (res.is_error())
-        dbgln("Failed to unmap MappedFile (@ {:p}): {}", m_data, res.error());
+        dbgln("Failed to unmap MappedFile (@ {:p}): {}", m_mapping, res.error());
 }
 
 }

--- a/Libraries/LibCore/MappedFile.h
+++ b/Libraries/LibCore/MappedFile.h
@@ -25,6 +25,7 @@ public:
     static ErrorOr<NonnullOwnPtr<MappedFile>> map(StringView path, Mode mode = Mode::ReadOnly);
     static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_file(NonnullOwnPtr<Core::File>, StringView path);
     static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path, Mode mode = Mode::ReadOnly);
+    static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_fd_range_and_close(int fd, StringView path, off_t offset, size_t size, Mode mode = Mode::ReadOnly);
     virtual ~MappedFile();
 
     // Non-stream APIs for using MappedFile as a simple POSIX API wrapper.
@@ -33,8 +34,10 @@ public:
     ReadonlyBytes bytes() const LIFETIME_BOUND { return { m_data, m_size }; }
 
 private:
-    explicit MappedFile(void*, size_t, Mode);
+    explicit MappedFile(void* mapping, size_t mapping_size, void* data, size_t size, Mode);
 
+    void* m_mapping { nullptr };
+    size_t m_mapping_size { 0 };
     void* m_data { nullptr };
     size_t m_size { 0 };
 };

--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -119,6 +119,7 @@ CacheEntryWriter::CacheEntryWriter(DiskCache& disk_cache, CacheIndex& index, u64
 ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optional<String> reason_phrase, HeaderList const& request_headers, HeaderList const& response_headers)
 {
     if (m_marked_for_deletion) {
+        remove_incomplete_temporary_file();
         close_and_destroy_cache_entry();
         return Error::from_string_literal("Cache entry has been deleted");
     }
@@ -137,6 +138,7 @@ ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optiona
 
         m_vary_key = create_vary_key(request_headers, response_headers);
         m_path = path_for_cache_entry(m_disk_cache.cache_directory(), m_cache_key, m_vary_key);
+        m_temporary_path = LexicalPath::join(m_disk_cache.cache_directory().string(), ByteString::formatted("{}.tmp", m_path->basename()));
 
         auto freshness_lifetime = calculate_freshness_lifetime(status_code, response_headers, m_current_time_offset_for_testing);
         auto current_age = calculate_age(response_headers, m_request_time, m_response_time, m_current_time_offset_for_testing);
@@ -146,7 +148,8 @@ ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optiona
         if (cache_lifetime_status(request_headers, response_headers, freshness_lifetime, current_age) == CacheLifetimeStatus::Expired)
             return Error::from_string_literal("Response has already expired");
 
-        auto unbuffered_file = TRY(Core::File::open(m_path->string(), Core::File::OpenMode::Write));
+        (void)FileSystem::remove(m_temporary_path->string(), FileSystem::RecursionMode::Disallowed);
+        auto unbuffered_file = TRY(Core::File::open(m_temporary_path->string(), Core::File::OpenMode::Write | Core::File::OpenMode::MustBeNew));
         m_file = TRY(Core::OutputBufferedFile::create(move(unbuffered_file)));
 
         TRY(m_file->write_value(m_cache_header));
@@ -161,7 +164,7 @@ ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optiona
     if (result.is_error()) {
         dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[31;1mUnable to write status/reason to cache entry for\033[0m {}: {}", m_url, result.error());
 
-        remove();
+        remove_incomplete_temporary_file();
         close_and_destroy_cache_entry();
 
         return result.release_error();
@@ -173,6 +176,7 @@ ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optiona
 ErrorOr<void> CacheEntryWriter::write_data(ReadonlyBytes data)
 {
     if (m_marked_for_deletion) {
+        remove_incomplete_temporary_file();
         close_and_destroy_cache_entry();
         return Error::from_string_literal("Cache entry has been deleted");
     }
@@ -180,7 +184,7 @@ ErrorOr<void> CacheEntryWriter::write_data(ReadonlyBytes data)
     if (auto result = m_file->write_until_depleted(data); result.is_error()) {
         dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[31;1mUnable to write data to cache entry for\033[0m {}: {}", m_url, result.error());
 
-        remove();
+        remove_incomplete_temporary_file();
         close_and_destroy_cache_entry();
 
         return result.release_error();
@@ -206,19 +210,29 @@ ErrorOr<void> CacheEntryWriter::flush_impl(NonnullRefPtr<HeaderList> request_hea
 {
     ScopeGuard guard { [&]() { close_and_destroy_cache_entry(); } };
 
-    if (m_marked_for_deletion)
+    if (m_marked_for_deletion) {
+        remove_incomplete_temporary_file();
         return Error::from_string_literal("Cache entry has been deleted");
+    }
+    VERIFY(m_path.has_value());
+    VERIFY(m_temporary_path.has_value());
+
+    ArmedScopeGuard remove_temporary_file = [&]() {
+        remove_incomplete_temporary_file();
+    };
 
     m_cache_footer.header_hash = m_cache_header.hash();
 
     if (auto result = m_file->write_value(m_cache_footer); result.is_error()) {
         dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[31;1mUnable to flush cache entry for\033[0m {}: {}", m_url, result.error());
-        remove();
 
         return result.release_error();
     }
 
     TRY(m_file->flush_buffer());
+    m_file.clear();
+    TRY(Core::System::rename(m_temporary_path->string(), m_path->string()));
+    remove_temporary_file.disarm();
 
     int body_fd = -1;
     ArmedScopeGuard close_body_fd = [&] {
@@ -254,8 +268,15 @@ ErrorOr<void> CacheEntryWriter::flush_impl(NonnullRefPtr<HeaderList> request_hea
 
 void CacheEntryWriter::remove_incomplete_entry()
 {
-    remove();
+    remove_incomplete_temporary_file();
     close_and_destroy_cache_entry();
+}
+
+void CacheEntryWriter::remove_incomplete_temporary_file()
+{
+    if (!m_temporary_path.has_value())
+        return;
+    (void)FileSystem::remove(m_temporary_path->string(), FileSystem::RecursionMode::Disallowed);
 }
 
 ErrorOr<NonnullOwnPtr<CacheEntryReader>> CacheEntryReader::create(DiskCache& disk_cache, CacheIndex& index, u64 cache_key, u64 vary_key, NonnullRefPtr<HeaderList> response_headers, u64 data_size)

--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -331,6 +331,29 @@ void CacheEntryReader::send_to(int socket_fd, Function<void(u64)> on_complete, F
     send_without_blocking();
 }
 
+ErrorOr<CacheEntryReader::BodyFile> CacheEntryReader::take_body_file()
+{
+    ScopeGuard guard { [&]() { close_and_destroy_cache_entry(); } };
+
+    if (m_marked_for_deletion)
+        return Error::from_string_literal("Cache entry has been deleted");
+
+    if (auto result = read_and_validate_footer(); result.is_error()) {
+        dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[31;1mError validating cache entry for\033[0m {}: {}", m_url, result.error());
+        remove();
+        return result.release_error();
+    }
+
+    auto fd = TRY(Core::System::dup(m_fd));
+    m_index.update_last_access_time(m_cache_key, m_vary_key);
+
+    return BodyFile {
+        .fd = fd,
+        .offset = m_data_offset,
+        .size = m_data_size,
+    };
+}
+
 void CacheEntryReader::send_without_blocking()
 {
     if (m_marked_for_deletion) {

--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -153,6 +153,7 @@ ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optiona
         TRY(m_file->write_until_depleted(m_url));
         if (reason_phrase.has_value())
             TRY(m_file->write_until_depleted(*reason_phrase));
+        m_data_offset = TRY(m_file->tell());
 
         return {};
     }();
@@ -191,6 +192,18 @@ ErrorOr<void> CacheEntryWriter::write_data(ReadonlyBytes data)
 
 ErrorOr<void> CacheEntryWriter::flush(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers)
 {
+    return flush_impl(move(request_headers), move(response_headers), nullptr);
+}
+
+ErrorOr<CacheEntryBodyFile> CacheEntryWriter::flush_and_take_body_file(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers)
+{
+    CacheEntryBodyFile body_file;
+    TRY(flush_impl(move(request_headers), move(response_headers), &body_file));
+    return body_file;
+}
+
+ErrorOr<void> CacheEntryWriter::flush_impl(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers, CacheEntryBodyFile* body_file)
+{
     ScopeGuard guard { [&]() { close_and_destroy_cache_entry(); } };
 
     if (m_marked_for_deletion)
@@ -203,6 +216,21 @@ ErrorOr<void> CacheEntryWriter::flush(NonnullRefPtr<HeaderList> request_headers,
         remove();
 
         return result.release_error();
+    }
+
+    TRY(m_file->flush_buffer());
+
+    int body_fd = -1;
+    ArmedScopeGuard close_body_fd = [&] {
+        if (body_fd != -1)
+            (void)Core::System::close(body_fd);
+    };
+    if (body_file) {
+        auto opened_body_file = TRY(Core::File::open(m_path->string(), Core::File::OpenMode::Read));
+        body_fd = TRY(Core::System::dup(opened_body_file->fd()));
+        body_file->fd = body_fd;
+        body_file->offset = m_data_offset;
+        body_file->size = m_cache_footer.data_size;
     }
 
     // Drop any sidecars left over from an older entry at the same (cache_key, vary_key). They are tied to the previous
@@ -220,6 +248,7 @@ ErrorOr<void> CacheEntryWriter::flush(NonnullRefPtr<HeaderList> request_headers,
     m_disk_cache.remove_entries_exceeding_cache_limit();
 
     dbgln_if(HTTP_DISK_CACHE_DEBUG, "\033[36m[disk]\033[0m \033[34;1mFinished caching\033[0m {} ({} bytes)", m_url, m_cache_footer.data_size);
+    close_body_fd.disarm();
     return {};
 }
 
@@ -331,7 +360,7 @@ void CacheEntryReader::send_to(int socket_fd, Function<void(u64)> on_complete, F
     send_without_blocking();
 }
 
-ErrorOr<CacheEntryReader::BodyFile> CacheEntryReader::take_body_file()
+ErrorOr<CacheEntryBodyFile> CacheEntryReader::take_body_file()
 {
     ScopeGuard guard { [&]() { close_and_destroy_cache_entry(); } };
 
@@ -347,7 +376,7 @@ ErrorOr<CacheEntryReader::BodyFile> CacheEntryReader::take_body_file()
     auto fd = TRY(Core::System::dup(m_fd));
     m_index.update_last_access_time(m_cache_key, m_vary_key);
 
-    return BodyFile {
+    return CacheEntryBodyFile {
         .fd = fd,
         .offset = m_data_offset,
         .size = m_data_size,

--- a/Libraries/LibHTTP/Cache/CacheEntry.h
+++ b/Libraries/LibHTTP/Cache/CacheEntry.h
@@ -137,6 +137,8 @@ public:
 
     ErrorOr<CacheEntryBodyFile> take_body_file();
 
+    u64 body_size() const { return m_data_size; }
+
     u32 status_code() const { return m_cache_header.status_code; }
     Optional<String> const& reason_phrase() const { return m_reason_phrase; }
     HeaderList& response_headers() { return m_response_headers; }

--- a/Libraries/LibHTTP/Cache/CacheEntry.h
+++ b/Libraries/LibHTTP/Cache/CacheEntry.h
@@ -60,6 +60,7 @@ public:
 
     u64 cache_key() const { return m_cache_key; }
     u64 vary_key() const { return m_vary_key; }
+    u64 body_size() const { return m_cache_footer.data_size; }
 
     void remove();
 
@@ -123,6 +124,13 @@ public:
     void revalidation_failed();
 
     void send_to(int socket_fd, Function<void(u64 bytes_sent)> on_complete, Function<void(u64 bytes_sent)> on_error);
+
+    struct BodyFile {
+        int fd { -1 };
+        u64 offset { 0 };
+        u64 size { 0 };
+    };
+    ErrorOr<BodyFile> take_body_file();
 
     u32 status_code() const { return m_cache_header.status_code; }
     Optional<String> const& reason_phrase() const { return m_reason_phrase; }

--- a/Libraries/LibHTTP/Cache/CacheEntry.h
+++ b/Libraries/LibHTTP/Cache/CacheEntry.h
@@ -49,6 +49,12 @@ struct CacheFooter {
     u32 header_hash { 0 };
 };
 
+struct CacheEntryBodyFile {
+    int fd { -1 };
+    u64 offset { 0 };
+    u64 size { 0 };
+};
+
 // A cache entry is an amalgamation of all information needed to reconstruct HTTP responses. It is created once we have
 // received the response headers for a request. The body is streamed into the entry as it is received. The cache format
 // on disk is:
@@ -94,12 +100,16 @@ public:
     ErrorOr<void> write_status_and_reason(u32 status_code, Optional<String> reason_phrase, HeaderList const& request_headers, HeaderList const& response_headers);
     ErrorOr<void> write_data(ReadonlyBytes);
     ErrorOr<void> flush(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers);
+    ErrorOr<CacheEntryBodyFile> flush_and_take_body_file(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers);
     void remove_incomplete_entry();
 
 private:
     CacheEntryWriter(DiskCache&, CacheIndex&, u64 cache_key, String url, CacheHeader, UnixDateTime request_time, AK::Duration current_time_offset_for_testing);
 
+    ErrorOr<void> flush_impl(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers, CacheEntryBodyFile*);
+
     OwnPtr<Core::OutputBufferedFile> m_file;
+    u64 m_data_offset { 0 };
 
     UnixDateTime m_request_time;
     UnixDateTime m_response_time;
@@ -125,12 +135,7 @@ public:
 
     void send_to(int socket_fd, Function<void(u64 bytes_sent)> on_complete, Function<void(u64 bytes_sent)> on_error);
 
-    struct BodyFile {
-        int fd { -1 };
-        u64 offset { 0 };
-        u64 size { 0 };
-    };
-    ErrorOr<BodyFile> take_body_file();
+    ErrorOr<CacheEntryBodyFile> take_body_file();
 
     u32 status_code() const { return m_cache_header.status_code; }
     Optional<String> const& reason_phrase() const { return m_reason_phrase; }

--- a/Libraries/LibHTTP/Cache/CacheEntry.h
+++ b/Libraries/LibHTTP/Cache/CacheEntry.h
@@ -107,8 +107,10 @@ private:
     CacheEntryWriter(DiskCache&, CacheIndex&, u64 cache_key, String url, CacheHeader, UnixDateTime request_time, AK::Duration current_time_offset_for_testing);
 
     ErrorOr<void> flush_impl(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers, CacheEntryBodyFile*);
+    void remove_incomplete_temporary_file();
 
     OwnPtr<Core::OutputBufferedFile> m_file;
+    Optional<LexicalPath> m_temporary_path;
     u64 m_data_offset { 0 };
 
     UnixDateTime m_request_time;

--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -286,6 +286,42 @@ ErrorOr<Optional<ByteBuffer>> DiskCache::retrieve_associated_data(URL::URL const
     return TRY(file.value()->read_until_eof());
 }
 
+ErrorOr<Optional<CacheEntryBodyFile>> DiskCache::retrieve_associated_data_file(URL::URL const& url, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData associated_data)
+{
+    if (!is_cacheable(method, request_headers))
+        return Optional<CacheEntryBodyFile> {};
+
+    auto serialized_url = serialize_url_for_cache_storage(url);
+    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    if (!vary_key.has_value()) {
+        auto index_entry = m_index.find_entry(cache_key, request_headers);
+        if (!index_entry.has_value())
+            return Optional<CacheEntryBodyFile> {};
+        vary_key = index_entry->vary_key;
+    }
+
+    if (!m_index.has_entry(cache_key, *vary_key))
+        return Optional<CacheEntryBodyFile> {};
+
+    auto path = path_for_cache_entry_associated_data(m_cache_directory, cache_key, *vary_key, associated_data);
+    auto file = Core::File::open(path.string(), Core::File::OpenMode::Read);
+    if (file.is_error()) {
+        if (file.error().is_errno() && file.error().code() == ENOENT)
+            return Optional<CacheEntryBodyFile> {};
+        return file.release_error();
+    }
+
+    auto size = TRY(file.value()->size());
+    if (!AK::is_within_range<u64>(size))
+        return Error::from_errno(EOVERFLOW);
+
+    return CacheEntryBodyFile {
+        .fd = file.value()->leak_fd(),
+        .offset = 0,
+        .size = static_cast<u64>(size),
+    };
+}
+
 bool DiskCache::check_if_cache_has_open_entry(CacheRequest& request, u64 cache_key, URL::URL const& url, CheckReaderEntries check_reader_entries)
 {
     // FIXME: We purposefully do not use the vary key here, as we do not yet have it when creating a CacheEntryWriter

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -56,6 +56,7 @@ public:
 
     ErrorOr<bool> store_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData, ReadonlyBytes);
     ErrorOr<Optional<ByteBuffer>> retrieve_associated_data(URL::URL const&, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData);
+    ErrorOr<Optional<CacheEntryBodyFile>> retrieve_associated_data_file(URL::URL const&, StringView method, HeaderList const& request_headers, Optional<u64> vary_key, CacheEntryAssociatedData);
 
     void remove_entries_exceeding_cache_limit();
     void set_maximum_disk_cache_size(u64 maximum_disk_cache_size);

--- a/Libraries/LibHTTP/Cache/MemoryCache.cpp
+++ b/Libraries/LibHTTP/Cache/MemoryCache.cpp
@@ -109,7 +109,7 @@ void MemoryCache::create_entry(URL::URL const& url, StringView method, HeaderLis
 
 // FIXME: It would be nicer if create_entry just returned the cache and vary keys. But the call sites of create_entry and
 //        finalize_entry are pretty far apart, so passing that information along is rather awkward in Fetch.
-void MemoryCache::finalize_entry(URL::URL const& url, StringView method, HeaderList const& request_headers, u32 status_code, HeaderList const& response_headers, ByteBuffer response_body)
+void MemoryCache::finalize_entry(URL::URL const& url, StringView method, HeaderList const& request_headers, u32 status_code, HeaderList const& response_headers, Core::ImmutableBytes response_body)
 {
     if (!is_cacheable(method, request_headers))
         return;

--- a/Libraries/LibHTTP/Cache/MemoryCache.h
+++ b/Libraries/LibHTTP/Cache/MemoryCache.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/Time.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibHTTP/Cache/CacheMode.h>
 #include <LibHTTP/Forward.h>
 #include <LibURL/URL.h>
@@ -26,7 +27,7 @@ public:
         ByteString reason_phrase;
         NonnullRefPtr<HeaderList> request_headers;
         NonnullRefPtr<HeaderList> response_headers;
-        ByteBuffer response_body;
+        Core::ImmutableBytes response_body;
 
         UnixDateTime request_time;
         UnixDateTime response_time;
@@ -37,7 +38,7 @@ public:
     Optional<Entry const&> open_entry(URL::URL const&, StringView method, HeaderList const& request_headers, CacheMode);
 
     void create_entry(URL::URL const&, StringView method, HeaderList const& request_headers, UnixDateTime request_time, u32 status_code, ByteString reason_phrase, HeaderList const& response_headers);
-    void finalize_entry(URL::URL const&, StringView method, HeaderList const& request_headers, u32 status_code, HeaderList const& response_headers, ByteBuffer response_body);
+    void finalize_entry(URL::URL const&, StringView method, HeaderList const& request_headers, u32 status_code, HeaderList const& response_headers, Core::ImmutableBytes response_body);
 
 private:
     HashMap<u64, Vector<Entry>, IdentityHashTraits<u64>> m_pending_entries;

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -24,9 +24,11 @@
 use std::ffi::c_void;
 
 use super::generator::{
-    AssembledBytecode, ConstantValue, Generator, PendingClassBlueprint, PendingClassElement, PendingLiteralValueKind,
+    AssembledBytecode, ConstantValue, ExceptionHandler, Generator, PendingClassBlueprint, PendingClassElement,
+    PendingLiteralValueKind,
 };
 use crate::ast::Utf16String;
+use crate::bytecode::basic_block::SourceMapEntry;
 use crate::u32_from_usize;
 
 /// Opaque pointer returned from rust_create_executable.
@@ -659,6 +661,45 @@ pub unsafe fn create_executable_with_dependencies(
     bp_ptrs: &[*mut c_void],
 ) -> ExecutableHandle {
     unsafe {
+        let parts = ExecutableParts {
+            bytecode: &assembled.bytecode,
+            exception_handlers: &assembled.exception_handlers,
+            source_map: &assembled.source_map,
+            basic_block_start_offsets: &assembled.basic_block_start_offsets,
+            number_of_registers: assembled.number_of_registers,
+            number_of_arguments: assembled.number_of_arguments,
+        };
+        create_executable_with_dependencies_from_parts(generator, parts, vm_ptr, source_code_ptr, sfd_ptrs, bp_ptrs)
+    }
+}
+
+pub struct ExecutableParts<'a> {
+    pub bytecode: &'a [u8],
+    pub exception_handlers: &'a [ExceptionHandler],
+    pub source_map: &'a [SourceMapEntry],
+    pub basic_block_start_offsets: &'a [usize],
+    pub number_of_registers: u32,
+    pub number_of_arguments: u32,
+}
+
+/// Create a C++ Executable from already materialized dependency objects and
+/// borrowed bytecode/table slices.
+///
+/// This variant lets bytecode cache materialization point at mmap-backed cache
+/// blob bytes without first cloning executable bytecode into a Rust Vec.
+///
+/// # Safety
+/// `vm_ptr`, `source_code_ptr`, all dependency pointers, and all borrowed
+/// slices must be valid for the duration of the call.
+pub unsafe fn create_executable_with_dependencies_from_parts(
+    generator: &Generator,
+    parts: ExecutableParts<'_>,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    sfd_ptrs: &[*const c_void],
+    bp_ptrs: &[*mut c_void],
+) -> ExecutableHandle {
+    unsafe {
         // Build FFI slices for tables
         let ident_slices: Vec<FFIUtf16Slice> = generator
             .identifier_table
@@ -682,7 +723,7 @@ pub unsafe fn create_executable_with_dependencies(
         let constants_buffer = encode_constants(&generator.constants);
 
         // Build FFI exception handlers
-        let ffi_handlers: Vec<FFIExceptionHandler> = assembled
+        let ffi_handlers: Vec<FFIExceptionHandler> = parts
             .exception_handlers
             .iter()
             .map(|h| FFIExceptionHandler {
@@ -693,7 +734,7 @@ pub unsafe fn create_executable_with_dependencies(
             .collect();
 
         // Build FFI source map
-        let ffi_source_map: Vec<FFISourceMapEntry> = assembled
+        let ffi_source_map: Vec<FFISourceMapEntry> = parts
             .source_map
             .iter()
             .map(|e| FFISourceMapEntry {
@@ -711,8 +752,8 @@ pub unsafe fn create_executable_with_dependencies(
             .collect();
 
         let ffi_data = FFIExecutableData {
-            bytecode: assembled.bytecode.as_ptr(),
-            bytecode_length: assembled.bytecode.len(),
+            bytecode: parts.bytecode.as_ptr(),
+            bytecode_length: parts.bytecode.len(),
             identifier_table: ident_slices.as_ptr(),
             identifier_count: ident_slices.len(),
             property_key_table: property_key_slices.as_ptr(),
@@ -726,8 +767,8 @@ pub unsafe fn create_executable_with_dependencies(
             exception_handler_count: ffi_handlers.len(),
             source_map: ffi_source_map.as_ptr(),
             source_map_count: ffi_source_map.len(),
-            basic_block_offsets: assembled.basic_block_start_offsets.as_ptr(),
-            basic_block_count: assembled.basic_block_start_offsets.len(),
+            basic_block_offsets: parts.basic_block_start_offsets.as_ptr(),
+            basic_block_count: parts.basic_block_start_offsets.len(),
             local_variable_names: local_var_slices.as_ptr(),
             local_variable_count: local_var_slices.len(),
             property_lookup_cache_count: generator.next_property_lookup_cache,
@@ -735,8 +776,8 @@ pub unsafe fn create_executable_with_dependencies(
             template_object_cache_count: generator.next_template_object_cache,
             object_shape_cache_count: generator.next_object_shape_cache,
             object_property_iterator_cache_count: generator.next_object_property_iterator_cache,
-            number_of_registers: assembled.number_of_registers,
-            number_of_arguments: assembled.number_of_arguments,
+            number_of_registers: parts.number_of_registers,
+            number_of_arguments: parts.number_of_arguments,
             is_strict: generator.strict,
             length_identifier: FFIOptionalU32::from(generator.length_identifier.map(|index| index.0)),
             shared_function_data: sfd_ptrs.as_ptr(),

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -12,6 +12,8 @@
 
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::ops::Range;
+use std::rc::Rc;
 
 use crate::bytecode::basic_block::SourceMapEntry;
 use crate::bytecode::ffi::{
@@ -67,7 +69,32 @@ pub(crate) fn decode_blob(
     expected_program_type: ast::ProgramType,
     expected_source_hash: &[u8; SOURCE_HASH_SIZE],
 ) -> Option<DecodedCacheBlob> {
-    let mut decoder = Decoder::new(bytes);
+    decode_blob_impl(bytes, expected_program_type, expected_source_hash, None)
+}
+
+pub(crate) type FreeBytecodeCacheBlobOwner = unsafe extern "C" fn(*mut c_void);
+
+pub(crate) struct ForeignBytecodeCacheBlobOwner {
+    pub(crate) owner: *mut c_void,
+    pub(crate) free_owner: FreeBytecodeCacheBlobOwner,
+}
+
+pub(crate) fn decode_blob_with_foreign_owner(
+    bytes: &[u8],
+    expected_program_type: ast::ProgramType,
+    expected_source_hash: &[u8; SOURCE_HASH_SIZE],
+    owner: ForeignBytecodeCacheBlobOwner,
+) -> Option<DecodedCacheBlob> {
+    decode_blob_impl(bytes, expected_program_type, expected_source_hash, Some(owner))
+}
+
+fn decode_blob_impl(
+    bytes: &[u8],
+    expected_program_type: ast::ProgramType,
+    expected_source_hash: &[u8; SOURCE_HASH_SIZE],
+    owner: Option<ForeignBytecodeCacheBlobOwner>,
+) -> Option<DecodedCacheBlob> {
+    let mut decoder = Decoder::new(bytes, owner);
     let blob = CacheBlob::decode(&mut decoder, expected_program_type, expected_source_hash)?;
     if !decoder.is_empty() {
         return None;
@@ -105,13 +132,42 @@ impl Encoder {
     }
 }
 
+struct ForeignBytecodeCacheBlob {
+    data: *const u8,
+    length: usize,
+    owner: *mut c_void,
+    free_owner: FreeBytecodeCacheBlobOwner,
+}
+
+impl Drop for ForeignBytecodeCacheBlob {
+    fn drop(&mut self) {
+        unsafe {
+            (self.free_owner)(self.owner);
+        }
+    }
+}
+
 struct Decoder<'a> {
     bytes: &'a [u8],
+    offset: usize,
+    foreign_blob: Option<Rc<ForeignBytecodeCacheBlob>>,
 }
 
 impl<'a> Decoder<'a> {
-    fn new(bytes: &'a [u8]) -> Self {
-        Self { bytes }
+    fn new(bytes: &'a [u8], owner: Option<ForeignBytecodeCacheBlobOwner>) -> Self {
+        let foreign_blob = owner.map(|owner| {
+            Rc::new(ForeignBytecodeCacheBlob {
+                data: bytes.as_ptr(),
+                length: bytes.len(),
+                owner: owner.owner,
+                free_owner: owner.free_owner,
+            })
+        });
+        Self {
+            bytes,
+            offset: 0,
+            foreign_blob,
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -125,7 +181,21 @@ impl<'a> Decoder<'a> {
 
         let (bytes, rest) = self.bytes.split_at(length);
         self.bytes = rest;
+        self.offset = self.offset.checked_add(length)?;
         Some(bytes)
+    }
+
+    fn bytecode_bytes(&mut self, length: usize) -> Option<DecodedBytecodeBytes> {
+        let offset = self.offset;
+        let bytes = self.bytes(length)?;
+        if let Some(foreign_blob) = &self.foreign_blob {
+            return Some(DecodedBytecodeBytes::Foreign {
+                blob: foreign_blob.clone(),
+                range: offset..offset + length,
+            });
+        }
+
+        Some(DecodedBytecodeBytes::Owned(bytes.to_vec()))
     }
 
     fn expect_bytes(&mut self, expected: &[u8]) -> Option<()> {
@@ -300,6 +370,35 @@ impl ByteVector {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<u8>> {
         let length: usize = u32::decode(decoder)?.try_into().ok()?;
         Some(decoder.bytes(length)?.to_vec())
+    }
+}
+
+enum DecodedBytecodeBytes {
+    Owned(Vec<u8>),
+    Foreign {
+        blob: Rc<ForeignBytecodeCacheBlob>,
+        range: Range<usize>,
+    },
+}
+
+impl DecodedBytecodeBytes {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        let length: usize = u32::decode(decoder)?.try_into().ok()?;
+        decoder.bytecode_bytes(length)
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Owned(bytes) => bytes,
+            Self::Foreign { blob, range } => {
+                debug_assert!(range.end <= blob.length);
+                unsafe { std::slice::from_raw_parts(blob.data.add(range.start), range.len()) }
+            }
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.as_slice().len()
     }
 }
 
@@ -792,23 +891,41 @@ unsafe fn materialize_executable(
     source_code_ptr: *const c_void,
 ) -> *mut c_void {
     unsafe {
-        let mut generator = Generator::new();
-        generator.strict = executable.strict;
-        generator.this_value_needs_environment_resolution = executable.this_value_needs_environment_resolution;
-        generator.next_property_lookup_cache = executable.cache_counters.property_lookup_cache_count;
-        generator.next_global_variable_cache = executable.cache_counters.global_variable_cache_count;
-        generator.next_template_object_cache = executable.cache_counters.template_object_cache_count;
-        generator.next_object_shape_cache = executable.cache_counters.object_shape_cache_count;
-        generator.next_object_property_iterator_cache = executable.cache_counters.object_property_iterator_cache_count;
-        generator.identifier_table = executable.identifier_table;
-        generator.property_key_table = executable.property_key_table;
-        generator.string_table = executable.string_table;
-        generator.constants = executable.constants;
-        generator.local_variables = executable.local_variables;
-        generator.length_identifier = executable.length_identifier.map(PropertyKeyTableIndex);
+        let DecodedExecutableRecord {
+            strict,
+            number_of_registers,
+            number_of_arguments,
+            cache_counters,
+            this_value_needs_environment_resolution,
+            length_identifier,
+            bytecode,
+            identifier_table,
+            property_key_table,
+            string_table,
+            constants,
+            exception_handlers,
+            source_map,
+            local_variables,
+            shared_functions,
+            class_blueprints,
+        } = executable;
 
-        let sfd_ptrs: Vec<*const c_void> = executable
-            .shared_functions
+        let mut generator = Generator::new();
+        generator.strict = strict;
+        generator.this_value_needs_environment_resolution = this_value_needs_environment_resolution;
+        generator.next_property_lookup_cache = cache_counters.property_lookup_cache_count;
+        generator.next_global_variable_cache = cache_counters.global_variable_cache_count;
+        generator.next_template_object_cache = cache_counters.template_object_cache_count;
+        generator.next_object_shape_cache = cache_counters.object_shape_cache_count;
+        generator.next_object_property_iterator_cache = cache_counters.object_property_iterator_cache_count;
+        generator.identifier_table = identifier_table;
+        generator.property_key_table = property_key_table;
+        generator.string_table = string_table;
+        generator.constants = constants;
+        generator.local_variables = local_variables;
+        generator.length_identifier = length_identifier.map(PropertyKeyTableIndex);
+
+        let sfd_ptrs: Vec<*const c_void> = shared_functions
             .into_iter()
             .map(|function| materialize_function(function, generator.strict, vm_ptr, source_code_ptr) as *const c_void)
             .collect();
@@ -816,11 +933,8 @@ unsafe fn materialize_executable(
             return std::ptr::null_mut();
         }
 
-        let class_blueprints: Vec<PendingClassBlueprint> = executable
-            .class_blueprints
-            .into_iter()
-            .map(PendingClassBlueprint::from)
-            .collect();
+        let class_blueprints: Vec<PendingClassBlueprint> =
+            class_blueprints.into_iter().map(PendingClassBlueprint::from).collect();
         let bp_ptrs: Vec<*mut c_void> = class_blueprints
             .iter()
             .map(|blueprint| crate::bytecode::ffi::materialize_class_blueprint(blueprint, vm_ptr, source_code_ptr))
@@ -829,18 +943,16 @@ unsafe fn materialize_executable(
             return std::ptr::null_mut();
         }
 
-        let assembled = AssembledBytecode {
-            bytecode: executable.bytecode,
-            source_map: executable.source_map,
-            exception_handlers: executable.exception_handlers,
-            basic_block_start_offsets: Vec::new(),
-            number_of_registers: executable.number_of_registers,
-            number_of_arguments: executable.number_of_arguments,
-        };
-
-        crate::bytecode::ffi::create_executable_with_dependencies(
+        crate::bytecode::ffi::create_executable_with_dependencies_from_parts(
             &generator,
-            &assembled,
+            crate::bytecode::ffi::ExecutableParts {
+                bytecode: bytecode.as_slice(),
+                exception_handlers: &exception_handlers,
+                source_map: &source_map,
+                basic_block_start_offsets: &[],
+                number_of_registers,
+                number_of_arguments,
+            },
             vm_ptr,
             source_code_ptr,
             &sfd_ptrs,
@@ -1918,7 +2030,7 @@ impl ExecutableRecord<'_> {
             cache_counters: CacheCounters::decode(decoder)?,
             this_value_needs_environment_resolution: bool::decode(decoder)?,
             length_identifier: Option::<u32>::decode(decoder)?,
-            bytecode: ByteVector::decode(decoder)?,
+            bytecode: DecodedBytecodeBytes::decode(decoder)?,
             identifier_table: Utf16Table::decode(decoder)?,
             property_key_table: Utf16Table::decode(decoder)?,
             string_table: Utf16Table::decode(decoder)?,
@@ -1939,7 +2051,7 @@ struct DecodedExecutableRecord {
     cache_counters: DecodedCacheCounters,
     this_value_needs_environment_resolution: bool,
     length_identifier: Option<u32>,
-    bytecode: Vec<u8>,
+    bytecode: DecodedBytecodeBytes,
     identifier_table: Vec<ast::Utf16String>,
     property_key_table: Vec<ast::Utf16String>,
     string_table: Vec<ast::Utf16String>,
@@ -2012,8 +2124,14 @@ impl DecodedExecutableRecord {
             .collect();
         let source_map_offsets: Vec<u32> = self.source_map.iter().map(|entry| entry.bytecode_offset).collect();
 
-        validate_bytecode(&self.bytecode, &bounds, &[], &exception_handlers, &source_map_offsets)
-            .map_err(|error| error.kind)?;
+        validate_bytecode(
+            self.bytecode.as_slice(),
+            &bounds,
+            &[],
+            &exception_handlers,
+            &source_map_offsets,
+        )
+        .map_err(|error| error.kind)?;
 
         for function in &self.shared_functions {
             function.precompiled.validate_cached_bytecode()?;

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -1067,10 +1067,10 @@ unsafe fn materialize_executable(
             .map(|value| value.to_utf16_string())
             .collect();
         generator.string_table = string_table.into_iter().map(|value| value.to_utf16_string()).collect();
-        generator.constants = constants
-            .into_iter()
-            .map(DecodedConstantValue::into_constant_value)
-            .collect();
+        let Some(constants) = constants.into_constant_values() else {
+            return std::ptr::null_mut();
+        };
+        generator.constants = constants;
         generator.local_variables = local_variables
             .into_iter()
             .map(DecodedLocalVariable::into_local_variable)
@@ -2207,7 +2207,7 @@ struct DecodedExecutableRecord {
     identifier_table: Vec<DecodedUtf16String>,
     property_key_table: Vec<DecodedUtf16String>,
     string_table: Vec<DecodedUtf16String>,
-    constants: Vec<DecodedConstantValue>,
+    constants: DecodedConstantTable,
     exception_handlers: Vec<ExceptionHandler>,
     source_map: Vec<SourceMapEntry>,
     local_variables: Vec<DecodedLocalVariable>,
@@ -2372,13 +2372,44 @@ struct ConstantTable<'a>(&'a [ConstantValue]);
 
 impl Encode for ConstantTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(self.0, |constant, encoder| constant.encode(encoder));
+        u32_from_usize(self.0.len()).encode(encoder);
+
+        let mut constant_encoder = Encoder::new();
+        for constant in self.0 {
+            constant.encode(&mut constant_encoder);
+        }
+        Bytes(&constant_encoder.finish()).encode(encoder);
     }
 }
 
 impl ConstantTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedConstantValue>> {
-        decoder.sequence_values(DecodedConstantValue::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedConstantTable> {
+        let count: usize = u32::decode(decoder)?.try_into().ok()?;
+        let byte_length: usize = u32::decode(decoder)?.try_into().ok()?;
+        Some(DecodedConstantTable {
+            count,
+            bytes: decoder.bytecode_bytes(byte_length)?,
+        })
+    }
+}
+
+struct DecodedConstantTable {
+    count: usize,
+    bytes: DecodedBytecodeBytes,
+}
+
+impl DecodedConstantTable {
+    fn len(&self) -> usize {
+        self.count
+    }
+
+    fn into_constant_values(self) -> Option<Vec<ConstantValue>> {
+        let mut decoder = Decoder::new(self.bytes.as_slice(), None);
+        let mut constants = Vec::with_capacity(self.count);
+        for _ in 0..self.count {
+            constants.push(DecodedConstantValue::decode(&mut decoder)?.into_constant_value());
+        }
+        decoder.is_empty().then_some(constants)
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -355,6 +355,75 @@ impl Decode for ast::Utf16String {
     }
 }
 
+enum DecodedUtf16String {
+    Owned(ast::Utf16String),
+    // The surrounding decoded executable keeps the mapped blob alive through its
+    // DecodedBytecodeBytes. Store only the payload pointer here so large string
+    // tables do not clone an owner handle for every string.
+    Foreign { data: *const u8, length: usize },
+}
+
+impl Decode for DecodedUtf16String {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        let length: usize = u32::decode(decoder)?.try_into().ok()?;
+        let byte_length = length.checked_mul(size_of::<u16>())?;
+        let bytes = decoder.bytes(byte_length)?;
+        if decoder.foreign_blob.is_some() {
+            return Some(Self::Foreign {
+                data: bytes.as_ptr(),
+                length,
+            });
+        }
+
+        let mut code_units = Vec::with_capacity(length);
+        for chunk in bytes.chunks_exact(size_of::<u16>()) {
+            code_units.push(u16::from_le_bytes(chunk.try_into().ok()?));
+        }
+        Some(Self::Owned(code_units.into()))
+    }
+}
+
+impl From<ast::Utf16String> for DecodedUtf16String {
+    fn from(value: ast::Utf16String) -> Self {
+        Self::Owned(value)
+    }
+}
+
+impl DecodedUtf16String {
+    fn len(&self) -> usize {
+        match self {
+            Self::Owned(value) => value.len(),
+            Self::Foreign { length, .. } => *length,
+        }
+    }
+
+    fn to_vec(&self) -> Vec<u16> {
+        match self {
+            Self::Owned(value) => value.to_vec(),
+            Self::Foreign { data, length } => {
+                let bytes = unsafe { std::slice::from_raw_parts(*data, length * size_of::<u16>()) };
+                bytes
+                    .chunks_exact(size_of::<u16>())
+                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                    .collect()
+            }
+        }
+    }
+
+    fn to_utf16_string(&self) -> ast::Utf16String {
+        self.to_vec().into()
+    }
+}
+
+fn utf16_slice_storage(strings: &[DecodedUtf16String]) -> (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) {
+    let storage: Vec<Vec<u16>> = strings.iter().map(DecodedUtf16String::to_vec).collect();
+    let slices = storage
+        .iter()
+        .map(|string| FFIUtf16Slice::from(string.as_slice()))
+        .collect();
+    (storage, slices)
+}
+
 struct Bytes<'a>(&'a [u8]);
 
 impl Encode for Bytes<'_> {
@@ -798,13 +867,13 @@ unsafe fn materialize_function(
             return std::ptr::null_mut();
         }
 
-        let parameter_names: Vec<FFIUtf16Slice> = function
+        let (_parameter_name_storage, parameter_names): (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) = function
             .parameter_names
             .as_ref()
-            .map(|names| names.iter().map(|name| FFIUtf16Slice::from(name.as_ref())).collect())
+            .map(|names| utf16_slice_storage(names))
             .unwrap_or_default();
-        let (name, name_len) = function
-            .name
+        let name_storage = function.name.as_ref().map(DecodedUtf16String::to_vec);
+        let (name, name_len) = name_storage
             .as_ref()
             .map(|name| (name.as_ptr(), name.len()))
             .unwrap_or((std::ptr::null(), 0));
@@ -839,10 +908,11 @@ unsafe fn materialize_function(
         }
 
         if let Some((name, is_private)) = &function.class_field_initializer_name {
+            let name_storage = name.to_vec();
             crate::bytecode::ffi::rust_sfd_set_class_field_initializer_name(
                 sfd_ptr,
-                name.as_ptr(),
-                name.len(),
+                name_storage.as_ptr(),
+                name_storage.len(),
                 *is_private,
             );
         }
@@ -918,11 +988,23 @@ unsafe fn materialize_executable(
         generator.next_template_object_cache = cache_counters.template_object_cache_count;
         generator.next_object_shape_cache = cache_counters.object_shape_cache_count;
         generator.next_object_property_iterator_cache = cache_counters.object_property_iterator_cache_count;
-        generator.identifier_table = identifier_table;
-        generator.property_key_table = property_key_table;
-        generator.string_table = string_table;
-        generator.constants = constants;
-        generator.local_variables = local_variables;
+        generator.identifier_table = identifier_table
+            .into_iter()
+            .map(|value| value.to_utf16_string())
+            .collect();
+        generator.property_key_table = property_key_table
+            .into_iter()
+            .map(|value| value.to_utf16_string())
+            .collect();
+        generator.string_table = string_table.into_iter().map(|value| value.to_utf16_string()).collect();
+        generator.constants = constants
+            .into_iter()
+            .map(DecodedConstantValue::into_constant_value)
+            .collect();
+        generator.local_variables = local_variables
+            .into_iter()
+            .map(DecodedLocalVariable::into_local_variable)
+            .collect();
         generator.length_identifier = length_identifier.map(PropertyKeyTableIndex);
 
         let sfd_ptrs: Vec<*const c_void> = shared_functions
@@ -2052,13 +2134,13 @@ struct DecodedExecutableRecord {
     this_value_needs_environment_resolution: bool,
     length_identifier: Option<u32>,
     bytecode: DecodedBytecodeBytes,
-    identifier_table: Vec<ast::Utf16String>,
-    property_key_table: Vec<ast::Utf16String>,
-    string_table: Vec<ast::Utf16String>,
-    constants: Vec<ConstantValue>,
+    identifier_table: Vec<DecodedUtf16String>,
+    property_key_table: Vec<DecodedUtf16String>,
+    string_table: Vec<DecodedUtf16String>,
+    constants: Vec<DecodedConstantValue>,
     exception_handlers: Vec<ExceptionHandler>,
     source_map: Vec<SourceMapEntry>,
-    local_variables: Vec<LocalVariable>,
+    local_variables: Vec<DecodedLocalVariable>,
     shared_functions: Vec<DecodedFunctionRecord>,
     class_blueprints: Vec<DecodedClassBlueprintRecord>,
 }
@@ -2211,8 +2293,8 @@ impl Encode for Utf16Table<'_> {
 }
 
 impl Utf16Table<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ast::Utf16String>> {
-        decoder.sequence_values(ast::Utf16String::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedUtf16String>> {
+        decoder.sequence_values(DecodedUtf16String::decode)
     }
 }
 
@@ -2225,8 +2307,8 @@ impl Encode for ConstantTable<'_> {
 }
 
 impl ConstantTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ConstantValue>> {
-        decoder.sequence_values(ConstantValue::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedConstantValue>> {
+        decoder.sequence_values(DecodedConstantValue::decode)
     }
 }
 
@@ -2289,6 +2371,63 @@ impl Decode for ConstantValue {
                 _ => None,
             },
             _ => None,
+        }
+    }
+}
+
+enum DecodedConstantValue {
+    Number(f64),
+    Boolean(bool),
+    Null,
+    Undefined,
+    Empty,
+    String(DecodedUtf16String),
+    BigInt(String),
+    WellKnownSymbol(WellKnownSymbolKind),
+    AbstractOperation(AbstractOperationKind),
+}
+
+impl DecodedConstantValue {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        match u8::decode(decoder)? {
+            tag if tag == ConstantTag::Number as u8 => Some(Self::Number(f64::decode(decoder)?)),
+            tag if tag == ConstantTag::BooleanTrue as u8 => Some(Self::Boolean(true)),
+            tag if tag == ConstantTag::BooleanFalse as u8 => Some(Self::Boolean(false)),
+            tag if tag == ConstantTag::Null as u8 => Some(Self::Null),
+            tag if tag == ConstantTag::Undefined as u8 => Some(Self::Undefined),
+            tag if tag == ConstantTag::Empty as u8 => Some(Self::Empty),
+            tag if tag == ConstantTag::String as u8 => Some(Self::String(DecodedUtf16String::decode(decoder)?)),
+            tag if tag == ConstantTag::BigInt as u8 => {
+                Some(Self::BigInt(String::from_utf8(ByteVector::decode(decoder)?).ok()?))
+            }
+            tag if tag == ConstantTag::WellKnownSymbol as u8 => match u8::decode(decoder)? {
+                0 => Some(Self::WellKnownSymbol(WellKnownSymbolKind::SymbolIterator)),
+                1 => Some(Self::WellKnownSymbol(WellKnownSymbolKind::SymbolAsyncIterator)),
+                _ => None,
+            },
+            tag if tag == ConstantTag::AbstractOperation as u8 => match u8::decode(decoder)? {
+                0 => Some(Self::AbstractOperation(AbstractOperationKind::AsyncIteratorClose)),
+                1 => Some(Self::AbstractOperation(AbstractOperationKind::GetMethod)),
+                2 => Some(Self::AbstractOperation(AbstractOperationKind::GetIteratorDirect)),
+                3 => Some(Self::AbstractOperation(AbstractOperationKind::GetIteratorFromMethod)),
+                4 => Some(Self::AbstractOperation(AbstractOperationKind::IteratorComplete)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn into_constant_value(self) -> ConstantValue {
+        match self {
+            Self::Number(value) => ConstantValue::Number(value),
+            Self::Boolean(value) => ConstantValue::Boolean(value),
+            Self::Null => ConstantValue::Null,
+            Self::Undefined => ConstantValue::Undefined,
+            Self::Empty => ConstantValue::Empty,
+            Self::String(value) => ConstantValue::String(value.to_utf16_string()),
+            Self::BigInt(value) => ConstantValue::BigInt(value),
+            Self::WellKnownSymbol(value) => ConstantValue::WellKnownSymbol(value),
+            Self::AbstractOperation(value) => ConstantValue::AbstractOperation(value),
         }
     }
 }
@@ -2356,14 +2495,30 @@ impl Encode for LocalVariableTable<'_> {
 }
 
 impl LocalVariableTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<LocalVariable>> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedLocalVariable>> {
         decoder.sequence_values(|decoder| {
-            Some(LocalVariable {
-                name: ast::Utf16String::decode(decoder)?,
+            Some(DecodedLocalVariable {
+                name: DecodedUtf16String::decode(decoder)?,
                 is_lexically_declared: bool::decode(decoder)?,
                 is_initialized_during_declaration_instantiation: bool::decode(decoder)?,
             })
         })
+    }
+}
+
+struct DecodedLocalVariable {
+    name: DecodedUtf16String,
+    is_lexically_declared: bool,
+    is_initialized_during_declaration_instantiation: bool,
+}
+
+impl DecodedLocalVariable {
+    fn into_local_variable(self) -> LocalVariable {
+        LocalVariable {
+            name: self.name.to_utf16_string(),
+            is_lexically_declared: self.is_lexically_declared,
+            is_initialized_during_declaration_instantiation: self.is_initialized_during_declaration_instantiation,
+        }
     }
 }
 
@@ -2452,7 +2607,7 @@ impl Encode for FunctionRecord<'_> {
 impl FunctionRecord<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedFunctionRecord> {
         Some(DecodedFunctionRecord {
-            name: Option::<ast::Utf16String>::decode(decoder)?,
+            name: Option::<DecodedUtf16String>::decode(decoder)?,
             source_text_start: u32::decode(decoder)?,
             source_text_end: u32::decode(decoder)?,
             function_length: i32::decode(decoder)?,
@@ -2471,7 +2626,7 @@ impl FunctionRecord<'_> {
 }
 
 struct DecodedFunctionRecord {
-    name: Option<ast::Utf16String>,
+    name: Option<DecodedUtf16String>,
     source_text_start: u32,
     source_text_end: u32,
     function_length: i32,
@@ -2479,17 +2634,17 @@ struct DecodedFunctionRecord {
     kind: ast::FunctionKind,
     is_strict_mode: bool,
     is_arrow_function: bool,
-    parameter_names: Option<Vec<ast::Utf16String>>,
+    parameter_names: Option<Vec<DecodedUtf16String>>,
     uses_this: bool,
     uses_this_from_environment: bool,
-    class_field_initializer_name: Option<(ast::Utf16String, bool)>,
+    class_field_initializer_name: Option<(DecodedUtf16String, bool)>,
     metadata: FunctionSfdMetadata,
     precompiled: DecodedExecutableRecord,
 }
 
 impl DecodedFunctionRecord {
     fn validate(&self) {
-        let _ = self.name.as_ref().map(|name| name.as_slice().len());
+        let _ = self.name.as_ref().map(DecodedUtf16String::len);
         let _ = self.source_text_start;
         let _ = self.source_text_end;
         let _ = self.formal_parameter_count;
@@ -2497,10 +2652,7 @@ impl DecodedFunctionRecord {
         let _ = self.kind as u8;
         let _ = self.is_strict_mode || self.is_arrow_function || self.uses_this || self.uses_this_from_environment;
         let _ = self.parameter_names.as_ref().map(|names| names.len());
-        let _ = self
-            .class_field_initializer_name
-            .as_ref()
-            .map(|(name, _)| name.as_slice().len());
+        let _ = self.class_field_initializer_name.as_ref().map(|(name, _)| name.len());
         self.precompiled.validate();
         validate_function_metadata(&self.metadata);
     }
@@ -2541,9 +2693,9 @@ impl Encode for SimpleParameterList<'_> {
 }
 
 impl SimpleParameterList<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Option<Vec<ast::Utf16String>>> {
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Option<Vec<DecodedUtf16String>>> {
         if bool::decode(decoder)? {
-            Some(Some(decoder.sequence_values(ast::Utf16String::decode)?))
+            Some(Some(decoder.sequence_values(DecodedUtf16String::decode)?))
         } else {
             Some(None)
         }
@@ -2580,8 +2732,8 @@ impl Encode for ClassFieldInitializerName<'_> {
 }
 
 impl ClassFieldInitializerName<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Option<(ast::Utf16String, bool)>> {
-        Option::<(ast::Utf16String, bool)>::decode(decoder)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Option<(DecodedUtf16String, bool)>> {
+        Option::<(DecodedUtf16String, bool)>::decode(decoder)
     }
 }
 
@@ -2592,9 +2744,9 @@ impl Encode for (Utf16<'_>, bool) {
     }
 }
 
-impl Decode for (ast::Utf16String, bool) {
+impl Decode for (DecodedUtf16String, bool) {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
-        Some((ast::Utf16String::decode(decoder)?, bool::decode(decoder)?))
+        Some((DecodedUtf16String::decode(decoder)?, bool::decode(decoder)?))
     }
 }
 
@@ -2686,7 +2838,7 @@ impl Encode for ClassBlueprintRecord<'_> {
 impl ClassBlueprintRecord<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedClassBlueprintRecord> {
         Some(DecodedClassBlueprintRecord {
-            name: Option::<ast::Utf16String>::decode(decoder)?,
+            name: Option::<DecodedUtf16String>::decode(decoder)?,
             source_text_offset: usize::decode(decoder)?,
             source_text_length: usize::decode(decoder)?,
             constructor_sfd_index: u32::decode(decoder)?,
@@ -2698,7 +2850,7 @@ impl ClassBlueprintRecord<'_> {
 }
 
 struct DecodedClassBlueprintRecord {
-    name: Option<ast::Utf16String>,
+    name: Option<DecodedUtf16String>,
     source_text_offset: usize,
     source_text_length: usize,
     constructor_sfd_index: u32,
@@ -2709,7 +2861,7 @@ struct DecodedClassBlueprintRecord {
 
 impl DecodedClassBlueprintRecord {
     fn validate(&self) {
-        let _ = self.name.as_ref().map(|name| name.as_slice().len());
+        let _ = self.name.as_ref().map(DecodedUtf16String::len);
         let _ = self.source_text_offset;
         let _ = self.source_text_length;
         let _ = self.constructor_sfd_index;
@@ -2735,7 +2887,7 @@ impl DecodedClassBlueprintRecord {
 impl From<DecodedClassBlueprintRecord> for PendingClassBlueprint {
     fn from(record: DecodedClassBlueprintRecord) -> Self {
         Self {
-            name: record.name,
+            name: record.name.map(|name| name.to_utf16_string()),
             source_text_offset: record.source_text_offset,
             source_text_length: record.source_text_length,
             constructor_sfd_index: record.constructor_sfd_index,
@@ -2768,12 +2920,12 @@ impl ClassElementRecord<'_> {
             kind: u8::decode(decoder)?,
             is_static: bool::decode(decoder)?,
             is_private: bool::decode(decoder)?,
-            private_identifier: Option::<ast::Utf16String>::decode(decoder)?,
+            private_identifier: Option::<DecodedUtf16String>::decode(decoder)?,
             shared_function_data_index: Option::<u32>::decode(decoder)?,
             has_initializer: bool::decode(decoder)?,
             literal_value_kind: PendingLiteralValueKind::decode(decoder)?,
             literal_value_number: f64::decode(decoder)?,
-            literal_value_string: Option::<ast::Utf16String>::decode(decoder)?,
+            literal_value_string: Option::<DecodedUtf16String>::decode(decoder)?,
         })
     }
 }
@@ -2782,23 +2934,23 @@ struct DecodedClassElementRecord {
     kind: u8,
     is_static: bool,
     is_private: bool,
-    private_identifier: Option<ast::Utf16String>,
+    private_identifier: Option<DecodedUtf16String>,
     shared_function_data_index: Option<u32>,
     has_initializer: bool,
     literal_value_kind: PendingLiteralValueKind,
     literal_value_number: f64,
-    literal_value_string: Option<ast::Utf16String>,
+    literal_value_string: Option<DecodedUtf16String>,
 }
 
 impl DecodedClassElementRecord {
     fn validate(&self) {
         let _ = self.kind;
         let _ = self.is_static || self.is_private || self.has_initializer;
-        let _ = self.private_identifier.as_ref().map(|name| name.as_slice().len());
+        let _ = self.private_identifier.as_ref().map(DecodedUtf16String::len);
         let _ = self.shared_function_data_index;
         let _ = literal_value_kind_tag(self.literal_value_kind);
         let _ = self.literal_value_number;
-        let _ = self.literal_value_string.as_ref().map(|value| value.as_slice().len());
+        let _ = self.literal_value_string.as_ref().map(DecodedUtf16String::len);
     }
 
     fn indices_are_valid(&self, shared_function_count: usize) -> bool {
@@ -2828,12 +2980,12 @@ impl From<DecodedClassElementRecord> for PendingClassElement {
             kind: record.kind,
             is_static: record.is_static,
             is_private: record.is_private,
-            private_identifier: record.private_identifier,
+            private_identifier: record.private_identifier.map(|identifier| identifier.to_utf16_string()),
             shared_function_data_index: record.shared_function_data_index,
             has_initializer: record.has_initializer,
             literal_value_kind: record.literal_value_kind,
             literal_value_number: record.literal_value_number,
-            literal_value_string: record.literal_value_string,
+            literal_value_string: record.literal_value_string.map(|value| value.to_utf16_string()),
         }
     }
 }
@@ -2871,7 +3023,7 @@ mod tests {
     fn sequence_decode_rejects_lengths_larger_than_remaining_bytes() {
         let bytes = u32::MAX.to_le_bytes();
 
-        let mut decoder = Decoder::new(&bytes);
+        let mut decoder = Decoder::new(&bytes, None);
         assert!(decoder.sequence_values(u8::decode).is_none());
     }
 
@@ -2881,7 +3033,7 @@ mod tests {
         bytes.extend_from_slice(&4u32.to_le_bytes());
         bytes.extend_from_slice(&[1, 2, 3]);
 
-        let mut decoder = Decoder::new(&bytes);
+        let mut decoder = Decoder::new(&bytes, None);
         assert!(decoder.sequence_values(u8::decode).is_none());
     }
 
@@ -2897,5 +3049,27 @@ mod tests {
         bytes.extend_from_slice(&stored_source_hash);
 
         assert!(decode_blob(&bytes, ast::ProgramType::Script, &expected_source_hash).is_none());
+    }
+
+    unsafe extern "C" fn ignore_foreign_owner(_: *mut c_void) {}
+
+    #[test]
+    fn utf16_decode_borrows_from_foreign_blob() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&0x41u16.to_le_bytes());
+        bytes.extend_from_slice(&0x2262u16.to_le_bytes());
+        bytes.extend_from_slice(&0x0391u16.to_le_bytes());
+
+        let mut decoder = Decoder::new(
+            &bytes,
+            Some(ForeignBytecodeCacheBlobOwner {
+                owner: std::ptr::null_mut(),
+                free_owner: ignore_foreign_owner,
+            }),
+        );
+        let decoded = DecodedUtf16String::decode(&mut decoder).unwrap();
+        assert!(matches!(decoded, DecodedUtf16String::Foreign { .. }));
+        assert_eq!(decoded.to_vec(), vec![0x41, 0x2262, 0x0391]);
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -31,7 +31,7 @@ use crate::bytecode::validator::{
 use crate::{CompiledProgram, CompiledProgramBytecode, ModuleCallbacks, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 6;
+const FORMAT_VERSION: u32 = 7;
 const SOURCE_HASH_SIZE: usize = 32;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;
 const ITERATOR_HINT_VARIANT_COUNT: u32 = 2;
@@ -541,6 +541,58 @@ impl DecodedBytecodeBytes {
 
     fn len(&self) -> usize {
         self.as_slice().len()
+    }
+
+    fn decoder(&self) -> Decoder<'_> {
+        match self {
+            Self::Owned(bytes) => Decoder {
+                bytes,
+                offset: 0,
+                foreign_blob: None,
+            },
+            Self::Foreign { blob, range } => Decoder {
+                bytes: self.as_slice(),
+                offset: range.start,
+                foreign_blob: Some(blob.clone()),
+            },
+        }
+    }
+}
+
+struct DecodedRecordSequence {
+    count: usize,
+    bytes: DecodedBytecodeBytes,
+}
+
+impl DecodedRecordSequence {
+    fn encode<T>(encoder: &mut Encoder, items: &[T], mut encode_item: impl FnMut(&T, &mut Encoder)) {
+        u32_from_usize(items.len()).encode(encoder);
+
+        let mut payload_encoder = Encoder::new();
+        for item in items {
+            encode_item(item, &mut payload_encoder);
+        }
+
+        encoder.align_to(align_of::<u16>());
+        Bytes(&payload_encoder.finish()).encode(encoder);
+    }
+
+    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        let count: usize = u32::decode(decoder)?.try_into().ok()?;
+        decoder.align_to(align_of::<u16>())?;
+        let byte_length: usize = u32::decode(decoder)?.try_into().ok()?;
+        Some(Self {
+            count,
+            bytes: decoder.bytecode_bytes(byte_length)?,
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.count
+    }
+
+    fn decoder(&self) -> Decoder<'_> {
+        self.bytes.decoder()
     }
 }
 
@@ -1058,25 +1110,40 @@ unsafe fn materialize_executable(
         generator.next_template_object_cache = cache_counters.template_object_cache_count;
         generator.next_object_shape_cache = cache_counters.object_shape_cache_count;
         generator.next_object_property_iterator_cache = cache_counters.object_property_iterator_cache_count;
+        let Some(identifier_table) = identifier_table.into_values() else {
+            return std::ptr::null_mut();
+        };
         generator.identifier_table = identifier_table
             .into_iter()
             .map(|value| value.to_utf16_string())
             .collect();
+        let Some(property_key_table) = property_key_table.into_values() else {
+            return std::ptr::null_mut();
+        };
         generator.property_key_table = property_key_table
             .into_iter()
             .map(|value| value.to_utf16_string())
             .collect();
+        let Some(string_table) = string_table.into_values() else {
+            return std::ptr::null_mut();
+        };
         generator.string_table = string_table.into_iter().map(|value| value.to_utf16_string()).collect();
         let Some(constants) = constants.into_constant_values() else {
             return std::ptr::null_mut();
         };
         generator.constants = constants;
+        let Some(local_variables) = local_variables.into_values() else {
+            return std::ptr::null_mut();
+        };
         generator.local_variables = local_variables
             .into_iter()
             .map(DecodedLocalVariable::into_local_variable)
             .collect();
         generator.length_identifier = length_identifier.map(PropertyKeyTableIndex);
 
+        let Some(shared_functions) = shared_functions.into_values() else {
+            return std::ptr::null_mut();
+        };
         let sfd_ptrs: Vec<*const c_void> = shared_functions
             .into_iter()
             .map(|function| materialize_function(function, generator.strict, vm_ptr, source_code_ptr) as *const c_void)
@@ -1085,6 +1152,9 @@ unsafe fn materialize_executable(
             return std::ptr::null_mut();
         }
 
+        let Some(class_blueprints) = class_blueprints.into_values() else {
+            return std::ptr::null_mut();
+        };
         let class_blueprints: Vec<PendingClassBlueprint> =
             class_blueprints.into_iter().map(PendingClassBlueprint::from).collect();
         let bp_ptrs: Vec<*mut c_void> = class_blueprints
@@ -1094,6 +1164,12 @@ unsafe fn materialize_executable(
         if bp_ptrs.iter().any(|ptr| ptr.is_null()) {
             return std::ptr::null_mut();
         }
+        let Some(exception_handlers) = exception_handlers.into_values() else {
+            return std::ptr::null_mut();
+        };
+        let Some(source_map) = source_map.into_values() else {
+            return std::ptr::null_mut();
+        };
 
         crate::bytecode::ffi::create_executable_with_dependencies_from_parts(
             &generator,
@@ -2204,15 +2280,15 @@ struct DecodedExecutableRecord {
     this_value_needs_environment_resolution: bool,
     length_identifier: Option<u32>,
     bytecode: DecodedBytecodeBytes,
-    identifier_table: Vec<DecodedUtf16String>,
-    property_key_table: Vec<DecodedUtf16String>,
-    string_table: Vec<DecodedUtf16String>,
+    identifier_table: DecodedUtf16Table,
+    property_key_table: DecodedUtf16Table,
+    string_table: DecodedUtf16Table,
     constants: DecodedConstantTable,
-    exception_handlers: Vec<ExceptionHandler>,
-    source_map: Vec<SourceMapEntry>,
-    local_variables: Vec<DecodedLocalVariable>,
-    shared_functions: Vec<DecodedFunctionRecord>,
-    class_blueprints: Vec<DecodedClassBlueprintRecord>,
+    exception_handlers: DecodedExceptionHandlerTable,
+    source_map: DecodedSourceMapTable,
+    local_variables: DecodedLocalVariableTable,
+    shared_functions: DecodedFunctionTable,
+    class_blueprints: DecodedClassBlueprintTable,
 }
 
 impl DecodedExecutableRecord {
@@ -2232,12 +2308,8 @@ impl DecodedExecutableRecord {
             + self.local_variables.len()
             + self.shared_functions.len()
             + self.class_blueprints.len();
-        for function in &self.shared_functions {
-            function.validate();
-        }
-        for blueprint in &self.class_blueprints {
-            blueprint.validate();
-        }
+        self.shared_functions.validate();
+        self.class_blueprints.validate();
     }
 
     fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
@@ -2265,8 +2337,11 @@ impl DecodedExecutableRecord {
             before_cache_fixup: true,
         };
 
-        let exception_handlers: Vec<FFIExceptionHandlerOffsets> = self
+        let exception_handlers = self
             .exception_handlers
+            .values()
+            .ok_or(ValidationErrorKind::InvalidLength)?;
+        let exception_handlers: Vec<FFIExceptionHandlerOffsets> = exception_handlers
             .iter()
             .map(|handler| FFIExceptionHandlerOffsets {
                 start: handler.start_offset,
@@ -2274,7 +2349,8 @@ impl DecodedExecutableRecord {
                 handler: handler.handler_offset,
             })
             .collect();
-        let source_map_offsets: Vec<u32> = self.source_map.iter().map(|entry| entry.bytecode_offset).collect();
+        let source_map = self.source_map.values().ok_or(ValidationErrorKind::InvalidLength)?;
+        let source_map_offsets: Vec<u32> = source_map.iter().map(|entry| entry.bytecode_offset).collect();
 
         validate_bytecode(
             self.bytecode.as_slice(),
@@ -2285,30 +2361,20 @@ impl DecodedExecutableRecord {
         )
         .map_err(|error| error.kind)?;
 
-        for function in &self.shared_functions {
-            function.precompiled.validate_cached_bytecode()?;
-        }
+        self.shared_functions.validate_cached_bytecode()?;
 
         Ok(())
     }
 
     fn source_ranges_are_valid(&self, source_len: usize) -> bool {
-        self.shared_functions
-            .iter()
-            .all(|function| function.source_ranges_are_valid(source_len))
-            && self
-                .class_blueprints
-                .iter()
-                .all(|blueprint| blueprint.source_range_is_valid(source_len))
+        self.shared_functions.source_ranges_are_valid(source_len)
+            && self.class_blueprints.source_ranges_are_valid(source_len)
     }
 
     fn indices_are_valid(&self) -> bool {
         self.length_identifier
             .is_none_or(|index| (index as usize) < self.property_key_table.len())
-            && self
-                .class_blueprints
-                .iter()
-                .all(|blueprint| blueprint.indices_are_valid(self.shared_functions.len()))
+            && self.class_blueprints.indices_are_valid(self.shared_functions.len())
     }
 }
 
@@ -2358,13 +2424,34 @@ struct Utf16Table<'a>(&'a [ast::Utf16String]);
 
 impl Encode for Utf16Table<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(self.0, |value, encoder| Utf16(value).encode(encoder));
+        DecodedRecordSequence::encode(encoder, self.0, |value, encoder| Utf16(value).encode(encoder));
     }
 }
 
 impl Utf16Table<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedUtf16String>> {
-        decoder.sequence_values(DecodedUtf16String::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedUtf16Table> {
+        Some(DecodedUtf16Table {
+            sequence: DecodedRecordSequence::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedUtf16Table {
+    sequence: DecodedRecordSequence,
+}
+
+impl DecodedUtf16Table {
+    fn len(&self) -> usize {
+        self.sequence.len()
+    }
+
+    fn into_values(self) -> Option<Vec<DecodedUtf16String>> {
+        let mut decoder = self.sequence.decoder();
+        let mut values = Vec::with_capacity(self.sequence.len());
+        for _ in 0..self.sequence.len() {
+            values.push(DecodedUtf16String::decode(&mut decoder)?);
+        }
+        decoder.is_empty().then_some(values)
     }
 }
 
@@ -2537,7 +2624,7 @@ struct ExceptionHandlerTable<'a>(&'a AssembledBytecode);
 
 impl Encode for ExceptionHandlerTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(&self.0.exception_handlers, |handler, encoder| {
+        DecodedRecordSequence::encode(encoder, &self.0.exception_handlers, |handler, encoder| {
             handler.start_offset.encode(encoder);
             handler.end_offset.encode(encoder);
             handler.handler_offset.encode(encoder);
@@ -2546,14 +2633,37 @@ impl Encode for ExceptionHandlerTable<'_> {
 }
 
 impl ExceptionHandlerTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<ExceptionHandler>> {
-        decoder.sequence_values(|decoder| {
-            Some(ExceptionHandler {
-                start_offset: u32::decode(decoder)?,
-                end_offset: u32::decode(decoder)?,
-                handler_offset: u32::decode(decoder)?,
-            })
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedExceptionHandlerTable> {
+        Some(DecodedExceptionHandlerTable {
+            sequence: DecodedRecordSequence::decode(decoder)?,
         })
+    }
+}
+
+struct DecodedExceptionHandlerTable {
+    sequence: DecodedRecordSequence,
+}
+
+impl DecodedExceptionHandlerTable {
+    fn len(&self) -> usize {
+        self.sequence.len()
+    }
+
+    fn values(&self) -> Option<Vec<ExceptionHandler>> {
+        let mut decoder = self.sequence.decoder();
+        let mut values = Vec::with_capacity(self.sequence.len());
+        for _ in 0..self.sequence.len() {
+            values.push(ExceptionHandler {
+                start_offset: u32::decode(&mut decoder)?,
+                end_offset: u32::decode(&mut decoder)?,
+                handler_offset: u32::decode(&mut decoder)?,
+            });
+        }
+        decoder.is_empty().then_some(values)
+    }
+
+    fn into_values(self) -> Option<Vec<ExceptionHandler>> {
+        self.values()
     }
 }
 
@@ -2561,7 +2671,7 @@ struct SourceMapTable<'a>(&'a AssembledBytecode);
 
 impl Encode for SourceMapTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(&self.0.source_map, |entry, encoder| {
+        DecodedRecordSequence::encode(encoder, &self.0.source_map, |entry, encoder| {
             entry.bytecode_offset.encode(encoder);
             entry.line.encode(encoder);
             entry.column.encode(encoder);
@@ -2570,14 +2680,37 @@ impl Encode for SourceMapTable<'_> {
 }
 
 impl SourceMapTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<SourceMapEntry>> {
-        decoder.sequence_values(|decoder| {
-            Some(SourceMapEntry {
-                bytecode_offset: u32::decode(decoder)?,
-                line: u32::decode(decoder)?,
-                column: u32::decode(decoder)?,
-            })
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedSourceMapTable> {
+        Some(DecodedSourceMapTable {
+            sequence: DecodedRecordSequence::decode(decoder)?,
         })
+    }
+}
+
+struct DecodedSourceMapTable {
+    sequence: DecodedRecordSequence,
+}
+
+impl DecodedSourceMapTable {
+    fn len(&self) -> usize {
+        self.sequence.len()
+    }
+
+    fn values(&self) -> Option<Vec<SourceMapEntry>> {
+        let mut decoder = self.sequence.decoder();
+        let mut values = Vec::with_capacity(self.sequence.len());
+        for _ in 0..self.sequence.len() {
+            values.push(SourceMapEntry {
+                bytecode_offset: u32::decode(&mut decoder)?,
+                line: u32::decode(&mut decoder)?,
+                column: u32::decode(&mut decoder)?,
+            });
+        }
+        decoder.is_empty().then_some(values)
+    }
+
+    fn into_values(self) -> Option<Vec<SourceMapEntry>> {
+        self.values()
     }
 }
 
@@ -2585,7 +2718,7 @@ struct LocalVariableTable<'a>(&'a Generator);
 
 impl Encode for LocalVariableTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(&self.0.local_variables, |local_variable, encoder| {
+        DecodedRecordSequence::encode(encoder, &self.0.local_variables, |local_variable, encoder| {
             Utf16(&local_variable.name).encode(encoder);
             local_variable.is_lexically_declared.encode(encoder);
             local_variable
@@ -2596,14 +2729,33 @@ impl Encode for LocalVariableTable<'_> {
 }
 
 impl LocalVariableTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedLocalVariable>> {
-        decoder.sequence_values(|decoder| {
-            Some(DecodedLocalVariable {
-                name: DecodedUtf16String::decode(decoder)?,
-                is_lexically_declared: bool::decode(decoder)?,
-                is_initialized_during_declaration_instantiation: bool::decode(decoder)?,
-            })
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedLocalVariableTable> {
+        Some(DecodedLocalVariableTable {
+            sequence: DecodedRecordSequence::decode(decoder)?,
         })
+    }
+}
+
+struct DecodedLocalVariableTable {
+    sequence: DecodedRecordSequence,
+}
+
+impl DecodedLocalVariableTable {
+    fn len(&self) -> usize {
+        self.sequence.len()
+    }
+
+    fn into_values(self) -> Option<Vec<DecodedLocalVariable>> {
+        let mut decoder = self.sequence.decoder();
+        let mut values = Vec::with_capacity(self.sequence.len());
+        for _ in 0..self.sequence.len() {
+            values.push(DecodedLocalVariable {
+                name: DecodedUtf16String::decode(&mut decoder)?,
+                is_lexically_declared: bool::decode(&mut decoder)?,
+                is_initialized_during_declaration_instantiation: bool::decode(&mut decoder)?,
+            });
+        }
+        decoder.is_empty().then_some(values)
     }
 }
 
@@ -2627,7 +2779,7 @@ struct SharedFunctionTable<'a>(&'a Generator);
 
 impl Encode for SharedFunctionTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(&self.0.shared_function_data, |shared_data, encoder| {
+        DecodedRecordSequence::encode(encoder, &self.0.shared_function_data, |shared_data, encoder| {
             FunctionRecord {
                 shared_data,
                 arena: &self.0.arena,
@@ -2638,8 +2790,58 @@ impl Encode for SharedFunctionTable<'_> {
 }
 
 impl SharedFunctionTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedFunctionRecord>> {
-        decoder.sequence_values(FunctionRecord::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedFunctionTable> {
+        Some(DecodedFunctionTable {
+            sequence: DecodedRecordSequence::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedFunctionTable {
+    sequence: DecodedRecordSequence,
+}
+
+impl DecodedFunctionTable {
+    fn len(&self) -> usize {
+        self.sequence.len()
+    }
+
+    fn validate(&self) {
+        let _ = self.sequence.len();
+    }
+
+    fn into_values(self) -> Option<Vec<DecodedFunctionRecord>> {
+        let mut decoder = self.sequence.decoder();
+        let mut values = Vec::with_capacity(self.sequence.len());
+        for _ in 0..self.sequence.len() {
+            values.push(FunctionRecord::decode(&mut decoder)?);
+        }
+        decoder.is_empty().then_some(values)
+    }
+
+    fn for_each(&self, mut callback: impl FnMut(DecodedFunctionRecord) -> Option<()>) -> Option<()> {
+        let mut decoder = self.sequence.decoder();
+        for _ in 0..self.sequence.len() {
+            callback(FunctionRecord::decode(&mut decoder)?)?;
+        }
+        decoder.is_empty().then_some(())
+    }
+
+    fn validate_cached_bytecode(&self) -> Result<(), ValidationErrorKind> {
+        let mut decoder = self.sequence.decoder();
+        for _ in 0..self.sequence.len() {
+            let function = FunctionRecord::decode(&mut decoder).ok_or(ValidationErrorKind::InvalidLength)?;
+            function.precompiled.validate_cached_bytecode()?;
+        }
+        decoder
+            .is_empty()
+            .then_some(())
+            .ok_or(ValidationErrorKind::InvalidLength)
+    }
+
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        self.for_each(|function| function.source_ranges_are_valid(source_len).then_some(()))
+            .is_some()
     }
 }
 
@@ -2908,15 +3110,58 @@ struct ClassBlueprintTable<'a>(&'a Generator);
 
 impl Encode for ClassBlueprintTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(&self.0.class_blueprints, |blueprint, encoder| {
+        DecodedRecordSequence::encode(encoder, &self.0.class_blueprints, |blueprint, encoder| {
             ClassBlueprintRecord(blueprint).encode(encoder);
         });
     }
 }
 
 impl ClassBlueprintTable<'_> {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedClassBlueprintRecord>> {
-        decoder.sequence_values(ClassBlueprintRecord::decode)
+    fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedClassBlueprintTable> {
+        Some(DecodedClassBlueprintTable {
+            sequence: DecodedRecordSequence::decode(decoder)?,
+        })
+    }
+}
+
+struct DecodedClassBlueprintTable {
+    sequence: DecodedRecordSequence,
+}
+
+impl DecodedClassBlueprintTable {
+    fn len(&self) -> usize {
+        self.sequence.len()
+    }
+
+    fn validate(&self) {
+        let _ = self.sequence.len();
+    }
+
+    fn into_values(self) -> Option<Vec<DecodedClassBlueprintRecord>> {
+        let mut decoder = self.sequence.decoder();
+        let mut values = Vec::with_capacity(self.sequence.len());
+        for _ in 0..self.sequence.len() {
+            values.push(ClassBlueprintRecord::decode(&mut decoder)?);
+        }
+        decoder.is_empty().then_some(values)
+    }
+
+    fn for_each(&self, mut callback: impl FnMut(DecodedClassBlueprintRecord) -> Option<()>) -> Option<()> {
+        let mut decoder = self.sequence.decoder();
+        for _ in 0..self.sequence.len() {
+            callback(ClassBlueprintRecord::decode(&mut decoder)?)?;
+        }
+        decoder.is_empty().then_some(())
+    }
+
+    fn source_ranges_are_valid(&self, source_len: usize) -> bool {
+        self.for_each(|blueprint| blueprint.source_range_is_valid(source_len).then_some(()))
+            .is_some()
+    }
+
+    fn indices_are_valid(&self, shared_function_count: usize) -> bool {
+        self.for_each(|blueprint| blueprint.indices_are_valid(shared_function_count).then_some(()))
+            .is_some()
     }
 }
 
@@ -2961,17 +3206,6 @@ struct DecodedClassBlueprintRecord {
 }
 
 impl DecodedClassBlueprintRecord {
-    fn validate(&self) {
-        let _ = self.name.as_ref().map(DecodedUtf16String::len);
-        let _ = self.source_text_offset;
-        let _ = self.source_text_length;
-        let _ = self.constructor_sfd_index;
-        let _ = self.has_super_class || self.has_name;
-        for element in &self.elements {
-            element.validate();
-        }
-    }
-
     fn source_range_is_valid(&self, source_len: usize) -> bool {
         source_range_is_valid(self.source_text_offset, self.source_text_length, source_len)
     }
@@ -3044,16 +3278,6 @@ struct DecodedClassElementRecord {
 }
 
 impl DecodedClassElementRecord {
-    fn validate(&self) {
-        let _ = self.kind;
-        let _ = self.is_static || self.is_private || self.has_initializer;
-        let _ = self.private_identifier.as_ref().map(DecodedUtf16String::len);
-        let _ = self.shared_function_data_index;
-        let _ = literal_value_kind_tag(self.literal_value_kind);
-        let _ = self.literal_value_number;
-        let _ = self.literal_value_string.as_ref().map(DecodedUtf16String::len);
-    }
-
     fn indices_are_valid(&self, shared_function_count: usize) -> bool {
         let shared_function_data_index_is_valid = || {
             self.shared_function_data_index

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -581,6 +581,12 @@ impl DecodedRecordSequence {
         let count: usize = u32::decode(decoder)?.try_into().ok()?;
         decoder.align_to(align_of::<u16>())?;
         let byte_length: usize = u32::decode(decoder)?.try_into().ok()?;
+        // Every record currently has at least one byte in the payload. Reject
+        // impossible counts up front so corrupt cache files cannot ask later
+        // materialization to reserve huge vectors for tiny payloads.
+        if count > byte_length {
+            return None;
+        }
         Some(Self {
             count,
             bytes: decoder.bytecode_bytes(byte_length)?,
@@ -2473,6 +2479,10 @@ impl ConstantTable<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedConstantTable> {
         let count: usize = u32::decode(decoder)?.try_into().ok()?;
         let byte_length: usize = u32::decode(decoder)?.try_into().ok()?;
+        // Constants are encoded as at least their one-byte tag.
+        if count > byte_length {
+            return None;
+        }
         Some(DecodedConstantTable {
             count,
             bytes: decoder.bytecode_bytes(byte_length)?,
@@ -3360,6 +3370,28 @@ mod tests {
 
         let mut decoder = Decoder::new(&bytes, None);
         assert!(decoder.sequence_values(u8::decode).is_none());
+    }
+
+    #[test]
+    fn record_sequence_decode_rejects_impossible_count_without_large_allocation() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&4u32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.push(0);
+
+        let mut decoder = Decoder::new(&bytes, None);
+        assert!(DecodedRecordSequence::decode(&mut decoder).is_none());
+    }
+
+    #[test]
+    fn constant_table_decode_rejects_impossible_count_without_large_allocation() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&4u32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.push(0);
+
+        let mut decoder = Decoder::new(&bytes, None);
+        assert!(ConstantTable::decode(&mut decoder).is_none());
     }
 
     #[test]

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -31,7 +31,7 @@ use crate::bytecode::validator::{
 use crate::{CompiledProgram, CompiledProgramBytecode, ModuleCallbacks, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 5;
+const FORMAT_VERSION: u32 = 6;
 const SOURCE_HASH_SIZE: usize = 32;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;
 const ITERATOR_HINT_VARIANT_COUNT: u32 = 2;
@@ -124,6 +124,11 @@ impl Encoder {
         self.bytes.extend_from_slice(bytes);
     }
 
+    fn align_to(&mut self, alignment: usize) {
+        let padding = self.bytes.len().next_multiple_of(alignment) - self.bytes.len();
+        self.bytes.extend(std::iter::repeat_n(0, padding));
+    }
+
     fn sequence<T>(&mut self, items: &[T], mut encode_item: impl FnMut(&T, &mut Self)) {
         u32_from_usize(items.len()).encode(self);
         for item in items {
@@ -183,6 +188,12 @@ impl<'a> Decoder<'a> {
         self.bytes = rest;
         self.offset = self.offset.checked_add(length)?;
         Some(bytes)
+    }
+
+    fn align_to(&mut self, alignment: usize) -> Option<()> {
+        let padding = self.offset.next_multiple_of(alignment) - self.offset;
+        self.bytes(padding)?;
+        Some(())
     }
 
     fn bytecode_bytes(&mut self, length: usize) -> Option<DecodedBytecodeBytes> {
@@ -345,6 +356,7 @@ impl<T: Decode> Decode for Option<T> {
 
 impl Decode for ast::Utf16String {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        decoder.align_to(align_of::<u16>())?;
         let length: usize = u32::decode(decoder)?.try_into().ok()?;
         let bytes = decoder.bytes(length.checked_mul(size_of::<u16>())?)?;
         let mut code_units = Vec::with_capacity(length);
@@ -360,17 +372,19 @@ enum DecodedUtf16String {
     // The surrounding decoded executable keeps the mapped blob alive through its
     // DecodedBytecodeBytes. Store only the payload pointer here so large string
     // tables do not clone an owner handle for every string.
-    Foreign { data: *const u8, length: usize },
+    Foreign { data: *const u16, length: usize },
 }
 
 impl Decode for DecodedUtf16String {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        decoder.align_to(align_of::<u16>())?;
         let length: usize = u32::decode(decoder)?.try_into().ok()?;
         let byte_length = length.checked_mul(size_of::<u16>())?;
         let bytes = decoder.bytes(byte_length)?;
         if decoder.foreign_blob.is_some() {
+            debug_assert_eq!((bytes.as_ptr() as usize) % align_of::<u16>(), 0);
             return Some(Self::Foreign {
-                data: bytes.as_ptr(),
+                data: bytes.as_ptr().cast(),
                 length,
             });
         }
@@ -400,13 +414,12 @@ impl DecodedUtf16String {
     fn to_vec(&self) -> Vec<u16> {
         match self {
             Self::Owned(value) => value.to_vec(),
-            Self::Foreign { data, length } => {
-                let bytes = unsafe { std::slice::from_raw_parts(*data, length * size_of::<u16>()) };
-                bytes
-                    .chunks_exact(size_of::<u16>())
-                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            Self::Foreign { data, length } => unsafe {
+                std::slice::from_raw_parts(*data, *length)
+                    .iter()
+                    .map(|code_unit| u16::from_le(*code_unit))
                     .collect()
-            }
+            },
         }
     }
 
@@ -415,12 +428,72 @@ impl DecodedUtf16String {
     }
 }
 
+struct PreparedUtf16Slice {
+    _storage: Option<Vec<u16>>,
+    slice: FFIUtf16Slice,
+}
+
+impl PreparedUtf16Slice {
+    fn new(value: &DecodedUtf16String) -> Self {
+        match value {
+            DecodedUtf16String::Owned(value) => Self {
+                _storage: None,
+                slice: FFIUtf16Slice::from(value.as_ref()),
+            },
+            DecodedUtf16String::Foreign { data, length } => {
+                #[cfg(target_endian = "little")]
+                {
+                    Self {
+                        _storage: None,
+                        slice: FFIUtf16Slice {
+                            data: *data,
+                            length: *length,
+                        },
+                    }
+                }
+                #[cfg(not(target_endian = "little"))]
+                {
+                    let storage = value.to_vec();
+                    let slice = FFIUtf16Slice::from(storage.as_slice());
+                    Self {
+                        _storage: Some(storage),
+                        slice,
+                    }
+                }
+            }
+        }
+    }
+
+    fn as_ptr_len(&self) -> (*const u16, usize) {
+        (self.slice.data, self.slice.length)
+    }
+}
+
 fn utf16_slice_storage(strings: &[DecodedUtf16String]) -> (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) {
-    let storage: Vec<Vec<u16>> = strings.iter().map(DecodedUtf16String::to_vec).collect();
-    let slices = storage
-        .iter()
-        .map(|string| FFIUtf16Slice::from(string.as_slice()))
-        .collect();
+    #[cfg(target_endian = "little")]
+    let storage = Vec::new();
+    #[cfg(not(target_endian = "little"))]
+    let mut storage = Vec::new();
+    let mut slices = Vec::with_capacity(strings.len());
+    for string in strings {
+        match string {
+            DecodedUtf16String::Owned(value) => slices.push(FFIUtf16Slice::from(value.as_ref())),
+            DecodedUtf16String::Foreign { data, length } => {
+                #[cfg(target_endian = "little")]
+                {
+                    slices.push(FFIUtf16Slice {
+                        data: *data,
+                        length: *length,
+                    });
+                }
+                #[cfg(not(target_endian = "little"))]
+                {
+                    storage.push(string.to_vec());
+                    slices.push(FFIUtf16Slice::from(storage.last().unwrap().as_slice()));
+                }
+            }
+        }
+    }
     (storage, slices)
 }
 
@@ -475,6 +548,7 @@ struct Utf16<'a>(&'a [u16]);
 
 impl Encode for Utf16<'_> {
     fn encode(&self, encoder: &mut Encoder) {
+        encoder.align_to(align_of::<u16>());
         u32_from_usize(self.0.len()).encode(encoder);
         for code_unit in self.0 {
             encoder.bytes(&code_unit.to_le_bytes());
@@ -872,10 +946,10 @@ unsafe fn materialize_function(
             .as_ref()
             .map(|names| utf16_slice_storage(names))
             .unwrap_or_default();
-        let name_storage = function.name.as_ref().map(DecodedUtf16String::to_vec);
+        let name_storage = function.name.as_ref().map(PreparedUtf16Slice::new);
         let (name, name_len) = name_storage
             .as_ref()
-            .map(|name| (name.as_ptr(), name.len()))
+            .map(PreparedUtf16Slice::as_ptr_len)
             .unwrap_or((std::ptr::null(), 0));
         let source_text_offset = function.source_text_start as usize;
         let source_text_length = function
@@ -908,13 +982,9 @@ unsafe fn materialize_function(
         }
 
         if let Some((name, is_private)) = &function.class_field_initializer_name {
-            let name_storage = name.to_vec();
-            crate::bytecode::ffi::rust_sfd_set_class_field_initializer_name(
-                sfd_ptr,
-                name_storage.as_ptr(),
-                name_storage.len(),
-                *is_private,
-            );
+            let name_storage = PreparedUtf16Slice::new(name);
+            let (name, name_len) = name_storage.as_ptr_len();
+            crate::bytecode::ffi::rust_sfd_set_class_field_initializer_name(sfd_ptr, name, name_len, *is_private);
         }
 
         let cached_executable_ptr = Box::into_raw(Box::new(function.precompiled)) as *mut c_void;

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -861,10 +861,55 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob(
             let expected_source_hash = std::slice::from_raw_parts(expected_source_hash, expected_source_hash_len)
                 .try_into()
                 .expect("source hash length was checked");
-            let Some(blob) = bytecode_cache::decode_blob(
+            let bytes = std::slice::from_raw_parts(data, length);
+            let Some(blob) = bytecode_cache::decode_blob(bytes, expected_program_type, expected_source_hash) else {
+                return std::ptr::null_mut();
+            };
+            Box::into_raw(Box::new(DecodedBytecodeCacheBlob { _blob: blob }))
+        })
+    }
+}
+
+/// Decode an mmap-backed bytecode cache blob into an owned parser-free cache handle.
+///
+/// # Safety
+/// - `data` must point to `length` readable bytes.
+/// - `owner` must keep `data` alive until `free_owner` is called.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_decode_bytecode_cache_blob_with_owner(
+    data: *const u8,
+    length: usize,
+    expected_program_type: u8,
+    expected_source_hash: *const u8,
+    expected_source_hash_len: usize,
+    owner: *mut c_void,
+    free_owner: bytecode_cache::FreeBytecodeCacheBlobOwner,
+) -> *mut DecodedBytecodeCacheBlob {
+    unsafe {
+        abort_on_panic(|| {
+            if owner.is_null() {
+                return std::ptr::null_mut();
+            }
+            let reject = || {
+                free_owner(owner);
+                std::ptr::null_mut()
+            };
+            if data.is_null() || expected_source_hash.is_null() || expected_source_hash_len != 32 {
+                return reject();
+            }
+            let expected_program_type = match expected_program_type {
+                0 => ast::ProgramType::Script,
+                1 => ast::ProgramType::Module,
+                _ => return reject(),
+            };
+            let expected_source_hash = std::slice::from_raw_parts(expected_source_hash, expected_source_hash_len)
+                .try_into()
+                .expect("source hash length was checked");
+            let Some(blob) = bytecode_cache::decode_blob_with_foreign_owner(
                 std::slice::from_raw_parts(data, length),
                 expected_program_type,
                 expected_source_hash,
+                bytecode_cache::ForeignBytecodeCacheBlobOwner { owner, free_owner },
             ) else {
                 return std::ptr::null_mut();
             };
@@ -3407,5 +3452,59 @@ pub unsafe extern "C" fn rust_validate_bytecode(
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static FREED_FOREIGN_OWNERS: AtomicUsize = AtomicUsize::new(0);
+
+    unsafe extern "C" fn count_freed_foreign_owner(owner: *mut c_void) {
+        FREED_FOREIGN_OWNERS.fetch_add(1, Ordering::Relaxed);
+        unsafe {
+            drop(Box::from_raw(owner.cast::<u8>()));
+        }
+    }
+
+    fn new_foreign_owner() -> *mut c_void {
+        Box::into_raw(Box::new(0u8)).cast()
+    }
+
+    #[test]
+    fn decode_blob_with_owner_frees_owner_on_early_rejection() {
+        FREED_FOREIGN_OWNERS.store(0, Ordering::Relaxed);
+        let source_hash = [0u8; 32];
+
+        let blob = unsafe {
+            rust_decode_bytecode_cache_blob_with_owner(
+                std::ptr::null(),
+                0,
+                0,
+                source_hash.as_ptr(),
+                source_hash.len(),
+                new_foreign_owner(),
+                count_freed_foreign_owner,
+            )
+        };
+        assert!(blob.is_null());
+        assert_eq!(FREED_FOREIGN_OWNERS.load(Ordering::Relaxed), 1);
+
+        let bytes = [0u8; 1];
+        let blob = unsafe {
+            rust_decode_bytecode_cache_blob_with_owner(
+                bytes.as_ptr(),
+                bytes.len(),
+                2,
+                source_hash.as_ptr(),
+                source_hash.len(),
+                new_foreign_owner(),
+                count_freed_foreign_owner,
+            )
+        };
+        assert!(blob.is_null());
+        assert_eq!(FREED_FOREIGN_OWNERS.load(Ordering::Relaxed), 2);
     }
 }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -409,6 +409,17 @@ DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes bytes, Progra
     return rust_decode_bytecode_cache_blob(bytes.data(), bytes.size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size());
 }
 
+static void free_bytecode_cache_blob_owner(void* owner)
+{
+    delete static_cast<Core::ImmutableBytes*>(owner);
+}
+
+DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash)
+{
+    auto* owner = new Core::ImmutableBytes(move(bytes));
+    return rust_decode_bytecode_cache_blob_with_owner(owner->bytes().data(), owner->bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, free_bytecode_cache_blob_owner);
+}
+
 void free_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob)
 {
     rust_free_decoded_bytecode_cache_blob(blob);

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -12,6 +12,7 @@
 #include <AK/Optional.h>
 #include <AK/Result.h>
 #include <AK/Utf16FlyString.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
 #include <LibJS/ModuleEntry.h>
@@ -113,6 +114,7 @@ JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledPro
 
 // Decode a bytecode cache blob into an owned parser-free cache handle.
 JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes, ProgramType, ReadonlyBytes source_hash);
+JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash);
 
 // Free a decoded bytecode cache blob.
 JS_API void free_decoded_bytecode_cache_blob(FFI::DecodedBytecodeCacheBlob*);

--- a/Libraries/LibRequests/Forward.h
+++ b/Libraries/LibRequests/Forward.h
@@ -10,6 +10,7 @@ namespace Requests {
 
 class Request;
 class RequestClient;
+class ResponseData;
 class WebSocket;
 struct RequestTimingInfo;
 

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -13,6 +13,27 @@
 
 namespace Requests {
 
+static Optional<Core::ImmutableBytes> map_body_file(int fd, u64 offset, u64 size)
+{
+    ArmedScopeGuard close_fd = [fd] {
+        (void)Core::System::close(fd);
+    };
+
+    if (!AK::is_within_range<off_t>(offset) || !AK::is_within_range<size_t>(size)) {
+        dbgln("Request: Received body file outside mappable range");
+        return {};
+    }
+
+    close_fd.disarm();
+    auto payload = Core::ImmutableBytes::map_from_fd_range_and_close(fd, "request response"sv, static_cast<off_t>(offset), static_cast<size_t>(size));
+    if (payload.is_error()) {
+        dbgln("Request: Failed to map body file: {}", payload.error());
+        return {};
+    }
+
+    return payload.release_value();
+}
+
 ErrorOr<NonnullOwnPtr<ReadStream>> ReadStream::create(int reader_fd)
 {
 #if defined(AK_OS_WINDOWS)
@@ -64,25 +85,13 @@ void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)
 
 void Request::set_request_body_file(Badge<Requests::RequestClient>, int fd, u64 offset, u64 size)
 {
-    ArmedScopeGuard close_fd = [fd] {
-        (void)Core::System::close(fd);
-    };
+    auto payload = map_body_file(fd, offset, size);
+    if (!payload.has_value())
+        return;
 
     // If the request was stopped while this IPC was in-flight, just bail.
     if (!m_internal_stream_data)
         return;
-
-    if (!AK::is_within_range<off_t>(offset) || !AK::is_within_range<size_t>(size)) {
-        dbgln("Request: Received cache body file outside mappable range");
-        return;
-    }
-
-    close_fd.disarm();
-    auto payload = Core::ImmutableBytes::map_from_fd_range_and_close(fd, "request response"sv, static_cast<off_t>(offset), static_cast<size_t>(size));
-    if (payload.is_error()) {
-        dbgln("Request: Failed to map cache body file: {}", payload.error());
-        return;
-    }
 
     if (m_mode == Mode::Buffered) {
         m_internal_buffered_data->payload = payload.release_value();
@@ -92,6 +101,26 @@ void Request::set_request_body_file(Badge<Requests::RequestClient>, int fd, u64 
     m_internal_stream_data->file_backed_payload = payload.release_value();
     if (m_internal_stream_data->on_data_available)
         m_internal_stream_data->on_data_available(ResponseData::from_immutable_bytes(*m_internal_stream_data->file_backed_payload));
+}
+
+void Request::set_request_cached_body_file(Badge<Requests::RequestClient>, int fd, u64 offset, u64 size)
+{
+    auto payload = map_body_file(fd, offset, size);
+    if (!payload.has_value())
+        return;
+
+    if (m_mode == Mode::Buffered) {
+        m_internal_buffered_data->payload = payload.release_value();
+        return;
+    }
+
+    // If the request was stopped while this IPC was in-flight, just bail.
+    if (!m_internal_stream_data)
+        return;
+
+    m_internal_stream_data->cached_payload = payload.release_value();
+    if (m_internal_stream_data->on_cached_body_available)
+        m_internal_stream_data->on_cached_body_available(*m_internal_stream_data->cached_payload);
 }
 
 void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_buffered_request_finished)
@@ -137,7 +166,7 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
     });
 }
 
-void Request::set_unbuffered_request_callbacks(HeadersReceived on_headers_received, DataReceived on_data_received, RequestFinished on_finish)
+void Request::set_unbuffered_request_callbacks(HeadersReceived on_headers_received, DataReceived on_data_received, CachedBodyAvailable on_cached_body_available, RequestFinished on_finish)
 {
     VERIFY(m_mode == Mode::Unknown);
     m_mode = Mode::Unbuffered;
@@ -146,6 +175,7 @@ void Request::set_unbuffered_request_callbacks(HeadersReceived on_headers_receiv
     this->on_finish = move(on_finish);
 
     set_up_internal_stream_data(move(on_data_received));
+    m_internal_stream_data->on_cached_body_available = move(on_cached_body_available);
 }
 
 void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error)

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -86,8 +86,11 @@ void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)
 void Request::set_request_body_file(Badge<Requests::RequestClient>, int fd, u64 offset, u64 size)
 {
     auto payload = map_body_file(fd, offset, size);
-    if (!payload.has_value())
+    if (!payload.has_value()) {
+        if (m_internal_stream_data)
+            m_body_delivery_error = NetworkError::CacheReadFailed;
         return;
+    }
 
     // If the request was stopped while this IPC was in-flight, just bail.
     if (!m_internal_stream_data)
@@ -180,8 +183,9 @@ void Request::set_unbuffered_request_callbacks(HeadersReceived on_headers_receiv
 
 void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error)
 {
+    auto effective_network_error = m_body_delivery_error.has_value() ? m_body_delivery_error : network_error;
     if (on_finish)
-        on_finish(total_size, timing_info, network_error);
+        on_finish(total_size, timing_info, effective_network_error);
 }
 
 void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -91,7 +91,7 @@ void Request::set_request_body_file(Badge<Requests::RequestClient>, int fd, u64 
 
     m_internal_stream_data->file_backed_payload = payload.release_value();
     if (m_internal_stream_data->on_data_available)
-        m_internal_stream_data->on_data_available(m_internal_stream_data->file_backed_payload->bytes());
+        m_internal_stream_data->on_data_available(ResponseData::from_immutable_bytes(*m_internal_stream_data->file_backed_payload));
 }
 
 void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_buffered_request_finished)
@@ -131,9 +131,9 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
             move(payload));
     };
 
-    set_up_internal_stream_data([this](auto read_bytes) {
+    set_up_internal_stream_data([this](auto data) {
         // FIXME: What do we do if this fails?
-        m_internal_buffered_data->payload_stream.write_until_depleted(read_bytes).release_value_but_fixme_should_propagate_errors();
+        m_internal_buffered_data->payload_stream.write_until_depleted(data.bytes()).release_value_but_fixme_should_propagate_errors();
     });
 }
 
@@ -223,7 +223,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
             if (read_bytes.is_empty())
                 break;
 
-            m_internal_stream_data->on_data_available(read_bytes);
+            m_internal_stream_data->on_data_available(ResponseData::from_bytes(read_bytes));
         } while (true);
 
         if (m_internal_stream_data->read_stream->is_eof())

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -188,7 +188,7 @@ void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo
         on_finish(total_size, timing_info, effective_network_error);
 }
 
-void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)
+void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)
 {
     if (on_headers_received)
         on_headers_received(move(response_headers), response_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
+#include <AK/ScopeGuard.h>
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
 
@@ -59,6 +62,38 @@ void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)
     m_internal_stream_data->read_stream = move(read_stream);
 }
 
+void Request::set_request_body_file(Badge<Requests::RequestClient>, int fd, u64 offset, u64 size)
+{
+    ArmedScopeGuard close_fd = [fd] {
+        (void)Core::System::close(fd);
+    };
+
+    // If the request was stopped while this IPC was in-flight, just bail.
+    if (!m_internal_stream_data)
+        return;
+
+    if (!AK::is_within_range<off_t>(offset) || !AK::is_within_range<size_t>(size)) {
+        dbgln("Request: Received cache body file outside mappable range");
+        return;
+    }
+
+    close_fd.disarm();
+    auto payload = Core::ImmutableBytes::map_from_fd_range_and_close(fd, "request response"sv, static_cast<off_t>(offset), static_cast<size_t>(size));
+    if (payload.is_error()) {
+        dbgln("Request: Failed to map cache body file: {}", payload.error());
+        return;
+    }
+
+    if (m_mode == Mode::Buffered) {
+        m_internal_buffered_data->payload = payload.release_value();
+        return;
+    }
+
+    m_internal_stream_data->file_backed_payload = payload.release_value();
+    if (m_internal_stream_data->on_data_available)
+        m_internal_stream_data->on_data_available(m_internal_stream_data->file_backed_payload->bytes());
+}
+
 void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_buffered_request_finished)
 {
     VERIFY(m_mode == Mode::Unknown);
@@ -75,8 +110,14 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
     };
 
     on_finish = [this, on_buffered_request_finished = move(on_buffered_request_finished)](auto total_size, auto& timing_info, auto network_error) {
-        auto output_buffer = ByteBuffer::create_uninitialized(m_internal_buffered_data->payload_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
-        m_internal_buffered_data->payload_stream.read_until_filled(output_buffer).release_value_but_fixme_should_propagate_errors();
+        auto payload = [&] {
+            if (m_internal_buffered_data->payload.has_value())
+                return m_internal_buffered_data->payload.release_value();
+
+            auto output_buffer = ByteBuffer::create_uninitialized(m_internal_buffered_data->payload_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
+            m_internal_buffered_data->payload_stream.read_until_filled(output_buffer).release_value_but_fixme_should_propagate_errors();
+            return Core::ImmutableBytes::adopt(move(output_buffer));
+        }();
 
         on_buffered_request_finished(
             total_size,
@@ -87,7 +128,7 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
             m_internal_buffered_data->reason_phrase,
             move(m_internal_buffered_data->javascript_bytecode),
             m_internal_buffered_data->javascript_bytecode_cache_vary_key,
-            output_buffer);
+            move(payload));
     };
 
     set_up_internal_stream_data([this](auto read_bytes) {
@@ -134,6 +175,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
     VERIFY(!m_internal_stream_data);
 
     m_internal_stream_data = make<InternalStreamData>();
+    m_internal_stream_data->on_data_available = move(on_data_available);
     m_internal_stream_data->read_notifier = Core::Notifier::construct(fd(), Core::Notifier::Type::Read);
     if (fd() != -1)
         m_internal_stream_data->read_stream = MUST(ReadStream::create(fd()));
@@ -162,7 +204,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
         }
     };
 
-    m_internal_stream_data->read_notifier->on_activation = [this, on_data_available = move(on_data_available)]() {
+    m_internal_stream_data->read_notifier->on_activation = [this]() {
         static constexpr size_t buffer_size = 256 * KiB;
         static char buffer[buffer_size];
 
@@ -181,7 +223,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
             if (read_bytes.is_empty())
                 break;
 
-            on_data_available(read_bytes);
+            m_internal_stream_data->on_data_available(read_bytes);
         } while (true);
 
         if (m_internal_stream_data->read_stream->is_eof())

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -14,6 +14,7 @@
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibCore/Notifier.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/NetworkError.h>
@@ -61,7 +62,7 @@ public:
     int fd() const { return m_fd; }
     bool stop();
 
-    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, ReadonlyBytes payload)>;
+    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Core::ImmutableBytes payload)>;
 
     // Configure the request such that the entirety of the response data is buffered. The callback receives that data and
     // the response headers all at once. Using this method is mutually exclusive with `set_unbuffered_data_received_callback`.
@@ -83,6 +84,7 @@ public:
 
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
     void set_request_fd(Badge<RequestClient>, int fd);
+    void set_request_body_file(Badge<RequestClient>, int fd, u64 offset, u64 size);
 
 private:
     Request(RequestClient&, u64 request_id);
@@ -113,6 +115,7 @@ private:
         Optional<String> reason_phrase;
         Optional<Core::AnonymousBuffer> javascript_bytecode;
         Optional<u64> javascript_bytecode_cache_vary_key;
+        Optional<Core::ImmutableBytes> payload;
     };
 
     struct InternalStreamData {
@@ -120,12 +123,14 @@ private:
 
         OwnPtr<ReadStream> read_stream;
         RefPtr<Core::Notifier> read_notifier;
-        u32 total_size { 0 };
+        u64 total_size { 0 };
         Optional<NetworkError> network_error;
         bool request_done { false };
         RequestTimingInfo timing_info;
+        DataReceived on_data_available;
         Function<void()> on_finish {};
         bool user_finish_called { false };
+        Optional<Core::ImmutableBytes> file_backed_payload;
     };
 
     OwnPtr<InternalBufferedData> m_internal_buffered_data;

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -98,11 +98,12 @@ public:
 
     using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using DataReceived = Function<void(ResponseData data)>;
+    using CachedBodyAvailable = Function<void(Core::ImmutableBytes data)>;
     using RequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> network_error)>;
 
     // Configure the request such that the response data is provided unbuffered as it is received. Using this method is
     // mutually exclusive with `set_buffered_request_finished_callback`.
-    void set_unbuffered_request_callbacks(HeadersReceived, DataReceived, RequestFinished);
+    void set_unbuffered_request_callbacks(HeadersReceived, DataReceived, CachedBodyAvailable, RequestFinished);
 
     Function<CertificateAndKey()> on_certificate_requested;
 
@@ -113,6 +114,7 @@ public:
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
     void set_request_fd(Badge<RequestClient>, int fd);
     void set_request_body_file(Badge<RequestClient>, int fd, u64 offset, u64 size);
+    void set_request_cached_body_file(Badge<RequestClient>, int fd, u64 offset, u64 size);
 
 private:
     Request(RequestClient&, u64 request_id);
@@ -156,9 +158,11 @@ private:
         bool request_done { false };
         RequestTimingInfo timing_info;
         DataReceived on_data_available;
+        CachedBodyAvailable on_cached_body_available;
         Function<void()> on_finish {};
         bool user_finish_called { false };
         Optional<Core::ImmutableBytes> file_backed_payload;
+        Optional<Core::ImmutableBytes> cached_payload;
     };
 
     OwnPtr<InternalBufferedData> m_internal_buffered_data;

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -13,7 +13,6 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
-#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ImmutableBytes.h>
 #include <LibCore/Notifier.h>
 #include <LibHTTP/HeaderList.h>
@@ -90,13 +89,13 @@ public:
     int fd() const { return m_fd; }
     bool stop();
 
-    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Core::ImmutableBytes payload)>;
+    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Core::ImmutableBytes payload)>;
 
     // Configure the request such that the entirety of the response data is buffered. The callback receives that data and
     // the response headers all at once. Using this method is mutually exclusive with `set_unbuffered_data_received_callback`.
     void set_buffered_request_finished_callback(BufferedRequestFinished);
 
-    using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
+    using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using DataReceived = Function<void(ResponseData data)>;
     using CachedBodyAvailable = Function<void(Core::ImmutableBytes data)>;
     using RequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> network_error)>;
@@ -108,7 +107,7 @@ public:
     Function<CertificateAndKey()> on_certificate_requested;
 
     void did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error);
-    void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key);
+    void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key);
     void did_request_certificates(Badge<RequestClient>);
 
     RefPtr<Core::Notifier>& write_notifier(Badge<RequestClient>) { return m_write_notifier; }
@@ -143,7 +142,7 @@ private:
         NonnullRefPtr<HTTP::HeaderList> response_headers;
         Optional<u32> response_code;
         Optional<String> reason_phrase;
-        Optional<Core::AnonymousBuffer> javascript_bytecode;
+        Optional<Core::ImmutableBytes> javascript_bytecode;
         Optional<u64> javascript_bytecode_cache_vary_key;
         Optional<Core::ImmutableBytes> payload;
     };

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -167,6 +167,7 @@ private:
 
     OwnPtr<InternalBufferedData> m_internal_buffered_data;
     OwnPtr<InternalStreamData> m_internal_stream_data;
+    Optional<NetworkError> m_body_delivery_error;
 };
 
 }

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -24,6 +24,34 @@ namespace Requests {
 
 class RequestClient;
 
+class ResponseData {
+public:
+    static ResponseData from_bytes(ReadonlyBytes bytes) { return ResponseData { bytes }; }
+    static ResponseData from_immutable_bytes(Core::ImmutableBytes bytes) { return ResponseData { move(bytes) }; }
+
+    [[nodiscard]] ReadonlyBytes bytes() const
+    {
+        if (m_immutable_bytes.has_value())
+            return m_immutable_bytes->bytes();
+        return m_bytes;
+    }
+    [[nodiscard]] Optional<Core::ImmutableBytes> const& immutable_bytes() const { return m_immutable_bytes; }
+
+private:
+    explicit ResponseData(ReadonlyBytes bytes)
+        : m_bytes(bytes)
+    {
+    }
+
+    explicit ResponseData(Core::ImmutableBytes bytes)
+        : m_immutable_bytes(move(bytes))
+    {
+    }
+
+    ReadonlyBytes m_bytes;
+    Optional<Core::ImmutableBytes> m_immutable_bytes;
+};
+
 class ReadStream {
 public:
     static ErrorOr<NonnullOwnPtr<ReadStream>> create(int reader_fd);
@@ -69,7 +97,7 @@ public:
     void set_buffered_request_finished_callback(BufferedRequestFinished);
 
     using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
-    using DataReceived = Function<void(ReadonlyBytes data)>;
+    using DataReceived = Function<void(ResponseData data)>;
     using RequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> network_error)>;
 
     // Configure the request such that the response data is provided unbuffered as it is received. Using this method is

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -142,6 +142,18 @@ void RequestClient::request_body_file_available(u64 request_id, IPC::File respon
     request.value()->set_request_body_file({}, response_fd, offset, size);
 }
 
+void RequestClient::request_cached_body_file_available(u64 request_id, IPC::File response_file, u64 offset, u64 size)
+{
+    auto request = m_requests.get(request_id);
+    if (!request.has_value()) {
+        warnln("Received cached response body file for non-existent request {}", request_id);
+        return;
+    }
+
+    auto response_fd = response_file.take_fd();
+    request.value()->set_request_cached_body_file({}, response_fd, offset, size);
+}
+
 void RequestClient::request_finished(u64 request_id, u64 total_size, RequestTimingInfo timing_info, Optional<NetworkError> network_error)
 {
     if (RefPtr<Request> request = m_requests.get(request_id).value_or(nullptr)) {

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -130,6 +130,18 @@ void RequestClient::request_started(u64 request_id, IPC::File response_file)
     request.value()->set_request_fd({}, response_fd);
 }
 
+void RequestClient::request_body_file_available(u64 request_id, IPC::File response_file, u64 offset, u64 size)
+{
+    auto request = m_requests.get(request_id);
+    if (!request.has_value()) {
+        warnln("Received response body file for non-existent request {}", request_id);
+        return;
+    }
+
+    auto response_fd = response_file.take_fd();
+    request.value()->set_request_body_file({}, response_fd, offset, size);
+}
+
 void RequestClient::request_finished(u64 request_id, u64 total_size, RequestTimingInfo timing_info, Optional<NetworkError> network_error)
 {
     if (RefPtr<Request> request = m_requests.get(request_id).value_or(nullptr)) {

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Promise.h>
 #include <LibCore/System.h>
@@ -11,6 +12,27 @@
 #include <LibRequests/RequestClient.h>
 
 namespace Requests {
+
+static Optional<Core::ImmutableBytes> map_javascript_bytecode_file(int fd, u64 size)
+{
+    ArmedScopeGuard close_fd = [fd] {
+        (void)Core::System::close(fd);
+    };
+
+    if (!AK::is_within_range<size_t>(size)) {
+        dbgln("RequestClient: Received JavaScript bytecode cache file outside mappable range");
+        return {};
+    }
+
+    close_fd.disarm();
+    auto payload = Core::ImmutableBytes::map_from_fd_range_and_close(fd, "javascript bytecode cache"sv, 0, static_cast<size_t>(size));
+    if (payload.is_error()) {
+        dbgln("RequestClient: Failed to map JavaScript bytecode cache file: {}", payload.error());
+        return {};
+    }
+
+    return payload.release_value();
+}
 
 RequestClient::RequestClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport))
@@ -162,8 +184,12 @@ void RequestClient::request_finished(u64 request_id, u64 total_size, RequestTimi
     }
 }
 
-void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)
+void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode_file, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key)
 {
+    Optional<Core::ImmutableBytes> javascript_bytecode;
+    if (javascript_bytecode_file.has_value())
+        javascript_bytecode = map_javascript_bytecode_file(javascript_bytecode_file->take_fd(), javascript_bytecode_size);
+
     if (auto request = m_requests.get(request_id); request.has_value())
         (*request)->did_receive_headers({}, HTTP::HeaderList::create(move(response_headers)), status_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
     else

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -54,6 +54,7 @@ private:
     virtual void die() override;
 
     virtual void request_started(u64 request_id, IPC::File) override;
+    virtual void request_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
     virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<Core::AnonymousBuffer>, Optional<u64>) override;
 

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -55,6 +55,7 @@ private:
 
     virtual void request_started(u64 request_id, IPC::File) override;
     virtual void request_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
+    virtual void request_cached_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
     virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<Core::AnonymousBuffer>, Optional<u64>) override;
 

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -57,7 +57,7 @@ private:
     virtual void request_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_cached_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
-    virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<Core::AnonymousBuffer>, Optional<u64>) override;
+    virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<IPC::File>, u64 javascript_bytecode_size, Optional<u64>) override;
 
     virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url) override;
 

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -40,7 +40,7 @@ void FetchedDataReceiver::set_body(GC::Ref<Fetch::Infrastructure::Body> body)
         m_pre_body_sniff_buffer.clear();
     }
     // If the stream already completed before the body was set,
-    // we missed the set_sniff_bytes_complete() call in handle_network_bytes.
+    // we missed the set_sniff_bytes_complete() call in handle_network_data.
     if (m_network_complete)
         m_body->set_sniff_bytes_complete();
 }
@@ -56,10 +56,10 @@ void FetchedDataReceiver::visit_edges(Visitor& visitor)
 
 // This implements the parallel steps of the pullAlgorithm in HTTP-network-fetch.
 // https://fetch.spec.whatwg.org/#ref-for-in-parallel⑤
-void FetchedDataReceiver::handle_network_bytes(ReadonlyBytes bytes, NetworkState state)
+void FetchedDataReceiver::handle_network_data(Requests::ResponseData data, NetworkState state)
 {
     if (state == NetworkState::Complete) {
-        VERIFY(bytes.is_empty());
+        VERIFY(data.bytes().is_empty());
         m_network_complete = true;
         // Mark sniff bytes as complete when the stream ends
         if (m_body)
@@ -77,6 +77,7 @@ void FetchedDataReceiver::handle_network_bytes(ReadonlyBytes bytes, NetworkState
         return;
 
     // 1. If one or more bytes have been transmitted from response’s message body, then:
+    auto bytes = data.bytes();
     if (bytes.is_empty())
         return;
 
@@ -96,8 +97,17 @@ void FetchedDataReceiver::handle_network_bytes(ReadonlyBytes bytes, NetworkState
         m_pre_body_sniff_buffer.append(bytes.slice(0, min(bytes.size(), space_remaining)));
     }
 
-    if (m_http_cache)
-        m_cache_buffer.append(bytes);
+    if (m_http_cache) {
+        if (auto const& immutable_bytes = data.immutable_bytes(); immutable_bytes.has_value() && immutable_bytes->is_file_backed() && m_cache_buffer.is_empty() && !m_cache_body.has_value()) {
+            m_cache_body = *immutable_bytes;
+        } else {
+            if (m_cache_body.has_value()) {
+                m_cache_buffer.append(m_cache_body->bytes());
+                m_cache_body.clear();
+            }
+            m_cache_buffer.append(bytes);
+        }
+    }
 
     // 7. Append bytes to buffer.
     enqueue_into_stream(bytes);
@@ -138,10 +148,14 @@ void FetchedDataReceiver::close_stream()
         auto request = m_fetch_params->request();
         if (m_stream->is_readable() && !m_fetch_params->is_canceled()
             && m_response && request->cache_mode() != HTTP::CacheMode::NoStore) {
-            m_http_cache->finalize_entry(request->current_url(), request->method(), request->header_list(), m_response->status(), m_response->header_list(), move(m_cache_buffer));
+            auto response_body = m_cache_body.has_value()
+                ? m_cache_body.release_value()
+                : Core::ImmutableBytes::adopt(move(m_cache_buffer));
+            m_http_cache->finalize_entry(request->current_url(), request->method(), request->header_list(), m_response->status(), m_response->header_list(), move(response_body));
         }
 
         m_http_cache.clear();
+        m_cache_body.clear();
     }
 
     if (!m_stream->is_readable())

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -97,7 +97,7 @@ void FetchedDataReceiver::handle_network_data(Requests::ResponseData data, Netwo
         m_pre_body_sniff_buffer.append(bytes.slice(0, min(bytes.size(), space_remaining)));
     }
 
-    if (m_http_cache) {
+    if (m_http_cache && !m_cache_body_replaces_network_buffer) {
         if (auto const& immutable_bytes = data.immutable_bytes(); immutable_bytes.has_value() && immutable_bytes->is_file_backed() && m_cache_buffer.is_empty() && !m_cache_body.has_value()) {
             m_cache_body = *immutable_bytes;
         } else {
@@ -114,6 +114,16 @@ void FetchedDataReceiver::handle_network_data(Requests::ResponseData data, Netwo
 
     // FIXME: 8. If the size of buffer is larger than an upper limit chosen by the user agent, ask the user agent
     //           to suspend the ongoing fetch.
+}
+
+void FetchedDataReceiver::set_cached_response_body(Core::ImmutableBytes body)
+{
+    if (!m_http_cache)
+        return;
+
+    m_cache_buffer.clear();
+    m_cache_body = move(body);
+    m_cache_body_replaces_network_buffer = true;
 }
 
 // This implements the parallel steps of the pullAlgorithm in HTTP-network-fetch.

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
@@ -33,6 +33,7 @@ public:
         Error,
     };
     void handle_network_data(Requests::ResponseData, NetworkState);
+    void set_cached_response_body(Core::ImmutableBytes);
 
 private:
     FetchedDataReceiver(GC::Ref<Infrastructure::FetchParams const>, GC::Ref<Streams::ReadableStream>, RefPtr<HTTP::MemoryCache>);
@@ -57,6 +58,7 @@ private:
     // Whole-response buffer retained only when m_http_cache is non-null, for finalize_entry().
     ByteBuffer m_cache_buffer;
     Optional<Core::ImmutableBytes> m_cache_body;
+    bool m_cache_body_replaces_network_buffer { false };
 
     bool m_network_complete { false };
 };

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
@@ -8,9 +8,11 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/CellAllocator.h>
 #include <LibHTTP/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibRequests/Request.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Fetch::Fetching {
@@ -30,7 +32,7 @@ public:
         Complete,
         Error,
     };
-    void handle_network_bytes(ReadonlyBytes, NetworkState);
+    void handle_network_data(Requests::ResponseData, NetworkState);
 
 private:
     FetchedDataReceiver(GC::Ref<Infrastructure::FetchParams const>, GC::Ref<Streams::ReadableStream>, RefPtr<HTTP::MemoryCache>);
@@ -54,6 +56,7 @@ private:
 
     // Whole-response buffer retained only when m_http_cache is non-null, for finalize_entry().
     ByteBuffer m_cache_buffer;
+    Optional<Core::ImmutableBytes> m_cache_body;
 
     bool m_network_complete { false };
 };

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2229,8 +2229,8 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
 
     // 16. Run these steps in parallel:
     //     FIXME: 1. Run these steps, but abort when fetchParams is canceled:
-    auto on_data_received = GC::create_function(vm.heap(), [fetched_data_receiver](ReadonlyBytes bytes) {
-        fetched_data_receiver->handle_network_bytes(bytes, FetchedDataReceiver::NetworkState::Ongoing);
+    auto on_data_received = GC::create_function(vm.heap(), [fetched_data_receiver](Requests::ResponseData data) {
+        fetched_data_receiver->handle_network_data(move(data), FetchedDataReceiver::NetworkState::Ongoing);
     });
 
     auto on_complete = GC::create_function(vm.heap(), [&vm, &realm, pending_response, stream, fetched_data_receiver](bool success, Requests::RequestTimingInfo const&, Optional<StringView> error_message) {
@@ -2238,7 +2238,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
         HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         if (success) {
-            fetched_data_receiver->handle_network_bytes({}, FetchedDataReceiver::NetworkState::Complete);
+            fetched_data_receiver->handle_network_data(Requests::ResponseData::from_bytes({}), FetchedDataReceiver::NetworkState::Complete);
         } else {
             // 16.1.2.2. Otherwise, if stream is readable, error stream with a TypeError.
             auto error = MUST(String::formatted("Load failed: {}", error_message.value_or("Unknown error"sv)));

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2188,7 +2188,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
     // 13. Set up stream with byte reading support with pullAlgorithm set to pullAlgorithm, cancelAlgorithm set to cancelAlgorithm.
     stream->set_up_with_byte_reading_support(pull_algorithm, cancel_algorithm);
 
-    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) {
+    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) {
         if (pending_response->is_resolved()) {
             // RequestServer will send us the response headers twice, the second time being for HTTP trailers. This
             // fetch algorithm is not interested in trailers, so just drop them here.

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2233,6 +2233,10 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
         fetched_data_receiver->handle_network_data(move(data), FetchedDataReceiver::NetworkState::Ongoing);
     });
 
+    auto on_cached_body_available = GC::create_function(vm.heap(), [fetched_data_receiver](Core::ImmutableBytes data) {
+        fetched_data_receiver->set_cached_response_body(move(data));
+    });
+
     auto on_complete = GC::create_function(vm.heap(), [&vm, &realm, pending_response, stream, fetched_data_receiver](bool success, Requests::RequestTimingInfo const&, Optional<StringView> error_message) {
         // FIXME: Implement on_complete timing info for unbuffered requests
         HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
@@ -2251,7 +2255,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
         }
     });
 
-    auto network_request = ResourceLoader::the().load(load_request, on_headers_received, on_data_received, on_complete);
+    auto network_request = ResourceLoader::the().load(load_request, on_headers_received, on_data_received, on_cached_body_available, on_complete);
     fetch_params.controller()->set_pending_request(network_request);
 
     return pending_response;

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -12,7 +12,7 @@
 #include <AK/Optional.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
-#include <LibCore/AnonymousBuffer.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/Ptr.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibJS/Forward.h>
@@ -106,8 +106,8 @@ public:
     [[nodiscard]] virtual BodyInfo const& body_info() const { return m_body_info; }
     virtual void set_body_info(BodyInfo body_info) { m_body_info = move(body_info); }
 
-    [[nodiscard]] Optional<Core::AnonymousBuffer> const& javascript_bytecode_cache() const { return m_javascript_bytecode_cache; }
-    void set_javascript_bytecode_cache(Optional<Core::AnonymousBuffer> javascript_bytecode_cache) { m_javascript_bytecode_cache = move(javascript_bytecode_cache); }
+    [[nodiscard]] Optional<Core::ImmutableBytes> const& javascript_bytecode_cache() const { return m_javascript_bytecode_cache; }
+    void set_javascript_bytecode_cache(Optional<Core::ImmutableBytes> javascript_bytecode_cache) { m_javascript_bytecode_cache = move(javascript_bytecode_cache); }
     [[nodiscard]] Optional<u64> javascript_bytecode_cache_vary_key() const { return m_javascript_bytecode_cache_vary_key; }
     void set_javascript_bytecode_cache_vary_key(Optional<u64> javascript_bytecode_cache_vary_key) { m_javascript_bytecode_cache_vary_key = javascript_bytecode_cache_vary_key; }
 
@@ -201,7 +201,7 @@ private:
     MonotonicTime m_monotonic_response_time;
 
     Optional<String> m_network_error_message;
-    Optional<Core::AnonymousBuffer> m_javascript_bytecode_cache;
+    Optional<Core::ImmutableBytes> m_javascript_bytecode_cache;
     Optional<u64> m_javascript_bytecode_cache_vary_key;
 
 public:

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -612,7 +612,7 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
             // so the fallback compile path below can reuse them if decode or materialization is rejected.
             if (auto const& bytecode = response->javascript_bytecode_cache(); bytecode.has_value()) {
                 auto source_hash = bytecode_cache_source_hash(*source_code);
-                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(bytecode->bytes(), JS::RustIntegration::ProgramType::Script, source_hash.bytes())) {
+                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_hash.bytes())) {
                     auto script = ClassicScript::create_from_bytecode_cache(response_url_string, source_code, settings_object, response_url, bytecode_cache, muted_errors);
                     // Bytecode validation runs during materialization and may reject a structurally valid blob whose
                     // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
@@ -998,7 +998,7 @@ void fetch_single_module_script(JS::Realm& realm,
                     auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
                     if (auto const& bytecode = internal_response->javascript_bytecode_cache(); bytecode.has_value()) {
                         auto source_hash = bytecode_cache_source_hash(*source_code);
-                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(bytecode->bytes(), JS::RustIntegration::ProgramType::Module, source_hash.bytes())) {
+                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_hash.bytes())) {
                             auto module_script = ModuleScript::create_from_bytecode_cache(url_string, source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
                             if (module_script && module_script->parse_error().is_null()) {
                                 settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -369,7 +369,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete = move(on_complete), request](ReadonlyBytes data, Requests::RequestTimingInfo const& timing_info, HTTP::HeaderList const& response_headers) {
                 log_success(request);
                 on_headers_received->function()(response_headers, {}, {}, {}, {});
-                on_data_received->function()(data);
+                on_data_received->function()(Requests::ResponseData::from_bytes(data));
                 on_complete->function()(true, timing_info, {});
             });
         return nullptr;
@@ -380,7 +380,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
                 on_headers_received->function()(load_result.response_headers, {}, {}, {}, {});
-                on_data_received->function()(load_result.data);
+                on_data_received->function()(Requests::ResponseData::from_bytes(load_result.data));
                 on_complete->function()(true, load_result.timing_info, {});
             },
             [on_complete](ByteString const& message) {
@@ -396,7 +396,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             [request, on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
                 log_success(request);
                 on_headers_received->function()(load_result.response_headers, {}, {}, {}, {});
-                on_data_received->function()(load_result.data);
+                on_data_received->function()(Requests::ResponseData::from_bytes(load_result.data));
                 on_complete->function()(true, load_result.timing_info, {});
             },
             [on_complete, request](ByteString const& message) {
@@ -431,8 +431,8 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
 
     auto protocol_data_received = [on_data_received = move(on_data_received), request, request_id = protocol_request->id()](auto data) {
         if (auto page = request.page())
-            page->client().page_did_receive_network_response_body(request_id, data);
-        on_data_received->function()(data);
+            page->client().page_did_receive_network_response_body(request_id, data.bytes());
+        on_data_received->function()(move(data));
     };
 
     auto protocol_complete = [this, on_complete = move(on_complete), request, &protocol_request = *protocol_request](u64 total_size, Requests::RequestTimingInfo const& timing_info, Optional<Requests::NetworkError> const& network_error) {

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -351,7 +351,7 @@ void ResourceLoader::handle_resource_load_request(LoadRequest const& request, Re
     on_resource(load_result);
 }
 
-RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<OnHeadersReceived> on_headers_received, GC::Root<OnDataReceived> on_data_received, GC::Root<OnComplete> on_complete)
+RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<OnHeadersReceived> on_headers_received, GC::Root<OnDataReceived> on_data_received, GC::Root<OnCachedBodyAvailable> on_cached_body_available, GC::Root<OnComplete> on_complete)
 {
     auto const& url = request.url().value();
 
@@ -453,7 +453,11 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         }
     };
 
-    protocol_request->set_unbuffered_request_callbacks(move(protocol_headers_received), move(protocol_data_received), move(protocol_complete));
+    auto protocol_cached_body_available = [on_cached_body_available = move(on_cached_body_available)](auto data) {
+        on_cached_body_available->function()(move(data));
+    };
+
+    protocol_request->set_unbuffered_request_callbacks(move(protocol_headers_received), move(protocol_data_received), move(protocol_cached_body_available), move(protocol_complete));
     return protocol_request;
 }
 

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -10,8 +10,8 @@
 #include <AK/ByteString.h>
 #include <AK/Function.h>
 #include <AK/HashTable.h>
-#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/EventReceiver.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/Function.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/Forward.h>
@@ -33,7 +33,7 @@ public:
 
     void set_client(NonnullRefPtr<Requests::RequestClient>);
 
-    using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
+    using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using OnDataReceived = GC::Function<void(Requests::ResponseData data)>;
     using OnCachedBodyAvailable = GC::Function<void(Core::ImmutableBytes data)>;
     using OnComplete = GC::Function<void(bool success, Requests::RequestTimingInfo const& timing_info, Optional<StringView> error_message)>;

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -15,6 +15,7 @@
 #include <LibGC/Function.h>
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/Forward.h>
+#include <LibRequests/Request.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
@@ -33,7 +34,7 @@ public:
     void set_client(NonnullRefPtr<Requests::RequestClient>);
 
     using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
-    using OnDataReceived = GC::Function<void(ReadonlyBytes data)>;
+    using OnDataReceived = GC::Function<void(Requests::ResponseData data)>;
     using OnComplete = GC::Function<void(bool success, Requests::RequestTimingInfo const& timing_info, Optional<StringView> error_message)>;
 
     RefPtr<Requests::Request> load(LoadRequest&, GC::Root<OnHeadersReceived>, GC::Root<OnDataReceived>, GC::Root<OnComplete>);

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -35,9 +35,10 @@ public:
 
     using OnHeadersReceived = GC::Function<void(HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
     using OnDataReceived = GC::Function<void(Requests::ResponseData data)>;
+    using OnCachedBodyAvailable = GC::Function<void(Core::ImmutableBytes data)>;
     using OnComplete = GC::Function<void(bool success, Requests::RequestTimingInfo const& timing_info, Optional<StringView> error_message)>;
 
-    RefPtr<Requests::Request> load(LoadRequest&, GC::Root<OnHeadersReceived>, GC::Root<OnDataReceived>, GC::Root<OnComplete>);
+    RefPtr<Requests::Request> load(LoadRequest&, GC::Root<OnHeadersReceived>, GC::Root<OnDataReceived>, GC::Root<OnCachedBodyAvailable>, GC::Root<OnComplete>);
 
     RefPtr<Requests::RequestClient>& request_client() { return m_request_client; }
 

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -304,7 +304,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
     m_request = Application::request_server_client().start_request("GET"sv, *url);
 
     m_request->set_buffered_request_finished_callback(
-        [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, ReadonlyBytes payload) {
+        [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, Core::ImmutableBytes payload) {
             Core::deferred_invoke([this]() { m_request.clear(); });
 
             if (m_query != query) {
@@ -325,7 +325,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
 
             auto content_type = response_headers.get("Content-Type"sv);
 
-            if (auto result = received_autocomplete_respsonse(engine, content_type, payload); result.is_error()) {
+            if (auto result = received_autocomplete_respsonse(engine, content_type, payload.bytes()); result.is_error()) {
                 warnln("Unable to handle autocomplete response: {}", result.error());
                 invoke_autocomplete_query_complete(merge_suggestions(search_suggestion, literal_suggestion, m_history_suggestions, {}, m_max_suggestions), AutocompleteResultKind::Final);
             } else {

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -304,7 +304,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
     m_request = Application::request_server_client().start_request("GET"sv, *url);
 
     m_request->set_buffered_request_finished_callback(
-        [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, Core::ImmutableBytes payload) {
+        [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Core::ImmutableBytes payload) {
             Core::deferred_invoke([this]() { m_request.clear(); });
 
             if (m_query != query) {

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -42,7 +42,7 @@ void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
     auto request_id = next_request_id++;
 
     request->set_buffered_request_finished_callback(
-        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, Core::ImmutableBytes payload) {
+        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Core::ImmutableBytes payload) {
             Core::deferred_invoke([this, request_id]() { m_requests.remove(request_id); });
 
             if (network_error.has_value()) {

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -42,7 +42,7 @@ void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
     auto request_id = next_request_id++;
 
     request->set_buffered_request_finished_callback(
-        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, ReadonlyBytes payload) {
+        [this, request_id, destination = move(destination)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const&, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::AnonymousBuffer>, Optional<u64>, Core::ImmutableBytes payload) {
             Core::deferred_invoke([this, request_id]() { m_requests.remove(request_id); });
 
             if (network_error.has_value()) {
@@ -58,7 +58,7 @@ void FileDownloader::download_file(URL::URL const& url, LexicalPath destination)
                 return;
             }
 
-            if (auto result = save_file(destination, payload); result.is_error()) {
+            if (auto result = save_file(destination, payload.bytes()); result.is_error()) {
                 auto error = MUST(String::formatted("Unable to save downloaded file file: {}", result.error()));
                 Application::the().display_error_dialog(error);
             }

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -1031,10 +1031,20 @@ void Request::handle_complete_state()
         // Finalize the disk cache entry before notifying WebContent that the request is complete: WebContent may
         // immediately fire off a JavaScript bytecode cache store against this entry, and that store needs the cache
         // index row to already exist. If we notified first the store would race the index write and be rejected.
+        Optional<HTTP::CacheEntryBodyFile> cached_body_file;
         if (m_cache_entry_writer.has_value()) {
-            (void)m_cache_entry_writer->flush(m_request_headers, m_response_headers);
+            if (m_cache_entry_writer->body_size() >= static_cast<u64>(PAGE_SIZE)) {
+                auto body_file = m_cache_entry_writer->flush_and_take_body_file(m_request_headers, m_response_headers);
+                if (!body_file.is_error())
+                    cached_body_file = body_file.release_value();
+            } else {
+                (void)m_cache_entry_writer->flush(m_request_headers, m_response_headers);
+            }
             m_cache_entry_writer.clear();
         }
+
+        if (cached_body_file.has_value())
+            m_client.async_request_cached_body_file_available(m_request_id, IPC::File::adopt_fd(cached_body_file->fd), cached_body_file->offset, cached_body_file->size);
 
         m_client.async_request_finished(m_request_id, m_bytes_transferred_to_client, timing_info, m_network_error);
     }

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -666,24 +666,44 @@ void Request::handle_read_cache_state()
     m_response_headers = m_cache_entry_reader->response_headers();
     m_cache_status = CacheStatus::ReadFromCache;
 
-    if (inform_client_request_started().is_error())
-        return;
     transfer_headers_to_client_if_needed();
 
-    m_cache_entry_reader->send_to(
-        m_client_request_pipe->writer_fd(),
-        weak_callback(*this, [](auto& self, auto bytes_sent) {
-            self.m_bytes_transferred_to_client = bytes_sent;
-            self.m_curl_result_code = CURLE_OK;
+    if (m_cache_entry_reader->body_size() < static_cast<u64>(PAGE_SIZE)) {
+        if (inform_client_request_started().is_error())
+            return;
 
-            self.transition_to_state(State::Complete);
-        }),
-        weak_callback(*this, [](auto& self, auto bytes_sent) {
-            self.m_bytes_transferred_to_client = bytes_sent;
-            self.m_network_error = Requests::NetworkError::CacheReadFailed;
+        m_cache_entry_reader->send_to(
+            m_client_request_pipe->writer_fd(),
+            weak_callback(*this, [](auto& self, auto bytes_sent) {
+                self.m_bytes_transferred_to_client = bytes_sent;
+                self.m_curl_result_code = CURLE_OK;
 
-            self.transition_to_state(State::Error);
-        }));
+                self.transition_to_state(State::Complete);
+            }),
+            weak_callback(*this, [](auto& self, auto bytes_sent) {
+                self.m_bytes_transferred_to_client = bytes_sent;
+                self.m_network_error = Requests::NetworkError::CacheReadFailed;
+
+                self.transition_to_state(State::Error);
+            }));
+        return;
+    }
+
+    auto body_file = m_cache_entry_reader->take_body_file();
+    if (body_file.is_error()) {
+        m_network_error = Requests::NetworkError::CacheReadFailed;
+        transition_to_state(State::Error);
+        return;
+    }
+
+    auto file = body_file.release_value();
+    m_bytes_transferred_to_client = file.size;
+    m_curl_result_code = CURLE_OK;
+
+    m_client.async_request_body_file_available(m_request_id, IPC::File::adopt_fd(file.fd), file.offset, file.size);
+    m_cache_entry_reader.clear();
+
+    transition_to_state(State::Complete);
 }
 
 void Request::handle_failed_cache_only_state()

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -7,7 +7,6 @@
 
 #include <AK/GenericShorthands.h>
 #include <AK/HashMap.h>
-#include <LibCore/AnonymousBuffer.h>
 #include <LibCore/File.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/Notifier.h>
@@ -1198,24 +1197,22 @@ void Request::transfer_headers_to_client_if_needed()
         }
     }
 
-    Optional<Core::AnonymousBuffer> javascript_bytecode;
+    Optional<IPC::File> javascript_bytecode;
+    u64 javascript_bytecode_size { 0 };
     Optional<u64> javascript_bytecode_cache_vary_key;
     if (m_cache_status == CacheStatus::ReadFromCache && m_disk_cache.has_value()) {
         VERIFY(m_cache_entry_reader.has_value());
         javascript_bytecode_cache_vary_key = m_cache_entry_reader->vary_key();
-        auto data = m_disk_cache->retrieve_associated_data(m_url, m_method, *m_request_headers, javascript_bytecode_cache_vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode);
+        auto data = m_disk_cache->retrieve_associated_data_file(m_url, m_method, *m_request_headers, javascript_bytecode_cache_vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode);
         if (!data.is_error() && data.value().has_value()) {
-            auto buffer = Core::AnonymousBuffer::create_with_size(data.value()->size());
-            if (!buffer.is_error()) {
-                memcpy(buffer.value().data<void>(), data.value()->data(), data.value()->size());
-                javascript_bytecode = buffer.release_value();
-            }
+            javascript_bytecode_size = data.value()->size;
+            javascript_bytecode = IPC::File::adopt_fd(data.value()->fd);
         }
     } else if (m_cache_status == CacheStatus::WrittenToCache && m_cache_entry_writer.has_value()) {
         javascript_bytecode_cache_vary_key = m_cache_entry_writer->vary_key();
     }
 
-    m_client.async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
+    m_client.async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_size, javascript_bytecode_cache_vary_key);
 }
 
 ErrorOr<void> Request::write_queued_bytes_without_blocking()

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -9,6 +9,7 @@
 endpoint RequestClient
 {
     request_started(u64 request_id, IPC::File fd) =|
+    request_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
     headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) =|
 

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -10,6 +10,7 @@ endpoint RequestClient
 {
     request_started(u64 request_id, IPC::File fd) =|
     request_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
+    request_cached_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
     headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) =|
 

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -1,4 +1,3 @@
-#include <LibCore/AnonymousBuffer.h>
 #include <LibHTTP/Header.h>
 #include <LibRequests/CacheSizes.h>
 #include <LibRequests/NetworkError.h>
@@ -12,7 +11,7 @@ endpoint RequestClient
     request_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_cached_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
-    headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<Core::AnonymousBuffer> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) =|
+    headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key) =|
 
     retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url) =|
 

--- a/Tests/LibCore/TestLibCoreMappedFile.cpp
+++ b/Tests/LibCore/TestLibCoreMappedFile.cpp
@@ -9,6 +9,7 @@
 #include <AK/MaybeOwned.h>
 #include <AK/String.h>
 #include <LibCore/File.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
@@ -126,6 +127,59 @@ TEST_CASE(mapped_file_adopt_fd)
     EXPECT_EQ(buffer_contents, expected_seek_contents1);
 
     // A single seek & read test should be fine for now.
+}
+
+TEST_CASE(mapped_file_adopt_fd_range)
+{
+    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
+    EXPECT(rc >= 0);
+
+    auto file = TRY_OR_FAIL(Core::MappedFile::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 500, 16));
+
+    EXPECT_EQ(file->size().release_value(), 16ul);
+    EXPECT_EQ(file->bytes(), expected_seek_contents1.bytes());
+
+    auto buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(16));
+    TRY_OR_FAIL(file->read_until_filled(buffer));
+    EXPECT_EQ(buffer.bytes(), expected_seek_contents1.bytes());
+    EXPECT(file->is_eof());
+}
+
+TEST_CASE(mapped_file_adopt_empty_fd_range)
+{
+    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
+    EXPECT(rc >= 0);
+
+    auto file = TRY_OR_FAIL(Core::MappedFile::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 500, 0));
+
+    EXPECT_EQ(file->size().release_value(), 0ul);
+    EXPECT(file->bytes().is_empty());
+    EXPECT(file->is_eof());
+}
+
+TEST_CASE(mapped_file_adopt_invalid_fd_range)
+{
+    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
+    EXPECT(rc >= 0);
+
+    auto maybe_file = Core::MappedFile::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 8700, 16);
+    EXPECT(maybe_file.is_error());
+    EXPECT_EQ(maybe_file.error().code(), EINVAL);
+}
+
+TEST_CASE(immutable_bytes_from_mapped_file_range)
+{
+    int rc = TRY_OR_FAIL(Core::System::open("./long_lines.txt"sv, O_RDONLY));
+    EXPECT(rc >= 0);
+
+    auto bytes = TRY_OR_FAIL(Core::ImmutableBytes::map_from_fd_range_and_close(rc, "./long_lines.txt"sv, 500, 16));
+
+    EXPECT(bytes.is_file_backed());
+    EXPECT_EQ(bytes.size(), 16ul);
+    EXPECT_EQ(bytes.bytes(), expected_seek_contents1.bytes());
+
+    auto copied_bytes = TRY_OR_FAIL(bytes.copy_to_byte_buffer());
+    EXPECT_EQ(copied_bytes.bytes(), expected_seek_contents1.bytes());
 }
 
 TEST_CASE(mapped_file_adopt_invalid_fd)

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibHTTP/Cache/CacheRequest.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibHTTP/Cache/Utilities.h>
@@ -109,6 +110,24 @@ TEST_CASE(replacing_cache_entry_removes_associated_data)
 
     retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
     EXPECT(!retrieved_bytecode.has_value());
+}
+
+TEST_CASE(flush_returns_mappable_body_file)
+{
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    TestCacheRequest request;
+
+    auto url = parse_url("https://example.com/script.js"sv);
+    auto request_headers = create_cacheable_request_headers();
+    auto response_headers = create_cacheable_response_headers();
+
+    auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+    TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+    TRY_OR_FAIL(writer.write_data("console.log('hello');"sv.bytes()));
+
+    auto body_file = TRY_OR_FAIL(writer.flush_and_take_body_file(request_headers, response_headers));
+    auto body = TRY_OR_FAIL(Core::ImmutableBytes::map_from_fd_range_and_close(body_file.fd, "cache body"sv, body_file.offset, body_file.size));
+    EXPECT_EQ(body.bytes(), "console.log('hello');"sv.bytes());
 }
 
 TEST_CASE(associated_data_round_trips_with_explicit_vary_key)

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -75,6 +75,11 @@ TEST_CASE(associated_data_round_trips_with_cache_entry)
     VERIFY(retrieved_bytecode.has_value());
     EXPECT_EQ(retrieved_bytecode->bytes(), bytecode.bytes());
 
+    auto retrieved_bytecode_file = TRY_OR_FAIL(disk_cache.retrieve_associated_data_file(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
+    VERIFY(retrieved_bytecode_file.has_value());
+    auto mapped_bytecode = TRY_OR_FAIL(Core::ImmutableBytes::map_from_fd_range_and_close(retrieved_bytecode_file->fd, "bytecode"sv, retrieved_bytecode_file->offset, retrieved_bytecode_file->size));
+    EXPECT_EQ(mapped_bytecode.bytes(), bytecode.bytes());
+
     disk_cache.remove_entries_accessed_since(UnixDateTime::earliest());
 
     retrieved_bytecode = TRY_OR_FAIL(disk_cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -135,6 +135,33 @@ TEST_CASE(flush_returns_mappable_body_file)
     EXPECT_EQ(body.bytes(), "console.log('hello');"sv.bytes());
 }
 
+TEST_CASE(replacing_cache_entry_keeps_existing_body_mapping_stable)
+{
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));
+    TestCacheRequest request;
+
+    auto url = parse_url("https://example.com/script.js"sv);
+    auto request_headers = create_cacheable_request_headers();
+    auto response_headers = create_cacheable_response_headers();
+
+    auto& writer = create_cache_entry(disk_cache, request, url, *request_headers);
+    TRY_OR_FAIL(writer.write_status_and_reason(200, "OK"_string, *request_headers, *response_headers));
+    TRY_OR_FAIL(writer.write_data("console.log('old');"sv.bytes()));
+
+    auto old_body_file = TRY_OR_FAIL(writer.flush_and_take_body_file(request_headers, response_headers));
+    auto old_body = TRY_OR_FAIL(Core::ImmutableBytes::map_from_fd_range_and_close(old_body_file.fd, "old cache body"sv, old_body_file.offset, old_body_file.size));
+    EXPECT_EQ(old_body.bytes(), "console.log('old');"sv.bytes());
+
+    auto replacement_request_headers = create_cacheable_request_headers();
+    auto replacement_response_headers = create_cacheable_response_headers();
+    auto& replacement_writer = create_cache_entry(disk_cache, request, url, *replacement_request_headers);
+    TRY_OR_FAIL(replacement_writer.write_status_and_reason(200, "OK"_string, *replacement_request_headers, *replacement_response_headers));
+    TRY_OR_FAIL(replacement_writer.write_data("console.log('new');"sv.bytes()));
+    TRY_OR_FAIL(replacement_writer.flush(replacement_request_headers, replacement_response_headers));
+
+    EXPECT_EQ(old_body.bytes(), "console.log('old');"sv.bytes());
+}
+
 TEST_CASE(associated_data_round_trips_with_explicit_vary_key)
 {
     auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing));

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -39,6 +39,12 @@ public:
         m_offset += length;
     }
 
+    void align_to(size_t alignment)
+    {
+        auto padding = (alignment - (m_offset % alignment)) % alignment;
+        skip(padding);
+    }
+
     bool read_bool()
     {
         return read_u8() != 0;
@@ -63,6 +69,7 @@ public:
 
     void skip_utf16()
     {
+        align_to(alignof(u16));
         auto length = read_u32();
         skip(length * sizeof(u16));
     }

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -5,6 +5,10 @@
  */
 
 #include <AK/ScopeGuard.h>
+#include <LibCore/File.h>
+#include <LibCore/ImmutableBytes.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 #include <LibCrypto/Hash/SHA2.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/ModuleRequest.h>
@@ -354,6 +358,37 @@ TEST_CASE(bytecode_cache_materializes_function_executables_lazily)
     VERIFY(!result.is_throw_completion());
     EXPECT(shared_data.m_executable);
     EXPECT(!shared_data.m_cached_bytecode_executable);
+}
+
+TEST_CASE(bytecode_cache_materializes_from_mapped_blob)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto test_data = create_bytecode_cache_blob("let f = function mapped() { return 1; }; f();"_string);
+    auto path = ByteString::formatted("{}/bytecode-cache-test-{}.blob", Core::StandardPaths::tempfile_directory(), Core::System::getpid());
+    ScopeGuard remove_file = [&] {
+        (void)Core::System::unlink(path);
+    };
+
+    {
+        auto file = TRY_OR_FAIL(Core::File::open(path, Core::File::OpenMode::Write | Core::File::OpenMode::Truncate));
+        TRY_OR_FAIL(file->write_until_depleted(test_data.blob.bytes()));
+    }
+
+    auto file = TRY_OR_FAIL(Core::File::open(path, Core::File::OpenMode::Read));
+    auto mapped_blob = TRY_OR_FAIL(Core::ImmutableBytes::map_from_fd_range_and_close(file->leak_fd(), path, 0, test_data.blob.size()));
+    EXPECT(mapped_blob.is_file_backed());
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(mapped_blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    auto script_or_error = JS::Script::create_from_bytecode_cache(decoded_blob, test_data.source_code, realm);
+    VERIFY(!script_or_error.is_error());
+
+    auto result = vm->run(script_or_error.release_value());
+    VERIFY(!result.is_throw_completion());
 }
 
 TEST_CASE(fresh_precompiled_function_executables_materialize_lazily)


### PR DESCRIPTION
Keep more cached response data backed by the HTTP disk cache instead of copying it into WebContent heap memory.

The biggest win here is the JS bytecode cache: mapped bytecode cache sidecars can now stay file-backed while LibJS decodes and validates them. On https://x.com/ this removes almost 200 MB of heap allocations from cached executable bytecode, strings, constant tables, and executable metadata tables.

This also lets large HTTP disk-cache hits travel as file-backed bodies when they are bigger than a page, so the browser can avoid copying those cached resources into anonymous heap memory too.

This adds `Core::ImmutableBytes` for owned or mapped immutable byte storage, sends large HTTP disk-cache hits to WebContent as file-backed bodies, preserves file-backed bodies through LibRequests, ResourceLoader, Fetch, and MemoryCache, reuses freshly written disk-cache body files after downloads, and sends bytecode cache sidecars as mapped files when available.

LibJS can now borrow bytecode, UTF-16 strings, constant tables, and executable metadata tables from mapped bytecode cache blobs. Disk-cache entries are published by rename so existing mappings stay stable when a cache entry is replaced, and bytecode cache decoding now rejects impossible table counts.