### PR TITLE
LibWeb: Support CSS transitions and animations on all pseudo-elements

### DIFF
--- a/Meta/Generators/generate_libweb_css_pseudo_element.py
+++ b/Meta/Generators/generate_libweb_css_pseudo_element.py
@@ -446,6 +446,26 @@ bool is_pseudo_element_root(PseudoElement pseudo_element)
 
 bool pseudo_element_supports_property(PseudoElement pseudo_element, PropertyID property_id)
 {
+    if (property_id == PropertyID::Transition
+        || property_id == PropertyID::TransitionBehavior
+        || property_id == PropertyID::TransitionDelay
+        || property_id == PropertyID::TransitionDuration
+        || property_id == PropertyID::TransitionProperty
+        || property_id == PropertyID::TransitionTimingFunction
+        || property_id == PropertyID::Animation
+        || property_id == PropertyID::AnimationComposition
+        || property_id == PropertyID::AnimationDelay
+        || property_id == PropertyID::AnimationDirection
+        || property_id == PropertyID::AnimationDuration
+        || property_id == PropertyID::AnimationFillMode
+        || property_id == PropertyID::AnimationIterationCount
+        || property_id == PropertyID::AnimationName
+        || property_id == PropertyID::AnimationPlayState
+        || property_id == PropertyID::AnimationTimeline
+        || property_id == PropertyID::AnimationTimingFunction) {
+        return true;
+    }
+
     switch (pseudo_element) {
 """)
 

--- a/Tests/LibWeb/Text/expected/css-placeholder-transition.txt
+++ b/Tests/LibWeb/Text/expected/css-placeholder-transition.txt
@@ -1,0 +1,6 @@
+initial opacity: 1
+initial color: rgb(255, 0, 0)
+initial background-color: rgb(0, 255, 0)
+opacity is transitioning (not snapped to 0.5)? true
+color is not at final value? true
+background-color is not at final value? true

--- a/Tests/LibWeb/Text/input/css-placeholder-transition.html
+++ b/Tests/LibWeb/Text/input/css-placeholder-transition.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<script src="include.js"></script>
+<style>
+    #target::placeholder {
+        transition: opacity 10s linear, color 10s linear, background-color 10s linear;
+        color: rgb(255, 0, 0);
+        background-color: rgb(0, 255, 0);
+        opacity: 1;
+    }
+    #target.fade::placeholder {
+        opacity: 0.5;
+        color: rgb(0, 0, 255);
+        background-color: rgb(0, 0, 0);
+    }
+</style>
+<input id="target" placeholder="Placeholder Text">
+<script>
+    // Verifies that CSS transition properties cascade correctly onto ::placeholder.
+    //
+    // Root cause: pseudo_element_supports_property() filtered out transition-* and
+    // animation-* properties for whitelisted pseudo-elements (e.g. ::placeholder).
+    // As a result, transition-duration and transition-delay resolved to 0s, which
+    // triggered the zero-duration fast-path in compute_transitioned_properties()
+    // and prevented transition registration entirely.
+    //
+    // Failure mode (without the fix): all three properties snap instantly to their
+    // final values the moment the class is added, producing:
+    //   opacity is transitioning (not snapped to 0.5)? false
+    //   color is not at final value? false
+    //   background-color is not at final value? false
+    //
+    // The transition duration is 10s so that at t=1ms the interpolated values are
+    // indistinguishable from the initial values, making the assertions robust against
+    // floating-point precision differences in opacity serialization.
+    asyncTest(async done => {
+        const target = document.getElementById("target");
+
+        println(`initial opacity: ${getComputedStyle(target, "::placeholder").getPropertyValue("opacity")}`);
+        println(`initial color: ${getComputedStyle(target, "::placeholder").getPropertyValue("color")}`);
+        println(`initial background-color: ${getComputedStyle(target, "::placeholder").getPropertyValue("background-color")}`);
+
+        target.classList.add("fade");
+
+        // Check shortly after triggering the transition.
+        // With a 10s linear transition, at t=1ms the values should still be
+        // extremely close to their initial values and NOT at their final values.
+        // If transitions are not supported, the values snap instantly to the final
+        // state and these checks will fail.
+        setTimeout(() => {
+            const opacity = parseFloat(getComputedStyle(target, "::placeholder").getPropertyValue("opacity"));
+            const color = getComputedStyle(target, "::placeholder").getPropertyValue("color");
+            const bgColor = getComputedStyle(target, "::placeholder").getPropertyValue("background-color");
+
+            println(`opacity is transitioning (not snapped to 0.5)? ${opacity > 0.5}`);
+            println(`color is not at final value? ${color !== "rgb(0, 0, 255)"}`);
+            println(`background-color is not at final value? ${bgColor !== "rgb(0, 0, 0)"}`);
+            done();
+        }, 1);
+    });
+</script>
+
+</html>


### PR DESCRIPTION
Whitelisted pseudo-elements (`::placeholder`, `::first-letter`, `::first-line`, and `::selection`) rejected all transition and animation properties, preventing transitions from working on them.

### Problem

A common pattern like this produces an instant snap instead of a smooth fade in Ladybird, despite working in other engines:

```css
input::placeholder {
  opacity: 1;
  transition: opacity 0.5s ease;
}
input.fade::placeholder {
  opacity: 0;
}
```

This is because `pseudo_element_supports_property()` rejected transition/animation properties during cascade filtering, causing durations/delays to resolve to `0s` and bypass registration.

### Fix

This PR modifies `generate_libweb_css_pseudo_element.py` to insert a fast-path check in `pseudo_element_supports_property()`, automatically returning `true` for all `transition-*` and `animation-*` properties on any styleable pseudo-element.

### Verification

- Live test case: https://placeholderopacity.netlify.app/
- Verified working on: Chrome (Blink), Firefox (Gecko), Epiphany(WebKitGTK), and Ladybird (LibWeb with this patch applied).
