### PR TITLE
LibWeb: Resolve SVG max-content width from CSS height

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -35,7 +35,7 @@ enum class SizeDimension {
 };
 
 // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
-static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural_size(Box const& box, CSS::SizeWithAspectRatio const& natural_size, SizeDimension dimension)
+static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural_size(Box const& box, CSS::SizeWithAspectRatio const& natural_size, SizeDimension dimension, Optional<CSSPixels> definite_opposite_size = {})
 {
     // the intrinsic sizes of replaced elements without natural sizes are defined below:
     auto is_width = dimension == SizeDimension::Width;
@@ -64,10 +64,17 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
     // For the max-content size:
     // If it has a preferred aspect ratio:
     if (natural_size.has_aspect_ratio()) {
+        auto aspect_ratio = natural_size.aspect_ratio.value();
+
         // If the available space is definite in the inline axis, use the stretch fit into that size for the inline size
         // and calculate the block size using the aspect ratio.
         //
-        // NB: This helper is only for the max-content size, which has no definite available inline size.
+        // NB: This helper is only for the max-content size, which has no definite available inline size. Callers may
+        //     still know a definite used size in the opposite axis when the box lacks a natural size in that axis.
+        if (definite_opposite_size.has_value()) {
+            auto opposite_size = definite_opposite_size.value();
+            return is_width ? opposite_size * aspect_ratio : opposite_size / aspect_ratio;
+        }
 
         // Otherwise if the box has a <length> as its computed value for min-width or min-height, use that size and
         // calculate the other dimension using the aspect ratio; if both dimensions have a <length> minimum, choose the
@@ -76,8 +83,6 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         // NOTE: This case was previous calculated from a 300x150 default size, rather than the box’s min size. This is
         //       believed to be a better behavior, and likely to be Web-compatible, but please send feedback to the CSSWG
         //       if there are any problems.
-        auto aspect_ratio = natural_size.aspect_ratio.value();
-
         Optional<CSSPixels> size_from_min_width;
         auto const& min_width = box.computed_values().min_width();
         if (min_width.is_length()) {
@@ -2059,9 +2064,17 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
 CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box) const
 {
-    if (auto auto_size = box.auto_content_box_size(); auto_size.has_width())
+    auto auto_size = box.auto_content_box_size();
+    if (auto_size.has_width())
         return auto_size.width.value();
-    if (auto max_content_width = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), SizeDimension::Width); max_content_width.has_value())
+
+    Optional<CSSPixels> definite_height;
+    if (box.is_replaced_box() && !auto_size.has_height()) {
+        if (auto const& box_state = m_state.get(box); box_state.has_definite_height())
+            definite_height = box_state.content_height();
+    }
+
+    if (auto max_content_width = max_content_size_for_replaced_element_without_natural_size(box, auto_size, SizeDimension::Width, definite_height); max_content_width.has_value())
         return max_content_width.value();
 
     // Boxes with no children have zero intrinsic width.

--- a/Tests/LibWeb/Layout/expected/flex/svg-css-height-viewbox-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/svg-css-height-viewbox-max-content-width.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+      Box <section> at [0,0] flex-container(row) [0+0+0 50 0+0+750] [0+0+0 20 0+0+0] [FFC] children: not-inline
+        BlockContainer <div> at [0,0] flex-item [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        Box <span> at [10,0] flex-container(row) flex-item [0+0+0 40 0+0+0] [0+0+0 20 0+0+0] [FFC] children: not-inline
+          SVGSVGBox <svg> at [10,0] flex-item [0+0+0 40 0+0+0] [0+0+0 20 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [0,20] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x20]
+      PaintableBox (Box<SECTION>) [0,0 50x20]
+        PaintableWithLines (BlockContainer<DIV>) [0,0 10x20]
+        PaintableBox (Box<SPAN>) [10,0 40x20]
+          SVGSVGPaintable (SVGSVGBox<svg>) [10,0 40x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,20 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x20] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/svg-css-height-viewbox-max-content-width.html
+++ b/Tests/LibWeb/Layout/input/flex/svg-css-height-viewbox-max-content-width.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+}
+
+section {
+    display: flex;
+    width: 50px;
+}
+
+div {
+    flex: 1;
+}
+
+span {
+    display: flex;
+    flex: none;
+}
+
+svg {
+    height: 20px;
+}
+</style><section><div></div><span><svg viewBox="0 0 2 1"></svg></span></section>


### PR DESCRIPTION
When a replaced element has no natural width or height but has a preferred aspect ratio, `max-content` width fell through to the CSS Sizing fallback that uses the initial containing block width.

Use a definite used height to derive `max-content` width through the aspect ratio before the fallback. Keep the existing natural-height SVG path first by only doing this for elements without natural height. Add a focused layout test for the nested flex item case.