### PR TITLE
LibGfx+LibWeb: Bound Skia cache growth

### DIFF
--- a/Libraries/LibGfx/DecodedImageFrameSkiaImageCache.cpp
+++ b/Libraries/LibGfx/DecodedImageFrameSkiaImageCache.cpp
@@ -20,6 +20,8 @@
 namespace Gfx {
 
 static constexpr u64 image_cache_max_unused_generations = 120;
+static constexpr size_t image_cache_max_entries = 128;
+static constexpr size_t image_cache_max_bytes = 64 * MiB;
 
 struct DecodedImageFrameSkiaImageCache::Impl {
     Impl() = default;
@@ -55,10 +57,33 @@ struct DecodedImageFrameSkiaImageCache::Impl {
     struct CachedImage {
         sk_sp<SkImage> image;
         u64 last_used_generation { 0 };
+        size_t approximate_byte_size { 0 };
     };
+
+    void prune_to_limits()
+    {
+        while (images.size() > image_cache_max_entries || approximate_byte_size > image_cache_max_bytes) {
+            Optional<DecodedImageFrame> oldest_frame;
+            Optional<u64> oldest_generation;
+            for (auto const& image : images) {
+                if (!oldest_generation.has_value() || image.value.last_used_generation < oldest_generation.value()) {
+                    oldest_frame = image.key;
+                    oldest_generation = image.value.last_used_generation;
+                }
+            }
+
+            if (!oldest_frame.has_value())
+                break;
+
+            auto cached_image = images.get(oldest_frame.value()).release_value();
+            approximate_byte_size -= min(approximate_byte_size, cached_image.approximate_byte_size);
+            images.remove(oldest_frame.value());
+        }
+    }
 
     RefPtr<SkiaBackendContext> skia_backend_context;
     HashMap<DecodedImageFrame, CachedImage, DecodedImageFrameKeyTraits> images;
+    size_t approximate_byte_size { 0 };
     u64 generation { 0 };
 };
 
@@ -99,16 +124,23 @@ sk_sp<SkImage> DecodedImageFrameSkiaImageCache::image_for_frame(DecodedImageFram
     Impl::CachedImage cached_image {
         .image = image,
         .last_used_generation = m_impl->generation,
+        .approximate_byte_size = bitmap.size_in_bytes(),
     };
+    m_impl->approximate_byte_size += cached_image.approximate_byte_size;
     m_impl->images.set(frame, move(cached_image));
+    m_impl->prune_to_limits();
     return image;
 }
 
 void DecodedImageFrameSkiaImageCache::prune()
 {
     m_impl->images.remove_all_matching([this](auto const&, auto const& cached_image) {
-        return m_impl->generation - cached_image.last_used_generation > image_cache_max_unused_generations;
+        if (m_impl->generation - cached_image.last_used_generation <= image_cache_max_unused_generations)
+            return false;
+        m_impl->approximate_byte_size -= min(m_impl->approximate_byte_size, cached_image.approximate_byte_size);
+        return true;
     });
+    m_impl->prune_to_limits();
     ++m_impl->generation;
 }
 

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -27,6 +27,10 @@
 
 namespace Gfx {
 
+#if defined(AK_OS_MACOS) || USE_VULKAN
+static constexpr size_t skia_resource_cache_limit = 256 * MiB;
+#endif
+
 static RefPtr<SkiaBackendContext> s_main_thread_context;
 
 void SkiaBackendContext::initialize_gpu_backend()
@@ -130,6 +134,7 @@ RefPtr<SkiaBackendContext> SkiaBackendContext::create_vulkan_context(VulkanConte
 
     sk_sp<GrDirectContext> ctx = GrDirectContexts::MakeVulkan(backend_context);
     VERIFY(ctx);
+    ctx->setResourceCacheLimit(skia_resource_cache_limit);
     return adopt_ref(*new SkiaVulkanBackendContext(ctx, vulkan_context, move(extensions)));
 }
 #endif
@@ -175,6 +180,8 @@ RefPtr<SkiaBackendContext> SkiaBackendContext::create_metal_context(NonnullRefPt
     backend_context.fDevice.retain(metal_context->device());
     backend_context.fQueue.retain(metal_context->queue());
     sk_sp<GrDirectContext> ctx = GrDirectContexts::MakeMetal(backend_context);
+    VERIFY(ctx);
+    ctx->setResourceCacheLimit(skia_resource_cache_limit);
     return adopt_ref(*new SkiaMetalBackendContext(move(ctx), move(metal_context)));
 }
 #endif

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -36,10 +36,17 @@
 #include <core/SkColor.h>
 #include <core/SkPaint.h>
 #include <core/SkRRect.h>
+#include <gpu/ganesh/GrDirectContext.h>
 
 #include <LibCore/Platform/ScopedAutoreleasePool.h>
 
 namespace Web::Compositor {
+
+static constexpr auto skia_deferred_cleanup_interval = AK::Duration::from_seconds(1);
+static constexpr auto skia_aggressive_cleanup_interval = AK::Duration::from_seconds(5);
+static constexpr auto skia_deferred_cleanup_resource_age = std::chrono::seconds(5);
+static constexpr auto skia_resource_cache_high_watermark = 384 * MiB;
+static constexpr auto skia_resource_cache_critical_watermark = 512 * MiB;
 
 struct BackingStoreState {
     RefPtr<Gfx::PaintingSurface> front_store;
@@ -215,8 +222,29 @@ static void paint_viewport_scrollbars(Gfx::PaintingSurface& surface, ReadonlySpa
 
 static void flush_surface(Gfx::PaintingSurface& surface)
 {
-    if (auto context = surface.skia_backend_context())
+    if (auto context = surface.skia_backend_context()) {
         context->flush_and_submit(&surface.sk_surface());
+        auto* skia_context = context->sk_context();
+
+        static thread_local Optional<MonotonicTime> s_last_deferred_cleanup;
+        static thread_local Optional<MonotonicTime> s_last_aggressive_cleanup;
+
+        auto const now = MonotonicTime::now();
+        if (!s_last_deferred_cleanup.has_value() || now - *s_last_deferred_cleanup >= skia_deferred_cleanup_interval) {
+            s_last_deferred_cleanup = now;
+            skia_context->performDeferredCleanup(skia_deferred_cleanup_resource_age);
+
+            size_t resource_bytes = 0;
+            skia_context->getResourceCacheUsage(nullptr, &resource_bytes);
+            if (resource_bytes >= skia_resource_cache_high_watermark && (!s_last_aggressive_cleanup.has_value() || now - *s_last_aggressive_cleanup >= skia_aggressive_cleanup_interval)) {
+                s_last_aggressive_cleanup = now;
+                skia_context->performDeferredCleanup(std::chrono::milliseconds(0));
+                skia_context->getResourceCacheUsage(nullptr, &resource_bytes);
+                if (resource_bytes >= skia_resource_cache_critical_watermark)
+                    skia_context->purgeUnlockedResources(GrPurgeResourceOptions::kScratchResourcesOnly);
+            }
+        }
+    }
     surface.flush();
 }
 


### PR DESCRIPTION
Set an explicit resource cache limit on Skia GPU contexts and ask Skia to perform deferred cleanup from the compositor at a throttled cadence. When resource usage crosses high watermarks, request more aggressive cleanup and purge scratch resources only as a last step.

Also cap the decoded frame Skia image cache by approximate bitmap bytes and entry count so route changes and pointer-driven repaint churn cannot keep an unbounded number of uploaded image textures alive.