### PR TITLE
UI: Focus web views after location bar navigation

### DIFF
--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -729,7 +729,7 @@ static NSImage* location_field_globe_icon()
     self.current_inline_autocomplete_suggestion = nil;
     self.suppressed_inline_autocomplete_query = nil;
     m_should_suppress_inline_autocomplete_on_next_change = false;
-    [self.window makeFirstResponder:nil];
+    [self focusWebView];
     [self.autocomplete close];
 
     return YES;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -513,6 +513,8 @@ void Tab::location_edit_return_pressed()
         navigate(*url);
     else
         view().load_navigation_error_page(ak_string_from_qstring(text));
+
+    view().setFocus();
 }
 
 QIcon Tab::tab_icon() const


### PR DESCRIPTION
Move keyboard focus to the web view when the user commits the location field. Relying on URL-change callbacks is unreliable because `ViewImplementation::load()` stores the requested URL before WebContent reports it, so same-URL reports are suppressed before frontends can perform their focus handoff.

Keep the new-tab page behavior unchanged: creating a blank tab still focuses the location field until the user starts a navigation.