### PR TITLE
LibJS: Keep cached bytecode instruction stream file-backed

### DIFF
--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -411,6 +411,12 @@ i64 asm_fallback_handler(VM* vm, u32 pc)
         return execute_throwing<Op::EnterObjectEnvironment>(*vm, pc);
     case Instruction::Type::Exp:
         return execute_throwing<Op::Exp>(*vm, pc);
+    case Instruction::Type::DynamicGetCalleeAndThisFromEnvironment:
+        return execute_throwing<Op::DynamicGetCalleeAndThisFromEnvironment>(*vm, pc);
+    case Instruction::Type::DynamicGetBinding:
+        return execute_throwing<Op::DynamicGetBinding>(*vm, pc);
+    case Instruction::Type::DynamicGetInitializedBinding:
+        return execute_throwing<Op::DynamicGetInitializedBinding>(*vm, pc);
     case Instruction::Type::GetByIdWithThis:
         return execute_throwing<Op::GetByIdWithThis>(*vm, pc);
     case Instruction::Type::GetByValueWithThis:
@@ -431,6 +437,10 @@ i64 asm_fallback_handler(VM* vm, u32 pc)
         return execute_throwing<Op::ImportCall>(*vm, pc);
     case Instruction::Type::In:
         return execute_throwing<Op::In>(*vm, pc);
+    case Instruction::Type::DynamicInitializeLexicalBinding:
+        return execute_throwing<Op::DynamicInitializeLexicalBinding>(*vm, pc);
+    case Instruction::Type::DynamicInitializeVariableBinding:
+        return execute_throwing<Op::DynamicInitializeVariableBinding>(*vm, pc);
     case Instruction::Type::InitializeVariableBinding:
         return execute_throwing<Op::InitializeVariableBinding>(*vm, pc);
     case Instruction::Type::IteratorClose:
@@ -453,6 +463,10 @@ i64 asm_fallback_handler(VM* vm, u32 pc)
         return execute_throwing<Op::PutByValueWithThis>(*vm, pc);
     case Instruction::Type::ResolveSuperBase:
         return execute_throwing<Op::ResolveSuperBase>(*vm, pc);
+    case Instruction::Type::DynamicSetLexicalBinding:
+        return execute_throwing<Op::DynamicSetLexicalBinding>(*vm, pc);
+    case Instruction::Type::DynamicSetVariableBinding:
+        return execute_throwing<Op::DynamicSetVariableBinding>(*vm, pc);
     case Instruction::Type::SetVariableBinding:
         return execute_throwing<Op::SetVariableBinding>(*vm, pc);
     case Instruction::Type::SuperCallWithArgumentArray:
@@ -465,6 +479,8 @@ i64 asm_fallback_handler(VM* vm, u32 pc)
         return execute_throwing<Op::ToObject>(*vm, pc);
     case Instruction::Type::TypeofBinding:
         return execute_throwing<Op::TypeofBinding>(*vm, pc);
+    case Instruction::Type::DynamicTypeofBinding:
+        return execute_throwing<Op::DynamicTypeofBinding>(*vm, pc);
 
     default:
         VERIFY_NOT_REACHED();

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -647,7 +647,7 @@ i64 asm_try_get_global_env_binding(VM* vm, u32 pc)
 {
     auto* bytecode = vm->current_executable().bytecode.data();
     auto& insn = *reinterpret_cast<Op::GetGlobal const*>(&bytecode[pc]);
-    auto& cache = *bit_cast<GlobalVariableCache*>(insn.cache());
+    auto& cache = vm->current_executable().global_variable_caches[insn.cache()];
 
     if (!cache.has_environment_binding_index) [[unlikely]]
         return 1;
@@ -677,7 +677,7 @@ i64 asm_try_set_global_env_binding(VM* vm, u32 pc)
 {
     auto* bytecode = vm->current_executable().bytecode.data();
     auto& insn = *reinterpret_cast<Op::SetGlobal const*>(&bytecode[pc]);
-    auto& cache = *bit_cast<GlobalVariableCache*>(insn.cache());
+    auto& cache = vm->current_executable().global_variable_caches[insn.cache()];
 
     if (!cache.has_environment_binding_index) [[unlikely]]
         return 1;
@@ -897,7 +897,7 @@ i64 asm_try_put_by_id_cache(VM* vm, u32 pc)
         return 1;
     auto& object = base.as_object();
     auto value = vm->get(insn.src());
-    auto& cache = *bit_cast<PropertyLookupCache*>(insn.cache());
+    auto& cache = vm->current_executable().property_lookup_caches[insn.cache()];
 
     for (size_t i = 0; i < cache.entries.size(); ++i) {
         auto& entry = cache.entries[i];
@@ -952,7 +952,7 @@ i64 asm_try_get_by_id_cache(VM* vm, u32 pc)
         return 1;
     auto& object = base.as_object();
     auto& shape = object.shape();
-    auto& cache = *bit_cast<PropertyLookupCache*>(insn.cache());
+    auto& cache = vm->current_executable().property_lookup_caches[insn.cache()];
 
     for (auto& entry : cache.entries) {
         auto cached_prototype = entry.prototype.ptr();

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -505,6 +505,24 @@ macro pop_inline_frame_and_resume(caller_frame, value_reg)
     dispatch_current
 end
 
+macro load_property_lookup_cache(cache)
+    temp exe, caches
+    load32 cache, [pb, pc, m_cache]
+    mul cache, cache, PROPERTY_LOOKUP_CACHE_SIZE
+    load64 exe, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 caches, [exe, EXECUTABLE_PROPERTY_LOOKUP_CACHES_DATA]
+    add cache, caches
+end
+
+macro load_global_variable_cache(cache)
+    temp exe, caches
+    load32 cache, [pb, pc, m_cache]
+    mul cache, cache, GLOBAL_VARIABLE_CACHE_SIZE
+    load64 exe, [exec_ctx, EXECUTION_CONTEXT_EXECUTABLE]
+    load64 caches, [exe, EXECUTABLE_GLOBAL_VARIABLE_CACHES_DATA]
+    add cache, caches
+end
+
 # ============================================================================
 # Simple data movement
 # ============================================================================
@@ -1673,8 +1691,7 @@ handler GetById
     unbox_object obj, base
     load64 shape, [obj, OBJECT_SHAPE]
     assert_nonzero shape
-    # Get PropertyLookupCache* (direct pointer from instruction stream)
-    load64 plc, [pb, pc, m_cache]
+    load_property_lookup_cache plc
     assert_nonzero plc
     load_pair64 cache_shape, cache_proto, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
     branch_ne cache_shape, shape, .try_cache
@@ -1727,7 +1744,7 @@ handler PutById
     unbox_object obj, base
     load64 shape, [obj, OBJECT_SHAPE]
     assert_nonzero shape
-    load64 plc, [pb, pc, m_cache]
+    load_property_lookup_cache plc
     assert_nonzero plc
     load_pair64 cache_shape, cache_proto, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
     branch_ne cache_shape, shape, .try_cache
@@ -1905,7 +1922,7 @@ handler GetLength
     # Non-magical length: IC fast path (same as GetById)
     load64 shape, [obj, OBJECT_SHAPE]
     assert_nonzero shape
-    load64 plc, [pb, pc, m_cache]
+    load_property_lookup_cache plc
     assert_nonzero plc
     load_pair64 cache_shape, cache_proto, [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_SHAPE], [plc, PROPERTY_LOOKUP_CACHE_ENTRY0_PROTOTYPE]
     branch_ne cache_shape, shape, .slow
@@ -1947,7 +1964,7 @@ handler GetGlobal
     load_pair64 global_object, env, [realm, REALM_GLOBAL_OBJECT], [realm, REALM_GLOBAL_DECLARATIVE_ENVIRONMENT]
     assert_nonzero global_object
     assert_nonzero env
-    load64 gvc, [pb, pc, m_cache]
+    load_global_variable_cache gvc
     assert_nonzero gvc
     load64 cache_serial, [gvc, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL]
     load_environment_serial env, env_serial
@@ -1995,7 +2012,7 @@ handler SetGlobal
     load_pair64 global_object, env, [realm, REALM_GLOBAL_OBJECT], [realm, REALM_GLOBAL_DECLARATIVE_ENVIRONMENT]
     assert_nonzero global_object
     assert_nonzero env
-    load64 gvc, [pb, pc, m_cache]
+    load_global_variable_cache gvc
     assert_nonzero gvc
     load64 cache_serial, [gvc, GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL]
     load_environment_serial env, env_serial

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -437,33 +437,27 @@ macro dispatch_current()
     goto_handler pc
 end
 
-# Walk the environment chain using a cached EnvironmentCoordinate.
+# Walk the environment chain using a statically computed EnvironmentCoordinate.
 # Input: m_cache_field is the offset of the EnvironmentCoordinate inside
 # the bytecode instruction.
 # Output: target_env points at the resolved environment, bind_index holds
 # the binding index within it.
-# On failure (invalid cache, screwed by eval): jumps to fail_label.
+# On failure (the caller's binding operation fails): jumps to fail_label.
 macro walk_env_chain(m_cache_field, target_env, bind_index, fail_label)
-    temp coord_addr, hops, sentinel, screw
+    temp coord_addr, hops
     lea coord_addr, [pb, pc]
     add coord_addr, m_cache_field
     load_pair32 hops, bind_index, [coord_addr, ENVIRONMENT_COORDINATE_HOPS], [coord_addr, ENVIRONMENT_COORDINATE_INDEX]
-    mov sentinel, ENVIRONMENT_COORDINATE_INVALID
-    branch_eq hops, sentinel, fail_label
     load64 target_env, [exec_ctx, EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT]
     assert_nonzero target_env
     branch_zero hops, .walk_done
 .walk_loop:
-    load8 screw, [target_env, ENVIRONMENT_SCREWED_BY_EVAL]
-    branch_nonzero screw, fail_label
     load64 target_env, [target_env, ENVIRONMENT_OUTER]
     assert_nonzero target_env
     sub hops, 1
     branch_nonzero hops, .walk_loop
 .walk_done:
     assert_nonzero target_env
-    load8 screw, [target_env, ENVIRONMENT_SCREWED_BY_EVAL]
-    branch_nonzero screw, fail_label
 end
 
 # Pop an inline frame and resume the caller without bouncing through C++.

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -131,6 +131,7 @@ int main()
     outln("\n# Executable layout");
     EMIT_OFFSET(EXECUTABLE_CONSTANTS, Executable, constants);
     EMIT_OFFSET(EXECUTABLE_PROPERTY_LOOKUP_CACHES, Executable, property_lookup_caches);
+    EMIT_OFFSET(EXECUTABLE_GLOBAL_VARIABLE_CACHES, Executable, global_variable_caches);
     EMIT_OFFSET(EXECUTABLE_REGISTERS_AND_LOCALS_COUNT, Executable, registers_and_locals_count);
     EMIT_OFFSET(EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT, Executable, registers_and_locals_and_constants_count);
     EMIT_OFFSET(EXECUTABLE_ASM_CONSTANTS_SIZE, Executable, asm_constants_size);
@@ -216,6 +217,8 @@ int main()
 
         // Composite offset for Executable.bytecode data pointer
         outln("const EXECUTABLE_BYTECODE_DATA = {}", offsetof(Executable, bytecode) + vec_data);
+        outln("const EXECUTABLE_PROPERTY_LOOKUP_CACHES_DATA = {}", offsetof(Executable, property_lookup_caches) + vec_data);
+        outln("const EXECUTABLE_GLOBAL_VARIABLE_CACHES_DATA = {}", offsetof(Executable, global_variable_caches) + vec_data);
         outln("const EXECUTABLE_CONSTANTS_DATA = {}", offsetof(Executable, constants) + vec_data);
         outln("const EXECUTABLE_CONSTANTS_SIZE = {}", offsetof(Executable, constants) + vec_size);
         outln("const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA = {}", offsetof(ObjectPropertyIteratorCacheData, m_property_values) + vec_data);

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -216,7 +216,7 @@ int main()
         outln("const VECTOR_SIZE = {}", vec_size);
 
         // Composite offset for Executable.bytecode data pointer
-        outln("const EXECUTABLE_BYTECODE_DATA = {}", offsetof(Executable, bytecode) + vec_data);
+        outln("const EXECUTABLE_BYTECODE_DATA = {}", offsetof(Executable, bytecode) + InstructionStream::data_member_offset());
         outln("const EXECUTABLE_PROPERTY_LOOKUP_CACHES_DATA = {}", offsetof(Executable, property_lookup_caches) + vec_data);
         outln("const EXECUTABLE_GLOBAL_VARIABLE_CACHES_DATA = {}", offsetof(Executable, global_variable_caches) + vec_data);
         outln("const EXECUTABLE_CONSTANTS_DATA = {}", offsetof(Executable, constants) + vec_data);

--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -472,6 +472,12 @@ op GetCalleeAndThisFromEnvironment < Instruction
     m_cache: EnvironmentCoordinate
 endop
 
+op DynamicGetCalleeAndThisFromEnvironment < Instruction
+    m_callee: Operand
+    m_this_value: Operand
+    m_identifier: IdentifierTableIndex
+endop
+
 op GetCompletionFields < Instruction
     @nothrow
     m_type_dst: Operand
@@ -555,10 +561,20 @@ op GetBinding < Instruction
     m_cache: EnvironmentCoordinate
 endop
 
+op DynamicGetBinding < Instruction
+    m_dst: Operand
+    m_identifier: IdentifierTableIndex
+endop
+
 op GetInitializedBinding < Instruction
     m_dst: Operand
     m_identifier: IdentifierTableIndex
     m_cache: EnvironmentCoordinate
+endop
+
+op DynamicGetInitializedBinding < Instruction
+    m_dst: Operand
+    m_identifier: IdentifierTableIndex
 endop
 
 op GreaterThan < Instruction
@@ -601,10 +617,20 @@ op InitializeLexicalBinding < Instruction
     m_cache: EnvironmentCoordinate
 endop
 
+op DynamicInitializeLexicalBinding < Instruction
+    m_identifier: IdentifierTableIndex
+    m_src: Operand
+endop
+
 op InitializeVariableBinding < Instruction
     m_identifier: IdentifierTableIndex
     m_src: Operand
     m_cache: EnvironmentCoordinate
+endop
+
+op DynamicInitializeVariableBinding < Instruction
+    m_identifier: IdentifierTableIndex
+    m_src: Operand
 endop
 
 op InstanceOf < Instruction
@@ -1021,10 +1047,20 @@ op SetLexicalBinding < Instruction
     m_cache: EnvironmentCoordinate
 endop
 
+op DynamicSetLexicalBinding < Instruction
+    m_identifier: IdentifierTableIndex
+    m_src: Operand
+endop
+
 op SetVariableBinding < Instruction
     m_identifier: IdentifierTableIndex
     m_src: Operand
     m_cache: EnvironmentCoordinate
+endop
+
+op DynamicSetVariableBinding < Instruction
+    m_identifier: IdentifierTableIndex
+    m_src: Operand
 endop
 
 op StrictlyEquals < Instruction
@@ -1097,6 +1133,11 @@ op TypeofBinding < Instruction
     m_dst: Operand
     m_identifier: IdentifierTableIndex
     m_cache: EnvironmentCoordinate
+endop
+
+op DynamicTypeofBinding < Instruction
+    m_dst: Operand
+    m_identifier: IdentifierTableIndex
 endop
 
 op UnaryMinus < Instruction

--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -440,7 +440,7 @@ op GetById < Instruction
     m_base: Operand
     m_property: PropertyKeyTableIndex
     m_base_identifier: Optional<IdentifierTableIndex>
-    m_cache: PropertyLookupCache*
+    m_cache: PropertyLookupCacheIndex
 endop
 
 op GetByIdWithThis < Instruction
@@ -448,7 +448,7 @@ op GetByIdWithThis < Instruction
     m_base: Operand
     m_property: PropertyKeyTableIndex
     m_this_value: Operand
-    m_cache: PropertyLookupCache*
+    m_cache: PropertyLookupCacheIndex
 endop
 
 op GetByValue < Instruction
@@ -482,7 +482,7 @@ endop
 op GetGlobal < Instruction
     m_dst: Operand
     m_identifier: IdentifierTableIndex
-    m_cache: GlobalVariableCache*
+    m_cache: GlobalVariableCacheIndex
 endop
 
 op GetImportMeta < Instruction
@@ -507,14 +507,14 @@ op GetLength < Instruction
     m_dst: Operand
     m_base: Operand
     m_base_identifier: Optional<IdentifierTableIndex>
-    m_cache: PropertyLookupCache*
+    m_cache: PropertyLookupCacheIndex
 endop
 
 op GetLengthWithThis < Instruction
     m_dst: Operand
     m_base: Operand
     m_this_value: Operand
-    m_cache: PropertyLookupCache*
+    m_cache: PropertyLookupCacheIndex
 endop
 
 op GetMethod < Instruction
@@ -531,7 +531,7 @@ endop
 op GetObjectPropertyIterator < Instruction
     m_dst_iterator: Operand
     m_object: Operand
-    m_cache: ObjectPropertyIteratorCache*
+    m_cache: ObjectPropertyIteratorCacheIndex
 endop
 
 op GetPrivateById < Instruction
@@ -545,7 +545,7 @@ op GetTemplateObject < Instruction
     m_length: u32
     m_dst: Operand
     m_strings_count: u32
-    m_cache: TemplateObjectCache*
+    m_cache: TemplateObjectCacheIndex
     m_strings: Operand[]
 endop
 
@@ -882,7 +882,7 @@ endop
 op NewObject < Instruction
     @nothrow
     m_dst: Operand
-    m_cache: ObjectShapeCache*
+    m_cache: ObjectShapeCacheIndex
 endop
 
 op NewObjectWithNoPrototype < Instruction
@@ -939,7 +939,7 @@ op PutById < Instruction
     m_property: PropertyKeyTableIndex
     m_src: Operand
     m_kind: PutKind
-    m_cache: PropertyLookupCache*
+    m_cache: PropertyLookupCacheIndex
     m_base_identifier: Optional<IdentifierTableIndex>
 endop
 
@@ -949,7 +949,7 @@ op PutByIdWithThis < Instruction
     m_property: PropertyKeyTableIndex
     m_src: Operand
     m_kind: PutKind
-    m_cache: PropertyLookupCache*
+    m_cache: PropertyLookupCacheIndex
 endop
 
 op PutBySpread < Instruction
@@ -1007,7 +1007,7 @@ endop
 op SetGlobal < Instruction
     m_identifier: IdentifierTableIndex
     m_src: Operand
-    m_cache: GlobalVariableCache*
+    m_cache: GlobalVariableCacheIndex
 endop
 
 op SetLexicalEnvironment < Instruction
@@ -1125,7 +1125,7 @@ endop
 op CacheObjectShape < Instruction
     @nothrow
     m_object: Operand
-    m_cache: ObjectShapeCache*
+    m_cache: ObjectShapeCacheIndex
 endop
 
 op InitObjectLiteralProperty < Instruction

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -26,6 +26,47 @@ namespace JS::Bytecode {
 GC_DEFINE_ALLOCATOR(Executable);
 GC_DEFINE_ALLOCATOR(ObjectPropertyIteratorCacheData);
 
+InstructionStream::InstructionStream(Vector<u8> bytecode)
+    : m_storage(move(bytecode))
+{
+    update_view_from_storage();
+}
+
+InstructionStream::InstructionStream(Core::ImmutableBytes bytecode, size_t offset, size_t size)
+    : m_storage(move(bytecode))
+{
+    update_view_from_storage(offset, size);
+}
+
+void InstructionStream::update_view_from_storage(size_t offset, Optional<size_t> size)
+{
+    auto bytes = m_storage.visit(
+        [](Vector<u8> const& bytecode) -> ReadonlyBytes {
+            return bytecode.span();
+        },
+        [](Core::ImmutableBytes const& bytecode) -> ReadonlyBytes {
+            return bytecode.bytes();
+        });
+
+    VERIFY(offset <= bytes.size());
+    m_size = size.value_or(bytes.size() - offset);
+    VERIFY(m_size <= bytes.size() - offset);
+    m_data = bytes.is_empty() ? nullptr : bytes.data() + offset;
+}
+
+size_t InstructionStream::external_memory_size() const
+{
+    return m_storage.visit(
+        [](Vector<u8> const& bytecode) -> size_t {
+            return vector_external_memory_size(bytecode);
+        },
+        [](Core::ImmutableBytes const& bytecode) -> size_t {
+            if (bytecode.is_file_backed())
+                return 0;
+            return bytecode.size();
+        });
+}
+
 ObjectPropertyIteratorCacheData::ObjectPropertyIteratorCacheData(VM& vm, Vector<PropertyKey> properties, ObjectPropertyIteratorFastPath fast_path, u32 indexed_property_count, bool receiver_has_magical_length_property, GC::Ref<Shape> shape, GC::Ptr<PrototypeChainValidity> prototype_chain_validity)
     : m_properties(move(properties))
     , m_shape(shape)
@@ -65,7 +106,7 @@ size_t ObjectPropertyIteratorCacheData::external_memory_size() const
 }
 
 Executable::Executable(
-    Vector<u8> bytecode,
+    InstructionStream bytecode,
     NonnullOwnPtr<IdentifierTable> identifier_table,
     NonnullOwnPtr<PropertyKeyTable> property_key_table,
     NonnullOwnPtr<StringTable> string_table,
@@ -370,7 +411,7 @@ void Executable::visit_edges(Visitor& visitor)
 
 size_t Executable::external_memory_size() const
 {
-    size_t size = vector_external_memory_size(bytecode);
+    size_t size = bytecode.external_memory_size();
     size = saturating_add_external_memory_size(size, vector_external_memory_size(property_lookup_caches));
     size = saturating_add_external_memory_size(size, vector_external_memory_size(global_variable_caches));
     size = saturating_add_external_memory_size(size, vector_external_memory_size(template_object_caches));

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -101,19 +101,6 @@ Executable::Executable(
 
 Executable::~Executable() = default;
 
-void Executable::fixup_cache_pointers()
-{
-    for (auto it = InstructionStreamIterator(bytecode); !it.at_end(); ++it) {
-        fixup_instruction_cache(
-            const_cast<Instruction&>(*it),
-            property_lookup_caches.span(),
-            global_variable_caches.span(),
-            template_object_caches.span(),
-            object_shape_caches.span(),
-            object_property_iterator_caches.span());
-    }
-}
-
 static SourceMapEntry const* first_real_source_map_entry(Executable const& executable)
 {
     SourceMapEntry const* first_entry = nullptr;

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -7,9 +7,13 @@
 #pragma once
 
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/Utf16FlyString.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibCore/ImmutableBytes.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/WeakContainer.h>
@@ -27,6 +31,29 @@
 #include <LibJS/SourceRange.h>
 
 namespace JS::Bytecode {
+
+class InstructionStream {
+public:
+    explicit InstructionStream(Vector<u8>);
+    InstructionStream(Core::ImmutableBytes, size_t offset, size_t size);
+
+    [[nodiscard]] ReadonlyBytes span() const LIFETIME_BOUND { return { m_data, m_size }; }
+    [[nodiscard]] u8 const* data() const LIFETIME_BOUND { return m_data; }
+    [[nodiscard]] size_t size() const { return m_size; }
+    [[nodiscard]] size_t external_memory_size() const;
+    [[nodiscard]] u8 operator[](size_t index) const { return m_data[index]; }
+
+    operator ReadonlyBytes() const LIFETIME_BOUND { return span(); }
+
+    static constexpr size_t data_member_offset() { return offsetof(InstructionStream, m_data); }
+
+private:
+    void update_view_from_storage(size_t offset = 0, Optional<size_t> size = {});
+
+    Variant<Vector<u8>, Core::ImmutableBytes> m_storage;
+    u8 const* m_data { nullptr };
+    size_t m_size { 0 };
+};
 
 // Represents one polymorphic inline cache used for property lookups.
 struct PropertyLookupCache {
@@ -151,7 +178,7 @@ class JS_API Executable final
 
 public:
     Executable(
-        Vector<u8> bytecode,
+        InstructionStream bytecode,
         NonnullOwnPtr<IdentifierTable>,
         NonnullOwnPtr<PropertyKeyTable>,
         NonnullOwnPtr<StringTable>,
@@ -169,7 +196,7 @@ public:
     virtual ~Executable() override;
 
     Utf16FlyString name;
-    Vector<u8> bytecode;
+    InstructionStream bytecode;
     Vector<PropertyLookupCache> property_lookup_caches;
     Vector<GlobalVariableCache> global_variable_caches;
     Vector<TemplateObjectCache> template_object_caches;

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -228,8 +228,6 @@ public:
 
     [[nodiscard]] SourceRange const& get_source_range(u32 program_counter);
 
-    void fixup_cache_pointers();
-
     void dump() const;
     [[nodiscard]] String dump_to_string() const;
 

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Debug.h>
 #include <AK/HashTable.h>
+#include <AK/NumericLimits.h>
 #include <AK/TemporaryChange.h>
 #include <LibGC/RootHashMap.h>
 #include <LibJS/Bytecode/AsmInterpreter/AsmInterpreter.h>
@@ -2073,7 +2074,7 @@ void NewPrimitiveArray::execute_impl(VM& vm) const
 // 13.2.8.4 GetTemplateObject ( templateLiteral ), https://tc39.es/ecma262/#sec-gettemplateobject
 void GetTemplateObject::execute_impl(VM& vm) const
 {
-    auto& cache = *bit_cast<TemplateObjectCache*>(m_cache);
+    auto& cache = vm.current_executable().template_object_caches[m_cache];
 
     // 1. Let realm be the current Realm Record.
     auto& realm = *vm.current_realm();
@@ -2192,8 +2193,8 @@ void NewObject::execute_impl(VM& vm) const
 {
     auto& realm = *vm.current_realm();
 
-    if (m_cache) {
-        auto& cache = *bit_cast<ObjectShapeCache*>(m_cache);
+    if (m_cache != NumericLimits<u32>::max()) {
+        auto& cache = vm.current_executable().object_shape_caches[m_cache];
         auto cached_shape = cache.shape.ptr();
         if (cached_shape) {
             vm.set(dst(), Object::create_with_premade_shape(*cached_shape));
@@ -2212,7 +2213,7 @@ void NewObjectWithNoPrototype::execute_impl(VM& vm) const
 
 void CacheObjectShape::execute_impl(VM& vm) const
 {
-    auto& cache = *bit_cast<ObjectShapeCache*>(m_cache);
+    auto& cache = vm.current_executable().object_shape_caches[m_cache];
     if (!cache.shape) {
         auto& object = vm.get(m_object).as_object();
         if (!object.shape().is_dictionary())
@@ -2364,7 +2365,7 @@ ThrowCompletionOr<void> GetCalleeAndThisFromEnvironment::execute_impl(VM& vm) co
 
 ThrowCompletionOr<void> GetGlobal::execute_impl(VM& vm) const
 {
-    vm.set(dst(), TRY(get_global(vm, m_identifier, strict(), *bit_cast<GlobalVariableCache*>(m_cache))));
+    vm.set(dst(), TRY(get_global(vm, m_identifier, strict(), vm.current_executable().global_variable_caches[m_cache])));
     return {};
 }
 
@@ -2373,7 +2374,7 @@ ThrowCompletionOr<void> SetGlobal::execute_impl(VM& vm) const
     auto& binding_object = vm.global_object();
     auto& declarative_record = vm.global_declarative_environment();
 
-    auto& cache = *bit_cast<GlobalVariableCache*>(m_cache);
+    auto& cache = vm.current_executable().global_variable_caches[m_cache];
     auto& shape = binding_object.shape();
     auto src = vm.get(m_src);
 
@@ -2618,7 +2619,7 @@ ThrowCompletionOr<void> SetVariableBinding::execute_impl(VM& vm) const
 ThrowCompletionOr<void> GetById::execute_impl(VM& vm) const
 {
     auto base_value = vm.get(base());
-    auto& cache = *bit_cast<PropertyLookupCache*>(m_cache);
+    auto& cache = vm.current_executable().property_lookup_caches[m_cache];
 
     vm.set(dst(), TRY(get_by_id<GetByIdMode::Normal>(vm, [&] { return vm.get_identifier(m_base_identifier); }, [&] -> PropertyKey const& { return vm.get_property_key(m_property); }, base_value, base_value, cache)));
     return {};
@@ -2628,7 +2629,7 @@ ThrowCompletionOr<void> GetByIdWithThis::execute_impl(VM& vm) const
 {
     auto base_value = vm.get(m_base);
     auto this_value = vm.get(m_this_value);
-    auto& cache = *bit_cast<PropertyLookupCache*>(m_cache);
+    auto& cache = vm.current_executable().property_lookup_caches[m_cache];
     vm.set(dst(), TRY(get_by_id<GetByIdMode::Normal>(vm, [] { return Optional<Utf16FlyString const&> {}; }, [&] -> PropertyKey const& { return vm.get_property_key(m_property); }, base_value, this_value, cache)));
     return {};
 }
@@ -2637,7 +2638,7 @@ ThrowCompletionOr<void> GetLength::execute_impl(VM& vm) const
 {
     auto base_value = vm.get(base());
     auto& executable = vm.current_executable();
-    auto& cache = *bit_cast<PropertyLookupCache*>(m_cache);
+    auto& cache = vm.current_executable().property_lookup_caches[m_cache];
     vm.set(dst(), TRY(get_by_id<GetByIdMode::Length>(vm, [&] { return vm.get_identifier(m_base_identifier); }, [&] { return executable.get_property_key(*executable.length_identifier); }, base_value, base_value, cache)));
     return {};
 }
@@ -2647,7 +2648,7 @@ ThrowCompletionOr<void> GetLengthWithThis::execute_impl(VM& vm) const
     auto base_value = vm.get(m_base);
     auto this_value = vm.get(m_this_value);
     auto& executable = vm.current_executable();
-    auto& cache = *bit_cast<PropertyLookupCache*>(m_cache);
+    auto& cache = vm.current_executable().property_lookup_caches[m_cache];
     vm.set(dst(), TRY(get_by_id<GetByIdMode::Length>(vm, [] { return Optional<Utf16FlyString const&> {}; }, [&] -> PropertyKey const& { return executable.get_property_key(*executable.length_identifier); }, base_value, this_value, cache)));
     return {};
 }
@@ -2694,7 +2695,7 @@ ThrowCompletionOr<void> PutById::execute_impl(VM& vm) const
     auto base = vm.get(m_base);
     auto const& base_identifier = vm.get_identifier(m_base_identifier);
     auto const& property_key = vm.get_property_key(m_property);
-    auto& cache = *bit_cast<PropertyLookupCache*>(m_cache);
+    auto& cache = vm.current_executable().property_lookup_caches[m_cache];
     TRY(put_by_property_key(vm, base, base, value, base_identifier, property_key, m_kind, strict(), &cache));
     return {};
 }
@@ -2704,7 +2705,7 @@ ThrowCompletionOr<void> PutByIdWithThis::execute_impl(VM& vm) const
     auto value = vm.get(m_src);
     auto base = vm.get(m_base);
     auto const& name = vm.get_property_key(m_property);
-    auto& cache = *bit_cast<PropertyLookupCache*>(m_cache);
+    auto& cache = vm.current_executable().property_lookup_caches[m_cache];
     TRY(put_by_property_key(vm, base, vm.get(m_this_value), value, {}, name, m_kind, strict(), &cache));
     return {};
 }
@@ -3298,7 +3299,7 @@ ThrowCompletionOr<void> GetMethod::execute_impl(VM& vm) const
 
 NEVER_INLINE ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(VM& vm) const
 {
-    auto* cache = bit_cast<ObjectPropertyIteratorCache*>(m_cache);
+    auto* cache = &vm.current_executable().object_property_iterator_caches[m_cache];
     vm.set(m_dst_iterator, TRY(get_object_property_iterator(vm, vm.get(m_object), cache)));
     return {};
 }

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -692,6 +692,7 @@ void VM::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(GetByValue);
             HANDLE_INSTRUCTION(GetByValueWithThis);
             HANDLE_INSTRUCTION(GetCalleeAndThisFromEnvironment);
+            HANDLE_INSTRUCTION(DynamicGetCalleeAndThisFromEnvironment);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetCompletionFields);
             HANDLE_INSTRUCTION(GetGlobal);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetImportMeta);
@@ -705,7 +706,9 @@ void VM::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(GetPrivateById);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetTemplateObject);
             HANDLE_INSTRUCTION(GetBinding);
+            HANDLE_INSTRUCTION(DynamicGetBinding);
             HANDLE_INSTRUCTION(GetInitializedBinding);
+            HANDLE_INSTRUCTION(DynamicGetInitializedBinding);
             HANDLE_INSTRUCTION(GreaterThan);
             HANDLE_INSTRUCTION(GreaterThanEquals);
             HANDLE_INSTRUCTION(HasPrivateId);
@@ -713,7 +716,9 @@ void VM::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(In);
             HANDLE_INSTRUCTION(Increment);
             HANDLE_INSTRUCTION(InitializeLexicalBinding);
+            HANDLE_INSTRUCTION(DynamicInitializeLexicalBinding);
             HANDLE_INSTRUCTION(InitializeVariableBinding);
+            HANDLE_INSTRUCTION(DynamicInitializeVariableBinding);
             HANDLE_INSTRUCTION(InstanceOf);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(IsCallable);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(IsConstructor);
@@ -760,7 +765,9 @@ void VM::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(SetGlobal);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(SetLexicalEnvironment);
             HANDLE_INSTRUCTION(SetLexicalBinding);
+            HANDLE_INSTRUCTION(DynamicSetLexicalBinding);
             HANDLE_INSTRUCTION(SetVariableBinding);
+            HANDLE_INSTRUCTION(DynamicSetVariableBinding);
             HANDLE_INSTRUCTION(StrictlyEquals);
             HANDLE_INSTRUCTION(StrictlyInequals);
             HANDLE_INSTRUCTION(Sub);
@@ -774,6 +781,7 @@ void VM::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(ToBoolean);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(Typeof);
             HANDLE_INSTRUCTION(TypeofBinding);
+            HANDLE_INSTRUCTION(DynamicTypeofBinding);
             HANDLE_INSTRUCTION(UnaryMinus);
             HANDLE_INSTRUCTION(UnaryPlus);
             HANDLE_INSTRUCTION(UnsignedRightShift);
@@ -1273,37 +1281,31 @@ struct CalleeAndThis {
     Value this_value;
 };
 
-inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(VM& vm, Utf16FlyString const& name, Strict strict, EnvironmentCoordinate& cache)
+inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(VM& vm, EnvironmentCoordinate const& cache)
 {
+    VERIFY(cache.is_valid());
 
     Value callee = js_undefined();
 
-    if (cache.is_valid()) [[likely]] {
-        auto const* environment = vm.running_execution_context().lexical_environment.ptr();
-        for (size_t i = 0; i < cache.hops; ++i) {
-            if (environment->is_permanently_screwed_by_eval()) [[unlikely]]
-                goto slow_path;
-            environment = environment->outer_environment();
-        }
-        if (!environment->is_permanently_screwed_by_eval()) [[likely]] {
-            callee = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, cache.index));
-            auto this_value = js_undefined();
-            if (auto base_object = environment->with_base_object()) [[unlikely]]
-                this_value = base_object;
-            return CalleeAndThis {
-                .callee = callee,
-                .this_value = this_value,
-            };
-        }
-    slow_path:
-        cache = {};
-    }
+    auto const* environment = vm.running_execution_context().lexical_environment.ptr();
+    for (size_t i = 0; i < cache.hops; ++i)
+        environment = environment->outer_environment();
 
+    callee = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, cache.index));
+    auto this_value = js_undefined();
+    if (auto base_object = environment->with_base_object()) [[unlikely]]
+        this_value = base_object;
+    return CalleeAndThis {
+        .callee = callee,
+        .this_value = this_value,
+    };
+}
+
+inline ThrowCompletionOr<CalleeAndThis> dynamically_get_callee_and_this_from_environment(VM& vm, Utf16FlyString const& name, Strict strict)
+{
     auto reference = TRY(vm.resolve_binding(name, strict));
-    if (reference.environment_coordinate().has_value())
-        cache = reference.environment_coordinate().value();
 
-    callee = TRY(reference.get_value(vm));
+    auto callee = TRY(reference.get_value(vm));
 
     Value this_value;
     if (reference.is_property_reference()) {
@@ -2308,34 +2310,28 @@ enum class BindingIsKnownToBeInitialized {
 };
 
 template<BindingIsKnownToBeInitialized binding_is_known_to_be_initialized>
-static ThrowCompletionOr<void> get_binding(VM& vm, Operand dst, IdentifierTableIndex identifier, Strict strict, EnvironmentCoordinate& cache)
+static ThrowCompletionOr<void> get_binding(VM& vm, Operand dst, EnvironmentCoordinate const& cache)
 {
+    VERIFY(cache.is_valid());
 
-    if (cache.is_valid()) [[likely]] {
-        auto const* environment = vm.running_execution_context().lexical_environment.ptr();
-        for (size_t i = 0; i < cache.hops; ++i) {
-            if (environment->is_permanently_screwed_by_eval()) [[unlikely]]
-                goto slow_path;
-            environment = environment->outer_environment();
-        }
-        if (!environment->is_permanently_screwed_by_eval()) [[likely]] {
-            Value value;
-            if constexpr (binding_is_known_to_be_initialized == BindingIsKnownToBeInitialized::No) {
-                value = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, cache.index));
-            } else {
-                value = static_cast<DeclarativeEnvironment const&>(*environment).get_initialized_binding_value_direct(cache.index);
-            }
-            vm.set(dst, value);
-            return {};
-        }
-    slow_path:
-        cache = {};
+    auto const* environment = vm.running_execution_context().lexical_environment.ptr();
+    for (size_t i = 0; i < cache.hops; ++i)
+        environment = environment->outer_environment();
+
+    Value value;
+    if constexpr (binding_is_known_to_be_initialized == BindingIsKnownToBeInitialized::No) {
+        value = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, cache.index));
+    } else {
+        value = static_cast<DeclarativeEnvironment const&>(*environment).get_initialized_binding_value_direct(cache.index);
     }
+    vm.set(dst, value);
+    return {};
+}
 
+static ThrowCompletionOr<void> dynamically_get_binding(VM& vm, Operand dst, IdentifierTableIndex identifier, Strict strict)
+{
     auto& executable = vm.current_executable();
     auto reference = TRY(vm.resolve_binding(executable.get_identifier(identifier), strict));
-    if (reference.environment_coordinate().has_value())
-        cache = reference.environment_coordinate().value();
 
     vm.set(dst, TRY(reference.get_value(vm)));
     return {};
@@ -2343,21 +2339,40 @@ static ThrowCompletionOr<void> get_binding(VM& vm, Operand dst, IdentifierTableI
 
 ThrowCompletionOr<void> GetBinding::execute_impl(VM& vm) const
 {
-    return get_binding<BindingIsKnownToBeInitialized::No>(vm, m_dst, m_identifier, strict(), m_cache);
+    return get_binding<BindingIsKnownToBeInitialized::No>(vm, m_dst, m_cache);
 }
 
 ThrowCompletionOr<void> GetInitializedBinding::execute_impl(VM& vm) const
 {
-    return get_binding<BindingIsKnownToBeInitialized::Yes>(vm, m_dst, m_identifier, strict(), m_cache);
+    return get_binding<BindingIsKnownToBeInitialized::Yes>(vm, m_dst, m_cache);
+}
+
+ThrowCompletionOr<void> DynamicGetBinding::execute_impl(VM& vm) const
+{
+    return dynamically_get_binding(vm, m_dst, m_identifier, strict());
+}
+
+ThrowCompletionOr<void> DynamicGetInitializedBinding::execute_impl(VM& vm) const
+{
+    return dynamically_get_binding(vm, m_dst, m_identifier, strict());
 }
 
 ThrowCompletionOr<void> GetCalleeAndThisFromEnvironment::execute_impl(VM& vm) const
 {
     auto callee_and_this = TRY(get_callee_and_this_from_environment(
         vm,
-        vm.get_identifier(m_identifier),
-        strict(),
         m_cache));
+    vm.set(m_callee, callee_and_this.callee);
+    vm.set(m_this_value, callee_and_this.this_value);
+    return {};
+}
+
+ThrowCompletionOr<void> DynamicGetCalleeAndThisFromEnvironment::execute_impl(VM& vm) const
+{
+    auto callee_and_this = TRY(dynamically_get_callee_and_this_from_environment(
+        vm,
+        vm.get_identifier(m_identifier),
+        strict()));
     vm.set(m_callee, callee_and_this.callee);
     vm.set(m_this_value, callee_and_this.this_value);
     return {};
@@ -2560,34 +2575,33 @@ void CreateArguments::execute_impl(VM& vm) const
 }
 
 template<EnvironmentMode environment_mode, BindingInitializationMode initialization_mode>
-static ThrowCompletionOr<void> initialize_or_set_binding(VM& vm, IdentifierTableIndex identifier_index, Strict strict, Value value, EnvironmentCoordinate& cache)
+static ThrowCompletionOr<void> initialize_or_set_binding(VM& vm, Strict strict, Value value, EnvironmentCoordinate const& cache)
 {
+    VERIFY(cache.is_valid());
 
     auto* environment = environment_mode == EnvironmentMode::Lexical
         ? vm.running_execution_context().lexical_environment.ptr()
         : vm.running_execution_context().variable_environment.ptr();
 
-    if (cache.is_valid()) [[likely]] {
-        for (size_t i = 0; i < cache.hops; ++i) {
-            if (environment->is_permanently_screwed_by_eval()) [[unlikely]]
-                goto slow_path;
-            environment = environment->outer_environment();
-        }
-        if (!environment->is_permanently_screwed_by_eval()) [[likely]] {
-            if constexpr (initialization_mode == BindingInitializationMode::Initialize) {
-                TRY(static_cast<DeclarativeEnvironment&>(*environment).initialize_binding_direct(vm, cache.index, value, Environment::InitializeBindingHint::Normal));
-            } else {
-                TRY(static_cast<DeclarativeEnvironment&>(*environment).set_mutable_binding_direct(vm, cache.index, value, strict == Strict::Yes));
-            }
-            return {};
-        }
-    slow_path:
-        cache = {};
+    for (size_t i = 0; i < cache.hops; ++i)
+        environment = environment->outer_environment();
+
+    if constexpr (initialization_mode == BindingInitializationMode::Initialize) {
+        TRY(static_cast<DeclarativeEnvironment&>(*environment).initialize_binding_direct(vm, cache.index, value, Environment::InitializeBindingHint::Normal));
+    } else {
+        TRY(static_cast<DeclarativeEnvironment&>(*environment).set_mutable_binding_direct(vm, cache.index, value, strict == Strict::Yes));
     }
+    return {};
+}
+
+template<EnvironmentMode environment_mode, BindingInitializationMode initialization_mode>
+static ThrowCompletionOr<void> dynamically_initialize_or_set_binding(VM& vm, IdentifierTableIndex identifier_index, Strict strict, Value value)
+{
+    auto* environment = environment_mode == EnvironmentMode::Lexical
+        ? vm.running_execution_context().lexical_environment.ptr()
+        : vm.running_execution_context().variable_environment.ptr();
 
     auto reference = TRY(vm.resolve_binding(vm.get_identifier(identifier_index), strict, environment));
-    if (reference.environment_coordinate().has_value())
-        cache = reference.environment_coordinate().value();
     if constexpr (initialization_mode == BindingInitializationMode::Initialize) {
         TRY(reference.initialize_referenced_binding(vm, value));
     } else if (initialization_mode == BindingInitializationMode::Set) {
@@ -2598,22 +2612,42 @@ static ThrowCompletionOr<void> initialize_or_set_binding(VM& vm, IdentifierTable
 
 ThrowCompletionOr<void> InitializeLexicalBinding::execute_impl(VM& vm) const
 {
-    return initialize_or_set_binding<EnvironmentMode::Lexical, BindingInitializationMode::Initialize>(vm, m_identifier, strict(), vm.get(m_src), m_cache);
+    return initialize_or_set_binding<EnvironmentMode::Lexical, BindingInitializationMode::Initialize>(vm, strict(), vm.get(m_src), m_cache);
 }
 
 ThrowCompletionOr<void> InitializeVariableBinding::execute_impl(VM& vm) const
 {
-    return initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Initialize>(vm, m_identifier, strict(), vm.get(m_src), m_cache);
+    return initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Initialize>(vm, strict(), vm.get(m_src), m_cache);
+}
+
+ThrowCompletionOr<void> DynamicInitializeLexicalBinding::execute_impl(VM& vm) const
+{
+    return dynamically_initialize_or_set_binding<EnvironmentMode::Lexical, BindingInitializationMode::Initialize>(vm, m_identifier, strict(), vm.get(m_src));
+}
+
+ThrowCompletionOr<void> DynamicInitializeVariableBinding::execute_impl(VM& vm) const
+{
+    return dynamically_initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Initialize>(vm, m_identifier, strict(), vm.get(m_src));
 }
 
 ThrowCompletionOr<void> SetLexicalBinding::execute_impl(VM& vm) const
 {
-    return initialize_or_set_binding<EnvironmentMode::Lexical, BindingInitializationMode::Set>(vm, m_identifier, strict(), vm.get(m_src), m_cache);
+    return initialize_or_set_binding<EnvironmentMode::Lexical, BindingInitializationMode::Set>(vm, strict(), vm.get(m_src), m_cache);
 }
 
 ThrowCompletionOr<void> SetVariableBinding::execute_impl(VM& vm) const
 {
-    return initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Set>(vm, m_identifier, strict(), vm.get(m_src), m_cache);
+    return initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Set>(vm, strict(), vm.get(m_src), m_cache);
+}
+
+ThrowCompletionOr<void> DynamicSetLexicalBinding::execute_impl(VM& vm) const
+{
+    return dynamically_initialize_or_set_binding<EnvironmentMode::Lexical, BindingInitializationMode::Set>(vm, m_identifier, strict(), vm.get(m_src));
+}
+
+ThrowCompletionOr<void> DynamicSetVariableBinding::execute_impl(VM& vm) const
+{
+    return dynamically_initialize_or_set_binding<EnvironmentMode::Var, BindingInitializationMode::Set>(vm, m_identifier, strict(), vm.get(m_src));
 }
 
 ThrowCompletionOr<void> GetById::execute_impl(VM& vm) const
@@ -3396,23 +3430,19 @@ NEVER_INLINE ThrowCompletionOr<void> NewClass::execute_impl(VM& vm) const
 // 13.5.3.1 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-typeof-operator-runtime-semantics-evaluation
 ThrowCompletionOr<void> TypeofBinding::execute_impl(VM& vm) const
 {
+    VERIFY(m_cache.is_valid());
 
-    if (m_cache.is_valid()) [[likely]] {
-        auto const* environment = vm.running_execution_context().lexical_environment.ptr();
-        for (size_t i = 0; i < m_cache.hops; ++i) {
-            if (environment->is_permanently_screwed_by_eval()) [[unlikely]]
-                goto slow_path;
-            environment = environment->outer_environment();
-        }
-        if (!environment->is_permanently_screwed_by_eval()) [[likely]] {
-            auto value = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, m_cache.index));
-            vm.set(dst(), value.typeof_(vm));
-            return {};
-        }
-    slow_path:
-        m_cache = {};
-    }
+    auto const* environment = vm.running_execution_context().lexical_environment.ptr();
+    for (size_t i = 0; i < m_cache.hops; ++i)
+        environment = environment->outer_environment();
 
+    auto value = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, m_cache.index));
+    vm.set(dst(), value.typeof_(vm));
+    return {};
+}
+
+ThrowCompletionOr<void> DynamicTypeofBinding::execute_impl(VM& vm) const
+{
     // 1. Let val be the result of evaluating UnaryExpression.
     auto reference = TRY(vm.resolve_binding(vm.get_identifier(m_identifier), strict()));
 
@@ -3425,9 +3455,6 @@ ThrowCompletionOr<void> TypeofBinding::execute_impl(VM& vm) const
 
     // 3. Set val to ? GetValue(val).
     auto value = TRY(reference.get_value(vm));
-
-    if (reference.environment_coordinate().has_value())
-        m_cache = reference.environment_coordinate().value();
 
     // 4. NOTE: This step is replaced in section B.3.6.3.
     // 5. Return a String according to Table 41.

--- a/Libraries/LibJS/Bytecode/Validator.cpp
+++ b/Libraries/LibJS/Bytecode/Validator.cpp
@@ -94,7 +94,7 @@ static_assert(put_kind_variant_count == 5);
 static constexpr u32 arguments_kind_variant_count = to_underlying(Op::ArgumentsKind::Unmapped) + 1;
 static_assert(arguments_kind_variant_count == 2);
 
-ErrorOr<void> validate_bytecode(Executable const& executable, ReadonlySpan<u32> basic_block_offsets, CacheState cache_state)
+ErrorOr<void> validate_bytecode(Executable const& executable, ReadonlySpan<u32> basic_block_offsets)
 {
     JS::FFI::FFIValidatorBounds bounds {
         .number_of_registers = executable.number_of_registers,
@@ -119,7 +119,6 @@ ErrorOr<void> validate_bytecode(Executable const& executable, ReadonlySpan<u32> 
         .environment_mode_variant_count = environment_mode_variant_count,
         .put_kind_variant_count = put_kind_variant_count,
         .arguments_kind_variant_count = arguments_kind_variant_count,
-        .before_cache_fixup = cache_state == CacheState::BeforeFixup,
     };
 
     // Project Executable's exception handlers down to plain offsets; the

--- a/Libraries/LibJS/Bytecode/Validator.h
+++ b/Libraries/LibJS/Bytecode/Validator.h
@@ -14,15 +14,6 @@ namespace JS::Bytecode {
 
 class Executable;
 
-// Whether the bytecode being validated still has m_cache fields stored as
-// indices (BeforeFixup) or has had Executable::fixup_cache_pointers() rewrite
-// them into live pointers (AfterFixup). Cache fields are only range-checked
-// in the BeforeFixup case.
-enum class CacheState : u8 {
-    BeforeFixup,
-    AfterFixup,
-};
-
-ErrorOr<void> validate_bytecode(Executable const&, ReadonlySpan<u32> basic_block_offsets, CacheState);
+ErrorOr<void> validate_bytecode(Executable const&, ReadonlySpan<u32> basic_block_offsets);
 
 }

--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -137,12 +137,11 @@ pub fn field_type_info(ty: &str) -> FieldType {
         "PutKind" => ("u32", 4, 4, "u32"),
         "ArgumentsKind" => ("u32", 4, 4, "u32"),
         "Value" => ("u64", 8, 8, "u64"),
-        // Cache pointer types: stored as u64, fixup pass replaces indices with pointers.
-        "PropertyLookupCache*"
-        | "GlobalVariableCache*"
-        | "TemplateObjectCache*"
-        | "ObjectShapeCache*"
-        | "ObjectPropertyIteratorCache*" => ("u64", 8, 8, "u64"),
+        "PropertyLookupCacheIndex"
+        | "GlobalVariableCacheIndex"
+        | "TemplateObjectCacheIndex"
+        | "ObjectShapeCacheIndex"
+        | "ObjectPropertyIteratorCacheIndex" => ("u32", 4, 4, "u32"),
         _ => unreachable!("Unknown field type: {ty}"),
     }
     .into()

--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -208,14 +208,16 @@ pub fn compute_layouts(ops: &[OpDef]) -> HashMap<String, OpLayout> {
             offset += info.size;
         }
 
-        // Array fields start at sizeof(*this), which is the fixed part rounded up
+        // Flexible array members start after the fixed fields with only the
+        // element's alignment. This can be before the struct's final tail
+        // padding on targets like MSVC.
         if has_array {
-            let sizeof_this = round_up(offset, STRUCT_ALIGN);
             for f in &op.fields {
                 if !f.is_array {
                     continue;
                 }
-                field_offsets.insert(f.name.clone(), sizeof_this);
+                let info = field_type_info(&f.ty);
+                field_offsets.insert(f.name.clone(), round_up(offset, info.align));
             }
         }
 

--- a/Libraries/LibJS/Rust/build.rs
+++ b/Libraries/LibJS/Rust/build.rs
@@ -193,25 +193,25 @@ fn emit_scalar_field_check(
         "RegexTableIndex" => {
             // The regex table is not consulted at runtime; skip range-checking.
         }
-        "PropertyLookupCache*" => writeln!(
+        "PropertyLookupCacheIndex" => writeln!(
             w,
-            "            validate_property_lookup_cache_index(read_u64(bytes, at + {offset}), ctx)?;"
+            "            validate_property_lookup_cache_index(read_u32(bytes, at + {offset}), ctx)?;"
         )?,
-        "GlobalVariableCache*" => writeln!(
+        "GlobalVariableCacheIndex" => writeln!(
             w,
-            "            validate_global_variable_cache_index(read_u64(bytes, at + {offset}), ctx)?;"
+            "            validate_global_variable_cache_index(read_u32(bytes, at + {offset}), ctx)?;"
         )?,
-        "TemplateObjectCache*" => writeln!(
+        "TemplateObjectCacheIndex" => writeln!(
             w,
-            "            validate_template_object_cache_index(read_u64(bytes, at + {offset}), ctx)?;"
+            "            validate_template_object_cache_index(read_u32(bytes, at + {offset}), ctx)?;"
         )?,
-        "ObjectShapeCache*" => writeln!(
+        "ObjectShapeCacheIndex" => writeln!(
             w,
-            "            validate_object_shape_cache_index(read_u64(bytes, at + {offset}), ctx)?;"
+            "            validate_object_shape_cache_index(read_u32(bytes, at + {offset}), ctx)?;"
         )?,
-        "ObjectPropertyIteratorCache*" => writeln!(
+        "ObjectPropertyIteratorCacheIndex" => writeln!(
             w,
-            "            validate_object_property_iterator_cache_index(read_u64(bytes, at + {offset}), ctx)?;"
+            "            validate_object_property_iterator_cache_index(read_u32(bytes, at + {offset}), ctx)?;"
         )?,
         "u32" => {
             // The .def gives us no first-class types for SFD, class-blueprint,
@@ -230,7 +230,7 @@ fn emit_scalar_field_check(
             } else if field_name == "m_shape_cache_index" {
                 writeln!(
                     w,
-                    "            validate_object_shape_cache_index(read_u32(bytes, at + {offset}) as u64, ctx)?;"
+                    "            validate_object_shape_cache_index(read_u32(bytes, at + {offset}), ctx)?;"
                 )?;
             }
         }

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -1789,7 +1789,7 @@ fn generate_identifier(
         generator.emit(Instruction::GetGlobal {
             dst: dst.operand(),
             identifier: id,
-            cache: cache as u64,
+            cache,
         });
     } else if ident.declaration_kind == Some(DeclarationKind::Var) {
         let id = generator.intern_identifier_id(ident.name);
@@ -2774,7 +2774,7 @@ fn generate_variable_declaration(
                                 generator.emit(Instruction::SetGlobal {
                                     identifier: id,
                                     src: value.operand(),
-                                    cache: cache as u64,
+                                    cache,
                                 });
                             } else {
                                 generator.emit(Instruction::SetLexicalBinding {
@@ -3394,7 +3394,7 @@ fn generate_update_expression(
                         base: base.operand(),
                         property: key,
                         src: value.operand(),
-                        cache: cache2 as u64,
+                        cache: cache2,
                         base_identifier: None,
                         kind: 0,
                     });
@@ -3707,7 +3707,7 @@ fn generate_assignment_expression(
                             base: base.operand(),
                             property: key,
                             src: dst.operand(),
-                            cache: cache2 as u64,
+                            cache: cache2,
                             base_identifier: None,
                             kind: 0,
                         });
@@ -3727,7 +3727,7 @@ fn generate_assignment_expression(
                         base: base.operand(),
                         property: key,
                         src: dst.operand(),
-                        cache: cache2 as u64,
+                        cache: cache2,
                         base_identifier: None,
                         kind: 0,
                     });
@@ -3865,7 +3865,7 @@ fn emit_super_put(
             this_value: this_value.operand(),
             property: key,
             src: value.operand(),
-            cache: cache as u64,
+            cache,
             kind: 0,
         });
     }
@@ -3887,7 +3887,7 @@ fn emit_get_by_id(
             dst: dst.operand(),
             base: base.operand(),
             base_identifier,
-            cache: cache as u64,
+            cache,
         });
     } else {
         let cache = generator.next_property_lookup_cache();
@@ -3896,7 +3896,7 @@ fn emit_get_by_id(
             base: base.operand(),
             property: key,
             base_identifier,
-            cache: cache as u64,
+            cache,
         });
     }
 }
@@ -3918,7 +3918,7 @@ fn emit_get_by_id_with_this(
             dst: dst.operand(),
             base: base.operand(),
             this_value: this_value.operand(),
-            cache: cache as u64,
+            cache,
         });
     } else {
         let cache = generator.next_property_lookup_cache();
@@ -3927,7 +3927,7 @@ fn emit_get_by_id_with_this(
             base: base.operand(),
             property: key,
             this_value: this_value.operand(),
-            cache: cache as u64,
+            cache,
         });
     }
 }
@@ -3983,7 +3983,7 @@ fn emit_get_by_value(
                 dst: dst.operand(),
                 base: base.operand(),
                 base_identifier,
-                cache: cache as u64,
+                cache,
             });
         } else {
             let cache = generator.next_property_lookup_cache();
@@ -3992,7 +3992,7 @@ fn emit_get_by_value(
                 base: base.operand(),
                 property: key,
                 base_identifier,
-                cache: cache as u64,
+                cache,
             });
         }
         return;
@@ -4021,7 +4021,7 @@ fn emit_get_by_value_with_this(
                 dst: dst.operand(),
                 base: base.operand(),
                 this_value: this_value.operand(),
-                cache: cache as u64,
+                cache,
             });
         } else {
             let cache = generator.next_property_lookup_cache();
@@ -4030,7 +4030,7 @@ fn emit_get_by_value_with_this(
                 base: base.operand(),
                 property: key,
                 this_value: this_value.operand(),
-                cache: cache as u64,
+                cache,
             });
         }
         return;
@@ -4057,7 +4057,7 @@ fn emit_put_normal_by_value(
             base: base.operand(),
             property: key,
             src: src.operand(),
-            cache: cache as u64,
+            cache,
             base_identifier,
             kind: 0,
         });
@@ -4087,7 +4087,7 @@ fn emit_put_normal_by_value_with_this(
             this_value: this_value.operand(),
             property: key,
             src: src.operand(),
-            cache: cache as u64,
+            cache,
             kind: 0,
         });
         return;
@@ -4123,7 +4123,7 @@ fn emit_put_by_value(
                     base: base.operand(),
                     property: key,
                     src: src.operand(),
-                    cache: cache as u64,
+                    cache,
                     base_identifier: None,
                     kind: 4,
                 });
@@ -4133,7 +4133,7 @@ fn emit_put_by_value(
                     base: base.operand(),
                     property: key,
                     src: src.operand(),
-                    cache: cache as u64,
+                    cache,
                     base_identifier: None,
                     kind: 1,
                 });
@@ -4143,7 +4143,7 @@ fn emit_put_by_value(
                     base: base.operand(),
                     property: key,
                     src: src.operand(),
-                    cache: cache as u64,
+                    cache,
                     base_identifier: None,
                     kind: 2,
                 });
@@ -4238,7 +4238,7 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
         generator.emit(Instruction::SetGlobal {
             identifier: id,
             src: value.operand(),
-            cache: cache as u64,
+            cache,
         });
     } else {
         // Non-local, non-global: use SetLexicalBinding which searches
@@ -4272,7 +4272,7 @@ fn emit_put_to_member(
             base: base.operand(),
             property: key,
             src: value.operand(),
-            cache: cache as u64,
+            cache,
             base_identifier: base_id,
             kind: 0,
         });
@@ -4507,7 +4507,7 @@ fn emit_store_to_evaluated_reference(generator: &mut Generator, reference: &Eval
                 base: base.operand(),
                 property: *property,
                 src: value.operand(),
-                cache: *cache as u64,
+                cache: *cache,
                 base_identifier: *base_identifier,
                 kind: 0,
             });
@@ -4537,7 +4537,7 @@ fn emit_store_to_evaluated_reference(generator: &mut Generator, reference: &Eval
                 this_value: this_value.operand(),
                 property: *property,
                 src: value.operand(),
-                cache: *cache as u64,
+                cache: *cache,
                 kind: 0,
             });
         }
@@ -4857,7 +4857,7 @@ fn generate_tagged_template_literal(
     generator.emit(Instruction::GetTemplateObject {
         dst: strings_array.operand(),
         strings_count: u32_from_usize(string_ops.len()),
-        cache: cache_index as u64,
+        cache: cache_index,
         strings: string_ops,
     });
 
@@ -5120,7 +5120,7 @@ fn generate_object_expression(
     };
     generator.emit(Instruction::NewObject {
         dst: dst.operand(),
-        cache: cache_index as u64,
+        cache: cache_index,
     });
 
     if properties.is_empty() {
@@ -5248,7 +5248,7 @@ fn generate_object_expression(
                         base: dst.operand(),
                         property: property_key,
                         src: value.operand(),
-                        cache: cache as u64,
+                        cache,
                         base_identifier: None,
                         kind: 4,
                     });
@@ -5275,7 +5275,7 @@ fn generate_object_expression(
                     base: dst.operand(),
                     property: key,
                     src: value.operand(),
-                    cache: cache as u64,
+                    cache,
                     base_identifier: None,
                     kind: 3,
                 });
@@ -5286,7 +5286,7 @@ fn generate_object_expression(
     if is_simple {
         generator.emit(Instruction::CacheObjectShape {
             object: dst.operand(),
-            cache: cache_index as u64,
+            cache: cache_index,
         });
     }
 
@@ -5377,7 +5377,7 @@ fn emit_object_accessor_by_key(
                 base: object.operand(),
                 property: property_key,
                 src: value.operand(),
-                cache: cache as u64,
+                cache,
                 base_identifier: None,
                 kind: 1,
             });
@@ -5386,7 +5386,7 @@ fn emit_object_accessor_by_key(
                 base: object.operand(),
                 property: property_key,
                 src: value.operand(),
-                cache: cache as u64,
+                cache,
                 base_identifier: None,
                 kind: 2,
             });
@@ -6309,7 +6309,7 @@ fn generate_for_in_statement(
         generator.emit(Instruction::GetObjectPropertyIterator {
             dst_iterator: iterator_object.operand(),
             object: object.operand(),
-            cache: cache as u64,
+            cache,
         });
 
         iterator_object
@@ -6975,7 +6975,7 @@ fn emit_set_variable_with_mode(
                     generator.emit(Instruction::SetGlobal {
                         identifier: id,
                         src: value.operand(),
-                        cache: cache as u64,
+                        cache,
                     });
                 } else {
                     generator.emit(Instruction::SetLexicalBinding {

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -330,10 +330,9 @@ fn generate_unary_expression(
         {
             let dst = choose_dst(generator, preferred_dst);
             let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
-            generator.emit(Instruction::TypeofBinding {
+            generator.emit(Instruction::DynamicTypeofBinding {
                 dst: dst.operand(),
                 identifier: id,
-                cache: EnvironmentCoordinate::empty(),
             });
             return Some(dst);
         }
@@ -582,10 +581,9 @@ fn generate_function_expression(
     });
 
     if has_name {
-        generator.emit(Instruction::InitializeLexicalBinding {
+        generator.emit(Instruction::DynamicInitializeLexicalBinding {
             identifier: name_id.expect("has_name guarantees name_id is set"),
             src: dst.operand(),
-            cache: EnvironmentCoordinate::empty(),
         });
 
         generator.end_variable_scope();
@@ -1002,15 +1000,13 @@ pub fn generate_statement(
                     let arena = generator.arena.clone();
                     let id = generator.intern_identifier_id(arena.identifiers[name_ident].name);
                     let value = generator.allocate_register();
-                    generator.emit(Instruction::GetBinding {
+                    generator.emit(Instruction::DynamicGetBinding {
                         dst: value.operand(),
                         identifier: id,
-                        cache: EnvironmentCoordinate::empty(),
                     });
-                    generator.emit(Instruction::SetVariableBinding {
+                    generator.emit(Instruction::DynamicSetVariableBinding {
                         identifier: id,
                         src: value.operand(),
-                        cache: EnvironmentCoordinate::empty(),
                     });
                 }
             }
@@ -1074,10 +1070,9 @@ pub fn generate_statement(
                     generator.emit_mov(&local, &value);
                 } else {
                     let id = generator.intern_identifier_id(name_ident.name);
-                    generator.emit(Instruction::InitializeLexicalBinding {
+                    generator.emit(Instruction::DynamicInitializeLexicalBinding {
                         identifier: id,
                         src: value.operand(),
-                        cache: EnvironmentCoordinate::empty(),
                     });
                 }
             }
@@ -1108,10 +1103,9 @@ pub fn generate_statement(
                         generator.pending_lhs_name = None;
                         if let Some(value) = value {
                             let local_name = generator.intern_identifier(utf16!("*default*"));
-                            generator.emit(Instruction::InitializeLexicalBinding {
+                            generator.emit(Instruction::DynamicInitializeLexicalBinding {
                                 identifier: local_name,
                                 src: value.operand(),
-                                cache: EnvironmentCoordinate::empty(),
                             });
                             Some(value)
                         } else {
@@ -1793,17 +1787,15 @@ fn generate_identifier(
         });
     } else if ident.declaration_kind == Some(DeclarationKind::Var) {
         let id = generator.intern_identifier_id(ident.name);
-        generator.emit(Instruction::GetInitializedBinding {
+        generator.emit(Instruction::DynamicGetInitializedBinding {
             dst: dst.operand(),
             identifier: id,
-            cache: EnvironmentCoordinate::empty(),
         });
     } else {
         let id = generator.intern_identifier_id(ident.name);
-        generator.emit(Instruction::GetBinding {
+        generator.emit(Instruction::DynamicGetBinding {
             dst: dst.operand(),
             identifier: id,
-            cache: EnvironmentCoordinate::empty(),
         });
     }
     dst
@@ -2490,10 +2482,9 @@ fn emit_per_iteration_bindings(generator: &mut Generator, bindings: &[Utf16Strin
     for name in bindings {
         let id = generator.intern_identifier(name);
         let reg = generator.allocate_register();
-        generator.emit(Instruction::GetBinding {
+        generator.emit(Instruction::DynamicGetBinding {
             dst: reg.operand(),
             identifier: id,
-            cache: EnvironmentCoordinate::empty(),
         });
         saved.push((reg, id));
     }
@@ -2519,10 +2510,9 @@ fn emit_per_iteration_bindings(generator: &mut Generator, bindings: &[Utf16Strin
             is_global: false,
             is_strict: false,
         });
-        generator.emit(Instruction::InitializeLexicalBinding {
+        generator.emit(Instruction::DynamicInitializeLexicalBinding {
             identifier: *id,
             src: reg.operand(),
-            cache: EnvironmentCoordinate::empty(),
         });
     }
 }
@@ -2682,10 +2672,9 @@ fn emit_lexical_declarations_for_block<'a>(
                     generator.mark_local_initialized(local_index);
                 } else {
                     let id = generator.intern_identifier_id(name_ident.name);
-                    generator.emit(Instruction::InitializeLexicalBinding {
+                    generator.emit(Instruction::DynamicInitializeLexicalBinding {
                         identifier: id,
                         src: fo.operand(),
-                        cache: EnvironmentCoordinate::empty(),
                     });
                 }
             }
@@ -2777,18 +2766,16 @@ fn generate_variable_declaration(
                                     cache,
                                 });
                             } else {
-                                generator.emit(Instruction::SetLexicalBinding {
+                                generator.emit(Instruction::DynamicSetLexicalBinding {
                                     identifier: id,
                                     src: value.operand(),
-                                    cache: EnvironmentCoordinate::empty(),
                                 });
                             }
                         }
                         DeclarationKind::Let | DeclarationKind::Const => {
-                            generator.emit(Instruction::InitializeLexicalBinding {
+                            generator.emit(Instruction::DynamicInitializeLexicalBinding {
                                 identifier: id,
                                 src: value.operand(),
-                                cache: EnvironmentCoordinate::empty(),
                             });
                         }
                     }
@@ -3130,11 +3117,10 @@ fn generate_call_expression(
                 let callee_reg = generator.allocate_register();
                 let this_reg = generator.allocate_register();
                 let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
-                generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
+                generator.emit(Instruction::DynamicGetCalleeAndThisFromEnvironment {
                     callee: callee_reg.operand(),
                     this_value: this_reg.operand(),
                     identifier: id,
-                    cache: EnvironmentCoordinate::empty(),
                 });
                 (callee_reg, Some(this_reg))
             }
@@ -4244,10 +4230,9 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
         // Non-local, non-global: use SetLexicalBinding which searches
         // the lexical environment chain (important for with-statement support).
         let id = generator.intern_identifier_id(ident.name);
-        generator.emit(Instruction::SetLexicalBinding {
+        generator.emit(Instruction::DynamicSetLexicalBinding {
             identifier: id,
             src: value.operand(),
-            cache: EnvironmentCoordinate::empty(),
         });
     }
 }
@@ -4813,11 +4798,10 @@ fn generate_tagged_template_literal(
             let this_reg = generator.allocate_register();
             let arena = generator.arena.clone();
             let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
-            generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
+            generator.emit(Instruction::DynamicGetCalleeAndThisFromEnvironment {
                 callee: callee_reg.operand(),
                 this_value: this_reg.operand(),
                 identifier: id,
-                cache: EnvironmentCoordinate::empty(),
             });
             (callee_reg, Some(this_reg))
         }
@@ -4983,15 +4967,13 @@ fn generate_switch_statement(
                 let arena = generator.arena.clone();
                 let id = generator.intern_identifier_id(arena.identifiers[name_ident_id].name);
                 let value = generator.allocate_register();
-                generator.emit(Instruction::GetBinding {
+                generator.emit(Instruction::DynamicGetBinding {
                     dst: value.operand(),
                     identifier: id,
-                    cache: EnvironmentCoordinate::empty(),
                 });
-                generator.emit(Instruction::SetVariableBinding {
+                generator.emit(Instruction::DynamicSetVariableBinding {
                     identifier: id,
                     src: value.operand(),
-                    cache: EnvironmentCoordinate::empty(),
                 });
             }
             let result = generate_statement(child, generator, None);
@@ -6963,10 +6945,9 @@ fn emit_set_variable_with_mode(
         let id = generator.intern_identifier_id(ident.name);
         match mode {
             BindingMode::InitializeLexical => {
-                generator.emit(Instruction::InitializeLexicalBinding {
+                generator.emit(Instruction::DynamicInitializeLexicalBinding {
                     identifier: id,
                     src: value.operand(),
-                    cache: EnvironmentCoordinate::empty(),
                 });
             }
             BindingMode::Set => {
@@ -6978,10 +6959,9 @@ fn emit_set_variable_with_mode(
                         cache,
                     });
                 } else {
-                    generator.emit(Instruction::SetLexicalBinding {
+                    generator.emit(Instruction::DynamicSetLexicalBinding {
                         identifier: id,
                         src: value.operand(),
-                        cache: EnvironmentCoordinate::empty(),
                     });
                 }
             }
@@ -7384,10 +7364,9 @@ fn generate_try_statement(
                             is_global: false,
                             is_strict: false,
                         });
-                        generator.emit(Instruction::InitializeLexicalBinding {
+                        generator.emit(Instruction::DynamicInitializeLexicalBinding {
                             identifier: id,
                             src: caught_value.operand(),
-                            cache: EnvironmentCoordinate::empty(),
                         });
                     }
                 }
@@ -7809,10 +7788,9 @@ pub fn emit_function_declaration_instantiation(
             });
             if has_duplicates {
                 let undef = generator.add_constant_undefined();
-                generator.emit(Instruction::InitializeLexicalBinding {
+                generator.emit(Instruction::DynamicInitializeLexicalBinding {
                     identifier: id,
                     src: undef.operand(),
-                    cache: EnvironmentCoordinate::empty(),
                 });
             }
         }
@@ -7904,16 +7882,14 @@ pub fn emit_function_declaration_instantiation(
                 } else {
                     let id = generator.intern_identifier_id(ident.name);
                     if has_duplicates {
-                        generator.emit(Instruction::SetLexicalBinding {
+                        generator.emit(Instruction::DynamicSetLexicalBinding {
                             identifier: id,
                             src: Operand::argument(parameter_index),
-                            cache: EnvironmentCoordinate::empty(),
                         });
                     } else {
-                        generator.emit(Instruction::InitializeLexicalBinding {
+                        generator.emit(Instruction::DynamicInitializeLexicalBinding {
                             identifier: id,
                             src: Operand::argument(parameter_index),
-                            cache: EnvironmentCoordinate::empty(),
                         });
                     }
                 }
@@ -7957,10 +7933,9 @@ pub fn emit_function_declaration_instantiation(
                         is_global: false,
                         is_strict: false,
                     });
-                    generator.emit(Instruction::InitializeVariableBinding {
+                    generator.emit(Instruction::DynamicInitializeVariableBinding {
                         identifier: id,
                         src: undef.operand(),
-                        cache: EnvironmentCoordinate::empty(),
                     });
                 }
             }
@@ -7999,10 +7974,9 @@ pub fn emit_function_declaration_instantiation(
                 } else {
                     let id = generator.intern_identifier(&var.name);
                     let value = generator.allocate_register();
-                    generator.emit(Instruction::GetBinding {
+                    generator.emit(Instruction::DynamicGetBinding {
                         dst: value.operand(),
                         identifier: id,
-                        cache: EnvironmentCoordinate::empty(),
                     });
                     value
                 };
@@ -8019,10 +7993,9 @@ pub fn emit_function_declaration_instantiation(
                         is_global: false,
                         is_strict: false,
                     });
-                    generator.emit(Instruction::InitializeVariableBinding {
+                    generator.emit(Instruction::DynamicInitializeVariableBinding {
                         identifier: id,
                         src: initial_value.operand(),
-                        cache: EnvironmentCoordinate::empty(),
                     });
                 }
             }
@@ -8047,10 +8020,9 @@ pub fn emit_function_declaration_instantiation(
                 is_strict: false,
             });
             let undef = generator.add_constant_undefined();
-            generator.emit(Instruction::InitializeVariableBinding {
+            generator.emit(Instruction::DynamicInitializeVariableBinding {
                 identifier: id,
                 src: undef.operand(),
-                cache: EnvironmentCoordinate::empty(),
             });
         }
     }
@@ -8140,10 +8112,9 @@ pub fn emit_function_declaration_instantiation(
                             lhs_name: None,
                         });
                         let id = generator.intern_identifier_id(name_ident.name);
-                        generator.emit(Instruction::SetVariableBinding {
+                        generator.emit(Instruction::DynamicSetVariableBinding {
                             identifier: id,
                             src: function_reg.operand(),
-                            cache: EnvironmentCoordinate::empty(),
                         });
                     }
                 }

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -73,6 +73,93 @@ pub fn generate_expression(
     result
 }
 
+fn emit_get_binding(
+    generator: &mut Generator,
+    dst: Operand,
+    identifier: IdentifierTableIndex,
+    known_initialized: bool,
+) {
+    // Prefer an eagerly-computed coordinate when the generator can prove that
+    // the binding lives in a known declarative environment. The dynamic forms
+    // remain necessary for outer functions, eval-poisoned scopes, and `with`.
+    match (
+        generator.environment_coordinate_for_identifier(identifier),
+        known_initialized,
+    ) {
+        (Some(cache), true) => generator.emit(Instruction::GetInitializedBinding { dst, identifier, cache }),
+        (Some(cache), false) => generator.emit(Instruction::GetBinding { dst, identifier, cache }),
+        (None, true) => generator.emit(Instruction::DynamicGetInitializedBinding { dst, identifier }),
+        (None, false) => generator.emit(Instruction::DynamicGetBinding { dst, identifier }),
+    }
+}
+
+fn emit_get_callee_and_this_from_environment(
+    generator: &mut Generator,
+    callee: Operand,
+    this_value: Operand,
+    identifier: IdentifierTableIndex,
+) {
+    if let Some(cache) = generator.environment_coordinate_for_identifier(identifier) {
+        generator.emit(Instruction::GetCalleeAndThisFromEnvironment {
+            callee,
+            this_value,
+            identifier,
+            cache,
+        });
+    } else {
+        generator.emit(Instruction::DynamicGetCalleeAndThisFromEnvironment {
+            callee,
+            this_value,
+            identifier,
+        });
+    }
+}
+
+fn emit_initialize_lexical_binding(generator: &mut Generator, identifier: IdentifierTableIndex, src: Operand) {
+    if let Some(cache) = generator.environment_coordinate_for_identifier(identifier) {
+        generator.emit(Instruction::InitializeLexicalBinding { identifier, src, cache });
+    } else {
+        generator.emit(Instruction::DynamicInitializeLexicalBinding { identifier, src });
+    }
+}
+
+fn emit_initialize_variable_binding(generator: &mut Generator, identifier: IdentifierTableIndex, src: Operand) {
+    // Var bindings are resolved from vm.variable_environment(), not from the
+    // current lexical environment. Use the generator's variable-environment
+    // anchor so nested lexical scopes do not affect the coordinate hops.
+    if let Some(cache) = generator.variable_environment_coordinate_for_identifier(identifier) {
+        generator.emit(Instruction::InitializeVariableBinding { identifier, src, cache });
+    } else {
+        generator.emit(Instruction::DynamicInitializeVariableBinding { identifier, src });
+    }
+}
+
+fn emit_set_lexical_binding(generator: &mut Generator, identifier: IdentifierTableIndex, src: Operand) {
+    if let Some(cache) = generator.environment_coordinate_for_identifier(identifier) {
+        generator.emit(Instruction::SetLexicalBinding { identifier, src, cache });
+    } else {
+        generator.emit(Instruction::DynamicSetLexicalBinding { identifier, src });
+    }
+}
+
+fn emit_set_variable_binding(generator: &mut Generator, identifier: IdentifierTableIndex, src: Operand) {
+    // See emit_initialize_variable_binding for why var coordinates use a
+    // different lookup anchor than ordinary lexical operations.
+    if let Some(cache) = generator.variable_environment_coordinate_for_identifier(identifier) {
+        generator.emit(Instruction::SetVariableBinding { identifier, src, cache });
+    } else {
+        generator.emit(Instruction::DynamicSetVariableBinding { identifier, src });
+    }
+}
+
+fn emit_typeof_binding(generator: &mut Generator, dst: Operand, identifier: IdentifierTableIndex) {
+    if let Some(cache) = generator.environment_coordinate_for_identifier(identifier) {
+        generator.emit(Instruction::TypeofBinding { dst, identifier, cache });
+    } else {
+        generator.emit(Instruction::DynamicTypeofBinding { dst, identifier });
+    }
+}
+
 fn generate_expression_inner(
     expression: &Expression,
     generator: &mut Generator,
@@ -330,10 +417,7 @@ fn generate_unary_expression(
         {
             let dst = choose_dst(generator, preferred_dst);
             let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
-            generator.emit(Instruction::DynamicTypeofBinding {
-                dst: dst.operand(),
-                identifier: id,
-            });
+            emit_typeof_binding(generator, dst.operand(), id);
             return Some(dst);
         }
         let dst = choose_dst(generator, preferred_dst);
@@ -537,7 +621,7 @@ fn generate_function_expression(
             capacity: 0,
             is_catch_environment: false,
         });
-        generator.lexical_environment_register_stack.push(new_env);
+        generator.push_static_lexical_environment(new_env);
 
         let name_id = data.name.expect("function declaration must have a name");
         let arena = generator.arena.clone();
@@ -581,10 +665,11 @@ fn generate_function_expression(
     });
 
     if has_name {
-        generator.emit(Instruction::DynamicInitializeLexicalBinding {
-            identifier: name_id.expect("has_name guarantees name_id is set"),
-            src: dst.operand(),
-        });
+        emit_initialize_lexical_binding(
+            generator,
+            name_id.expect("has_name guarantees name_id is set"),
+            dst.operand(),
+        );
 
         generator.end_variable_scope();
     }
@@ -1000,14 +1085,8 @@ pub fn generate_statement(
                     let arena = generator.arena.clone();
                     let id = generator.intern_identifier_id(arena.identifiers[name_ident].name);
                     let value = generator.allocate_register();
-                    generator.emit(Instruction::DynamicGetBinding {
-                        dst: value.operand(),
-                        identifier: id,
-                    });
-                    generator.emit(Instruction::DynamicSetVariableBinding {
-                        identifier: id,
-                        src: value.operand(),
-                    });
+                    emit_get_binding(generator, value.operand(), id, false);
+                    emit_set_variable_binding(generator, id, value.operand());
                 }
             }
             None
@@ -1021,7 +1100,7 @@ pub fn generate_statement(
                 dst: object_environment.operand(),
                 object: obj.operand(),
             });
-            generator.lexical_environment_register_stack.push(object_environment);
+            generator.push_dynamic_lexical_environment(object_environment);
             generator.start_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
 
             let result = generate_statement(&data.body, generator, preferred_dst);
@@ -1070,10 +1149,7 @@ pub fn generate_statement(
                     generator.emit_mov(&local, &value);
                 } else {
                     let id = generator.intern_identifier_id(name_ident.name);
-                    generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                        identifier: id,
-                        src: value.operand(),
-                    });
+                    emit_initialize_lexical_binding(generator, id, value.operand());
                 }
             }
             None
@@ -1103,10 +1179,7 @@ pub fn generate_statement(
                         generator.pending_lhs_name = None;
                         if let Some(value) = value {
                             let local_name = generator.intern_identifier(utf16!("*default*"));
-                            generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                                identifier: local_name,
-                                src: value.operand(),
-                            });
+                            emit_initialize_lexical_binding(generator, local_name, value.operand());
                             Some(value)
                         } else {
                             None
@@ -1787,16 +1860,10 @@ fn generate_identifier(
         });
     } else if ident.declaration_kind == Some(DeclarationKind::Var) {
         let id = generator.intern_identifier_id(ident.name);
-        generator.emit(Instruction::DynamicGetInitializedBinding {
-            dst: dst.operand(),
-            identifier: id,
-        });
+        emit_get_binding(generator, dst.operand(), id, true);
     } else {
         let id = generator.intern_identifier_id(ident.name);
-        generator.emit(Instruction::DynamicGetBinding {
-            dst: dst.operand(),
-            identifier: id,
-        });
+        emit_get_binding(generator, dst.operand(), id, false);
     }
     dst
 }
@@ -2410,7 +2477,7 @@ fn generate_for_statement(
             generator.switch_to_basic_block(end_block);
             if has_lexical_environment {
                 generator.end_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
-                generator.lexical_environment_register_stack.pop();
+                generator.pop_tracked_lexical_environment();
                 if !generator.is_current_block_terminated() {
                     let parent = generator.current_lexical_environment();
                     generator.emit(Instruction::SetLexicalEnvironment {
@@ -2457,7 +2524,7 @@ fn generate_for_statement(
     // end_variable_scope: restore parent environment
     if has_lexical_environment {
         generator.end_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
-        generator.lexical_environment_register_stack.pop();
+        generator.pop_tracked_lexical_environment();
         if !generator.is_current_block_terminated() {
             let parent = generator.current_lexical_environment();
             generator.emit(Instruction::SetLexicalEnvironment {
@@ -2482,16 +2549,13 @@ fn emit_per_iteration_bindings(generator: &mut Generator, bindings: &[Utf16Strin
     for name in bindings {
         let id = generator.intern_identifier(name);
         let reg = generator.allocate_register();
-        generator.emit(Instruction::DynamicGetBinding {
-            dst: reg.operand(),
-            identifier: id,
-        });
+        emit_get_binding(generator, reg.operand(), id, false);
         saved.push((reg, id));
     }
 
     // Pop current environment (end_variable_scope).
     generator.end_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
-    generator.lexical_environment_register_stack.pop();
+    generator.pop_tracked_lexical_environment();
     let parent = generator.current_lexical_environment();
     generator.emit(Instruction::SetLexicalEnvironment {
         environment: parent.operand(),
@@ -2510,10 +2574,7 @@ fn emit_per_iteration_bindings(generator: &mut Generator, bindings: &[Utf16Strin
             is_global: false,
             is_strict: false,
         });
-        generator.emit(Instruction::DynamicInitializeLexicalBinding {
-            identifier: *id,
-            src: reg.operand(),
-        });
+        emit_initialize_lexical_binding(generator, *id, reg.operand());
     }
 }
 
@@ -2672,10 +2733,7 @@ fn emit_lexical_declarations_for_block<'a>(
                     generator.mark_local_initialized(local_index);
                 } else {
                     let id = generator.intern_identifier_id(name_ident.name);
-                    generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                        identifier: id,
-                        src: fo.operand(),
-                    });
+                    emit_initialize_lexical_binding(generator, id, fo.operand());
                 }
             }
             _ => {}
@@ -2766,17 +2824,11 @@ fn generate_variable_declaration(
                                     cache,
                                 });
                             } else {
-                                generator.emit(Instruction::DynamicSetLexicalBinding {
-                                    identifier: id,
-                                    src: value.operand(),
-                                });
+                                emit_set_lexical_binding(generator, id, value.operand());
                             }
                         }
                         DeclarationKind::Let | DeclarationKind::Const => {
-                            generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                                identifier: id,
-                                src: value.operand(),
-                            });
+                            emit_initialize_lexical_binding(generator, id, value.operand());
                         }
                     }
                 }
@@ -3117,11 +3169,7 @@ fn generate_call_expression(
                 let callee_reg = generator.allocate_register();
                 let this_reg = generator.allocate_register();
                 let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
-                generator.emit(Instruction::DynamicGetCalleeAndThisFromEnvironment {
-                    callee: callee_reg.operand(),
-                    this_value: this_reg.operand(),
-                    identifier: id,
-                });
+                emit_get_callee_and_this_from_environment(generator, callee_reg.operand(), this_reg.operand(), id);
                 (callee_reg, Some(this_reg))
             }
             ExpressionKind::OptionalChain(oc_data) => {
@@ -4230,10 +4278,7 @@ fn emit_set_variable(generator: &mut Generator, id: crate::ast::IdentifierId, va
         // Non-local, non-global: use SetLexicalBinding which searches
         // the lexical environment chain (important for with-statement support).
         let id = generator.intern_identifier_id(ident.name);
-        generator.emit(Instruction::DynamicSetLexicalBinding {
-            identifier: id,
-            src: value.operand(),
-        });
+        emit_set_lexical_binding(generator, id, value.operand());
     }
 }
 
@@ -4798,11 +4843,7 @@ fn generate_tagged_template_literal(
             let this_reg = generator.allocate_register();
             let arena = generator.arena.clone();
             let id = generator.intern_identifier_id(arena.identifiers[*ident].name);
-            generator.emit(Instruction::DynamicGetCalleeAndThisFromEnvironment {
-                callee: callee_reg.operand(),
-                this_value: this_reg.operand(),
-                identifier: id,
-            });
+            emit_get_callee_and_this_from_environment(generator, callee_reg.operand(), this_reg.operand(), id);
             (callee_reg, Some(this_reg))
         }
         _ => {
@@ -4967,14 +5008,8 @@ fn generate_switch_statement(
                 let arena = generator.arena.clone();
                 let id = generator.intern_identifier_id(arena.identifiers[name_ident_id].name);
                 let value = generator.allocate_register();
-                generator.emit(Instruction::DynamicGetBinding {
-                    dst: value.operand(),
-                    identifier: id,
-                });
-                generator.emit(Instruction::DynamicSetVariableBinding {
-                    identifier: id,
-                    src: value.operand(),
-                });
+                emit_get_binding(generator, value.operand(), id, false);
+                emit_set_variable_binding(generator, id, value.operand());
             }
             let result = generate_statement(child, generator, None);
             if generator.is_current_block_terminated() {
@@ -5004,7 +5039,7 @@ fn generate_switch_statement(
 
     if did_create_env {
         generator.end_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
-        generator.lexical_environment_register_stack.pop();
+        generator.pop_tracked_lexical_environment();
         if !generator.is_current_block_terminated() {
             let parent = generator.current_lexical_environment();
             generator.emit(Instruction::SetLexicalEnvironment {
@@ -5640,7 +5675,7 @@ fn generate_class_expression(
         capacity: 0,
         is_catch_environment: false,
     });
-    generator.lexical_environment_register_stack.push(class_env.clone());
+    generator.push_static_lexical_environment(class_env.clone());
 
     // Step 3.a: Create binding for the class name in the class environment.
     // Only emit when the class has a name, or when there's no lhs_name
@@ -5970,7 +6005,7 @@ fn generate_class_expression(
     generator.emit(Instruction::SetLexicalEnvironment {
         environment: parent_env.operand(),
     });
-    generator.lexical_environment_register_stack.pop();
+    generator.pop_tracked_lexical_environment();
 
     // Allocate dst after element keys.
     let dst = choose_dst(generator, preferred_dst);
@@ -6204,7 +6239,7 @@ fn enter_for_in_of_head_tdz(generator: &mut Generator, lhs: &ForInOfLhs) -> bool
 
 /// Tear down the TDZ environment after RHS evaluation.
 fn leave_for_in_of_head_tdz(generator: &mut Generator) {
-    generator.lexical_environment_register_stack.pop();
+    generator.pop_tracked_lexical_environment();
     if !generator.is_current_block_terminated() {
         let parent = generator.current_lexical_environment();
         generator.emit(Instruction::SetLexicalEnvironment {
@@ -6577,7 +6612,7 @@ fn generate_for_of_statement_inner(
     // Restore lexical env before continuing
     if needs_lexical_env {
         generator.end_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
-        generator.lexical_environment_register_stack.pop();
+        generator.pop_tracked_lexical_environment();
     }
     generator.end_continuable_scope();
 
@@ -6945,10 +6980,7 @@ fn emit_set_variable_with_mode(
         let id = generator.intern_identifier_id(ident.name);
         match mode {
             BindingMode::InitializeLexical => {
-                generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                    identifier: id,
-                    src: value.operand(),
-                });
+                emit_initialize_lexical_binding(generator, id, value.operand());
             }
             BindingMode::Set => {
                 if ident.is_global {
@@ -6959,10 +6991,7 @@ fn emit_set_variable_with_mode(
                         cache,
                     });
                 } else {
-                    generator.emit(Instruction::DynamicSetLexicalBinding {
-                        identifier: id,
-                        src: value.operand(),
-                    });
+                    emit_set_lexical_binding(generator, id, value.operand());
                 }
             }
         }
@@ -7364,10 +7393,7 @@ fn generate_try_statement(
                             is_global: false,
                             is_strict: false,
                         });
-                        generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                            identifier: id,
-                            src: caught_value.operand(),
-                        });
+                        emit_initialize_lexical_binding(generator, id, caught_value.operand());
                     }
                 }
                 CatchBinding::BindingPattern(pattern) => {
@@ -7788,10 +7814,7 @@ pub fn emit_function_declaration_instantiation(
             });
             if has_duplicates {
                 let undef = generator.add_constant_undefined();
-                generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                    identifier: id,
-                    src: undef.operand(),
-                });
+                emit_initialize_lexical_binding(generator, id, undef.operand());
             }
         }
     }
@@ -7882,15 +7905,9 @@ pub fn emit_function_declaration_instantiation(
                 } else {
                     let id = generator.intern_identifier_id(ident.name);
                     if has_duplicates {
-                        generator.emit(Instruction::DynamicSetLexicalBinding {
-                            identifier: id,
-                            src: Operand::argument(parameter_index),
-                        });
+                        emit_set_lexical_binding(generator, id, Operand::argument(parameter_index));
                     } else {
-                        generator.emit(Instruction::DynamicInitializeLexicalBinding {
-                            identifier: id,
-                            src: Operand::argument(parameter_index),
-                        });
+                        emit_initialize_lexical_binding(generator, id, Operand::argument(parameter_index));
                     }
                 }
             }
@@ -7933,10 +7950,7 @@ pub fn emit_function_declaration_instantiation(
                         is_global: false,
                         is_strict: false,
                     });
-                    generator.emit(Instruction::DynamicInitializeVariableBinding {
-                        identifier: id,
-                        src: undef.operand(),
-                    });
+                    emit_initialize_variable_binding(generator, id, undef.operand());
                 }
             }
         } else {
@@ -7954,7 +7968,7 @@ pub fn emit_function_declaration_instantiation(
                 // parameter scope.
                 let var_env = generator.allocate_register();
                 generator.emit(Instruction::GetLexicalEnvironment { dst: var_env.operand() });
-                generator.lexical_environment_register_stack.push(var_env);
+                generator.push_static_variable_environment(var_env);
             }
 
             for var in &fsd.vars_to_initialize {
@@ -7974,10 +7988,7 @@ pub fn emit_function_declaration_instantiation(
                 } else {
                     let id = generator.intern_identifier(&var.name);
                     let value = generator.allocate_register();
-                    generator.emit(Instruction::DynamicGetBinding {
-                        dst: value.operand(),
-                        identifier: id,
-                    });
+                    emit_get_binding(generator, value.operand(), id, false);
                     value
                 };
 
@@ -7993,10 +8004,7 @@ pub fn emit_function_declaration_instantiation(
                         is_global: false,
                         is_strict: false,
                     });
-                    generator.emit(Instruction::DynamicInitializeVariableBinding {
-                        identifier: id,
-                        src: initial_value.operand(),
-                    });
+                    emit_initialize_variable_binding(generator, id, initial_value.operand());
                 }
             }
         }
@@ -8020,10 +8028,7 @@ pub fn emit_function_declaration_instantiation(
                 is_strict: false,
             });
             let undef = generator.add_constant_undefined();
-            generator.emit(Instruction::DynamicInitializeVariableBinding {
-                identifier: id,
-                src: undef.operand(),
-            });
+            emit_initialize_variable_binding(generator, id, undef.operand());
         }
     }
 
@@ -8112,10 +8117,7 @@ pub fn emit_function_declaration_instantiation(
                             lhs_name: None,
                         });
                         let id = generator.intern_identifier_id(name_ident.name);
-                        generator.emit(Instruction::DynamicSetVariableBinding {
-                            identifier: id,
-                            src: function_reg.operand(),
-                        });
+                        emit_set_variable_binding(generator, id, function_reg.operand());
                     }
                 }
             }

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -191,6 +191,7 @@ pub struct FFISharedFunctionData {
 pub struct FFIExecutableData {
     pub bytecode: *const u8,
     pub bytecode_length: usize,
+    pub bytecode_owner: *mut c_void,
     pub identifier_table: *const FFIUtf16Slice,
     pub identifier_count: usize,
     pub property_key_table: *const FFIUtf16Slice,
@@ -663,6 +664,7 @@ pub unsafe fn create_executable_with_dependencies(
     unsafe {
         let parts = ExecutableParts {
             bytecode: &assembled.bytecode,
+            bytecode_owner: std::ptr::null_mut(),
             exception_handlers: &assembled.exception_handlers,
             source_map: &assembled.source_map,
             basic_block_start_offsets: &assembled.basic_block_start_offsets,
@@ -675,6 +677,7 @@ pub unsafe fn create_executable_with_dependencies(
 
 pub struct ExecutableParts<'a> {
     pub bytecode: &'a [u8],
+    pub bytecode_owner: *mut c_void,
     pub exception_handlers: &'a [ExceptionHandler],
     pub source_map: &'a [SourceMapEntry],
     pub basic_block_start_offsets: &'a [usize],
@@ -754,6 +757,7 @@ pub unsafe fn create_executable_with_dependencies_from_parts(
         let ffi_data = FFIExecutableData {
             bytecode: parts.bytecode.as_ptr(),
             bytecode_length: parts.bytecode.len(),
+            bytecode_owner: parts.bytecode_owner,
             identifier_table: ident_slices.as_ptr(),
             identifier_count: ident_slices.len(),
             property_key_table: property_key_slices.as_ptr(),

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -253,6 +253,7 @@ unsafe extern "C" {
         this_value_needs_environment_resolution: bool,
         function_environment_needed: bool,
         function_environment_bindings_count: usize,
+        var_environment_bindings_count: usize,
         might_need_arguments_object: bool,
         contains_direct_call_to_eval: bool,
     );
@@ -264,6 +265,7 @@ unsafe extern "C" {
         this_value_needs_environment_resolution: bool,
         function_environment_needed: bool,
         function_environment_bindings_count: usize,
+        var_environment_bindings_count: usize,
         might_need_arguments_object: bool,
         contains_direct_call_to_eval: bool,
     );
@@ -275,6 +277,7 @@ unsafe extern "C" {
         this_value_needs_environment_resolution: bool,
         function_environment_needed: bool,
         function_environment_bindings_count: usize,
+        var_environment_bindings_count: usize,
         might_need_arguments_object: bool,
         contains_direct_call_to_eval: bool,
     );
@@ -474,6 +477,7 @@ unsafe fn materialize_shared_function_data(
                     precompiled.metadata.this_value_needs_environment_resolution;
                 let function_environment_needed = precompiled.metadata.function_environment_needed;
                 let function_environment_bindings_count = precompiled.metadata.function_environment_bindings_count;
+                let var_environment_bindings_count = precompiled.metadata.var_environment_bindings_count;
                 let might_need_arguments = precompiled.metadata.might_need_arguments;
                 let contains_eval = precompiled.metadata.contains_eval;
                 let precompiled_ptr = Box::into_raw(precompiled) as *mut c_void;
@@ -484,6 +488,7 @@ unsafe fn materialize_shared_function_data(
                     this_value_needs_environment_resolution,
                     function_environment_needed,
                     function_environment_bindings_count,
+                    var_environment_bindings_count,
                     might_need_arguments,
                     contains_eval,
                 );

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -97,6 +97,23 @@ pub struct PendingClassBlueprint {
     pub elements: Vec<PendingClassElement>,
 }
 
+struct EnvironmentCoordinateScope {
+    bindings: HashMap<Utf16String, u32>,
+    next_binding_index: u32,
+    kind: EnvironmentCoordinateScopeKind,
+}
+
+#[derive(PartialEq)]
+enum EnvironmentCoordinateScopeKind {
+    // A declarative environment whose bindings are created by bytecode we emit.
+    // The binding indexes are therefore known while generating the instruction
+    // stream and can be embedded in EnvironmentCoordinate operands.
+    Static,
+    // An object environment, such as `with`, can intercept any name. Once one
+    // is between the current point and a binding, resolution must stay dynamic.
+    Dynamic,
+}
+
 impl std::fmt::Debug for ScopedOperandInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ScopedOperandInner({:?})", self.operand)
@@ -221,6 +238,14 @@ pub struct Generator {
     pub breakable_scopes: Vec<LabelableScope>,
     pub pending_labels: Vec<Utf16String>,
     pub lexical_environment_register_stack: Vec<ScopedOperand>,
+    // Mirrors lexical_environment_register_stack for environments whose binding
+    // layout is known to codegen. This lets us emit immutable coordinates
+    // instead of runtime-updated caches in common lexical lookup instructions.
+    environment_coordinate_scope_stack: Vec<EnvironmentCoordinateScope>,
+    // `var` binding instructions start from vm.variable_environment(), not the
+    // current lexical environment. Keep a separate anchor so a var write inside
+    // a nested block does not accidentally count the block as a hop.
+    variable_environment_coordinate_scope_index: Option<usize>,
     pub home_objects: Vec<ScopedOperand>,
 
     // --- Finally context ---
@@ -390,6 +415,8 @@ impl Generator {
             breakable_scopes: Vec::new(),
             pending_labels: Vec::new(),
             lexical_environment_register_stack: Vec::new(),
+            environment_coordinate_scope_stack: Vec::new(),
+            variable_environment_coordinate_scope_index: None,
             home_objects: Vec::new(),
             finally_contexts: Vec::new(),
             current_finally_context: None,
@@ -783,6 +810,26 @@ impl Generator {
         if self.is_current_block_terminated() {
             return;
         }
+        // Keep coordinate scopes in lockstep with the actual declarative
+        // environment shape. Most bindings are created explicitly, while
+        // CreateArguments can implicitly create an `arguments` binding.
+        if let Instruction::CreateVariable {
+            identifier, is_global, ..
+        } = &instruction
+            && !is_global
+        {
+            let name = self.identifier_table[identifier.0 as usize].clone();
+            self.record_environment_binding(name);
+        }
+        if let Instruction::CreateMutableBinding { identifier, .. }
+        | Instruction::CreateImmutableBinding { identifier, .. } = &instruction
+        {
+            let name = self.identifier_table[identifier.0 as usize].clone();
+            self.record_environment_binding(name);
+        }
+        if let Instruction::CreateArguments { dst: None, .. } = &instruction {
+            self.record_environment_binding(Utf16String::from(utf16!("arguments")));
+        }
         let source_map = SourceMapEntry {
             bytecode_offset: 0, // filled during flattening
             line: self.current_source_start.line,
@@ -928,12 +975,19 @@ impl Generator {
     pub fn capture_saved_lexical_environment(&mut self) {
         let env_reg = self.scoped_operand(Operand::register(Register::SAVED_LEXICAL_ENVIRONMENT));
         self.emit(Instruction::GetLexicalEnvironment { dst: env_reg.operand() });
-        self.lexical_environment_register_stack.push(env_reg);
+        self.push_untracked_lexical_environment(env_reg);
+    }
+
+    pub fn capture_saved_lexical_environment_with_coordinates(&mut self) {
+        let env_reg = self.scoped_operand(Operand::register(Register::SAVED_LEXICAL_ENVIRONMENT));
+        self.emit(Instruction::GetLexicalEnvironment { dst: env_reg.operand() });
+        self.push_static_lexical_environment(env_reg);
+        self.variable_environment_coordinate_scope_index = self.environment_coordinate_scope_stack.len().checked_sub(1);
     }
 
     pub fn end_variable_scope(&mut self) {
         self.end_boundary(BlockBoundaryType::LeaveLexicalEnvironment);
-        self.lexical_environment_register_stack.pop();
+        self.pop_tracked_lexical_environment();
         if !self.is_current_block_terminated() {
             let parent = self.current_lexical_environment();
             self.emit(Instruction::SetLexicalEnvironment {
@@ -970,8 +1024,114 @@ impl Generator {
             capacity,
             is_catch_environment,
         });
-        self.lexical_environment_register_stack.push(new_env.clone());
+        self.push_static_lexical_environment(new_env.clone());
         new_env
+    }
+
+    pub fn push_untracked_lexical_environment(&mut self, environment: ScopedOperand) {
+        self.lexical_environment_register_stack.push(environment);
+    }
+
+    pub fn push_static_lexical_environment(&mut self, environment: ScopedOperand) {
+        self.push_untracked_lexical_environment(environment);
+        self.push_environment_coordinate_scope(EnvironmentCoordinateScopeKind::Static);
+    }
+
+    pub fn push_dynamic_lexical_environment(&mut self, environment: ScopedOperand) {
+        self.push_untracked_lexical_environment(environment);
+        self.push_environment_coordinate_scope(EnvironmentCoordinateScopeKind::Dynamic);
+    }
+
+    pub fn push_static_variable_environment(&mut self, environment: ScopedOperand) {
+        self.push_static_lexical_environment(environment);
+        self.variable_environment_coordinate_scope_index = self.environment_coordinate_scope_stack.len().checked_sub(1);
+    }
+
+    pub fn pop_untracked_lexical_environment(&mut self) -> Option<ScopedOperand> {
+        self.lexical_environment_register_stack.pop()
+    }
+
+    pub fn pop_tracked_lexical_environment(&mut self) -> Option<ScopedOperand> {
+        self.pop_environment_coordinate_scope();
+        self.pop_untracked_lexical_environment()
+    }
+
+    fn push_environment_coordinate_scope(&mut self, kind: EnvironmentCoordinateScopeKind) {
+        self.environment_coordinate_scope_stack
+            .push(EnvironmentCoordinateScope {
+                bindings: HashMap::new(),
+                next_binding_index: 0,
+                kind,
+            });
+    }
+
+    fn pop_environment_coordinate_scope(&mut self) {
+        self.environment_coordinate_scope_stack.pop();
+    }
+
+    fn record_environment_binding(&mut self, name: Utf16String) {
+        let Some(scope) = self.environment_coordinate_scope_stack.last_mut() else {
+            return;
+        };
+        if scope.kind == EnvironmentCoordinateScopeKind::Dynamic {
+            return;
+        }
+        // Duplicate function declarations can try to create the same binding
+        // more than once. The runtime keeps a single binding, so the coordinate
+        // tracker must not advance its slot counter for duplicates.
+        if scope.bindings.contains_key(&name) {
+            return;
+        }
+        scope.bindings.insert(name, scope.next_binding_index);
+        scope.next_binding_index += 1;
+    }
+
+    pub fn environment_coordinate_for(&self, name: &[u16]) -> Option<EnvironmentCoordinate> {
+        self.environment_coordinate_for_from_scope_index(
+            name,
+            self.environment_coordinate_scope_stack.len().checked_sub(1)?,
+        )
+    }
+
+    fn environment_coordinate_for_from_scope_index(
+        &self,
+        name: &[u16],
+        scope_index: usize,
+    ) -> Option<EnvironmentCoordinate> {
+        // Coordinates are only safe through fully-known declarative scopes. If
+        // any dynamic scope is crossed, preserve the runtime lookup semantics.
+        for (hops, scope) in self.environment_coordinate_scope_stack[..=scope_index]
+            .iter()
+            .rev()
+            .enumerate()
+        {
+            if scope.kind == EnvironmentCoordinateScopeKind::Dynamic {
+                return None;
+            }
+            if let Some(index) = scope.bindings.get(name) {
+                return Some(EnvironmentCoordinate {
+                    hops: u32_from_usize(hops),
+                    index: *index,
+                });
+            }
+        }
+        None
+    }
+
+    pub fn environment_coordinate_for_identifier(
+        &self,
+        identifier: IdentifierTableIndex,
+    ) -> Option<EnvironmentCoordinate> {
+        let name = &self.identifier_table[identifier.0 as usize];
+        self.environment_coordinate_for(name)
+    }
+
+    pub fn variable_environment_coordinate_for_identifier(
+        &self,
+        identifier: IdentifierTableIndex,
+    ) -> Option<EnvironmentCoordinate> {
+        let name = &self.identifier_table[identifier.0 as usize];
+        self.environment_coordinate_for_from_scope_index(name, self.variable_environment_coordinate_scope_index?)
     }
 
     // --- Boundary management ---

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -1099,12 +1099,8 @@ impl Generator {
         if scope.kind == EnvironmentCoordinateScopeKind::Dynamic {
             return;
         }
-        // Duplicate function declarations can try to create the same binding
-        // more than once. The runtime keeps a single binding, so the coordinate
-        // tracker must not advance its slot counter for duplicates.
-        if scope.bindings.contains_key(&name) {
-            return;
-        }
+        // DeclarativeEnvironment appends duplicate bindings and resolves the
+        // name to the newest slot, so mirror that layout here.
         scope.bindings.insert(name, scope.next_binding_index);
         scope.next_binding_index += 1;
     }

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -114,6 +114,8 @@ enum EnvironmentCoordinateScopeKind {
     Dynamic,
 }
 
+const ENVIRONMENT_MODE_LEXICAL: u32 = 0;
+
 impl std::fmt::Debug for ScopedOperandInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ScopedOperandInner({:?})", self.operand)
@@ -814,12 +816,19 @@ impl Generator {
         // environment shape. Most bindings are created explicitly, while
         // CreateArguments can implicitly create an `arguments` binding.
         if let Instruction::CreateVariable {
-            identifier, is_global, ..
+            identifier,
+            mode,
+            is_global,
+            ..
         } = &instruction
             && !is_global
         {
             let name = self.identifier_table[identifier.0 as usize].clone();
-            self.record_environment_binding(name);
+            if *mode == ENVIRONMENT_MODE_LEXICAL {
+                self.record_environment_binding(name);
+            } else {
+                self.record_variable_environment_binding(name);
+            }
         }
         if let Instruction::CreateMutableBinding { identifier, .. }
         | Instruction::CreateImmutableBinding { identifier, .. } = &instruction
@@ -1070,7 +1079,21 @@ impl Generator {
     }
 
     fn record_environment_binding(&mut self, name: Utf16String) {
-        let Some(scope) = self.environment_coordinate_scope_stack.last_mut() else {
+        let Some(scope_index) = self.environment_coordinate_scope_stack.len().checked_sub(1) else {
+            return;
+        };
+        self.record_environment_binding_at_scope_index(name, scope_index);
+    }
+
+    fn record_variable_environment_binding(&mut self, name: Utf16String) {
+        let Some(scope_index) = self.variable_environment_coordinate_scope_index else {
+            return;
+        };
+        self.record_environment_binding_at_scope_index(name, scope_index);
+    }
+
+    fn record_environment_binding_at_scope_index(&mut self, name: Utf16String, scope_index: usize) {
+        let Some(scope) = self.environment_coordinate_scope_stack.get_mut(scope_index) else {
             return;
         };
         if scope.kind == EnvironmentCoordinateScopeKind::Dynamic {

--- a/Libraries/LibJS/Rust/src/bytecode/operand.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/operand.rs
@@ -152,7 +152,7 @@ pub struct PropertyKeyTableIndex(pub u32);
 #[derive(Debug, Clone, Copy)]
 pub struct RegexTableIndex(pub u32);
 
-/// Environment coordinate used as a mutable cache in some instructions.
+/// Environment coordinate used by environment lookup instructions.
 /// Layout: two `u32` fields (hops + index).
 #[derive(Debug, Clone, Copy)]
 pub struct EnvironmentCoordinate {

--- a/Libraries/LibJS/Rust/src/bytecode/validator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/validator.rs
@@ -24,10 +24,9 @@ use super::instruction::{NUM_OPCODES, instruction_length_from_bytes, validate_in
 /// `Bytecode/Operand.h` and the per-table index types.
 const INVALID_INDEX_U32: u32 = 0xFFFF_FFFF;
 
-/// Sentinel u64 written into cache fields by the bytecode encoder when no
-/// cache slot was reserved. The fixup pass replaces real indices with
-/// pointers, leaving the sentinel as `0`.
-const NO_CACHE_INDEX: u64 = u32::MAX as u64;
+/// Sentinel u32 written into cache fields by the bytecode encoder when no
+/// cache slot was reserved.
+const NO_CACHE_INDEX: u32 = u32::MAX;
 
 /// Bounds against which bytecode references are checked.
 #[repr(C)]
@@ -56,11 +55,6 @@ pub struct FFIValidatorBounds {
     pub environment_mode_variant_count: u32,
     pub put_kind_variant_count: u32,
     pub arguments_kind_variant_count: u32,
-    /// If true, m_cache fields hold indices that should be range-checked
-    /// against the corresponding cache_count. If false, the cache fixup
-    /// pass has already replaced them with real pointers and they are
-    /// skipped during validation.
-    pub before_cache_fixup: bool,
 }
 
 /// Categorization of validation failures, mirrored to C++ as an enum class.
@@ -242,44 +236,44 @@ pub fn validate_property_key_index(raw: u32, ctx: &ValidationContext) -> Result<
 }
 
 #[inline]
-pub fn validate_property_lookup_cache_index(raw: u64, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
-    if !ctx.bounds.before_cache_fixup || raw == NO_CACHE_INDEX {
+pub fn validate_property_lookup_cache_index(raw: u32, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
+    if raw == NO_CACHE_INDEX {
         return Ok(());
     }
-    if raw >= ctx.bounds.property_lookup_cache_count as u64 {
+    if raw >= ctx.bounds.property_lookup_cache_count {
         return Err(ValidationErrorKind::PropertyLookupCacheIndexOutOfRange);
     }
     Ok(())
 }
 
 #[inline]
-pub fn validate_global_variable_cache_index(raw: u64, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
-    if !ctx.bounds.before_cache_fixup || raw == NO_CACHE_INDEX {
+pub fn validate_global_variable_cache_index(raw: u32, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
+    if raw == NO_CACHE_INDEX {
         return Ok(());
     }
-    if raw >= ctx.bounds.global_variable_cache_count as u64 {
+    if raw >= ctx.bounds.global_variable_cache_count {
         return Err(ValidationErrorKind::GlobalVariableCacheIndexOutOfRange);
     }
     Ok(())
 }
 
 #[inline]
-pub fn validate_template_object_cache_index(raw: u64, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
-    if !ctx.bounds.before_cache_fixup || raw == NO_CACHE_INDEX {
+pub fn validate_template_object_cache_index(raw: u32, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
+    if raw == NO_CACHE_INDEX {
         return Ok(());
     }
-    if raw >= ctx.bounds.template_object_cache_count as u64 {
+    if raw >= ctx.bounds.template_object_cache_count {
         return Err(ValidationErrorKind::TemplateObjectCacheIndexOutOfRange);
     }
     Ok(())
 }
 
 #[inline]
-pub fn validate_object_shape_cache_index(raw: u64, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
-    if !ctx.bounds.before_cache_fixup || raw == NO_CACHE_INDEX {
+pub fn validate_object_shape_cache_index(raw: u32, ctx: &ValidationContext) -> Result<(), ValidationErrorKind> {
+    if raw == NO_CACHE_INDEX {
         return Ok(());
     }
-    if raw >= ctx.bounds.object_shape_cache_count as u64 {
+    if raw >= ctx.bounds.object_shape_cache_count {
         return Err(ValidationErrorKind::ObjectShapeCacheIndexOutOfRange);
     }
     Ok(())
@@ -287,13 +281,13 @@ pub fn validate_object_shape_cache_index(raw: u64, ctx: &ValidationContext) -> R
 
 #[inline]
 pub fn validate_object_property_iterator_cache_index(
-    raw: u64,
+    raw: u32,
     ctx: &ValidationContext,
 ) -> Result<(), ValidationErrorKind> {
-    if !ctx.bounds.before_cache_fixup || raw == NO_CACHE_INDEX {
+    if raw == NO_CACHE_INDEX {
         return Ok(());
     }
-    if raw >= ctx.bounds.object_property_iterator_cache_count as u64 {
+    if raw >= ctx.bounds.object_property_iterator_cache_count {
         return Err(ValidationErrorKind::ObjectPropertyIteratorCacheIndexOutOfRange);
     }
     Ok(())
@@ -511,7 +505,6 @@ mod tests {
             environment_mode_variant_count: 2,
             put_kind_variant_count: 5,
             arguments_kind_variant_count: 2,
-            before_cache_fixup: true,
         }
     }
 
@@ -672,20 +665,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_cache_index_out_of_range_before_fixup() {
-        // NewObject layout: header(2) + pad(2) + m_dst(4) + m_cache(8) -> 16 bytes.
+    fn rejects_cache_index_out_of_range() {
+        // NewObject layout: header(2) + pad(2) + m_dst(4) + m_cache(4) -> 16 bytes.
         let mut bytes = [0u8; 16];
         bytes[0] = OpCode::NewObject as u8;
         // m_dst at offset 4 stays 0 (register 0).
         // m_cache at offset 8: an index well past object_shape_cache_count.
-        bytes[8..16].copy_from_slice(&999_999_u64.to_ne_bytes());
+        put_u32(&mut bytes, 8, 999_999);
 
         let err = validate(&bytes, &permissive_bounds()).unwrap_err();
         assert_eq!(err.kind, ValidationErrorKind::ObjectShapeCacheIndexOutOfRange);
     }
 
     #[test]
-    fn rejects_object_literal_shape_cache_index_out_of_range_before_fixup() {
+    fn rejects_object_literal_shape_cache_index_out_of_range() {
         // InitObjectLiteralProperty layout: header(2) + pad(2) + m_object(4)
         // + m_property(4) + m_src(4) + m_shape_cache_index(4)
         // + m_property_slot(4) = 24 bytes.
@@ -710,18 +703,5 @@ mod tests {
         put_u32(&mut bytes, 8, 99);
         let err = validate(&bytes, &permissive_bounds()).unwrap_err();
         assert_eq!(err.kind, ValidationErrorKind::EnumOutOfRange);
-    }
-
-    #[test]
-    fn skips_cache_fields_after_fixup() {
-        let mut bytes = [0u8; 16];
-        bytes[0] = OpCode::NewObject as u8;
-        // Same out-of-range garbage as above; once before_cache_fixup is
-        // false, the validator must treat the slot as an opaque pointer.
-        bytes[8..16].copy_from_slice(&999_999_u64.to_ne_bytes());
-
-        let mut bounds = permissive_bounds();
-        bounds.before_cache_fixup = false;
-        validate(&bytes, &bounds).expect("post-fixup cache slot is opaque and should be skipped");
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -31,7 +31,7 @@ use crate::bytecode::validator::{
 use crate::{CompiledProgram, CompiledProgramBytecode, ModuleCallbacks, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 8;
+const FORMAT_VERSION: u32 = 9;
 const SOURCE_HASH_SIZE: usize = 32;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;
 const ITERATOR_HINT_VARIANT_COUNT: u32 = 2;

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -2348,7 +2348,6 @@ impl DecodedExecutableRecord {
             environment_mode_variant_count: ENVIRONMENT_MODE_VARIANT_COUNT,
             put_kind_variant_count: PUT_KIND_VARIANT_COUNT,
             arguments_kind_variant_count: ARGUMENTS_KIND_VARIANT_COUNT,
-            before_cache_fixup: true,
         };
 
         let exception_handlers = self

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -31,8 +31,9 @@ use crate::bytecode::validator::{
 use crate::{CompiledProgram, CompiledProgramBytecode, ModuleCallbacks, ast, u32_from_usize};
 
 const MAGIC: &[u8; 8] = b"LBJSBC\0\0";
-const FORMAT_VERSION: u32 = 9;
+const FORMAT_VERSION: u32 = 10;
 const SOURCE_HASH_SIZE: usize = 32;
+const BYTECODE_ALIGNMENT: usize = 8;
 const COMPLETION_TYPE_VARIANT_COUNT: u32 = 6;
 const ITERATOR_HINT_VARIANT_COUNT: u32 = 2;
 const ENVIRONMENT_MODE_VARIANT_COUNT: u32 = 2;
@@ -73,9 +74,11 @@ pub(crate) fn decode_blob(
 }
 
 pub(crate) type FreeBytecodeCacheBlobOwner = unsafe extern "C" fn(*mut c_void);
+pub(crate) type CloneBytecodeCacheBlobOwner = unsafe extern "C" fn(*const c_void) -> *mut c_void;
 
 pub(crate) struct ForeignBytecodeCacheBlobOwner {
     pub(crate) owner: *mut c_void,
+    pub(crate) clone_owner: CloneBytecodeCacheBlobOwner,
     pub(crate) free_owner: FreeBytecodeCacheBlobOwner,
 }
 
@@ -129,6 +132,12 @@ impl Encoder {
         self.bytes.extend(std::iter::repeat_n(0, padding));
     }
 
+    fn align_bytes_payload_to(&mut self, alignment: usize) {
+        let payload_offset = self.bytes.len() + size_of::<u32>();
+        let padding = payload_offset.next_multiple_of(alignment) - payload_offset;
+        self.bytes.extend(std::iter::repeat_n(0, padding));
+    }
+
     fn sequence<T>(&mut self, items: &[T], mut encode_item: impl FnMut(&T, &mut Self)) {
         u32_from_usize(items.len()).encode(self);
         for item in items {
@@ -141,6 +150,7 @@ struct ForeignBytecodeCacheBlob {
     data: *const u8,
     length: usize,
     owner: *mut c_void,
+    clone_owner: CloneBytecodeCacheBlobOwner,
     free_owner: FreeBytecodeCacheBlobOwner,
 }
 
@@ -165,6 +175,7 @@ impl<'a> Decoder<'a> {
                 data: bytes.as_ptr(),
                 length: bytes.len(),
                 owner: owner.owner,
+                clone_owner: owner.clone_owner,
                 free_owner: owner.free_owner,
             })
         });
@@ -192,6 +203,13 @@ impl<'a> Decoder<'a> {
 
     fn align_to(&mut self, alignment: usize) -> Option<()> {
         let padding = self.offset.next_multiple_of(alignment) - self.offset;
+        self.bytes(padding)?;
+        Some(())
+    }
+
+    fn align_bytes_payload_to(&mut self, alignment: usize) -> Option<()> {
+        let payload_offset = self.offset.checked_add(size_of::<u32>())?;
+        let padding = payload_offset.next_multiple_of(alignment) - payload_offset;
         self.bytes(padding)?;
         Some(())
     }
@@ -539,6 +557,17 @@ impl DecodedBytecodeBytes {
         }
     }
 
+    fn owner_for_ffi(&self) -> *mut c_void {
+        match self {
+            Self::Owned(_) => std::ptr::null_mut(),
+            // The C++ executable retains the immutable blob so the hot
+            // instruction stream can point directly into the cache file. Clone
+            // the small owner wrapper here; the original decoded blob still
+            // owns its copy until materialization finishes.
+            Self::Foreign { blob, .. } => unsafe { (blob.clone_owner)(blob.owner.cast_const()) },
+        }
+    }
+
     fn len(&self) -> usize {
         self.as_slice().len()
     }
@@ -566,6 +595,17 @@ struct DecodedRecordSequence {
 
 impl DecodedRecordSequence {
     fn encode<T>(encoder: &mut Encoder, items: &[T], mut encode_item: impl FnMut(&T, &mut Encoder)) {
+        Self::encode_with_alignment(encoder, items, align_of::<u16>(), |item, encoder| {
+            encode_item(item, encoder);
+        });
+    }
+
+    fn encode_with_alignment<T>(
+        encoder: &mut Encoder,
+        items: &[T],
+        alignment: usize,
+        mut encode_item: impl FnMut(&T, &mut Encoder),
+    ) {
         u32_from_usize(items.len()).encode(encoder);
 
         let mut payload_encoder = Encoder::new();
@@ -573,13 +613,17 @@ impl DecodedRecordSequence {
             encode_item(item, &mut payload_encoder);
         }
 
-        encoder.align_to(align_of::<u16>());
+        encoder.align_bytes_payload_to(alignment);
         Bytes(&payload_encoder.finish()).encode(encoder);
     }
 
     fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
+        Self::decode_with_alignment(decoder, align_of::<u16>())
+    }
+
+    fn decode_with_alignment(decoder: &mut Decoder<'_>, alignment: usize) -> Option<Self> {
         let count: usize = u32::decode(decoder)?.try_into().ok()?;
-        decoder.align_to(align_of::<u16>())?;
+        decoder.align_bytes_payload_to(alignment)?;
         let byte_length: usize = u32::decode(decoder)?.try_into().ok()?;
         // Every record currently has at least one byte in the payload. Reject
         // impossible counts up front so corrupt cache files cannot ask later
@@ -1189,6 +1233,7 @@ unsafe fn materialize_executable(
             &generator,
             crate::bytecode::ffi::ExecutableParts {
                 bytecode: bytecode.as_slice(),
+                bytecode_owner: bytecode.owner_for_ffi(),
                 exception_handlers: &exception_handlers,
                 source_map: &source_map,
                 basic_block_start_offsets: &[],
@@ -2250,6 +2295,7 @@ impl Encode for ExecutableRecord<'_> {
         self.generator.this_value_needs_environment_resolution.encode(encoder);
         self.generator.length_identifier.map(|index| index.0).encode(encoder);
 
+        encoder.align_bytes_payload_to(BYTECODE_ALIGNMENT);
         Bytes(&self.assembled.bytecode).encode(encoder);
         Utf16Table(&self.generator.identifier_table).encode(encoder);
         Utf16Table(&self.generator.property_key_table).encode(encoder);
@@ -2272,7 +2318,10 @@ impl ExecutableRecord<'_> {
             cache_counters: CacheCounters::decode(decoder)?,
             this_value_needs_environment_resolution: bool::decode(decoder)?,
             length_identifier: Option::<u32>::decode(decoder)?,
-            bytecode: DecodedBytecodeBytes::decode(decoder)?,
+            bytecode: {
+                decoder.align_bytes_payload_to(BYTECODE_ALIGNMENT)?;
+                DecodedBytecodeBytes::decode(decoder)?
+            },
             identifier_table: Utf16Table::decode(decoder)?,
             property_key_table: Utf16Table::decode(decoder)?,
             string_table: Utf16Table::decode(decoder)?,
@@ -2823,20 +2872,25 @@ struct SharedFunctionTable<'a>(&'a Generator);
 
 impl Encode for SharedFunctionTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        DecodedRecordSequence::encode(encoder, &self.0.shared_function_data, |shared_data, encoder| {
-            FunctionRecord {
-                shared_data,
-                arena: &self.0.arena,
-            }
-            .encode(encoder);
-        });
+        DecodedRecordSequence::encode_with_alignment(
+            encoder,
+            &self.0.shared_function_data,
+            BYTECODE_ALIGNMENT,
+            |shared_data, encoder| {
+                FunctionRecord {
+                    shared_data,
+                    arena: &self.0.arena,
+                }
+                .encode(encoder);
+            },
+        );
     }
 }
 
 impl SharedFunctionTable<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedFunctionTable> {
         Some(DecodedFunctionTable {
-            sequence: DecodedRecordSequence::decode(decoder)?,
+            sequence: DecodedRecordSequence::decode_with_alignment(decoder, BYTECODE_ALIGNMENT)?,
         })
     }
 }
@@ -2893,19 +2947,35 @@ struct DeclarationFunctionTable<'a>(&'a [PendingSharedFunctionData]);
 
 impl Encode for DeclarationFunctionTable<'_> {
     fn encode(&self, encoder: &mut Encoder) {
-        encoder.sequence(self.0, |shared_data, encoder| {
+        u32_from_usize(self.0.len()).encode(encoder);
+        let mut payload_encoder = Encoder::new();
+        for shared_data in self.0 {
             let arena = shared_data
                 .arena
                 .as_deref()
                 .expect("bytecode cache declaration function is missing its AST arena");
-            FunctionRecord { shared_data, arena }.encode(encoder);
-        });
+            FunctionRecord { shared_data, arena }.encode(&mut payload_encoder);
+        }
+        encoder.align_bytes_payload_to(BYTECODE_ALIGNMENT);
+        Bytes(&payload_encoder.finish()).encode(encoder);
     }
 }
 
 impl DeclarationFunctionTable<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<Vec<DecodedFunctionRecord>> {
-        decoder.sequence_values(FunctionRecord::decode)
+        let count: usize = u32::decode(decoder)?.try_into().ok()?;
+        decoder.align_bytes_payload_to(BYTECODE_ALIGNMENT)?;
+        let byte_length: usize = u32::decode(decoder)?.try_into().ok()?;
+        if count > byte_length {
+            return None;
+        }
+        let bytes = decoder.bytecode_bytes(byte_length)?;
+        let mut decoder = bytes.decoder();
+        let mut values = Vec::with_capacity(count);
+        for _ in 0..count {
+            values.push(FunctionRecord::decode(&mut decoder)?);
+        }
+        decoder.is_empty().then_some(values)
     }
 }
 
@@ -3142,14 +3212,14 @@ impl Encode for PrecompiledFunctionRecord<'_> {
             assembled: &self.0.assembled,
         }
         .encode(&mut payload_encoder);
-        encoder.align_to(align_of::<u16>());
+        encoder.align_bytes_payload_to(BYTECODE_ALIGNMENT);
         Bytes(&payload_encoder.finish()).encode(encoder);
     }
 }
 
 impl PrecompiledFunctionRecord<'_> {
     fn decode(decoder: &mut Decoder<'_>) -> Option<DecodedCachedExecutableRecord> {
-        decoder.align_to(align_of::<u16>())?;
+        decoder.align_bytes_payload_to(BYTECODE_ALIGNMENT)?;
         Some(DecodedCachedExecutableRecord {
             bytes: DecodedBytecodeBytes::decode(decoder)?,
         })

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -1097,6 +1097,7 @@ unsafe fn materialize_function(
             function.metadata.this_value_needs_environment_resolution,
             function.metadata.function_environment_needed,
             function.metadata.function_environment_bindings_count,
+            function.metadata.var_environment_bindings_count,
             function.metadata.might_need_arguments,
             function.metadata.contains_eval,
         );

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -875,6 +875,7 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob(
 /// # Safety
 /// - `data` must point to `length` readable bytes.
 /// - `owner` must keep `data` alive until `free_owner` is called.
+/// - `clone_owner` must return a new owner that keeps the same bytes alive.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_decode_bytecode_cache_blob_with_owner(
     data: *const u8,
@@ -883,6 +884,7 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob_with_owner(
     expected_source_hash: *const u8,
     expected_source_hash_len: usize,
     owner: *mut c_void,
+    clone_owner: bytecode_cache::CloneBytecodeCacheBlobOwner,
     free_owner: bytecode_cache::FreeBytecodeCacheBlobOwner,
 ) -> *mut DecodedBytecodeCacheBlob {
     unsafe {
@@ -909,7 +911,11 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob_with_owner(
                 std::slice::from_raw_parts(data, length),
                 expected_program_type,
                 expected_source_hash,
-                bytecode_cache::ForeignBytecodeCacheBlobOwner { owner, free_owner },
+                bytecode_cache::ForeignBytecodeCacheBlobOwner {
+                    owner,
+                    clone_owner,
+                    free_owner,
+                },
             ) else {
                 return std::ptr::null_mut();
             };
@@ -3469,6 +3475,11 @@ mod tests {
         }
     }
 
+    unsafe extern "C" fn clone_foreign_owner(owner: *const c_void) -> *mut c_void {
+        let value = unsafe { *owner.cast::<u8>() };
+        Box::into_raw(Box::new(value)).cast()
+    }
+
     fn new_foreign_owner() -> *mut c_void {
         Box::into_raw(Box::new(0u8)).cast()
     }
@@ -3486,6 +3497,7 @@ mod tests {
                 source_hash.as_ptr(),
                 source_hash.len(),
                 new_foreign_owner(),
+                clone_foreign_owner,
                 count_freed_foreign_owner,
             )
         };
@@ -3501,6 +3513,7 @@ mod tests {
                 source_hash.as_ptr(),
                 source_hash.len(),
                 new_foreign_owner(),
+                clone_foreign_owner,
                 count_freed_foreign_owner,
             )
         };

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -2930,7 +2930,7 @@ fn compile_function_payload_to_bytecode(
         generator.switch_to_basic_block(start_block);
     }
 
-    generator.capture_saved_lexical_environment();
+    generator.capture_saved_lexical_environment_with_coordinates();
 
     if let Some(scope_id) = body_scope {
         let arena_clone = generator.arena.clone();

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -2854,6 +2854,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_function(
             let this_value_needs_environment_resolution = precompiled.metadata.this_value_needs_environment_resolution;
             let function_environment_needed = precompiled.metadata.function_environment_needed;
             let function_environment_bindings_count = precompiled.metadata.function_environment_bindings_count;
+            let var_environment_bindings_count = precompiled.metadata.var_environment_bindings_count;
             let might_need_arguments = precompiled.metadata.might_need_arguments;
             let contains_eval = precompiled.metadata.contains_eval;
             let precompiled_ptr = Box::into_raw(precompiled) as *mut c_void;
@@ -2864,6 +2865,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_function(
                 this_value_needs_environment_resolution,
                 function_environment_needed,
                 function_environment_bindings_count,
+                var_environment_bindings_count,
                 might_need_arguments,
                 contains_eval,
             );
@@ -3215,6 +3217,7 @@ unsafe fn write_sfd_metadata(sfd_ptr: *mut c_void, metadata: &bytecode::generato
             metadata.this_value_needs_environment_resolution,
             metadata.function_environment_needed,
             metadata.function_environment_bindings_count,
+            metadata.var_environment_bindings_count,
             metadata.might_need_arguments,
             metadata.contains_eval,
         );
@@ -3319,6 +3322,7 @@ unsafe extern "C" {
         this_value_needs_environment_resolution: bool,
         function_environment_needed: bool,
         function_environment_bindings_count: usize,
+        var_environment_bindings_count: usize,
         might_need_arguments_object: bool,
         contains_direct_call_to_eval: bool,
     );

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1190,6 +1190,7 @@ extern "C" void rust_sfd_set_metadata(
     bool this_value_needs_environment_resolution,
     bool function_environment_needed,
     size_t function_environment_bindings_count,
+    size_t var_environment_bindings_count,
     bool might_need_arguments_object,
     bool contains_direct_call_to_eval)
 {
@@ -1199,6 +1200,7 @@ extern "C" void rust_sfd_set_metadata(
     shared.m_function_environment_needed = function_environment_needed;
     shared.update_asm_call_metadata();
     shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_var_environment_bindings_count = var_environment_bindings_count;
     shared.m_might_need_arguments_object = might_need_arguments_object;
     shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
 }
@@ -1225,6 +1227,7 @@ extern "C" void rust_sfd_set_precompiled_executable(
     bool this_value_needs_environment_resolution,
     bool function_environment_needed,
     size_t function_environment_bindings_count,
+    size_t var_environment_bindings_count,
     bool might_need_arguments_object,
     bool contains_direct_call_to_eval)
 {
@@ -1235,6 +1238,7 @@ extern "C" void rust_sfd_set_precompiled_executable(
     shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
     shared.m_function_environment_needed = function_environment_needed;
     shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_var_environment_bindings_count = var_environment_bindings_count;
     shared.m_might_need_arguments_object = might_need_arguments_object;
     shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
     shared.set_executable(executable);
@@ -1251,6 +1255,7 @@ extern "C" void rust_sfd_set_cached_bytecode_executable(
     bool this_value_needs_environment_resolution,
     bool function_environment_needed,
     size_t function_environment_bindings_count,
+    size_t var_environment_bindings_count,
     bool might_need_arguments_object,
     bool contains_direct_call_to_eval)
 {
@@ -1260,6 +1265,7 @@ extern "C" void rust_sfd_set_cached_bytecode_executable(
     shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
     shared.m_function_environment_needed = function_environment_needed;
     shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_var_environment_bindings_count = var_environment_bindings_count;
     shared.m_might_need_arguments_object = might_need_arguments_object;
     shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
     shared.m_cached_bytecode_executable = cached_executable_ptr;
@@ -1273,6 +1279,7 @@ extern "C" void rust_sfd_set_precompiled_bytecode_executable(
     bool this_value_needs_environment_resolution,
     bool function_environment_needed,
     size_t function_environment_bindings_count,
+    size_t var_environment_bindings_count,
     bool might_need_arguments_object,
     bool contains_direct_call_to_eval)
 {
@@ -1282,6 +1289,7 @@ extern "C" void rust_sfd_set_precompiled_bytecode_executable(
     shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
     shared.m_function_environment_needed = function_environment_needed;
     shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_var_environment_bindings_count = var_environment_bindings_count;
     shared.m_might_need_arguments_object = might_need_arguments_object;
     shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
     shared.m_precompiled_bytecode_executable = precompiled_executable_ptr;

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1106,7 +1106,7 @@ extern "C" void* rust_create_executable(
     auto const should_validate_bytecode = is_materializing_bytecode_cache;
 #endif
     if (should_validate_bytecode) {
-        if (auto validation = JS::Bytecode::validate_bytecode(*executable, basic_block_offsets.span(), JS::Bytecode::CacheState::BeforeFixup); validation.is_error()) {
+        if (auto validation = JS::Bytecode::validate_bytecode(*executable, basic_block_offsets.span()); validation.is_error()) {
             if (is_materializing_bytecode_cache)
                 return nullptr;
 #if !defined(NDEBUG) || defined(HAS_ADDRESS_SANITIZER)
@@ -1116,8 +1116,6 @@ extern "C" void* rust_create_executable(
 #endif
         }
     }
-
-    executable->fixup_cache_pointers();
 
     return executable.ptr();
 }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -414,10 +414,15 @@ static void free_bytecode_cache_blob_owner(void* owner)
     delete static_cast<Core::ImmutableBytes*>(owner);
 }
 
+static void* clone_bytecode_cache_blob_owner(void const* owner)
+{
+    return new Core::ImmutableBytes(*static_cast<Core::ImmutableBytes const*>(owner));
+}
+
 DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash)
 {
     auto* owner = new Core::ImmutableBytes(move(bytes));
-    return rust_decode_bytecode_cache_blob_with_owner(owner->bytes().data(), owner->bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, free_bytecode_cache_blob_owner);
+    return rust_decode_bytecode_cache_blob_with_owner(owner->bytes().data(), owner->bytes().size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size(), owner, clone_bytecode_cache_blob_owner, free_bytecode_cache_blob_owner);
 }
 
 void free_decoded_bytecode_cache_blob(DecodedBytecodeCacheBlob* blob)
@@ -981,9 +986,25 @@ extern "C" void* rust_create_executable(
     auto& vm = *static_cast<JS::VM*>(vm_ptr);
     auto& source_code = *static_cast<JS::SourceCode const*>(source_code_ptr);
 
-    // Build bytecode vector
-    Vector<u8> bytecode_vec;
-    bytecode_vec.append(data->bytecode, data->bytecode_length);
+    auto bytecode = [&] {
+        if (data->bytecode_owner) {
+            auto bytecode_owner = adopt_own_if_nonnull(static_cast<Core::ImmutableBytes*>(data->bytecode_owner));
+            VERIFY(bytecode_owner);
+            auto bytes = bytecode_owner->bytes();
+            size_t offset = 0;
+            if (!bytes.is_empty()) {
+                VERIFY(data->bytecode >= bytes.data());
+                offset = static_cast<size_t>(data->bytecode - bytes.data());
+            }
+            VERIFY(data->bytecode_length <= bytes.size());
+            VERIFY(offset <= bytes.size() - data->bytecode_length);
+            return JS::Bytecode::InstructionStream { move(*bytecode_owner), offset, data->bytecode_length };
+        }
+
+        Vector<u8> bytecode_vec;
+        bytecode_vec.append(data->bytecode, data->bytecode_length);
+        return JS::Bytecode::InstructionStream { move(bytecode_vec) };
+    }();
 
     // Build identifier table
     auto ident_table = make<JS::Bytecode::IdentifierTable>();
@@ -1024,7 +1045,7 @@ extern "C" void* rust_create_executable(
 
     // Create executable
     auto executable = vm.heap().allocate<JS::Bytecode::Executable>(
-        move(bytecode_vec),
+        move(bytecode),
         move(ident_table),
         move(prop_key_table),
         move(str_table),

--- a/Meta/Generators/generate_libjs_bytecode_def_derived.py
+++ b/Meta/Generators/generate_libjs_bytecode_def_derived.py
@@ -304,11 +304,6 @@ def generate_class(op: OpDef) -> str:
         lines.append("")
         lines.extend(getters)
 
-    # Emit set_cache() for ops that have a cache pointer field.
-    has_cache = any(f.name == "m_cache" and is_cache_pointer_type(f.type) for f in op.fields)
-    if has_cache:
-        lines.append("    void set_cache(u64 value) { m_cache = value; }")
-
     lines.append("")
     lines.append("private:")
     for f in op.fields:
@@ -354,25 +349,23 @@ NUMERIC_TYPES = {
     "size_t",
 }
 
-# Cache pointer types stored as u64 in the instruction stream.
-# The Executable::fixup_cache_pointers() pass replaces indices with actual pointers.
-CACHE_POINTER_TYPES = {
-    "PropertyLookupCache*": "property_lookup_caches",
-    "GlobalVariableCache*": "global_variable_caches",
-    "TemplateObjectCache*": "template_object_caches",
-    "ObjectShapeCache*": "object_shape_caches",
-    "ObjectPropertyIteratorCache*": "object_property_iterator_caches",
+CACHE_INDEX_TYPES = {
+    "PropertyLookupCacheIndex",
+    "GlobalVariableCacheIndex",
+    "TemplateObjectCacheIndex",
+    "ObjectShapeCacheIndex",
+    "ObjectPropertyIteratorCacheIndex",
 }
 
 
-def is_cache_pointer_type(t: str) -> bool:
-    return t.strip() in CACHE_POINTER_TYPES
+def is_cache_index_type(t: str) -> bool:
+    return t.strip() in CACHE_INDEX_TYPES
 
 
 def cpp_type_for_field(t: str) -> str:
     """Return the C++ storage type for a Bytecode.def field type."""
-    if is_cache_pointer_type(t):
-        return "u64"
+    if is_cache_index_type(t):
+        return "u32"
     return t
 
 
@@ -601,49 +594,6 @@ def generate_to_byte_string_impl(op: OpDef) -> str:
     return "\n".join(lines)
 
 
-def generate_fixup_cache_function(ops: List[OpDef]) -> str:
-    """Generate fixup_instruction_cache() that replaces cache indices with pointers."""
-    lines: List[str] = []
-    lines.append("void fixup_instruction_cache(")
-    lines.append("    Instruction& insn,")
-    lines.append("    Span<PropertyLookupCache> property_lookup_caches,")
-    lines.append("    Span<GlobalVariableCache> global_variable_caches,")
-    lines.append("    Span<TemplateObjectCache> template_object_caches,")
-    lines.append("    Span<ObjectShapeCache> object_shape_caches,")
-    lines.append("    Span<ObjectPropertyIteratorCache> object_property_iterator_caches)")
-    lines.append("{")
-    lines.append('    // Sentinel value used to indicate "no cache" (originally u32::MAX).')
-    lines.append("    static constexpr u64 NO_CACHE = NumericLimits<u32>::max();")
-    lines.append("    switch (insn.type()) {")
-
-    for op in ops:
-        cache_field = None
-        for f in op.fields:
-            if f.name == "m_cache" and is_cache_pointer_type(f.type):
-                cache_field = f
-                break
-        if cache_field is None:
-            continue
-
-        vector_name = CACHE_POINTER_TYPES[cache_field.type.strip()]
-        lines.append(f"    case Instruction::Type::{op.name}: {{")
-        lines.append(f"        auto& op = static_cast<Op::{op.name}&>(insn);")
-        lines.append("        auto index = op.cache();")
-        lines.append("        if (index != NO_CACHE)")
-        lines.append(f"            op.set_cache(bit_cast<u64>(&{vector_name}[index]));")
-        lines.append("        else")
-        lines.append("            op.set_cache(0);")
-        lines.append("        break;")
-        lines.append("    }")
-
-    lines.append("    default:")
-    lines.append("        break;")
-    lines.append("    }")
-    lines.append("}")
-    lines.append("")
-    return "\n".join(lines)
-
-
 def generate_op_cpp_body(ops: List[OpDef]) -> str:
     lines: List[str] = []
     lines.append("#include <AK/StringBuilder.h>")
@@ -660,11 +610,6 @@ def generate_op_cpp_body(ops: List[OpDef]) -> str:
             lines.append(impl)
 
     lines.append("} // namespace JS::Bytecode::Op")
-    lines.append("")
-    lines.append("namespace JS::Bytecode {")
-    lines.append("")
-    lines.append(generate_fixup_cache_function(ops))
-    lines.append("} // namespace JS::Bytecode")
     return "\n".join(lines)
 
 
@@ -698,20 +643,7 @@ def generate_op_h(ops: List[OpDef]) -> str:
 #include <LibJS/Runtime/Value.h>
 """
     body = generate_op_namespace_body(ops)
-    fixup_decl = """
-namespace JS::Bytecode {
-
-void fixup_instruction_cache(
-    Instruction& insn,
-    Span<PropertyLookupCache> property_lookup_caches,
-    Span<GlobalVariableCache> global_variable_caches,
-    Span<TemplateObjectCache> template_object_caches,
-    Span<ObjectShapeCache> object_shape_caches,
-    Span<ObjectPropertyIteratorCache> object_property_iterator_caches);
-
-} // namespace JS::Bytecode
-"""
-    return includes + "\n" + body + "\n" + fixup_decl
+    return includes + "\n" + body
 
 
 def usage(prog: str) -> None:

--- a/Meta/Generators/generate_libjs_bytecode_def_derived.py
+++ b/Meta/Generators/generate_libjs_bytecode_def_derived.py
@@ -311,10 +311,7 @@ def generate_class(op: OpDef) -> str:
         if f.is_array:
             lines.append(f"    {cpp_t} {f.name}[];")
         else:
-            if f.type.strip() == "EnvironmentCoordinate":
-                lines.append(f"    mutable {cpp_t} {f.name};")
-            else:
-                lines.append(f"    {cpp_t} {f.name};")
+            lines.append(f"    {cpp_t} {f.name};")
 
     lines.append("};")
     lines.append(f"static_assert(IsTriviallyDestructible<{op.name}>);")

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -20,7 +20,7 @@ block0:
   [ 110] End value:reg7
 
 
-annexBFunctionInIf$f1f2b149 annex-b-function-in-if.js:2:5
+annexBFunctionInIf$1321fe09 annex-b-function-in-if.js:2:5
   Registers: 8
   Blocks:    4
   Constants:
@@ -29,32 +29,32 @@ annexBFunctionInIf$f1f2b149 annex-b-function-in-if.js:2:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  18] InitializeVariableBinding `inner`, src:Undefined
-  [  30] JumpFalse condition:arg0, target:block2
+  [  18] DynamicInitializeVariableBinding `inner`, src:Undefined
+  [  28] JumpFalse condition:arg0, target:block2
 
 block1:
-  [  40] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  58] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [  68] NewFunction dst:reg6, shared_function_data_index:0
-  [  80] InitializeLexicalBinding `inner`, src:reg6
-  [  98] GetBinding dst:reg6, `inner`
-  [  b0] SetVariableBinding `inner`, src:reg6
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] Jump target:block3
+  [  38] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  50] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [  60] NewFunction dst:reg6, shared_function_data_index:0
+  [  78] DynamicInitializeLexicalBinding `inner`, src:reg6
+  [  88] DynamicGetBinding dst:reg6, `inner`
+  [  98] DynamicSetVariableBinding `inner`, src:reg6
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] Jump target:block3
 
 block2:
-  [  d8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  f0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [ 100] NewFunction dst:reg6, shared_function_data_index:1
-  [ 118] InitializeLexicalBinding `inner`, src:reg6
-  [ 130] GetBinding dst:reg6, `inner`
-  [ 148] SetVariableBinding `inner`, src:reg6
-  [ 160] SetLexicalEnvironment environment:reg4
+  [  b8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  d0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [  e0] NewFunction dst:reg6, shared_function_data_index:1
+  [  f8] DynamicInitializeLexicalBinding `inner`, src:reg6
+  [ 108] DynamicGetBinding dst:reg6, `inner`
+  [ 118] DynamicSetVariableBinding `inner`, src:reg6
+  [ 128] SetLexicalEnvironment environment:reg4
 
 block3:
-  [ 168] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [ 180] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [ 1a0] Return value:reg5
+  [ 130] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [ 140] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [ 160] Return value:reg5
 
 
 inner$b5b8e95a annex-b-function-in-if.js:4:13

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -20,7 +20,7 @@ block0:
   [ 110] End value:reg7
 
 
-annexBFunctionInIf$1321fe09 annex-b-function-in-if.js:2:5
+annexBFunctionInIf$f1f2b149 annex-b-function-in-if.js:2:5
   Registers: 8
   Blocks:    4
   Constants:
@@ -29,32 +29,32 @@ annexBFunctionInIf$1321fe09 annex-b-function-in-if.js:2:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  18] DynamicInitializeVariableBinding `inner`, src:Undefined
-  [  28] JumpFalse condition:arg0, target:block2
+  [  18] InitializeVariableBinding `inner`, src:Undefined
+  [  30] JumpFalse condition:arg0, target:block2
 
 block1:
-  [  38] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  50] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [  60] NewFunction dst:reg6, shared_function_data_index:0
-  [  78] DynamicInitializeLexicalBinding `inner`, src:reg6
-  [  88] DynamicGetBinding dst:reg6, `inner`
-  [  98] DynamicSetVariableBinding `inner`, src:reg6
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] Jump target:block3
+  [  40] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  58] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [  68] NewFunction dst:reg6, shared_function_data_index:0
+  [  80] InitializeLexicalBinding `inner`, src:reg6
+  [  98] GetBinding dst:reg6, `inner`
+  [  b0] SetVariableBinding `inner`, src:reg6
+  [  c8] SetLexicalEnvironment environment:reg4
+  [  d0] Jump target:block3
 
 block2:
-  [  b8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  d0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
-  [  e0] NewFunction dst:reg6, shared_function_data_index:1
-  [  f8] DynamicInitializeLexicalBinding `inner`, src:reg6
-  [ 108] DynamicGetBinding dst:reg6, `inner`
-  [ 118] DynamicSetVariableBinding `inner`, src:reg6
-  [ 128] SetLexicalEnvironment environment:reg4
+  [  d8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  f0] CreateMutableBinding environment:reg5, `inner`, can_be_deleted:false
+  [ 100] NewFunction dst:reg6, shared_function_data_index:1
+  [ 118] InitializeLexicalBinding `inner`, src:reg6
+  [ 130] GetBinding dst:reg6, `inner`
+  [ 148] SetVariableBinding `inner`, src:reg6
+  [ 160] SetLexicalEnvironment environment:reg4
 
 block3:
-  [ 130] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [ 140] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [ 160] Return value:reg5
+  [ 168] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [ 180] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [ 1a0] Return value:reg5
 
 
 inner$b5b8e95a annex-b-function-in-if.js:4:13

--- a/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
+++ b/Tests/LibJS/Bytecode/expected/annex-b-function-in-if.txt
@@ -1,4 +1,4 @@
-$eeeaa256 annex-b-function-in-if.js:13:1
+$f7367586 annex-b-function-in-if.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -8,16 +8,16 @@ $eeeaa256 annex-b-function-in-if.js:13:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `annexBFunctionInIf`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(true)]
-  [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg6, `console`
-  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d8] GetGlobal dst:reg10, `annexBFunctionInIf`
-  [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(false)]
-  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 140] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `annexBFunctionInIf`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(true)]
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `annexBFunctionInIf`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, annexBFunctionInIf, arguments:[Bool(false)]
+  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 110] End value:reg7
 
 
 annexBFunctionInIf$f1f2b149 annex-b-function-in-if.js:2:5

--- a/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-test$02c02c04 annexb-function-existing-var.js:2:5
+test$0b0bff34 annexb-function-existing-var.js:2:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -21,14 +21,14 @@ test$02c02c04 annexb-function-existing-var.js:2:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateVariable `f`, is_immutable:false, is_global:false, is_strict:false
-  [  18] InitializeVariableBinding `f`, src:Undefined
-  [  30] SetLexicalBinding `f`, src:Int32(123)
-  [  48] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  60] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
-  [  70] NewFunction dst:reg6, shared_function_data_index:0
-  [  88] InitializeLexicalBinding `f`, src:reg6
-  [  a0] GetBinding dst:reg6, `f`
-  [  b8] SetVariableBinding `f`, src:reg6
-  [  d0] SetLexicalEnvironment environment:reg4
-  [  d8] GetInitializedBinding dst:reg5, `f`
-  [  f0] Return value:reg5
+  [  18] DynamicInitializeVariableBinding `f`, src:Undefined
+  [  28] DynamicSetLexicalBinding `f`, src:Int32(123)
+  [  38] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  50] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
+  [  60] NewFunction dst:reg6, shared_function_data_index:0
+  [  78] DynamicInitializeLexicalBinding `f`, src:reg6
+  [  88] DynamicGetBinding dst:reg6, `f`
+  [  98] DynamicSetVariableBinding `f`, src:reg6
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] DynamicGetInitializedBinding dst:reg5, `f`
+  [  c0] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-test$0b0bff34 annexb-function-existing-var.js:2:5
+test$02c02c04 annexb-function-existing-var.js:2:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -21,14 +21,14 @@ test$0b0bff34 annexb-function-existing-var.js:2:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateVariable `f`, is_immutable:false, is_global:false, is_strict:false
-  [  18] DynamicInitializeVariableBinding `f`, src:Undefined
-  [  28] DynamicSetLexicalBinding `f`, src:Int32(123)
-  [  38] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  50] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
-  [  60] NewFunction dst:reg6, shared_function_data_index:0
-  [  78] DynamicInitializeLexicalBinding `f`, src:reg6
-  [  88] DynamicGetBinding dst:reg6, `f`
-  [  98] DynamicSetVariableBinding `f`, src:reg6
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] DynamicGetInitializedBinding dst:reg5, `f`
-  [  c0] Return value:reg5
+  [  18] InitializeVariableBinding `f`, src:Undefined
+  [  30] SetLexicalBinding `f`, src:Int32(123)
+  [  48] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  60] CreateMutableBinding environment:reg5, `f`, can_be_deleted:false
+  [  70] NewFunction dst:reg6, shared_function_data_index:0
+  [  88] InitializeLexicalBinding `f`, src:reg6
+  [  a0] GetBinding dst:reg6, `f`
+  [  b8] SetVariableBinding `f`, src:reg6
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] GetInitializedBinding dst:reg5, `f`
+  [  f0] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-function-existing-var.txt
@@ -1,4 +1,4 @@
-$d36729be annexb-function-existing-var.js:10:1
+$49b95e06 annexb-function-existing-var.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $d36729be annexb-function-existing-var.js:10:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  30] End value:reg5
 
 
 test$02c02c04 annexb-function-existing-var.js:2:5

--- a/Tests/LibJS/Bytecode/expected/annexb-var-coordinate-with-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/annexb-var-coordinate-with-default-param.txt
@@ -1,0 +1,58 @@
+$546ebce0 annexb-var-coordinate-with-default-param.js:12:1
+  Registers: 7
+  Blocks:    1
+  Constants:
+    [0] = Undefined
+
+block0:
+  [   0] GetGlobal dst:reg6, `f`
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
+
+
+f$40af7db5 annexb-var-coordinate-with-default-param.js:4:5
+  Registers: 10
+  Blocks:    3
+  Constants:
+    [0] = Int32(1)
+    [1] = Undefined
+    [2] = Int32(2)
+    [3] = Bool(true)
+
+block0:
+  [   0] GetLexicalEnvironment dst:reg4
+  [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [  30] JumpUndefined condition:arg0, true_target:block1, false_target:block2
+
+block1:
+  [  40] Mov dst:arg0, src:Int32(1)
+
+block2:
+  [  50] InitializeLexicalBinding `x`, src:arg0
+  [  68] CreateVariable `g`, is_immutable:false, is_global:false, is_strict:false
+  [  78] InitializeVariableBinding `g`, src:Undefined
+  [  90] CreateLexicalEnvironment dst:reg6, parent:reg5, capacity:1, is_catch_environment:false
+  [  a8] CreateVariable `y`, is_immutable:false, is_global:false, is_strict:false
+  [  b8] InitializeLexicalBinding `y`, src:Int32(2)
+  [  d0] CreateLexicalEnvironment dst:reg7, parent:reg6, capacity:0, is_catch_environment:false
+  [  e8] CreateMutableBinding environment:reg7, `g`, can_be_deleted:false
+  [  f8] NewFunction dst:reg8, shared_function_data_index:0
+  [ 110] InitializeLexicalBinding `g`, src:reg8
+  [ 128] GetBinding dst:reg8, `g`
+  [ 140] SetVariableBinding `g`, src:reg8
+  [ 158] SetLexicalEnvironment environment:reg6
+  [ 160] GetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `g`
+  [ 178] Call dst:reg7, callee:reg8, this_value:reg9, g
+  [ 198] Return value:reg7
+
+
+g$b7262970 annexb-var-coordinate-with-default-param.js:7:13
+  Registers: 8
+  Blocks:    1
+
+block0:
+  [   0] DynamicGetBinding dst:reg5, `x`
+  [  10] DynamicGetBinding dst:reg6, `y`
+  [  20] Add dst:reg7, lhs:reg5, rhs:reg6
+  [  30] Return value:reg7

--- a/Tests/LibJS/Bytecode/expected/argument-postfix-self-move.txt
+++ b/Tests/LibJS/Bytecode/expected/argument-postfix-self-move.txt
@@ -1,4 +1,4 @@
-$9431c529 argument-postfix-self-move.js:5:1
+$12cfcca1 argument-postfix-self-move.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $9431c529 argument-postfix-self-move.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(10)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(10)]
+  [  38] End value:reg5
 
 
 f$833b82e7 argument-postfix-self-move.js:2:6

--- a/Tests/LibJS/Bytecode/expected/argument-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/argument-variables.txt
@@ -1,4 +1,4 @@
-$3b8b4350 argument-variables.js:12:1
+$495ef8a0 argument-variables.js:12:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -8,10 +8,10 @@ $3b8b4350 argument-variables.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `identity`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, identity, arguments:[Int32(1)]
-  [  40] GetGlobal dst:reg7, `swap`
-  [  58] Call dst:reg6, callee:reg7, this_value:Undefined, swap, arguments:[Int32(1), Int32(2)]
-  [  80] End value:reg6
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, identity, arguments:[Int32(1)]
+  [  38] GetGlobal dst:reg7, `swap`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, swap, arguments:[Int32(1), Int32(2)]
+  [  70] End value:reg6
 
 
 identity$753f961b argument-variables.js:5:5

--- a/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
+++ b/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
@@ -1,4 +1,4 @@
-$2b997e90 arguments-with-arguments-fn.js:4:1
+$bacf2c68 arguments-with-arguments-fn.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $2b997e90 arguments-with-arguments-fn.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
 f$6cd6eab3

--- a/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
@@ -1,4 +1,4 @@
-$393b7f47 assign-to-argument-no-tdz.js:11:1
+$ba9d77cf assign-to-argument-no-tdz.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $393b7f47 assign-to-argument-no-tdz.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(0)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(0)]
+  [  38] End value:reg5
 
 
 f$44906188 assign-to-argument-no-tdz.js:6:5

--- a/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
@@ -1,4 +1,4 @@
-$bced3bd8 assign-to-let-variable-tdz.js:12:1
+$495ef8a0 assign-to-let-variable-tdz.js:12:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,14 +7,14 @@ $bced3bd8 assign-to-let-variable-tdz.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewObject dst:reg7
-  [  28] InitObjectLiteralProperty object:reg7, `location`, src:String("hello"), shape_cache_index:0, property_slot:0
-  [  40] CacheObjectShape object:reg7
-  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  78] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] InitObjectLiteralProperty object:reg7, `location`, src:String("hello"), shape_cache_index:0, property_slot:0
+  [  38] CacheObjectShape object:reg7
+  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  70] End value:reg5
 
 
-f$7105e5e6 assign-to-let-variable-tdz.js:7:5
+f$ce57f4e1 assign-to-let-variable-tdz.js:7:5
   Registers: 10
   Blocks:    3
   Locals:    a~0
@@ -25,24 +25,24 @@ f$7105e5e6 assign-to-let-variable-tdz.js:7:5
 block0:
   [   0] ThrowIfNullish src:arg0
   [   8] GetById dst:reg5, base:arg0, `location`
-  [  28] Mov dst:a~0, src:reg5
-  [  38] ThrowIfTDZ src:a~0
-  [  40] Typeof dst:reg5, src:a~0
-  [  50] LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
-  [  60] Mov dst:reg5, src:reg6
-  [  70] JumpFalse condition:reg6, target:block2
+  [  20] Mov dst:a~0, src:reg5
+  [  30] ThrowIfTDZ src:a~0
+  [  38] Typeof dst:reg5, src:a~0
+  [  48] LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
+  [  58] Mov dst:reg5, src:reg6
+  [  68] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  80] GetGlobal dst:reg8, `g`
-  [  98] ThrowIfTDZ src:a~0
-  [  a0] Mov dst:reg9, src:a~0
-  [  b0] Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
-  [  d8] ThrowIfTDZ src:a~0
-  [  e0] Mov2 dst1:a~0, src1:reg7, dst2:reg5, src2:reg7
+  [  78] GetGlobal dst:reg8, `g`
+  [  88] ThrowIfTDZ src:a~0
+  [  90] Mov dst:reg9, src:a~0
+  [  a0] Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
+  [  c8] ThrowIfTDZ src:a~0
+  [  d0] Mov2 dst1:a~0, src1:reg7, dst2:reg5, src2:reg7
 
 block2:
-  [  f8] ThrowIfTDZ src:a~0
-  [ 100] Return value:a~0
+  [  e8] ThrowIfTDZ src:a~0
+  [  f0] Return value:a~0
 
 
 g$f452072f assign-to-let-variable-tdz.js:4:17

--- a/Tests/LibJS/Bytecode/expected/assign-to-parameter.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-parameter.txt
@@ -1,4 +1,4 @@
-$162ec0dc assign-to-parameter.js:8:1
+$a2a07da4 assign-to-parameter.js:8:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $162ec0dc assign-to-parameter.js:8:1
 
 block0:
   [   0] GetGlobal dst:reg6, `isect`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, isect
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, isect
+  [  30] End value:reg5
 
 
 isect$41c8d351 assign-to-parameter.js:5:9

--- a/Tests/LibJS/Bytecode/expected/async-await-in-try-catch.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await-in-try-catch.txt
@@ -1,4 +1,4 @@
-$793f2555 async-await-in-try-catch.js:9:1
+$faa11ddd async-await-in-try-catch.js:9:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,9 +6,9 @@ $793f2555 async-await-in-try-catch.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewObject dst:reg7
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  50] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  48] End value:reg5
 
 
 f$8982c134 async-await-in-try-catch.js:2:5

--- a/Tests/LibJS/Bytecode/expected/async-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-await.txt
@@ -1,4 +1,4 @@
-$fd650eed async-await.js:9:1
+$89d6cbb5 async-await.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $fd650eed async-await.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
-f$efa3ed5e async-await.js:7:5
+f$ecdffc4e async-await.js:7:5
   Registers: 10
   Blocks:    8
   Constants:
@@ -23,29 +23,29 @@ block0:
 
 block1:
   [  10] GetGlobal dst:reg6, `Promise`
-  [  28] GetById dst:reg7, base:reg6, `resolve` (Promise.resolve)
-  [  48] Call dst:reg5, callee:reg7, this_value:reg6, Promise.resolve, arguments:[Int32(42)]
-  [  70] Mov dst:reg7, src:reg0
-  [  80] Await continuation_label:block2, argument:reg5
+  [  20] GetById dst:reg7, base:reg6, `resolve` (Promise.resolve)
+  [  38] Call dst:reg5, callee:reg7, this_value:reg6, Promise.resolve, arguments:[Int32(42)]
+  [  60] Mov dst:reg7, src:reg0
+  [  70] Await continuation_label:block2, argument:reg5
 
 block2:
-  [  90] Mov dst:reg7, src:reg0
-  [  a0] GetCompletionFields type_dst:reg6, value_dst:reg8, completion:reg7
-  [  b0] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block3, false_target:block4
+  [  80] Mov dst:reg7, src:reg0
+  [  90] GetCompletionFields type_dst:reg6, value_dst:reg8, completion:reg7
+  [  a0] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block3, false_target:block4
 
 block3:
-  [  c8] Await continuation_label:block5, argument:reg8
+  [  b8] Await continuation_label:block5, argument:reg8
 
 block4:
-  [  d8] Throw src:reg8
+  [  c8] Throw src:reg8
 
 block5:
-  [  e0] Mov dst:reg5, src:reg0
-  [  f0] GetCompletionFields type_dst:reg7, value_dst:reg6, completion:reg5
-  [ 100] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block6, false_target:block7
+  [  d0] Mov dst:reg5, src:reg0
+  [  e0] GetCompletionFields type_dst:reg7, value_dst:reg6, completion:reg5
+  [  f0] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block6, false_target:block7
 
 block6:
-  [ 118] Yield value:reg6
+  [ 108] Yield value:reg6
 
 block7:
-  [ 128] Throw src:reg6
+  [ 118] Throw src:reg6

--- a/Tests/LibJS/Bytecode/expected/async-generator-yield-await.txt
+++ b/Tests/LibJS/Bytecode/expected/async-generator-yield-await.txt
@@ -1,4 +1,4 @@
-$6a33dffa async-generator-yield-await.js:6:1
+$e8d1e772 async-generator-yield-await.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $6a33dffa async-generator-yield-await.js:6:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  38] End value:reg5
 
 
 f$7363bd74 async-generator-yield-await.js:4:5

--- a/Tests/LibJS/Bytecode/expected/async-generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/async-generator-yield.txt
@@ -1,4 +1,4 @@
-$516a2e0b async-generator-yield.js:7:1
+$d0083583 async-generator-yield.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $516a2e0b async-generator-yield.js:7:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  38] End value:reg5
 
 
 f$aa186530 async-generator-yield.js:5:5

--- a/Tests/LibJS/Bytecode/expected/async-return-bare.txt
+++ b/Tests/LibJS/Bytecode/expected/async-return-bare.txt
@@ -1,4 +1,4 @@
-$2b997e90 async-return-bare.js:4:1
+$bacf2c68 async-return-bare.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $2b997e90 async-return-bare.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
 f$e16999cc async-return-bare.js:2:5

--- a/Tests/LibJS/Bytecode/expected/baseline.txt
+++ b/Tests/LibJS/Bytecode/expected/baseline.txt
@@ -1,4 +1,4 @@
-$8ea9e309 baseline.js:5:1
+$04fc1751 baseline.js:5:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -8,11 +8,11 @@ $8ea9e309 baseline.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `add`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, add, arguments:[Int32(1), Int32(2)]
-  [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `add`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, add, arguments:[Int32(1), Int32(2)]
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] End value:reg5
 
 
 add$9f351e1b baseline.js:2:5

--- a/Tests/LibJS/Bytecode/expected/bigint-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-constant-folding.txt
@@ -1,4 +1,4 @@
-$7ca8f805 bigint-constant-folding.js:1:1
+$00cee19d bigint-constant-folding.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -31,12 +31,12 @@ $7ca8f805 bigint-constant-folding.js:1:1
 
 block0:
   [   0] SetGlobal `a`, src:BigInt(3n)
-  [  18] SetGlobal `b`, src:BigInt(7n)
-  [  30] SetGlobal `c`, src:BigInt(6n)
-  [  48] SetGlobal `d`, src:BigInt(3n)
-  [  60] SetGlobal `e`, src:BigInt(1n)
-  [  78] SetGlobal `f`, src:BigInt(8n)
-  [  90] SetGlobal `g`, src:Bool(true)
-  [  a8] SetGlobal `h`, src:Bool(true)
-  [  c0] SetGlobal `i`, src:BigInt(-2n)
-  [  d8] End value:Undefined
+  [  10] SetGlobal `b`, src:BigInt(7n)
+  [  20] SetGlobal `c`, src:BigInt(6n)
+  [  30] SetGlobal `d`, src:BigInt(3n)
+  [  40] SetGlobal `e`, src:BigInt(1n)
+  [  50] SetGlobal `f`, src:BigInt(8n)
+  [  60] SetGlobal `g`, src:Bool(true)
+  [  70] SetGlobal `h`, src:Bool(true)
+  [  80] SetGlobal `i`, src:BigInt(-2n)
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-large-constant-folding.txt
@@ -1,4 +1,4 @@
-$343fb726 bigint-large-constant-folding.js:2:1
+$b019cd8e bigint-large-constant-folding.js:2:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -15,6 +15,6 @@ $343fb726 bigint-large-constant-folding.js:2:1
 
 block0:
   [   0] SetGlobal `a`, src:BigInt(337264356397531028994973048178108678400n)
-  [  18] SetGlobal `b`, src:BigInt(340282366920938463463374607431768211456n)
-  [  30] SetGlobal `c`, src:BigInt(6193778470904512180693671865081363252814433915244866048000n)
-  [  48] End value:Undefined
+  [  10] SetGlobal `b`, src:BigInt(340282366920938463463374607431768211456n)
+  [  20] SetGlobal `c`, src:BigInt(6193778470904512180693671865081363252814433915244866048000n)
+  [  30] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
+++ b/Tests/LibJS/Bytecode/expected/bigint-truthiness.txt
@@ -1,4 +1,4 @@
-$266c01d6 bigint-truthiness.js:2:1
+$947262ee bigint-truthiness.js:2:1
   Registers: 6
   Blocks:    1
   Constants:
@@ -19,12 +19,12 @@ $266c01d6 bigint-truthiness.js:2:1
 
 block0:
   [   0] SetGlobal `a`, src:String("falsy")
-  [  18] SetGlobal `b`, src:String("falsy")
-  [  30] SetGlobal `c`, src:String("falsy")
-  [  48] SetGlobal `d`, src:String("falsy")
-  [  60] SetGlobal `e`, src:String("truthy")
-  [  78] SetGlobal `f`, src:String("truthy")
-  [  90] SetGlobal `g`, src:String("truthy")
-  [  a8] SetGlobal `h`, src:Bool(true)
-  [  c0] SetGlobal `i`, src:Bool(false)
-  [  d8] End value:Undefined
+  [  10] SetGlobal `b`, src:String("falsy")
+  [  20] SetGlobal `c`, src:String("falsy")
+  [  30] SetGlobal `d`, src:String("falsy")
+  [  40] SetGlobal `e`, src:String("truthy")
+  [  50] SetGlobal `f`, src:String("truthy")
+  [  60] SetGlobal `g`, src:String("truthy")
+  [  70] SetGlobal `h`, src:Bool(true)
+  [  80] SetGlobal `i`, src:Bool(false)
+  [  90] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/bitwise-numeric-preconvert.txt
+++ b/Tests/LibJS/Bytecode/expected/bitwise-numeric-preconvert.txt
@@ -1,4 +1,4 @@
-$acfb7718 bitwise-numeric-preconvert.js:4:1
+$2b997e90 bitwise-numeric-preconvert.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $acfb7718 bitwise-numeric-preconvert.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[Int32(1)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[Int32(1)]
+  [  38] End value:reg5
 
 
 test$e718c164 bitwise-numeric-preconvert.js:2:5

--- a/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
+++ b/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
@@ -1,4 +1,4 @@
-$7ca8f805 block-function-declaration-order.js:1:1
+$2d2a9e5a block-function-declaration-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -9,13 +9,13 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateMutableBinding environment:reg5, `f1`, can_be_deleted:false
   [  30] NewFunction dst:reg6, shared_function_data_index:0
-  [  48] DynamicInitializeLexicalBinding `f1`, src:reg6
-  [  58] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
-  [  68] NewFunction dst:reg6, shared_function_data_index:1
-  [  80] DynamicInitializeLexicalBinding `f2`, src:reg6
-  [  90] DynamicGetBinding dst:reg6, `f1`
-  [  a0] DynamicSetVariableBinding `f1`, src:reg6
-  [  b0] DynamicGetBinding dst:reg6, `f2`
-  [  c0] DynamicSetVariableBinding `f2`, src:reg6
-  [  d0] SetLexicalEnvironment environment:reg4
-  [  d8] End value:Undefined
+  [  48] InitializeLexicalBinding `f1`, src:reg6
+  [  60] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
+  [  70] NewFunction dst:reg6, shared_function_data_index:1
+  [  88] InitializeLexicalBinding `f2`, src:reg6
+  [  a0] GetBinding dst:reg6, `f1`
+  [  b8] DynamicSetVariableBinding `f1`, src:reg6
+  [  c8] GetBinding dst:reg6, `f2`
+  [  e0] DynamicSetVariableBinding `f2`, src:reg6
+  [  f0] SetLexicalEnvironment environment:reg4
+  [  f8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
+++ b/Tests/LibJS/Bytecode/expected/block-function-declaration-order.txt
@@ -1,4 +1,4 @@
-$2a66ad4a block-function-declaration-order.js:1:1
+$7ca8f805 block-function-declaration-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -9,13 +9,13 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateMutableBinding environment:reg5, `f1`, can_be_deleted:false
   [  30] NewFunction dst:reg6, shared_function_data_index:0
-  [  48] InitializeLexicalBinding `f1`, src:reg6
-  [  60] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
-  [  70] NewFunction dst:reg6, shared_function_data_index:1
-  [  88] InitializeLexicalBinding `f2`, src:reg6
-  [  a0] GetBinding dst:reg6, `f1`
-  [  b8] SetVariableBinding `f1`, src:reg6
-  [  d0] GetBinding dst:reg6, `f2`
-  [  e8] SetVariableBinding `f2`, src:reg6
-  [ 100] SetLexicalEnvironment environment:reg4
-  [ 108] End value:Undefined
+  [  48] DynamicInitializeLexicalBinding `f1`, src:reg6
+  [  58] CreateMutableBinding environment:reg5, `f2`, can_be_deleted:false
+  [  68] NewFunction dst:reg6, shared_function_data_index:1
+  [  80] DynamicInitializeLexicalBinding `f2`, src:reg6
+  [  90] DynamicGetBinding dst:reg6, `f1`
+  [  a0] DynamicSetVariableBinding `f1`, src:reg6
+  [  b0] DynamicGetBinding dst:reg6, `f2`
+  [  c0] DynamicSetVariableBinding `f2`, src:reg6
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
@@ -1,4 +1,4 @@
-$d36729be block-scoped-function-no-tdz.js:10:1
+$49b95e06 block-scoped-function-no-tdz.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $d36729be block-scoped-function-no-tdz.js:10:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  30] End value:reg5
 
 
 test$e46e97f5 block-scoped-function-no-tdz.js:3:5

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -18,7 +18,7 @@ block0:
   [ 100] End value:reg7
 
 
-closureOverBlockScope$19ddc477 block-scoping.js:2:15
+closureOverBlockScope$61104af2 block-scoping.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    fns~0
@@ -32,26 +32,26 @@ block0:
   [   8] NewArray dst:fns~0
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  30] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  40] DynamicInitializeLexicalBinding `x`, src:Int32(1)
-  [  50] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  68] Mov dst:reg8, src:fns~0
-  [  78] NewFunction dst:reg9, shared_function_data_index:0
-  [  90] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [  b8] SetLexicalEnvironment environment:reg4
-  [  c0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  d8] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
-  [  e8] DynamicInitializeLexicalBinding `y`, src:Int32(2)
-  [  f8] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [ 110] Mov dst:reg8, src:fns~0
-  [ 120] NewFunction dst:reg9, shared_function_data_index:1
-  [ 138] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 160] SetLexicalEnvironment environment:reg4
-  [ 168] GetByValue dst:reg6, base:fns~0, property:Int32(0)
-  [ 180] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
-  [ 1a0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
-  [ 1b8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
-  [ 1d8] Add dst:reg7, lhs:reg5, rhs:reg6
-  [ 1e8] Return value:reg7
+  [  40] InitializeLexicalBinding `x`, src:Int32(1)
+  [  58] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  70] Mov dst:reg8, src:fns~0
+  [  80] NewFunction dst:reg9, shared_function_data_index:0
+  [  98] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [  c0] SetLexicalEnvironment environment:reg4
+  [  c8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  e0] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
+  [  f0] InitializeLexicalBinding `y`, src:Int32(2)
+  [ 108] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [ 120] Mov dst:reg8, src:fns~0
+  [ 130] NewFunction dst:reg9, shared_function_data_index:1
+  [ 148] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 170] SetLexicalEnvironment environment:reg4
+  [ 178] GetByValue dst:reg6, base:fns~0, property:Int32(0)
+  [ 190] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
+  [ 1b0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
+  [ 1c8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
+  [ 1e8] Add dst:reg7, lhs:reg5, rhs:reg6
+  [ 1f8] Return value:reg7
 
 
 $cff4e98a block-scoping.js:5:18
@@ -72,7 +72,7 @@ block0:
   [  10] Return value:reg5
 
 
-breakThroughBlockScopes$3cf1eeb7 block-scoping.js:16:5
+breakThroughBlockScopes$3fb5dfc7 block-scoping.js:16:5
   Registers: 8
   Blocks:    7
   Locals:    f~0, i~1, result~2
@@ -90,29 +90,29 @@ block0:
 block1:
   [  28] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  40] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  50] DynamicInitializeLexicalBinding `x`, src:i~1
-  [  60] NewFunction dst:f~0, shared_function_data_index:0 (f)
-  [  78] DynamicGetBinding dst:reg6, `x`
-  [  88] JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:block5, false_target:block6
+  [  50] InitializeLexicalBinding `x`, src:i~1
+  [  68] NewFunction dst:f~0, shared_function_data_index:0 (f)
+  [  80] GetBinding dst:reg6, `x`
+  [  98] JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:block5, false_target:block6
 
 block2:
-  [  a0] PostfixIncrement dst:reg5, src:i~1
+  [  b0] PostfixIncrement dst:reg5, src:i~1
 
 block3:
-  [  b0] JumpLessThan lhs:i~1, rhs:Int32(3), true_target:block1, false_target:block4
+  [  c0] JumpLessThan lhs:i~1, rhs:Int32(3), true_target:block1, false_target:block4
 
 block4:
-  [  c8] Call dst:reg5, callee:result~2, this_value:Undefined, result
-  [  e8] Return value:reg5
+  [  d8] Call dst:reg5, callee:result~2, this_value:Undefined, result
+  [  f8] Return value:reg5
 
 block5:
-  [  f0] Mov dst:result~2, src:f~0
-  [ 100] SetLexicalEnvironment environment:reg4
-  [ 108] Jump target:block4
+  [ 100] Mov dst:result~2, src:f~0
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Jump target:block4
 
 block6:
-  [ 110] SetLexicalEnvironment environment:reg4
-  [ 118] Jump target:block2
+  [ 120] SetLexicalEnvironment environment:reg4
+  [ 128] Jump target:block2
 
 
 f$63b62772 block-scoping.js:20:21

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -1,4 +1,4 @@
-$fcbe57a6 block-scoping.js:13:1
+$f9fa6696 block-scoping.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -6,19 +6,19 @@ $fcbe57a6 block-scoping.js:13:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `closureOverBlockScope`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, closureOverBlockScope
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg6, `console`
-  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d0] GetGlobal dst:reg10, `breakThroughBlockScopes`
-  [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughBlockScopes
-  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 130] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `closureOverBlockScope`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, closureOverBlockScope
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] GetGlobal dst:reg6, `console`
+  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  a8] GetGlobal dst:reg10, `breakThroughBlockScopes`
+  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughBlockScopes
+  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 100] End value:reg7
 
 
-closureOverBlockScope$5e4c59e2 block-scoping.js:2:15
+closureOverBlockScope$61104af2 block-scoping.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    fns~0
@@ -34,24 +34,24 @@ block0:
   [  30] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
   [  40] InitializeLexicalBinding `x`, src:Int32(1)
   [  58] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  78] Mov dst:reg8, src:fns~0
-  [  88] NewFunction dst:reg9, shared_function_data_index:0
-  [  a0] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  e8] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
-  [  f8] InitializeLexicalBinding `y`, src:Int32(2)
-  [ 110] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [ 130] Mov dst:reg8, src:fns~0
-  [ 140] NewFunction dst:reg9, shared_function_data_index:1
-  [ 158] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 180] SetLexicalEnvironment environment:reg4
-  [ 188] GetByValue dst:reg6, base:fns~0, property:Int32(0)
-  [ 1a0] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
-  [ 1c0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
-  [ 1d8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
-  [ 1f8] Add dst:reg7, lhs:reg5, rhs:reg6
-  [ 208] Return value:reg7
+  [  70] Mov dst:reg8, src:fns~0
+  [  80] NewFunction dst:reg9, shared_function_data_index:0
+  [  98] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [  c0] SetLexicalEnvironment environment:reg4
+  [  c8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  e0] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
+  [  f0] InitializeLexicalBinding `y`, src:Int32(2)
+  [ 108] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [ 120] Mov dst:reg8, src:fns~0
+  [ 130] NewFunction dst:reg9, shared_function_data_index:1
+  [ 148] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 170] SetLexicalEnvironment environment:reg4
+  [ 178] GetByValue dst:reg6, base:fns~0, property:Int32(0)
+  [ 190] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
+  [ 1b0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
+  [ 1c8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
+  [ 1e8] Add dst:reg7, lhs:reg5, rhs:reg6
+  [ 1f8] Return value:reg7
 
 
 $4bcefff2 block-scoping.js:5:18

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -18,7 +18,7 @@ block0:
   [ 100] End value:reg7
 
 
-closureOverBlockScope$61104af2 block-scoping.js:2:15
+closureOverBlockScope$19ddc477 block-scoping.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    fns~0
@@ -32,47 +32,47 @@ block0:
   [   8] NewArray dst:fns~0
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  30] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  40] InitializeLexicalBinding `x`, src:Int32(1)
-  [  58] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  70] Mov dst:reg8, src:fns~0
-  [  80] NewFunction dst:reg9, shared_function_data_index:0
-  [  98] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  e0] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
-  [  f0] InitializeLexicalBinding `y`, src:Int32(2)
-  [ 108] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [ 120] Mov dst:reg8, src:fns~0
-  [ 130] NewFunction dst:reg9, shared_function_data_index:1
-  [ 148] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 170] SetLexicalEnvironment environment:reg4
-  [ 178] GetByValue dst:reg6, base:fns~0, property:Int32(0)
-  [ 190] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
-  [ 1b0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
-  [ 1c8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
-  [ 1e8] Add dst:reg7, lhs:reg5, rhs:reg6
-  [ 1f8] Return value:reg7
+  [  40] DynamicInitializeLexicalBinding `x`, src:Int32(1)
+  [  50] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  68] Mov dst:reg8, src:fns~0
+  [  78] NewFunction dst:reg9, shared_function_data_index:0
+  [  90] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  d8] CreateMutableBinding environment:reg5, `y`, can_be_deleted:false
+  [  e8] DynamicInitializeLexicalBinding `y`, src:Int32(2)
+  [  f8] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [ 110] Mov dst:reg8, src:fns~0
+  [ 120] NewFunction dst:reg9, shared_function_data_index:1
+  [ 138] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 160] SetLexicalEnvironment environment:reg4
+  [ 168] GetByValue dst:reg6, base:fns~0, property:Int32(0)
+  [ 180] Call dst:reg5, callee:reg6, this_value:fns~0, fns[0]
+  [ 1a0] GetByValue dst:reg7, base:fns~0, property:Int32(1)
+  [ 1b8] Call dst:reg6, callee:reg7, this_value:fns~0, fns[1]
+  [ 1d8] Add dst:reg7, lhs:reg5, rhs:reg6
+  [ 1e8] Return value:reg7
 
 
-$4bcefff2 block-scoping.js:5:18
+$cff4e98a block-scoping.js:5:18
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `x`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `x`
+  [  10] Return value:reg5
 
 
-$3664423e block-scoping.js:9:18
+$b7c63ac6 block-scoping.js:9:18
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `y`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `y`
+  [  10] Return value:reg5
 
 
-breakThroughBlockScopes$3fb5dfc7 block-scoping.js:16:5
+breakThroughBlockScopes$3cf1eeb7 block-scoping.js:16:5
   Registers: 8
   Blocks:    7
   Locals:    f~0, i~1, result~2
@@ -90,38 +90,38 @@ block0:
 block1:
   [  28] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  40] CreateMutableBinding environment:reg5, `x`, can_be_deleted:false
-  [  50] InitializeLexicalBinding `x`, src:i~1
-  [  68] NewFunction dst:f~0, shared_function_data_index:0 (f)
-  [  80] GetBinding dst:reg6, `x`
-  [  98] JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:block5, false_target:block6
+  [  50] DynamicInitializeLexicalBinding `x`, src:i~1
+  [  60] NewFunction dst:f~0, shared_function_data_index:0 (f)
+  [  78] DynamicGetBinding dst:reg6, `x`
+  [  88] JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:block5, false_target:block6
 
 block2:
-  [  b0] PostfixIncrement dst:reg5, src:i~1
+  [  a0] PostfixIncrement dst:reg5, src:i~1
 
 block3:
-  [  c0] JumpLessThan lhs:i~1, rhs:Int32(3), true_target:block1, false_target:block4
+  [  b0] JumpLessThan lhs:i~1, rhs:Int32(3), true_target:block1, false_target:block4
 
 block4:
-  [  d8] Call dst:reg5, callee:result~2, this_value:Undefined, result
-  [  f8] Return value:reg5
+  [  c8] Call dst:reg5, callee:result~2, this_value:Undefined, result
+  [  e8] Return value:reg5
 
 block5:
-  [ 100] Mov dst:result~2, src:f~0
-  [ 110] SetLexicalEnvironment environment:reg4
-  [ 118] Jump target:block4
+  [  f0] Mov dst:result~2, src:f~0
+  [ 100] SetLexicalEnvironment environment:reg4
+  [ 108] Jump target:block4
 
 block6:
-  [ 120] SetLexicalEnvironment environment:reg4
-  [ 128] Jump target:block2
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Jump target:block2
 
 
-f$e7dc110a block-scoping.js:20:21
+f$63b62772 block-scoping.js:20:21
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `x`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `x`
+  [  10] Return value:reg5
 
 
 3

--- a/Tests/LibJS/Bytecode/expected/call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$973653fe call-spread-register-order.js:2:1
+$15d45b76 call-spread-register-order.js:2:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -7,12 +7,12 @@ $973653fe call-spread-register-order.js:2:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Mov dst:reg8, src:Int32(42)
-  [  28] NewArray dst:reg7, elements:[reg8]
-  [  40] NewPrimitiveArray dst:reg9, elements:[1]
-  [  58] ArrayAppend dst:reg7, src:reg9, is_spread:true
-  [  68] CallWithArgumentArray dst:reg5, callee:reg6, this_value:Undefined, arguments:reg7, f
-  [  80] End value:reg5
+  [  10] Mov dst:reg8, src:Int32(42)
+  [  20] NewArray dst:reg7, elements:[reg8]
+  [  38] NewPrimitiveArray dst:reg9, elements:[1]
+  [  50] ArrayAppend dst:reg7, src:reg9, is_spread:true
+  [  60] CallWithArgumentArray dst:reg5, callee:reg6, this_value:Undefined, arguments:reg7, f
+  [  78] End value:reg5
 
 
 f$7aaaa003

--- a/Tests/LibJS/Bytecode/expected/captured-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/captured-variables.txt
@@ -1,4 +1,4 @@
-$c7fd0018 captured-variables.js:12:1
+$546ebce0 captured-variables.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $c7fd0018 captured-variables.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `outer`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, outer
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, outer
+  [  30] End value:reg5
 
 
 outer$65f64384 captured-variables.js:5:5

--- a/Tests/LibJS/Bytecode/expected/captured-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/captured-variables.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-outer$e7583c0c captured-variables.js:5:5
+outer$65f64384 captured-variables.js:5:5
   Registers: 7
   Blocks:    1
   Locals:    inner~0
@@ -24,9 +24,9 @@ block0:
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  30] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
   [  40] NewFunction dst:inner~0, shared_function_data_index:0
-  [  58] DynamicInitializeLexicalBinding `captured`, src:Int32(1)
-  [  68] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
-  [  88] Return value:reg6
+  [  58] InitializeLexicalBinding `captured`, src:Int32(1)
+  [  70] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
+  [  90] Return value:reg6
 
 
 inner$6897e27d captured-variables.js:7:9

--- a/Tests/LibJS/Bytecode/expected/captured-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/captured-variables.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-outer$65f64384 captured-variables.js:5:5
+outer$e7583c0c captured-variables.js:5:5
   Registers: 7
   Blocks:    1
   Locals:    inner~0
@@ -24,15 +24,15 @@ block0:
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  30] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
   [  40] NewFunction dst:inner~0, shared_function_data_index:0
-  [  58] InitializeLexicalBinding `captured`, src:Int32(1)
-  [  70] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
-  [  90] Return value:reg6
+  [  58] DynamicInitializeLexicalBinding `captured`, src:Int32(1)
+  [  68] Call dst:reg6, callee:inner~0, this_value:Undefined, inner
+  [  88] Return value:reg6
 
 
-inner$e471f8e5 captured-variables.js:7:9
+inner$6897e27d captured-variables.js:7:9
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `captured`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `captured`
+  [  10] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
+++ b/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
@@ -1,4 +1,4 @@
-$3a6e508d catch-scope-boundary.js:14:1
+$37aa5f7d catch-scope-boundary.js:14:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -6,16 +6,16 @@ $3a6e508d catch-scope-boundary.js:14:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `throwInCatch`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, throwInCatch
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg6, `console`
-  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d0] GetGlobal dst:reg10, `throwInCatchWithLocals`
-  [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, throwInCatchWithLocals
-  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 130] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `throwInCatch`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, throwInCatch
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] GetGlobal dst:reg6, `console`
+  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  a8] GetGlobal dst:reg10, `throwInCatchWithLocals`
+  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, throwInCatchWithLocals
+  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 100] End value:reg7
 
 
 throwInCatch$94c0d746 catch-scope-boundary.js:2:5

--- a/Tests/LibJS/Bytecode/expected/chained-member-call.txt
+++ b/Tests/LibJS/Bytecode/expected/chained-member-call.txt
@@ -1,4 +1,4 @@
-$82bdc9cb chained-member-call.js:12:1
+$8581badb chained-member-call.js:12:1
   Registers: 10
   Blocks:    6
   Constants:
@@ -20,29 +20,29 @@ block2:
 block3:
   [  40] Mov dst:reg5, src:Undefined
   [  50] GetGlobal dst:reg8, `chained_computed_call`
-  [  68] Call dst:reg6, callee:reg8, this_value:Undefined, chained_computed_call, arguments:[Int32(0), Int32(0), Int32(0)]
-  [  98] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
-  [  b0] Jump target:block2
+  [  60] Call dst:reg6, callee:reg8, this_value:Undefined, chained_computed_call, arguments:[Int32(0), Int32(0), Int32(0)]
+  [  90] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+  [  a8] Jump target:block2
 
 block4:
-  [  b8] Catch dst:reg5
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] Mov2 dst1:reg7, src1:Undefined, dst2:reg8, src2:reg7
-  [  e0] End value:reg7
+  [  b0] Catch dst:reg5
+  [  b8] SetLexicalEnvironment environment:reg4
+  [  c0] Mov2 dst1:reg7, src1:Undefined, dst2:reg8, src2:reg7
+  [  d8] End value:reg7
 
 block5:
-  [  e8] Mov dst:reg5, src:Undefined
-  [  f8] GetGlobal dst:reg9, `chained_dot_call`
-  [ 110] Call dst:reg7, callee:reg9, this_value:Undefined, chained_dot_call, arguments:[Int32(0)]
-  [ 138] Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
-  [ 150] End value:reg7
+  [  e0] Mov dst:reg5, src:Undefined
+  [  f0] GetGlobal dst:reg9, `chained_dot_call`
+  [ 100] Call dst:reg7, callee:reg9, this_value:Undefined, chained_dot_call, arguments:[Int32(0)]
+  [ 128] Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
+  [ 140] End value:reg7
 
 Exception handlers:
-  [  40 ..   b8] => handler block1
-  [  e8 ..  158] => handler block4
+  [  40 ..   b0] => handler block1
+  [  e0 ..  148] => handler block4
 
 
-chained_computed_call$78bf026a chained-member-call.js:5:5
+chained_computed_call$f75d09e2 chained-member-call.js:5:5
   Registers: 8
   Blocks:    1
 
@@ -51,18 +51,18 @@ block0:
   [  10] GetByValue dst:reg7, base:reg6, property:arg1 (a[arg1])
   [  28] GetByValue dst:reg6, base:reg7, property:arg2 (a[j][arg2])
   [  40] GetById dst:reg7, base:reg6, `foo` (a[j][k].foo)
-  [  60] Call dst:reg5, callee:reg7, this_value:reg6, a[j][k].foo
-  [  80] Return value:reg5
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, a[j][k].foo
+  [  78] Return value:reg5
 
 
-chained_dot_call$4ef00940 chained-member-call.js:9:5
+chained_dot_call$d315f2d8 chained-member-call.js:9:5
   Registers: 8
   Blocks:    1
 
 block0:
   [   0] Mov dst:reg6, src:arg0
   [  10] GetById dst:reg7, base:reg6, `b` (a.b)
-  [  30] GetById dst:reg6, base:reg7, `c` (a.b.c)
-  [  50] GetById dst:reg7, base:reg6, `bar` (a.b.c.bar)
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, a.b.c.bar
-  [  90] Return value:reg5
+  [  28] GetById dst:reg6, base:reg7, `c` (a.b.c)
+  [  40] GetById dst:reg7, base:reg6, `bar` (a.b.c.bar)
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, a.b.c.bar
+  [  78] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-field-lhs-name.txt
@@ -1,4 +1,4 @@
-$87b8bc45 class-computed-field-lhs-name.js:1:1
+$7f6ce915 class-computed-field-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -13,9 +13,9 @@ block0:
   [  20] SetLexicalEnvironment environment:reg4
   [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (C), element_keys:[element_keys:Int32(3)]
   [  50] SetGlobal `C`, src:reg6
-  [  68] GetGlobal dst:reg5, `C`
-  [  80] CallConstruct dst:reg6, callee:reg5, C
-  [  98] End value:reg6
+  [  60] GetGlobal dst:reg5, `C`
+  [  70] CallConstruct dst:reg6, callee:reg5, C
+  [  88] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/class-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/class-computed-key.txt
@@ -1,4 +1,4 @@
-$d36729be class-computed-key.js:10:1
+$49b95e06 class-computed-key.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $d36729be class-computed-key.js:10:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
-f$01c8ca6a class-computed-key.js:4:5
+f$0a149d9a class-computed-key.js:4:5
   Registers: 8
   Blocks:    1
 
@@ -19,7 +19,7 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateVariable ``, is_immutable:true, is_global:false, is_strict:false
   [  30] GetGlobal dst:reg6, `Symbol`
-  [  48] GetById dst:reg7, base:reg6, `iterator` (Symbol.iterator)
-  [  68] SetLexicalEnvironment environment:reg4
-  [  70] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:reg7]
-  [  98] Return value:reg6
+  [  40] GetById dst:reg7, base:reg6, `iterator` (Symbol.iterator)
+  [  58] SetLexicalEnvironment environment:reg4
+  [  60] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:reg7]
+  [  88] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/class-environment.txt
+++ b/Tests/LibJS/Bytecode/expected/class-environment.txt
@@ -44,13 +44,13 @@ block0:
   [   0] End value:Undefined
 
 
-method$f198ceab class-environment.js:4:13
+method$67eb02f3 class-environment.js:4:13
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `Foo`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `Foo`
+  [  10] Return value:reg5
 
 
 true

--- a/Tests/LibJS/Bytecode/expected/class-environment.txt
+++ b/Tests/LibJS/Bytecode/expected/class-environment.txt
@@ -1,4 +1,4 @@
-$241c3dcd class-environment.js:9:1
+$9d326325 class-environment.js:9:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -6,14 +6,14 @@ $241c3dcd class-environment.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `classWithName`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, classWithName
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `classWithName`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, classWithName
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] End value:reg5
 
 
-classWithName$99834c89 class-environment.js:2:13
+classWithName$155d62f1 class-environment.js:2:13
   Registers: 8
   Blocks:    1
   Locals:    C~0
@@ -29,9 +29,9 @@ block0:
   [  38] NewClass dst:C~0, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
   [  60] CallConstruct dst:reg6, callee:C~0, C
   [  78] GetById dst:reg7, base:reg6, `method`
-  [  98] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
-  [  b8] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
-  [  c8] Return value:reg7
+  [  90] Call dst:reg5, callee:reg7, this_value:reg6, <object>.method
+  [  b0] StrictlyEquals dst:reg7, lhs:reg5, rhs:C~0
+  [  c0] Return value:reg7
 
 
 Foo$534d924b

--- a/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
+++ b/Tests/LibJS/Bytecode/expected/class-lhs-name-no-createvariable.txt
@@ -1,4 +1,4 @@
-$63c57e75 class-lhs-name-no-createvariable.js:1:1
+$e7eb680d class-lhs-name-no-createvariable.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,4 +11,4 @@ block0:
   [  20] SetLexicalEnvironment environment:reg4
   [  28] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0 (x), element_keys:[element_keys:String("method")]
   [  50] SetGlobal `x`, src:reg6
-  [  68] End value:Undefined
+  [  60] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
+++ b/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
@@ -1,4 +1,4 @@
-$015bd143 class-literal-fields.js:12:1
+$77ae058b class-literal-fields.js:12:1
   Registers: 15
   Blocks:    1
   Constants:
@@ -7,23 +7,23 @@ $015bd143 class-literal-fields.js:12:1
 block0:
   [   0] GetGlobal dst:reg6, `test`
   [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  30] InitializeLexicalBinding `a`, src:reg5
-  [  48] GetGlobal dst:reg6, `console`
-  [  58] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  70] GetGlobal dst:reg8, `a`
-  [  80] GetById dst:reg9, base:reg8, `x` (a.x)
-  [  98] GetGlobal dst:reg8, `a`
-  [  a8] GetById dst:reg10, base:reg8, `y` (a.y)
-  [  c0] GetGlobal dst:reg8, `a`
-  [  d0] GetById dst:reg11, base:reg8, `z` (a.z)
-  [  e8] GetGlobal dst:reg8, `a`
-  [  f8] GetById dst:reg12, base:reg8, `w` (a.w)
-  [ 110] GetGlobal dst:reg8, `a`
-  [ 120] GetById dst:reg13, base:reg8, `s` (a.s)
-  [ 138] GetGlobal dst:reg8, `a`
-  [ 148] GetById dst:reg14, base:reg8, `computed` (a.computed)
-  [ 160] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg9, reg10, reg11, reg12, reg13, reg14]
-  [ 198] End value:reg5
+  [  30] DynamicInitializeLexicalBinding `a`, src:reg5
+  [  40] GetGlobal dst:reg6, `console`
+  [  50] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  68] GetGlobal dst:reg8, `a`
+  [  78] GetById dst:reg9, base:reg8, `x` (a.x)
+  [  90] GetGlobal dst:reg8, `a`
+  [  a0] GetById dst:reg10, base:reg8, `y` (a.y)
+  [  b8] GetGlobal dst:reg8, `a`
+  [  c8] GetById dst:reg11, base:reg8, `z` (a.z)
+  [  e0] GetGlobal dst:reg8, `a`
+  [  f0] GetById dst:reg12, base:reg8, `w` (a.w)
+  [ 108] GetGlobal dst:reg8, `a`
+  [ 118] GetById dst:reg13, base:reg8, `s` (a.s)
+  [ 130] GetGlobal dst:reg8, `a`
+  [ 140] GetById dst:reg14, base:reg8, `computed` (a.computed)
+  [ 158] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg9, reg10, reg11, reg12, reg13, reg14]
+  [ 190] End value:reg5
 
 
 test$fa7458d4 class-literal-fields.js:2:5

--- a/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
+++ b/Tests/LibJS/Bytecode/expected/class-literal-fields.txt
@@ -1,4 +1,4 @@
-$ccb44156 class-literal-fields.js:12:1
+$015bd143 class-literal-fields.js:12:1
   Registers: 15
   Blocks:    1
   Constants:
@@ -6,24 +6,24 @@ $ccb44156 class-literal-fields.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  38] InitializeLexicalBinding `a`, src:reg5
-  [  50] GetGlobal dst:reg6, `console`
-  [  68] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  88] GetGlobal dst:reg8, `a`
-  [  a0] GetById dst:reg9, base:reg8, `x` (a.x)
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  30] InitializeLexicalBinding `a`, src:reg5
+  [  48] GetGlobal dst:reg6, `console`
+  [  58] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  70] GetGlobal dst:reg8, `a`
+  [  80] GetById dst:reg9, base:reg8, `x` (a.x)
+  [  98] GetGlobal dst:reg8, `a`
+  [  a8] GetById dst:reg10, base:reg8, `y` (a.y)
   [  c0] GetGlobal dst:reg8, `a`
-  [  d8] GetById dst:reg10, base:reg8, `y` (a.y)
-  [  f8] GetGlobal dst:reg8, `a`
-  [ 110] GetById dst:reg11, base:reg8, `z` (a.z)
-  [ 130] GetGlobal dst:reg8, `a`
-  [ 148] GetById dst:reg12, base:reg8, `w` (a.w)
-  [ 168] GetGlobal dst:reg8, `a`
-  [ 180] GetById dst:reg13, base:reg8, `s` (a.s)
-  [ 1a0] GetGlobal dst:reg8, `a`
-  [ 1b8] GetById dst:reg14, base:reg8, `computed` (a.computed)
-  [ 1d8] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg9, reg10, reg11, reg12, reg13, reg14]
-  [ 210] End value:reg5
+  [  d0] GetById dst:reg11, base:reg8, `z` (a.z)
+  [  e8] GetGlobal dst:reg8, `a`
+  [  f8] GetById dst:reg12, base:reg8, `w` (a.w)
+  [ 110] GetGlobal dst:reg8, `a`
+  [ 120] GetById dst:reg13, base:reg8, `s` (a.s)
+  [ 138] GetGlobal dst:reg8, `a`
+  [ 148] GetById dst:reg14, base:reg8, `computed` (a.computed)
+  [ 160] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg9, reg10, reg11, reg12, reg13, reg14]
+  [ 198] End value:reg5
 
 
 test$fa7458d4 class-literal-fields.js:2:5

--- a/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-compound-assign-register-reuse.txt
@@ -1,4 +1,4 @@
-$9d326325 computed-compound-assign-register-reuse.js:9:1
+$1e945bad computed-compound-assign-register-reuse.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,10 +6,10 @@ $9d326325 computed-compound-assign-register-reuse.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `subVector`
-  [  18] NewPrimitiveArray dst:reg7, elements:[1, 2]
-  [  38] NewPrimitiveArray dst:reg8, elements:[3, 4]
-  [  58] Call dst:reg5, callee:reg6, this_value:Undefined, subVector, arguments:[reg7, reg8]
-  [  80] End value:reg5
+  [  10] NewPrimitiveArray dst:reg7, elements:[1, 2]
+  [  30] NewPrimitiveArray dst:reg8, elements:[3, 4]
+  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, subVector, arguments:[reg7, reg8]
+  [  78] End value:reg5
 
 
 subVector$3599dc10 computed-compound-assign-register-reuse.js:5:13

--- a/Tests/LibJS/Bytecode/expected/computed-member-access.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-access.txt
@@ -1,4 +1,4 @@
-$3e4f3460 computed-member-access.js:12:1
+$41132570 computed-member-access.js:12:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -7,12 +7,12 @@ $3e4f3460 computed-member-access.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `computed_read`
-  [  18] NewPrimitiveArray dst:reg7, elements:[1]
-  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, computed_read, arguments:[reg7]
-  [  58] GetGlobal dst:reg7, `computed_read_expression`
-  [  70] NewPrimitiveArray dst:reg8, elements:[1]
-  [  88] Call dst:reg6, callee:reg7, this_value:Undefined, computed_read_expression, arguments:[reg8, Int32(0)]
-  [  b0] End value:reg6
+  [  10] NewPrimitiveArray dst:reg7, elements:[1]
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, computed_read, arguments:[reg7]
+  [  50] GetGlobal dst:reg7, `computed_read_expression`
+  [  60] NewPrimitiveArray dst:reg8, elements:[1]
+  [  78] Call dst:reg6, callee:reg7, this_value:Undefined, computed_read_expression, arguments:[reg8, Int32(0)]
+  [  a0] End value:reg6
 
 
 computed_read$f0ef6ac1 computed-member-access.js:5:5

--- a/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
@@ -1,4 +1,4 @@
-$7fc74e7b computed-member-compound-assign.js:15:1
+$828b3f8b computed-member-compound-assign.js:15:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -8,14 +8,14 @@ $7fc74e7b computed-member-compound-assign.js:15:1
 
 block0:
   [   0] GetGlobal dst:reg6, `compound_computed`
-  [  18] NewObject dst:reg7
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, compound_computed, arguments:[reg7, String("x")]
-  [  50] GetGlobal dst:reg7, `compound_then_assign`
-  [  68] NewObject dst:reg8
-  [  78] InitObjectLiteralProperty object:reg8, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  90] CacheObjectShape object:reg8
-  [  a0] Call dst:reg6, callee:reg7, this_value:Undefined, compound_then_assign, arguments:[reg8, String("x")]
-  [  c8] End value:reg6
+  [  10] NewObject dst:reg7
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, compound_computed, arguments:[reg7, String("x")]
+  [  48] GetGlobal dst:reg7, `compound_then_assign`
+  [  58] NewObject dst:reg8
+  [  68] InitObjectLiteralProperty object:reg8, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  80] CacheObjectShape object:reg8
+  [  90] Call dst:reg6, callee:reg7, this_value:Undefined, compound_then_assign, arguments:[reg8, String("x")]
+  [  b8] End value:reg6
 
 
 compound_computed$811bdddb computed-member-compound-assign.js:7:14

--- a/Tests/LibJS/Bytecode/expected/computed-string-object-literal.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-string-object-literal.txt
@@ -1,4 +1,4 @@
-$f8dd73d3 computed-string-object-literal.js:15:1
+$7d035d6b computed-string-object-literal.js:15:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,12 +7,12 @@ $f8dd73d3 computed-string-object-literal.js:15:1
 
 block0:
   [   0] GetGlobal dst:reg6, `simple_computed`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, simple_computed
-  [  38] GetGlobal dst:reg7, `mixed`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, mixed
-  [  70] GetGlobal dst:reg7, `dynamic`
-  [  88] Call dst:reg5, callee:reg7, this_value:Undefined, dynamic, arguments:[String("x")]
-  [  b0] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, simple_computed
+  [  30] GetGlobal dst:reg7, `mixed`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, mixed
+  [  60] GetGlobal dst:reg7, `dynamic`
+  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, dynamic, arguments:[String("x")]
+  [  98] End value:reg5
 
 
 simple_computed$ee1d99de computed-string-object-literal.js:6:5

--- a/Tests/LibJS/Bytecode/expected/computed-string-to-ById.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-string-to-ById.txt
@@ -1,4 +1,4 @@
-$dc43d5b2 computed-string-to-ById.js:17:1
+$e1cbb7d2 computed-string-to-ById.js:17:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,21 +6,21 @@ $dc43d5b2 computed-string-to-ById.js:17:1
 
 block0:
   [   0] GetGlobal dst:reg6, `get_string_prop`
-  [  18] NewObject dst:reg7
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, get_string_prop, arguments:[reg7]
-  [  50] GetGlobal dst:reg7, `set_string_prop`
-  [  68] NewObject dst:reg8
-  [  78] Call dst:reg6, callee:reg7, this_value:Undefined, set_string_prop, arguments:[reg8]
-  [  a0] GetGlobal dst:reg7, `get_index_prop`
-  [  b8] NewArray dst:reg8
-  [  c8] Call dst:reg5, callee:reg7, this_value:Undefined, get_index_prop, arguments:[reg8]
-  [  f0] GetGlobal dst:reg7, `get_length_prop`
-  [ 108] NewArray dst:reg8
-  [ 118] Call dst:reg6, callee:reg7, this_value:Undefined, get_length_prop, arguments:[reg8]
-  [ 140] End value:reg6
+  [  10] NewObject dst:reg7
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, get_string_prop, arguments:[reg7]
+  [  48] GetGlobal dst:reg7, `set_string_prop`
+  [  58] NewObject dst:reg8
+  [  68] Call dst:reg6, callee:reg7, this_value:Undefined, set_string_prop, arguments:[reg8]
+  [  90] GetGlobal dst:reg7, `get_index_prop`
+  [  a0] NewArray dst:reg8
+  [  b0] Call dst:reg5, callee:reg7, this_value:Undefined, get_index_prop, arguments:[reg8]
+  [  d8] GetGlobal dst:reg7, `get_length_prop`
+  [  e8] NewArray dst:reg8
+  [  f8] Call dst:reg6, callee:reg7, this_value:Undefined, get_length_prop, arguments:[reg8]
+  [ 120] End value:reg6
 
 
-get_string_prop$d6b42da3 computed-string-to-ById.js:5:5
+get_string_prop$5816262b computed-string-to-ById.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -29,10 +29,10 @@ get_string_prop$d6b42da3 computed-string-to-ById.js:5:5
 block0:
   [   0] Mov dst:reg5, src:arg0
   [  10] GetById dst:reg6, base:reg5, `hello` (o.hello)
-  [  30] Return value:reg6
+  [  28] Return value:reg6
 
 
-set_string_prop$592a21c7 computed-string-to-ById.js:8:16
+set_string_prop$d240471f computed-string-to-ById.js:8:16
   Registers: 6
   Blocks:    1
   Constants:
@@ -43,7 +43,7 @@ set_string_prop$592a21c7 computed-string-to-ById.js:8:16
 block0:
   [   0] Mov dst:reg5, src:arg0
   [  10] PutById base:reg5, `hello`, src:Int32(42), kind:Normal (o.hello)
-  [  38] End value:Undefined
+  [  30] End value:Undefined
 
 
 get_index_prop$a54df54e computed-string-to-ById.js:11:5

--- a/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-update-register-order.txt
@@ -1,4 +1,4 @@
-$9790b964 computed-update-register-order.js:8:1
+$18f2b1ec computed-update-register-order.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $9790b964 computed-update-register-order.js:8:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] NewPrimitiveArray dst:reg7, elements:[1, 2, 3, 4]
-  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
-  [  70] End value:reg5
+  [  10] NewPrimitiveArray dst:reg7, elements:[1, 2, 3, 4]
+  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
+  [  68] End value:reg5
 
 
-test$7becb49f computed-update-register-order.js:5:9
+test$fa8abc17 computed-update-register-order.js:5:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -23,9 +23,9 @@ block0:
   [  18] PostfixIncrement dst:reg6, src:reg5
   [  28] PutByValue base:arg0, property:Int32(3), src:reg5, kind:Normal
   [  40] GetGlobal dst:reg5, `foo`
-  [  58] Mov dst:reg7, src:arg0
-  [  68] Call dst:reg6, callee:reg5, this_value:Undefined, foo, arguments:[reg7]
-  [  90] End value:Undefined
+  [  50] Mov dst:reg7, src:arg0
+  [  60] Call dst:reg6, callee:reg5, this_value:Undefined, foo, arguments:[reg7]
+  [  88] End value:Undefined
 
 
 foo$93622fcc computed-update-register-order.js:2:5

--- a/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
+++ b/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
@@ -1,4 +1,4 @@
-$ec8fc79b condition-dead-code-elim.js:141:1
+$7bc57573 condition-dead-code-elim.js:141:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,28 +7,28 @@ $ec8fc79b condition-dead-code-elim.js:141:1
 
 block0:
   [   0] GetGlobal dst:reg6, `ternary_true`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, ternary_true
-  [  38] GetGlobal dst:reg7, `ternary_truthy`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_truthy
-  [  70] GetGlobal dst:reg7, `ternary_false`
-  [  88] Call dst:reg5, callee:reg7, this_value:Undefined, ternary_false
-  [  a8] GetGlobal dst:reg7, `ternary_falsey`
-  [  c0] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_falsey
-  [  e0] GetGlobal dst:reg7, `while_falsey`
-  [  f8] Call dst:reg5, callee:reg7, this_value:Undefined, while_falsey
-  [ 118] GetGlobal dst:reg7, `do_while_falsey`
-  [ 130] Call dst:reg6, callee:reg7, this_value:Undefined, do_while_falsey
-  [ 150] GetGlobal dst:reg7, `if_falsely`
-  [ 168] Call dst:reg5, callee:reg7, this_value:Undefined, if_falsely
-  [ 188] GetGlobal dst:reg7, `if_truthy`
-  [ 1a0] Call dst:reg6, callee:reg7, this_value:Undefined, if_truthy
-  [ 1c0] GetGlobal dst:reg7, `if_exhausted`
-  [ 1d8] Call dst:reg5, callee:reg7, this_value:Undefined, if_exhausted
-  [ 1f8] GetGlobal dst:reg7, `for_false`
-  [ 210] Call dst:reg6, callee:reg7, this_value:Undefined, for_false
-  [ 230] GetGlobal dst:reg7, `for_true`
-  [ 248] Call dst:reg5, callee:reg7, this_value:Undefined, for_true, arguments:[Bool(true)]
-  [ 270] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, ternary_true
+  [  30] GetGlobal dst:reg7, `ternary_truthy`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_truthy
+  [  60] GetGlobal dst:reg7, `ternary_false`
+  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, ternary_false
+  [  90] GetGlobal dst:reg7, `ternary_falsey`
+  [  a0] Call dst:reg6, callee:reg7, this_value:Undefined, ternary_falsey
+  [  c0] GetGlobal dst:reg7, `while_falsey`
+  [  d0] Call dst:reg5, callee:reg7, this_value:Undefined, while_falsey
+  [  f0] GetGlobal dst:reg7, `do_while_falsey`
+  [ 100] Call dst:reg6, callee:reg7, this_value:Undefined, do_while_falsey
+  [ 120] GetGlobal dst:reg7, `if_falsely`
+  [ 130] Call dst:reg5, callee:reg7, this_value:Undefined, if_falsely
+  [ 150] GetGlobal dst:reg7, `if_truthy`
+  [ 160] Call dst:reg6, callee:reg7, this_value:Undefined, if_truthy
+  [ 180] GetGlobal dst:reg7, `if_exhausted`
+  [ 190] Call dst:reg5, callee:reg7, this_value:Undefined, if_exhausted
+  [ 1b0] GetGlobal dst:reg7, `for_false`
+  [ 1c0] Call dst:reg6, callee:reg7, this_value:Undefined, for_false
+  [ 1e0] GetGlobal dst:reg7, `for_true`
+  [ 1f0] Call dst:reg5, callee:reg7, this_value:Undefined, for_true, arguments:[Bool(true)]
+  [ 218] End value:reg5
 
 
 ternary_true$cd62d477 condition-dead-code-elim.js:9:5
@@ -74,7 +74,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-while_falsey$17590e95 condition-dead-code-elim.js:33:5
+while_falsey$95f7160d condition-dead-code-elim.js:33:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -84,8 +84,8 @@ while_falsey$17590e95 condition-dead-code-elim.js:33:5
 
 block0:
   [   0] GetGlobal dst:reg6, `alive`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  38] End value:Undefined
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  30] End value:Undefined
 
 
 alive$dfea904d condition-dead-code-elim.js:2:5
@@ -98,7 +98,7 @@ block0:
   [   0] Return value:String("alive")
 
 
-do_while_falsey$2b22dba1 condition-dead-code-elim.js:37:9
+do_while_falsey$30aabdc1 condition-dead-code-elim.js:37:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -108,17 +108,17 @@ do_while_falsey$2b22dba1 condition-dead-code-elim.js:37:9
 
 block0:
   [   0] GetGlobal dst:reg6, `alive`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  38] GetGlobal dst:reg6, `alive`
-  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  70] GetGlobal dst:reg6, `alive`
-  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  a8] GetGlobal dst:reg6, `alive`
-  [  c0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  e0] End value:Undefined
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  30] GetGlobal dst:reg6, `alive`
+  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  60] GetGlobal dst:reg6, `alive`
+  [  70] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  90] GetGlobal dst:reg6, `alive`
+  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  c0] End value:Undefined
 
 
-if_falsely$537336d6 condition-dead-code-elim.js:62:5
+if_falsely$c17997ee condition-dead-code-elim.js:62:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -128,11 +128,11 @@ if_falsely$537336d6 condition-dead-code-elim.js:62:5
 
 block0:
   [   0] GetGlobal dst:reg6, `alive`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  38] End value:Undefined
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  30] End value:Undefined
 
 
-if_truthy$a6783770 condition-dead-code-elim.js:66:9
+if_truthy$a0f05550 condition-dead-code-elim.js:66:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -143,17 +143,17 @@ if_truthy$a6783770 condition-dead-code-elim.js:66:9
 
 block0:
   [   0] GetGlobal dst:reg6, `alive`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  38] GetGlobal dst:reg6, `alive`
-  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  70] GetGlobal dst:reg6, `alive`
-  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  a8] GetGlobal dst:reg6, `alive`
-  [  c0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  e0] End value:Undefined
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  30] GetGlobal dst:reg6, `alive`
+  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  60] GetGlobal dst:reg6, `alive`
+  [  70] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  90] GetGlobal dst:reg6, `alive`
+  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  c0] End value:Undefined
 
 
-if_exhausted$9d4f2301 condition-dead-code-elim.js:90:9
+if_exhausted$19293969 condition-dead-code-elim.js:90:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -163,15 +163,15 @@ if_exhausted$9d4f2301 condition-dead-code-elim.js:90:9
 
 block0:
   [   0] GetGlobal dst:reg6, `alive`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  38] GetGlobal dst:reg6, `alive`
-  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  70] GetGlobal dst:reg6, `alive`
-  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  a8] End value:Undefined
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  30] GetGlobal dst:reg6, `alive`
+  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  60] GetGlobal dst:reg6, `alive`
+  [  70] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  90] End value:Undefined
 
 
-for_false$23671fdc condition-dead-code-elim.js:109:5
+for_false$20a32ecc condition-dead-code-elim.js:109:5
   Registers: 7
   Blocks:    9
   Locals:    x~0
@@ -200,16 +200,16 @@ block5:
 
 block6:
   [  30] GetGlobal dst:reg5, `call_this`
-  [  48] Call dst:x~0, callee:reg5, this_value:Undefined, call_this
-  [  68] Jump target:block8
+  [  40] Call dst:x~0, callee:reg5, this_value:Undefined, call_this
+  [  60] Jump target:block8
 
 block7:
-  [  70] End value:Undefined
+  [  68] End value:Undefined
 
 block8:
-  [  78] GetGlobal dst:reg6, `alive`
-  [  90] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  b0] End value:Undefined
+  [  70] GetGlobal dst:reg6, `alive`
+  [  80] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  a0] End value:Undefined
 
 
 call_this$7cdf005a condition-dead-code-elim.js:105:5
@@ -222,7 +222,7 @@ block0:
   [   0] Return value:Int32(1)
 
 
-for_true$e3e30115 condition-dead-code-elim.js:128:5
+for_true$3f41bfe2 condition-dead-code-elim.js:128:5
   Registers: 7
   Blocks:    11
   Constants:
@@ -235,36 +235,36 @@ block0:
 
 block1:
   [   8] GetGlobal dst:reg6, `alive`
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  40] JumpIf condition:arg0, true_target:block4, false_target:block5
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  38] JumpIf condition:arg0, true_target:block4, false_target:block5
 
 block2:
-  [  50] Jump target:block1
+  [  48] Jump target:block1
 
 block3:
-  [  58] Jump target:block7
+  [  50] Jump target:block7
 
 block4:
-  [  60] Jump target:block3
+  [  58] Jump target:block3
 
 block5:
-  [  68] Jump target:block2
+  [  60] Jump target:block2
 
 block6:
-  [  70] GetGlobal dst:reg6, `alive`
-  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  a8] JumpIf condition:arg0, true_target:block9, false_target:block10
+  [  68] GetGlobal dst:reg6, `alive`
+  [  78] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  98] JumpIf condition:arg0, true_target:block9, false_target:block10
 
 block7:
-  [  b8] Jump target:block6
+  [  a8] Jump target:block6
 
 block8:
-  [  c0] GetGlobal dst:reg6, `alive`
-  [  d8] Call dst:reg5, callee:reg6, this_value:Undefined, alive
-  [  f8] End value:Undefined
+  [  b0] GetGlobal dst:reg6, `alive`
+  [  c0] Call dst:reg5, callee:reg6, this_value:Undefined, alive
+  [  e0] End value:Undefined
 
 block9:
-  [ 100] Jump target:block8
+  [  e8] Jump target:block8
 
 block10:
-  [ 108] Jump target:block7
+  [  f0] Jump target:block7

--- a/Tests/LibJS/Bytecode/expected/conditional-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/conditional-register-order.txt
@@ -1,4 +1,4 @@
-$2b997e90 conditional-register-order.js:4:1
+$bacf2c68 conditional-register-order.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $2b997e90 conditional-register-order.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `foo`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  30] End value:reg5
 
 
 foo$1d0ffb84 conditional-register-order.js:2:5

--- a/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
@@ -1,4 +1,4 @@
-$0a83f971 const-assignment-no-extra-tdz.js:5:1
+$8ea9e309 const-assignment-no-extra-tdz.js:5:1
   Registers: 9
   Blocks:    3
   Locals:    e~0
@@ -18,12 +18,12 @@ block1:
 block2:
   [  48] Mov dst:reg5, src:Undefined
   [  58] GetGlobal dst:reg8, `f`
-  [  70] Call dst:reg6, callee:reg8, this_value:Undefined, f
-  [  90] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
-  [  a8] End value:reg6
+  [  68] Call dst:reg6, callee:reg8, this_value:Undefined, f
+  [  88] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+  [  a0] End value:reg6
 
 Exception handlers:
-  [  48 ..   b0] => handler block1
+  [  48 ..   a8] => handler block1
 
 
 f$e16999cc const-assignment-no-extra-tdz.js:2:5

--- a/Tests/LibJS/Bytecode/expected/const-fold-exponentiation.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-exponentiation.txt
@@ -1,4 +1,4 @@
-$e7eb680d const-fold-exponentiation.js:1:1
+$e26385ed const-fold-exponentiation.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -13,8 +13,8 @@ $e7eb680d const-fold-exponentiation.js:1:1
     [8] = Undefined
 
 block0:
-  [   0] InitializeLexicalBinding `a`, src:Double(nan)
-  [  18] InitializeLexicalBinding `b`, src:Double(nan)
-  [  30] InitializeLexicalBinding `c`, src:Double(nan)
-  [  48] InitializeLexicalBinding `d`, src:Int32(1024)
-  [  60] End value:Undefined
+  [   0] DynamicInitializeLexicalBinding `a`, src:Double(nan)
+  [  10] DynamicInitializeLexicalBinding `b`, src:Double(nan)
+  [  20] DynamicInitializeLexicalBinding `c`, src:Double(nan)
+  [  30] DynamicInitializeLexicalBinding `d`, src:Int32(1024)
+  [  40] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -1,4 +1,4 @@
-$52f83a5e const-fold-template-literals.js:20:1
+$e22de836 const-fold-template-literals.js:20:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -12,34 +12,34 @@ $52f83a5e const-fold-template-literals.js:20:1
     [7] = Int32(3)
 
 block0:
-  [   0] InitializeLexicalBinding `a`, src:String("abcxyz")
-  [  18] InitializeLexicalBinding `b`, src:String("abcxyz")
-  [  30] InitializeLexicalBinding `c`, src:String("abcxyz")
-  [  48] InitializeLexicalBinding `d`, src:String("abcxyz")
-  [  60] InitializeLexicalBinding `e`, src:String("abcxyz")
-  [  78] InitializeLexicalBinding `f`, src:String("abcxyz")
-  [  90] Mov dst:reg5, src:String("abc")
-  [  a0] ConcatString dst:reg5, src:String("xyz")
-  [  b0] InitializeLexicalBinding `g`, src:reg5
-  [  c8] GetGlobal dst:reg6, `prefix`
-  [  d8] Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
-  [ 100] InitializeLexicalBinding `_prefix`, src:reg5
-  [ 118] GetGlobal dst:reg6, `suffix`
-  [ 128] Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
-  [ 150] InitializeLexicalBinding `_suffix`, src:reg5
-  [ 168] GetGlobal dst:reg6, `tostring`
-  [ 178] Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
-  [ 1a0] InitializeLexicalBinding `_tostring`, src:reg5
-  [ 1b8] GetGlobal dst:reg6, `multi`
-  [ 1c8] Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
-  [ 1f8] InitializeLexicalBinding `_multi`, src:reg5
-  [ 210] GetGlobal dst:reg6, `literal`
-  [ 220] Call dst:reg5, callee:reg6, this_value:Undefined, literal
-  [ 240] InitializeLexicalBinding `_literal`, src:reg5
-  [ 258] GetGlobal dst:reg6, `empty`
-  [ 268] Call dst:reg5, callee:reg6, this_value:Undefined, empty
-  [ 288] InitializeLexicalBinding `_empty`, src:reg5
-  [ 2a0] End value:Undefined
+  [   0] DynamicInitializeLexicalBinding `a`, src:String("abcxyz")
+  [  10] DynamicInitializeLexicalBinding `b`, src:String("abcxyz")
+  [  20] DynamicInitializeLexicalBinding `c`, src:String("abcxyz")
+  [  30] DynamicInitializeLexicalBinding `d`, src:String("abcxyz")
+  [  40] DynamicInitializeLexicalBinding `e`, src:String("abcxyz")
+  [  50] DynamicInitializeLexicalBinding `f`, src:String("abcxyz")
+  [  60] Mov dst:reg5, src:String("abc")
+  [  70] ConcatString dst:reg5, src:String("xyz")
+  [  80] DynamicInitializeLexicalBinding `g`, src:reg5
+  [  90] GetGlobal dst:reg6, `prefix`
+  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
+  [  c8] DynamicInitializeLexicalBinding `_prefix`, src:reg5
+  [  d8] GetGlobal dst:reg6, `suffix`
+  [  e8] Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
+  [ 110] DynamicInitializeLexicalBinding `_suffix`, src:reg5
+  [ 120] GetGlobal dst:reg6, `tostring`
+  [ 130] Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
+  [ 158] DynamicInitializeLexicalBinding `_tostring`, src:reg5
+  [ 168] GetGlobal dst:reg6, `multi`
+  [ 178] Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
+  [ 1a8] DynamicInitializeLexicalBinding `_multi`, src:reg5
+  [ 1b8] GetGlobal dst:reg6, `literal`
+  [ 1c8] Call dst:reg5, callee:reg6, this_value:Undefined, literal
+  [ 1e8] DynamicInitializeLexicalBinding `_literal`, src:reg5
+  [ 1f8] GetGlobal dst:reg6, `empty`
+  [ 208] Call dst:reg5, callee:reg6, this_value:Undefined, empty
+  [ 228] DynamicInitializeLexicalBinding `_empty`, src:reg5
+  [ 238] End value:Undefined
 
 
 prefix$722bd91a const-fold-template-literals.js:2:5

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -1,4 +1,4 @@
-$5034494e const-fold-template-literals.js:20:1
+$52f83a5e const-fold-template-literals.js:20:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -22,24 +22,24 @@ block0:
   [  a0] ConcatString dst:reg5, src:String("xyz")
   [  b0] InitializeLexicalBinding `g`, src:reg5
   [  c8] GetGlobal dst:reg6, `prefix`
-  [  e0] Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
-  [ 108] InitializeLexicalBinding `_prefix`, src:reg5
-  [ 120] GetGlobal dst:reg6, `suffix`
-  [ 138] Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
-  [ 160] InitializeLexicalBinding `_suffix`, src:reg5
-  [ 178] GetGlobal dst:reg6, `tostring`
-  [ 190] Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
-  [ 1b8] InitializeLexicalBinding `_tostring`, src:reg5
-  [ 1d0] GetGlobal dst:reg6, `multi`
-  [ 1e8] Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
-  [ 218] InitializeLexicalBinding `_multi`, src:reg5
-  [ 230] GetGlobal dst:reg6, `literal`
-  [ 248] Call dst:reg5, callee:reg6, this_value:Undefined, literal
-  [ 268] InitializeLexicalBinding `_literal`, src:reg5
-  [ 280] GetGlobal dst:reg6, `empty`
-  [ 298] Call dst:reg5, callee:reg6, this_value:Undefined, empty
-  [ 2b8] InitializeLexicalBinding `_empty`, src:reg5
-  [ 2d0] End value:Undefined
+  [  d8] Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
+  [ 100] InitializeLexicalBinding `_prefix`, src:reg5
+  [ 118] GetGlobal dst:reg6, `suffix`
+  [ 128] Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
+  [ 150] InitializeLexicalBinding `_suffix`, src:reg5
+  [ 168] GetGlobal dst:reg6, `tostring`
+  [ 178] Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
+  [ 1a0] InitializeLexicalBinding `_tostring`, src:reg5
+  [ 1b8] GetGlobal dst:reg6, `multi`
+  [ 1c8] Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
+  [ 1f8] InitializeLexicalBinding `_multi`, src:reg5
+  [ 210] GetGlobal dst:reg6, `literal`
+  [ 220] Call dst:reg5, callee:reg6, this_value:Undefined, literal
+  [ 240] InitializeLexicalBinding `_literal`, src:reg5
+  [ 258] GetGlobal dst:reg6, `empty`
+  [ 268] Call dst:reg5, callee:reg6, this_value:Undefined, empty
+  [ 288] InitializeLexicalBinding `_empty`, src:reg5
+  [ 2a0] End value:Undefined
 
 
 prefix$722bd91a const-fold-template-literals.js:2:5

--- a/Tests/LibJS/Bytecode/expected/constant-fold-large-string-to-number.txt
+++ b/Tests/LibJS/Bytecode/expected/constant-fold-large-string-to-number.txt
@@ -1,4 +1,4 @@
-$e7eb680d constant-fold-large-string-to-number.js:1:1
+$e26385ed constant-fold-large-string-to-number.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -11,7 +11,7 @@ $e7eb680d constant-fold-large-string-to-number.js:1:1
 
 block0:
   [   0] SetGlobal `a`, src:Double(18446744073709552000)
-  [  18] SetGlobal `b`, src:Double(18446744073709552000)
-  [  30] SetGlobal `c`, src:Double(18446744073709552000)
-  [  48] SetGlobal `d`, src:Double(18446744073709552000)
-  [  60] End value:Undefined
+  [  10] SetGlobal `b`, src:Double(18446744073709552000)
+  [  20] SetGlobal `c`, src:Double(18446744073709552000)
+  [  30] SetGlobal `d`, src:Double(18446744073709552000)
+  [  40] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/constant-fold-string-to-number.txt
+++ b/Tests/LibJS/Bytecode/expected/constant-fold-string-to-number.txt
@@ -1,4 +1,4 @@
-$e7eb680d constant-fold-string-to-number.js:1:1
+$e26385ed constant-fold-string-to-number.js:1:1
   Registers: 5
   Blocks:    1
   Constants:
@@ -14,7 +14,7 @@ $e7eb680d constant-fold-string-to-number.js:1:1
 
 block0:
   [   0] SetGlobal `a`, src:Int32(12345)
-  [  18] SetGlobal `b`, src:Int32(123450)
-  [  30] SetGlobal `c`, src:Int32(-42)
-  [  48] SetGlobal `d`, src:Int32(-6)
-  [  60] End value:Undefined
+  [  10] SetGlobal `b`, src:Int32(123450)
+  [  20] SetGlobal `c`, src:Int32(-42)
+  [  30] SetGlobal `d`, src:Int32(-6)
+  [  40] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/default-param-self-reference.txt
+++ b/Tests/LibJS/Bytecode/expected/default-param-self-reference.txt
@@ -1,4 +1,4 @@
-$b865a0be default-param-self-reference.js:2:1
+$3703a836 default-param-self-reference.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $b865a0be default-param-self-reference.js:2:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  38] End value:reg5
 
 
 f$d753a0ea default-param-self-reference.js:1:16

--- a/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
@@ -1,4 +1,4 @@
-$6a33dffa delete-expression-register.js:6:1
+$e8d1e772 delete-expression-register.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $6a33dffa delete-expression-register.js:6:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  38] End value:reg5
 
 
 f$04c49ea7 delete-expression-register.js:3:7

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -1,4 +1,4 @@
-$ebe22a63 delete-super-eval-order.js:4:1
+$6a8031db delete-super-eval-order.js:4:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -12,26 +12,26 @@ block0:
   [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("m")]
-  [  60] InitializeLexicalBinding `A`, src:reg6
-  [  78] Jump target:block2
+  [  60] DynamicInitializeLexicalBinding `A`, src:reg6
+  [  70] Jump target:block2
 
 block1:
-  [  80] Catch dst:reg6
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] Mov2 dst1:reg5, src1:Undefined, dst2:reg7, src2:reg5
-  [  a8] End value:reg5
+  [  78] Catch dst:reg6
+  [  80] SetLexicalEnvironment environment:reg4
+  [  88] Mov2 dst1:reg5, src1:Undefined, dst2:reg7, src2:reg5
+  [  a0] End value:reg5
 
 block2:
-  [  b0] Mov dst:reg6, src:Undefined
-  [  c0] GetGlobal dst:reg9, `A`
-  [  d0] CallConstruct dst:reg8, callee:reg9, A
-  [  e8] GetById dst:reg9, base:reg8, `m`
-  [ 100] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
-  [ 128] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
-  [ 140] End value:reg5
+  [  a8] Mov dst:reg6, src:Undefined
+  [  b8] GetGlobal dst:reg9, `A`
+  [  c8] CallConstruct dst:reg8, callee:reg9, A
+  [  e0] GetById dst:reg9, base:reg8, `m`
+  [  f8] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
+  [ 120] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 138] End value:reg5
 
 Exception handlers:
-  [  b0 ..  148] => handler block1
+  [  a8 ..  140] => handler block1
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -1,4 +1,4 @@
-$e91e3953 delete-super-eval-order.js:4:1
+$ebe22a63 delete-super-eval-order.js:4:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -24,14 +24,14 @@ block1:
 block2:
   [  b0] Mov dst:reg6, src:Undefined
   [  c0] GetGlobal dst:reg9, `A`
-  [  d8] CallConstruct dst:reg8, callee:reg9, A
-  [  f0] GetById dst:reg9, base:reg8, `m`
-  [ 110] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
-  [ 138] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
-  [ 150] End value:reg5
+  [  d0] CallConstruct dst:reg8, callee:reg9, A
+  [  e8] GetById dst:reg9, base:reg8, `m`
+  [ 100] Call dst:reg5, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
+  [ 128] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 140] End value:reg5
 
 Exception handlers:
-  [  b0 ..  158] => handler block1
+  [  b0 ..  148] => handler block1
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -1,4 +1,4 @@
-$eb7ff9ff delete-super-property.js:1:1
+$6fa5e397 delete-super-property.js:1:1
   Registers: 11
   Blocks:    6
   Locals:    e~0, e~1
@@ -13,44 +13,44 @@ block0:
   [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("foo"), element_keys:String("baz")]
-  [  60] InitializeLexicalBinding `A`, src:reg6
-  [  78] Jump target:block3
+  [  60] DynamicInitializeLexicalBinding `A`, src:reg6
+  [  70] Jump target:block3
 
 block1:
-  [  80] Catch dst:reg6
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] Mov3 dst1:e~0, src1:reg6, dst2:reg5, src2:Undefined, dst3:reg7, src3:reg5
+  [  78] Catch dst:reg6
+  [  80] SetLexicalEnvironment environment:reg4
+  [  88] Mov3 dst1:e~0, src1:reg6, dst2:reg5, src2:Undefined, dst3:reg7, src3:reg5
 
 block2:
-  [  b0] Jump target:block5
+  [  a8] Jump target:block5
 
 block3:
-  [  b8] Mov dst:reg6, src:Undefined
-  [  c8] GetGlobal dst:reg9, `A`
-  [  d8] CallConstruct dst:reg8, callee:reg9, A
-  [  f0] GetById dst:reg9, base:reg8, `foo`
-  [ 108] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
-  [ 128] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
-  [ 140] Jump target:block2
+  [  b0] Mov dst:reg6, src:Undefined
+  [  c0] GetGlobal dst:reg9, `A`
+  [  d0] CallConstruct dst:reg8, callee:reg9, A
+  [  e8] GetById dst:reg9, base:reg8, `foo`
+  [ 100] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
+  [ 120] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 138] Jump target:block2
 
 block4:
-  [ 148] Catch dst:reg6
-  [ 150] SetLexicalEnvironment environment:reg4
-  [ 158] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
-  [ 178] End value:reg7
+  [ 140] Catch dst:reg6
+  [ 148] SetLexicalEnvironment environment:reg4
+  [ 150] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
+  [ 170] End value:reg7
 
 block5:
-  [ 180] Mov dst:reg6, src:Undefined
-  [ 190] GetGlobal dst:reg10, `A`
-  [ 1a0] CallConstruct dst:reg8, callee:reg10, A
-  [ 1b8] GetById dst:reg10, base:reg8, `baz`
-  [ 1d0] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
-  [ 1f0] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
-  [ 208] End value:reg7
+  [ 178] Mov dst:reg6, src:Undefined
+  [ 188] GetGlobal dst:reg10, `A`
+  [ 198] CallConstruct dst:reg8, callee:reg10, A
+  [ 1b0] GetById dst:reg10, base:reg8, `baz`
+  [ 1c8] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
+  [ 1e8] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
+  [ 200] End value:reg7
 
 Exception handlers:
-  [  b8 ..  148] => handler block1
-  [ 180 ..  210] => handler block4
+  [  b0 ..  140] => handler block1
+  [ 178 ..  208] => handler block4
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -1,4 +1,4 @@
-$f107dc1f delete-super-property.js:1:1
+$eb7ff9ff delete-super-property.js:1:1
   Registers: 11
   Blocks:    6
   Locals:    e~0, e~1
@@ -27,30 +27,30 @@ block2:
 block3:
   [  b8] Mov dst:reg6, src:Undefined
   [  c8] GetGlobal dst:reg9, `A`
-  [  e0] CallConstruct dst:reg8, callee:reg9, A
-  [  f8] GetById dst:reg9, base:reg8, `foo`
-  [ 118] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
-  [ 138] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
-  [ 150] Jump target:block2
+  [  d8] CallConstruct dst:reg8, callee:reg9, A
+  [  f0] GetById dst:reg9, base:reg8, `foo`
+  [ 108] Call dst:reg5, callee:reg9, this_value:reg8, <object>.foo
+  [ 128] Mov2 dst1:reg6, src1:reg5, dst2:reg5, src2:reg6
+  [ 140] Jump target:block2
 
 block4:
-  [ 158] Catch dst:reg6
-  [ 160] SetLexicalEnvironment environment:reg4
-  [ 168] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
-  [ 188] End value:reg7
+  [ 148] Catch dst:reg6
+  [ 150] SetLexicalEnvironment environment:reg4
+  [ 158] Mov3 dst1:e~1, src1:reg6, dst2:reg7, src2:Undefined, dst3:reg9, src3:reg7
+  [ 178] End value:reg7
 
 block5:
-  [ 190] Mov dst:reg6, src:Undefined
-  [ 1a0] GetGlobal dst:reg10, `A`
-  [ 1b8] CallConstruct dst:reg8, callee:reg10, A
-  [ 1d0] GetById dst:reg10, base:reg8, `baz`
-  [ 1f0] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
-  [ 210] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
-  [ 228] End value:reg7
+  [ 180] Mov dst:reg6, src:Undefined
+  [ 190] GetGlobal dst:reg10, `A`
+  [ 1a0] CallConstruct dst:reg8, callee:reg10, A
+  [ 1b8] GetById dst:reg10, base:reg8, `baz`
+  [ 1d0] Call dst:reg7, callee:reg10, this_value:reg8, <object>.baz
+  [ 1f0] Mov2 dst1:reg6, src1:reg7, dst2:reg7, src2:reg6
+  [ 208] End value:reg7
 
 Exception handlers:
-  [  b8 ..  158] => handler block1
-  [ 190 ..  230] => handler block4
+  [  b8 ..  148] => handler block1
+  [ 180 ..  210] => handler block4
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/destructure-array-rest.txt
+++ b/Tests/LibJS/Bytecode/expected/destructure-array-rest.txt
@@ -1,4 +1,4 @@
-$fd650eed destructure-array-rest.js:9:1
+$89d6cbb5 destructure-array-rest.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $fd650eed destructure-array-rest.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
 f$88fef6f3 destructure-array-rest.js:6:5

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
@@ -1,4 +1,4 @@
-$9431c529 destructuring-assignment-in-logical-and.js:5:1
+$12cfcca1 destructuring-assignment-in-logical-and.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -8,8 +8,8 @@ $9431c529 destructuring-assignment-in-logical-and.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Int32(0)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Int32(0)]
+  [  38] End value:reg5
 
 
 f$bd59b03f destructuring-assignment-in-logical-and.js:2:5

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
@@ -1,4 +1,4 @@
-$f2f04dd8 destructuring-assignment.js:28:1
+$77163770 destructuring-assignment.js:28:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $f2f04dd8 destructuring-assignment.js:28:1
 
 block0:
   [   0] GetGlobal dst:reg6, `array_destructuring_with_class_default`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, array_destructuring_with_class_default
-  [  38] GetGlobal dst:reg7, `object_destructuring_with_function_default`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, object_destructuring_with_function_default
-  [  70] GetGlobal dst:reg7, `setter_parameter_resolution`
-  [  88] Call dst:reg5, callee:reg7, this_value:Undefined, setter_parameter_resolution
-  [  a8] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, array_destructuring_with_class_default
+  [  30] GetGlobal dst:reg7, `object_destructuring_with_function_default`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, object_destructuring_with_function_default
+  [  60] GetGlobal dst:reg7, `setter_parameter_resolution`
+  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, setter_parameter_resolution
+  [  90] End value:reg5
 
 
 array_destructuring_with_class_default$a4c92b11 destructuring-assignment.js:6:10
@@ -57,7 +57,7 @@ block6:
   [ 148] Return value:x~0
 
 
-object_destructuring_with_function_default$497a8092 destructuring-assignment.js:12:12
+object_destructuring_with_function_default$cadc791a destructuring-assignment.js:12:12
   Registers: 8
   Blocks:    3
   Locals:    x~0
@@ -69,18 +69,18 @@ block0:
   [  10] NewObject dst:reg5
   [  20] ThrowIfNullish src:reg5
   [  28] GetById dst:reg6, base:reg5, `x`
-  [  48] JumpUndefined condition:reg6, true_target:block1, false_target:block2
+  [  40] JumpUndefined condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  58] NewFunction dst:reg7, shared_function_data_index:0 (x)
-  [  70] Mov dst:reg6, src:reg7
+  [  50] NewFunction dst:reg7, shared_function_data_index:0 (x)
+  [  68] Mov dst:reg6, src:reg7
 
 block2:
-  [  80] Mov dst:x~0, src:reg6
-  [  90] Return value:x~0
+  [  78] Mov dst:x~0, src:reg6
+  [  88] Return value:x~0
 
 
-setter_parameter_resolution$2898cc06 destructuring-assignment.js:19:9
+setter_parameter_resolution$2b5cbd16 destructuring-assignment.js:19:9
   Registers: 12
   Blocks:    5
   Constants:
@@ -96,24 +96,24 @@ block0:
   [  68] NewObject dst:reg10
   [  78] NewFunction dst:reg11, shared_function_data_index:0 (set y), home_object:reg10
   [  90] PutById base:reg10, `y`, src:reg11, kind:Setter
-  [  b8] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  d0] JumpFalse condition:reg6, target:block2
+  [  b0] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  c8] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  e0] Mov dst:reg11, src:Undefined
-  [  f0] Jump target:block2
+  [  d8] Mov dst:reg11, src:Undefined
+  [  e8] Jump target:block2
 
 block2:
-  [  f8] PutById base:reg10, `y`, src:reg11, kind:Normal
-  [ 120] JumpFalse condition:reg6, target:block4
+  [  f0] PutById base:reg10, `y`, src:reg11, kind:Normal
+  [ 110] JumpFalse condition:reg6, target:block4
 
 block3:
-  [ 130] GetInitializedBinding dst:reg5, `setValue`
-  [ 148] Return value:reg5
+  [ 120] GetInitializedBinding dst:reg5, `setValue`
+  [ 138] Return value:reg5
 
 block4:
-  [ 150] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 168] Jump target:block3
+  [ 140] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 158] Jump target:block3
 
 
 set y$72954fa9 destructuring-assignment.js:21:26

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
@@ -80,7 +80,7 @@ block2:
   [  88] Return value:x~0
 
 
-setter_parameter_resolution$2b5cbd16 destructuring-assignment.js:19:9
+setter_parameter_resolution$2e20ae26 destructuring-assignment.js:19:9
   Registers: 12
   Blocks:    5
   Constants:
@@ -89,39 +89,39 @@ setter_parameter_resolution$2b5cbd16 destructuring-assignment.js:19:9
 
 block0:
   [   0] CreateVariable `setValue`, is_immutable:false, is_global:false, is_strict:false
-  [  10] InitializeVariableBinding `setValue`, src:Undefined
-  [  28] NewPrimitiveArray dst:reg5, elements:[23]
-  [  40] Mov dst:reg6, src:Bool(false)
-  [  50] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  68] NewObject dst:reg10
-  [  78] NewFunction dst:reg11, shared_function_data_index:0 (set y), home_object:reg10
-  [  90] PutById base:reg10, `y`, src:reg11, kind:Setter
-  [  b0] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  c8] JumpFalse condition:reg6, target:block2
+  [  10] DynamicInitializeVariableBinding `setValue`, src:Undefined
+  [  20] NewPrimitiveArray dst:reg5, elements:[23]
+  [  38] Mov dst:reg6, src:Bool(false)
+  [  48] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  60] NewObject dst:reg10
+  [  70] NewFunction dst:reg11, shared_function_data_index:0 (set y), home_object:reg10
+  [  88] PutById base:reg10, `y`, src:reg11, kind:Setter
+  [  a8] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  c0] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  d8] Mov dst:reg11, src:Undefined
-  [  e8] Jump target:block2
+  [  d0] Mov dst:reg11, src:Undefined
+  [  e0] Jump target:block2
 
 block2:
-  [  f0] PutById base:reg10, `y`, src:reg11, kind:Normal
-  [ 110] JumpFalse condition:reg6, target:block4
+  [  e8] PutById base:reg10, `y`, src:reg11, kind:Normal
+  [ 108] JumpFalse condition:reg6, target:block4
 
 block3:
-  [ 120] GetInitializedBinding dst:reg5, `setValue`
-  [ 138] Return value:reg5
+  [ 118] DynamicGetInitializedBinding dst:reg5, `setValue`
+  [ 128] Return value:reg5
 
 block4:
-  [ 140] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 158] Jump target:block3
+  [ 130] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 148] Jump target:block3
 
 
-set y$72954fa9 destructuring-assignment.js:21:26
+set y$f3f74831 destructuring-assignment.js:21:26
   Registers: 5
   Blocks:    1
   Constants:
     [0] = Undefined
 
 block0:
-  [   0] SetLexicalBinding `setValue`, src:arg0
-  [  18] End value:Undefined
+  [   0] DynamicSetLexicalBinding `setValue`, src:arg0
+  [  10] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment.txt
@@ -80,7 +80,7 @@ block2:
   [  88] Return value:x~0
 
 
-setter_parameter_resolution$2e20ae26 destructuring-assignment.js:19:9
+setter_parameter_resolution$2b5cbd16 destructuring-assignment.js:19:9
   Registers: 12
   Blocks:    5
   Constants:
@@ -89,31 +89,31 @@ setter_parameter_resolution$2e20ae26 destructuring-assignment.js:19:9
 
 block0:
   [   0] CreateVariable `setValue`, is_immutable:false, is_global:false, is_strict:false
-  [  10] DynamicInitializeVariableBinding `setValue`, src:Undefined
-  [  20] NewPrimitiveArray dst:reg5, elements:[23]
-  [  38] Mov dst:reg6, src:Bool(false)
-  [  48] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  60] NewObject dst:reg10
-  [  70] NewFunction dst:reg11, shared_function_data_index:0 (set y), home_object:reg10
-  [  88] PutById base:reg10, `y`, src:reg11, kind:Setter
-  [  a8] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  c0] JumpFalse condition:reg6, target:block2
+  [  10] InitializeVariableBinding `setValue`, src:Undefined
+  [  28] NewPrimitiveArray dst:reg5, elements:[23]
+  [  40] Mov dst:reg6, src:Bool(false)
+  [  50] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  68] NewObject dst:reg10
+  [  78] NewFunction dst:reg11, shared_function_data_index:0 (set y), home_object:reg10
+  [  90] PutById base:reg10, `y`, src:reg11, kind:Setter
+  [  b0] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  c8] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  d0] Mov dst:reg11, src:Undefined
-  [  e0] Jump target:block2
+  [  d8] Mov dst:reg11, src:Undefined
+  [  e8] Jump target:block2
 
 block2:
-  [  e8] PutById base:reg10, `y`, src:reg11, kind:Normal
-  [ 108] JumpFalse condition:reg6, target:block4
+  [  f0] PutById base:reg10, `y`, src:reg11, kind:Normal
+  [ 110] JumpFalse condition:reg6, target:block4
 
 block3:
-  [ 118] DynamicGetInitializedBinding dst:reg5, `setValue`
-  [ 128] Return value:reg5
+  [ 120] GetInitializedBinding dst:reg5, `setValue`
+  [ 138] Return value:reg5
 
 block4:
-  [ 130] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 148] Jump target:block3
+  [ 140] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 158] Jump target:block3
 
 
 set y$f3f74831 destructuring-assignment.js:21:26

--- a/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-let-compound-assign.txt
@@ -1,4 +1,4 @@
-$99b9a749 destructuring-let-compound-assign.js:5:1
+$1857aec1 destructuring-let-compound-assign.js:5:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,13 +6,13 @@ $99b9a749 destructuring-let-compound-assign.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewObject dst:reg7
-  [  28] NewObject dst:reg8
-  [  38] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
-  [  60] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] NewObject dst:reg8
+  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
+  [  58] End value:reg5
 
 
-f$fa4d135c destructuring-let-compound-assign.js:2:5
+f$f789224c destructuring-let-compound-assign.js:2:5
   Registers: 8
   Blocks:    1
   Locals:    a~0
@@ -23,11 +23,11 @@ f$fa4d135c destructuring-let-compound-assign.js:2:5
 block0:
   [   0] ThrowIfNullish src:arg0
   [   8] GetById dst:reg5, base:arg0, `patchFlag`
-  [  28] Mov dst:a~0, src:reg5
-  [  38] ThrowIfTDZ src:a~0
-  [  40] Mov2 dst1:reg5, src1:a~0, dst2:reg6, src2:arg1
-  [  58] GetById dst:reg7, base:reg6, `patchFlag` (e.patchFlag)
-  [  78] BitwiseAnd dst:reg6, lhs:Int32(16), rhs:reg7
-  [  88] BitwiseOr dst:reg7, lhs:reg5, rhs:reg6
-  [  98] Mov dst:a~0, src:reg7
-  [  a8] End value:Undefined
+  [  20] Mov dst:a~0, src:reg5
+  [  30] ThrowIfTDZ src:a~0
+  [  38] Mov2 dst1:reg5, src1:a~0, dst2:reg6, src2:arg1
+  [  50] GetById dst:reg7, base:reg6, `patchFlag` (e.patchFlag)
+  [  68] BitwiseAnd dst:reg6, lhs:Int32(16), rhs:reg7
+  [  78] BitwiseOr dst:reg7, lhs:reg5, rhs:reg6
+  [  88] Mov dst:a~0, src:reg7
+  [  98] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/destructuring-no-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-no-base-identifier.txt
@@ -1,4 +1,4 @@
-$32b2807a destructuring-no-base-identifier.js:1:1
+$ae8c96e2 destructuring-no-base-identifier.js:1:1
   Registers: 12
   Blocks:    5
   Constants:
@@ -8,24 +8,24 @@ $32b2807a destructuring-no-base-identifier.js:1:1
 block0:
   [   0] NewObject dst:reg5
   [  10] SetGlobal `x`, src:reg5
-  [  28] NewPrimitiveArray dst:reg5, elements:[42]
-  [  40] Mov dst:reg6, src:Bool(false)
-  [  50] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
-  [  68] GetGlobal dst:reg10, `x`
-  [  80] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
-  [  98] JumpFalse condition:reg6, target:block2
+  [  20] NewPrimitiveArray dst:reg5, elements:[42]
+  [  38] Mov dst:reg6, src:Bool(false)
+  [  48] GetIterator dst_iterator_object:reg7, dst_iterator_next:reg8, dst_iterator_done:reg9, iterable:reg5
+  [  60] GetGlobal dst:reg10, `x`
+  [  70] IteratorNextUnpack dst_value:reg11, dst_done:reg6, iterator_object:reg7, iterator_next:reg8, iterator_done:reg9
+  [  88] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  a8] Mov dst:reg11, src:Undefined
-  [  b8] Jump target:block2
+  [  98] Mov dst:reg11, src:Undefined
+  [  a8] Jump target:block2
 
 block2:
-  [  c0] PutById base:reg10, `y`, src:reg11, kind:Normal
-  [  e8] JumpFalse condition:reg6, target:block4
+  [  b0] PutById base:reg10, `y`, src:reg11, kind:Normal
+  [  d0] JumpFalse condition:reg6, target:block4
 
 block3:
-  [  f8] End value:reg5
+  [  e0] End value:reg5
 
 block4:
-  [ 100] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 118] End value:reg5
+  [  e8] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 100] End value:reg5

--- a/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
@@ -16,7 +16,7 @@ block0:
   [  88] End value:reg5
 
 
-f$4a320b49 destructuring-param-no-param-expressions.js:7:5
+f$c60c21b1 destructuring-param-no-param-expressions.js:7:5
   Registers: 6
   Blocks:    1
   Locals:    local~0
@@ -25,8 +25,8 @@ block0:
   [   0] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
   [  10] ThrowIfNullish src:arg0
   [  18] GetById dst:reg5, base:arg0, `captured`
-  [  30] InitializeLexicalBinding `captured`, src:reg5
-  [  48] GetById dst:reg5, base:arg0, `local`
-  [  60] Mov dst:local~0, src:reg5
-  [  70] NewFunction dst:reg5, shared_function_data_index:0
-  [  88] Return value:reg5
+  [  30] DynamicInitializeLexicalBinding `captured`, src:reg5
+  [  40] GetById dst:reg5, base:arg0, `local`
+  [  58] Mov dst:local~0, src:reg5
+  [  68] NewFunction dst:reg5, shared_function_data_index:0
+  [  80] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
@@ -16,7 +16,7 @@ block0:
   [  88] End value:reg5
 
 
-f$c60c21b1 destructuring-param-no-param-expressions.js:7:5
+f$4a320b49 destructuring-param-no-param-expressions.js:7:5
   Registers: 6
   Blocks:    1
   Locals:    local~0
@@ -25,8 +25,8 @@ block0:
   [   0] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
   [  10] ThrowIfNullish src:arg0
   [  18] GetById dst:reg5, base:arg0, `captured`
-  [  30] DynamicInitializeLexicalBinding `captured`, src:reg5
-  [  40] GetById dst:reg5, base:arg0, `local`
-  [  58] Mov dst:local~0, src:reg5
-  [  68] NewFunction dst:reg5, shared_function_data_index:0
-  [  80] Return value:reg5
+  [  30] InitializeLexicalBinding `captured`, src:reg5
+  [  48] GetById dst:reg5, base:arg0, `local`
+  [  60] Mov dst:local~0, src:reg5
+  [  70] NewFunction dst:reg5, shared_function_data_index:0
+  [  88] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-param-no-param-expressions.txt
@@ -1,4 +1,4 @@
-$2e11f366 destructuring-param-no-param-expressions.js:10:1
+$af73ebee destructuring-param-no-param-expressions.js:10:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -8,15 +8,15 @@ $2e11f366 destructuring-param-no-param-expressions.js:10:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewObject dst:reg7
-  [  28] InitObjectLiteralProperty object:reg7, `captured`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  40] InitObjectLiteralProperty object:reg7, `local`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  58] CacheObjectShape object:reg7
-  [  68] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  90] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] InitObjectLiteralProperty object:reg7, `captured`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  38] InitObjectLiteralProperty object:reg7, `local`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  50] CacheObjectShape object:reg7
+  [  60] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  88] End value:reg5
 
 
-f$41e63819 destructuring-param-no-param-expressions.js:7:5
+f$4a320b49 destructuring-param-no-param-expressions.js:7:5
   Registers: 6
   Blocks:    1
   Locals:    local~0
@@ -25,8 +25,8 @@ block0:
   [   0] CreateVariable `captured`, is_immutable:false, is_global:false, is_strict:false
   [  10] ThrowIfNullish src:arg0
   [  18] GetById dst:reg5, base:arg0, `captured`
-  [  38] InitializeLexicalBinding `captured`, src:reg5
-  [  50] GetById dst:reg5, base:arg0, `local`
-  [  70] Mov dst:local~0, src:reg5
-  [  80] NewFunction dst:reg5, shared_function_data_index:0
-  [  98] Return value:reg5
+  [  30] InitializeLexicalBinding `captured`, src:reg5
+  [  48] GetById dst:reg5, base:arg0, `local`
+  [  60] Mov dst:local~0, src:reg5
+  [  70] NewFunction dst:reg5, shared_function_data_index:0
+  [  88] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
+++ b/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
@@ -1,4 +1,4 @@
-$6c6bb70b do-while-register-allocation.js:15:1
+$e2bdeb53 do-while-register-allocation.js:15:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $6c6bb70b do-while-register-allocation.js:15:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  30] End value:reg5
 
 
-test$e414328f do-while-register-allocation.js:9:5
+test$e6d8239f do-while-register-allocation.js:9:5
   Registers: 9
   Blocks:    3
   Locals:    i~0
@@ -22,18 +22,18 @@ test$e414328f do-while-register-allocation.js:9:5
 block0:
   [   0] Mov2 dst1:i~0, src1:Undefined, dst2:i~0, src2:Int32(0)
   [  18] GetGlobal dst:reg6, `foo`
-  [  30] NewArray dst:reg7
-  [  40] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
+  [  28] NewArray dst:reg7
+  [  38] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
 
 block1:
-  [  68] GetGlobal dst:reg7, `bar`
-  [  80] Mov dst:reg8, src:i~0
-  [  90] Call dst:reg6, callee:reg7, this_value:Undefined, bar, arguments:[reg8]
-  [  b8] PostfixIncrement dst:reg6, src:i~0
-  [  c8] JumpLessThan lhs:i~0, rhs:Int32(7), true_target:block1, false_target:block2
+  [  60] GetGlobal dst:reg7, `bar`
+  [  70] Mov dst:reg8, src:i~0
+  [  80] Call dst:reg6, callee:reg7, this_value:Undefined, bar, arguments:[reg8]
+  [  a8] PostfixIncrement dst:reg6, src:i~0
+  [  b8] JumpLessThan lhs:i~0, rhs:Int32(7), true_target:block1, false_target:block2
 
 block2:
-  [  e0] End value:Undefined
+  [  d0] End value:Undefined
 
 
 foo$93622fcc do-while-register-allocation.js:2:5

--- a/Tests/LibJS/Bytecode/expected/double-constant-deduplication.txt
+++ b/Tests/LibJS/Bytecode/expected/double-constant-deduplication.txt
@@ -1,4 +1,4 @@
-$162ec0dc double-constant-deduplication.js:8:1
+$a2a07da4 double-constant-deduplication.js:8:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $162ec0dc double-constant-deduplication.js:8:1
 
 block0:
   [   0] GetGlobal dst:reg6, `foo`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  30] End value:reg5
 
 
 foo$9e71f40c double-constant-deduplication.js:2:5

--- a/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
@@ -12,7 +12,7 @@ block0:
   [  60] End value:reg6
 
 
-with_eval$33576ddd eval-prevents-locals.js:6:5
+with_eval$361b5eed eval-prevents-locals.js:6:5
   Registers: 9
   Blocks:    1
   Constants:
@@ -24,11 +24,11 @@ block0:
   [   8] CreateArguments is_immutable:false
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  30] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  40] DynamicInitializeLexicalBinding `x`, src:Int32(1)
-  [  50] DynamicGetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
-  [  60] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
-  [  88] DynamicGetBinding dst:reg6, `x`
-  [  98] Return value:reg6
+  [  40] InitializeLexicalBinding `x`, src:Int32(1)
+  [  58] DynamicGetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
+  [  68] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
+  [  90] GetBinding dst:reg6, `x`
+  [  a8] Return value:reg6
 
 
 eval$b72141f3
@@ -41,7 +41,7 @@ block0:
   [   0] End value:Undefined
 
 
-outer_eval$6d0cf89a eval-prevents-locals.js:14:9
+outer_eval$e6231df2 eval-prevents-locals.js:14:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -51,14 +51,14 @@ outer_eval$6d0cf89a eval-prevents-locals.js:14:9
 block0:
   [   0] CreateArguments is_immutable:false
   [  10] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  20] DynamicInitializeVariableBinding `inner`, src:Undefined
-  [  30] NewFunction dst:reg5, shared_function_data_index:0
-  [  48] DynamicSetVariableBinding `inner`, src:reg5
-  [  58] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
-  [  68] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("")]
-  [  90] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [  a0] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [  c0] Return value:reg5
+  [  20] InitializeVariableBinding `inner`, src:Undefined
+  [  38] NewFunction dst:reg5, shared_function_data_index:0
+  [  50] SetVariableBinding `inner`, src:reg5
+  [  68] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
+  [  78] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("")]
+  [  a0] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [  b8] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [  d8] Return value:reg5
 
 
 eval$b72141f3

--- a/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
@@ -12,7 +12,7 @@ block0:
   [  60] End value:reg6
 
 
-with_eval$b4b96665 eval-prevents-locals.js:6:5
+with_eval$33576ddd eval-prevents-locals.js:6:5
   Registers: 9
   Blocks:    1
   Constants:
@@ -24,11 +24,11 @@ block0:
   [   8] CreateArguments is_immutable:false
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  30] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  40] InitializeLexicalBinding `x`, src:Int32(1)
-  [  58] GetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
-  [  70] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
-  [  98] GetBinding dst:reg6, `x`
-  [  b0] Return value:reg6
+  [  40] DynamicInitializeLexicalBinding `x`, src:Int32(1)
+  [  50] DynamicGetCalleeAndThisFromEnvironment callee:reg7, this_value:reg8, `eval`
+  [  60] CallDirectEval dst:reg6, callee:reg7, this_value:reg8, eval, arguments:[String("")]
+  [  88] DynamicGetBinding dst:reg6, `x`
+  [  98] Return value:reg6
 
 
 eval$b72141f3
@@ -41,7 +41,7 @@ block0:
   [   0] End value:Undefined
 
 
-outer_eval$6785167a eval-prevents-locals.js:14:9
+outer_eval$6d0cf89a eval-prevents-locals.js:14:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -51,14 +51,14 @@ outer_eval$6785167a eval-prevents-locals.js:14:9
 block0:
   [   0] CreateArguments is_immutable:false
   [  10] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  20] InitializeVariableBinding `inner`, src:Undefined
-  [  38] NewFunction dst:reg5, shared_function_data_index:0
-  [  50] SetVariableBinding `inner`, src:reg5
-  [  68] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
-  [  80] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("")]
-  [  a8] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
-  [  c0] Call dst:reg5, callee:reg6, this_value:reg7, inner
-  [  e0] Return value:reg5
+  [  20] DynamicInitializeVariableBinding `inner`, src:Undefined
+  [  30] NewFunction dst:reg5, shared_function_data_index:0
+  [  48] DynamicSetVariableBinding `inner`, src:reg5
+  [  58] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
+  [  68] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("")]
+  [  90] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `inner`
+  [  a0] Call dst:reg5, callee:reg6, this_value:reg7, inner
+  [  c0] Return value:reg5
 
 
 eval$b72141f3

--- a/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-prevents-locals.txt
@@ -1,4 +1,4 @@
-$a036f1fa eval-prevents-locals.js:22:1
+$9d7300ea eval-prevents-locals.js:22:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,10 +6,10 @@ $a036f1fa eval-prevents-locals.js:22:1
 
 block0:
   [   0] GetGlobal dst:reg6, `with_eval`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, with_eval
-  [  38] GetGlobal dst:reg7, `outer_eval`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, outer_eval
-  [  70] End value:reg6
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, with_eval
+  [  30] GetGlobal dst:reg7, `outer_eval`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, outer_eval
+  [  60] End value:reg6
 
 
 with_eval$b4b96665 eval-prevents-locals.js:6:5

--- a/Tests/LibJS/Bytecode/expected/eval-same-function.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-same-function.txt
@@ -1,4 +1,4 @@
-$d36729be eval-same-function.js:10:1
+$49b95e06 eval-same-function.js:10:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $d36729be eval-same-function.js:10:1
 
 block0:
   [   0] GetGlobal dst:reg6, `foo`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  30] End value:reg5
 
 
 foo$c25bdd1c eval-same-function.js:6:9

--- a/Tests/LibJS/Bytecode/expected/eval-same-function.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-same-function.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-foo$c25bdd1c eval-same-function.js:6:9
+foo$bf97ec0c eval-same-function.js:6:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -20,14 +20,14 @@ foo$c25bdd1c eval-same-function.js:6:9
 
 block0:
   [   0] CreateArguments is_immutable:false
-  [  10] GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
-  [  28] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("var x = 1")]
-  [  50] GetBinding dst:reg6, `Number`
-  [  68] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-  [  88] Return value:reg5
+  [  10] DynamicGetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, `eval`
+  [  20] CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("var x = 1")]
+  [  48] DynamicGetBinding dst:reg6, `Number`
+  [  58] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
+  [  78] Return value:reg5
 
 
-eval$6295ffeb line 1, column 1
+eval$d8e83433 line 1, column 1
   Registers: 5
   Blocks:    1
   Constants:
@@ -35,5 +35,5 @@ eval$6295ffeb line 1, column 1
     [1] = Undefined
 
 block0:
-  [   0] SetLexicalBinding `x`, src:Int32(1)
-  [  18] End value:Undefined
+  [   0] DynamicSetLexicalBinding `x`, src:Int32(1)
+  [  10] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
@@ -1,4 +1,4 @@
-$c7fd0018 eval-scope-optimization.js:12:1
+$546ebce0 eval-scope-optimization.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $c7fd0018 eval-scope-optimization.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `outer`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, outer
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, outer
+  [  30] End value:reg5
 
 
-outer$2f7d7ac8 eval-scope-optimization.js:9:5
+outer$ae1b8240 eval-scope-optimization.js:9:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -23,5 +23,5 @@ block0:
   [  28] NewFunction dst:reg5, shared_function_data_index:0
   [  40] SetVariableBinding `inner`, src:reg5
   [  58] GetGlobal dst:reg6, `Number`
-  [  70] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-  [  90] Return value:reg5
+  [  68] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
+  [  88] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-outer$b0df7350 eval-scope-optimization.js:9:5
+outer$ae1b8240 eval-scope-optimization.js:9:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -19,9 +19,9 @@ outer$b0df7350 eval-scope-optimization.js:9:5
 
 block0:
   [   0] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  10] DynamicInitializeVariableBinding `inner`, src:Undefined
-  [  20] NewFunction dst:reg5, shared_function_data_index:0
-  [  38] DynamicSetVariableBinding `inner`, src:reg5
-  [  48] GetGlobal dst:reg6, `Number`
-  [  58] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-  [  78] Return value:reg5
+  [  10] InitializeVariableBinding `inner`, src:Undefined
+  [  28] NewFunction dst:reg5, shared_function_data_index:0
+  [  40] SetVariableBinding `inner`, src:reg5
+  [  58] GetGlobal dst:reg6, `Number`
+  [  68] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
+  [  88] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-outer$ae1b8240 eval-scope-optimization.js:9:5
+outer$b0df7350 eval-scope-optimization.js:9:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -19,9 +19,9 @@ outer$ae1b8240 eval-scope-optimization.js:9:5
 
 block0:
   [   0] CreateVariable `inner`, is_immutable:false, is_global:false, is_strict:false
-  [  10] InitializeVariableBinding `inner`, src:Undefined
-  [  28] NewFunction dst:reg5, shared_function_data_index:0
-  [  40] SetVariableBinding `inner`, src:reg5
-  [  58] GetGlobal dst:reg6, `Number`
-  [  68] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-  [  88] Return value:reg5
+  [  10] DynamicInitializeVariableBinding `inner`, src:Undefined
+  [  20] NewFunction dst:reg5, shared_function_data_index:0
+  [  38] DynamicSetVariableBinding `inner`, src:reg5
+  [  48] GetGlobal dst:reg6, `Number`
+  [  58] CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
+  [  78] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/expression-identifier-number-format.txt
+++ b/Tests/LibJS/Bytecode/expected/expression-identifier-number-format.txt
@@ -1,4 +1,4 @@
-$f8830e6d expression-identifier-number-format.js:1:1
+$091ab4cd expression-identifier-number-format.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -8,10 +8,10 @@ $f8830e6d expression-identifier-number-format.js:1:1
 block0:
   [   0] NewObject dst:reg5
   [  10] SetGlobal `x`, src:reg5
-  [  28] GetGlobal dst:reg5, `x`
-  [  40] NewObject dst:reg6
-  [  50] PutByValue base:reg5, property:Double(1.1e-32), src:reg6, kind:Normal (x[Double(1.1e-32)])
-  [  68] GetGlobal dst:reg5, `x`
-  [  80] GetByValue dst:reg7, base:reg5, property:Double(1.1e-32) (x[Double(1.1e-32)])
-  [  98] PutById base:reg7, `foo`, src:Int32(42), kind:Normal (x[1.1e-32].foo)
-  [  c0] End value:Int32(42)
+  [  20] GetGlobal dst:reg5, `x`
+  [  30] NewObject dst:reg6
+  [  40] PutByValue base:reg5, property:Double(1.1e-32), src:reg6, kind:Normal (x[Double(1.1e-32)])
+  [  58] GetGlobal dst:reg5, `x`
+  [  68] GetByValue dst:reg7, base:reg5, property:Double(1.1e-32) (x[Double(1.1e-32)])
+  [  80] PutById base:reg7, `foo`, src:Int32(42), kind:Normal (x[1.1e-32].foo)
+  [  a0] End value:Int32(42)

--- a/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-block-order.txt
@@ -1,4 +1,4 @@
-$916dd419 for-in-block-order.js:5:1
+$100bdb91 for-in-block-order.js:5:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $916dd419 for-in-block-order.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `foo`
-  [  18] NewObject dst:reg7
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
-  [  50] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
+  [  48] End value:reg5
 
 
-foo$3b347bf9 for-in-block-order.js:2:16
+foo$b9d28371 for-in-block-order.js:2:16
   Registers: 8
   Blocks:    6
   Locals:    k~0
@@ -34,8 +34,8 @@ block3:
 
 block4:
   [  50] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
-  [  68] Jump target:block2
+  [  60] Jump target:block2
 
 block5:
-  [  70] Mov dst:k~0, src:reg6
-  [  80] Jump target:block2
+  [  68] Mov dst:k~0, src:reg6
+  [  78] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$2e5e925b for-in-lexical-scope.js:1:12
+$b5486d03 for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:
@@ -33,13 +33,13 @@ block4:
 block5:
   [  d8] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
   [  f0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [ 100] DynamicInitializeLexicalBinding `x`, src:reg7
-  [ 110] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
-  [ 128] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
-  [ 138] NewFunction dst:reg11, shared_function_data_index:0
-  [ 150] DynamicInitializeLexicalBinding `probeDecl`, src:reg11
-  [ 160] DynamicGetBinding dst:reg11, `probeDecl`
-  [ 170] DynamicSetVariableBinding `probeDecl`, src:reg11
-  [ 180] SetLexicalEnvironment environment:reg9
-  [ 188] SetLexicalEnvironment environment:reg4
-  [ 190] Jump target:block2
+  [ 100] InitializeLexicalBinding `x`, src:reg7
+  [ 118] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
+  [ 130] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
+  [ 140] NewFunction dst:reg11, shared_function_data_index:0
+  [ 158] InitializeLexicalBinding `probeDecl`, src:reg11
+  [ 170] GetBinding dst:reg11, `probeDecl`
+  [ 188] DynamicSetVariableBinding `probeDecl`, src:reg11
+  [ 198] SetLexicalEnvironment environment:reg9
+  [ 1a0] SetLexicalEnvironment environment:reg4
+  [ 1a8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$b80c5e13 for-in-lexical-scope.js:1:12
+$33e6747b for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:
@@ -27,19 +27,19 @@ block3:
 
 block4:
   [  b0] GetObjectPropertyIterator dst_iterator:reg5, object:reg6
-  [  c8] Mov dst:reg6, src:Undefined
-  [  d8] Jump target:block2
+  [  c0] Mov dst:reg6, src:Undefined
+  [  d0] Jump target:block2
 
 block5:
-  [  e0] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
-  [  f8] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [ 108] InitializeLexicalBinding `x`, src:reg7
-  [ 120] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
-  [ 138] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
-  [ 148] NewFunction dst:reg11, shared_function_data_index:0
-  [ 160] InitializeLexicalBinding `probeDecl`, src:reg11
-  [ 178] GetBinding dst:reg11, `probeDecl`
-  [ 190] SetVariableBinding `probeDecl`, src:reg11
-  [ 1a8] SetLexicalEnvironment environment:reg9
-  [ 1b0] SetLexicalEnvironment environment:reg4
-  [ 1b8] Jump target:block2
+  [  d8] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
+  [  f0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
+  [ 100] InitializeLexicalBinding `x`, src:reg7
+  [ 118] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
+  [ 130] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
+  [ 140] NewFunction dst:reg11, shared_function_data_index:0
+  [ 158] InitializeLexicalBinding `probeDecl`, src:reg11
+  [ 170] GetBinding dst:reg11, `probeDecl`
+  [ 188] SetVariableBinding `probeDecl`, src:reg11
+  [ 1a0] SetLexicalEnvironment environment:reg9
+  [ 1a8] SetLexicalEnvironment environment:reg4
+  [ 1b0] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-lexical-scope.txt
@@ -1,4 +1,4 @@
-$33e6747b for-in-lexical-scope.js:1:12
+$2e5e925b for-in-lexical-scope.js:1:12
   Registers: 12
   Blocks:    6
   Constants:
@@ -33,13 +33,13 @@ block4:
 block5:
   [  d8] CreateLexicalEnvironment dst:reg9, parent:reg4, capacity:0, is_catch_environment:false
   [  f0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [ 100] InitializeLexicalBinding `x`, src:reg7
-  [ 118] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
-  [ 130] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
-  [ 140] NewFunction dst:reg11, shared_function_data_index:0
-  [ 158] InitializeLexicalBinding `probeDecl`, src:reg11
-  [ 170] GetBinding dst:reg11, `probeDecl`
-  [ 188] SetVariableBinding `probeDecl`, src:reg11
-  [ 1a0] SetLexicalEnvironment environment:reg9
-  [ 1a8] SetLexicalEnvironment environment:reg4
-  [ 1b0] Jump target:block2
+  [ 100] DynamicInitializeLexicalBinding `x`, src:reg7
+  [ 110] CreateLexicalEnvironment dst:reg10, parent:reg9, capacity:0, is_catch_environment:false
+  [ 128] CreateMutableBinding environment:reg10, `probeDecl`, can_be_deleted:false
+  [ 138] NewFunction dst:reg11, shared_function_data_index:0
+  [ 150] DynamicInitializeLexicalBinding `probeDecl`, src:reg11
+  [ 160] DynamicGetBinding dst:reg11, `probeDecl`
+  [ 170] DynamicSetVariableBinding `probeDecl`, src:reg11
+  [ 180] SetLexicalEnvironment environment:reg9
+  [ 188] SetLexicalEnvironment environment:reg4
+  [ 190] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-object-property-iterator-next.txt
@@ -1,4 +1,4 @@
-$298a584c for-in-object-property-iterator-next.js:8:1
+$2c4e495c for-in-object-property-iterator-next.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,17 +11,17 @@ $298a584c for-in-object-property-iterator-next.js:8:1
 
 block0:
   [   0] GetGlobal dst:reg6, `collect`
-  [  18] NewObject dst:reg7
-  [  28] ToPrimitiveWithStringHint dst:Int32(2), value:Int32(2)
-  [  38] PutByValue base:reg7, property:Int32(2), src:String("two"), kind:Own
-  [  50] PutById base:reg7, `foo`, src:String("foo"), kind:Own
-  [  78] ToPrimitiveWithStringHint dst:Int32(7), value:Int32(7)
-  [  88] PutByValue base:reg7, property:Int32(7), src:String("seven"), kind:Own
-  [  a0] Call dst:reg5, callee:reg6, this_value:Undefined, collect, arguments:[reg7]
-  [  c8] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] ToPrimitiveWithStringHint dst:Int32(2), value:Int32(2)
+  [  30] PutByValue base:reg7, property:Int32(2), src:String("two"), kind:Own
+  [  48] PutById base:reg7, `foo`, src:String("foo"), kind:Own
+  [  68] ToPrimitiveWithStringHint dst:Int32(7), value:Int32(7)
+  [  78] PutByValue base:reg7, property:Int32(7), src:String("seven"), kind:Own
+  [  90] Call dst:reg5, callee:reg6, this_value:Undefined, collect, arguments:[reg7]
+  [  b8] End value:reg5
 
 
-collect$a74ca55b for-in-object-property-iterator-next.js:2:18
+collect$aa10966b for-in-object-property-iterator-next.js:2:18
   Registers: 12
   Blocks:    6
   Locals:    key~0, keys~1
@@ -42,13 +42,13 @@ block3:
 
 block4:
   [  50] GetObjectPropertyIterator dst_iterator:reg5, object:arg0
-  [  68] Jump target:block2
+  [  60] Jump target:block2
 
 block5:
-  [  70] Mov dst:key~0, src:reg6
-  [  80] GetById dst:reg9, base:keys~1, `push` (keys.push)
-  [  a0] Mov dst:reg10, src:keys~1
-  [  b0] ThrowIfTDZ src:key~0
-  [  b8] Mov dst:reg11, src:key~0
-  [  c8] Call dst:reg8, callee:reg9, this_value:reg10, keys.push, arguments:[reg11]
-  [  f0] Jump target:block2
+  [  68] Mov dst:key~0, src:reg6
+  [  78] GetById dst:reg9, base:keys~1, `push` (keys.push)
+  [  90] Mov dst:reg10, src:keys~1
+  [  a0] ThrowIfTDZ src:key~0
+  [  a8] Mov dst:reg11, src:key~0
+  [  b8] Call dst:reg8, callee:reg9, this_value:reg10, keys.push, arguments:[reg11]
+  [  e0] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
@@ -1,4 +1,4 @@
-$ee43eb0f for-in-register-lifetime.js:1:1
+$460e17ea for-in-register-lifetime.js:1:1
   Registers: 14
   Blocks:    6
   Constants:
@@ -10,39 +10,39 @@ $ee43eb0f for-in-register-lifetime.js:1:1
 
 block0:
   [   0] SetGlobal `result`, src:String("")
-  [  18] NewObject dst:reg5
-  [  28] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  40] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  58] InitObjectLiteralProperty object:reg5, `c`, src:Int32(3), shape_cache_index:0, property_slot:2
-  [  70] CacheObjectShape object:reg5
-  [  80] SetGlobal `obj`, src:reg5
-  [  98] GetGlobal dst:reg5, `obj`
-  [  b0] JumpNullish condition:reg5, true_target:block3, false_target:block4
+  [  10] NewObject dst:reg5
+  [  20] InitObjectLiteralProperty object:reg5, `a`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  38] InitObjectLiteralProperty object:reg5, `b`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  50] InitObjectLiteralProperty object:reg5, `c`, src:Int32(3), shape_cache_index:0, property_slot:2
+  [  68] CacheObjectShape object:reg5
+  [  78] SetGlobal `obj`, src:reg5
+  [  88] GetGlobal dst:reg5, `obj`
+  [  98] JumpNullish condition:reg5, true_target:block3, false_target:block4
 
 block1:
-  [  c0] End value:reg5
+  [  a8] End value:reg5
 
 block2:
-  [  c8] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
-  [  d8] JumpIf condition:reg8, true_target:block1, false_target:block5
+  [  b0] ObjectPropertyIteratorNext dst_value:reg7, dst_done:reg8, iterator_object:reg6
+  [  c0] JumpIf condition:reg8, true_target:block1, false_target:block5
 
 block3:
-  [  e8] End value:reg5
+  [  d0] End value:reg5
 
 block4:
-  [  f0] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [ 108] Mov dst:reg5, src:Undefined
-  [ 118] Jump target:block2
+  [  d8] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
+  [  e8] Mov dst:reg5, src:Undefined
+  [  f8] Jump target:block2
 
 block5:
-  [ 120] SetGlobal `k`, src:reg7
-  [ 138] GetGlobal dst:reg9, `result`
-  [ 150] GetGlobal dst:reg10, `k`
-  [ 168] GetGlobal dst:reg11, `obj`
-  [ 180] GetGlobal dst:reg12, `k`
-  [ 198] GetByValue dst:reg13, base:reg11, property:reg12 (obj[reg12])
-  [ 1b0] Add dst:reg11, lhs:reg10, rhs:reg13
-  [ 1c0] Add dst:reg10, lhs:reg9, rhs:reg11
-  [ 1d0] SetGlobal `result`, src:reg10
-  [ 1e8] Mov dst:reg5, src:reg10
-  [ 1f8] Jump target:block2
+  [ 100] SetGlobal `k`, src:reg7
+  [ 110] GetGlobal dst:reg9, `result`
+  [ 120] GetGlobal dst:reg10, `k`
+  [ 130] GetGlobal dst:reg11, `obj`
+  [ 140] GetGlobal dst:reg12, `k`
+  [ 150] GetByValue dst:reg13, base:reg11, property:reg12 (obj[reg12])
+  [ 168] Add dst:reg11, lhs:reg10, rhs:reg13
+  [ 178] Add dst:reg10, lhs:reg9, rhs:reg11
+  [ 188] SetGlobal `result`, src:reg10
+  [ 198] Mov dst:reg5, src:reg10
+  [ 1a8] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-var-function-lhs-name.txt
@@ -1,4 +1,4 @@
-$d0083583 for-in-var-function-lhs-name.js:7:1
+$491e5adb for-in-var-function-lhs-name.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $d0083583 for-in-var-function-lhs-name.js:7:1
 
 block0:
   [   0] GetGlobal dst:reg6, `fn`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, fn
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, fn
+  [  30] End value:reg5
 
 
-fn$4477295a for-in-var-function-lhs-name.js:4:19
+fn$c5d921e2 for-in-var-function-lhs-name.js:4:19
   Registers: 8
   Blocks:    6
   Locals:    f~0
@@ -36,8 +36,8 @@ block3:
 
 block4:
   [  88] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  a0] Jump target:block2
+  [  98] Jump target:block2
 
 block5:
-  [  a8] Mov dst:f~0, src:reg5
-  [  b8] Jump target:block2
+  [  a0] Mov dst:f~0, src:reg5
+  [  b0] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/for-loop-break-after-if-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-break-after-if-continue.txt
@@ -1,4 +1,4 @@
-$393b7f47 for-loop-break-after-if-continue.js:11:1
+$ba9d77cf for-loop-break-after-if-continue.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $393b7f47 for-loop-break-after-if-continue.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `bok`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, bok, arguments:[Bool(false)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, bok, arguments:[Bool(false)]
+  [  38] End value:reg5
 
 
 bok$3c12db64 for-loop-break-after-if-continue.js:6:9

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -13,7 +13,7 @@ block0:
   [  80] End value:reg5
 
 
-forLetClosure$10bc68b5 for-loop-scoping.js:2:15
+forLetClosure$1bcc2cf5 for-loop-scoping.js:2:15
   Registers: 10
   Blocks:    4
   Locals:    fns~0
@@ -26,39 +26,39 @@ block0:
   [   8] NewArray dst:fns~0
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  30] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  40] DynamicInitializeLexicalBinding `i`, src:Int32(0)
-  [  50] DynamicGetBinding dst:reg6, `i`
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  80] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  90] DynamicInitializeLexicalBinding `i`, src:reg6
-  [  a0] Jump target:block2
+  [  40] InitializeLexicalBinding `i`, src:Int32(0)
+  [  58] GetBinding dst:reg6, `i`
+  [  70] SetLexicalEnvironment environment:reg4
+  [  78] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  90] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [  a0] InitializeLexicalBinding `i`, src:reg6
+  [  b8] Jump target:block2
 
 block1:
-  [  a8] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  c0] Mov dst:reg8, src:fns~0
-  [  d0] NewFunction dst:reg9, shared_function_data_index:0
-  [  e8] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 110] DynamicGetBinding dst:reg6, `i`
-  [ 120] SetLexicalEnvironment environment:reg4
-  [ 128] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [ 140] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [ 150] DynamicInitializeLexicalBinding `i`, src:reg6
-  [ 160] DynamicGetBinding dst:reg7, `i`
-  [ 170] PostfixIncrement dst:reg6, src:reg7
-  [ 180] DynamicSetLexicalBinding `i`, src:reg7
+  [  c0] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  d8] Mov dst:reg8, src:fns~0
+  [  e8] NewFunction dst:reg9, shared_function_data_index:0
+  [ 100] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 128] GetBinding dst:reg6, `i`
+  [ 140] SetLexicalEnvironment environment:reg4
+  [ 148] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [ 160] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [ 170] InitializeLexicalBinding `i`, src:reg6
+  [ 188] GetBinding dst:reg7, `i`
+  [ 1a0] PostfixIncrement dst:reg6, src:reg7
+  [ 1b0] SetLexicalBinding `i`, src:reg7
 
 block2:
-  [ 190] DynamicGetBinding dst:reg6, `i`
-  [ 1a0] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
+  [ 1c8] GetBinding dst:reg6, `i`
+  [ 1e0] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
 
 block3:
-  [ 1b8] SetLexicalEnvironment environment:reg4
-  [ 1c0] GetById dst:reg6, base:fns~0, `map` (fns.map)
-  [ 1d8] Mov dst:reg7, src:fns~0
-  [ 1e8] NewFunction dst:reg8, shared_function_data_index:1
-  [ 200] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
-  [ 228] Return value:reg5
+  [ 1f8] SetLexicalEnvironment environment:reg4
+  [ 200] GetById dst:reg6, base:fns~0, `map` (fns.map)
+  [ 218] Mov dst:reg7, src:fns~0
+  [ 228] NewFunction dst:reg8, shared_function_data_index:1
+  [ 240] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
+  [ 268] Return value:reg5
 
 
 $617ce76f for-loop-scoping.js:6:20

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -1,4 +1,4 @@
-$3ce5efbc for-loop-scoping.js:8:1
+$b5fc1514 for-loop-scoping.js:8:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -6,14 +6,14 @@ $3ce5efbc for-loop-scoping.js:8:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `forLetClosure`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, forLetClosure
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `forLetClosure`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, forLetClosure
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] End value:reg5
 
 
-forLetClosure$24180025 for-loop-scoping.js:2:15
+forLetClosure$1bcc2cf5 for-loop-scoping.js:2:15
   Registers: 10
   Blocks:    4
   Locals:    fns~0
@@ -36,29 +36,29 @@ block0:
 
 block1:
   [  c0] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  e0] Mov dst:reg8, src:fns~0
-  [  f0] NewFunction dst:reg9, shared_function_data_index:0
-  [ 108] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 130] GetBinding dst:reg6, `i`
-  [ 148] SetLexicalEnvironment environment:reg4
-  [ 150] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [ 168] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [ 178] InitializeLexicalBinding `i`, src:reg6
-  [ 190] GetBinding dst:reg7, `i`
-  [ 1a8] PostfixIncrement dst:reg6, src:reg7
-  [ 1b8] SetLexicalBinding `i`, src:reg7
+  [  d8] Mov dst:reg8, src:fns~0
+  [  e8] NewFunction dst:reg9, shared_function_data_index:0
+  [ 100] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 128] GetBinding dst:reg6, `i`
+  [ 140] SetLexicalEnvironment environment:reg4
+  [ 148] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [ 160] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [ 170] InitializeLexicalBinding `i`, src:reg6
+  [ 188] GetBinding dst:reg7, `i`
+  [ 1a0] PostfixIncrement dst:reg6, src:reg7
+  [ 1b0] SetLexicalBinding `i`, src:reg7
 
 block2:
-  [ 1d0] GetBinding dst:reg6, `i`
-  [ 1e8] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
+  [ 1c8] GetBinding dst:reg6, `i`
+  [ 1e0] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
 
 block3:
-  [ 200] SetLexicalEnvironment environment:reg4
-  [ 208] GetById dst:reg6, base:fns~0, `map` (fns.map)
-  [ 228] Mov dst:reg7, src:fns~0
-  [ 238] NewFunction dst:reg8, shared_function_data_index:1
-  [ 250] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
-  [ 278] Return value:reg5
+  [ 1f8] SetLexicalEnvironment environment:reg4
+  [ 200] GetById dst:reg6, base:fns~0, `map` (fns.map)
+  [ 218] Mov dst:reg7, src:fns~0
+  [ 228] NewFunction dst:reg8, shared_function_data_index:1
+  [ 240] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
+  [ 268] Return value:reg5
 
 
 $617ce76f for-loop-scoping.js:6:20

--- a/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/for-loop-scoping.txt
@@ -13,7 +13,7 @@ block0:
   [  80] End value:reg5
 
 
-forLetClosure$1bcc2cf5 for-loop-scoping.js:2:15
+forLetClosure$10bc68b5 for-loop-scoping.js:2:15
   Registers: 10
   Blocks:    4
   Locals:    fns~0
@@ -26,39 +26,39 @@ block0:
   [   8] NewArray dst:fns~0
   [  18] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  30] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  40] InitializeLexicalBinding `i`, src:Int32(0)
-  [  58] GetBinding dst:reg6, `i`
-  [  70] SetLexicalEnvironment environment:reg4
-  [  78] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [  90] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [  a0] InitializeLexicalBinding `i`, src:reg6
-  [  b8] Jump target:block2
+  [  40] DynamicInitializeLexicalBinding `i`, src:Int32(0)
+  [  50] DynamicGetBinding dst:reg6, `i`
+  [  60] SetLexicalEnvironment environment:reg4
+  [  68] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [  80] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [  90] DynamicInitializeLexicalBinding `i`, src:reg6
+  [  a0] Jump target:block2
 
 block1:
-  [  c0] GetById dst:reg7, base:fns~0, `push` (fns.push)
-  [  d8] Mov dst:reg8, src:fns~0
-  [  e8] NewFunction dst:reg9, shared_function_data_index:0
-  [ 100] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
-  [ 128] GetBinding dst:reg6, `i`
-  [ 140] SetLexicalEnvironment environment:reg4
-  [ 148] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
-  [ 160] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
-  [ 170] InitializeLexicalBinding `i`, src:reg6
-  [ 188] GetBinding dst:reg7, `i`
-  [ 1a0] PostfixIncrement dst:reg6, src:reg7
-  [ 1b0] SetLexicalBinding `i`, src:reg7
+  [  a8] GetById dst:reg7, base:fns~0, `push` (fns.push)
+  [  c0] Mov dst:reg8, src:fns~0
+  [  d0] NewFunction dst:reg9, shared_function_data_index:0
+  [  e8] Call dst:reg6, callee:reg7, this_value:reg8, fns.push, arguments:[reg9]
+  [ 110] DynamicGetBinding dst:reg6, `i`
+  [ 120] SetLexicalEnvironment environment:reg4
+  [ 128] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
+  [ 140] CreateVariable `i`, is_immutable:false, is_global:false, is_strict:false
+  [ 150] DynamicInitializeLexicalBinding `i`, src:reg6
+  [ 160] DynamicGetBinding dst:reg7, `i`
+  [ 170] PostfixIncrement dst:reg6, src:reg7
+  [ 180] DynamicSetLexicalBinding `i`, src:reg7
 
 block2:
-  [ 1c8] GetBinding dst:reg6, `i`
-  [ 1e0] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
+  [ 190] DynamicGetBinding dst:reg6, `i`
+  [ 1a0] JumpLessThan lhs:reg6, rhs:Int32(3), true_target:block1, false_target:block3
 
 block3:
-  [ 1f8] SetLexicalEnvironment environment:reg4
-  [ 200] GetById dst:reg6, base:fns~0, `map` (fns.map)
-  [ 218] Mov dst:reg7, src:fns~0
-  [ 228] NewFunction dst:reg8, shared_function_data_index:1
-  [ 240] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
-  [ 268] Return value:reg5
+  [ 1b8] SetLexicalEnvironment environment:reg4
+  [ 1c0] GetById dst:reg6, base:fns~0, `map` (fns.map)
+  [ 1d8] Mov dst:reg7, src:fns~0
+  [ 1e8] NewFunction dst:reg8, shared_function_data_index:1
+  [ 200] Call dst:reg5, callee:reg6, this_value:reg7, fns.map, arguments:[reg8]
+  [ 228] Return value:reg5
 
 
 $617ce76f for-loop-scoping.js:6:20
@@ -72,13 +72,13 @@ block0:
   [  20] Return value:reg5
 
 
-$732f8c03 for-loop-scoping.js:4:18
+$f755759b for-loop-scoping.js:4:18
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `i`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `i`
+  [  10] Return value:reg5
 
 
 [ 0, 1, 2 ]

--- a/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-cond-rhs-block-order.txt
@@ -1,4 +1,4 @@
-$6a33dffa for-of-cond-rhs-block-order.js:6:1
+$e8d1e772 for-of-cond-rhs-block-order.js:6:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,11 +7,11 @@ $6a33dffa for-of-cond-rhs-block-order.js:6:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Null]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Null, Null]
+  [  38] End value:reg5
 
 
-f$567c3f32 for-of-cond-rhs-block-order.js:2:21
+f$daa228ca for-of-cond-rhs-block-order.js:2:21
   Registers: 17
   Blocks:    19
   Locals:    r~0, n~1
@@ -35,73 +35,73 @@ block2:
 block3:
   [  48] Mov dst:reg6, src:arg0
   [  58] GetById dst:reg7, base:reg6, `x` (o.x)
-  [  78] Mov dst:reg5, src:reg7
-  [  88] Jump target:block5
+  [  70] Mov dst:reg5, src:reg7
+  [  80] Jump target:block5
 
 block4:
-  [  90] Mov dst:reg5, src:arg1
+  [  88] Mov dst:reg5, src:arg1
 
 block5:
-  [  a0] GetGlobal dst:reg6, `Object`
-  [  b8] GetById dst:reg8, base:reg6, `entries` (Object.entries)
-  [  d8] NewObject dst:reg9
-  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, Object.entries, arguments:[reg9]
-  [ 110] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg8, dst_iterator_done:reg6, iterable:reg7
-  [ 128] Jump target:block2
+  [  98] GetGlobal dst:reg6, `Object`
+  [  a8] GetById dst:reg8, base:reg6, `entries` (Object.entries)
+  [  c0] NewObject dst:reg9
+  [  d0] Call dst:reg7, callee:reg8, this_value:reg6, Object.entries, arguments:[reg9]
+  [  f8] GetIterator dst_iterator_object:reg5, dst_iterator_next:reg8, dst_iterator_done:reg6, iterable:reg7
+  [ 110] Jump target:block2
 
 block6:
-  [ 130] Catch dst:reg9
-  [ 138] SetLexicalEnvironment environment:reg4
-  [ 140] Mov dst:reg7, src:Int32(1)
-  [ 150] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block15, false_target:block16
+  [ 118] Catch dst:reg9
+  [ 120] SetLexicalEnvironment environment:reg4
+  [ 128] Mov dst:reg7, src:Int32(1)
+  [ 138] JumpStrictlyEquals lhs:reg7, rhs:Int32(1), true_target:block15, false_target:block16
 
 block7:
-  [ 168] Mov dst:reg12, src:Bool(false)
-  [ 178] GetIterator dst_iterator_object:reg13, dst_iterator_next:reg14, dst_iterator_done:reg15, iterable:reg10
-  [ 190] IteratorNextUnpack dst_value:reg16, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
-  [ 1a8] JumpFalse condition:reg12, target:block9
+  [ 150] Mov dst:reg12, src:Bool(false)
+  [ 160] GetIterator dst_iterator_object:reg13, dst_iterator_next:reg14, dst_iterator_done:reg15, iterable:reg10
+  [ 178] IteratorNextUnpack dst_value:reg16, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
+  [ 190] JumpFalse condition:reg12, target:block9
 
 block8:
-  [ 1b8] Mov dst:reg16, src:Undefined
-  [ 1c8] Jump target:block9
+  [ 1a0] Mov dst:reg16, src:Undefined
+  [ 1b0] Jump target:block9
 
 block9:
-  [ 1d0] Mov dst:r~0, src:reg16
-  [ 1e0] JumpFalse condition:reg12, target:block11
+  [ 1b8] Mov dst:r~0, src:reg16
+  [ 1c8] JumpFalse condition:reg12, target:block11
 
 block10:
-  [ 1f0] Mov dst:reg16, src:Undefined
-  [ 200] Jump target:block12
+  [ 1d8] Mov dst:reg16, src:Undefined
+  [ 1e8] Jump target:block12
 
 block11:
-  [ 208] IteratorNextUnpack dst_value:reg16, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
-  [ 220] JumpTrue condition:reg12, target:block10
+  [ 1f0] IteratorNextUnpack dst_value:reg16, dst_done:reg12, iterator_object:reg13, iterator_next:reg14, iterator_done:reg15
+  [ 208] JumpTrue condition:reg12, target:block10
 
 block12:
-  [ 230] Mov dst:n~1, src:reg16
-  [ 240] JumpFalse condition:reg12, target:block14
+  [ 218] Mov dst:n~1, src:reg16
+  [ 228] JumpFalse condition:reg12, target:block14
 
 block13:
-  [ 250] ThrowIfTDZ src:r~0
-  [ 258] Jump target:block2
+  [ 238] ThrowIfTDZ src:r~0
+  [ 240] Jump target:block2
 
 block14:
-  [ 260] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:Undefined
-  [ 278] Jump target:block13
+  [ 248] IteratorClose iterator_object:reg13, iterator_next:reg14, iterator_done:reg15, completion_value:Undefined
+  [ 260] Jump target:block13
 
 block15:
-  [ 280] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:reg9
-  [ 298] Throw src:reg9
+  [ 268] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:reg9
+  [ 280] Throw src:reg9
 
 block16:
-  [ 2a0] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:Undefined
-  [ 2b8] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block17, false_target:block18
+  [ 288] IteratorClose iterator_object:reg5, iterator_next:reg8, iterator_done:reg6, completion_value:Undefined
+  [ 2a0] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block17, false_target:block18
 
 block17:
-  [ 2d0] Return value:reg9
+  [ 2b8] Return value:reg9
 
 block18:
-  [ 2d8] Throw src:reg9
+  [ 2c0] Throw src:reg9
 
 Exception handlers:
-  [ 168 ..  280] => handler block6
+  [ 150 ..  268] => handler block6

--- a/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
@@ -1,4 +1,4 @@
-$2b0d6491 for-of-continue-with-block-scope.js:13:1
+$ac6f5d19 for-of-continue-with-block-scope.js:13:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $2b0d6491 for-of-continue-with-block-scope.js:13:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewArray dst:reg7
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  50] End value:reg5
+  [  10] NewArray dst:reg7
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  48] End value:reg5
 
 
-f$a9a62cb8 for-of-continue-with-block-scope.js:2:15
+f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
   Registers: 18
   Blocks:    11
   Locals:    o~0, t~1
@@ -52,33 +52,33 @@ block4:
 
 block5:
   [ 148] GetById dst:reg15, base:t~1, `push` (t.push)
-  [ 168] Mov dst:reg16, src:t~1
-  [ 178] GetBinding dst:reg17, `r`
-  [ 190] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
-  [ 1b8] SetLexicalEnvironment environment:reg4
-  [ 1c0] Jump target:block2
+  [ 160] Mov dst:reg16, src:t~1
+  [ 170] GetBinding dst:reg17, `r`
+  [ 188] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
+  [ 1b0] SetLexicalEnvironment environment:reg4
+  [ 1b8] Jump target:block2
 
 block6:
-  [ 1c8] GetById dst:reg13, base:t~1, `find` (t.find)
-  [ 1e8] Mov dst:reg14, src:t~1
-  [ 1f8] NewFunction dst:reg15, shared_function_data_index:0
-  [ 210] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
-  [ 238] SetLexicalEnvironment environment:reg4
-  [ 240] Jump target:block2
+  [ 1c0] GetById dst:reg13, base:t~1, `find` (t.find)
+  [ 1d8] Mov dst:reg14, src:t~1
+  [ 1e8] NewFunction dst:reg15, shared_function_data_index:0
+  [ 200] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
+  [ 228] SetLexicalEnvironment environment:reg4
+  [ 230] Jump target:block2
 
 block7:
-  [ 248] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
-  [ 260] Throw src:reg9
+  [ 238] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
+  [ 250] Throw src:reg9
 
 block8:
-  [ 268] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
-  [ 280] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
+  [ 258] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
+  [ 270] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
 
 block9:
-  [ 298] Return value:reg9
+  [ 288] Return value:reg9
 
 block10:
-  [ 2a0] Throw src:reg9
+  [ 290] Throw src:reg9
 
 Exception handlers:
-  [  d0 ..  248] => handler block3
+  [  d0 ..  238] => handler block3

--- a/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
@@ -11,7 +11,7 @@ block0:
   [  48] End value:reg5
 
 
-f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
+f$22bc5210 for-of-continue-with-block-scope.js:2:15
   Registers: 18
   Blocks:    11
   Locals:    o~0, t~1
@@ -45,40 +45,40 @@ block3:
 block4:
   [  d0] CreateLexicalEnvironment dst:reg12, parent:reg4, capacity:0, is_catch_environment:false
   [  e8] CreateVariable `r`, is_immutable:true, is_global:false, is_strict:true
-  [  f8] InitializeLexicalBinding `r`, src:reg10
-  [ 110] GetBinding dst:reg14, `r`
-  [ 128] Not dst:reg13, src:reg14
-  [ 138] JumpFalse condition:reg13, target:block6
+  [  f8] DynamicInitializeLexicalBinding `r`, src:reg10
+  [ 108] DynamicGetBinding dst:reg14, `r`
+  [ 118] Not dst:reg13, src:reg14
+  [ 128] JumpFalse condition:reg13, target:block6
 
 block5:
-  [ 148] GetById dst:reg15, base:t~1, `push` (t.push)
-  [ 160] Mov dst:reg16, src:t~1
-  [ 170] GetBinding dst:reg17, `r`
-  [ 188] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
-  [ 1b0] SetLexicalEnvironment environment:reg4
-  [ 1b8] Jump target:block2
+  [ 138] GetById dst:reg15, base:t~1, `push` (t.push)
+  [ 150] Mov dst:reg16, src:t~1
+  [ 160] DynamicGetBinding dst:reg17, `r`
+  [ 170] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
+  [ 198] SetLexicalEnvironment environment:reg4
+  [ 1a0] Jump target:block2
 
 block6:
-  [ 1c0] GetById dst:reg13, base:t~1, `find` (t.find)
-  [ 1d8] Mov dst:reg14, src:t~1
-  [ 1e8] NewFunction dst:reg15, shared_function_data_index:0
-  [ 200] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
-  [ 228] SetLexicalEnvironment environment:reg4
-  [ 230] Jump target:block2
+  [ 1a8] GetById dst:reg13, base:t~1, `find` (t.find)
+  [ 1c0] Mov dst:reg14, src:t~1
+  [ 1d0] NewFunction dst:reg15, shared_function_data_index:0
+  [ 1e8] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
+  [ 210] SetLexicalEnvironment environment:reg4
+  [ 218] Jump target:block2
 
 block7:
-  [ 238] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
-  [ 250] Throw src:reg9
+  [ 220] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
+  [ 238] Throw src:reg9
 
 block8:
-  [ 258] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
-  [ 270] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
+  [ 240] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
+  [ 258] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
 
 block9:
-  [ 288] Return value:reg9
+  [ 270] Return value:reg9
 
 block10:
-  [ 290] Throw src:reg9
+  [ 278] Throw src:reg9
 
 Exception handlers:
-  [  d0 ..  238] => handler block3
+  [  d0 ..  220] => handler block3

--- a/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-continue-with-block-scope.txt
@@ -11,7 +11,7 @@ block0:
   [  48] End value:reg5
 
 
-f$22bc5210 for-of-continue-with-block-scope.js:2:15
+f$a6e23ba8 for-of-continue-with-block-scope.js:2:15
   Registers: 18
   Blocks:    11
   Locals:    o~0, t~1
@@ -45,40 +45,40 @@ block3:
 block4:
   [  d0] CreateLexicalEnvironment dst:reg12, parent:reg4, capacity:0, is_catch_environment:false
   [  e8] CreateVariable `r`, is_immutable:true, is_global:false, is_strict:true
-  [  f8] DynamicInitializeLexicalBinding `r`, src:reg10
-  [ 108] DynamicGetBinding dst:reg14, `r`
-  [ 118] Not dst:reg13, src:reg14
-  [ 128] JumpFalse condition:reg13, target:block6
+  [  f8] InitializeLexicalBinding `r`, src:reg10
+  [ 110] GetBinding dst:reg14, `r`
+  [ 128] Not dst:reg13, src:reg14
+  [ 138] JumpFalse condition:reg13, target:block6
 
 block5:
-  [ 138] GetById dst:reg15, base:t~1, `push` (t.push)
-  [ 150] Mov dst:reg16, src:t~1
-  [ 160] DynamicGetBinding dst:reg17, `r`
-  [ 170] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
-  [ 198] SetLexicalEnvironment environment:reg4
-  [ 1a0] Jump target:block2
+  [ 148] GetById dst:reg15, base:t~1, `push` (t.push)
+  [ 160] Mov dst:reg16, src:t~1
+  [ 170] GetBinding dst:reg17, `r`
+  [ 188] Call dst:reg14, callee:reg15, this_value:reg16, t.push, arguments:[reg17]
+  [ 1b0] SetLexicalEnvironment environment:reg4
+  [ 1b8] Jump target:block2
 
 block6:
-  [ 1a8] GetById dst:reg13, base:t~1, `find` (t.find)
-  [ 1c0] Mov dst:reg14, src:t~1
-  [ 1d0] NewFunction dst:reg15, shared_function_data_index:0
-  [ 1e8] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
-  [ 210] SetLexicalEnvironment environment:reg4
-  [ 218] Jump target:block2
+  [ 1c0] GetById dst:reg13, base:t~1, `find` (t.find)
+  [ 1d8] Mov dst:reg14, src:t~1
+  [ 1e8] NewFunction dst:reg15, shared_function_data_index:0
+  [ 200] Call dst:o~0, callee:reg13, this_value:reg14, t.find, arguments:[reg15]
+  [ 228] SetLexicalEnvironment environment:reg4
+  [ 230] Jump target:block2
 
 block7:
-  [ 220] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
-  [ 238] Throw src:reg9
+  [ 238] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:reg9
+  [ 250] Throw src:reg9
 
 block8:
-  [ 240] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
-  [ 258] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
+  [ 258] IteratorClose iterator_object:reg5, iterator_next:reg6, iterator_done:reg7, completion_value:Undefined
+  [ 270] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block9, false_target:block10
 
 block9:
-  [ 270] Return value:reg9
+  [ 288] Return value:reg9
 
 block10:
-  [ 278] Throw src:reg9
+  [ 290] Throw src:reg9
 
 Exception handlers:
-  [  d0 ..  220] => handler block3
+  [  d0 ..  238] => handler block3

--- a/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
@@ -1,4 +1,4 @@
-$04795212 for-of-iterator-close.js:6:1
+$8053687a for-of-iterator-close.js:6:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,13 +6,13 @@ $04795212 for-of-iterator-close.js:6:1
 
 block0:
   [   0] GetGlobal dst:reg6, `forOfBreak`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, forOfBreak
-  [  38] GetGlobal dst:reg7, `forOfReturn`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, forOfReturn
-  [  70] GetGlobal dst:reg7, `forAwaitOfBreak`
-  [  88] NewPrimitiveArray dst:reg8, elements:[1, 2, 3]
-  [  b0] Call dst:reg5, callee:reg7, this_value:Undefined, forAwaitOfBreak, arguments:[reg8]
-  [  d8] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, forOfBreak
+  [  30] GetGlobal dst:reg7, `forOfReturn`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, forOfReturn
+  [  60] GetGlobal dst:reg7, `forAwaitOfBreak`
+  [  70] NewPrimitiveArray dst:reg8, elements:[1, 2, 3]
+  [  98] Call dst:reg5, callee:reg7, this_value:Undefined, forAwaitOfBreak, arguments:[reg8]
+  [  c0] End value:reg5
 
 
 forOfBreak$0dacb993 for-of-iterator-close.js:2:18
@@ -133,7 +133,7 @@ Exception handlers:
   [  b8 ..   f0] => handler block3
 
 
-forAwaitOfBreak$0834dde7 for-of-iterator-close.js:16:24
+forAwaitOfBreak$16089337 for-of-iterator-close.js:16:24
   Registers: 18
   Blocks:    30
   Locals:    x~0
@@ -176,87 +176,87 @@ block7:
   [  f0] Mov dst:reg12, src:reg15
   [ 100] ThrowIfNotObject src:reg12
   [ 108] GetById dst:reg11, base:reg12, `done`
-  [ 128] JumpIf condition:reg11, true_target:block2, false_target:block9
+  [ 120] JumpIf condition:reg11, true_target:block2, false_target:block9
 
 block8:
-  [ 138] Throw src:reg15
+  [ 130] Throw src:reg15
 
 block9:
-  [ 140] GetById dst:reg10, base:reg12, `value`
+  [ 138] GetById dst:reg10, base:reg12, `value`
 
 block10:
-  [ 160] Mov dst:x~0, src:reg10
-  [ 170] ThrowIfTDZ src:x~0
-  [ 178] JumpStrictlyEquals lhs:x~0, rhs:Int32(2), true_target:block11, false_target:block12
+  [ 150] Mov dst:x~0, src:reg10
+  [ 160] ThrowIfTDZ src:x~0
+  [ 168] JumpStrictlyEquals lhs:x~0, rhs:Int32(2), true_target:block11, false_target:block12
 
 block11:
-  [ 190] Mov dst:reg8, src:Int32(3)
-  [ 1a0] Jump target:block5
+  [ 180] Mov dst:reg8, src:Int32(3)
+  [ 190] Jump target:block5
 
 block12:
-  [ 1a8] Jump target:block3
+  [ 198] Jump target:block3
 
 block13:
-  [ 1b0] Jump target:block25
+  [ 1a0] Jump target:block25
 
 block14:
-  [ 1b8] GetMethod dst:reg12, object:reg5, `return`
-  [ 1c8] JumpUndefined condition:reg12, true_target:block15, false_target:block16
+  [ 1a8] GetMethod dst:reg12, object:reg5, `return`
+  [ 1b8] JumpUndefined condition:reg12, true_target:block15, false_target:block16
 
 block15:
-  [ 1d8] JumpStrictlyEquals lhs:reg8, rhs:Int32(3), true_target:block2, false_target:block20
+  [ 1c8] JumpStrictlyEquals lhs:reg8, rhs:Int32(3), true_target:block2, false_target:block20
 
 block16:
-  [ 1f0] Call dst:reg13, callee:reg12, this_value:reg5
-  [ 210] Await continuation_label:block17, argument:reg13
+  [ 1e0] Call dst:reg13, callee:reg12, this_value:reg5
+  [ 200] Await continuation_label:block17, argument:reg13
 
 block17:
-  [ 220] Mov dst:reg14, src:reg0
-  [ 230] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
-  [ 240] JumpStrictlyEquals lhs:reg15, rhs:Int32(1), true_target:block18, false_target:block19
+  [ 210] Mov dst:reg14, src:reg0
+  [ 220] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
+  [ 230] JumpStrictlyEquals lhs:reg15, rhs:Int32(1), true_target:block18, false_target:block19
 
 block18:
-  [ 258] ThrowIfNotObject src:reg16
-  [ 260] Jump target:block15
+  [ 248] ThrowIfNotObject src:reg16
+  [ 250] Jump target:block15
 
 block19:
-  [ 268] Throw src:reg16
+  [ 258] Throw src:reg16
 
 block20:
-  [ 270] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block21, false_target:block22
+  [ 260] JumpStrictlyEquals lhs:reg8, rhs:Int32(2), true_target:block21, false_target:block22
 
 block21:
-  [ 288] Return value:reg9
+  [ 278] Return value:reg9
 
 block22:
-  [ 290] Throw src:reg9
+  [ 280] Throw src:reg9
 
 block23:
-  [ 298] Throw src:reg9
+  [ 288] Throw src:reg9
 
 block24:
-  [ 2a0] Catch dst:reg12
-  [ 2a8] Jump target:block23
+  [ 290] Catch dst:reg12
+  [ 298] Jump target:block23
 
 block25:
-  [ 2b0] GetMethod dst:reg12, object:reg5, `return`
-  [ 2c0] JumpUndefined condition:reg12, true_target:block23, false_target:block26
+  [ 2a0] GetMethod dst:reg12, object:reg5, `return`
+  [ 2b0] JumpUndefined condition:reg12, true_target:block23, false_target:block26
 
 block26:
-  [ 2d0] Call dst:reg13, callee:reg12, this_value:reg5
-  [ 2f0] Await continuation_label:block27, argument:reg13
+  [ 2c0] Call dst:reg13, callee:reg12, this_value:reg5
+  [ 2e0] Await continuation_label:block27, argument:reg13
 
 block27:
-  [ 300] Mov dst:reg14, src:reg0
-  [ 310] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
-  [ 320] JumpStrictlyEquals lhs:reg15, rhs:Int32(1), true_target:block28, false_target:block29
+  [ 2f0] Mov dst:reg14, src:reg0
+  [ 300] GetCompletionFields type_dst:reg15, value_dst:reg16, completion:reg14
+  [ 310] JumpStrictlyEquals lhs:reg15, rhs:Int32(1), true_target:block28, false_target:block29
 
 block28:
-  [ 338] Jump target:block23
+  [ 328] Jump target:block23
 
 block29:
-  [ 340] Throw src:reg16
+  [ 330] Throw src:reg16
 
 Exception handlers:
-  [ 160 ..  1b0] => handler block4
-  [ 2b0 ..  348] => handler block24
+  [ 150 ..  1a0] => handler block4
+  [ 2a0 ..  338] => handler block24

--- a/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
@@ -1,4 +1,4 @@
-$6ce1f287 for-try-finally-continue.js:1:1
+$3afe53aa for-try-finally-continue.js:1:1
   Registers: 11
   Blocks:    16
   Locals:    e~0
@@ -14,69 +14,69 @@ $6ce1f287 for-try-finally-continue.js:1:1
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] SetGlobal `i`, src:Int32(0)
-  [  20] Mov dst:reg5, src:Undefined
-  [  30] Jump target:block3
+  [  18] Mov dst:reg5, src:Undefined
+  [  28] Jump target:block3
 
 block1:
-  [  38] Jump target:block8
+  [  30] Jump target:block8
 
 block2:
-  [  40] GetGlobal dst:reg7, `i`
-  [  58] PostfixIncrement dst:reg6, src:reg7
-  [  68] SetGlobal `i`, src:reg7
+  [  38] GetGlobal dst:reg7, `i`
+  [  48] PostfixIncrement dst:reg6, src:reg7
+  [  58] SetGlobal `i`, src:reg7
 
 block3:
-  [  80] GetGlobal dst:reg6, `i`
-  [  98] JumpLessThan lhs:reg6, rhs:Int32(5), true_target:block1, false_target:block4
+  [  68] GetGlobal dst:reg6, `i`
+  [  78] JumpLessThan lhs:reg6, rhs:Int32(5), true_target:block1, false_target:block4
 
 block4:
-  [  b0] GetGlobal dst:reg10, `i`
-  [  c8] StrictlyInequals dst:reg8, lhs:reg10, rhs:Int32(5)
-  [  d8] Mov dst:reg10, src:Undefined
-  [  e8] JumpIf condition:reg8, true_target:block14, false_target:block15
+  [  90] GetGlobal dst:reg10, `i`
+  [  a0] StrictlyInequals dst:reg8, lhs:reg10, rhs:Int32(5)
+  [  b0] Mov dst:reg10, src:Undefined
+  [  c0] JumpIf condition:reg8, true_target:block14, false_target:block15
 
 block5:
-  [  f8] Catch dst:reg7
-  [ 100] SetLexicalEnvironment environment:reg4
-  [ 108] Mov dst:reg6, src:Int32(1)
+  [  d0] Catch dst:reg7
+  [  d8] SetLexicalEnvironment environment:reg4
+  [  e0] Mov dst:reg6, src:Int32(1)
 
 block6:
-  [ 118] Mov dst:reg9, src:Undefined
-  [ 128] JumpStrictlyEquals lhs:reg6, rhs:Int32(0), true_target:block9, false_target:block10
+  [  f0] Mov dst:reg9, src:Undefined
+  [ 100] JumpStrictlyEquals lhs:reg6, rhs:Int32(0), true_target:block9, false_target:block10
 
 block7:
-  [ 140] Catch dst:reg8
-  [ 148] SetLexicalEnvironment environment:reg4
-  [ 150] Mov3 dst1:e~0, src1:reg8, dst2:reg9, src2:Undefined, dst3:reg10, src3:reg9
-  [ 170] Mov dst:reg6, src:Int32(0)
-  [ 180] Jump target:block6
+  [ 118] Catch dst:reg8
+  [ 120] SetLexicalEnvironment environment:reg4
+  [ 128] Mov3 dst1:e~0, src1:reg8, dst2:reg9, src2:Undefined, dst3:reg10, src3:reg9
+  [ 148] Mov dst:reg6, src:Int32(0)
+  [ 158] Jump target:block6
 
 block8:
-  [ 188] Mov3 dst1:reg8, src1:Undefined, dst2:reg5, src2:reg8, dst3:reg6, src3:Int32(3)
-  [ 1a8] Jump target:block6
+  [ 160] Mov3 dst1:reg8, src1:Undefined, dst2:reg5, src2:reg8, dst3:reg6, src3:Int32(3)
+  [ 180] Jump target:block6
 
 block9:
-  [ 1b0] Mov dst:reg5, src:reg10
-  [ 1c0] Jump target:block2
+  [ 188] Mov dst:reg5, src:reg10
+  [ 198] Jump target:block2
 
 block10:
-  [ 1c8] JumpStrictlyEquals lhs:reg6, rhs:Int32(3), true_target:block2, false_target:block11
+  [ 1a0] JumpStrictlyEquals lhs:reg6, rhs:Int32(3), true_target:block2, false_target:block11
 
 block11:
-  [ 1e0] JumpStrictlyEquals lhs:reg6, rhs:Int32(2), true_target:block12, false_target:block13
+  [ 1b8] JumpStrictlyEquals lhs:reg6, rhs:Int32(2), true_target:block12, false_target:block13
 
 block12:
-  [ 1f8] Return value:reg7
+  [ 1d0] Return value:reg7
 
 block13:
-  [ 200] Throw src:reg7
+  [ 1d8] Throw src:reg7
 
 block14:
-  [ 208] Throw src:String("bad")
+  [ 1e0] Throw src:String("bad")
 
 block15:
-  [ 210] End value:reg10
+  [ 1e8] End value:reg10
 
 Exception handlers:
-  [ 140 ..  188] => handler block5
-  [ 188 ..  1b0] => handler block7
+  [ 118 ..  160] => handler block5
+  [ 160 ..  188] => handler block7

--- a/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/function-decl-source-order.txt
@@ -1,4 +1,4 @@
-$7ed51afa function-decl-source-order.js:17:1
+$df07c6c2 function-decl-source-order.js:17:1
   Registers: 14
   Blocks:    1
   Constants:
@@ -6,19 +6,19 @@ $7ed51afa function-decl-source-order.js:17:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `alpha`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, alpha
-  [  70] GetGlobal dst:reg10, `beta`
-  [  88] Call dst:reg9, callee:reg10, this_value:Undefined, beta
-  [  a8] GetGlobal dst:reg11, `gamma`
-  [  c0] Call dst:reg10, callee:reg11, this_value:Undefined, gamma
-  [  e0] GetGlobal dst:reg12, `delta`
-  [  f8] Call dst:reg11, callee:reg12, this_value:Undefined, delta
-  [ 118] GetGlobal dst:reg13, `dup`
-  [ 130] Call dst:reg12, callee:reg13, this_value:Undefined, dup
-  [ 150] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8, reg9, reg10, reg11, reg12]
-  [ 188] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `alpha`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, alpha
+  [  58] GetGlobal dst:reg10, `beta`
+  [  68] Call dst:reg9, callee:reg10, this_value:Undefined, beta
+  [  88] GetGlobal dst:reg11, `gamma`
+  [  98] Call dst:reg10, callee:reg11, this_value:Undefined, gamma
+  [  b8] GetGlobal dst:reg12, `delta`
+  [  c8] Call dst:reg11, callee:reg12, this_value:Undefined, delta
+  [  e8] GetGlobal dst:reg13, `dup`
+  [  f8] Call dst:reg12, callee:reg13, this_value:Undefined, dup
+  [ 118] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8, reg9, reg10, reg11, reg12]
+  [ 150] End value:reg5
 
 
 alpha$29e24060 function-decl-source-order.js:5:20

--- a/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-call.txt
@@ -1,4 +1,4 @@
-$9ff65435 generator-yield-call.js:9:1
+$21584cbd generator-yield-call.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -8,17 +8,17 @@ $9ff65435 generator-yield-call.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewObject dst:reg7
-  [  28] InitObjectLiteralProperty object:reg7, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  40] CacheObjectShape object:reg7
-  [  50] NewObject dst:reg8
-  [  60] InitObjectLiteralProperty object:reg8, `y`, src:Int32(2), shape_cache_index:1, property_slot:0
-  [  78] CacheObjectShape object:reg8
-  [  88] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
-  [  b0] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] InitObjectLiteralProperty object:reg7, `x`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  38] CacheObjectShape object:reg7
+  [  48] NewObject dst:reg8
+  [  58] InitObjectLiteralProperty object:reg8, `y`, src:Int32(2), shape_cache_index:1, property_slot:0
+  [  70] CacheObjectShape object:reg8
+  [  80] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7, reg8]
+  [  a8] End value:reg5
 
 
-f$914aca23 generator-yield-call.js:6:5
+f$8e86d913 generator-yield-call.js:6:5
   Registers: 11
   Blocks:    12
   Constants:
@@ -32,40 +32,40 @@ block0:
 block1:
   [  10] Mov dst:reg8, src:arg0
   [  20] GetById dst:reg9, base:reg8, `x` (a.x)
-  [  40] Yield continuation_label:block2, value:reg9
+  [  38] Yield continuation_label:block2, value:reg9
 
 block2:
-  [  50] Mov dst:reg5, src:reg0
-  [  60] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-  [  70] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block3, false_target:block4
+  [  48] Mov dst:reg5, src:reg0
+  [  58] GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+  [  68] JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:block3, false_target:block4
 
 block3:
-  [  88] Mov dst:reg9, src:arg1
-  [  98] GetById dst:reg8, base:reg9, `y` (b.y)
-  [  b8] Yield continuation_label:block7, value:reg8
+  [  80] Mov dst:reg9, src:arg1
+  [  90] GetById dst:reg8, base:reg9, `y` (b.y)
+  [  a8] Yield continuation_label:block7, value:reg8
 
 block4:
-  [  c8] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block5, false_target:block6
+  [  b8] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block5, false_target:block6
 
 block5:
-  [  e0] Throw src:reg7
+  [  d0] Throw src:reg7
 
 block6:
-  [  e8] Yield value:reg7
+  [  d8] Yield value:reg7
 
 block7:
-  [  f8] Mov dst:reg7, src:reg0
-  [ 108] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
-  [ 118] JumpStrictlyEquals lhs:reg5, rhs:Int32(1), true_target:block8, false_target:block9
+  [  e8] Mov dst:reg7, src:reg0
+  [  f8] GetCompletionFields type_dst:reg5, value_dst:reg6, completion:reg7
+  [ 108] JumpStrictlyEquals lhs:reg5, rhs:Int32(1), true_target:block8, false_target:block9
 
 block8:
-  [ 130] Yield value:Undefined
+  [ 120] Yield value:Undefined
 
 block9:
-  [ 140] JumpStrictlyEquals lhs:reg5, rhs:Int32(5), true_target:block10, false_target:block11
+  [ 130] JumpStrictlyEquals lhs:reg5, rhs:Int32(5), true_target:block10, false_target:block11
 
 block10:
-  [ 158] Throw src:reg6
+  [ 148] Throw src:reg6
 
 block11:
-  [ 160] Yield value:reg6
+  [ 150] Yield value:reg6

--- a/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
@@ -1,4 +1,4 @@
-$ba9d77cf generator-yield-finally.js:11:1
+$30efac17 generator-yield-finally.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $ba9d77cf generator-yield-finally.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
 f$6b17ea44 generator-yield-finally.js:4:5

--- a/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
@@ -1,4 +1,4 @@
-$6fbbc21a generator-yield-star.js:6:1
+$ee59c992 generator-yield-star.js:6:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $6fbbc21a generator-yield-star.js:6:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] NewPrimitiveArray dst:reg7, elements:[1, 2]
-  [  38] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
-  [  60] End value:reg5
+  [  10] NewPrimitiveArray dst:reg7, elements:[1, 2]
+  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[reg7]
+  [  58] End value:reg5
 
 
-f$289ca507 generator-yield-star.js:4:5
+f$b50e61cf generator-yield-star.js:4:5
   Registers: 22
   Blocks:    19
   Constants:
@@ -41,59 +41,59 @@ block5:
   [  90] Call dst:reg12, callee:reg9, this_value:reg8, arguments:[reg7]
   [  b8] ThrowIfNotObject src:reg12
   [  c0] GetById dst:reg13, base:reg12, `done`
-  [  e0] JumpIf condition:reg13, true_target:block7, false_target:block8
+  [  d8] JumpIf condition:reg13, true_target:block7, false_target:block8
 
 block6:
-  [  f0] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block9, false_target:block10
+  [  e8] JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:block9, false_target:block10
 
 block7:
-  [ 108] GetById dst:reg14, base:reg12, `value`
-  [ 128] Jump target:block4
+  [ 100] GetById dst:reg14, base:reg12, `value`
+  [ 118] Jump target:block4
 
 block8:
-  [ 130] GetById dst:reg15, base:reg12, `value`
-  [ 150] Yield continuation_label:block3, value:reg15
+  [ 120] GetById dst:reg15, base:reg12, `value`
+  [ 138] Yield continuation_label:block3, value:reg15
 
 block9:
-  [ 160] GetMethod dst:reg16, object:reg8, `throw`
-  [ 170] JumpUndefined condition:reg16, true_target:block12, false_target:block11
+  [ 148] GetMethod dst:reg16, object:reg8, `throw`
+  [ 158] JumpUndefined condition:reg16, true_target:block12, false_target:block11
 
 block10:
-  [ 180] GetMethod dst:reg18, object:reg8, `return`
-  [ 190] JumpUndefined condition:reg18, true_target:block15, false_target:block16
+  [ 168] GetMethod dst:reg18, object:reg8, `return`
+  [ 178] JumpUndefined condition:reg18, true_target:block15, false_target:block16
 
 block11:
-  [ 1a0] Call dst:reg12, callee:reg16, this_value:reg8, arguments:[reg7]
-  [ 1c8] ThrowIfNotObject src:reg12
-  [ 1d0] GetById dst:reg13, base:reg12, `done`
-  [ 1f0] JumpIf condition:reg13, true_target:block13, false_target:block14
+  [ 188] Call dst:reg12, callee:reg16, this_value:reg8, arguments:[reg7]
+  [ 1b0] ThrowIfNotObject src:reg12
+  [ 1b8] GetById dst:reg13, base:reg12, `done`
+  [ 1d0] JumpIf condition:reg13, true_target:block13, false_target:block14
 
 block12:
-  [ 200] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg13, completion_value:Undefined
-  [ 218] NewTypeError dst:reg17, yield* protocol violation: iterator must have a throw method
-  [ 228] Throw src:reg17
+  [ 1e0] IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg13, completion_value:Undefined
+  [ 1f8] NewTypeError dst:reg17, yield* protocol violation: iterator must have a throw method
+  [ 208] Throw src:reg17
 
 block13:
-  [ 230] GetById dst:reg14, base:reg12, `value`
-  [ 250] Jump target:block4
+  [ 210] GetById dst:reg14, base:reg12, `value`
+  [ 228] Jump target:block4
 
 block14:
-  [ 258] GetById dst:reg17, base:reg12, `value`
-  [ 278] Yield continuation_label:block3, value:reg17
+  [ 230] GetById dst:reg17, base:reg12, `value`
+  [ 248] Yield continuation_label:block3, value:reg17
 
 block15:
-  [ 288] Yield value:reg7
+  [ 258] Yield value:reg7
 
 block16:
-  [ 298] Call dst:reg19, callee:reg18, this_value:reg8, arguments:[reg7]
-  [ 2c0] ThrowIfNotObject src:reg19
-  [ 2c8] GetById dst:reg13, base:reg19, `done`
-  [ 2e8] JumpFalse condition:reg13, target:block18
+  [ 268] Call dst:reg19, callee:reg18, this_value:reg8, arguments:[reg7]
+  [ 290] ThrowIfNotObject src:reg19
+  [ 298] GetById dst:reg13, base:reg19, `done`
+  [ 2b0] JumpFalse condition:reg13, target:block18
 
 block17:
-  [ 2f8] GetById dst:reg20, base:reg19, `value`
-  [ 318] Yield value:reg20
+  [ 2c0] GetById dst:reg20, base:reg19, `value`
+  [ 2d8] Yield value:reg20
 
 block18:
-  [ 328] GetById dst:reg21, base:reg19, `value`
-  [ 348] Yield continuation_label:block3, value:reg21
+  [ 2e8] GetById dst:reg21, base:reg19, `value`
+  [ 300] Yield continuation_label:block3, value:reg21

--- a/Tests/LibJS/Bytecode/expected/generator-yield.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield.txt
@@ -1,4 +1,4 @@
-$ef4507bc generator-yield.js:11:1
+$205805b7 generator-yield.js:11:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,15 +6,15 @@ $ef4507bc generator-yield.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `multi_yield`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, multi_yield
-  [  38] SetGlobal `g`, src:reg5
-  [  50] GetGlobal dst:reg6, `g`
-  [  68] GetById dst:reg7, base:reg6, `next` (g.next)
-  [  88] Call dst:reg5, callee:reg7, this_value:reg6, g.next
-  [  a8] GetGlobal dst:reg6, `g`
-  [  c0] GetById dst:reg8, base:reg6, `next` (g.next)
-  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, g.next
-  [ 100] End value:reg7
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, multi_yield
+  [  30] SetGlobal `g`, src:reg5
+  [  40] GetGlobal dst:reg6, `g`
+  [  50] GetById dst:reg7, base:reg6, `next` (g.next)
+  [  68] Call dst:reg5, callee:reg7, this_value:reg6, g.next
+  [  88] GetGlobal dst:reg6, `g`
+  [  98] GetById dst:reg8, base:reg6, `next` (g.next)
+  [  b0] Call dst:reg7, callee:reg8, this_value:reg6, g.next
+  [  d0] End value:reg7
 
 
 multi_yield$7e2d183f generator-yield.js:7:5

--- a/Tests/LibJS/Bytecode/expected/global-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/global-variables.txt
@@ -1,4 +1,4 @@
-$9f27c1c8 global-variables.js:4:1
+$afbf6828 global-variables.js:4:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $9f27c1c8 global-variables.js:4:1
 
 block0:
   [   0] SetGlobal `x`, src:Int32(1)
-  [  18] GetGlobal dst:reg6, `console`
-  [  30] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  50] GetGlobal dst:reg8, `x`
-  [  68] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  90] End value:reg5
+  [  10] GetGlobal dst:reg6, `console`
+  [  20] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  38] GetGlobal dst:reg8, `x`
+  [  48] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  70] End value:reg5
 
 
 1

--- a/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
@@ -1,4 +1,4 @@
-$c02559ef if-else-register-lifetime.js:11:1
+$36778e37 if-else-register-lifetime.js:11:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $c02559ef if-else-register-lifetime.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] NewPrimitiveArray dst:reg7, elements:[1]
-  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
-  [  58] End value:reg5
+  [  10] NewPrimitiveArray dst:reg7, elements:[1]
+  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, test, arguments:[reg7]
+  [  50] End value:reg5
 
 
-test$5f5e45da if-else-register-lifetime.js:2:5
+test$622236ea if-else-register-lifetime.js:2:5
   Registers: 13
   Blocks:    12
   Locals:    a~0, i~1, j~2
@@ -40,37 +40,37 @@ block3:
 
 block4:
   [  80] GetGlobal dst:reg7, `parseInt`
-  [  98] Mov dst:reg10, src:a~0
-  [  a8] Call dst:reg5, callee:reg7, this_value:Undefined, parseInt, arguments:[reg10]
-  [  d0] Return value:reg5
+  [  90] Mov dst:reg10, src:a~0
+  [  a0] Call dst:reg5, callee:reg7, this_value:Undefined, parseInt, arguments:[reg10]
+  [  c8] Return value:reg5
 
 block5:
-  [  d8] JumpLessThan lhs:j~2, rhs:Int32(5), true_target:block9, false_target:block10
+  [  d0] JumpLessThan lhs:j~2, rhs:Int32(5), true_target:block9, false_target:block10
 
 block6:
-  [  f0] PostfixIncrement dst:reg5, src:j~2
+  [  e8] PostfixIncrement dst:reg5, src:j~2
 
 block7:
-  [ 100] JumpLessThan lhs:j~2, rhs:Int32(10), true_target:block5, false_target:block8
+  [  f8] JumpLessThan lhs:j~2, rhs:Int32(10), true_target:block5, false_target:block8
 
 block8:
-  [ 118] Jump target:block2
+  [ 110] Jump target:block2
 
 block9:
-  [ 120] Mov3 dst1:reg6, src1:arg0, dst2:reg7, src2:j~2, dst3:reg8, src3:arg0
-  [ 140] Add dst:reg9, lhs:i~1, rhs:j~2
-  [ 150] GetByValue dst:reg10, base:reg8, property:reg9 (x[reg9])
-  [ 168] PutByValue base:reg6, property:reg7, src:reg10, kind:Normal (x[reg7])
-  [ 180] Jump target:block11
+  [ 118] Mov3 dst1:reg6, src1:arg0, dst2:reg7, src2:j~2, dst3:reg8, src3:arg0
+  [ 138] Add dst:reg9, lhs:i~1, rhs:j~2
+  [ 148] GetByValue dst:reg10, base:reg8, property:reg9 (x[reg9])
+  [ 160] PutByValue base:reg6, property:reg7, src:reg10, kind:Normal (x[reg7])
+  [ 178] Jump target:block11
 
 block10:
-  [ 188] Mov2 dst1:reg10, src1:arg0, dst2:reg6, src2:j~2
-  [ 1a0] GetGlobal dst:reg8, `parseInt`
-  [ 1b8] Mov dst:reg9, src:arg0
-  [ 1c8] Sub dst:reg11, lhs:j~2, rhs:Int32(3)
-  [ 1d8] GetByValue dst:reg12, base:reg9, property:reg11 (x[reg11])
-  [ 1f0] Call dst:reg7, callee:reg8, this_value:Undefined, parseInt, arguments:[reg12, Int32(1)]
-  [ 218] PutByValue base:reg10, property:reg6, src:reg7, kind:Normal (x[reg6])
+  [ 180] Mov2 dst1:reg10, src1:arg0, dst2:reg6, src2:j~2
+  [ 198] GetGlobal dst:reg8, `parseInt`
+  [ 1a8] Mov dst:reg9, src:arg0
+  [ 1b8] Sub dst:reg11, lhs:j~2, rhs:Int32(3)
+  [ 1c8] GetByValue dst:reg12, base:reg9, property:reg11 (x[reg11])
+  [ 1e0] Call dst:reg7, callee:reg8, this_value:Undefined, parseInt, arguments:[reg12, Int32(1)]
+  [ 208] PutByValue base:reg10, property:reg6, src:reg7, kind:Normal (x[reg6])
 
 block11:
-  [ 230] Jump target:block6
+  [ 220] Jump target:block6

--- a/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
+++ b/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
@@ -1,4 +1,4 @@
-$40a540f0 indexed-append-guards.js:16:1
+$8829d5d5 indexed-append-guards.js:16:1
   Registers: 11
   Blocks:    7
   Constants:
@@ -15,67 +15,67 @@ $40a540f0 indexed-append-guards.js:16:1
 
 block0:
   [   0] GetGlobal dst:reg6, `Object`
-  [  18] GetById dst:reg7, base:reg6, `preventExtensions` (Object.preventExtensions)
-  [  38] NewObject dst:reg8
-  [  48] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
-  [  58] PutByValue base:reg8, property:Int32(0), src:Int32(1), kind:Own
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, Object.preventExtensions, arguments:[reg8]
-  [  98] InitializeLexicalBinding `object`, src:reg5
-  [  b0] GetGlobal dst:reg7, `expect_type_error`
-  [  c8] NewFunction dst:reg6, shared_function_data_index:0
-  [  e0] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
-  [ 108] GetGlobal dst:reg7, `object`
-  [ 120] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
-  [ 138] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
-  [ 148] Mov dst:reg6, src:Undefined
-  [ 158] JumpFalse condition:reg7, target:block2
+  [  10] GetById dst:reg7, base:reg6, `preventExtensions` (Object.preventExtensions)
+  [  28] NewObject dst:reg8
+  [  38] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
+  [  48] PutByValue base:reg8, property:Int32(0), src:Int32(1), kind:Own
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, Object.preventExtensions, arguments:[reg8]
+  [  88] InitializeLexicalBinding `object`, src:reg5
+  [  a0] GetGlobal dst:reg7, `expect_type_error`
+  [  b0] NewFunction dst:reg6, shared_function_data_index:0
+  [  c8] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
+  [  f0] GetGlobal dst:reg7, `object`
+  [ 100] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
+  [ 118] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
+  [ 128] Mov dst:reg6, src:Undefined
+  [ 138] JumpFalse condition:reg7, target:block2
 
 block1:
-  [ 168] GetGlobal dst:reg9, `Error`
-  [ 180] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Indexed object append mutated")]
-  [ 1a0] Throw src:reg8
+  [ 148] GetGlobal dst:reg9, `Error`
+  [ 158] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Indexed object append mutated")]
+  [ 178] Throw src:reg8
 
 block2:
-  [ 1a8] NewPrimitiveArray dst:reg5, elements:[1, 2]
-  [ 1c8] InitializeLexicalBinding `array`, src:reg5
-  [ 1e0] GetGlobal dst:reg7, `Object`
-  [ 1f8] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
-  [ 218] GetGlobal dst:reg9, `array`
-  [ 230] NewObject dst:reg10
-  [ 240] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
-  [ 258] CacheObjectShape object:reg10
-  [ 268] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
-  [ 298] GetGlobal dst:reg8, `expect_type_error`
-  [ 2b0] NewFunction dst:reg7, shared_function_data_index:1
-  [ 2c8] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
-  [ 2f0] GetGlobal dst:reg5, `array`
-  [ 308] GetLength dst:reg8, base:reg5 (array.length)
-  [ 320] StrictlyInequals dst:reg5, lhs:reg8, rhs:Int32(2)
-  [ 330] Mov dst:reg8, src:Undefined
-  [ 340] JumpFalse condition:reg5, target:block4
+  [ 180] NewPrimitiveArray dst:reg5, elements:[1, 2]
+  [ 1a0] InitializeLexicalBinding `array`, src:reg5
+  [ 1b8] GetGlobal dst:reg7, `Object`
+  [ 1c8] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
+  [ 1e0] GetGlobal dst:reg9, `array`
+  [ 1f0] NewObject dst:reg10
+  [ 200] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
+  [ 218] CacheObjectShape object:reg10
+  [ 228] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
+  [ 258] GetGlobal dst:reg8, `expect_type_error`
+  [ 268] NewFunction dst:reg7, shared_function_data_index:1
+  [ 280] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
+  [ 2a8] GetGlobal dst:reg5, `array`
+  [ 2b8] GetLength dst:reg8, base:reg5 (array.length)
+  [ 2d0] StrictlyInequals dst:reg5, lhs:reg8, rhs:Int32(2)
+  [ 2e0] Mov dst:reg8, src:Undefined
+  [ 2f0] JumpFalse condition:reg5, target:block4
 
 block3:
-  [ 350] GetGlobal dst:reg10, `Error`
-  [ 368] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
-  [ 388] Throw src:reg7
+  [ 300] GetGlobal dst:reg10, `Error`
+  [ 310] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
+  [ 330] Throw src:reg7
 
 block4:
-  [ 390] GetGlobal dst:reg6, `array`
-  [ 3a8] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
-  [ 3c0] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
-  [ 3d0] Mov dst:reg5, src:Undefined
-  [ 3e0] JumpFalse condition:reg6, target:block6
+  [ 338] GetGlobal dst:reg6, `array`
+  [ 348] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
+  [ 360] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
+  [ 370] Mov dst:reg5, src:Undefined
+  [ 380] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 3f0] GetGlobal dst:reg10, `Error`
-  [ 408] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
-  [ 428] Throw src:reg7
+  [ 390] GetGlobal dst:reg10, `Error`
+  [ 3a0] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
+  [ 3c0] Throw src:reg7
 
 block6:
-  [ 430] End value:reg5
+  [ 3c8] End value:reg5
 
 
-expect_type_error$f9cd6888 indexed-append-guards.js:4:5
+expect_type_error$fc915998 indexed-append-guards.js:4:5
   Registers: 9
   Blocks:    8
   Locals:    error~0, did_throw~1
@@ -95,37 +95,37 @@ block1:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] Mov dst:error~0, src:reg5
   [  40] GetGlobal dst:reg7, `TypeError`
-  [  58] InstanceOf dst:reg8, lhs:error~0, rhs:reg7
-  [  68] Not dst:reg6, src:reg8
-  [  78] JumpFalse condition:reg6, target:block3
+  [  50] InstanceOf dst:reg8, lhs:error~0, rhs:reg7
+  [  60] Not dst:reg6, src:reg8
+  [  70] JumpFalse condition:reg6, target:block3
 
 block2:
-  [  88] Throw src:error~0
+  [  80] Throw src:error~0
 
 block3:
-  [  90] Mov dst:did_throw~1, src:Bool(true)
+  [  88] Mov dst:did_throw~1, src:Bool(true)
 
 block4:
-  [  a0] Not dst:reg5, src:did_throw~1
-  [  b0] JumpIf condition:reg5, true_target:block6, false_target:block7
+  [  98] Not dst:reg5, src:did_throw~1
+  [  a8] JumpIf condition:reg5, true_target:block6, false_target:block7
 
 block5:
-  [  c0] Call dst:reg5, callee:arg0, this_value:Undefined, callback
-  [  e0] Jump target:block4
+  [  b8] Call dst:reg5, callee:arg0, this_value:Undefined, callback
+  [  d8] Jump target:block4
 
 block6:
-  [  e8] GetGlobal dst:reg8, `Error`
-  [ 100] CallConstruct dst:reg6, callee:reg8, Error, arguments:[String("Expected TypeError")]
-  [ 120] Throw src:reg6
+  [  e0] GetGlobal dst:reg8, `Error`
+  [  f0] CallConstruct dst:reg6, callee:reg8, Error, arguments:[String("Expected TypeError")]
+  [ 110] Throw src:reg6
 
 block7:
-  [ 128] End value:Undefined
+  [ 118] End value:Undefined
 
 Exception handlers:
-  [  c0 ..   e8] => handler block1
+  [  b8 ..   e0] => handler block1
 
 
-$6dd371fa indexed-append-guards.js:18:5
+$ec717972 indexed-append-guards.js:18:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -135,11 +135,11 @@ $6dd371fa indexed-append-guards.js:18:5
 
 block0:
   [   0] GetGlobal dst:reg5, `object`
-  [  18] PutByValue base:reg5, property:Int32(1), src:Int32(2), kind:Normal (object[Int32(1)])
-  [  30] End value:Undefined
+  [  10] PutByValue base:reg5, property:Int32(1), src:Int32(2), kind:Normal (object[Int32(1)])
+  [  28] End value:Undefined
 
 
-$f99f4d22 indexed-append-guards.js:26:5
+$01eb2052 indexed-append-guards.js:26:5
   Registers: 8
   Blocks:    1
   Constants:
@@ -148,7 +148,7 @@ $f99f4d22 indexed-append-guards.js:26:5
 
 block0:
   [   0] GetGlobal dst:reg5, `array`
-  [  18] GetGlobal dst:reg6, `array`
-  [  30] GetLength dst:reg7, base:reg6 (array.length)
-  [  48] PutByValue base:reg5, property:reg7, src:Int32(3), kind:Normal (array[reg7])
-  [  60] End value:Undefined
+  [  10] GetGlobal dst:reg6, `array`
+  [  20] GetLength dst:reg7, base:reg6 (array.length)
+  [  38] PutByValue base:reg5, property:reg7, src:Int32(3), kind:Normal (array[reg7])
+  [  50] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
+++ b/Tests/LibJS/Bytecode/expected/indexed-append-guards.txt
@@ -1,4 +1,4 @@
-$8829d5d5 indexed-append-guards.js:16:1
+$8565e4c5 indexed-append-guards.js:16:1
   Registers: 11
   Blocks:    7
   Constants:
@@ -20,59 +20,59 @@ block0:
   [  38] ToPrimitiveWithStringHint dst:Int32(0), value:Int32(0)
   [  48] PutByValue base:reg8, property:Int32(0), src:Int32(1), kind:Own
   [  60] Call dst:reg5, callee:reg7, this_value:reg6, Object.preventExtensions, arguments:[reg8]
-  [  88] InitializeLexicalBinding `object`, src:reg5
-  [  a0] GetGlobal dst:reg7, `expect_type_error`
-  [  b0] NewFunction dst:reg6, shared_function_data_index:0
-  [  c8] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
-  [  f0] GetGlobal dst:reg7, `object`
-  [ 100] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
-  [ 118] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
-  [ 128] Mov dst:reg6, src:Undefined
-  [ 138] JumpFalse condition:reg7, target:block2
+  [  88] DynamicInitializeLexicalBinding `object`, src:reg5
+  [  98] GetGlobal dst:reg7, `expect_type_error`
+  [  a8] NewFunction dst:reg6, shared_function_data_index:0
+  [  c0] Call dst:reg5, callee:reg7, this_value:Undefined, expect_type_error, arguments:[reg6]
+  [  e8] GetGlobal dst:reg7, `object`
+  [  f8] GetByValue dst:reg6, base:reg7, property:Int32(1) (object[Int32(1)])
+  [ 110] StrictlyInequals dst:reg7, lhs:reg6, rhs:Undefined
+  [ 120] Mov dst:reg6, src:Undefined
+  [ 130] JumpFalse condition:reg7, target:block2
 
 block1:
-  [ 148] GetGlobal dst:reg9, `Error`
-  [ 158] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Indexed object append mutated")]
-  [ 178] Throw src:reg8
+  [ 140] GetGlobal dst:reg9, `Error`
+  [ 150] CallConstruct dst:reg8, callee:reg9, Error, arguments:[String("Indexed object append mutated")]
+  [ 170] Throw src:reg8
 
 block2:
-  [ 180] NewPrimitiveArray dst:reg5, elements:[1, 2]
-  [ 1a0] InitializeLexicalBinding `array`, src:reg5
-  [ 1b8] GetGlobal dst:reg7, `Object`
-  [ 1c8] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
-  [ 1e0] GetGlobal dst:reg9, `array`
-  [ 1f0] NewObject dst:reg10
-  [ 200] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
-  [ 218] CacheObjectShape object:reg10
-  [ 228] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
-  [ 258] GetGlobal dst:reg8, `expect_type_error`
-  [ 268] NewFunction dst:reg7, shared_function_data_index:1
-  [ 280] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
-  [ 2a8] GetGlobal dst:reg5, `array`
-  [ 2b8] GetLength dst:reg8, base:reg5 (array.length)
-  [ 2d0] StrictlyInequals dst:reg5, lhs:reg8, rhs:Int32(2)
-  [ 2e0] Mov dst:reg8, src:Undefined
-  [ 2f0] JumpFalse condition:reg5, target:block4
+  [ 178] NewPrimitiveArray dst:reg5, elements:[1, 2]
+  [ 198] DynamicInitializeLexicalBinding `array`, src:reg5
+  [ 1a8] GetGlobal dst:reg7, `Object`
+  [ 1b8] GetById dst:reg8, base:reg7, `defineProperty` (Object.defineProperty)
+  [ 1d0] GetGlobal dst:reg9, `array`
+  [ 1e0] NewObject dst:reg10
+  [ 1f0] InitObjectLiteralProperty object:reg10, `writable`, src:Bool(false), shape_cache_index:0, property_slot:0
+  [ 208] CacheObjectShape object:reg10
+  [ 218] Call dst:reg5, callee:reg8, this_value:reg7, Object.defineProperty, arguments:[reg9, String("length"), reg10]
+  [ 248] GetGlobal dst:reg8, `expect_type_error`
+  [ 258] NewFunction dst:reg7, shared_function_data_index:1
+  [ 270] Call dst:reg6, callee:reg8, this_value:Undefined, expect_type_error, arguments:[reg7]
+  [ 298] GetGlobal dst:reg5, `array`
+  [ 2a8] GetLength dst:reg8, base:reg5 (array.length)
+  [ 2c0] StrictlyInequals dst:reg5, lhs:reg8, rhs:Int32(2)
+  [ 2d0] Mov dst:reg8, src:Undefined
+  [ 2e0] JumpFalse condition:reg5, target:block4
 
 block3:
-  [ 300] GetGlobal dst:reg10, `Error`
-  [ 310] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
-  [ 330] Throw src:reg7
+  [ 2f0] GetGlobal dst:reg10, `Error`
+  [ 300] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array length changed")]
+  [ 320] Throw src:reg7
 
 block4:
-  [ 338] GetGlobal dst:reg6, `array`
-  [ 348] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
-  [ 360] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
-  [ 370] Mov dst:reg5, src:Undefined
-  [ 380] JumpFalse condition:reg6, target:block6
+  [ 328] GetGlobal dst:reg6, `array`
+  [ 338] GetByValue dst:reg5, base:reg6, property:Int32(2) (array[Int32(2)])
+  [ 350] StrictlyInequals dst:reg6, lhs:reg5, rhs:Undefined
+  [ 360] Mov dst:reg5, src:Undefined
+  [ 370] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 390] GetGlobal dst:reg10, `Error`
-  [ 3a0] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
-  [ 3c0] Throw src:reg7
+  [ 380] GetGlobal dst:reg10, `Error`
+  [ 390] CallConstruct dst:reg7, callee:reg10, Error, arguments:[String("Array append mutated")]
+  [ 3b0] Throw src:reg7
 
 block6:
-  [ 3c8] End value:reg5
+  [ 3b8] End value:reg5
 
 
 expect_type_error$fc915998 indexed-append-guards.js:4:5

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
@@ -1,4 +1,4 @@
-$aaec50d4 invalid-lhs-assignment-no-dead-code.js:8:1
+$2c4e495c invalid-lhs-assignment-no-dead-code.js:8:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -17,13 +17,13 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:Undefined
   [  50] GetGlobal dst:reg8, `f`
-  [  68] NewFunction dst:reg9, shared_function_data_index:0
-  [  80] Call dst:reg6, callee:reg8, this_value:Undefined, f, arguments:[reg9]
-  [  a8] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
-  [  c0] End value:reg6
+  [  60] NewFunction dst:reg9, shared_function_data_index:0
+  [  78] Call dst:reg6, callee:reg8, this_value:Undefined, f, arguments:[reg9]
+  [  a0] Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+  [  b8] End value:reg6
 
 Exception handlers:
-  [  40 ..   c8] => handler block1
+  [  40 ..   c0] => handler block1
 
 
 f$36958900 invalid-lhs-assignment-no-dead-code.js:5:6

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-forin-no-dead-code.txt
@@ -1,4 +1,4 @@
-$03b9f5e5 invalid-lhs-forin-no-dead-code.js:6:6
+$00f604d5 invalid-lhs-forin-no-dead-code.js:6:6
   Registers: 11
   Blocks:    6
   Constants:
@@ -20,11 +20,11 @@ block3:
 
 block4:
   [  50] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  68] Mov dst:reg5, src:Undefined
-  [  78] Jump target:block2
+  [  60] Mov dst:reg5, src:Undefined
+  [  70] Jump target:block2
 
 block5:
-  [  80] GetGlobal dst:reg10, `f`
-  [  98] Call dst:reg9, callee:reg10, this_value:Undefined, f
-  [  b8] NewReferenceError dst:reg9, Invalid left-hand side in assignment
-  [  c8] Throw src:reg9
+  [  78] GetGlobal dst:reg10, `f`
+  [  88] Call dst:reg9, callee:reg10, this_value:Undefined, f
+  [  a8] NewReferenceError dst:reg9, Invalid left-hand side in assignment
+  [  b8] Throw src:reg9

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -1,4 +1,4 @@
-$e76f7008 lexical-env-teardown.js:13:1
+$73e12cd0 lexical-env-teardown.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -34,18 +34,18 @@ block0:
   [ 288] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
   [ 2a0] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
   [ 2b0] NewFunction dst:reg6, shared_function_data_index:0
-  [ 2c8] InitializeLexicalBinding `myName`, src:reg6
-  [ 2e0] SetLexicalEnvironment environment:reg4
-  [ 2e8] SetGlobal `namedFn`, src:reg6
-  [ 2f8] GetGlobal dst:reg7, `console`
-  [ 308] GetById dst:reg8, base:reg7, `log` (console.log)
-  [ 320] GetGlobal dst:reg10, `namedFn`
-  [ 330] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
-  [ 350] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 378] End value:reg6
+  [ 2c8] DynamicInitializeLexicalBinding `myName`, src:reg6
+  [ 2d8] SetLexicalEnvironment environment:reg4
+  [ 2e0] SetGlobal `namedFn`, src:reg6
+  [ 2f0] GetGlobal dst:reg7, `console`
+  [ 300] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 318] GetGlobal dst:reg10, `namedFn`
+  [ 328] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
+  [ 348] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 370] End value:reg6
 
 
-withTeardown$7751edc5 lexical-env-teardown.js:7:5
+withTeardown$71ca0ba5 lexical-env-teardown.js:7:5
   Registers: 10
   Blocks:    1
   Locals:    inner~0
@@ -58,17 +58,17 @@ block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  20] CreateVariable `outer`, is_immutable:false, is_global:false, is_strict:false
-  [  30] InitializeLexicalBinding `outer`, src:Int32(1)
-  [  48] NewObject dst:reg6
-  [  58] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
-  [  70] CacheObjectShape object:reg6
-  [  80] EnterObjectEnvironment dst:reg7, object:reg6
-  [  90] GetBinding dst:reg8, `x`
-  [  a8] GetBinding dst:reg9, `outer`
-  [  c0] Add dst:inner~0, lhs:reg8, rhs:reg9
-  [  d0] SetLexicalEnvironment environment:reg5
-  [  d8] GetBinding dst:reg6, `outer`
-  [  f0] Return value:reg6
+  [  30] DynamicInitializeLexicalBinding `outer`, src:Int32(1)
+  [  40] NewObject dst:reg6
+  [  50] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
+  [  68] CacheObjectShape object:reg6
+  [  78] EnterObjectEnvironment dst:reg7, object:reg6
+  [  88] DynamicGetBinding dst:reg8, `x`
+  [  98] DynamicGetBinding dst:reg9, `outer`
+  [  a8] Add dst:inner~0, lhs:reg8, rhs:reg9
+  [  b8] SetLexicalEnvironment environment:reg5
+  [  c0] DynamicGetBinding dst:reg6, `outer`
+  [  d0] Return value:reg6
 
 
 blockTeardown$b6f5c4f0 lexical-env-teardown.js:17:5
@@ -203,13 +203,13 @@ Exception handlers:
   [  48 ..   80] => handler block1
 
 
-myName$b54e4267 lexical-env-teardown.js:60:5
+myName$2e6467bf lexical-env-teardown.js:60:5
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] TypeofBinding dst:reg5, `myName`
-  [  18] Return value:reg5
+  [   0] DynamicTypeofBinding dst:reg5, `myName`
+  [  10] Return value:reg5
 
 
 1

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -1,4 +1,4 @@
-$73e12cd0 lexical-env-teardown.js:13:1
+$e76f7008 lexical-env-teardown.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -34,18 +34,18 @@ block0:
   [ 288] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
   [ 2a0] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
   [ 2b0] NewFunction dst:reg6, shared_function_data_index:0
-  [ 2c8] DynamicInitializeLexicalBinding `myName`, src:reg6
-  [ 2d8] SetLexicalEnvironment environment:reg4
-  [ 2e0] SetGlobal `namedFn`, src:reg6
-  [ 2f0] GetGlobal dst:reg7, `console`
-  [ 300] GetById dst:reg8, base:reg7, `log` (console.log)
-  [ 318] GetGlobal dst:reg10, `namedFn`
-  [ 328] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
-  [ 348] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 370] End value:reg6
+  [ 2c8] InitializeLexicalBinding `myName`, src:reg6
+  [ 2e0] SetLexicalEnvironment environment:reg4
+  [ 2e8] SetGlobal `namedFn`, src:reg6
+  [ 2f8] GetGlobal dst:reg7, `console`
+  [ 308] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 320] GetGlobal dst:reg10, `namedFn`
+  [ 330] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
+  [ 350] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 378] End value:reg6
 
 
-withTeardown$71ca0ba5 lexical-env-teardown.js:7:5
+withTeardown$748dfcb5 lexical-env-teardown.js:7:5
   Registers: 10
   Blocks:    1
   Locals:    inner~0
@@ -58,17 +58,17 @@ block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  20] CreateVariable `outer`, is_immutable:false, is_global:false, is_strict:false
-  [  30] DynamicInitializeLexicalBinding `outer`, src:Int32(1)
-  [  40] NewObject dst:reg6
-  [  50] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
-  [  68] CacheObjectShape object:reg6
-  [  78] EnterObjectEnvironment dst:reg7, object:reg6
-  [  88] DynamicGetBinding dst:reg8, `x`
-  [  98] DynamicGetBinding dst:reg9, `outer`
-  [  a8] Add dst:inner~0, lhs:reg8, rhs:reg9
-  [  b8] SetLexicalEnvironment environment:reg5
-  [  c0] DynamicGetBinding dst:reg6, `outer`
-  [  d0] Return value:reg6
+  [  30] InitializeLexicalBinding `outer`, src:Int32(1)
+  [  48] NewObject dst:reg6
+  [  58] InitObjectLiteralProperty object:reg6, `x`, src:Int32(10), shape_cache_index:0, property_slot:0
+  [  70] CacheObjectShape object:reg6
+  [  80] EnterObjectEnvironment dst:reg7, object:reg6
+  [  90] DynamicGetBinding dst:reg8, `x`
+  [  a0] DynamicGetBinding dst:reg9, `outer`
+  [  b0] Add dst:inner~0, lhs:reg8, rhs:reg9
+  [  c0] SetLexicalEnvironment environment:reg5
+  [  c8] GetBinding dst:reg6, `outer`
+  [  e0] Return value:reg6
 
 
 blockTeardown$b6f5c4f0 lexical-env-teardown.js:17:5

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -1,4 +1,4 @@
-$31b7f5fd lexical-env-teardown.js:13:1
+$e76f7008 lexical-env-teardown.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -7,42 +7,42 @@ $31b7f5fd lexical-env-teardown.js:13:1
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] GetGlobal dst:reg6, `console`
-  [  20] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  40] GetGlobal dst:reg9, `withTeardown`
-  [  58] Call dst:reg8, callee:reg9, this_value:Undefined, withTeardown
-  [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg6, `console`
-  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d8] GetGlobal dst:reg10, `blockTeardown`
-  [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, blockTeardown
-  [ 110] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 138] GetGlobal dst:reg8, `console`
-  [ 150] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 170] GetGlobal dst:reg10, `forInTeardown`
-  [ 188] Call dst:reg9, callee:reg10, this_value:Undefined, forInTeardown
-  [ 1a8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 1d0] GetGlobal dst:reg6, `console`
-  [ 1e8] GetById dst:reg8, base:reg6, `log` (console.log)
-  [ 208] GetGlobal dst:reg10, `forOfTeardown`
-  [ 220] Call dst:reg9, callee:reg10, this_value:Undefined, forOfTeardown
-  [ 240] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 268] GetGlobal dst:reg8, `console`
-  [ 280] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 2a0] GetGlobal dst:reg10, `catchTeardown`
-  [ 2b8] Call dst:reg9, callee:reg10, this_value:Undefined, catchTeardown
-  [ 2d8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 300] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
-  [ 318] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
-  [ 328] NewFunction dst:reg6, shared_function_data_index:0
-  [ 340] InitializeLexicalBinding `myName`, src:reg6
-  [ 358] SetLexicalEnvironment environment:reg4
-  [ 360] SetGlobal `namedFn`, src:reg6
-  [ 378] GetGlobal dst:reg7, `console`
-  [ 390] GetById dst:reg8, base:reg7, `log` (console.log)
-  [ 3b0] GetGlobal dst:reg10, `namedFn`
-  [ 3c8] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
-  [ 3e8] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [ 410] End value:reg6
+  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  30] GetGlobal dst:reg9, `withTeardown`
+  [  40] Call dst:reg8, callee:reg9, this_value:Undefined, withTeardown
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `blockTeardown`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, blockTeardown
+  [  e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 108] GetGlobal dst:reg8, `console`
+  [ 118] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 130] GetGlobal dst:reg10, `forInTeardown`
+  [ 140] Call dst:reg9, callee:reg10, this_value:Undefined, forInTeardown
+  [ 160] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 188] GetGlobal dst:reg6, `console`
+  [ 198] GetById dst:reg8, base:reg6, `log` (console.log)
+  [ 1b0] GetGlobal dst:reg10, `forOfTeardown`
+  [ 1c0] Call dst:reg9, callee:reg10, this_value:Undefined, forOfTeardown
+  [ 1e0] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 208] GetGlobal dst:reg8, `console`
+  [ 218] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 230] GetGlobal dst:reg10, `catchTeardown`
+  [ 240] Call dst:reg9, callee:reg10, this_value:Undefined, catchTeardown
+  [ 260] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 288] CreateLexicalEnvironment dst:reg7, parent:reg4, capacity:0, is_catch_environment:false
+  [ 2a0] CreateVariable `myName`, is_immutable:true, is_global:false, is_strict:false
+  [ 2b0] NewFunction dst:reg6, shared_function_data_index:0
+  [ 2c8] InitializeLexicalBinding `myName`, src:reg6
+  [ 2e0] SetLexicalEnvironment environment:reg4
+  [ 2e8] SetGlobal `namedFn`, src:reg6
+  [ 2f8] GetGlobal dst:reg7, `console`
+  [ 308] GetById dst:reg8, base:reg7, `log` (console.log)
+  [ 320] GetGlobal dst:reg10, `namedFn`
+  [ 330] Call dst:reg9, callee:reg10, this_value:Undefined, namedFn
+  [ 350] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [ 378] End value:reg6
 
 
 withTeardown$7751edc5 lexical-env-teardown.js:7:5
@@ -84,7 +84,7 @@ block0:
   [  18] Return value:outer~1
 
 
-forInTeardown$00ab80a8 lexical-env-teardown.js:28:5
+forInTeardown$7c859710 lexical-env-teardown.js:28:5
   Registers: 8
   Blocks:    6
   Locals:    k~0, outer~1
@@ -113,12 +113,12 @@ block3:
 
 block4:
   [  a0] GetObjectPropertyIterator dst_iterator:reg6, object:reg5
-  [  b8] Jump target:block2
+  [  b0] Jump target:block2
 
 block5:
-  [  c0] Mov dst:k~0, src:reg5
-  [  d0] ThrowIfTDZ src:k~0
-  [  d8] Jump target:block2
+  [  b8] Mov dst:k~0, src:reg5
+  [  c8] ThrowIfTDZ src:k~0
+  [  d0] Jump target:block2
 
 
 forOfTeardown$94a2ae97 lexical-env-teardown.js:38:5
@@ -174,7 +174,7 @@ Exception handlers:
   [  c0 ..   e0] => handler block3
 
 
-catchTeardown$ea214605 lexical-env-teardown.js:48:5
+catchTeardown$6b833e8d lexical-env-teardown.js:48:5
   Registers: 7
   Blocks:    3
   Locals:    e~0, outer~1
@@ -196,11 +196,11 @@ block1:
 
 block2:
   [  48] GetGlobal dst:reg6, `Error`
-  [  60] CallConstruct dst:reg5, callee:reg6, Error, arguments:[String("test")]
-  [  80] Throw src:reg5
+  [  58] CallConstruct dst:reg5, callee:reg6, Error, arguments:[String("test")]
+  [  78] Throw src:reg5
 
 Exception handlers:
-  [  48 ..   88] => handler block1
+  [  48 ..   80] => handler block1
 
 
 myName$b54e4267 lexical-env-teardown.js:60:5

--- a/Tests/LibJS/Bytecode/expected/local-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/local-source-order.txt
@@ -1,4 +1,4 @@
-$c7fd0018 local-source-order.js:12:1
+$546ebce0 local-source-order.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $c7fd0018 local-source-order.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `source_order_locals`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, source_order_locals
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, source_order_locals
+  [  30] End value:reg5
 
 
 source_order_locals$4b1aeb83 local-source-order.js:6:5

--- a/Tests/LibJS/Bytecode/expected/local-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/local-variables.txt
@@ -1,4 +1,4 @@
-$568ccc50 local-variables.js:20:1
+$dd76a6f8 local-variables.js:20:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,12 +6,12 @@ $568ccc50 local-variables.js:20:1
 
 block0:
   [   0] GetGlobal dst:reg6, `simple_let`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, simple_let
-  [  38] GetGlobal dst:reg7, `simple_const`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, simple_const
-  [  70] GetGlobal dst:reg7, `multiple_locals`
-  [  88] Call dst:reg5, callee:reg7, this_value:Undefined, multiple_locals
-  [  a8] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, simple_let
+  [  30] GetGlobal dst:reg7, `simple_const`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, simple_const
+  [  60] GetGlobal dst:reg7, `multiple_locals`
+  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, multiple_locals
+  [  90] End value:reg5
 
 
 simple_let$40478631 local-variables.js:5:5

--- a/Tests/LibJS/Bytecode/expected/logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-assignment-register-order.txt
@@ -1,17 +1,17 @@
-$932d2a38 logical-assignment-register-order.js:2:7
+$7fd192c8 logical-assignment-register-order.js:2:7
   Registers: 8
   Blocks:    3
 
 block0:
   [   0] GetGlobal dst:reg5, `value`
-  [  18] JumpFalse condition:reg5, target:block2
+  [  10] JumpFalse condition:reg5, target:block2
 
 block1:
-  [  28] NewFunction dst:reg6, shared_function_data_index:0 (value)
-  [  40] Mov dst:reg7, src:reg6
-  [  50] SetGlobal `value`, src:reg7
-  [  68] End value:reg7
+  [  20] NewFunction dst:reg6, shared_function_data_index:0 (value)
+  [  38] Mov dst:reg7, src:reg6
+  [  48] SetGlobal `value`, src:reg7
+  [  58] End value:reg7
 
 block2:
-  [  70] Mov dst:reg7, src:reg5
-  [  80] End value:reg7
+  [  60] Mov dst:reg7, src:reg5
+  [  70] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/logical-constant-folding.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-constant-folding.txt
@@ -1,4 +1,4 @@
-$84f4cb35 logical-constant-folding.js:1:1
+$e52776fd logical-constant-folding.js:1:1
   Registers: 6
   Blocks:    1
   Constants:
@@ -11,10 +11,10 @@ $84f4cb35 logical-constant-folding.js:1:1
 
 block0:
   [   0] SetGlobal `a`, src:Int32(42)
-  [  18] SetGlobal `b`, src:Int32(42)
-  [  30] SetGlobal `c`, src:Int32(0)
-  [  48] SetGlobal `d`, src:Int32(42)
-  [  60] SetGlobal `e`, src:Bool(true)
-  [  78] SetGlobal `f`, src:Int32(42)
-  [  90] SetGlobal `g`, src:Bool(false)
-  [  a8] End value:Undefined
+  [  10] SetGlobal `b`, src:Int32(42)
+  [  20] SetGlobal `c`, src:Int32(0)
+  [  30] SetGlobal `d`, src:Int32(42)
+  [  40] SetGlobal `e`, src:Bool(true)
+  [  50] SetGlobal `f`, src:Int32(42)
+  [  60] SetGlobal `g`, src:Bool(false)
+  [  70] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/logical-or-in-if-condition.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-or-in-if-condition.txt
@@ -1,4 +1,4 @@
-$469b0790 logical-or-in-if-condition.js:12:1
+$c7fd0018 logical-or-in-if-condition.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $469b0790 logical-or-in-if-condition.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `blocked`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
+  [  38] End value:reg5
 
 
 blocked$f2600453 logical-or-in-if-condition.js:7:9

--- a/Tests/LibJS/Bytecode/expected/logical-or-preferred-dst.txt
+++ b/Tests/LibJS/Bytecode/expected/logical-or-preferred-dst.txt
@@ -1,4 +1,4 @@
-$393b7f47 logical-or-preferred-dst.js:11:1
+$ba9d77cf logical-or-preferred-dst.js:11:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $393b7f47 logical-or-preferred-dst.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `blocked`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, blocked, arguments:[Bool(false)]
+  [  38] End value:reg5
 
 
 blocked$0b29b642 logical-or-preferred-dst.js:6:9

--- a/Tests/LibJS/Bytecode/expected/mov-merging.txt
+++ b/Tests/LibJS/Bytecode/expected/mov-merging.txt
@@ -1,4 +1,4 @@
-$3a6e508d mov-merging.js:14:1
+$37aa5f7d mov-merging.js:14:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -6,16 +6,16 @@ $3a6e508d mov-merging.js:14:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `twoLocals`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, twoLocals
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg6, `console`
-  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d0] GetGlobal dst:reg10, `threeLocals`
-  [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, threeLocals
-  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 130] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `twoLocals`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, twoLocals
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] GetGlobal dst:reg6, `console`
+  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  a8] GetGlobal dst:reg10, `threeLocals`
+  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, threeLocals
+  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 100] End value:reg7
 
 
 twoLocals$848f6408 mov-merging.js:2:5

--- a/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
+++ b/Tests/LibJS/Bytecode/expected/named-class-expression-no-lhs-name-leak.txt
@@ -1,4 +1,4 @@
-$221ada1a named-class-expression-no-lhs-name-leak.js:1:1
+$b15087f2 named-class-expression-no-lhs-name-leak.js:1:1
   Registers: 13
   Blocks:    7
   Constants:
@@ -29,11 +29,11 @@ block3:
 
 block4:
   [  f0] SetGlobal `C`, src:reg10
-  [ 108] JumpFalse condition:reg6, target:block6
+  [ 100] JumpFalse condition:reg6, target:block6
 
 block5:
-  [ 118] End value:Undefined
+  [ 110] End value:Undefined
 
 block6:
-  [ 120] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
-  [ 138] Jump target:block5
+  [ 118] IteratorClose iterator_object:reg7, iterator_next:reg8, iterator_done:reg9, completion_value:Undefined
+  [ 130] Jump target:block5

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,4 +1,4 @@
-$615c3fdf named-function-expression.js:4:6
+$dffa4757 named-function-expression.js:4:6
   Registers: 8
   Blocks:    1
 
@@ -7,9 +7,9 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateVariable `Oops`, is_immutable:true, is_global:false, is_strict:false
   [  30] NewFunction dst:reg6, shared_function_data_index:0
-  [  48] InitializeLexicalBinding `Oops`, src:reg6
-  [  60] SetLexicalEnvironment environment:reg4
-  [  68] SetGlobal `Oops`, src:reg6
-  [  78] GetGlobal dst:reg5, `Oops`
-  [  88] GetById dst:reg7, base:reg5, `x` (Oops.x)
-  [  a0] End value:reg7
+  [  48] DynamicInitializeLexicalBinding `Oops`, src:reg6
+  [  58] SetLexicalEnvironment environment:reg4
+  [  60] SetGlobal `Oops`, src:reg6
+  [  70] GetGlobal dst:reg5, `Oops`
+  [  80] GetById dst:reg7, base:reg5, `x` (Oops.x)
+  [  98] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,4 +1,4 @@
-$dffa4757 named-function-expression.js:4:6
+$615c3fdf named-function-expression.js:4:6
   Registers: 8
   Blocks:    1
 
@@ -7,9 +7,9 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateVariable `Oops`, is_immutable:true, is_global:false, is_strict:false
   [  30] NewFunction dst:reg6, shared_function_data_index:0
-  [  48] DynamicInitializeLexicalBinding `Oops`, src:reg6
-  [  58] SetLexicalEnvironment environment:reg4
-  [  60] SetGlobal `Oops`, src:reg6
-  [  70] GetGlobal dst:reg5, `Oops`
-  [  80] GetById dst:reg7, base:reg5, `x` (Oops.x)
-  [  98] End value:reg7
+  [  48] InitializeLexicalBinding `Oops`, src:reg6
+  [  60] SetLexicalEnvironment environment:reg4
+  [  68] SetGlobal `Oops`, src:reg6
+  [  78] GetGlobal dst:reg5, `Oops`
+  [  88] GetById dst:reg7, base:reg5, `x` (Oops.x)
+  [  a0] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,4 +1,4 @@
-$cf62a0f7 named-function-expression.js:4:6
+$615c3fdf named-function-expression.js:4:6
   Registers: 8
   Blocks:    1
 
@@ -10,6 +10,6 @@ block0:
   [  48] InitializeLexicalBinding `Oops`, src:reg6
   [  60] SetLexicalEnvironment environment:reg4
   [  68] SetGlobal `Oops`, src:reg6
-  [  80] GetGlobal dst:reg5, `Oops`
-  [  98] GetById dst:reg7, base:reg5, `x` (Oops.x)
-  [  b8] End value:reg7
+  [  78] GetGlobal dst:reg5, `Oops`
+  [  88] GetById dst:reg7, base:reg5, `x` (Oops.x)
+  [  a0] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
@@ -1,4 +1,4 @@
-$700813fb nested-for-loop-completion.js:4:1
+$7b17d83b nested-for-loop-completion.js:4:1
   Registers: 9
   Blocks:    8
   Constants:
@@ -11,35 +11,35 @@ $700813fb nested-for-loop-completion.js:4:1
 
 block0:
   [   0] SetGlobal `n`, src:Int32(4)
-  [  18] Mov dst:reg5, src:Undefined
-  [  28] Jump target:block3
+  [  10] Mov dst:reg5, src:Undefined
+  [  20] Jump target:block3
 
 block1:
-  [  30] SetGlobal `depth`, src:Int32(0)
-  [  48] Mov dst:reg6, src:Undefined
-  [  58] Jump target:block6
+  [  28] SetGlobal `depth`, src:Int32(0)
+  [  38] Mov dst:reg6, src:Undefined
+  [  48] Jump target:block6
 
 block2:
-  [  60] GetGlobal dst:reg7, `n`
-  [  78] Add dst:reg6, lhs:reg7, rhs:Int32(1)
-  [  88] SetGlobal `n`, src:reg6
+  [  50] GetGlobal dst:reg7, `n`
+  [  60] Add dst:reg6, lhs:reg7, rhs:Int32(1)
+  [  70] SetGlobal `n`, src:reg6
 
 block3:
-  [  a0] GetGlobal dst:reg6, `n`
-  [  b8] JumpLessThanEquals lhs:reg6, rhs:Int32(7), true_target:block1, false_target:block4
+  [  80] GetGlobal dst:reg6, `n`
+  [  90] JumpLessThanEquals lhs:reg6, rhs:Int32(7), true_target:block1, false_target:block4
 
 block4:
-  [  d0] End value:reg5
+  [  a8] End value:reg5
 
 block5:
-  [  d8] GetGlobal dst:reg8, `depth`
-  [  f0] Add dst:reg7, lhs:reg8, rhs:Int32(2)
-  [ 100] SetGlobal `depth`, src:reg7
+  [  b0] GetGlobal dst:reg8, `depth`
+  [  c0] Add dst:reg7, lhs:reg8, rhs:Int32(2)
+  [  d0] SetGlobal `depth`, src:reg7
 
 block6:
-  [ 118] GetGlobal dst:reg7, `depth`
-  [ 130] JumpLessThanEquals lhs:reg7, rhs:Int32(0), true_target:block5, false_target:block7
+  [  e0] GetGlobal dst:reg7, `depth`
+  [  f0] JumpLessThanEquals lhs:reg7, rhs:Int32(0), true_target:block5, false_target:block7
 
 block7:
-  [ 148] Mov dst:reg5, src:reg6
-  [ 158] Jump target:block2
+  [ 108] Mov dst:reg5, src:reg6
+  [ 118] Jump target:block2

--- a/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-function-decl-source-order.txt
@@ -1,4 +1,4 @@
-$06b12923 nested-function-decl-source-order.js:15:1
+$01294703 nested-function-decl-source-order.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -7,13 +7,13 @@ $06b12923 nested-function-decl-source-order.js:15:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg10, `outer`
-  [  50] Call dst:reg9, callee:reg10, this_value:Undefined, outer
-  [  70] GetById dst:reg10, base:reg9, `join`
-  [  90] Call dst:reg8, callee:reg10, this_value:reg9, <object>.join, arguments:[String(",")]
-  [  b8] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  e0] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg10, `outer`
+  [  38] Call dst:reg9, callee:reg10, this_value:Undefined, outer
+  [  58] GetById dst:reg10, base:reg9, `join`
+  [  70] Call dst:reg8, callee:reg10, this_value:reg9, <object>.join, arguments:[String(",")]
+  [  98] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  c0] End value:reg5
 
 
 outer$f608465a nested-function-decl-source-order.js:12:5

--- a/Tests/LibJS/Bytecode/expected/nested-member-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-member-base-identifier.txt
@@ -1,4 +1,4 @@
-$9a6e7215 nested-member-base-identifier.js:9:1
+$1bd06a9d nested-member-base-identifier.js:9:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -7,15 +7,15 @@ $9a6e7215 nested-member-base-identifier.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `assign_nested`
-  [  18] NewObject dst:reg7
-  [  28] InitObjectLiteralProperty object:reg7, `shader`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  40] CacheObjectShape object:reg7
-  [  50] NewArray dst:reg8, elements:[reg7]
-  [  68] Call dst:reg5, callee:reg6, this_value:Undefined, assign_nested, arguments:[reg8, Int32(1)]
-  [  90] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] InitObjectLiteralProperty object:reg7, `shader`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  38] CacheObjectShape object:reg7
+  [  48] NewArray dst:reg8, elements:[reg7]
+  [  60] Call dst:reg5, callee:reg6, this_value:Undefined, assign_nested, arguments:[reg8, Int32(1)]
+  [  88] End value:reg5
 
 
-assign_nested$126a4010 nested-member-base-identifier.js:6:8
+assign_nested$93cc3898 nested-member-base-identifier.js:6:8
   Registers: 8
   Blocks:    1
   Constants:
@@ -28,4 +28,4 @@ block0:
   [  10] Sub dst:reg6, lhs:arg1, rhs:Int32(1)
   [  20] GetByValue dst:reg7, base:reg5, property:reg6 (arr[reg6])
   [  38] PutById base:reg7, `shader`, src:Int32(0), kind:Normal (arr.shader)
-  [  60] End value:Undefined
+  [  58] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
@@ -1,4 +1,4 @@
-$853568fa nested-try-finally-continue.js:14:1
+$fb879d42 nested-try-finally-continue.js:14:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $853568fa nested-try-finally-continue.js:14:1
 
 block0:
   [   0] GetGlobal dst:reg6, `nestedTryFinallyContinue`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, nestedTryFinallyContinue
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, nestedTryFinallyContinue
+  [  30] End value:reg5
 
 
-nestedTryFinallyContinue$4f168066 nested-try-finally-continue.js:2:5
+nestedTryFinallyContinue$498e9e46 nested-try-finally-continue.js:2:5
   Registers: 13
   Blocks:    24
   Locals:    i~0
@@ -47,77 +47,77 @@ block5:
 
 block6:
   [  78] GetGlobal dst:reg8, `console`
-  [  90] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  b0] Mov dst:reg11, src:i~0
-  [  c0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg11]
-  [  e8] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block19, false_target:block20
+  [  88] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  a0] Mov dst:reg11, src:i~0
+  [  b0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg11]
+  [  d8] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block19, false_target:block20
 
 block7:
-  [ 100] Jump target:block10
+  [  f0] Jump target:block10
 
 block8:
-  [ 108] Catch dst:reg8
-  [ 110] SetLexicalEnvironment environment:reg4
-  [ 118] Mov dst:reg7, src:Int32(1)
+  [  f8] Catch dst:reg8
+  [ 100] SetLexicalEnvironment environment:reg4
+  [ 108] Mov dst:reg7, src:Int32(1)
 
 block9:
-  [ 128] GetGlobal dst:reg10, `console`
-  [ 140] GetById dst:reg11, base:reg10, `log` (console.log)
-  [ 160] Mov dst:reg12, src:i~0
-  [ 170] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner"), reg12]
-  [ 198] JumpStrictlyEquals lhs:reg7, rhs:Int32(0), true_target:block14, false_target:block15
+  [ 118] GetGlobal dst:reg10, `console`
+  [ 128] GetById dst:reg11, base:reg10, `log` (console.log)
+  [ 140] Mov dst:reg12, src:i~0
+  [ 150] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner"), reg12]
+  [ 178] JumpStrictlyEquals lhs:reg7, rhs:Int32(0), true_target:block14, false_target:block15
 
 block10:
-  [ 1b0] JumpStrictlyEquals lhs:i~0, rhs:Int32(1), true_target:block11, false_target:block12
+  [ 190] JumpStrictlyEquals lhs:i~0, rhs:Int32(1), true_target:block11, false_target:block12
 
 block11:
-  [ 1c8] Mov dst:reg7, src:Int32(3)
-  [ 1d8] Jump target:block9
+  [ 1a8] Mov dst:reg7, src:Int32(3)
+  [ 1b8] Jump target:block9
 
 block12:
-  [ 1e0] Mov dst:reg7, src:Int32(0)
-  [ 1f0] Jump target:block9
+  [ 1c0] Mov dst:reg7, src:Int32(0)
+  [ 1d0] Jump target:block9
 
 block13:
-  [ 1f8] Mov dst:reg5, src:Int32(3)
-  [ 208] Jump target:block6
+  [ 1d8] Mov dst:reg5, src:Int32(3)
+  [ 1e8] Jump target:block6
 
 block14:
-  [ 210] Mov dst:reg5, src:Int32(0)
-  [ 220] Jump target:block6
+  [ 1f0] Mov dst:reg5, src:Int32(0)
+  [ 200] Jump target:block6
 
 block15:
-  [ 228] JumpStrictlyEquals lhs:reg7, rhs:Int32(3), true_target:block13, false_target:block16
+  [ 208] JumpStrictlyEquals lhs:reg7, rhs:Int32(3), true_target:block13, false_target:block16
 
 block16:
-  [ 240] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block17, false_target:block18
+  [ 220] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block17, false_target:block18
 
 block17:
-  [ 258] Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
-  [ 270] Jump target:block6
+  [ 238] Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
+  [ 250] Jump target:block6
 
 block18:
-  [ 278] Throw src:reg8
+  [ 258] Throw src:reg8
 
 block19:
-  [ 280] Jump target:block2
+  [ 260] Jump target:block2
 
 block20:
-  [ 288] JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:block2, false_target:block21
+  [ 268] JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:block2, false_target:block21
 
 block21:
-  [ 2a0] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block22, false_target:block23
+  [ 280] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block22, false_target:block23
 
 block22:
-  [ 2b8] Return value:reg6
+  [ 298] Return value:reg6
 
 block23:
-  [ 2c0] Throw src:reg6
+  [ 2a0] Throw src:reg6
 
 Exception handlers:
-  [ 100 ..  1b0] => handler block5
-  [ 1b0 ..  210] => handler block8
-  [ 210 ..  280] => handler block5
+  [  f0 ..  190] => handler block5
+  [ 190 ..  1f0] => handler block8
+  [ 1f0 ..  260] => handler block5
 
 
 "inner" 0

--- a/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
@@ -1,4 +1,4 @@
-$f5bf1d5d numeric-class-field-name.js:1:1
+$745d24d5 numeric-class-field-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -11,12 +11,12 @@ block0:
   [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
-  [  60] InitializeLexicalBinding `C`, src:reg6
-  [  78] GetGlobal dst:reg5, `C`
-  [  88] CallConstruct dst:reg6, callee:reg5, C
-  [  a0] GetByValue dst:reg5, base:reg6, property:Int32(42)
-  [  b8] GetById dst:reg6, base:reg5, `name` ([42].name)
-  [  d0] End value:reg6
+  [  60] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  70] GetGlobal dst:reg5, `C`
+  [  80] CallConstruct dst:reg6, callee:reg5, C
+  [  98] GetByValue dst:reg5, base:reg6, property:Int32(42)
+  [  b0] GetById dst:reg6, base:reg5, `name` ([42].name)
+  [  c8] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-class-field-name.txt
@@ -1,4 +1,4 @@
-$fe0af08d numeric-class-field-name.js:1:1
+$f5bf1d5d numeric-class-field-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -13,10 +13,10 @@ block0:
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:Int32(42)]
   [  60] InitializeLexicalBinding `C`, src:reg6
   [  78] GetGlobal dst:reg5, `C`
-  [  90] CallConstruct dst:reg6, callee:reg5, C
-  [  a8] GetByValue dst:reg5, base:reg6, property:Int32(42)
-  [  c0] GetById dst:reg6, base:reg5, `name` ([42].name)
-  [  e0] End value:reg6
+  [  88] CallConstruct dst:reg6, callee:reg5, C
+  [  a0] GetByValue dst:reg5, base:reg6, property:Int32(42)
+  [  b8] GetById dst:reg6, base:reg5, `name` ([42].name)
+  [  d0] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/numeric-getter-no-lhs-name.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-getter-no-lhs-name.txt
@@ -1,4 +1,4 @@
-$87b8bc45 numeric-getter-no-lhs-name.js:1:1
+$7f6ce915 numeric-getter-no-lhs-name.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,9 +10,9 @@ block0:
   [  20] NewFunction dst:reg6, shared_function_data_index:0, home_object:reg5
   [  38] PutByValue base:reg5, property:Int32(0), src:reg6, kind:Getter
   [  50] SetGlobal `obj`, src:reg5
-  [  68] GetGlobal dst:reg5, `obj`
-  [  80] GetByValue dst:reg6, base:reg5, property:Int32(0) (obj[Int32(0)])
-  [  98] End value:reg6
+  [  60] GetGlobal dst:reg5, `obj`
+  [  70] GetByValue dst:reg6, base:reg5, property:Int32(0) (obj[Int32(0)])
+  [  88] End value:reg6
 
 
 get 0$4c2eeb71 numeric-getter-no-lhs-name.js:3:9

--- a/Tests/LibJS/Bytecode/expected/numeric-index-object-literal.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-index-object-literal.txt
@@ -1,4 +1,4 @@
-$2b997e90 numeric-index-object-literal.js:4:1
+$bacf2c68 numeric-index-object-literal.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $2b997e90 numeric-index-object-literal.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `test`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, test
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, test
+  [  30] End value:reg5
 
 
 test$7e9a426c numeric-index-object-literal.js:2:5

--- a/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
+++ b/Tests/LibJS/Bytecode/expected/numeric-property-key.txt
@@ -1,4 +1,4 @@
-$aa378608 numeric-property-key.js:4:1
+$28d58d80 numeric-property-key.js:4:1
   Registers: 6
   Blocks:    1
   Constants:
@@ -11,4 +11,4 @@ block0:
   [  10] ToPrimitiveWithStringHint dst:Int32(20), value:Int32(20)
   [  20] PutByValue base:reg5, property:Int32(20), src:Int32(3), kind:Own
   [  38] SetGlobal `obj`, src:reg5
-  [  50] End value:Undefined
+  [  48] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/object-rest-computed-key.txt
+++ b/Tests/LibJS/Bytecode/expected/object-rest-computed-key.txt
@@ -1,4 +1,4 @@
-$fb46ff7d object-rest-computed-key.js:1:1
+$f5bf1d5d object-rest-computed-key.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -9,14 +9,14 @@ $fb46ff7d object-rest-computed-key.js:1:1
 
 block0:
   [   0] SetGlobal `a`, src:String("foo")
-  [  18] NewObject dst:reg5
-  [  28] InitObjectLiteralProperty object:reg5, `foo`, src:Int32(1), shape_cache_index:0, property_slot:0
-  [  40] InitObjectLiteralProperty object:reg5, `bar`, src:Int32(2), shape_cache_index:0, property_slot:1
-  [  58] CacheObjectShape object:reg5
-  [  68] ThrowIfNullish src:reg5
-  [  70] GetGlobal dst:reg7, `a`
-  [  88] GetByValue dst:reg6, base:reg5, property:reg7
-  [  a0] SetGlobal `b`, src:reg6
-  [  b8] CopyObjectExcludingProperties dst:reg6, from_object:reg5, excluded_names:[reg7]
-  [  d8] SetGlobal `rest`, src:reg6
-  [  f0] End value:Undefined
+  [  10] NewObject dst:reg5
+  [  20] InitObjectLiteralProperty object:reg5, `foo`, src:Int32(1), shape_cache_index:0, property_slot:0
+  [  38] InitObjectLiteralProperty object:reg5, `bar`, src:Int32(2), shape_cache_index:0, property_slot:1
+  [  50] CacheObjectShape object:reg5
+  [  60] ThrowIfNullish src:reg5
+  [  68] GetGlobal dst:reg7, `a`
+  [  78] GetByValue dst:reg6, base:reg5, property:reg7
+  [  90] SetGlobal `b`, src:reg6
+  [  a0] CopyObjectExcludingProperties dst:reg6, from_object:reg5, excluded_names:[reg7]
+  [  c0] SetGlobal `rest`, src:reg6
+  [  d0] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
@@ -1,4 +1,4 @@
-$a37cd2a2 optional-chain-base-identifier.js:1:1
+$b4147902 optional-chain-base-identifier.js:1:1
   Registers: 9
   Blocks:    3
   Constants:
@@ -13,17 +13,17 @@ block0:
   [  48] InitObjectLiteralProperty object:reg5, `a`, src:reg6, shape_cache_index:0, property_slot:0
   [  60] CacheObjectShape object:reg5
   [  70] SetGlobal `obj`, src:reg5
-  [  88] Mov dst:reg5, src:Undefined
-  [  98] GetGlobal dst:reg7, `obj`
-  [  b0] GetById dst:reg8, base:reg7, `a` (obj.a)
-  [  d0] Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
-  [  e8] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [  80] Mov dst:reg5, src:Undefined
+  [  90] GetGlobal dst:reg7, `obj`
+  [  a0] GetById dst:reg8, base:reg7, `a` (obj.a)
+  [  b8] Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
+  [  d0] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  f8] Mov dst:reg6, src:Undefined
-  [ 108] End value:reg6
+  [  e0] Mov dst:reg6, src:Undefined
+  [  f0] End value:reg6
 
 block2:
-  [ 110] Mov dst:reg5, src:reg6
-  [ 120] GetById dst:reg6, base:reg6, `b`
-  [ 140] End value:reg6
+  [  f8] Mov dst:reg5, src:reg6
+  [ 108] GetById dst:reg6, base:reg6, `b`
+  [ 120] End value:reg6

--- a/Tests/LibJS/Bytecode/expected/optional-chain.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain.txt
@@ -1,4 +1,4 @@
-$9712b2ea optional-chain.js:25:1
+$78a7573a optional-chain.js:25:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,21 +7,21 @@ $9712b2ea optional-chain.js:25:1
 
 block0:
   [   0] GetGlobal dst:reg6, `member`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, member, arguments:[Null]
-  [  40] GetGlobal dst:reg7, `nested_member`
-  [  58] Call dst:reg6, callee:reg7, this_value:Undefined, nested_member, arguments:[Null]
-  [  80] GetGlobal dst:reg7, `call_no_args`
-  [  98] Call dst:reg5, callee:reg7, this_value:Undefined, call_no_args, arguments:[Null]
-  [  c0] GetGlobal dst:reg7, `call_with_args`
-  [  d8] Call dst:reg6, callee:reg7, this_value:Undefined, call_with_args, arguments:[Null]
-  [ 100] GetGlobal dst:reg7, `computed`
-  [ 118] Call dst:reg5, callee:reg7, this_value:Undefined, computed, arguments:[Null]
-  [ 140] GetGlobal dst:reg7, `member_then_call`
-  [ 158] Call dst:reg6, callee:reg7, this_value:Undefined, member_then_call, arguments:[Null]
-  [ 180] End value:reg6
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, member, arguments:[Null]
+  [  38] GetGlobal dst:reg7, `nested_member`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, nested_member, arguments:[Null]
+  [  70] GetGlobal dst:reg7, `call_no_args`
+  [  80] Call dst:reg5, callee:reg7, this_value:Undefined, call_no_args, arguments:[Null]
+  [  a8] GetGlobal dst:reg7, `call_with_args`
+  [  b8] Call dst:reg6, callee:reg7, this_value:Undefined, call_with_args, arguments:[Null]
+  [  e0] GetGlobal dst:reg7, `computed`
+  [  f0] Call dst:reg5, callee:reg7, this_value:Undefined, computed, arguments:[Null]
+  [ 118] GetGlobal dst:reg7, `member_then_call`
+  [ 128] Call dst:reg6, callee:reg7, this_value:Undefined, member_then_call, arguments:[Null]
+  [ 150] End value:reg6
 
 
-member$b5894147 optional-chain.js:7:5
+member$36eb39cf optional-chain.js:7:5
   Registers: 7
   Blocks:    3
   Constants:
@@ -38,10 +38,10 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:reg6
   [  50] GetById dst:reg6, base:reg6, `x`
-  [  70] Return value:reg6
+  [  68] Return value:reg6
 
 
-nested_member$830d1888 optional-chain.js:10:5
+nested_member$85d10998 optional-chain.js:10:5
   Registers: 7
   Blocks:    4
   Constants:
@@ -58,15 +58,15 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:reg6
   [  50] GetById dst:reg6, base:reg6, `x`
-  [  70] JumpNullish condition:reg6, true_target:block1, false_target:block3
+  [  68] JumpNullish condition:reg6, true_target:block1, false_target:block3
 
 block3:
-  [  80] Mov dst:reg5, src:reg6
-  [  90] GetById dst:reg6, base:reg6, `y`
-  [  b0] Return value:reg6
+  [  78] Mov dst:reg5, src:reg6
+  [  88] GetById dst:reg6, base:reg6, `y`
+  [  a0] Return value:reg6
 
 
-call_no_args$f2028fc1 optional-chain.js:13:5
+call_no_args$70a09739 optional-chain.js:13:5
   Registers: 8
   Blocks:    3
   Constants:
@@ -83,13 +83,13 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:reg6
   [  50] GetById dst:reg6, base:reg6, `foo`
-  [  70] NewArray dst:reg7
-  [  80] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  98] Mov dst:reg5, src:Undefined
-  [  a8] Return value:reg6
+  [  68] NewArray dst:reg7
+  [  78] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  90] Mov dst:reg5, src:Undefined
+  [  a0] Return value:reg6
 
 
-call_with_args$339c1d87 optional-chain.js:16:5
+call_with_args$b7c2071f optional-chain.js:16:5
   Registers: 11
   Blocks:    3
   Constants:
@@ -109,14 +109,14 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:reg6
   [  50] GetById dst:reg6, base:reg6, `foo`
-  [  70] Mov3 dst1:reg8, src1:Int32(1), dst2:reg9, src2:Int32(2), dst3:reg10, src3:Int32(3)
-  [  90] NewArray dst:reg7, elements:[reg8, reg9, reg10]
-  [  b0] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  c8] Mov dst:reg5, src:Undefined
-  [  d8] Return value:reg6
+  [  68] Mov3 dst1:reg8, src1:Int32(1), dst2:reg9, src2:Int32(2), dst3:reg10, src3:Int32(3)
+  [  88] NewArray dst:reg7, elements:[reg8, reg9, reg10]
+  [  a8] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  c0] Mov dst:reg5, src:Undefined
+  [  d0] Return value:reg6
 
 
-computed$1d9658d2 optional-chain.js:19:5
+computed$9ef8515a optional-chain.js:19:5
   Registers: 7
   Blocks:    3
   Constants:
@@ -134,10 +134,10 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:reg6
   [  50] GetById dst:reg6, base:reg6, `hello`
-  [  70] Return value:reg6
+  [  68] Return value:reg6
 
 
-member_then_call$adb462b3 optional-chain.js:22:5
+member_then_call$b60035e3 optional-chain.js:22:5
   Registers: 8
   Blocks:    3
   Constants:
@@ -154,9 +154,9 @@ block1:
 block2:
   [  40] Mov dst:reg5, src:reg6
   [  50] GetById dst:reg6, base:reg6, `x`
-  [  70] Mov dst:reg5, src:reg6
-  [  80] GetById dst:reg6, base:reg6, `foo`
-  [  a0] NewArray dst:reg7
-  [  b0] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  c8] Mov dst:reg5, src:Undefined
-  [  d8] Return value:reg6
+  [  68] Mov dst:reg5, src:reg6
+  [  78] GetById dst:reg6, base:reg6, `foo`
+  [  90] NewArray dst:reg7
+  [  a0] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  b8] Mov dst:reg5, src:Undefined
+  [  c8] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
+++ b/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
@@ -1,4 +1,4 @@
-$cd444473 parameter-createvariable-order.js:7:1
+$516a2e0b parameter-createvariable-order.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -9,8 +9,8 @@ $cd444473 parameter-createvariable-order.js:7:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1), Int32(2), Int32(3)]
-  [  48] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1), Int32(2), Int32(3)]
+  [  40] End value:reg5
 
 
 f$8982c134 parameter-createvariable-order.js:2:5

--- a/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
+++ b/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
@@ -13,7 +13,7 @@ block0:
   [  40] End value:reg5
 
 
-f$0820c8ac parameter-createvariable-order.js:2:5
+f$8982c134 parameter-createvariable-order.js:2:5
   Registers: 6
   Blocks:    1
   Locals:    inner~0
@@ -24,14 +24,14 @@ block0:
   [   0] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
   [  20] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [  30] DynamicInitializeLexicalBinding `a`, src:arg0
-  [  40] DynamicInitializeLexicalBinding `b`, src:arg1
-  [  50] DynamicInitializeLexicalBinding `c`, src:arg2
-  [  60] Mov dst:inner~0, src:Undefined
-  [  70] NewFunction dst:reg5, shared_function_data_index:0 (inner)
-  [  88] Mov dst:inner~0, src:reg5
-  [  98] Call dst:reg5, callee:inner~0, this_value:Undefined, inner
-  [  b8] Return value:reg5
+  [  30] InitializeLexicalBinding `a`, src:arg0
+  [  48] InitializeLexicalBinding `b`, src:arg1
+  [  60] InitializeLexicalBinding `c`, src:arg2
+  [  78] Mov dst:inner~0, src:Undefined
+  [  88] NewFunction dst:reg5, shared_function_data_index:0 (inner)
+  [  a0] Mov dst:inner~0, src:reg5
+  [  b0] Call dst:reg5, callee:inner~0, this_value:Undefined, inner
+  [  d0] Return value:reg5
 
 
 inner$2575e5f9 parameter-createvariable-order.js:3:9

--- a/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
+++ b/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
@@ -13,7 +13,7 @@ block0:
   [  40] End value:reg5
 
 
-f$8982c134 parameter-createvariable-order.js:2:5
+f$0820c8ac parameter-createvariable-order.js:2:5
   Registers: 6
   Blocks:    1
   Locals:    inner~0
@@ -24,24 +24,24 @@ block0:
   [   0] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
   [  20] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [  30] InitializeLexicalBinding `a`, src:arg0
-  [  48] InitializeLexicalBinding `b`, src:arg1
-  [  60] InitializeLexicalBinding `c`, src:arg2
-  [  78] Mov dst:inner~0, src:Undefined
-  [  88] NewFunction dst:reg5, shared_function_data_index:0 (inner)
-  [  a0] Mov dst:inner~0, src:reg5
-  [  b0] Call dst:reg5, callee:inner~0, this_value:Undefined, inner
-  [  d0] Return value:reg5
+  [  30] DynamicInitializeLexicalBinding `a`, src:arg0
+  [  40] DynamicInitializeLexicalBinding `b`, src:arg1
+  [  50] DynamicInitializeLexicalBinding `c`, src:arg2
+  [  60] Mov dst:inner~0, src:Undefined
+  [  70] NewFunction dst:reg5, shared_function_data_index:0 (inner)
+  [  88] Mov dst:inner~0, src:reg5
+  [  98] Call dst:reg5, callee:inner~0, this_value:Undefined, inner
+  [  b8] Return value:reg5
 
 
-inner$9e8c0b51 parameter-createvariable-order.js:3:9
+inner$2575e5f9 parameter-createvariable-order.js:3:9
   Registers: 8
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `a`
-  [  18] GetBinding dst:reg6, `b`
-  [  30] Add dst:reg7, lhs:reg5, rhs:reg6
-  [  40] GetBinding dst:reg5, `c`
-  [  58] Add dst:reg6, lhs:reg7, rhs:reg5
-  [  68] Return value:reg6
+  [   0] DynamicGetBinding dst:reg5, `a`
+  [  10] DynamicGetBinding dst:reg6, `b`
+  [  20] Add dst:reg7, lhs:reg5, rhs:reg6
+  [  30] DynamicGetBinding dst:reg5, `c`
+  [  40] Add dst:reg6, lhs:reg7, rhs:reg5
+  [  50] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
@@ -1,4 +1,4 @@
-$ae8c96e2 postfix-increment-private-member.js:1:1
+$fb46ff7d postfix-increment-private-member.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -16,10 +16,10 @@ block0:
   [  70] LeavePrivateEnvironment
   [  78] InitializeLexicalBinding `C`, src:reg6
   [  90] GetGlobal dst:reg7, `C`
-  [  a8] CallConstruct dst:reg5, callee:reg7, C
-  [  c0] GetById dst:reg7, base:reg5, `nextId`
-  [  e0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
-  [ 100] End value:reg6
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `nextId`
+  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
+  [  f0] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-increment-private-member.txt
@@ -1,4 +1,4 @@
-$fb46ff7d postfix-increment-private-member.js:1:1
+$79e506f5 postfix-increment-private-member.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,12 +14,12 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("nextId")]
   [  70] LeavePrivateEnvironment
-  [  78] InitializeLexicalBinding `C`, src:reg6
-  [  90] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg5, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg5, `nextId`
-  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
-  [  f0] End value:reg6
+  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  88] GetGlobal dst:reg7, `C`
+  [  98] CallConstruct dst:reg5, callee:reg7, C
+  [  b0] GetById dst:reg7, base:reg5, `nextId`
+  [  c8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.nextId
+  [  e8] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
@@ -1,4 +1,4 @@
-$acfb7718 postfix-update-in-logical-and.js:4:1
+$2b997e90 postfix-update-in-logical-and.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $acfb7718 postfix-update-in-logical-and.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `postfixInLogicalAnd`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, postfixInLogicalAnd, arguments:[Int32(5)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, postfixInLogicalAnd, arguments:[Int32(5)]
+  [  38] End value:reg5
 
 
 postfixInLogicalAnd$ff9880b2 postfix-update-in-logical-and.js:2:5

--- a/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
+++ b/Tests/LibJS/Bytecode/expected/private-identifier-access-patterns.txt
@@ -1,4 +1,4 @@
-$00cee19d private-identifier-access-patterns.js:1:1
+$7f6ce915 private-identifier-access-patterns.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -14,5 +14,5 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
   [  70] LeavePrivateEnvironment
-  [  78] InitializeLexicalBinding `C`, src:reg6
-  [  90] End value:Undefined
+  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  88] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
@@ -1,4 +1,4 @@
-$ae8c96e2 private-logical-assignment-register-order.js:1:1
+$fb46ff7d private-logical-assignment-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -16,10 +16,10 @@ block0:
   [  70] LeavePrivateEnvironment
   [  78] InitializeLexicalBinding `C`, src:reg6
   [  90] GetGlobal dst:reg7, `C`
-  [  a8] CallConstruct dst:reg5, callee:reg7, C
-  [  c0] GetById dst:reg7, base:reg5, `f`
-  [  e0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
-  [ 100] End value:reg6
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `f`
+  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
+  [  f0] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/private-logical-assignment-register-order.txt
@@ -1,4 +1,4 @@
-$fb46ff7d private-logical-assignment-register-order.js:1:1
+$79e506f5 private-logical-assignment-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,12 +14,12 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("f")]
   [  70] LeavePrivateEnvironment
-  [  78] InitializeLexicalBinding `C`, src:reg6
-  [  90] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg5, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg5, `f`
-  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
-  [  f0] End value:reg6
+  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  88] GetGlobal dst:reg7, `C`
+  [  98] CallConstruct dst:reg5, callee:reg7, C
+  [  b0] GetById dst:reg7, base:reg5, `f`
+  [  c8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.f
+  [  e8] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
+++ b/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
@@ -1,4 +1,4 @@
-$ae8c96e2 private-method-call-description.js:1:1
+$fb46ff7d private-method-call-description.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -16,10 +16,10 @@ block0:
   [  70] LeavePrivateEnvironment
   [  78] InitializeLexicalBinding `C`, src:reg6
   [  90] GetGlobal dst:reg7, `C`
-  [  a8] CallConstruct dst:reg5, callee:reg7, C
-  [  c0] GetById dst:reg7, base:reg5, `call`
-  [  e0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
-  [ 100] End value:reg6
+  [  a0] CallConstruct dst:reg5, callee:reg7, C
+  [  b8] GetById dst:reg7, base:reg5, `call`
+  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
+  [  f0] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
+++ b/Tests/LibJS/Bytecode/expected/private-method-call-description.txt
@@ -1,4 +1,4 @@
-$fb46ff7d private-method-call-description.js:1:1
+$79e506f5 private-method-call-description.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -14,12 +14,12 @@ block0:
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("call")]
   [  70] LeavePrivateEnvironment
-  [  78] InitializeLexicalBinding `C`, src:reg6
-  [  90] GetGlobal dst:reg7, `C`
-  [  a0] CallConstruct dst:reg5, callee:reg7, C
-  [  b8] GetById dst:reg7, base:reg5, `call`
-  [  d0] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
-  [  f0] End value:reg6
+  [  78] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  88] GetGlobal dst:reg7, `C`
+  [  98] CallConstruct dst:reg5, callee:reg7, C
+  [  b0] GetById dst:reg7, base:reg5, `call`
+  [  c8] Call dst:reg6, callee:reg7, this_value:reg5, <object>.call
+  [  e8] End value:reg6
 
 
 C$e7b179de

--- a/Tests/LibJS/Bytecode/expected/regex-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/regex-literals.txt
@@ -1,4 +1,4 @@
-$a7cdfa5e regex-literals.js:2:1
+$266c01d6 regex-literals.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -15,17 +15,17 @@ block0:
   [  78] Add dst:reg6, lhs:Int32(1), rhs:reg5
   [  88] InitializeLexicalBinding `c`, src:reg6
   [  a0] GetGlobal dst:reg5, `matchDigits`
-  [  b8] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
-  [  e0] End value:reg6
+  [  b0] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
+  [  d8] End value:reg6
 
 
-matchDigits$5149c62f regex-literals.js:8:5
+matchDigits$cfe7cda7 regex-literals.js:8:5
   Registers: 9
   Blocks:    1
 
 block0:
   [   0] NewRegExp dst:reg6, \d+, g
   [  18] GetById dst:reg7, base:reg6, `test`
-  [  38] Mov dst:reg8, src:arg0
-  [  48] Call dst:reg5, callee:reg7, this_value:reg6, <object>.test, arguments:[reg8]
-  [  70] Return value:reg5
+  [  30] Mov dst:reg8, src:arg0
+  [  40] Call dst:reg5, callee:reg7, this_value:reg6, <object>.test, arguments:[reg8]
+  [  68] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/regex-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/regex-literals.txt
@@ -1,4 +1,4 @@
-$266c01d6 regex-literals.js:2:1
+$a246183e regex-literals.js:2:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -8,15 +8,15 @@ $266c01d6 regex-literals.js:2:1
 
 block0:
   [   0] NewRegExp dst:reg5, foo, 
-  [  18] InitializeLexicalBinding `a`, src:reg5
-  [  30] NewRegExp dst:reg5, bar, gi
-  [  48] InitializeLexicalBinding `b`, src:reg5
-  [  60] NewRegExp dst:reg5, baz, i
-  [  78] Add dst:reg6, lhs:Int32(1), rhs:reg5
-  [  88] InitializeLexicalBinding `c`, src:reg6
-  [  a0] GetGlobal dst:reg5, `matchDigits`
-  [  b0] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
-  [  d8] End value:reg6
+  [  18] DynamicInitializeLexicalBinding `a`, src:reg5
+  [  28] NewRegExp dst:reg5, bar, gi
+  [  40] DynamicInitializeLexicalBinding `b`, src:reg5
+  [  50] NewRegExp dst:reg5, baz, i
+  [  68] Add dst:reg6, lhs:Int32(1), rhs:reg5
+  [  78] DynamicInitializeLexicalBinding `c`, src:reg6
+  [  88] GetGlobal dst:reg5, `matchDigits`
+  [  98] Call dst:reg6, callee:reg5, this_value:Undefined, matchDigits, arguments:[String("abc123")]
+  [  c0] End value:reg6
 
 
 matchDigits$cfe7cda7 regex-literals.js:8:5

--- a/Tests/LibJS/Bytecode/expected/resolve-this-caching.txt
+++ b/Tests/LibJS/Bytecode/expected/resolve-this-caching.txt
@@ -1,4 +1,4 @@
-$2b997e90 resolve-this-caching.js:4:1
+$bacf2c68 resolve-this-caching.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $2b997e90 resolve-this-caching.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `foo`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo
+  [  30] End value:reg5
 
 
 foo$1d0ffb84 resolve-this-caching.js:2:5
@@ -22,13 +22,13 @@ block0:
   [  38] Return value:reg5
 
 
-$9bf17e5a resolve-this-caching.js:2:13
+$93a5ab2a resolve-this-caching.js:2:13
   Registers: 8
   Blocks:    1
 
 block0:
   [   0] ResolveThisBinding
   [   8] GetById dst:reg5, base:this, `x` (this.x)
-  [  28] GetById dst:reg6, base:this, `y` (this.y)
-  [  48] Add dst:reg7, lhs:reg5, rhs:reg6
-  [  58] Return value:reg7
+  [  20] GetById dst:reg6, base:this, `y` (this.y)
+  [  38] Add dst:reg7, lhs:reg5, rhs:reg6
+  [  48] Return value:reg7

--- a/Tests/LibJS/Bytecode/expected/right-shift-by-zero.txt
+++ b/Tests/LibJS/Bytecode/expected/right-shift-by-zero.txt
@@ -1,4 +1,4 @@
-$9431c529 right-shift-by-zero.js:5:1
+$12cfcca1 right-shift-by-zero.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $9431c529 right-shift-by-zero.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `foo`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[Double(1.5)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[Double(1.5)]
+  [  38] End value:reg5
 
 
 foo$962620dc right-shift-by-zero.js:2:5

--- a/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
+++ b/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
@@ -1,4 +1,4 @@
-$b56ffb15 sequential-try-blocks.js:17:1
+$3c59d5bd sequential-try-blocks.js:17:1
   Registers: 10
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $b56ffb15 sequential-try-blocks.js:17:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `sequentialTryCatch`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, sequentialTryCatch
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `sequentialTryCatch`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, sequentialTryCatch
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] End value:reg5
 
 
 sequentialTryCatch$0a8456ee sequential-try-blocks.js:2:5

--- a/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-from-char-code-builtin.txt
@@ -1,4 +1,4 @@
-$8130931f string-from-char-code-builtin.js:3:1
+$7ba8b0ff string-from-char-code-builtin.js:3:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -7,9 +7,9 @@ $8130931f string-from-char-code-builtin.js:3:1
 
 block0:
   [   0] GetGlobal dst:reg6, `String`
-  [  18] GetById dst:reg7, base:reg6, `fromCharCode` (String.fromCharCode)
-  [  38] CallBuiltinStringFromCharCode dst:reg5, callee:reg7, this_value:reg6, argument:Int32(65), String.fromCharCode
-  [  50] GetGlobal dst:reg6, `String`
-  [  68] GetById dst:reg8, base:reg6, `fromCharCode` (String.fromCharCode)
-  [  88] Call dst:reg7, callee:reg8, this_value:reg6, String.fromCharCode, arguments:[Int32(65), Int32(66)]
-  [  b0] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `fromCharCode` (String.fromCharCode)
+  [  28] CallBuiltinStringFromCharCode dst:reg5, callee:reg7, this_value:reg6, argument:Int32(65), String.fromCharCode
+  [  40] GetGlobal dst:reg6, `String`
+  [  50] GetById dst:reg8, base:reg6, `fromCharCode` (String.fromCharCode)
+  [  68] Call dst:reg7, callee:reg8, this_value:reg6, String.fromCharCode, arguments:[Int32(65), Int32(66)]
+  [  90] End value:reg7

--- a/Tests/LibJS/Bytecode/expected/string-prototype-char-at-builtin.txt
+++ b/Tests/LibJS/Bytecode/expected/string-prototype-char-at-builtin.txt
@@ -1,4 +1,4 @@
-$ffb83754 string-prototype-char-at-builtin.js:4:13
+$23ab7524 string-prototype-char-at-builtin.js:4:13
   Registers: 8
   Blocks:    1
   Constants:
@@ -8,7 +8,7 @@ $ffb83754 string-prototype-char-at-builtin.js:4:13
 
 block0:
   [   0] GetById dst:reg6, base:String("abc"), `charAt` ('abc'.charAt)
-  [  20] CallBuiltinStringPrototypeCharAt dst:reg5, callee:reg6, this_value:String("abc"), argument:Int32(1), 'abc'.charAt
-  [  38] GetById dst:reg7, base:String("abc"), `charAt`
-  [  58] Call dst:reg6, callee:reg7, this_value:String("abc"), 'abc'['charAt'], arguments:[Int32(1)]
-  [  80] End value:reg6
+  [  18] CallBuiltinStringPrototypeCharAt dst:reg5, callee:reg6, this_value:String("abc"), argument:Int32(1), 'abc'.charAt
+  [  30] GetById dst:reg7, base:String("abc"), `charAt`
+  [  48] Call dst:reg6, callee:reg7, this_value:String("abc"), 'abc'['charAt'], arguments:[Int32(1)]
+  [  70] End value:reg6

--- a/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$772115e5 super-call-spread-register-order.js:1:1
+$84f4cb35 super-call-spread-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -9,12 +9,12 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
   [  30] GetGlobal dst:reg6, `Object`
-  [  48] SetLexicalEnvironment environment:reg4
-  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  70] InitializeLexicalBinding `C`, src:reg7
-  [  88] GetGlobal dst:reg5, `C`
-  [  a0] CallConstruct dst:reg7, callee:reg5, C
-  [  b8] End value:reg7
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
+  [  68] InitializeLexicalBinding `C`, src:reg7
+  [  80] GetGlobal dst:reg5, `C`
+  [  90] CallConstruct dst:reg7, callee:reg5, C
+  [  a8] End value:reg7
 
 
 C$c11ea3e3 super-call-spread-register-order.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-call-spread-register-order.txt
@@ -1,4 +1,4 @@
-$84f4cb35 super-call-spread-register-order.js:1:1
+$091ab4cd super-call-spread-register-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,10 +11,10 @@ block0:
   [  30] GetGlobal dst:reg6, `Object`
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  68] InitializeLexicalBinding `C`, src:reg7
-  [  80] GetGlobal dst:reg5, `C`
-  [  90] CallConstruct dst:reg7, callee:reg5, C
-  [  a8] End value:reg7
+  [  68] DynamicInitializeLexicalBinding `C`, src:reg7
+  [  78] GetGlobal dst:reg5, `C`
+  [  88] CallConstruct dst:reg7, callee:reg5, C
+  [  a0] End value:reg7
 
 
 C$c11ea3e3 super-call-spread-register-order.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
@@ -1,4 +1,4 @@
-$24decb2a super-computed-eval-order.js:1:1
+$a0b8e192 super-computed-eval-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -15,14 +15,14 @@ block0:
   [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
   [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
   [  98] GetGlobal dst:reg5, `Base`
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
-  [  e0] InitializeLexicalBinding `Derived`, src:reg7
-  [  f8] GetGlobal dst:reg5, `Derived`
-  [ 110] CallConstruct dst:reg6, callee:reg5, Derived
-  [ 128] GetById dst:reg5, base:reg6, `test`
-  [ 148] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
-  [ 168] End value:reg7
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
+  [  d8] InitializeLexicalBinding `Derived`, src:reg7
+  [  f0] GetGlobal dst:reg5, `Derived`
+  [ 100] CallConstruct dst:reg6, callee:reg5, Derived
+  [ 118] GetById dst:reg5, base:reg6, `test`
+  [ 130] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
+  [ 150] End value:reg7
 
 
 Derived$730ebf72 super-computed-eval-order.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-eval-order.txt
@@ -1,4 +1,4 @@
-$a0b8e192 super-computed-eval-order.js:1:1
+$a37cd2a2 super-computed-eval-order.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,18 +11,18 @@ block0:
   [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  58] InitializeLexicalBinding `Base`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
-  [  98] GetGlobal dst:reg5, `Base`
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
-  [  d8] InitializeLexicalBinding `Derived`, src:reg7
-  [  f0] GetGlobal dst:reg5, `Derived`
-  [ 100] CallConstruct dst:reg6, callee:reg5, Derived
-  [ 118] GetById dst:reg5, base:reg6, `test`
-  [ 130] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
-  [ 150] End value:reg7
+  [  58] DynamicInitializeLexicalBinding `Base`, src:reg6
+  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  80] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
+  [  90] GetGlobal dst:reg5, `Base`
+  [  a0] SetLexicalEnvironment environment:reg4
+  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("test")]
+  [  d0] DynamicInitializeLexicalBinding `Derived`, src:reg7
+  [  e0] GetGlobal dst:reg5, `Derived`
+  [  f0] CallConstruct dst:reg6, callee:reg5, Derived
+  [ 108] GetById dst:reg5, base:reg6, `test`
+  [ 120] Call dst:reg7, callee:reg5, this_value:reg6, <object>.test
+  [ 140] End value:reg7
 
 
 Derived$730ebf72 super-computed-eval-order.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
@@ -1,4 +1,4 @@
-$772115e5 super-computed-string-to-id.js:1:1
+$84f4cb35 super-computed-string-to-id.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -9,12 +9,12 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
   [  30] GetGlobal dst:reg6, `Object`
-  [  48] SetLexicalEnvironment environment:reg4
-  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  70] InitializeLexicalBinding `C`, src:reg7
-  [  88] GetGlobal dst:reg5, `C`
-  [  a0] CallConstruct dst:reg7, callee:reg5, C
-  [  b8] End value:reg7
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
+  [  68] InitializeLexicalBinding `C`, src:reg7
+  [  80] GetGlobal dst:reg5, `C`
+  [  90] CallConstruct dst:reg7, callee:reg5, C
+  [  a8] End value:reg7
 
 
 C$be5ab2d3 super-computed-string-to-id.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
+++ b/Tests/LibJS/Bytecode/expected/super-computed-string-to-id.txt
@@ -1,4 +1,4 @@
-$84f4cb35 super-computed-string-to-id.js:1:1
+$091ab4cd super-computed-string-to-id.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,10 +11,10 @@ block0:
   [  30] GetGlobal dst:reg6, `Object`
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0
-  [  68] InitializeLexicalBinding `C`, src:reg7
-  [  80] GetGlobal dst:reg5, `C`
-  [  90] CallConstruct dst:reg7, callee:reg5, C
-  [  a8] End value:reg7
+  [  68] DynamicInitializeLexicalBinding `C`, src:reg7
+  [  78] GetGlobal dst:reg5, `C`
+  [  88] CallConstruct dst:reg7, callee:reg5, C
+  [  a0] End value:reg7
 
 
 C$be5ab2d3 super-computed-string-to-id.js:3:14

--- a/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
+++ b/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
@@ -1,4 +1,4 @@
-$32b2807a super-constructor-call.js:1:1
+$2a66ad4a super-constructor-call.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,16 +11,16 @@ block0:
   [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  58] InitializeLexicalBinding `Base`, src:reg6
-  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
-  [  98] GetGlobal dst:reg5, `Base`
-  [  a8] SetLexicalEnvironment environment:reg4
-  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
-  [  d0] InitializeLexicalBinding `Derived`, src:reg7
-  [  e8] GetGlobal dst:reg6, `Derived`
-  [  f8] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
-  [ 118] End value:reg7
+  [  58] DynamicInitializeLexicalBinding `Base`, src:reg6
+  [  68] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  80] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
+  [  90] GetGlobal dst:reg5, `Base`
+  [  a0] SetLexicalEnvironment environment:reg4
+  [  a8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
+  [  c8] DynamicInitializeLexicalBinding `Derived`, src:reg7
+  [  d8] GetGlobal dst:reg6, `Derived`
+  [  e8] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
+  [ 108] End value:reg7
 
 
 Derived$eee8d5da super-constructor-call.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
+++ b/Tests/LibJS/Bytecode/expected/super-constructor-call.txt
@@ -1,4 +1,4 @@
-$2fee8f6a super-constructor-call.js:1:1
+$32b2807a super-constructor-call.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -15,12 +15,12 @@ block0:
   [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
   [  88] CreateVariable `Derived`, is_immutable:true, is_global:false, is_strict:false
   [  98] GetGlobal dst:reg5, `Base`
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
-  [  d8] InitializeLexicalBinding `Derived`, src:reg7
-  [  f0] GetGlobal dst:reg6, `Derived`
-  [ 108] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
-  [ 128] End value:reg7
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1
+  [  d0] InitializeLexicalBinding `Derived`, src:reg7
+  [  e8] GetGlobal dst:reg6, `Derived`
+  [  f8] CallConstruct dst:reg7, callee:reg6, Derived, arguments:[Int32(1)]
+  [ 118] End value:reg7
 
 
 Derived$eee8d5da super-constructor-call.js:4:14

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -1,4 +1,4 @@
-$c7701072 super-evaluation-order.js:1:1
+$460e17ea super-evaluation-order.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -14,33 +14,33 @@ block0:
   [  30] GetGlobal dst:reg6, `Object`
   [  40] SetLexicalEnvironment environment:reg4
   [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
-  [  78] InitializeLexicalBinding `A`, src:reg7
-  [  90] GetGlobal dst:reg6, `A`
-  [  a0] CallConstruct dst:reg5, callee:reg6, A
-  [  b8] GetById dst:reg6, base:reg5, `read`
-  [  d0] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
-  [  f0] GetGlobal dst:reg8, `A`
-  [ 100] CallConstruct dst:reg5, callee:reg8, A
-  [ 118] GetById dst:reg8, base:reg5, `write`
-  [ 130] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
-  [ 150] GetGlobal dst:reg5, `A`
-  [ 160] CallConstruct dst:reg8, callee:reg5, A
-  [ 178] GetById dst:reg5, base:reg8, `update`
-  [ 190] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
-  [ 1b0] End value:reg7
+  [  78] DynamicInitializeLexicalBinding `A`, src:reg7
+  [  88] GetGlobal dst:reg6, `A`
+  [  98] CallConstruct dst:reg5, callee:reg6, A
+  [  b0] GetById dst:reg6, base:reg5, `read`
+  [  c8] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
+  [  e8] GetGlobal dst:reg8, `A`
+  [  f8] CallConstruct dst:reg5, callee:reg8, A
+  [ 110] GetById dst:reg8, base:reg5, `write`
+  [ 128] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
+  [ 148] GetGlobal dst:reg5, `A`
+  [ 158] CallConstruct dst:reg8, callee:reg5, A
+  [ 170] GetById dst:reg5, base:reg8, `update`
+  [ 188] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
+  [ 1a8] End value:reg7
 
 
-A$3d02c59c super-evaluation-order.js:1:1
+A$3fc6b6ac super-evaluation-order.js:1:1
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] InitializeLexicalBinding `args`, src:arg0
-  [  38] GetBinding dst:reg5, `args`
-  [  50] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
-  [  60] Return value:reg6
+  [  20] DynamicInitializeLexicalBinding `args`, src:arg0
+  [  30] DynamicGetBinding dst:reg5, `args`
+  [  40] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
+  [  50] Return value:reg6
 
 
 read$5dc3ca35 super-evaluation-order.js:3:9

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -1,4 +1,4 @@
-$3afe53aa super-evaluation-order.js:1:1
+$c7701072 super-evaluation-order.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -12,22 +12,22 @@ block0:
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0, is_catch_environment:false
   [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
   [  30] GetGlobal dst:reg6, `Object`
-  [  48] SetLexicalEnvironment environment:reg4
-  [  50] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
-  [  80] InitializeLexicalBinding `A`, src:reg7
-  [  98] GetGlobal dst:reg6, `A`
-  [  b0] CallConstruct dst:reg5, callee:reg6, A
-  [  c8] GetById dst:reg6, base:reg5, `read`
-  [  e8] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
-  [ 108] GetGlobal dst:reg8, `A`
-  [ 120] CallConstruct dst:reg5, callee:reg8, A
-  [ 138] GetById dst:reg8, base:reg5, `write`
-  [ 158] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
-  [ 178] GetGlobal dst:reg5, `A`
-  [ 190] CallConstruct dst:reg8, callee:reg5, A
-  [ 1a8] GetById dst:reg5, base:reg8, `update`
-  [ 1c8] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
-  [ 1e8] End value:reg7
+  [  40] SetLexicalEnvironment environment:reg4
+  [  48] NewClass dst:reg7, super_class:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("read"), element_keys:String("write"), element_keys:String("update")]
+  [  78] InitializeLexicalBinding `A`, src:reg7
+  [  90] GetGlobal dst:reg6, `A`
+  [  a0] CallConstruct dst:reg5, callee:reg6, A
+  [  b8] GetById dst:reg6, base:reg5, `read`
+  [  d0] Call dst:reg7, callee:reg6, this_value:reg5, <object>.read
+  [  f0] GetGlobal dst:reg8, `A`
+  [ 100] CallConstruct dst:reg5, callee:reg8, A
+  [ 118] GetById dst:reg8, base:reg5, `write`
+  [ 130] Call dst:reg6, callee:reg8, this_value:reg5, <object>.write
+  [ 150] GetGlobal dst:reg5, `A`
+  [ 160] CallConstruct dst:reg8, callee:reg5, A
+  [ 178] GetById dst:reg5, base:reg8, `update`
+  [ 190] Call dst:reg7, callee:reg5, this_value:reg8, <object>.update
+  [ 1b0] End value:reg7
 
 
 A$3d02c59c super-evaluation-order.js:1:1
@@ -43,7 +43,7 @@ block0:
   [  60] Return value:reg6
 
 
-read$df25c2bd super-evaluation-order.js:3:9
+read$5dc3ca35 super-evaluation-order.js:3:9
   Registers: 7
   Blocks:    1
   Constants:
@@ -53,7 +53,7 @@ block0:
   [   0] ResolveThisBinding
   [   8] ResolveSuperBase dst:reg5
   [  10] GetByIdWithThis dst:reg6, base:reg5, `x`, this_value:this
-  [  30] Return value:reg6
+  [  28] Return value:reg6
 
 
 write$7ede70d2 super-evaluation-order.js:6:20
@@ -71,7 +71,7 @@ block0:
   [  30] End value:Undefined
 
 
-update$044d6445 super-evaluation-order.js:9:16
+update$85af5ccd super-evaluation-order.js:9:16
   Registers: 8
   Blocks:    1
   Constants:
@@ -81,6 +81,6 @@ block0:
   [   0] ResolveThisBinding
   [   8] ResolveSuperBase dst:reg5
   [  10] GetByIdWithThis dst:reg6, base:reg5, `x`, this_value:this
-  [  30] PostfixIncrement dst:reg7, src:reg6
-  [  40] PutByIdWithThis base:reg5, this_value:this, `x`, src:reg6, kind:Normal
-  [  60] End value:Undefined
+  [  28] PostfixIncrement dst:reg7, src:reg6
+  [  38] PutByIdWithThis base:reg5, this_value:this, `x`, src:reg6, kind:Normal
+  [  58] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-evaluation-order.txt
@@ -30,17 +30,17 @@ block0:
   [ 1a8] End value:reg7
 
 
-A$3fc6b6ac super-evaluation-order.js:1:1
+A$3d02c59c super-evaluation-order.js:1:1
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] DynamicInitializeLexicalBinding `args`, src:arg0
-  [  30] DynamicGetBinding dst:reg5, `args`
-  [  40] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
-  [  50] Return value:reg6
+  [  20] InitializeLexicalBinding `args`, src:arg0
+  [  38] GetBinding dst:reg5, `args`
+  [  50] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
+  [  60] Return value:reg6
 
 
 read$5dc3ca35 super-evaluation-order.js:3:9

--- a/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
@@ -1,4 +1,4 @@
-$87b8bc45 super-for-of-resolve-order.js:1:1
+$00cee19d super-for-of-resolve-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -10,10 +10,10 @@ block0:
   [  20] CreateVariable `C`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
-  [  58] InitializeLexicalBinding `C`, src:reg6
-  [  70] GetGlobal dst:reg5, `C`
-  [  80] CallConstruct dst:reg6, callee:reg5, C
-  [  98] End value:reg6
+  [  58] DynamicInitializeLexicalBinding `C`, src:reg6
+  [  68] GetGlobal dst:reg5, `C`
+  [  78] CallConstruct dst:reg6, callee:reg5, C
+  [  90] End value:reg6
 
 
 C$9d8b2466 super-for-of-resolve-order.js:3:28

--- a/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-for-of-resolve-order.txt
@@ -1,4 +1,4 @@
-$091ab4cd super-for-of-resolve-order.js:1:1
+$87b8bc45 super-for-of-resolve-order.js:1:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -12,8 +12,8 @@ block0:
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0
   [  58] InitializeLexicalBinding `C`, src:reg6
   [  70] GetGlobal dst:reg5, `C`
-  [  88] CallConstruct dst:reg6, callee:reg5, C
-  [  a0] End value:reg6
+  [  80] CallConstruct dst:reg6, callee:reg5, C
+  [  98] End value:reg6
 
 
 C$9d8b2466 super-for-of-resolve-order.js:3:28

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -1,4 +1,4 @@
-$63792c94 super-length-access.js:3:1
+$e4db251c super-length-access.js:3:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -16,14 +16,14 @@ block0:
   [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
   [  90] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:false
   [  a0] GetGlobal dst:reg5, `A`
-  [  b8] SetLexicalEnvironment environment:reg4
-  [  c0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
-  [  e8] InitializeLexicalBinding `B`, src:reg7
-  [ 100] GetGlobal dst:reg5, `B`
-  [ 118] CallConstruct dst:reg6, callee:reg5, B
-  [ 130] GetById dst:reg5, base:reg6, `m`
-  [ 150] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
-  [ 170] End value:reg7
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
+  [  e0] InitializeLexicalBinding `B`, src:reg7
+  [  f8] GetGlobal dst:reg5, `B`
+  [ 108] CallConstruct dst:reg6, callee:reg5, B
+  [ 120] GetById dst:reg5, base:reg6, `m`
+  [ 138] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
+  [ 158] End value:reg7
 
 
 B$cbd8a311 super-length-access.js:7:1

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -1,4 +1,4 @@
-$e4db251c super-length-access.js:3:1
+$dc8f51ec super-length-access.js:3:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -12,31 +12,31 @@ block0:
   [  20] CreateVariable `A`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("length")]
-  [  60] InitializeLexicalBinding `A`, src:reg6
-  [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  90] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:false
-  [  a0] GetGlobal dst:reg5, `A`
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
-  [  e0] InitializeLexicalBinding `B`, src:reg7
-  [  f8] GetGlobal dst:reg5, `B`
-  [ 108] CallConstruct dst:reg6, callee:reg5, B
-  [ 120] GetById dst:reg5, base:reg6, `m`
-  [ 138] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
-  [ 158] End value:reg7
+  [  60] DynamicInitializeLexicalBinding `A`, src:reg6
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  88] CreateVariable `B`, is_immutable:true, is_global:false, is_strict:false
+  [  98] GetGlobal dst:reg5, `A`
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("m")]
+  [  d8] DynamicInitializeLexicalBinding `B`, src:reg7
+  [  e8] GetGlobal dst:reg5, `B`
+  [  f8] CallConstruct dst:reg6, callee:reg5, B
+  [ 110] GetById dst:reg5, base:reg6, `m`
+  [ 128] Call dst:reg7, callee:reg5, this_value:reg6, <object>.m
+  [ 148] End value:reg7
 
 
-B$cbd8a311 super-length-access.js:7:1
+B$d4247641 super-length-access.js:7:1
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] InitializeLexicalBinding `args`, src:arg0
-  [  38] GetBinding dst:reg5, `args`
-  [  50] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
-  [  60] Return value:reg6
+  [  20] DynamicInitializeLexicalBinding `args`, src:arg0
+  [  30] DynamicGetBinding dst:reg5, `args`
+  [  40] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
+  [  50] Return value:reg6
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/super-length-access.txt
+++ b/Tests/LibJS/Bytecode/expected/super-length-access.txt
@@ -26,17 +26,17 @@ block0:
   [ 148] End value:reg7
 
 
-B$d4247641 super-length-access.js:7:1
+B$cbd8a311 super-length-access.js:7:1
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] DynamicInitializeLexicalBinding `args`, src:arg0
-  [  30] DynamicGetBinding dst:reg5, `args`
-  [  40] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
-  [  50] Return value:reg6
+  [  20] InitializeLexicalBinding `args`, src:arg0
+  [  38] GetBinding dst:reg5, `args`
+  [  50] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
+  [  60] Return value:reg6
 
 
 A$ef0589ec

--- a/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
+++ b/Tests/LibJS/Bytecode/expected/super-method-call-order.txt
@@ -1,4 +1,4 @@
-$0463738f super-method-call-order.js:1:1
+$6ce1f287 super-method-call-order.js:1:1
   Registers: 9
   Blocks:    1
 
@@ -8,28 +8,28 @@ block0:
   [  28] InitObjectLiteralProperty object:reg5, `m`, src:reg6, shape_cache_index:0, property_slot:0
   [  40] CacheObjectShape object:reg5
   [  50] SetGlobal `proto`, src:reg5
-  [  68] NewObject dst:reg5
-  [  78] GetGlobal dst:reg6, `proto`
-  [  90] PutById base:reg5, `__proto__`, src:reg6, kind:Prototype
-  [  b8] NewFunction dst:reg6, shared_function_data_index:1 (test), home_object:reg5
-  [  d0] PutById base:reg5, `test`, src:reg6, kind:Own
-  [  f8] NewFunction dst:reg6, shared_function_data_index:2 (get x), home_object:reg5
-  [ 110] PutById base:reg5, `x`, src:reg6, kind:Getter
-  [ 138] NewFunction dst:reg6, shared_function_data_index:3 (test2), home_object:reg5
-  [ 150] PutById base:reg5, `test2`, src:reg6, kind:Own
-  [ 178] SetGlobal `obj`, src:reg5
-  [ 190] GetGlobal dst:reg6, `obj`
-  [ 1a8] GetById dst:reg7, base:reg6, `test` (obj.test)
-  [ 1c8] Call dst:reg5, callee:reg7, this_value:reg6, obj.test
-  [ 1e8] GetGlobal dst:reg7, `obj`
-  [ 200] GetById dst:reg6, base:reg7, `x` (obj.x)
-  [ 220] GetGlobal dst:reg7, `obj`
-  [ 238] GetById dst:reg8, base:reg7, `test2` (obj.test2)
-  [ 258] Call dst:reg5, callee:reg8, this_value:reg7, obj.test2
-  [ 278] End value:reg5
+  [  60] NewObject dst:reg5
+  [  70] GetGlobal dst:reg6, `proto`
+  [  80] PutById base:reg5, `__proto__`, src:reg6, kind:Prototype
+  [  a0] NewFunction dst:reg6, shared_function_data_index:1 (test), home_object:reg5
+  [  b8] PutById base:reg5, `test`, src:reg6, kind:Own
+  [  d8] NewFunction dst:reg6, shared_function_data_index:2 (get x), home_object:reg5
+  [  f0] PutById base:reg5, `x`, src:reg6, kind:Getter
+  [ 110] NewFunction dst:reg6, shared_function_data_index:3 (test2), home_object:reg5
+  [ 128] PutById base:reg5, `test2`, src:reg6, kind:Own
+  [ 148] SetGlobal `obj`, src:reg5
+  [ 158] GetGlobal dst:reg6, `obj`
+  [ 168] GetById dst:reg7, base:reg6, `test` (obj.test)
+  [ 180] Call dst:reg5, callee:reg7, this_value:reg6, obj.test
+  [ 1a0] GetGlobal dst:reg7, `obj`
+  [ 1b0] GetById dst:reg6, base:reg7, `x` (obj.x)
+  [ 1c8] GetGlobal dst:reg7, `obj`
+  [ 1d8] GetById dst:reg8, base:reg7, `test2` (obj.test2)
+  [ 1f0] Call dst:reg5, callee:reg8, this_value:reg7, obj.test2
+  [ 210] End value:reg5
 
 
-test$70dcf05f super-method-call-order.js:5:9
+test$ef7af7d7 super-method-call-order.js:5:9
   Registers: 8
   Blocks:    1
 
@@ -37,8 +37,8 @@ block0:
   [   0] ResolveThisBinding
   [   8] ResolveSuperBase dst:reg6
   [  10] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
-  [  30] Call dst:reg5, callee:reg7, this_value:this, <object>.m
-  [  50] Return value:reg5
+  [  28] Call dst:reg5, callee:reg7, this_value:this, <object>.m
+  [  48] Return value:reg5
 
 
 m$685877e0
@@ -51,7 +51,7 @@ block0:
   [   0] End value:Undefined
 
 
-get x$97875862 super-method-call-order.js:8:9
+get x$18e950ea super-method-call-order.js:8:9
   Registers: 8
   Blocks:    1
 
@@ -59,11 +59,11 @@ block0:
   [   0] ResolveThisBinding
   [   8] ResolveSuperBase dst:reg6
   [  10] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
-  [  30] Call dst:reg5, callee:reg7, this_value:this, <object>.m
-  [  50] Return value:reg5
+  [  28] Call dst:reg5, callee:reg7, this_value:this, <object>.m
+  [  48] Return value:reg5
 
 
-test2$5d2fb73b super-method-call-order.js:11:9
+test2$dbcdbeb3 super-method-call-order.js:11:9
   Registers: 8
   Blocks:    1
   Constants:
@@ -73,5 +73,5 @@ block0:
   [   0] ResolveThisBinding
   [   8] ResolveSuperBase dst:reg6
   [  10] GetByIdWithThis dst:reg7, base:reg6, `m`, this_value:this
-  [  30] Call dst:reg5, callee:reg7, this_value:this, <object>['m']
-  [  50] Return value:reg5
+  [  28] Call dst:reg5, callee:reg7, this_value:this, <object>['m']
+  [  48] Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -1,4 +1,4 @@
-$a640c3b2 super-optional-call-this.js:1:1
+$27a2bc3a super-optional-call-this.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -15,14 +15,14 @@ block0:
   [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
   [  90] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
   [  a0] GetGlobal dst:reg5, `Base`
-  [  b8] SetLexicalEnvironment environment:reg4
-  [  c0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
-  [  e8] InitializeLexicalBinding `Foo`, src:reg7
-  [ 100] GetGlobal dst:reg5, `Foo`
-  [ 118] CallConstruct dst:reg6, callee:reg5, Foo
-  [ 130] GetById dst:reg5, base:reg6, `method`
-  [ 150] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
-  [ 170] End value:reg7
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
+  [  e0] InitializeLexicalBinding `Foo`, src:reg7
+  [  f8] GetGlobal dst:reg5, `Foo`
+  [ 108] CallConstruct dst:reg6, callee:reg5, Foo
+  [ 120] GetById dst:reg5, base:reg6, `method`
+  [ 138] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
+  [ 158] End value:reg7
 
 
 Foo$f8ebe2ee super-optional-call-this.js:4:1
@@ -48,7 +48,7 @@ block0:
   [   0] End value:Undefined
 
 
-method$994e3bed super-optional-call-this.js:6:9
+method$25bff8b5 super-optional-call-this.js:6:9
   Registers: 9
   Blocks:    3
   Constants:
@@ -59,18 +59,18 @@ block0:
   [  10] ResolveThisBinding
   [  18] ResolveSuperBase dst:reg7
   [  20] GetByIdWithThis dst:reg8, base:reg7, `method`, this_value:this
-  [  40] Mov2 dst1:reg5, src1:this, dst2:reg6, src2:reg8
-  [  58] JumpNullish condition:reg6, true_target:block1, false_target:block2
+  [  38] Mov2 dst1:reg5, src1:this, dst2:reg6, src2:reg8
+  [  50] JumpNullish condition:reg6, true_target:block1, false_target:block2
 
 block1:
-  [  68] Mov dst:reg6, src:Undefined
-  [  78] Return value:reg6
+  [  60] Mov dst:reg6, src:Undefined
+  [  70] Return value:reg6
 
 block2:
-  [  80] NewArray dst:reg7
-  [  90] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-  [  a8] Mov dst:reg5, src:Undefined
-  [  b8] Return value:reg6
+  [  78] NewArray dst:reg7
+  [  88] CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+  [  a0] Mov dst:reg5, src:Undefined
+  [  b0] Return value:reg6
 
 
 method$6c22ae6a

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -1,4 +1,4 @@
-$27a2bc3a super-optional-call-this.js:1:1
+$1f56e90a super-optional-call-this.js:1:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -11,31 +11,31 @@ block0:
   [  20] CreateVariable `Base`, is_immutable:true, is_global:false, is_strict:false
   [  30] SetLexicalEnvironment environment:reg4
   [  38] NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("method")]
-  [  60] InitializeLexicalBinding `Base`, src:reg6
-  [  78] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
-  [  90] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
-  [  a0] GetGlobal dst:reg5, `Base`
-  [  b0] SetLexicalEnvironment environment:reg4
-  [  b8] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
-  [  e0] InitializeLexicalBinding `Foo`, src:reg7
-  [  f8] GetGlobal dst:reg5, `Foo`
-  [ 108] CallConstruct dst:reg6, callee:reg5, Foo
-  [ 120] GetById dst:reg5, base:reg6, `method`
-  [ 138] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
-  [ 158] End value:reg7
+  [  60] DynamicInitializeLexicalBinding `Base`, src:reg6
+  [  70] CreateLexicalEnvironment dst:reg6, parent:reg4, capacity:0, is_catch_environment:false
+  [  88] CreateVariable `Foo`, is_immutable:true, is_global:false, is_strict:false
+  [  98] GetGlobal dst:reg5, `Base`
+  [  a8] SetLexicalEnvironment environment:reg4
+  [  b0] NewClass dst:reg7, super_class:reg5, class_environment:reg6, class_blueprint_index:1, element_keys:[element_keys:String("method")]
+  [  d8] DynamicInitializeLexicalBinding `Foo`, src:reg7
+  [  e8] GetGlobal dst:reg5, `Foo`
+  [  f8] CallConstruct dst:reg6, callee:reg5, Foo
+  [ 110] GetById dst:reg5, base:reg6, `method`
+  [ 128] Call dst:reg7, callee:reg5, this_value:reg6, <object>.method
+  [ 148] End value:reg7
 
 
-Foo$f8ebe2ee super-optional-call-this.js:4:1
+Foo$0137b61e super-optional-call-this.js:4:1
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] InitializeLexicalBinding `args`, src:arg0
-  [  38] GetBinding dst:reg5, `args`
-  [  50] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
-  [  60] Return value:reg6
+  [  20] DynamicInitializeLexicalBinding `args`, src:arg0
+  [  30] DynamicGetBinding dst:reg5, `args`
+  [  40] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
+  [  50] Return value:reg6
 
 
 Base$a461b108

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -25,17 +25,17 @@ block0:
   [ 148] End value:reg7
 
 
-Foo$0137b61e super-optional-call-this.js:4:1
+Foo$f8ebe2ee super-optional-call-this.js:4:1
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] CreateVariable `args`, is_immutable:false, is_global:false, is_strict:false
   [  10] CreateRestParams dst:arg0, rest_index:0
-  [  20] DynamicInitializeLexicalBinding `args`, src:arg0
-  [  30] DynamicGetBinding dst:reg5, `args`
-  [  40] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
-  [  50] Return value:reg6
+  [  20] InitializeLexicalBinding `args`, src:arg0
+  [  38] GetBinding dst:reg5, `args`
+  [  50] SuperCallWithArgumentArray dst:reg6, arguments:reg5, is_synthetic:true
+  [  60] Return value:reg6
 
 
 Base$a461b108

--- a/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
@@ -1,4 +1,4 @@
-$bf243d42 switch-completion-value.js:1:1
+$48d208fa switch-completion-value.js:1:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -9,21 +9,21 @@ $bf243d42 switch-completion-value.js:1:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `eval`
-  [  50] CallDirectEval dst:reg8, callee:reg9, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'hello'; let x = 1; }")]
-  [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg6, `console`
-  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d8] GetGlobal dst:reg10, `eval`
-  [  f0] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'first'; 'second'; }")]
-  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 140] GetGlobal dst:reg8, `console`
-  [ 158] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 178] GetGlobal dst:reg10, `eval`
-  [ 190] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'matched'; break; default: 'default'; }")]
-  [ 1b8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 1e0] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `eval`
+  [  38] CallDirectEval dst:reg8, callee:reg9, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'hello'; let x = 1; }")]
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `eval`
+  [  c0] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'first'; 'second'; }")]
+  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 110] GetGlobal dst:reg8, `console`
+  [ 120] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 138] GetGlobal dst:reg10, `eval`
+  [ 148] CallDirectEval dst:reg9, callee:reg10, this_value:Undefined, eval, arguments:[String("switch(1) { case 1: 'matched'; break; default: 'default'; }")]
+  [ 170] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 198] End value:reg5
 
 
 eval$6559f0fb line 1, column 1

--- a/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-local-only-let.txt
@@ -1,4 +1,4 @@
-$c7ca75d8 switch-local-only-let.js:15:1
+$3e1caa20 switch-local-only-let.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -9,21 +9,21 @@ $c7ca75d8 switch-local-only-let.js:15:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `switchLocalOnly`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, switchLocalOnly, arguments:[Int32(1)]
-  [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg6, `console`
-  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d8] GetGlobal dst:reg10, `switchLocalOnly`
-  [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(2)]
-  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 140] GetGlobal dst:reg8, `console`
-  [ 158] GetById dst:reg6, base:reg8, `log` (console.log)
-  [ 178] GetGlobal dst:reg10, `switchLocalOnly`
-  [ 190] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(3)]
-  [ 1b8] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
-  [ 1e0] End value:reg5
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `switchLocalOnly`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, switchLocalOnly, arguments:[Int32(1)]
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `switchLocalOnly`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(2)]
+  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 110] GetGlobal dst:reg8, `console`
+  [ 120] GetById dst:reg6, base:reg8, `log` (console.log)
+  [ 138] GetGlobal dst:reg10, `switchLocalOnly`
+  [ 148] Call dst:reg9, callee:reg10, this_value:Undefined, switchLocalOnly, arguments:[Int32(3)]
+  [ 170] Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+  [ 198] End value:reg5
 
 
 switchLocalOnly$fc47fb27 switch-local-only-let.js:4:5

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -1,4 +1,4 @@
-$ac230b38 switch-scoping.js:15:1
+$9e4f55e8 switch-scoping.js:15:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -8,16 +8,16 @@ $ac230b38 switch-scoping.js:15:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `switchWithBlockDecl`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(1)]
-  [  78] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  a0] GetGlobal dst:reg6, `console`
-  [  b8] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d8] GetGlobal dst:reg10, `switchWithBlockDecl`
-  [  f0] Call dst:reg9, callee:reg10, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(2)]
-  [ 118] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 140] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `switchWithBlockDecl`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(1)]
+  [  60] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  88] GetGlobal dst:reg6, `console`
+  [  98] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  b0] GetGlobal dst:reg10, `switchWithBlockDecl`
+  [  c0] Call dst:reg9, callee:reg10, this_value:Undefined, switchWithBlockDecl, arguments:[Int32(2)]
+  [  e8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 110] End value:reg7
 
 
 switchWithBlockDecl$ba88cf0a switch-scoping.js:2:5

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -20,7 +20,7 @@ block0:
   [ 110] End value:reg7
 
 
-switchWithBlockDecl$cde4667a switch-scoping.js:2:5
+switchWithBlockDecl$ba88cf0a switch-scoping.js:2:5
   Registers: 7
   Blocks:    6
   Locals:    result~0
@@ -46,20 +46,20 @@ block2:
   [  80] Jump target:block5
 
 block3:
-  [  88] DynamicInitializeLexicalBinding `a`, src:String("one")
-  [  98] NewFunction dst:reg6, shared_function_data_index:0 (result)
-  [  b0] Mov dst:result~0, src:reg6
-  [  c0] Jump target:block5
+  [  88] InitializeLexicalBinding `a`, src:String("one")
+  [  a0] NewFunction dst:reg6, shared_function_data_index:0 (result)
+  [  b8] Mov dst:result~0, src:reg6
+  [  c8] Jump target:block5
 
 block4:
-  [  c8] DynamicInitializeLexicalBinding `b`, src:String("two")
-  [  d8] NewFunction dst:reg6, shared_function_data_index:1 (result)
-  [  f0] Mov dst:result~0, src:reg6
+  [  d0] InitializeLexicalBinding `b`, src:String("two")
+  [  e8] NewFunction dst:reg6, shared_function_data_index:1 (result)
+  [ 100] Mov dst:result~0, src:reg6
 
 block5:
-  [ 100] SetLexicalEnvironment environment:reg4
-  [ 108] Call dst:reg5, callee:result~0, this_value:Undefined, result
-  [ 128] Return value:reg5
+  [ 110] SetLexicalEnvironment environment:reg4
+  [ 118] Call dst:reg5, callee:result~0, this_value:Undefined, result
+  [ 138] Return value:reg5
 
 
 result$bf9aaf34 switch-scoping.js:6:22

--- a/Tests/LibJS/Bytecode/expected/switch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-scoping.txt
@@ -20,7 +20,7 @@ block0:
   [ 110] End value:reg7
 
 
-switchWithBlockDecl$ba88cf0a switch-scoping.js:2:5
+switchWithBlockDecl$cde4667a switch-scoping.js:2:5
   Registers: 7
   Blocks:    6
   Locals:    result~0
@@ -46,38 +46,38 @@ block2:
   [  80] Jump target:block5
 
 block3:
-  [  88] InitializeLexicalBinding `a`, src:String("one")
-  [  a0] NewFunction dst:reg6, shared_function_data_index:0 (result)
-  [  b8] Mov dst:result~0, src:reg6
-  [  c8] Jump target:block5
+  [  88] DynamicInitializeLexicalBinding `a`, src:String("one")
+  [  98] NewFunction dst:reg6, shared_function_data_index:0 (result)
+  [  b0] Mov dst:result~0, src:reg6
+  [  c0] Jump target:block5
 
 block4:
-  [  d0] InitializeLexicalBinding `b`, src:String("two")
-  [  e8] NewFunction dst:reg6, shared_function_data_index:1 (result)
-  [ 100] Mov dst:result~0, src:reg6
+  [  c8] DynamicInitializeLexicalBinding `b`, src:String("two")
+  [  d8] NewFunction dst:reg6, shared_function_data_index:1 (result)
+  [  f0] Mov dst:result~0, src:reg6
 
 block5:
-  [ 110] SetLexicalEnvironment environment:reg4
-  [ 118] Call dst:reg5, callee:result~0, this_value:Undefined, result
-  [ 138] Return value:reg5
+  [ 100] SetLexicalEnvironment environment:reg4
+  [ 108] Call dst:reg5, callee:result~0, this_value:Undefined, result
+  [ 128] Return value:reg5
 
 
-result$38b0d48c switch-scoping.js:6:22
+result$bf9aaf34 switch-scoping.js:6:22
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `a`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `a`
+  [  10] Return value:reg5
 
 
-result$ff741ac0 switch-scoping.js:10:22
+result$8921e678 switch-scoping.js:10:22
   Registers: 6
   Blocks:    1
 
 block0:
-  [   0] GetBinding dst:reg5, `b`
-  [  18] Return value:reg5
+  [   0] DynamicGetBinding dst:reg5, `b`
+  [  10] Return value:reg5
 
 
 "one"

--- a/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
@@ -1,4 +1,4 @@
-$469b0790 switch-with-block-scope-return.js:12:1
+$c7fd0018 switch-with-block-scope-return.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -7,8 +7,8 @@ $469b0790 switch-with-block-scope-return.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
-  [  40] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f, arguments:[Int32(1)]
+  [  38] End value:reg5
 
 
 f$83fadf14 switch-with-block-scope-return.js:2:5

--- a/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
@@ -11,7 +11,7 @@ block0:
   [  38] End value:reg5
 
 
-f$055cd79c switch-with-block-scope-return.js:2:5
+f$83fadf14 switch-with-block-scope-return.js:2:5
   Registers: 8
   Blocks:    7
   Constants:
@@ -39,16 +39,16 @@ block3:
   [  70] Return value:String("one")
 
 block4:
-  [  78] DynamicInitializeLexicalBinding `y`, src:String("two")
-  [  88] NewFunction dst:reg7, shared_function_data_index:0
-  [  a0] Call dst:reg6, callee:reg7, this_value:Undefined
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] Return value:reg6
+  [  78] InitializeLexicalBinding `y`, src:String("two")
+  [  90] NewFunction dst:reg7, shared_function_data_index:0
+  [  a8] Call dst:reg6, callee:reg7, this_value:Undefined
+  [  c8] SetLexicalEnvironment environment:reg4
+  [  d0] Return value:reg6
 
 block5:
-  [  d0] SetLexicalEnvironment environment:reg4
-  [  d8] Return value:String("other")
+  [  d8] SetLexicalEnvironment environment:reg4
+  [  e0] Return value:String("other")
 
 block6:
-  [  e0] SetLexicalEnvironment environment:reg4
-  [  e8] End value:Undefined
+  [  e8] SetLexicalEnvironment environment:reg4
+  [  f0] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-with-block-scope-return.txt
@@ -11,7 +11,7 @@ block0:
   [  38] End value:reg5
 
 
-f$83fadf14 switch-with-block-scope-return.js:2:5
+f$055cd79c switch-with-block-scope-return.js:2:5
   Registers: 8
   Blocks:    7
   Constants:
@@ -39,16 +39,16 @@ block3:
   [  70] Return value:String("one")
 
 block4:
-  [  78] InitializeLexicalBinding `y`, src:String("two")
-  [  90] NewFunction dst:reg7, shared_function_data_index:0
-  [  a8] Call dst:reg6, callee:reg7, this_value:Undefined
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] Return value:reg6
+  [  78] DynamicInitializeLexicalBinding `y`, src:String("two")
+  [  88] NewFunction dst:reg7, shared_function_data_index:0
+  [  a0] Call dst:reg6, callee:reg7, this_value:Undefined
+  [  c0] SetLexicalEnvironment environment:reg4
+  [  c8] Return value:reg6
 
 block5:
-  [  d8] SetLexicalEnvironment environment:reg4
-  [  e0] Return value:String("other")
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] Return value:String("other")
 
 block6:
-  [  e8] SetLexicalEnvironment environment:reg4
-  [  f0] End value:Undefined
+  [  e0] SetLexicalEnvironment environment:reg4
+  [  e8] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/tagged-template-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-base-identifier.txt
@@ -1,4 +1,4 @@
-$79e506f5 tagged-template-base-identifier.js:1:1
+$f5bf1d5d tagged-template-base-identifier.js:1:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -10,11 +10,11 @@ block0:
   [  28] InitObjectLiteralProperty object:reg5, `f`, src:reg6, shape_cache_index:0, property_slot:0
   [  40] CacheObjectShape object:reg5
   [  50] SetGlobal `obj`, src:reg5
-  [  68] GetGlobal dst:reg5, `obj`
-  [  80] GetById dst:reg6, base:reg5, `f` (obj.f)
-  [  a0] GetTemplateObject dst:reg7, strings:[String(""), String("")]
-  [  c0] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
-  [  e8] End value:reg8
+  [  60] GetGlobal dst:reg5, `obj`
+  [  70] GetById dst:reg6, base:reg5, `f` (obj.f)
+  [  88] GetTemplateObject dst:reg7, strings:[String(""), String("")]
+  [  a8] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
+  [  d0] End value:reg8
 
 
 f$eef94cf9 tagged-template-base-identifier.js:3:9

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -1,4 +1,4 @@
-$54bb0ec1 tagged-template-if-register-order.js:2:1
+$73266a71 tagged-template-if-register-order.js:2:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -9,22 +9,22 @@ $54bb0ec1 tagged-template-if-register-order.js:2:1
 
 block0:
   [   0] GetGlobal dst:reg5, `String`
-  [  18] GetById dst:reg6, base:reg5, `raw` (String.raw)
-  [  38] GetTemplateObject dst:reg7, strings:[String("hello"), String("hello")]
-  [  58] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
-  [  80] InitializeLexicalBinding `x`, src:reg8
-  [  98] InitializeLexicalBinding `y`, src:Null
-  [  b0] GetGlobal dst:reg8, `x`
-  [  c8] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
-  [  d8] Mov dst:reg8, src:Undefined
-  [  e8] JumpFalse condition:reg6, target:block2
+  [  10] GetById dst:reg6, base:reg5, `raw` (String.raw)
+  [  28] GetTemplateObject dst:reg7, strings:[String("hello"), String("hello")]
+  [  48] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
+  [  70] InitializeLexicalBinding `x`, src:reg8
+  [  88] InitializeLexicalBinding `y`, src:Null
+  [  a0] GetGlobal dst:reg8, `x`
+  [  b0] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
+  [  c0] Mov dst:reg8, src:Undefined
+  [  d0] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  f8] GetGlobal dst:reg5, `x`
-  [ 110] GetById dst:reg9, base:reg5, `toUpperCase` (x.toUpperCase)
-  [ 130] Call dst:reg7, callee:reg9, this_value:reg5, x.toUpperCase
-  [ 150] SetGlobal `y`, src:reg7
-  [ 168] Mov dst:reg8, src:reg7
+  [  e0] GetGlobal dst:reg5, `x`
+  [  f0] GetById dst:reg9, base:reg5, `toUpperCase` (x.toUpperCase)
+  [ 108] Call dst:reg7, callee:reg9, this_value:reg5, x.toUpperCase
+  [ 128] SetGlobal `y`, src:reg7
+  [ 138] Mov dst:reg8, src:reg7
 
 block2:
-  [ 178] End value:reg8
+  [ 148] End value:reg8

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -1,4 +1,4 @@
-$73266a71 tagged-template-if-register-order.js:2:1
+$75ea5b81 tagged-template-if-register-order.js:2:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -12,19 +12,19 @@ block0:
   [  10] GetById dst:reg6, base:reg5, `raw` (String.raw)
   [  28] GetTemplateObject dst:reg7, strings:[String("hello"), String("hello")]
   [  48] Call dst:reg8, callee:reg6, this_value:reg5, arguments:[reg7]
-  [  70] InitializeLexicalBinding `x`, src:reg8
-  [  88] InitializeLexicalBinding `y`, src:Null
-  [  a0] GetGlobal dst:reg8, `x`
-  [  b0] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
-  [  c0] Mov dst:reg8, src:Undefined
-  [  d0] JumpFalse condition:reg6, target:block2
+  [  70] DynamicInitializeLexicalBinding `x`, src:reg8
+  [  80] DynamicInitializeLexicalBinding `y`, src:Null
+  [  90] GetGlobal dst:reg8, `x`
+  [  a0] StrictlyEquals dst:reg6, lhs:reg8, rhs:String("hello")
+  [  b0] Mov dst:reg8, src:Undefined
+  [  c0] JumpFalse condition:reg6, target:block2
 
 block1:
-  [  e0] GetGlobal dst:reg5, `x`
-  [  f0] GetById dst:reg9, base:reg5, `toUpperCase` (x.toUpperCase)
-  [ 108] Call dst:reg7, callee:reg9, this_value:reg5, x.toUpperCase
-  [ 128] SetGlobal `y`, src:reg7
-  [ 138] Mov dst:reg8, src:reg7
+  [  d0] GetGlobal dst:reg5, `x`
+  [  e0] GetById dst:reg9, base:reg5, `toUpperCase` (x.toUpperCase)
+  [  f8] Call dst:reg7, callee:reg9, this_value:reg5, x.toUpperCase
+  [ 118] SetGlobal `y`, src:reg7
+  [ 128] Mov dst:reg8, src:reg7
 
 block2:
-  [ 148] End value:reg8
+  [ 138] End value:reg8

--- a/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
@@ -1,4 +1,4 @@
-$80aea387 this-base-identifier.js:16:1
+$fc88b9ef this-base-identifier.js:16:1
   Registers: 10
   Blocks:    3
   Constants:
@@ -7,38 +7,38 @@ $80aea387 this-base-identifier.js:16:1
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] GetGlobal dst:reg6, `get_from_this`
-  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, get_from_this
-  [  40] GetGlobal dst:reg7, `set_on_this`
-  [  58] Call dst:reg6, callee:reg7, this_value:Undefined, set_on_this
-  [  78] Jump target:block2
+  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, get_from_this
+  [  38] GetGlobal dst:reg7, `set_on_this`
+  [  48] Call dst:reg6, callee:reg7, this_value:Undefined, set_on_this
+  [  68] Jump target:block2
 
 block1:
-  [  80] Catch dst:reg5
-  [  88] SetLexicalEnvironment environment:reg4
-  [  90] Mov2 dst1:reg7, src1:Undefined, dst2:reg8, src2:reg7
-  [  a8] End value:reg7
+  [  70] Catch dst:reg5
+  [  78] SetLexicalEnvironment environment:reg4
+  [  80] Mov2 dst1:reg7, src1:Undefined, dst2:reg8, src2:reg7
+  [  98] End value:reg7
 
 block2:
-  [  b0] Mov dst:reg5, src:Undefined
-  [  c0] GetGlobal dst:reg9, `chained_this_access`
-  [  d8] Call dst:reg7, callee:reg9, this_value:Undefined, chained_this_access
-  [  f8] Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
-  [ 110] End value:reg7
+  [  a0] Mov dst:reg5, src:Undefined
+  [  b0] GetGlobal dst:reg9, `chained_this_access`
+  [  c0] Call dst:reg7, callee:reg9, this_value:Undefined, chained_this_access
+  [  e0] Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
+  [  f8] End value:reg7
 
 Exception handlers:
-  [  b0 ..  118] => handler block1
+  [  a0 ..  100] => handler block1
 
 
-get_from_this$7b4d6173 this-base-identifier.js:5:5
+get_from_this$fcaf59fb this-base-identifier.js:5:5
   Registers: 6
   Blocks:    1
 
 block0:
   [   0] GetById dst:reg5, base:this, `foo` (this.foo)
-  [  20] Return value:reg5
+  [  18] Return value:reg5
 
 
-set_on_this$1818839f this-base-identifier.js:9:14
+set_on_this$997a7c27 this-base-identifier.js:9:14
   Registers: 5
   Blocks:    1
   Constants:
@@ -47,14 +47,14 @@ set_on_this$1818839f this-base-identifier.js:9:14
 
 block0:
   [   0] PutById base:this, `bar`, src:Int32(1), kind:Normal (this.bar)
-  [  28] End value:Undefined
+  [  20] End value:Undefined
 
 
-chained_this_access$4d4a3dab this-base-identifier.js:13:5
+chained_this_access$39eea63b this-base-identifier.js:13:5
   Registers: 7
   Blocks:    1
 
 block0:
   [   0] GetById dst:reg5, base:this, `a` (this.a)
-  [  20] GetById dst:reg6, base:reg5, `b` (this.a.b)
-  [  40] Return value:reg6
+  [  18] GetById dst:reg6, base:reg5, `b` (this.a.b)
+  [  30] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
@@ -1,4 +1,4 @@
-$3bff7057 try-catch-scoping.js:11:1
+$3ec36167 try-catch-scoping.js:11:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,13 +6,13 @@ $3bff7057 try-catch-scoping.js:11:1
 
 block0:
   [   0] GetGlobal dst:reg6, `tryCatchWithBlocks`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, tryCatchWithBlocks
-  [  38] GetGlobal dst:reg7, `tryCatchFinallyWithBlocks`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, tryCatchFinallyWithBlocks
-  [  70] End value:reg6
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, tryCatchWithBlocks
+  [  30] GetGlobal dst:reg7, `tryCatchFinallyWithBlocks`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, tryCatchFinallyWithBlocks
+  [  60] End value:reg6
 
 
-tryCatchWithBlocks$fc7f9ac0 try-catch-scoping.js:2:5
+tryCatchWithBlocks$04cb6df0 try-catch-scoping.js:2:5
   Registers: 11
   Blocks:    3
   Locals:    y~0, z~1, e~2, x~3
@@ -32,21 +32,21 @@ block1:
   [  28] SetLexicalEnvironment environment:reg4
   [  30] Mov2 dst1:e~2, src1:reg5, dst2:z~1, src2:Int32(3)
   [  48] GetGlobal dst:reg7, `console`
-  [  60] GetById dst:reg8, base:reg7, `log` (console.log)
-  [  80] Add dst:reg9, lhs:x~3, rhs:e~2
-  [  90] Add dst:reg10, lhs:reg9, rhs:z~1
-  [  a0] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg10]
-  [  c8] End value:Undefined
+  [  58] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  70] Add dst:reg9, lhs:x~3, rhs:e~2
+  [  80] Add dst:reg10, lhs:reg9, rhs:z~1
+  [  90] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg10]
+  [  b8] End value:Undefined
 
 block2:
-  [  d0] Mov dst:y~0, src:Int32(2)
-  [  e0] Throw src:y~0
+  [  c0] Mov dst:y~0, src:Int32(2)
+  [  d0] Throw src:y~0
 
 Exception handlers:
-  [  d0 ..   e8] => handler block1
+  [  c0 ..   d8] => handler block1
 
 
-tryCatchFinallyWithBlocks$b3c419da try-catch-scoping.js:14:5
+tryCatchFinallyWithBlocks$ae3c37ba try-catch-scoping.js:14:5
   Registers: 12
   Blocks:    9
   Locals:    y~0, e~1, z~2, x~3
@@ -70,41 +70,41 @@ block1:
 block2:
   [  40] Mov dst:z~2, src:Int32(3)
   [  50] GetGlobal dst:reg8, `console`
-  [  68] GetById dst:reg10, base:reg8, `log` (console.log)
-  [  88] Mov dst:reg9, src:z~2
-  [  98] Call dst:reg7, callee:reg10, this_value:reg8, console.log, arguments:[reg9]
-  [  c0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block5, false_target:block6
+  [  60] GetById dst:reg10, base:reg8, `log` (console.log)
+  [  78] Mov dst:reg9, src:z~2
+  [  88] Call dst:reg7, callee:reg10, this_value:reg8, console.log, arguments:[reg9]
+  [  b0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block5, false_target:block6
 
 block3:
-  [  d8] Catch dst:reg7
-  [  e0] SetLexicalEnvironment environment:reg4
-  [  e8] Mov dst:e~1, src:reg7
-  [  f8] GetGlobal dst:reg9, `console`
-  [ 110] GetById dst:reg10, base:reg9, `log` (console.log)
-  [ 130] Mov dst:reg11, src:e~1
-  [ 140] Call dst:reg8, callee:reg10, this_value:reg9, console.log, arguments:[reg11]
-  [ 168] Mov dst:reg5, src:Int32(0)
-  [ 178] Jump target:block2
+  [  c8] Catch dst:reg7
+  [  d0] SetLexicalEnvironment environment:reg4
+  [  d8] Mov dst:e~1, src:reg7
+  [  e8] GetGlobal dst:reg9, `console`
+  [  f8] GetById dst:reg10, base:reg9, `log` (console.log)
+  [ 110] Mov dst:reg11, src:e~1
+  [ 120] Call dst:reg8, callee:reg10, this_value:reg9, console.log, arguments:[reg11]
+  [ 148] Mov dst:reg5, src:Int32(0)
+  [ 158] Jump target:block2
 
 block4:
-  [ 180] Mov dst:y~0, src:Int32(2)
-  [ 190] Throw src:y~0
+  [ 160] Mov dst:y~0, src:Int32(2)
+  [ 170] Throw src:y~0
 
 block5:
-  [ 198] End value:Undefined
+  [ 178] End value:Undefined
 
 block6:
-  [ 1a0] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block7, false_target:block8
+  [ 180] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block7, false_target:block8
 
 block7:
-  [ 1b8] Return value:reg6
+  [ 198] Return value:reg6
 
 block8:
-  [ 1c0] Throw src:reg6
+  [ 1a0] Throw src:reg6
 
 Exception handlers:
-  [  d8 ..  180] => handler block1
-  [ 180 ..  198] => handler block3
+  [  c8 ..  160] => handler block1
+  [ 160 ..  178] => handler block3
 
 
 6

--- a/Tests/LibJS/Bytecode/expected/try-catch-terminated.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-terminated.txt
@@ -1,4 +1,4 @@
-$c7fd0018 try-catch-terminated.js:12:1
+$546ebce0 try-catch-terminated.js:12:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $c7fd0018 try-catch-terminated.js:12:1
 
 block0:
   [   0] GetGlobal dst:reg6, `try_return`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, try_return
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, try_return
+  [  30] End value:reg5
 
 
 try_return$6825fe97 try-catch-terminated.js:5:5

--- a/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
@@ -1,4 +1,4 @@
-$fcbe57a6 try-finally-continue.js:13:1
+$f9fa6696 try-finally-continue.js:13:1
   Registers: 11
   Blocks:    1
   Constants:
@@ -6,16 +6,16 @@ $fcbe57a6 try-finally-continue.js:13:1
 
 block0:
   [   0] GetGlobal dst:reg6, `console`
-  [  18] GetById dst:reg7, base:reg6, `log` (console.log)
-  [  38] GetGlobal dst:reg9, `continueThroughFinally`
-  [  50] Call dst:reg8, callee:reg9, this_value:Undefined, continueThroughFinally
-  [  70] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-  [  98] GetGlobal dst:reg6, `console`
-  [  b0] GetById dst:reg8, base:reg6, `log` (console.log)
-  [  d0] GetGlobal dst:reg10, `breakThroughFinally`
-  [  e8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughFinally
-  [ 108] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-  [ 130] End value:reg7
+  [  10] GetById dst:reg7, base:reg6, `log` (console.log)
+  [  28] GetGlobal dst:reg9, `continueThroughFinally`
+  [  38] Call dst:reg8, callee:reg9, this_value:Undefined, continueThroughFinally
+  [  58] Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+  [  80] GetGlobal dst:reg6, `console`
+  [  90] GetById dst:reg8, base:reg6, `log` (console.log)
+  [  a8] GetGlobal dst:reg10, `breakThroughFinally`
+  [  b8] Call dst:reg9, callee:reg10, this_value:Undefined, breakThroughFinally
+  [  d8] Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+  [ 100] End value:reg7
 
 
 continueThroughFinally$49ed363e try-finally-continue.js:2:5

--- a/Tests/LibJS/Bytecode/expected/try-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally.txt
@@ -1,4 +1,4 @@
-$3a21feac try-finally.js:8:1
+$b3382404 try-finally.js:8:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,15 +6,15 @@ $3a21feac try-finally.js:8:1
 
 block0:
   [   0] GetGlobal dst:reg6, `basicTryFinally`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, basicTryFinally
-  [  38] GetGlobal dst:reg7, `breakThroughFinally`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, breakThroughFinally
-  [  70] GetGlobal dst:reg7, `nestedTryFinallyWithBreak`
-  [  88] Call dst:reg5, callee:reg7, this_value:Undefined, nestedTryFinallyWithBreak
-  [  a8] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, basicTryFinally
+  [  30] GetGlobal dst:reg7, `breakThroughFinally`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, breakThroughFinally
+  [  60] GetGlobal dst:reg7, `nestedTryFinallyWithBreak`
+  [  70] Call dst:reg5, callee:reg7, this_value:Undefined, nestedTryFinallyWithBreak
+  [  90] End value:reg5
 
 
-basicTryFinally$280b5166 try-finally.js:2:5
+basicTryFinally$2acf4276 try-finally.js:2:5
   Registers: 10
   Blocks:    8
   Constants:
@@ -35,31 +35,31 @@ block1:
 
 block2:
   [  30] GetGlobal dst:reg8, `console`
-  [  48] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  68] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("finally")]
-  [  90] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block4, false_target:block5
+  [  40] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  58] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("finally")]
+  [  80] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block4, false_target:block5
 
 block3:
-  [  a8] Mov2 dst1:reg6, src1:Int32(1), dst2:reg5, src2:Int32(2)
-  [  c0] Jump target:block2
+  [  98] Mov2 dst1:reg6, src1:Int32(1), dst2:reg5, src2:Int32(2)
+  [  b0] Jump target:block2
 
 block4:
-  [  c8] End value:Undefined
+  [  b8] End value:Undefined
 
 block5:
-  [  d0] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block6, false_target:block7
+  [  c0] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block6, false_target:block7
 
 block6:
-  [  e8] Return value:reg6
+  [  d8] Return value:reg6
 
 block7:
-  [  f0] Throw src:reg6
+  [  e0] Throw src:reg6
 
 Exception handlers:
-  [  a8 ..   c8] => handler block1
+  [  98 ..   b8] => handler block1
 
 
-breakThroughFinally$8a0e33e1 try-finally.js:11:5
+breakThroughFinally$874a42d1 try-finally.js:11:5
   Registers: 11
   Blocks:    15
   Locals:    i~0
@@ -96,42 +96,42 @@ block5:
 
 block6:
   [  78] GetGlobal dst:reg8, `console`
-  [  90] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  b0] Mov dst:reg10, src:i~0
-  [  c0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[reg10]
-  [  e8] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block10, false_target:block11
+  [  88] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  a0] Mov dst:reg10, src:i~0
+  [  b0] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[reg10]
+  [  d8] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block10, false_target:block11
 
 block7:
-  [ 100] JumpStrictlyEquals lhs:i~0, rhs:Int32(5), true_target:block8, false_target:block9
+  [  f0] JumpStrictlyEquals lhs:i~0, rhs:Int32(5), true_target:block8, false_target:block9
 
 block8:
-  [ 118] Mov dst:reg5, src:Int32(3)
-  [ 128] Jump target:block6
+  [ 108] Mov dst:reg5, src:Int32(3)
+  [ 118] Jump target:block6
 
 block9:
-  [ 130] Mov dst:reg5, src:Int32(0)
-  [ 140] Jump target:block6
+  [ 120] Mov dst:reg5, src:Int32(0)
+  [ 130] Jump target:block6
 
 block10:
-  [ 148] Jump target:block2
+  [ 138] Jump target:block2
 
 block11:
-  [ 150] JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:block4, false_target:block12
+  [ 140] JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:block4, false_target:block12
 
 block12:
-  [ 168] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block13, false_target:block14
+  [ 158] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block13, false_target:block14
 
 block13:
-  [ 180] Return value:reg6
+  [ 170] Return value:reg6
 
 block14:
-  [ 188] Throw src:reg6
+  [ 178] Throw src:reg6
 
 Exception handlers:
-  [ 100 ..  148] => handler block5
+  [  f0 ..  138] => handler block5
 
 
-nestedTryFinallyWithBreak$a67b40bb try-finally.js:22:12
+nestedTryFinallyWithBreak$ac0322db try-finally.js:22:12
   Registers: 12
   Blocks:    21
   Locals:    i~0
@@ -165,68 +165,68 @@ block4:
 
 block5:
   [  60] GetGlobal dst:reg8, `console`
-  [  78] GetById dst:reg9, base:reg8, `log` (console.log)
-  [  98] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer")]
-  [  c0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block16, false_target:block17
+  [  70] GetById dst:reg9, base:reg8, `log` (console.log)
+  [  88] Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer")]
+  [  b0] JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:block16, false_target:block17
 
 block6:
-  [  d8] Jump target:block9
+  [  c8] Jump target:block9
 
 block7:
-  [  e0] Catch dst:reg8
-  [  e8] SetLexicalEnvironment environment:reg4
-  [  f0] Mov dst:reg7, src:Int32(1)
+  [  d0] Catch dst:reg8
+  [  d8] SetLexicalEnvironment environment:reg4
+  [  e0] Mov dst:reg7, src:Int32(1)
 
 block8:
-  [ 100] GetGlobal dst:reg10, `console`
-  [ 118] GetById dst:reg11, base:reg10, `log` (console.log)
-  [ 138] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner")]
-  [ 160] JumpStrictlyEquals lhs:reg7, rhs:Int32(0), true_target:block11, false_target:block12
+  [  f0] GetGlobal dst:reg10, `console`
+  [ 100] GetById dst:reg11, base:reg10, `log` (console.log)
+  [ 118] Call dst:reg9, callee:reg11, this_value:reg10, console.log, arguments:[String("inner")]
+  [ 140] JumpStrictlyEquals lhs:reg7, rhs:Int32(0), true_target:block11, false_target:block12
 
 block9:
-  [ 178] Mov dst:reg7, src:Int32(3)
-  [ 188] Jump target:block8
+  [ 158] Mov dst:reg7, src:Int32(3)
+  [ 168] Jump target:block8
 
 block10:
-  [ 190] Mov dst:reg5, src:Int32(3)
-  [ 1a0] Jump target:block5
+  [ 170] Mov dst:reg5, src:Int32(3)
+  [ 180] Jump target:block5
 
 block11:
-  [ 1a8] Mov dst:reg5, src:Int32(0)
-  [ 1b8] Jump target:block5
+  [ 188] Mov dst:reg5, src:Int32(0)
+  [ 198] Jump target:block5
 
 block12:
-  [ 1c0] JumpStrictlyEquals lhs:reg7, rhs:Int32(3), true_target:block10, false_target:block13
+  [ 1a0] JumpStrictlyEquals lhs:reg7, rhs:Int32(3), true_target:block10, false_target:block13
 
 block13:
-  [ 1d8] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block14, false_target:block15
+  [ 1b8] JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:block14, false_target:block15
 
 block14:
-  [ 1f0] Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
-  [ 208] Jump target:block5
+  [ 1d0] Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
+  [ 1e8] Jump target:block5
 
 block15:
-  [ 210] Throw src:reg8
+  [ 1f0] Throw src:reg8
 
 block16:
-  [ 218] Jump target:block2
+  [ 1f8] Jump target:block2
 
 block17:
-  [ 220] JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:block3, false_target:block18
+  [ 200] JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:block3, false_target:block18
 
 block18:
-  [ 238] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block19, false_target:block20
+  [ 218] JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:block19, false_target:block20
 
 block19:
-  [ 250] Return value:reg6
+  [ 230] Return value:reg6
 
 block20:
-  [ 258] Throw src:reg6
+  [ 238] Throw src:reg6
 
 Exception handlers:
-  [  d8 ..  178] => handler block4
-  [ 178 ..  1a8] => handler block7
-  [ 1a8 ..  218] => handler block4
+  [  c8 ..  158] => handler block4
+  [ 158 ..  188] => handler block7
+  [ 188 ..  1f8] => handler block4
 
 
 "finally"

--- a/Tests/LibJS/Bytecode/expected/update-member-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/update-member-expression.txt
@@ -1,4 +1,4 @@
-$28497381 update-member-expression.js:13:1
+$1ffda051 update-member-expression.js:13:1
   Registers: 9
   Blocks:    1
   Constants:
@@ -6,15 +6,15 @@ $28497381 update-member-expression.js:13:1
 
 block0:
   [   0] GetGlobal dst:reg6, `postfix_increment`
-  [  18] NewObject dst:reg7
-  [  28] Call dst:reg5, callee:reg6, this_value:Undefined, postfix_increment, arguments:[reg7]
-  [  50] GetGlobal dst:reg7, `prefix_decrement`
-  [  68] NewObject dst:reg8
-  [  78] Call dst:reg6, callee:reg7, this_value:Undefined, prefix_decrement, arguments:[reg8]
-  [  a0] End value:reg6
+  [  10] NewObject dst:reg7
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, postfix_increment, arguments:[reg7]
+  [  48] GetGlobal dst:reg7, `prefix_decrement`
+  [  58] NewObject dst:reg8
+  [  68] Call dst:reg6, callee:reg7, this_value:Undefined, prefix_decrement, arguments:[reg8]
+  [  90] End value:reg6
 
 
-postfix_increment$43f18c4c update-member-expression.js:6:14
+postfix_increment$4c3d5f7c update-member-expression.js:6:14
   Registers: 7
   Blocks:    1
   Constants:
@@ -22,12 +22,12 @@ postfix_increment$43f18c4c update-member-expression.js:6:14
 
 block0:
   [   0] GetById dst:reg5, base:arg0, `count` (obj.count)
-  [  20] PostfixIncrement dst:reg6, src:reg5
-  [  30] PutById base:arg0, `count`, src:reg5, kind:Normal
-  [  58] End value:Undefined
+  [  18] PostfixIncrement dst:reg6, src:reg5
+  [  28] PutById base:arg0, `count`, src:reg5, kind:Normal
+  [  48] End value:Undefined
 
 
-prefix_decrement$f522dc02 update-member-expression.js:10:5
+prefix_decrement$f7e6cd12 update-member-expression.js:10:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -35,6 +35,6 @@ prefix_decrement$f522dc02 update-member-expression.js:10:5
 
 block0:
   [   0] GetById dst:reg5, base:arg0, `count` (obj.count)
-  [  20] Decrement dst:reg5
-  [  28] PutById base:arg0, `count`, src:reg5, kind:Normal
-  [  50] End value:Undefined
+  [  18] Decrement dst:reg5
+  [  20] PutById base:arg0, `count`, src:reg5, kind:Normal
+  [  40] End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-binding-access.txt
+++ b/Tests/LibJS/Bytecode/expected/var-binding-access.txt
@@ -12,7 +12,7 @@ block0:
   [  60] End value:reg6
 
 
-var_access$d4439383 var-binding-access.js:5:5
+var_access$52e19afb var-binding-access.js:5:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -21,14 +21,14 @@ var_access$d4439383 var-binding-access.js:5:5
 
 block0:
   [   0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  10] DynamicInitializeVariableBinding `x`, src:Undefined
-  [  20] DynamicSetLexicalBinding `x`, src:Int32(1)
-  [  30] NewFunction dst:reg5, shared_function_data_index:0
-  [  48] DynamicGetInitializedBinding dst:reg5, `x`
-  [  58] Return value:reg5
+  [  10] InitializeVariableBinding `x`, src:Undefined
+  [  28] SetLexicalBinding `x`, src:Int32(1)
+  [  40] NewFunction dst:reg5, shared_function_data_index:0
+  [  58] GetInitializedBinding dst:reg5, `x`
+  [  70] Return value:reg5
 
 
-let_access$43c44200 var-binding-access.js:14:5
+let_access$6d3f61f0 var-binding-access.js:14:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -38,7 +38,7 @@ block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  30] DynamicInitializeLexicalBinding `x`, src:Int32(1)
-  [  40] NewFunction dst:reg6, shared_function_data_index:0
-  [  58] DynamicGetBinding dst:reg6, `x`
-  [  68] Return value:reg6
+  [  30] InitializeLexicalBinding `x`, src:Int32(1)
+  [  48] NewFunction dst:reg6, shared_function_data_index:0
+  [  60] GetBinding dst:reg6, `x`
+  [  78] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/var-binding-access.txt
+++ b/Tests/LibJS/Bytecode/expected/var-binding-access.txt
@@ -1,4 +1,4 @@
-$a036f1fa var-binding-access.js:22:1
+$9d7300ea var-binding-access.js:22:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -6,10 +6,10 @@ $a036f1fa var-binding-access.js:22:1
 
 block0:
   [   0] GetGlobal dst:reg6, `var_access`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, var_access
-  [  38] GetGlobal dst:reg7, `let_access`
-  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, let_access
-  [  70] End value:reg6
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, var_access
+  [  30] GetGlobal dst:reg7, `let_access`
+  [  40] Call dst:reg6, callee:reg7, this_value:Undefined, let_access
+  [  60] End value:reg6
 
 
 var_access$52e19afb var-binding-access.js:5:5

--- a/Tests/LibJS/Bytecode/expected/var-binding-access.txt
+++ b/Tests/LibJS/Bytecode/expected/var-binding-access.txt
@@ -12,7 +12,7 @@ block0:
   [  60] End value:reg6
 
 
-var_access$52e19afb var-binding-access.js:5:5
+var_access$d4439383 var-binding-access.js:5:5
   Registers: 6
   Blocks:    1
   Constants:
@@ -21,14 +21,14 @@ var_access$52e19afb var-binding-access.js:5:5
 
 block0:
   [   0] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  10] InitializeVariableBinding `x`, src:Undefined
-  [  28] SetLexicalBinding `x`, src:Int32(1)
-  [  40] NewFunction dst:reg5, shared_function_data_index:0
-  [  58] GetInitializedBinding dst:reg5, `x`
-  [  70] Return value:reg5
+  [  10] DynamicInitializeVariableBinding `x`, src:Undefined
+  [  20] DynamicSetLexicalBinding `x`, src:Int32(1)
+  [  30] NewFunction dst:reg5, shared_function_data_index:0
+  [  48] DynamicGetInitializedBinding dst:reg5, `x`
+  [  58] Return value:reg5
 
 
-let_access$6d3f61f0 var-binding-access.js:14:5
+let_access$43c44200 var-binding-access.js:14:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -38,7 +38,7 @@ block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:1, is_catch_environment:false
   [  20] CreateVariable `x`, is_immutable:false, is_global:false, is_strict:false
-  [  30] InitializeLexicalBinding `x`, src:Int32(1)
-  [  48] NewFunction dst:reg6, shared_function_data_index:0
-  [  60] GetBinding dst:reg6, `x`
-  [  78] Return value:reg6
+  [  30] DynamicInitializeLexicalBinding `x`, src:Int32(1)
+  [  40] NewFunction dst:reg6, shared_function_data_index:0
+  [  58] DynamicGetBinding dst:reg6, `x`
+  [  68] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-f$a23ee45e var-env-capacity-with-param-expressions.js:3:9
+f$2664cdf6 var-env-capacity-with-param-expressions.js:3:9
   Registers: 10
   Blocks:    3
   Constants:
@@ -29,21 +29,21 @@ block1:
   [  50] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  60] InitializeLexicalBinding `x`, src:arg0
-  [  78] CreateVariableEnvironment capacity:3
-  [  80] GetLexicalEnvironment dst:reg6
-  [  88] Mov dst:reg7, src:Undefined
-  [  98] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
-  [  a8] InitializeVariableBinding `a`, src:reg7
-  [  c0] Mov dst:reg7, src:Undefined
-  [  d0] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
-  [  e0] InitializeVariableBinding `b`, src:reg7
-  [  f8] Mov dst:reg7, src:Undefined
-  [ 108] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [ 118] InitializeVariableBinding `c`, src:reg7
-  [ 130] GetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
-  [ 148] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
-  [ 170] End value:Undefined
+  [  60] DynamicInitializeLexicalBinding `x`, src:arg0
+  [  70] CreateVariableEnvironment capacity:3
+  [  78] GetLexicalEnvironment dst:reg6
+  [  80] Mov dst:reg7, src:Undefined
+  [  90] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
+  [  a0] DynamicInitializeVariableBinding `a`, src:reg7
+  [  b0] Mov dst:reg7, src:Undefined
+  [  c0] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
+  [  d0] DynamicInitializeVariableBinding `b`, src:reg7
+  [  e0] Mov dst:reg7, src:Undefined
+  [  f0] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
+  [ 100] DynamicInitializeVariableBinding `c`, src:reg7
+  [ 110] DynamicGetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
+  [ 120] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
+  [ 148] End value:Undefined
 
 
 eval$b72141f3

--- a/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-f$2664cdf6 var-env-capacity-with-param-expressions.js:3:9
+f$20dcebd6 var-env-capacity-with-param-expressions.js:3:9
   Registers: 10
   Blocks:    3
   Constants:
@@ -29,21 +29,21 @@ block1:
   [  50] Mov dst:arg0, src:Int32(1)
 
 block2:
-  [  60] DynamicInitializeLexicalBinding `x`, src:arg0
-  [  70] CreateVariableEnvironment capacity:3
-  [  78] GetLexicalEnvironment dst:reg6
-  [  80] Mov dst:reg7, src:Undefined
-  [  90] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
-  [  a0] DynamicInitializeVariableBinding `a`, src:reg7
-  [  b0] Mov dst:reg7, src:Undefined
-  [  c0] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
-  [  d0] DynamicInitializeVariableBinding `b`, src:reg7
-  [  e0] Mov dst:reg7, src:Undefined
-  [  f0] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
-  [ 100] DynamicInitializeVariableBinding `c`, src:reg7
-  [ 110] DynamicGetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
-  [ 120] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
-  [ 148] End value:Undefined
+  [  60] InitializeLexicalBinding `x`, src:arg0
+  [  78] CreateVariableEnvironment capacity:3
+  [  80] GetLexicalEnvironment dst:reg6
+  [  88] Mov dst:reg7, src:Undefined
+  [  98] CreateVariable `a`, is_immutable:false, is_global:false, is_strict:false
+  [  a8] InitializeVariableBinding `a`, src:reg7
+  [  c0] Mov dst:reg7, src:Undefined
+  [  d0] CreateVariable `b`, is_immutable:false, is_global:false, is_strict:false
+  [  e0] InitializeVariableBinding `b`, src:reg7
+  [  f8] Mov dst:reg7, src:Undefined
+  [ 108] CreateVariable `c`, is_immutable:false, is_global:false, is_strict:false
+  [ 118] InitializeVariableBinding `c`, src:reg7
+  [ 130] DynamicGetCalleeAndThisFromEnvironment callee:reg8, this_value:reg9, `eval`
+  [ 140] CallDirectEval dst:reg7, callee:reg8, this_value:reg9, eval, arguments:[String("")]
+  [ 168] End value:Undefined
 
 
 eval$b72141f3

--- a/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
+++ b/Tests/LibJS/Bytecode/expected/var-env-capacity-with-param-expressions.txt
@@ -1,4 +1,4 @@
-$12cfcca1 var-env-capacity-with-param-expressions.js:5:1
+$a2057a79 var-env-capacity-with-param-expressions.js:5:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $12cfcca1 var-env-capacity-with-param-expressions.js:5:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
 f$a23ee45e var-env-capacity-with-param-expressions.js:3:9

--- a/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
@@ -1,4 +1,4 @@
-$fd650eed var-hoisting-tdz.js:9:1
+$89d6cbb5 var-hoisting-tdz.js:9:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $fd650eed var-hoisting-tdz.js:9:1
 
 block0:
   [   0] GetGlobal dst:reg6, `isect`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, isect
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, isect
+  [  30] End value:reg5
 
 
 isect$63c4d7d5 var-hoisting-tdz.js:5:5

--- a/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
@@ -1,4 +1,4 @@
-$2b997e90 var-init-in-param-body-scope.js:4:1
+$bacf2c68 var-init-in-param-body-scope.js:4:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,8 +6,8 @@ $2b997e90 var-init-in-param-body-scope.js:4:1
 
 block0:
   [   0] GetGlobal dst:reg6, `f`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, f
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, f
+  [  30] End value:reg5
 
 
 f$6f9adbc3

--- a/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
@@ -1,4 +1,4 @@
-$d85408b3 var-shadow-in-default-param.js:7:1
+$542e1f1b var-shadow-in-default-param.js:7:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,11 +7,11 @@ $d85408b3 var-shadow-in-default-param.js:7:1
 
 block0:
   [   0] SetGlobal `shadow`, src:String("outer")
-  [  18] GetGlobal dst:reg6, `shadow_in_default`
-  [  30] Call dst:reg5, callee:reg6, this_value:Undefined, shadow_in_default
-  [  50] GetGlobal dst:reg7, `no_conflict`
-  [  68] Call dst:reg6, callee:reg7, this_value:Undefined, no_conflict
-  [  88] End value:reg6
+  [  10] GetGlobal dst:reg6, `shadow_in_default`
+  [  20] Call dst:reg5, callee:reg6, this_value:Undefined, shadow_in_default
+  [  40] GetGlobal dst:reg7, `no_conflict`
+  [  50] Call dst:reg6, callee:reg7, this_value:Undefined, no_conflict
+  [  70] End value:reg6
 
 
 shadow_in_default$adf74487 var-shadow-in-default-param.js:8:32

--- a/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
@@ -14,7 +14,7 @@ block0:
   [  70] End value:reg6
 
 
-shadow_in_default$adf74487 var-shadow-in-default-param.js:8:32
+shadow_in_default$34e11f2f var-shadow-in-default-param.js:8:32
   Registers: 7
   Blocks:    3
   Constants:
@@ -25,17 +25,17 @@ block0:
   [   0] JumpUndefined condition:arg0, true_target:block1, false_target:block2
 
 block1:
-  [  10] GetInitializedBinding dst:reg5, `shadow`
-  [  28] Mov dst:arg0, src:reg5
+  [  10] DynamicGetInitializedBinding dst:reg5, `shadow`
+  [  20] Mov dst:arg0, src:reg5
 
 block2:
-  [  38] CreateVariableEnvironment capacity:1
-  [  40] GetLexicalEnvironment dst:reg5
-  [  48] Mov dst:reg6, src:Undefined
-  [  58] CreateVariable `shadow`, is_immutable:false, is_global:false, is_strict:false
-  [  68] InitializeVariableBinding `shadow`, src:reg6
-  [  80] SetLexicalBinding `shadow`, src:String("inner")
-  [  98] Return value:arg0
+  [  30] CreateVariableEnvironment capacity:1
+  [  38] GetLexicalEnvironment dst:reg5
+  [  40] Mov dst:reg6, src:Undefined
+  [  50] CreateVariable `shadow`, is_immutable:false, is_global:false, is_strict:false
+  [  60] DynamicInitializeVariableBinding `shadow`, src:reg6
+  [  70] DynamicSetLexicalBinding `shadow`, src:String("inner")
+  [  80] Return value:arg0
 
 
 no_conflict$f0c5f291 var-shadow-in-default-param.js:17:5

--- a/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
@@ -14,7 +14,7 @@ block0:
   [  70] End value:reg6
 
 
-shadow_in_default$34e11f2f var-shadow-in-default-param.js:8:32
+shadow_in_default$321d2e1f var-shadow-in-default-param.js:8:32
   Registers: 7
   Blocks:    3
   Constants:
@@ -33,9 +33,9 @@ block2:
   [  38] GetLexicalEnvironment dst:reg5
   [  40] Mov dst:reg6, src:Undefined
   [  50] CreateVariable `shadow`, is_immutable:false, is_global:false, is_strict:false
-  [  60] DynamicInitializeVariableBinding `shadow`, src:reg6
-  [  70] DynamicSetLexicalBinding `shadow`, src:String("inner")
-  [  80] Return value:arg0
+  [  60] InitializeVariableBinding `shadow`, src:reg6
+  [  78] SetLexicalBinding `shadow`, src:String("inner")
+  [  90] Return value:arg0
 
 
 no_conflict$f0c5f291 var-shadow-in-default-param.js:17:5

--- a/Tests/LibJS/Bytecode/expected/with-return.txt
+++ b/Tests/LibJS/Bytecode/expected/with-return.txt
@@ -14,7 +14,7 @@ block0:
   [  70] End value:reg5
 
 
-with_return$d690ef5a with-return.js:5:5
+with_return$57f2e7e2 with-return.js:5:5
   Registers: 7
   Blocks:    1
   Constants:
@@ -23,6 +23,6 @@ with_return$d690ef5a with-return.js:5:5
 block0:
   [   0] GetLexicalEnvironment dst:reg4
   [   8] EnterObjectEnvironment dst:reg5, object:arg0
-  [  18] GetBinding dst:reg6, `x`
-  [  30] SetLexicalEnvironment environment:reg4
-  [  38] Return value:reg6
+  [  18] DynamicGetBinding dst:reg6, `x`
+  [  28] SetLexicalEnvironment environment:reg4
+  [  30] Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/with-return.txt
+++ b/Tests/LibJS/Bytecode/expected/with-return.txt
@@ -1,4 +1,4 @@
-$b237dcfe with-return.js:10:1
+$54c92246 with-return.js:10:1
   Registers: 8
   Blocks:    1
   Constants:
@@ -7,11 +7,11 @@ $b237dcfe with-return.js:10:1
 
 block0:
   [   0] GetGlobal dst:reg6, `with_return`
-  [  18] NewObject dst:reg7
-  [  28] InitObjectLiteralProperty object:reg7, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
-  [  40] CacheObjectShape object:reg7
-  [  50] Call dst:reg5, callee:reg6, this_value:Undefined, with_return, arguments:[reg7]
-  [  78] End value:reg5
+  [  10] NewObject dst:reg7
+  [  20] InitObjectLiteralProperty object:reg7, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
+  [  38] CacheObjectShape object:reg7
+  [  48] Call dst:reg5, callee:reg6, this_value:Undefined, with_return, arguments:[reg7]
+  [  70] End value:reg5
 
 
 with_return$d690ef5a with-return.js:5:5

--- a/Tests/LibJS/Bytecode/expected/with-statement.txt
+++ b/Tests/LibJS/Bytecode/expected/with-statement.txt
@@ -1,4 +1,4 @@
-$d0083583 with-statement.js:7:1
+$491e5adb with-statement.js:7:1
   Registers: 7
   Blocks:    1
   Constants:
@@ -6,11 +6,11 @@ $d0083583 with-statement.js:7:1
 
 block0:
   [   0] GetGlobal dst:reg6, `withBlock`
-  [  18] Call dst:reg5, callee:reg6, this_value:Undefined, withBlock
-  [  38] End value:reg5
+  [  10] Call dst:reg5, callee:reg6, this_value:Undefined, withBlock
+  [  30] End value:reg5
 
 
-withBlock$8fb7b75b with-statement.js:2:15
+withBlock$0e55bed3 with-statement.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    obj~0
@@ -26,10 +26,10 @@ block0:
   [  40] EnterObjectEnvironment dst:reg5, object:obj~0
   [  50] GetBinding dst:reg7, `console`
   [  68] GetById dst:reg8, base:reg7, `log` (console.log)
-  [  88] GetBinding dst:reg9, `x`
-  [  a0] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [  c8] SetLexicalEnvironment environment:reg4
-  [  d0] End value:Undefined
+  [  80] GetBinding dst:reg9, `x`
+  [  98] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [  c0] SetLexicalEnvironment environment:reg4
+  [  c8] End value:Undefined
 
 
 42

--- a/Tests/LibJS/Bytecode/expected/with-statement.txt
+++ b/Tests/LibJS/Bytecode/expected/with-statement.txt
@@ -10,7 +10,7 @@ block0:
   [  30] End value:reg5
 
 
-withBlock$0e55bed3 with-statement.js:2:15
+withBlock$1119afe3 with-statement.js:2:15
   Registers: 10
   Blocks:    1
   Locals:    obj~0
@@ -24,12 +24,12 @@ block0:
   [  18] InitObjectLiteralProperty object:obj~0, `x`, src:Int32(42), shape_cache_index:0, property_slot:0
   [  30] CacheObjectShape object:obj~0
   [  40] EnterObjectEnvironment dst:reg5, object:obj~0
-  [  50] GetBinding dst:reg7, `console`
-  [  68] GetById dst:reg8, base:reg7, `log` (console.log)
-  [  80] GetBinding dst:reg9, `x`
-  [  98] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
-  [  c0] SetLexicalEnvironment environment:reg4
-  [  c8] End value:Undefined
+  [  50] DynamicGetBinding dst:reg7, `console`
+  [  60] GetById dst:reg8, base:reg7, `log` (console.log)
+  [  78] DynamicGetBinding dst:reg9, `x`
+  [  88] Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+  [  b0] SetLexicalEnvironment environment:reg4
+  [  b8] End value:Undefined
 
 
 42

--- a/Tests/LibJS/Bytecode/input/annexb-var-coordinate-with-default-param.js
+++ b/Tests/LibJS/Bytecode/input/annexb-var-coordinate-with-default-param.js
@@ -1,0 +1,12 @@
+// An Annex B function var binding must be tracked in the variable environment,
+// not in the parameter-expression environment.
+function f(x = 1) {
+    let y = 2;
+    if (true) {
+        function g() {
+            return x + y;
+        }
+    }
+    return g();
+}
+f();

--- a/Tests/LibJS/Runtime/var-shadow-in-default-param.js
+++ b/Tests/LibJS/Runtime/var-shadow-in-default-param.js
@@ -90,6 +90,20 @@ describe("var shadowing in default parameter expressions", () => {
         expect(f()).toBe(42);
     });
 
+    test("Annex B function binding with parameter and body lexical scopes", () => {
+        function f(x = 1) {
+            let y = 2;
+            if (true) {
+                function g() {
+                    return x + y;
+                }
+            }
+            return g();
+        }
+        expect(f()).toBe(3);
+        expect(f(10)).toBe(12);
+    });
+
     test("nested function scope with shadowed default", () => {
         var v = "outer";
         function outer() {

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCrypto/Hash/SHA2.h>
+#include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/ModuleRequest.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
@@ -75,6 +76,13 @@ public:
         skip(padding);
     }
 
+    void align_bytes_payload_to(size_t alignment)
+    {
+        auto payload_offset = m_offset + sizeof(u32);
+        auto padding = (alignment - (payload_offset % alignment)) % alignment;
+        skip(padding);
+    }
+
     bool read_bool()
     {
         return read_u8() != 0;
@@ -137,6 +145,73 @@ static void write_u32(ByteBuffer& bytes, size_t offset, u32 value)
     bytes[offset + 1] = (value >> 8) & 0xff;
     bytes[offset + 2] = (value >> 16) & 0xff;
     bytes[offset + 3] = (value >> 24) & 0xff;
+}
+
+static void skip_script_declaration_metadata(BytecodeCacheBlobReader& reader)
+{
+    EXPECT_EQ(reader.read_u8(), 0); // Script declaration metadata.
+    reader.skip_utf16_vector();     // Lexical names.
+    reader.skip_utf16_vector();     // Var names.
+    reader.skip_utf16_vector();     // Function names.
+    reader.skip_utf16_vector();     // Var-scoped names.
+    reader.skip_utf16_vector();     // Annex B candidate names.
+
+    auto lexical_binding_count = reader.read_u32();
+    for (u32 i = 0; i < lexical_binding_count; ++i) {
+        reader.skip_utf16();
+        reader.skip(1);
+    }
+}
+
+static size_t executable_bytecode_payload_offset(BytecodeCacheBlobReader& reader)
+{
+    reader.skip(1);               // Executable strict mode.
+    reader.skip(sizeof(u32));     // Number of registers.
+    reader.skip(sizeof(u32));     // Number of arguments.
+    reader.skip(5 * sizeof(u32)); // Cache counters.
+    reader.skip(1);               // This value needs environment resolution.
+    reader.skip_optional_u32();   // Length identifier.
+
+    reader.align_bytes_payload_to(alignof(JS::Bytecode::Instruction));
+    auto bytecode_length = reader.read_u32();
+    VERIFY(bytecode_length > 0);
+    return reader.offset();
+}
+
+static void enter_declaration_function_table(BytecodeCacheBlobReader&, bool require_nonempty);
+
+static size_t top_level_bytecode_payload_offset(ReadonlyBytes blob)
+{
+    BytecodeCacheBlobReader reader { blob };
+
+    reader.skip(8);           // Magic.
+    reader.skip(sizeof(u32)); // Format version.
+    reader.skip(1);           // Program type.
+    reader.skip(32);          // Source hash.
+    reader.skip(1);           // Has top-level await.
+    reader.skip(1);           // Is strict mode.
+
+    skip_script_declaration_metadata(reader);
+
+    enter_declaration_function_table(reader, false);
+
+    reader.skip(1); // Program kind.
+    return executable_bytecode_payload_offset(reader);
+}
+
+static void enter_declaration_function_table(BytecodeCacheBlobReader& reader, bool require_nonempty)
+{
+    auto declaration_function_count = reader.read_u32();
+    if (require_nonempty)
+        VERIFY(declaration_function_count > 0);
+    else
+        VERIFY(declaration_function_count == 0);
+    reader.align_bytes_payload_to(alignof(JS::Bytecode::Instruction));
+    auto declaration_function_payload_length = reader.read_u32();
+    if (require_nonempty)
+        VERIFY(declaration_function_payload_length > 0);
+    else
+        VERIFY(declaration_function_payload_length == 0);
 }
 
 static BytecodeCacheTestData create_bytecode_cache_blob(StringView source)
@@ -208,21 +283,8 @@ static size_t first_declaration_function_bytecode_payload_offset(ReadonlyBytes b
     reader.skip(1);           // Has top-level await.
     reader.skip(1);           // Is strict mode.
 
-    EXPECT_EQ(reader.read_u8(), 0); // Script declaration metadata.
-    reader.skip_utf16_vector();     // Lexical names.
-    reader.skip_utf16_vector();     // Var names.
-    reader.skip_utf16_vector();     // Function names.
-    reader.skip_utf16_vector();     // Var-scoped names.
-    reader.skip_utf16_vector();     // Annex B candidate names.
-
-    auto lexical_binding_count = reader.read_u32();
-    for (u32 i = 0; i < lexical_binding_count; ++i) {
-        reader.skip_utf16();
-        reader.skip(1);
-    }
-
-    auto declaration_function_count = reader.read_u32();
-    VERIFY(declaration_function_count > 0);
+    skip_script_declaration_metadata(reader);
+    enter_declaration_function_table(reader, true);
 
     reader.skip_optional_utf16(); // Function name.
     reader.skip(sizeof(u32));     // Source text start.
@@ -248,20 +310,11 @@ static size_t first_declaration_function_bytecode_payload_offset(ReadonlyBytes b
     reader.skip(sizeof(u64)); // Var environment bindings count.
     reader.skip(2);           // Function metadata bools.
 
-    reader.align_to(alignof(u16));
+    reader.align_bytes_payload_to(alignof(JS::Bytecode::Instruction));
     auto executable_length = reader.read_u32();
     VERIFY(executable_length > 0);
 
-    reader.skip(1);               // Executable strict mode.
-    reader.skip(sizeof(u32));     // Number of registers.
-    reader.skip(sizeof(u32));     // Number of arguments.
-    reader.skip(5 * sizeof(u32)); // Cache counters.
-    reader.skip(1);               // This value needs environment resolution.
-    reader.skip_optional_u32();   // Length identifier.
-
-    auto bytecode_length = reader.read_u32();
-    VERIFY(bytecode_length > 0);
-    return reader.offset();
+    return executable_bytecode_payload_offset(reader);
 }
 
 static size_t first_declaration_function_source_text_start_offset(ReadonlyBytes blob)
@@ -275,21 +328,8 @@ static size_t first_declaration_function_source_text_start_offset(ReadonlyBytes 
     reader.skip(1);           // Has top-level await.
     reader.skip(1);           // Is strict mode.
 
-    EXPECT_EQ(reader.read_u8(), 0); // Script declaration metadata.
-    reader.skip_utf16_vector();     // Lexical names.
-    reader.skip_utf16_vector();     // Var names.
-    reader.skip_utf16_vector();     // Function names.
-    reader.skip_utf16_vector();     // Var-scoped names.
-    reader.skip_utf16_vector();     // Annex B candidate names.
-
-    auto lexical_binding_count = reader.read_u32();
-    for (u32 i = 0; i < lexical_binding_count; ++i) {
-        reader.skip_utf16();
-        reader.skip(1);
-    }
-
-    auto declaration_function_count = reader.read_u32();
-    VERIFY(declaration_function_count > 0);
+    skip_script_declaration_metadata(reader);
+    enter_declaration_function_table(reader, true);
 
     reader.skip_optional_utf16(); // Function name.
     return reader.offset();
@@ -305,13 +345,9 @@ TEST_CASE(bytecode_cache_materialization_failure_has_parser_error)
 
     auto corrupted_blob = MUST(ByteBuffer::copy(test_data.blob.bytes()));
 
-    // For this minimal script, the encoded top-level bytecode payload begins
-    // after the cache header, empty declaration metadata, and executable
-    // metadata. Corrupting the payload keeps the blob structurally decodable
-    // while causing executable validation to reject it during materialization.
-    constexpr size_t bytecode_payload_offset_for_empty_script = 112;
-    VERIFY(corrupted_blob.size() > bytecode_payload_offset_for_empty_script);
-    corrupted_blob[bytecode_payload_offset_for_empty_script] ^= 0xff;
+    auto bytecode_payload_offset = top_level_bytecode_payload_offset(corrupted_blob.bytes());
+    VERIFY(corrupted_blob.size() > bytecode_payload_offset);
+    corrupted_blob[bytecode_payload_offset] ^= 0xff;
 
     // Structural decode still succeeds because the blob is internally well-formed; the corruption is in the bytecode
     // payload, which is only checked by the validator that runs during materialization.


### PR DESCRIPTION
This reduces WebContent heap usage by keeping cached LibJS bytecode instruction streams backed by the disk-cache blob instead of copying them into heap-owned `Vector<u8>` storage during materialization.

On https://x.com/awesomekling, this reduces WebContent memory footprint by 43 MiB. :^) But ofc basically every website benefits!

Things we had to do to make bytecode immutable and file-backed:

- replacing inline cache pointers with compact cache indexes
- splitting dynamic environment lookups from eagerly resolved coordinate instructions
- emitting environment coordinates eagerly during bytecode generation
- making `Bytecode::Executable` retain file-backed `Core::ImmutableBytes` for cached byte code
- preserving a direct bytecode data pointer for the asm interpreter hot path
- aligning bytecode cache payloads so `mmap`-backed instruction streams satisfy the existing bytecode ABI constraints

The bytecode cache format is bumped accordingly, and the mapped-cache path is covered by `test-bytecode-cache`.