### PR TITLE
LibWeb: Preserve file-backed cached response bodies

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -500,9 +500,20 @@ private:
         Visitor(Fs&&... args)
             : Fs(forward<Fs>(args))...
         {
+            static_assert((visitor_accepts_possible_alternative<Fs>() && ...), "Variant visitor has an overload for a type this Variant cannot contain");
         }
 
         using Fs::operator()...;
+
+    private:
+        template<typename VisitorFunction>
+        static consteval bool visitor_accepts_possible_alternative()
+        {
+            if constexpr (!requires { &VisitorFunction::operator(); })
+                return true;
+            else
+                return (requires { declval<VisitorFunction>()(declval<Ts&>()); } || ...);
+        }
     };
 
     // Note: Make sure not to default-initialize!

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -757,14 +757,14 @@ void VM::load_imported_module(ImportedModuleReferrer referrer, ModuleRequest con
 
 #if JS_MODULE_DEBUG
     ByteString referencing_module_string = referrer.visit(
-        [&](Empty) -> ByteString {
-            return ".";
+        [&](GC::Ref<Script> const& script) {
+            return ByteString::formatted("Script @ {}", script.ptr());
         },
-        [&](auto& script_or_module) {
-            if constexpr (IsSame<Script*, decltype(script_or_module)>) {
-                return ByteString::formatted("Script @ {}", script_or_module.ptr());
-            }
-            return ByteString::formatted("Module @ {}", script_or_module.ptr());
+        [&](GC::Ref<CyclicModule> const& module) {
+            return ByteString::formatted("Module @ {}", module.ptr());
+        },
+        [&](GC::Ref<Realm> const& realm) {
+            return ByteString::formatted("Realm @ {}", realm.ptr());
         });
 
     dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] load_imported_module({}, {})", referencing_module_string, filename);

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -164,7 +164,7 @@ void CSSImportRule::fetch()
             };
 
             // 1. If byteStream is not a byte stream, return.
-            auto byte_stream = maybe_byte_stream.template get_pointer<ByteBuffer>();
+            auto byte_stream = maybe_byte_stream.template get_pointer<Core::ImmutableBytes>();
             if (!byte_stream) {
                 // AD-HOC: This means the fetch failed, so we should report this as a load failure.
                 strong_this->set_loading_state(CSSStyleSheet::LoadingState::Error);
@@ -195,7 +195,7 @@ void CSSImportRule::fetch()
             // The environment encoding of an imported style sheet is the encoding of the style sheet that imported it. [css-syntax-3]
             // FIXME: Save encoding on Stylesheet to get it here
             Optional<StringView> environment_encoding;
-            auto decoded_or_error = css_decode_bytes(environment_encoding, mime_type_charset, *byte_stream);
+            auto decoded_or_error = css_decode_bytes(environment_encoding, mime_type_charset, byte_stream->bytes());
             if (decoded_or_error.is_error()) {
                 dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Failed to decode CSS file: {}", url);
                 return;

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -140,8 +140,8 @@ void FontLoader::start_loading_next_url()
             // 1. If stream is null, return.
             // 2. Load a font from stream according to its type.
 
-            auto* bytes = stream.template get_pointer<ByteBuffer>();
-            if (!bytes) {
+            auto* immutable_bytes = stream.template get_pointer<Core::ImmutableBytes>();
+            if (!immutable_bytes) {
                 if (loader->m_urls.is_empty()) {
                     loader->font_did_load_or_fail(nullptr);
                 } else {
@@ -150,10 +150,11 @@ void FontLoader::start_loading_next_url()
                 }
                 return;
             }
+            auto bytes = immutable_bytes->copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
 
-            auto mime_type_essence = loader->try_load_font_mime_type_essence(response, *bytes);
-            if (!requires_off_thread_vector_font_preparation(*bytes, mime_type_essence)) {
-                auto maybe_typeface = try_load_vector_font(*bytes, mime_type_essence);
+            auto mime_type_essence = loader->try_load_font_mime_type_essence(response, bytes);
+            if (!requires_off_thread_vector_font_preparation(bytes, mime_type_essence)) {
+                auto maybe_typeface = try_load_vector_font(bytes, mime_type_essence);
                 if (maybe_typeface.is_error()) {
                     if (loader->m_urls.is_empty()) {
                         loader->font_did_load_or_fail(nullptr);
@@ -169,7 +170,7 @@ void FontLoader::start_loading_next_url()
             }
 
             auto loader_handle = GC::make_root(GC::Ref(*loader));
-            prepare_vector_font_data_off_thread(move(*bytes), [loader = move(loader_handle)](auto prepared_font_data) mutable {
+            prepare_vector_font_data_off_thread(move(bytes), [loader = move(loader_handle)](auto prepared_font_data) mutable {
                 if (prepared_font_data.is_error()) {
                     // NB: If we have other sources available, try the next one.
                     if (loader->m_urls.is_empty()) {

--- a/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -150,7 +150,7 @@ Vector<CSS::Parser::ComponentValue> parse_component_values_list(CSS::Parser::Par
 }
 
 // https://drafts.csswg.org/css-syntax/#css-decode-bytes
-ErrorOr<String> css_decode_bytes(Optional<StringView> const& environment_encoding, Optional<String> mime_type_charset, ByteBuffer const& encoded_string)
+ErrorOr<String> css_decode_bytes(Optional<StringView> const& environment_encoding, Optional<String> mime_type_charset, ReadonlyBytes encoded_string)
 {
     // https://drafts.csswg.org/css-syntax/#determine-the-fallback-encoding
     auto determine_the_fallback_encoding = [&mime_type_charset, &environment_encoding, &encoded_string]() -> StringView {
@@ -172,7 +172,7 @@ ErrorOr<String> css_decode_bytes(Optional<StringView> const& environment_encodin
             if (scan_length < pattern_start.length())
                 return {};
 
-            StringView buffer_view = encoded_string.bytes().slice(0, scan_length);
+            StringView buffer_view = encoded_string.slice(0, scan_length);
             if (!buffer_view.starts_with(pattern_start))
                 return {};
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -672,7 +672,7 @@ Vector<NonnullRefPtr<CSS::MediaQuery>> parse_media_query_list(CSS::Parser::Parsi
 RefPtr<CSS::Supports> parse_css_supports(CSS::Parser::ParsingParams const&, StringView);
 Vector<CSS::Parser::ComponentValue> parse_component_values_list(CSS::Parser::ParsingParams const&, StringView);
 GC::Ref<JS::Realm> internal_css_realm();
-ErrorOr<String> css_decode_bytes(Optional<StringView> const& environment_encoding, Optional<String> mime_type_charset, ByteBuffer const& encoded_string);
+ErrorOr<String> css_decode_bytes(Optional<StringView> const& environment_encoding, Optional<String> mime_type_charset, ReadonlyBytes encoded_string);
 bool is_valid_custom_ident(FlyString const&, ReadonlySpan<StringView> const& blacklist);
 
 }

--- a/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -91,6 +91,11 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
             source = MUST(ByteBuffer::copy(bytes));
             return {};
         },
+        [&](Core::ImmutableBytes const& bytes) -> WebIDL::ExceptionOr<void> {
+            // Set source to object.
+            source = bytes;
+            return {};
+        },
         [&](GC::Root<WebIDL::BufferSource> const& buffer_source) -> WebIDL::ExceptionOr<void> {
             // Set source to a copy of the bytes held by object.
             source = MUST(WebIDL::get_buffer_source_copy(*buffer_source->raw_object()));
@@ -140,6 +145,11 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
             return move(source);
         };
         length = source.get<ByteBuffer>().size();
+    } else if (source.has<Core::ImmutableBytes>()) {
+        action = [source = source.get<Core::ImmutableBytes>()]() mutable {
+            return source.copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
+        };
+        length = source.get<Core::ImmutableBytes>().size();
     }
 
     // 12. If action is non-null, then run these steps in parallel:

--- a/Libraries/LibWeb/Fetch/BodyInit.h
+++ b/Libraries/LibWeb/Fetch/BodyInit.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Variant.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -18,7 +19,7 @@ namespace Web::Fetch {
 using BodyInit = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String>;
 using NullableBodyInit = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String, Empty>;
 
-using BodyInitOrReadableBytes = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String, ReadonlyBytes>;
+using BodyInitOrReadableBytes = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String, ReadonlyBytes, Core::ImmutableBytes>;
 WEB_API Infrastructure::BodyWithType safely_extract_body(JS::Realm&, BodyInitOrReadableBytes const&);
 WEB_API WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm&, BodyInitOrReadableBytes const&, bool keepalive = false);
 

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -91,6 +91,8 @@ void FetchedDataReceiver::handle_network_data(Requests::ResponseData data, Netwo
 
     // Capture bytes for MIME sniffing
     if (m_body) {
+        if (auto const& immutable_bytes = data.immutable_bytes(); immutable_bytes.has_value() && immutable_bytes->is_file_backed() && m_body->source().has<Empty>() && bytes.size() == immutable_bytes->size())
+            m_body->set_source(*immutable_bytes, static_cast<u64>(immutable_bytes->size()));
         m_body->append_sniff_bytes(bytes);
     } else if (m_pre_body_sniff_buffer.size() < Infrastructure::MAX_SNIFF_BYTES) {
         auto space_remaining = Infrastructure::MAX_SNIFF_BYTES - m_pre_body_sniff_buffer.size();

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -925,7 +925,13 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         // 1. Let processBody given nullOrBytes be this step: run fetchParams’s process response consume body given
         //    response and nullOrBytes.
         auto process_body = GC::create_function(vm.heap(), [algorithms, &response](ByteBuffer bytes) {
-            (algorithms->process_response_consume_body())(response, move(bytes));
+            if (response.body()) {
+                if (auto const* source_bytes = response.body()->source().get_pointer<Core::ImmutableBytes>()) {
+                    (algorithms->process_response_consume_body())(response, *source_bytes);
+                    return;
+                }
+            }
+            (algorithms->process_response_consume_body())(response, Core::ImmutableBytes::adopt(move(bytes)));
         });
 
         // 2. Let processBodyError be this step: run fetchParams’s process response consume body given response and
@@ -1537,9 +1543,11 @@ GC::Ptr<PendingResponse> http_redirect_fetch(JS::Realm& realm, Infrastructure::F
     if (!request->body().has<Empty>()) {
         auto const& source = request->body().get<GC::Ref<Infrastructure::Body>>()->source();
         // NOTE: BodyInitOrReadableBytes is a superset of Body::SourceType
-        auto converted_source = source.has<ByteBuffer>()
-            ? BodyInitOrReadableBytes { source.get<ByteBuffer>() }
-            : BodyInitOrReadableBytes { source.get<GC::Ref<FileAPI::Blob>>() };
+        auto converted_source = source.visit(
+            [](ByteBuffer const& byte_buffer) -> BodyInitOrReadableBytes { return byte_buffer.bytes(); },
+            [](Core::ImmutableBytes const& bytes) -> BodyInitOrReadableBytes { return bytes; },
+            [](GC::Ref<FileAPI::Blob> const& blob) -> BodyInitOrReadableBytes { return GC::make_root(blob); },
+            [](Empty) -> BodyInitOrReadableBytes { VERIFY_NOT_REACHED(); });
         auto [body, _] = safely_extract_body(realm, converted_source);
         request->set_body(body);
     }
@@ -1994,9 +2002,11 @@ GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm& realm, Infrastru
                 // 2. Set request’s body to the body of the result of safely extracting request’s body’s source.
                 auto const& source = request->body().get<GC::Ref<Infrastructure::Body>>()->source();
                 // NOTE: BodyInitOrReadableBytes is a superset of Body::SourceType
-                auto converted_source = source.has<ByteBuffer>()
-                    ? BodyInitOrReadableBytes { source.get<ByteBuffer>() }
-                    : BodyInitOrReadableBytes { source.get<GC::Ref<FileAPI::Blob>>() };
+                auto converted_source = source.visit(
+                    [](ByteBuffer const& byte_buffer) -> BodyInitOrReadableBytes { return byte_buffer.bytes(); },
+                    [](Core::ImmutableBytes const& bytes) -> BodyInitOrReadableBytes { return bytes; },
+                    [](GC::Ref<FileAPI::Blob> const& blob) -> BodyInitOrReadableBytes { return GC::make_root(blob); },
+                    [](Empty) -> BodyInitOrReadableBytes { VERIFY_NOT_REACHED(); });
                 auto [body, _] = safely_extract_body(realm, converted_source);
                 request->set_body(body);
             }
@@ -2150,8 +2160,11 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
             [&](ByteBuffer const& byte_buffer) {
                 load_request.set_body(MUST(ByteBuffer::copy(byte_buffer)));
             },
-            [&](GC::Root<FileAPI::Blob> const& blob_handle) {
-                load_request.set_body(MUST(ByteBuffer::copy(blob_handle->raw_bytes())));
+            [&](Core::ImmutableBytes const& bytes) {
+                load_request.set_body(MUST(bytes.copy_to_byte_buffer()));
+            },
+            [&](GC::Ref<FileAPI::Blob> const& blob) {
+                load_request.set_body(MUST(ByteBuffer::copy(blob->raw_bytes())));
             },
             [](Empty) {
             });

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/Function.h>
 #include <LibGC/Ptr.h>
 #include <LibJS/Heap/Cell.h>
@@ -22,7 +23,7 @@ class WEB_API FetchAlgorithms : public JS::Cell {
 
 public:
     struct ConsumeBodyFailureTag { };
-    using BodyBytes = Variant<Empty, ConsumeBodyFailureTag, ByteBuffer>;
+    using BodyBytes = Variant<Empty, ConsumeBodyFailureTag, Core::ImmutableBytes>;
 
     using ProcessRequestBodyChunkLengthFunction = Function<void(u64)>;
     using ProcessRequestEndOfBodyFunction = Function<void()>;

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -24,6 +24,7 @@ static Body::SourceTypeInternal to_source_type_internal(Body::SourceType&& sourc
     return source_type.visit(
         [](Empty) -> Body::SourceTypeInternal { return Empty {}; },
         [](ByteBuffer& buffer) -> Body::SourceTypeInternal { return move(buffer); },
+        [](Core::ImmutableBytes& bytes) -> Body::SourceTypeInternal { return move(bytes); },
         [](GC::Root<FileAPI::Blob> const& blob) -> Body::SourceTypeInternal { return GC::Ref { *blob }; });
 }
 
@@ -52,6 +53,12 @@ Body::Body(GC::Ref<Streams::ReadableStream> stream, SourceTypeInternal source, O
     , m_source(move(source))
     , m_length(move(length))
 {
+}
+
+void Body::set_source(Core::ImmutableBytes source, Optional<u64> length)
+{
+    m_source = move(source);
+    m_length = length;
 }
 
 void Body::visit_edges(Cell::Visitor& visitor)
@@ -99,6 +106,11 @@ Optional<ReadonlyBytes> Body::sniff_bytes_if_available() const
     if (m_source.has<ByteBuffer>()) {
         auto const& buffer = m_source.get<ByteBuffer>();
         return buffer.bytes().slice(0, min(buffer.size(), MAX_SNIFF_BYTES));
+    }
+
+    if (m_source.has<Core::ImmutableBytes>()) {
+        auto bytes = m_source.get<Core::ImmutableBytes>().bytes();
+        return bytes.slice(0, min(bytes.size(), MAX_SNIFF_BYTES));
     }
 
     if (m_source.has<GC::Ref<FileAPI::Blob>>()) {

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/Variant.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
 #include <LibWeb/Export.h>
@@ -30,8 +31,8 @@ class WEB_API Body final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(Body);
 
 public:
-    using SourceType = Variant<Empty, ByteBuffer, GC::Root<FileAPI::Blob>>;
-    using SourceTypeInternal = Variant<Empty, ByteBuffer, GC::Ref<FileAPI::Blob>>;
+    using SourceType = Variant<Empty, ByteBuffer, Core::ImmutableBytes, GC::Root<FileAPI::Blob>>;
+    using SourceTypeInternal = Variant<Empty, ByteBuffer, Core::ImmutableBytes, GC::Ref<FileAPI::Blob>>;
     // processBody must be an algorithm accepting a byte sequence.
     using ProcessBodyCallback = GC::Ref<GC::Function<void(ByteBuffer)>>;
     // processBodyError must be an algorithm optionally accepting an exception.
@@ -48,6 +49,7 @@ public:
     [[nodiscard]] GC::Ref<Streams::ReadableStream> stream() const { return *m_stream; }
     void set_stream(GC::Ref<Streams::ReadableStream> value) { m_stream = value; }
     [[nodiscard]] SourceTypeInternal const& source() const { return m_source; }
+    void set_source(Core::ImmutableBytes, Optional<u64> length);
     [[nodiscard]] Optional<u64> const& length() const { return m_length; }
 
     // https://mimesniff.spec.whatwg.org/#reading-the-resource-header

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibTextCodec/Decoder.h>
@@ -456,16 +457,16 @@ void HTMLLinkElement::default_fetch_and_process_linked_resource(u64 fetch_genera
 
         // 1. Let success be true.
         bool success = true;
-        ByteBuffer successful_body_bytes;
+        Core::ImmutableBytes const* successful_body_bytes = nullptr;
 
         // 2. If either of the following conditions are met:
         // - bodyBytes is null or failure; or
         // - response's status is not an ok status,
         // then set success to false.
         body_bytes.visit(
-            [&](ByteBuffer& body_bytes) {
+            [&](Core::ImmutableBytes& body_bytes) {
                 if (Fetch::Infrastructure::is_ok_status(response->status()))
-                    successful_body_bytes = move(body_bytes);
+                    successful_body_bytes = &body_bytes;
                 else
                     success = false;
             },
@@ -474,7 +475,7 @@ void HTMLLinkElement::default_fetch_and_process_linked_resource(u64 fetch_genera
         // FIXME: 3. Otherwise, wait for the link resource's critical subresources to finish loading.
 
         // 4. Process the linked resource given el, success, response, and bodyBytes.
-        process_linked_resource(success, response, move(successful_body_bytes));
+        process_linked_resource(success, response, successful_body_bytes);
     };
 
     m_fetch_controller = Fetch::Fetching::fetch(realm(), *request, Fetch::Infrastructure::FetchAlgorithms::create(vm(), move(fetch_algorithms_input)));
@@ -780,12 +781,19 @@ void HTMLLinkElement::preload(LinkProcessingOptions& options, Function<void(Fetc
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#process-the-linked-resource
-void HTMLLinkElement::process_linked_resource(bool success, Fetch::Infrastructure::Response const& response, ByteBuffer body_bytes)
+void HTMLLinkElement::process_linked_resource(bool success, Fetch::Infrastructure::Response const& response, Core::ImmutableBytes const* body_bytes)
 {
-    if (m_relationship & Relationship::Icon)
-        process_icon_resource(success, response, move(body_bytes));
-    else if (m_relationship & Relationship::Stylesheet)
-        process_stylesheet_resource(success, response, move(body_bytes));
+    if (success)
+        VERIFY(body_bytes);
+
+    if (m_relationship & Relationship::Icon) {
+        ByteBuffer icon_bytes;
+        if (success)
+            icon_bytes = body_bytes->copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
+        process_icon_resource(success, response, move(icon_bytes));
+    } else if (m_relationship & Relationship::Stylesheet) {
+        process_stylesheet_resource(success, response, success ? body_bytes->bytes() : ReadonlyBytes {});
+    }
 }
 
 // AD-HOC: The spec is underspecified for fetching and processing rel="icon" See:
@@ -800,7 +808,7 @@ void HTMLLinkElement::process_icon_resource(bool success, Fetch::Infrastructure:
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:process-the-linked-resource
-void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const& response, ByteBuffer body_bytes)
+void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const& response, ReadonlyBytes body_bytes)
 {
     if (!document().is_fully_active())
         return;

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -734,8 +734,8 @@ void HTMLLinkElement::preload(LinkProcessingOptions& options, Function<void(Fetc
         response = response->unsafe_response();
 
         // 1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
-        if (auto* byte_sequence = body_bytes.get_pointer<ByteBuffer>())
-            response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, *byte_sequence));
+        if (auto* byte_sequence = body_bytes.get_pointer<Core::ImmutableBytes>())
+            response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, byte_sequence->bytes()));
         // 2. Otherwise, set response to a network error.
         else
             response = Fetch::Infrastructure::Response::network_error(realm.vm(), "Expected preload response to contain a body"_string);

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -164,9 +164,9 @@ private:
     void preconnect(LinkProcessingOptions const&);
     void preload(LinkProcessingOptions&, Function<void(Fetch::Infrastructure::Response&)> process_response = {});
 
-    void process_linked_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer);
+    void process_linked_resource(bool success, Fetch::Infrastructure::Response const&, Core::ImmutableBytes const*);
     void process_icon_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer);
-    void process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer);
+    void process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const&, ReadonlyBytes);
 
     bool should_fetch_and_process_resource_type() const;
 

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -100,6 +100,16 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
     };
 }
 
+static ReadonlyBytes body_bytes_view(Fetch::Infrastructure::FetchAlgorithms::BodyBytes const& body_bytes)
+{
+    return body_bytes.get<Core::ImmutableBytes>().bytes();
+}
+
+static ByteBuffer take_body_bytes_as_byte_buffer(Fetch::Infrastructure::FetchAlgorithms::BodyBytes& body_bytes)
+{
+    return body_bytes.get<Core::ImmutableBytes>().copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
+}
+
 // Schedule a fresh, fully off-thread compile of the script source for the sole purpose of producing a bytecode cache
 // blob to hand to RequestServer. The execution path has already received its (latency-trimmed) compile artifact and is
 // running, so this work happens entirely on a background thread and never blocks the main thread on cache generation.
@@ -606,7 +616,7 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
         auto fallback_decoder = TextCodec::decoder_for(extracted_character_encoding);
         VERIFY(fallback_decoder.has_value());
 
-        auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, body_bytes.template get<ByteBuffer>()).release_value_but_fixme_should_propagate_errors();
+        auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
 
         // 6. Let muted errors be true if response was CORS-cross-origin, and false otherwise.
         auto muted_errors = response->is_cors_cross_origin() ? ClassicScript::MutedErrors::Yes : ClassicScript::MutedErrors::No;
@@ -722,7 +732,7 @@ WebIDL::ExceptionOr<void> fetch_classic_worker_script(URL::URL const& url, Envir
         // 4. Let sourceText be the result of UTF-8 decoding bodyBytes.
         auto decoder = TextCodec::decoder_for("UTF-8"sv);
         VERIFY(decoder.has_value());
-        auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes.template get<ByteBuffer>()).release_value_but_fixme_should_propagate_errors();
+        auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
 
         // 5. Let script be the result of creating a classic script using sourceText, settingsObject,
         //    response's URL, and the default classic script fetch options.
@@ -812,7 +822,7 @@ WebIDL::ExceptionOr<GC::Ref<ClassicScript>> fetch_a_classic_worker_imported_scri
     // 8. Let sourceText be the result of UTF-8 decoding bodyBytes.
     auto decoder = TextCodec::decoder_for("UTF-8"sv);
     VERIFY(decoder.has_value());
-    auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes.get<ByteBuffer>()).release_value_but_fixme_should_propagate_errors();
+    auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
 
     // 9. Let mutedErrors be true if response was CORS-cross-origin, and false otherwise.
     auto muted_errors = response->is_cors_cross_origin() ? ClassicScript::MutedErrors::Yes : ClassicScript::MutedErrors::No;
@@ -988,7 +998,7 @@ void fetch_single_module_script(JS::Realm& realm,
         //     options.
         // FIXME: Pass options.
         if (mime_type.has_value() && mime_type->essence() == "application/wasm"sv && module_type == "javascript-or-wasm") {
-            module_script = ModuleScript::create_a_webassembly_module_script(url.to_byte_string(), body_bytes.get<ByteBuffer>(), settings_object, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
+            module_script = ModuleScript::create_a_webassembly_module_script(url.to_byte_string(), take_body_bytes_as_byte_buffer(body_bytes), settings_object, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
         }
 
         // 7. Otherwise
@@ -996,7 +1006,7 @@ void fetch_single_module_script(JS::Realm& realm,
             // 1. Let sourceText be the result of UTF-8 decoding bodyBytes.
             auto decoder = TextCodec::decoder_for("UTF-8"sv);
             VERIFY(decoder.has_value());
-            auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes.get<ByteBuffer>()).release_value_but_fixme_should_propagate_errors();
+            auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
 
             // 2. If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript to
             //    the result of creating a JavaScript module script given sourceText, moduleMapRealm, response's URL,

--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/ScopeGuard.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibWeb/Bindings/SVGScriptElement.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
@@ -128,11 +129,14 @@ void SVGScriptElement::process_the_script_element()
         Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
         fetch_algorithms_input.process_response_consume_body
             = [self = GC::Ref { *this }, script_url](auto response, auto body_bytes) {
-                  ByteBuffer body;
-                  if (!response->is_network_error())
-                      body_bytes.visit([&](ByteBuffer& bytes) { body = move(bytes); }, [](auto) {});
+                  if (response->is_network_error()) {
+                      self->finish_external_script_fetch(script_url, {});
+                      return;
+                  }
 
-                  self->finish_external_script_fetch(script_url, body);
+                  body_bytes.visit(
+                      [&](Core::ImmutableBytes& bytes) { self->finish_external_script_fetch(script_url, bytes.bytes()); },
+                      [&](auto) { self->finish_external_script_fetch(script_url, {}); });
               };
 
         (void)Fetch::Fetching::fetch(realm(), request,
@@ -151,7 +155,7 @@ void SVGScriptElement::process_the_script_element()
     execute_script();
 }
 
-void SVGScriptElement::finish_external_script_fetch(URL::URL const& script_url, ByteBuffer const& body)
+void SVGScriptElement::finish_external_script_fetch(URL::URL const& script_url, ReadonlyBytes body)
 {
     if (!body.is_empty() && in_a_document_tree() && !is_scripting_disabled()) {
         auto script_content = String::from_utf8(body);

--- a/Libraries/LibWeb/SVG/SVGScriptElement.h
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <LibURL/URL.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/SVG/SVGElement.h>
@@ -45,7 +46,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    void finish_external_script_fetch(URL::URL const& script_url, ByteBuffer const& body);
+    void finish_external_script_fetch(URL::URL const& script_url, ReadonlyBytes body);
     void execute_script();
 
     bool m_already_processed { false };

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -893,15 +893,15 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
         IGNORE_USE_IN_ESCAPING_LAMBDA bool processed_response = false;
 
         // 2. Let processResponseConsumeBody, given a response and nullOrFailureOrBytes, be these steps:
-        auto process_response_consume_body = [this, &processed_response](GC::Ref<Fetch::Infrastructure::Response> response, Variant<Empty, Fetch::Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag, ByteBuffer> null_or_failure_or_bytes) {
+        auto process_response_consume_body = [this, &processed_response](GC::Ref<Fetch::Infrastructure::Response> response, Fetch::Infrastructure::FetchAlgorithms::BodyBytes null_or_failure_or_bytes) {
             // 1. If nullOrFailureOrBytes is not failure, then set this’s response to response.
             if (!null_or_failure_or_bytes.has<Fetch::Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag>())
                 m_response = response;
 
             // 2. If nullOrFailureOrBytes is a byte sequence, then append nullOrFailureOrBytes to this’s received bytes.
-            if (null_or_failure_or_bytes.has<ByteBuffer>()) {
+            if (null_or_failure_or_bytes.has<Core::ImmutableBytes>()) {
                 // NOTE: We are not in a context where we can throw if this fails due to OOM.
-                m_received_bytes.append(null_or_failure_or_bytes.get<ByteBuffer>());
+                m_received_bytes.append(null_or_failure_or_bytes.get<Core::ImmutableBytes>().bytes());
             }
 
             // 3. Set processedResponse to true.


### PR DESCRIPTION
Keep consumed fetch response body bytes in `Core::ImmutableBytes` instead of forcing them into `ByteBuffer`. This lets disk-cached resources stay file-backed all the way from RequestServer's HTTP disk cache through fetch body consumption, avoiding an eager copy for consumers that only need to inspect the bytes!

Update the fetch body consumers that inspect bytes to use immutable byte views, and only copy at existing ownership boundaries such as font preparation and WebAssembly module creation.

This also tightens `Variant::visit` so typed overloads that cannot match any variant alternative are rejected at compile time, catching stale body-byte visitors when payload types change. (I shot myself in the foot here while working on this :)