### PR TITLE
LibWeb: Absolutize `@font-face` descriptors before reading

### DIFF
--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -301,7 +301,7 @@ void FontFace::reparse_connected_css_font_face_rule_descriptors()
 
     set_family_impl(*descriptors->descriptor(DescriptorNameAndID::from_id(DescriptorID::FontFamily)));
     set_style_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontStyle))->absolutized(computation_context));
-    set_weight_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWeight))->absolutized(computation_context));
+    set_weight_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWeight)));
     set_stretch_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWidth)));
     set_unicode_range_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::UnicodeRange)));
     set_feature_settings_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontFeatureSettings)));
@@ -518,8 +518,10 @@ WebIDL::ExceptionOr<void> FontFace::set_weight(String const& string)
 
 void FontFace::set_weight_impl(NonnullRefPtr<StyleValue const> const& value)
 {
-    m_weight = value->to_string(SerializationMode::Normal);
-    m_cached_weight_range = compute_weight_range(*value);
+    auto context = computation_context();
+    NonnullRefPtr<StyleValue const> absolutized_value = context.has_value() ? value->absolutized(*context) : value;
+    m_weight = absolutized_value->to_string(SerializationMode::Normal);
+    m_cached_weight_range = compute_weight_range(*absolutized_value);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-stretch

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -295,12 +295,8 @@ void FontFace::reparse_connected_css_font_face_rule_descriptors()
 {
     auto const& descriptors = m_css_font_face_rule->descriptors();
 
-    ComputationContext computation_context {
-        .length_resolution_context = Length::ResolutionContext::for_document(*descriptors->parent_rule()->parent_style_sheet()->owning_document())
-    };
-
     set_family_impl(*descriptors->descriptor(DescriptorNameAndID::from_id(DescriptorID::FontFamily)));
-    set_style_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontStyle))->absolutized(computation_context));
+    set_style_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontStyle)));
     set_weight_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWeight)));
     set_stretch_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWidth)));
     set_unicode_range_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::UnicodeRange)));
@@ -483,8 +479,10 @@ WebIDL::ExceptionOr<void> FontFace::set_style(String const& string)
 
 void FontFace::set_style_impl(NonnullRefPtr<StyleValue const> const& value)
 {
-    m_style = value->to_string(SerializationMode::Normal);
-    m_cached_slope = compute_slope(*value);
+    auto context = computation_context();
+    NonnullRefPtr<StyleValue const> absolutized_value = context.has_value() ? value->absolutized(*context) : value;
+    m_style = absolutized_value->to_string(SerializationMode::Normal);
+    m_cached_slope = compute_slope(*absolutized_value);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-weight

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -302,7 +302,7 @@ void FontFace::reparse_connected_css_font_face_rule_descriptors()
     set_family_impl(*descriptors->descriptor(DescriptorNameAndID::from_id(DescriptorID::FontFamily)));
     set_style_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontStyle))->absolutized(computation_context));
     set_weight_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWeight))->absolutized(computation_context));
-    set_stretch_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWidth))->absolutized(computation_context));
+    set_stretch_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontWidth)));
     set_unicode_range_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::UnicodeRange)));
     set_feature_settings_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontFeatureSettings)));
     set_variation_settings_impl(*descriptors->descriptor_or_initial_value(DescriptorNameAndID::from_id(DescriptorID::FontVariationSettings)));
@@ -384,6 +384,18 @@ Optional<FontComputer&> FontFace::font_computer() const
         if (auto* window = as_if<HTML::Window>(global))
             return window->associated_document().font_computer();
     }
+    return {};
+}
+
+Optional<ComputationContext> FontFace::computation_context() const
+{
+    if (m_css_font_face_rule) {
+        if (auto document = m_css_font_face_rule->descriptors()->parent_rule()->parent_style_sheet()->owning_document())
+            return ComputationContext { .length_resolution_context = Length::ResolutionContext::for_document(*document) };
+    }
+    auto& global = HTML::relevant_global_object(*this);
+    if (auto* window = as_if<HTML::Window>(global))
+        return ComputationContext { .length_resolution_context = Length::ResolutionContext::for_document(window->associated_document()) };
     return {};
 }
 
@@ -542,8 +554,10 @@ WebIDL::ExceptionOr<void> FontFace::set_stretch(String const& string)
 
 void FontFace::set_stretch_impl(NonnullRefPtr<StyleValue const> const& value)
 {
-    m_stretch = value->to_string(SerializationMode::Normal);
-    m_cached_width = compute_width(*value);
+    auto context = computation_context();
+    NonnullRefPtr<StyleValue const> absolutized_value = context.has_value() ? value->absolutized(*context) : value;
+    m_stretch = absolutized_value->to_string(SerializationMode::Normal);
+    m_cached_width = compute_width(*absolutized_value);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-unicoderange

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/FontFace.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/ParsedFontFace.h>
+#include <LibWeb/CSS/StyleValues/ComputationContext.h>
 
 namespace Web::CSS {
 
@@ -116,6 +117,8 @@ private:
     void reject_status_promise(JS::Value reason);
 
     Optional<FontComputer&> font_computer() const;
+
+    [[nodiscard]] Optional<ComputationContext> computation_context() const;
 
     // FIXME: Should we be storing StyleValues instead?
     String m_family;

--- a/Tests/LibWeb/Crash/CSS/font-face-stretch-constructor-with-calc.html
+++ b/Tests/LibWeb/Crash/CSS/font-face-stretch-constructor-with-calc.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+    new FontFace("Foo", "url(x.ttf)", { stretch: "calc(sign(1rem - 1px) * 100%)" });
+</script>

--- a/Tests/LibWeb/Crash/CSS/font-face-stretch-setter-with-calc.html
+++ b/Tests/LibWeb/Crash/CSS/font-face-stretch-setter-with-calc.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+    const font = new FontFace("Foo", "url(x.ttf)");
+    font.stretch = "calc(sign(1rem - 1px) * 100%)";
+</script>

--- a/Tests/LibWeb/Crash/CSS/font-face-weight-constructor-with-calc.html
+++ b/Tests/LibWeb/Crash/CSS/font-face-weight-constructor-with-calc.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+    new FontFace("Foo", "url(x.ttf)", { weight: "calc(sign(1rem - 1px) * 400)" });
+</script>

--- a/Tests/LibWeb/Crash/CSS/font-face-weight-setter-with-calc.html
+++ b/Tests/LibWeb/Crash/CSS/font-face-weight-setter-with-calc.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+    const font = new FontFace("Foo", "url(x.ttf)");
+    font.weight = "calc(sign(1rem - 1px) * 400)";
+</script>


### PR DESCRIPTION
This PR prevents crashes when reading `@font-face` descriptors with `calc()` values containing relative units. See individual commits for details.

NB: The change in the last commit is not currently observable, but I made the change to match the style used in the previous commits.