### PR TITLE
LibJS: Avoid repeated lazy source decoding

### DIFF
--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
@@ -77,7 +77,12 @@ Utf16String SharedFunctionInstanceData::source_text() const
     if (!m_source_code)
         return {};
 
-    return m_source_code->source_text_from_offsets(m_source_text_offset, m_source_text_length);
+    auto old_external_memory_size = utf16_string_external_memory_size(m_source_text_owner);
+    m_source_text_owner = m_source_code->source_text_from_offsets(m_source_text_offset, m_source_text_length);
+    auto new_external_memory_size = utf16_string_external_memory_size(m_source_text_owner);
+    if (new_external_memory_size > old_external_memory_size)
+        heap().did_allocate_external_memory(new_external_memory_size - old_external_memory_size);
+    return m_source_text_owner;
 }
 
 void SharedFunctionInstanceData::set_source_text(Utf16View source_text)

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
@@ -89,7 +89,7 @@ public:
     //     source text needs to be owned by the function data (e.g. for
     //     dynamically created functions via Function constructor).
     RefPtr<SourceCode const> m_source_code;
-    Utf16String m_source_text_owner;
+    Utf16String mutable m_source_text_owner;
     size_t m_source_text_offset { 0 };
     size_t m_source_text_length { 0 }; // [[SourceText]]
 

--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -4,13 +4,39 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AllOf.h>
 #include <AK/BinarySearch.h>
+#include <AK/CharacterTypes.h>
 #include <LibJS/SourceCode.h>
 #include <LibJS/SourceRange.h>
 #include <LibJS/Token.h>
 #include <LibTextCodec/Decoder.h>
 
 namespace JS {
+
+static bool ascii_source_bytes_decode_to_same_code_units(StringView standardized_encoding, ReadonlyBytes bytes)
+{
+    auto decoder = TextCodec::decoder_for_exact_name(standardized_encoding);
+    if (!decoder.has_value())
+        return false;
+
+    size_t byte_offset = 0;
+    bool bytes_are_identity_mapped = true;
+    auto result = decoder->process_code_points(StringView { bytes }, [&](auto code_point) -> ErrorOr<void> {
+        if (byte_offset >= bytes.size()) {
+            bytes_are_identity_mapped = false;
+            return {};
+        }
+
+        auto byte = bytes[byte_offset++];
+        if (code_point != byte)
+            bytes_are_identity_mapped = false;
+        return {};
+    });
+    result.release_value_but_fixme_should_propagate_errors();
+
+    return bytes_are_identity_mapped && byte_offset == bytes.size();
+}
 
 NonnullRefPtr<SourceCode const> SourceCode::create(String filename, Utf16String code)
 {
@@ -84,11 +110,52 @@ Utf16String SourceCode::source_text_from_offsets(size_t start_offset, size_t len
     if (m_code.has_value())
         return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
 
-    if (m_source_bytes.is_valid())
+    if (m_source_bytes.is_valid()) {
+        if (source_bytes_can_be_sliced_by_code_unit_offsets()) {
+            auto bytes = m_source_bytes.bytes();
+            VERIFY(m_length_in_code_units == bytes.size());
+            auto source_text_bytes = bytes.slice(start_offset, length);
+            if (all_of(source_text_bytes, AK::is_ascii))
+                return Utf16String::from_ascii_without_validation(source_text_bytes);
+            return Utf16String::from_utf8(StringView { source_text_bytes });
+        }
         return decode_source_range(start_offset, length);
+    }
 
     ensure_code();
     return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
+}
+
+bool SourceCode::source_bytes_can_be_sliced_by_code_unit_offsets() const
+{
+    if (!m_source_bytes_can_be_sliced_by_code_unit_offsets.has_value()) {
+        auto standardized_encoding = TextCodec::get_standardized_encoding(m_source_encoding);
+        if (!standardized_encoding.has_value()) {
+            m_source_bytes_can_be_sliced_by_code_unit_offsets = false;
+            return *m_source_bytes_can_be_sliced_by_code_unit_offsets;
+        }
+
+        auto bytes = m_source_bytes.bytes();
+        if (m_length_in_code_units != bytes.size()) {
+            m_source_bytes_can_be_sliced_by_code_unit_offsets = false;
+            return *m_source_bytes_can_be_sliced_by_code_unit_offsets;
+        }
+
+        auto source_bytes_are_ascii = all_of(bytes, AK::is_ascii);
+        if (standardized_encoding->equals_ignoring_ascii_case("UTF-8"sv)) {
+            m_source_bytes_can_be_sliced_by_code_unit_offsets = source_bytes_are_ascii;
+            return *m_source_bytes_can_be_sliced_by_code_unit_offsets;
+        }
+
+        if (!source_bytes_are_ascii) {
+            m_source_bytes_can_be_sliced_by_code_unit_offsets = false;
+            return *m_source_bytes_can_be_sliced_by_code_unit_offsets;
+        }
+
+        m_source_bytes_can_be_sliced_by_code_unit_offsets = ascii_source_bytes_decode_to_same_code_units(*standardized_encoding, bytes);
+    }
+
+    return *m_source_bytes_can_be_sliced_by_code_unit_offsets;
 }
 
 Utf16String SourceCode::decode_source_range(size_t start_offset, size_t length) const

--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -7,6 +7,7 @@
 #include <AK/AllOf.h>
 #include <AK/BinarySearch.h>
 #include <AK/CharacterTypes.h>
+#include <AK/Utf8View.h>
 #include <LibJS/SourceCode.h>
 #include <LibJS/SourceRange.h>
 #include <LibJS/Token.h>
@@ -107,6 +108,8 @@ Utf16String SourceCode::source_text_from_offsets(size_t start_offset, size_t len
     if (length == 0)
         return {};
 
+    VERIFY(start_offset <= NumericLimits<size_t>::max() - length);
+
     if (m_code.has_value())
         return Utf16String::from_utf16(m_code->utf16_view().substring_view(start_offset, length));
 
@@ -119,6 +122,8 @@ Utf16String SourceCode::source_text_from_offsets(size_t start_offset, size_t len
                 return Utf16String::from_ascii_without_validation(source_text_bytes);
             return Utf16String::from_utf8(StringView { source_text_bytes });
         }
+        if (auto source_text = source_text_from_utf8_source_bytes(start_offset, length); source_text.has_value())
+            return source_text.release_value();
         return decode_source_range(start_offset, length);
     }
 
@@ -156,6 +161,114 @@ bool SourceCode::source_bytes_can_be_sliced_by_code_unit_offsets() const
     }
 
     return *m_source_bytes_can_be_sliced_by_code_unit_offsets;
+}
+
+Optional<Utf16String> SourceCode::source_text_from_utf8_source_bytes(size_t start_offset, size_t length) const
+{
+    auto start_byte_offset = byte_offset_for_utf8_code_unit_offset(start_offset);
+    if (!start_byte_offset.has_value())
+        return {};
+
+    auto end_byte_offset = byte_offset_for_utf8_code_unit_offset(start_offset + length);
+    if (!end_byte_offset.has_value())
+        return {};
+
+    VERIFY(*start_byte_offset <= *end_byte_offset);
+    auto source_text_bytes = m_source_bytes.bytes().slice(*start_byte_offset, *end_byte_offset - *start_byte_offset);
+    if (all_of(source_text_bytes, AK::is_ascii))
+        return Utf16String::from_ascii_without_validation(source_text_bytes);
+    return Utf16String::from_utf8(StringView { source_text_bytes });
+}
+
+bool SourceCode::ensure_utf8_source_byte_spans() const
+{
+    if (m_tried_to_build_utf8_source_byte_spans)
+        return m_can_use_utf8_source_byte_spans;
+
+    m_tried_to_build_utf8_source_byte_spans = true;
+
+    auto standardized_encoding = TextCodec::get_standardized_encoding(m_source_encoding);
+    if (!standardized_encoding.has_value() || !standardized_encoding->equals_ignoring_ascii_case("UTF-8"sv))
+        return false;
+
+    auto bytes = m_source_bytes.bytes();
+    StringView input { bytes };
+
+    if (bytes.size() >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+        input = input.substring_view(3);
+        m_utf8_source_byte_span_initial_byte_offset = 3;
+    } else if (bytes.size() >= 2 && ((bytes[0] == 0xFE && bytes[1] == 0xFF) || (bytes[0] == 0xFF && bytes[1] == 0xFE))) {
+        return false;
+    }
+
+    auto utf8_view = Utf8View { input };
+    if (!utf8_view.validate(AllowLonelySurrogates::No))
+        return false;
+
+    size_t code_unit_offset = 0;
+    for (auto it = utf8_view.begin(); it != utf8_view.end(); ++it) {
+        auto code_point = *it;
+        size_t code_unit_length = code_point <= 0xffff ? 1 : 2;
+        auto byte_length = it.underlying_code_point_length_in_bytes();
+        if (byte_length != code_unit_length) {
+            m_utf8_source_byte_spans.append({
+                .code_unit_offset = code_unit_offset,
+                .code_unit_length = code_unit_length,
+                .byte_offset = m_utf8_source_byte_span_initial_byte_offset + utf8_view.byte_offset_of(it),
+                .byte_length = byte_length,
+            });
+        }
+        code_unit_offset += code_unit_length;
+    }
+
+    if (code_unit_offset != m_length_in_code_units) {
+        m_utf8_source_byte_spans.clear();
+        return false;
+    }
+
+    m_can_use_utf8_source_byte_spans = true;
+    return true;
+}
+
+Optional<size_t> SourceCode::byte_offset_for_utf8_code_unit_offset(size_t code_unit_offset) const
+{
+    if (code_unit_offset > m_length_in_code_units)
+        return {};
+
+    if (!ensure_utf8_source_byte_spans())
+        return {};
+
+    size_t low = 0;
+    size_t high = m_utf8_source_byte_spans.size();
+    while (low < high) {
+        auto middle = low + (high - low) / 2;
+        auto const& span = m_utf8_source_byte_spans[middle];
+        auto span_end = span.code_unit_offset + span.code_unit_length;
+        if (span_end <= code_unit_offset)
+            low = middle + 1;
+        else
+            high = middle;
+    }
+
+    if (low < m_utf8_source_byte_spans.size()) {
+        auto const& span = m_utf8_source_byte_spans[low];
+        if (code_unit_offset >= span.code_unit_offset && code_unit_offset < span.code_unit_offset + span.code_unit_length) {
+            if (code_unit_offset == span.code_unit_offset)
+                return span.byte_offset;
+            return {};
+        }
+    }
+
+    size_t byte_delta = m_utf8_source_byte_span_initial_byte_offset;
+    if (low > 0) {
+        auto const& previous_span = m_utf8_source_byte_spans[low - 1];
+        auto previous_span_end_byte_offset = previous_span.byte_offset + previous_span.byte_length;
+        auto previous_span_end_code_unit_offset = previous_span.code_unit_offset + previous_span.code_unit_length;
+        VERIFY(previous_span_end_byte_offset >= previous_span_end_code_unit_offset);
+        byte_delta = previous_span_end_byte_offset - previous_span_end_code_unit_offset;
+    }
+
+    return code_unit_offset + byte_delta;
 }
 
 Utf16String SourceCode::decode_source_range(size_t start_offset, size_t length) const

--- a/Libraries/LibJS/SourceCode.h
+++ b/Libraries/LibJS/SourceCode.h
@@ -37,6 +37,7 @@ private:
     SourceCode(String filename, size_t length_in_code_units, String source_encoding, Core::ImmutableBytes source_bytes);
     void ensure_code() const;
     Utf16String decode_source_range(size_t start_offset, size_t length) const;
+    bool source_bytes_can_be_sliced_by_code_unit_offsets() const;
 
     String m_filename;
     Optional<Utf16String> mutable m_code;
@@ -58,6 +59,7 @@ private:
     // Cached UTF-16 widening of ASCII source data, lazily populated by
     // utf16_data() for use by the Rust compilation pipeline.
     Vector<u16> mutable m_utf16_data_cache;
+    Optional<bool> mutable m_source_bytes_can_be_sliced_by_code_unit_offsets;
 };
 
 }

--- a/Libraries/LibJS/SourceCode.h
+++ b/Libraries/LibJS/SourceCode.h
@@ -38,6 +38,16 @@ private:
     void ensure_code() const;
     Utf16String decode_source_range(size_t start_offset, size_t length) const;
     bool source_bytes_can_be_sliced_by_code_unit_offsets() const;
+    Optional<Utf16String> source_text_from_utf8_source_bytes(size_t start_offset, size_t length) const;
+    bool ensure_utf8_source_byte_spans() const;
+    Optional<size_t> byte_offset_for_utf8_code_unit_offset(size_t code_unit_offset) const;
+
+    struct Utf8SourceByteSpan {
+        size_t code_unit_offset { 0 };
+        size_t code_unit_length { 0 };
+        size_t byte_offset { 0 };
+        size_t byte_length { 0 };
+    };
 
     String m_filename;
     Optional<Utf16String> mutable m_code;
@@ -60,6 +70,10 @@ private:
     // utf16_data() for use by the Rust compilation pipeline.
     Vector<u16> mutable m_utf16_data_cache;
     Optional<bool> mutable m_source_bytes_can_be_sliced_by_code_unit_offsets;
+    Vector<Utf8SourceByteSpan> mutable m_utf8_source_byte_spans;
+    size_t mutable m_utf8_source_byte_span_initial_byte_offset { 0 };
+    bool mutable m_tried_to_build_utf8_source_byte_spans { false };
+    bool mutable m_can_use_utf8_source_byte_spans { false };
 };
 
 }

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -77,6 +77,19 @@ TEST_CASE(lazy_source_code_decoding_replaces_overlong_utf8_sequences)
     EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd"sv);
 }
 
+TEST_CASE(lazy_source_code_decoding_extracts_utf8_range_after_non_ascii)
+{
+    auto prefix = "// Known Trick\xe2\x84\xa2\n"sv;
+    auto function_source = "function f() { return 1; }"sv;
+    auto source = ByteString::formatted("{}{}", prefix, function_source);
+    auto source_utf16 = Utf16String::from_utf8(source.view());
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source.bytes()));
+    auto source_code = JS::SourceCode::create("test.js"_string, source_utf16.length_in_code_units(), "UTF-8"_string, move(source_bytes));
+
+    auto start_offset = Utf16String::from_utf8(prefix).length_in_code_units();
+    EXPECT_EQ(source_code->source_text_from_offsets(start_offset, function_source.length()).to_utf8(), function_source);
+}
+
 class BytecodeCacheBlobReader {
 public:
     explicit BytecodeCacheBlobReader(ReadonlyBytes bytes)
@@ -488,6 +501,40 @@ TEST_CASE(bytecode_cache_to_string_caches_lazy_ascii_source_text)
     VERIFY(result.value().is_string());
     EXPECT_EQ(result.value().as_string().utf8_string(), "function mapped() { return 'hello'; }|function mapped() { return 'hello'; }"_string);
     EXPECT_EQ(shared_data.m_source_text_owner.to_utf8(), "function mapped() { return 'hello'; }"sv);
+}
+
+TEST_CASE(bytecode_cache_to_string_uses_lazy_utf8_offset_map)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto prefix = "// Known Trick\xe2\x84\xa2\n"sv;
+    auto body = "let f = function mapped() { return 'Known Trick\xe2\x84\xa2'; }; f.toString();"sv;
+    auto source = ByteString::formatted("{}{}", prefix, body);
+    auto test_data = create_bytecode_cache_blob(source.view());
+
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source.bytes()));
+    auto source_code = JS::SourceCode::create("test.js"_string, test_data.source_code->length_in_code_units(), "UTF-8"_string, move(source_bytes));
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    auto script_or_error = JS::Script::create_from_bytecode_cache(decoded_blob, source_code, realm);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+
+    auto* executable = script->cached_executable();
+    VERIFY(executable);
+    VERIFY(!executable->shared_function_data.is_empty());
+    auto& shared_data = *executable->shared_function_data[0];
+    EXPECT(shared_data.m_source_text_owner.is_empty());
+
+    auto result = vm->run(script);
+    VERIFY(!result.is_throw_completion());
+    VERIFY(result.value().is_string());
+    EXPECT_EQ(result.value().as_string().utf8_string(), "function mapped() { return 'Known Trick\xe2\x84\xa2'; }"_string);
+    EXPECT_EQ(shared_data.m_source_text_owner.to_utf8(), "function mapped() { return 'Known Trick\xe2\x84\xa2'; }"sv);
 }
 
 TEST_CASE(bytecode_cache_materializes_from_mapped_blob)

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -33,8 +33,8 @@ TEST_CASE(lazy_source_code_decoding_replaces_utf8_surrogates)
     auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source_data.span()));
     auto source_code = JS::SourceCode::create("test.js"_string, 3, "UTF-8"_string, move(source_bytes));
 
-    EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"sv);
     EXPECT_EQ(source_code->source_text_from_offsets(0, 3).to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"sv);
+    EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd"sv);
 }
 
 TEST_CASE(lazy_source_code_decoding_replaces_odd_trailing_utf16_byte)
@@ -47,14 +47,34 @@ TEST_CASE(lazy_source_code_decoding_replaces_odd_trailing_utf16_byte)
     EXPECT_EQ(source_code->source_text_from_offsets(0, 2).to_utf8(), "A\xef\xbf\xbd"sv);
 }
 
+TEST_CASE(lazy_source_code_decoding_replaces_single_trailing_utf16_byte)
+{
+    auto source_data = Vector<u8> { 'A' };
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source_data.span()));
+    auto source_code = JS::SourceCode::create("test.js"_string, 1, "UTF-16LE"_string, move(source_bytes));
+
+    EXPECT_EQ(source_code->source_text_from_offsets(0, 1).to_utf8(), "\xef\xbf\xbd"sv);
+}
+
+TEST_CASE(lazy_source_code_decoding_uses_pdfdocencoding_mapping)
+{
+    auto source_data = Vector<u8> { 0x18, 'A' };
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source_data.span()));
+    auto source_code = JS::SourceCode::create("test.js"_string, 2, "PDFDocEncoding"_string, move(source_bytes));
+
+    EXPECT_EQ(source_code->source_text_from_offsets(0, 1).to_utf8(), "\xcb\x98"sv);
+    EXPECT_EQ(source_code->code().to_utf8(), "\xcb\x98"
+                                             "A"sv);
+}
+
 TEST_CASE(lazy_source_code_decoding_replaces_overlong_utf8_sequences)
 {
     auto source_data = Vector<u8> { 0xc0, 0x80 };
     auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source_data.span()));
     auto source_code = JS::SourceCode::create("test.js"_string, 2, "UTF-8"_string, move(source_bytes));
 
-    EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd"sv);
     EXPECT_EQ(source_code->source_text_from_offsets(0, 2).to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd"sv);
+    EXPECT_EQ(source_code->code().to_utf8(), "\xef\xbf\xbd\xef\xbf\xbd"sv);
 }
 
 class BytecodeCacheBlobReader {
@@ -436,6 +456,38 @@ TEST_CASE(bytecode_cache_materializes_function_executables_lazily)
     VERIFY(!result.is_throw_completion());
     EXPECT(shared_data.m_executable);
     EXPECT(!shared_data.m_cached_bytecode_executable);
+}
+
+TEST_CASE(bytecode_cache_to_string_caches_lazy_ascii_source_text)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "let f = function mapped() { return 'hello'; }; f.toString() + '|' + f.toString();"sv;
+    auto test_data = create_bytecode_cache_blob(source);
+
+    auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source.bytes()));
+    auto source_code = JS::SourceCode::create("test.js"_string, test_data.source_code->length_in_code_units(), "UTF-8"_string, move(source_bytes));
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    auto script_or_error = JS::Script::create_from_bytecode_cache(decoded_blob, source_code, realm);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+
+    auto* executable = script->cached_executable();
+    VERIFY(executable);
+    VERIFY(!executable->shared_function_data.is_empty());
+    auto& shared_data = *executable->shared_function_data[0];
+    EXPECT(shared_data.m_source_text_owner.is_empty());
+
+    auto result = vm->run(script);
+    VERIFY(!result.is_throw_completion());
+    VERIFY(result.value().is_string());
+    EXPECT_EQ(result.value().as_string().utf8_string(), "function mapped() { return 'hello'; }|function mapped() { return 'hello'; }"_string);
+    EXPECT_EQ(shared_data.m_source_text_owner.to_utf8(), "function mapped() { return 'hello'; }"sv);
 }
 
 TEST_CASE(bytecode_cache_materializes_from_mapped_blob)


### PR DESCRIPTION
This fixes a Speedometer 2.1 hang in EmberJS-Debug-TodoMVC after loading scripts from the HTTP disk cache with bytecode-cache sidecars.

When a script is materialized from cached bytecode, its `SourceCode` can still own only the encoded source bytes. `Function.prototype.toString()` then repeatedly decoded source ranges from those bytes, which made Ember’s debug build spend a large amount of time in UTF-8 decoding.

The change keeps source text lazy, but avoids repeated decoding by:

- caching extracted function source text on `SharedFunctionInstanceData`
- directly slicing byte-backed ASCII UTF-8 source
- verifying identity mapping before direct slicing other ASCII byte-backed encodings
- lazily building a UTF-8 code-unit-to-byte-offset map for non-ASCII UTF-8 source

Invalid UTF-8, UTF-16 edge cases, and non-identity encodings keep using the decoder path. The added tests cover bytecode-cache `toString()`, malformed UTF-8, UTF-16 edge cases, PDFDocEncoding, and non-ASCII UTF-8 offsets.
