### PR TITLE
LibJS: Reduce bytecode cache materialization churn

### DIFF
--- a/Libraries/LibJS/Bytecode/IdentifierTable.h
+++ b/Libraries/LibJS/Bytecode/IdentifierTable.h
@@ -29,6 +29,7 @@ public:
     IdentifierTableIndex insert(Utf16FlyString);
     Utf16FlyString const& get(IdentifierTableIndex) const;
     void dump() const;
+    void ensure_capacity(size_t capacity) { m_identifiers.ensure_capacity(capacity); }
     bool is_empty() const { return m_identifiers.is_empty(); }
     size_t external_memory_size() const { return vector_external_memory_size(m_identifiers); }
 

--- a/Libraries/LibJS/Bytecode/PropertyKeyTable.h
+++ b/Libraries/LibJS/Bytecode/PropertyKeyTable.h
@@ -29,6 +29,7 @@ public:
     PropertyKeyTableIndex insert(PropertyKey);
     PropertyKey const& get(PropertyKeyTableIndex) const;
     void dump() const;
+    void ensure_capacity(size_t capacity) { m_property_keys.ensure_capacity(capacity); }
     bool is_empty() const { return m_property_keys.is_empty(); }
     size_t external_memory_size() const { return vector_external_memory_size(m_property_keys); }
 

--- a/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Libraries/LibJS/Bytecode/StringTable.h
@@ -29,6 +29,7 @@ public:
     StringTableIndex insert(Utf16String);
     Utf16String const& get(StringTableIndex) const;
     void dump() const;
+    void ensure_capacity(size_t capacity) { m_strings.ensure_capacity(capacity); }
     bool is_empty() const { return m_strings.is_empty(); }
     size_t size() const { return m_strings.size(); }
     size_t external_memory_size() const

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -592,7 +592,7 @@ pub enum ConstantTag {
 }
 
 /// Encode constants into a tagged byte buffer for FFI.
-fn encode_constants(constants: &[ConstantValue]) -> Vec<u8> {
+pub(crate) fn encode_constants(constants: &[ConstantValue]) -> Vec<u8> {
     let mut buffer = Vec::new();
     for c in constants {
         match c {
@@ -690,6 +690,109 @@ pub struct ExecutableParts<'a> {
     pub number_of_arguments: u32,
 }
 
+pub struct ExecutableMetadata {
+    pub property_lookup_cache_count: u32,
+    pub global_variable_cache_count: u32,
+    pub template_object_cache_count: u32,
+    pub object_shape_cache_count: u32,
+    pub object_property_iterator_cache_count: u32,
+    pub is_strict: bool,
+    pub length_identifier: Option<u32>,
+}
+
+pub struct ExecutableSlices<'a> {
+    pub identifier_table: &'a [FFIUtf16Slice],
+    pub property_key_table: &'a [FFIUtf16Slice],
+    pub string_table: &'a [FFIUtf16Slice],
+    pub constants_data: &'a [u8],
+    pub constants_count: usize,
+    pub local_variable_names: &'a [FFIUtf16Slice],
+    pub compiled_regexes: &'a [*mut c_void],
+}
+
+/// Create a C++ Executable from borrowed FFI slices.
+///
+/// This is the lowest-level executable constructor wrapper. It lets cache
+/// materialization pass table slices borrowed from mmap-backed cache bytes
+/// without first copying them into the bytecode generator's owned tables.
+///
+/// # Safety
+/// `vm_ptr`, `source_code_ptr`, all dependency pointers, and all borrowed
+/// slices must be valid for the duration of the call.
+pub unsafe fn create_executable_from_slices(
+    parts: ExecutableParts<'_>,
+    metadata: ExecutableMetadata,
+    slices: ExecutableSlices<'_>,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    sfd_ptrs: &[*const c_void],
+    bp_ptrs: &[*mut c_void],
+) -> ExecutableHandle {
+    unsafe {
+        // Build FFI exception handlers
+        let ffi_handlers: Vec<FFIExceptionHandler> = parts
+            .exception_handlers
+            .iter()
+            .map(|h| FFIExceptionHandler {
+                start_offset: h.start_offset,
+                end_offset: h.end_offset,
+                handler_offset: h.handler_offset,
+            })
+            .collect();
+
+        // Build FFI source map
+        let ffi_source_map: Vec<FFISourceMapEntry> = parts
+            .source_map
+            .iter()
+            .map(|e| FFISourceMapEntry {
+                bytecode_offset: e.bytecode_offset,
+                source_start_line: e.line,
+                source_start_column: e.column,
+            })
+            .collect();
+
+        let ffi_data = FFIExecutableData {
+            bytecode: parts.bytecode.as_ptr(),
+            bytecode_length: parts.bytecode.len(),
+            bytecode_owner: parts.bytecode_owner,
+            identifier_table: slices.identifier_table.as_ptr(),
+            identifier_count: slices.identifier_table.len(),
+            property_key_table: slices.property_key_table.as_ptr(),
+            property_key_count: slices.property_key_table.len(),
+            string_table: slices.string_table.as_ptr(),
+            string_count: slices.string_table.len(),
+            constants_data: slices.constants_data.as_ptr(),
+            constants_data_length: slices.constants_data.len(),
+            constants_count: slices.constants_count,
+            exception_handlers: ffi_handlers.as_ptr(),
+            exception_handler_count: ffi_handlers.len(),
+            source_map: ffi_source_map.as_ptr(),
+            source_map_count: ffi_source_map.len(),
+            basic_block_offsets: parts.basic_block_start_offsets.as_ptr(),
+            basic_block_count: parts.basic_block_start_offsets.len(),
+            local_variable_names: slices.local_variable_names.as_ptr(),
+            local_variable_count: slices.local_variable_names.len(),
+            property_lookup_cache_count: metadata.property_lookup_cache_count,
+            global_variable_cache_count: metadata.global_variable_cache_count,
+            template_object_cache_count: metadata.template_object_cache_count,
+            object_shape_cache_count: metadata.object_shape_cache_count,
+            object_property_iterator_cache_count: metadata.object_property_iterator_cache_count,
+            number_of_registers: parts.number_of_registers,
+            number_of_arguments: parts.number_of_arguments,
+            is_strict: metadata.is_strict,
+            length_identifier: FFIOptionalU32::from(metadata.length_identifier),
+            shared_function_data: sfd_ptrs.as_ptr(),
+            shared_function_data_count: sfd_ptrs.len(),
+            class_blueprints: bp_ptrs.as_ptr(),
+            class_blueprint_count: bp_ptrs.len(),
+            compiled_regexes: slices.compiled_regexes.as_ptr(),
+            regex_count: slices.compiled_regexes.len(),
+        };
+
+        rust_create_executable(vm_ptr, source_code_ptr, &raw const ffi_data)
+    }
+}
+
 /// Create a C++ Executable from already materialized dependency objects and
 /// borrowed bytecode/table slices.
 ///
@@ -730,28 +833,6 @@ pub unsafe fn create_executable_with_dependencies_from_parts(
         // Encode constants
         let constants_buffer = encode_constants(&generator.constants);
 
-        // Build FFI exception handlers
-        let ffi_handlers: Vec<FFIExceptionHandler> = parts
-            .exception_handlers
-            .iter()
-            .map(|h| FFIExceptionHandler {
-                start_offset: h.start_offset,
-                end_offset: h.end_offset,
-                handler_offset: h.handler_offset,
-            })
-            .collect();
-
-        // Build FFI source map
-        let ffi_source_map: Vec<FFISourceMapEntry> = parts
-            .source_map
-            .iter()
-            .map(|e| FFISourceMapEntry {
-                bytecode_offset: e.bytecode_offset,
-                source_start_line: e.line,
-                source_start_column: e.column,
-            })
-            .collect();
-
         // Build local variable name slices
         let local_var_slices: Vec<FFIUtf16Slice> = generator
             .local_variables
@@ -759,45 +840,27 @@ pub unsafe fn create_executable_with_dependencies_from_parts(
             .map(|v| FFIUtf16Slice::from(v.name.as_ref()))
             .collect();
 
-        let ffi_data = FFIExecutableData {
-            bytecode: parts.bytecode.as_ptr(),
-            bytecode_length: parts.bytecode.len(),
-            bytecode_owner: parts.bytecode_owner,
-            identifier_table: ident_slices.as_ptr(),
-            identifier_count: ident_slices.len(),
-            property_key_table: property_key_slices.as_ptr(),
-            property_key_count: property_key_slices.len(),
-            string_table: string_slices.as_ptr(),
-            string_count: string_slices.len(),
-            constants_data: constants_buffer.as_ptr(),
-            constants_data_length: constants_buffer.len(),
-            constants_count: generator.constants.len(),
-            exception_handlers: ffi_handlers.as_ptr(),
-            exception_handler_count: ffi_handlers.len(),
-            source_map: ffi_source_map.as_ptr(),
-            source_map_count: ffi_source_map.len(),
-            basic_block_offsets: parts.basic_block_start_offsets.as_ptr(),
-            basic_block_count: parts.basic_block_start_offsets.len(),
-            local_variable_names: local_var_slices.as_ptr(),
-            local_variable_count: local_var_slices.len(),
+        let metadata = ExecutableMetadata {
             property_lookup_cache_count: generator.next_property_lookup_cache,
             global_variable_cache_count: generator.next_global_variable_cache,
             template_object_cache_count: generator.next_template_object_cache,
             object_shape_cache_count: generator.next_object_shape_cache,
             object_property_iterator_cache_count: generator.next_object_property_iterator_cache,
-            number_of_registers: parts.number_of_registers,
-            number_of_arguments: parts.number_of_arguments,
             is_strict: generator.strict,
-            length_identifier: FFIOptionalU32::from(generator.length_identifier.map(|index| index.0)),
-            shared_function_data: sfd_ptrs.as_ptr(),
-            shared_function_data_count: sfd_ptrs.len(),
-            class_blueprints: bp_ptrs.as_ptr(),
-            class_blueprint_count: bp_ptrs.len(),
-            compiled_regexes: generator.compiled_regexes.as_ptr(),
-            regex_count: generator.compiled_regexes.len(),
+            length_identifier: generator.length_identifier.map(|index| index.0),
         };
 
-        rust_create_executable(vm_ptr, source_code_ptr, &raw const ffi_data)
+        let slices = ExecutableSlices {
+            identifier_table: &ident_slices,
+            property_key_table: &property_key_slices,
+            string_table: &string_slices,
+            constants_data: &constants_buffer,
+            constants_count: generator.constants.len(),
+            local_variable_names: &local_var_slices,
+            compiled_regexes: &generator.compiled_regexes,
+        };
+
+        create_executable_from_slices(parts, metadata, slices, vm_ptr, source_code_ptr, sfd_ptrs, bp_ptrs)
     }
 }
 

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -22,6 +22,7 @@
 //! All `FFI*` structs are `#[repr(C)]`.
 
 use std::ffi::c_void;
+use std::mem::align_of;
 
 use super::generator::{
     AssembledBytecode, ConstantValue, ExceptionHandler, Generator, PendingClassBlueprint, PendingClassElement,
@@ -607,6 +608,7 @@ pub(crate) fn encode_constants(constants: &[ConstantValue]) -> Vec<u8> {
             ConstantValue::Empty => buffer.push(ConstantTag::Empty as u8),
             ConstantValue::String(s) => {
                 buffer.push(ConstantTag::String as u8);
+                align_buffer_to(&mut buffer, align_of::<u16>());
                 let len = u32_from_usize(s.len());
                 buffer.extend_from_slice(&len.to_le_bytes());
                 for &code_unit in s {
@@ -630,6 +632,11 @@ pub(crate) fn encode_constants(constants: &[ConstantValue]) -> Vec<u8> {
         }
     }
     buffer
+}
+
+fn align_buffer_to(buffer: &mut Vec<u8>, alignment: usize) {
+    let padding = buffer.len().next_multiple_of(alignment) - buffer.len();
+    buffer.extend(std::iter::repeat_n(0, padding));
 }
 
 /// Create a C++ Executable from the generator's assembled output.

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -1173,10 +1173,9 @@ unsafe fn materialize_executable(
             return std::ptr::null_mut();
         };
         let (_string_table_storage, string_table_slices) = utf16_slice_storage(string_table.iter());
-        let Some(constants) = constants.into_constant_values() else {
+        let Some((constants_count, constants_bytes)) = constants.into_ffi_data() else {
             return std::ptr::null_mut();
         };
-        let constants_buffer = crate::bytecode::ffi::encode_constants(&constants);
         let Some(local_variables) = local_variables.into_values() else {
             return std::ptr::null_mut();
         };
@@ -1240,8 +1239,8 @@ unsafe fn materialize_executable(
                 identifier_table: &identifier_table_slices,
                 property_key_table: &property_key_table_slices,
                 string_table: &string_table_slices,
-                constants_data: &constants_buffer,
-                constants_count: constants.len(),
+                constants_data: constants_bytes.as_slice(),
+                constants_count,
                 local_variable_names: &local_variable_name_slices,
                 compiled_regexes: &[],
             },
@@ -2588,14 +2587,51 @@ impl DecodedConstantTable {
         self.count
     }
 
-    fn into_constant_values(self) -> Option<Vec<ConstantValue>> {
-        let mut decoder = Decoder::new(self.bytes.as_slice(), None);
-        let mut constants = Vec::with_capacity(self.count);
-        for _ in 0..self.count {
-            constants.push(DecodedConstantValue::decode(&mut decoder)?.into_constant_value());
+    fn into_ffi_data(self) -> Option<(usize, DecodedBytecodeBytes)> {
+        {
+            let mut decoder = Decoder::new(self.bytes.as_slice(), None);
+            for _ in 0..self.count {
+                validate_constant_value(&mut decoder)?;
+            }
+            if !decoder.is_empty() {
+                return None;
+            }
         }
-        decoder.is_empty().then_some(constants)
+        Some((self.count, self.bytes))
     }
+}
+
+fn validate_constant_value(decoder: &mut Decoder<'_>) -> Option<()> {
+    match u8::decode(decoder)? {
+        tag if tag == ConstantTag::Number as u8 => {
+            f64::decode(decoder)?;
+        }
+        tag if tag == ConstantTag::BooleanTrue as u8 => {}
+        tag if tag == ConstantTag::BooleanFalse as u8 => {}
+        tag if tag == ConstantTag::Null as u8 => {}
+        tag if tag == ConstantTag::Undefined as u8 => {}
+        tag if tag == ConstantTag::Empty as u8 => {}
+        tag if tag == ConstantTag::String as u8 => {
+            decoder.align_to(align_of::<u16>())?;
+            let length: usize = u32::decode(decoder)?.try_into().ok()?;
+            decoder.bytes(length.checked_mul(size_of::<u16>())?)?;
+        }
+        tag if tag == ConstantTag::BigInt as u8 => {
+            let length: usize = u32::decode(decoder)?.try_into().ok()?;
+            std::str::from_utf8(decoder.bytes(length)?).ok()?;
+        }
+        tag if tag == ConstantTag::WellKnownSymbol as u8 => match u8::decode(decoder)? {
+            0 | 1 => {}
+            _ => return None,
+        },
+        tag if tag == ConstantTag::AbstractOperation as u8 => match u8::decode(decoder)? {
+            0..=4 => {}
+            _ => return None,
+        },
+        _ => return None,
+    }
+
+    Some(())
 }
 
 impl Encode for ConstantValue {
@@ -2657,63 +2693,6 @@ impl Decode for ConstantValue {
                 _ => None,
             },
             _ => None,
-        }
-    }
-}
-
-enum DecodedConstantValue {
-    Number(f64),
-    Boolean(bool),
-    Null,
-    Undefined,
-    Empty,
-    String(DecodedUtf16String),
-    BigInt(String),
-    WellKnownSymbol(WellKnownSymbolKind),
-    AbstractOperation(AbstractOperationKind),
-}
-
-impl DecodedConstantValue {
-    fn decode(decoder: &mut Decoder<'_>) -> Option<Self> {
-        match u8::decode(decoder)? {
-            tag if tag == ConstantTag::Number as u8 => Some(Self::Number(f64::decode(decoder)?)),
-            tag if tag == ConstantTag::BooleanTrue as u8 => Some(Self::Boolean(true)),
-            tag if tag == ConstantTag::BooleanFalse as u8 => Some(Self::Boolean(false)),
-            tag if tag == ConstantTag::Null as u8 => Some(Self::Null),
-            tag if tag == ConstantTag::Undefined as u8 => Some(Self::Undefined),
-            tag if tag == ConstantTag::Empty as u8 => Some(Self::Empty),
-            tag if tag == ConstantTag::String as u8 => Some(Self::String(DecodedUtf16String::decode(decoder)?)),
-            tag if tag == ConstantTag::BigInt as u8 => {
-                Some(Self::BigInt(String::from_utf8(ByteVector::decode(decoder)?).ok()?))
-            }
-            tag if tag == ConstantTag::WellKnownSymbol as u8 => match u8::decode(decoder)? {
-                0 => Some(Self::WellKnownSymbol(WellKnownSymbolKind::SymbolIterator)),
-                1 => Some(Self::WellKnownSymbol(WellKnownSymbolKind::SymbolAsyncIterator)),
-                _ => None,
-            },
-            tag if tag == ConstantTag::AbstractOperation as u8 => match u8::decode(decoder)? {
-                0 => Some(Self::AbstractOperation(AbstractOperationKind::AsyncIteratorClose)),
-                1 => Some(Self::AbstractOperation(AbstractOperationKind::GetMethod)),
-                2 => Some(Self::AbstractOperation(AbstractOperationKind::GetIteratorDirect)),
-                3 => Some(Self::AbstractOperation(AbstractOperationKind::GetIteratorFromMethod)),
-                4 => Some(Self::AbstractOperation(AbstractOperationKind::IteratorComplete)),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    fn into_constant_value(self) -> ConstantValue {
-        match self {
-            Self::Number(value) => ConstantValue::Number(value),
-            Self::Boolean(value) => ConstantValue::Boolean(value),
-            Self::Null => ConstantValue::Null,
-            Self::Undefined => ConstantValue::Undefined,
-            Self::Empty => ConstantValue::Empty,
-            Self::String(value) => ConstantValue::String(value.to_utf16_string()),
-            Self::BigInt(value) => ConstantValue::BigInt(value),
-            Self::WellKnownSymbol(value) => ConstantValue::WellKnownSymbol(value),
-            Self::AbstractOperation(value) => ConstantValue::AbstractOperation(value),
         }
     }
 }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -20,11 +20,9 @@ use crate::bytecode::ffi::{
     AbstractOperationKind, ConstantTag, FFISharedFunctionData, FFIUtf16Slice, WellKnownSymbolKind,
 };
 use crate::bytecode::generator::{
-    AssembledBytecode, ConstantValue, ExceptionHandler, FunctionSfdMetadata, Generator, LocalVariable,
-    PendingClassBlueprint, PendingClassElement, PendingLiteralValueKind, PendingSharedFunctionData,
-    PrecompiledFunction,
+    AssembledBytecode, ConstantValue, ExceptionHandler, FunctionSfdMetadata, Generator, PendingClassBlueprint,
+    PendingClassElement, PendingLiteralValueKind, PendingSharedFunctionData, PrecompiledFunction,
 };
-use crate::bytecode::operand::PropertyKeyTableIndex;
 use crate::bytecode::validator::{
     FFIExceptionHandlerOffsets, FFIValidatorBounds, ValidationErrorKind, validate_bytecode,
 };
@@ -487,7 +485,9 @@ impl PreparedUtf16Slice {
     }
 }
 
-fn utf16_slice_storage(strings: &[DecodedUtf16String]) -> (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) {
+fn utf16_slice_storage<'a>(
+    strings: impl ExactSizeIterator<Item = &'a DecodedUtf16String>,
+) -> (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) {
     #[cfg(target_endian = "little")]
     let storage = Vec::new();
     #[cfg(not(target_endian = "little"))]
@@ -1046,7 +1046,7 @@ unsafe fn materialize_function(
         let (_parameter_name_storage, parameter_names): (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) = function
             .parameter_names
             .as_ref()
-            .map(|names| utf16_slice_storage(names))
+            .map(|names| utf16_slice_storage(names.iter()))
             .unwrap_or_default();
         let name_storage = function.name.as_ref().map(PreparedUtf16Slice::new);
         let (name, name_len) = name_storage
@@ -1147,7 +1147,7 @@ unsafe fn materialize_executable(
             number_of_registers,
             number_of_arguments,
             cache_counters,
-            this_value_needs_environment_resolution,
+            this_value_needs_environment_resolution: _,
             length_identifier,
             bytecode,
             identifier_table,
@@ -1161,51 +1161,38 @@ unsafe fn materialize_executable(
             class_blueprints,
         } = executable;
 
-        let mut generator = Generator::new();
-        generator.strict = strict;
-        generator.this_value_needs_environment_resolution = this_value_needs_environment_resolution;
-        generator.next_property_lookup_cache = cache_counters.property_lookup_cache_count;
-        generator.next_global_variable_cache = cache_counters.global_variable_cache_count;
-        generator.next_template_object_cache = cache_counters.template_object_cache_count;
-        generator.next_object_shape_cache = cache_counters.object_shape_cache_count;
-        generator.next_object_property_iterator_cache = cache_counters.object_property_iterator_cache_count;
         let Some(identifier_table) = identifier_table.into_values() else {
             return std::ptr::null_mut();
         };
-        generator.identifier_table = identifier_table
-            .into_iter()
-            .map(|value| value.to_utf16_string())
-            .collect();
+        let (_identifier_table_storage, identifier_table_slices) = utf16_slice_storage(identifier_table.iter());
         let Some(property_key_table) = property_key_table.into_values() else {
             return std::ptr::null_mut();
         };
-        generator.property_key_table = property_key_table
-            .into_iter()
-            .map(|value| value.to_utf16_string())
-            .collect();
+        let (_property_key_table_storage, property_key_table_slices) = utf16_slice_storage(property_key_table.iter());
         let Some(string_table) = string_table.into_values() else {
             return std::ptr::null_mut();
         };
-        generator.string_table = string_table.into_iter().map(|value| value.to_utf16_string()).collect();
+        let (_string_table_storage, string_table_slices) = utf16_slice_storage(string_table.iter());
         let Some(constants) = constants.into_constant_values() else {
             return std::ptr::null_mut();
         };
-        generator.constants = constants;
+        let constants_buffer = crate::bytecode::ffi::encode_constants(&constants);
         let Some(local_variables) = local_variables.into_values() else {
             return std::ptr::null_mut();
         };
-        generator.local_variables = local_variables
-            .into_iter()
-            .map(DecodedLocalVariable::into_local_variable)
-            .collect();
-        generator.length_identifier = length_identifier.map(PropertyKeyTableIndex);
+        let (_local_variable_storage, local_variable_name_slices) =
+            utf16_slice_storage(local_variables.iter().map(|local_variable| {
+                let _ = local_variable.is_lexically_declared;
+                let _ = local_variable.is_initialized_during_declaration_instantiation;
+                &local_variable.name
+            }));
 
         let Some(shared_functions) = shared_functions.into_values() else {
             return std::ptr::null_mut();
         };
         let sfd_ptrs: Vec<*const c_void> = shared_functions
             .into_iter()
-            .map(|function| materialize_function(function, generator.strict, vm_ptr, source_code_ptr) as *const c_void)
+            .map(|function| materialize_function(function, strict, vm_ptr, source_code_ptr) as *const c_void)
             .collect();
         if sfd_ptrs.iter().any(|ptr| ptr.is_null()) {
             return std::ptr::null_mut();
@@ -1230,8 +1217,7 @@ unsafe fn materialize_executable(
             return std::ptr::null_mut();
         };
 
-        crate::bytecode::ffi::create_executable_with_dependencies_from_parts(
-            &generator,
+        crate::bytecode::ffi::create_executable_from_slices(
             crate::bytecode::ffi::ExecutableParts {
                 bytecode: bytecode.as_slice(),
                 bytecode_owner: bytecode.owner_for_ffi(),
@@ -1240,6 +1226,24 @@ unsafe fn materialize_executable(
                 basic_block_start_offsets: &[],
                 number_of_registers,
                 number_of_arguments,
+            },
+            crate::bytecode::ffi::ExecutableMetadata {
+                property_lookup_cache_count: cache_counters.property_lookup_cache_count,
+                global_variable_cache_count: cache_counters.global_variable_cache_count,
+                template_object_cache_count: cache_counters.template_object_cache_count,
+                object_shape_cache_count: cache_counters.object_shape_cache_count,
+                object_property_iterator_cache_count: cache_counters.object_property_iterator_cache_count,
+                is_strict: strict,
+                length_identifier,
+            },
+            crate::bytecode::ffi::ExecutableSlices {
+                identifier_table: &identifier_table_slices,
+                property_key_table: &property_key_table_slices,
+                string_table: &string_table_slices,
+                constants_data: &constants_buffer,
+                constants_count: constants.len(),
+                local_variable_names: &local_variable_name_slices,
+                compiled_regexes: &[],
             },
             vm_ptr,
             source_code_ptr,
@@ -2857,16 +2861,6 @@ struct DecodedLocalVariable {
     name: DecodedUtf16String,
     is_lexically_declared: bool,
     is_initialized_during_declaration_instantiation: bool,
-}
-
-impl DecodedLocalVariable {
-    fn into_local_variable(self) -> LocalVariable {
-        LocalVariable {
-            name: self.name.to_utf16_string(),
-            is_lexically_declared: self.is_lexically_declared,
-            is_initialized_during_declaration_instantiation: self.is_initialized_during_declaration_instantiation,
-        }
-    }
 }
 
 struct SharedFunctionTable<'a>(&'a Generator);

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -883,7 +883,20 @@ static Utf16FlyString utf16_fly_from_ffi(FFIUtf16Slice slice)
     return Utf16FlyString::from_utf16(view_from_ffi(slice));
 }
 
-static JS::Value decode_constant(JS::VM& vm, uint8_t const*& cursor, uint8_t const* end)
+static void align_constant_cursor(uint8_t const* begin, uint8_t const*& cursor, uint8_t const* end, size_t alignment)
+{
+    auto offset = static_cast<size_t>(cursor - begin);
+    auto aligned_offset = (offset + alignment - 1) & ~(alignment - 1);
+    VERIFY(aligned_offset <= static_cast<size_t>(end - begin));
+    cursor = begin + aligned_offset;
+}
+
+static bool constant_cursor_is_aligned(uint8_t const* cursor, size_t alignment)
+{
+    return reinterpret_cast<FlatPtr>(cursor) % alignment == 0;
+}
+
+static JS::Value decode_constant(JS::VM& vm, uint8_t const* begin, uint8_t const*& cursor, uint8_t const* end)
 {
     VERIFY(cursor < end);
     auto const tag = *cursor++;
@@ -907,19 +920,25 @@ static JS::Value decode_constant(JS::VM& vm, uint8_t const*& cursor, uint8_t con
     case ConstantTag::Empty:
         return JS::js_special_empty_value();
     case ConstantTag::String: {
+        align_constant_cursor(begin, cursor, end, alignof(char16_t));
         VERIFY(cursor + 4 <= end);
         uint32_t len;
         memcpy(&len, cursor, 4);
         cursor += 4;
-        VERIFY(cursor + len * 2 <= end);
+        VERIFY(len <= static_cast<size_t>(end - cursor) / sizeof(char16_t));
         if (len == 0)
             return JS::PrimitiveString::create(vm, Utf16String {});
-        // NB: cursor may not be 2-byte aligned, so copy to an aligned buffer.
-        Vector<char16_t> aligned_buf;
-        aligned_buf.resize(len);
-        memcpy(aligned_buf.data(), cursor, len * 2);
-        auto str = Utf16String::from_utf16(Utf16View(aligned_buf.data(), len));
-        cursor += len * 2;
+        auto string_byte_length = static_cast<size_t>(len) * sizeof(char16_t);
+        auto str = [&] {
+            if (constant_cursor_is_aligned(cursor, alignof(char16_t)))
+                return Utf16String::from_utf16(Utf16View(reinterpret_cast<char16_t const*>(cursor), len));
+
+            Vector<char16_t> code_units;
+            code_units.resize(len);
+            memcpy(code_units.data(), cursor, string_byte_length);
+            return Utf16String::from_utf16(Utf16View(code_units.data(), len));
+        }();
+        cursor += string_byte_length;
         return JS::PrimitiveString::create(vm, move(str));
     }
     case ConstantTag::BigInt: {
@@ -1042,7 +1061,7 @@ extern "C" void* rust_create_executable(
     auto const* cursor = data->constants_data;
     auto const* end = data->constants_data + data->constants_data_length;
     for (size_t i = 0; i < data->constants_count; ++i) {
-        constants_vec.append(decode_constant(vm, cursor, end));
+        constants_vec.append(decode_constant(vm, data->constants_data, cursor, end));
     }
     VERIFY(cursor == end);
 

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1008,18 +1008,21 @@ extern "C" void* rust_create_executable(
 
     // Build identifier table
     auto ident_table = make<JS::Bytecode::IdentifierTable>();
+    ident_table->ensure_capacity(data->identifier_count);
     for (size_t i = 0; i < data->identifier_count; ++i) {
         ident_table->insert(utf16_fly_from_ffi(data->identifier_table[i]));
     }
 
     // Build property key table
     auto prop_key_table = make<JS::Bytecode::PropertyKeyTable>();
+    prop_key_table->ensure_capacity(data->property_key_count);
     for (size_t i = 0; i < data->property_key_count; ++i) {
         prop_key_table->insert(utf16_fly_from_ffi(data->property_key_table[i]));
     }
 
     // Build string table
     auto str_table = make<JS::Bytecode::StringTable>();
+    str_table->ensure_capacity(data->string_count);
     for (size_t i = 0; i < data->string_count; ++i) {
         str_table->insert(utf16_from_ffi(data->string_table[i]));
     }
@@ -1061,6 +1064,7 @@ extern "C" void* rust_create_executable(
         data->is_strict ? JS::Strict::Yes : JS::Strict::No);
 
     // Set exception handlers
+    executable->exception_handlers.ensure_capacity(data->exception_handler_count);
     for (size_t i = 0; i < data->exception_handler_count; ++i) {
         executable->exception_handlers.append({
             data->exception_handlers[i].start_offset,
@@ -1070,6 +1074,7 @@ extern "C" void* rust_create_executable(
     }
 
     // Set source map
+    executable->source_map.ensure_capacity(data->source_map_count);
     for (size_t i = 0; i < data->source_map_count; ++i) {
         executable->source_map.append({
             data->source_map[i].bytecode_offset,
@@ -1088,6 +1093,7 @@ extern "C" void* rust_create_executable(
     }
 
     // Set local variable names
+    executable->local_variable_names.ensure_capacity(data->local_variable_count);
     for (size_t i = 0; i < data->local_variable_count; ++i) {
         executable->local_variable_names.append({
             .name = utf16_fly_from_ffi(data->local_variable_names[i]),
@@ -1107,6 +1113,7 @@ extern "C" void* rust_create_executable(
         executable->length_identifier = JS::Bytecode::PropertyKeyTableIndex(data->length_identifier.value);
 
     // Set shared function data (inner function definitions)
+    executable->shared_function_data.ensure_capacity(data->shared_function_data_count);
     for (size_t i = 0; i < data->shared_function_data_count; ++i) {
         auto* sfd = const_cast<JS::SharedFunctionInstanceData*>(
             static_cast<JS::SharedFunctionInstanceData const*>(data->shared_function_data[i]));
@@ -1114,6 +1121,7 @@ extern "C" void* rust_create_executable(
     }
 
     // Set class blueprints (move from heap-allocated objects)
+    executable->class_blueprints.ensure_capacity(data->class_blueprint_count);
     for (size_t i = 0; i < data->class_blueprint_count; ++i) {
         auto* bp = static_cast<JS::Bytecode::ClassBlueprint*>(data->class_blueprints[i]);
         executable->class_blueprints.append(move(*bp));

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -444,7 +444,7 @@ TEST_CASE(bytecode_cache_materializes_from_mapped_blob)
     auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
     auto& realm = *root_execution_context->realm;
 
-    auto test_data = create_bytecode_cache_blob("let f = function mapped() { return 1; }; f();"_string);
+    auto test_data = create_bytecode_cache_blob("let f = function mapped() { return 'hello'; }; f();"_string);
     auto path = ByteString::formatted("{}/bytecode-cache-test-{}.blob", Core::StandardPaths::tempfile_directory(), Core::System::getpid());
     ScopeGuard remove_file = [&] {
         (void)Core::System::unlink(path);
@@ -467,6 +467,8 @@ TEST_CASE(bytecode_cache_materializes_from_mapped_blob)
 
     auto result = vm->run(script_or_error.release_value());
     VERIFY(!result.is_throw_completion());
+    VERIFY(result.value().is_string());
+    EXPECT_EQ(result.value().as_string().utf8_string(), "hello"_string);
 }
 
 TEST_CASE(fresh_precompiled_function_executables_materialize_lazily)


### PR DESCRIPTION
Materializing cached bytecode used to rebuild generator-owned Rust tables and constant values before passing the data to C++. This made the cache path do extra allocation, copying, decoding, and re-encoding work for data that C++ immediately materializes into its final executable-owned structures.

Pass borrowed FFI slices for cache-backed UTF-16 tables, validate cached constant bytes without expanding them into Rust `ConstantValue` objects, and feed those bytes directly to the C++ executable factory. Also pre-size the final C++ bytecode tables and executable vectors from the decoded counts.

The updated bytecode cache test covers materializing a mapped cache blob with a string constant.