### PR TITLE
LibWeb: Stop leaking the previous document on page refresh

### DIFF
--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -248,8 +248,8 @@ void SharedResourceRequest::handle_successful_fetch(URL::URL const& url_string, 
 void SharedResourceRequest::handle_failed_fetch()
 {
     m_state = State::Failed;
-    m_fetch_controller = nullptr;
     m_load_event_delayer.clear();
+    m_fetch_controller = nullptr;
     for (auto& callback : m_callbacks) {
         if (callback.on_fail)
             callback.on_fail->function()();
@@ -260,8 +260,8 @@ void SharedResourceRequest::handle_failed_fetch()
 void SharedResourceRequest::handle_successful_resource_load()
 {
     m_state = State::Finished;
-    m_fetch_controller = nullptr;
     m_load_event_delayer.clear();
+    m_fetch_controller = nullptr;
     for (auto& callback : m_callbacks) {
         if (callback.on_finish)
             callback.on_finish->function()();

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -95,9 +95,19 @@ void XMLHttpRequest::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_request_body);
     visitor.visit(m_response);
     visitor.visit(m_fetch_controller);
+    visitor.visit(m_timeout_timer);
 
     if (auto* value = m_response_object.get_pointer<GC::Ref<JS::Object>>())
         visitor.visit(*value);
+}
+
+void XMLHttpRequest::stop_timeout_timer()
+{
+    if (!m_timeout_timer)
+        return;
+    m_timeout_timer->stop();
+    m_timeout_timer->on_timeout = nullptr;
+    m_timeout_timer = nullptr;
 }
 
 // https://xhr.spec.whatwg.org/#concept-event-fire-progress
@@ -871,20 +881,17 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
         //     1. Wait until either req’s done flag is set or this’s timeout is not 0 and this’s timeout milliseconds have passed since now.
         //     2. If req’s done flag is unset, then set this’s timed out flag and terminate this’s fetch controller.
         if (m_timeout != 0) {
-            auto timer = Platform::Timer::create_single_shot(heap(), m_timeout, nullptr);
-
-            // NOTE: `timer` is kept alive by capturing into the lambda for the GC to see
-            // NOTE: `this` and `request` is kept alive by Platform::Timer using a Handle.
-            timer->on_timeout = GC::create_function(heap(), [this, request, timer]() {
-                (void)timer;
+            stop_timeout_timer();
+            m_timeout_timer = Platform::Timer::create_single_shot(heap(), m_timeout, nullptr);
+            m_timeout_timer->on_timeout = GC::create_function(heap(), [this, request]() {
                 if (!request->done()) {
                     m_timed_out = true;
                     m_fetch_controller->terminate();
                     MUST(handle_errors());
                 }
+                stop_timeout_timer();
             });
-
-            timer->start();
+            m_timeout_timer->start();
         }
     }
     // 12. Otherwise, if this’s synchronous flag is set:
@@ -928,21 +935,21 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
         IGNORE_USE_IN_ESCAPING_LAMBDA bool did_time_out = false;
 
         if (m_timeout != 0) {
-            auto timer = Platform::Timer::create_single_shot(heap(), m_timeout, nullptr);
-
-            // NOTE: `timer` is kept alive by capturing into the lambda for the GC to see
-            timer->on_timeout = GC::create_function(heap(), [timer, &did_time_out]() {
-                (void)timer;
+            stop_timeout_timer();
+            m_timeout_timer = Platform::Timer::create_single_shot(heap(), m_timeout, nullptr);
+            m_timeout_timer->on_timeout = GC::create_function(heap(), [this, &did_time_out]() {
                 did_time_out = true;
+                stop_timeout_timer();
             });
-
-            timer->start();
+            m_timeout_timer->start();
         }
 
         // FIXME: This is not exactly correct, as it allows the HTML event loop to continue executing tasks.
         HTML::main_thread_event_loop().spin_until(GC::create_function(heap(), [&]() {
             return processed_response || did_time_out;
         }));
+
+        stop_timeout_timer();
 
         // 6. If processedResponse is false, then set this’s timed out flag and terminate this’s fetch controller.
         if (!processed_response) {
@@ -1115,6 +1122,8 @@ bool XMLHttpRequest::must_survive_garbage_collection() const
 // https://xhr.spec.whatwg.org/#dom-xmlhttprequest-abort
 void XMLHttpRequest::abort()
 {
+    stop_timeout_timer();
+
     // 1. Abort this’s fetch controller.
     m_fetch_controller->abort(realm(), {});
 
@@ -1159,6 +1168,8 @@ WebIDL::ExceptionOr<String> XMLHttpRequest::status_text() const
 WebIDL::ExceptionOr<void> XMLHttpRequest::handle_response_end_of_body()
 {
     auto& realm = this->realm();
+
+    stop_timeout_timer();
 
     // 1. Handle errors for xhr.
     TRY(handle_errors());
@@ -1227,6 +1238,8 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_errors()
 
 JS::ThrowCompletionOr<void> XMLHttpRequest::request_error_steps(FlyString const& event_name, GC::Ptr<WebIDL::DOMException> exception)
 {
+    stop_timeout_timer();
+
     // 1. Set xhr’s state to done.
     m_state = State::Done;
 

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -1089,6 +1089,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_with_credentials(bool with_credent
 // https://xhr.spec.whatwg.org/#garbage-collection
 bool XMLHttpRequest::must_survive_garbage_collection() const
 {
+    // AD-HOC: Don't keep XHRs alive once their associated document is destroyed. No listener can ever fire at this point.
+    auto& global = HTML::relevant_global_object(*this);
+    if (auto* window = as_if<HTML::Window>(global); window && window->associated_document().has_been_destroyed())
+        return false;
+
     // An XMLHttpRequest object must not be garbage collected
     // if its state is either opened with the send() flag set, headers received, or loading,
     // and it has one or more event listeners registered whose type is one of

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -21,6 +21,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Statuses.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/MimeSniff/MimeType.h>
+#include <LibWeb/Platform/Timer.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/XHR/XMLHttpRequestEventTarget.h>
 
@@ -98,6 +99,8 @@ private:
     WebIDL::ExceptionOr<void> handle_response_end_of_body();
     WebIDL::ExceptionOr<void> handle_errors();
     JS::ThrowCompletionOr<void> request_error_steps(FlyString const& event_name, GC::Ptr<WebIDL::DOMException> exception = nullptr);
+
+    void stop_timeout_timer();
 
     XMLHttpRequest(JS::Realm&, XMLHttpRequestUpload&, NonnullRefPtr<HTTP::HeaderList>, Fetch::Infrastructure::Response&, Fetch::Infrastructure::FetchController&);
 
@@ -207,6 +210,8 @@ private:
     u64 m_request_body_transmitted { 0 };
     Optional<MonotonicTime> m_last_upload_progress_timestamp;
     Optional<MonotonicTime> m_last_download_progress_timestamp;
+
+    GC::Ptr<Platform::Timer> m_timeout_timer;
 };
 
 }


### PR DESCRIPTION
When visiting https://bbc.co.uk, refreshing the page caused a large memory usage spike. I also saw this issue on a few other sufficiently complex pages. This PR prevents some large object graphs being kept alive across page refreshes. See the individual commits for details.

Here is the initial page load memory usage vs. memory usage after 5 page refreshes for https://bbc.co.uk (after manually collecting garbage):

Before:

1.04GB -> 3.14GB

After:

1.05GGB -> 2.48GB

More work to do here, but this is a definite improvement.