### PR TITLE
UI: Add QT, GTK and Appkit UI for permissions

### DIFF
--- a/Documentation/GtkFrontend.md
+++ b/Documentation/GtkFrontend.md
@@ -83,6 +83,7 @@ g_autofree char* path = g_file_get_path(file);
 - [ ] Download save dialog
 - [ ] Download confirmation toast
 - [ ] Error dialog
+- [x] Permission dialog
 
 ### Window Management
 - [ ] Minimize/maximize/close

--- a/Libraries/LibWeb/Geolocation/Geolocation.cpp
+++ b/Libraries/LibWeb/Geolocation/Geolocation.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Time.h>
+#include <Bindings/Permissions.h>
 #include <LibWeb/Bindings/Geolocation.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/Permissions.h>
@@ -120,17 +121,21 @@ void Geolocation::acquire_a_position(GC::Ref<WebIDL::CallbackType> success_callb
     // FIXME: 5. Create an implementation-specific timeout task that elapses at timeoutTime, during which it tries to acquire
     //    the device's position by running the following steps:
     {
-        // FIXME: 1. Let permission be get the current permission state of "geolocation".
+        // 1. Let permission be get the current permission state of "geolocation".
+        Bindings::PermissionState permission = PermissionsAPI::get_current_permission_state("geolocation"_string, HTML::relevant_settings_object(*this));
 
-        // FIXME: 2. If permission is "denied":
-        if (false) {
+        // 2. If permission is "denied":
+        if (permission == Bindings::PermissionState::Denied) {
             // FIXME: 1. Stop timeout.
 
-            // FIXME: 2. Do the user or system denied permission failure case step.
+            // 2. Do the user or system denied permission failure case step.
+            // User or system denied permission:
+            // Call back with error passing errorCallback and PERMISSION_DENIED.
+            call_back_with_error(error_callback, GeolocationPositionError::ErrorCode::PermissionDenied);
         }
 
-        // FIXME: 3. If permission is "granted":
-        if (true) {
+        // 3. If permission is "granted":
+        if (permission == Bindings::PermissionState::Granted) {
             // 1. Check if an emulated position should be used by running the following steps:
             {
                 // 1. Let emulatedPositionData be get emulated position data passing this.
@@ -334,40 +339,40 @@ void Geolocation::request_a_position(GC::Ref<WebIDL::CallbackType> success_callb
         // AD-HOC: run_in_parallel_when_document_is_visible() already runs this in parallel.
         {
             // 1. Set permission to request permission to use descriptor.
-            auto permission = Web::PermissionsAPI::request_permission(descriptor);
+            Web::PermissionsAPI::request_permission(descriptor, GC::create_function(heap(), [this, watch_id, success_callback, error_callback, options](Bindings::PermissionState permission) {
+                // 2. If permission is "denied", then:
+                if (permission == Bindings::PermissionState::Denied) {
+                    // 1. If watchId was passed, remove watchId from watchIDs.
+                    if (watch_id.has_value())
+                        m_watch_ids.remove(watch_id.value());
 
-            // 2. If permission is "denied", then:
-            if (permission == Bindings::PermissionState::Denied) {
-                // 1. If watchId was passed, remove watchId from watchIDs.
-                if (watch_id.has_value())
-                    m_watch_ids.remove(watch_id.value());
+                    // 2. Call back with error passing errorCallback and PERMISSION_DENIED.
+                    call_back_with_error(error_callback, GeolocationPositionError::ErrorCode::PermissionDenied);
 
-                // 2. Call back with error passing errorCallback and PERMISSION_DENIED.
-                call_back_with_error(error_callback, GeolocationPositionError::ErrorCode::PermissionDenied);
-
-                // 3. Terminate this algorithm.
-                return;
-            }
-
-            // FIXME: 3. Wait to acquire a position passing successCallback, errorCallback, options, and watchId.
-            acquire_a_position(success_callback, error_callback, options, watch_id);
-
-            // 4. If watchId was not passed, terminate this algorithm.
-            if (!watch_id.has_value())
-                return;
-
-            // FIXME: 5. While watchIDs contains watchId:
-            {
-                // FIXME: 1. Wait for a significant change of geographic position. What constitutes a significant change of
-                //    geographic position is left to the implementation. User agents MAY impose a rate limit on how
-                //    frequently position changes are reported. User agents MUST consider invoking set emulated position
-                //    data as a significant change.
-
-                // FIXME: 2. If document is not fully active or visibility state is not "visible", go back to the previous step
-                //    and again wait for a significant change of geographic position.
+                    // 3. Terminate this algorithm.
+                    return;
+                }
 
                 // FIXME: 3. Wait to acquire a position passing successCallback, errorCallback, options, and watchId.
-            }
+                acquire_a_position(success_callback, error_callback, options, watch_id);
+
+                // 4. If watchId was not passed, terminate this algorithm.
+                if (!watch_id.has_value())
+                    return;
+
+                // FIXME: 5. While watchIDs contains watchId:
+                {
+                    // FIXME: 1. Wait for a significant change of geographic position. What constitutes a significant change of
+                    //    geographic position is left to the implementation. User agents MAY impose a rate limit on how
+                    //    frequently position changes are reported. User agents MUST consider invoking set emulated position
+                    //    data as a significant change.
+
+                    // FIXME: 2. If document is not fully active or visibility state is not "visible", go back to the previous step
+                    //    and again wait for a significant change of geographic position.
+
+                    // FIXME: 3. Wait to acquire a position passing successCallback, errorCallback, options, and watchId.
+                }
+            }));
         }
     }));
 }

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -85,6 +85,7 @@ void Page::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_client);
     visitor.visit(m_window_rect_observer);
     visitor.visit(m_on_pending_dialog_closed);
+    visitor.visit(m_pending_permission_request);
     visitor.visit(m_pending_clipboard_requests);
     m_pending_fullscreen_operations.for_each([&](auto const& operation) {
         operation.visit([&](PendingFullscreenEnter const& enter_operation) {
@@ -631,6 +632,30 @@ void Page::retrieved_clipboard_entries(u64 request_id, Vector<Clipboard::SystemC
 {
     if (auto request = m_pending_clipboard_requests.take(request_id); request.has_value())
         (*request)->function()(move(items));
+}
+
+void Page::did_request_permission(String const& permission_name, String const& origin, PermissionRequestCallback callback)
+{
+    if (m_pending_non_blocking_dialog == PendingNonBlockingDialog::None) {
+        m_pending_non_blocking_dialog = PendingNonBlockingDialog::Permission;
+        m_pending_permission_request = callback;
+        m_client->page_did_request_permission(permission_name, origin);
+    } else {
+        // FIXME: If a pending dialog is active do not deny automatically and wait for it to not be active anymore
+        callback->function()(false);
+    }
+}
+
+void Page::retrieve_permission_response(bool response)
+{
+    if (m_pending_non_blocking_dialog == PendingNonBlockingDialog::Permission) {
+        m_pending_non_blocking_dialog = PendingNonBlockingDialog::None;
+        if (m_pending_permission_request) {
+            auto callback = m_pending_permission_request;
+            m_pending_permission_request = nullptr;
+            callback->function()(response);
+        }
+    }
 }
 
 void Page::register_media_element(Badge<HTML::HTMLMediaElement>, UniqueNodeID media_id)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -210,11 +210,16 @@ public:
     void request_clipboard_entries(ClipboardRequest);
     void retrieved_clipboard_entries(u64 request_id, Vector<Clipboard::SystemClipboardItem>);
 
+    using PermissionRequestCallback = GC::Ptr<GC::Function<void(bool)>>;
+    void did_request_permission(String const& permission_name, String const& origin, PermissionRequestCallback);
+    void retrieve_permission_response(bool response);
+
     enum class PendingNonBlockingDialog {
         None,
         ColorPicker,
         FilePicker,
         Select,
+        Permission,
     };
 
     void register_media_element(Badge<HTML::HTMLMediaElement>, UniqueNodeID media_id);
@@ -344,6 +349,7 @@ private:
     Optional<Empty> m_pending_alert_response;
     Optional<bool> m_pending_confirm_response;
     Optional<Optional<String>> m_pending_prompt_response;
+    PermissionRequestCallback m_pending_permission_request;
     GC::Ptr<GC::Function<void()>> m_on_pending_dialog_closed;
 
     PendingNonBlockingDialog m_pending_non_blocking_dialog { PendingNonBlockingDialog::None };
@@ -517,6 +523,7 @@ public:
     virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }
     virtual void page_did_request_primary_paste() { }
     virtual void page_did_update_primary_selection(String const&) { }
+    virtual void page_did_request_permission([[maybe_unused]] String const& permission_name, [[maybe_unused]] String const& origin) { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 

--- a/Libraries/LibWeb/PermissionsAPI/Permissions.cpp
+++ b/Libraries/LibWeb/PermissionsAPI/Permissions.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/PermissionsAPI/PermissionStatus.h>
 #include <LibWeb/PermissionsAPI/PermissionStore.h>
 #include <LibWeb/PermissionsAPI/Permissions.h>
@@ -29,39 +30,45 @@ bool is_permission_supported(String const& name)
 }
 
 // https://w3c.github.io/permissions/#dfn-request-permission-to-use
-Bindings::PermissionState request_permission(Bindings::PermissionDescriptor const& descriptor)
+void request_permission(Bindings::PermissionDescriptor const& descriptor, GC::Ref<GC::Function<void(Bindings::PermissionState)>> callback)
 {
     // 1. Let current state be the descriptor's permission state.
     auto current_state = permission_state(descriptor);
 
     // 2. If current state is not "prompt", return current state and abort these steps.
-    if (current_state != Bindings::PermissionState::Prompt)
-        return current_state;
+    if (current_state != Bindings::PermissionState::Prompt) {
+        callback->function()(current_state);
+        return;
+    }
 
-    // FIXME: 3. Ask the user for express permission for the calling algorithm to use the powerful feature described by descriptor.
-
-    // 4. If the user gives express permission to use the powerful feature, set current state to "granted"; otherwise to "denied".
-    // The user's interaction may provide new information about the user's intent for the origin.
-    if (false) {
-        current_state = Bindings::PermissionState::Granted;
-    } else {
-        current_state = Bindings::PermissionState::Denied;
+    // 3. Ask the user for express permission for the calling algorithm to use the powerful feature described by descriptor.
+    auto* window = as_if<HTML::Window>(HTML::current_global_object());
+    if (!window) {
+        callback->function()(Bindings::PermissionState::Denied);
+        return;
     }
 
     // 5. Let settings be the current settings object.
-    auto& settings = HTML::current_settings_object();
+    GC::Ref<HTML::EnvironmentSettingsObject> settings = HTML::current_settings_object();
+    auto& realm = settings->realm();
 
-    // 6. Let key be the result of generating a permission key for descriptor with settings's top-level origin and settings's origin.
-    VERIFY(settings.top_level_origin.has_value());
-    auto key = permission_key_generation_algorithm(settings.top_level_origin.value(), settings.origin());
+    window->page().did_request_permission(descriptor.name, settings->origin().serialize(), GC::create_function(realm.heap(), [descriptor, settings, callback](bool state) mutable {
+        // 4. If the user gives express permission to use the powerful feature, set current state to "granted"; otherwise to "denied".
+        // The user's interaction may provide new information about the user's intent for the origin.
+        auto current_state = state ? Bindings::PermissionState::Granted : Bindings::PermissionState::Denied;
 
-    // 7. Queue a task on the current settings object's responsible event loop to set a permission store entry with descriptor, key, and current state.
-    HTML::queue_global_task(HTML::Task::Source::Permissions, settings.global_object(), GC::create_function(settings.realm().heap(), [descriptor, key, current_state] {
-        PermissionStore::the().set_permission_store_entry(descriptor, key, current_state);
+        // 6. Let key be the result of generating a permission key for descriptor with settings's top-level origin and settings's origin.
+        VERIFY(settings->top_level_origin.has_value());
+        auto key = permission_key_generation_algorithm(settings->top_level_origin.value(), settings->origin());
+
+        // 7. Queue a task on the current settings object's responsible event loop to set a permission store entry with descriptor, key, and current state.
+        HTML::queue_global_task(HTML::Task::Source::Permissions, settings->global_object(), GC::create_function(settings->realm().heap(), [descriptor, key, current_state, callback] mutable {
+            PermissionStore::the().set_permission_store_entry(descriptor, key, current_state);
+
+            // 8. Return current state.
+            callback->function()(current_state);
+        }));
     }));
-
-    // 8. Return current state.
-    return current_state;
 }
 
 // https://w3c.github.io/permissions/#dfn-permission-state

--- a/Libraries/LibWeb/PermissionsAPI/Permissions.h
+++ b/Libraries/LibWeb/PermissionsAPI/Permissions.h
@@ -20,7 +20,7 @@ Bindings::PermissionState permission_state(Bindings::PermissionDescriptor descri
 
 Bindings::PermissionState get_current_permission_state(String const& name, Optional<HTML::EnvironmentSettingsObject&> settings = {});
 
-Bindings::PermissionState request_permission(Bindings::PermissionDescriptor const& descriptor);
+void request_permission(Bindings::PermissionDescriptor const& descriptor, GC::Ref<GC::Function<void(Bindings::PermissionState)>> callback);
 
 class WEB_API Permissions : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Permissions, Bindings::PlatformObject);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -652,6 +652,11 @@ void ViewImplementation::confirm_closed(bool accepted)
     client().async_confirm_closed(page_id(), accepted);
 }
 
+void ViewImplementation::permission_closed(bool granted)
+{
+    client().async_permission_response(page_id(), granted);
+}
+
 void ViewImplementation::prompt_closed(Optional<String> const& response)
 {
     client().async_prompt_closed(page_id(), response);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -165,6 +165,7 @@ public:
 
     void alert_closed();
     void confirm_closed(bool accepted);
+    void permission_closed(bool granted);
     void prompt_closed(Optional<String> const& response);
     void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
     void file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files);
@@ -268,6 +269,7 @@ public:
     Function<void(Color current_color)> on_request_color_picker;
     Function<void(Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles)> on_request_file_picker;
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;
+    Function<void(String const& permission_name, String const& origin)> on_request_permission;
     Function<void(Web::KeyEvent const&)> on_finish_handling_key_event;
     Function<void(Web::DragEvent const&)> on_finish_handling_drag_event;
     Function<void(String const&)> on_test_finish;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1180,6 +1180,14 @@ void WebContentClient::did_update_primary_selection(u64 page_id, String text)
         Application::the().set_clipboard_text(move(text), Application::ClipboardType::Selection);
 }
 
+void WebContentClient::did_request_permission(u64 page_id, String permission_name, String origin)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_request_permission)
+            view->on_request_permission(permission_name, origin);
+    }
+}
+
 void WebContentClient::did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -187,6 +187,7 @@ private:
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
     virtual void did_request_primary_paste(u64 page_id) override;
     virtual void did_update_primary_selection(u64 page_id, String) override;
+    virtual void did_request_permission(u64 page_id, String permission_name, String origin) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual Messages::WebContentClient::StartWorkerAgentResponse start_worker_agent(u64 page_id, Web::HTML::WorkerAgentStartRequest request) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1801,6 +1801,12 @@ void ConnectionFromClient::prompt_closed(u64 page_id, Optional<String> response)
         page->page().prompt_closed(move(response));
 }
 
+void ConnectionFromClient::permission_response(u64 page_id, bool granted)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().retrieve_permission_response(granted);
+}
+
 void ConnectionFromClient::color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -149,6 +149,7 @@ private:
     virtual void alert_closed(u64 page_id) override;
     virtual void confirm_closed(u64 page_id, bool accepted) override;
     virtual void prompt_closed(u64 page_id, Optional<String> response) override;
+    virtual void permission_response(u64 page_id, bool granted) override;
     virtual void color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) override;
     virtual void file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> selected_files) override;
     virtual void select_dropdown_closed(u64 page_id, Optional<u32> selected_item_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -788,6 +788,11 @@ void PageClient::page_did_update_primary_selection(String const& text)
     client().async_did_update_primary_selection(m_id, text);
 }
 
+void PageClient::page_did_request_permission(String const& permission_name, String const& origin)
+{
+    client().async_did_request_permission(m_id, permission_name, origin);
+}
+
 void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play_state)
 {
     client().async_did_change_audio_play_state(m_id, play_state);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -204,6 +204,7 @@ private:
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_request_primary_paste() override;
     virtual void page_did_update_primary_selection(String const&) override;
+    virtual void page_did_request_permission(String const& permission_name, String const& origin) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual Web::HTML::WorkerAgentId start_worker_agent(Web::HTML::WorkerAgentStartRequest&&) override;
     virtual void close_worker_agent(Web::HTML::WorkerAgentId, Web::HTML::WorkerAgentOwnerToken) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -126,6 +126,8 @@ endpoint WebContentClient
     did_request_primary_paste(u64 page_id) =|
     did_update_primary_selection(u64 page_id, String text) =|
 
+    did_request_permission(u64 page_id, String permission_name, String origin) =|
+
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
 
     did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -133,6 +133,7 @@ endpoint WebContentServer
     alert_closed(u64 page_id) =|
     confirm_closed(u64 page_id, bool accepted) =|
     prompt_closed(u64 page_id, Optional<String> response) =|
+    permission_response(u64 page_id, bool granted) =|
     color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) =|
     file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> selected_files) =|
     select_dropdown_closed(u64 page_id, Optional<u32> selected_item_id) =|

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -604,6 +604,29 @@ struct HideCursor {
                             }];
     };
 
+    m_web_view_bridge->on_request_permission = [weak_self](auto const& permission_name, auto const& origin) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+
+        auto origin_text = origin.is_empty() ? "this site"_string : origin;
+        auto message = MUST(String::formatted("Allow {} to use the {} permission?", origin_text, permission_name));
+        auto* ns_message = Ladybird::string_to_ns_string(message);
+
+        self.dialog = [[NSAlert alloc] init];
+        [self.dialog setAlertStyle:NSAlertStyleWarning];
+        [[self.dialog addButtonWithTitle:@"Deny"] setTag:NSModalResponseCancel];
+        [[self.dialog addButtonWithTitle:@"Allow"] setTag:NSModalResponseOK];
+        [self.dialog setMessageText:ns_message];
+
+        [self.dialog beginSheetModalForWindow:[self window]
+                            completionHandler:^(NSModalResponse response) {
+                                m_web_view_bridge->permission_closed(response == NSModalResponseOK);
+                                self.dialog = nil;
+                            }];
+    };
+
     m_web_view_bridge->on_request_prompt = [weak_self](auto const& message, auto const& default_) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {

--- a/UI/Gtk/Dialogs.cpp
+++ b/UI/Gtk/Dialogs.cpp
@@ -202,4 +202,22 @@ void show_file_picker(GtkWindow* parent, WebContentView* view, Web::HTML::FileFi
     }
 }
 
+void show_permission(GtkWindow* parent, WebContentView* view, String const& permission_name, String const& origin)
+{
+    auto* dialog = adw_alert_dialog_new("Permission Request", nullptr);
+    auto body = ByteString::formatted("{} wants to use the {} permission.", origin, permission_name);
+
+    adw_alert_dialog_set_body(ADW_ALERT_DIALOG(dialog), body.characters());
+    adw_alert_dialog_add_response(ADW_ALERT_DIALOG(dialog), "deny", "Deny");
+    adw_alert_dialog_add_response(ADW_ALERT_DIALOG(dialog), "allow", "Allow");
+    adw_alert_dialog_set_response_appearance(ADW_ALERT_DIALOG(dialog), "allow", ADW_RESPONSE_SUGGESTED);
+    adw_alert_dialog_set_default_response(ADW_ALERT_DIALOG(dialog), "deny");
+    g_signal_connect(dialog, "response", G_CALLBACK(+[](AdwAlertDialog*, char const* response, gpointer user_data) {
+        auto* view = static_cast<WebContentView*>(user_data);
+        view->permission_closed(StringView(response, strlen(response)) == "allow"sv);
+    }),
+        view);
+    adw_dialog_present(ADW_DIALOG(dialog), GTK_WIDGET(parent));
+}
+
 }

--- a/UI/Gtk/Dialogs.h
+++ b/UI/Gtk/Dialogs.h
@@ -25,6 +25,7 @@ void show_confirm(GtkWindow* parent, WebContentView* view, String const& message
 void show_prompt(GtkWindow* parent, WebContentView* view, String const& message, String const& default_value);
 void show_color_picker(GtkWindow* parent, WebContentView* view, Color current_color);
 void show_file_picker(GtkWindow* parent, WebContentView* view, Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple);
+void show_permission(GtkWindow* parent, WebContentView* view, String const& permission_name, String const& origin);
 
 }
 

--- a/UI/Gtk/Tab.cpp
+++ b/UI/Gtk/Tab.cpp
@@ -84,6 +84,7 @@ Tab::Tab(BrowserWindow& window, RefPtr<WebView::WebContentClient> parent_client,
     m_web_view = ladybird_web_view_new();
     gtk_widget_set_vexpand(GTK_WIDGET(m_web_view), TRUE);
     gtk_widget_set_hexpand(GTK_WIDGET(m_web_view), TRUE);
+
     m_view = adopt_own(*new WebContentView(m_web_view, parent_client, page_index));
 
     setup_callbacks();
@@ -197,6 +198,10 @@ void Tab::setup_callbacks()
 
     m_view->on_request_confirm = [this](auto const& message) {
         Dialogs::show_confirm(m_window.gtk_window(), m_view.ptr(), message);
+    };
+
+    m_view->on_request_permission = [this](auto const& feature, auto const& origin) {
+        Dialogs::show_permission(m_window.gtk_window(), m_view.ptr(), feature, origin);
     };
 
     m_view->on_request_prompt = [this](auto const& message, auto const& default_value) {

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -23,15 +23,20 @@
 #include <QFileDialog>
 #include <QFont>
 #include <QFontMetrics>
+#include <QFrame>
 #include <QHBoxLayout>
 #include <QImage>
 #include <QInputDialog>
+#include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QMimeDatabase>
+#include <QPushButton>
 #include <QResizeEvent>
+#include <QSizePolicy>
 #include <QTimer>
+#include <QVBoxLayout>
 
 namespace Ladybird {
 
@@ -273,6 +278,80 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         });
 
         m_dialog->open();
+    };
+
+    view().on_request_permission = [this](String const& feature, String const& origin) {
+        auto origin_text = origin.is_empty() ? "this site"_string : origin;
+        auto message = MUST(String::formatted("{} wants to use the {} permission.", origin_text, feature));
+
+        hide_permission_prompt();
+
+        m_permission_overlay = new QWidget(&view());
+        m_permission_overlay->setAttribute(Qt::WA_TransparentForMouseEvents, false);
+        m_permission_overlay->setAutoFillBackground(true);
+        auto overlay_color = view().palette().color(QPalette::Window);
+        overlay_color.setAlpha(120);
+        m_permission_overlay->setStyleSheet(QString("background-color: rgba(%1, %2, %3, %4);")
+                .arg(overlay_color.red())
+                .arg(overlay_color.green())
+                .arg(overlay_color.blue())
+                .arg(overlay_color.alpha()));
+        m_permission_overlay->setGeometry(view().rect());
+
+        auto* overlay_layout = new QVBoxLayout(m_permission_overlay);
+        overlay_layout->setAlignment(Qt::AlignCenter);
+
+        auto* panel = new QFrame(m_permission_overlay);
+        panel->setFrameShape(QFrame::StyledPanel);
+        auto panel_bg = view().palette().color(QPalette::Window);
+        auto panel_text = view().palette().color(QPalette::WindowText);
+        panel->setAutoFillBackground(true);
+        panel->setStyleSheet(QString("QFrame { background-color: %1; color: %2; border-radius: 8px; }")
+                .arg(panel_bg.name())
+                .arg(panel_text.name()));
+        panel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        panel->setFixedWidth(400);
+
+        auto* panel_layout = new QVBoxLayout(panel);
+        panel_layout->setContentsMargins(20, 20, 20, 20);
+        panel_layout->setSpacing(16);
+
+        auto* label = new QLabel(qstring_from_ak_string(message), panel);
+        label->setWordWrap(true);
+        label->setAlignment(Qt::AlignCenter);
+        label->setStyleSheet(QString("QLabel { font-weight: bold; font-size: 14px; }"));
+        panel_layout->addWidget(label);
+
+        auto* buttons = new QHBoxLayout();
+        buttons->setSpacing(10);
+        buttons->setAlignment(Qt::AlignCenter);
+
+        auto* deny_button = new QPushButton("Deny", panel);
+        auto* allow_button = new QPushButton("Allow", panel);
+        deny_button->setMinimumSize(100, 32);
+        allow_button->setMinimumSize(100, 32);
+
+        buttons->addWidget(deny_button);
+        buttons->addWidget(allow_button);
+        panel_layout->addLayout(buttons);
+
+        overlay_layout->addWidget(panel);
+
+        auto finish_permission_request = [this](bool granted) {
+            hide_permission_prompt();
+            view().permission_closed(granted);
+        };
+
+        QObject::connect(allow_button, &QPushButton::clicked, this, [finish_permission_request]() mutable {
+            finish_permission_request(true);
+        });
+        QObject::connect(deny_button, &QPushButton::clicked, this, [finish_permission_request]() mutable {
+            finish_permission_request(false);
+        });
+
+        m_permission_overlay->show();
+        m_permission_overlay->raise();
+        panel->raise();
     };
 
     view().on_request_prompt = [this](auto const& message, auto const& default_) {
@@ -633,6 +712,8 @@ void Tab::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
     if (m_hover_label->isVisible())
         update_hover_label();
+    if (m_permission_overlay)
+        m_permission_overlay->setGeometry(rect());
 }
 
 void Tab::update_hover_label()
@@ -727,6 +808,15 @@ void Tab::request_close()
     // If the user has already requested a close, then respect the user's request and just close the tab.
     // For example, the WebContent process may not be responding.
     m_window->definitely_close_tab(tab_index());
+}
+
+void Tab::hide_permission_prompt()
+{
+    if (m_permission_overlay) {
+        m_permission_overlay->hide();
+        m_permission_overlay->deleteLater();
+        m_permission_overlay = nullptr;
+    }
 }
 
 }

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -135,6 +135,9 @@ private:
     QAction* m_reload_action { nullptr };
 
     QPointer<QDialog> m_dialog;
+    QWidget* m_permission_overlay { nullptr };
+
+    void hide_permission_prompt();
 
     bool m_already_requested_close { false };
 };


### PR DESCRIPTION
Connects permissions.cpp to the UI with IPC.

I cannot test the UI on macOS, so I'll appreciate if someone can try if it works correctly.
I usually go on https://permission.site/ and click on the location button, or on google maps.
Both buttons needs to work and resizing the window must not break the permission UI.

Here is what it looks like currently in the Qt and Gtk UIs:

<img width="1920" height="1200" alt="permission-ladybird-gtk" src="https://github.com/user-attachments/assets/a731afee-0088-4104-ad8a-90523d475c19" />

<img width="1920" height="1200" alt="permission-ladybird-qt-2" src="https://github.com/user-attachments/assets/933fc0ad-7f41-4d1e-8b16-6abd1600a1de" />
