### PR TITLE
UI/AppKit: Add New Window menu action

### DIFF
--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -193,6 +193,13 @@
     [controller focusLocationToolbarItem];
 }
 
+- (void)createNewWindow:(id)sender
+{
+    [self createNewTab:WebView::Application::settings().new_tab_page_url()
+               fromTab:nil
+           activateTab:Web::HTML::ActivateTab::Yes];
+}
+
 - (nonnull TabController*)createChildTab:(Web::HTML::ActivateTab)activate_tab
                                  fromTab:(nonnull Tab*)tab
                                pageIndex:(u64)page_index
@@ -270,6 +277,9 @@
     auto* menu = [[NSMenuItem alloc] init];
     auto* submenu = [[NSMenu alloc] initWithTitle:@"File"];
 
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"New Window"
+                                                action:@selector(createNewWindow:)
+                                         keyEquivalent:@"n"]];
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"New Tab"
                                                 action:@selector(createNewTab:)
                                          keyEquivalent:@"t"]];


### PR DESCRIPTION
Open the configured new tab page in a separate AppKit window from the File menu, matching the existing Qt action.