### PR TITLE
LibWeb: Fix load event timing and PerformanceTiming clock

### DIFF
--- a/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
+++ b/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
@@ -46,4 +46,18 @@ u64 PerformanceTiming::monotonic_timestamp_to_wall_time_milliseconds(Function<Hi
     return static_cast<u64>(coarsened_time);
 }
 
+u64 PerformanceTiming::relative_timestamp_to_wall_time_milliseconds(Function<HighResolutionTime::DOMHighResTimeStamp(DOM::DocumentLoadTimingInfo const&)> selector) const
+{
+    auto& global_object = HTML::relevant_global_object(*this);
+    auto const& load_info = document_load_timing_info(global_object);
+    auto relative_timestamp = selector(load_info);
+    if (relative_timestamp == 0)
+        return 0;
+
+    auto absolute_timestamp = relative_timestamp + load_info.navigation_start_time;
+    auto wall_time = absolute_timestamp - HighResolutionTime::estimated_monotonic_time_of_the_unix_epoch();
+    auto coarsened_time = HighResolutionTime::coarsen_time(wall_time);
+    return static_cast<u64>(coarsened_time);
+}
+
 }

--- a/Libraries/LibWeb/NavigationTiming/PerformanceTiming.h
+++ b/Libraries/LibWeb/NavigationTiming/PerformanceTiming.h
@@ -41,27 +41,27 @@ public:
     u64 dom_loading() { return 0; }
     u64 dom_interactive()
     {
-        return monotonic_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_interactive_time; });
+        return relative_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_interactive_time; });
     }
     u64 dom_content_loaded_event_start()
     {
-        return monotonic_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_content_loaded_event_start_time; });
+        return relative_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_content_loaded_event_start_time; });
     }
     u64 dom_content_loaded_event_end()
     {
-        return monotonic_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_content_loaded_event_end_time; });
+        return relative_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_content_loaded_event_end_time; });
     }
     u64 dom_complete()
     {
-        return monotonic_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_complete_time; });
+        return relative_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.dom_complete_time; });
     }
     u64 load_event_start()
     {
-        return monotonic_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.load_event_start_time; });
+        return relative_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.load_event_start_time; });
     }
     u64 load_event_end()
     {
-        return monotonic_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.load_event_end_time; });
+        return relative_timestamp_to_wall_time_milliseconds([](auto& load_info) { return load_info.load_event_end_time; });
     }
 
 private:
@@ -69,6 +69,7 @@ private:
 
     DOM::DocumentLoadTimingInfo const& document_load_timing_info(JS::Object const& global_object) const;
     u64 monotonic_timestamp_to_wall_time_milliseconds(Function<HighResolutionTime::DOMHighResTimeStamp(DOM::DocumentLoadTimingInfo const&)> selector) const;
+    u64 relative_timestamp_to_wall_time_milliseconds(Function<HighResolutionTime::DOMHighResTimeStamp(DOM::DocumentLoadTimingInfo const&)> selector) const;
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -383,7 +383,7 @@ void XMLDocumentBuilder::document_end()
         // FIXME: Set the Document object's navigation id to null.
 
         // Set the Document's load timing info's load event end time to the current high resolution time given window.
-        document->load_timing_info().dom_content_loaded_event_end_time = HighResolutionTime::current_high_resolution_time(window);
+        document->load_timing_info().load_event_end_time = HighResolutionTime::current_high_resolution_time(window);
 
         // Assert: Document's page showing is false.
         VERIFY(!document->page_showing());

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -350,9 +350,6 @@ Ref/input/wpt-import/css/css-contain/contain-size-replaced-006.html
 ; https://github.com/LadybirdBrowser/ladybird/issues/2900
 Text/input/ShadowDOM/css-hover-shadow-dom.html
 
-; Test is flaky on CI, as navigationStart time is not set according to spec.
-Text/input/wpt-import/user-timing/measure_associated_with_navigation_timing.html
-
 ; Cancelling the beforeunload event in this test causes the subsequent test to fail.
 ; https://github.com/LadybirdBrowser/ladybird/issues/3461
 Text/input/wpt-import/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html

--- a/Tests/LibWeb/Text/expected/wpt-import/user-timing/measure_associated_with_navigation_timing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/user-timing/measure_associated_with_navigation_timing.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 8 tests
 
-6 Pass
-2 Fail
+8 Pass
 Pass	Measure of navigationStart to now should be positive value.
 Pass	Measure of navigationStart to loadEventEnd should be positive value.
 Pass	Measure of current mark to navigationStart should be negative value.
-Fail	loadTime plus loadEventEnd to a mark "a" should equal to navigationStart to "a".
+Pass	loadTime plus loadEventEnd to a mark "a" should equal to navigationStart to "a".
 Pass	Second measure of current mark to navigationStart should be negative value.
 Pass	Measures of loadTime should have same duration.
-Fail	Measure from domComplete event to most recent mark "a" should have longer duration.
+Pass	Measure from domComplete event to most recent mark "a" should have longer duration.
 Pass	Measure from most recent mark to navigationStart should have longer duration.


### PR DESCRIPTION
This PR improves the accuracy and correctness of navigation timing metrics in the `PerformanceTiming` class, refactors related code for clarity, and updates tests to reflect these changes. The main focus is on how relative timestamps are converted to wall time, addressing previous issues with event timing calculations and ensuring compliance with web platform specifications.

**Navigation timing calculation improvements:**

* Introduced a new method `relative_timestamp_to_wall_time_milliseconds` in `PerformanceTiming.cpp` to correctly convert relative event timestamps to wall time, improving the accuracy of reported metrics.
* Updated several timing-related getters in `PerformanceTiming.h` (such as `dom_interactive`, `dom_content_loaded_event_start`, `dom_content_loaded_event_end`, `dom_complete`, `load_event_start`, and `load_event_end`) to use the new method, replacing the previous `monotonic_timestamp_to_wall_time_milliseconds` approach.

**Bug fix in XMLDocumentBuilder:**

* Fixed a bug in `XMLDocumentBuilder.cpp` where we were setting `dom_content_loaded_event_end_time` instead of `load_event_end_time`.

**Test updates and configuration:**

* Removed a flaky test exclusion in `TestConfig.ini` now that navigationStart timing is set correctly, allowing the test to run as expected.
* Updated the expected results for the user-timing test to show all tests passing, reflecting the fixes to navigation timing calculations.