### PR TITLE
LibWeb: Clear selection when no find in page matches are found

### DIFF
--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -110,17 +110,21 @@ void Range::set_associated_selection(Badge<Selection::Selection>, GC::Ptr<Select
 
 void Range::update_associated_selection()
 {
-    if (!m_associated_selection)
-        return;
-
     auto& document = m_start_container->document();
-    document.reset_cursor_blink_cycle();
 
     // NB: Called during selection update after range change.
     if (auto viewport = document.unsafe_paintable()) {
-        viewport->recompute_selection_states(*this);
+        if (m_associated_selection)
+            viewport->recompute_selection_states(*this);
+        else
+            viewport->reset_selection_states();
         viewport->set_needs_repaint();
     }
+
+    if (!m_associated_selection)
+        return;
+
+    document.reset_cursor_blink_cycle();
 
     // https://w3c.github.io/selection-api/#selectionchange-event
     // When the selection is dissociated with its range, associated with a new range, or the associated range's boundary

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -2025,6 +2025,7 @@ bool Window::find(String const& string)
             string,
             CaseSensitivity::CaseInsensitive,
             Page::WrapAround::No,
+            Page::ClearSelectionOnNoMatch::No,
         };
 
         result = page.find_in_page(query);

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -834,7 +834,7 @@ Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& q
         }
     }
 
-    update_find_in_page_selection(all_matches);
+    update_find_in_page_selection(all_matches, query.clear_selection_on_no_match);
 
     return Page::FindInPageResult {
         .current_match_index = m_find_in_page_match_index,
@@ -879,10 +879,13 @@ Page::FindInPageResult Page::find_in_page_previous_match()
     return result;
 }
 
-void Page::update_find_in_page_selection(Vector<GC::Root<DOM::Range>> matches)
+void Page::update_find_in_page_selection(Vector<GC::Root<DOM::Range>> matches, ClearSelectionOnNoMatch clear_selection_on_no_match)
 {
-    if (matches.is_empty())
+    if (matches.is_empty()) {
+        if (clear_selection_on_no_match == ClearSelectionOnNoMatch::Yes)
+            clear_selection();
         return;
+    }
 
     clear_selection();
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -251,10 +251,15 @@ public:
         Yes,
         No,
     };
+    enum class ClearSelectionOnNoMatch {
+        Yes,
+        No,
+    };
     struct FindInPageQuery {
         String string {};
         CaseSensitivity case_sensitivity { CaseSensitivity::CaseInsensitive };
         WrapAround wrap_around { WrapAround::Yes };
+        ClearSelectionOnNoMatch clear_selection_on_no_match { ClearSelectionOnNoMatch::Yes };
     };
     struct FindInPageResult {
         size_t current_match_index { 0 };
@@ -294,7 +299,7 @@ private:
         Backward,
     };
     FindInPageResult perform_find_in_page_query(FindInPageQuery const&, Optional<SearchDirection> = {});
-    void update_find_in_page_selection(Vector<GC::Root<DOM::Range>> matches);
+    void update_find_in_page_selection(Vector<GC::Root<DOM::Range>> matches, ClearSelectionOnNoMatch);
 
     void on_pending_dialog_closed();
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -572,13 +572,18 @@ GC::Ptr<Selection::Selection> ViewportPaintable::selection() const
     return document().get_selection();
 }
 
-void ViewportPaintable::recompute_selection_states(DOM::Range& range)
+void ViewportPaintable::reset_selection_states()
 {
-    // 1. Start by resetting the selection state of all layout nodes to None.
-    for_each_in_inclusive_subtree([&](auto& layout_node) {
+    for_each_in_inclusive_subtree([](auto& layout_node) {
         layout_node.set_selection_state(SelectionState::None);
         return TraversalDecision::Continue;
     });
+}
+
+void ViewportPaintable::recompute_selection_states(DOM::Range& range)
+{
+    // 1. Start by resetting the selection state of all layout nodes to None.
+    reset_selection_states();
 
     auto set_selection_state_on_all_slices = [](DOM::Node& container, SelectionState state) {
         if (auto* text = as_if<DOM::Text>(container)) {

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -31,6 +31,7 @@ public:
 
     GC::Ptr<Selection::Selection> selection() const;
     void recompute_selection_states(DOM::Range&);
+    void reset_selection_states();
 
     bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, double wheel_delta_x, double wheel_delta_y) override;
 

--- a/Tests/LibWeb/Text/expected/HTML/Window-find-no-match-preserves-selection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find-no-match-preserves-selection.txt
@@ -1,0 +1,2 @@
+window.find("findable"): true, rangeCount: 1
+window.find("nonexistent"): false, rangeCount: 1

--- a/Tests/LibWeb/Text/input/HTML/Window-find-no-match-preserves-selection.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-find-no-match-preserves-selection.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div>findable text</div>
+<script>
+    test(() => {
+        const selection = window.getSelection();
+
+        const foundResult = window.find("findable");
+        println(`window.find("findable"): ${foundResult}, rangeCount: ${selection.rangeCount}`);
+
+        const missingResult = window.find("nonexistent");
+        println(`window.find("nonexistent"): ${missingResult}, rangeCount: ${selection.rangeCount}`);
+    });
+</script>


### PR DESCRIPTION
Previously, if the find in page query was updated and no matches were found we would keep the old selection instead of clearing it.

`window.find` behaves differently from the find in page UI and preserves the old behavior.

In order to make this work, I've included a change that makes sure we repaint when dissociating a range from a selection.