### PR TITLE
LibGC+LibJS+LibWeb: Introduce RootHashTable and start fixing GC objects in non-GC container issues

### DIFF
--- a/Libraries/LibGC/CMakeLists.txt
+++ b/Libraries/LibGC/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ConservativeVector.cpp
     Root.cpp
     RootHashMap.cpp
+    RootHashTable.cpp
     RootVector.cpp
     Heap.cpp
     HeapBlock.cpp

--- a/Libraries/LibGC/Forward.h
+++ b/Libraries/LibGC/Forward.h
@@ -40,4 +40,7 @@ class HeapVector;
 template<class T, size_t inline_capacity = 0>
 class RootVector;
 
+template<typename T, typename TraitsForT, bool IsOrdered>
+class RootHashTable;
+
 }

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -489,6 +489,9 @@ public:
                 case HeapRoot::Type::RootHashMap:
                     node.set("root"sv, "RootHashMap"sv);
                     break;
+                case HeapRoot::Type::RootHashTable:
+                    node.set("root"sv, "RootHashTable"sv);
+                    break;
                 case HeapRoot::Type::RegisterPointer:
                     node.set("root"sv, "RegisterPointer"sv);
                     if (it.value.root_origin->stack_frame_index.has_value())
@@ -787,6 +790,9 @@ void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots, Vector<StackFrameInfo>*
         for (auto& hash_map : m_root_hash_maps)
             hash_map.gather_roots(roots);
     }
+
+    for (auto& hash_table : m_root_hash_tables)
+        hash_table.gather_roots(roots);
 
     if constexpr (HEAP_DEBUG) {
         dbgln("gather_roots:");

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -25,6 +25,7 @@
 #include <LibGC/IdleCollectionPolicy.h>
 #include <LibGC/Root.h>
 #include <LibGC/RootHashMap.h>
+#include <LibGC/RootHashTable.h>
 #include <LibGC/RootVector.h>
 #include <LibGC/WeakBlock.h>
 #include <LibGC/WeakContainer.h>
@@ -82,6 +83,8 @@ public:
 
     void did_create_root_hash_map(Badge<RootHashMapBase>, RootHashMapBase&);
     void did_destroy_root_hash_map(Badge<RootHashMapBase>, RootHashMapBase&);
+    void did_create_root_hash_table(Badge<RootHashTableBase>, RootHashTableBase&);
+    void did_destroy_root_hash_table(Badge<RootHashTableBase>, RootHashTableBase&);
 
     void did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
     void did_destroy_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
@@ -175,6 +178,7 @@ private:
     RootImpl::List m_roots;
     RootVectorBase::List m_root_vectors;
     RootHashMapBase::List m_root_hash_maps;
+    RootHashTableBase::List m_root_hash_tables;
     ConservativeVectorBase::List m_conservative_vectors;
     WeakContainer::List m_weak_containers;
 
@@ -241,6 +245,18 @@ inline void Heap::did_destroy_root_hash_map(Badge<RootHashMapBase>, RootHashMapB
 {
     VERIFY(m_root_hash_maps.contains(hash_map));
     m_root_hash_maps.remove(hash_map);
+}
+
+inline void Heap::did_create_root_hash_table(Badge<RootHashTableBase>, RootHashTableBase& hash_table)
+{
+    VERIFY(!m_root_hash_tables.contains(hash_table));
+    m_root_hash_tables.append(hash_table);
+}
+
+inline void Heap::did_destroy_root_hash_table(Badge<RootHashTableBase>, RootHashTableBase& hash_table)
+{
+    VERIFY(m_root_hash_tables.contains(hash_table));
+    m_root_hash_tables.remove(hash_table);
 }
 
 inline void Heap::did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase& vector)

--- a/Libraries/LibGC/HeapRoot.h
+++ b/Libraries/LibGC/HeapRoot.h
@@ -20,6 +20,7 @@ struct GC_API HeapRoot {
         RegisterPointer,
         Root,
         RootHashMap,
+        RootHashTable,
         RootVector,
         StackPointer,
         VM,

--- a/Libraries/LibGC/RootHashTable.cpp
+++ b/Libraries/LibGC/RootHashTable.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGC/Heap.h>
+#include <LibGC/RootHashTable.h>
+
+namespace GC {
+
+RootHashTableBase::RootHashTableBase(Heap& heap)
+    : m_heap(&heap)
+{
+    m_heap->did_create_root_hash_table({}, *this);
+}
+
+RootHashTableBase::~RootHashTableBase()
+{
+    m_heap->did_destroy_root_hash_table({}, *this);
+}
+
+}

--- a/Libraries/LibGC/RootHashTable.h
+++ b/Libraries/LibGC/RootHashTable.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashTable.h>
+#include <AK/IntrusiveList.h>
+#include <LibGC/Cell.h>
+#include <LibGC/Forward.h>
+#include <LibGC/HeapRoot.h>
+
+namespace GC {
+
+class GC_API RootHashTableBase {
+public:
+    virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>&) const = 0;
+
+protected:
+    explicit RootHashTableBase(Heap&);
+    ~RootHashTableBase();
+
+    Heap* m_heap { nullptr };
+    IntrusiveListNode<RootHashTableBase> m_list_node;
+
+public:
+    using List = IntrusiveList<&RootHashTableBase::m_list_node>;
+};
+
+template<typename T, typename TraitsForT = Traits<T>, bool IsOrdered = false>
+class RootHashTable final
+    : public RootHashTableBase
+    , public HashTable<T, TraitsForT, IsOrdered> {
+
+    using HashTableBase = HashTable<T, TraitsForT, IsOrdered>;
+
+public:
+    explicit RootHashTable(Heap& heap)
+        : RootHashTableBase(heap)
+    {
+    }
+
+    ~RootHashTable() = default;
+
+    virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
+    {
+        static_assert(IsBaseOf<NanBoxedValue, T> || IsConvertible<T, Cell const*>,
+            "RootHashTable element type must be convertible to Cell const* or derive from NanBoxedValue");
+        for (auto& value : *this) {
+            if constexpr (IsBaseOf<NanBoxedValue, T>) {
+                if (value.is_cell())
+                    roots.set(&const_cast<T&>(value).as_cell(), HeapRoot { .type = HeapRoot::Type::RootHashTable });
+            } else if constexpr (IsConvertible<T, Cell const*>) {
+                roots.set(const_cast<Cell*>(static_cast<Cell const*>(value)), HeapRoot { .type = HeapRoot::Type::RootHashTable });
+            }
+        }
+    }
+};
+
+template<typename T, typename TraitsForT = Traits<T>>
+using OrderedRootHashTable = RootHashTable<T, TraitsForT, true>;
+
+}

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -3480,7 +3480,7 @@ NEVER_INLINE ThrowCompletionOr<void> NewClass::execute_impl(VM& vm) const
     Value super_class;
     if (m_super_class.has_value())
         super_class = vm.get(m_super_class.value());
-    Vector<Value> element_keys;
+    GC::RootVector<Value> element_keys(vm.heap());
     element_keys.ensure_capacity(m_element_keys_count);
     for (size_t i = 0; i < m_element_keys_count; ++i) {
         Value element_key;

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -10,6 +10,7 @@
 #include <AK/NumericLimits.h>
 #include <AK/TemporaryChange.h>
 #include <LibGC/RootHashMap.h>
+#include <LibGC/RootHashTable.h>
 #include <LibJS/Bytecode/AsmInterpreter/AsmInterpreter.h>
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Builtins.h>
@@ -1571,7 +1572,7 @@ static ThrowCompletionOr<Optional<FastPropertyNameIteratorData>> try_get_fast_pr
     result.receiver_has_magical_length_property = object.has_magical_length_property();
     result.shape = &object.shape();
 
-    HashTable<GC::Ref<Object>> seen_objects;
+    GC::RootHashTable<GC::Ref<Object>> seen_objects(vm.heap());
     size_t estimated_properties_count = 0;
     bool prototype_chain_has_enumerable_named_properties = false;
     for (auto object_to_check = GC::Ptr { &object }; object_to_check && !seen_objects.contains(*object_to_check); object_to_check = TRY(object_to_check->internal_get_prototype_of())) {
@@ -1725,7 +1726,7 @@ inline ThrowCompletionOr<GC::Ref<PropertyNameIterator>> get_object_property_iter
     }
 
     size_t estimated_properties_count = 0;
-    HashTable<GC::Ref<Object>> seen_objects;
+    GC::RootHashTable<GC::Ref<Object>> seen_objects(vm.heap());
     for (auto object_to_check = GC::Ptr { object.ptr() }; object_to_check && !seen_objects.contains(*object_to_check); object_to_check = TRY(object_to_check->internal_get_prototype_of())) {
         seen_objects.set(*object_to_check);
         estimated_properties_count += object_to_check->own_properties_count();

--- a/Libraries/LibJS/CyclicModule.cpp
+++ b/Libraries/LibJS/CyclicModule.cpp
@@ -868,7 +868,7 @@ GC::Ref<Module> CyclicModule::get_imported_module(ModuleRequest const& request)
 {
     // 1. Let records be a List consisting of each LoadedModuleRequest Record r of referrer.[[LoadedModules]]
     //    such that ModuleRequestsEqual(r, request) is true.
-    Vector<LoadedModuleRequest> records;
+    GC::ConservativeVector<LoadedModuleRequest> records(vm().heap());
     for (auto const& r : m_loaded_modules) {
         if (module_requests_equal(r, request))
             records.append(r);

--- a/Libraries/LibJS/CyclicModule.cpp
+++ b/Libraries/LibJS/CyclicModule.cpp
@@ -222,7 +222,7 @@ ThrowCompletionOr<void> CyclicModule::link(VM& vm)
     // 1. Assert: module.[[Status]] is one of unlinked, linked, evaluating-async, or evaluated.
     VERIFY(m_status == ModuleStatus::Unlinked || m_status == ModuleStatus::Linked || m_status == ModuleStatus::EvaluatingAsync || m_status == ModuleStatus::Evaluated);
     // 2. Let stack be a new empty List.
-    Vector<Module*> stack;
+    GC::RootVector<GC::Ref<Module>> stack(vm.heap());
 
     // 3. Let result be Completion(InnerModuleLinking(module, stack, 0)).
     auto result = inner_module_linking(vm, stack, 0);
@@ -230,8 +230,8 @@ ThrowCompletionOr<void> CyclicModule::link(VM& vm)
     // 4. If result is an abrupt completion, then
     if (result.is_throw_completion()) {
         // a. For each Cyclic Module Record m of stack, do
-        for (auto* module : stack) {
-            if (is<CyclicModule>(module)) {
+        for (auto module : stack) {
+            if (is<CyclicModule>(*module)) {
                 auto& cyclic_module = static_cast<CyclicModule&>(*module);
                 // i. Assert: m.[[Status]] is linking.
                 VERIFY(cyclic_module.m_status == ModuleStatus::Linking);
@@ -257,7 +257,7 @@ ThrowCompletionOr<void> CyclicModule::link(VM& vm)
 }
 
 // 16.2.1.5.1.1 InnerModuleLinking ( module, stack, index ), https://tc39.es/ecma262/#sec-InnerModuleLinking
-ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index)
+ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, GC::RootVector<GC::Ref<Module>>& stack, u32 index)
 {
     // 1. If module is not a Cyclic Module Record, then
     //    a. Perform ? module.Link().
@@ -288,7 +288,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
     ++index;
 
     // 8. Append module to stack.
-    stack.append(this);
+    stack.append(*this);
 
 #if JS_MODULE_DEBUG
     StringBuilder request_module_names;
@@ -315,7 +315,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
             VERIFY(cyclic_module.m_status == ModuleStatus::Linking || cyclic_module.m_status == ModuleStatus::Linked || cyclic_module.m_status == ModuleStatus::EvaluatingAsync || cyclic_module.m_status == ModuleStatus::Evaluated);
 
             // ii. Assert: requiredModule.[[Status]] is linking if and only if requiredModule is in stack.
-            VERIFY((cyclic_module.m_status == ModuleStatus::Linking) == (stack.contains_slow(&cyclic_module)));
+            VERIFY((cyclic_module.m_status == ModuleStatus::Linking) == (stack.contains_slow(GC::Ref { cyclic_module })));
 
             // iii. If requiredModule.[[Status]] is linking, then
             if (cyclic_module.m_status == ModuleStatus::Linking) {
@@ -330,7 +330,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
 
     // 11. Assert: module occurs exactly once in stack.
     size_t count = 0;
-    for (auto* module : stack) {
+    for (auto module : stack) {
         if (module == this)
             count++;
     }
@@ -348,7 +348,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
         while (true) {
             // i. Let requiredModule be the last element in stack.
             // ii. Remove the last element of stack.
-            auto* required_module = stack.take_last();
+            auto required_module = stack.take_last();
 
             // iii. Assert: requiredModule is a Cyclic Module Record.
             VERIFY(is<CyclicModule>(*required_module));
@@ -398,7 +398,7 @@ ThrowCompletionOr<GC::Ref<PromiseCapability>> CyclicModule::evaluate(VM& vm)
     }
 
     // 5. Let stack be a new empty List.
-    Vector<Module*> stack;
+    GC::RootVector<GC::Ref<Module>> stack(vm.heap());
 
     auto& realm = *vm.current_realm();
 
@@ -414,7 +414,7 @@ ThrowCompletionOr<GC::Ref<PromiseCapability>> CyclicModule::evaluate(VM& vm)
         VERIFY(!m_evaluation_error.is_error());
 
         // a. For each Cyclic Module Record m of stack, do
-        for (auto* mod : stack) {
+        for (auto mod : stack) {
             if (!is<CyclicModule>(*mod))
                 continue;
 
@@ -465,7 +465,7 @@ ThrowCompletionOr<GC::Ref<PromiseCapability>> CyclicModule::evaluate(VM& vm)
 }
 
 // 16.2.1.5.2.1 InnerModuleEvaluation ( module, stack, index ), https://tc39.es/ecma262/#sec-innermoduleevaluation
-ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index)
+ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, GC::RootVector<GC::Ref<Module>>& stack, u32 index)
 {
     dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] inner_module_evaluation[{}](vm, {}, {})", this, ByteString::join(", "sv, stack), index);
     // Note: Step 1 is performed in Module.cpp
@@ -503,7 +503,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Modu
     ++index;
 
     // 10. Append module to stack.
-    stack.append(this);
+    stack.append(*this);
 
     // 11. For each ModuleRequest Record request of module.[[RequestedModules]], do
     for (auto& request : m_requested_modules) {
@@ -575,7 +575,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Modu
 
     // 14. Assert: module occurs exactly once in stack.
     auto count = 0;
-    for (auto* module : stack) {
+    for (auto module : stack) {
         if (module == this)
             count++;
     }
@@ -593,7 +593,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Modu
 
             // i. Let requiredModule be the last element in stack.
             // ii. Remove the last element of stack.
-            auto* required_module = stack.take_last();
+            auto required_module = stack.take_last();
 
             // iii. Assert: requiredModule is a Cyclic Module Record.
             VERIFY(is<CyclicModule>(*required_module));
@@ -684,7 +684,7 @@ void CyclicModule::execute_async_module(VM& vm)
 }
 
 // 16.2.1.5.2.3 GatherAvailableAncestors ( module, execList ), https://tc39.es/ecma262/#sec-gather-available-ancestors
-void CyclicModule::gather_available_ancestors(Vector<CyclicModule*>& exec_list)
+void CyclicModule::gather_available_ancestors(GC::RootVector<GC::Ptr<CyclicModule>>& exec_list)
 {
     // 1. For each Cyclic Module Record m of module.[[AsyncParentModules]], do
     for (auto module : m_async_parent_modules) {
@@ -757,7 +757,7 @@ void CyclicModule::async_module_execution_fulfilled(VM& vm)
     }
 
     // 8. Let execList be a new empty List.
-    Vector<CyclicModule*> exec_list;
+    GC::RootVector<GC::Ptr<CyclicModule>> exec_list(vm.heap());
 
     // 9. Perform GatherAvailableAncestors(module, execList).
     gather_available_ancestors(exec_list);
@@ -766,10 +766,10 @@ void CyclicModule::async_module_execution_fulfilled(VM& vm)
     // FIXME: Sort the list. To do this we need to use more than an Optional<bool> to track [[AsyncEvaluation]].
 
     // 11. Assert: All elements of sortedExecList have their [[AsyncEvaluation]] field set to true, [[PendingAsyncDependencies]] field set to 0, and [[EvaluationError]] field set to empty.
-    VERIFY(all_of(exec_list, [&](CyclicModule* module) { return module->m_async_evaluation && module->m_pending_async_dependencies.value() == 0 && !module->m_evaluation_error.is_error(); }));
+    VERIFY(all_of(exec_list, [&](auto module) { return module->m_async_evaluation && module->m_pending_async_dependencies.value() == 0 && !module->m_evaluation_error.is_error(); }));
 
     // 12. For each Cyclic Module Record m of sortedExecList, do
-    for (auto* module : exec_list) {
+    for (auto module : exec_list) {
         // a. If m.[[Status]] is evaluated, then
         if (module->m_status == ModuleStatus::Evaluated) {
             // i. Assert: m.[[EvaluationError]] is not empty.

--- a/Libraries/LibJS/CyclicModule.h
+++ b/Libraries/LibJS/CyclicModule.h
@@ -51,8 +51,8 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
     virtual size_t external_memory_size() const override;
 
-    virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override final;
-    virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override final;
+    virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, GC::RootVector<GC::Ref<Module>>& stack, u32 index) override final;
+    virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, GC::RootVector<GC::Ref<Module>>& stack, u32 index) override final;
 
     virtual ThrowCompletionOr<void> initialize_environment(VM& vm);
     virtual ThrowCompletionOr<void> execute_module(VM& vm, GC::Ptr<PromiseCapability> capability = {});
@@ -60,7 +60,7 @@ protected:
     [[nodiscard]] GC::Ref<Module> get_imported_module(ModuleRequest const& request);
 
     void execute_async_module(VM& vm);
-    void gather_available_ancestors(Vector<CyclicModule*>& exec_list);
+    void gather_available_ancestors(GC::RootVector<GC::Ptr<CyclicModule>>& exec_list);
     void async_module_execution_fulfilled(VM& vm);
     void async_module_execution_rejected(VM& vm, Value error);
 

--- a/Libraries/LibJS/Module.cpp
+++ b/Libraries/LibJS/Module.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/GenericShorthands.h>
+#include <LibGC/RootHashTable.h>
 #include <LibJS/CyclicModule.h>
 #include <LibJS/Module.h>
 #include <LibJS/Runtime/ExternalMemory.h>
@@ -186,7 +187,7 @@ GC::Ref<Object> Module::get_module_namespace(VM& vm)
 
 Vector<Utf16FlyString> Module::get_exported_names(VM& vm)
 {
-    HashTable<Module const*> export_star_set;
+    GC::RootHashTable<GC::Ref<Module const>> export_star_set(vm.heap());
     return get_exported_names(vm, export_star_set);
 }
 

--- a/Libraries/LibJS/Module.cpp
+++ b/Libraries/LibJS/Module.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/GenericShorthands.h>
 #include <LibGC/RootHashTable.h>
+#include <LibGC/RootVector.h>
 #include <LibJS/CyclicModule.h>
 #include <LibJS/Module.h>
 #include <LibJS/Runtime/ExternalMemory.h>
@@ -76,7 +77,7 @@ ThrowCompletionOr<void> Module::evaluate_module_sync(VM& vm)
 }
 
 // 16.2.1.5.1.1 InnerModuleLinking ( module, stack, index ), https://tc39.es/ecma262/#sec-InnerModuleLinking
-ThrowCompletionOr<u32> Module::inner_module_linking(VM& vm, Vector<Module*>&, u32 index)
+ThrowCompletionOr<u32> Module::inner_module_linking(VM& vm, GC::RootVector<GC::Ref<Module>>&, u32 index)
 {
     // 1. If module is not a Cyclic Module Record, then
     // a. Perform ? module.Link().
@@ -86,7 +87,7 @@ ThrowCompletionOr<u32> Module::inner_module_linking(VM& vm, Vector<Module*>&, u3
 }
 
 // 16.2.1.5.2.1 InnerModuleEvaluation ( module, stack, index ), https://tc39.es/ecma262/#sec-innermoduleevaluation
-ThrowCompletionOr<u32> Module::inner_module_evaluation(VM& vm, Vector<Module*>&, u32 index)
+ThrowCompletionOr<u32> Module::inner_module_evaluation(VM& vm, GC::RootVector<GC::Ref<Module>>&, u32 index)
 {
     // 1. If module is not a Cyclic Module Record, then
     // a. Perform ? EvaluateModuleSync(module).

--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -113,7 +113,7 @@ public:
     virtual ThrowCompletionOr<GC::Ref<PromiseCapability>> evaluate(VM& vm) = 0;
 
     Vector<Utf16FlyString> get_exported_names(VM& vm);
-    virtual Vector<Utf16FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) = 0;
+    virtual Vector<Utf16FlyString> get_exported_names(VM& vm, GC::RootHashTable<GC::Ref<Module const>>& export_star_set) = 0;
 
     virtual ResolvedBinding resolve_export(VM& vm, Utf16FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) = 0;
 

--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -117,8 +117,8 @@ public:
 
     virtual ResolvedBinding resolve_export(VM& vm, Utf16FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) = 0;
 
-    virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index);
-    virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index);
+    virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, GC::RootVector<GC::Ref<Module>>& stack, u32 index);
+    virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, GC::RootVector<GC::Ref<Module>>& stack, u32 index);
 
     virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) = 0;
 

--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -94,10 +94,10 @@ static ErrorOr<String> escape_for_string_literal(StringView string)
     return builder.to_string();
 }
 
-ErrorOr<void> print_value(JS::PrintContext&, JS::Value value, HashTable<JS::Object*>& seen_objects);
+ErrorOr<void> print_value(JS::PrintContext&, JS::Value value, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects);
 
 template<typename T>
-ErrorOr<void> print_value(JS::PrintContext& print_context, JS::ThrowCompletionOr<T> value_or_error, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_value(JS::PrintContext& print_context, JS::ThrowCompletionOr<T> value_or_error, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     if (value_or_error.is_error()) {
         auto error = value_or_error.release_error();
@@ -158,7 +158,7 @@ ErrorOr<void> print_separator(JS::PrintContext& print_context, bool& first)
     return {};
 }
 
-ErrorOr<void> print_array(JS::PrintContext& print_context, JS::Array const& array, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_array(JS::PrintContext& print_context, JS::Array const& array, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(js_out(print_context, "["));
     bool first = true;
@@ -186,7 +186,7 @@ ErrorOr<void> print_array(JS::PrintContext& print_context, JS::Array const& arra
     return {};
 }
 
-ErrorOr<void> print_object(JS::PrintContext& print_context, JS::Object const& object, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_object(JS::PrintContext& print_context, JS::Object const& object, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(js_out(print_context, "{}{{", object.class_name()));
     bool first = true;
@@ -234,7 +234,7 @@ ErrorOr<void> print_object(JS::PrintContext& print_context, JS::Object const& ob
     return {};
 }
 
-ErrorOr<void> print_function(JS::PrintContext& print_context, JS::FunctionObject const& function_object, HashTable<JS::Object*>&)
+ErrorOr<void> print_function(JS::PrintContext& print_context, JS::FunctionObject const& function_object, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     if (is<JS::ECMAScriptFunctionObject>(function_object)) {
         auto const& ecmascript_function_object = static_cast<JS::ECMAScriptFunctionObject const&>(function_object);
@@ -264,14 +264,14 @@ ErrorOr<void> print_function(JS::PrintContext& print_context, JS::FunctionObject
     return {};
 }
 
-ErrorOr<void> print_date(JS::PrintContext& print_context, JS::Date const& date, HashTable<JS::Object*>&)
+ErrorOr<void> print_date(JS::PrintContext& print_context, JS::Date const& date, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, "Date"sv));
     TRY(js_out(print_context, " \033[34;1m{}\033[0m", JS::to_date_string(date.date_value())));
     return {};
 }
 
-ErrorOr<void> print_error(JS::PrintContext& print_context, JS::Object const& object, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_error(JS::PrintContext& print_context, JS::Object const& object, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     auto name = object.get_without_side_effects(print_context.vm.names.name);
     auto message = object.get_without_side_effects(print_context.vm.names.message);
@@ -287,14 +287,14 @@ ErrorOr<void> print_error(JS::PrintContext& print_context, JS::Object const& obj
     return {};
 }
 
-ErrorOr<void> print_regexp_object(JS::PrintContext& print_context, JS::RegExpObject const& regexp_object, HashTable<JS::Object*>&)
+ErrorOr<void> print_regexp_object(JS::PrintContext& print_context, JS::RegExpObject const& regexp_object, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, "RegExp"sv));
     TRY(js_out(print_context, " \033[34;1m/{}/{}\033[0m", regexp_object.escape_regexp_pattern(), regexp_object.flags()));
     return {};
 }
 
-ErrorOr<void> print_proxy_object(JS::PrintContext& print_context, JS::ProxyObject const& proxy_object, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_proxy_object(JS::PrintContext& print_context, JS::ProxyObject const& proxy_object, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Proxy"sv));
     TRY(js_out(print_context, "\n  target: "));
@@ -304,7 +304,7 @@ ErrorOr<void> print_proxy_object(JS::PrintContext& print_context, JS::ProxyObjec
     return {};
 }
 
-ErrorOr<void> print_map(JS::PrintContext& print_context, JS::Map const& map, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_map(JS::PrintContext& print_context, JS::Map const& map, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Map"sv));
     TRY(js_out(print_context, " {{"));
@@ -321,7 +321,7 @@ ErrorOr<void> print_map(JS::PrintContext& print_context, JS::Map const& map, Has
     return {};
 }
 
-ErrorOr<void> print_set(JS::PrintContext& print_context, JS::Set const& set, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_set(JS::PrintContext& print_context, JS::Set const& set, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Set"sv));
     TRY(js_out(print_context, " {{"));
@@ -336,7 +336,7 @@ ErrorOr<void> print_set(JS::PrintContext& print_context, JS::Set const& set, Has
     return {};
 }
 
-ErrorOr<void> print_weak_map(JS::PrintContext& print_context, JS::WeakMap const& weak_map, HashTable<JS::Object*>&)
+ErrorOr<void> print_weak_map(JS::PrintContext& print_context, JS::WeakMap const& weak_map, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, "WeakMap"sv));
     TRY(js_out(print_context, " ({})", weak_map.weak_map_size()));
@@ -344,7 +344,7 @@ ErrorOr<void> print_weak_map(JS::PrintContext& print_context, JS::WeakMap const&
     return {};
 }
 
-ErrorOr<void> print_weak_set(JS::PrintContext& print_context, JS::WeakSet const& weak_set, HashTable<JS::Object*>&)
+ErrorOr<void> print_weak_set(JS::PrintContext& print_context, JS::WeakSet const& weak_set, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, "WeakSet"sv));
     TRY(js_out(print_context, " ({})", weak_set.weak_set_size()));
@@ -352,7 +352,7 @@ ErrorOr<void> print_weak_set(JS::PrintContext& print_context, JS::WeakSet const&
     return {};
 }
 
-ErrorOr<void> print_weak_ref(JS::PrintContext& print_context, JS::WeakRef const& weak_ref, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_weak_ref(JS::PrintContext& print_context, JS::WeakRef const& weak_ref, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "WeakRef"sv));
     TRY(js_out(print_context, " "));
@@ -360,7 +360,7 @@ ErrorOr<void> print_weak_ref(JS::PrintContext& print_context, JS::WeakRef const&
     return {};
 }
 
-ErrorOr<void> print_promise(JS::PrintContext& print_context, JS::Promise const& promise, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_promise(JS::PrintContext& print_context, JS::Promise const& promise, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Promise"sv));
     switch (promise.state()) {
@@ -386,7 +386,7 @@ ErrorOr<void> print_promise(JS::PrintContext& print_context, JS::Promise const& 
     return {};
 }
 
-ErrorOr<void> print_array_buffer(JS::PrintContext& print_context, JS::ArrayBuffer const& array_buffer, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_array_buffer(JS::PrintContext& print_context, JS::ArrayBuffer const& array_buffer, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "ArrayBuffer"sv));
 
@@ -418,13 +418,13 @@ ErrorOr<void> print_array_buffer(JS::PrintContext& print_context, JS::ArrayBuffe
     return {};
 }
 
-ErrorOr<void> print_generator(JS::PrintContext& print_context, JS::GeneratorObject const& generator, HashTable<JS::Object*>&)
+ErrorOr<void> print_generator(JS::PrintContext& print_context, JS::GeneratorObject const& generator, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, generator.class_name()));
     return {};
 }
 
-ErrorOr<void> print_async_generator(JS::PrintContext& print_context, JS::AsyncGenerator const& generator, HashTable<JS::Object*>&)
+ErrorOr<void> print_async_generator(JS::PrintContext& print_context, JS::AsyncGenerator const& generator, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, generator.class_name()));
     return {};
@@ -439,7 +439,7 @@ ErrorOr<void> print_number(JS::PrintContext& print_context, T number)
     return {};
 }
 
-ErrorOr<void> print_typed_array(JS::PrintContext& print_context, JS::TypedArrayBase const& typed_array_base, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_typed_array(JS::PrintContext& print_context, JS::TypedArrayBase const& typed_array_base, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     auto& array_buffer = *typed_array_base.viewed_array_buffer();
 
@@ -488,7 +488,7 @@ ErrorOr<void> print_typed_array(JS::PrintContext& print_context, JS::TypedArrayB
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<void> print_data_view(JS::PrintContext& print_context, JS::DataView const& data_view, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_data_view(JS::PrintContext& print_context, JS::DataView const& data_view, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     auto view_record = JS::make_data_view_with_buffer_witness_record(data_view, JS::ArrayBuffer::Order::SeqCst);
     TRY(print_type(print_context, "DataView"sv));
@@ -509,7 +509,7 @@ ErrorOr<void> print_data_view(JS::PrintContext& print_context, JS::DataView cons
     return {};
 }
 
-ErrorOr<void> print_intl_display_names(JS::PrintContext& print_context, JS::Intl::DisplayNames const& display_names, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_display_names(JS::PrintContext& print_context, JS::Intl::DisplayNames const& display_names, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.DisplayNames"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -527,7 +527,7 @@ ErrorOr<void> print_intl_display_names(JS::PrintContext& print_context, JS::Intl
     return {};
 }
 
-ErrorOr<void> print_intl_locale(JS::PrintContext& print_context, JS::Intl::Locale const& locale, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_locale(JS::PrintContext& print_context, JS::Intl::Locale const& locale, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.Locale"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -557,7 +557,7 @@ ErrorOr<void> print_intl_locale(JS::PrintContext& print_context, JS::Intl::Local
     return {};
 }
 
-ErrorOr<void> print_intl_list_format(JS::PrintContext& print_context, JS::Intl::ListFormat const& list_format, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_list_format(JS::PrintContext& print_context, JS::Intl::ListFormat const& list_format, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.ListFormat"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -569,7 +569,7 @@ ErrorOr<void> print_intl_list_format(JS::PrintContext& print_context, JS::Intl::
     return {};
 }
 
-ErrorOr<void> print_intl_number_format(JS::PrintContext& print_context, JS::Intl::NumberFormat const& number_format, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_number_format(JS::PrintContext& print_context, JS::Intl::NumberFormat const& number_format, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.NumberFormat"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -637,7 +637,7 @@ ErrorOr<void> print_intl_number_format(JS::PrintContext& print_context, JS::Intl
     return {};
 }
 
-ErrorOr<void> print_intl_date_time_format(JS::PrintContext& print_context, JS::Intl::DateTimeFormat& date_time_format, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_date_time_format(JS::PrintContext& print_context, JS::Intl::DateTimeFormat& date_time_format, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.DateTimeFormat"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -690,7 +690,7 @@ ErrorOr<void> print_intl_date_time_format(JS::PrintContext& print_context, JS::I
     return {};
 }
 
-ErrorOr<void> print_intl_relative_time_format(JS::PrintContext& print_context, JS::Intl::RelativeTimeFormat const& date_time_format, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_relative_time_format(JS::PrintContext& print_context, JS::Intl::RelativeTimeFormat const& date_time_format, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.RelativeTimeFormat"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -704,7 +704,7 @@ ErrorOr<void> print_intl_relative_time_format(JS::PrintContext& print_context, J
     return {};
 }
 
-ErrorOr<void> print_intl_plural_rules(JS::PrintContext& print_context, JS::Intl::PluralRules const& plural_rules, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_plural_rules(JS::PrintContext& print_context, JS::Intl::PluralRules const& plural_rules, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.PluralRules"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -736,7 +736,7 @@ ErrorOr<void> print_intl_plural_rules(JS::PrintContext& print_context, JS::Intl:
     return {};
 }
 
-ErrorOr<void> print_intl_collator(JS::PrintContext& print_context, JS::Intl::Collator const& collator, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_collator(JS::PrintContext& print_context, JS::Intl::Collator const& collator, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.Collator"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -756,7 +756,7 @@ ErrorOr<void> print_intl_collator(JS::PrintContext& print_context, JS::Intl::Col
     return {};
 }
 
-ErrorOr<void> print_intl_segmenter(JS::PrintContext& print_context, JS::Intl::Segmenter const& segmenter, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_segmenter(JS::PrintContext& print_context, JS::Intl::Segmenter const& segmenter, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.Segmenter"sv));
     TRY(js_out(print_context, "\n  locale: "));
@@ -766,7 +766,7 @@ ErrorOr<void> print_intl_segmenter(JS::PrintContext& print_context, JS::Intl::Se
     return {};
 }
 
-ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Segments const& segments, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Segments const& segments, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Segments"sv));
     TRY(js_out(print_context, "\n  string: "));
@@ -774,7 +774,7 @@ ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Seg
     return {};
 }
 
-ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::Intl::DurationFormat const& duration_format, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::Intl::DurationFormat const& duration_format, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     auto print_style_and_display = [&](StringView style_name, StringView display_name, JS::Intl::DurationFormat::DurationUnitOptions options) -> ErrorOr<void> {
         auto style = JS::Intl::DurationFormat::value_style_to_string(options.style);
@@ -815,14 +815,14 @@ ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::In
     return {};
 }
 
-ErrorOr<void> print_temporal_duration(JS::PrintContext& print_context, JS::Temporal::Duration const& duration, HashTable<JS::Object*>&)
+ErrorOr<void> print_temporal_duration(JS::PrintContext& print_context, JS::Temporal::Duration const& duration, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, "Temporal.Duration"sv));
     TRY(js_out(print_context, " \033[34;1m{} y, {} M, {} w, {} d, {} h, {} m, {} s, {} ms, {} us, {} ns\033[0m", duration.years(), duration.months(), duration.weeks(), duration.days(), duration.hours(), duration.minutes(), duration.seconds(), duration.milliseconds(), duration.microseconds(), duration.nanoseconds()));
     return {};
 }
 
-ErrorOr<void> print_temporal_instant(JS::PrintContext& print_context, JS::Temporal::Instant const& instant, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_temporal_instant(JS::PrintContext& print_context, JS::Temporal::Instant const& instant, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Temporal.Instant"sv));
     TRY(js_out(print_context, " "));
@@ -830,7 +830,7 @@ ErrorOr<void> print_temporal_instant(JS::PrintContext& print_context, JS::Tempor
     return {};
 }
 
-ErrorOr<void> print_temporal_plain_date(JS::PrintContext& print_context, JS::Temporal::PlainDate const& plain_date, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_temporal_plain_date(JS::PrintContext& print_context, JS::Temporal::PlainDate const& plain_date, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Temporal.PlainDate"sv));
     TRY(js_out(print_context, " \033[34;1m{:04}-{:02}-{:02}\033[0m", plain_date.iso_date().year, plain_date.iso_date().month, plain_date.iso_date().day));
@@ -839,7 +839,7 @@ ErrorOr<void> print_temporal_plain_date(JS::PrintContext& print_context, JS::Tem
     return {};
 }
 
-ErrorOr<void> print_temporal_plain_date_time(JS::PrintContext& print_context, JS::Temporal::PlainDateTime const& plain_date_time, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_temporal_plain_date_time(JS::PrintContext& print_context, JS::Temporal::PlainDateTime const& plain_date_time, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Temporal.PlainDateTime"sv));
     TRY(js_out(print_context, " \033[34;1m{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:03}{:03}{:03}\033[0m", plain_date_time.iso_date_time().iso_date.year, plain_date_time.iso_date_time().iso_date.month, plain_date_time.iso_date_time().iso_date.day, plain_date_time.iso_date_time().time.hour, plain_date_time.iso_date_time().time.minute, plain_date_time.iso_date_time().time.second, plain_date_time.iso_date_time().time.millisecond, plain_date_time.iso_date_time().time.microsecond, plain_date_time.iso_date_time().time.nanosecond));
@@ -848,7 +848,7 @@ ErrorOr<void> print_temporal_plain_date_time(JS::PrintContext& print_context, JS
     return {};
 }
 
-ErrorOr<void> print_temporal_plain_month_day(JS::PrintContext& print_context, JS::Temporal::PlainMonthDay const& plain_month_day, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_temporal_plain_month_day(JS::PrintContext& print_context, JS::Temporal::PlainMonthDay const& plain_month_day, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Temporal.PlainMonthDay"sv));
     TRY(js_out(print_context, " \033[34;1m{:02}-{:02}\033[0m", plain_month_day.iso_date().month, plain_month_day.iso_date().day));
@@ -857,14 +857,14 @@ ErrorOr<void> print_temporal_plain_month_day(JS::PrintContext& print_context, JS
     return {};
 }
 
-ErrorOr<void> print_temporal_plain_time(JS::PrintContext& print_context, JS::Temporal::PlainTime const& plain_time, HashTable<JS::Object*>&)
+ErrorOr<void> print_temporal_plain_time(JS::PrintContext& print_context, JS::Temporal::PlainTime const& plain_time, GC::RootHashTable<GC::Ref<JS::Object>>&)
 {
     TRY(print_type(print_context, "Temporal.PlainTime"sv));
     TRY(js_out(print_context, " \033[34;1m{:02}:{:02}:{:02}.{:03}{:03}{:03}\033[0m", plain_time.time().hour, plain_time.time().minute, plain_time.time().second, plain_time.time().millisecond, plain_time.time().microsecond, plain_time.time().nanosecond));
     return {};
 }
 
-ErrorOr<void> print_temporal_plain_year_month(JS::PrintContext& print_context, JS::Temporal::PlainYearMonth const& plain_year_month, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_temporal_plain_year_month(JS::PrintContext& print_context, JS::Temporal::PlainYearMonth const& plain_year_month, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Temporal.PlainYearMonth"sv));
     TRY(js_out(print_context, " \033[34;1m{:04}-{:02}\033[0m", plain_year_month.iso_date().year, plain_year_month.iso_date().month));
@@ -873,7 +873,7 @@ ErrorOr<void> print_temporal_plain_year_month(JS::PrintContext& print_context, J
     return {};
 }
 
-ErrorOr<void> print_temporal_zoned_date_time(JS::PrintContext& print_context, JS::Temporal::ZonedDateTime const& zoned_date_time, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_temporal_zoned_date_time(JS::PrintContext& print_context, JS::Temporal::ZonedDateTime const& zoned_date_time, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Temporal.ZonedDateTime"sv));
     TRY(js_out(print_context, "\n  epochNanoseconds: "));
@@ -885,7 +885,7 @@ ErrorOr<void> print_temporal_zoned_date_time(JS::PrintContext& print_context, JS
     return {};
 }
 
-ErrorOr<void> print_boolean_object(JS::PrintContext& print_context, JS::BooleanObject const& boolean_object, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_boolean_object(JS::PrintContext& print_context, JS::BooleanObject const& boolean_object, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Boolean"sv));
     TRY(js_out(print_context, " "));
@@ -893,7 +893,7 @@ ErrorOr<void> print_boolean_object(JS::PrintContext& print_context, JS::BooleanO
     return {};
 }
 
-ErrorOr<void> print_number_object(JS::PrintContext& print_context, JS::NumberObject const& number_object, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_number_object(JS::PrintContext& print_context, JS::NumberObject const& number_object, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "Number"sv));
     TRY(js_out(print_context, " "));
@@ -901,7 +901,7 @@ ErrorOr<void> print_number_object(JS::PrintContext& print_context, JS::NumberObj
     return {};
 }
 
-ErrorOr<void> print_string_object(JS::PrintContext& print_context, JS::StringObject const& string_object, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_string_object(JS::PrintContext& print_context, JS::StringObject const& string_object, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     TRY(print_type(print_context, "String"sv));
     TRY(js_out(print_context, " "));
@@ -909,7 +909,7 @@ ErrorOr<void> print_string_object(JS::PrintContext& print_context, JS::StringObj
     return {};
 }
 
-ErrorOr<void> print_value(JS::PrintContext& print_context, JS::Value value, HashTable<JS::Object*>& seen_objects)
+ErrorOr<void> print_value(JS::PrintContext& print_context, JS::Value value, GC::RootHashTable<GC::Ref<JS::Object>>& seen_objects)
 {
     if (value.is_special_empty_value()) {
         TRY(js_out(print_context, "\033[34;1m<empty>\033[0m"));
@@ -917,13 +917,13 @@ ErrorOr<void> print_value(JS::PrintContext& print_context, JS::Value value, Hash
     }
 
     if (value.is_object()) {
-        if (seen_objects.contains(&value.as_object())) {
+        if (seen_objects.contains(value.as_object())) {
             // FIXME: Maybe we should only do this for circular references,
             //        not for all reoccurring objects.
             TRY(js_out(print_context, "<already printed Object {}>", &value.as_object()));
             return {};
         }
-        seen_objects.set(&value.as_object());
+        seen_objects.set(value.as_object());
     }
 
     if (value.is_object()) {
@@ -1051,7 +1051,7 @@ namespace JS {
 
 ErrorOr<void> print(JS::Value value, PrintContext& print_context)
 {
-    HashTable<JS::Object*> seen_objects;
+    GC::RootHashTable<GC::Ref<JS::Object>> seen_objects { print_context.vm.heap() };
     return print_value(print_context, value, seen_objects);
 }
 

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGC/DeferGC.h>
+#include <LibGC/RootHashTable.h>
 #include <LibJS/Runtime/DescriptorArray.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
@@ -533,7 +534,7 @@ void Shape::invalidate_all_prototype_chains_leading_to_this()
     if (!m_child_prototype_shapes || m_child_prototype_shapes->is_empty())
         return;
 
-    HashTable<Shape*> shapes_to_invalidate;
+    GC::RootHashTable<Shape*> shapes_to_invalidate(heap());
     Vector<Shape*> worklist;
     auto enqueue_children_of = [&](Shape& shape) {
         if (!shape.m_child_prototype_shapes)

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -7,6 +7,7 @@
 
 #include <LibGC/DeferGC.h>
 #include <LibGC/RootHashTable.h>
+#include <LibGC/RootVector.h>
 #include <LibJS/Runtime/DescriptorArray.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
@@ -535,7 +536,7 @@ void Shape::invalidate_all_prototype_chains_leading_to_this()
         return;
 
     GC::RootHashTable<Shape*> shapes_to_invalidate(heap());
-    Vector<Shape*> worklist;
+    GC::RootVector<Shape*> worklist(heap());
     auto enqueue_children_of = [&](Shape& shape) {
         if (!shape.m_child_prototype_shapes)
             return;

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Debug.h>
 #include <AK/QuickSort.h>
+#include <LibGC/RootHashTable.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/AsyncFunctionDriverWrapper.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
@@ -201,7 +202,7 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(S
 }
 
 // 16.2.1.7.2.1 GetExportedNames ( [ exportStarSet ] ), https://tc39.es/ecma262/#sec-getexportednames
-Vector<Utf16FlyString> SourceTextModule::get_exported_names(VM& vm, HashTable<Module const*>& export_star_set)
+Vector<Utf16FlyString> SourceTextModule::get_exported_names(VM& vm, GC::RootHashTable<GC::Ref<Module const>>& export_star_set)
 {
     dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] get_export_names of {}", filename());
 
@@ -212,7 +213,7 @@ Vector<Utf16FlyString> SourceTextModule::get_exported_names(VM& vm, HashTable<Mo
     // NOTE: This is done by Module.
 
     // 3. If exportStarSet contains module, then
-    if (export_star_set.contains(this)) {
+    if (export_star_set.contains(GC::Ref<Module const>(*this))) {
         // a. Assert: We've reached the starting point of an export * circularity.
         // FIXME: How do we check that?
 
@@ -221,7 +222,7 @@ Vector<Utf16FlyString> SourceTextModule::get_exported_names(VM& vm, HashTable<Mo
     }
 
     // 4. Append module to exportStarSet.
-    export_star_set.set(this);
+    export_star_set.set(GC::Ref<Module const>(*this));
 
     // 5. Let exportedNames be a new empty List.
     Vector<Utf16FlyString> exported_names;

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -117,7 +117,7 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_f
     if (rust_result->is_error())
         return rust_result->release_error();
     auto& module_result = rust_result->value();
-    Vector<FunctionToInitialize> functions_to_initialize;
+    GC::ConservativeVector<FunctionToInitialize> functions_to_initialize(realm.heap());
     functions_to_initialize.ensure_capacity(module_result.functions_to_initialize.size());
     for (auto& f : module_result.functions_to_initialize)
         functions_to_initialize.append({ *f.shared_data, move(f.name) });
@@ -187,7 +187,7 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(S
         return rust_result->release_error();
 
     auto& module_result = rust_result->value();
-    Vector<FunctionToInitialize> functions_to_initialize;
+    GC::ConservativeVector<FunctionToInitialize> functions_to_initialize(realm.heap());
     functions_to_initialize.ensure_capacity(module_result.functions_to_initialize.size());
     for (auto& f : module_result.functions_to_initialize)
         functions_to_initialize.append({ *f.shared_data, move(f.name) });

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -36,7 +36,7 @@ public:
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_pre_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
     static Result<GC::Ref<SourceTextModule>, Vector<ParserError>> parse_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, Script::HostDefined* host_defined = nullptr);
 
-    virtual Vector<Utf16FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
+    virtual Vector<Utf16FlyString> get_exported_names(VM& vm, GC::RootHashTable<GC::Ref<Module const>>& export_star_set) override;
     virtual ResolvedBinding resolve_export(VM& vm, Utf16FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;
 
     Object* import_meta() { return m_import_meta; }

--- a/Libraries/LibJS/SyntheticModule.cpp
+++ b/Libraries/LibJS/SyntheticModule.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/RootHashTable.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/ExternalMemory.h>
@@ -105,7 +106,7 @@ PromiseCapability& SyntheticModule::load_requested_modules(GC::Ptr<GraphLoadingS
 }
 
 // 16.2.1.8.4.2 GetExportedNames ( ), https://tc39.es/ecma262/#sec-smr-getexportednames
-Vector<Utf16FlyString> SyntheticModule::get_exported_names(VM&, HashTable<Module const*>&)
+Vector<Utf16FlyString> SyntheticModule::get_exported_names(VM&, GC::RootHashTable<GC::Ref<Module const>>&)
 {
     // 1. Return module.[[ExportNames]].
     return m_export_names;

--- a/Libraries/LibJS/SyntheticModule.h
+++ b/Libraries/LibJS/SyntheticModule.h
@@ -25,7 +25,7 @@ public:
     ThrowCompletionOr<void> set_synthetic_module_export(Utf16FlyString const& export_name, Value export_value);
 
     virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
-    virtual Vector<Utf16FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
+    virtual Vector<Utf16FlyString> get_exported_names(VM& vm, GC::RootHashTable<GC::Ref<Module const>>& export_star_set) override;
     virtual ResolvedBinding resolve_export(VM& vm, Utf16FlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
     virtual ThrowCompletionOr<void> link(VM& vm) override;
     virtual ThrowCompletionOr<GC::Ref<PromiseCapability>> evaluate(VM& vm) override;

--- a/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/HasMutationInvalidator.cpp
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/RootHashMap.h>
+#include <LibGC/RootHashTable.h>
+#include <LibGC/RootVector.h>
 #include <LibWeb/CSS/Invalidation/HasMutationFeatureCollector.h>
 #include <LibWeb/CSS/Invalidation/HasMutationInvalidator.h>
 #include <LibWeb/CSS/StyleScope.h>
@@ -334,12 +337,14 @@ static void invalidate_style_of_elements_affected_by_pending_has_mutations(Style
     auto& counters = style_scope.document().style_invalidation_counters();
     ++counters.has_ancestor_walk_invocations;
 
-    HashTable<GC::Ref<DOM::Element>> elements_already_invalidated_for_has;
-    auto pending_has_invalidations = style_scope.m_pending_has_invalidations;
+    GC::RootHashTable<GC::Ref<DOM::Element>> elements_already_invalidated_for_has { style_scope.node().heap() };
+    GC::OrderedRootHashMap<GC::Ref<DOM::Node>, PendingHasInvalidationMutationFeatures> pending_has_invalidations { style_scope.node().heap() };
+    for (auto& [node, features] : style_scope.m_pending_has_invalidations)
+        pending_has_invalidations.set(node, features);
     bool should_scan_ancestor_siblings = style_scope.have_has_selectors_with_relative_selector_that_has_sibling_combinator();
     for (auto& [node, mutation_features] : pending_has_invalidations) {
-        HashTable<GC::Ref<DOM::Element>> elements_skipped_by_has_feature_filter;
-        Vector<GC::Ref<DOM::Element>, 16> has_scope_ancestors;
+        GC::RootHashTable<GC::Ref<DOM::Element>> elements_skipped_by_has_feature_filter { style_scope.node().heap() };
+        GC::RootVector<GC::Ref<DOM::Element>, 16> has_scope_ancestors { style_scope.node().heap() };
         bool should_delay_ancestor_sibling_scans = false;
         for (GC::Ptr<DOM::Node> ancestor = node; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
             if (!ancestor->is_element())

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1971,7 +1971,7 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
 
     // Reconstruct the line of ancestor elements we need to inherit style from, and then do the cascade again
     // but only for the font-size property.
-    Vector<DOM::AbstractElement> ancestors;
+    GC::ConservativeVector<DOM::AbstractElement> ancestors { heap() };
     for (auto ancestor = abstract_element.element_to_inherit_style_from(); ancestor.has_value(); ancestor = ancestor->element_to_inherit_style_from())
         ancestors.append(*ancestor);
 

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -72,7 +72,7 @@ WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> StylePropertyMapRead
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
-WebIDL::ExceptionOr<Vector<GC::Ref<CSSStyleValue>>> StylePropertyMapReadOnly::get_all(String property_name)
+WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> StylePropertyMapReadOnly::get_all(String property_name)
 {
     // The getAll(property) method, when called on a StylePropertyMap this, must perform the following steps:
 
@@ -85,17 +85,18 @@ WebIDL::ExceptionOr<Vector<GC::Ref<CSSStyleValue>>> StylePropertyMapReadOnly::ge
     // 3. Let props be the value of this’s [[declarations]] internal slot.
     auto& props = m_declarations;
 
+    GC::RootVector<GC::Ref<CSSStyleValue>> results { heap() };
+
     // 4. If props[property] exists, subdivide into iterations props[property], then reify each item of the result, and return the list.
     if (auto property_value = get_style_value(props, property.value())) {
         auto iterations = property_value->subdivide_into_iterations(property.value());
-        GC::RootVector<GC::Ref<CSSStyleValue>> results { heap() };
         for (auto const& style_value : iterations)
             results.append(style_value->reify(realm(), property->name()));
         return results;
     }
 
     // 5. Otherwise, return an empty list.
-    return Vector<GC::Ref<CSSStyleValue>> {};
+    return results;
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.h
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.h
@@ -24,7 +24,7 @@ public:
     virtual ~StylePropertyMapReadOnly() override;
 
     WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> get(String property);
-    WebIDL::ExceptionOr<Vector<GC::Ref<CSSStyleValue>>> get_all(String property);
+    WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> get_all(String property);
     WebIDL::ExceptionOr<bool> has(String property);
     WebIDL::UnsignedLong size() const;
 

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -323,7 +323,7 @@ void StyleScope::for_each_stylesheet(CascadeOrigin cascade_origin, Function<void
 
 void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin, StyleCache& style_cache)
 {
-    Vector<MatchingRule> matching_rules;
+    GC::ConservativeVector<MatchingRule> matching_rules { m_node->heap() };
     size_t style_sheet_index = 0;
     for_each_stylesheet(cascade_origin, [&](auto& sheet) {
         auto& rule_caches = [&] -> RuleCaches& {

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -113,7 +113,7 @@ static ErrorOr<GC::Ref<CSSStyleValue>> reify_a_transform_list(JS::Realm& realm, 
         // NB: Not all transform functions are reifiable, in which case we give up reifying as a transform list.
         transform_components.append(TRY(transform->as_transformation().reify_a_transform_function(realm)));
     }
-    return CSSTransformValue::create(realm, static_cast<Vector<GC::Ref<CSSTransformComponent>>>(move(transform_components)));
+    return CSSTransformValue::create(realm, move(transform_components));
 }
 
 GC::Ref<CSSStyleValue> StyleValueList::reify(JS::Realm& realm, FlyString const& associated_property) const

--- a/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -40,11 +40,11 @@ void SVGGradientElement::attribute_changed(FlyString const& name, Optional<Strin
 
 GradientUnits SVGGradientElement::gradient_units() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return gradient_units_impl(seen_gradients);
 }
 
-GradientUnits SVGGradientElement::gradient_units_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+GradientUnits SVGGradientElement::gradient_units_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_gradient_units.has_value())
         return *m_gradient_units;
@@ -55,11 +55,11 @@ GradientUnits SVGGradientElement::gradient_units_impl(HashTable<SVGGradientEleme
 
 SpreadMethod SVGGradientElement::spread_method() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return spread_method_impl(seen_gradients);
 }
 
-SpreadMethod SVGGradientElement::spread_method_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+SpreadMethod SVGGradientElement::spread_method_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_spread_method.has_value())
         return *m_spread_method;
@@ -83,11 +83,11 @@ Gfx::InterpolationColorSpace SVGGradientElement::color_space() const
 
 Optional<Gfx::AffineTransform> SVGGradientElement::gradient_transform() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return gradient_transform_impl(seen_gradients);
 }
 
-Optional<Gfx::AffineTransform> SVGGradientElement::gradient_transform_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+Optional<Gfx::AffineTransform> SVGGradientElement::gradient_transform_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_gradient_transform.has_value())
         return m_gradient_transform;
@@ -129,7 +129,7 @@ void SVGGradientElement::add_color_stops(Painting::GradientPaintStyle& paint_sty
     });
 }
 
-GC::Ptr<SVGGradientElement const> SVGGradientElement::linked_gradient(HashTable<SVGGradientElement const*>& seen_gradients) const
+GC::Ptr<SVGGradientElement const> SVGGradientElement::linked_gradient(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     // FIXME: This entire function is an ad-hoc hack!
     // It can only resolve #<ids> in the same document.

--- a/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/IterationDecision.h>
+#include <LibGC/RootHashTable.h>
 #include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGElement.h>
@@ -61,14 +62,14 @@ protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    GC::Ptr<SVGGradientElement const> linked_gradient(HashTable<SVGGradientElement const*>& seen_gradients) const;
+    GC::Ptr<SVGGradientElement const> linked_gradient(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
 
     Gfx::AffineTransform gradient_paint_transform(SVGPaintContext const&) const;
 
     template<VoidFunction<SVGStopElement> Callback>
     void for_each_color_stop(Callback const& callback) const
     {
-        HashTable<SVGGradientElement const*> seen_gradients;
+        GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
         return for_each_color_stop_impl(callback, seen_gradients);
     }
 
@@ -76,7 +77,7 @@ protected:
 
 private:
     template<VoidFunction<SVGStopElement> Callback>
-    void for_each_color_stop_impl(Callback const& callback, HashTable<SVGGradientElement const*>& seen_gradients) const
+    void for_each_color_stop_impl(Callback const& callback, GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
     {
         bool color_stops_found = false;
         for_each_child_of_type<SVG::SVGStopElement>([&](auto& stop) {
@@ -90,9 +91,9 @@ private:
         }
     }
 
-    GradientUnits gradient_units_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    SpreadMethod spread_method_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    Optional<Gfx::AffineTransform> gradient_transform_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
+    GradientUnits gradient_units_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    SpreadMethod spread_method_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    Optional<Gfx::AffineTransform> gradient_transform_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
 
     // https://svgwg.org/svg2-draft/pservers.html#LinearGradientAttributes
     Optional<GradientUnits> m_gradient_units = {};

--- a/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -47,11 +47,11 @@ void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional
 // https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementX1Attribute
 NumberPercentage SVGLinearGradientElement::start_x() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return start_x_impl(seen_gradients);
 }
 
-NumberPercentage SVGLinearGradientElement::start_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGLinearGradientElement::start_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_x1.has_value())
         return *m_x1;
@@ -64,11 +64,11 @@ NumberPercentage SVGLinearGradientElement::start_x_impl(HashTable<SVGGradientEle
 // https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementY1Attribute
 NumberPercentage SVGLinearGradientElement::start_y() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return start_y_impl(seen_gradients);
 }
 
-NumberPercentage SVGLinearGradientElement::start_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGLinearGradientElement::start_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_y1.has_value())
         return *m_y1;
@@ -81,11 +81,11 @@ NumberPercentage SVGLinearGradientElement::start_y_impl(HashTable<SVGGradientEle
 // https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementX2Attribute
 NumberPercentage SVGLinearGradientElement::end_x() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return end_x_impl(seen_gradients);
 }
 
-NumberPercentage SVGLinearGradientElement::end_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGLinearGradientElement::end_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_x2.has_value())
         return *m_x2;
@@ -98,11 +98,11 @@ NumberPercentage SVGLinearGradientElement::end_x_impl(HashTable<SVGGradientEleme
 // https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementY2Attribute
 NumberPercentage SVGLinearGradientElement::end_y() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return end_y_impl(seen_gradients);
 }
 
-NumberPercentage SVGLinearGradientElement::end_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGLinearGradientElement::end_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_y2.has_value())
         return *m_y2;

--- a/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -34,7 +34,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
 private:
-    GC::Ptr<SVGLinearGradientElement const> linked_linear_gradient(HashTable<SVGGradientElement const*>& seen_gradients) const
+    GC::Ptr<SVGLinearGradientElement const> linked_linear_gradient(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
     {
         if (auto gradient = linked_gradient(seen_gradients); gradient && is<SVGLinearGradientElement>(*gradient))
             return &as<SVGLinearGradientElement>(*gradient);
@@ -46,10 +46,10 @@ private:
     NumberPercentage end_x() const;
     NumberPercentage end_y() const;
 
-    NumberPercentage start_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage start_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage end_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage end_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage start_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage start_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage end_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage end_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
 
     Optional<NumberPercentage> m_x1;
     Optional<NumberPercentage> m_y1;

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -71,7 +71,7 @@ void SVGPatternElement::attribute_changed(FlyString const& name, Optional<String
     }
 }
 
-GC::Ptr<SVGPatternElement const> SVGPatternElement::linked_pattern(HashTable<SVGPatternElement const*>& seen_patterns) const
+GC::Ptr<SVGPatternElement const> SVGPatternElement::linked_pattern(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     // FIXME: This can only resolve same-document references. The spec allows cross-document references.
     auto link = has_attribute(AttributeNames::href) ? get_attribute(AttributeNames::href) : get_attribute("xlink:href"_fly_string);
@@ -105,11 +105,11 @@ GC::Ptr<SVGPatternElement const> SVGPatternElement::linked_pattern(HashTable<SVG
 
 GC::Ptr<SVGPatternElement const> SVGPatternElement::pattern_content_element() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_content_element_impl(seen_patterns);
 }
 
-GC::Ptr<SVGPatternElement const> SVGPatternElement::pattern_content_element_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+GC::Ptr<SVGPatternElement const> SVGPatternElement::pattern_content_element_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (child_element_count() > 0)
         return this;
@@ -121,11 +121,11 @@ GC::Ptr<SVGPatternElement const> SVGPatternElement::pattern_content_element_impl
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternUnitsAttribute
 SVGUnits SVGPatternElement::pattern_units() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_units_impl(seen_patterns);
 }
 
-SVGUnits SVGPatternElement::pattern_units_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+SVGUnits SVGPatternElement::pattern_units_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_pattern_units.has_value())
         return *m_pattern_units;
@@ -138,11 +138,11 @@ SVGUnits SVGPatternElement::pattern_units_impl(HashTable<SVGPatternElement const
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute
 SVGUnits SVGPatternElement::pattern_content_units() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_content_units_impl(seen_patterns);
 }
 
-SVGUnits SVGPatternElement::pattern_content_units_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+SVGUnits SVGPatternElement::pattern_content_units_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_pattern_content_units.has_value())
         return *m_pattern_content_units;
@@ -155,11 +155,11 @@ SVGUnits SVGPatternElement::pattern_content_units_impl(HashTable<SVGPatternEleme
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternTransformAttribute
 Optional<Gfx::AffineTransform> SVGPatternElement::pattern_transform() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_transform_impl(seen_patterns);
 }
 
-Optional<Gfx::AffineTransform> SVGPatternElement::pattern_transform_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+Optional<Gfx::AffineTransform> SVGPatternElement::pattern_transform_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_pattern_transform.has_value())
         return m_pattern_transform;
@@ -171,11 +171,11 @@ Optional<Gfx::AffineTransform> SVGPatternElement::pattern_transform_impl(HashTab
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementXAttribute
 NumberPercentage SVGPatternElement::pattern_x() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_x_impl(seen_patterns);
 }
 
-NumberPercentage SVGPatternElement::pattern_x_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+NumberPercentage SVGPatternElement::pattern_x_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_x.has_value())
         return *m_x;
@@ -187,11 +187,11 @@ NumberPercentage SVGPatternElement::pattern_x_impl(HashTable<SVGPatternElement c
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementYAttribute
 NumberPercentage SVGPatternElement::pattern_y() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_y_impl(seen_patterns);
 }
 
-NumberPercentage SVGPatternElement::pattern_y_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+NumberPercentage SVGPatternElement::pattern_y_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_y.has_value())
         return *m_y;
@@ -203,11 +203,11 @@ NumberPercentage SVGPatternElement::pattern_y_impl(HashTable<SVGPatternElement c
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementWidthAttribute
 NumberPercentage SVGPatternElement::pattern_width() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_width_impl(seen_patterns);
 }
 
-NumberPercentage SVGPatternElement::pattern_width_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+NumberPercentage SVGPatternElement::pattern_width_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_width.has_value())
         return *m_width;
@@ -219,11 +219,11 @@ NumberPercentage SVGPatternElement::pattern_width_impl(HashTable<SVGPatternEleme
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementHeightAttribute
 NumberPercentage SVGPatternElement::pattern_height() const
 {
-    HashTable<SVGPatternElement const*> seen_patterns;
+    GC::RootHashTable<SVGPatternElement const*> seen_patterns(heap());
     return pattern_height_impl(seen_patterns);
 }
 
-NumberPercentage SVGPatternElement::pattern_height_impl(HashTable<SVGPatternElement const*>& seen_patterns) const
+NumberPercentage SVGPatternElement::pattern_height_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const
 {
     if (m_height.has_value())
         return *m_height;

--- a/Libraries/LibWeb/SVG/SVGPatternElement.h
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGC/RootHashTable.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
@@ -54,16 +55,16 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    GC::Ptr<SVGPatternElement const> linked_pattern(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    GC::Ptr<SVGPatternElement const> pattern_content_element_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
+    GC::Ptr<SVGPatternElement const> linked_pattern(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    GC::Ptr<SVGPatternElement const> pattern_content_element_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
 
-    SVGUnits pattern_units_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    SVGUnits pattern_content_units_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    Optional<Gfx::AffineTransform> pattern_transform_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    NumberPercentage pattern_x_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    NumberPercentage pattern_y_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    NumberPercentage pattern_width_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
-    NumberPercentage pattern_height_impl(HashTable<SVGPatternElement const*>& seen_patterns) const;
+    SVGUnits pattern_units_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    SVGUnits pattern_content_units_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    Optional<Gfx::AffineTransform> pattern_transform_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    NumberPercentage pattern_x_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    NumberPercentage pattern_y_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    NumberPercentage pattern_width_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
+    NumberPercentage pattern_height_impl(GC::RootHashTable<SVGPatternElement const*>& seen_patterns) const;
 
     Optional<SVGUnits> m_pattern_units;
     Optional<SVGUnits> m_pattern_content_units;

--- a/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -49,11 +49,11 @@ void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional
 // https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFXAttribute
 NumberPercentage SVGRadialGradientElement::start_circle_x() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return start_circle_x_impl(seen_gradients);
 }
 
-NumberPercentage SVGRadialGradientElement::start_circle_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGRadialGradientElement::start_circle_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_fx.has_value())
         return *m_fx;
@@ -69,11 +69,11 @@ NumberPercentage SVGRadialGradientElement::start_circle_x_impl(HashTable<SVGGrad
 // https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFYAttribute
 NumberPercentage SVGRadialGradientElement::start_circle_y() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return start_circle_y_impl(seen_gradients);
 }
 
-NumberPercentage SVGRadialGradientElement::start_circle_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGRadialGradientElement::start_circle_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_fy.has_value())
         return *m_fy;
@@ -89,11 +89,11 @@ NumberPercentage SVGRadialGradientElement::start_circle_y_impl(HashTable<SVGGrad
 // https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFRAttribute
 NumberPercentage SVGRadialGradientElement::start_circle_radius() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return start_circle_radius_impl(seen_gradients);
 }
 
-NumberPercentage SVGRadialGradientElement::start_circle_radius_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGRadialGradientElement::start_circle_radius_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     // Note: A negative value is an error.
     if (m_fr.has_value() && m_fr->value() >= 0)
@@ -109,11 +109,11 @@ NumberPercentage SVGRadialGradientElement::start_circle_radius_impl(HashTable<SV
 // https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCXAttribute
 NumberPercentage SVGRadialGradientElement::end_circle_x() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return end_circle_x_impl(seen_gradients);
 }
 
-NumberPercentage SVGRadialGradientElement::end_circle_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGRadialGradientElement::end_circle_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_cx.has_value())
         return *m_cx;
@@ -125,11 +125,11 @@ NumberPercentage SVGRadialGradientElement::end_circle_x_impl(HashTable<SVGGradie
 // https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCYAttribute
 NumberPercentage SVGRadialGradientElement::end_circle_y() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return end_circle_y_impl(seen_gradients);
 }
 
-NumberPercentage SVGRadialGradientElement::end_circle_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGRadialGradientElement::end_circle_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     if (m_cy.has_value())
         return *m_cy;
@@ -141,11 +141,11 @@ NumberPercentage SVGRadialGradientElement::end_circle_y_impl(HashTable<SVGGradie
 // https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementRAttribute
 NumberPercentage SVGRadialGradientElement::end_circle_radius() const
 {
-    HashTable<SVGGradientElement const*> seen_gradients;
+    GC::RootHashTable<SVGGradientElement const*> seen_gradients(heap());
     return end_circle_radius_impl(seen_gradients);
 }
 
-NumberPercentage SVGRadialGradientElement::end_circle_radius_impl(HashTable<SVGGradientElement const*>& seen_gradients) const
+NumberPercentage SVGRadialGradientElement::end_circle_radius_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
 {
     // Note: A negative value is an error.
     if (m_r.has_value() && m_r->value() >= 0)

--- a/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -36,7 +36,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
 private:
-    GC::Ptr<SVGRadialGradientElement const> linked_radial_gradient(HashTable<SVGGradientElement const*>& seen_gradients) const
+    GC::Ptr<SVGRadialGradientElement const> linked_radial_gradient(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const
     {
         if (auto gradient = linked_gradient(seen_gradients); gradient && is<SVGRadialGradientElement>(*gradient))
             return &as<SVGRadialGradientElement>(*gradient);
@@ -50,12 +50,12 @@ private:
     NumberPercentage end_circle_y() const;
     NumberPercentage end_circle_radius() const;
 
-    NumberPercentage start_circle_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage start_circle_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage start_circle_radius_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage end_circle_x_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage end_circle_y_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
-    NumberPercentage end_circle_radius_impl(HashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage start_circle_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage start_circle_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage start_circle_radius_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage end_circle_x_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage end_circle_y_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
+    NumberPercentage end_circle_radius_impl(GC::RootHashTable<SVGGradientElement const*>& seen_gradients) const;
 
     Optional<NumberPercentage> m_cx;
     Optional<NumberPercentage> m_cy;

--- a/Libraries/LibWeb/WebAssembly/WebAssemblyModule.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssemblyModule.cpp
@@ -140,7 +140,7 @@ Vector<Utf16FlyString> WebAssemblyModule::export_name_list()
 }
 
 // https://webassembly.github.io/esm-integration/js-api/index.html#get-exported-names
-Vector<Utf16FlyString> WebAssemblyModule::get_exported_names(JS::VM&, HashTable<Module const*>&)
+Vector<Utf16FlyString> WebAssemblyModule::get_exported_names(JS::VM&, GC::RootHashTable<GC::Ref<Module const>>&)
 {
     // 1. Let record be this WebAssembly Module Record.
     auto* record = this;

--- a/Libraries/LibWeb/WebAssembly/WebAssemblyModule.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssemblyModule.h
@@ -25,7 +25,7 @@ public:
 
     Vector<Utf16FlyString> export_name_list();
 
-    virtual Vector<Utf16FlyString> get_exported_names(JS::VM& vm, HashTable<Module const*>& export_star_set) override;
+    virtual Vector<Utf16FlyString> get_exported_names(JS::VM& vm, GC::RootHashTable<GC::Ref<Module const>>& export_star_set) override;
     virtual JS::ResolvedBinding resolve_export(JS::VM& vm, Utf16FlyString const& export_name, Vector<JS::ResolvedBinding> resolve_set = {}) override;
 
 protected:

--- a/Meta/Lagom/ClangPlugins/LibJSGCPluginAction.cpp
+++ b/Meta/Lagom/ClangPlugins/LibJSGCPluginAction.cpp
@@ -115,6 +115,8 @@ static ContainsGCPtrResult record_contains_gc_ptr(clang::CXXRecordDecl const* re
         "GC::CellAllocator",
         "GC::TypeIsolatingCellAllocator",
         "GC::RootVector",
+        "GC::RootHashTable",
+        "GC::RootHashTableBase",
         "GC::Heap",
         "GC::MarkedVector",
         "GC::ConservativeVector",
@@ -189,7 +191,7 @@ static ContainsGCPtrResult type_contains_gc_ptr(clang::QualType const& type, std
             return ContainsGCPtrResult::No;
 
         // Root types handle their own visiting
-        if (template_name == "GC::Root" || template_name == "GC::RootVector")
+        if (template_name == "GC::Root" || template_name == "GC::RootVector" || template_name == "GC::RootHashTable")
             return ContainsGCPtrResult::No;
 
         // Check template arguments recursively for containers
@@ -229,6 +231,7 @@ static std::vector<clang::QualType> get_all_qualified_types(clang::QualType cons
             "GC::RawPtr",
             "GC::RawRef",
             "GC::RootVector",
+            "GC::RootHashTable",
             "GC::Root",
         };
 

--- a/Tests/ClangPlugins/LibJSGCTests/root_container_non_gc_type.cpp
+++ b/Tests/ClangPlugins/LibJSGCTests/root_container_non_gc_type.cpp
@@ -7,6 +7,7 @@
 // RUN: %clang++ -Xclang -verify %plugin_opts% -c %s -o %t 2>&1
 
 #include <LibGC/RootHashMap.h>
+#include <LibGC/RootHashTable.h>
 #include <LibGC/RootVector.h>
 
 // RootVector with a non-GC element type should fail.
@@ -23,4 +24,12 @@ void test_root_hash_map_non_gc_types(GC::Heap& heap)
     // expected-error@*{{RootHashMap requires at least one of key or value types to be convertible to Cell const* or derive from NanBoxedValue}}
     // expected-note@+1 {{in instantiation of member function}}
     GC::RootHashMap<int, int> bad_map(heap);
+}
+
+// RootHashTable with a non-GC element type should fail.
+void test_root_hash_table_non_gc_type(GC::Heap& heap)
+{
+    // expected-error@*{{RootHashTable element type must be convertible to Cell const* or derive from NanBoxedValue}}
+    // expected-note@+1 {{in instantiation of member function}}
+    GC::RootHashTable<int> bad_table(heap);
 }

--- a/Tests/LibGC/TestGCContainers.cpp
+++ b/Tests/LibGC/TestGCContainers.cpp
@@ -13,6 +13,7 @@
 #include <LibGC/HeapVector.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/RootHashMap.h>
+#include <LibGC/RootHashTable.h>
 #include <LibGC/RootVector.h>
 #include <LibTest/TestCase.h>
 
@@ -218,4 +219,34 @@ TEST_CASE(empty_heap_hash_table_visit_edges_reports_nothing)
     table->visit_edges(visitor);
 
     EXPECT_EQ(visitor.visited_cells.size(), 0u);
+}
+
+TEST_CASE(root_hash_table_reports_roots)
+{
+    auto& heap = test_heap();
+    GC::RootHashTable<GC::Ref<TestCell>> table(heap);
+
+    auto cell = heap.allocate<TestCell>();
+    table.set(cell);
+
+    HashMap<GC::Cell*, GC::HeapRoot> roots;
+    table.gather_roots(roots);
+
+    EXPECT(roots.contains(cell.ptr()));
+    EXPECT_EQ(roots.size(), 1u);
+}
+
+TEST_CASE(empty_containers_report_no_roots)
+{
+    auto& heap = test_heap();
+    GC::RootVector<GC::Ref<TestCell>> vector(heap);
+    GC::RootHashTable<GC::Ref<TestCell>> table(heap);
+    GC::RootHashMap<int, GC::Ref<TestCell>> map(heap);
+
+    HashMap<GC::Cell*, GC::HeapRoot> roots;
+    vector.gather_roots(roots);
+    table.gather_roots(roots);
+    map.gather_roots(roots);
+
+    EXPECT_EQ(roots.size(), 0u);
 }


### PR DESCRIPTION
This is part 3 of a series of fixing GC issues. The previous part was https://github.com/LadybirdBrowser/ladybird/pull/9303

This introduces RootHashTable in the same vain as RootHashMap and starts using it, alongside making a start on fixing other places using GC objects in non-GC containers.