### PR TITLE
LibWeb: Avoid repainting for unchanged animations

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2063,7 +2063,12 @@ void Document::set_needs_animated_style_update()
         return;
 
     m_needs_animated_style_update = true;
-    set_needs_repaint(InvalidateDisplayList::No);
+
+    auto navigable = this->navigable();
+    if (navigable && navigable->has_inclusive_ancestor_with_visibility_hidden())
+        return;
+
+    page().client().request_frame();
 }
 
 void Document::update_paint_and_hit_testing_properties_if_needed()


### PR DESCRIPTION
Animation updates need a rendering opportunity so current time can advance and effects can update computed properties. They should not mark the document as needing paint before any animated value changed.

Request a frame for pending animation style updates. The existing AnimationUpdateContext invalidation will decide whether layout or paint work is needed. This avoids presenting unchanged frames for infinite animations on pages like x.com.