### PR TITLE
LibWeb: Synchronize display list resources via transactions

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 namespace Web::CSS {
 
@@ -109,7 +110,8 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
 
         // Paint the cursor into a bitmap.
         auto display_list = Painting::DisplayList::create(Painting::AccumulatedVisualContextTree::create());
-        Painting::DisplayListRecorder display_list_recorder(display_list);
+        Painting::DisplayListResourceStorage resource_storage;
+        Painting::DisplayListRecorder display_list_recorder(display_list, resource_storage);
         DisplayListRecordingContext paint_context { display_list_recorder, document.page().palette(), document.page().client().device_pixels_per_css_pixel(), document.page().chrome_metrics() };
 
         image.resolve_for_size(layout_node, CSSPixelSize { bitmap.size() });
@@ -120,7 +122,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         case DisplayListPlayerType::SkiaCPU: {
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
             Painting::DisplayListPlayerSkia display_list_player;
-            display_list_player.execute(*display_list, {}, painting_surface);
+            display_list_player.execute(*display_list, resource_storage, {}, painting_surface);
             break;
         }
         }

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -45,6 +45,7 @@ static constexpr auto skia_resource_cache_critical_watermark = 512 * MiB;
 
 struct UpdateDisplayListCommand {
     NonnullRefPtr<Painting::DisplayList> display_list;
+    Painting::DisplayListResourceTransaction resource_transaction;
     Painting::ScrollStateSnapshot scroll_state_snapshot;
 };
 
@@ -594,6 +595,7 @@ public:
                     [this](UpdateDisplayListCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing display list update (deferred_async_present={})",
                             m_has_deferred_async_scroll_present);
+                        m_display_list_resource_storage.apply_transaction(move(cmd.resource_transaction));
                         m_cached_display_list = move(cmd.display_list);
                         m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
                         auto async_scrolling_state = async_scrolling_state_from_display_list(*m_cached_display_list);
@@ -728,7 +730,7 @@ public:
                     [this](ScreenshotCommand& cmd) {
                         if (!m_cached_display_list)
                             return;
-                        m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, *cmd.target_surface);
+                        m_skia_player->execute(*m_cached_display_list, m_display_list_resource_storage, m_cached_scroll_state_snapshot, *cmd.target_surface);
                         paint_viewport_scrollbar_overlay(*cmd.target_surface);
                         flush_surface(*cmd.target_surface);
                         if (cmd.callback) {
@@ -1012,7 +1014,7 @@ private:
                 // cleared before repainting.
                 back_store.canvas().clear(SK_ColorTRANSPARENT);
             }
-            m_skia_player->execute(*m_cached_display_list, m_cached_scroll_state_snapshot, back_store);
+            m_skia_player->execute(*m_cached_display_list, m_display_list_resource_storage, m_cached_scroll_state_snapshot, back_store);
             paint_viewport_scrollbar_overlay(back_store);
             flush_surface(back_store);
             i32 rendered_bitmap_id = m_backing_store_manager.back_bitmap_id();
@@ -1107,6 +1109,7 @@ private:
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
+    Painting::DisplayListResourceStorage m_display_list_resource_storage;
     RefPtr<Painting::DisplayList> m_cached_display_list;
     Painting::ScrollStateSnapshot m_cached_scroll_state_snapshot;
     Vector<ViewportScrollbar> m_viewport_scrollbars;
@@ -1432,9 +1435,12 @@ void CompositorThread::stop_presenting_to_client()
     unregister_page_compositor(m_thread_data->page_id(), *m_thread_data);
 }
 
-void CompositorThread::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+void CompositorThread::update_display_list(
+    NonnullRefPtr<Painting::DisplayList> display_list,
+    Painting::DisplayListResourceTransaction&& resource_transaction,
+    Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot) });
+    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(resource_transaction), move(scroll_state_snapshot) });
 }
 
 void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -24,6 +24,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 namespace Web::Compositor {
 
@@ -78,7 +79,7 @@ public:
     void stop_presenting_to_client();
     void set_presentation_mode(PresentationMode);
 
-    void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&);
+    void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
     void update_scroll_state(Painting::ScrollStateSnapshot&&);
     void invalidate_wheel_event_listener_state(u64 generation);
     AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7621,13 +7621,13 @@ void Document::set_needs_to_record_display_list()
         navigable->set_needs_to_record_display_list();
 }
 
-RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig config)
+RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig config, Painting::DisplayListResourceStorage& resource_storage)
 {
     update_paint_and_hit_testing_properties_if_needed();
     VERIFY(paintable());
 
     auto display_list = Painting::DisplayList::create(paintable()->visual_context_tree());
-    Painting::DisplayListRecorder display_list_recorder(display_list);
+    Painting::DisplayListRecorder display_list_recorder(display_list, resource_storage);
 
     // https://drafts.csswg.org/css-color-adjust-1/#color-scheme-effect
     // On the root element, the used color scheme additionally must affect the surface color of the canvas, and the viewport’s scrollbars.
@@ -8016,7 +8016,8 @@ String Document::dump_display_list()
     if (!viewport_paintable)
         return "No paintable"_string;
 
-    auto display_list = record_display_list(HTML::PaintConfig {});
+    Painting::DisplayListResourceStorage resource_storage;
+    auto display_list = record_display_list(HTML::PaintConfig {}, resource_storage);
     if (!display_list)
         return "No display list"_string;
 
@@ -8086,7 +8087,7 @@ String Document::dump_display_list()
                 builder.append('\n');
 
                 if (nested_display_list_id.has_value()) {
-                    auto& nested_display_list = list.resource_storage().display_list(*nested_display_list_id);
+                    auto& nested_display_list = resource_storage.display_list(*nested_display_list_id);
                     dump_commands(nested_display_list, indent + 1);
                 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -959,7 +959,7 @@ public:
         set_needs_repaint(should_invalidate_display_list);
     }
 
-    RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig);
+    RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig, Painting::DisplayListResourceStorage&);
 
     void set_needs_to_record_display_list();
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3303,10 +3303,17 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
         || !(m_rendering_thread_display_list_paint_config.value() == paint_config);
 
     RefPtr<Painting::DisplayList> display_list;
+    Painting::DisplayListResourceTransaction resource_transaction;
     if (should_record_display_list) {
-        display_list = document->record_display_list(paint_config);
+        display_list = document->record_display_list(paint_config, m_display_list_resource_storage);
         if (!display_list)
             return;
+        auto display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
+        resource_transaction = m_display_list_resource_storage.create_transaction(
+            m_rendering_thread_display_list_resources,
+            display_list_resources);
+        m_display_list_resource_storage.retain_only(display_list_resources);
+        m_rendering_thread_display_list_resources = move(display_list_resources);
     }
 
     auto document_paintable = document->paintable();
@@ -3315,7 +3322,7 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
-        m_rendering_thread.update_display_list(*display_list, move(scroll_state_snapshot));
+        m_rendering_thread.update_display_list(*display_list, move(resource_transaction), move(scroll_state_snapshot));
         m_needs_to_record_display_list = false;
         m_rendering_thread_display_list_paint_config = paint_config;
     } else {

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -31,6 +31,7 @@
 #include <LibWeb/HTML/WindowType.h>
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Page/EventHandler.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/XHR/FormDataEntry.h>
 
@@ -330,6 +331,8 @@ private:
     bool m_pending_set_browser_zoom_request { false };
     bool m_should_show_line_box_borders { false };
     Optional<PaintConfig> m_rendering_thread_display_list_paint_config;
+    Painting::DisplayListResourceStorage m_display_list_resource_storage;
+    Painting::DisplayListResourceSet m_rendering_thread_display_list_resources;
     Compositor::CompositorThread m_rendering_thread;
     RefPtr<Painting::ExternalContentSource> m_external_content_source;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -40,6 +40,7 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/WebIDL/Promise.h>
@@ -649,7 +650,8 @@ static Optional<AsyncScrollingStateSnapshot> capture_async_scrolling_state(DOM::
     auto document_paintable = document.paintable();
     if (!navigable || !document_paintable)
         return {};
-    auto display_list = document.record_display_list(HTML::PaintConfig {});
+    Painting::DisplayListResourceStorage resource_storage;
+    auto display_list = document.record_display_list(HTML::PaintConfig {}, resource_storage);
     if (!display_list)
         return {};
     return AsyncScrollingStateSnapshot {

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -29,11 +29,8 @@ static void set_command_sequence_visual_context(Bytes command_bytes, VisualConte
 
 DisplayListCommandSequence::DisplayListCommandSequence() = default;
 
-DisplayList::DisplayList(
-    NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree,
-    DisplayListResourceStorage resource_storage)
+DisplayList::DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
     : m_visual_context_tree(move(visual_context_tree))
-    , m_resource_storage(move(resource_storage))
     , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
 {
 }
@@ -73,12 +70,15 @@ bool DisplayList::append_bytes(
     return true;
 }
 
-void DisplayList::append_command_sequence(DisplayListCommandSequence const& sequence, VisualContextIndex context_index)
+void DisplayList::append_command_sequence(
+    DisplayListCommandSequence const& sequence,
+    VisualContextIndex context_index,
+    DisplayListResourceStorage& resource_storage)
 {
     auto command_bytes = MUST(ByteBuffer::copy(sequence.m_command_bytes.span()));
 
     set_command_sequence_visual_context(command_bytes.span(), context_index);
-    m_resource_storage.append_referenced_resources_from(sequence.m_resource_storage, command_bytes.span());
+    resource_storage.append_referenced_resources_from(sequence.m_resource_storage, command_bytes.span());
     VERIFY(m_command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
     VERIFY(command_bytes.size() % DisplayListCommandSequence::command_alignment == 0);
 
@@ -86,22 +86,30 @@ void DisplayList::append_command_sequence(DisplayListCommandSequence const& sequ
         m_command_bytes.append(command_bytes.data(), command_bytes.size());
 }
 
-DisplayListCommandSequence DisplayList::copy_command_sequence_from(size_t command_start_offset) const
+DisplayListCommandSequence DisplayList::copy_command_sequence_from(
+    size_t command_start_offset,
+    DisplayListResourceStorage const& resource_storage) const
 {
     VERIFY(command_start_offset <= m_command_bytes.size());
     DisplayListCommandSequence sequence;
     sequence.m_command_bytes = MUST(m_command_bytes.slice(command_start_offset, m_command_bytes.size() - command_start_offset));
-    sequence.m_resource_storage.append_referenced_resources_from(m_resource_storage, sequence.m_command_bytes.span());
+    sequence.m_resource_storage.append_referenced_resources_from(resource_storage, sequence.m_command_bytes.span());
     return sequence;
 }
 
-void DisplayListPlayer::execute(DisplayList const& display_list, ScrollStateSnapshot const& scroll_state_snapshot, RefPtr<Gfx::PaintingSurface> surface)
+void DisplayListPlayer::execute(
+    DisplayList const& display_list,
+    DisplayListResourceStorage const& resource_storage,
+    ScrollStateSnapshot const& scroll_state_snapshot,
+    RefPtr<Gfx::PaintingSurface> surface)
 {
     m_surface = surface;
     m_active_display_list = &display_list;
+    m_resource_storage = &resource_storage;
     execute_impl(display_list, scroll_state_snapshot);
     if (surface)
         flush();
+    m_resource_storage = nullptr;
     m_active_display_list = nullptr;
     m_surface = nullptr;
 }
@@ -110,6 +118,7 @@ void DisplayListPlayer::execute_display_list_into_surface(DisplayList const& dis
 {
     TemporaryChange surface_change { m_surface, RefPtr<Gfx::PaintingSurface> { target_surface } };
     TemporaryChange display_list_change { m_active_display_list, &display_list };
+    VERIFY(m_resource_storage);
     ScrollStateSnapshot scroll_state_snapshot;
     execute_impl(display_list, scroll_state_snapshot);
 }
@@ -120,6 +129,7 @@ void DisplayListPlayer::execute_nested_display_list(
     ReadonlyBytes command_bytes)
 {
     TemporaryChange display_list_change { m_active_display_list, &display_list };
+    VERIFY(m_resource_storage);
     execute_impl(display_list, scroll_state_snapshot, command_bytes);
 }
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -67,11 +67,12 @@ class DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
 
-    void execute(DisplayList const&, ScrollStateSnapshot const&, RefPtr<Gfx::PaintingSurface>);
+    void execute(DisplayList const&, DisplayListResourceStorage const&, ScrollStateSnapshot const&, RefPtr<Gfx::PaintingSurface>);
 
 protected:
     Gfx::PaintingSurface& surface() const { return *m_surface; }
     DisplayList const& active_display_list() const { return *m_active_display_list; }
+    DisplayListResourceStorage const& resource_storage() const { return *m_resource_storage; }
     ReadonlyBytes inline_data(DisplayListDataSpan span) const
     {
         VERIFY(static_cast<size_t>(span.offset) + span.size <= m_current_command_payload.size());
@@ -133,6 +134,7 @@ private:
     virtual void add_clip_path(Gfx::Path const&) = 0;
 
     DisplayList const* m_active_display_list { nullptr };
+    DisplayListResourceStorage const* m_resource_storage { nullptr };
     RefPtr<Gfx::PaintingSurface> m_surface;
     ReadonlyBytes m_current_command_payload;
 };
@@ -148,14 +150,7 @@ public:
 
     static NonnullRefPtr<DisplayList> create(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
     {
-        return adopt_ref(*new DisplayList(move(visual_context_tree), DisplayListResourceStorage {}));
-    }
-
-    static NonnullRefPtr<DisplayList> create(
-        NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree,
-        DisplayListResourceStorage resource_storage)
-    {
-        return adopt_ref(*new DisplayList(move(visual_context_tree), move(resource_storage)));
+        return adopt_ref(*new DisplayList(move(visual_context_tree)));
     }
 
     template<DisplayListCommand Command>
@@ -174,8 +169,6 @@ public:
     u64 id() const { return m_id; }
 
     ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
-    DisplayListResourceStorage& resource_storage() { return m_resource_storage; }
-    DisplayListResourceStorage const& resource_storage() const { return m_resource_storage; }
     void set_async_scrolling_metadata(AsyncScrollingMetadata metadata) { m_async_scrolling_metadata = metadata; }
     Optional<AsyncScrollingMetadata> const& async_scrolling_metadata() const { return m_async_scrolling_metadata; }
 
@@ -191,14 +184,12 @@ public:
         DisplayListCommandSequence::for_each_command_header(command_bytes(), move(callback));
     }
 
-    void append_command_sequence(DisplayListCommandSequence const&, VisualContextIndex);
-    DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset) const;
+    void append_command_sequence(DisplayListCommandSequence const&, VisualContextIndex, DisplayListResourceStorage&);
+    DisplayListCommandSequence copy_command_sequence_from(size_t command_start_offset, DisplayListResourceStorage const&) const;
     size_t command_byte_size() const { return m_command_bytes.size(); }
 
 private:
-    explicit DisplayList(
-        NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree,
-        DisplayListResourceStorage resource_storage);
+    explicit DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree);
 
     static Optional<Gfx::IntRect> command_bounding_rectangle(auto const& command)
     {
@@ -225,7 +216,6 @@ private:
         bool is_clip);
 
     NonnullRefPtr<AccumulatedVisualContextTree const> const m_visual_context_tree;
-    DisplayListResourceStorage m_resource_storage;
     u64 m_id { 0 };
     ByteBuffer m_command_bytes;
     Optional<AsyncScrollingMetadata> m_async_scrolling_metadata;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -115,7 +115,7 @@ void DisplayListPlayerSkia::flush()
 
 void DisplayListPlayerSkia::draw_glyph_run(DrawGlyphRun const& command)
 {
-    auto const& font = active_display_list().resource_storage().font(command.font_id);
+    auto const& font = resource_storage().font(command.font_id);
     auto glyphs = inline_objects<Gfx::DrawGlyph>(command.glyphs);
     if (glyphs.is_empty())
         return;
@@ -167,7 +167,7 @@ void DisplayListPlayerSkia::fill_rect(FillRect const& command)
 
 void DisplayListPlayerSkia::draw_external_content(DrawExternalContent const& command)
 {
-    auto frame = active_display_list().resource_storage().external_content_source(command.source_id).current_frame();
+    auto frame = resource_storage().external_content_source(command.source_id).current_frame();
     if (!frame.has_value())
         return;
     auto image = m_image_cache.image_for_frame(*frame);
@@ -183,7 +183,7 @@ void DisplayListPlayerSkia::draw_external_content(DrawExternalContent const& com
 
 void DisplayListPlayerSkia::draw_video_frame_source(DrawVideoFrameSource const& command)
 {
-    auto frame = active_display_list().resource_storage().video_frame_source(command.source_id).current_frame();
+    auto frame = resource_storage().video_frame_source(command.source_id).current_frame();
     if (!frame)
         return;
 
@@ -226,7 +226,7 @@ void DisplayListPlayerSkia::draw_video_frame_source(DrawVideoFrameSource const& 
 
 void DisplayListPlayerSkia::draw_scaled_decoded_image_frame(DrawScaledDecodedImageFrame const& command)
 {
-    auto const& frame = active_display_list().resource_storage().image_frame(command.frame_id);
+    auto const& frame = resource_storage().image_frame(command.frame_id);
     auto image = m_image_cache.image_for_frame(frame);
     if (!image)
         return;
@@ -244,7 +244,7 @@ void DisplayListPlayerSkia::draw_scaled_decoded_image_frame(DrawScaledDecodedIma
 
 void DisplayListPlayerSkia::draw_repeated_decoded_image_frame(DrawRepeatedDecodedImageFrame const& command)
 {
-    auto const& frame = active_display_list().resource_storage().image_frame(command.frame_id);
+    auto const& frame = resource_storage().image_frame(command.frame_id);
     auto image = m_image_cache.image_for_frame(frame);
     if (!image)
         return;
@@ -581,7 +581,7 @@ SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(DisplayListPaintStyle c
 
         auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_skia_backend_context);
 
-        auto const& tile_display_list = active_display_list().resource_storage().display_list(paint_style.pattern_tile_display_list_id);
+        auto const& tile_display_list = resource_storage().display_list(paint_style.pattern_tile_display_list_id);
         execute_display_list_into_surface(tile_display_list, *tile_surface);
 
         auto image = tile_surface->sk_surface().makeImageSnapshot();
@@ -727,7 +727,7 @@ void DisplayListPlayerSkia::apply_backdrop_filter(ApplyBackdropFilter const& com
 
     if (command.has_backdrop_filter) {
         auto filter = Gfx::deserialize_filter(inline_data(command.backdrop_filter_data), [&](u64 image_id) {
-            return active_display_list().resource_storage().image_frame(ImageFrameResourceId { image_id });
+            return resource_storage().image_frame(ImageFrameResourceId { image_id });
         });
         auto image_filter = to_skia_image_filter(filter);
         canvas.saveLayer(SkCanvas::SaveLayerRec(nullptr, nullptr, image_filter.get(), 0));
@@ -817,7 +817,7 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
     canvas.translate(command.rect.x(), command.rect.y());
     ScrollStateSnapshot scroll_state_snapshot;
     auto command_bytes = inline_data(command.command_bytes);
-    auto& nested_display_list = active_display_list().resource_storage().display_list(command.display_list_id);
+    auto& nested_display_list = resource_storage().display_list(command.display_list_id);
     execute_nested_display_list(nested_display_list, scroll_state_snapshot, command_bytes);
 }
 
@@ -888,7 +888,7 @@ void DisplayListPlayerSkia::apply_effects(ApplyEffects const& command, Gfx::Filt
     if (command.has_filter) {
         if (!filter) {
             deserialized_filter = Gfx::deserialize_filter(inline_data(command.filter_data), [&](u64 image_id) {
-                return active_display_list().resource_storage().image_frame(ImageFrameResourceId { image_id });
+                return resource_storage().image_frame(ImageFrameResourceId { image_id });
             });
             filter = &deserialized_filter.value();
         }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -12,8 +12,9 @@
 
 namespace Web::Painting {
 
-DisplayListRecorder::DisplayListRecorder(DisplayList& command_list)
+DisplayListRecorder::DisplayListRecorder(DisplayList& command_list, DisplayListResourceStorage& resource_storage)
     : m_display_list(command_list)
+    , m_resource_storage(resource_storage)
 {
 }
 
@@ -33,7 +34,9 @@ DisplayListRecorder::CommandCapture::~CommandCapture()
 DisplayListCommandSequence DisplayListRecorder::CommandCapture::take()
 {
     VERIFY(m_recorder);
-    auto commands = m_recorder->m_display_list.copy_command_sequence_from(m_recorder->m_capture_start_command_offset);
+    auto commands = m_recorder->m_display_list.copy_command_sequence_from(
+        m_recorder->m_capture_start_command_offset,
+        m_recorder->m_resource_storage);
     m_recorder->m_is_capturing = false;
     m_recorder = nullptr;
     return commands;
@@ -276,7 +279,7 @@ void DisplayListRecorder::replay_cached_commands(DisplayListCommandSequence cons
     commands.for_each_command_header([&](DisplayListCommandHeader const& header, ReadonlyBytes) {
         m_save_nesting_level += display_list_command_nesting_level_change(header.type);
     });
-    m_display_list.append_command_sequence(commands, m_accumulated_visual_context_index);
+    m_display_list.append_command_sequence(commands, m_accumulated_visual_context_index, m_resource_storage);
 }
 
 void DisplayListRecorder::paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -150,12 +150,12 @@ public:
 
     void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {}, Optional<Gfx::MaskKind> mask_kind = {});
 
-    DisplayListRecorder(DisplayList&);
+    DisplayListRecorder(DisplayList&, DisplayListResourceStorage&);
     ~DisplayListRecorder();
 
     DisplayList& display_list() { return m_display_list; }
     DisplayList const& display_list() const { return m_display_list; }
-    DisplayListResourceStorage& resource_storage() { return m_display_list.resource_storage(); }
+    DisplayListResourceStorage& resource_storage() { return m_resource_storage; }
 
     int m_save_nesting_level { 0 };
 
@@ -172,6 +172,7 @@ private:
     VisualContextIndex m_accumulated_visual_context_index {};
     Vector<size_t> m_push_sc_index_stack;
     DisplayList& m_display_list;
+    DisplayListResourceStorage& m_resource_storage;
     bool m_is_capturing { false };
     size_t m_capture_start_command_offset { 0 };
 };

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -16,18 +16,14 @@ DisplayListResourceStorage::~DisplayListResourceStorage() = default;
 FontResourceId DisplayListResourceStorage::add_font(Gfx::Font const& font)
 {
     auto id = font.id();
-    m_fonts.ensure(id, [&]() -> NonnullRefPtr<Gfx::Font const> {
-        return font;
-    });
+    m_fonts.ensure(id, [&]() -> NonnullRefPtr<Gfx::Font const> { return font; });
     return { id };
 }
 
 ImageFrameResourceId DisplayListResourceStorage::add_image_frame(Gfx::DecodedImageFrame const& frame)
 {
     auto id = frame.id();
-    m_image_frames.ensure(id, [&] {
-        return frame;
-    });
+    m_image_frames.ensure(id, [&] { return frame; });
     return { id };
 }
 
@@ -35,27 +31,21 @@ ExternalContentResourceId DisplayListResourceStorage::add_external_content_sourc
     NonnullRefPtr<ExternalContentSource const> source)
 {
     auto id = source->id();
-    m_external_content_sources.ensure(id, [&] {
-        return move(source);
-    });
+    m_external_content_sources.ensure(id, [&] { return move(source); });
     return { id };
 }
 
 VideoFrameResourceId DisplayListResourceStorage::add_video_frame_source(NonnullRefPtr<VideoFrameSource const> source)
 {
     auto id = source->id();
-    m_video_frame_sources.ensure(id, [&] {
-        return move(source);
-    });
+    m_video_frame_sources.ensure(id, [&] { return move(source); });
     return { id };
 }
 
 DisplayListResourceId DisplayListResourceStorage::add_display_list(NonnullRefPtr<DisplayList const> display_list)
 {
     auto id = display_list->id();
-    m_display_lists.ensure(id, [&] {
-        return move(display_list);
-    });
+    m_display_lists.ensure(id, [&] { return move(display_list); });
     return { id };
 }
 
@@ -69,43 +59,166 @@ void DisplayListResourceStorage::append_referenced_resources_from(
     DisplayListResourceStorage const& source,
     ReadonlyBytes command_bytes)
 {
+    auto referenced_resources = source.collect_referenced_resources(command_bytes);
+    for (auto id : referenced_resources.fonts)
+        add_font(source.font(id));
+    for (auto id : referenced_resources.image_frames)
+        add_image_frame(source.image_frame(id));
+    for (auto id : referenced_resources.external_content_sources)
+        add_external_content_source(source.external_content_source(id));
+    for (auto id : referenced_resources.video_frame_sources)
+        add_video_frame_source(source.video_frame_source(id));
+    for (auto id : referenced_resources.display_lists)
+        add_display_list(source.display_list(id));
+}
+
+void DisplayListResourceStorage::collect_referenced_resources(
+    ReadonlyBytes command_bytes,
+    DisplayListResourceSet& referenced_resources) const
+{
+    auto add_display_list_resource = [&](DisplayListResourceId id, Optional<ReadonlyBytes> command_bytes_to_collect) {
+        if (referenced_resources.display_lists.set(id, AK::HashSetExistingEntryBehavior::Keep) != HashSetResult::InsertedNewEntry)
+            return;
+        auto const& nested_display_list = display_list(id);
+        collect_referenced_resources(command_bytes_to_collect.value_or(nested_display_list.command_bytes()), referenced_resources);
+    };
+
     DisplayList::for_each_command_header(command_bytes, [&](DisplayListCommandHeader const& header, ReadonlyBytes payload) {
         visit_display_list_command(header.type, payload, [&](auto const& command) {
             if constexpr (requires { command.font_id; })
-                add_font(source.font(command.font_id));
+                referenced_resources.fonts.set(command.font_id, AK::HashSetExistingEntryBehavior::Keep);
             if constexpr (requires { command.frame_id; })
-                add_image_frame(source.image_frame(command.frame_id));
-            if constexpr (requires { source.external_content_source(command.source_id); })
-                add_external_content_source(source.external_content_source(command.source_id));
-            if constexpr (requires { source.video_frame_source(command.source_id); })
-                add_video_frame_source(source.video_frame_source(command.source_id));
+                referenced_resources.image_frames.set(command.frame_id, AK::HashSetExistingEntryBehavior::Keep);
+            if constexpr (requires { external_content_source(command.source_id); })
+                referenced_resources.external_content_sources.set(command.source_id, AK::HashSetExistingEntryBehavior::Keep);
+            if constexpr (requires { video_frame_source(command.source_id); })
+                referenced_resources.video_frame_sources.set(command.source_id, AK::HashSetExistingEntryBehavior::Keep);
             if constexpr (requires { command.paint_style; command.paint_kind; }) {
                 if (command.paint_kind == decltype(command.paint_kind)::PaintStyle
                     && command.paint_style.type == DisplayListPaintStyleType::Pattern)
-                    add_display_list(source.display_list(command.paint_style.pattern_tile_display_list_id));
+                    add_display_list_resource(command.paint_style.pattern_tile_display_list_id, {});
             }
             if constexpr (requires { command.backdrop_filter_data; }) {
                 if (command.has_backdrop_filter) {
                     Gfx::deserialize_filter(inline_data(payload, command.backdrop_filter_data), [&](u64 image_id) {
-                        auto const& frame = source.image_frame(ImageFrameResourceId { image_id });
-                        add_image_frame(frame);
-                        return frame;
+                        referenced_resources.image_frames.set(ImageFrameResourceId { image_id }, AK::HashSetExistingEntryBehavior::Keep);
+                        return image_frame(ImageFrameResourceId { image_id });
                     });
                 }
             }
             if constexpr (requires { command.filter_data; }) {
                 if (command.has_filter) {
                     Gfx::deserialize_filter(inline_data(payload, command.filter_data), [&](u64 image_id) {
-                        auto const& frame = source.image_frame(ImageFrameResourceId { image_id });
-                        add_image_frame(frame);
-                        return frame;
+                        referenced_resources.image_frames.set(ImageFrameResourceId { image_id }, AK::HashSetExistingEntryBehavior::Keep);
+                        return image_frame(ImageFrameResourceId { image_id });
                     });
                 }
             }
-            if constexpr (requires { command.display_list_id; })
-                add_display_list(source.display_list(command.display_list_id));
+            if constexpr (requires { command.display_list_id; }) {
+                if constexpr (requires { command.command_bytes; })
+                    add_display_list_resource(command.display_list_id, inline_data(payload, command.command_bytes));
+                else
+                    add_display_list_resource(command.display_list_id, {});
+            }
         });
     });
+}
+
+DisplayListResourceSet DisplayListResourceStorage::collect_referenced_resources(ReadonlyBytes command_bytes) const
+{
+    DisplayListResourceSet referenced_resources;
+    collect_referenced_resources(command_bytes, referenced_resources);
+    return referenced_resources;
+}
+
+DisplayListResourceSet DisplayListResourceStorage::collect_referenced_resources(DisplayList const& display_list) const
+{
+    return collect_referenced_resources(display_list.command_bytes());
+}
+
+DisplayListResourceTransaction DisplayListResourceStorage::create_transaction(
+    DisplayListResourceSet const& previous,
+    DisplayListResourceSet const& current) const
+{
+    DisplayListResourceTransaction transaction;
+
+    for (auto id : current.fonts) {
+        if (!previous.fonts.contains(id))
+            transaction.fonts.append(font(id));
+    }
+    for (auto id : current.image_frames) {
+        if (!previous.image_frames.contains(id))
+            transaction.image_frames.append(image_frame(id));
+    }
+    for (auto id : current.external_content_sources) {
+        if (!previous.external_content_sources.contains(id))
+            transaction.external_content_sources.append(external_content_source(id));
+    }
+    for (auto id : current.video_frame_sources) {
+        if (!previous.video_frame_sources.contains(id))
+            transaction.video_frame_sources.append(video_frame_source(id));
+    }
+    for (auto id : current.display_lists) {
+        if (!previous.display_lists.contains(id))
+            transaction.display_lists.append(display_list(id));
+    }
+
+    for (auto id : previous.fonts) {
+        if (!current.fonts.contains(id))
+            transaction.font_ids_to_remove.append(id);
+    }
+    for (auto id : previous.image_frames) {
+        if (!current.image_frames.contains(id))
+            transaction.image_frame_ids_to_remove.append(id);
+    }
+    for (auto id : previous.external_content_sources) {
+        if (!current.external_content_sources.contains(id))
+            transaction.external_content_source_ids_to_remove.append(id);
+    }
+    for (auto id : previous.video_frame_sources) {
+        if (!current.video_frame_sources.contains(id))
+            transaction.video_frame_source_ids_to_remove.append(id);
+    }
+    for (auto id : previous.display_lists) {
+        if (!current.display_lists.contains(id))
+            transaction.display_list_ids_to_remove.append(id);
+    }
+
+    return transaction;
+}
+
+void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransaction&& transaction)
+{
+    for (auto const& font : transaction.fonts)
+        add_font(*font);
+    for (auto const& frame : transaction.image_frames)
+        add_image_frame(frame);
+    for (auto& source : transaction.external_content_sources)
+        add_external_content_source(move(source));
+    for (auto& source : transaction.video_frame_sources)
+        add_video_frame_source(move(source));
+    for (auto& display_list : transaction.display_lists)
+        add_display_list(move(display_list));
+
+    for (auto id : transaction.font_ids_to_remove)
+        m_fonts.remove(id.value());
+    for (auto id : transaction.image_frame_ids_to_remove)
+        m_image_frames.remove(id.value());
+    for (auto id : transaction.external_content_source_ids_to_remove)
+        m_external_content_sources.remove(id.value());
+    for (auto id : transaction.video_frame_source_ids_to_remove)
+        m_video_frame_sources.remove(id.value());
+    for (auto id : transaction.display_list_ids_to_remove)
+        m_display_lists.remove(id.value());
+}
+
+void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resource_set)
+{
+    m_fonts.remove_all_matching([&](auto id, auto const&) { return !resource_set.fonts.contains(FontResourceId { id }); });
+    m_image_frames.remove_all_matching([&](auto id, auto const&) { return !resource_set.image_frames.contains(ImageFrameResourceId { id }); });
+    m_external_content_sources.remove_all_matching([&](auto id, auto const&) { return !resource_set.external_content_sources.contains(ExternalContentResourceId { id }); });
+    m_video_frame_sources.remove_all_matching([&](auto id, auto const&) { return !resource_set.video_frame_sources.contains(VideoFrameResourceId { id }); });
+    m_display_lists.remove_all_matching([&](auto id, auto const&) { return !resource_set.display_lists.contains(DisplayListResourceId { id }); });
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -8,9 +8,11 @@
 
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
+#include <AK/HashTable.h>
 #include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Span.h>
+#include <AK/Vector.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
@@ -19,6 +21,28 @@
 #include <LibWeb/Painting/VideoFrameSource.h>
 
 namespace Web::Painting {
+
+struct DisplayListResourceSet {
+    HashTable<FontResourceId> fonts;
+    HashTable<ImageFrameResourceId> image_frames;
+    HashTable<ExternalContentResourceId> external_content_sources;
+    HashTable<VideoFrameResourceId> video_frame_sources;
+    HashTable<DisplayListResourceId> display_lists;
+};
+
+struct DisplayListResourceTransaction {
+    Vector<NonnullRefPtr<Gfx::Font const>> fonts;
+    Vector<Gfx::DecodedImageFrame> image_frames;
+    Vector<NonnullRefPtr<ExternalContentSource const>> external_content_sources;
+    Vector<NonnullRefPtr<VideoFrameSource const>> video_frame_sources;
+    Vector<NonnullRefPtr<DisplayList const>> display_lists;
+
+    Vector<FontResourceId> font_ids_to_remove;
+    Vector<ImageFrameResourceId> image_frame_ids_to_remove;
+    Vector<ExternalContentResourceId> external_content_source_ids_to_remove;
+    Vector<VideoFrameResourceId> video_frame_source_ids_to_remove;
+    Vector<DisplayListResourceId> display_list_ids_to_remove;
+};
 
 class DisplayListResourceStorage {
     AK_MAKE_NONCOPYABLE(DisplayListResourceStorage);
@@ -34,6 +58,11 @@ public:
     VideoFrameResourceId add_video_frame_source(NonnullRefPtr<VideoFrameSource const>);
     DisplayListResourceId add_display_list(NonnullRefPtr<DisplayList const>);
     void append_referenced_resources_from(DisplayListResourceStorage const& source, ReadonlyBytes command_bytes);
+    void apply_transaction(DisplayListResourceTransaction&&);
+    DisplayListResourceTransaction create_transaction(DisplayListResourceSet const& previous, DisplayListResourceSet const& current) const;
+    DisplayListResourceSet collect_referenced_resources(DisplayList const&) const;
+    DisplayListResourceSet collect_referenced_resources(ReadonlyBytes command_bytes) const;
+    void retain_only(DisplayListResourceSet const&);
 
     Gfx::Font const& font(FontResourceId id) const { return *m_fonts.get(id.value()).value(); }
     Gfx::DecodedImageFrame const& image_frame(ImageFrameResourceId id) const { return m_image_frames.get(id.value()).value(); }
@@ -42,6 +71,8 @@ public:
     DisplayList const& display_list(DisplayListResourceId id) const { return *m_display_lists.get(id.value()).value(); }
 
 private:
+    void collect_referenced_resources(ReadonlyBytes command_bytes, DisplayListResourceSet&) const;
+
     HashMap<u64, NonnullRefPtr<Gfx::Font const>> m_fonts;
     HashMap<u64, Gfx::DecodedImageFrame> m_image_frames;
     HashMap<u64, NonnullRefPtr<ExternalContentSource const>> m_external_content_sources;

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -85,7 +85,7 @@ static RefPtr<DisplayList> paint_mask_or_clip_to_display_list(
 {
     auto mask_rect = context.enclosing_device_rect(area);
     auto display_list = DisplayList::create(AccumulatedVisualContextTree::create());
-    DisplayListRecorder display_list_recorder(*display_list);
+    DisplayListRecorder display_list_recorder(*display_list, context.display_list_recorder().resource_storage());
     display_list_recorder.translate(-mask_rect.location().to_type<int>());
     auto paint_context = context.clone(display_list_recorder);
     auto const& mask_element = as<SVG::SVGGraphicsElement const>(*paintable.dom_node());

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -366,7 +366,7 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
 
     if (mask_image) {
         auto mask_display_list = DisplayList::create(AccumulatedVisualContextTree::create());
-        DisplayListRecorder display_list_recorder(*mask_display_list);
+        DisplayListRecorder display_list_recorder(*mask_display_list, context.display_list_recorder().resource_storage());
         auto mask_painting_context = context.clone(display_list_recorder);
         auto mask_rect_in_device_pixels = context.enclosing_device_rect(paintable_box().absolute_padding_box_rect());
         mask_image->paint(mask_painting_context, { {}, mask_rect_in_device_pixels.size() }, CSS::ImageRendering::Auto);

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 #include <LibWeb/XML/XMLDocumentBuilder.h>
@@ -134,11 +135,11 @@ size_t SVGDecodedImageData::external_memory_size() const
     return size;
 }
 
-RefPtr<Painting::DisplayList> SVGDecodedImageData::record_display_list(Gfx::IntSize size) const
+RefPtr<Painting::DisplayList> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& resource_storage) const
 {
     m_document->navigable()->set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout(DOM::UpdateLayoutReason::SVGDecodedImageDataRender);
-    return m_document->record_display_list({});
+    return m_document->record_display_list({}, resource_storage);
 }
 
 RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize size) const
@@ -157,7 +158,8 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize
         m_cached_rendered_surfaces.remove(m_cached_rendered_surfaces.begin());
 
     auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
-    auto display_list = record_display_list(size);
+    Painting::DisplayListResourceStorage resource_storage;
+    auto display_list = record_display_list(size, resource_storage);
     if (!display_list)
         return nullptr;
 
@@ -165,7 +167,7 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize
     case DisplayListPlayerType::SkiaGPUIfAvailable:
     case DisplayListPlayerType::SkiaCPU: {
         Painting::DisplayListPlayerSkia display_list_player;
-        display_list_player.execute(*display_list, {}, surface);
+        display_list_player.execute(*display_list, resource_storage, {}, surface);
         break;
     }
     default:
@@ -260,7 +262,7 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::surface(size_t, Gfx::IntSize s
 
 void SVGDecodedImageData::paint(DisplayListRecordingContext& context, size_t, Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, Gfx::ScalingMode) const
 {
-    auto display_list = record_display_list(dst_rect.size());
+    auto display_list = record_display_list(dst_rect.size(), context.display_list_recorder().resource_storage());
     if (!display_list)
         return;
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -46,7 +46,7 @@ private:
 
     RefPtr<Gfx::PaintingSurface> surface(size_t frame_index, Gfx::IntSize) const;
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
-    RefPtr<Painting::DisplayList> record_display_list(Gfx::IntSize) const;
+    RefPtr<Painting::DisplayList> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
 
     // FIXME: Remove this once everything is using surfaces instead.
     mutable HashMap<Gfx::IntSize, Gfx::DecodedImageFrame> m_cached_rendered_frames;

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -290,7 +290,7 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
     tile_rect.translate_by(svg_offset);
 
     auto display_list = Painting::DisplayList::create(Painting::AccumulatedVisualContextTree::create());
-    Painting::DisplayListRecorder display_list_recorder(*display_list);
+    Painting::DisplayListRecorder display_list_recorder(*display_list, recording_context.display_list_recorder().resource_storage());
     auto content_origin = paint_context.paint_transform.map(Gfx::FloatPoint { 0, 0 }) + svg_offset;
     display_list_recorder.translate(-Gfx::IntPoint(content_origin.to_type<int>()));
     auto paint_context_copy = recording_context.clone(display_list_recorder);


### PR DESCRIPTION
Display lists used to own the resource storage needed to replay their command bytes. That kept the compositor tied to in-process object ownership: sending a display list update also meant sharing the same resource container with the recording side.

Move resource storage out of DisplayList and make display list updates carry a transaction of resources to add and remove. Navigable now tracks the resources referenced by the current display list, sends only the delta to the compositor, and trims its recording-side storage to the active set. The compositor applies those transactions to its own storage before replacing the cached display list.

This still carries in-process resource objects, but it puts the ownership boundary in the right place. Command bytes and resource lifetime are now synchronized explicitly, which is the shape needed before the compositor can receive serializable resource updates across a process boundary.