### PR TITLE
LibWeb: Preserve overflowing grid content center alignment

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2026,7 +2026,13 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
         CSSPixels start_offset = 0;
         CSSPixels end_offset = 0;
-        if (alignment == Alignment::Center || alignment == Alignment::SpaceAround || alignment == Alignment::SpaceEvenly) {
+        if (alignment == Alignment::Center) {
+            // CSS Align's automatic overflow alignment is unsafe for grid content
+            // alignment, so preserve negative free space here.
+            auto free_space = grid_container_size - sum_of_base_sizes_including_gaps;
+            start_offset = free_space / 2;
+            end_offset = free_space / 2;
+        } else if (alignment == Alignment::SpaceAround || alignment == Alignment::SpaceEvenly) {
             auto free_space = grid_container_size - sum_of_base_sizes_including_gaps;
             free_space = max(free_space, 0);
             start_offset = free_space / 2;
@@ -2293,7 +2299,12 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
             auto alignment = dimension == GridDimension::Column
                 ? to_alignment(grid_container().computed_values().justify_content())
                 : to_alignment(grid_container().computed_values().align_content());
-            if (alignment == Alignment::Center || alignment == Alignment::SpaceAround || alignment == Alignment::SpaceEvenly) {
+            if (alignment == Alignment::Center) {
+                // CSS Align's automatic overflow alignment is unsafe for grid content
+                // alignment, so preserve negative free space here.
+                auto free_space = grid_container_size.to_px_or_zero() - sum_of_base_sizes_including_gaps;
+                offset = free_space / 2;
+            } else if (alignment == Alignment::SpaceAround || alignment == Alignment::SpaceEvenly) {
                 auto free_space = grid_container_size.to_px_or_zero() - sum_of_base_sizes_including_gaps;
                 offset = max(free_space, 0) / 2;
             } else if (alignment == Alignment::End) {

--- a/Tests/LibWeb/Text/expected/grid/content-alignment-overflow.txt
+++ b/Tests/LibWeb/Text/expected/grid/content-alignment-overflow.txt
@@ -1,0 +1,4 @@
+left: 10.0
+top: 10.0
+right: 30.0
+bottom: 30.0

--- a/Tests/LibWeb/Text/input/grid/content-alignment-overflow.html
+++ b/Tests/LibWeb/Text/input/grid/content-alignment-overflow.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.grid {
+    display: grid;
+    width: 40px;
+    height: 40px;
+    padding: 15px;
+    box-sizing: border-box;
+    justify-content: center;
+    align-content: center;
+}
+
+.item {
+    width: 20px;
+    height: 20px;
+}
+</style>
+<div class="grid"><div id="item" class="item"></div></div>
+<script>
+test(() => {
+    const rect = document.getElementById("item").getBoundingClientRect();
+    println(`left: ${rect.left.toFixed(1)}`);
+    println(`top: ${rect.top.toFixed(1)}`);
+    println(`right: ${rect.right.toFixed(1)}`);
+    println(`bottom: ${rect.bottom.toFixed(1)}`);
+});
+</script>


### PR DESCRIPTION
Let centered grid content alignment use signed free space when grid tracks overflow the grid container content box. CSS Align defaults this case to unsafe overflow alignment, while distributed alignment values keep their safe fallback behavior.

Add a text test covering an oversized centered grid inside a padded grid container.

Visual progression on GitHub repo stargazer buttons:

Before:
<img width="153" height="35" alt="Screenshot 2026-05-20 at 20 21 32" src="https://github.com/user-attachments/assets/5c7aac43-4102-4ea8-93ff-8852280a46dd" />

After:
<img width="151" height="36" alt="Screenshot 2026-05-20 at 20 21 48" src="https://github.com/user-attachments/assets/26b13987-aa73-4c6a-b4d0-2f1a302f75ac" />
