### PR TITLE
LibWeb+LibGfx: Match macOS system UI fonts

### DIFF
--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -98,7 +98,8 @@ hb_font_t* Font::harfbuzz_font() const
     if (!m_harfbuzz_font) {
         m_harfbuzz_font = hb_font_create(typeface().harfbuzz_typeface());
         hb_font_set_scale(m_harfbuzz_font, pixel_size() * text_shaping_resolution, pixel_size() * text_shaping_resolution);
-        hb_font_set_ptem(m_harfbuzz_font, point_size());
+        // HarfBuzz uses ptem for AAT 'trak' table lookup; use CSS pixels instead of physical points here.
+        hb_font_set_ptem(m_harfbuzz_font, pixel_size());
 
         auto variations = m_font_variation_settings.axes;
         if (!variations.is_empty()) {

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -24,7 +24,9 @@
 #endif
 
 #ifdef AK_OS_MACOS
+#    include <CoreText/CoreText.h>
 #    include <ports/SkFontMgr_mac_ct.h>
+#    include <ports/SkTypeface_mac.h>
 #endif
 
 namespace Gfx {
@@ -76,33 +78,8 @@ static SkFontStyle::Slant slope_to_skia_slant(u8 slope)
     }
 }
 
-ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::ReadonlyBytes buffer, u32 ttc_index)
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<SkTypeface> skia_typeface)
 {
-    auto data = SkData::MakeWithoutCopy(buffer.data(), buffer.size());
-
-    // https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header
-    // TrueType Collection files bundle multiple fonts (often different weights of the same
-    // family). We use SkFontArguments to specify which font to load from the collection.
-    SkFontArguments font_args;
-    font_args.setCollectionIndex(static_cast<int>(ttc_index));
-
-    auto stream = std::make_unique<SkMemoryStream>(data);
-    auto skia_typeface = font_manager().makeFromStream(std::move(stream), font_args);
-
-    if (!skia_typeface) {
-        return Error::from_string_literal("Failed to load typeface from buffer");
-    }
-
-    return adopt_ref(*new TypefaceSkia { make<TypefaceSkia::Impl>(skia_typeface), buffer, ttc_index });
-}
-
-ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope)
-{
-    SkFontStyle style(weight, width, slope_to_skia_slant(slope));
-
-    auto skia_typeface = font_manager().matchFamilyStyleCharacter(
-        nullptr, style, nullptr, 0, code_point);
-
     if (!skia_typeface)
         return RefPtr<TypefaceSkia> {};
 
@@ -127,9 +104,130 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::find_typeface_for_code_point(u32 cod
     if (data->size() > 0)
         memcpy(anonymous_buffer.data<void>(), data->data(), data->size());
 
-    auto result = TRY(load_from_buffer(anonymous_buffer.bytes(), ttc_index));
+    auto result = TRY(TypefaceSkia::load_from_buffer(anonymous_buffer.bytes(), ttc_index));
     result->set_anonymous_font_data(move(anonymous_buffer));
     return result;
+}
+
+ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::ReadonlyBytes buffer, u32 ttc_index)
+{
+    auto data = SkData::MakeWithoutCopy(buffer.data(), buffer.size());
+
+    // https://learn.microsoft.com/en-us/typography/opentype/spec/otff#ttc-header
+    // TrueType Collection files bundle multiple fonts (often different weights of the same
+    // family). We use SkFontArguments to specify which font to load from the collection.
+    SkFontArguments font_args;
+    font_args.setCollectionIndex(static_cast<int>(ttc_index));
+
+    auto stream = std::make_unique<SkMemoryStream>(data);
+    auto skia_typeface = font_manager().makeFromStream(std::move(stream), font_args);
+
+    if (!skia_typeface) {
+        return Error::from_string_literal("Failed to load typeface from buffer");
+    }
+
+    return adopt_ref(*new TypefaceSkia { make<TypefaceSkia::Impl>(skia_typeface), buffer, ttc_index });
+}
+
+#ifdef AK_OS_MACOS
+// NB: These are the CoreText string values behind the public AppKit NSFontDescriptorSystemDesign constants.
+// Keeping them here avoids pulling Objective-C headers into this C++ file.
+static CFStringRef core_text_ui_font_design(SystemUIFontKind kind)
+{
+    switch (kind) {
+    case SystemUIFontKind::System:
+        return CFSTR("NSCTFontUIFontDesignDefault");
+    case SystemUIFontKind::Serif:
+        return CFSTR("NSCTFontUIFontDesignSerif");
+    case SystemUIFontKind::Monospace:
+        return CFSTR("NSCTFontUIFontDesignMonospaced");
+    case SystemUIFontKind::Rounded:
+        return CFSTR("NSCTFontUIFontDesignRounded");
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static CTFontDescriptorRef create_system_ui_font_descriptor(SystemUIFontKind kind, u8 slope)
+{
+    CGFloat core_text_slant = slope == 0 ? 0.0f : 1.0f;
+    auto slant_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &core_text_slant);
+    if (!slant_number)
+        return nullptr;
+
+    CFTypeRef trait_keys[] = { kCTFontSlantTrait, CFSTR("NSCTFontUIFontDesignTrait") };
+    CFTypeRef trait_values[] = { slant_number, core_text_ui_font_design(kind) };
+    auto traits = CFDictionaryCreate(kCFAllocatorDefault, trait_keys, trait_values, array_size(trait_keys), &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFRelease(slant_number);
+    if (!traits)
+        return nullptr;
+
+    CFTypeRef attribute_keys[] = { kCTFontTraitsAttribute };
+    CFTypeRef attribute_values[] = { traits };
+    auto attributes = CFDictionaryCreate(kCFAllocatorDefault, attribute_keys, attribute_values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    CFRelease(traits);
+    if (!attributes)
+        return nullptr;
+
+    auto descriptor = CTFontDescriptorCreateWithAttributes(attributes);
+    CFRelease(attributes);
+    return descriptor;
+}
+
+static CTFontRef create_system_ui_font(SystemUIFontKind kind, float point_size, u8 slope)
+{
+    auto base_font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, point_size, nullptr);
+    if (!base_font)
+        return nullptr;
+
+    auto descriptor = create_system_ui_font_descriptor(kind, slope);
+    if (!descriptor) {
+        CFRelease(base_font);
+        return nullptr;
+    }
+
+    auto font = CTFontCreateCopyWithAttributes(base_font, point_size, nullptr, descriptor);
+    if (!font)
+        font = CTFontCreateWithFontDescriptor(descriptor, point_size, nullptr);
+    CFRelease(base_font);
+    CFRelease(descriptor);
+    return font;
+}
+#endif
+
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_system_ui(SystemUIFontKind kind, float point_size, u16 weight, double width, u8 slope)
+{
+#ifdef AK_OS_MACOS
+    (void)weight;
+    (void)width;
+    auto ct_font = create_system_ui_font(kind, point_size, slope);
+    if (!ct_font)
+        return RefPtr<TypefaceSkia> {};
+
+    auto skia_typeface = SkMakeTypefaceFromCTFont(ct_font);
+    auto typeface = typeface_from_skia_typeface(move(skia_typeface));
+    CFRelease(ct_font);
+    return typeface;
+#else
+    (void)kind;
+    (void)point_size;
+    (void)weight;
+    (void)width;
+    (void)slope;
+    return RefPtr<TypefaceSkia> {};
+#endif
+}
+
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope)
+{
+    SkFontStyle style(weight, width, slope_to_skia_slant(slope));
+
+    auto skia_typeface = font_manager().matchFamilyStyleCharacter(
+        nullptr, style, nullptr, 0, code_point);
+
+    if (!skia_typeface)
+        return RefPtr<TypefaceSkia> {};
+
+    return typeface_from_skia_typeface(move(skia_typeface));
 }
 
 Optional<FlyString> TypefaceSkia::resolve_generic_family(StringView family_name, u16 weight, u8 slope)

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -8,13 +8,24 @@
 
 #include <LibGfx/Font/Typeface.h>
 
+template<typename T>
+class sk_sp;
+
 namespace Gfx {
+
+enum class SystemUIFontKind : u8 {
+    System,
+    Serif,
+    Monospace,
+    Rounded,
+};
 
 class TypefaceSkia : public Gfx::Typeface {
     AK_MAKE_NONCOPYABLE(TypefaceSkia);
 
 public:
     static ErrorOr<NonnullRefPtr<TypefaceSkia>> load_from_buffer(ReadonlyBytes, u32 ttc_index = 0);
+    static ErrorOr<RefPtr<TypefaceSkia>> match_system_ui(SystemUIFontKind, float point_size, u16 weight, double width, u8 slope);
     static ErrorOr<RefPtr<TypefaceSkia>> find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope);
     static Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
 
@@ -37,6 +48,8 @@ private:
     struct Impl;
     Impl& impl() const { return *m_impl; }
     NonnullOwnPtr<Impl> m_impl;
+
+    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_skia_typeface(sk_sp<SkTypeface>);
 
     TypefaceSkia(NonnullOwnPtr<Impl>, ReadonlyBytes, u32 ttc_index = 0);
 

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -613,6 +613,7 @@
     "cursive",
     "fantasy",
     "monospace",
+    "system-ui",
     "math",
     "ui-serif",
     "ui-sans-serif",

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -9,8 +9,10 @@
  */
 
 #include "FontComputer.h"
+#include <AK/Platform.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/TypefaceSkia.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSFontFeatureValuesRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
@@ -256,6 +258,21 @@ static unsigned font_width_bucket_from_percentage(double percentage)
     }
     return best.width;
 }
+
+#ifdef AK_OS_MACOS
+static Optional<Gfx::SystemUIFontKind> macos_system_ui_font_kind_from_family_name(StringView family)
+{
+    if (family.is_one_of("-apple-system"sv, "-apple-system-font"sv, "-webkit-system-font"sv, "system-ui"sv, "ui-sans-serif"sv))
+        return Gfx::SystemUIFontKind::System;
+    if (family == "ui-serif"sv)
+        return Gfx::SystemUIFontKind::Serif;
+    if (family == "ui-monospace"sv)
+        return Gfx::SystemUIFontKind::Monospace;
+    if (family == "ui-rounded"sv)
+        return Gfx::SystemUIFontKind::Rounded;
+    return {};
+}
+#endif
 
 struct FontComputer::MatchingFontCandidate {
     FontFaceKey key;
@@ -523,6 +540,20 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
     // FIXME: Implement the full font-matching algorithm: https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm
     float const font_size_in_pt = font_size_used_value * 0.75f;
 
+#ifdef AK_OS_MACOS
+    auto find_macos_system_ui_font = [&](Gfx::SystemUIFontKind kind, FlyString const& family) -> RefPtr<Gfx::FontCascadeList const> {
+        auto const& font_feature_values = font_feature_values_for_family(family);
+        auto shape_features = font_feature_data.to_shape_features(font_feature_values);
+        auto typeface = Gfx::TypefaceSkia::match_system_ui(kind, font_size_used_value, weight, font_width.value(), slope);
+        if (typeface.is_error() || !typeface.value())
+            return {};
+
+        auto font_list = Gfx::FontCascadeList::create();
+        font_list->add(typeface.value()->font(font_size_in_pt, variation, shape_features));
+        return font_list;
+    };
+#endif
+
     auto find_font = [&](FlyString const& family) -> RefPtr<Gfx::FontCascadeList const> {
         auto const& font_feature_values = font_feature_values_for_family(family);
 
@@ -545,6 +576,13 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
                 return result;
         }
 
+#ifdef AK_OS_MACOS
+        if (auto system_ui_font_kind = macos_system_ui_font_kind_from_family_name(family.bytes_as_string_view()); system_ui_font_kind.has_value()) {
+            if (auto system_font = find_macos_system_ui_font(system_ui_font_kind.value(), family))
+                return system_font;
+        }
+#endif
+
         if (auto found_font = font_matching_algorithm(family, weight, font_width, slope, font_size_in_pt, variation, font_feature_data, font_feature_values); found_font && !found_font->is_empty())
             return found_font;
 
@@ -552,11 +590,21 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
     };
 
     auto find_generic_font = [&](Keyword font_id) -> RefPtr<Gfx::FontCascadeList const> {
+#ifdef AK_OS_MACOS
+        if (auto system_ui_font_kind = macos_system_ui_font_kind_from_family_name(string_from_keyword(font_id)); system_ui_font_kind.has_value()) {
+            auto family = MUST(FlyString::from_utf8(string_from_keyword(font_id)));
+            if (auto system_font = find_macos_system_ui_font(system_ui_font_kind.value(), family))
+                return system_font;
+        }
+#endif
+
         Platform::GenericFont generic_font {};
         switch (font_id) {
         case Keyword::Monospace:
-        case Keyword::UiMonospace:
             generic_font = Platform::GenericFont::Monospace;
+            break;
+        case Keyword::UiMonospace:
+            generic_font = Platform::GenericFont::UiMonospace;
             break;
         case Keyword::Serif:
             generic_font = Platform::GenericFont::Serif;
@@ -567,17 +615,18 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
         case Keyword::SansSerif:
             generic_font = Platform::GenericFont::SansSerif;
             break;
-        case Keyword::Cursive:
-            generic_font = Platform::GenericFont::Cursive;
-            break;
         case Keyword::UiSerif:
             generic_font = Platform::GenericFont::UiSerif;
             break;
+        case Keyword::UiRounded:
+            generic_font = Platform::GenericFont::UiRounded;
+            break;
+        case Keyword::SystemUi:
         case Keyword::UiSansSerif:
             generic_font = Platform::GenericFont::UiSansSerif;
             break;
-        case Keyword::UiRounded:
-            generic_font = Platform::GenericFont::UiRounded;
+        case Keyword::Cursive:
+            generic_font = Platform::GenericFont::Cursive;
             break;
         default:
             return {};

--- a/Libraries/LibWeb/CSS/Keywords.json
+++ b/Libraries/LibWeb/CSS/Keywords.json
@@ -737,6 +737,7 @@
   "sw-resize",
   "swap",
   "symbolic",
+  "system-ui",
   "table",
   "table-caption",
   "table-cell",

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/generic-family-keywords-003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/generic-family-keywords-003.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 15 tests
 
-10 Pass
-5 Fail
+11 Pass
+4 Fail
 Pass	@font-face matching for quoted and unquoted serif (drawing text in a canvas)
 Pass	@font-face matching for quoted and unquoted sans-serif (drawing text in a canvas)
 Pass	@font-face matching for quoted and unquoted cursive (drawing text in a canvas)
 Pass	@font-face matching for quoted and unquoted fantasy (drawing text in a canvas)
 Pass	@font-face matching for quoted and unquoted monospace (drawing text in a canvas)
-Fail	@font-face matching for quoted and unquoted system-ui (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted system-ui (drawing text in a canvas)
 Pass	@font-face matching for quoted and unquoted math (drawing text in a canvas)
 Fail	@font-face matching for quoted and unquoted generic(fangsong) (drawing text in a canvas)
 Fail	@font-face matching for quoted and unquoted generic(kai) (drawing text in a canvas)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-family-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-family-valid.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 11 tests
 
-9 Pass
-2 Fail
+10 Pass
+1 Fail
 Pass	e.style['font-family'] = "Serif" should set the property value
 Pass	e.style['font-family'] = "Sans-Serif" should set the property value
 Pass	e.style['font-family'] = "Cursive" should set the property value
 Pass	e.style['font-family'] = "Fantasy" should set the property value
 Pass	e.style['font-family'] = "Monospace" should set the property value
-Fail	e.style['font-family'] = "System-UI" should set the property value
+Pass	e.style['font-family'] = "System-UI" should set the property value
 Pass	e.style['font-family'] = "serif, sans-serif, cursive, fantasy, monospace, system-ui" should set the property value
 Pass	e.style['font-family'] = "Helvetica, Verdana, sans-serif" should set the property value
 Fail	e.style['font-family'] = "\"New Century Schoolbook\", serif" should set the property value


### PR DESCRIPTION
Use CoreText on macOS to resolve CSS UI generic families and Apple system family aliases, including `-apple-system`, `system-ui`, `ui-serif`, `ui-sans-serif`, `ui-monospace`, and `ui-rounded`.

The CoreText-selected font is converted back into a Skia typeface, so text still goes through the existing HarfBuzz shaping path. CSS weight and width continue through the normal font variation settings.

Also pass CSS pixel size to HarfBuzz ptem so AAT `trak` metrics for macOS system fonts line up with other browsers, and update CSS Fonts expectations for `system-ui` parsing and matching.

Before:
<img width="1275" height="892" alt="Screenshot 2026-05-20 at 13 45 38" src="https://github.com/user-attachments/assets/c2bb8c90-a45a-4fed-bb97-28c7846dc5f3" />

After:
<img width="1275" height="892" alt="Screenshot 2026-05-20 at 13 46 07" src="https://github.com/user-attachments/assets/a6b55d70-164f-4c19-a7da-ffa40e4833f6" />
