### PR TITLE
UI/Qt: Remove collect garbage shortcut

### DIFF
--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -287,7 +287,6 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         break;
     case WebView::ActionID::CollectGarbage:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/trash-can.png"sv));
-        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_G));
         break;
 
     default:


### PR DESCRIPTION
Leave the debug menu action available without binding Ctrl+Shift+G, which conflicts with the standard find previous shortcut.