### PR TITLE
LibWeb: Fix unwanted scrolling on blt.se

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -80,13 +80,13 @@ Gfx::FloatPoint AsyncScrollTree::scroll_offset_for_node(AsyncScrollNode const& n
 bool AsyncScrollTree::can_scroll_node_by_delta(AsyncScrollNode const& node, Painting::ScrollStateSnapshot const& scroll_state_snapshot, Gfx::FloatPoint delta)
 {
     auto scroll_offset = scroll_offset_for_node(node, scroll_state_snapshot);
-    if (delta.x() < 0 && scroll_offset.x() > 0)
+    if (node.can_be_wheel_scrolled_horizontally && delta.x() < 0 && scroll_offset.x() > 0)
         return true;
-    if (delta.x() > 0 && scroll_offset.x() < node.max_scroll_offset.x())
+    if (node.can_be_wheel_scrolled_horizontally && delta.x() > 0 && scroll_offset.x() < node.max_scroll_offset.x())
         return true;
-    if (delta.y() < 0 && scroll_offset.y() > 0)
+    if (node.can_be_wheel_scrolled_vertically && delta.y() < 0 && scroll_offset.y() > 0)
         return true;
-    if (delta.y() > 0 && scroll_offset.y() < node.max_scroll_offset.y())
+    if (node.can_be_wheel_scrolled_vertically && delta.y() > 0 && scroll_offset.y() < node.max_scroll_offset.y())
         return true;
     return false;
 }
@@ -146,7 +146,11 @@ Gfx::FloatPoint AsyncScrollTree::cumulative_device_offset_for_frame(Painting::Sc
 Gfx::FloatPoint AsyncScrollTree::apply_scroll_delta_to_node(AsyncScrollNode const& node, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot& scroll_state_snapshot)
 {
     auto old_scroll_offset = scroll_offset_for_node(node, scroll_state_snapshot);
-    auto new_scroll_offset = clamp_scroll_offset_to_node(node, old_scroll_offset.translated(delta));
+    Gfx::FloatPoint wheel_scrollable_delta {
+        node.can_be_wheel_scrolled_horizontally ? delta.x() : 0,
+        node.can_be_wheel_scrolled_vertically ? delta.y() : 0,
+    };
+    auto new_scroll_offset = clamp_scroll_offset_to_node(node, old_scroll_offset.translated(wheel_scrollable_delta));
     if (new_scroll_offset == old_scroll_offset) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll node {} did not move for delta {},{} (offset={},{} max={},{})",
             node.node_id.scroll_frame_index.value(), delta.x(), delta.y(), old_scroll_offset.x(), old_scroll_offset.y(), node.max_scroll_offset.x(), node.max_scroll_offset.y());

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -120,6 +120,7 @@ static CSSPixelPoint maximum_scroll_offset_for(Painting::PaintableBox const& pai
         return max_scroll_offset;
 
     auto scrollport_rect = paintable_box.absolute_padding_box_rect();
+
     max_scroll_offset.set_x(max(CSSPixels(0), scrollable_overflow_rect->width() - scrollport_rect.width()));
     max_scroll_offset.set_y(max(CSSPixels(0), scrollable_overflow_rect->height() - scrollport_rect.height()));
     return max_scroll_offset;
@@ -150,6 +151,8 @@ static void record_scroll_node(Painting::PaintableBox const& paintable_box, Disp
         .scroll_node_kind = *scroll_node_kind,
         .pseudo_element_type = pseudo_element_type_for(paintable_box),
         .is_viewport = paintable_box.is_viewport_paintable(),
+        .can_be_wheel_scrolled_horizontally = paintable_box.could_be_scrolled_by_wheel_event(Painting::PaintableBox::ScrollDirection::Horizontal),
+        .can_be_wheel_scrolled_vertically = paintable_box.could_be_scrolled_by_wheel_event(Painting::PaintableBox::ScrollDirection::Vertical),
     });
 }
 
@@ -390,6 +393,8 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
                 .scrollport_rect = command.scrollport_rect,
                 .max_scroll_offset = command.max_scroll_offset,
                 .is_viewport = command.is_viewport,
+                .can_be_wheel_scrolled_horizontally = command.can_be_wheel_scrolled_horizontally,
+                .can_be_wheel_scrolled_vertically = command.can_be_wheel_scrolled_vertically,
             });
             parent_scroll_frame_indices.append(command.parent_scroll_frame_index);
             break;

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -61,6 +61,8 @@ struct AsyncScrollNode {
     Gfx::IntRect scrollport_rect;
     Gfx::FloatPoint max_scroll_offset;
     bool is_viewport { false };
+    bool can_be_wheel_scrolled_horizontally { false };
+    bool can_be_wheel_scrolled_vertically { false };
 };
 
 // Sticky elements are represented as scroll frames whose offset is derived from ancestor scroll offsets. Keep only

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3426,8 +3426,8 @@ GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoi
     // NB: Must update layout before accessing paintables.
     doc->update_layout(DOM::UpdateLayoutReason::NavigableViewportScroll);
 
-    // AD-HOC: Skip scrolling unscrollable boxes.
-    if (!doc->paintable_box()->could_be_scrolled_by_wheel_event())
+    // AD-HOC: Skip scrolling unscrollable boxes, unless this scroll can pan the visual viewport.
+    if (!doc->paintable_box()->could_be_scrolled_by_wheel_event() && visual_dx == 0.0 && visual_dy == 0.0)
         return WebIDL::create_resolved_promise(doc->realm(), JS::js_undefined());
 
     auto scrolling_area = doc->paintable_box()->scrollable_overflow_rect()->to_type<float>();

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -184,13 +184,44 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
 
     // - The scroll container’s own padding box.
     auto const paintable_absolute_padding_box = paintable_box.absolute_padding_box_rect();
+    auto const paintable_absolute_content_box = paintable_box.absolute_rect();
     auto scrollable_overflow_rect = paintable_absolute_padding_box;
     auto overflow_directions = physical_overflow_directions(box);
+    auto content_overflows_content_box_in_x_axis = false;
+    auto content_overflows_content_box_in_y_axis = false;
+    auto content_overflows_content_box_on_right = false;
+    auto content_overflows_content_box_on_bottom = false;
+
+    auto update_content_overflow_x_axis = [&](CSSPixelRect const& rect) {
+        if (rect.left() < paintable_absolute_content_box.left()
+            || rect.right() > paintable_absolute_content_box.right()) {
+            content_overflows_content_box_in_x_axis = true;
+        }
+        if (rect.right() > paintable_absolute_content_box.right())
+            content_overflows_content_box_on_right = true;
+    };
+
+    auto update_content_overflow_y_axis = [&](CSSPixelRect const& rect) {
+        if (rect.top() < paintable_absolute_content_box.top()
+            || rect.bottom() > paintable_absolute_content_box.bottom()) {
+            content_overflows_content_box_in_y_axis = true;
+        }
+        if (rect.bottom() > paintable_absolute_content_box.bottom())
+            content_overflows_content_box_on_bottom = true;
+    };
+
+    auto update_content_overflow_axes = [&](CSSPixelRect const& rect) {
+        update_content_overflow_x_axis(rect);
+        update_content_overflow_y_axis(rect);
+    };
 
     // - All line boxes directly contained by the scroll container.
     if (auto first_paintable = box.first_paintable(); auto const* paintable_with_lines = as_if<Painting::PaintableWithLines>(first_paintable.ptr())) {
-        for (auto const& fragment : paintable_with_lines->fragments())
-            scrollable_overflow_rect.unite(fragment.absolute_rect());
+        for (auto const& fragment : paintable_with_lines->fragments()) {
+            auto fragment_rect = fragment.absolute_rect();
+            scrollable_overflow_rect.unite(fragment_rect);
+            update_content_overflow_axes(fragment_rect);
+        }
     }
 
     auto content_overflow_rect = scrollable_overflow_rect;
@@ -225,6 +256,7 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
             if (!child_border_box.is_empty()) {
                 scrollable_overflow_rect.unite(child_border_box);
                 content_overflow_rect.unite(child_border_box);
+                update_content_overflow_axes(child_border_box);
             }
 
             // - The scrollable overflow areas of all of the above boxes (including zero-area boxes and accounting for
@@ -238,10 +270,14 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
             if (child.computed_values().overflow_x() == CSS::Overflow::Visible || child.computed_values().overflow_y() == CSS::Overflow::Visible) {
                 auto child_scrollable_overflow = measure_scrollable_overflow(child, contained_boxes_map);
                 if (!child_scrollable_overflow.is_empty()) {
-                    if (child.computed_values().overflow_x() == CSS::Overflow::Visible)
+                    if (child.computed_values().overflow_x() == CSS::Overflow::Visible) {
                         scrollable_overflow_rect.unite_horizontally(child_scrollable_overflow);
-                    if (child.computed_values().overflow_y() == CSS::Overflow::Visible)
+                        update_content_overflow_x_axis(child_scrollable_overflow);
+                    }
+                    if (child.computed_values().overflow_y() == CSS::Overflow::Visible) {
                         scrollable_overflow_rect.unite_vertically(child_scrollable_overflow);
+                        update_content_overflow_y_axis(child_scrollable_overflow);
+                    }
                 }
             }
         }
@@ -251,22 +287,32 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMa
 
     // - Additional padding added to the scrollable overflow rectangle as necessary to enable scroll positions that
     //   satisfy the requirements of both place-content: start and place-content: end alignment.
-    auto has_scrollable_overflow = !paintable_absolute_padding_box.contains(scrollable_overflow_rect) && box.is_scroll_container();
+    auto has_scrollable_overflow_in_x_axis = box.is_scroll_container()
+        && (scrollable_overflow_rect.left() < paintable_absolute_padding_box.left()
+            || scrollable_overflow_rect.right() > paintable_absolute_padding_box.right());
+    auto has_scrollable_overflow_in_y_axis = box.is_scroll_container()
+        && (scrollable_overflow_rect.top() < paintable_absolute_padding_box.top()
+            || scrollable_overflow_rect.bottom() > paintable_absolute_padding_box.bottom());
+    auto has_scrollable_overflow = has_scrollable_overflow_in_x_axis || has_scrollable_overflow_in_y_axis;
     if (has_scrollable_overflow) {
         auto left = scrollable_overflow_rect.x();
         auto top = scrollable_overflow_rect.y();
         auto right = scrollable_overflow_rect.right();
         auto bottom = scrollable_overflow_rect.bottom();
 
-        if (overflow_directions.x_positive)
-            right = max(right, content_overflow_rect.right() + paintable_box.box_model().padding.right);
-        else
-            left = min(left, content_overflow_rect.x() - paintable_box.box_model().padding.left);
+        if (content_overflows_content_box_in_x_axis) {
+            if (overflow_directions.x_positive && content_overflows_content_box_on_right)
+                right = max(right, content_overflow_rect.right() + paintable_box.box_model().padding.right);
+            else if (!overflow_directions.x_positive)
+                left = min(left, content_overflow_rect.x() - paintable_box.box_model().padding.left);
+        }
 
-        if (overflow_directions.y_positive)
-            bottom = max(bottom, content_overflow_rect.bottom() + paintable_box.box_model().padding.bottom);
-        else
-            top = min(top, content_overflow_rect.y() - paintable_box.box_model().padding.top);
+        if (content_overflows_content_box_in_y_axis) {
+            if (overflow_directions.y_positive && content_overflows_content_box_on_bottom)
+                bottom = max(bottom, content_overflow_rect.bottom() + paintable_box.box_model().padding.bottom);
+            else if (!overflow_directions.y_positive)
+                top = min(top, content_overflow_rect.y() - paintable_box.box_model().padding.top);
+        }
 
         scrollable_overflow_rect = {
             left,

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -593,9 +593,19 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             if (!document || !document->paintable_box())
                 return EventResult::Dropped;
 
-            if (document->paintable_box()->could_be_scrolled_by_wheel_event()) {
+            auto visual_viewport = document->visual_viewport();
+            auto visual_viewport_max_x = m_navigable->viewport_rect().width().to_double() - visual_viewport->width();
+            auto visual_viewport_max_y = m_navigable->viewport_rect().height().to_double() - visual_viewport->height();
+            auto visual_viewport_can_scroll_horizontally = (wheel_delta_x < 0 && visual_viewport->offset_left() > 0)
+                || (wheel_delta_x > 0 && visual_viewport->offset_left() < visual_viewport_max_x);
+            auto visual_viewport_can_scroll_vertically = (wheel_delta_y < 0 && visual_viewport->offset_top() > 0)
+                || (wheel_delta_y > 0 && visual_viewport->offset_top() < visual_viewport_max_y);
+            auto viewport_wheel_delta_x = document->paintable_box()->could_be_scrolled_by_wheel_event(Painting::PaintableBox::ScrollDirection::Horizontal) || visual_viewport_can_scroll_horizontally ? wheel_delta_x : 0;
+            auto viewport_wheel_delta_y = document->paintable_box()->could_be_scrolled_by_wheel_event(Painting::PaintableBox::ScrollDirection::Vertical) || visual_viewport_can_scroll_vertically ? wheel_delta_y : 0;
+
+            if (viewport_wheel_delta_x != 0 || viewport_wheel_delta_y != 0) {
                 auto viewport_scroll_position_before = CSSPixelPoint { CSSPixels(document->visual_viewport()->page_left()), CSSPixels(document->visual_viewport()->page_top()) };
-                m_navigable->scroll_viewport_by_delta({ CSSPixels::nearest_value_for(wheel_delta_x), CSSPixels::nearest_value_for(wheel_delta_y) });
+                m_navigable->scroll_viewport_by_delta({ CSSPixels::nearest_value_for(viewport_wheel_delta_x), CSSPixels::nearest_value_for(viewport_wheel_delta_y) });
                 auto viewport_scroll_position_after = CSSPixelPoint { CSSPixels(document->visual_viewport()->page_left()), CSSPixels(document->visual_viewport()->page_top()) };
                 return viewport_scroll_position_before != viewport_scroll_position_after ? EventResult::Handled : EventResult::Accepted;
             }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -526,6 +526,8 @@ struct CompositorScrollNode {
     CompositorScrollNodeKind scroll_node_kind { CompositorScrollNodeKind::Element };
     u8 pseudo_element_type { 0 };
     bool is_viewport { false };
+    bool can_be_wheel_scrolled_horizontally { false };
+    bool can_be_wheel_scrolled_vertically { false };
 
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -9,10 +9,12 @@
 
 #include <AK/GenericShorthands.h>
 #include <LibGfx/Font/Font.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Layout/InlineNode.h>
@@ -505,11 +507,44 @@ NonnullRefPtr<Scrollbar> PaintableBox::ensure_scrollbar(ScrollDirection directio
     return *slot;
 }
 
+static CSS::Overflow overflow_value_applied_to_viewport_for_wheel_scrolling(DOM::Document const& document, PaintableBox::ScrollDirection direction)
+{
+    auto overflow_for_direction = [direction](CSS::ComputedProperties const& computed_properties) {
+        return direction == PaintableBox::ScrollDirection::Horizontal
+            ? computed_properties.overflow_x()
+            : computed_properties.overflow_y();
+    };
+
+    auto* root_element = document.document_element();
+    if (!root_element || !root_element->computed_properties())
+        return CSS::Overflow::Auto;
+
+    auto* overflow_origin_element = root_element;
+    if (root_element->is_html_html_element() && root_element->computed_properties()->contain().is_empty()) {
+        auto root_overflow_x = root_element->computed_properties()->overflow_x();
+        auto root_overflow_y = root_element->computed_properties()->overflow_y();
+        if (root_overflow_x == CSS::Overflow::Visible && root_overflow_y == CSS::Overflow::Visible) {
+            auto* body_element = root_element->first_child_of_type<HTML::HTMLBodyElement>();
+            if (body_element && body_element->computed_properties() && body_element->computed_properties()->contain().is_empty())
+                overflow_origin_element = body_element;
+        }
+    }
+
+    auto overflow = overflow_for_direction(*overflow_origin_element->computed_properties());
+    if (overflow == CSS::Overflow::Visible)
+        return CSS::Overflow::Auto;
+    if (overflow == CSS::Overflow::Clip)
+        return CSS::Overflow::Hidden;
+    return overflow;
+}
+
 bool PaintableBox::could_be_scrolled_by_wheel_event(ScrollDirection direction) const
 {
     bool is_horizontal = direction == ScrollDirection::Horizontal;
     Gfx::Orientation orientation = is_horizontal ? Gfx::Orientation::Horizontal : Gfx::Orientation::Vertical;
     auto overflow = is_horizontal ? computed_values().overflow_x() : computed_values().overflow_y();
+    if (is_viewport_paintable())
+        overflow = overflow_value_applied_to_viewport_for_wheel_scrolling(document(), direction);
 
     auto scrollable_overflow_rect = this->scrollable_overflow_rect();
     if (!scrollable_overflow_rect.has_value())
@@ -518,8 +553,7 @@ bool PaintableBox::could_be_scrolled_by_wheel_event(ScrollDirection direction) c
     CSSPixels scrollable_overflow_size = scrollable_overflow_rect->primary_size_for_orientation(orientation);
     CSSPixels scrollport_size = absolute_padding_box_rect().primary_size_for_orientation(orientation);
 
-    bool overflow_value_allows_scrolling = overflow == CSS::Overflow::Auto || overflow == CSS::Overflow::Scroll;
-    if ((is_viewport_paintable() && overflow != CSS::Overflow::Hidden) || overflow_value_allows_scrolling)
+    if (overflow == CSS::Overflow::Auto || overflow == CSS::Overflow::Scroll)
         return scrollable_overflow_size > scrollport_size;
 
     return false;
@@ -1107,10 +1141,16 @@ NonnullRefPtr<ResizeHandle> PaintableBox::ensure_resize_handle()
 
 bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, double wheel_delta_x, double wheel_delta_y)
 {
+    auto can_scroll_horizontally = could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal);
+    auto can_scroll_vertically = could_be_scrolled_by_wheel_event(ScrollDirection::Vertical);
+    if (!can_scroll_horizontally)
+        wheel_delta_x = 0;
+    if (!can_scroll_vertically)
+        wheel_delta_y = 0;
+
     // if none of the axes we scrolled with can be accepted by this element, don't handle scroll.
-    if ((wheel_delta_x == 0 || !could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal)) && (wheel_delta_y == 0 || !could_be_scrolled_by_wheel_event(ScrollDirection::Vertical))) {
+    if (wheel_delta_x == 0 && wheel_delta_y == 0)
         return false;
-    }
 
     auto scroll_handled = scroll_by(wheel_delta_x, wheel_delta_y);
     return scroll_handled == ScrollHandled::Yes;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -272,6 +272,7 @@ public:
     void set_sticky_insets(OwnPtr<StickyInsets> sticky_insets) { m_sticky_insets = move(sticky_insets); }
 
     [[nodiscard]] bool could_be_scrolled_by_wheel_event() const;
+    [[nodiscard]] bool could_be_scrolled_by_wheel_event(ScrollDirection direction) const;
 
     void set_used_values_for_grid_template_columns(RefPtr<CSS::GridTrackSizeListStyleValue const> style_value) { m_used_values_for_grid_template_columns = move(style_value); }
     RefPtr<CSS::GridTrackSizeListStyleValue const> const& used_values_for_grid_template_columns() const { return m_used_values_for_grid_template_columns; }
@@ -337,7 +338,6 @@ protected:
 
     CSSPixels available_scrollbar_length(ScrollDirection direction, ChromeMetrics const& chrome_metrics) const;
     Optional<CSSPixelRect> absolute_resizer_rect(ChromeMetrics const& chrome_metrics) const;
-    bool could_be_scrolled_by_wheel_event(ScrollDirection direction) const;
 
 private:
     [[nodiscard]] virtual bool is_paintable_box() const final { return true; }

--- a/Tests/LibWeb/Text/expected/async-scrolling/hidden-axis-programmatic-scroll-preserved.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/hidden-axis-programmatic-scroll-preserved.txt
@@ -1,0 +1,5 @@
+initial scrollLeft: 50
+vertical wheel target: non-viewport
+horizontal wheel target: none
+final scrollLeft: 50
+final scrollTop: 100

--- a/Tests/LibWeb/Text/expected/async-scrolling/orthogonal-overflow-padding-wheel-target.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/orthogonal-overflow-padding-wheel-target.txt
@@ -1,0 +1,3 @@
+client width: 100
+scroll width: 100
+horizontal wheel target: none

--- a/Tests/LibWeb/Text/expected/async-scrolling/overflow-hidden-axis-wheel-target.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/overflow-hidden-axis-wheel-target.txt
@@ -1,0 +1,2 @@
+horizontal wheel target: non-viewport
+vertical wheel target: none

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-body-overflow-hidden-horizontal-wheel-target.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-body-overflow-hidden-horizontal-wheel-target.txt
@@ -1,0 +1,4 @@
+document scroll width: 813
+horizontal wheel target: none
+vertical wheel target: viewport
+scroll x after horizontal wheel: 0

--- a/Tests/LibWeb/Text/expected/scrollable-overflow-clipped-child-axis.txt
+++ b/Tests/LibWeb/Text/expected/scrollable-overflow-clipped-child-axis.txt
@@ -1,0 +1,4 @@
+client width: 100
+scroll width: 200
+client height: 108
+scroll height: 108

--- a/Tests/LibWeb/Text/expected/scrollable-overflow-negative-start-padding.txt
+++ b/Tests/LibWeb/Text/expected/scrollable-overflow-negative-start-padding.txt
@@ -1,0 +1,3 @@
+client width: 208
+scroll width: 208
+scroll left: 0

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/negative-overflow.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/negative-overflow.txt
@@ -2,15 +2,14 @@ Harness status: OK
 
 Found 11 tests
 
-9 Pass
-2 Fail
+11 Pass
 Pass	.flexbox 1
 Pass	.flexbox 2
 Pass	.flexbox 3
 Pass	.flexbox 4
 Pass	.flexbox 5
-Fail	.flexbox 6
-Fail	.flexbox 7
+Pass	.flexbox 6
+Pass	.flexbox 7
 Pass	.flexbox 8
 Pass	.flexbox 9
 Pass	.flexbox 10

--- a/Tests/LibWeb/Text/input/async-scrolling/hidden-axis-programmatic-scroll-preserved.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/hidden-axis-programmatic-scroll-preserved.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        width: 100px;
+        height: 100px;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    #spacer {
+        width: 300px;
+        height: 300px;
+    }
+</style>
+<div id="scroller"><div id="spacer"></div></div>
+<script>
+    promiseTest(async () => {
+        scroller.scrollLeft = 50;
+        scroller.scrollTop = 0;
+
+        await animationFrame();
+        await animationFrame();
+
+        println(`initial scrollLeft: ${scroller.scrollLeft}`);
+        println(`vertical wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+        println(`horizontal wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 100, 0)}`);
+
+        await internals.wheel(50, 50, 0, 100);
+
+        println(`final scrollLeft: ${scroller.scrollLeft}`);
+        println(`final scrollTop: ${scroller.scrollTop}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/orthogonal-overflow-padding-wheel-target.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/orthogonal-overflow-padding-wheel-target.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        width: 92px;
+        height: 100px;
+        padding-right: 8px;
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
+
+    #spacer {
+        width: 50px;
+        height: 200px;
+    }
+</style>
+<div id="scroller"><div id="spacer"></div></div>
+<script>
+    test(() => {
+        println(`client width: ${scroller.clientWidth}`);
+        println(`scroll width: ${scroller.scrollWidth}`);
+        println(`horizontal wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 100, 0)}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/overflow-hidden-axis-wheel-target.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/overflow-hidden-axis-wheel-target.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        width: 100px;
+        height: 100px;
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
+
+    #spacer {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<div id="scroller"><div id="spacer"></div></div>
+<script>
+    test(() => {
+        println(`horizontal wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 100, 0)}`);
+        println(`vertical wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/viewport-body-overflow-hidden-horizontal-wheel-target.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/viewport-body-overflow-hidden-horizontal-wheel-target.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    #button {
+        position: relative;
+        width: 22px;
+        height: 24px;
+        margin-left: 758px;
+    }
+
+    #button::after {
+        content: "";
+        position: absolute;
+        left: 11px;
+        top: 12px;
+        width: 44px;
+        height: 44px;
+    }
+
+    #spacer {
+        height: 2000px;
+    }
+</style>
+<div id="button"></div>
+<div id="spacer"></div>
+<script>
+    promiseTest(async () => {
+        println(`document scroll width: ${document.documentElement.scrollWidth}`);
+        println(`horizontal wheel target: ${internals.asyncScrollingStateWheelTargetAt(400, 12, 100, 0)}`);
+        println(`vertical wheel target: ${internals.asyncScrollingStateWheelTargetAt(400, 12, 0, 100)}`);
+        await internals.wheel(400, 12, 100, 0);
+        println(`scroll x after horizontal wheel: ${window.scrollX}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/scrollable-overflow-clipped-child-axis.html
+++ b/Tests/LibWeb/Text/input/scrollable-overflow-clipped-child-axis.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scroller {
+        width: 100px;
+        height: 100px;
+        padding-bottom: 8px;
+        overflow: auto;
+    }
+
+    #child {
+        width: 200px;
+        height: 100px;
+        overflow-x: visible;
+        overflow-y: clip;
+    }
+
+    #grandchild {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<div id="scroller"><div id="child"><div id="grandchild"></div></div></div>
+<script>
+    test(() => {
+        println(`client width: ${scroller.clientWidth}`);
+        println(`scroll width: ${scroller.scrollWidth}`);
+        println(`client height: ${scroller.clientHeight}`);
+        println(`scroll height: ${scroller.scrollHeight}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/scrollable-overflow-negative-start-padding.html
+++ b/Tests/LibWeb/Text/input/scrollable-overflow-negative-start-padding.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    #scroller {
+        display: flex;
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding-right: 8px;
+        width: 200px;
+    }
+
+    #content {
+        background: green;
+        flex: 0 0 auto;
+        height: 20px;
+        margin-left: -32px;
+        width: 160px;
+    }
+</style>
+<div id="scroller">
+    <div id="content"></div>
+</div>
+<script>
+    test(() => {
+        println(`client width: ${scroller.clientWidth}`);
+        println(`scroll width: ${scroller.scrollWidth}`);
+        scroller.scrollLeft = 100;
+        println(`scroll left: ${scroller.scrollLeft}`);
+    });
+</script>


### PR DESCRIPTION
Fix unwanted horizontal and vertical scrolling in the top navigation bar on https://blt.se/.

This came from two separate issues. Async wheel hit testing treated hidden overflow axes as wheel-scrollable when scrollable overflow existed on that axis. Also, scrollable overflow measurement could add end padding for one axis because content overflowed in the other axis.

Separate wheel-scrollability from programmatic scroll ranges so hidden axes no longer accept wheel input while still preserving CSSOM scroll offsets. Only add extra scrollable-overflow padding on axes where content actually overflows the content box.