### PR TITLE
LibWeb: Keep ResizeObserver targets weakly

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6725,24 +6725,33 @@ void Document::gather_active_observations_at_depth(size_t depth)
     // 1. Let depth be the depth passed in.
 
     // 2. For each observer in [[resizeObservers]] run these steps:
-    for (auto& observer : m_resize_observers) {
+    auto resize_observers = GC::RootVector<GC::Ref<ResizeObserver::ResizeObserver>> { heap() };
+    for (auto& observer : m_resize_observers)
+        resize_observers.append(observer);
+
+    for (auto const& observer : resize_observers) {
+        observer->remove_dead_observations();
+
         // 1. Clear observer’s [[activeTargets]], and [[skippedTargets]].
-        observer.active_targets().clear();
-        observer.skipped_targets().clear();
+        observer->active_targets().clear();
+        observer->skipped_targets().clear();
 
         // 2. For each observation in observer.[[observationTargets]] run this step:
-        for (auto& observation : observer.observation_targets()) {
+        for (auto& observation : observer->observation_targets()) {
             // 1. If observation.isActive() is true
             if (observation->is_active()) {
+                auto target = observation->target();
+                VERIFY(target);
+
                 // 1. Let targetDepth be result of calculate depth for node for observation.target.
-                auto target_depth = calculate_depth_for_node(*observation->target());
+                auto target_depth = calculate_depth_for_node(*target);
 
                 // 2. If targetDepth is greater than depth then add observation to [[activeTargets]].
                 if (target_depth > depth) {
-                    observer.active_targets().append(observation);
+                    observer->active_targets().append(observation);
                 } else {
                     // 3. Else add observation to [[skippedTargets]].
-                    observer.skipped_targets().append(observation);
+                    observer->skipped_targets().append(observation);
                 }
             }
         }
@@ -6762,6 +6771,15 @@ size_t Document::broadcast_active_resize_observations()
     for (auto& observer : m_resize_observers)
         resize_observers.append(observer);
 
+    // Keep all gathered targets alive while resize observer callbacks run.
+    auto active_targets = GC::RootVector<GC::Ref<Element>> { heap() };
+    for (auto const& observer : resize_observers) {
+        for (auto const& observation : observer->active_targets()) {
+            if (auto target = observation->target())
+                active_targets.append(*target);
+        }
+    }
+
     for (auto const& observer : resize_observers) {
         // 1. If observer.[[activeTargets]] slot is empty, continue.
         if (observer->active_targets().is_empty()) {
@@ -6773,8 +6791,12 @@ size_t Document::broadcast_active_resize_observations()
 
         // 3. For each observation in [[activeTargets]] perform these steps:
         for (auto const& observation : observer->active_targets()) {
+            auto target = observation->target();
+            if (!target)
+                continue;
+
             // 1. Let entry be the result of running create and populate a ResizeObserverEntry given observation.target.
-            auto entry = ResizeObserver::ResizeObserverEntry::create_and_populate(realm(), *observation->target()).release_value_but_fixme_should_propagate_errors();
+            auto entry = ResizeObserver::ResizeObserverEntry::create_and_populate(realm(), *target).release_value_but_fixme_should_propagate_errors();
 
             // 2. Add entry to entries.
             entries.append(entry);
@@ -6798,11 +6820,16 @@ size_t Document::broadcast_active_resize_observations()
             }
 
             // 4. Set targetDepth to the result of calculate depth for node for observation.target.
-            auto target_depth = calculate_depth_for_node(*observation->target());
+            auto target_depth = calculate_depth_for_node(*target);
 
             // 5. Set shallowestTargetDepth to targetDepth if targetDepth < shallowestTargetDepth
             if (target_depth < shallowest_target_depth)
                 shallowest_target_depth = target_depth;
+        }
+
+        if (entries.is_empty()) {
+            observer->active_targets().clear();
+            continue;
         }
 
         // 4. Invoke observer.[[callback]] with entries.

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -7,7 +7,10 @@
 
 #include <AK/JsonObject.h>
 #include <LibGfx/Cursor.h>
+#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Date.h>
+#include <LibJS/Runtime/Error.h>
+#include <LibJS/Runtime/Reference.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibURL/Parser.h>
 #include <LibUnicode/TimeZone.h>
@@ -174,6 +177,31 @@ GC::Ref<WebIDL::Promise> Internals::gc_async()
     }));
 
     return promise;
+}
+
+WebIDL::ExceptionOr<void> Internals::mark_as_garbage(StringView variable_name)
+{
+    auto& vm = this->vm();
+
+    // This helper is intentionally limited to real environment bindings. It cannot
+    // find values that the bytecode generator stored only in optimized locals.
+    // In native functions we don't have a lexical environment so get the outer via the execution stack.
+    auto outer_environment = vm.last_execution_context_matching([&](auto* execution_context) {
+        return execution_context->lexical_environment != nullptr;
+    });
+    if (!outer_environment.has_value())
+        return vm.throw_completion<JS::ReferenceError>(JS::ErrorType::UnknownIdentifier, variable_name);
+
+    auto reference = TRY(vm.resolve_binding(Utf16FlyString::from_utf8(variable_name), JS::Strict::No, outer_environment.value()->lexical_environment));
+    auto value = TRY(reference.get_value(vm));
+
+    if (!JS::can_be_held_weakly(value))
+        return vm.throw_completion<JS::TypeError>(JS::ErrorType::CannotBeHeldWeakly, value);
+
+    TRY(reference.put_value(vm, JS::js_undefined()));
+    (void)TRY(reference.delete_(vm));
+    vm.heap().uproot_cell(&value.as_cell());
+    return {};
 }
 
 WebIDL::ExceptionOr<String> Internals::set_time_zone(StringView time_zone)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -42,6 +42,7 @@ public:
 
     void gc();
     GC::Ref<WebIDL::Promise> gc_async();
+    WebIDL::ExceptionOr<void> mark_as_garbage(StringView variable_name);
     JS::Object* hit_test(double x, double y);
 
     void send_text(HTML::HTMLElement&, String const&, WebIDL::UnsignedShort modifiers);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -10,6 +10,9 @@ interface Internals {
 
     undefined gc();
     Promise<undefined> gcAsync();
+    // Clears a named environment binding and forces its current cell to be treated as garbage.
+    // This does not work for values stored only in optimized locals or registers.
+    undefined markAsGarbage(DOMString variableName);
     object hitTest(double x, double y);
 
     const unsigned short MOD_NONE = 0;

--- a/Libraries/LibWeb/ResizeObserver/ResizeObservation.cpp
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObservation.cpp
@@ -32,15 +32,17 @@ void ResizeObservation::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_realm);
-    visitor.visit(m_target);
     visitor.visit(m_last_reported_sizes);
 }
 
 // https://drafts.csswg.org/resize-observer-1/#dom-resizeobservation-isactive
 bool ResizeObservation::is_active()
 {
+    if (!m_target)
+        return false;
+
     // 1. Set currentSize by calculate box size given target and observedBox.
-    auto current_size = ResizeObserverSize::compute_box_size(m_target, m_observed_box);
+    auto current_size = ResizeObserverSize::compute_box_size(*m_target, m_observed_box);
 
     // 2. Return true if currentSize is not equal to the first entry in this.lastReportedSizes.
     VERIFY(!m_last_reported_sizes.is_empty());

--- a/Libraries/LibWeb/ResizeObserver/ResizeObservation.h
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObservation.h
@@ -22,7 +22,7 @@ public:
 
     bool is_active();
 
-    GC::Ref<DOM::Element> target() const { return m_target; }
+    GC::Ptr<DOM::Element> target() const { return m_target.ptr(); }
     Bindings::ResizeObserverBoxOptions observed_box() const { return m_observed_box; }
 
     Vector<GC::Ref<ResizeObserverSize>>& last_reported_sizes() { return m_last_reported_sizes; }
@@ -33,7 +33,7 @@ private:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     GC::Ref<JS::Realm> m_realm;
-    GC::Ref<DOM::Element> m_target;
+    GC::Weak<DOM::Element> m_target;
     Bindings::ResizeObserverBoxOptions m_observed_box;
     Vector<GC::Ref<ResizeObserverSize>> m_last_reported_sizes;
 };

--- a/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -107,6 +107,21 @@ void ResizeObserver::disconnect()
     unregister_observer_if_needed();
 }
 
+void ResizeObserver::remove_dead_observations()
+{
+    m_observation_targets.remove_all_matching([](auto& observation) {
+        return !observation->target();
+    });
+    m_active_targets.remove_all_matching([](auto& observation) {
+        return !observation->target();
+    });
+    m_skipped_targets.remove_all_matching([](auto& observation) {
+        return !observation->target();
+    });
+
+    unregister_observer_if_needed();
+}
+
 void ResizeObserver::invoke_callback(ReadonlySpan<GC::Ref<ResizeObserverEntry>> entries) const
 {
     auto& callback = *m_callback;

--- a/Libraries/LibWeb/ResizeObserver/ResizeObserver.h
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObserver.h
@@ -35,6 +35,7 @@ public:
     Vector<GC::Ref<ResizeObservation>>& observation_targets() { return m_observation_targets; }
     Vector<GC::Ref<ResizeObservation>>& active_targets() { return m_active_targets; }
     Vector<GC::Ref<ResizeObservation>>& skipped_targets() { return m_skipped_targets; }
+    void remove_dead_observations();
 
 private:
     explicit ResizeObserver(JS::Realm&, WebIDL::CallbackType* callback);

--- a/Tests/LibWeb/Text/expected/ResizeObserver/active-target-survives-earlier-callback-gc.txt
+++ b/Tests/LibWeb/Text/expected/ResizeObserver/active-target-survives-earlier-callback-gc.txt
@@ -1,0 +1,5 @@
+first observer target: first
+second observer entries: 1
+second observer target: second
+first observer callbacks: 1
+second observer callbacks: 1

--- a/Tests/LibWeb/Text/expected/ResizeObserver/dead-observer-does-not-skip-active-observer.txt
+++ b/Tests/LibWeb/Text/expected/ResizeObserver/dead-observer-does-not-skip-active-observer.txt
@@ -1,0 +1,3 @@
+active observer callback: 200px x 200px
+active callbacks after first rendering opportunity: 1
+active callbacks after second rendering opportunity: 1

--- a/Tests/LibWeb/Text/input/ResizeObserver/active-target-survives-earlier-callback-gc.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/active-target-survives-earlier-callback-gc.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<style>
+.box {
+    width: 200px;
+    height: 200px;
+}
+</style>
+<script src="../include.js"></script>
+<div id="first" class="box"></div>
+<div id="second" class="box"></div>
+<script>
+    let secondTarget = null;
+
+    asyncTest(async done => {
+        let firstCallbackCount = 0;
+        let secondCallbackCount = 0;
+        secondTarget = document.getElementById("second");
+
+        let observers = (() => {
+            let firstObserver = new ResizeObserver(entries => {
+                ++firstCallbackCount;
+                println(`first observer target: ${entries[0].target.id}`);
+
+                secondTarget.remove();
+                secondTarget = null;
+                internals.gc();
+            });
+
+            let secondObserver = new ResizeObserver(entries => {
+                ++secondCallbackCount;
+                println(`second observer entries: ${entries.length}`);
+                println(`second observer target: ${entries[0].target.id}`);
+            });
+
+            firstObserver.observe(document.getElementById("first"));
+            secondObserver.observe(secondTarget);
+
+            return [firstObserver, secondObserver];
+        })();
+
+        await animationFrame();
+        await timeout(0);
+
+        println(`first observer callbacks: ${firstCallbackCount}`);
+        println(`second observer callbacks: ${secondCallbackCount}`);
+
+        observers = null;
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/dead-observer-does-not-skip-active-observer.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/dead-observer-does-not-skip-active-observer.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<style>
+#active-box {
+    width: 200px;
+    height: 200px;
+}
+</style>
+<script src="../include.js"></script>
+<div id="active-box"></div>
+<script>
+    let deadBox = null;
+
+    asyncTest(async done => {
+        let deadObserver = new ResizeObserver(() => {
+            println("dead observer callback");
+        });
+
+        deadBox = document.createElement("div");
+        deadBox.style.width = "100px";
+        deadBox.style.height = "100px";
+        document.body.appendChild(deadBox);
+        deadObserver.observe(deadBox);
+        deadBox.remove();
+        internals.markAsGarbage("deadBox");
+        internals.gc();
+
+        let activeCallbackCount = 0;
+        let activeObserver = new ResizeObserver(entries => {
+            ++activeCallbackCount;
+            const { width, height } = entries[0].contentRect;
+            println(`active observer callback: ${width}px x ${height}px`);
+        });
+        activeObserver.observe(document.getElementById("active-box"));
+
+        await animationFrame();
+        await timeout(0);
+        println(`active callbacks after first rendering opportunity: ${activeCallbackCount}`);
+
+        await animationFrame();
+        await timeout(0);
+        println(`active callbacks after second rendering opportunity: ${activeCallbackCount}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Store `ResizeObservation` targets weakly, matching Blink and WebKit. A `ResizeObserver` can be kept alive by the document while it has observed targets, but the observation itself should not keep a removed target and its subtree alive forever.

Prune dead observations before gathering active resize observations. Snapshot the document observer list before pruning so unregistering an observer cannot mutate the intrusive list being iterated. Keep gathered active targets rooted while broadcasting callbacks, since an earlier callback can remove a later target and trigger GC before delivery.

Expose an `internals` helper to force environment-bound test objects to be treated as garbage. Add text coverage for both pruning a dead observer during gather and GC during an earlier resize observer callback.