### PR TITLE
Fix wasi memory end bound

### DIFF
--- a/Libraries/LibWasm/CraneliftBridge.cpp
+++ b/Libraries/LibWasm/CraneliftBridge.cpp
@@ -232,7 +232,9 @@ static inline MemoryInstance* wasm_cl_get_memory(void* config_ptr, i32 mem_idx)
 
 static inline u8 const* wasm_cl_memory_data_if_in_bounds(MemoryInstance* memory, u64 instance_addr, size_t size)
 {
-    if (instance_addr + size > memory->size())
+    Checked<u64> end { instance_addr };
+    end += size;
+    if (end.has_overflow() || end.value() > memory->size())
         return nullptr;
     return memory->data().offset_pointer(instance_addr);
 }
@@ -314,7 +316,9 @@ static inline bool wasm_cl_memory_store_in_bounds(void* config_ptr, i32 mem_idx,
 {
     auto* memory = wasm_cl_get_memory(config_ptr, mem_idx);
     auto instance_addr = static_cast<u64>(addr);
-    if (instance_addr + size > memory->size())
+    Checked<u64> end { instance_addr };
+    end += size;
+    if (end.has_overflow() || end.value() > memory->size())
         return false;
     data = memory->data().offset_pointer(instance_addr);
     return true;

--- a/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Libraries/LibWasm/WASI/Wasi.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteReader.h>
+#include <AK/Checked.h>
 #include <AK/Debug.h>
 #include <AK/FlyString.h>
 #include <AK/Random.h>
@@ -72,6 +73,19 @@ CompatibleValue<T> to_compatible_value(Wasm::Value const& value)
 }
 
 namespace Wasm::Wasi {
+
+static ErrorOr<size_t> checked_typed_memory_size(size_t memory_size, UnderlyingPointerType address, size_t element_size, Size count)
+{
+    Checked<size_t> byte_count { element_size };
+    byte_count *= static_cast<size_t>(count);
+    if (byte_count.has_overflow())
+        return Error::from_errno(ENOBUFS);
+    if (address > memory_size)
+        return Error::from_errno(ENOBUFS);
+    if (byte_count.value() > memory_size - address)
+        return Error::from_errno(ENOBUFS);
+    return byte_count.value();
+}
 
 void ArgsSizes::serialize_into(Array<Bytes, 2> bytes) const
 {
@@ -232,9 +246,7 @@ ErrorOr<Vector<T>> copy_typed_array(Configuration& configuration, Pointer<T> sou
 
     UnderlyingPointerType address = source.value();
     auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + (size * count)) {
-        return Error::from_errno(ENOBUFS);
-    }
+    TRY(checked_typed_memory_size(memory->size(), address, size, count));
 
     for (Size i = 0; i < count; i += 1) {
         values.unchecked_append(T::read_from(Array { ReadonlyBytes { memory->data().bytes().slice(address, size) } }));
@@ -253,9 +265,7 @@ ErrorOr<void> copy_typed_value_to(Configuration& configuration, T const& value, 
 
     UnderlyingPointerType address = destination.value();
     auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + size) {
-        return Error::from_errno(ENOBUFS);
-    }
+    TRY(checked_typed_memory_size(memory->size(), address, size, 1));
 
     ABI::serialize(value, Array { Bytes { memory->data().bytes().slice(address, size) } });
     return {};
@@ -270,10 +280,9 @@ ErrorOr<Span<T>> slice_typed_memory(Configuration& configuration, Pointer<T> sou
 
     auto address = source.value();
     auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + (size * count))
-        return Error::from_errno(ENOBUFS);
+    auto byte_count = TRY(checked_typed_memory_size(memory->size(), address, size, count));
 
-    auto untyped_slice = memory->data().bytes().slice(address, size * count);
+    auto untyped_slice = memory->data().bytes().slice(address, byte_count);
     return Span<T>(untyped_slice.data(), count);
 }
 
@@ -286,10 +295,9 @@ ErrorOr<Span<T const>> slice_typed_memory(Configuration& configuration, ConstPoi
 
     auto address = source.value();
     auto size = sizeof(T);
-    if (memory->size() < address || memory->size() <= address + (size * count))
-        return Error::from_errno(ENOBUFS);
+    auto byte_count = TRY(checked_typed_memory_size(memory->size(), address, size, count));
 
-    auto untyped_slice = memory->data().bytes().slice(address, size * count);
+    auto untyped_slice = memory->data().bytes().slice(address, byte_count);
     return Span<T const>(untyped_slice.data(), count);
 }
 


### PR DESCRIPTION
Fix bounds checks for linear-memory ranges in LibWasm.

WASI typed-memory helpers now allow valid half-open ranges that end exactly at `memory.size()`, while still rejecting ranges that overflow or extend past memory.

Cranelift runtime memory helpers now use checked arithmetic when validating load/store ranges before taking a pointer into linear memory.

This does not include a regression test. The reproducer depends on running a WASI module, and the current LibWasm JS test harness does not support that without adding extra harness plumbing.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/6086