### PR TITLE
LibWeb+LibWebView+UI: Do not allow `SelectedFile` to transfer directories

### DIFF
--- a/Libraries/LibWeb/HTML/SelectedFile.cpp
+++ b/Libraries/LibWeb/HTML/SelectedFile.cpp
@@ -4,24 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
 #include <LibCore/File.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibWeb/HTML/SelectedFile.h>
 
 namespace Web::HTML {
-
-ErrorOr<SelectedFile> SelectedFile::from_file_path(ByteString const& file_path)
-{
-    // https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file):concept-input-file-path
-    // Filenames must not contain path components, even in the case that a user has selected an entire directory
-    // hierarchy or multiple files with the same name from different directories.
-    auto name = LexicalPath::basename(file_path);
-
-    auto file = TRY(Core::File::open(file_path, Core::File::OpenMode::Read));
-    return SelectedFile { move(name), IPC::File::adopt_file(move(file)) };
-}
 
 SelectedFile::SelectedFile(ByteString name, ByteBuffer contents)
     : m_name(move(name))

--- a/Libraries/LibWeb/HTML/SelectedFile.h
+++ b/Libraries/LibWeb/HTML/SelectedFile.h
@@ -22,8 +22,6 @@ enum class AllowMultipleFiles {
 
 class WEB_API SelectedFile {
 public:
-    static ErrorOr<SelectedFile> from_file_path(ByteString const& file_path);
-
     SelectedFile(ByteString name, ByteBuffer contents);
     SelectedFile(ByteString name, IPC::File file);
 

--- a/Libraries/LibWebView/Utilities.cpp
+++ b/Libraries/LibWebView/Utilities.cpp
@@ -17,6 +17,7 @@
 #include <LibCore/ResourceImplementationFile.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Utilities.h>
 
 #define TOKENCAT(x, y) x##y
@@ -143,6 +144,17 @@ ErrorOr<void> handle_attached_debugger()
 #endif
 
     return {};
+}
+
+ErrorOr<Web::HTML::SelectedFile> create_selected_file(ByteString const& file_path)
+{
+    // https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file):concept-input-file-path
+    // Filenames must not contain path components, even in the case that a user has selected an entire directory
+    // hierarchy or multiple files with the same name from different directories.
+    auto name = LexicalPath::basename(file_path);
+
+    auto file = TRY(Core::File::open(file_path, Core::File::OpenMode::Read));
+    return Web::HTML::SelectedFile { move(name), IPC::File::adopt_file(move(file)) };
 }
 
 ErrorOr<JsonObject> read_json_file(ByteString const& path)

--- a/Libraries/LibWebView/Utilities.cpp
+++ b/Libraries/LibWebView/Utilities.cpp
@@ -148,6 +148,11 @@ ErrorOr<void> handle_attached_debugger()
 
 ErrorOr<Web::HTML::SelectedFile> create_selected_file(ByteString const& file_path)
 {
+    // FIXME: Implement the File and Directory Entries API.
+    //        https://wicg.github.io/entries-api/
+    if (FileSystem::is_directory(file_path))
+        return Error::from_string_literal("Only files may currently be selected");
+
     // https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file):concept-input-file-path
     // Filenames must not contain path components, even in the case that a user has selected an entire directory
     // hierarchy or multiple files with the same name from different directories.

--- a/Libraries/LibWebView/Utilities.h
+++ b/Libraries/LibWebView/Utilities.h
@@ -12,6 +12,7 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibWeb/Forward.h>
 #include <LibWebView/Forward.h>
 
 namespace WebView {
@@ -26,6 +27,8 @@ WEBVIEW_API void set_mach_server_name(ByteString name);
 WEBVIEW_API ByteString mach_server_name_for_process(StringView process_name, pid_t pid);
 
 WEBVIEW_API ErrorOr<void> handle_attached_debugger();
+
+WEBVIEW_API ErrorOr<Web::HTML::SelectedFile> create_selected_file(ByteString const&);
 
 ErrorOr<JsonObject> read_json_file(ByteString const& path);
 ErrorOr<void> write_json_file(ByteString const& path, JsonValue const& value);

--- a/UI/AppKit/Interface/Event.mm
+++ b/UI/AppKit/Interface/Event.mm
@@ -9,6 +9,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/UIEvents/KeyCode.h>
+#include <LibWebView/Utilities.h>
 
 #import <Carbon/Carbon.h>
 #import <Interface/Event.h>
@@ -103,7 +104,7 @@ Web::DragEvent ns_event_to_drag_event(Web::DragEvent::Type type, id<NSDraggingIn
 
     if (type == Web::DragEvent::Type::DragStart) {
         for_each_file([&](ByteString const& file_path) {
-            if (auto file = Web::HTML::SelectedFile::from_file_path(file_path); file.is_error())
+            if (auto file = WebView::create_selected_file(file_path); file.is_error())
                 warnln("Unable to open file {}: {}", file_path, file.error());
             else
                 files.append(file.release_value());

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -9,6 +9,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/Utilities.h>
 
 #import <Application/ApplicationDelegate.h>
 #import <Interface/Event.h>
@@ -741,7 +742,7 @@ struct HideCursor {
                           auto create_selected_file = [&](NSString* ns_file_path) {
                               auto file_path = Ladybird::ns_string_to_byte_string(ns_file_path);
 
-                              if (auto file = Web::HTML::SelectedFile::from_file_path(file_path); file.is_error())
+                              if (auto file = WebView::create_selected_file(file_path); file.is_error())
                                   warnln("Unable to open file {}: {}", file_path, file.error());
                               else
                                   selected_files.append(file.release_value());

--- a/UI/Gtk/Dialogs.cpp
+++ b/UI/Gtk/Dialogs.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWebView/Utilities.h>
 #include <UI/Gtk/Dialogs.h>
 #include <UI/Gtk/GLibPtr.h>
 #include <UI/Gtk/WebContentView.h>
@@ -175,8 +176,7 @@ void show_file_picker(GtkWindow* parent, WebContentView* view, Web::HTML::FileFi
                     GObjectPtr file { g_list_model_get_item(G_LIST_MODEL(file_list), i) };
                     g_autofree char* path = g_file_get_path(G_FILE(file.ptr()));
                     if (path) {
-                        auto selected_file = Web::HTML::SelectedFile::from_file_path(ByteString(path));
-                        if (!selected_file.is_error())
+                        if (auto selected_file = WebView::create_selected_file(ByteString(path)); !selected_file.is_error())
                             selected.append(selected_file.release_value());
                     }
                 }
@@ -195,8 +195,7 @@ void show_file_picker(GtkWindow* parent, WebContentView* view, Web::HTML::FileFi
                 Vector<Web::HTML::SelectedFile> selected;
                 g_autofree char* path = g_file_get_path(file);
                 if (path) {
-                    auto selected_file = Web::HTML::SelectedFile::from_file_path(ByteString(path));
-                    if (!selected_file.is_error())
+                    if (auto selected_file = WebView::create_selected_file(ByteString(path)); !selected_file.is_error())
                         selected.append(selected_file.release_value());
                 }
                 view->file_picker_closed(move(selected)); }, view);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -9,6 +9,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/Utilities.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
@@ -317,7 +318,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         auto create_selected_file = [&](auto const& qfile_path) {
             auto file_path = ak_byte_string_from_qstring(qfile_path);
 
-            if (auto file = Web::HTML::SelectedFile::from_file_path(file_path); file.is_error())
+            if (auto file = WebView::create_selected_file(file_path); file.is_error())
                 warnln("Unable to open file {}: {}", file_path, file.error());
             else
                 selected_files.append(file.release_value());

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/StringUtils.h>
@@ -863,7 +864,7 @@ void WebContentView::enqueue_native_event(Web::DragEvent::Type type, QDropEvent 
         for (auto const& url : event.mimeData()->urls()) {
             auto file_path = ak_byte_string_from_qstring(url.toLocalFile());
 
-            if (auto file = Web::HTML::SelectedFile::from_file_path(file_path); file.is_error())
+            if (auto file = WebView::create_selected_file(file_path); file.is_error())
                 warnln("Unable to open file {}: {}", file_path, file.error());
             else
                 files.append(file.release_value());


### PR DESCRIPTION
There is a spec to allow doing so via the `webkitdirectory` attribute:
https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory

Until we implement this spec, disallow transferring directories.

Fixes #9514

<img width="1332" height="1060" alt="dnd" src="https://github.com/user-attachments/assets/bf3e048e-a747-4905-81ba-46d2f7a514cf" />
