### PR TITLE
LibJS: Bound the shared RegExp compilation cache

### DIFF
--- a/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -375,6 +375,7 @@ ThrowCompletionOr<GC::Ref<RegExpObject>> RegExpObject::regexp_initialize(VM& vm,
 {
     // Invalidate the cached compiled regex since the pattern/flags may change.
     m_cached_regex = nullptr;
+    m_owned_regex = nullptr;
 
     // 1. If pattern is undefined, let P be the empty String.
     // 2. Else, let P be ? ToString(pattern).

--- a/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Libraries/LibJS/Runtime/RegExpObject.h
@@ -62,6 +62,8 @@ public:
     regex::ECMAScriptRegex const* cached_regex() const { return m_cached_regex; }
     void set_cached_regex(regex::ECMAScriptRegex const* ptr) const { m_cached_regex = ptr; }
 
+    void adopt_owned_regex(OwnPtr<regex::ECMAScriptRegex> ptr) const { m_owned_regex = move(ptr); }
+
 private:
     RegExpObject(Object& prototype);
     RegExpObject(Utf16String pattern, Utf16String flags, Object& prototype);
@@ -74,6 +76,9 @@ private:
     Flags m_flag_bits { 0 };
     bool m_legacy_features_enabled { false }; // [[LegacyFeaturesEnabled]]
     mutable regex::ECMAScriptRegex const* m_cached_regex { nullptr };
+    // Populated only when the shared compilation cache was full at compile time;
+    // keeps the compile alive for this object's lifetime so m_cached_regex stays valid.
+    mutable OwnPtr<regex::ECMAScriptRegex> m_owned_regex;
     // Note: This is initialized in RegExpAlloc, but will be non-null afterwards
     GC::Ptr<Realm> m_realm; // [[Realm]]
 };

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -75,7 +75,10 @@ static ThrowCompletionOr<void> increment_last_index(VM& vm, Object& regexp_objec
     return {};
 }
 
-// FIXME: Add an eviction policy to bound the size of this cache.
+// FIXME: Add an eviction policy. The cap below prevents unbounded growth but
+//        does not reclaim entries from the shared cache; once it is full,
+//        further unique patterns are owned by their RegExpObject instead.
+static constexpr size_t s_regex_cache_max_entries = 1024;
 static HashMap<String, NonnullOwnPtr<regex::ECMAScriptRegex>> s_regex_cache;
 
 static regex::ECMAScriptRegex const* get_or_compile_regex(RegExpObject& regexp_object)
@@ -125,7 +128,13 @@ static regex::ECMAScriptRegex const* get_or_compile_regex(RegExpObject& regexp_o
 
     auto owned = make<regex::ECMAScriptRegex>(compiled.release_value());
     auto* ptr = owned.ptr();
-    s_regex_cache.set(cache_key, move(owned));
+    if (s_regex_cache.size() < s_regex_cache_max_entries) {
+        s_regex_cache.set(cache_key, move(owned));
+    } else {
+        // Shared cache is full; let the RegExpObject own this compile so the
+        // inline cache below stays valid for its lifetime.
+        regexp_object.adopt_owned_regex(move(owned));
+    }
     regexp_object.set_cached_regex(ptr);
     return ptr;
 }

--- a/Tests/LibJS/Runtime/regexp-shared-cache-overflow.js
+++ b/Tests/LibJS/Runtime/regexp-shared-cache-overflow.js
@@ -1,0 +1,23 @@
+test("compiled RegExps remain valid after many distinct patterns", () => {
+    // Exceed the shared compile cache and make sure each RegExp still
+    // matches its own pattern. Patterns past the cap are owned by the
+    // RegExpObject rather than the shared table.
+    const expressions = [];
+    for (let i = 0; i < 1500; i++) {
+        const re = new RegExp("^a" + i + "$");
+        expressions.push({ re, expected: "a" + i });
+    }
+    for (const { re, expected } of expressions) {
+        expect(re.test(expected)).toBe(true);
+        expect(re.test(expected + "x")).toBe(false);
+    }
+
+    // A RegExp compiled before the cap was reached still matches correctly.
+    expect(expressions[0].re.test(expressions[0].expected)).toBe(true);
+
+    // Re-initialising a RegExpObject drops the previously-owned compile.
+    const reused = expressions[500].re;
+    reused.compile("^zzz$");
+    expect(reused.test("zzz")).toBe(true);
+    expect(reused.test("a500")).toBe(false);
+});


### PR DESCRIPTION
The compiled-regex cache in RegExpPrototype.cpp is a process-wide HashMap with no upper bound. A page that creates a stream of distinct patterns (a common shape is \`new RegExp("a" + i)\` in a loop) can grow the process-wide cache without limit.

This caps the shared cache at 1024 entries. Once it is full, further unique patterns are compiled into a regex that the RegExpObject owns directly.

The cap is intentionally conservative and the patch does not introduce eviction: live RegExpObjects hold raw pointers into the shared cache, and an LRU-style policy would require additional lifetime tracking to avoid use-after-free. Per-object ownership for over-cap patterns avoids that entirely.

## Test plan
- [x] New \`Tests/LibJS/Runtime/regexp-shared-cache-overflow.js\` — 1500 distinct patterns, all still match correctly after the cache fills
- [x] Existing \`Tests/LibJS/**/*regexp*\` suite: 90/90 suites, 221/221 tests pass
- [x] \`Build/release/bin/js\` smoke: 5000 distinct RegExps compile and match correctly