### PR TITLE
LibWeb: Cache recorded display lists for SVG images by output size

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -137,9 +137,25 @@ size_t SVGDecodedImageData::external_memory_size() const
 
 RefPtr<Painting::DisplayList> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& resource_storage) const
 {
+    if (auto it = m_cached_display_lists.find(size); it != m_cached_display_lists.end()) {
+        resource_storage.append_referenced_resources_from(it->value.resource_storage, it->value.display_list->command_bytes());
+        return it->value.display_list;
+    }
+
+    // FIXME: Evict least used entries.
+    if (m_cached_display_lists.size() > 10)
+        m_cached_display_lists.remove(m_cached_display_lists.begin());
+
+    Painting::DisplayListResourceStorage local_storage;
     m_document->navigable()->set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout(DOM::UpdateLayoutReason::SVGDecodedImageDataRender);
-    return m_document->record_display_list({}, resource_storage);
+    auto display_list = m_document->record_display_list({}, local_storage);
+    if (!display_list)
+        return nullptr;
+
+    resource_storage.append_referenced_resources_from(local_storage, display_list->command_bytes());
+    m_cached_display_lists.set(size, CachedDisplayList { display_list, move(local_storage) });
+    return display_list;
 }
 
 RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize size) const

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -9,6 +9,8 @@
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 namespace Web::SVG {
 
@@ -52,6 +54,12 @@ private:
     mutable HashMap<Gfx::IntSize, Gfx::DecodedImageFrame> m_cached_rendered_frames;
 
     mutable HashMap<Gfx::IntSize, NonnullRefPtr<Gfx::PaintingSurface>> m_cached_rendered_surfaces;
+
+    struct CachedDisplayList {
+        RefPtr<Painting::DisplayList> display_list;
+        Painting::DisplayListResourceStorage resource_storage;
+    };
+    mutable HashMap<Gfx::IntSize, CachedDisplayList> m_cached_display_lists;
 
     GC::Ref<Page> m_page;
     GC::Ref<SVGPageClient> m_page_client;


### PR DESCRIPTION
Recording a display list for an SVG image triggered a full layout update on the SVG's internal document and re-recorded the commands on every paint. Pages with many small SVG icons therefore could accumulate tens of thousands of redundant layout updates per page load.

We now cache these display lists per output size to avoid this redundant work.

The cache currently uses the same 10 entry cap as the cache for rendered surfaces.

To show the performance improvement, I added some instrumentation to show the time spent in `update_layout()` by layout reason - it shows the following on https://en.wikipedia.org/wiki/2023_in_American_television:

Before:
```
=== update_layout timing summary (pid 841471, 40588 calls, 14.667s total) ===
  HTMLEventLoopRenderingUpdate                           123 calls     13.154s   89.7%  avg  106.943ms
  SVGDecodedImageDataRender                            40462 calls      1.278s    8.7%  avg  31.593µs
  HTMLElementOffsetParent                                  1 calls   234.519ms    1.6%  avg  234.519ms
  ElementScrollHeight                                      1 calls       801ns    0.0%  avg      801ns
  ElementClientHeight                                      1 calls       361ns    0.0%  avg      361ns
```

After:
```
=== update_layout timing summary (pid 838737, 157 calls, 12.97s total) ===
  HTMLEventLoopRenderingUpdate                           135 calls     12.761s   98.4%  avg   94.528ms
  HTMLElementOffsetParent                                  1 calls   201.323ms    1.6%  avg  201.323ms
  SVGDecodedImageDataRender                               19 calls     7.275ms    0.1%  avg 382.901µs
  ElementScrollHeight                                      1 calls       631ns    0.0%  avg      631ns
  ElementClientHeight                                      1 calls       100ns  7.7e-7%  avg      100ns
```