### PR TITLE
LibWeb/CSS: Support oblique angles in font-style for @font-face

### DIFF
--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -5,10 +5,13 @@
  */
 
 #include <LibWeb/CSS/CSSDescriptors.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/StyleValues/FontStyleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShorthandStyleValue.h>
+#include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -95,6 +98,28 @@ WebIDL::ExceptionOr<void> CSSDescriptors::set_property(FlyString const& property
     // 6. If component value list is null, then return.
     if (!component_value_list)
         return {};
+
+    // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-style
+    // Normalize font-style StyleValueList to FontStyleStyleValue so serialization
+    // uses the specialized path (oblique 0deg → "normal", equal-bound collapsing, etc.)
+    if (descriptor_name_and_id->id() == DescriptorID::FontStyle && component_value_list->is_value_list()) {
+        auto const& values = component_value_list->as_value_list().values();
+        if (values.size() >= 1 && values[0]->is_keyword()) {
+            auto keyword = keyword_to_font_style_keyword(values[0]->to_keyword());
+            if (keyword.has_value()) {
+                ValueComparingRefPtr<StyleValue const> angle1;
+                ValueComparingRefPtr<StyleValue const> angle2;
+                if (values.size() > 1 && values[1]->is_value_list()) {
+                    auto const& inner = values[1]->as_value_list().values();
+                    if (inner.size() > 0 && !inner[0]->is_empty_optional())
+                        angle1 = inner[0];
+                    if (inner.size() > 1 && !inner[1]->is_empty_optional())
+                        angle2 = inner[1];
+                }
+                component_value_list = FontStyleStyleValue::create(keyword.release_value(), move(angle1), move(angle2));
+            }
+        }
+    }
 
     // 7. Let updated be false.
     auto updated = false;

--- a/Libraries/LibWeb/CSS/Descriptors.json
+++ b/Libraries/LibWeb/CSS/Descriptors.json
@@ -56,10 +56,13 @@
       },
       "font-style": {
         "initial": "auto",
-        "FIXME": "Support angles for oblique",
         "syntax": [
           "auto",
-          "<'font-style'>"
+          "normal",
+          "italic",
+          "left",
+          "right",
+          "<font-style-oblique>"
         ]
       },
       "font-variation-settings": {

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -479,9 +479,23 @@ WebIDL::ExceptionOr<void> FontFace::set_style(String const& string)
 
 void FontFace::set_style_impl(NonnullRefPtr<StyleValue const> const& value)
 {
+    // AD-HOC: Chromium and Firefox both return "normal" from the FontFace style
+    // getter when the stored value is auto (e.g., when descriptor parsing fails and
+    // the initial value auto is used, or when the descriptor is not specified).
+    // Spec issue: https://github.com/w3c/csswg-drafts/issues/11561
+    if (value->is_keyword() && value->to_keyword() == Keyword::Auto) {
+        m_style = "normal"_string;
+        m_cached_slope = 0;
+        return;
+    }
+
     auto context = computation_context();
     NonnullRefPtr<StyleValue const> absolutized_value = context.has_value() ? value->absolutized(*context) : value;
-    m_style = absolutized_value->to_string(SerializationMode::Normal);
+
+    // Normalize to FontStyleStyleValue for proper serialization
+    // (oblique 0deg → "normal", equal-bound collapsing, etc.)
+    auto computed = StyleComputer::compute_font_style(absolutized_value);
+    m_style = computed->to_string(SerializationMode::Normal);
     m_cached_slope = compute_slope(*absolutized_value);
 }
 

--- a/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/CSS/StyleValues/CounterStyleSystemStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FontSourceStyleValue.h>
+#include <LibWeb/CSS/StyleValues/FontStyleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
@@ -303,6 +304,9 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_descriptor_v
                     if (!second)
                         return nullptr;
                     return StyleValueList::create({ first.release_nonnull(), second.release_nonnull() }, StyleValueList::Separator::Space);
+                }
+                case DescriptorMetadata::ValueType::FontStyleOblique: {
+                    return parse_font_style_oblique_value(tokens);
                 }
                 case DescriptorMetadata::ValueType::Length:
                     return parse_length_value(tokens, infinite_range);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2858,8 +2858,35 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_style(NonnullRefPtr<
     // the keyword specified, plus angle in degrees if specified
 
     // NB: We always parse as a FontStyleStyleValue, but StylePropertyMap is able to set a KeywordStyleValue directly.
-    if (absolutized_value->is_keyword())
-        return FontStyleStyleValue::create(keyword_to_font_style_keyword(absolutized_value->to_keyword()).release_value());
+    if (absolutized_value->is_keyword()) {
+        auto font_style_keyword = keyword_to_font_style_keyword(absolutized_value->to_keyword());
+        if (font_style_keyword.has_value())
+            return FontStyleStyleValue::create(font_style_keyword.release_value());
+        return absolutized_value;
+    }
+
+    // NB: The @font-face descriptor parser returns a StyleValueList for the oblique case.
+    if (absolutized_value->is_value_list()) {
+        auto const& values = absolutized_value->as_value_list().values();
+        if (values.size() < 1 || !values[0]->is_keyword())
+            return absolutized_value;
+
+        auto keyword = keyword_to_font_style_keyword(values[0]->to_keyword());
+        if (!keyword.has_value())
+            return absolutized_value;
+
+        ValueComparingRefPtr<StyleValue const> angle1;
+        ValueComparingRefPtr<StyleValue const> angle2;
+        if (values.size() > 1 && values[1]->is_value_list()) {
+            auto const& inner = values[1]->as_value_list().values();
+            if (inner.size() > 0 && !inner[0]->is_empty_optional())
+                angle1 = inner[0];
+            if (inner.size() > 1 && !inner[1]->is_empty_optional())
+                angle2 = inner[1];
+        }
+
+        return FontStyleStyleValue::create(keyword.release_value(), move(angle1), move(angle2));
+    }
 
     return absolutized_value;
 }

--- a/Libraries/LibWeb/CSS/StyleValues/FontStyleStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FontStyleStyleValue.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 
 namespace Web::CSS {
@@ -42,32 +43,95 @@ int FontStyleStyleValue::to_font_slope() const
 
 void FontStyleStyleValue::serialize(StringBuilder& builder, SerializationMode mode) const
 {
-    Optional<String> angle_string;
     if (m_angle_value) {
-        angle_string = m_angle_value->to_string(mode);
-        if (m_font_style == FontStyleKeyword::Oblique && angle_string == "0deg"sv) {
+        Optional<String> angle_string;
+        bool is_zero_angle = false;
+
+        if (m_angle_value->is_angle()) {
+            auto angle = m_angle_value->as_angle().angle();
+            angle_string = angle.to_string(mode);
+            is_zero_angle = (angle.to_degrees() == 0.0);
+
+            if (m_second_angle_value && m_second_angle_value->is_angle()) {
+                auto second_angle = m_second_angle_value->as_angle().angle();
+                // https://drafts.csswg.org/css-fonts-4/#serializing-at-rules
+                // "if the start and end values are the same (the range is zero)
+                //  the descriptor is serialized as a single value, not a range."
+                // FIXME: The WPT test at-font-face-descriptors.html is missing an
+                // expectedValue for "oblique 20deg 20deg" (defaults to the input
+                // string). Per §13.2 (added by w3c/csswg-drafts#7964), equal bounds
+                // should serialize as a single value, so we correctly produce
+                // "oblique 20deg". This spec-correct behavior causes a test regression.
+                if (angle.to_degrees() != second_angle.to_degrees()) {
+                    builder.append(CSS::to_string(m_font_style));
+                    builder.appendff(" {}", *angle_string);
+                    builder.appendff(" {}", m_second_angle_value->to_string(mode));
+                    return;
+                }
+                // Equal bounds collapsed — fall through to single-angle handling
+            } else if (m_second_angle_value) {
+                // Second angle is not an AngleStyleValue (e.g. calc), can't collapse
+                builder.append(CSS::to_string(m_font_style));
+                builder.appendff(" {}", *angle_string);
+                builder.appendff(" {}", m_second_angle_value->to_string(mode));
+                return;
+            }
+        } else {
+            angle_string = m_angle_value->to_string(mode);
+            if (m_second_angle_value) {
+                builder.append(CSS::to_string(m_font_style));
+                builder.appendff(" {}", *angle_string);
+                builder.appendff(" {}", m_second_angle_value->to_string(mode));
+                return;
+            }
+        }
+
+        // https://drafts.csswg.org/css-fonts/#valdef-font-style-normal
+        // normal "represents an oblique value of 0"
+        if (m_font_style == FontStyleKeyword::Oblique && is_zero_angle) {
             builder.append("normal"sv);
             return;
         }
+
+        builder.append(CSS::to_string(m_font_style));
+        // https://drafts.csswg.org/css-fonts/#valdef-font-style-oblique-angle--90deg-90deg
+        // The lack of an <angle> represents 14deg.
+        if (angle_string.has_value() && *angle_string != "14deg"sv)
+            builder.appendff(" {}", *angle_string);
+        return;
     }
+
     builder.append(CSS::to_string(m_font_style));
-    // https://drafts.csswg.org/css-fonts/#valdef-font-style-oblique-angle--90deg-90deg
-    // The lack of an <angle> represents 14deg. (Note that a font might internally provide its own mapping for "oblique", but the mapping within the font is disregarded.)
-    if (angle_string.has_value() && angle_string != "14deg"sv)
-        builder.appendff(" {}", angle_string);
 }
 
 ValueComparingNonnullRefPtr<StyleValue const> FontStyleStyleValue::absolutized(ComputationContext const& computation_context) const
 {
     ValueComparingRefPtr<StyleValue const> absolutized_angle;
+    ValueComparingRefPtr<StyleValue const> absolutized_second_angle;
 
     if (m_angle_value)
         absolutized_angle = m_angle_value->absolutized(computation_context);
+    if (m_second_angle_value)
+        absolutized_second_angle = m_second_angle_value->absolutized(computation_context);
 
-    if (absolutized_angle == m_angle_value)
+    // If the inner angle is still a CalculatedStyleValue (e.g. calc(10deg - 10deg)),
+    // resolve it to a concrete AngleStyleValue so serialization can use numeric
+    // comparison for the zero-angle check and equal-bound collapsing.
+    if (absolutized_angle && absolutized_angle->is_calculated()) {
+        auto resolution_context = CalculationResolutionContext::from_computation_context(computation_context);
+        if (auto resolved = absolutized_angle->as_calculated().resolve_angle(resolution_context); resolved.has_value())
+            absolutized_angle = AngleStyleValue::create(resolved.release_value());
+    }
+    if (absolutized_second_angle && absolutized_second_angle->is_calculated()) {
+        auto resolution_context = CalculationResolutionContext::from_computation_context(computation_context);
+        if (auto resolved = absolutized_second_angle->as_calculated().resolve_angle(resolution_context); resolved.has_value())
+            absolutized_second_angle = AngleStyleValue::create(resolved.release_value());
+    }
+
+    if (absolutized_angle == m_angle_value && absolutized_second_angle == m_second_angle_value)
         return *this;
 
-    return FontStyleStyleValue::create(m_font_style, absolutized_angle);
+    return FontStyleStyleValue::create(m_font_style, absolutized_angle, absolutized_second_angle);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/FontStyleStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FontStyleStyleValue.cpp
@@ -13,10 +13,11 @@
 
 namespace Web::CSS {
 
-FontStyleStyleValue::FontStyleStyleValue(FontStyleKeyword font_style, ValueComparingRefPtr<StyleValue const> angle_value)
+FontStyleStyleValue::FontStyleStyleValue(FontStyleKeyword font_style, ValueComparingRefPtr<StyleValue const> angle_value, ValueComparingRefPtr<StyleValue const> second_angle_value)
     : StyleValueWithDefaultOperators(Type::FontStyle)
     , m_font_style(font_style)
     , m_angle_value(angle_value)
+    , m_second_angle_value(second_angle_value)
 {
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/FontStyleStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FontStyleStyleValue.h
@@ -12,15 +12,16 @@ namespace Web::CSS {
 
 class FontStyleStyleValue final : public StyleValueWithDefaultOperators<FontStyleStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<FontStyleStyleValue const> create(FontStyleKeyword font_style, ValueComparingRefPtr<StyleValue const> angle_value = {})
+    static ValueComparingNonnullRefPtr<FontStyleStyleValue const> create(FontStyleKeyword font_style, ValueComparingRefPtr<StyleValue const> angle_value = {}, ValueComparingRefPtr<StyleValue const> second_angle_value = {})
     {
-        return adopt_ref(*new (nothrow) FontStyleStyleValue(font_style, angle_value));
+        return adopt_ref(*new (nothrow) FontStyleStyleValue(font_style, angle_value, second_angle_value));
     }
 
     virtual ~FontStyleStyleValue() override;
 
     FontStyleKeyword font_style() const { return m_font_style; }
     ValueComparingRefPtr<StyleValue const> angle() const { return m_angle_value; }
+    ValueComparingRefPtr<StyleValue const> second_angle() const { return m_second_angle_value; }
 
     int to_font_slope() const;
 
@@ -32,18 +33,19 @@ public:
         if (type() != other.type())
             return false;
         auto const& other_font_style = other.as_font_style();
-        return m_font_style == other_font_style.m_font_style && m_angle_value == other_font_style.m_angle_value;
+        return m_font_style == other_font_style.m_font_style && m_angle_value == other_font_style.m_angle_value && m_second_angle_value == other_font_style.m_second_angle_value;
     }
 
-    bool properties_equal(FontStyleStyleValue const& other) const { return m_font_style == other.m_font_style && m_angle_value == other.m_angle_value; }
+    bool properties_equal(FontStyleStyleValue const& other) const { return m_font_style == other.m_font_style && m_angle_value == other.m_angle_value && m_second_angle_value == other.m_second_angle_value; }
 
-    virtual bool is_computationally_independent() const override { return !m_angle_value || m_angle_value->is_computationally_independent(); }
+    virtual bool is_computationally_independent() const override { return (!m_angle_value || m_angle_value->is_computationally_independent()) && (!m_second_angle_value || m_second_angle_value->is_computationally_independent()); }
 
 private:
-    FontStyleStyleValue(FontStyleKeyword, ValueComparingRefPtr<StyleValue const> angle_value);
+    FontStyleStyleValue(FontStyleKeyword, ValueComparingRefPtr<StyleValue const> angle_value, ValueComparingRefPtr<StyleValue const> second_angle_value);
 
     FontStyleKeyword m_font_style;
     ValueComparingRefPtr<StyleValue const> m_angle_value;
+    ValueComparingRefPtr<StyleValue const> m_second_angle_value;
 };
 
 }

--- a/Libraries/LibWeb/CSS/ValueTypes.json
+++ b/Libraries/LibWeb/CSS/ValueTypes.json
@@ -1,4 +1,8 @@
 {
+    "<font-style-oblique>": {
+        "spec": "https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-style",
+        "grammar": "oblique [ <angle [-90deg,90deg]>{1,2} ]?"
+    },
     "<font-weight-absolute>": {
         "spec": "https://drafts.csswg.org/css-fonts-4/#font-weight-absolute-values",
         "grammar": "[ normal | bold | <number [1,1000]> ]"

--- a/Meta/Generators/generate_libweb_css_descriptors.py
+++ b/Meta/Generators/generate_libweb_css_descriptors.py
@@ -86,6 +86,7 @@ struct DescriptorMetadata {
         CropOrCross,
         FamilyName,
         FontSrcList,
+        FontStyleOblique,
         FontWeightAbsolutePair,
         Length,
         OptionalDeclarationValue,
@@ -109,6 +110,7 @@ DescriptorMetadata get_descriptor_metadata(AtRuleID, DescriptorID);
 VALUE_TYPE_NAMES = {
     "<family-name>": "FamilyName",
     "<font-src-list>": "FontSrcList",
+    "<font-style-oblique>": "FontStyleOblique",
     "<font-weight-absolute>{1,2}": "FontWeightAbsolutePair",
     "<declaration-value>?": "OptionalDeclarationValue",
     "<length>": "Length",

--- a/Meta/Utils/CSSGrammar/Parser/grammar_node.py
+++ b/Meta/Utils/CSSGrammar/Parser/grammar_node.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
 from Utils.CSSGrammar.Parser.component_values import ComponentValue
 
@@ -57,3 +58,17 @@ class OptionalGrammarNode(GrammarNode):
 
     def dump(self, indent: int = 0) -> str:
         return f"{'': >{indent}}Optional:\n" + self.child.dump(indent + 2)
+
+
+@dataclass(frozen=True)
+class MultiplierGrammarNode(GrammarNode):
+    child: GrammarNode
+    minimum: int
+    maximum: Optional[int]
+
+    def dump(self, indent: int = 0) -> str:
+        if self.maximum is None:
+            return f"{'': >{indent}}Multiplier {{{self.minimum},}}:\n" + self.child.dump(indent + 2)
+        if self.minimum == self.maximum:
+            return f"{'': >{indent}}Multiplier {{{self.minimum}}}:\n" + self.child.dump(indent + 2)
+        return f"{'': >{indent}}Multiplier {{{self.minimum},{self.maximum}}}:\n" + self.child.dump(indent + 2)

--- a/Meta/Utils/CSSGrammar/Parser/parser.py
+++ b/Meta/Utils/CSSGrammar/Parser/parser.py
@@ -1,8 +1,10 @@
+from Utils.CSSGrammar.Parser.component_values import Keyword
 from Utils.CSSGrammar.Parser.grammar_node import CombinatorGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import CombinatorType
 from Utils.CSSGrammar.Parser.grammar_node import ComponentValueGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GroupGrammarNode
+from Utils.CSSGrammar.Parser.grammar_node import MultiplierGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import OptionalGrammarNode
 from Utils.CSSGrammar.Parser.token import Token
 from Utils.CSSGrammar.Parser.token import TokenType
@@ -75,6 +77,44 @@ class Parser:
         if self.peek().is_token_type(TokenType.QUESTION_MARK):
             self.consume()
             component_value = OptionalGrammarNode(component_value)
+
+        # A single number in curly braces ({A}) indicates that the preceding type, word, or group occurs A times.
+        # A comma-separated pair of numbers in curly braces ({A,B}) indicates that the preceding type, word, or group
+        # occurs at least A and at most B times. The B may be omitted ({A,}) to indicate that there must be
+        # at least A repetitions, with no upper bound on the number of repetitions.
+        if self.peek().is_token_type(TokenType.OPEN_CURLY_BRACKET):
+            self.consume()
+
+            if not self.peek().is_token_type(TokenType.COMPONENT_VALUE):
+                raise SyntaxError("CSSGrammar::Parser: Expected an integer in multiplier")
+            min_token = self.consume().component_value()
+            assert isinstance(min_token, Keyword)
+            minimum = int(min_token.value)
+
+            if self.peek().is_token_type(TokenType.COMMA):
+                self.consume()
+
+                if self.peek().is_token_type(TokenType.CLOSE_CURLY_BRACKET):
+                    # {A,} — unbounded
+                    self.consume()
+                    component_value = MultiplierGrammarNode(component_value, minimum, None)
+                elif self.peek().is_token_type(TokenType.COMPONENT_VALUE):
+                    # {A,B}
+                    max_token = self.consume().component_value()
+                    assert isinstance(max_token, Keyword)
+                    maximum = int(max_token.value)
+                    if not self.peek().is_token_type(TokenType.CLOSE_CURLY_BRACKET):
+                        raise SyntaxError("CSSGrammar::Parser: Expected '}' to close multiplier")
+                    self.consume()
+                    component_value = MultiplierGrammarNode(component_value, minimum, maximum)
+                else:
+                    raise SyntaxError("CSSGrammar::Parser: Expected integer or '}' in multiplier")
+            elif self.peek().is_token_type(TokenType.CLOSE_CURLY_BRACKET):
+                # {A} — exact count
+                self.consume()
+                component_value = MultiplierGrammarNode(component_value, minimum, minimum)
+            else:
+                raise SyntaxError("CSSGrammar::Parser: Expected ',' or '}' after integer in multiplier")
 
         return component_value
 

--- a/Meta/Utils/CSSGrammar/Parser/token.py
+++ b/Meta/Utils/CSSGrammar/Parser/token.py
@@ -11,6 +11,9 @@ class TokenType(Enum):
     OPEN_SQUARE_BRACKET = "open-square-bracket"
     CLOSE_SQUARE_BRACKET = "close-square-bracket"
     QUESTION_MARK = "question-mark"
+    OPEN_CURLY_BRACKET = "open-curly-bracket"
+    CLOSE_CURLY_BRACKET = "close-curly-bracket"
+    COMMA = "comma"
     COMPONENT_VALUE = "component-value"
 
 

--- a/Meta/Utils/CSSGrammar/Parser/tokenizer.py
+++ b/Meta/Utils/CSSGrammar/Parser/tokenizer.py
@@ -54,13 +54,22 @@ class Tokenizer:
         if peeked == "?":
             self.lexer.consume()
             return Token.create(TokenType.QUESTION_MARK)
+        if peeked == "{":
+            self.lexer.consume()
+            return Token.create(TokenType.OPEN_CURLY_BRACKET)
+        if peeked == "}":
+            self.lexer.consume()
+            return Token.create(TokenType.CLOSE_CURLY_BRACKET)
+        if peeked == ",":
+            self.lexer.consume()
+            return Token.create(TokenType.COMMA)
         if peeked == "<":
             return self.consume_a_non_terminal_token()
 
         if is_identifier_character(peeked):
             return self.consume_a_keyword_token()
 
-        raise SyntaxError("CSSGrammar::Tokenizer: Unexpected character")
+        raise SyntaxError(f"CSSGrammar::Tokenizer: Unexpected character: {peeked}")
 
     def consume_custom_ident_blacklist(self) -> list[str]:
         # NB: This notation isn't yet included in the spec but we use it internally and the CSSWG has resolved to add it in

--- a/Meta/Utils/CSSGrammar/generator.py
+++ b/Meta/Utils/CSSGrammar/generator.py
@@ -9,6 +9,7 @@ from Utils.CSSGrammar.Parser.grammar_node import CombinatorType
 from Utils.CSSGrammar.Parser.grammar_node import ComponentValueGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import GroupGrammarNode
+from Utils.CSSGrammar.Parser.grammar_node import MultiplierGrammarNode
 from Utils.CSSGrammar.Parser.grammar_node import OptionalGrammarNode
 from Utils.CSSGrammar.Parser.parser import parse_value_definition_grammar
 from Utils.utils import snake_casify
@@ -158,6 +159,62 @@ def generate_css_parser_expression_for_optional_grammar_node(
 """)
 
 
+def generate_css_parser_expression_for_multiplier_grammar_node(
+    out: TextIO, cpp_name: str, grammar_node: MultiplierGrammarNode
+) -> None:
+    # Generate a helper lambda for parsing one repetition of the child component.
+    out.write(f"auto const parse_{cpp_name}_repetition = [&]() -> RefPtr<StyleValue const> {{\n")
+    generate_css_parser_expression_for_grammar_node(out, f"{cpp_name}_rep", grammar_node.child)
+    out.write(f"    return {cpp_name}_rep;\n")
+    out.write("};\n\n")
+
+    capacity = grammar_node.maximum if grammar_node.maximum is not None else grammar_node.minimum
+    out.write(f"""auto const parse_{cpp_name}_multiplier = [&]() -> RefPtr<StyleValue const> {{
+auto {cpp_name}_transaction = tokens.begin_transaction();
+StyleValueVector {cpp_name}_values;
+{cpp_name}_values.ensure_capacity({capacity});
+
+""")
+    # Minimum repetitions (required)
+    for i in range(grammar_node.minimum):
+        out.write(f"""auto {cpp_name}_min_{i} = parse_{cpp_name}_repetition();
+if (!{cpp_name}_min_{i})
+    return nullptr;
+{cpp_name}_values.append({cpp_name}_min_{i}.release_nonnull());
+
+""")
+    # Optional additional repetitions
+    if grammar_node.maximum is not None:
+        remaining = grammar_node.maximum - grammar_node.minimum
+        if remaining > 0:
+            for i in range(remaining):
+                out.write(f"""do {{
+auto {cpp_name}_extra_{i} = parse_{cpp_name}_repetition();
+if (!{cpp_name}_extra_{i})
+    break;
+{cpp_name}_values.append({cpp_name}_extra_{i}.release_nonnull());
+}} while (false);
+
+""")
+            out.write("\n")
+    else:
+        # {A,} — unbounded: keep trying until failure
+        out.write(f"""while (true) {{
+auto {cpp_name}_extra = parse_{cpp_name}_repetition();
+if (!{cpp_name}_extra)
+    break;
+{cpp_name}_values.append({cpp_name}_extra.release_nonnull());
+}}
+
+""")
+
+    out.write(f"""{cpp_name}_transaction.commit();
+return StyleValueList::create(move({cpp_name}_values), StyleValueList::Separator::Space, StyleValueList::Collapsible::No);
+}};
+auto {cpp_name} = parse_{cpp_name}_multiplier();
+""")
+
+
 def generate_css_parser_expression_for_grammar_node(out: TextIO, cpp_name: str, grammar_node: GrammarNode) -> None:
     if isinstance(grammar_node, ComponentValueGrammarNode):
         generate_css_parser_expression_for_component_value_grammar_node(out, cpp_name, grammar_node)
@@ -167,6 +224,9 @@ def generate_css_parser_expression_for_grammar_node(out: TextIO, cpp_name: str, 
         return
     if isinstance(grammar_node, OptionalGrammarNode):
         generate_css_parser_expression_for_optional_grammar_node(out, cpp_name, grammar_node)
+        return
+    if isinstance(grammar_node, MultiplierGrammarNode):
+        generate_css_parser_expression_for_multiplier_grammar_node(out, cpp_name, grammar_node)
         return
     if isinstance(grammar_node, CombinatorGrammarNode):
         generate_css_parser_expression_for_combinator_grammar_node(out, cpp_name, grammar_node)

--- a/Tests/LibWeb/Text/expected/css/css-connected-font-face-parsing.txt
+++ b/Tests/LibWeb/Text/expected/css/css-connected-font-face-parsing.txt
@@ -5,6 +5,6 @@ Ahem
 normal
 normal
 auto
-auto
+normal
 U+0-10FFFF
 auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/font-face-style-normal.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/font-face-style-normal.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	CSS Fonts: parsing 'normal' in the font-style descriptor
+Pass	CSS Fonts: parsing 'normal' in the font-style descriptor 1
+Pass	CSS Fonts: parsing 'normal' in the font-style descriptor 2
+Pass	CSS Fonts: parsing 'normal' in the font-style descriptor 3

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/variations/at-font-face-descriptors.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/variations/at-font-face-descriptors.txt
@@ -1,0 +1,94 @@
+Harness status: Error
+
+Found 88 tests
+
+81 Pass
+7 Fail
+Pass	font-weight(valid): 'normal' keyword: normal
+Pass	font-weight(valid): 'bold' keyword: bold
+Pass	font-weight(valid): 'auto' keyword inside @font-face: auto
+Pass	font-weight(invalid): 'lighter' keyword inside @font-face: lighter
+Pass	font-weight(invalid): 'bolder' keyword inside @font-face: bolder
+Pass	font-weight(invalid): Extra content after keyword: bold a
+Pass	font-weight(valid): Values that are not multiple of 100 should be parsed successfully: 401
+Pass	font-weight(valid): Non-integer values should be parsed successfully: 400.1
+Pass	font-weight(valid): Minimum allowed value should be parsed successfully: 1
+Pass	font-weight(invalid): Values below minimum should be rejected: 0.999
+Pass	font-weight(invalid): Values below zero should be rejected: -100
+Pass	font-weight(valid): Maximum allowed value should be parsed successfully: 1000
+Pass	font-weight(invalid): Values above maximum should be rejected: 1000.001
+Pass	font-weight(invalid): Extra content after value: 100 a
+Pass	font-weight(valid): Simple calc value: calc(100.5)
+Pass	font-weight(valid): Out-of-range simple calc value: calc(1001)
+Pass	font-weight(valid): Valid calc expression: calc(100.5*3 + 50.5)
+Pass	font-weight(valid): Valid calc expression with out-of-range value: calc(100.5*3 + 800)
+Pass	font-weight(invalid): Valid calc expression with units: calc(100.5px + 50.5px)
+Pass	font-weight(valid): Simple range: 100 900
+Pass	font-weight(valid): Simple range with equal upper and lower bounds: 500 500
+Pass	font-weight(invalid): Lower bound out of range: 0.9 100
+Pass	font-weight(invalid): Upper bound out of range: 100 1001
+Pass	font-weight(valid): Lower bound calc(): calc(100 + 100) 400
+Pass	font-weight(valid): Upper bound calc(): 200 calc(200 + 200)
+Pass	font-weight(valid): Both bounds are calc(): calc(100 + 100) calc(200 + 200)
+Pass	font-weight(valid): Bounds out of order are valid: 400 200
+Pass	font-weight(invalid): Extra content after upper bound: 100 200 300
+Pass	font-stretch(valid): 'ultra-condensed' keyword: ultra-condensed
+Pass	font-stretch(valid): 'extra-condensed' keyword: extra-condensed
+Pass	font-stretch(valid): 'condensed' keyword: condensed
+Pass	font-stretch(valid): 'semi-condensed' keyword: semi-condensed
+Pass	font-stretch(valid): 'normal' keyword: normal
+Pass	font-stretch(valid): 'semi-expanded' keyword: semi-expanded
+Pass	font-stretch(valid): 'expanded' keyword: expanded
+Pass	font-stretch(valid): 'extra-expanded' keyword: extra-expanded
+Pass	font-stretch(valid): 'ultra-expanded' keyword: ultra-expanded
+Pass	font-stretch(invalid): Extra content after value: expanded a
+Pass	font-stretch(valid): 'auto' keyword inside @font-face: auto
+Pass	font-stretch(valid): Legal percentage: 1%
+Pass	font-stretch(valid): Legal percentage: 10.5%
+Pass	font-stretch(valid): Legal percentage: 100%
+Pass	font-stretch(valid): Legal percentage: 1000%
+Pass	font-stretch(invalid): Only percentages, not numbers allowed: 100
+Pass	font-stretch(invalid): Negative values are illegal: -1%
+Pass	font-stretch(valid): Zero is legal: 0%
+Pass	font-stretch(invalid): Extra content after value: 100% a
+Pass	font-stretch(valid): Simple calc value: calc(200.5%)
+Pass	font-stretch(valid): Valid calc expression: calc(50%*2 - 20%)
+Pass	font-stretch(valid): Negative calc value (to be clamped): calc(-100%)
+Pass	font-stretch(valid): Negative calc expression (to be clamped): calc(50% - 50%*2)
+Pass	font-stretch(invalid): Unit-less calc value: calc(100)
+Pass	font-stretch(invalid): Calc value with units: calc(100px)
+Fail	font-stretch(valid): Simple range: 100% 200%
+Fail	font-stretch(valid): Simple range with equal upper and lower bounds: 100% 100%
+Pass	font-stretch(invalid): Lower bound out of range: -100% 100%
+Fail	font-stretch(valid): Lower bound calc(): calc(10% + 10%) 30%
+Fail	font-stretch(valid): Upper bound calc(): 10% calc(10% + 10%)
+Fail	font-stretch(valid): Both bounds are calc(): calc(10% + 10%) calc(20% + 20%)
+Fail	font-stretch(valid): Bounds out of order: 200% 100%
+Pass	font-stretch(invalid): Extra content after upper bound: 100% 200% 300%
+Pass	font-style(valid): 'normal' keyword: normal
+Pass	font-style(valid): 'italic' keyword: italic
+Pass	font-style(valid): 'oblique' keyword: oblique
+Pass	font-style(valid): 'auto' keyword inside @font-face: auto
+Pass	font-style(invalid): 'italic' followed by angle: italic 20deg
+Pass	font-style(invalid): Extra content after keyword: italic a
+Pass	font-style(valid): 'oblique' followed by zero degrees: oblique 0deg
+Pass	font-style(valid): 'oblique' followed by former default 20deg angle: oblique 20deg
+Pass	font-style(valid): 'oblique' followed by maxumum 90 degree angle: oblique 90deg
+Pass	font-style(valid): 'oblique' followed by minimum -90 degree angle: oblique -90deg
+Pass	font-style(valid): 'oblique' followed by calc with out of range value (should be clamped): oblique calc(91deg)
+Pass	font-style(valid): 'oblique' followed by calc with out of range value (should be clamped): oblique calc(-91deg)
+Pass	font-style(valid): 'oblique' followed by angle in radians: oblique 0rad
+Pass	font-style(invalid): 'oblique' followed by unit-less number: oblique 20
+Pass	font-style(invalid): 'oblique' followed by non-angle: oblique 20px
+Pass	font-style(invalid): 'oblique' followed by non-number: oblique a
+Pass	font-style(invalid): 'oblique' followed by isolated minus: oblique -
+Pass	font-style(invalid): 'oblique' followed by minus and angle separated by space: oblique - 20deg
+Pass	font-style(invalid): 'oblique' followed by minus and non-number: oblique -a
+Pass	font-style(valid): Simple range: oblique 10deg 20deg
+Pass	font-style(valid): Simple range with equal upper and lower bounds: oblique 10deg 10deg
+Pass	font-style(valid): Simple range with equal upper and lower bounds: oblique 0deg 0deg
+Fail	font-style(valid): Simple range with former default angle for both bounds: oblique 20deg 20deg
+Pass	font-style(valid): Bounds out of order: oblique 20deg 10deg
+Pass	font-style(invalid): Lower bound out of range: oblique -100deg 20deg
+Pass	font-style(invalid): Upper bound out of range: oblique 20deg 100deg
+Pass	font-style(invalid): Extra content after upper bound: oblique 10deg 20deg 30deg

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/font-face-style-normal.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/font-face-style-normal.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Fonts: parsing 'normal' in the font-style descriptor</title>
+<link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#descdef-font-face-font-style">
+<meta name="assert" content="Ensure that although 'normal' equates to 'oblique 0deg', a following <angle> is not allowed.">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<style>
+@font-face {
+  font-family: test1;
+  font-style: normal;
+  src: url(../../fonts/Ahem.ttf);
+}
+@font-face {
+  font-family: test2;
+  font-style: oblique 0deg;
+  src: url(../../fonts/Ahem.ttf);
+}
+@font-face {
+  font-family: test3;
+  font-style: oblique 0deg 10deg;
+  src: url(../../fonts/Ahem.ttf);
+}
+@font-face {
+  font-family: test4;
+  font-style: normal 10deg;
+  src: url(../../fonts/Ahem.ttf);
+}
+</style>
+<script>
+  promise_test(async (t) => {
+    const fonts = await document.fonts.load("12px test1");
+    assert_equals(fonts[0].style, "normal", "'normal' serializes as specified");
+  });
+  promise_test(async (t) => {
+    const fonts = await document.fonts.load("12px test2");
+    assert_equals(fonts[0].style, "normal", "'oblique 0deg' serializes as 'normal'");
+  });
+  promise_test(async (t) => {
+    const fonts = await document.fonts.load("12px test3");
+    assert_equals(fonts[0].style, "oblique 0deg 10deg", "oblique range serializes as specified");
+  });
+  promise_test(async (t) => {
+    const fonts = await document.fonts.load("12px test4");
+    assert_equals(fonts[0].style, "normal", "'normal 10deg' is not a valid range");
+  });
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/variations/at-font-face-descriptors.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/variations/at-font-face-descriptors.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Testing @font-face descriptor values introduced in CSS Fonts level 4</title>
+    <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-face-rule" />
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <style id="testStyle">
+        @font-face { font-family: Test; src: local('Courier New'), local('Courier'); }
+    </style>
+</head>
+<body>
+    <div>@font-face descriptor tests</div>
+    <script>
+
+        function updateFontFaceRule(descriptorName, descriptorValue) {
+            let testRule = document.getElementById("testStyle").sheet.cssRules[0];
+
+            testRule.style.fontWeight = "normal";
+            testRule.style.fontStyle = "normal";
+            testRule.style.fontStretch = "normal";
+            assert_equals(testRule.style.fontWeight, "normal", "Can't clear @font-face.");
+            assert_equals(testRule.style.fontStyle, "normal", "Can't clear @font-face.");
+            assert_equals(testRule.style.fontStretch,  "normal", "Can't clear @font-face.");
+
+            testRule.style.fontWeight = "";
+            testRule.style.fontStyle = "";
+            testRule.style.fontStretch = "";
+            assert_true(!testRule.style.fontWeight, "", "Can't clear @font-face.");
+            assert_true(!testRule.style.fontStyle, "", "Can't clear @font-face.");
+            assert_true(!testRule.style.fontStretch,  "", "Can't clear @font-face.");
+
+            testRule.style[descriptorName] = descriptorValue;
+
+            return testRule;
+        }
+
+        function testDescriptor(descriptorName, testCases) {
+            var propertyName = { 'font-weight':'fontWeight', 'font-stretch':'fontStretch', 'font-style':'fontStyle' }[descriptorName];
+            testCases.forEach(function (testCase) {
+                test(() => {
+                    let rule = updateFontFaceRule(descriptorName, testCase.value);
+
+                    if (testCase.isValid) {
+                        assert_not_equals(rule.style[propertyName], "", "Valid value should be accepted.");
+
+                        let expectedValue = (testCase.expectedValue) ? testCase.expectedValue : testCase.value;
+                        assert_equals(rule.style[propertyName], expectedValue, "Unexpected resulting value.");
+                    }
+                    else {
+                        assert_equals(rule.style[propertyName], "", "No properties should be set.");
+                    }
+                }, descriptorName + (testCase.isValid ? "(valid): " : "(invalid): ") + testCase.description + ": " + testCase.value);
+
+            });
+        }
+
+        testDescriptor("font-weight", [
+            // Single value, keyword
+            { value: "normal",                  isValid: true,  description: "'normal' keyword" },
+            { value: "bold",                    isValid: true,  description: "'bold' keyword" },
+            { value: "auto",                    isValid: true,  description: "'auto' keyword inside @font-face" },
+            { value: "lighter",                 isValid: false, description: "'lighter' keyword inside @font-face" },
+            { value: "bolder",                  isValid: false, description: "'bolder' keyword inside @font-face" },
+            { value: "bold a",                  isValid: false, description: "Extra content after keyword" },
+
+            // Single value, number
+            { value: "401",                     isValid: true,  description: "Values that are not multiple of 100 should be parsed successfully" },
+            { value: "400.1",                   isValid: true,  description: "Non-integer values should be parsed successfully" },
+            { value: "1",                       isValid: true,  description: "Minimum allowed value should be parsed successfully" },
+            { value: "0.999",                   isValid: false, description: "Values below minimum should be rejected" },
+            { value: "-100",                    isValid: false, description: "Values below zero should be rejected" },
+            { value: "1000",                    isValid: true,  description: "Maximum allowed value should be parsed successfully" },
+            { value: "1000.001",                isValid: false, description: "Values above maximum should be rejected" },
+            { value: "100 a",                   isValid: false, description: "Extra content after value" },
+
+            // Single value, calc
+            { value: "calc(100.5)",             isValid: true,  expectedValue: "calc(100.5)", description: "Simple calc value" },
+            { value: "calc(1001)",              isValid: true, description: "Out-of-range simple calc value" },
+            { value: "calc(100.5*3 + 50.5)",    isValid: true,  expectedValue: "calc(352)", description: "Valid calc expression" },
+            { value: "calc(100.5*3 + 800)",     isValid: true,  expectedValue: "calc(1101.5)", description: "Valid calc expression with out-of-range value" },
+            { value: "calc(100.5px + 50.5px)",  isValid: false, description: "Valid calc expression with units" },
+
+            // Value range
+            { value: "100 900",                         isValid: true,  description: "Simple range" },
+            { value: "500 500",                         isValid: true,  expectedValue: "500", description: "Simple range with equal upper and lower bounds" },
+            { value: "0.9 100",                         isValid: false, description: "Lower bound out of range" },
+            { value: "100 1001",                        isValid: false, description: "Upper bound out of range" },
+            { value: "calc(100 + 100) 400",             isValid: true,  expectedValue: "calc(200) 400", description: "Lower bound calc()" },
+            { value: "200 calc(200 + 200)",             isValid: true,  expectedValue: "200 calc(400)", description: "Upper bound calc()" },
+            { value: "calc(100 + 100) calc(200 + 200)", isValid: true,  expectedValue: "calc(200) calc(400)", description: "Both bounds are calc()" },
+            { value: "400 200",                         isValid: true,  expectedValue: "400 200", description: "Bounds out of order are valid" },
+            { value: "100 200 300",                     isValid: false, description: "Extra content after upper bound" },
+        ]);
+
+        testDescriptor("font-stretch", [
+            // Single value, keyword
+            { value: "ultra-condensed",         isValid: true,  description: "'ultra-condensed' keyword" },
+            { value: "extra-condensed",         isValid: true,  description: "'extra-condensed' keyword" },
+            { value: "condensed",               isValid: true,  description: "'condensed' keyword" },
+            { value: "semi-condensed",          isValid: true,  description: "'semi-condensed' keyword" },
+            { value: "normal",                  isValid: true,  description: "'normal' keyword" },
+            { value: "semi-expanded",           isValid: true,  description: "'semi-expanded' keyword" },
+            { value: "expanded",                isValid: true,  description: "'expanded' keyword" },
+            { value: "extra-expanded",          isValid: true,  description: "'extra-expanded' keyword" },
+            { value: "ultra-expanded",          isValid: true,  description: "'ultra-expanded' keyword" },
+            { value: "expanded a",              isValid: false, description: "Extra content after value" },
+            { value: "auto",                    isValid: true,  description: "'auto' keyword inside @font-face" },
+
+            // Single value, number
+            { value: "1%",                      isValid: true,  description:"Legal percentage" },
+            { value: "10.5%",                   isValid: true,  description:"Legal percentage" },
+            { value: "100%",                    isValid: true,  description:"Legal percentage" },
+            { value: "1000%",                   isValid: true,  description:"Legal percentage" },
+            { value: "100",                     isValid: false, description:"Only percentages, not numbers allowed" },
+            { value: "-1%",                     isValid: false, description:"Negative values are illegal" },
+            { value: "0%",                      isValid: true,  description:"Zero is legal" },
+            { value: "100% a",                  isValid: false, description:"Extra content after value" },
+
+            // Single value, calc
+            { value: "calc(200.5%)",            isValid: true,  expectedValue: "calc(200.5%)", description: "Simple calc value" },
+            { value: "calc(50%*2 - 20%)",       isValid: true,  expectedValue: "calc(80%)", description: "Valid calc expression" },
+            { value: "calc(-100%)",             isValid: true,  description: "Negative calc value (to be clamped)" },
+            { value: "calc(50% - 50%*2)",       isValid: true,  expectedValue: "calc(-50%)", description: "Negative calc expression (to be clamped)" },
+            { value: "calc(100)",               isValid: false, description: "Unit-less calc value" },
+            { value: "calc(100px)",             isValid: false, description: "Calc value with units" },
+
+            // Value range
+            { value: "100% 200%",                       isValid: true,  description: "Simple range" },
+            { value: "100% 100%",                       isValid: true,  expectedValue: "100%", description: "Simple range with equal upper and lower bounds" },
+            { value: "-100% 100%",                      isValid: false, description: "Lower bound out of range" },
+            { value: "calc(10% + 10%) 30%",             isValid: true,  expectedValue: "calc(20%) 30%", description: "Lower bound calc()" },
+            { value: "10% calc(10% + 10%)",             isValid: true,  expectedValue: "10% calc(20%)", description: "Upper bound calc()" },
+            { value: "calc(10% + 10%) calc(20% + 20%)", isValid: true,  expectedValue: "calc(20%) calc(40%)", description: "Both bounds are calc()" },
+            { value: "200% 100%",                       isValid: true,  expectedValue: "200% 100%", description: "Bounds out of order" },
+            { value: "100% 200% 300%",                  isValid: false, description: "Extra content after upper bound" },
+        ]);
+
+        testDescriptor("font-style", [
+            // Single value, keyword
+            { value: "normal",                  isValid: true,  description: "'normal' keyword" },
+            { value: "italic",                  isValid: true,  description: "'italic' keyword" },
+            { value: "oblique",                 isValid: true,  description: "'oblique' keyword" },
+            { value: "auto",                    isValid: true,  description: "'auto' keyword inside @font-face" },
+
+            // Single value
+            { value: "italic 20deg",            isValid: false, description: "'italic' followed by angle" },
+            { value: "italic a",                isValid: false, description: "Extra content after keyword" },
+            { value: "oblique 0deg",            isValid: true,  expectedValue: "normal", description: "'oblique' followed by zero degrees" },
+            { value: "oblique 20deg",           isValid: true,  description: "'oblique' followed by former default 20deg angle" },
+            { value: "oblique 90deg",           isValid: true,  description: "'oblique' followed by maxumum 90 degree angle" },
+            { value: "oblique -90deg",          isValid: true,  description: "'oblique' followed by minimum -90 degree angle" },
+            { value: "oblique calc(91deg)",     isValid: true,  description: "'oblique' followed by calc with out of range value (should be clamped)" },
+            { value: "oblique calc(-91deg)",    isValid: true,  description: "'oblique' followed by calc with out of range value (should be clamped)" },
+            { value: "oblique 0rad",            isValid: true,  expectedValue: "normal", description: "'oblique' followed by angle in radians" },
+            { value: "oblique 20",              isValid: false, description: "'oblique' followed by unit-less number" },
+            { value: "oblique 20px",            isValid: false, description: "'oblique' followed by non-angle" },
+            { value: "oblique a",               isValid: false, description: "'oblique' followed by non-number" },
+            { value: "oblique -",               isValid: false, description: "'oblique' followed by isolated minus" },
+            { value: "oblique - 20deg",         isValid: false, description: "'oblique' followed by minus and angle separated by space" },
+            { value: "oblique -a",              isValid: false, description: "'oblique' followed by minus and non-number" },
+
+            // Value range
+            { value: "oblique 10deg 20deg",         isValid: true,  description: "Simple range" },
+            { value: "oblique 10deg 10deg",         isValid: true,  expectedValue: "oblique 10deg", description: "Simple range with equal upper and lower bounds" },
+            { value: "oblique 0deg 0deg",           isValid: true,  expectedValue: "normal", description: "Simple range with equal upper and lower bounds" },
+            { value: "oblique 20deg 20deg",         isValid: true,  description: "Simple range with former default angle for both bounds" },
+            { value: "oblique 20deg 10deg",         isValid: true,  expectedValue: "oblique 20deg 10deg", description: "Bounds out of order" },
+            { value: "oblique -100deg 20deg",       isValid: false, description: "Lower bound out of range" },
+            { value: "oblique 20deg 100deg",        isValid: false, description: "Upper bound out of range" },
+            { value: "oblique 10deg 20deg 30deg",   isValid: false, description: "Extra content after upper bound" },
+        ]);
+    </script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/fonts/Ahem.ttf.headers
+++ b/Tests/LibWeb/Text/input/wpt-import/fonts/Ahem.ttf.headers
@@ -1,0 +1,3 @@
+Access-Control-Allow-Origin: *
+Cache-Control: max-age=3600
+Timing-Allow-Origin: *


### PR DESCRIPTION
The `@font-face` `font-style` descriptor grammar now accepts up to two angles for the oblique keyword (e.g. "oblique 0deg 10deg"). 

Fixes following WPT tests:
```md
css/css-fonts/font-face-style-normal.html
CSS Fonts: parsing 'normal' in the font-style descriptor 2	❌ -> ✅
CSS Fonts: parsing 'normal' in the font-style descriptor 3	❌ -> ✅

css/css-fonts/variations/at-font-face-descriptors.html
font-style(valid): 'oblique' followed by angle in radians: oblique 0rad					❌ -> ✅
font-style(valid): Simple range: oblique 10deg 20deg									❌ -> ✅
font-style(valid): Simple range with equal upper and lower bounds: oblique 10deg 10deg	❌ -> ✅
font-style(valid): Simple range with equal upper and lower bounds: oblique 0deg 0deg	❌ -> ✅
font-style(valid): Bounds out of order: oblique 20deg 10deg								❌ -> ✅
```