### PR TITLE
LibWeb: Treat cyclic grid percentages as auto

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2509,6 +2509,24 @@ CSSPixels GridFormattingContext::calculate_grid_container_maximum_size(GridDimen
     return calculate_inner_height(grid_container(), m_available_space.value(), computed_values.max_height());
 }
 
+bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_contribution(GridItem const& item, GridDimension dimension) const
+{
+    auto available_space_for_item = item.available_space();
+    auto should_treat_preferred_size_as_auto = [&] {
+        if (dimension == GridDimension::Column)
+            return should_treat_width_as_auto(item.box, available_space_for_item);
+        return should_treat_height_as_auto(item.box, available_space_for_item);
+    }();
+    if (should_treat_preferred_size_as_auto)
+        return true;
+
+    // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
+    // When a non-replaced grid item's percentage preferred size contributes to
+    // sizing tracks in the same axis, the percentage is cyclic and behaves as
+    // the property's initial value for intrinsic contribution calculations.
+    return !item.box->is_replaced_box() && item.preferred_size(dimension).contains_percentage();
+}
+
 CSSPixels GridFormattingContext::calculate_min_content_size(GridItem const& item, GridDimension dimension) const
 {
     if (dimension == GridDimension::Column) {
@@ -2536,13 +2554,7 @@ CSSPixels GridFormattingContext::containing_block_size_for_item(GridItem const& 
 
 CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem const& item, GridDimension dimension) const
 {
-    auto available_space_for_item = item.available_space();
-
-    auto should_treat_preferred_size_as_auto = [&] {
-        if (dimension == GridDimension::Column)
-            return should_treat_width_as_auto(item.box, available_space_for_item);
-        return should_treat_height_as_auto(item.box, available_space_for_item);
-    }();
+    auto should_treat_preferred_size_as_auto = should_treat_preferred_size_as_auto_for_intrinsic_contribution(item, dimension);
 
     auto maximum_size = CSSPixels::max();
     if (auto const& css_maximum_size = item.maximum_size(dimension); css_maximum_size.is_length_percentage() && !css_maximum_size.contains_percentage())
@@ -2576,11 +2588,7 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
 {
     auto available_space_for_item = item.available_space();
 
-    auto should_treat_preferred_size_as_auto = [&] {
-        if (dimension == GridDimension::Column)
-            return should_treat_width_as_auto(item.box, available_space_for_item);
-        return should_treat_height_as_auto(item.box, available_space_for_item);
-    }();
+    auto should_treat_preferred_size_as_auto = should_treat_preferred_size_as_auto_for_intrinsic_contribution(item, dimension);
 
     auto maximum_size = CSSPixels::max();
     if (auto const& css_maximum_size = item.maximum_size(dimension); css_maximum_size.is_length_percentage() && !css_maximum_size.contains_percentage())
@@ -2711,6 +2719,9 @@ Optional<CSSPixels> GridFormattingContext::specified_size_suggestion(GridItem co
     // https://www.w3.org/TR/css-grid-1/#specified-size-suggestion
     // If the item’s preferred size in the relevant axis is definite, then the specified size suggestion is that size.
     // It is otherwise undefined.
+    if (!item.box->is_replaced_box() && item.preferred_size(dimension).contains_percentage())
+        return {};
+
     auto has_definite_preferred_size = dimension == GridDimension::Column ? item.used_values.has_definite_width() : item.used_values.has_definite_height();
     if (has_definite_preferred_size) {
         // FIXME: consider margins, padding and borders because it is outer size.
@@ -2841,12 +2852,7 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
     // contribution is its min-content contribution. Because the minimum contribution often depends on
     // the size of the item’s content, it is considered a type of intrinsic size contribution.
 
-    auto preferred_size = item.preferred_size(dimension);
-    auto should_treat_preferred_size_as_auto = [&] {
-        if (dimension == GridDimension::Column)
-            return should_treat_width_as_auto(item.box, item.available_space());
-        return should_treat_height_as_auto(item.box, item.available_space());
-    }();
+    auto should_treat_preferred_size_as_auto = should_treat_preferred_size_as_auto_for_intrinsic_contribution(item, dimension);
 
     if (should_treat_preferred_size_as_auto) {
         auto minimum_size = item.minimum_size(dimension);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -364,6 +364,7 @@ private:
 
     bool should_treat_grid_container_maximum_size_as_none(GridDimension) const;
     CSSPixels calculate_grid_container_maximum_size(GridDimension) const;
+    bool should_treat_preferred_size_as_auto_for_intrinsic_contribution(GridItem const&, GridDimension) const;
 
     CSSPixels calculate_min_content_size(GridItem const&, GridDimension) const;
     CSSPixels calculate_max_content_size(GridItem const&, GridDimension) const;

--- a/Tests/LibWeb/Layout/expected/grid-nested-percent-height-contribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid-nested-percent-height-contribution.txt
@@ -7,15 +7,15 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         Box <div.table> at [0,0] [0+0+0 240 0+0+0] [0+0+0 333.328125 0+0+0] [GFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          BlockContainer <div.card.first> at [0,0] [0+0+0 100 0+0+0] [0+0+0 333.328125 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.card.first> at [0,0] [0+0+0 100 0+0+0] [0+0+0 80 0+0+0] [BFC] children: not-inline
             BlockContainer <div.content> at [0,0] [0+0+0 100 0+0+0] [0+0+0 80 0+0+0] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          BlockContainer <div.card.second> at [0,353.328125] [0+0+0 100 0+0+0] [0+0+0 333.328125 0+0+0] [BFC] children: not-inline
-            BlockContainer <div.content> at [0,353.328125] [0+0+0 100 0+0+0] [0+0+0 40 0+0+0] children: not-inline
+          BlockContainer <div.card.second> at [0,100] [0+0+0 100 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+            BlockContainer <div.content> at [0,100] [0+0+0 100 0+0+0] [0+0+0 40 0+0+0] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          BlockContainer <div.image> at [120,0] [0+0+0 100 0+0+0] [0+0+0 320 0+0+386.65625] [BFC] children: not-inline
+          BlockContainer <div.image> at [120,0] [0+0+0 100 0+0+0] [0+0+0 320 0+0+13.328125] [BFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -26,15 +26,15 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <(anonymous)> at [0,383.328125] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x686.65625]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x383.328125]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x383.328125]
       PaintableBox (Box<DIV>.parent) [0,0 240x383.328125]
         PaintableBox (Box<DIV>.table) [0,0 240x333.328125]
-          PaintableWithLines (BlockContainer<DIV>.card.first) [0,0 100x333.328125]
+          PaintableWithLines (BlockContainer<DIV>.card.first) [0,0 100x80]
             PaintableWithLines (BlockContainer<DIV>.content) [0,0 100x80]
-          PaintableWithLines (BlockContainer<DIV>.card.second) [0,353.328125 100x333.328125]
-            PaintableWithLines (BlockContainer<DIV>.content) [0,353.328125 100x40]
+          PaintableWithLines (BlockContainer<DIV>.card.second) [0,100 100x40]
+            PaintableWithLines (BlockContainer<DIV>.content) [0,100 100x40]
           PaintableWithLines (BlockContainer<DIV>.image) [120,0 100x320]
         PaintableWithLines (BlockContainer<DIV>.next) [0,353.328125 240x30]
       PaintableWithLines (BlockContainer(anonymous)) [0,383.328125 800x0]

--- a/Tests/LibWeb/Layout/expected/grid-nested-percent-height-contribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid-nested-percent-height-contribution.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 383.328125 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 383.328125 0+0+0] children: not-inline
+      Box <div.parent> at [0,0] [0+0+0 240 0+0+560] [0+0+0 383.328125 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.table> at [0,0] [0+0+0 240 0+0+0] [0+0+0 333.328125 0+0+0] [GFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.card.first> at [0,0] [0+0+0 100 0+0+0] [0+0+0 333.328125 0+0+0] [BFC] children: not-inline
+            BlockContainer <div.content> at [0,0] [0+0+0 100 0+0+0] [0+0+0 80 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.card.second> at [0,353.328125] [0+0+0 100 0+0+0] [0+0+0 333.328125 0+0+0] [BFC] children: not-inline
+            BlockContainer <div.content> at [0,353.328125] [0+0+0 100 0+0+0] [0+0+0 40 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.image> at [120,0] [0+0+0 100 0+0+0] [0+0+0 320 0+0+386.65625] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.next> at [0,353.328125] [0+0+0 240 0+0+0] [0+0+0 30 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,383.328125] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x686.65625]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x383.328125]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x383.328125]
+      PaintableBox (Box<DIV>.parent) [0,0 240x383.328125]
+        PaintableBox (Box<DIV>.table) [0,0 240x333.328125]
+          PaintableWithLines (BlockContainer<DIV>.card.first) [0,0 100x333.328125]
+            PaintableWithLines (BlockContainer<DIV>.content) [0,0 100x80]
+          PaintableWithLines (BlockContainer<DIV>.card.second) [0,353.328125 100x333.328125]
+            PaintableWithLines (BlockContainer<DIV>.content) [0,353.328125 100x40]
+          PaintableWithLines (BlockContainer<DIV>.image) [120,0 100x320]
+        PaintableWithLines (BlockContainer<DIV>.next) [0,353.328125 240x30]
+      PaintableWithLines (BlockContainer(anonymous)) [0,383.328125 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x383.328125] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-percent-height-auto-row-contribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid-percent-height-auto-row-contribution.txt
@@ -7,26 +7,26 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         BlockContainer <div.label> at [0,0] [0+0+0 120 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [0,30] [0+0+0 120 0+0+0] [0+0+0 300 0+0+0] [BFC] children: not-inline
+        BlockContainer <div.item> at [0,30] [0+0+0 120 0+0+0] [0+0+0 125 0+0+0] [BFC] children: not-inline
           BlockContainer <div.content> at [0,30] [0+0+0 120 0+0+0] [0+0+0 30 0+0+0] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item> at [0,350] [0+0+0 120 0+0+0] [0+0+0 300 0+0+0] [BFC] children: not-inline
-          BlockContainer <div.content> at [0,350] [0+0+0 120 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+        BlockContainer <div.item> at [0,175] [0+0+0 120 0+0+0] [0+0+0 125 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.content> at [0,175] [0+0+0 120 0+0+0] [0+0+0 30 0+0+0] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [0,300] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x650]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x300]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x300]
       PaintableBox (Box<DIV>.grid) [0,0 120x300]
         PaintableWithLines (BlockContainer<DIV>.label) [0,0 120x10]
-        PaintableWithLines (BlockContainer<DIV>.item) [0,30 120x300]
+        PaintableWithLines (BlockContainer<DIV>.item) [0,30 120x125]
           PaintableWithLines (BlockContainer<DIV>.content) [0,30 120x30]
-        PaintableWithLines (BlockContainer<DIV>.item) [0,350 120x300]
-          PaintableWithLines (BlockContainer<DIV>.content) [0,350 120x30]
+        PaintableWithLines (BlockContainer<DIV>.item) [0,175 120x125]
+          PaintableWithLines (BlockContainer<DIV>.content) [0,175 120x30]
       PaintableWithLines (BlockContainer(anonymous)) [0,300 800x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-percent-height-auto-row-contribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid-percent-height-auto-row-contribution.txt
@@ -1,0 +1,33 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 300 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 300 0+0+0] children: not-inline
+      Box <div.grid> at [0,0] [0+0+0 120 0+0+680] [0+0+0 300 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.label> at [0,0] [0+0+0 120 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [0,30] [0+0+0 120 0+0+0] [0+0+0 300 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.content> at [0,30] [0+0+0 120 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [0,350] [0+0+0 120 0+0+0] [0+0+0 300 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.content> at [0,350] [0+0+0 120 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,300] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x650]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x300]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x300]
+      PaintableBox (Box<DIV>.grid) [0,0 120x300]
+        PaintableWithLines (BlockContainer<DIV>.label) [0,0 120x10]
+        PaintableWithLines (BlockContainer<DIV>.item) [0,30 120x300]
+          PaintableWithLines (BlockContainer<DIV>.content) [0,30 120x30]
+        PaintableWithLines (BlockContainer<DIV>.item) [0,350 120x300]
+          PaintableWithLines (BlockContainer<DIV>.content) [0,350 120x30]
+      PaintableWithLines (BlockContainer(anonymous)) [0,300 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x300] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid-nested-percent-height-contribution.html
+++ b/Tests/LibWeb/Layout/input/grid-nested-percent-height-contribution.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .parent {
+        display: grid;
+        grid-template-rows: repeat(2, max-content);
+        row-gap: 20px;
+        align-items: start;
+        width: 240px;
+    }
+
+    .table {
+        display: grid;
+        grid-template-columns: 100px 100px;
+        grid-template-rows: max-content;
+        grid-auto-flow: dense;
+        gap: 20px;
+        align-items: start;
+    }
+
+    .card {
+        grid-column: 1;
+        height: 100%;
+        background: royalblue;
+    }
+
+    .first {
+        order: 10;
+    }
+
+    .second {
+        order: 11;
+    }
+
+    .first .content {
+        height: 80px;
+    }
+
+    .second .content {
+        height: 40px;
+    }
+
+    .image {
+        grid-column: 2;
+        grid-row: auto / span 3;
+        order: 12;
+        height: 320px;
+        background: seagreen;
+    }
+
+    .next {
+        height: 30px;
+        background: crimson;
+    }
+</style>
+<div class="parent">
+    <div class="table">
+        <div class="card first"><div class="content"></div></div>
+        <div class="card second"><div class="content"></div></div>
+        <div class="image"></div>
+    </div>
+    <div class="next"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid-percent-height-auto-row-contribution.html
+++ b/Tests/LibWeb/Layout/input/grid-percent-height-auto-row-contribution.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .grid {
+        display: grid;
+        grid-template-rows: max-content;
+        row-gap: 20px;
+        align-items: start;
+        width: 120px;
+        height: 300px;
+    }
+
+    .label {
+        height: 10px;
+        background: crimson;
+    }
+
+    .item {
+        height: 100%;
+        background: royalblue;
+    }
+
+    .content {
+        height: 30px;
+    }
+</style>
+<div class="grid">
+    <div class="label"></div>
+    <div class="item"><div class="content"></div></div>
+    <div class="item"><div class="content"></div></div>
+</div>


### PR DESCRIPTION
Treat non-replaced grid item percentage preferred sizes as auto when computing intrinsic grid track contributions. This matches the CSS Sizing cyclic percentage contribution rule and avoids inflating auto rows before the final grid area size is known.
    
Keep resolving those percentages during final item layout. Update the new layout tests to cover row inflation and nested overlap.

Visual progression on https://www.washingtonpost.com/

Before:
<img width="1476" height="981" alt="Screenshot from 2026-05-18 00-22-59" src="https://github.com/user-attachments/assets/0c4a1eb5-f5d7-4d73-853f-7927a2ffd01f" />

After:
<img width="1476" height="981" alt="Screenshot from 2026-05-18 00-22-30" src="https://github.com/user-attachments/assets/9ae1d97a-e997-426f-9336-719fee8734ea" />
