### PR TITLE
LibRegex: Link libregex_rust before LibUnicode

### DIFF
--- a/Libraries/LibRegex/CMakeLists.txt
+++ b/Libraries/LibRegex/CMakeLists.txt
@@ -4,10 +4,9 @@ set(SOURCES
 )
 
 ladybird_lib(LibRegex regex EXPLICIT_SYMBOL_EXPORT)
-target_link_libraries(LibRegex PRIVATE LibUnicode)
 
 import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libregex_rust FFI_HEADER RustFFI.h)
-target_link_libraries(LibRegex PRIVATE libregex_rust)
+target_link_libraries(LibRegex PRIVATE libregex_rust LibUnicode)
 if ((LINUX OR BSD) AND NOT BUILD_SHARED_LIBS)
     target_link_options(LibRegex INTERFACE LINKER:--allow-multiple-definition)
 endif()


### PR DESCRIPTION
When I was building Ladybird on Debian 13 and Ubuntu 24, I saw error messages like the following when linking lib/liblagom-regex.so.0.1.0:
```
/usr/bin/ld: cargo/build/x86_64-unknown-linux-gnu/release/liblibregex_rust.a(libunicode_rust-e5c4b03112dff673.libunicode_rust.1dfb392cd1cf5df3-cgu.0.rcgu.o): in function `libunicode_rust::character_types::get_case_closure':
libunicode_rust.1dfb392cd1cf5df3-cgu.0:(.text._ZN15libunicode_rust15character_types16get_case_closure17h6a1c800e97b66deaE+0xf): undefined reference to `unicode_get_case_closure'
```
It seems to be caused by the `--as-needed` option and the linking order. Moving LibUnicode after libregex_rust fixed the issue.

Fixes #9230.