### PR TITLE
LibWeb: Reduce memory growth in long-lived pages

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -115,6 +115,7 @@
 #include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
 #include <LibWeb/HTML/CustomElements/CustomElementReactionNames.h>
 #include <LibWeb/HTML/CustomElements/CustomElementRegistry.h>
+#include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/DocumentState.h>
 #include <LibWeb/HTML/DragEvent.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -6110,6 +6111,62 @@ void Document::set_latest_entry(RefPtr<HTML::SessionHistoryEntry> entry)
 HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& Document::shared_resource_requests()
 {
     return m_shared_resource_requests;
+}
+
+void Document::prune_image_resource_caches()
+{
+    static constexpr size_t decoded_image_resource_cache_limit = 8 * MiB;
+    static constexpr size_t decoded_image_resource_cache_count_limit = 96;
+
+    struct CacheSize {
+        size_t decoded_image_size { 0 };
+        size_t decoded_image_count { 0 };
+    };
+
+    auto cache_size = [&] {
+        CacheSize cache_size;
+        size_t size = 0;
+        size_t count = 0;
+        for (auto const& it : m_shared_resource_requests) {
+            auto const& request = *it.value;
+            if (!request.can_be_pruned_from_memory_cache())
+                continue;
+            ++count;
+            if (auto image_data = request.image_data())
+                size += image_data->external_memory_size();
+        }
+        cache_size.decoded_image_size = size;
+        cache_size.decoded_image_count = count;
+        return cache_size;
+    };
+
+    auto size = cache_size();
+    while (size.decoded_image_size > decoded_image_resource_cache_limit || size.decoded_image_count > decoded_image_resource_cache_count_limit) {
+        Optional<URL::URL> least_recently_used_url;
+        u64 least_recently_used_serial = NumericLimits<u64>::max();
+
+        for (auto const& it : m_shared_resource_requests) {
+            auto const& request = *it.value;
+            if (!request.can_be_pruned_from_memory_cache())
+                continue;
+            if (request.cache_touch_serial() >= least_recently_used_serial)
+                continue;
+            least_recently_used_url = it.key;
+            least_recently_used_serial = request.cache_touch_serial();
+        }
+
+        if (!least_recently_used_url.has_value())
+            break;
+
+        m_shared_resource_requests.remove(least_recently_used_url.value());
+
+        auto new_size = cache_size();
+        if (new_size.decoded_image_size == size.decoded_image_size && new_size.decoded_image_count == size.decoded_image_count)
+            break;
+        size = new_size;
+    }
+
+    m_list_of_available_images->prune_to_limits(decoded_image_resource_cache_limit, decoded_image_resource_cache_count_limit);
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-document-timeline

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -795,6 +795,7 @@ public:
     void update_for_history_step_application(NonnullRefPtr<HTML::SessionHistoryEntry>, bool do_not_reactivate, size_t script_history_length, size_t script_history_index, Optional<Bindings::NavigationType> navigation_type, Optional<Vector<NonnullRefPtr<HTML::SessionHistoryEntry>>> entries_for_navigation_api = {}, RefPtr<HTML::SessionHistoryEntry> previous_entry_for_activation = {}, bool update_navigation_api = true);
 
     HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& shared_resource_requests();
+    void prune_image_resource_caches();
 
     void restore_the_history_object_state(NonnullRefPtr<HTML::SessionHistoryEntry> entry);
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -927,6 +927,7 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
 
                 // 3. Add the image to the list of available images using the key key, with the ignore higher-layer caching flag set.
                 document().list_of_available_images().add(key, *image_data, true);
+                document().prune_image_resource_caches();
 
                 set_needs_style_update(true);
                 set_needs_layout_update(DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
@@ -1077,6 +1078,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
 
             // 4. Add the image to the list of available images using the key key, with the ignore higher-layer caching flag set.
             document().list_of_available_images().add(key, image_data, true);
+            document().prune_image_resource_caches();
 
             // 5. Upgrade the pending request to the current request.
             upgrade_pending_request_to_current_request();

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -448,6 +448,7 @@ void HTMLLinkElement::default_fetch_and_process_linked_resource(u64 fetch_genera
         // "if, since the resource in question was fetched, it has become appropriate to fetch it again"
         if (fetch_generation != m_current_fetch_generation)
             return;
+        m_fetch_controller = nullptr;
 
         // FIXME: If the response is CORS cross-origin, we must use its internal response to query any of its data. See:
         //        https://github.com/whatwg/html/issues/9355
@@ -529,9 +530,13 @@ void HTMLLinkElement::fetch_and_process_linked_preload_resource()
 
     // 6. Preload options, with the following steps given a response response:
     GC::Weak weak_this { *this };
-    preload(options, [weak_this](Fetch::Infrastructure::Response& response) {
+    auto fetch_generation = m_current_fetch_generation;
+    preload(options, [weak_this, fetch_generation](Fetch::Infrastructure::Response& response) {
         // 1. If response is a network error, fire an event named error at el. Otherwise, fire an event named load at el.
         if (auto link_element = weak_this.ptr()) {
+            if (fetch_generation != link_element->m_current_fetch_generation)
+                return;
+            link_element->m_fetch_controller = nullptr;
             if (response.is_network_error())
                 link_element->dispatch_event(DOM::Event::create(link_element->realm(), HTML::EventNames::error));
             else

--- a/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
+++ b/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
@@ -11,6 +11,8 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(ListOfAvailableImages);
 
+static u64 s_next_available_image_cache_touch_serial;
+
 ListOfAvailableImages::ListOfAvailableImages() = default;
 ListOfAvailableImages::~ListOfAvailableImages() = default;
 
@@ -40,7 +42,8 @@ void ListOfAvailableImages::visit_edges(JS::Cell::Visitor& visitor)
 
 void ListOfAvailableImages::add(Key const& key, GC::Ref<DecodedImageData> image_data, bool ignore_higher_layer_caching)
 {
-    m_images.set(key, make<Entry>(image_data, ignore_higher_layer_caching));
+    auto cache_touch_serial = ++s_next_available_image_cache_touch_serial;
+    m_images.set(key, make<Entry>(image_data, ignore_higher_layer_caching, cache_touch_serial));
 }
 
 void ListOfAvailableImages::remove(Key const& key)
@@ -48,11 +51,52 @@ void ListOfAvailableImages::remove(Key const& key)
     m_images.remove(key);
 }
 
+void ListOfAvailableImages::prune_to_limits(size_t external_memory_limit, size_t count_limit)
+{
+    struct CacheSize {
+        size_t decoded_image_size { 0 };
+        size_t decoded_image_count { 0 };
+    };
+
+    auto cache_size = [&] {
+        CacheSize cache_size;
+        for (auto const& it : m_images)
+            cache_size.decoded_image_size += it.value->image_data->external_memory_size();
+        cache_size.decoded_image_count = m_images.size();
+        return cache_size;
+    };
+
+    auto size = cache_size();
+    while (size.decoded_image_size > external_memory_limit || size.decoded_image_count > count_limit) {
+        Optional<Key> least_recently_used_key;
+        u64 least_recently_used_serial = NumericLimits<u64>::max();
+
+        for (auto const& it : m_images) {
+            if (it.value->cache_touch_serial >= least_recently_used_serial)
+                continue;
+            least_recently_used_key = it.key;
+            least_recently_used_serial = it.value->cache_touch_serial;
+        }
+
+        if (!least_recently_used_key.has_value())
+            break;
+
+        m_images.remove(least_recently_used_key.value());
+
+        auto new_size = cache_size();
+        if (new_size.decoded_image_size == size.decoded_image_size
+            && new_size.decoded_image_count == size.decoded_image_count)
+            break;
+        size = new_size;
+    }
+}
+
 ListOfAvailableImages::Entry* ListOfAvailableImages::get(Key const& key)
 {
     auto it = m_images.find(key);
     if (it == m_images.end())
         return nullptr;
+    it->value->cache_touch_serial = ++s_next_available_image_cache_touch_serial;
     return it->value.ptr();
 }
 

--- a/Libraries/LibWeb/HTML/ListOfAvailableImages.h
+++ b/Libraries/LibWeb/HTML/ListOfAvailableImages.h
@@ -34,14 +34,16 @@ public:
     };
 
     struct Entry {
-        Entry(GC::Ref<DecodedImageData> image_data, bool ignore_higher_layer_caching)
+        Entry(GC::Ref<DecodedImageData> image_data, bool ignore_higher_layer_caching, u64 cache_touch_serial)
             : image_data(move(image_data))
             , ignore_higher_layer_caching(ignore_higher_layer_caching)
+            , cache_touch_serial(cache_touch_serial)
         {
         }
 
         GC::Ref<DecodedImageData> image_data;
         bool ignore_higher_layer_caching { false };
+        u64 cache_touch_serial { 0 };
     };
 
     ListOfAvailableImages();
@@ -49,6 +51,7 @@ public:
 
     void add(Key const&, GC::Ref<DecodedImageData>, bool ignore_higher_layer_caching);
     void remove(Key const&);
+    void prune_to_limits(size_t external_memory_limit, size_t count_limit);
     [[nodiscard]] Entry* get(Key const&);
 
     void visit_edges(JS::Cell::Visitor& visitor) override;

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -28,13 +28,17 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(SharedResourceRequest);
 
+static u64 s_next_memory_cache_touch_serial;
+
 GC::Ref<SharedResourceRequest> SharedResourceRequest::get_or_create(JS::Realm& realm, GC::Ref<Page> page, URL::URL const& url)
 {
     auto document = Bindings::principal_host_defined_environment_settings_object(realm).responsible_document();
     VERIFY(document);
     auto& shared_resource_requests = document->shared_resource_requests();
-    if (auto it = shared_resource_requests.find(url); it != shared_resource_requests.end())
+    if (auto it = shared_resource_requests.find(url); it != shared_resource_requests.end()) {
+        it->value->touch_memory_cache_entry();
         return *it->value;
+    }
     auto request = realm.create<SharedResourceRequest>(page, url, *document);
     shared_resource_requests.set(url, request);
     return request;
@@ -45,6 +49,7 @@ SharedResourceRequest::SharedResourceRequest(GC::Ref<Page> page, URL::URL url, G
     , m_url(move(url))
     , m_document(document)
 {
+    touch_memory_cache_entry();
 }
 
 SharedResourceRequest::~SharedResourceRequest() = default;
@@ -60,7 +65,9 @@ void SharedResourceRequest::finalize()
 
     if (m_document) {
         auto& shared_resource_requests = m_document->shared_resource_requests();
-        shared_resource_requests.remove(m_url);
+        if (auto it = shared_resource_requests.find(m_url);
+            it != shared_resource_requests.end() && it->value.ptr() == this)
+            shared_resource_requests.remove(it);
         m_document = nullptr;
     }
 }
@@ -81,6 +88,11 @@ void SharedResourceRequest::visit_edges(JS::Cell::Visitor& visitor)
 GC::Ptr<DecodedImageData> SharedResourceRequest::image_data() const
 {
     return m_image_data;
+}
+
+void SharedResourceRequest::touch_memory_cache_entry()
+{
+    m_cache_touch_serial = ++s_next_memory_cache_touch_serial;
 }
 
 GC::Ptr<Fetch::Infrastructure::FetchController> SharedResourceRequest::fetch_controller()
@@ -247,6 +259,7 @@ void SharedResourceRequest::handle_successful_resource_load()
             callback.on_finish->function()();
     }
     m_callbacks.clear();
+    m_document->prune_image_resource_caches();
 }
 
 bool SharedResourceRequest::needs_fetching() const

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -242,6 +242,7 @@ void SharedResourceRequest::handle_successful_fetch(URL::URL const& url_string, 
 void SharedResourceRequest::handle_failed_fetch()
 {
     m_state = State::Failed;
+    m_fetch_controller = nullptr;
     m_load_event_delayer.clear();
     for (auto& callback : m_callbacks) {
         if (callback.on_fail)
@@ -253,6 +254,7 @@ void SharedResourceRequest::handle_failed_fetch()
 void SharedResourceRequest::handle_successful_resource_load()
 {
     m_state = State::Finished;
+    m_fetch_controller = nullptr;
     m_load_event_delayer.clear();
     for (auto& callback : m_callbacks) {
         if (callback.on_finish)

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.h
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.h
@@ -29,6 +29,9 @@ public:
     URL::URL const& url() const { return m_url; }
 
     [[nodiscard]] GC::Ptr<DecodedImageData> image_data() const;
+    [[nodiscard]] bool can_be_pruned_from_memory_cache() const { return m_image_data; }
+    [[nodiscard]] u64 cache_touch_serial() const { return m_cache_touch_serial; }
+    void touch_memory_cache_entry();
 
     [[nodiscard]] GC::Ptr<Fetch::Infrastructure::FetchController> fetch_controller();
     void set_fetch_controller(GC::Ptr<Fetch::Infrastructure::FetchController>);
@@ -70,6 +73,7 @@ private:
     URL::URL m_url;
     GC::Ptr<DecodedImageData> m_image_data;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;
+    u64 m_cache_touch_serial { 0 };
 
     GC::Ptr<DOM::Document> m_document;
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -1071,7 +1071,7 @@ void WindowOrWorkerGlobalScopeMixin::forcibly_close_all_event_sources()
 void WindowOrWorkerGlobalScopeMixin::close_all_idb_connections()
 {
     IndexedDB::Database::for_each_database([&](IndexedDB::Database& database) {
-        for (auto& connection : database.associated_connections_as_root_vector()) {
+        for (auto& connection : database.associated_connections_as_root_vector(this_impl().heap())) {
             if (connection->close_pending())
                 continue;
             if (&as<WindowOrWorkerGlobalScopeMixin>(relevant_global_object(*connection)) == this)

--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -97,7 +97,7 @@ void open_a_database_connection(JS::Realm& realm, StorageAPI::StorageKey storage
         // 6. If db is null, let db be a new database with name name, version 0 (zero), and with no object stores.
         // If this fails for any reason, return an appropriate error (e.g. a "QuotaExceededError" or "UnknownError" DOMException).
         if (!maybe_db.has_value()) {
-            auto maybe_database = Database::create_for_key_and_name(realm, storage_key, name);
+            auto maybe_database = Database::create_for_key_and_name(realm.heap(), storage_key, name);
 
             if (maybe_database.is_error()) {
                 call_completion(queue, on_complete, WebIDL::OperationError::create(realm, "Unable to create a new database"_utf16));
@@ -125,7 +125,7 @@ void open_a_database_connection(JS::Realm& realm, StorageAPI::StorageKey storage
             dbgln_if(IDB_DEBUG, "open_a_database_connection: Upgrading database from version {} to {}", db->version(), version);
 
             // 1. Let openConnections be the set of all connections, except connection, associated with db.
-            auto open_connections = db->associated_connections_as_heap_vector_except(connection);
+            auto open_connections = db->associated_connections_as_heap_vector_except(realm.heap(), connection);
 
             // 2. For each entry of openConnections that does not have its close pending flag set to true,
             //    queue a database task to fire a version change event named versionchange at entry with db’s version and version.
@@ -504,7 +504,7 @@ void delete_a_database(JS::Realm& realm, StorageAPI::StorageKey storage_key, Str
         GC::Ref db = maybe_db.value();
 
         // 5. Let openConnections be the set of all connections associated with db.
-        auto open_connections = db->associated_connections_as_heap_vector();
+        auto open_connections = db->associated_connections_as_heap_vector(realm.heap());
 
         // 6. For each entry of openConnections that does not have its close pending flag set to true,
         //    queue a database task to fire a version change event named versionchange at entry with db’s version and null.
@@ -2221,7 +2221,7 @@ bool cleanup_indexed_database_transactions(GC::Ref<HTML::EventLoop> event_loop)
     bool has_matching_event_loop = false;
 
     Database::for_each_database([&has_matching_event_loop, event_loop](Database& database) {
-        for (auto const& connection : database.associated_connections_as_root_vector()) {
+        for (auto const& connection : database.associated_connections_as_root_vector(event_loop->heap())) {
             for (auto const& transaction : connection->transactions()) {
                 // 2. For each transaction transaction with cleanup event loop matching the current event loop:
                 if (transaction->cleanup_event_loop() == event_loop) {

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/Heap.h>
 #include <LibWeb/IndexedDB/IDBDatabase.h>
 #include <LibWeb/IndexedDB/IDBTransaction.h>
 #include <LibWeb/IndexedDB/Internal/Algorithms.h>
@@ -30,9 +31,9 @@ GC_DEFINE_ALLOCATOR(Database);
 
 Database::~Database() = default;
 
-GC::Ref<Database> Database::create(JS::Realm& realm, String const& name)
+GC::Ref<Database> Database::create(GC::Heap& heap, String const& name)
 {
-    return realm.create<Database>(realm, name);
+    return heap.allocate<Database>(name);
 }
 
 void Database::visit_edges(Visitor& visitor)
@@ -88,13 +89,13 @@ Optional<Database&> Database::for_key_and_name(StorageAPI::StorageKey const& key
     return {};
 }
 
-ErrorOr<GC::Ref<Database>> Database::create_for_key_and_name(JS::Realm& realm, StorageAPI::StorageKey const& key, String const& name)
+ErrorOr<GC::Ref<Database>> Database::create_for_key_and_name(GC::Heap& heap, StorageAPI::StorageKey const& key, String const& name)
 {
     auto database_mapping = TRY(m_databases.try_ensure(key, [] {
         return HashMap<String, GC::Root<Database>>();
     }));
 
-    auto value = Database::create(realm, name);
+    auto value = Database::create(heap, name);
 
     database_mapping.set(name, value);
     m_databases.set(key, database_mapping);
@@ -133,9 +134,9 @@ void Database::dissociate(IDBDatabase& connection)
     m_associated_connections.remove_first_matching([&](auto& entry) { return entry == &connection; });
 }
 
-GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_heap_vector()
+GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_heap_vector(GC::Heap& heap)
 {
-    auto connections = realm().heap().allocate<AssociatedConnections>();
+    auto connections = heap.allocate<AssociatedConnections>();
     for (auto& associated_connection : m_associated_connections) {
         if (associated_connection)
             connections->elements().append(*associated_connection);
@@ -143,9 +144,9 @@ GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_hea
     return connections;
 }
 
-GC::RootVector<GC::Ref<IDBDatabase>> Database::associated_connections_as_root_vector()
+GC::RootVector<GC::Ref<IDBDatabase>> Database::associated_connections_as_root_vector(GC::Heap& heap)
 {
-    GC::RootVector<GC::Ref<IDBDatabase>> connections(realm().heap());
+    GC::RootVector<GC::Ref<IDBDatabase>> connections(heap);
     for (auto& connection : m_associated_connections) {
         if (connection)
             connections.append(*connection);
@@ -153,9 +154,9 @@ GC::RootVector<GC::Ref<IDBDatabase>> Database::associated_connections_as_root_ve
     return connections;
 }
 
-GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_heap_vector_except(IDBDatabase& connection)
+GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_heap_vector_except(GC::Heap& heap, IDBDatabase& connection)
 {
-    auto connections = realm().heap().allocate<AssociatedConnections>();
+    auto connections = heap.allocate<AssociatedConnections>();
     for (auto& associated_connection : m_associated_connections) {
         if (associated_connection && associated_connection != &connection)
             connections->elements().append(*associated_connection);

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.h
@@ -6,19 +6,20 @@
 
 #pragma once
 
+#include <LibGC/Forward.h>
 #include <LibGC/HeapVector.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/RootVector.h>
 #include <LibGC/Weak.h>
-#include <LibWeb/DOM/EventTarget.h>
+#include <LibJS/Heap/Cell.h>
 #include <LibWeb/IndexedDB/Internal/ObjectStore.h>
 #include <LibWeb/StorageAPI/StorageKey.h>
 
 namespace Web::IndexedDB {
 
 // https://www.w3.org/TR/IndexedDB/#database-construct
-class Database : public Bindings::PlatformObject {
-    WEB_NON_IDL_PLATFORM_OBJECT(Database, Bindings::PlatformObject);
+class Database : public JS::Cell {
+    GC_CELL(Database, JS::Cell);
     GC_DECLARE_ALLOCATOR(Database);
 
 public:
@@ -32,9 +33,9 @@ public:
     void associate(GC::Ref<IDBDatabase> connection);
     void dissociate(IDBDatabase& connection);
     using AssociatedConnections = GC::HeapVector<GC::Ref<IDBDatabase>>;
-    GC::Ref<AssociatedConnections> associated_connections_as_heap_vector();
-    GC::Ref<AssociatedConnections> associated_connections_as_heap_vector_except(IDBDatabase& connection);
-    GC::RootVector<GC::Ref<IDBDatabase>> associated_connections_as_root_vector();
+    GC::Ref<AssociatedConnections> associated_connections_as_heap_vector(GC::Heap&);
+    GC::Ref<AssociatedConnections> associated_connections_as_heap_vector_except(GC::Heap&, IDBDatabase& connection);
+    GC::RootVector<GC::Ref<IDBDatabase>> associated_connections_as_root_vector(GC::Heap&);
 
     ReadonlySpan<GC::Ref<ObjectStore>> object_stores() { return m_object_stores; }
     GC::Ptr<ObjectStore> object_store_with_name(String const& name) const;
@@ -46,12 +47,12 @@ public:
 
     [[nodiscard]] static Vector<GC::Weak<Database>> for_key(StorageAPI::StorageKey const&);
     [[nodiscard]] static Optional<Database&> for_key_and_name(StorageAPI::StorageKey const&, String const&);
-    [[nodiscard]] static ErrorOr<GC::Ref<Database>> create_for_key_and_name(JS::Realm&, StorageAPI::StorageKey const&, String const&);
+    [[nodiscard]] static ErrorOr<GC::Ref<Database>> create_for_key_and_name(GC::Heap&, StorageAPI::StorageKey const&, String const&);
     [[nodiscard]] static ErrorOr<void> delete_for_key_and_name(StorageAPI::StorageKey const&, String const&);
 
     static void for_each_database(AK::Function<void(Database&)> const& visitor);
 
-    [[nodiscard]] static GC::Ref<Database> create(JS::Realm&, String const&);
+    [[nodiscard]] static GC::Ref<Database> create(GC::Heap&, String const&);
     virtual ~Database();
 
     void wait_for_connections_to_close(ReadonlySpan<GC::Ref<IDBDatabase>> connections, GC::Ref<GC::Function<void()>> after_all);
@@ -60,9 +61,8 @@ public:
 protected:
     explicit Database(IDBDatabase& database);
 
-    explicit Database(JS::Realm& realm, String name)
-        : PlatformObject(realm)
-        , m_name(move(name))
+    explicit Database(String name)
+        : m_name(move(name))
     {
     }
 


### PR DESCRIPTION
While analyzing memory growth over time on https://x.com, several independent retention paths showed up in long-lived documents. This tightens those lifetimes by bounding per-document decoded image caches, releasing completed shared image and link fetch controllers, clearing timers when documents become inactive, and preventing internal IndexedDB databases from keeping realms alive.

The image cache keeps a small hot working set for repeat loads while pruning stale decoded image data from shared image requests and the list of available images. The fetch and timer changes make completed or inactive work stop retaining request clients, documents, and realms longer than needed.