### PR TITLE
LibWeb: Share one compositor thread across page navigables

### DIFF
--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -89,6 +89,11 @@ using CompositorCommand = Variant<UpdateDisplayListCommand, AsyncScrollByCommand
     UpdateScrollStateCommand, UpdateCompositorSurfaceCommand, ClearCompositorSurfaceCommand, ViewportSizeUpdatedCommand,
     ScreenshotCommand>;
 
+struct CompositorCommandEnvelope {
+    CompositorContextId context_id;
+    CompositorCommand command;
+};
+
 static SkRect to_skia_rect(Gfx::IntRect const& rect)
 {
     return SkRect::MakeXYWH(rect.x(), rect.y(), rect.width(), rect.height());
@@ -240,10 +245,9 @@ static void flush_surface(Gfx::PaintingSurface& surface)
 
 class CompositorThread::ThreadData final : public AtomicRefCounted<ThreadData> {
 public:
-    ThreadData(u64 page_id, NonnullRefPtr<Core::WeakEventLoopReference>&& main_thread_event_loop, CompositorThread::PagePresentationRegistration page_presentation_registration)
+    ThreadData(u64 page_id, NonnullRefPtr<Core::WeakEventLoopReference>&& main_thread_event_loop)
         : m_page_id(page_id)
         , m_main_thread_event_loop(move(main_thread_event_loop))
-        , m_presents_to_client(page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes)
     {
     }
 
@@ -251,6 +255,12 @@ public:
 
     u64 page_id() const { return m_page_id; }
     bool presents_to_client() const { return m_presents_to_client; }
+    void set_presents_to_client()
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        m_presents_to_client = true;
+    }
+
     void stop_presenting_to_client()
     {
         Sync::MutexLocker const locker { m_mutex };
@@ -271,13 +281,25 @@ public:
         m_frame_completed.broadcast();
     }
 
-    void enqueue_command(CompositorCommand&& command)
+    void enqueue_command(CompositorContextId context_id, CompositorCommand&& command)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_command_queue.enqueue(move(command));
+        m_command_queue.enqueue({ context_id, move(command) });
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor command queued (queue_size={}, awaiting_bitmap={}, needs_present={}, deferred_async_present={})",
             m_command_queue.size(), m_presented_bitmap_id_awaiting_ack.value_or(-1), m_needs_present, m_has_deferred_async_scroll_present);
         m_command_ready.signal();
+    }
+
+    void enqueue_command(CompositorCommand&& command)
+    {
+        VERIFY(m_default_context_id.has_value());
+        enqueue_command(*m_default_context_id, move(command));
+    }
+
+    void set_default_context_id(CompositorContextId context_id)
+    {
+        if (!m_default_context_id.has_value())
+            m_default_context_id = context_id;
     }
 
     u64 set_needs_present(Gfx::IntRect viewport_rect)
@@ -587,7 +609,7 @@ public:
             Core::ScopedAutoreleasePool autorelease_pool;
 
             while (true) {
-                auto command = [this]() -> Optional<CompositorCommand> {
+                auto command = [this]() -> Optional<CompositorCommandEnvelope> {
                     Sync::MutexLocker const locker { m_mutex };
                     if (m_command_queue.is_empty())
                         return {};
@@ -599,7 +621,7 @@ public:
                     break;
 
                 bool should_yield_to_async_scroll_present = false;
-                command->visit(
+                command->command.visit(
                     [this](UpdateDisplayListCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing display list update (deferred_async_present={})",
                             m_has_deferred_async_scroll_present);
@@ -1120,7 +1142,8 @@ private:
     mutable Sync::ConditionVariable m_command_ready { m_mutex };
     Atomic<bool> m_exit { false };
 
-    Queue<CompositorCommand> m_command_queue;
+    Queue<CompositorCommandEnvelope> m_command_queue;
+    Optional<CompositorContextId> m_default_context_id;
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
@@ -1213,24 +1236,16 @@ static FramePresentationState& frame_presentation_state()
     return *state;
 }
 
-CompositorThread::CompositorThread(u64 page_id, PagePresentationRegistration page_presentation_registration)
-    : m_thread_data(adopt_ref(*new ThreadData(page_id, Core::EventLoop::current_weak(), page_presentation_registration)))
+CompositorThread::Context::Context(NonnullRefPtr<ThreadData> thread_data, CompositorContextId context_id)
+    : m_thread_data(move(thread_data))
+    , m_context_id(context_id)
 {
     m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this] {
         enqueue_viewport_size_updated(m_last_viewport_size, m_last_viewport_size_is_top_level_traversable, WindowResizingInProgress::No);
     });
-
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        VERIFY(!context_compositors().contains(m_context_id));
-        context_compositors().set(m_context_id, m_thread_data);
-    }
-
-    if (page_presentation_registration == PagePresentationRegistration::Yes)
-        register_page_compositor(page_id, m_thread_data);
 }
 
-CompositorThread::~CompositorThread()
+CompositorThread::Context::~Context()
 {
     m_backing_store_shrink_timer->on_timeout = {};
     m_backing_store_shrink_timer->stop();
@@ -1241,8 +1256,37 @@ CompositorThread::~CompositorThread()
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
         VERIFY(context_compositors().remove(m_context_id));
     }
+}
 
+CompositorThread::CompositorThread(u64 page_id, PagePresentationRegistration page_presentation_registration)
+    : m_thread_data(adopt_ref(*new ThreadData(page_id, Core::EventLoop::current_weak())))
+    , m_context(create_context(page_presentation_registration))
+{
+}
+
+CompositorThread::~CompositorThread()
+{
+    m_context.clear();
     m_thread_data->exit();
+}
+
+OwnPtr<CompositorThread::Context> CompositorThread::create_context(PagePresentationRegistration page_presentation_registration)
+{
+    auto context_id = allocate_compositor_context_id();
+    m_thread_data->set_default_context_id(context_id);
+
+    {
+        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
+        VERIFY(!context_compositors().contains(context_id));
+        context_compositors().set(context_id, m_thread_data);
+    }
+
+    if (page_presentation_registration == PagePresentationRegistration::Yes) {
+        m_thread_data->set_presents_to_client();
+        register_page_compositor(m_thread_data->page_id(), m_thread_data);
+    }
+
+    return adopt_own(*new Context(m_thread_data, context_id));
 }
 
 void CompositorThread::register_page_compositor(u64 page_id, NonnullRefPtr<ThreadData> thread_data)
@@ -1285,7 +1329,7 @@ bool CompositorThread::update_compositor_surface_for_context(CompositorContextId
         }
         thread_data = compositor->value;
     }
-    thread_data->enqueue_command(UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
+    thread_data->enqueue_command(context_id, UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
     return true;
 }
 
@@ -1473,67 +1517,67 @@ void CompositorThread::start(DisplayListPlayerType display_list_player_type)
     m_thread->detach();
 }
 
-void CompositorThread::set_presentation_mode(PresentationMode mode)
+void CompositorThread::Context::set_presentation_mode(PresentationMode mode)
 {
     m_thread_data->set_presentation_mode(move(mode));
 }
 
-void CompositorThread::stop_presenting_to_client()
+void CompositorThread::Context::stop_presenting_to_client()
 {
     m_thread_data->stop_presenting_to_client();
     unregister_page_compositor(m_thread_data->page_id(), *m_thread_data);
 }
 
-void CompositorThread::update_display_list(
+void CompositorThread::Context::update_display_list(
     NonnullRefPtr<Painting::DisplayList> display_list,
     Painting::DisplayListResourceTransaction&& resource_transaction,
     Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(resource_transaction), move(scroll_state_snapshot) });
+    m_thread_data->enqueue_command(m_context_id, UpdateDisplayListCommand { move(display_list), move(resource_transaction), move(scroll_state_snapshot) });
 }
 
-void CompositorThread::update_compositor_surface(Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+void CompositorThread::Context::update_compositor_surface(Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
 {
-    m_thread_data->enqueue_command(UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
+    m_thread_data->enqueue_command(m_context_id, UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
 }
 
-void CompositorThread::clear_compositor_surface(Painting::CompositorSurfaceId surface_id)
+void CompositorThread::Context::clear_compositor_surface(Painting::CompositorSurfaceId surface_id)
 {
-    m_thread_data->enqueue_command(ClearCompositorSurfaceCommand { surface_id });
+    m_thread_data->enqueue_command(m_context_id, ClearCompositorSurfaceCommand { surface_id });
 }
 
-void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)
+void CompositorThread::Context::invalidate_wheel_event_listener_state(u64 generation)
 {
     m_thread_data->invalidate_wheel_event_listener_state(generation);
 }
 
-CompositorThread::AsyncScrollEnqueueResult CompositorThread::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+CompositorThread::AsyncScrollEnqueueResult CompositorThread::Context::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
     Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
 {
     return m_thread_data->enqueue_async_scroll_by(expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
-bool CompositorThread::should_defer_async_scroll_offset_adoption() const
+bool CompositorThread::Context::should_defer_async_scroll_offset_adoption() const
 {
     return m_thread_data->should_defer_async_scroll_offset_adoption();
 }
 
-bool CompositorThread::should_defer_main_thread_present_for_async_scroll() const
+bool CompositorThread::Context::should_defer_main_thread_present_for_async_scroll() const
 {
     return m_thread_data->should_defer_main_thread_present_for_async_scroll();
 }
 
-CompositorThread::PendingAsyncScrollUpdates CompositorThread::take_pending_async_scroll_updates()
+CompositorThread::PendingAsyncScrollUpdates CompositorThread::Context::take_pending_async_scroll_updates()
 {
     return m_thread_data->take_pending_async_scroll_updates();
 }
 
-void CompositorThread::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+void CompositorThread::Context::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_thread_data->enqueue_command(UpdateScrollStateCommand { move(scroll_state_snapshot) });
+    m_thread_data->enqueue_command(m_context_id, UpdateScrollStateCommand { move(scroll_state_snapshot) });
 }
 
-void CompositorThread::viewport_size_updated(
+void CompositorThread::Context::viewport_size_updated(
     Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
 {
     m_last_viewport_size = viewport_size;
@@ -1543,26 +1587,106 @@ void CompositorThread::viewport_size_updated(
     enqueue_viewport_size_updated(viewport_size, is_top_level_traversable, window_resize_in_progress);
 }
 
-void CompositorThread::enqueue_viewport_size_updated(
+void CompositorThread::Context::enqueue_viewport_size_updated(
     Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
 {
-    m_thread_data->enqueue_command(
+    m_thread_data->enqueue_command(m_context_id,
         ViewportSizeUpdatedCommand { viewport_size, is_top_level_traversable, window_resize_in_progress });
 }
 
-u64 CompositorThread::present_frame(Gfx::IntRect viewport_rect)
+u64 CompositorThread::Context::present_frame(Gfx::IntRect viewport_rect)
 {
     return m_thread_data->set_needs_present(viewport_rect);
 }
 
-void CompositorThread::wait_for_frame(u64 frame_id)
+void CompositorThread::Context::wait_for_frame(u64 frame_id)
 {
     m_thread_data->wait_for_frame(frame_id);
 }
 
+void CompositorThread::Context::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
+{
+    m_thread_data->enqueue_command(m_context_id, ScreenshotCommand { move(target_surface), move(callback) });
+}
+
+void CompositorThread::set_presentation_mode(PresentationMode mode)
+{
+    m_context->set_presentation_mode(move(mode));
+}
+
+void CompositorThread::stop_presenting_to_client()
+{
+    m_context->stop_presenting_to_client();
+}
+
+void CompositorThread::update_display_list(
+    NonnullRefPtr<Painting::DisplayList> display_list,
+    Painting::DisplayListResourceTransaction&& resource_transaction,
+    Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    m_context->update_display_list(move(display_list), move(resource_transaction), move(scroll_state_snapshot));
+}
+
+void CompositorThread::update_compositor_surface(Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+{
+    m_context->update_compositor_surface(surface_id, move(shared_image));
+}
+
+void CompositorThread::clear_compositor_surface(Painting::CompositorSurfaceId surface_id)
+{
+    m_context->clear_compositor_surface(surface_id);
+}
+
+void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)
+{
+    m_context->invalidate_wheel_event_listener_state(generation);
+}
+
+CompositorThread::AsyncScrollEnqueueResult CompositorThread::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+    Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
+{
+    return m_context->async_scroll_by(expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+}
+
+bool CompositorThread::should_defer_async_scroll_offset_adoption() const
+{
+    return m_context->should_defer_async_scroll_offset_adoption();
+}
+
+bool CompositorThread::should_defer_main_thread_present_for_async_scroll() const
+{
+    return m_context->should_defer_main_thread_present_for_async_scroll();
+}
+
+CompositorThread::PendingAsyncScrollUpdates CompositorThread::take_pending_async_scroll_updates()
+{
+    return m_context->take_pending_async_scroll_updates();
+}
+
+void CompositorThread::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    m_context->update_scroll_state(move(scroll_state_snapshot));
+}
+
+void CompositorThread::viewport_size_updated(
+    Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
+{
+    m_context->viewport_size_updated(viewport_size, is_top_level_traversable, window_resize_in_progress);
+}
+
+u64 CompositorThread::present_frame(Gfx::IntRect viewport_rect)
+{
+    return m_context->present_frame(viewport_rect);
+}
+
+void CompositorThread::wait_for_frame(u64 frame_id)
+{
+    m_context->wait_for_frame(frame_id);
+}
+
 void CompositorThread::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
 {
-    m_thread_data->enqueue_command(ScreenshotCommand { move(target_surface), move(callback) });
+    m_context->request_screenshot(move(target_surface), move(callback));
 }
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -243,23 +243,38 @@ static void flush_surface(Gfx::PaintingSurface& surface)
     surface.flush();
 }
 
+static constexpr u64 page_presenting_context_id_tag = 1ull << 63;
+
+static CompositorContextId compositor_context_id_for_page(u64 page_id)
+{
+    VERIFY((page_id & page_presenting_context_id_tag) == 0);
+    return CompositorContextId { page_presenting_context_id_tag | page_id };
+}
+
+static bool is_page_presenting_context_id(CompositorContextId context_id)
+{
+    return (context_id.value() & page_presenting_context_id_tag) != 0;
+}
+
 class CompositorThread::ThreadData final : public AtomicRefCounted<ThreadData> {
 public:
-    ThreadData(u64 page_id, NonnullRefPtr<Core::WeakEventLoopReference>&& main_thread_event_loop)
-        : m_page_id(page_id)
-        , m_main_thread_event_loop(move(main_thread_event_loop))
+    explicit ThreadData(NonnullRefPtr<Core::WeakEventLoopReference>&& main_thread_event_loop)
+        : m_main_thread_event_loop(move(main_thread_event_loop))
     {
     }
 
     ~ThreadData() = default;
 
     struct ContextState final : public AtomicRefCounted<ContextState> {
-        ContextState(CompositorThread::PagePresentationRegistration page_presentation_registration)
+        ContextState(Optional<u64> page_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
             : presents_to_client(page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes)
+            , page_id(page_id)
         {
+            VERIFY(!presents_to_client || page_id.has_value());
         }
 
         bool presents_to_client { false };
+        Optional<u64> page_id;
         Painting::DisplayListResourceStorage display_list_resource_storage;
         RefPtr<Painting::DisplayList> cached_display_list;
         Painting::ScrollStateSnapshot cached_scroll_state_snapshot;
@@ -292,25 +307,24 @@ public:
         WheelRoutingAdmission wheel_routing_admission { WheelRoutingAdmission::NoAsyncScrollingState };
     };
 
-    void register_context(CompositorContextId context_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
+    void register_context(CompositorContextId context_id, Optional<u64> page_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
     {
         Sync::MutexLocker const locker { m_mutex };
         VERIFY(!m_contexts.contains(context_id));
-        if (!m_default_context_id.has_value())
-            m_default_context_id = context_id;
-        if (page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes)
-            m_page_presentation_context_id = context_id;
-        m_contexts.set(context_id, adopt_ref(*new ContextState(page_presentation_registration)));
+        if (page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes) {
+            VERIFY(page_id.has_value());
+            VERIFY(context_id == compositor_context_id_for_page(*page_id));
+        } else {
+            VERIFY(!page_id.has_value());
+            VERIFY(!is_page_presenting_context_id(context_id));
+        }
+        m_contexts.set(context_id, adopt_ref(*new ContextState(page_id, page_presentation_registration)));
     }
 
     void unregister_context(CompositorContextId context_id)
     {
         Sync::MutexLocker const locker { m_mutex };
         m_contexts.remove(context_id);
-        if (m_default_context_id == context_id)
-            m_default_context_id.clear();
-        if (m_page_presentation_context_id == context_id)
-            m_page_presentation_context_id.clear();
     }
 
     RefPtr<ContextState> context_state(CompositorContextId context_id)
@@ -319,54 +333,18 @@ public:
         return m_contexts.get(context_id).value_or(nullptr);
     }
 
-    RefPtr<ContextState> default_context_state()
-    {
-        Sync::MutexLocker const locker { m_mutex };
-        if (!m_default_context_id.has_value())
-            return nullptr;
-        auto context = m_contexts.get(*m_default_context_id);
-        if (!context.has_value())
-            return nullptr;
-        return context.value();
-    }
-
-    RefPtr<ContextState> page_presentation_context_state()
-    {
-        Sync::MutexLocker const locker { m_mutex };
-        auto context_id = m_page_presentation_context_id.has_value() ? m_page_presentation_context_id : m_default_context_id;
-        if (!context_id.has_value())
-            return nullptr;
-        auto context = m_contexts.get(*context_id);
-        if (!context.has_value())
-            return nullptr;
-        return context.value();
-    }
-
-    Optional<CompositorContextId> page_presentation_context_id() const
-    {
-        Sync::MutexLocker const locker { m_mutex };
-        return m_page_presentation_context_id.has_value() ? m_page_presentation_context_id : m_default_context_id;
-    }
-
-    u64 page_id() const { return m_page_id; }
-    bool presents_to_client() const
-    {
-        Sync::MutexLocker const locker { m_mutex };
-        if (!m_page_presentation_context_id.has_value())
-            return false;
-        auto context = m_contexts.get(*m_page_presentation_context_id);
-        return context.has_value() && context.value()->presents_to_client;
-    }
-
     void stop_presenting_to_client(CompositorContextId context_id)
     {
         Sync::MutexLocker const locker { m_mutex };
-        auto context = m_contexts.get(context_id);
-        if (!context.has_value())
-            return;
-        context.value()->presents_to_client = false;
-        if (m_page_presentation_context_id == context_id)
-            m_page_presentation_context_id.clear();
+        if (auto context = m_contexts.get(context_id).value_or(nullptr))
+            context->presents_to_client = false;
+    }
+
+    bool context_presents_to_client(CompositorContextId context_id) const
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        auto context = m_contexts.get(context_id).value_or(nullptr);
+        return context && context->presents_to_client;
     }
 
     void set_presentation_mode(CompositorContextId context_id, CompositorThread::PresentationMode mode)
@@ -397,12 +375,6 @@ public:
                 context ? context->has_deferred_async_scroll_present : false);
         }
         m_command_ready.signal();
-    }
-
-    void enqueue_command(CompositorCommand&& command)
-    {
-        VERIFY(m_default_context_id.has_value());
-        enqueue_command(*m_default_context_id, move(command));
     }
 
     u64 set_needs_present(CompositorContextId context_id, Gfx::IntRect viewport_rect)
@@ -544,13 +516,15 @@ public:
         return { true, operation_id };
     }
 
-    bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
+    bool enqueue_async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
     {
-        auto context_state = page_presentation_context_state();
-        auto context_id = page_presentation_context_id();
-        if (!context_state || !context_id.has_value())
+        auto context_id = compositor_context_id_for_page(page_id);
+        auto context_state = this->context_state(context_id);
+        if (!context_state)
             return false;
         auto& context = *context_state;
+        if (!context.presents_to_client)
+            return false;
         if (!context.can_accept_async_wheel_events.load()) {
             auto wheel_routing_admission = [&] {
                 Sync::MutexLocker const locker { m_mutex };
@@ -584,7 +558,7 @@ public:
 
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted async scroll enqueue at {},{} device delta {},{} for scroll node {} viewport={}x{} at {},{}",
             position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), scroll_target.node_id->scroll_frame_index.value(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(*context_id, AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
+        enqueue_command(context_id, AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
         return true;
     }
 
@@ -603,13 +577,15 @@ public:
         return {};
     }
 
-    bool handle_viewport_scrollbar_mouse_event(MouseEvent const& event)
+    bool handle_viewport_scrollbar_mouse_event(u64 page_id, MouseEvent const& event)
     {
-        auto context_state = page_presentation_context_state();
-        auto context_id = page_presentation_context_id();
-        if (!context_state || !context_id.has_value())
+        auto context_id = compositor_context_id_for_page(page_id);
+        auto context_state = this->context_state(context_id);
+        if (!context_state)
             return false;
         auto& context = *context_state;
+        if (!context.presents_to_client)
+            return false;
         auto position = Gfx::FloatPoint {
             static_cast<float>(event.position.x().value()),
             static_cast<float>(event.position.y().value()),
@@ -664,7 +640,7 @@ public:
             }
 
             schedule_viewport_scrollbar_present(context);
-            enqueue_command(*context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+            enqueue_command(context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseMove: {
@@ -684,7 +660,7 @@ public:
                 }
             }
             if (scrollbar_index.has_value()) {
-                enqueue_command(*context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+                enqueue_command(context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
                 return true;
             }
             auto hovered_scrollbar_index = hit_test_viewport_scrollbar(context, position);
@@ -709,7 +685,7 @@ public:
                 context.captured_viewport_scrollbar_index.clear();
             }
             schedule_viewport_scrollbar_present(context);
-            enqueue_command(*context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+            enqueue_command(context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseLeave: {
@@ -1216,12 +1192,13 @@ private:
             presentation_mode.visit(
                 [this, &context, viewport_rect, rendered_bitmap_id, delivery](CompositorThread::PresentToUI) {
                     if (context.presents_to_client) {
+                        VERIFY(context.page_id.has_value());
                         finish_rasterizing(context, rendered_bitmap_id);
                         if (delivery == PresentFrameDelivery::AsyncScroll) {
                             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Finished async scroll raster into bitmap {}",
                                 rendered_bitmap_id);
                         }
-                        VERIFY(CompositorThread::present_frame_to_client(m_page_id, viewport_rect, rendered_bitmap_id));
+                        VERIFY(CompositorThread::present_frame_to_client(*context.page_id, viewport_rect, rendered_bitmap_id));
                     } else {
                         Sync::MutexLocker const locker { m_mutex };
                         context.is_rasterizing = false;
@@ -1271,9 +1248,10 @@ private:
     {
         if (!context.presents_to_client)
             return;
+        VERIFY(context.page_id.has_value());
 
         VERIFY(CompositorThread::present_backing_stores_to_client(
-            m_page_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image)));
+            *context.page_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image)));
     }
 
     template<typename Invokee>
@@ -1289,7 +1267,6 @@ private:
         });
     }
 
-    u64 m_page_id { 0 };
     NonnullRefPtr<Core::WeakEventLoopReference> m_main_thread_event_loop;
 
     mutable Sync::Mutex m_mutex;
@@ -1298,8 +1275,6 @@ private:
 
     Queue<CompositorCommandEnvelope> m_command_queue;
     HashMap<CompositorContextId, NonnullRefPtr<ContextState>> m_contexts;
-    Optional<CompositorContextId> m_default_context_id;
-    Optional<CompositorContextId> m_page_presentation_context_id;
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
@@ -1316,13 +1291,15 @@ public:
             bitmap_id);
     }
 
-    void mark_presented_bitmap_ready_to_paint(i32 bitmap_id)
+    void mark_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
     {
-        auto context_state = page_presentation_context_state();
+        auto context_state = this->context_state(compositor_context_id_for_page(page_id));
         if (!context_state)
             return;
         auto& context = *context_state;
         Sync::MutexLocker const locker { m_mutex };
+        if (!context.presents_to_client)
+            return;
         if (context.presented_bitmap_id_awaiting_ack != bitmap_id) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Ignoring stale ready_to_paint for bitmap {} while awaiting bitmap {}",
                 bitmap_id, context.presented_bitmap_id_awaiting_ack.value_or(-1));
@@ -1348,16 +1325,33 @@ static Sync::Mutex& compositor_presentation_state_mutex()
     return *mutex;
 }
 
-static HashMap<u64, NonnullRefPtr<CompositorThread::ThreadData>>& page_compositors()
-{
-    static NeverDestroyed<HashMap<u64, NonnullRefPtr<CompositorThread::ThreadData>>> compositors;
-    return *compositors;
-}
-
 static HashMap<CompositorContextId, NonnullRefPtr<CompositorThread::ThreadData>>& context_compositors()
 {
     static NeverDestroyed<HashMap<CompositorContextId, NonnullRefPtr<CompositorThread::ThreadData>>> compositors;
     return *compositors;
+}
+
+static RefPtr<CompositorThread::ThreadData> thread_data_for_context(CompositorContextId context_id)
+{
+    Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
+    auto compositor = context_compositors().get(context_id);
+    if (!compositor.has_value())
+        return nullptr;
+    return compositor.value();
+}
+
+static RefPtr<CompositorThread::ThreadData> thread_data_for_page(u64 page_id)
+{
+    return thread_data_for_context(compositor_context_id_for_page(page_id));
+}
+
+static bool page_context_presents_to_client(u64 page_id)
+{
+    auto context_id = compositor_context_id_for_page(page_id);
+    auto thread_data = thread_data_for_context(context_id);
+    if (!thread_data)
+        return false;
+    return thread_data->context_presents_to_client(context_id);
 }
 
 static FramePresentationState& frame_presentation_state()
@@ -1381,7 +1375,6 @@ CompositorThread::Context::~Context()
     m_backing_store_shrink_timer->stop();
     m_backing_store_shrink_timer.clear();
 
-    unregister_page_compositor(m_thread_data->page_id(), *m_thread_data);
     m_thread_data->unregister_context(m_context_id);
     {
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
@@ -1389,22 +1382,28 @@ CompositorThread::Context::~Context()
     }
 }
 
-CompositorThread::CompositorThread(u64 page_id, PagePresentationRegistration page_presentation_registration)
-    : m_thread_data(adopt_ref(*new ThreadData(page_id, Core::EventLoop::current_weak())))
-    , m_context(create_context(page_presentation_registration))
+CompositorThread::CompositorThread()
+    : m_thread_data(adopt_ref(*new ThreadData(Core::EventLoop::current_weak())))
 {
 }
 
 CompositorThread::~CompositorThread()
 {
-    m_context.clear();
     m_thread_data->exit();
 }
 
-OwnPtr<CompositorThread::Context> CompositorThread::create_context(PagePresentationRegistration page_presentation_registration)
+OwnPtr<CompositorThread::Context> CompositorThread::create_context(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
 {
-    auto context_id = allocate_compositor_context_id();
-    m_thread_data->register_context(context_id, page_presentation_registration);
+    CompositorContextId context_id;
+    if (page_presentation_registration == PagePresentationRegistration::Yes) {
+        VERIFY(page_id.has_value());
+        context_id = compositor_context_id_for_page(*page_id);
+    } else {
+        VERIFY(!page_id.has_value());
+        context_id = allocate_compositor_context_id();
+        VERIFY(!is_page_presenting_context_id(context_id));
+    }
+    m_thread_data->register_context(context_id, page_id, page_presentation_registration);
 
     {
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
@@ -1412,51 +1411,16 @@ OwnPtr<CompositorThread::Context> CompositorThread::create_context(PagePresentat
         context_compositors().set(context_id, m_thread_data);
     }
 
-    if (page_presentation_registration == PagePresentationRegistration::Yes)
-        register_page_compositor(m_thread_data->page_id(), m_thread_data);
-
     return adopt_own(*new Context(m_thread_data, context_id));
-}
-
-void CompositorThread::register_page_compositor(u64 page_id, NonnullRefPtr<ThreadData> thread_data)
-{
-    Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-    auto replaced_existing_compositor = page_compositors().contains(page_id);
-    page_compositors().set(page_id, move(thread_data));
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Registered page {} for compositor presentation (replaced_existing={})",
-        page_id, replaced_existing_compositor);
-}
-
-void CompositorThread::unregister_page_compositor(u64 page_id, ThreadData& thread_data)
-{
-    Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-    auto compositor = page_compositors().find(page_id);
-    if (compositor == page_compositors().end()) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Skipping compositor unregister for page {}: no compositor registered",
-            page_id);
-        return;
-    }
-    if (compositor->value.ptr() != &thread_data) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Skipping compositor unregister for page {}: compositor changed",
-            page_id);
-        return;
-    }
-    page_compositors().remove(compositor);
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Unregistered page {} from compositor presentation", page_id);
 }
 
 bool CompositorThread::update_compositor_surface_for_context(CompositorContextId context_id, Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
 {
-    RefPtr<ThreadData> thread_data;
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto compositor = context_compositors().find(context_id);
-        if (compositor == context_compositors().end()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping compositor surface {} update for unknown context {}",
-                surface_id, context_id);
-            return false;
-        }
-        thread_data = compositor->value;
+    auto thread_data = thread_data_for_context(context_id);
+    if (!thread_data) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping compositor surface {} update for unknown context {}",
+            surface_id, context_id);
+        return false;
     }
     thread_data->enqueue_command(context_id, UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
     return true;
@@ -1484,14 +1448,17 @@ void CompositorThread::clear_frame_presentation_callbacks()
 
 bool CompositorThread::present_backing_stores_to_client(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage&& front_shared_image, i32 back_bitmap_id, Gfx::SharedImage&& back_shared_image)
 {
+    auto context_id = compositor_context_id_for_page(page_id);
+    auto thread_data = thread_data_for_context(context_id);
+    if (!thread_data || !thread_data->context_presents_to_client(context_id)) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no presenting context registered",
+            front_bitmap_id, back_bitmap_id, page_id);
+        return false;
+    }
+
     RefPtr<Core::WeakEventLoopReference> event_loop_reference;
     {
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        if (!page_compositors().contains(page_id)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no compositor registered",
-                front_bitmap_id, back_bitmap_id, page_id);
-            return false;
-        }
         auto& state = frame_presentation_state();
         if (!state.backing_store_callback) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no presentation callback",
@@ -1516,12 +1483,12 @@ bool CompositorThread::present_backing_stores_to_client(u64 page_id, i32 front_b
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Queueing UI backing stores for page {} front={} back={}",
         page_id, front_bitmap_id, back_bitmap_id);
     event_loop->deferred_invoke([page_id, front_bitmap_id, front_shared_image = move(front_shared_image), back_bitmap_id, back_shared_image = move(back_shared_image)]() mutable {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        if (!page_compositors().contains(page_id)) {
+        if (!page_context_presents_to_client(page_id)) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping queued UI backing stores for page {} front={} back={}: page unregistered",
                 page_id, front_bitmap_id, back_bitmap_id);
             return;
         }
+        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
         auto& state = frame_presentation_state();
         if (state.backing_store_callback) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Delivering UI backing stores for page {} front={} back={}",
@@ -1537,14 +1504,17 @@ bool CompositorThread::present_backing_stores_to_client(u64 page_id, i32 front_b
 
 bool CompositorThread::present_frame_to_client(u64 page_id, Gfx::IntRect const& viewport_rect, i32 bitmap_id)
 {
+    auto context_id = compositor_context_id_for_page(page_id);
+    auto thread_data = thread_data_for_context(context_id);
+    if (!thread_data || !thread_data->context_presents_to_client(context_id)) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no presenting context registered",
+            bitmap_id, page_id);
+        return false;
+    }
+
     RefPtr<Core::WeakEventLoopReference> event_loop_reference;
     {
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        if (!page_compositors().contains(page_id)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no compositor registered",
-                bitmap_id, page_id);
-            return false;
-        }
         auto& state = frame_presentation_state();
         if (!state.frame_callback) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no presentation callback",
@@ -1569,12 +1539,12 @@ bool CompositorThread::present_frame_to_client(u64 page_id, Gfx::IntRect const& 
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Queueing UI present for page {} bitmap {} viewport={}x{} at {},{}",
         page_id, bitmap_id, viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
     event_loop->deferred_invoke([page_id, viewport_rect, bitmap_id] {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        if (!page_compositors().contains(page_id)) {
+        if (!page_context_presents_to_client(page_id)) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping queued UI present for page {} bitmap {}: page unregistered",
                 page_id, bitmap_id);
             return;
         }
+        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
         auto& state = frame_presentation_state();
         if (state.frame_callback) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Delivering UI present for page {} bitmap {} viewport={}x{} at {},{}",
@@ -1592,48 +1562,33 @@ void CompositorThread::presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_i
 {
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Received compositor ready_to_paint for page {} bitmap {}",
         page_id, bitmap_id);
-    RefPtr<ThreadData> thread_data;
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto compositor = page_compositors().find(page_id);
-        if (compositor == page_compositors().end()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Ignoring compositor ready_to_paint for page {} bitmap {}: no compositor registered",
-                page_id, bitmap_id);
-            return;
-        }
-        thread_data = compositor->value;
+    auto thread_data = thread_data_for_page(page_id);
+    if (!thread_data) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Ignoring compositor ready_to_paint for page {} bitmap {}: no presenting context registered",
+            page_id, bitmap_id);
+        return;
     }
-    thread_data->mark_presented_bitmap_ready_to_paint(bitmap_id);
+    thread_data->mark_presented_bitmap_ready_to_paint(page_id, bitmap_id);
 }
 
 bool CompositorThread::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
-    RefPtr<ThreadData> thread_data;
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto compositor = page_compositors().find(page_id);
-        if (compositor == page_compositors().end()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll cannot scroll page {}: no compositor registered", page_id);
-            return false;
-        }
-        thread_data = compositor->value;
+    auto thread_data = thread_data_for_page(page_id);
+    if (!thread_data) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll cannot scroll page {}: no presenting context registered", page_id);
+        return false;
     }
-    return thread_data->enqueue_async_scroll_by(position, delta_in_device_pixels);
+    return thread_data->enqueue_async_scroll_by(page_id, position, delta_in_device_pixels);
 }
 
 bool CompositorThread::handle_mouse_event(u64 page_id, MouseEvent const& event)
 {
-    RefPtr<ThreadData> thread_data;
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto compositor = page_compositors().find(page_id);
-        if (compositor == page_compositors().end()) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Viewport scrollbar mouse event cannot be handled for page {}: no compositor registered", page_id);
-            return false;
-        }
-        thread_data = compositor->value;
+    auto thread_data = thread_data_for_page(page_id);
+    if (!thread_data) {
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Viewport scrollbar mouse event cannot be handled for page {}: no presenting context registered", page_id);
+        return false;
     }
-    return thread_data->handle_viewport_scrollbar_mouse_event(event);
+    return thread_data->handle_viewport_scrollbar_mouse_event(page_id, event);
 }
 
 void CompositorThread::start(DisplayListPlayerType display_list_player_type)
@@ -1654,7 +1609,6 @@ void CompositorThread::Context::set_presentation_mode(PresentationMode mode)
 void CompositorThread::Context::stop_presenting_to_client()
 {
     m_thread_data->stop_presenting_to_client(m_context_id);
-    unregister_page_compositor(m_thread_data->page_id(), *m_thread_data);
 }
 
 void CompositorThread::Context::update_display_list(
@@ -1736,86 +1690,6 @@ void CompositorThread::Context::wait_for_frame(u64 frame_id)
 void CompositorThread::Context::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
 {
     m_thread_data->enqueue_command(m_context_id, ScreenshotCommand { move(target_surface), move(callback) });
-}
-
-void CompositorThread::set_presentation_mode(PresentationMode mode)
-{
-    m_context->set_presentation_mode(move(mode));
-}
-
-void CompositorThread::stop_presenting_to_client()
-{
-    m_context->stop_presenting_to_client();
-}
-
-void CompositorThread::update_display_list(
-    NonnullRefPtr<Painting::DisplayList> display_list,
-    Painting::DisplayListResourceTransaction&& resource_transaction,
-    Painting::ScrollStateSnapshot&& scroll_state_snapshot)
-{
-    m_context->update_display_list(move(display_list), move(resource_transaction), move(scroll_state_snapshot));
-}
-
-void CompositorThread::update_compositor_surface(Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
-{
-    m_context->update_compositor_surface(surface_id, move(shared_image));
-}
-
-void CompositorThread::clear_compositor_surface(Painting::CompositorSurfaceId surface_id)
-{
-    m_context->clear_compositor_surface(surface_id);
-}
-
-void CompositorThread::invalidate_wheel_event_listener_state(u64 generation)
-{
-    m_context->invalidate_wheel_event_listener_state(generation);
-}
-
-CompositorThread::AsyncScrollEnqueueResult CompositorThread::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
-    Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
-{
-    return m_context->async_scroll_by(expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
-}
-
-bool CompositorThread::should_defer_async_scroll_offset_adoption() const
-{
-    return m_context->should_defer_async_scroll_offset_adoption();
-}
-
-bool CompositorThread::should_defer_main_thread_present_for_async_scroll() const
-{
-    return m_context->should_defer_main_thread_present_for_async_scroll();
-}
-
-CompositorThread::PendingAsyncScrollUpdates CompositorThread::take_pending_async_scroll_updates()
-{
-    return m_context->take_pending_async_scroll_updates();
-}
-
-void CompositorThread::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
-{
-    m_context->update_scroll_state(move(scroll_state_snapshot));
-}
-
-void CompositorThread::viewport_size_updated(
-    Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
-{
-    m_context->viewport_size_updated(viewport_size, is_top_level_traversable, window_resize_in_progress);
-}
-
-u64 CompositorThread::present_frame(Gfx::IntRect viewport_rect)
-{
-    return m_context->present_frame(viewport_rect);
-}
-
-void CompositorThread::wait_for_frame(u64 frame_id)
-{
-    m_context->wait_for_frame(frame_id);
-}
-
-void CompositorThread::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
-{
-    m_context->request_screenshot(move(target_surface), move(callback));
 }
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -82,7 +82,6 @@ struct ViewportSizeUpdatedCommand {
 
 struct PresentFrameCommand {
     Gfx::IntRect viewport_rect;
-    u64 frame_id { 0 };
 };
 
 struct ScreenshotCommand {
@@ -300,8 +299,6 @@ public:
         bool has_deferred_async_scroll_present { false };
         Gfx::IntRect deferred_async_scroll_present_viewport_rect;
 
-        u64 submitted_frame_id { 0 };
-        u64 completed_frame_id { 0 };
         Vector<AsyncScrollOffset> pending_async_scroll_offsets;
         Vector<AsyncScrollOperationID> completed_async_scroll_operation_ids;
         Atomic<AsyncScrollOperationID> next_async_scroll_operation_id { 0 };
@@ -364,7 +361,6 @@ public:
         Sync::MutexLocker const locker { m_mutex };
         m_exit = true;
         m_command_ready.signal();
-        m_frame_completed.broadcast();
     }
 
     void enqueue_command(CompositorContextId context_id, CompositorCommand&& command)
@@ -382,35 +378,13 @@ public:
         m_command_ready.signal();
     }
 
-    u64 enqueue_present_frame(CompositorContextId context_id, Gfx::IntRect viewport_rect)
+    void enqueue_present_frame(CompositorContextId context_id, Gfx::IntRect viewport_rect)
     {
         Sync::MutexLocker const locker { m_mutex };
-        auto context_state = m_contexts.get(context_id);
-        if (!context_state.has_value())
-            return 0;
-        auto& context = *context_state.value();
-        context.submitted_frame_id++;
-        m_command_queue.enqueue({ context_id, PresentFrameCommand { viewport_rect, context.submitted_frame_id } });
-        m_command_ready.signal();
-        return context.submitted_frame_id;
-    }
-
-    void mark_frame_complete(ContextState& context, u64 frame_id)
-    {
-        Sync::MutexLocker const locker { m_mutex };
-        context.completed_frame_id = frame_id;
-        m_frame_completed.broadcast();
-    }
-
-    void wait_for_frame(CompositorContextId context_id, u64 frame_id)
-    {
-        Sync::MutexLocker const locker { m_mutex };
-        auto context_state = m_contexts.get(context_id);
-        if (!context_state.has_value())
+        if (!m_contexts.contains(context_id))
             return;
-        auto& context = *context_state.value();
-        while (context.completed_frame_id < frame_id && !m_exit)
-            m_frame_completed.wait();
+        m_command_queue.enqueue({ context_id, PresentFrameCommand { viewport_rect } });
+        m_command_ready.signal();
     }
 
     CompositorThread::PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId context_id)
@@ -890,11 +864,10 @@ public:
                             if (has_presented_bitmap_awaiting_ack_while_locked(context)) {
                                 context.needs_present = true;
                                 context.pending_viewport_rect = cmd.viewport_rect;
-                                context.submitted_frame_id = cmd.frame_id;
                                 return;
                             }
                         }
-                        present_frame(context, cmd.viewport_rect, cmd.frame_id, PresentFrameDelivery::MainThread);
+                        present_frame(context, cmd.viewport_rect, PresentFrameDelivery::MainThread);
                     },
                     [this, &context](ScreenshotCommand& cmd) {
                         if (!context.cached_display_list)
@@ -923,10 +896,8 @@ public:
             bool should_present = false;
             RefPtr<ContextState> present_context_state;
             Gfx::IntRect viewport_rect;
-            u64 presenting_frame_id = 0;
             bool should_present_deferred_async_scroll = false;
             Gfx::IntRect deferred_async_scroll_viewport_rect;
-            Optional<u64> deferred_async_scroll_presenting_frame_id;
             {
                 Sync::MutexLocker const locker { m_mutex };
                 for (auto& [_, context] : m_contexts) {
@@ -935,12 +906,11 @@ public:
                         should_present_deferred_async_scroll = true;
                         deferred_async_scroll_viewport_rect = context->deferred_async_scroll_present_viewport_rect;
                         context->has_deferred_async_scroll_present = false;
-                        if (context->needs_present) {
-                            deferred_async_scroll_presenting_frame_id = context->submitted_frame_id;
+                        auto had_pending_main_thread_present = context->needs_present;
+                        if (had_pending_main_thread_present)
                             context->needs_present = false;
-                        }
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor selected deferred async present (pending_main_thread_present={})",
-                            deferred_async_scroll_presenting_frame_id.has_value());
+                            had_pending_main_thread_present);
                         break;
                     }
 
@@ -948,7 +918,6 @@ public:
                         present_context_state = context;
                         should_present = true;
                         viewport_rect = context->pending_viewport_rect;
-                        presenting_frame_id = context->submitted_frame_id;
                         context->needs_present = false;
                         break;
                     }
@@ -956,9 +925,9 @@ public:
             }
 
             if (should_present_deferred_async_scroll)
-                present_frame(*present_context_state, deferred_async_scroll_viewport_rect, deferred_async_scroll_presenting_frame_id, PresentFrameDelivery::AsyncScroll);
+                present_frame(*present_context_state, deferred_async_scroll_viewport_rect, PresentFrameDelivery::AsyncScroll);
             else if (should_present)
-                present_frame(*present_context_state, viewport_rect, presenting_frame_id, PresentFrameDelivery::MainThread);
+                present_frame(*present_context_state, viewport_rect, PresentFrameDelivery::MainThread);
         }
     }
 
@@ -1169,14 +1138,14 @@ private:
         return CompositorThread::update_compositor_surface_for_context(context_id, surface_id, move(shared_image));
     }
 
-    void present_frame(ContextState& context, Gfx::IntRect viewport_rect, Optional<u64> presenting_frame_id = {}, PresentFrameDelivery delivery = PresentFrameDelivery::MainThread)
+    void present_frame(ContextState& context, Gfx::IntRect viewport_rect, PresentFrameDelivery delivery)
     {
         auto delivery_name = delivery == PresentFrameDelivery::AsyncScroll ? "compositor-thread"sv : "main-thread"sv;
 
         {
             Sync::MutexLocker const locker { m_mutex };
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Begin {} present (frame={}, awaiting_bitmap={}, viewport={}x{} at {},{})",
-                delivery_name, presenting_frame_id.value_or(0), context.presented_bitmap_id_awaiting_ack.value_or(-1), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Begin {} present (awaiting_bitmap={}, viewport={}x{} at {},{})",
+                delivery_name, context.presented_bitmap_id_awaiting_ack.value_or(-1), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
 
             if (delivery == PresentFrameDelivery::AsyncScroll && has_presented_bitmap_awaiting_ack_while_locked(context)) {
                 context.has_deferred_async_scroll_present = true;
@@ -1251,9 +1220,6 @@ private:
             }
         }
 
-        if (presenting_frame_id.has_value())
-            mark_frame_complete(context, *presenting_frame_id);
-
         queue_rendering_update_if_async_scroll_updates_pending(context);
     }
 
@@ -1303,7 +1269,6 @@ private:
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
-    mutable Sync::ConditionVariable m_frame_completed { m_mutex };
 
 public:
     void finish_rasterizing(ContextState& context, i32 bitmap_id)
@@ -1702,14 +1667,9 @@ void CompositorThread::Context::enqueue_viewport_size_updated(
         ViewportSizeUpdatedCommand { viewport_size, is_top_level_traversable, window_resize_in_progress });
 }
 
-u64 CompositorThread::Context::present_frame(Gfx::IntRect viewport_rect)
+void CompositorThread::Context::present_frame(Gfx::IntRect viewport_rect)
 {
-    return m_thread_data->enqueue_present_frame(m_context_id, viewport_rect);
-}
-
-void CompositorThread::Context::wait_for_frame(u64 frame_id)
-{
-    m_thread_data->wait_for_frame(m_context_id, frame_id);
+    m_thread_data->enqueue_present_frame(m_context_id, viewport_rect);
 }
 
 void CompositorThread::Context::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -80,6 +80,11 @@ struct ViewportSizeUpdatedCommand {
     WindowResizingInProgress window_resize_in_progress { WindowResizingInProgress::No };
 };
 
+struct PresentFrameCommand {
+    Gfx::IntRect viewport_rect;
+    u64 frame_id { 0 };
+};
+
 struct ScreenshotCommand {
     NonnullRefPtr<Gfx::PaintingSurface> target_surface;
     Function<void()> callback;
@@ -87,7 +92,7 @@ struct ScreenshotCommand {
 
 using CompositorCommand = Variant<UpdateDisplayListCommand, AsyncScrollByCommand, ViewportScrollbarDragCommand,
     UpdateScrollStateCommand, UpdateCompositorSurfaceCommand, ClearCompositorSurfaceCommand, ViewportSizeUpdatedCommand,
-    ScreenshotCommand>;
+    PresentFrameCommand, ScreenshotCommand>;
 
 struct CompositorCommandEnvelope {
     CompositorContextId context_id;
@@ -377,16 +382,15 @@ public:
         m_command_ready.signal();
     }
 
-    u64 set_needs_present(CompositorContextId context_id, Gfx::IntRect viewport_rect)
+    u64 enqueue_present_frame(CompositorContextId context_id, Gfx::IntRect viewport_rect)
     {
         Sync::MutexLocker const locker { m_mutex };
         auto context_state = m_contexts.get(context_id);
         if (!context_state.has_value())
             return 0;
         auto& context = *context_state.value();
-        context.needs_present = true;
-        context.pending_viewport_rect = viewport_rect;
         context.submitted_frame_id++;
+        m_command_queue.enqueue({ context_id, PresentFrameCommand { viewport_rect, context.submitted_frame_id } });
         m_command_ready.signal();
         return context.submitted_frame_id;
     }
@@ -880,6 +884,18 @@ public:
                         if (auto publication = context.backing_store_manager.allocate_backing_stores(*allocation, m_skia_backend_context, context.presents_to_client); publication.has_value())
                             publish_backing_store_pair(context, publication.release_value());
                     },
+                    [this, &context](PresentFrameCommand& cmd) {
+                        {
+                            Sync::MutexLocker const locker { m_mutex };
+                            if (has_presented_bitmap_awaiting_ack_while_locked(context)) {
+                                context.needs_present = true;
+                                context.pending_viewport_rect = cmd.viewport_rect;
+                                context.submitted_frame_id = cmd.frame_id;
+                                return;
+                            }
+                        }
+                        present_frame(context, cmd.viewport_rect, cmd.frame_id, PresentFrameDelivery::MainThread);
+                    },
                     [this, &context](ScreenshotCommand& cmd) {
                         if (!context.cached_display_list)
                             return;
@@ -1144,6 +1160,15 @@ private:
         return context.has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked(context);
     }
 
+    bool route_compositor_surface_to_context(CompositorContextId context_id, Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+    {
+        if (auto target_context = context_state(context_id); target_context) {
+            target_context->display_list_resource_storage.update_compositor_surface(surface_id, move(shared_image));
+            return true;
+        }
+        return CompositorThread::update_compositor_surface_for_context(context_id, surface_id, move(shared_image));
+    }
+
     void present_frame(ContextState& context, Gfx::IntRect viewport_rect, Optional<u64> presenting_frame_id = {}, PresentFrameDelivery delivery = PresentFrameDelivery::MainThread)
     {
         auto delivery_name = delivery == PresentFrameDelivery::AsyncScroll ? "compositor-thread"sv : "main-thread"sv;
@@ -1212,7 +1237,7 @@ private:
                     if (context.has_async_scrolling_state)
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Publishing present to compositor surface");
                     auto& front_store = context.backing_store_manager.front_store();
-                    VERIFY(CompositorThread::update_compositor_surface_for_context(
+                    VERIFY(route_compositor_surface_to_context(
                         mode.target_context_id, mode.surface_id, front_store.snapshot_into_shared_image()));
                 });
         } else {
@@ -1679,7 +1704,7 @@ void CompositorThread::Context::enqueue_viewport_size_updated(
 
 u64 CompositorThread::Context::present_frame(Gfx::IntRect viewport_rect)
 {
-    return m_thread_data->set_needs_present(m_context_id, viewport_rect);
+    return m_thread_data->enqueue_present_frame(m_context_id, viewport_rect);
 }
 
 void CompositorThread::Context::wait_for_frame(u64 frame_id)

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -253,24 +253,127 @@ public:
 
     ~ThreadData() = default;
 
+    struct ContextState final : public AtomicRefCounted<ContextState> {
+        ContextState(CompositorThread::PagePresentationRegistration page_presentation_registration)
+            : presents_to_client(page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes)
+        {
+        }
+
+        bool presents_to_client { false };
+        Painting::DisplayListResourceStorage display_list_resource_storage;
+        RefPtr<Painting::DisplayList> cached_display_list;
+        Painting::ScrollStateSnapshot cached_scroll_state_snapshot;
+        Vector<ViewportScrollbar> viewport_scrollbars;
+        Optional<size_t> hovered_viewport_scrollbar_index;
+        Optional<size_t> captured_viewport_scrollbar_index;
+        float viewport_scrollbar_thumb_grab_position { 0 };
+        mutable Sync::Mutex async_scroll_tree_mutex;
+        AsyncScrollTree async_scroll_tree;
+        BackingStoreManager backing_store_manager;
+        CompositorThread::PresentationMode presentation_mode { CompositorThread::PresentToUI {} };
+
+        Optional<i32> presented_bitmap_id_awaiting_ack;
+        bool is_rasterizing { false };
+
+        bool needs_present { false };
+        Gfx::IntRect pending_viewport_rect;
+        bool has_deferred_async_scroll_present { false };
+        Gfx::IntRect deferred_async_scroll_present_viewport_rect;
+
+        u64 submitted_frame_id { 0 };
+        u64 completed_frame_id { 0 };
+        Vector<AsyncScrollOffset> pending_async_scroll_offsets;
+        Vector<AsyncScrollOperationID> completed_async_scroll_operation_ids;
+        Atomic<AsyncScrollOperationID> next_async_scroll_operation_id { 0 };
+        Gfx::IntRect async_scrolling_viewport_rect;
+        Atomic<bool> has_async_scrolling_state { false };
+        Atomic<bool> can_accept_async_wheel_events { false };
+        u64 wheel_event_listener_state_generation { 0 };
+        WheelRoutingAdmission wheel_routing_admission { WheelRoutingAdmission::NoAsyncScrollingState };
+    };
+
+    void register_context(CompositorContextId context_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        VERIFY(!m_contexts.contains(context_id));
+        if (!m_default_context_id.has_value())
+            m_default_context_id = context_id;
+        if (page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes)
+            m_page_presentation_context_id = context_id;
+        m_contexts.set(context_id, adopt_ref(*new ContextState(page_presentation_registration)));
+    }
+
+    void unregister_context(CompositorContextId context_id)
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        m_contexts.remove(context_id);
+        if (m_default_context_id == context_id)
+            m_default_context_id.clear();
+        if (m_page_presentation_context_id == context_id)
+            m_page_presentation_context_id.clear();
+    }
+
+    RefPtr<ContextState> context_state(CompositorContextId context_id)
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        return m_contexts.get(context_id).value_or(nullptr);
+    }
+
+    RefPtr<ContextState> default_context_state()
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        if (!m_default_context_id.has_value())
+            return nullptr;
+        auto context = m_contexts.get(*m_default_context_id);
+        if (!context.has_value())
+            return nullptr;
+        return context.value();
+    }
+
+    RefPtr<ContextState> page_presentation_context_state()
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        auto context_id = m_page_presentation_context_id.has_value() ? m_page_presentation_context_id : m_default_context_id;
+        if (!context_id.has_value())
+            return nullptr;
+        auto context = m_contexts.get(*context_id);
+        if (!context.has_value())
+            return nullptr;
+        return context.value();
+    }
+
+    Optional<CompositorContextId> page_presentation_context_id() const
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        return m_page_presentation_context_id.has_value() ? m_page_presentation_context_id : m_default_context_id;
+    }
+
     u64 page_id() const { return m_page_id; }
-    bool presents_to_client() const { return m_presents_to_client; }
-    void set_presents_to_client()
+    bool presents_to_client() const
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_presents_to_client = true;
+        if (!m_page_presentation_context_id.has_value())
+            return false;
+        auto context = m_contexts.get(*m_page_presentation_context_id);
+        return context.has_value() && context.value()->presents_to_client;
     }
 
-    void stop_presenting_to_client()
+    void stop_presenting_to_client(CompositorContextId context_id)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_presents_to_client = false;
+        auto context = m_contexts.get(context_id);
+        if (!context.has_value())
+            return;
+        context.value()->presents_to_client = false;
+        if (m_page_presentation_context_id == context_id)
+            m_page_presentation_context_id.clear();
     }
 
-    void set_presentation_mode(CompositorThread::PresentationMode mode)
+    void set_presentation_mode(CompositorContextId context_id, CompositorThread::PresentationMode mode)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_presentation_mode = move(mode);
+        if (auto context = m_contexts.get(context_id).value_or(nullptr))
+            context->presentation_mode = move(mode);
     }
 
     void exit()
@@ -285,8 +388,14 @@ public:
     {
         Sync::MutexLocker const locker { m_mutex };
         m_command_queue.enqueue({ context_id, move(command) });
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor command queued (queue_size={}, awaiting_bitmap={}, needs_present={}, deferred_async_present={})",
-            m_command_queue.size(), m_presented_bitmap_id_awaiting_ack.value_or(-1), m_needs_present, m_has_deferred_async_scroll_present);
+        if constexpr (COMPOSITOR_DEBUG) {
+            auto context = m_contexts.get(context_id).value_or(nullptr);
+            dbgln("[Compositor] Compositor command queued (queue_size={}, awaiting_bitmap={}, needs_present={}, deferred_async_present={})",
+                m_command_queue.size(),
+                context ? context->presented_bitmap_id_awaiting_ack.value_or(-1) : -1,
+                context ? context->needs_present : false,
+                context ? context->has_deferred_async_scroll_present : false);
+        }
         m_command_ready.signal();
     }
 
@@ -296,65 +405,78 @@ public:
         enqueue_command(*m_default_context_id, move(command));
     }
 
-    void set_default_context_id(CompositorContextId context_id)
-    {
-        if (!m_default_context_id.has_value())
-            m_default_context_id = context_id;
-    }
-
-    u64 set_needs_present(Gfx::IntRect viewport_rect)
+    u64 set_needs_present(CompositorContextId context_id, Gfx::IntRect viewport_rect)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_needs_present = true;
-        m_pending_viewport_rect = viewport_rect;
-        m_submitted_frame_id++;
+        auto context_state = m_contexts.get(context_id);
+        if (!context_state.has_value())
+            return 0;
+        auto& context = *context_state.value();
+        context.needs_present = true;
+        context.pending_viewport_rect = viewport_rect;
+        context.submitted_frame_id++;
         m_command_ready.signal();
-        return m_submitted_frame_id;
+        return context.submitted_frame_id;
     }
 
-    void mark_frame_complete(u64 frame_id)
+    void mark_frame_complete(ContextState& context, u64 frame_id)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_completed_frame_id = frame_id;
+        context.completed_frame_id = frame_id;
         m_frame_completed.broadcast();
     }
 
-    void wait_for_frame(u64 frame_id)
+    void wait_for_frame(CompositorContextId context_id, u64 frame_id)
     {
         Sync::MutexLocker const locker { m_mutex };
-        while (m_completed_frame_id < frame_id && !m_exit)
+        auto context_state = m_contexts.get(context_id);
+        if (!context_state.has_value())
+            return;
+        auto& context = *context_state.value();
+        while (context.completed_frame_id < frame_id && !m_exit)
             m_frame_completed.wait();
     }
 
-    CompositorThread::PendingAsyncScrollUpdates take_pending_async_scroll_updates()
+    CompositorThread::PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId context_id)
     {
         Sync::MutexLocker const locker { m_mutex };
         CompositorThread::PendingAsyncScrollUpdates updates;
-        AK::swap(updates.scroll_offsets, m_pending_async_scroll_offsets);
-        AK::swap(updates.completed_operation_ids, m_completed_async_scroll_operation_ids);
+        if (auto context = m_contexts.get(context_id).value_or(nullptr)) {
+            AK::swap(updates.scroll_offsets, context->pending_async_scroll_offsets);
+            AK::swap(updates.completed_operation_ids, context->completed_async_scroll_operation_ids);
+        }
         return updates;
     }
 
-    bool should_defer_async_scroll_offset_adoption() const
+    bool should_defer_async_scroll_offset_adoption(CompositorContextId context_id) const
     {
         Sync::MutexLocker const locker { m_mutex };
-        return !m_pending_async_scroll_offsets.is_empty()
-            && m_is_rasterizing;
+        auto context = m_contexts.get(context_id).value_or(nullptr);
+        if (!context)
+            return false;
+        return !context->pending_async_scroll_offsets.is_empty()
+            && context->is_rasterizing;
     }
 
-    bool should_defer_main_thread_present_for_async_scroll() const
+    bool should_defer_main_thread_present_for_async_scroll(CompositorContextId context_id) const
     {
         Sync::MutexLocker const locker { m_mutex };
-        return !m_pending_async_scroll_offsets.is_empty()
-            && (m_is_rasterizing || m_has_deferred_async_scroll_present || has_presented_bitmap_awaiting_ack_while_locked());
+        auto context = m_contexts.get(context_id).value_or(nullptr);
+        if (!context)
+            return false;
+        return !context->pending_async_scroll_offsets.is_empty()
+            && (context->is_rasterizing || context->has_deferred_async_scroll_present || has_presented_bitmap_awaiting_ack_while_locked(*context));
     }
 
-    void invalidate_wheel_event_listener_state(u64 generation)
+    void invalidate_wheel_event_listener_state(CompositorContextId context_id, u64 generation)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_wheel_event_listener_state_generation = max(m_wheel_event_listener_state_generation, generation);
-        m_wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
-        m_can_accept_async_wheel_events = false;
+        auto context = m_contexts.get(context_id).value_or(nullptr);
+        if (!context)
+            return;
+        context->wheel_event_listener_state_generation = max(context->wheel_event_listener_state_generation, generation);
+        context->wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
+        context->can_accept_async_wheel_events = false;
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Invalidated compositor wheel listener state (generation={})", generation);
     }
 
@@ -364,10 +486,10 @@ public:
         bool blocked_by_wheel_event_region { false };
     };
 
-    WheelTarget hit_test_scroll_node_for_wheel(Gfx::FloatPoint position, Gfx::FloatPoint delta) const
+    WheelTarget hit_test_scroll_node_for_wheel(ContextState& context, Gfx::FloatPoint position, Gfx::FloatPoint delta) const
     {
-        Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-        auto scroll_target = m_async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
+        Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+        auto scroll_target = context.async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
         return {
             .node_id = scroll_target.node_id,
             .blocked_by_main_thread_region = scroll_target.blocked_by_main_thread_region,
@@ -375,19 +497,23 @@ public:
         };
     }
 
-    CompositorThread::AsyncScrollEnqueueResult enqueue_async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+    CompositorThread::AsyncScrollEnqueueResult enqueue_async_scroll_by(CompositorContextId context_id, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, CompositorThread::AsyncScrollOperationTracking operation_tracking)
     {
-        if (!m_can_accept_async_wheel_events.load()) {
-            auto wheel_routing_admission = [this] {
+        auto context_state = this->context_state(context_id);
+        if (!context_state)
+            return {};
+        auto& context = *context_state;
+        if (!context.can_accept_async_wheel_events.load()) {
+            auto wheel_routing_admission = [&] {
                 Sync::MutexLocker const locker { m_mutex };
-                return m_wheel_routing_admission;
+                return context.wheel_routing_admission;
             }();
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: compositor cannot accept async wheel events ({})",
                 wheel_routing_admission_to_string(wheel_routing_admission));
             return {};
         }
-        auto scroll_target = hit_test_scroll_node_for_wheel(position, delta_in_device_pixels);
+        auto scroll_target = hit_test_scroll_node_for_wheel(context, position, delta_in_device_pixels);
         if (scroll_target.blocked_by_main_thread_region) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: main-thread wheel region at {},{} device delta {},{}",
                 position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
@@ -411,30 +537,35 @@ public:
 
         Optional<AsyncScrollOperationID> operation_id;
         if (operation_tracking == CompositorThread::AsyncScrollOperationTracking::Yes)
-            operation_id = next_async_scroll_operation_id();
+            operation_id = next_async_scroll_operation_id(context);
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted main-thread async scroll enqueue at {},{} device delta {},{} for scroll node {} viewport={}x{} at {},{}",
             position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), scroll_target.node_id->scroll_frame_index.value(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, operation_id });
+        enqueue_command(context_id, AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, operation_id });
         return { true, operation_id };
     }
 
     bool enqueue_async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
     {
-        if (!m_can_accept_async_wheel_events.load()) {
-            auto wheel_routing_admission = [this] {
+        auto context_state = page_presentation_context_state();
+        auto context_id = page_presentation_context_id();
+        if (!context_state || !context_id.has_value())
+            return false;
+        auto& context = *context_state;
+        if (!context.can_accept_async_wheel_events.load()) {
+            auto wheel_routing_admission = [&] {
                 Sync::MutexLocker const locker { m_mutex };
-                return m_wheel_routing_admission;
+                return context.wheel_routing_admission;
             }();
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: compositor cannot accept async wheel events ({})",
                 wheel_routing_admission_to_string(wheel_routing_admission));
             return false;
         }
 
-        auto viewport_rect = [this] {
+        auto viewport_rect = [&] {
             Sync::MutexLocker const locker { m_mutex };
-            return m_async_scrolling_viewport_rect;
+            return context.async_scrolling_viewport_rect;
         }();
-        auto scroll_target = hit_test_scroll_node_for_wheel(position, delta_in_device_pixels);
+        auto scroll_target = hit_test_scroll_node_for_wheel(context, position, delta_in_device_pixels);
         if (scroll_target.blocked_by_main_thread_region) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rejecting async scroll enqueue: main-thread wheel region at {},{} device delta {},{}",
                 position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
@@ -453,16 +584,16 @@ public:
 
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted async scroll enqueue at {},{} device delta {},{} for scroll node {} viewport={}x{} at {},{}",
             position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), scroll_target.node_id->scroll_frame_index.value(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
+        enqueue_command(*context_id, AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
         return true;
     }
 
-    Optional<size_t> hit_test_viewport_scrollbar(Gfx::FloatPoint position) const
+    Optional<size_t> hit_test_viewport_scrollbar(ContextState& context, Gfx::FloatPoint position) const
     {
-        Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-        for (size_t i = 0; i < m_viewport_scrollbars.size(); ++i) {
-            auto const& scrollbar = m_viewport_scrollbars[i];
-            auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
+        Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+        for (size_t i = 0; i < context.viewport_scrollbars.size(); ++i) {
+            auto const& scrollbar = context.viewport_scrollbars[i];
+            auto scroll_offset = context.async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, context.cached_scroll_state_snapshot);
             if (!scroll_offset.has_value())
                 continue;
 
@@ -474,6 +605,11 @@ public:
 
     bool handle_viewport_scrollbar_mouse_event(MouseEvent const& event)
     {
+        auto context_state = page_presentation_context_state();
+        auto context_id = page_presentation_context_id();
+        if (!context_state || !context_id.has_value())
+            return false;
+        auto& context = *context_state;
         auto position = Gfx::FloatPoint {
             static_cast<float>(event.position.x().value()),
             static_cast<float>(event.position.y().value()),
@@ -491,14 +627,14 @@ public:
             float thumb_grab_position = 0;
             float primary_position = 0;
             {
-                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                for (size_t i = 0; i < m_viewport_scrollbars.size(); ++i) {
-                    auto const& scrollbar = m_viewport_scrollbars[i];
-                    auto scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
+                Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+                for (size_t i = 0; i < context.viewport_scrollbars.size(); ++i) {
+                    auto const& scrollbar = context.viewport_scrollbars[i];
+                    auto scroll_offset = context.async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, context.cached_scroll_state_snapshot);
                     if (!scroll_offset.has_value())
                         continue;
 
-                    auto expanded = m_hovered_viewport_scrollbar_index == i || m_captured_viewport_scrollbar_index == i;
+                    auto expanded = context.hovered_viewport_scrollbar_index == i || context.captured_viewport_scrollbar_index == i;
                     auto orientation = orientation_for_scrollbar(scrollbar);
                     auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
                     primary_position = primary_position_for_scrollbar(scrollbar);
@@ -522,13 +658,13 @@ public:
                 if (!scrollbar_index.has_value())
                     return false;
 
-                m_captured_viewport_scrollbar_index = *scrollbar_index;
-                m_hovered_viewport_scrollbar_index = *scrollbar_index;
-                m_viewport_scrollbar_thumb_grab_position = thumb_grab_position;
+                context.captured_viewport_scrollbar_index = *scrollbar_index;
+                context.hovered_viewport_scrollbar_index = *scrollbar_index;
+                context.viewport_scrollbar_thumb_grab_position = thumb_grab_position;
             }
 
-            schedule_viewport_scrollbar_present();
-            enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+            schedule_viewport_scrollbar_present(context);
+            enqueue_command(*context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseMove: {
@@ -536,23 +672,23 @@ public:
             float thumb_grab_position = 0;
             float primary_position = 0;
             {
-                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                if (m_captured_viewport_scrollbar_index.has_value()) {
-                    scrollbar_index = *m_captured_viewport_scrollbar_index;
-                    thumb_grab_position = m_viewport_scrollbar_thumb_grab_position;
-                    if (*scrollbar_index >= m_viewport_scrollbars.size()) {
-                        m_captured_viewport_scrollbar_index.clear();
+                Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+                if (context.captured_viewport_scrollbar_index.has_value()) {
+                    scrollbar_index = *context.captured_viewport_scrollbar_index;
+                    thumb_grab_position = context.viewport_scrollbar_thumb_grab_position;
+                    if (*scrollbar_index >= context.viewport_scrollbars.size()) {
+                        context.captured_viewport_scrollbar_index.clear();
                         return false;
                     }
-                    primary_position = primary_position_for_scrollbar(m_viewport_scrollbars[*scrollbar_index]);
+                    primary_position = primary_position_for_scrollbar(context.viewport_scrollbars[*scrollbar_index]);
                 }
             }
             if (scrollbar_index.has_value()) {
-                enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+                enqueue_command(*context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
                 return true;
             }
-            auto hovered_scrollbar_index = hit_test_viewport_scrollbar(position);
-            set_hovered_viewport_scrollbar(hovered_scrollbar_index);
+            auto hovered_scrollbar_index = hit_test_viewport_scrollbar(context, position);
+            set_hovered_viewport_scrollbar(context, hovered_scrollbar_index);
             return hovered_scrollbar_index.has_value();
         }
         case MouseEvent::Type::MouseUp: {
@@ -560,28 +696,28 @@ public:
             float thumb_grab_position = 0;
             float primary_position = 0;
             {
-                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                if (!m_captured_viewport_scrollbar_index.has_value())
+                Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+                if (!context.captured_viewport_scrollbar_index.has_value())
                     return false;
-                scrollbar_index = *m_captured_viewport_scrollbar_index;
-                thumb_grab_position = m_viewport_scrollbar_thumb_grab_position;
-                if (*scrollbar_index >= m_viewport_scrollbars.size()) {
-                    m_captured_viewport_scrollbar_index.clear();
+                scrollbar_index = *context.captured_viewport_scrollbar_index;
+                thumb_grab_position = context.viewport_scrollbar_thumb_grab_position;
+                if (*scrollbar_index >= context.viewport_scrollbars.size()) {
+                    context.captured_viewport_scrollbar_index.clear();
                     return false;
                 }
-                primary_position = primary_position_for_scrollbar(m_viewport_scrollbars[*scrollbar_index]);
-                m_captured_viewport_scrollbar_index.clear();
+                primary_position = primary_position_for_scrollbar(context.viewport_scrollbars[*scrollbar_index]);
+                context.captured_viewport_scrollbar_index.clear();
             }
-            schedule_viewport_scrollbar_present();
-            enqueue_command(ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
+            schedule_viewport_scrollbar_present(context);
+            enqueue_command(*context_id, ViewportScrollbarDragCommand { *scrollbar_index, primary_position, thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseLeave: {
-            auto has_capture = [this] {
-                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                return m_captured_viewport_scrollbar_index.has_value();
+            auto has_capture = [&] {
+                Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+                return context.captured_viewport_scrollbar_index.has_value();
             }();
-            set_hovered_viewport_scrollbar({});
+            set_hovered_viewport_scrollbar(context, {});
             return has_capture;
         }
         case MouseEvent::Type::MouseWheel:
@@ -620,82 +756,87 @@ public:
                 if (!command.has_value())
                     break;
 
+                auto context_state = this->context_state(command->context_id);
+                if (!context_state)
+                    continue;
+                auto& context = *context_state;
+
                 bool should_yield_to_async_scroll_present = false;
                 command->command.visit(
-                    [this](UpdateDisplayListCommand& cmd) {
+                    [this, &context](UpdateDisplayListCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing display list update (deferred_async_present={})",
-                            m_has_deferred_async_scroll_present);
-                        m_display_list_resource_storage.apply_transaction(move(cmd.resource_transaction));
-                        m_cached_display_list = move(cmd.display_list);
-                        m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
-                        auto async_scrolling_state = async_scrolling_state_from_display_list(*m_cached_display_list);
+                            context.has_deferred_async_scroll_present);
+                        context.display_list_resource_storage.apply_transaction(move(cmd.resource_transaction));
+                        context.cached_display_list = move(cmd.display_list);
+                        context.cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
+                        auto async_scrolling_state = async_scrolling_state_from_display_list(*context.cached_display_list);
                         auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
                         auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
                         auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
                         {
                             Sync::MutexLocker const locker { m_mutex };
-                            if (wheel_event_listener_state_generation < m_wheel_event_listener_state_generation)
+                            if (wheel_event_listener_state_generation < context.wheel_event_listener_state_generation)
                                 wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
                             else
-                                m_wheel_event_listener_state_generation = wheel_event_listener_state_generation;
-                            m_wheel_routing_admission = wheel_routing_admission;
+                                context.wheel_event_listener_state_generation = wheel_event_listener_state_generation;
+                            context.wheel_routing_admission = wheel_routing_admission;
                         }
-                        m_can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
+                        context.can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor wheel routing admission: {} (scroll_nodes={}, sticky_areas={}, blocking_regions={})",
                             wheel_routing_admission_to_string(wheel_routing_admission),
                             async_scrolling_state.scroll_nodes.size(),
                             async_scrolling_state.sticky_areas.size(),
                             async_scrolling_state.blocking_wheel_event_regions.size());
-                        auto pending_async_scroll_offsets = [this] {
+                        auto pending_async_scroll_offsets = [this, &context] {
                             Sync::MutexLocker const locker { m_mutex };
-                            return m_pending_async_scroll_offsets;
+                            return context.pending_async_scroll_offsets;
                         }();
 
                         {
-                            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                            auto hovered_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_hovered_viewport_scrollbar_index);
-                            auto captured_scrollbar_identity = viewport_scrollbar_identity_at(m_viewport_scrollbars, m_captured_viewport_scrollbar_index);
-                            m_viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
-                            m_hovered_viewport_scrollbar_index = hovered_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *hovered_scrollbar_identity) : Optional<size_t> {};
-                            m_captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(m_viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
-                            m_async_scroll_tree.set_state(move(async_scrolling_state));
+                            Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+                            auto hovered_scrollbar_identity = viewport_scrollbar_identity_at(context.viewport_scrollbars, context.hovered_viewport_scrollbar_index);
+                            auto captured_scrollbar_identity = viewport_scrollbar_identity_at(context.viewport_scrollbars, context.captured_viewport_scrollbar_index);
+                            context.viewport_scrollbars = move(async_scrolling_state.viewport_scrollbars);
+                            context.hovered_viewport_scrollbar_index = hovered_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(context.viewport_scrollbars, *hovered_scrollbar_identity) : Optional<size_t> {};
+                            context.captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(context.viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
+                            context.async_scroll_tree.set_state(move(async_scrolling_state));
                             if (!pending_async_scroll_offsets.is_empty()) {
                                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying {} pending async scroll offset(s) to display list update",
                                     pending_async_scroll_offsets.size());
-                                if (auto viewport_scroll_offset = reapply_pending_async_scroll_offsets(pending_async_scroll_offsets); viewport_scroll_offset.has_value())
+                                if (auto viewport_scroll_offset = reapply_pending_async_scroll_offsets(context, pending_async_scroll_offsets); viewport_scroll_offset.has_value())
                                     async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
                             }
-                            m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.cached_display_list, context.cached_scroll_state_snapshot);
                         }
                         {
                             Sync::MutexLocker const locker { m_mutex };
-                            m_async_scrolling_viewport_rect = async_scrolling_viewport_rect;
+                            context.async_scrolling_viewport_rect = async_scrolling_viewport_rect;
                         }
-                        m_has_async_scrolling_state = true;
+                        context.has_async_scrolling_state = true;
                     },
-                    [this, &should_yield_to_async_scroll_present](AsyncScrollByCommand& cmd) {
+                    [this, &context, &should_yield_to_async_scroll_present](AsyncScrollByCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing async scroll command at {},{} device delta {},{} for scroll node {} (deferred_async_present={})",
-                            cmd.position.x(), cmd.position.y(), cmd.delta_in_device_pixels.x(), cmd.delta_in_device_pixels.y(), cmd.scroll_target.scroll_frame_index.value(), m_has_deferred_async_scroll_present);
+                            cmd.position.x(), cmd.position.y(), cmd.delta_in_device_pixels.x(), cmd.delta_in_device_pixels.y(), cmd.scroll_target.scroll_frame_index.value(), context.has_deferred_async_scroll_present);
                         auto async_scroll_viewport_rect = cmd.viewport_rect;
                         Vector<AsyncScrollOffset> scroll_offsets;
                         {
-                            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-                            scroll_offsets = m_async_scroll_tree.apply_scroll_delta(cmd.scroll_target, cmd.delta_in_device_pixels, m_cached_scroll_state_snapshot);
+                            Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+                            scroll_offsets = context.async_scroll_tree.apply_scroll_delta(cmd.scroll_target, cmd.delta_in_device_pixels, context.cached_scroll_state_snapshot);
                             if (scroll_offsets.is_empty()) {
                                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping async scroll command: scroll tree consumed no delta");
                                 // The operation produced no scroll offset (e.g. already at the scroll boundary), so it
                                 // cannot be reported through the pending-offset path; report its completion separately.
-                                complete_async_scroll_operation(cmd.operation_id);
+                                complete_async_scroll_operation(context, cmd.operation_id);
                                 return;
                             }
-                            m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                            context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.cached_display_list, context.cached_scroll_state_snapshot);
                         }
                         if (auto viewport_scroll_offset = viewport_scroll_offset_from(scroll_offsets); viewport_scroll_offset.has_value())
                             async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-                        store_pending_async_scroll_offsets(scroll_offsets, cmd.operation_id);
+                        store_pending_async_scroll_offsets(context, scroll_offsets, cmd.operation_id);
                         {
                             Sync::MutexLocker const locker { m_mutex };
-                            m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
+                            context.async_scrolling_viewport_rect = async_scroll_viewport_rect;
                         }
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Stored {} pending async scroll offset(s)",
                             scroll_offsets.size());
@@ -704,70 +845,70 @@ public:
                         });
                         {
                             Sync::MutexLocker const locker { m_mutex };
-                            m_has_deferred_async_scroll_present = true;
-                            m_deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
+                            context.has_deferred_async_scroll_present = true;
+                            context.deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
                         }
-                        should_yield_to_async_scroll_present = can_present_deferred_async_scroll();
+                        should_yield_to_async_scroll_present = can_present_deferred_async_scroll(context);
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor async scroll command complete (yield_to_present={})",
                             should_yield_to_async_scroll_present);
                     },
-                    [this, &should_yield_to_async_scroll_present](ViewportScrollbarDragCommand& cmd) {
+                    [this, &context, &should_yield_to_async_scroll_present](ViewportScrollbarDragCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing viewport scrollbar drag (index={}, position={}, grab={})",
                             cmd.scrollbar_index, cmd.primary_position, cmd.thumb_grab_position);
-                        if (apply_viewport_scrollbar_drag(cmd.scrollbar_index, cmd.primary_position, cmd.thumb_grab_position)) {
-                            should_yield_to_async_scroll_present = can_present_deferred_async_scroll();
+                        if (apply_viewport_scrollbar_drag(context, cmd.scrollbar_index, cmd.primary_position, cmd.thumb_grab_position)) {
+                            should_yield_to_async_scroll_present = can_present_deferred_async_scroll(context);
                             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor viewport scrollbar drag complete (yield_to_present={})",
                                 should_yield_to_async_scroll_present);
                         }
                     },
-                    [this](UpdateScrollStateCommand& cmd) {
-                        m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
-                        if (m_has_async_scrolling_state) {
-                            auto pending_async_scroll_offsets = [this] {
+                    [this, &context](UpdateScrollStateCommand& cmd) {
+                        context.cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
+                        if (context.has_async_scrolling_state) {
+                            auto pending_async_scroll_offsets = [this, &context] {
                                 Sync::MutexLocker const locker { m_mutex };
-                                return m_pending_async_scroll_offsets;
+                                return context.pending_async_scroll_offsets;
                             }();
                             Optional<Gfx::FloatPoint> reconciled_viewport_scroll_offset;
                             {
-                                Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
+                                Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
                                 // A main-thread scroll-state update can be older than compositor-side async
                                 // scrolling. Preserve compositor-visible offsets in the fresh snapshot before
                                 // rebuilding hit-test data from it.
-                                reconciled_viewport_scroll_offset = reapply_pending_async_scroll_offsets(pending_async_scroll_offsets);
-                                m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+                                reconciled_viewport_scroll_offset = reapply_pending_async_scroll_offsets(context, pending_async_scroll_offsets);
+                                context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.cached_display_list, context.cached_scroll_state_snapshot);
                             }
                             if (reconciled_viewport_scroll_offset.has_value()) {
                                 Sync::MutexLocker const mutex_locker { m_mutex };
-                                auto reconciled_viewport_rect = m_async_scrolling_viewport_rect;
+                                auto reconciled_viewport_rect = context.async_scrolling_viewport_rect;
                                 reconciled_viewport_rect.set_location(reconciled_viewport_scroll_offset->to_type<int>());
-                                m_async_scrolling_viewport_rect = reconciled_viewport_rect;
+                                context.async_scrolling_viewport_rect = reconciled_viewport_rect;
                             }
                         }
                     },
-                    [this](UpdateCompositorSurfaceCommand& cmd) {
-                        m_display_list_resource_storage.update_compositor_surface(cmd.surface_id, move(cmd.shared_image));
+                    [&context](UpdateCompositorSurfaceCommand& cmd) {
+                        context.display_list_resource_storage.update_compositor_surface(cmd.surface_id, move(cmd.shared_image));
                     },
-                    [this](ClearCompositorSurfaceCommand& cmd) {
-                        m_display_list_resource_storage.clear_compositor_surface(cmd.surface_id);
+                    [&context](ClearCompositorSurfaceCommand& cmd) {
+                        context.display_list_resource_storage.clear_compositor_surface(cmd.surface_id);
                     },
-                    [this](ViewportSizeUpdatedCommand& cmd) {
-                        auto allocation = m_backing_store_manager.resize_backing_stores_if_needed(
+                    [this, &context](ViewportSizeUpdatedCommand& cmd) {
+                        auto allocation = context.backing_store_manager.resize_backing_stores_if_needed(
                             cmd.viewport_size, cmd.is_top_level_traversable, cmd.window_resize_in_progress);
                         if (!allocation.has_value())
                             return;
 
-                        if (m_has_async_scrolling_state) {
+                        if (context.has_async_scrolling_state) {
                             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor resizing backing stores front={} back={} size={}x{}",
                                 allocation->front_bitmap_id, allocation->back_bitmap_id, allocation->size.width(), allocation->size.height());
                         }
-                        if (auto publication = m_backing_store_manager.allocate_backing_stores(*allocation, m_skia_backend_context, m_presents_to_client); publication.has_value())
-                            publish_backing_store_pair(publication.release_value());
+                        if (auto publication = context.backing_store_manager.allocate_backing_stores(*allocation, m_skia_backend_context, context.presents_to_client); publication.has_value())
+                            publish_backing_store_pair(context, publication.release_value());
                     },
-                    [this](ScreenshotCommand& cmd) {
-                        if (!m_cached_display_list)
+                    [this, &context](ScreenshotCommand& cmd) {
+                        if (!context.cached_display_list)
                             return;
-                        m_skia_player->execute(*m_cached_display_list, m_display_list_resource_storage, m_cached_scroll_state_snapshot, *cmd.target_surface);
-                        paint_viewport_scrollbar_overlay(*cmd.target_surface);
+                        m_skia_player->execute(*context.cached_display_list, context.display_list_resource_storage, context.cached_scroll_state_snapshot, *cmd.target_surface);
+                        paint_viewport_scrollbar_overlay(context, *cmd.target_surface);
                         flush_surface(*cmd.target_surface);
                         if (cmd.callback) {
                             invoke_on_main_thread([callback = move(cmd.callback)]() mutable {
@@ -788,6 +929,7 @@ public:
                 break;
 
             bool should_present = false;
+            RefPtr<ContextState> present_context_state;
             Gfx::IntRect viewport_rect;
             u64 presenting_frame_id = 0;
             bool should_present_deferred_async_scroll = false;
@@ -795,28 +937,36 @@ public:
             Optional<u64> deferred_async_scroll_presenting_frame_id;
             {
                 Sync::MutexLocker const locker { m_mutex };
-                if (m_has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked()) {
-                    should_present_deferred_async_scroll = true;
-                    deferred_async_scroll_viewport_rect = m_deferred_async_scroll_present_viewport_rect;
-                    m_has_deferred_async_scroll_present = false;
-                    if (m_needs_present) {
-                        deferred_async_scroll_presenting_frame_id = m_submitted_frame_id;
-                        m_needs_present = false;
+                for (auto& [_, context] : m_contexts) {
+                    if (context->has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked(*context)) {
+                        present_context_state = context;
+                        should_present_deferred_async_scroll = true;
+                        deferred_async_scroll_viewport_rect = context->deferred_async_scroll_present_viewport_rect;
+                        context->has_deferred_async_scroll_present = false;
+                        if (context->needs_present) {
+                            deferred_async_scroll_presenting_frame_id = context->submitted_frame_id;
+                            context->needs_present = false;
+                        }
+                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor selected deferred async present (pending_main_thread_present={})",
+                            deferred_async_scroll_presenting_frame_id.has_value());
+                        break;
                     }
-                    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor selected deferred async present (pending_main_thread_present={})",
-                        deferred_async_scroll_presenting_frame_id.has_value());
-                } else if (m_needs_present && !has_presented_bitmap_awaiting_ack_while_locked()) {
-                    should_present = true;
-                    viewport_rect = m_pending_viewport_rect;
-                    presenting_frame_id = m_submitted_frame_id;
-                    m_needs_present = false;
+
+                    if (context->needs_present && !has_presented_bitmap_awaiting_ack_while_locked(*context)) {
+                        present_context_state = context;
+                        should_present = true;
+                        viewport_rect = context->pending_viewport_rect;
+                        presenting_frame_id = context->submitted_frame_id;
+                        context->needs_present = false;
+                        break;
+                    }
                 }
             }
 
             if (should_present_deferred_async_scroll)
-                present_frame(deferred_async_scroll_viewport_rect, deferred_async_scroll_presenting_frame_id, PresentFrameDelivery::AsyncScroll);
+                present_frame(*present_context_state, deferred_async_scroll_viewport_rect, deferred_async_scroll_presenting_frame_id, PresentFrameDelivery::AsyncScroll);
             else if (should_present)
-                present_frame(viewport_rect, presenting_frame_id, PresentFrameDelivery::MainThread);
+                present_frame(*present_context_state, viewport_rect, presenting_frame_id, PresentFrameDelivery::MainThread);
         }
     }
 
@@ -826,24 +976,24 @@ private:
         AsyncScroll,
     };
 
-    bool has_presented_bitmap_awaiting_ack_while_locked() const
+    bool has_presented_bitmap_awaiting_ack_while_locked(ContextState const& context) const
     {
-        return m_presented_bitmap_id_awaiting_ack.has_value();
+        return context.presented_bitmap_id_awaiting_ack.has_value();
     }
 
-    AsyncScrollOperationID next_async_scroll_operation_id()
+    AsyncScrollOperationID next_async_scroll_operation_id(ContextState& context)
     {
-        return m_next_async_scroll_operation_id.fetch_add(1) + 1;
+        return context.next_async_scroll_operation_id.fetch_add(1) + 1;
     }
 
-    void complete_async_scroll_operation(Optional<AsyncScrollOperationID> operation_id)
+    void complete_async_scroll_operation(ContextState& context, Optional<AsyncScrollOperationID> operation_id)
     {
         if (!operation_id.has_value())
             return;
 
         {
             Sync::MutexLocker const locker { m_mutex };
-            m_completed_async_scroll_operation_ids.append(*operation_id);
+            context.completed_async_scroll_operation_ids.append(*operation_id);
         }
 
         // No scroll offset was produced, so nothing else will wake the main thread; schedule a rendering update so it
@@ -853,12 +1003,12 @@ private:
         });
     }
 
-    void queue_rendering_update_if_async_scroll_updates_pending()
+    void queue_rendering_update_if_async_scroll_updates_pending(ContextState& context)
     {
-        auto has_pending_updates = [this] {
+        auto has_pending_updates = [this, &context] {
             Sync::MutexLocker const locker { m_mutex };
-            return !m_pending_async_scroll_offsets.is_empty()
-                || !m_completed_async_scroll_operation_ids.is_empty();
+            return !context.pending_async_scroll_offsets.is_empty()
+                || !context.completed_async_scroll_operation_ids.is_empty();
         }();
         if (!has_pending_updates)
             return;
@@ -868,30 +1018,30 @@ private:
         });
     }
 
-    void store_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const& scroll_offsets, Optional<AsyncScrollOperationID> operation_id = {})
+    void store_pending_async_scroll_offsets(ContextState& context, Vector<AsyncScrollOffset> const& scroll_offsets, Optional<AsyncScrollOperationID> operation_id = {})
     {
         Sync::MutexLocker const locker { m_mutex };
         for (auto const& scroll_offset : scroll_offsets)
-            set_or_append_pending_scroll_offset(m_pending_async_scroll_offsets, scroll_offset);
+            set_or_append_pending_scroll_offset(context.pending_async_scroll_offsets, scroll_offset);
         if (operation_id.has_value())
-            m_completed_async_scroll_operation_ids.append(*operation_id);
+            context.completed_async_scroll_operation_ids.append(*operation_id);
     }
 
-    Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const& pending_scroll_offsets)
+    Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(ContextState& context, Vector<AsyncScrollOffset> const& pending_scroll_offsets)
     {
         Optional<Gfx::FloatPoint> viewport_scroll_offset;
         for (auto const& pending_scroll_offset : pending_scroll_offsets) {
-            auto node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(pending_scroll_offset.stable_node_id);
+            auto node_id = context.async_scroll_tree.scroll_node_id_for_stable_id(pending_scroll_offset.stable_node_id);
             if (!node_id.has_value())
                 continue;
-            auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(*node_id, m_cached_scroll_state_snapshot);
+            auto current_scroll_offset = context.async_scroll_tree.scroll_offset_for_node(*node_id, context.cached_scroll_state_snapshot);
             if (!current_scroll_offset.has_value())
                 continue;
             // Reapplying pending async offsets is a restoration step for a freshly received
             // main-thread snapshot. The pending offset is already the compositor-visible
             // position, so applying the unadopted delta here would compound it.
-            auto reconciled_scroll_offset = m_async_scroll_tree.set_scroll_offset(*node_id, pending_scroll_offset.compositor_scroll_offset, m_cached_scroll_state_snapshot);
-            if (reconciled_scroll_offset.has_value() && m_async_scroll_tree.scroll_node_is_viewport(*node_id))
+            auto reconciled_scroll_offset = context.async_scroll_tree.set_scroll_offset(*node_id, pending_scroll_offset.compositor_scroll_offset, context.cached_scroll_state_snapshot);
+            if (reconciled_scroll_offset.has_value() && context.async_scroll_tree.scroll_node_is_viewport(*node_id))
                 viewport_scroll_offset = *reconciled_scroll_offset;
         }
         return viewport_scroll_offset;
@@ -906,59 +1056,59 @@ private:
         return {};
     }
 
-    void paint_viewport_scrollbar_overlay(Gfx::PaintingSurface& surface)
+    void paint_viewport_scrollbar_overlay(ContextState& context, Gfx::PaintingSurface& surface)
     {
         Vector<ViewportScrollbar> scrollbars;
         Optional<size_t> hovered_scrollbar_index;
         Optional<size_t> captured_scrollbar_index;
         {
-            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-            scrollbars = m_viewport_scrollbars;
-            hovered_scrollbar_index = m_hovered_viewport_scrollbar_index;
-            captured_scrollbar_index = m_captured_viewport_scrollbar_index;
+            Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+            scrollbars = context.viewport_scrollbars;
+            hovered_scrollbar_index = context.hovered_viewport_scrollbar_index;
+            captured_scrollbar_index = context.captured_viewport_scrollbar_index;
         }
-        paint_viewport_scrollbars(surface, scrollbars, m_cached_scroll_state_snapshot, hovered_scrollbar_index, captured_scrollbar_index);
+        paint_viewport_scrollbars(surface, scrollbars, context.cached_scroll_state_snapshot, hovered_scrollbar_index, captured_scrollbar_index);
     }
 
-    void schedule_viewport_scrollbar_present()
+    void schedule_viewport_scrollbar_present(ContextState& context)
     {
         Sync::MutexLocker const locker { m_mutex };
-        if (m_async_scrolling_viewport_rect.is_empty())
+        if (context.async_scrolling_viewport_rect.is_empty())
             return;
-        m_has_deferred_async_scroll_present = true;
-        m_deferred_async_scroll_present_viewport_rect = m_async_scrolling_viewport_rect;
+        context.has_deferred_async_scroll_present = true;
+        context.deferred_async_scroll_present_viewport_rect = context.async_scrolling_viewport_rect;
         m_command_ready.signal();
     }
 
-    void set_hovered_viewport_scrollbar(Optional<size_t> scrollbar_index)
+    void set_hovered_viewport_scrollbar(ContextState& context, Optional<size_t> scrollbar_index)
     {
         bool changed = false;
         {
-            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-            if (m_hovered_viewport_scrollbar_index == scrollbar_index)
+            Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+            if (context.hovered_viewport_scrollbar_index == scrollbar_index)
                 return;
             changed = true;
-            m_hovered_viewport_scrollbar_index = scrollbar_index;
+            context.hovered_viewport_scrollbar_index = scrollbar_index;
         }
         if (changed)
-            schedule_viewport_scrollbar_present();
+            schedule_viewport_scrollbar_present(context);
     }
 
-    bool apply_viewport_scrollbar_drag(size_t scrollbar_index, float primary_position, float thumb_grab_position)
+    bool apply_viewport_scrollbar_drag(ContextState& context, size_t scrollbar_index, float primary_position, float thumb_grab_position)
     {
         Vector<AsyncScrollOffset> scroll_offsets;
         {
-            Sync::MutexLocker const locker { m_async_scroll_tree_mutex };
-            if (scrollbar_index >= m_viewport_scrollbars.size())
+            Sync::MutexLocker const locker { context.async_scroll_tree_mutex };
+            if (scrollbar_index >= context.viewport_scrollbars.size())
                 return false;
 
-            auto const& scrollbar = m_viewport_scrollbars[scrollbar_index];
-            auto expanded = m_hovered_viewport_scrollbar_index == scrollbar_index || m_captured_viewport_scrollbar_index == scrollbar_index;
+            auto const& scrollbar = context.viewport_scrollbars[scrollbar_index];
+            auto expanded = context.hovered_viewport_scrollbar_index == scrollbar_index || context.captured_viewport_scrollbar_index == scrollbar_index;
             auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);
             if (scroll_size == 0)
                 return false;
 
-            auto current_scroll_offset = m_async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, m_cached_scroll_state_snapshot);
+            auto current_scroll_offset = context.async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, context.cached_scroll_state_snapshot);
             if (!current_scroll_offset.has_value())
                 return false;
 
@@ -974,26 +1124,26 @@ private:
             if (delta.x() == 0 && delta.y() == 0)
                 return false;
 
-            scroll_offsets = m_async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, m_cached_scroll_state_snapshot);
+            scroll_offsets = context.async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, context.cached_scroll_state_snapshot);
             if (scroll_offsets.is_empty())
                 return false;
-            m_async_scroll_tree.rebuild_wheel_hit_test_targets(m_cached_display_list, m_cached_scroll_state_snapshot);
+            context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.cached_display_list, context.cached_scroll_state_snapshot);
         }
 
         auto scroll_offset = viewport_scroll_offset_from(scroll_offsets);
         if (!scroll_offset.has_value())
             return false;
 
-        store_pending_async_scroll_offsets(scroll_offsets);
+        store_pending_async_scroll_offsets(context, scroll_offsets);
 
         Gfx::IntRect async_scroll_viewport_rect;
         {
             Sync::MutexLocker const locker { m_mutex };
-            async_scroll_viewport_rect = m_async_scrolling_viewport_rect;
+            async_scroll_viewport_rect = context.async_scrolling_viewport_rect;
             async_scroll_viewport_rect.set_location(scroll_offset->to_type<int>());
-            m_async_scrolling_viewport_rect = async_scroll_viewport_rect;
-            m_has_deferred_async_scroll_present = true;
-            m_deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
+            context.async_scrolling_viewport_rect = async_scroll_viewport_rect;
+            context.has_deferred_async_scroll_present = true;
+            context.deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
         }
         invoke_on_main_thread([] {
             HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
@@ -1003,65 +1153,70 @@ private:
 
     bool has_presentable_work() const
     {
-        return (m_has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked())
-            || (m_needs_present && !has_presented_bitmap_awaiting_ack_while_locked());
+        for (auto const& [_, context] : m_contexts) {
+            if ((context->has_deferred_async_scroll_present || context->needs_present)
+                && !has_presented_bitmap_awaiting_ack_while_locked(*context)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    bool can_present_deferred_async_scroll() const
+    bool can_present_deferred_async_scroll(ContextState& context) const
     {
         Sync::MutexLocker const locker { m_mutex };
-        return m_has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked();
+        return context.has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked(context);
     }
 
-    void present_frame(Gfx::IntRect viewport_rect, Optional<u64> presenting_frame_id = {}, PresentFrameDelivery delivery = PresentFrameDelivery::MainThread)
+    void present_frame(ContextState& context, Gfx::IntRect viewport_rect, Optional<u64> presenting_frame_id = {}, PresentFrameDelivery delivery = PresentFrameDelivery::MainThread)
     {
         auto delivery_name = delivery == PresentFrameDelivery::AsyncScroll ? "compositor-thread"sv : "main-thread"sv;
 
         {
             Sync::MutexLocker const locker { m_mutex };
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Begin {} present (frame={}, awaiting_bitmap={}, viewport={}x{} at {},{})",
-                delivery_name, presenting_frame_id.value_or(0), m_presented_bitmap_id_awaiting_ack.value_or(-1), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
+                delivery_name, presenting_frame_id.value_or(0), context.presented_bitmap_id_awaiting_ack.value_or(-1), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
 
-            if (delivery == PresentFrameDelivery::AsyncScroll && has_presented_bitmap_awaiting_ack_while_locked()) {
-                m_has_deferred_async_scroll_present = true;
-                m_deferred_async_scroll_present_viewport_rect = viewport_rect;
+            if (delivery == PresentFrameDelivery::AsyncScroll && has_presented_bitmap_awaiting_ack_while_locked(context)) {
+                context.has_deferred_async_scroll_present = true;
+                context.deferred_async_scroll_present_viewport_rect = viewport_rect;
                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Deferring async scroll present until bitmap {} is ready to paint",
-                    m_presented_bitmap_id_awaiting_ack.value());
+                    context.presented_bitmap_id_awaiting_ack.value());
                 return;
             }
-            VERIFY(!has_presented_bitmap_awaiting_ack_while_locked());
+            VERIFY(!has_presented_bitmap_awaiting_ack_while_locked(context));
             if (m_exit)
                 return;
-            m_is_rasterizing = true;
+            context.is_rasterizing = true;
         }
 
-        auto presentation_mode = [this] {
+        auto presentation_mode = [&] {
             Sync::MutexLocker const locker { m_mutex };
-            return m_presentation_mode;
+            return context.presentation_mode;
         }();
 
-        if (m_cached_display_list && m_backing_store_manager.is_valid()) {
+        if (context.cached_display_list && context.backing_store_manager.is_valid()) {
             auto should_clear_back_store = presentation_mode.visit(
                 [](CompositorThread::PresentToUI) { return false; },
                 [](CompositorThread::PublishToCompositorSurface const&) { return true; });
-            auto& back_store = m_backing_store_manager.back_store();
+            auto& back_store = context.backing_store_manager.back_store();
             if (should_clear_back_store) {
                 // Embedded navigables leave their PaintConfig canvas unfilled, so double-buffered back stores must be
                 // cleared before repainting.
                 back_store.canvas().clear(SK_ColorTRANSPARENT);
             }
-            m_skia_player->execute(*m_cached_display_list, m_display_list_resource_storage, m_cached_scroll_state_snapshot, back_store);
-            paint_viewport_scrollbar_overlay(back_store);
+            m_skia_player->execute(*context.cached_display_list, context.display_list_resource_storage, context.cached_scroll_state_snapshot, back_store);
+            paint_viewport_scrollbar_overlay(context, back_store);
             flush_surface(back_store);
-            i32 rendered_bitmap_id = m_backing_store_manager.back_bitmap_id();
-            m_backing_store_manager.swap();
+            i32 rendered_bitmap_id = context.backing_store_manager.back_bitmap_id();
+            context.backing_store_manager.swap();
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Finished {} display-list replay into bitmap {}",
                 delivery_name, rendered_bitmap_id);
 
             presentation_mode.visit(
-                [this, viewport_rect, rendered_bitmap_id, delivery](CompositorThread::PresentToUI) {
-                    if (m_presents_to_client) {
-                        finish_rasterizing(rendered_bitmap_id);
+                [this, &context, viewport_rect, rendered_bitmap_id, delivery](CompositorThread::PresentToUI) {
+                    if (context.presents_to_client) {
+                        finish_rasterizing(context, rendered_bitmap_id);
                         if (delivery == PresentFrameDelivery::AsyncScroll) {
                             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Finished async scroll raster into bitmap {}",
                                 rendered_bitmap_id);
@@ -1069,35 +1224,35 @@ private:
                         VERIFY(CompositorThread::present_frame_to_client(m_page_id, viewport_rect, rendered_bitmap_id));
                     } else {
                         Sync::MutexLocker const locker { m_mutex };
-                        m_is_rasterizing = false;
+                        context.is_rasterizing = false;
                     }
                 },
-                [this](CompositorThread::PublishToCompositorSurface const& mode) {
+                [this, &context](CompositorThread::PublishToCompositorSurface const& mode) {
                     {
                         Sync::MutexLocker const locker { m_mutex };
-                        m_is_rasterizing = false;
+                        context.is_rasterizing = false;
                     }
-                    if (m_has_async_scrolling_state)
+                    if (context.has_async_scrolling_state)
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Publishing present to compositor surface");
-                    auto& front_store = m_backing_store_manager.front_store();
+                    auto& front_store = context.backing_store_manager.front_store();
                     VERIFY(CompositorThread::update_compositor_surface_for_context(
                         mode.target_context_id, mode.surface_id, front_store.snapshot_into_shared_image()));
                 });
         } else {
             {
                 Sync::MutexLocker const locker { m_mutex };
-                m_is_rasterizing = false;
+                context.is_rasterizing = false;
             }
-            if (m_has_async_scrolling_state) {
+            if (context.has_async_scrolling_state) {
                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Skipping {} present: cached_display_list={}, backing_stores_valid={}",
-                    delivery_name, !!m_cached_display_list, m_backing_store_manager.is_valid());
+                    delivery_name, !!context.cached_display_list, context.backing_store_manager.is_valid());
             }
         }
 
         if (presenting_frame_id.has_value())
-            mark_frame_complete(*presenting_frame_id);
+            mark_frame_complete(context, *presenting_frame_id);
 
-        queue_rendering_update_if_async_scroll_updates_pending();
+        queue_rendering_update_if_async_scroll_updates_pending(context);
     }
 
     void initialize_skia_player(DisplayListPlayerType display_list_player_type)
@@ -1112,9 +1267,9 @@ private:
         m_skia_player = make<Painting::DisplayListPlayerSkia>(m_skia_backend_context);
     }
 
-    void publish_backing_store_pair(BackingStoreManager::Publication&& publication)
+    void publish_backing_store_pair(ContextState& context, BackingStoreManager::Publication&& publication)
     {
-        if (!m_presents_to_client)
+        if (!context.presents_to_client)
             return;
 
         VERIFY(CompositorThread::present_backing_stores_to_client(
@@ -1136,70 +1291,45 @@ private:
 
     u64 m_page_id { 0 };
     NonnullRefPtr<Core::WeakEventLoopReference> m_main_thread_event_loop;
-    bool m_presents_to_client { false };
 
     mutable Sync::Mutex m_mutex;
     mutable Sync::ConditionVariable m_command_ready { m_mutex };
     Atomic<bool> m_exit { false };
 
     Queue<CompositorCommandEnvelope> m_command_queue;
+    HashMap<CompositorContextId, NonnullRefPtr<ContextState>> m_contexts;
     Optional<CompositorContextId> m_default_context_id;
+    Optional<CompositorContextId> m_page_presentation_context_id;
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
-    Painting::DisplayListResourceStorage m_display_list_resource_storage;
-    RefPtr<Painting::DisplayList> m_cached_display_list;
-    Painting::ScrollStateSnapshot m_cached_scroll_state_snapshot;
-    Vector<ViewportScrollbar> m_viewport_scrollbars;
-    Optional<size_t> m_hovered_viewport_scrollbar_index;
-    Optional<size_t> m_captured_viewport_scrollbar_index;
-    float m_viewport_scrollbar_thumb_grab_position { 0 };
-    mutable Sync::Mutex m_async_scroll_tree_mutex;
-    AsyncScrollTree m_async_scroll_tree;
-    BackingStoreManager m_backing_store_manager;
-    CompositorThread::PresentationMode m_presentation_mode { CompositorThread::PresentToUI {} };
-
-    Optional<i32> m_presented_bitmap_id_awaiting_ack;
-    bool m_is_rasterizing { false };
-
-    bool m_needs_present { false };
-    Gfx::IntRect m_pending_viewport_rect;
-    bool m_has_deferred_async_scroll_present { false };
-    Gfx::IntRect m_deferred_async_scroll_present_viewport_rect;
-
-    u64 m_submitted_frame_id { 0 };
-    u64 m_completed_frame_id { 0 };
     mutable Sync::ConditionVariable m_frame_completed { m_mutex };
-    Vector<AsyncScrollOffset> m_pending_async_scroll_offsets;
-    Vector<AsyncScrollOperationID> m_completed_async_scroll_operation_ids;
-    Atomic<AsyncScrollOperationID> m_next_async_scroll_operation_id { 0 };
-    Gfx::IntRect m_async_scrolling_viewport_rect;
-    Atomic<bool> m_has_async_scrolling_state { false };
-    Atomic<bool> m_can_accept_async_wheel_events { false };
-    u64 m_wheel_event_listener_state_generation { 0 };
-    WheelRoutingAdmission m_wheel_routing_admission { WheelRoutingAdmission::NoAsyncScrollingState };
 
 public:
-    void finish_rasterizing(i32 bitmap_id)
+    void finish_rasterizing(ContextState& context, i32 bitmap_id)
     {
         Sync::MutexLocker const locker { m_mutex };
-        m_is_rasterizing = false;
-        VERIFY(!m_presented_bitmap_id_awaiting_ack.has_value());
-        m_presented_bitmap_id_awaiting_ack = bitmap_id;
+        context.is_rasterizing = false;
+        VERIFY(!context.presented_bitmap_id_awaiting_ack.has_value());
+        context.presented_bitmap_id_awaiting_ack = bitmap_id;
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rasterized bitmap {} waiting for ready_to_paint",
             bitmap_id);
     }
 
     void mark_presented_bitmap_ready_to_paint(i32 bitmap_id)
     {
+        auto context_state = page_presentation_context_state();
+        if (!context_state)
+            return;
+        auto& context = *context_state;
         Sync::MutexLocker const locker { m_mutex };
-        if (m_presented_bitmap_id_awaiting_ack != bitmap_id) {
+        if (context.presented_bitmap_id_awaiting_ack != bitmap_id) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Ignoring stale ready_to_paint for bitmap {} while awaiting bitmap {}",
-                bitmap_id, m_presented_bitmap_id_awaiting_ack.value_or(-1));
+                bitmap_id, context.presented_bitmap_id_awaiting_ack.value_or(-1));
             return;
         }
 
-        m_presented_bitmap_id_awaiting_ack.clear();
+        context.presented_bitmap_id_awaiting_ack.clear();
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor ready_to_paint released bitmap {}",
             bitmap_id);
         m_command_ready.signal();
@@ -1252,6 +1382,7 @@ CompositorThread::Context::~Context()
     m_backing_store_shrink_timer.clear();
 
     unregister_page_compositor(m_thread_data->page_id(), *m_thread_data);
+    m_thread_data->unregister_context(m_context_id);
     {
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
         VERIFY(context_compositors().remove(m_context_id));
@@ -1273,7 +1404,7 @@ CompositorThread::~CompositorThread()
 OwnPtr<CompositorThread::Context> CompositorThread::create_context(PagePresentationRegistration page_presentation_registration)
 {
     auto context_id = allocate_compositor_context_id();
-    m_thread_data->set_default_context_id(context_id);
+    m_thread_data->register_context(context_id, page_presentation_registration);
 
     {
         Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
@@ -1281,10 +1412,8 @@ OwnPtr<CompositorThread::Context> CompositorThread::create_context(PagePresentat
         context_compositors().set(context_id, m_thread_data);
     }
 
-    if (page_presentation_registration == PagePresentationRegistration::Yes) {
-        m_thread_data->set_presents_to_client();
+    if (page_presentation_registration == PagePresentationRegistration::Yes)
         register_page_compositor(m_thread_data->page_id(), m_thread_data);
-    }
 
     return adopt_own(*new Context(m_thread_data, context_id));
 }
@@ -1519,12 +1648,12 @@ void CompositorThread::start(DisplayListPlayerType display_list_player_type)
 
 void CompositorThread::Context::set_presentation_mode(PresentationMode mode)
 {
-    m_thread_data->set_presentation_mode(move(mode));
+    m_thread_data->set_presentation_mode(m_context_id, move(mode));
 }
 
 void CompositorThread::Context::stop_presenting_to_client()
 {
-    m_thread_data->stop_presenting_to_client();
+    m_thread_data->stop_presenting_to_client(m_context_id);
     unregister_page_compositor(m_thread_data->page_id(), *m_thread_data);
 }
 
@@ -1548,28 +1677,28 @@ void CompositorThread::Context::clear_compositor_surface(Painting::CompositorSur
 
 void CompositorThread::Context::invalidate_wheel_event_listener_state(u64 generation)
 {
-    m_thread_data->invalidate_wheel_event_listener_state(generation);
+    m_thread_data->invalidate_wheel_event_listener_state(m_context_id, generation);
 }
 
 CompositorThread::AsyncScrollEnqueueResult CompositorThread::Context::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
     Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
 {
-    return m_thread_data->enqueue_async_scroll_by(expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+    return m_thread_data->enqueue_async_scroll_by(m_context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
 bool CompositorThread::Context::should_defer_async_scroll_offset_adoption() const
 {
-    return m_thread_data->should_defer_async_scroll_offset_adoption();
+    return m_thread_data->should_defer_async_scroll_offset_adoption(m_context_id);
 }
 
 bool CompositorThread::Context::should_defer_main_thread_present_for_async_scroll() const
 {
-    return m_thread_data->should_defer_main_thread_present_for_async_scroll();
+    return m_thread_data->should_defer_main_thread_present_for_async_scroll(m_context_id);
 }
 
 CompositorThread::PendingAsyncScrollUpdates CompositorThread::Context::take_pending_async_scroll_updates()
 {
-    return m_thread_data->take_pending_async_scroll_updates();
+    return m_thread_data->take_pending_async_scroll_updates(m_context_id);
 }
 
 void CompositorThread::Context::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
@@ -1596,12 +1725,12 @@ void CompositorThread::Context::enqueue_viewport_size_updated(
 
 u64 CompositorThread::Context::present_frame(Gfx::IntRect viewport_rect)
 {
-    return m_thread_data->set_needs_present(viewport_rect);
+    return m_thread_data->set_needs_present(m_context_id, viewport_rect);
 }
 
 void CompositorThread::Context::wait_for_frame(u64 frame_id)
 {
-    m_thread_data->wait_for_frame(frame_id);
+    m_thread_data->wait_for_frame(m_context_id, frame_id);
 }
 
 void CompositorThread::Context::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -109,7 +109,7 @@ public:
         bool m_last_viewport_size_is_top_level_traversable { false };
     };
 
-    CompositorThread(u64 page_id, PagePresentationRegistration);
+    CompositorThread();
     ~CompositorThread();
 
     static void set_frame_presentation_callbacks(NonnullRefPtr<Core::WeakEventLoopReference>, BackingStorePresentationCallback, FramePresentationCallback);
@@ -118,34 +118,13 @@ public:
     static bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     static bool handle_mouse_event(u64 page_id, MouseEvent const&);
 
-    CompositorContextId context_id() const { return m_context->id(); }
-    OwnPtr<Context> create_context(PagePresentationRegistration);
+    OwnPtr<Context> create_context(Optional<u64> page_id, PagePresentationRegistration);
     void start(DisplayListPlayerType);
-    void stop_presenting_to_client();
-    void set_presentation_mode(PresentationMode);
-
-    void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
-    void update_compositor_surface(Painting::CompositorSurfaceId, Gfx::SharedImage&&);
-    void clear_compositor_surface(Painting::CompositorSurfaceId);
-    void update_scroll_state(Painting::ScrollStateSnapshot&&);
-    void invalidate_wheel_event_listener_state(u64 generation);
-    AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
-        Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
-    bool should_defer_async_scroll_offset_adoption() const;
-    bool should_defer_main_thread_present_for_async_scroll() const;
-    PendingAsyncScrollUpdates take_pending_async_scroll_updates();
-    void viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
-    u64 present_frame(Gfx::IntRect);
-    void wait_for_frame(u64 frame_id);
-    void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:
     NonnullRefPtr<ThreadData> m_thread_data;
-    OwnPtr<Context> m_context;
     RefPtr<Threading::Thread> m_thread;
 
-    static void register_page_compositor(u64 page_id, NonnullRefPtr<ThreadData>);
-    static void unregister_page_compositor(u64 page_id, ThreadData&);
     static bool update_compositor_surface_for_context(CompositorContextId, Painting::CompositorSurfaceId, Gfx::SharedImage&&);
     static bool present_backing_stores_to_client(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage&&, i32 back_bitmap_id, Gfx::SharedImage&&);
     static bool present_frame_to_client(u64 page_id, Gfx::IntRect const&, i32 bitmap_id);

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -91,8 +91,7 @@ public:
         bool should_defer_main_thread_present_for_async_scroll() const;
         PendingAsyncScrollUpdates take_pending_async_scroll_updates();
         void viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
-        u64 present_frame(Gfx::IntRect);
-        void wait_for_frame(u64 frame_id);
+        void present_frame(Gfx::IntRect);
         void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
     private:

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -9,6 +9,7 @@
 #include <AK/Noncopyable.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
+#include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
@@ -68,6 +69,46 @@ public:
     };
     using PresentationMode = Variant<PresentToUI, PublishToCompositorSurface>;
 
+    class WEB_API Context {
+        AK_MAKE_NONCOPYABLE(Context);
+        AK_MAKE_NONMOVABLE(Context);
+
+    public:
+        ~Context();
+
+        CompositorContextId id() const { return m_context_id; }
+        void stop_presenting_to_client();
+        void set_presentation_mode(PresentationMode);
+
+        void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
+        void update_compositor_surface(Painting::CompositorSurfaceId, Gfx::SharedImage&&);
+        void clear_compositor_surface(Painting::CompositorSurfaceId);
+        void update_scroll_state(Painting::ScrollStateSnapshot&&);
+        void invalidate_wheel_event_listener_state(u64 generation);
+        AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
+            Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
+        bool should_defer_async_scroll_offset_adoption() const;
+        bool should_defer_main_thread_present_for_async_scroll() const;
+        PendingAsyncScrollUpdates take_pending_async_scroll_updates();
+        void viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
+        u64 present_frame(Gfx::IntRect);
+        void wait_for_frame(u64 frame_id);
+        void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
+
+    private:
+        friend class CompositorThread;
+
+        Context(NonnullRefPtr<ThreadData>, CompositorContextId);
+
+        void enqueue_viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
+
+        NonnullRefPtr<ThreadData> m_thread_data;
+        CompositorContextId m_context_id;
+        RefPtr<Core::Timer> m_backing_store_shrink_timer;
+        Gfx::IntSize m_last_viewport_size;
+        bool m_last_viewport_size_is_top_level_traversable { false };
+    };
+
     CompositorThread(u64 page_id, PagePresentationRegistration);
     ~CompositorThread();
 
@@ -77,7 +118,8 @@ public:
     static bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     static bool handle_mouse_event(u64 page_id, MouseEvent const&);
 
-    CompositorContextId context_id() const { return m_context_id; }
+    CompositorContextId context_id() const { return m_context->id(); }
+    OwnPtr<Context> create_context(PagePresentationRegistration);
     void start(DisplayListPlayerType);
     void stop_presenting_to_client();
     void set_presentation_mode(PresentationMode);
@@ -98,14 +140,9 @@ public:
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:
-    void enqueue_viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
-
-    CompositorContextId m_context_id { allocate_compositor_context_id() };
     NonnullRefPtr<ThreadData> m_thread_data;
+    OwnPtr<Context> m_context;
     RefPtr<Threading::Thread> m_thread;
-    RefPtr<Core::Timer> m_backing_store_shrink_timer;
-    Gfx::IntSize m_last_viewport_size;
-    bool m_last_viewport_size_is_top_level_traversable { false };
 
     static void register_page_compositor(u64 page_id, NonnullRefPtr<ThreadData>);
     static void unregister_page_compositor(u64 page_id, ThreadData&);

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -453,8 +453,8 @@ void HTMLCanvasElement::present()
 
     if (auto surface = this->surface()) {
         surface->flush();
-        if (auto navigable = document().navigable())
-            navigable->rendering_thread().update_compositor_surface(ensure_compositor_surface_id(), surface->snapshot_into_shared_image());
+        if (auto navigable = document().navigable(); navigable && navigable->has_compositor_context())
+            navigable->compositor_context().update_compositor_surface(ensure_compositor_surface_id(), surface->snapshot_into_shared_image());
     }
 }
 
@@ -462,8 +462,8 @@ void HTMLCanvasElement::clear_compositor_surface()
 {
     if (!m_compositor_surface_id.has_value())
         return;
-    if (auto navigable = document().navigable())
-        navigable->rendering_thread().clear_compositor_surface(*m_compositor_surface_id);
+    if (auto navigable = document().navigable(); navigable && navigable->has_compositor_context())
+        navigable->compositor_context().clear_compositor_surface(*m_compositor_surface_id);
 }
 
 RefPtr<Gfx::PaintingSurface> HTMLCanvasElement::surface() const

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3381,9 +3381,7 @@ void Navigable::paint_next_frame()
         return;
     }
 
-    auto frame_id = compositor_context().present_frame(viewport_rect);
-    if (!is_top_level_traversable())
-        compositor_context().wait_for_frame(frame_id);
+    compositor_context().present_frame(viewport_rect);
 }
 
 void Navigable::render_screenshot(Gfx::PaintingSurface& painting_surface, PaintConfig paint_config, Function<void()>&& callback)

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -280,15 +280,14 @@ Navigable::Navigable(
     : m_page(page)
     , m_event_handler({}, *this)
     , m_is_svg_page(is_svg_page)
-    , m_rendering_thread(
-          is_svg_page ? 0 : page->client().id(),
-          is_svg_page ? Compositor::CompositorThread::PagePresentationRegistration::No : page_presentation_registration)
 {
     all_navigables().set(*this);
 
-    if (!m_is_svg_page) {
-        auto display_list_player_type = page->client().display_list_player_type();
-        m_rendering_thread.start(display_list_player_type);
+    if (!m_is_svg_page && page->has_compositor_thread()) {
+        Optional<u64> page_id;
+        if (page_presentation_registration == Compositor::CompositorThread::PagePresentationRegistration::Yes)
+            page_id = page->client().id();
+        m_compositor_context = page->compositor_thread().create_context(page_id, page_presentation_registration);
     }
 }
 
@@ -431,10 +430,10 @@ void Navigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state
     m_parent = parent;
     if (parent)
         m_should_show_line_box_borders = parent->m_should_show_line_box_borders;
-    if (parent && !m_is_svg_page) {
+    if (parent && !m_is_svg_page && has_compositor_context() && parent->has_compositor_context()) {
         m_compositor_surface_id = Painting::allocate_compositor_surface_id();
-        m_rendering_thread.set_presentation_mode(Compositor::CompositorThread::PublishToCompositorSurface {
-            .target_context_id = parent->rendering_thread().context_id(),
+        compositor_context().set_presentation_mode(Compositor::CompositorThread::PublishToCompositorSurface {
+            .target_context_id = parent->compositor_context().id(),
             .surface_id = *m_compositor_surface_id,
         });
     }
@@ -2851,8 +2850,8 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
 
     m_viewport_size = size;
 
-    if (!m_is_svg_page) {
-        m_rendering_thread.viewport_size_updated(
+    if (has_compositor_context()) {
+        compositor_context().viewport_size_updated(
             page().css_to_device_rect(viewport_rect()).size().to_type<int>(),
             is_top_level_traversable(),
             Compositor::WindowResizingInProgress::Yes);
@@ -3031,17 +3030,17 @@ static bool adopt_async_viewport_scroll_delta(Navigable& navigable, CSSPixelPoin
 
 void Navigable::adopt_pending_async_scroll_offsets()
 {
-    if (!page().async_scrolling_enabled())
+    if (!page().async_scrolling_enabled() || !has_compositor_context())
         return;
 
     // The compositor thread may have already presented newer scroll offsets. Adopt the latest ones before running
     // rendering-update observers so they see the same scroll positions as the user.
-    if (m_rendering_thread.should_defer_async_scroll_offset_adoption()) {
+    if (compositor_context().should_defer_async_scroll_offset_adoption()) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred async scroll offset adoption");
         return;
     }
 
-    auto async_scroll_updates = m_rendering_thread.take_pending_async_scroll_updates();
+    auto async_scroll_updates = compositor_context().take_pending_async_scroll_updates();
     if (async_scroll_updates.scroll_offsets.is_empty() && async_scroll_updates.completed_operation_ids.is_empty())
         return;
 
@@ -3289,8 +3288,8 @@ void Navigable::clear_compositor_surface()
 {
     if (!m_compositor_surface_id.has_value())
         return;
-    if (auto parent = this->parent())
-        parent->rendering_thread().clear_compositor_surface(*m_compositor_surface_id);
+    if (auto parent = this->parent(); parent && parent->has_compositor_context())
+        parent->compositor_context().clear_compositor_surface(*m_compositor_surface_id);
     m_compositor_surface_id.clear();
 }
 
@@ -3305,6 +3304,9 @@ void Navigable::set_should_show_line_box_borders(bool value)
 
 void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 {
+    if (!has_compositor_context())
+        return;
+
     m_needs_repaint = false;
     auto document = active_document();
     if (!document)
@@ -3336,11 +3338,11 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
-        m_rendering_thread.update_display_list(*display_list, move(resource_transaction), move(scroll_state_snapshot));
+        compositor_context().update_display_list(*display_list, move(resource_transaction), move(scroll_state_snapshot));
         m_needs_to_record_display_list = false;
         m_rendering_thread_display_list_paint_config = paint_config;
     } else {
-        m_rendering_thread.update_scroll_state(move(scroll_state_snapshot));
+        compositor_context().update_scroll_state(move(scroll_state_snapshot));
     }
 }
 
@@ -3348,6 +3350,10 @@ void Navigable::paint_next_frame()
 {
     if (has_been_destroyed())
         return;
+    if (!has_compositor_context()) {
+        m_needs_repaint = false;
+        return;
+    }
 
     auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
     PaintConfig paint_config { .paint_overlay = true, .should_show_line_box_borders = m_should_show_line_box_borders };
@@ -3362,7 +3368,7 @@ void Navigable::paint_next_frame()
 
     auto should_defer_main_thread_present_for_async_scroll = [&] {
         return page().async_scrolling_enabled()
-            && m_rendering_thread.should_defer_main_thread_present_for_async_scroll();
+            && compositor_context().should_defer_main_thread_present_for_async_scroll();
     };
     if (should_defer_main_thread_present_for_async_scroll())
         return;
@@ -3375,15 +3381,20 @@ void Navigable::paint_next_frame()
         return;
     }
 
-    auto frame_id = m_rendering_thread.present_frame(viewport_rect);
+    auto frame_id = compositor_context().present_frame(viewport_rect);
     if (!is_top_level_traversable())
-        m_rendering_thread.wait_for_frame(frame_id);
+        compositor_context().wait_for_frame(frame_id);
 }
 
 void Navigable::render_screenshot(Gfx::PaintingSurface& painting_surface, PaintConfig paint_config, Function<void()>&& callback)
 {
+    if (!has_compositor_context()) {
+        callback();
+        return;
+    }
+
     record_display_list_and_scroll_state(paint_config);
-    m_rendering_thread.request_screenshot(painting_surface, move(callback));
+    compositor_context().request_screenshot(painting_surface, move(callback));
 }
 
 GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta)

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/HashTable.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/Tuple.h>
 #include <LibJS/Heap/Cell.h>
@@ -239,7 +241,12 @@ public:
 
     [[nodiscard]] bool has_inclusive_ancestor_with_visibility_hidden() const;
 
-    Compositor::CompositorThread& rendering_thread() { return m_rendering_thread; }
+    Compositor::CompositorThread::Context& compositor_context()
+    {
+        VERIFY(m_compositor_context);
+        return *m_compositor_context;
+    }
+    bool has_compositor_context() const { return m_compositor_context; }
 
     Painting::CompositorSurfaceId compositor_surface_id() const;
     bool has_compositor_surface_id() const { return m_compositor_surface_id.has_value(); }
@@ -335,7 +342,7 @@ private:
     Optional<PaintConfig> m_rendering_thread_display_list_paint_config;
     Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Painting::DisplayListResourceSet m_rendering_thread_display_list_resources;
-    Compositor::CompositorThread m_rendering_thread;
+    OwnPtr<Compositor::CompositorThread::Context> m_compositor_context;
     Optional<Painting::CompositorSurfaceId> m_compositor_surface_id;
 
     struct PendingAsyncScrollOperation {

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -77,6 +77,7 @@ BrowsingContextAndDocument create_a_new_top_level_browsing_context_and_document(
 GC::Ref<TraversableNavigable> TraversableNavigable::create_a_new_top_level_traversable(GC::Ref<Page> page, GC::Ptr<HTML::BrowsingContext> opener, String target_name)
 {
     auto& vm = Bindings::main_thread_vm();
+    page->ensure_compositor_thread();
 
     // 1. Let document be null.
     GC::Ptr<DOM::Document> document = nullptr;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -533,11 +533,12 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value())
         paintable = result->paintable;
 
-    if (m_navigable->page().async_scrolling_enabled() && async_scroll_performed_default_action) {
+    auto can_attempt_async_scroll = m_navigable->page().async_scrolling_enabled() && m_navigable->has_compositor_context();
+    if (can_attempt_async_scroll && async_scroll_performed_default_action) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: default action already performed");
-    } else if (m_navigable->page().async_scrolling_enabled() && visual_viewport->scale() != 1.0) {
+    } else if (can_attempt_async_scroll && visual_viewport->scale() != 1.0) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Not attempting wheel async scroll: visual viewport is scaled");
-    } else if (m_navigable->page().async_scrolling_enabled()) {
+    } else if (can_attempt_async_scroll) {
         if (paintable) {
             auto viewport_rect = m_navigable->page().css_to_device_rect(m_navigable->viewport_rect()).to_type<int>();
             auto async_scroll_delta = Gfx::FloatPoint { static_cast<float>(wheel_delta_x), static_cast<float>(wheel_delta_y) };
@@ -548,7 +549,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             auto operation_tracking = async_scroll_operation
                 ? Compositor::CompositorThread::AsyncScrollOperationTracking::Yes
                 : Compositor::CompositorThread::AsyncScrollOperationTracking::No;
-            auto enqueue_result = m_navigable->rendering_thread().async_scroll_by(
+            auto enqueue_result = m_navigable->compositor_context().async_scroll_by(
                 document->unique_id(), async_scroll_position, async_scroll_delta_in_device_pixels, viewport_rect, operation_tracking);
             async_scroll_performed_default_action = enqueue_result.accepted;
             if (enqueue_result.operation_id.has_value() && async_scroll_operation)

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/Clipboard/SystemClipboard.h>
+#include <LibWeb/Compositor/CompositorThread.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Range.h>
@@ -45,6 +46,33 @@ Page::Page(GC::Ref<PageClient> client)
 }
 
 Page::~Page() = default;
+
+bool Page::has_compositor_thread() const
+{
+    return m_client->compositor_thread();
+}
+
+void Page::ensure_compositor_thread()
+{
+    if (!m_client->supports_compositor())
+        return;
+
+    m_client->ensure_compositor_thread();
+}
+
+Compositor::CompositorThread& Page::compositor_thread()
+{
+    auto* compositor_thread = m_client->compositor_thread();
+    VERIFY(compositor_thread);
+    return *compositor_thread;
+}
+
+Compositor::CompositorThread const& Page::compositor_thread() const
+{
+    auto const* compositor_thread = m_client->compositor_thread();
+    VERIFY(compositor_thread);
+    return *compositor_thread;
+}
 
 void Page::visit_edges(JS::Cell::Visitor& visitor)
 {
@@ -301,10 +329,10 @@ void Page::invalidate_compositor_wheel_event_listener_state()
 {
     ++m_wheel_event_listener_state_generation;
 
-    if (!m_async_scrolling_enabled || !top_level_traversable_is_initialized())
+    if (!m_async_scrolling_enabled || !top_level_traversable_is_initialized() || !top_level_traversable()->has_compositor_context())
         return;
 
-    top_level_traversable()->rendering_thread().invalidate_wheel_event_listener_state(m_wheel_event_listener_state_generation);
+    top_level_traversable()->compositor_context().invalidate_wheel_event_listener_state(m_wheel_event_listener_state_generation);
 }
 
 void Page::set_top_level_traversable(GC::Ref<HTML::TraversableNavigable> navigable)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -56,6 +56,11 @@
 namespace Web {
 
 class PageClient;
+namespace Compositor {
+
+class CompositorThread;
+
+}
 
 class WEB_API Page final : public JS::Cell {
     GC_CELL(Page, JS::Cell);
@@ -68,6 +73,10 @@ public:
 
     PageClient& client() { return m_client; }
     PageClient const& client() const { return m_client; }
+    bool has_compositor_thread() const;
+    void ensure_compositor_thread();
+    Compositor::CompositorThread& compositor_thread();
+    Compositor::CompositorThread const& compositor_thread() const;
 
     void set_top_level_traversable(GC::Ref<HTML::TraversableNavigable>);
 
@@ -509,6 +518,10 @@ public:
     virtual bool is_headless() const = 0;
 
     virtual bool is_svg_page_client() const { return false; }
+    virtual bool supports_compositor() const { return false; }
+    virtual void ensure_compositor_thread() { }
+    virtual Compositor::CompositorThread* compositor_thread() { return nullptr; }
+    virtual Compositor::CompositorThread const* compositor_thread() const { return nullptr; }
 
 protected:
     virtual ~PageClient() = default;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -683,7 +683,7 @@ void PageClient::page_did_request_activate_tab()
 
 void PageClient::page_did_close_top_level_traversable()
 {
-    page().top_level_traversable()->rendering_thread().stop_presenting_to_client();
+    page().top_level_traversable()->compositor_context().stop_presenting_to_client();
 
     // FIXME: Rename this IPC call
     client().async_did_close_browsing_context(m_id);
@@ -1011,6 +1011,21 @@ Web::DisplayListPlayerType PageClient::display_list_player_type() const
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+void PageClient::ensure_compositor_thread()
+{
+    m_owner.ensure_compositor_thread(display_list_player_type());
+}
+
+Web::Compositor::CompositorThread* PageClient::compositor_thread()
+{
+    return m_owner.compositor_thread();
+}
+
+Web::Compositor::CompositorThread const* PageClient::compositor_thread() const
+{
+    return m_owner.compositor_thread();
 }
 
 void PageClient::queue_screenshot_task(Optional<Web::UniqueNodeID> node_id)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -99,6 +99,10 @@ public:
     virtual double device_pixels_per_css_pixel() const override { return m_device_pixel_ratio * m_zoom_level; }
 
     virtual Web::DisplayListPlayerType display_list_player_type() const override;
+    virtual bool supports_compositor() const override { return true; }
+    virtual void ensure_compositor_thread() override;
+    virtual Web::Compositor::CompositorThread* compositor_thread() override;
+    virtual Web::Compositor::CompositorThread const* compositor_thread() const override;
 
     void queue_screenshot_task(Optional<Web::UniqueNodeID> node_id);
 

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Compositor/CompositorThread.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
@@ -42,5 +43,13 @@ Optional<PageClient&> PageHost::page(u64 index)
 }
 
 PageHost::~PageHost() = default;
+
+void PageHost::ensure_compositor_thread(Web::DisplayListPlayerType display_list_player_type)
+{
+    if (m_compositor_thread)
+        return;
+    m_compositor_thread = make<Web::Compositor::CompositorThread>();
+    m_compositor_thread->start(display_list_player_type);
+}
 
 }

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -11,8 +11,21 @@
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
 #include <LibGC/Root.h>
 #include <WebContent/Forward.h>
+
+namespace Web {
+
+enum class DisplayListPlayerType;
+
+namespace Compositor {
+
+class CompositorThread;
+
+}
+
+}
 
 namespace WebContent {
 
@@ -29,11 +42,15 @@ public:
     void remove_page(Badge<PageClient>, u64 index);
 
     ConnectionFromClient& client() const { return m_client; }
+    void ensure_compositor_thread(Web::DisplayListPlayerType);
+    Web::Compositor::CompositorThread* compositor_thread() { return m_compositor_thread.ptr(); }
+    Web::Compositor::CompositorThread const* compositor_thread() const { return m_compositor_thread.ptr(); }
 
 private:
     explicit PageHost(ConnectionFromClient&);
 
     ConnectionFromClient& m_client;
+    OwnPtr<Web::Compositor::CompositorThread> m_compositor_thread;
     HashMap<u64, GC::Root<PageClient>> m_pages;
     u64 m_next_id { 0 };
 };


### PR DESCRIPTION
This changes compositor ownership so Page owns a single compositor thread, and each non-SVG Navigable registers its own compositor context on that thread. Per-navigable compositor state is now stored by CompositorContextId, including display lists, scroll state, backing stores, presentation mode, and compositor resources.

Nested navigable painting no longer blocks the main rendering update with wait_for_frame(). Instead, iframe presents are enqueued before parent work through the existing reverse document-tree paint order. When a nested context publishes to a parent compositor surface, the shared compositor loop updates the parent context synchronously before later parent present work runs. This removes a main-thread wait from iframe rendering, which is better for rendering latency and overall page responsiveness.

This also moves the architecture closer to a compositor-process model where one compositor service can manage rendering work for all pages. The context-scoped API makes compositor work explicit without tying each navigable to its own thread.