### PR TITLE
LibWeb: Remove some uses of `LRC::for_layout_node`

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -267,7 +267,6 @@ public:
     static BorderCollapse border_collapse() { return BorderCollapse::Separate; }
     static EmptyCells empty_cells() { return EmptyCells::Show; }
     static GridTemplateAreas grid_template_areas() { return {}; }
-    static Time transition_delay() { return Time::make_seconds(0); }
     static ObjectFit object_fit() { return ObjectFit::Fill; }
     static Position object_position() { return {}; }
     static Color outline_color() { return Color::Black; }
@@ -758,7 +757,6 @@ public:
     Optional<FlyString> font_language_override() const { return m_inherited.font_language_override; }
     HashMap<FlyString, double> font_variation_settings() const { return m_inherited.font_variation_settings; }
     CSSPixels line_height() const { return m_inherited.line_height; }
-    Time transition_delay() const { return m_noninherited.transition_delay; }
 
     Color outline_color() const { return m_noninherited.outline_color; }
     Length outline_offset() const { return m_noninherited.outline_offset; }
@@ -938,7 +936,6 @@ protected:
         GridTemplateAreas grid_template_areas { InitialValues::grid_template_areas() };
         Gfx::Color stop_color { InitialValues::stop_color() };
         float stop_opacity { InitialValues::stop_opacity() };
-        Time transition_delay { InitialValues::transition_delay() };
         Color outline_color { InitialValues::outline_color() };
         CSSPixels outline_width { InitialValues::outline_width() };
         Length outline_offset { InitialValues::outline_offset() };
@@ -1156,7 +1153,6 @@ public:
     void set_empty_cells(EmptyCells const empty_cells) { m_inherited.empty_cells = empty_cells; }
     void set_grid_template_areas(GridTemplateAreas grid_template_areas) { m_noninherited.grid_template_areas = move(grid_template_areas); }
     void set_grid_auto_flow(GridAutoFlow grid_auto_flow) { m_noninherited.grid_auto_flow = grid_auto_flow; }
-    void set_transition_delay(Time const& transition_delay) { m_noninherited.transition_delay = transition_delay; }
     void set_table_layout(TableLayout value) { m_noninherited.table_layout = value; }
     void set_quotes(QuotesData value) { m_inherited.quotes = move(value); }
     void set_object_fit(ObjectFit value) { m_noninherited.object_fit = value; }

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -118,6 +118,7 @@ public:
                 return t;
             },
             [&](Percentage const& percentage) {
+                // FIXME: This doesn't necessarily round correctly
                 return Length::make_px(CSSPixels(percentage.value() * reference_value) / 100);
             },
             [&](NonnullRefPtr<CalculatedStyleValue const> const& calculated) {

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -47,12 +47,8 @@ void ConicGradientStyleValue::serialize(StringBuilder& builder, SerializationMod
 
 void ConicGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node, CSSPixelSize size) const
 {
-    ResolvedDataCacheKey cache_key {
-        .length_resolution_context = Length::ResolutionContext::for_layout_node(node),
-        .size = size,
-    };
-    if (m_resolved_data_cache_key != cache_key) {
-        m_resolved_data_cache_key = move(cache_key);
+    if (m_resolved_size != size) {
+        m_resolved_size = size;
         m_resolved = ResolvedData { Painting::resolve_conic_gradient_data(node, *this), {} };
     }
     m_resolved->position = m_properties.position->resolved(node, CSSPixelRect { { 0, 0 }, size });

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -72,12 +72,7 @@ private:
         bool operator==(Properties const&) const = default;
     } m_properties;
 
-    struct ResolvedDataCacheKey {
-        Length::ResolutionContext length_resolution_context;
-        CSSPixelSize size;
-        bool operator==(ResolvedDataCacheKey const&) const = default;
-    };
-    mutable Optional<ResolvedDataCacheKey> m_resolved_data_cache_key;
+    mutable Optional<CSSPixelSize> m_resolved_size;
 
     struct ResolvedData {
         Painting::ConicGradientData data;

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -65,10 +65,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
 
     auto const& document = layout_node.document();
 
-    CacheKey cache_key {
-        .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node),
-        .current_color = layout_node.computed_values().color(),
-    };
+    auto const& current_color = layout_node.computed_values().color();
 
     // Create a bitmap if needed.
     // The cursor size for a given image never changes. It's based either on the image itself, or our default size,
@@ -100,8 +97,8 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
     }
 
     // Repaint the bitmap if necessary
-    if (m_cache_key != cache_key) {
-        m_cache_key = move(cache_key);
+    if (m_cached_bitmap_color != current_color) {
+        m_cached_bitmap_color = current_color;
 
         // Clear whatever was in the bitmap before.
         auto& bitmap = *m_cached_bitmap->bitmap();

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
@@ -51,13 +51,7 @@ private:
         bool operator==(Properties const&) const = default;
     } m_properties;
 
-    // Data that can affect the bitmap rendering.
-    struct CacheKey {
-        Length::ResolutionContext length_resolution_context;
-        Gfx::Color current_color;
-        bool operator==(CacheKey const&) const = default;
-    };
-    mutable Optional<CacheKey> m_cache_key;
+    mutable Optional<Color> m_cached_bitmap_color;
     mutable Optional<Gfx::ShareableBitmap> m_cached_bitmap;
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -30,19 +30,7 @@ ImageSetStyleValue::ImageSetStyleValue(Vector<Option> options)
 {
 }
 
-static Optional<double> option_resolution_in_dppx(ImageSetStyleValue::Option const& option, Optional<CalculationResolutionContext> const& calculation_resolution_context)
-{
-    if (option.resolution->is_resolution())
-        return option.resolution->as_resolution().resolution().to_dots_per_pixel();
-    if (option.resolution->is_calculated()) {
-        auto resolution = option.resolution->as_calculated().resolve_resolution(calculation_resolution_context.value_or({}));
-        if (resolution.has_value())
-            return resolution->to_dots_per_pixel();
-    }
-    return {};
-}
-
-AbstractImageStyleValue const* ImageSetStyleValue::select_image(double device_pixels_per_css_pixel, Optional<CalculationResolutionContext> const& calculation_resolution_context) const
+AbstractImageStyleValue const* ImageSetStyleValue::select_image(double device_pixels_per_css_pixel) const
 {
     ImageSetStyleValue::Option const* best_below_or_equal = nullptr;
     Optional<double> best_below_or_equal_resolution;
@@ -53,21 +41,19 @@ AbstractImageStyleValue const* ImageSetStyleValue::select_image(double device_pi
         if (option.type.has_value() && !HTML::is_supported_image_type(*option.type))
             continue;
 
-        auto resolution = option_resolution_in_dppx(option, calculation_resolution_context);
-        if (!resolution.has_value())
-            continue;
+        auto resolution = Resolution::from_style_value(option.resolution).to_dots_per_pixel();
 
-        if (*resolution >= device_pixels_per_css_pixel) {
-            if (!best_above_resolution.has_value() || *resolution < *best_above_resolution) {
+        if (resolution >= device_pixels_per_css_pixel) {
+            if (!best_above_resolution.has_value() || resolution < *best_above_resolution) {
                 best_above = &option;
-                best_above_resolution = *resolution;
+                best_above_resolution = resolution;
             }
             continue;
         }
 
-        if (!best_below_or_equal_resolution.has_value() || *resolution > *best_below_or_equal_resolution) {
+        if (!best_below_or_equal_resolution.has_value() || resolution > *best_below_or_equal_resolution) {
             best_below_or_equal = &option;
-            best_below_or_equal_resolution = *resolution;
+            best_below_or_equal_resolution = resolution;
         }
     }
 
@@ -140,41 +126,12 @@ bool ImageSetStyleValue::is_computationally_independent() const
 void ImageSetStyleValue::load_any_resources(DOM::Document& document)
 {
     auto dpr = document.page().client().device_pixels_per_css_pixel();
-    if (auto const* image = select_image(dpr, {}); image && image != m_selected_image) {
+    if (auto const* image = select_image(dpr); image && image != m_selected_image) {
         const_cast<AbstractImageStyleValue&>(*image).set_style_sheet(m_style_sheet);
         m_selected_image = image;
     }
     if (m_selected_image)
         const_cast<AbstractImageStyleValue&>(*m_selected_image).load_any_resources(document);
-}
-
-void ImageSetStyleValue::load_any_resources(Layout::NodeWithStyle const& layout_node)
-{
-    update_selected_image_for_layout_node(layout_node);
-    if (m_selected_image)
-        const_cast<AbstractImageStyleValue&>(*m_selected_image).load_any_resources(const_cast<DOM::Document&>(layout_node.document()));
-}
-
-void ImageSetStyleValue::update_selected_image_for_layout_node(Layout::NodeWithStyle const& layout_node) const
-{
-    Optional<DOM::AbstractElement> abstract_element;
-    if (layout_node.is_generated_for_pseudo_element()) {
-        if (auto const* pseudo_element_generator = layout_node.pseudo_element_generator())
-            abstract_element = DOM::AbstractElement { *pseudo_element_generator, layout_node.generated_for_pseudo_element() };
-    } else if (auto const* dom_node = layout_node.dom_node(); dom_node && dom_node->is_element()) {
-        abstract_element = DOM::AbstractElement { static_cast<DOM::Element const&>(*dom_node) };
-    }
-
-    auto context = CalculationResolutionContext {
-        .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node),
-        .abstract_element = abstract_element,
-    };
-    auto dpr = layout_node.document().page().client().device_pixels_per_css_pixel();
-
-    if (auto const* image = select_image(dpr, context); image && image != m_selected_image) {
-        const_cast<AbstractImageStyleValue&>(*image).set_style_sheet(m_style_sheet);
-        m_selected_image = image;
-    }
 }
 
 Optional<CSSPixels> ImageSetStyleValue::natural_width() const
@@ -200,7 +157,6 @@ Optional<CSSPixelFraction> ImageSetStyleValue::natural_aspect_ratio() const
 
 void ImageSetStyleValue::resolve_for_size(Layout::NodeWithStyle const& layout_node, CSSPixelSize size) const
 {
-    update_selected_image_for_layout_node(layout_node);
     if (m_selected_image)
         m_selected_image->resolve_for_size(layout_node, size);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -33,7 +33,6 @@ public:
     virtual bool is_computationally_independent() const override;
 
     virtual void load_any_resources(DOM::Document&) override;
-    virtual void load_any_resources(Layout::NodeWithStyle const&) override;
 
     virtual Optional<CSSPixels> natural_width() const override;
     virtual Optional<CSSPixels> natural_height() const override;
@@ -52,8 +51,7 @@ private:
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
-    AbstractImageStyleValue const* select_image(double device_pixels_per_css_pixel, Optional<CalculationResolutionContext> const&) const;
-    void update_selected_image_for_layout_node(Layout::NodeWithStyle const&) const;
+    AbstractImageStyleValue const* select_image(double device_pixels_per_css_pixel) const;
 
     Vector<Option> m_options;
     GC::Ptr<CSSStyleSheet> m_style_sheet;

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -134,12 +134,8 @@ float LinearGradientStyleValue::angle_degrees(CSSPixelSize gradient_size) const
 
 void LinearGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node, CSSPixelSize size) const
 {
-    ResolvedDataCacheKey cache_key {
-        .length_resolution_context = Length::ResolutionContext::for_layout_node(node),
-        .size = size,
-    };
-    if (m_resolved_data_cache_key != cache_key) {
-        m_resolved_data_cache_key = move(cache_key);
+    if (m_resolved_size != size) {
+        m_resolved_size = move(size);
         m_resolved = Painting::resolve_linear_gradient_data(node, size, *this);
     }
 }

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -103,12 +103,7 @@ private:
         bool operator==(Properties const&) const = default;
     } m_properties;
 
-    struct ResolvedDataCacheKey {
-        Length::ResolutionContext length_resolution_context;
-        CSSPixelSize size;
-        bool operator==(ResolvedDataCacheKey const&) const = default;
-    };
-    mutable Optional<ResolvedDataCacheKey> m_resolved_data_cache_key;
+    mutable Optional<CSSPixelSize> m_resolved_size;
     mutable Optional<Painting::LinearGradientData> m_resolved;
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -69,12 +69,8 @@ void RadialGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& nod
     auto center = m_properties.position->resolved(node, gradient_box);
     auto gradient_size = resolve_size(center, gradient_box, node);
 
-    ResolvedDataCacheKey cache_key {
-        .length_resolution_context = Length::ResolutionContext::for_layout_node(node),
-        .size = paint_size,
-    };
-    if (m_resolved_data_cache_key != cache_key) {
-        m_resolved_data_cache_key = move(cache_key);
+    if (m_resolved_size != paint_size) {
+        m_resolved_size = move(paint_size);
         m_resolved = ResolvedData {
             Painting::resolve_radial_gradient_data(node, gradient_size, *this),
             gradient_size,

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -80,12 +80,7 @@ private:
         bool operator==(Properties const&) const = default;
     } m_properties;
 
-    struct ResolvedDataCacheKey {
-        Length::ResolutionContext length_resolution_context;
-        CSSPixelSize size;
-        bool operator==(ResolvedDataCacheKey const&) const = default;
-    };
-    mutable Optional<ResolvedDataCacheKey> m_resolved_data_cache_key;
+    mutable Optional<CSSPixelSize> m_resolved_size;
 
     struct ResolvedData {
         Painting::RadialGradientData data;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -857,33 +857,19 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues con
             return false;
         }
 
-        if (size.is_calculated()) {
-            CSS::CalculationResolutionContext context {
-                .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(node),
-            };
-            if (size.calculated().contains_percentage()) {
+        if (size.is_length_percentage()) {
+            if (size.contains_percentage()) {
                 if (!containing_block_has_definite_size)
                     return false;
                 auto containing_block_size_as_length = width ? containing_block_used_values->content_width() : containing_block_used_values->content_height();
-                context.percentage_basis = CSS::Length::make_px(containing_block_size_as_length);
+                resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(node, containing_block_size_as_length), size, width));
+                return true;
             }
-            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.calculated().resolve_length(context)->to_px(node), size, width));
+
+            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(node, CSSPixels { 0 }), size, width));
             return true;
         }
 
-        if (size.is_length()) {
-            VERIFY(!size.is_auto()); // This should have been covered by the Size::is_auto() branch above.
-            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.length().to_px(node), size, width));
-            return true;
-        }
-        if (size.is_percentage()) {
-            if (containing_block_has_definite_size) {
-                auto containing_block_size = width ? containing_block_used_values->content_width() : containing_block_used_values->content_height();
-                resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(containing_block_size.scaled(size.percentage().as_fraction()), size, width));
-                return true;
-            }
-            return false;
-        }
         return false;
     };
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -867,15 +867,6 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_perspective(computed_style.perspective());
     computed_values.set_perspective_origin(computed_style.perspective_origin());
 
-    auto const& transition_delay_property = computed_style.property(CSS::PropertyID::TransitionDelay);
-    if (transition_delay_property.is_time()) {
-        auto const& transition_delay = transition_delay_property.as_time();
-        computed_values.set_transition_delay(transition_delay.time());
-    } else if (transition_delay_property.is_calculated()) {
-        auto const& transition_delay = transition_delay_property.as_calculated();
-        computed_values.set_transition_delay(transition_delay.resolve_time({ .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
-    }
-
     auto do_border_style = [&](CSS::BorderData& border, CSS::PropertyID width_property, CSS::PropertyID color_property, CSS::PropertyID style_property) {
         // FIXME: Support <image-1d>
         border.color = computed_style.color(color_property, color_resolution_context);

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -276,7 +276,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                         TextNode <#text> (not painted)
                     BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
-                    BlockContainer <div#editorModeSeparator.verticalToolbarSeparator> at [704,4.796875] flex-item [2+1+0 0 0+0+2] [0+0+0 22.40625 0+0+0] [BFC] children: not-inline
+                    BlockContainer <div#editorModeSeparator.verticalToolbarSeparator> at [704,4.8125] flex-item [2+1+0 0 0+0+2] [0+0+0 22.390625 0+0+0] [BFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
                     Box <div.toolbarHorizontalGroup.hiddenMediumView> at [707,2] flex-container(row) flex-item [0+0+0 57 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
@@ -310,7 +310,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                         TextNode <#text> (not painted)
                     BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
-                    BlockContainer <div.verticalToolbarSeparator.hiddenMediumView> at [768,4.796875] flex-item [2+1+0 0 0+0+2] [0+0+0 22.40625 0+0+0] [BFC] children: not-inline
+                    BlockContainer <div.verticalToolbarSeparator.hiddenMediumView> at [768,4.8125] flex-item [2+1+0 0 0+0+2] [0+0+0 22.390625 0+0+0] [BFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
                     BlockContainer <div#secondaryToolbarToggle.toolbarButtonWithContainer> at [771,2] positioned flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [BFC] children: not-inline
@@ -474,7 +474,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                           PaintableWithLines (BlockContainer<SPAN>) [694,16 0x0] overflow: [694,16 51.734375x72]
                             TextPaintable (TextNode<#text>)
                         PaintableWithLines (BlockContainer(anonymous)) [672,30 28x0]
-                    PaintableWithLines (BlockContainer<DIV>#editorModeSeparator.verticalToolbarSeparator) [703,4.796875 1x22.40625]
+                    PaintableWithLines (BlockContainer<DIV>#editorModeSeparator.verticalToolbarSeparator) [703,4.8125 1x22.390625]
                     PaintableBox (Box<DIV>.toolbarHorizontalGroup.hiddenMediumView) [707,2 57x28]
                       PaintableBox (Box<BUTTON>#printButton.toolbarButton) [707,2 28x28]
                         PaintableWithLines (BlockContainer(anonymous)) [713,8 16x16]
@@ -484,7 +484,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                         PaintableWithLines (BlockContainer(anonymous)) [742,8 16x16]
                         PaintableWithLines (BlockContainer<SPAN>) [758,16 0x0] overflow: [758,16 38.234375x18]
                           TextPaintable (TextNode<#text>)
-                    PaintableWithLines (BlockContainer<DIV>.verticalToolbarSeparator.hiddenMediumView) [767,4.796875 1x22.40625]
+                    PaintableWithLines (BlockContainer<DIV>.verticalToolbarSeparator.hiddenMediumView) [767,4.8125 1x22.390625]
                     PaintableWithLines (BlockContainer<DIV>#secondaryToolbarToggle.toolbarButtonWithContainer) [771,2 28x28]
                       PaintableWithLines (BlockContainer(anonymous)) [771,2 28x0]
                       PaintableBox (Box<BUTTON>#secondaryToolbarToggleButton.toolbarButton) [771,2 28x28]


### PR DESCRIPTION
Relative lengths should always be absolutized at style computation time so we have no need for `Length::ResolutionContext::for_layout_node` - this gets us a bit closer to removing it entirely. The remaining users (`TransformationStyleValue`, `ColorResolutionContext`, and `LengthPercentage::resolved`) are a bit more complicated and will get their own PRs