### PR TITLE
LibWeb: Fix nested SVG partial relayout transform lookup

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1548,14 +1548,12 @@ static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
     if (auto paintable = svg_root.paintable_box())
         layout_state.populate_from_paintable(svg_root, *paintable);
 
-    // Pre-populate SVGGraphicsBox ancestors (up to outer SVG) for get_parent_svg_transform().
+    // Pre-populate SVGGraphicsBox ancestors for get_parent_svg_transform().
     for (auto* ancestor = svg_root.parent(); ancestor; ancestor = ancestor->parent()) {
         if (auto const* svg_graphics_ancestor = as_if<Layout::SVGGraphicsBox>(*ancestor)) {
             if (auto paintable = svg_graphics_ancestor->paintable_box())
                 layout_state.populate_from_paintable(*svg_graphics_ancestor, *paintable);
         }
-        if (is<Layout::SVGSVGBox>(*ancestor))
-            break;
     }
 
     // Pre-populate the viewport for position:fixed elements inside <foreignObject>.

--- a/Tests/LibWeb/Crash/SVG/deeply-nested-transform-partial-relayout.html
+++ b/Tests/LibWeb/Crash/SVG/deeply-nested-transform-partial-relayout.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<body>
+<svg width="100" height="100">
+    <g transform="translate(10, 10)">
+        <svg width="80" height="80">
+            <svg id="inner" width="50" height="50">
+                <rect id="target" width="30" height="30" fill="blue"/>
+            </svg>
+        </svg>
+    </g>
+</svg>
+<script>
+    document.body.offsetWidth;
+    target.setAttribute("transform", "translate(5, 5)");
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            document.documentElement.classList.remove("test-wait");
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Partial SVG relayout builds a throwaway layout state rooted at the nearest dirty SVG viewport. SVG graphics layout can still walk past intermediate SVG viewports when looking for ancestor transforms, so pre-populate every SVG graphics ancestor instead of stopping at the first ancestor SVG viewport.

Fixes an issue where the typing indicator would crash Discord when someone starts typing a message. :^)