### PR TITLE
LibWeb: Drop `:local-link` rule-cache gate from base URL change handler

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -485,8 +485,6 @@ void StyleScope::collect_selector_insights(Selector const& selector, SelectorIns
     for (auto const& compound_selector : selector.compound_selectors()) {
         for (auto const& simple_selector : compound_selector.simple_selectors) {
             if (simple_selector.type == Selector::SimpleSelector::Type::PseudoClass) {
-                if (simple_selector.pseudo_class().type == PseudoClass::LocalLink)
-                    insights.has_local_link_selectors = true;
                 if (simple_selector.pseudo_class().type == PseudoClass::Has) {
                     insights.has_has_selectors = true;
                     for (auto const& argument_selector : simple_selector.pseudo_class().argument_selector_list) {
@@ -916,12 +914,6 @@ bool StyleScope::have_has_selectors_with_relative_selector_that_has_sibling_comb
 {
     build_rule_cache_if_needed();
     return m_rule_cache->selector_insights.has_has_selectors_with_relative_selector_that_has_sibling_combinator;
-}
-
-bool StyleScope::have_local_link_selectors() const
-{
-    build_rule_cache_if_needed();
-    return m_rule_cache->selector_insights.has_local_link_selectors;
 }
 
 bool StyleScope::have_size_container_queries() const

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -79,7 +79,6 @@ struct RuleCaches {
 struct SelectorInsights {
     bool has_has_selectors { false };
     bool has_has_selectors_with_relative_selector_that_has_sibling_combinator { false };
-    bool has_local_link_selectors { false };
 };
 
 struct StyleCache : public RefCounted<StyleCache> {
@@ -142,7 +141,6 @@ public:
     [[nodiscard]] bool have_has_selectors() const;
     [[nodiscard]] bool may_have_has_selectors_with_relative_selector_that_has_sibling_combinator() const;
     [[nodiscard]] bool have_has_selectors_with_relative_selector_that_has_sibling_combinator() const;
-    [[nodiscard]] bool have_local_link_selectors() const;
     [[nodiscard]] bool have_size_container_queries() const;
 
     void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)> const& callback) const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -446,9 +446,9 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
     document->m_active_sandboxing_flag_set = navigation_params.final_sandboxing_flag_set;
     document->m_navigation_id = navigation_params.id;
     document->set_load_timing_info(load_timing_info);
+    document->m_about_base_url = navigation_params.about_base_url;
     document->set_url(*creation_url);
     document->m_readiness = HTML::DocumentReadyState::Loading;
-    document->m_about_base_url = navigation_params.about_base_url;
     document->set_allow_declarative_shadow_roots(true);
     document->set_custom_element_registry(realm.create<HTML::CustomElementRegistry>(realm));
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1380,25 +1380,7 @@ void Document::respond_to_base_url_changes(URL::URL const& old_document_url, URL
 
     // 2. Ensure that the CSS :link/:visited/etc. pseudo-classes are updated appropriately.
     // FIXME: When we track which links have been visited, then :link and :visited will also depend on the new URL and
-    //        and this early return will need to be replaced with something that identifies which links will be
-    //        affected by the URL change.
-    auto any_scope_has_local_link = style_scope().have_local_link_selectors();
-    if (!any_scope_has_local_link) {
-        for_each_shadow_including_descendant([&](Node& node) {
-            auto* element = as_if<Element>(node);
-            if (!element)
-                return TraversalDecision::Continue;
-            auto shadow_root = element->shadow_root();
-            if (shadow_root && shadow_root->style_scope().have_local_link_selectors()) {
-                any_scope_has_local_link = true;
-                return TraversalDecision::Break;
-            }
-            return TraversalDecision::Continue;
-        });
-    }
-    if (!any_scope_has_local_link)
-        return;
-
+    //        the link walk below will need to take those pseudo-classes into account.
     auto const& new_document_url = m_url;
     auto new_base_url = base_url();
     bool const base_url_unchanged = (old_base_url == new_base_url);


### PR DESCRIPTION
This fixes a Speedometer2 regression introduced in #9274.

The base URL change handler checked whether any style scope contained a `:local-link` rule before walking the document's links, this forced a rule cache rebuild, which is generally slower than the link walk we were trying to avoid.

On Speedometer2 the duplicated rule-cache and invalidation-set construction accounted for roughly 4% of total samples. Removing the gate lets the URL-unchanged early-exit handle the no-op case and runs the link walk only when the URL actually changes, which the profile showed to be inexpensive on its own.