### PR TITLE
LibWeb: Report IndexSizeError for unsupported ImageData bitmap sizes

### DIFF
--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -116,7 +116,7 @@ Bitmap::Bitmap(BitmapFormat format, AlphaType alpha_type, IntSize size, BackingS
 ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::create_wrapper(BitmapFormat format, AlphaType alpha_type, IntSize size, size_t pitch, void* data, Function<void()>&& destruction_callback)
 {
     if (size_would_overflow(format, size))
-        return Error::from_string_literal("Gfx::Bitmap::create_wrapper size overflow");
+        return Error::from_errno(EOVERFLOW);
     return adopt_ref(*new Bitmap(format, alpha_type, size, pitch, data, move(destruction_callback)));
 }
 

--- a/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Libraries/LibWeb/HTML/ImageData.cpp
@@ -105,8 +105,12 @@ WebIDL::ExceptionOr<GC::Ref<ImageData>> ImageData::initialize(JS::Realm& realm, 
         return TRY(JS::Uint8ClampedArray::create(realm, sizeof(u32) * rows * pixels_per_row));
     }());
 
-    // AD-HOC: Create the bitmap backed by the Uint8ClampedArray.
-    auto bitmap = TRY_OR_THROW_OOM(realm.vm(), create_bitmap_backed_by_uint8_clamped_array(pixels_per_row, rows, *data));
+    // AD-HOC: The bitmap factory can still reject dimensions that satisfied
+    // the u32 byte-count check above (e.g. its internal pitch overflows).
+    auto bitmap_or_error = create_bitmap_backed_by_uint8_clamped_array(pixels_per_row, rows, *data);
+    if (bitmap_or_error.is_error() && bitmap_or_error.error().code() == EOVERFLOW)
+        return WebIDL::IndexSizeError::create(realm, "The specified image size is too large to create"_utf16);
+    auto bitmap = TRY_OR_THROW_OOM(realm.vm(), move(bitmap_or_error));
 
     // 4. Initialize the width attribute of imageData to pixelsPerRow.
     // 5. Initialize the height attribute of imageData to rows.

--- a/Tests/LibWeb/Crash/HTML/oversized-ImageData-should-not-crash.html
+++ b/Tests/LibWeb/Crash/HTML/oversized-ImageData-should-not-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script>
+// Regression for #8496: ImageData dimensions that pass the WebIDL u32
+// byte-count check but exceed Gfx::Bitmap's backing-store limits used to
+// crash via TRY_OR_THROW_OOM.
+
+// width > UINT16_MAX path inside Gfx::Bitmap::size_would_overflow; the
+// backing Uint8ClampedArray itself is small (800KB) so this case runs
+// on memory-constrained CI machines too.
+try { new ImageData(100000, 2); } catch (e) {}
+
+// pitch * height overflow path; matches the exact 32767x32767 repro from
+// the issue, but needs ~4 GiB for the Uint8ClampedArray so it only
+// exercises the bitmap-factory failure when the allocation succeeds.
+try { new ImageData(32767, 32767); } catch (e) {}
+</script>


### PR DESCRIPTION
Fixes #8496.

Creating ImageData can pass the WebIDL size checks while still exceeding the dimensions supported by the bitmap backing store. This reports IndexSizeError for that case instead of routing the error through TRY_OR_THROW_OOM, which used to VERIFY-crash on a non-ENOMEM error code.

## Test plan
- [x] \`Tests/LibWeb/Crash/HTML/oversized-ImageData-should-not-crash.html\` — oversized ImageData cases no longer crash
- [x] Existing ImageData text-test suite (5 tests) passes unchanged
- [x] Manual smoke with Ladybird headless-text on the repro: exits 0 with no VERIFY