### PR TITLE
UI/Qt: Disable QWinEventNotifier before closing process_handle

### DIFF
--- a/UI/Qt/EventLoopImplementationQt.cpp
+++ b/UI/Qt/EventLoopImplementationQt.cpp
@@ -406,6 +406,7 @@ void EventLoopManagerQt::register_process(pid_t pid, ESCAPING Function<void(pid_
                     VERIFY(maybe_process.value() == process);
             });
 
+            process->setEnabled(false);
             CloseHandle(process_handle);
             process->deleteLater();
             exit_handler(process_id);
@@ -425,13 +426,16 @@ void EventLoopManagerQt::unregister_process(pid_t pid)
 
     auto* process = maybe_process.release_value();
     HANDLE process_handle = process->handle();
+
     if (QThread::currentThread() != process->thread()) {
         QMetaObject::invokeMethod(process, [process, process_handle] {
+            process->setEnabled(false);
             CloseHandle(process_handle);
             delete process; }, Qt::QueuedConnection);
         return;
     }
 
+    process->setEnabled(false);
     CloseHandle(process_handle);
     delete process;
 }


### PR DESCRIPTION
When a child process terminates on Windows, the QWinEventNotifier emits 
the activated signal it its event handler. Before this happens, we need to 
call setEnabled(false) to unregister the wait object from the Windows 
thread pool. setEnabled(false) also causes us to wait for any outstanding 
callbacks to complete and then prevents QWinEventNotifier from trying 
to use the closed handle.

This seems to follow the pattern from Qt where the destructor also calls 
setEnabled(false) before destruction.