### PR TITLE
LibJS+LibWeb+LibTextCodec: Lazily decode cached script source text

### DIFF
--- a/Libraries/LibJS/Bytecode/ClassBlueprint.h
+++ b/Libraries/LibJS/Bytecode/ClassBlueprint.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <AK/RefPtr.h>
 #include <AK/Utf16FlyString.h>
-#include <AK/Utf16View.h>
 #include <AK/Vector.h>
+#include <LibJS/Forward.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS::Bytecode {
@@ -37,7 +38,9 @@ struct ClassBlueprint {
     bool has_super_class;
     bool has_name;
     Utf16FlyString name;
-    Utf16View source_text;
+    RefPtr<SourceCode const> source_code;
+    size_t source_text_offset { 0 };
+    size_t source_text_length { 0 };
     Vector<ClassElementDescriptor> elements;
 };
 

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -507,7 +507,7 @@ SourceRange const& Executable::get_source_range(u32 program_counter)
     return m_source_range_cache.ensure(program_counter, [&] {
         if (auto source_range = source_range_at(program_counter); source_range.has_value())
             return *source_range;
-        static SourceRange dummy { SourceCode::create({}, {}), {} };
+        static SourceRange dummy { SourceCode::create({}, Utf16String {}), {} };
         return dummy;
     });
 }

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -271,7 +271,7 @@ set(GENERATED_SOURCES Bytecode/Op.cpp)
 
 ladybird_lib(LibJS js EXPLICIT_SYMBOL_EXPORT)
 
-target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibGC simdjson::simdjson)
+target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibTextCodec LibGC simdjson::simdjson)
 
 # Link LibUnicode publicly to ensure ICU data (which is in libicudata.a) is available in any process using LibJS.
 target_link_libraries(LibJS PUBLIC LibUnicode)

--- a/Libraries/LibJS/Runtime/ClassConstruction.cpp
+++ b/Libraries/LibJS/Runtime/ClassConstruction.cpp
@@ -297,7 +297,8 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> construct_class(
             }));
     }
 
-    class_constructor->set_source_text(blueprint.source_text);
+    if (blueprint.source_code)
+        class_constructor->set_source_text_range(*blueprint.source_code, blueprint.source_text_offset, blueprint.source_text_length);
 
     return { class_constructor };
 }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -91,8 +91,12 @@ public:
     Object* home_object() const { return m_home_object; }
     void set_home_object(Object* home_object) { m_home_object = home_object; }
 
-    [[nodiscard]] Utf16View source_text() const { return shared_data().m_source_text; }
-    void set_source_text(Utf16View source_text) { const_cast<SharedFunctionInstanceData&>(shared_data()).m_source_text = move(source_text); }
+    [[nodiscard]] Utf16String source_text() const { return shared_data().source_text(); }
+    void set_source_text(Utf16View source_text) { const_cast<SharedFunctionInstanceData&>(shared_data()).set_source_text(source_text); }
+    void set_source_text_range(SourceCode const& source_code, size_t source_text_offset, size_t source_text_length)
+    {
+        const_cast<SharedFunctionInstanceData&>(shared_data()).set_source_text_range(source_code, source_text_offset, source_text_length);
+    }
 
     Vector<ClassFieldDefinition> const& fields() const { return ensure_class_data().fields; }
     void add_field(ClassFieldDefinition field) { ensure_class_data().fields.append(move(field)); }

--- a/Libraries/LibJS/Runtime/ErrorData.cpp
+++ b/Libraries/LibJS/Runtime/ErrorData.cpp
@@ -15,7 +15,7 @@
 
 namespace JS {
 
-static SourceRange dummy_source_range { SourceCode::create({}, {}), {} };
+static SourceRange dummy_source_range { SourceCode::create({}, Utf16String {}), {} };
 
 SourceRange const& TracebackFrame::source_range() const
 {

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
 #include <LibJS/RustIntegration.h>
+#include <LibJS/SourceCode.h>
 
 namespace JS {
 
@@ -66,6 +67,33 @@ size_t SharedFunctionInstanceData::external_memory_size() const
     size = saturating_add_external_memory_size(size, vector_external_memory_size(m_function_names_to_initialize_binding));
     size = saturating_add_external_memory_size(size, vector_external_memory_size(m_lexical_bindings));
     return size;
+}
+
+Utf16String SharedFunctionInstanceData::source_text() const
+{
+    if (!m_source_text_owner.is_empty())
+        return m_source_text_owner;
+
+    if (!m_source_code)
+        return {};
+
+    return m_source_code->source_text_from_offsets(m_source_text_offset, m_source_text_length);
+}
+
+void SharedFunctionInstanceData::set_source_text(Utf16View source_text)
+{
+    m_source_text_owner = Utf16String::from_utf16(source_text);
+    m_source_code = nullptr;
+    m_source_text_offset = 0;
+    m_source_text_length = 0;
+}
+
+void SharedFunctionInstanceData::set_source_text_range(SourceCode const& source_code, size_t source_text_offset, size_t source_text_length)
+{
+    m_source_text_owner = {};
+    m_source_code = &source_code;
+    m_source_text_offset = source_text_offset;
+    m_source_text_length = source_text_length;
 }
 
 SharedFunctionInstanceData::~SharedFunctionInstanceData() = default;

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
@@ -79,12 +79,19 @@ public:
 
     Utf16FlyString m_name;
 
-    // NB: m_source_text is normally a view into the underlying JS::SourceCode we parsed the AST from,
-    //     kept alive by m_source_code. m_source_text_owner is used if the source text needs to be
-    //     owned by the function data (e.g. for dynamically created functions via Function constructor).
+    Utf16String source_text() const;
+    void set_source_text(Utf16View);
+    void set_source_text_range(SourceCode const&, size_t source_text_offset, size_t source_text_length);
+
+    // NB: m_source_text_offset and m_source_text_length normally refer to
+    //     ranges within the underlying JS::SourceCode we parsed the AST from,
+    //     kept alive by m_source_code. m_source_text_owner is used if the
+    //     source text needs to be owned by the function data (e.g. for
+    //     dynamically created functions via Function constructor).
     RefPtr<SourceCode const> m_source_code;
     Utf16String m_source_text_owner;
-    Utf16View m_source_text; // [[SourceText]]
+    size_t m_source_text_offset { 0 };
+    size_t m_source_text_length { 0 }; // [[SourceText]]
 
     Vector<LocalVariable> m_local_variables_names;
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -747,7 +747,6 @@ Optional<Result<GC::Ref<SharedFunctionInstanceData>, String>> compile_dynamic_fu
 
     auto& function_data = *static_cast<SharedFunctionInstanceData*>(sfd_ptr);
     function_data.m_source_text_owner = Utf16String::from_utf8(source_text);
-    function_data.m_source_text = function_data.m_source_text_owner.utf16_view();
 
     return GC::Ref<SharedFunctionInstanceData> { function_data };
 }
@@ -1161,12 +1160,7 @@ extern "C" void* rust_create_sfd(
         shared->m_function_environment_needed = true;
     shared->update_asm_call_metadata();
 
-    // Set source text as a view into the original source code.
-    shared->m_source_code = &source_code;
-    if (data->source_text_length > 0) {
-        auto const& code_view = source_code.code_view();
-        shared->m_source_text = code_view.substring_view(data->source_text_offset, data->source_text_length);
-    }
+    shared->set_source_text_range(source_code, data->source_text_offset, data->source_text_length);
 
     return shared.ptr();
 }
@@ -1298,12 +1292,9 @@ extern "C" void* rust_create_class_blueprint(
     if (name_len > 0)
         blueprint->name = Utf16FlyString::from_utf16(JS::RustIntegration::utf16_view_from_bytes(name, name_len));
 
-    // Store source text as a view into the SourceCode buffer.
-    if (source_text_len > 0) {
-        auto& source_code = *static_cast<JS::SourceCode const*>(source_code_ptr);
-        auto const& code_view = source_code.code_view();
-        blueprint->source_text = code_view.substring_view(source_text_offset, source_text_len);
-    }
+    blueprint->source_code = static_cast<JS::SourceCode const*>(source_code_ptr);
+    blueprint->source_text_offset = source_text_offset;
+    blueprint->source_text_length = source_text_len;
 
     for (size_t i = 0; i < element_count; ++i) {
         auto const& elem = elements[i];

--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/BinarySearch.h>
-#include <AK/Utf8View.h>
 #include <LibJS/SourceCode.h>
 #include <LibJS/SourceRange.h>
 #include <LibJS/Token.h>
@@ -13,20 +12,7 @@
 
 namespace JS {
 
-static size_t utf16_length_from_utf8(String const& code)
-{
-    size_t length = 0;
-    for (auto code_point : code.code_points())
-        length += code_point > 0xffff ? 2 : 1;
-    return length;
-}
-
 NonnullRefPtr<SourceCode const> SourceCode::create(String filename, Utf16String code)
-{
-    return adopt_ref(*new SourceCode(move(filename), move(code)));
-}
-
-NonnullRefPtr<SourceCode const> SourceCode::create(String filename, String code)
 {
     return adopt_ref(*new SourceCode(move(filename), move(code)));
 }
@@ -44,13 +30,6 @@ SourceCode::SourceCode(String filename, Utf16String code)
 {
 }
 
-SourceCode::SourceCode(String filename, String code)
-    : m_filename(move(filename))
-    , m_utf8_code(move(code))
-    , m_length_in_code_units(utf16_length_from_utf8(*m_utf8_code))
-{
-}
-
 SourceCode::SourceCode(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes)
     : m_filename(move(filename))
     , m_source_encoding(move(source_encoding))
@@ -64,13 +43,8 @@ void SourceCode::ensure_code() const
     if (m_code.has_value())
         return;
 
-    if (m_utf8_code.has_value()) {
-        m_code = Utf16String::from_utf8(*m_utf8_code);
-        m_utf8_code.clear();
-    } else {
-        m_code = decode_source_range(0, m_length_in_code_units);
-        m_source_bytes = {};
-    }
+    m_code = decode_source_range(0, m_length_in_code_units);
+    m_source_bytes = {};
     m_code_view = m_code->utf16_view();
 }
 
@@ -113,33 +87,8 @@ Utf16String SourceCode::source_text_from_offsets(size_t start_offset, size_t len
     if (m_source_bytes.is_valid())
         return decode_source_range(start_offset, length);
 
-    if (!m_utf8_code.has_value()) {
-        ensure_code();
-        return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
-    }
-
-    if (m_utf8_code->is_ascii())
-        return Utf16String::from_utf8(m_utf8_code->bytes_as_string_view().substring_view(start_offset, length));
-
-    auto view = m_utf8_code->code_points();
-    Optional<size_t> start_byte_offset;
-    Optional<size_t> end_byte_offset;
-    size_t current_offset = 0;
-    for (auto it = view.begin(); it != view.end(); ++it) {
-        if (!start_byte_offset.has_value() && current_offset >= start_offset)
-            start_byte_offset = view.byte_offset_of(it);
-        if (!end_byte_offset.has_value() && current_offset >= start_offset + length) {
-            end_byte_offset = view.byte_offset_of(it);
-            break;
-        }
-        current_offset += *it > 0xffff ? 2 : 1;
-    }
-
-    auto source_byte_count = m_utf8_code->byte_count();
-    auto start = start_byte_offset.value_or(source_byte_count);
-    auto end = end_byte_offset.value_or(source_byte_count);
-    VERIFY(end >= start);
-    return Utf16String::from_utf8(m_utf8_code->bytes_as_string_view().substring_view(start, end - start));
+    ensure_code();
+    return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
 }
 
 Utf16String SourceCode::decode_source_range(size_t start_offset, size_t length) const

--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -9,24 +9,87 @@
 #include <LibJS/SourceCode.h>
 #include <LibJS/SourceRange.h>
 #include <LibJS/Token.h>
+#include <LibTextCodec/Decoder.h>
 
 namespace JS {
+
+static size_t utf16_length_from_utf8(String const& code)
+{
+    size_t length = 0;
+    for (auto code_point : code.code_points())
+        length += code_point > 0xffff ? 2 : 1;
+    return length;
+}
 
 NonnullRefPtr<SourceCode const> SourceCode::create(String filename, Utf16String code)
 {
     return adopt_ref(*new SourceCode(move(filename), move(code)));
 }
 
+NonnullRefPtr<SourceCode const> SourceCode::create(String filename, String code)
+{
+    return adopt_ref(*new SourceCode(move(filename), move(code)));
+}
+
+NonnullRefPtr<SourceCode const> SourceCode::create(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes)
+{
+    return adopt_ref(*new SourceCode(move(filename), length_in_code_units, move(source_encoding), move(source_bytes)));
+}
+
 SourceCode::SourceCode(String filename, Utf16String code)
     : m_filename(move(filename))
     , m_code(move(code))
-    , m_code_view(m_code.utf16_view())
+    , m_code_view(m_code->utf16_view())
     , m_length_in_code_units(m_code_view.length_in_code_units())
 {
 }
 
+SourceCode::SourceCode(String filename, String code)
+    : m_filename(move(filename))
+    , m_utf8_code(move(code))
+    , m_length_in_code_units(utf16_length_from_utf8(*m_utf8_code))
+{
+}
+
+SourceCode::SourceCode(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes)
+    : m_filename(move(filename))
+    , m_source_encoding(move(source_encoding))
+    , m_source_bytes(move(source_bytes))
+    , m_length_in_code_units(length_in_code_units)
+{
+}
+
+void SourceCode::ensure_code() const
+{
+    if (m_code.has_value())
+        return;
+
+    if (m_utf8_code.has_value()) {
+        m_code = Utf16String::from_utf8(*m_utf8_code);
+        m_utf8_code.clear();
+    } else {
+        m_code = decode_source_range(0, m_length_in_code_units);
+        m_source_bytes = {};
+    }
+    m_code_view = m_code->utf16_view();
+}
+
+Utf16String const& SourceCode::code() const
+{
+    ensure_code();
+    return *m_code;
+}
+
+Utf16View const& SourceCode::code_view() const
+{
+    ensure_code();
+    return m_code_view;
+}
+
 u16 const* SourceCode::utf16_data() const
 {
+    ensure_code();
+
     if (!m_code_view.has_ascii_storage())
         return reinterpret_cast<u16 const*>(m_code_view.utf16_span().data());
 
@@ -39,13 +102,97 @@ u16 const* SourceCode::utf16_data() const
     return m_utf16_data_cache.data();
 }
 
+Utf16String SourceCode::source_text_from_offsets(size_t start_offset, size_t length) const
+{
+    if (length == 0)
+        return {};
+
+    if (m_code.has_value())
+        return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
+
+    if (m_source_bytes.is_valid())
+        return decode_source_range(start_offset, length);
+
+    if (!m_utf8_code.has_value()) {
+        ensure_code();
+        return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
+    }
+
+    if (m_utf8_code->is_ascii())
+        return Utf16String::from_utf8(m_utf8_code->bytes_as_string_view().substring_view(start_offset, length));
+
+    auto view = m_utf8_code->code_points();
+    Optional<size_t> start_byte_offset;
+    Optional<size_t> end_byte_offset;
+    size_t current_offset = 0;
+    for (auto it = view.begin(); it != view.end(); ++it) {
+        if (!start_byte_offset.has_value() && current_offset >= start_offset)
+            start_byte_offset = view.byte_offset_of(it);
+        if (!end_byte_offset.has_value() && current_offset >= start_offset + length) {
+            end_byte_offset = view.byte_offset_of(it);
+            break;
+        }
+        current_offset += *it > 0xffff ? 2 : 1;
+    }
+
+    auto source_byte_count = m_utf8_code->byte_count();
+    auto start = start_byte_offset.value_or(source_byte_count);
+    auto end = end_byte_offset.value_or(source_byte_count);
+    VERIFY(end >= start);
+    return Utf16String::from_utf8(m_utf8_code->bytes_as_string_view().substring_view(start, end - start));
+}
+
+Utf16String SourceCode::decode_source_range(size_t start_offset, size_t length) const
+{
+    if (length == 0)
+        return {};
+
+    VERIFY(start_offset <= NumericLimits<size_t>::max() - length);
+    auto end_offset = start_offset + length;
+    StringView input { m_source_bytes.bytes() };
+    auto decoder = TextCodec::decoder_for(m_source_encoding);
+    VERIFY(decoder.has_value());
+    TextCodec::Decoder* actual_decoder = &decoder.value();
+
+    auto unicode_decoder = TextCodec::bom_sniff_to_decoder(input);
+    if (unicode_decoder.has_value()) {
+        auto input_bytes = input.bytes();
+        auto byte_order_mark_size = input_bytes.size() >= 3 && input_bytes[0] == 0xEF && input_bytes[1] == 0xBB && input_bytes[2] == 0xBF ? 3 : 2;
+        actual_decoder = &unicode_decoder.value();
+        input = input.substring_view(byte_order_mark_size);
+    }
+
+    StringBuilder builder(StringBuilder::Mode::UTF16, length);
+    size_t current_offset = 0;
+    auto result = actual_decoder->process_code_points(input, [&](auto code_point) -> ErrorOr<void> {
+        char16_t code_units[2];
+        size_t code_point_length_in_code_units = 0;
+        (void)AK::UnicodeUtils::code_point_to_utf16(code_point, [&](auto code_unit) {
+            code_units[code_point_length_in_code_units++] = code_unit;
+        });
+
+        for (size_t i = 0; i < code_point_length_in_code_units; ++i) {
+            auto code_unit_offset = current_offset + i;
+            if (code_unit_offset >= start_offset && code_unit_offset < end_offset)
+                TRY(builder.try_append_code_unit(code_units[i]));
+        }
+
+        current_offset += code_point_length_in_code_units;
+        return {};
+    });
+    result.release_value_but_fixme_should_propagate_errors();
+
+    return builder.to_utf16_string();
+}
+
 void SourceCode::fill_position_cache() const
 {
     constexpr size_t predicted_minimum_cached_positions = 8;
     constexpr size_t minimum_distance_between_cached_positions = 32;
     constexpr size_t maximum_distance_between_cached_positions = 8192;
 
-    if (m_code.is_empty())
+    auto const& code = this->code();
+    if (code.is_empty())
         return;
 
     u32 previous_code_point = 0;
@@ -53,10 +200,10 @@ void SourceCode::fill_position_cache() const
     u32 column = 1;
     u32 offset_of_last_starting_point = 0;
 
-    m_cached_positions.ensure_capacity(predicted_minimum_cached_positions + (m_code.length_in_code_units() / maximum_distance_between_cached_positions));
+    m_cached_positions.ensure_capacity(predicted_minimum_cached_positions + (code.length_in_code_units() / maximum_distance_between_cached_positions));
     m_cached_positions.append({ .position = { .line = 1, .column = 1 }, .offset = 0 });
 
-    auto view = m_code.utf16_view();
+    auto view = code.utf16_view();
 
     for (auto it = view.begin(); it != view.end(); ++it) {
         u32 code_point = *it;
@@ -87,7 +234,8 @@ void SourceCode::fill_position_cache() const
 SourceRange SourceCode::range_from_offsets(u32 start_offset, [[maybe_unused]] u32 end_offset) const
 {
     // If the underlying code is an empty string, the range is 1,1 no matter what.
-    if (m_code.is_empty())
+    auto const& code = this->code();
+    if (code.is_empty())
         return { *this, { .line = 1, .column = 1 } };
 
     if (m_cached_positions.is_empty())
@@ -110,7 +258,7 @@ SourceRange SourceCode::range_from_offsets(u32 start_offset, [[maybe_unused]] u3
 
     u32 previous_code_point = 0;
 
-    auto view = m_code.utf16_view();
+    auto view = code.utf16_view();
 
     for (auto it = view.iterator_at_code_unit_offset(current.offset); it != view.end(); ++it) {
         // If we're on or after the start offset, this is the start position.

--- a/Libraries/LibJS/SourceCode.h
+++ b/Libraries/LibJS/SourceCode.h
@@ -20,7 +20,6 @@ namespace JS {
 class JS_API SourceCode : public RefCounted<SourceCode> {
 public:
     static NonnullRefPtr<SourceCode const> create(String filename, Utf16String code);
-    static NonnullRefPtr<SourceCode const> create(String filename, String code);
     static NonnullRefPtr<SourceCode const> create(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes);
 
     String const& filename() const { return m_filename; }
@@ -35,14 +34,12 @@ public:
 
 private:
     SourceCode(String filename, Utf16String code);
-    SourceCode(String filename, String code);
     SourceCode(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes);
     void ensure_code() const;
     Utf16String decode_source_range(size_t start_offset, size_t length) const;
 
     String m_filename;
     Optional<Utf16String> mutable m_code;
-    Optional<String> mutable m_utf8_code;
     String m_source_encoding;
     Core::ImmutableBytes mutable m_source_bytes;
     Utf16View mutable m_code_view;

--- a/Libraries/LibJS/SourceCode.h
+++ b/Libraries/LibJS/SourceCode.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Utf16String.h>
 #include <AK/Vector.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Position.h>
@@ -18,22 +20,32 @@ namespace JS {
 class JS_API SourceCode : public RefCounted<SourceCode> {
 public:
     static NonnullRefPtr<SourceCode const> create(String filename, Utf16String code);
+    static NonnullRefPtr<SourceCode const> create(String filename, String code);
+    static NonnullRefPtr<SourceCode const> create(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes);
 
     String const& filename() const { return m_filename; }
-    Utf16String const& code() const { return m_code; }
-    Utf16View const& code_view() const { return m_code_view; }
+    Utf16String const& code() const;
+    Utf16View const& code_view() const;
     size_t length_in_code_units() const { return m_length_in_code_units; }
 
     u16 const* utf16_data() const;
+    Utf16String source_text_from_offsets(size_t start_offset, size_t length) const;
 
     SourceRange range_from_offsets(u32 start_offset, u32 end_offset) const;
 
 private:
     SourceCode(String filename, Utf16String code);
+    SourceCode(String filename, String code);
+    SourceCode(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes);
+    void ensure_code() const;
+    Utf16String decode_source_range(size_t start_offset, size_t length) const;
 
     String m_filename;
-    Utf16String m_code;
-    Utf16View m_code_view;
+    Optional<Utf16String> mutable m_code;
+    Optional<String> mutable m_utf8_code;
+    String m_source_encoding;
+    Core::ImmutableBytes mutable m_source_bytes;
+    Utf16View mutable m_code_view;
     size_t m_length_in_code_units { 0 };
 
     // For fast mapping of offsets to line/column numbers, we build a list of

--- a/Libraries/LibTextCodec/Decoder.cpp
+++ b/Libraries/LibTextCodec/Decoder.cpp
@@ -694,22 +694,93 @@ ErrorOr<String> StreamingDecoder::finish()
     return decoded;
 }
 
+static ErrorOr<void> process_utf8_with_replacement_character(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
+{
+    auto bytes = input.bytes();
+
+    for (size_t i = 0; i < bytes.size();) {
+        auto byte = bytes[i];
+        if (byte <= 0x7f) {
+            TRY(on_code_point(byte));
+            ++i;
+            continue;
+        }
+
+        size_t sequence_length = 0;
+        u32 code_point = 0;
+        u32 minimum_code_point = 0;
+
+        if (byte >= 0xc2 && byte <= 0xdf) {
+            sequence_length = 2;
+            code_point = byte & 0x1f;
+            minimum_code_point = 0x80;
+        } else if (byte >= 0xe0 && byte <= 0xef) {
+            sequence_length = 3;
+            code_point = byte & 0x0f;
+            minimum_code_point = 0x800;
+        } else if (byte >= 0xf0 && byte <= 0xf4) {
+            sequence_length = 4;
+            code_point = byte & 0x07;
+            minimum_code_point = 0x10000;
+        } else {
+            TRY(on_code_point(replacement_code_point));
+            ++i;
+            continue;
+        }
+
+        if (i + sequence_length > bytes.size()) {
+            TRY(on_code_point(replacement_code_point));
+            ++i;
+            continue;
+        }
+
+        bool has_valid_continuation_bytes = true;
+        for (size_t offset = 1; offset < sequence_length; ++offset) {
+            auto continuation_byte = bytes[i + offset];
+            if ((continuation_byte & 0xc0) != 0x80) {
+                has_valid_continuation_bytes = false;
+                break;
+            }
+            code_point <<= 6;
+            code_point |= continuation_byte & 0x3f;
+        }
+
+        if (!has_valid_continuation_bytes || code_point < minimum_code_point || code_point > 0x10ffff) {
+            TRY(on_code_point(replacement_code_point));
+            ++i;
+            continue;
+        }
+
+        if (is_unicode_surrogate(code_point)) {
+            TRY(on_code_point(replacement_code_point));
+            i += sequence_length;
+            continue;
+        }
+
+        TRY(on_code_point(code_point));
+        i += sequence_length;
+    }
+
+    return {};
+}
+
 ErrorOr<void> UTF8Decoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
 {
-    for (auto c : Utf8View(input)) {
-        TRY(on_code_point(c));
-    }
-    return {};
+    return process_utf8_with_replacement_character(input, move(on_code_point));
 }
 
 bool UTF8Decoder::validate(StringView input)
 {
-    return Utf8View(input).validate();
+    return Utf8View(input).validate(AllowLonelySurrogates::No);
 }
 
 ErrorOr<String> UTF8Decoder::to_utf8(StringView input)
 {
-    return String::from_utf8_with_replacement_character(input);
+    StringBuilder builder(input.length());
+    TRY(process_utf8_with_replacement_character(input, [&](auto code_point) {
+        return builder.try_append_code_point(code_point);
+    }));
+    return builder.to_string_without_validation();
 }
 
 bool UTF16BEDecoder::validate(StringView input)

--- a/Libraries/LibTextCodec/Decoder.cpp
+++ b/Libraries/LibTextCodec/Decoder.cpp
@@ -730,22 +730,28 @@ static ErrorOr<void> process_utf8_with_replacement_character(StringView input, F
 
         if (i + sequence_length > bytes.size()) {
             TRY(on_code_point(replacement_code_point));
-            ++i;
+            i = bytes.size();
             continue;
         }
 
-        bool has_valid_continuation_bytes = true;
+        Optional<size_t> invalid_continuation_offset;
         for (size_t offset = 1; offset < sequence_length; ++offset) {
             auto continuation_byte = bytes[i + offset];
-            if ((continuation_byte & 0xc0) != 0x80) {
-                has_valid_continuation_bytes = false;
+            if (!is_utf8_continuation_byte(continuation_byte)) {
+                invalid_continuation_offset = offset;
                 break;
             }
             code_point <<= 6;
             code_point |= continuation_byte & 0x3f;
         }
 
-        if (!has_valid_continuation_bytes || code_point < minimum_code_point || code_point > 0x10ffff) {
+        if (invalid_continuation_offset.has_value()) {
+            TRY(on_code_point(replacement_code_point));
+            i += *invalid_continuation_offset;
+            continue;
+        }
+
+        if (code_point < minimum_code_point || code_point > 0x10ffff) {
             TRY(on_code_point(replacement_code_point));
             ++i;
             continue;
@@ -776,6 +782,9 @@ bool UTF8Decoder::validate(StringView input)
 
 ErrorOr<String> UTF8Decoder::to_utf8(StringView input)
 {
+    if (auto bytes = input.bytes(); bytes.starts_with({ { 0xEF, 0xBB, 0xBF } }))
+        input = input.substring_view(3);
+
     StringBuilder builder(input.length());
     TRY(process_utf8_with_replacement_character(input, [&](auto code_point) {
         return builder.try_append_code_point(code_point);

--- a/Libraries/LibTextCodec/Decoder.cpp
+++ b/Libraries/LibTextCodec/Decoder.cpp
@@ -354,6 +354,11 @@ ErrorOr<String> Decoder::to_utf8(StringView input)
     return builder.to_string_without_validation();
 }
 
+ErrorOr<void> Decoder::process_code_points(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
+{
+    return process(input, move(on_code_point));
+}
+
 // Tail-length helpers for chunked decoding. Each returns the number of trailing bytes that must
 // be buffered until more input arrives, because they form an incomplete trailing sequence per the
 // Encoding Standard's decoder handler byte ranges.
@@ -712,6 +717,52 @@ bool UTF16BEDecoder::validate(StringView input)
     return AK::validate_utf16_be(input.bytes());
 }
 
+static ErrorOr<void> process_utf16(StringView input, bool big_endian, Function<ErrorOr<void>(u32)> on_code_point)
+{
+    auto bytes = input.bytes();
+    if (bytes.size() >= 2) {
+        if ((big_endian && bytes[0] == 0xFE && bytes[1] == 0xFF)
+            || (!big_endian && bytes[0] == 0xFF && bytes[1] == 0xFE))
+            bytes = bytes.slice(2);
+    }
+
+    auto read_code_unit = [&](size_t offset) {
+        return big_endian
+            ? (static_cast<u16>(bytes[offset]) << 8) | bytes[offset + 1]
+            : (static_cast<u16>(bytes[offset + 1]) << 8) | bytes[offset];
+    };
+
+    for (size_t i = 0; i + 1 < bytes.size(); i += 2) {
+        auto code_unit = read_code_unit(i);
+        if (AK::UnicodeUtils::is_utf16_high_surrogate(code_unit)) {
+            if (i + 3 < bytes.size()) {
+                auto low_surrogate = read_code_unit(i + 2);
+                if (AK::UnicodeUtils::is_utf16_low_surrogate(low_surrogate)) {
+                    TRY(on_code_point(AK::UnicodeUtils::decode_utf16_surrogate_pair(code_unit, low_surrogate)));
+                    i += 2;
+                    continue;
+                }
+            }
+            TRY(on_code_point(replacement_code_point));
+            continue;
+        }
+
+        if (AK::UnicodeUtils::is_utf16_low_surrogate(code_unit)) {
+            TRY(on_code_point(replacement_code_point));
+            continue;
+        }
+
+        TRY(on_code_point(code_unit));
+    }
+
+    return {};
+}
+
+ErrorOr<void> UTF16BEDecoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
+{
+    return process_utf16(input, true, move(on_code_point));
+}
+
 ErrorOr<String> UTF16BEDecoder::to_utf8(StringView input)
 {
     // Discard the BOM
@@ -724,6 +775,11 @@ ErrorOr<String> UTF16BEDecoder::to_utf8(StringView input)
 bool UTF16LEDecoder::validate(StringView input)
 {
     return AK::validate_utf16_le(input.bytes());
+}
+
+ErrorOr<void> UTF16LEDecoder::process(StringView input, Function<ErrorOr<void>(u32)> on_code_point)
+{
+    return process_utf16(input, false, move(on_code_point));
 }
 
 ErrorOr<String> UTF16LEDecoder::to_utf8(StringView input)

--- a/Libraries/LibTextCodec/Decoder.h
+++ b/Libraries/LibTextCodec/Decoder.h
@@ -22,6 +22,7 @@ class TEXTCODEC_API Decoder {
 public:
     virtual bool validate(StringView);
     virtual ErrorOr<String> to_utf8(StringView);
+    ErrorOr<void> process_code_points(StringView, Function<ErrorOr<void>(u32)>);
 
     // Returns the number of trailing bytes that form an incomplete sequence and must be buffered
     // until more input arrives. Used by StreamingDecoder for chunked decoding.
@@ -47,7 +48,7 @@ public:
     virtual size_t incomplete_tail_length(ReadonlyBytes) const override;
 
 private:
-    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)>) override { VERIFY_NOT_REACHED(); }
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)>) override;
 };
 
 class TEXTCODEC_API UTF16LEDecoder final : public Decoder {
@@ -57,7 +58,7 @@ public:
     virtual size_t incomplete_tail_length(ReadonlyBytes) const override;
 
 private:
-    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)>) override { VERIFY_NOT_REACHED(); }
+    virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)>) override;
 };
 
 template<Integral ArrayType = u32>

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -7,8 +7,12 @@
  */
 
 #include <AK/Array.h>
+#include <AK/NumericLimits.h>
+#include <AK/StringBuilder.h>
+#include <AK/UnicodeUtils.h>
 #include <AK/Utf16String.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibCrypto/Hash/SHA2.h>
 #include <LibGC/Function.h>
 #include <LibGC/Root.h>
@@ -80,6 +84,93 @@ static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_c
     return ::Crypto::Hash::SHA256::hash(reinterpret_cast<u8 const*>(source_code.utf16_data()), source_code.length_in_code_units() * sizeof(u16));
 }
 
+struct DecodedSourceTextInfo {
+    ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> hash;
+    size_t length_in_code_units { 0 };
+};
+
+static ErrorOr<String> decode_source_text(TextCodec::Decoder& fallback_decoder, StringView input)
+{
+    return TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(fallback_decoder, input);
+}
+
+static ErrorOr<String> decode_source_text(TextCodec::Decoder& fallback_decoder, ReadonlyBytes bytes)
+{
+    return decode_source_text(fallback_decoder, StringView { bytes });
+}
+
+static ReadonlyBytes body_bytes_view(Fetch::Infrastructure::FetchAlgorithms::BodyBytes const& body_bytes)
+{
+    return body_bytes.get<Core::ImmutableBytes>().bytes();
+}
+
+static Core::ImmutableBytes take_body_bytes(Fetch::Infrastructure::FetchAlgorithms::BodyBytes& body_bytes)
+{
+    return move(body_bytes.get<Core::ImmutableBytes>());
+}
+
+static ByteBuffer take_body_bytes_as_byte_buffer(Fetch::Infrastructure::FetchAlgorithms::BodyBytes& body_bytes)
+{
+    return body_bytes.get<Core::ImmutableBytes>().copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
+}
+
+static ErrorOr<DecodedSourceTextInfo> decoded_source_text_info(TextCodec::Decoder& fallback_decoder, ReadonlyBytes bytes)
+{
+    StringView input { bytes };
+    TextCodec::Decoder* actual_decoder = &fallback_decoder;
+
+    auto unicode_decoder = TextCodec::bom_sniff_to_decoder(input);
+    if (unicode_decoder.has_value()) {
+        auto input_bytes = input.bytes();
+        auto byte_order_mark_size = input_bytes.size() >= 3 && input_bytes[0] == 0xEF && input_bytes[1] == 0xBB && input_bytes[2] == 0xBF ? 3 : 2;
+        actual_decoder = &unicode_decoder.value();
+        input = input.substring_view(byte_order_mark_size);
+    }
+
+    auto hasher = ::Crypto::Hash::SHA256::create();
+
+    constexpr size_t chunk_size = 4096;
+    Array<u16, chunk_size> utf16_data;
+    size_t chunk_offset = 0;
+    auto flush_chunk = [&] {
+        if (chunk_offset == 0)
+            return;
+        hasher->update(reinterpret_cast<u8 const*>(utf16_data.data()), chunk_offset * sizeof(u16));
+        chunk_offset = 0;
+    };
+
+    size_t length_in_code_units = 0;
+    TRY(actual_decoder->process_code_points(input, [&](auto code_point) -> ErrorOr<void> {
+        if (code_point <= 0xffff) {
+            ++length_in_code_units;
+            utf16_data[chunk_offset++] = static_cast<u16>(code_point);
+            if (chunk_offset == chunk_size)
+                flush_chunk();
+            return {};
+        }
+
+        Array<char16_t, 2> code_units;
+        size_t code_point_length_in_code_units = 0;
+        (void)AK::UnicodeUtils::code_point_to_utf16(code_point, [&](auto code_unit) {
+            code_units[code_point_length_in_code_units++] = code_unit;
+        });
+
+        length_in_code_units += code_point_length_in_code_units;
+        for (size_t i = 0; i < code_point_length_in_code_units; ++i) {
+            utf16_data[chunk_offset++] = code_units[i];
+            if (chunk_offset == chunk_size)
+                flush_chunk();
+        }
+        return {};
+    }));
+
+    flush_chunk();
+    return DecodedSourceTextInfo {
+        .hash = hasher->digest(),
+        .length_in_code_units = length_in_code_units,
+    };
+}
+
 static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::Infrastructure::Request const& request, Fetch::Infrastructure::Response const& response, URL::URL const& response_url)
 {
     if (!Fetch::Infrastructure::is_http_or_https_scheme(response_url.scheme()))
@@ -98,16 +189,6 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
         .request_headers = HTTP::HeaderList::create(request.header_list()->headers()),
         .vary_key = *vary_key,
     };
-}
-
-static ReadonlyBytes body_bytes_view(Fetch::Infrastructure::FetchAlgorithms::BodyBytes const& body_bytes)
-{
-    return body_bytes.get<Core::ImmutableBytes>().bytes();
-}
-
-static ByteBuffer take_body_bytes_as_byte_buffer(Fetch::Infrastructure::FetchAlgorithms::BodyBytes& body_bytes)
-{
-    return body_bytes.get<Core::ImmutableBytes>().copy_to_byte_buffer().release_value_but_fixme_should_propagate_errors();
 }
 
 // Schedule a fresh, fully off-thread compile of the script source for the sole purpose of producing a bytecode cache
@@ -616,8 +697,6 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
         auto fallback_decoder = TextCodec::decoder_for(extracted_character_encoding);
         VERIFY(fallback_decoder.has_value());
 
-        auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*fallback_decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
-
         // 6. Let muted errors be true if response was CORS-cross-origin, and false otherwise.
         auto muted_errors = response->is_cors_cross_origin() ? ClassicScript::MutedErrors::Yes : ClassicScript::MutedErrors::No;
 
@@ -631,16 +710,29 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
             auto on_complete_root = GC::make_root(on_complete);
             auto settings_root = GC::make_root(settings_object);
             auto response_url_string = response_url.to_byte_string();
-            auto source_code = JS::SourceCode::create(
-                String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                Utf16String::from_utf8(source_text));
+            auto source_bytes = body_bytes_view(body_bytes);
+            auto const& bytecode = response->javascript_bytecode_cache();
+            Optional<DecodedSourceTextInfo> source_text_info;
+            if (bytecode.has_value())
+                source_text_info = decoded_source_text_info(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors();
+            auto source_code_filename = String::from_utf8(response_url_string.view()).release_value_but_fixme_should_propagate_errors();
+            auto source_code = [&] {
+                if (source_text_info.has_value()) {
+                    return JS::SourceCode::create(
+                        move(source_code_filename),
+                        source_text_info->length_in_code_units,
+                        String::from_utf8(extracted_character_encoding).release_value_but_fixme_should_propagate_errors(),
+                        take_body_bytes(body_bytes));
+                }
+                return JS::SourceCode::create(move(source_code_filename), Utf16String::from_utf8(decode_source_text(*fallback_decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
+            }();
             auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *response, response_url);
             // Warm-cache fast path: a sidecar arrived with the response, decode it, and try to materialize a script
             // straight from the cached bytecode without parsing or compiling. Pass non-moved source_code / response_url
             // so the fallback compile path below can reuse them if decode or materialization is rejected.
-            if (auto const& bytecode = response->javascript_bytecode_cache(); bytecode.has_value()) {
-                auto source_hash = bytecode_cache_source_hash(*source_code);
-                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_hash.bytes())) {
+            if (bytecode.has_value()) {
+                VERIFY(source_text_info.has_value());
+                if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Script, source_text_info->hash.bytes())) {
                     auto script = ClassicScript::create_from_bytecode_cache(response_url_string, source_code, settings_object, response_url, bytecode_cache, muted_errors);
                     // Bytecode validation runs during materialization and may reject a structurally valid blob whose
                     // bytecode is corrupt. Treat that as a cache miss and fall through to off-thread source compile.
@@ -670,6 +762,7 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                         schedule_bytecode_cache_generation(*source_code_for_cache, JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value());
                 });
         } else {
+            auto source_text = decode_source_text(*fallback_decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
             auto script = ClassicScript::create(response_url.to_byte_string(), source_text, settings_object, response_url, 1, muted_errors);
 
             // 8. Run onComplete given script.
@@ -1003,16 +1096,13 @@ void fetch_single_module_script(JS::Realm& realm,
 
         // 7. Otherwise
         else {
-            // 1. Let sourceText be the result of UTF-8 decoding bodyBytes.
-            auto decoder = TextCodec::decoder_for("UTF-8"sv);
-            VERIFY(decoder.has_value());
-            auto source_text = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
-
             // 2. If mimeType is a JavaScript MIME type and moduleType is "javascript-or-wasm", then set moduleScript to
             //    the result of creating a JavaScript module script given sourceText, moduleMapRealm, response's URL,
             //    and options.
             // FIXME: Pass options.
             if (mime_type.has_value() && mime_type->is_javascript() && module_type == "javascript-or-wasm") {
+                auto decoder = TextCodec::decoder_for("UTF-8"sv);
+                VERIFY(decoder.has_value());
                 // If the Rust pipeline is available, parse off the main thread.
                 if (JS::RustIntegration::rust_pipeline_available()) {
                     auto on_complete_root = GC::make_root(on_complete);
@@ -1020,13 +1110,26 @@ void fetch_single_module_script(JS::Realm& realm,
                     auto url_string = url.to_byte_string();
                     auto response_url = response->url().value_or({});
                     auto module_type_string = module_type.to_byte_string();
-                    auto source_code = JS::SourceCode::create(
-                        String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors(),
-                        Utf16String::from_utf8(source_text));
+                    auto source_bytes = body_bytes_view(body_bytes);
+                    auto const& bytecode = internal_response->javascript_bytecode_cache();
+                    Optional<DecodedSourceTextInfo> source_text_info;
+                    if (bytecode.has_value())
+                        source_text_info = decoded_source_text_info(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors();
+                    auto source_code_filename = String::from_utf8(url_string.view()).release_value_but_fixme_should_propagate_errors();
+                    auto source_code = [&] {
+                        if (source_text_info.has_value()) {
+                            return JS::SourceCode::create(
+                                move(source_code_filename),
+                                source_text_info->length_in_code_units,
+                                "UTF-8"_string,
+                                take_body_bytes(body_bytes));
+                        }
+                        return JS::SourceCode::create(move(source_code_filename), Utf16String::from_utf8(decode_source_text(*decoder, source_bytes).release_value_but_fixme_should_propagate_errors()));
+                    }();
                     auto bytecode_cache_context = bytecode_cache_context_for_request(*request, *internal_response, response_url);
-                    if (auto const& bytecode = internal_response->javascript_bytecode_cache(); bytecode.has_value()) {
-                        auto source_hash = bytecode_cache_source_hash(*source_code);
-                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_hash.bytes())) {
+                    if (bytecode.has_value()) {
+                        VERIFY(source_text_info.has_value());
+                        if (auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(*bytecode, JS::RustIntegration::ProgramType::Module, source_text_info->hash.bytes())) {
                             auto module_script = ModuleScript::create_from_bytecode_cache(url_string, source_code, settings_object, response_url, bytecode_cache).release_value_but_fixme_should_propagate_errors();
                             if (module_script && module_script->parse_error().is_null()) {
                                 settings_object.module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
@@ -1056,6 +1159,7 @@ void fetch_single_module_script(JS::Realm& realm,
                         });
                     return;
                 }
+                auto source_text = decode_source_text(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
                 module_script = ModuleScript::create_a_javascript_module_script(url.to_byte_string(), source_text, settings_object, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
             }
 
@@ -1064,13 +1168,21 @@ void fetch_single_module_script(JS::Realm& realm,
 
             // 4. If the MIME type essence of mimeType is "text/css" and moduleType is "css", then set moduleScript to
             //    the result of creating a CSS module script given sourceText and settingsObject.
-            if (mime_type.has_value() && mime_type->essence() == "text/css"sv && module_type == "css")
+            if (mime_type.has_value() && mime_type->essence() == "text/css"sv && module_type == "css") {
+                auto decoder = TextCodec::decoder_for("UTF-8"sv);
+                VERIFY(decoder.has_value());
+                auto source_text = decode_source_text(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
                 module_script = ModuleScript::create_a_css_module_script(url.to_byte_string(), source_text, settings_object).release_value_but_fixme_should_propagate_errors();
+            }
 
             // 4. If mimeType is a JSON MIME type and moduleType is "json", then set moduleScript to the result of
             //    creating a JSON module script given sourceText and settingsObject.
-            if (mime_type.has_value() && mime_type->is_json() && module_type == "json")
+            if (mime_type.has_value() && mime_type->is_json() && module_type == "json") {
+                auto decoder = TextCodec::decoder_for("UTF-8"sv);
+                VERIFY(decoder.has_value());
+                auto source_text = decode_source_text(*decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
                 module_script = ModuleScript::create_a_json_module_script(url.to_byte_string(), source_text, settings_object).release_value_but_fixme_should_propagate_errors();
+            }
         }
 
         // 8. Set moduleMap[(url, moduleType)] to moduleScript, and run onComplete given moduleScript.

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -26,6 +26,26 @@ struct BytecodeCacheTestData {
     Crypto::Hash::SHA256::DigestType source_hash;
 };
 
+TEST_CASE(lazy_source_code_decoding_replaces_utf8_surrogates)
+{
+    auto source_data = Vector<u8> { 0xed, 0xa0, 0x80 };
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source_data.span()));
+    auto source_code = JS::SourceCode::create("test.js"_string, 1, "UTF-8"_string, move(source_bytes));
+
+    EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd"sv);
+    EXPECT_EQ(source_code->source_text_from_offsets(0, 1).to_utf8(), "\xef\xbf\xbd"sv);
+}
+
+TEST_CASE(lazy_source_code_decoding_replaces_overlong_utf8_sequences)
+{
+    auto source_data = Vector<u8> { 0xc0, 0x80 };
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source_data.span()));
+    auto source_code = JS::SourceCode::create("test.js"_string, 2, "UTF-8"_string, move(source_bytes));
+
+    EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd"sv);
+    EXPECT_EQ(source_code->source_text_from_offsets(0, 2).to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd"sv);
+}
+
 class BytecodeCacheBlobReader {
 public:
     explicit BytecodeCacheBlobReader(ReadonlyBytes bytes)

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -21,6 +21,16 @@ static TextCodec::Decoder& decoder_for(StringView encoding)
     return decoder.value();
 }
 
+static Vector<u32> process_code_points(TextCodec::Decoder& decoder, StringView input)
+{
+    Vector<u32> code_points;
+    MUST(decoder.process_code_points(input, [&](u32 code_point) -> ErrorOr<void> {
+        TRY(code_points.try_append(code_point));
+        return {};
+    }));
+    return code_points;
+}
+
 TEST_CASE(test_utf8_decode)
 {
     auto decoder = TextCodec::UTF8Decoder();
@@ -39,6 +49,14 @@ TEST_CASE(test_utf8_decode)
     EXPECT(MUST(decoder.to_utf8(test_string)) == test_string);
 }
 
+TEST_CASE(test_utf8_process_code_points)
+{
+    auto decoder = TextCodec::UTF8Decoder();
+    auto test_string = "A\xf0\x9f\x98\x80"sv;
+
+    EXPECT_EQ(process_code_points(decoder, test_string), (Vector<u32> { 0x41, 0x1F600 }));
+}
+
 TEST_CASE(test_utf16be_decode)
 {
     auto decoder = TextCodec::UTF16BEDecoder();
@@ -48,6 +66,14 @@ TEST_CASE(test_utf16be_decode)
     EXPECT(decoder.validate(test_string));
     auto utf8 = MUST(decoder.to_utf8(test_string));
     EXPECT_EQ(utf8, "säk😀"sv);
+}
+
+TEST_CASE(test_utf16be_process_code_points)
+{
+    auto decoder = TextCodec::UTF16BEDecoder();
+
+    EXPECT_EQ(process_code_points(decoder, StringView(bytes({ 0xfe, 0xff, 0x00, 'A', 0xd8, 0x3d, 0xde, 0x00 }))), (Vector<u32> { 0x41, 0x1F600 }));
+    EXPECT_EQ(process_code_points(decoder, StringView(bytes({ 0xd8, 0x3d, 0x00, 'A', 0xde, 0x00 }))), (Vector<u32> { 0xfffd, 0x41, 0xfffd }));
 }
 
 TEST_CASE(test_streaming_decoder_utf8_mid_sequence)
@@ -147,4 +173,12 @@ TEST_CASE(test_utf16le_decode)
     EXPECT(decoder.validate(test_string));
     auto utf8 = MUST(decoder.to_utf8(test_string));
     EXPECT_EQ(utf8, "säk😀"sv);
+}
+
+TEST_CASE(test_utf16le_process_code_points)
+{
+    auto decoder = TextCodec::UTF16LEDecoder();
+
+    EXPECT_EQ(process_code_points(decoder, StringView(bytes({ 0xff, 0xfe, 'A', 0x00, 0x3d, 0xd8, 0x00, 0xde }))), (Vector<u32> { 0x41, 0x1F600 }));
+    EXPECT_EQ(process_code_points(decoder, StringView(bytes({ 0x3d, 0xd8, 'A', 0x00, 0x00, 0xde }))), (Vector<u32> { 0xfffd, 0x41, 0xfffd }));
 }

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -57,6 +57,28 @@ TEST_CASE(test_utf8_process_code_points)
     EXPECT_EQ(process_code_points(decoder, test_string), (Vector<u32> { 0x41, 0x1F600 }));
 }
 
+TEST_CASE(test_utf8_process_code_points_replaces_surrogates)
+{
+    auto decoder = TextCodec::UTF8Decoder();
+    auto utf8_encoded_surrogate_bytes = Vector<u8> { 0xed, 0xa0, 0x80 };
+    auto utf8_encoded_surrogate = StringView(bytes(utf8_encoded_surrogate_bytes));
+
+    EXPECT(!decoder.validate(utf8_encoded_surrogate));
+    EXPECT_EQ(MUST(decoder.to_utf8(utf8_encoded_surrogate)), "\xef\xbf\xbd"sv);
+    EXPECT_EQ(process_code_points(decoder, utf8_encoded_surrogate), (Vector<u32> { 0xfffd }));
+}
+
+TEST_CASE(test_utf8_process_code_points_replaces_overlong_sequences)
+{
+    auto decoder = TextCodec::UTF8Decoder();
+    auto overlong_null_bytes = Vector<u8> { 0xc0, 0x80 };
+    auto overlong_null = StringView(bytes(overlong_null_bytes));
+
+    EXPECT(!decoder.validate(overlong_null));
+    EXPECT_EQ(MUST(decoder.to_utf8(overlong_null)), "\xef\xbf\xbd\xef\xbf\xbd"sv);
+    EXPECT_EQ(process_code_points(decoder, overlong_null), (Vector<u32> { 0xfffd, 0xfffd }));
+}
+
 TEST_CASE(test_utf16be_decode)
 {
     auto decoder = TextCodec::UTF16BEDecoder();

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -68,6 +68,17 @@ TEST_CASE(test_utf8_process_code_points_replaces_surrogates)
     EXPECT_EQ(process_code_points(decoder, utf8_encoded_surrogate), (Vector<u32> { 0xfffd }));
 }
 
+TEST_CASE(test_utf8_process_code_points_replaces_truncated_tail_as_single_error)
+{
+    auto decoder = TextCodec::UTF8Decoder();
+    auto truncated_tail_bytes = Vector<u8> { 0xf0, 0x9f, 0x98 };
+    auto truncated_tail = StringView(bytes(truncated_tail_bytes));
+
+    EXPECT(!decoder.validate(truncated_tail));
+    EXPECT_EQ(MUST(decoder.to_utf8(truncated_tail)), "\xef\xbf\xbd"sv);
+    EXPECT_EQ(process_code_points(decoder, truncated_tail), (Vector<u32> { 0xfffd }));
+}
+
 TEST_CASE(test_utf8_process_code_points_replaces_overlong_sequences)
 {
     auto decoder = TextCodec::UTF8Decoder();

--- a/Tests/LibWeb/Text/expected/Encoding/TextDecoder-decode.txt
+++ b/Tests/LibWeb/Text/expected/Encoding/TextDecoder-decode.txt
@@ -1,3 +1,4 @@
 [ABC]
 []
 [fffd]
+[1, fffd]

--- a/Tests/LibWeb/Text/input/Encoding/TextDecoder-decode.html
+++ b/Tests/LibWeb/Text/input/Encoding/TextDecoder-decode.html
@@ -9,6 +9,9 @@
 
             const surrogate = decoder.decode(new Uint8Array([0xed, 0xa0, 0x80])); // U+D800
             println(`[${surrogate.codePointAt(0).toString(16)}]`);
+
+            const truncatedTail = decoder.decode(new Uint8Array([0xf0, 0x9f, 0x98]));
+            println(`[${truncatedTail.length}, ${truncatedTail.codePointAt(0).toString(16)}]`);
         } catch (e) {
             println("ERROR: " + e.name + ": " + e.message);
         }


### PR DESCRIPTION
This keeps script source bytes lazy when a bytecode cache sidecar is available, avoiding eager UTF-16 materialization for source text that is usually not needed after cached bytecode is loaded.

The source text is still available when needed, such as for fallback parsing, function source reconstruction, and diagnostics. The lazy decode path uses the same UTF-8 replacement behavior as the existing eager path, including malformed surrogate and overlong sequence handling.

This also adds streaming decoded-code-point support in LibTextCodec so the bytecode cache source hash and lazy source materialization can avoid creating intermediate strings.