### PR TITLE
LibWeb: Unify WebIDL C++ type generation 

### DIFF
--- a/Libraries/LibGC/Forward.h
+++ b/Libraries/LibGC/Forward.h
@@ -31,6 +31,12 @@ class HeapHashTable;
 template<class T>
 class Root;
 
+template<class T>
+class Ref;
+
+template<class T>
+class Ptr;
+
 template<class T, size_t inline_capacity = 0>
 class ConservativeVector;
 

--- a/Libraries/LibGC/RootHashMap.h
+++ b/Libraries/LibGC/RootHashMap.h
@@ -11,6 +11,7 @@
 #include <LibGC/Cell.h>
 #include <LibGC/Forward.h>
 #include <LibGC/HeapRoot.h>
+#include <LibGC/Rootable.h>
 
 namespace GC {
 
@@ -49,24 +50,15 @@ public:
 
     virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
     {
-        static constexpr bool KeyIsGCType = IsBaseOf<NanBoxedValue, K> || IsConvertible<K, Cell const*>;
-        static constexpr bool ValueIsGCType = IsBaseOf<NanBoxedValue, V> || IsConvertible<V, Cell const*>;
+        static constexpr bool KeyIsGCType = Detail::RootableValueTraits<K>::is_rootable;
+        static constexpr bool ValueIsGCType = Detail::RootableValueTraits<V>::is_rootable;
         static_assert(KeyIsGCType || ValueIsGCType,
             "RootHashMap requires at least one of key or value types to be convertible to Cell const* or derive from NanBoxedValue");
         for (auto& [key, value] : *this) {
-            if constexpr (IsBaseOf<NanBoxedValue, K>) {
-                if (key.is_cell())
-                    roots.set(&const_cast<K&>(key).as_cell(), HeapRoot { .type = HeapRoot::Type::RootHashMap });
-            } else if constexpr (IsConvertible<K, Cell const*>) {
-                roots.set(const_cast<Cell*>(static_cast<Cell const*>(key)), HeapRoot { .type = HeapRoot::Type::RootHashMap });
-            }
-
-            if constexpr (IsBaseOf<NanBoxedValue, V>) {
-                if (value.is_cell())
-                    roots.set(&const_cast<V&>(value).as_cell(), HeapRoot { .type = HeapRoot::Type::RootHashMap });
-            } else if constexpr (IsConvertible<V, Cell const*>) {
-                roots.set(const_cast<Cell*>(static_cast<Cell const*>(value)), HeapRoot { .type = HeapRoot::Type::RootHashMap });
-            }
+            if constexpr (KeyIsGCType)
+                Detail::gather_root(roots, key, HeapRoot::Type::RootHashMap);
+            if constexpr (ValueIsGCType)
+                Detail::gather_root(roots, value, HeapRoot::Type::RootHashMap);
         }
     }
 };

--- a/Libraries/LibGC/RootHashTable.h
+++ b/Libraries/LibGC/RootHashTable.h
@@ -12,6 +12,7 @@
 #include <LibGC/Cell.h>
 #include <LibGC/Forward.h>
 #include <LibGC/HeapRoot.h>
+#include <LibGC/Rootable.h>
 
 namespace GC {
 
@@ -48,16 +49,10 @@ public:
 
     virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
     {
-        static_assert(IsBaseOf<NanBoxedValue, T> || IsConvertible<T, Cell const*>,
+        static_assert(Detail::RootableValueTraits<T>::is_rootable,
             "RootHashTable element type must be convertible to Cell const* or derive from NanBoxedValue");
-        for (auto& value : *this) {
-            if constexpr (IsBaseOf<NanBoxedValue, T>) {
-                if (value.is_cell())
-                    roots.set(&const_cast<T&>(value).as_cell(), HeapRoot { .type = HeapRoot::Type::RootHashTable });
-            } else if constexpr (IsConvertible<T, Cell const*>) {
-                roots.set(const_cast<Cell*>(static_cast<Cell const*>(value)), HeapRoot { .type = HeapRoot::Type::RootHashTable });
-            }
-        }
+        for (auto& value : *this)
+            Detail::gather_root(roots, value, HeapRoot::Type::RootHashTable);
     }
 };
 

--- a/Libraries/LibGC/RootVector.h
+++ b/Libraries/LibGC/RootVector.h
@@ -13,6 +13,7 @@
 #include <LibGC/Cell.h>
 #include <LibGC/Forward.h>
 #include <LibGC/HeapRoot.h>
+#include <LibGC/Rootable.h>
 
 namespace GC {
 
@@ -86,16 +87,10 @@ public:
 
     virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
     {
-        static_assert(IsBaseOf<NanBoxedValue, T> || IsConvertible<T, Cell const*>,
+        static_assert(Detail::RootableValueTraits<T>::is_rootable,
             "RootVector element type must be convertible to Cell const* or derive from NanBoxedValue");
-        for (auto& value : *this) {
-            if constexpr (IsBaseOf<NanBoxedValue, T>) {
-                if (value.is_cell())
-                    roots.set(&const_cast<T&>(value).as_cell(), HeapRoot { .type = HeapRoot::Type::RootVector });
-            } else if constexpr (IsConvertible<T, Cell const*>) {
-                roots.set(const_cast<Cell*>(static_cast<Cell const*>(value)), HeapRoot { .type = HeapRoot::Type::RootVector });
-            }
-        }
+        for (auto& value : *this)
+            Detail::gather_root(roots, value, HeapRoot::Type::RootVector);
     }
 };
 

--- a/Libraries/LibGC/Rootable.h
+++ b/Libraries/LibGC/Rootable.h
@@ -8,6 +8,7 @@
 
 #include <LibGC/Cell.h>
 #include <LibGC/HeapRoot.h>
+#include <LibGC/Ptr.h>
 
 namespace GC::Detail {
 
@@ -25,6 +26,26 @@ struct RootableValueTraits {
         }
 
         return nullptr;
+    }
+};
+
+template<typename T>
+struct RootableValueTraits<Ref<T>> {
+    static constexpr bool is_rootable = true;
+
+    static Cell* cell(Ref<T> const& value)
+    {
+        return const_cast<Cell*>(reinterpret_cast<Cell const*>(value.ptr()));
+    }
+};
+
+template<typename T>
+struct RootableValueTraits<Ptr<T>> {
+    static constexpr bool is_rootable = true;
+
+    static Cell* cell(Ptr<T> const& value)
+    {
+        return const_cast<Cell*>(reinterpret_cast<Cell const*>(value.ptr()));
     }
 };
 

--- a/Libraries/LibGC/Rootable.h
+++ b/Libraries/LibGC/Rootable.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/Cell.h>
+#include <LibGC/HeapRoot.h>
+
+namespace GC::Detail {
+
+template<typename T>
+struct RootableValueTraits {
+    static constexpr bool is_rootable = IsBaseOf<NanBoxedValue, T> || IsConvertible<T, Cell const*>;
+
+    static Cell* cell(T const& value)
+    {
+        if constexpr (IsBaseOf<NanBoxedValue, T>) {
+            if (value.is_cell())
+                return &const_cast<T&>(value).as_cell();
+        } else if constexpr (IsConvertible<T, Cell const*>) {
+            return const_cast<Cell*>(static_cast<Cell const*>(value));
+        }
+
+        return nullptr;
+    }
+};
+
+template<typename T>
+static void gather_root(HashMap<Cell*, GC::HeapRoot>& roots, T const& value, HeapRoot::Type root_type)
+{
+    if (auto* cell = RootableValueTraits<T>::cell(value))
+        roots.set(cell, HeapRoot { .type = root_type });
+}
+
+}

--- a/Libraries/LibIDL/Types.h
+++ b/Libraries/LibIDL/Types.h
@@ -30,16 +30,6 @@ static size_t get_function_shortest_length(FunctionType& function)
     return length;
 }
 
-enum class SequenceStorageType {
-    Vector,     // Used to safely store non-JS values
-    RootVector, // Used to safely store JS::Value and anything that inherits JS::Cell, e.g. JS::Object
-};
-
-struct CppType {
-    ByteString name;
-    SequenceStorageType sequence_storage_type;
-};
-
 class Context;
 class ParameterizedType;
 class UnionType;

--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -26,7 +26,7 @@ struct Animatable::Transition {
 Animatable::Impl::~Impl() = default;
 
 // https://www.w3.org/TR/web-animations-1/#dom-animatable-animate
-WebIDL::ExceptionOr<GC::Ref<Animation>> Animatable::animate(Optional<GC::Root<JS::Object>> keyframes, Variant<Empty, double, Bindings::KeyframeAnimationOptions> const& options)
+WebIDL::ExceptionOr<GC::Ref<Animation>> Animatable::animate(GC::Ptr<JS::Object> keyframes, Variant<Empty, double, Bindings::KeyframeAnimationOptions> const& options)
 {
     // 1. Let target be the object on which this method was called.
     GC::Ref target { *static_cast<DOM::Element*>(this) };
@@ -46,7 +46,7 @@ WebIDL::ExceptionOr<GC::Ref<Animation>> Animatable::animate(Optional<GC::Root<JS
     //    on which this method was called.
     Optional<GC::Ptr<AnimationTimeline>> timeline;
     if (options.has<Bindings::KeyframeAnimationOptions>() && options.get<Bindings::KeyframeAnimationOptions>().timeline.has_value())
-        timeline = options.get<Bindings::KeyframeAnimationOptions>().timeline->ptr();
+        timeline = options.get<Bindings::KeyframeAnimationOptions>().timeline.value();
     if (!timeline.has_value())
         timeline = target->document().timeline();
 

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -39,7 +39,7 @@ public:
         Yes
     };
 
-    WebIDL::ExceptionOr<GC::Ref<Animation>> animate(Optional<GC::Root<JS::Object>> keyframes, Variant<Empty, double, Bindings::KeyframeAnimationOptions> const& options = {});
+    WebIDL::ExceptionOr<GC::Ref<Animation>> animate(GC::Ptr<JS::Object> keyframes, Variant<Empty, double, Bindings::KeyframeAnimationOptions> const& options = {});
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations(Optional<Bindings::GetAnimationsOptions> const& options = {});
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations_internal(GetAnimationsSorted sorted, Optional<Bindings::GetAnimationsOptions> const& options = {});
 

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -225,7 +225,7 @@ WebIDL::ExceptionOr<Optional<TimeValue>> Animation::validate_a_css_numberish_tim
         m_timeline && m_timeline->is_progress_based() &&
 
         // time is not a CSSNumeric value with percent units:
-        (!time.has<GC::Root<CSS::CSSNumericValue>>() || !time.get<GC::Root<CSS::CSSNumericValue>>()->type().matches_percentage())) {
+        (!time.has<GC::Ref<CSS::CSSNumericValue>>() || !time.get<GC::Ref<CSS::CSSNumericValue>>()->type().matches_percentage())) {
         // throw a TypeError.
         // return false;
         return WebIDL::SimpleException {
@@ -240,14 +240,14 @@ WebIDL::ExceptionOr<Optional<TimeValue>> Animation::validate_a_css_numberish_tim
         (!m_timeline || !m_timeline->is_progress_based()) &&
 
         // time is a CSSNumericValue, and
-        time.has<GC::Root<CSS::CSSNumericValue>>() &&
+        time.has<GC::Ref<CSS::CSSNumericValue>>() &&
 
         // the units of time are not duration units:
-        !time.get<GC::Root<CSS::CSSNumericValue>>()->type().matches_time({}) &&
+        !time.get<GC::Ref<CSS::CSSNumericValue>>()->type().matches_time({}) &&
 
         // AD-HOC: While it's not mentioned in the spec WPT also expects us to support CSSNumericValue number value, see
         //         https://github.com/w3c/csswg-drafts/issues/13196
-        !time.get<GC::Root<CSS::CSSNumericValue>>()->type().matches_number({})) {
+        !time.get<GC::Ref<CSS::CSSNumericValue>>()->type().matches_number({})) {
         // throw a TypeError.
         // return false.
         return WebIDL::SimpleException {
@@ -266,7 +266,7 @@ WebIDL::ExceptionOr<Optional<TimeValue>> Animation::validate_a_css_numberish_tim
 
     // FIXME: Figure out which element we should use for this, for now we just use the document element of the current
     //        window
-    return TimeValue::from_css_numberish(time.downcast<double, GC::Root<CSS::CSSNumericValue>>(), DOM::AbstractElement { *as<HTML::Window>(realm().global_object()).associated_document().document_element() });
+    return TimeValue::from_css_numberish(time.downcast<double, GC::Ref<CSS::CSSNumericValue>>(), DOM::AbstractElement { *as<HTML::Window>(realm().global_object()).associated_document().document_element() });
 
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -72,7 +72,7 @@ Bindings::OptionalEffectTiming to_optional_effect_timing(Bindings::EffectTiming 
             [](double const& value) -> Variant<double, String> { return value; },
             [](String const& value) -> Variant<double, String> { return value; },
             // NB: We check that this isn't the case in the caller
-            [](GC::Root<CSS::CSSNumericValue> const&) -> Variant<double, String> { VERIFY_NOT_REACHED(); }),
+            [](GC::Ref<CSS::CSSNumericValue>) -> Variant<double, String> { VERIFY_NOT_REACHED(); }),
         .easing = effect_timing.easing,
         .end_delay = effect_timing.end_delay,
         .fill = effect_timing.fill,

--- a/Libraries/LibWeb/Animations/AnimationPlaybackEvent.cpp
+++ b/Libraries/LibWeb/Animations/AnimationPlaybackEvent.cpp
@@ -25,18 +25,10 @@ WebIDL::ExceptionOr<GC::Ref<AnimationPlaybackEvent>> AnimationPlaybackEvent::con
     return create(realm, type, event_init);
 }
 
-AnimationPlaybackEvent::CSSNumberishInternal AnimationPlaybackEvent::to_numberish_internal(NullableCSSNumberish const& numberish_root)
-{
-    return numberish_root.visit(
-        [](Empty) -> CSSNumberishInternal { return Empty {}; },
-        [](GC::Root<CSS::CSSNumericValue> const& root) -> CSSNumberishInternal { return GC::Ref { *root }; },
-        [](auto const& other) -> CSSNumberishInternal { return other; });
-}
-
 AnimationPlaybackEvent::AnimationPlaybackEvent(JS::Realm& realm, FlyString const& type, Bindings::AnimationPlaybackEventInit const& event_init)
     : DOM::Event(realm, type, event_init)
-    , m_current_time(to_numberish_internal(event_init.current_time))
-    , m_timeline_time(to_numberish_internal(event_init.timeline_time))
+    , m_current_time(event_init.current_time)
+    , m_timeline_time(event_init.timeline_time)
 {
 }
 
@@ -53,21 +45,14 @@ void AnimationPlaybackEvent::visit_edges(Visitor& visitor)
     visitor.visit(m_timeline_time);
 }
 
-NullableCSSNumberish AnimationPlaybackEvent::to_nullable_numberish(CSSNumberishInternal const& numberish)
-{
-    return numberish.visit(
-        [](GC::Ref<CSS::CSSNumericValue> const& ref) -> NullableCSSNumberish { return GC::Root { *ref }; },
-        [](auto const& other) -> NullableCSSNumberish { return other; });
-}
-
 NullableCSSNumberish AnimationPlaybackEvent::current_time() const
 {
-    return to_nullable_numberish(m_current_time);
+    return m_current_time;
 }
 
 NullableCSSNumberish AnimationPlaybackEvent::timeline_time() const
 {
-    return to_nullable_numberish(m_timeline_time);
+    return m_timeline_time;
 }
 
 }

--- a/Libraries/LibWeb/Animations/AnimationPlaybackEvent.h
+++ b/Libraries/LibWeb/Animations/AnimationPlaybackEvent.h
@@ -34,15 +34,11 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;
 
-    using CSSNumberishInternal = Variant<Empty, double, GC::Ref<CSS::CSSNumericValue>>;
-    static CSSNumberishInternal to_numberish_internal(NullableCSSNumberish const&);
-    static NullableCSSNumberish to_nullable_numberish(CSSNumberishInternal const&);
-
     // https://drafts.csswg.org/web-animations-2/#dom-animationplaybackevent-currenttime
-    CSSNumberishInternal m_current_time;
+    NullableCSSNumberish m_current_time;
 
     // https://drafts.csswg.org/web-animations-2/#dom-animationplaybackevent-timelinetime
-    CSSNumberishInternal m_timeline_time;
+    NullableCSSNumberish m_timeline_time;
 };
 
 }

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -664,8 +664,8 @@ GC::Ref<KeyframeEffect> KeyframeEffect::create(JS::Realm& realm)
 // https://www.w3.org/TR/web-animations-1/#dom-keyframeeffect-keyframeeffect
 WebIDL::ExceptionOr<GC::Ref<KeyframeEffect>> KeyframeEffect::construct_impl(
     JS::Realm& realm,
-    GC::Root<DOM::Element> const& target,
-    Optional<GC::Root<JS::Object>> const& keyframes,
+    GC::Ptr<DOM::Element> target,
+    GC::Ptr<JS::Object> keyframes,
     Variant<double, Bindings::KeyframeEffectOptions> options)
 {
     // 1. Create a new KeyframeEffect object, effect.
@@ -711,7 +711,7 @@ WebIDL::ExceptionOr<GC::Ref<KeyframeEffect>> KeyframeEffect::construct_impl(
     //       returned as a CSSNumericValue when resolving the duration in getComputedTiming(). Future versions of
     //       the spec may enable setting the duration as a CSSNumeric value, where the unit is a valid time unit or
     //       percent.
-    if (timing_input.duration.has<GC::Root<CSS::CSSNumericValue>>())
+    if (timing_input.duration.has<GC::Ref<CSS::CSSNumericValue>>())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Setting duration as a CSSNumericValue is not supported"sv };
 
     // 5. Call the procedure to update the timing properties of an animation effect of effect from timing input.
@@ -894,10 +894,10 @@ WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> KeyframeEffect::get_keyframes()
 }
 
 // https://www.w3.org/TR/web-animations-1/#dom-keyframeeffect-setkeyframes
-WebIDL::ExceptionOr<void> KeyframeEffect::set_keyframes(Optional<GC::Root<JS::Object>> const& keyframe_object)
+WebIDL::ExceptionOr<void> KeyframeEffect::set_keyframes(GC::Ptr<JS::Object> keyframe_object)
 {
     m_keyframe_objects.clear();
-    m_keyframes = TRY(process_a_keyframes_argument(realm(), keyframe_object.has_value() ? GC::Ptr { keyframe_object->ptr() } : GC::Ptr<Object> {}));
+    m_keyframes = TRY(process_a_keyframes_argument(realm(), keyframe_object));
     // FIXME: After processing the keyframe argument, we need to turn the set of keyframes into a set of computed
     //        keyframes using the procedure outlined in the second half of
     //        https://www.w3.org/TR/web-animations-1/#calculating-computed-keyframes. For now, just compute the

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -76,8 +76,8 @@ public:
 
     static WebIDL::ExceptionOr<GC::Ref<KeyframeEffect>> construct_impl(
         JS::Realm&,
-        GC::Root<DOM::Element> const& target,
-        Optional<GC::Root<JS::Object>> const& keyframes,
+        GC::Ptr<DOM::Element> target,
+        GC::Ptr<JS::Object> keyframes,
         Variant<double, Bindings::KeyframeEffectOptions> options = Bindings::KeyframeEffectOptions {});
 
     static WebIDL::ExceptionOr<GC::Ref<KeyframeEffect>> construct_impl(JS::Realm&, GC::Ref<KeyframeEffect> source);
@@ -99,7 +99,7 @@ public:
     void set_composite(Bindings::CompositeOperation value);
 
     WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> get_keyframes();
-    WebIDL::ExceptionOr<void> set_keyframes(Optional<GC::Root<JS::Object>> const&);
+    WebIDL::ExceptionOr<void> set_keyframes(GC::Ptr<JS::Object>);
 
     KeyFrameSet const* key_frame_set() { return m_key_frame_set; }
     void set_key_frame_set(RefPtr<KeyFrameSet const> key_frame_set) { m_key_frame_set = key_frame_set; }

--- a/Libraries/LibWeb/Animations/ScrollTimeline.cpp
+++ b/Libraries/LibWeb/Animations/ScrollTimeline.cpp
@@ -36,7 +36,7 @@ GC::Ref<ScrollTimeline> ScrollTimeline::construct_impl(JS::Realm& realm, Binding
         // If the source member of options is present,
         // The source member of options.
         if (options.source.has_value())
-            return options.source.value().ptr();
+            return options.source.value();
 
         // Otherwise,
         // The scrollingElement of the Document associated with the Window that is the current global object.

--- a/Libraries/LibWeb/Animations/TimeValue.cpp
+++ b/Libraries/LibWeb/Animations/TimeValue.cpp
@@ -16,7 +16,7 @@ TimeValue TimeValue::from_css_numberish(CSS::CSSNumberish const& time, DOM::Abst
     if (time.has<double>())
         return { Type::Milliseconds, time.get<double>() };
 
-    auto const& numeric_value = time.get<GC::Root<CSS::CSSNumericValue>>();
+    auto const& numeric_value = time.get<GC::Ref<CSS::CSSNumericValue>>();
 
     // NB: Skip creating a calculation node for simple unit values
     if (auto const* unit_value = as_if<CSS::CSSUnitValue>(*numeric_value)) {
@@ -70,7 +70,7 @@ CSS::CSSNumberish TimeValue::as_css_numberish(JS::Realm& realm) const
         return value;
     case Type::Percentage:
         GC::Ref<CSS::CSSNumericValue> numeric_value = CSS::CSSUnitValue::create(realm, value, "percent"_fly_string);
-        return GC::Root { numeric_value };
+        return numeric_value;
     }
 
     VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/PromiseRejectionEvent.h>
 #include <LibWeb/Bindings/WindowExposedInterfaces.h>
 #include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h>

--- a/Libraries/LibWeb/CSS/CSSKeywordValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSKeywordValue.cpp
@@ -124,8 +124,8 @@ GC::Ref<CSSKeywordValue> rectify_a_keywordish_value(JS::Realm& realm, CSSKeyword
     // To rectify a keywordish value val, perform the following steps:
     return keywordish.visit(
         // 1. If val is a CSSKeywordValue, return val.
-        [](GC::Root<CSSKeywordValue> const& value) -> GC::Ref<CSSKeywordValue> {
-            return *value;
+        [](GC::Ref<CSSKeywordValue> const& value) -> GC::Ref<CSSKeywordValue> {
+            return value;
         },
 
         // 2. If val is a DOMString, return a new CSSKeywordValue with its value internal slot set to val.

--- a/Libraries/LibWeb/CSS/CSSKeywordValue.h
+++ b/Libraries/LibWeb/CSS/CSSKeywordValue.h
@@ -12,7 +12,7 @@
 namespace Web::CSS {
 
 // https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-csskeywordish
-using CSSKeywordish = Variant<String, GC::Root<CSSKeywordValue>>;
+using CSSKeywordish = Variant<String, GC::Ref<CSSKeywordValue>>;
 
 // https://drafts.css-houdini.org/css-typed-om-1/#csskeywordvalue
 class CSSKeywordValue final : public CSSStyleValue {

--- a/Libraries/LibWeb/CSS/CSSMathMin.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathMin.cpp
@@ -44,7 +44,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSMathMin>> CSSMathMin::add_all_types_into_math_min
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathmin-cssmathmin
-WebIDL::ExceptionOr<GC::Ref<CSSMathMin>> CSSMathMin::construct_impl(JS::Realm& realm, Vector<CSSNumberish> values)
+WebIDL::ExceptionOr<GC::Ref<CSSMathMin>> CSSMathMin::construct_impl(JS::Realm& realm, ReadonlySpan<CSSNumberish> values)
 {
     // The CSSMathMin(...args) and CSSMathMax(...args) constructors are defined identically to the above, except that
     // in the last step they return a new CSSMathMin or CSSMathMax object, respectively.

--- a/Libraries/LibWeb/CSS/CSSMathMin.h
+++ b/Libraries/LibWeb/CSS/CSSMathMin.h
@@ -17,7 +17,7 @@ class CSSMathMin final : public CSSMathValue {
 
 public:
     [[nodiscard]] static GC::Ref<CSSMathMin> create(JS::Realm&, NumericType, GC::Ref<CSSNumericArray>);
-    static WebIDL::ExceptionOr<GC::Ref<CSSMathMin>> construct_impl(JS::Realm&, Vector<CSSNumberish>);
+    static WebIDL::ExceptionOr<GC::Ref<CSSMathMin>> construct_impl(JS::Realm&, ReadonlySpan<CSSNumberish>);
     static WebIDL::ExceptionOr<GC::Ref<CSSMathMin>> add_all_types_into_math_min(JS::Realm&, GC::RootVector<GC::Ref<CSSNumericValue>> const&);
 
     virtual ~CSSMathMin() override;

--- a/Libraries/LibWeb/CSS/CSSMathProduct.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathProduct.cpp
@@ -43,7 +43,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSMathProduct>> CSSMathProduct::multiply_all_types_
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathproduct-cssmathproduct
-WebIDL::ExceptionOr<GC::Ref<CSSMathProduct>> CSSMathProduct::construct_impl(JS::Realm& realm, Vector<CSSNumberish> values)
+WebIDL::ExceptionOr<GC::Ref<CSSMathProduct>> CSSMathProduct::construct_impl(JS::Realm& realm, ReadonlySpan<CSSNumberish> values)
 {
     // The CSSMathProduct(...args) constructor is defined identically to the above, except that in step 3 it multiplies
     // the types instead of adding, and in the last step it returns a CSSMathProduct.

--- a/Libraries/LibWeb/CSS/CSSMathProduct.h
+++ b/Libraries/LibWeb/CSS/CSSMathProduct.h
@@ -17,7 +17,7 @@ class CSSMathProduct final : public CSSMathValue {
 
 public:
     [[nodiscard]] static GC::Ref<CSSMathProduct> create(JS::Realm&, NumericType, GC::Ref<CSSNumericArray>);
-    static WebIDL::ExceptionOr<GC::Ref<CSSMathProduct>> construct_impl(JS::Realm&, Vector<CSSNumberish>);
+    static WebIDL::ExceptionOr<GC::Ref<CSSMathProduct>> construct_impl(JS::Realm&, ReadonlySpan<CSSNumberish>);
     static WebIDL::ExceptionOr<GC::Ref<CSSMathProduct>> multiply_all_types_into_math_product(JS::Realm&, GC::RootVector<GC::Ref<CSSNumericValue>> const&);
 
     virtual ~CSSMathProduct() override;

--- a/Libraries/LibWeb/CSS/CSSMathSum.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathSum.cpp
@@ -43,7 +43,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSMathSum>> CSSMathSum::add_all_types_into_math_sum
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathsum-cssmathsum
-WebIDL::ExceptionOr<GC::Ref<CSSMathSum>> CSSMathSum::construct_impl(JS::Realm& realm, Vector<CSSNumberish> values)
+WebIDL::ExceptionOr<GC::Ref<CSSMathSum>> CSSMathSum::construct_impl(JS::Realm& realm, ReadonlySpan<CSSNumberish> values)
 {
     // The CSSMathSum(...args) constructor must, when called, perform the following steps:
 

--- a/Libraries/LibWeb/CSS/CSSMathSum.h
+++ b/Libraries/LibWeb/CSS/CSSMathSum.h
@@ -17,7 +17,7 @@ class CSSMathSum final : public CSSMathValue {
 
 public:
     [[nodiscard]] static GC::Ref<CSSMathSum> create(JS::Realm&, NumericType, GC::Ref<CSSNumericArray>);
-    static WebIDL::ExceptionOr<GC::Ref<CSSMathSum>> construct_impl(JS::Realm&, Vector<CSSNumberish>);
+    static WebIDL::ExceptionOr<GC::Ref<CSSMathSum>> construct_impl(JS::Realm&, ReadonlySpan<CSSNumberish>);
     static WebIDL::ExceptionOr<GC::Ref<CSSMathSum>> add_all_types_into_math_sum(JS::Realm&, GC::RootVector<GC::Ref<CSSNumericValue>> const&);
 
     virtual ~CSSMathSum() override;

--- a/Libraries/LibWeb/CSS/CSSNumericValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSNumericValue.cpp
@@ -63,7 +63,7 @@ void CSSNumericValue::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-static bool all_values_are_css_unit_values_with_the_same_unit(GC::RootVector<GC::Ref<CSSNumericValue>> const& values)
+static bool all_values_are_css_unit_values_with_the_same_unit(ReadonlySpan<GC::Ref<CSSNumericValue>> const& values)
 {
     VERIFY(!values.is_empty());
     return all_of(values, [&](auto& value) {
@@ -74,7 +74,7 @@ static bool all_values_are_css_unit_values_with_the_same_unit(GC::RootVector<GC:
 }
 
 template<typename Operation>
-static GC::Ref<CSSNumericValue> apply_math_operation_on_css_unit_values(JS::Realm& realm, GC::RootVector<GC::Ref<CSSNumericValue>> const& values, Operation&& operation)
+static GC::Ref<CSSNumericValue> apply_math_operation_on_css_unit_values(JS::Realm& realm, ReadonlySpan<GC::Ref<CSSNumericValue>> values, Operation&& operation)
 {
     auto& first_unit_value = as<CSSUnitValue>(*values[0]);
     auto& unit = first_unit_value.unit();
@@ -86,7 +86,7 @@ static GC::Ref<CSSNumericValue> apply_math_operation_on_css_unit_values(JS::Real
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-add
-WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::add(Vector<CSSNumberish> const& initial_values)
+WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::add(ReadonlySpan<CSSNumberish> initial_values)
 {
     auto& realm = this->realm();
 
@@ -118,7 +118,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::add(Vector<CSSNum
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-sub
-WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::sub(Vector<CSSNumberish> const& initial_values)
+WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::sub(ReadonlySpan<CSSNumberish> initial_values)
 {
     auto& realm = this->realm();
 
@@ -136,19 +136,19 @@ CSSNumberish CSSNumericValue::negate()
 {
     // 1. If this is a CSSMathNegate object, return this’s value internal slot.
     if (auto* negate = as_if<CSSMathNegate>(*this))
-        return GC::Root<CSSNumericValue> { negate->value().ptr() };
+        return GC::Ref<CSSNumericValue> { negate->value() };
 
     // 2. If this is a CSSUnitValue object, return a new CSSUnitValue with the same unit internal slot as this, and a
     //    value internal slot set to the negation of this’s.
     if (auto* unit_value = as_if<CSSUnitValue>(*this))
-        return GC::Root<CSSNumericValue> { CSSUnitValue::create(realm(), -unit_value->value(), unit_value->unit()).ptr() };
+        return GC::Ref<CSSNumericValue> { CSSUnitValue::create(realm(), -unit_value->value(), unit_value->unit()) };
 
     // 3. Otherwise, return a new CSSMathNegate object whose value internal slot is set to this.
-    return GC::Root<CSSNumericValue> { CSSMathNegate::construct_impl(realm(), GC::Root<CSSNumericValue> { this }).ptr() };
+    return GC::Ref<CSSNumericValue> { CSSMathNegate::construct_impl(realm(), GC::Ref<CSSNumericValue> { *this }) };
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-mul
-WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::mul(Vector<CSSNumberish> const& initial_values)
+WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::mul(ReadonlySpan<CSSNumberish> initial_values)
 {
     auto& realm = this->realm();
     // 1. Replace each item of values with the result of rectifying a numberish value for the item.
@@ -209,7 +209,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::mul(Vector<CSSNum
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-div
-WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::div(Vector<CSSNumberish> const& initial_values)
+WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::div(ReadonlySpan<CSSNumberish> initial_values)
 {
     auto& realm = this->realm();
 
@@ -227,7 +227,7 @@ WebIDL::ExceptionOr<CSSNumberish> CSSNumericValue::invert()
 {
     // 1. If this is a CSSMathInvert object, return this’s value internal slot.
     if (auto* invert = as_if<CSSMathInvert>(*this))
-        return GC::Root<CSSNumericValue> { invert->value().ptr() };
+        return CSSNumberish { GC::Ref<CSSNumericValue> { invert->value() } };
 
     // 2. If this is a CSSUnitValue object with unit internal slot set to "number":
     if (auto* unit_value = as_if<CSSUnitValue>(*this); unit_value && unit_value->unit() == "number"sv) {
@@ -237,15 +237,15 @@ WebIDL::ExceptionOr<CSSNumberish> CSSNumericValue::invert()
 
         // 2. Else return a new CSSUnitValue with the unit internal slot set to "number", and a value internal slot set
         //    to 1 divided by this’s {CSSUnitValue/value}} internal slot.
-        return GC::Root<CSSNumericValue> { CSSUnitValue::create(realm(), 1.0 / unit_value->value(), "number"_fly_string).ptr() };
+        return CSSNumberish { GC::Ref<CSSNumericValue> { CSSUnitValue::create(realm(), 1.0 / unit_value->value(), "number"_fly_string) } };
     }
 
     // 3. Otherwise, return a new CSSMathInvert object whose value internal slot is set to this.
-    return GC::Root<CSSNumericValue> { CSSMathInvert::construct_impl(realm(), GC::Root<CSSNumericValue> { this }).ptr() };
+    return CSSNumberish { GC::Ref<CSSNumericValue> { CSSMathInvert::construct_impl(realm(), GC::Ref<CSSNumericValue> { *this }) } };
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-min
-WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::min(Vector<CSSNumberish> const& initial_values)
+WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::min(ReadonlySpan<CSSNumberish> initial_values)
 {
     auto& realm = this->realm();
 
@@ -275,7 +275,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::min(Vector<CSSNum
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-max
-WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::max(Vector<CSSNumberish> const& initial_values)
+WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::max(ReadonlySpan<CSSNumberish> initial_values)
 {
     auto& realm = this->realm();
 
@@ -305,7 +305,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> CSSNumericValue::max(Vector<CSSNum
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssnumericvalue-equals
-bool CSSNumericValue::equals_for_bindings(Vector<CSSNumberish> values) const
+bool CSSNumericValue::equals_for_bindings(ReadonlySpan<CSSNumberish> values) const
 {
     // The equals(...values) method, when called on a CSSNumericValue this, must perform the following steps:
 
@@ -432,8 +432,8 @@ GC::Ref<CSSNumericValue> rectify_a_numberish_value(JS::Realm& realm, CSSNumberis
     // To rectify a numberish value num, optionally to a given unit unit (defaulting to "number"), perform the following steps:
     return numberish.visit(
         // 1. If num is a CSSNumericValue, return num.
-        [](GC::Root<CSSNumericValue> const& num) -> GC::Ref<CSSNumericValue> {
-            return GC::Ref { *num };
+        [](GC::Ref<CSSNumericValue> num) -> GC::Ref<CSSNumericValue> {
+            return num;
         },
         // 2. If num is a double, return a new CSSUnitValue with its value internal slot set to num and its unit
         //    internal slot set to unit.

--- a/Libraries/LibWeb/CSS/CSSNumericValue.h
+++ b/Libraries/LibWeb/CSS/CSSNumericValue.h
@@ -36,14 +36,14 @@ public:
     };
     virtual ~CSSNumericValue() override = default;
 
-    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> add(Vector<CSSNumberish> const&);
-    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> sub(Vector<CSSNumberish> const&);
-    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> mul(Vector<CSSNumberish> const&);
-    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> div(Vector<CSSNumberish> const&);
-    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> min(Vector<CSSNumberish> const&);
-    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> max(Vector<CSSNumberish> const&);
+    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> add(ReadonlySpan<CSSNumberish>);
+    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> sub(ReadonlySpan<CSSNumberish>);
+    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> mul(ReadonlySpan<CSSNumberish>);
+    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> div(ReadonlySpan<CSSNumberish>);
+    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> min(ReadonlySpan<CSSNumberish>);
+    WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> max(ReadonlySpan<CSSNumberish>);
 
-    bool equals_for_bindings(Vector<CSSNumberish>) const;
+    bool equals_for_bindings(ReadonlySpan<CSSNumberish>) const;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const = 0;
 
     WebIDL::ExceptionOr<GC::Ref<CSSUnitValue>> to(FlyString const& unit) const;

--- a/Libraries/LibWeb/CSS/CSSPerspective.cpp
+++ b/Libraries/LibWeb/CSS/CSSPerspective.cpp
@@ -24,7 +24,7 @@ static WebIDL::ExceptionOr<CSSPerspectiveValueInternal> to_internal(JS::Realm& r
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssperspective-cssperspective
     return value.visit(
         // 1. If length is a CSSNumericValue:
-        [](GC::Root<CSSNumericValue> const& numeric_value) -> WebIDL::ExceptionOr<CSSPerspectiveValueInternal> {
+        [](GC::Ref<CSSNumericValue> const& numeric_value) -> WebIDL::ExceptionOr<CSSPerspectiveValueInternal> {
             // 1. If length does not match <length>, throw a TypeError.
             if (!numeric_value->type().matches_length({})) {
                 return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "CSSPerspective length component doesn't match <length>"sv };
@@ -135,13 +135,7 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMMatrix>> CSSPerspective::to_matrix() co
 
 CSSPerspectiveValue CSSPerspective::length() const
 {
-    return m_length.visit(
-        [](GC::Ref<CSSNumericValue> const& numeric_value) -> CSSPerspectiveValue {
-            return GC::Root { numeric_value };
-        },
-        [](GC::Ref<CSSKeywordValue> const& keyword_value) -> CSSPerspectiveValue {
-            return CSSKeywordish { keyword_value };
-        });
+    return m_length;
 }
 
 WebIDL::ExceptionOr<void> CSSPerspective::set_length(CSSPerspectiveValue value)

--- a/Libraries/LibWeb/CSS/CSSPerspective.h
+++ b/Libraries/LibWeb/CSS/CSSPerspective.h
@@ -14,7 +14,7 @@ namespace Web::CSS {
 
 // https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-cssperspectivevalue
 // NB: CSSKeywordish is flattened here, because our bindings generator flattens nested variants.
-using CSSPerspectiveValue = Variant<GC::Root<CSSNumericValue>, String, GC::Root<CSSKeywordValue>>;
+using CSSPerspectiveValue = Variant<GC::Ref<CSSNumericValue>, String, GC::Ref<CSSKeywordValue>>;
 using CSSPerspectiveValueInternal = Variant<GC::Ref<CSSNumericValue>, GC::Ref<CSSKeywordValue>>;
 
 // https://drafts.css-houdini.org/css-typed-om-1/#cssperspective

--- a/Libraries/LibWeb/CSS/CSSRotate.h
+++ b/Libraries/LibWeb/CSS/CSSRotate.h
@@ -27,9 +27,9 @@ public:
 
     virtual WebIDL::ExceptionOr<GC::Ref<Geometry::DOMMatrix>> to_matrix() const override;
 
-    CSSNumberish x() const { return GC::Root { m_x }; }
-    CSSNumberish y() const { return GC::Root { m_y }; }
-    CSSNumberish z() const { return GC::Root { m_z }; }
+    CSSNumberish x() const { return m_x; }
+    CSSNumberish y() const { return m_y; }
+    CSSNumberish z() const { return m_z; }
     GC::Ref<CSSNumericValue> angle() const { return m_angle; }
     WebIDL::ExceptionOr<void> set_x(CSSNumberish value);
     WebIDL::ExceptionOr<void> set_y(CSSNumberish value);

--- a/Libraries/LibWeb/CSS/CSSScale.h
+++ b/Libraries/LibWeb/CSS/CSSScale.h
@@ -26,9 +26,9 @@ public:
 
     virtual WebIDL::ExceptionOr<GC::Ref<Geometry::DOMMatrix>> to_matrix() const override;
 
-    CSSNumberish x() const { return GC::Root { m_x }; }
-    CSSNumberish y() const { return GC::Root { m_y }; }
-    CSSNumberish z() const { return GC::Root { m_z }; }
+    CSSNumberish x() const { return m_x; }
+    CSSNumberish y() const { return m_y; }
+    CSSNumberish z() const { return m_z; }
     WebIDL::ExceptionOr<void> set_x(CSSNumberish value);
     WebIDL::ExceptionOr<void> set_y(CSSNumberish value);
     WebIDL::ExceptionOr<void> set_z(CSSNumberish value);

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -92,7 +92,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> CSSStyleSheet::construct_impl(JS::Re
         if (options->media.has<String>()) {
             sheet->set_media(options->media.get<String>());
         } else {
-            sheet->m_media = *options->media.get<GC::Root<MediaList>>();
+            sheet->m_media = *options->media.get<GC::Ref<MediaList>>();
         }
     }
 

--- a/Libraries/LibWeb/CSS/CSSTransformValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransformValue.cpp
@@ -18,13 +18,17 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSTransformValue);
 
-GC::Ref<CSSTransformValue> CSSTransformValue::create(JS::Realm& realm, Vector<GC::Ref<CSSTransformComponent>> transforms)
+GC::Ref<CSSTransformValue> CSSTransformValue::create(JS::Realm& realm, ReadonlySpan<GC::Ref<CSSTransformComponent>> transforms)
 {
-    return realm.create<CSSTransformValue>(realm, move(transforms));
+    Vector<GC::Ref<CSSTransformComponent>> converted_transforms;
+    converted_transforms.ensure_capacity(transforms.size());
+    for (auto const& transform : transforms)
+        converted_transforms.append(transform);
+    return realm.create<CSSTransformValue>(realm, move(converted_transforms));
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-csstransformvalue-csstransformvalue
-WebIDL::ExceptionOr<GC::Ref<CSSTransformValue>> CSSTransformValue::construct_impl(JS::Realm& realm, Vector<GC::Root<CSSTransformComponent>> const& transforms)
+WebIDL::ExceptionOr<GC::Ref<CSSTransformValue>> CSSTransformValue::construct_impl(JS::Realm& realm, ReadonlySpan<GC::Ref<CSSTransformComponent>> const& transforms)
 {
     // The CSSTransformValue(transforms) constructor must, when called, perform the following steps:
 
@@ -33,11 +37,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSTransformValue>> CSSTransformValue::construct_imp
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "CSSTransformValue's transforms list cannot be empty."sv };
 
     // 2. Return a new CSSTransformValue whose values to iterate over is transforms.
-    Vector<GC::Ref<CSSTransformComponent>> converted_transforms;
-    converted_transforms.ensure_capacity(transforms.size());
-    for (auto const& transform : transforms)
-        converted_transforms.append(*transform);
-    return CSSTransformValue::create(realm, move(converted_transforms));
+    return CSSTransformValue::create(realm, transforms);
 }
 
 CSSTransformValue::CSSTransformValue(JS::Realm& realm, Vector<GC::Ref<CSSTransformComponent>> transforms)

--- a/Libraries/LibWeb/CSS/CSSTransformValue.h
+++ b/Libraries/LibWeb/CSS/CSSTransformValue.h
@@ -17,8 +17,8 @@ class CSSTransformValue final : public CSSStyleValue {
     GC_DECLARE_ALLOCATOR(CSSTransformValue);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSTransformValue> create(JS::Realm&, Vector<GC::Ref<CSSTransformComponent>>);
-    static WebIDL::ExceptionOr<GC::Ref<CSSTransformValue>> construct_impl(JS::Realm&, Vector<GC::Root<CSSTransformComponent>> const&);
+    [[nodiscard]] static GC::Ref<CSSTransformValue> create(JS::Realm&, ReadonlySpan<GC::Ref<CSSTransformComponent>>);
+    static WebIDL::ExceptionOr<GC::Ref<CSSTransformValue>> construct_impl(JS::Realm&, ReadonlySpan<GC::Ref<CSSTransformComponent>> const&);
 
     virtual ~CSSTransformValue() override;
 

--- a/Libraries/LibWeb/CSS/CSSUnparsedValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSUnparsedValue.cpp
@@ -16,13 +16,13 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSUnparsedValue);
 
-GC::Ref<CSSUnparsedValue> CSSUnparsedValue::create(JS::Realm& realm, Vector<GCRootCSSUnparsedSegment> value)
+GC::Ref<CSSUnparsedValue> CSSUnparsedValue::create(JS::Realm& realm, ReadonlySpan<CSSUnparsedSegment> value)
 {
-    // NB: Convert our GC::Roots into GC::Refs.
+    // NB: Convert our Span into a Vector of Refs.
     Vector<CSSUnparsedSegment> converted_value;
     for (auto const& variant : value) {
         variant.visit(
-            [&](GC::Root<CSSVariableReferenceValue> const& it) { converted_value.append(GC::Ref { *it }); },
+            [&](GC::Ref<CSSVariableReferenceValue> it) { converted_value.append(it); },
             [&](String const& it) { converted_value.append(it); });
     }
 
@@ -30,14 +30,14 @@ GC::Ref<CSSUnparsedValue> CSSUnparsedValue::create(JS::Realm& realm, Vector<GCRo
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssunparsedvalue-cssunparsedvalue
-WebIDL::ExceptionOr<GC::Ref<CSSUnparsedValue>> CSSUnparsedValue::construct_impl(JS::Realm& realm, Vector<GCRootCSSUnparsedSegment> value)
+WebIDL::ExceptionOr<GC::Ref<CSSUnparsedValue>> CSSUnparsedValue::construct_impl(JS::Realm& realm, ReadonlySpan<CSSUnparsedSegment> value)
 {
     // AD-HOC: There is no spec for this, see https://github.com/w3c/css-houdini-drafts/issues/1146
 
     return CSSUnparsedValue::create(realm, move(value));
 }
 
-CSSUnparsedValue::CSSUnparsedValue(JS::Realm& realm, Vector<CSSUnparsedSegment> value)
+CSSUnparsedValue::CSSUnparsedValue(JS::Realm& realm, ReadonlySpan<CSSUnparsedSegment> value)
     : CSSStyleValue(realm)
     , m_tokens(move(value))
 {

--- a/Libraries/LibWeb/CSS/CSSUnparsedValue.h
+++ b/Libraries/LibWeb/CSS/CSSUnparsedValue.h
@@ -12,7 +12,6 @@
 namespace Web::CSS {
 
 using CSSUnparsedSegment = Variant<String, GC::Ref<CSSVariableReferenceValue>>;
-using GCRootCSSUnparsedSegment = Variant<String, GC::Root<CSSVariableReferenceValue>>;
 
 // https://drafts.css-houdini.org/css-typed-om-1/#cssunparsedvalue
 class CSSUnparsedValue final : public CSSStyleValue {
@@ -20,8 +19,8 @@ class CSSUnparsedValue final : public CSSStyleValue {
     GC_DECLARE_ALLOCATOR(CSSUnparsedValue);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSUnparsedValue> create(JS::Realm&, Vector<GCRootCSSUnparsedSegment>);
-    static WebIDL::ExceptionOr<GC::Ref<CSSUnparsedValue>> construct_impl(JS::Realm&, Vector<GCRootCSSUnparsedSegment>);
+    [[nodiscard]] static GC::Ref<CSSUnparsedValue> create(JS::Realm&, ReadonlySpan<CSSUnparsedSegment>);
+    static WebIDL::ExceptionOr<GC::Ref<CSSUnparsedValue>> construct_impl(JS::Realm&, ReadonlySpan<CSSUnparsedSegment>);
 
     virtual ~CSSUnparsedValue() override;
 
@@ -34,7 +33,7 @@ public:
     virtual WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> create_an_internal_representation(PropertyNameAndID const&, PerformTypeCheck) const override;
 
 private:
-    explicit CSSUnparsedValue(JS::Realm&, Vector<CSSUnparsedSegment>);
+    explicit CSSUnparsedValue(JS::Realm&, ReadonlySpan<CSSUnparsedSegment>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -177,7 +177,7 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
         font_face->m_urls = ParsedFontFace::sources_from_style_value(*parsed_source);
         font_face->m_urls.remove_all_matching(is_unsupported_source);
     } else {
-        auto buffer_source = source.get<GC::Root<WebIDL::BufferSource>>();
+        auto buffer_source = source.get<GC::Ref<WebIDL::BufferSource>>();
         auto maybe_buffer = WebIDL::get_buffer_source_copy(buffer_source->raw_object());
         if (maybe_buffer.is_error()) {
             VERIFY(maybe_buffer.error().code() == ENOMEM);

--- a/Libraries/LibWeb/CSS/FontFace.h
+++ b/Libraries/LibWeb/CSS/FontFace.h
@@ -22,7 +22,7 @@ class FontFace final : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(FontFace);
 
 public:
-    using FontFaceSource = Variant<String, GC::Root<WebIDL::BufferSource>>;
+    using FontFaceSource = Variant<String, GC::Ref<WebIDL::BufferSource>>;
 
     [[nodiscard]] static GC::Ref<FontFace> construct_impl(JS::Realm&, String family, FontFaceSource source, Bindings::FontFaceDescriptors const& descriptors);
     [[nodiscard]] static GC::Ref<FontFace> create_css_connected(JS::Realm&, CSSFontFaceRule&);

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/Set.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/FontFaceSet.h>
+#include <LibWeb/Bindings/FontFaceSetLoadEvent.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFace.h>
@@ -375,7 +376,7 @@ void FontFaceSet::fire_a_font_load_event(FlyString name, Vector<GC::Ref<FontFace
     // event named e using the FontFaceSetLoadEvent interface that also meets these conditions:
     // 1. The fontfaces attribute is initialized to the result of filtering font faces to only contain FontFace
     //    objects contained in target.
-    Bindings::FontFaceSetLoadEventInit load_event_init {};
+    Bindings::FontFaceSetLoadEventInit load_event_init;
     for (auto const& font_face : font_faces) {
         if (set_entries()->set_has(font_face))
             load_event_init.fontfaces.append(font_face);

--- a/Libraries/LibWeb/CSS/FontFaceSetLoadEvent.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSetLoadEvent.cpp
@@ -29,8 +29,7 @@ FontFaceSetLoadEvent::FontFaceSetLoadEvent(JS::Realm& realm, FlyString const& ev
 {
     m_fontfaces.ensure_capacity(event_init.fontfaces.size());
     for (auto const& font_face : event_init.fontfaces) {
-        VERIFY(font_face);
-        m_fontfaces.unchecked_append(*font_face);
+        m_fontfaces.unchecked_append(font_face);
     }
 }
 

--- a/Libraries/LibWeb/CSS/FontFaceSetLoadEvent.h
+++ b/Libraries/LibWeb/CSS/FontFaceSetLoadEvent.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <LibWeb/Bindings/FontFaceSetLoadEvent.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/DOM/Event.h>
 
@@ -17,15 +16,15 @@ class FontFaceSetLoadEvent : public DOM::Event {
     GC_DECLARE_ALLOCATOR(FontFaceSetLoadEvent);
 
 public:
-    [[nodiscard]] static GC::Ref<FontFaceSetLoadEvent> create(JS::Realm&, FlyString const& type, Bindings::FontFaceSetLoadEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<GC::Ref<FontFaceSetLoadEvent>> construct_impl(JS::Realm&, FlyString const& type, Bindings::FontFaceSetLoadEventInit const& event_init = {});
+    [[nodiscard]] static GC::Ref<FontFaceSetLoadEvent> create(JS::Realm&, FlyString const& type, Bindings::FontFaceSetLoadEventInit const&);
+    static WebIDL::ExceptionOr<GC::Ref<FontFaceSetLoadEvent>> construct_impl(JS::Realm&, FlyString const& type, Bindings::FontFaceSetLoadEventInit const&);
 
     virtual ~FontFaceSetLoadEvent() override = default;
 
     Vector<GC::Ref<FontFace>> const& fontfaces() const { return m_fontfaces; }
 
 private:
-    FontFaceSetLoadEvent(JS::Realm&, FlyString const& type, Bindings::FontFaceSetLoadEventInit const& event_init = {});
+    FontFaceSetLoadEvent(JS::Realm&, FlyString const& type, Bindings::FontFaceSetLoadEventInit const&);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;

--- a/Libraries/LibWeb/CSS/StylePropertyMap.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.cpp
@@ -45,10 +45,10 @@ void StylePropertyMap::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-static bool any_have_non_matching_associated_property(FlyString const& property, Vector<Variant<GC::Root<CSSStyleValue>, String>> values)
+static bool any_have_non_matching_associated_property(FlyString const& property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
 {
-    return any_of(values, [&property](Variant<GC::Root<CSSStyleValue>, String> const& value) {
-        if (auto* style_value = value.get_pointer<GC::Root<CSSStyleValue>>()) {
+    return any_of(values, [&property](Variant<GC::Ref<CSSStyleValue>, String> const& value) {
+        if (auto* style_value = value.get_pointer<GC::Ref<CSSStyleValue>>()) {
             if (auto associated_property = (*style_value)->associated_property();
                 associated_property.has_value() && associated_property != property)
                 return true;
@@ -58,11 +58,11 @@ static bool any_have_non_matching_associated_property(FlyString const& property,
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#create-an-internal-representation
-static WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> create_an_internal_representation(JS::VM& vm, PropertyNameAndID const& property, Variant<GC::Root<CSSStyleValue>, String> const& value)
+static WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> create_an_internal_representation(JS::VM& vm, PropertyNameAndID const& property, Variant<GC::Ref<CSSStyleValue>, String> const& value)
 {
     // To create an internal representation, given a string property and a string or CSSStyleValue value:
     return value.visit(
-        [&property](GC::Root<CSSStyleValue> const& css_style_value) {
+        [&property](GC::Ref<CSSStyleValue> const& css_style_value) {
             return css_style_value->create_an_internal_representation(property, CSSStyleValue::PerformTypeCheck::Yes);
         },
         [&](String const& css_text) -> WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> {
@@ -77,7 +77,7 @@ static WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> create_an_internal_r
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-set
-WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Vector<Variant<GC::Root<CSSStyleValue>, String>> values)
+WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
 {
     // The set(property, ...values) method, when called on a StylePropertyMap this, must perform the following steps:
 
@@ -180,7 +180,7 @@ WebIDL::ExceptionOr<void> StylePropertyMap::set(FlyString property_name, Vector<
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-append
-WebIDL::ExceptionOr<void> StylePropertyMap::append(FlyString property_name, Vector<Variant<GC::Root<CSSStyleValue>, String>> values)
+WebIDL::ExceptionOr<void> StylePropertyMap::append(FlyString property_name, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values)
 {
     // The append(property, ...values) method, when called on a StylePropertyMap this, must perform the following steps:
 

--- a/Libraries/LibWeb/CSS/StylePropertyMap.h
+++ b/Libraries/LibWeb/CSS/StylePropertyMap.h
@@ -20,8 +20,8 @@ public:
 
     virtual ~StylePropertyMap() override;
 
-    WebIDL::ExceptionOr<void> set(FlyString property, Vector<Variant<GC::Root<CSSStyleValue>, String>> values);
-    WebIDL::ExceptionOr<void> append(FlyString property, Vector<Variant<GC::Root<CSSStyleValue>, String>> values);
+    WebIDL::ExceptionOr<void> set(FlyString property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values);
+    WebIDL::ExceptionOr<void> append(FlyString property, ReadonlySpan<Variant<GC::Ref<CSSStyleValue>, String>> values);
     WebIDL::ExceptionOr<void> delete_(FlyString property);
     WebIDL::ExceptionOr<void> clear();
 

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
@@ -52,7 +52,7 @@ bool UnresolvedStyleValue::equals(StyleValue const& other) const
 static GC::Ref<CSSUnparsedValue> reify_a_list_of_component_values(JS::Realm&, Vector<Parser::ComponentValue>);
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-var
-static GC::Root<CSSVariableReferenceValue> reify_a_var_reference(JS::Realm& realm, Parser::Function function)
+static GC::Ptr<CSSVariableReferenceValue> reify_a_var_reference(JS::Realm& realm, Parser::Function function)
 {
     // NB: A var() might not be representable as a CSSVariableReferenceValue, for example if it has invalid syntax or
     //    it contains an ASF in its variable-name slot. In those cases, we return null here, so it's treated like a
@@ -90,7 +90,7 @@ static GC::Root<CSSVariableReferenceValue> reify_a_var_reference(JS::Realm& real
 
 class Reifier {
 public:
-    static Vector<GCRootCSSUnparsedSegment> reify(JS::Realm& realm, Vector<Parser::ComponentValue> const& source_values)
+    static Vector<CSSUnparsedSegment> reify(JS::Realm& realm, Vector<Parser::ComponentValue> const& source_values)
     {
         Reifier reifier;
         reifier.process_values(realm, source_values);
@@ -112,7 +112,7 @@ private:
                 // serializing it like a regular function.
                 if (auto var_reference = reify_a_var_reference(realm, component_value.function())) {
                     serialize_unserialized_values();
-                    m_reified_values.append(move(var_reference));
+                    m_reified_values.append(GC::Ref { *var_reference });
                     continue;
                 }
             }
@@ -143,7 +143,7 @@ private:
         m_unserialized_values.clear_with_capacity();
     }
 
-    Vector<GCRootCSSUnparsedSegment> m_reified_values {};
+    Vector<CSSUnparsedSegment> m_reified_values {};
     Vector<Parser::ComponentValue> m_unserialized_values {};
 };
 

--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -398,7 +398,7 @@ GC::Ref<WebIDL::Promise> Clipboard::read_text()
 }
 
 // https://w3c.github.io/clipboard-apis/#dom-clipboard-write
-GC::Ref<WebIDL::Promise> Clipboard::write(Vector<GC::Root<ClipboardItem>> const& data)
+GC::Ref<WebIDL::Promise> Clipboard::write(GC::RootVector<GC::Ref<ClipboardItem>> const& data)
 {
     // 1. Let realm be this's relevant realm.
     auto& realm = HTML::relevant_realm(*this);

--- a/Libraries/LibWeb/Clipboard/Clipboard.h
+++ b/Libraries/LibWeb/Clipboard/Clipboard.h
@@ -27,7 +27,7 @@ public:
     GC::Ref<WebIDL::Promise> read(Bindings::ClipboardUnsanitizedFormats formats = {});
     GC::Ref<WebIDL::Promise> read_text();
 
-    GC::Ref<WebIDL::Promise> write(Vector<GC::Root<ClipboardItem>> const&);
+    GC::Ref<WebIDL::Promise> write(GC::RootVector<GC::Ref<ClipboardItem>> const&);
     GC::Ref<WebIDL::Promise> write_text(String);
 
 private:

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
@@ -16,7 +16,7 @@ namespace Web::Clipboard {
 GC_DEFINE_ALLOCATOR(ClipboardItem);
 
 // https://w3c.github.io/clipboard-apis/#dom-clipboarditem-clipboarditem
-WebIDL::ExceptionOr<GC::Ref<ClipboardItem>> ClipboardItem::construct_impl(JS::Realm& realm, OrderedHashMap<String, GC::Root<WebIDL::Promise>> const& items, Bindings::ClipboardItemOptions const& options)
+WebIDL::ExceptionOr<GC::Ref<ClipboardItem>> ClipboardItem::construct_impl(JS::Realm& realm, GC::OrderedRootHashMap<String, GC::Ref<WebIDL::Promise>> const& items, Bindings::ClipboardItemOptions const& options)
 {
     // 1. If items is empty, then throw a TypeError.
     if (items.is_empty())

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.h
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.h
@@ -35,7 +35,7 @@ public:
         GC::Ref<WebIDL::Promise> data; // The actual data for this representation.
     };
 
-    static WebIDL::ExceptionOr<GC::Ref<ClipboardItem>> construct_impl(JS::Realm&, OrderedHashMap<String, GC::Root<WebIDL::Promise>> const& items, Bindings::ClipboardItemOptions const& options = {});
+    static WebIDL::ExceptionOr<GC::Ref<ClipboardItem>> construct_impl(JS::Realm&, GC::OrderedRootHashMap<String, GC::Ref<WebIDL::Promise>> const& items, Bindings::ClipboardItemOptions const& options = {});
 
     virtual ~ClipboardItem() override;
 

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -56,8 +56,7 @@ static JS::ThrowCompletionOr<HashAlgorithmIdentifier> hash_algorithm_identifier_
         }
         if (hash_value.is_object()) {
             auto const hash_object = TRY(hash_value.to_object(vm));
-            auto const hash_object_root = GC::make_root(hash_object);
-            return normalize_an_algorithm(*realm, hash_object_root, "digest"_string);
+            return normalize_an_algorithm(*realm, hash_object, "digest"_string);
         }
         VERIFY_NOT_REACHED();
     }();

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -22,9 +22,9 @@
 
 namespace Web::Crypto {
 
-using AlgorithmIdentifier = Variant<GC::Root<JS::Object>, String>;
+using AlgorithmIdentifier = Variant<GC::Ref<JS::Object>, String>;
 using NamedCurve = String;
-using KeyDataType = Variant<GC::Root<WebIDL::BufferSource>, JsonWebKey>;
+using KeyDataType = Variant<GC::Ref<WebIDL::BufferSource>, JsonWebKey>;
 
 // https://wicg.github.io/webcrypto-modern-algos/#encapsulation
 struct EncapsulatedKey {

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -109,9 +109,8 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
     if (algorithm.has<String>()) {
         // Return the result of running the normalize an algorithm algorithm,
         // with the alg set to a new Algorithm dictionary whose name attribute is alg, and with the op set to op.
-        auto dictionary = GC::make_root(JS::Object::create(realm, realm.intrinsics().object_prototype()));
+        auto dictionary = JS::Object::create(realm, realm.intrinsics().object_prototype());
         TRY(dictionary->create_data_property("name"_utf16_fly_string, JS::PrimitiveString::create(vm, algorithm.get<String>())));
-
         return normalize_an_algorithm(realm, dictionary, operation);
     }
 
@@ -127,7 +126,7 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
     // 3. If an error occurred, return the error and terminate this algorithm.
     // Note: We're not going to bother creating an Algorithm object, all we want is the name attribute so that we can
     //       fetch the actual algorithm factory from the registeredAlgorithms map.
-    auto initial_algorithm = TRY(algorithm.get<GC::Root<JS::Object>>()->get("name"_utf16_fly_string));
+    auto initial_algorithm = TRY(algorithm.get<GC::Ref<JS::Object>>()->get("name"_utf16_fly_string));
 
     if (initial_algorithm.is_undefined()) {
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "Algorithm");
@@ -159,7 +158,7 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
     // 12. For each dictionary dictionary in dictionaries:
     //    Note: All of these steps are handled by the create_methods and parameter_from_value methods.
     auto methods = desired_type.create_methods(realm);
-    auto parameter = TRY(desired_type.parameter_from_value(vm, algorithm.get<GC::Root<JS::Object>>()));
+    auto parameter = TRY(desired_type.parameter_from_value(vm, algorithm.get<GC::Ref<JS::Object>>()));
 
     // 9. Set the name attribute of normalizedAlgorithm to algName.
     VERIFY(parameter->name.is_empty());
@@ -447,7 +446,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::generate_key(AlgorithmIdentifier algorith
 }
 
 // https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey
-JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Bindings::KeyFormat format, Variant<GC::Root<WebIDL::BufferSource>, Bindings::JsonWebKey> key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages)
+JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Bindings::KeyFormat format, Variant<GC::Ref<WebIDL::BufferSource>, Bindings::JsonWebKey> key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages)
 {
     auto& realm = this->realm();
 
@@ -469,7 +468,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Binding
         }
 
         // 2. Let keyData be the result of getting a copy of the bytes held by the keyData parameter passed to the importKey() method.
-        real_key_data = MUST(WebIDL::get_buffer_source_copy(*key_data.get<GC::Root<WebIDL::BufferSource>>()->raw_object()));
+        real_key_data = MUST(WebIDL::get_buffer_source_copy(*key_data.get<GC::Ref<WebIDL::BufferSource>>()->raw_object()));
     }
 
     if (format == Bindings::KeyFormat::Jwk) {
@@ -1079,7 +1078,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::unwrap_key(Bindings::KeyFormat format, Ke
     auto normalized_key_algorithm = normalized_key_algorithm_or_error.release_value();
 
     // 7. Let wrappedKey be the result of getting a copy of the bytes held by the wrappedKey parameter passed to the unwrapKey() method.
-    auto real_wrapped_key = MUST(WebIDL::get_buffer_source_copy(*wrapped_key.get<GC::Root<WebIDL::BufferSource>>()->raw_object()));
+    auto real_wrapped_key = MUST(WebIDL::get_buffer_source_copy(*wrapped_key.get<GC::Ref<WebIDL::BufferSource>>()->raw_object()));
 
     // 9. Let promise be a new Promise.
     auto promise = WebIDL::create_promise(realm);

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.h
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.h
@@ -37,7 +37,7 @@ public:
     GC::Ref<WebIDL::Promise> derive_bits(AlgorithmIdentifier algorithm, GC::Ref<CryptoKey> base_key, Optional<u32> length_optional);
     GC::Ref<WebIDL::Promise> derive_key(AlgorithmIdentifier algorithm, GC::Ref<CryptoKey> base_key, AlgorithmIdentifier derived_key_type, bool extractable, Vector<Bindings::KeyUsage> key_usages);
 
-    JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> import_key(Bindings::KeyFormat format, Variant<GC::Root<WebIDL::BufferSource>, Bindings::JsonWebKey> key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
+    JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> import_key(Bindings::KeyFormat format, Variant<GC::Ref<WebIDL::BufferSource>, Bindings::JsonWebKey> key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
     GC::Ref<WebIDL::Promise> export_key(Bindings::KeyFormat format, GC::Ref<CryptoKey> key);
 
     GC::Ref<WebIDL::Promise> wrap_key(Bindings::KeyFormat format, GC::Ref<CryptoKey> key, GC::Ref<CryptoKey> wrapping_key, AlgorithmIdentifier wrap_algorithm);

--- a/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Libraries/LibWeb/DOM/AbortController.cpp
@@ -41,10 +41,10 @@ void AbortController::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://dom.spec.whatwg.org/#dom-abortcontroller-abort
-void AbortController::abort(JS::Value reason)
+void AbortController::abort(Optional<JS::Value> reason)
 {
     // The abort(reason) method steps are to signal abort on this’s signal with reason if it is given.
-    m_signal->signal_abort(reason);
+    m_signal->signal_abort(reason.value_or(JS::js_undefined()));
 }
 
 }

--- a/Libraries/LibWeb/DOM/AbortController.h
+++ b/Libraries/LibWeb/DOM/AbortController.h
@@ -24,7 +24,7 @@ public:
     // https://dom.spec.whatwg.org/#dom-abortcontroller-signal
     GC::Ref<AbortSignal> signal() const { return *m_signal; }
 
-    void abort(JS::Value reason);
+    void abort(Optional<JS::Value> reason);
 
 private:
     AbortController(JS::Realm&, GC::Ref<AbortSignal>);

--- a/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -144,12 +144,13 @@ size_t AbortSignal::external_memory_size() const
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-abort
-WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::abort(JS::VM& vm, JS::Value reason)
+WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::abort(JS::VM& vm, Optional<JS::Value> maybe_reason)
 {
     // 1. Let signal be a new AbortSignal object.
     auto signal = TRY(construct_impl(*vm.current_realm()));
 
     // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
+    auto reason = maybe_reason.value_or(JS::js_undefined());
     if (reason.is_undefined())
         reason = WebIDL::AbortError::create(*vm.current_realm(), "Aborted without reason"_utf16).ptr();
 
@@ -185,14 +186,14 @@ WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::timeout(JS::VM& vm, WebID
 }
 
 // https://dom.spec.whatwg.org/#dom-abortsignal-any
-WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::any(JS::VM& vm, Vector<GC::Root<AbortSignal>> const& signals)
+WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::any(JS::VM& vm, ReadonlySpan<GC::Ref<AbortSignal>> signals)
 {
     // The static any(signals) method steps are to return the result of creating a dependent abort signal from signals using AbortSignal and the current realm.
     return create_dependent_abort_signal(*vm.current_realm(), signals);
 }
 
 // https://dom.spec.whatwg.org/#create-a-dependent-abort-signal
-WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::create_dependent_abort_signal(JS::Realm& realm, Vector<GC::Root<AbortSignal>> const& signals)
+WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::create_dependent_abort_signal(JS::Realm& realm, ReadonlySpan<GC::Ref<AbortSignal>> signals)
 {
     // 1. Let resultSignal be a new object implementing signalInterface using realm.
     auto result_signal = TRY(construct_impl(realm));

--- a/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Libraries/LibWeb/DOM/AbortSignal.h
@@ -46,11 +46,11 @@ public:
 
     JS::ThrowCompletionOr<void> throw_if_aborted() const;
 
-    static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> abort(JS::VM&, JS::Value reason);
+    static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> abort(JS::VM&, Optional<JS::Value> reason);
     static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> timeout(JS::VM&, Web::WebIDL::UnsignedLongLong milliseconds);
-    static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> any(JS::VM&, Vector<GC::Root<AbortSignal>> const&);
+    static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> any(JS::VM&, ReadonlySpan<GC::Ref<AbortSignal>>);
 
-    static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> create_dependent_abort_signal(JS::Realm&, Vector<GC::Root<AbortSignal>> const&);
+    static WebIDL::ExceptionOr<GC::Ref<AbortSignal>> create_dependent_abort_signal(JS::Realm&, ReadonlySpan<GC::Ref<AbortSignal>>);
 
 private:
     explicit AbortSignal(JS::Realm&);

--- a/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Libraries/LibWeb/DOM/ChildNode.h
@@ -16,7 +16,7 @@ template<typename NodeType>
 class ChildNode {
 public:
     // https://dom.spec.whatwg.org/#dom-childnode-before
-    WebIDL::ExceptionOr<void> before(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+    WebIDL::ExceptionOr<void> before(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -46,7 +46,7 @@ public:
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-after
-    WebIDL::ExceptionOr<void> after(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+    WebIDL::ExceptionOr<void> after(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -70,7 +70,7 @@ public:
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-replacewith
-    WebIDL::ExceptionOr<void> replace_with(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+    WebIDL::ExceptionOr<void> replace_with(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -117,7 +117,7 @@ protected:
     ChildNode() = default;
 
 private:
-    GC::Ptr<Node> viable_previous_sibling_for_insertion(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+    GC::Ptr<Node> viable_previous_sibling_for_insertion(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -125,11 +125,11 @@ private:
             bool contained_in_nodes = false;
 
             for (auto const& node_or_string : nodes) {
-                if (!node_or_string.template has<GC::Root<Node>>())
+                if (!node_or_string.template has<GC::Ref<Node>>())
                     continue;
 
-                auto const& node_in_vector = node_or_string.template get<GC::Root<Node>>();
-                if (node_in_vector.cell() == sibling) {
+                auto const& node_in_vector = node_or_string.template get<GC::Ref<Node>>();
+                if (node_in_vector == sibling) {
                     contained_in_nodes = true;
                     break;
                 }
@@ -142,7 +142,7 @@ private:
         return nullptr;
     }
 
-    GC::Ptr<Node> viable_next_sibling_for_insertion(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+    GC::Ptr<Node> viable_next_sibling_for_insertion(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -150,11 +150,11 @@ private:
             bool contained_in_nodes = false;
 
             for (auto const& node_or_string : nodes) {
-                if (!node_or_string.template has<GC::Root<Node>>())
+                if (!node_or_string.template has<GC::Ref<Node>>())
                     continue;
 
-                auto const& node_in_vector = node_or_string.template get<GC::Root<Node>>();
-                if (node_in_vector.cell() == sibling) {
+                auto const& node_in_vector = node_or_string.template get<GC::Ref<Node>>();
+                if (node_in_vector == sibling) {
                     contained_in_nodes = true;
                     break;
                 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -42,6 +42,8 @@
 #include <LibWeb/Bindings/Document.h>
 #include <LibWeb/Bindings/IntersectionObserver.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/MessageEvent.h>
+#include <LibWeb/Bindings/PointerEvent.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 #include <LibWeb/CSS/CSSAnimation.h>
@@ -2560,11 +2562,11 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
 
     // https://w3c.github.io/pointerevents/#the-pointerout-event
     if (old_hovered_node && old_hovered_node != m_hovered_node) {
-        Bindings::PointerEventInit pointer_event_init {};
+        Bindings::PointerEventInit pointer_event_init;
         pointer_event_init.bubbles = true;
         pointer_event_init.cancelable = true;
         pointer_event_init.composed = true;
-        pointer_event_init.related_target = GC::Root<DOM::EventTarget> { m_hovered_node.ptr() };
+        pointer_event_init.related_target = m_hovered_node;
         pointer_event_init.is_primary = true;
         pointer_event_init.pointer_type = UIEvents::PointerTypes::Mouse;
         pointer_event_init.view = window_proxy;
@@ -2582,7 +2584,7 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
         mouse_event_init.bubbles = true;
         mouse_event_init.cancelable = true;
         mouse_event_init.composed = true;
-        mouse_event_init.related_target = GC::Root<DOM::EventTarget> { m_hovered_node.ptr() };
+        mouse_event_init.related_target = m_hovered_node;
         mouse_event_init.view = window_proxy;
         if (hover_event_data.has_value())
             populate_mouse_event_init_from_hover_event_data(mouse_event_init, *hover_event_data, window_proxy);
@@ -2595,8 +2597,8 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
     // https://w3c.github.io/pointerevents/#the-pointerleave-event
     if (!pointer_leave_targets.is_empty()) {
         for (auto const& target : pointer_leave_targets) {
-            Bindings::PointerEventInit pointer_event_init {};
-            pointer_event_init.related_target = GC::Root<DOM::EventTarget> { m_hovered_node.ptr() };
+            Bindings::PointerEventInit pointer_event_init;
+            pointer_event_init.related_target = m_hovered_node;
             pointer_event_init.is_primary = true;
             pointer_event_init.pointer_type = UIEvents::PointerTypes::Mouse;
             pointer_event_init.view = window_proxy;
@@ -2613,7 +2615,7 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
     if (!mouse_leave_targets.is_empty()) {
         for (auto const& target : mouse_leave_targets) {
             Bindings::MouseEventInit mouse_event_init {};
-            mouse_event_init.related_target = GC::Root<DOM::EventTarget> { m_hovered_node.ptr() };
+            mouse_event_init.related_target = m_hovered_node;
             if (hover_event_data.has_value())
                 populate_mouse_event_init_from_hover_event_data(mouse_event_init, *hover_event_data, window_proxy);
             auto offset = target.offset;
@@ -2625,11 +2627,11 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
 
     // https://w3c.github.io/pointerevents/#the-pointerover-event
     if (m_hovered_node && m_hovered_node != old_hovered_node) {
-        Bindings::PointerEventInit pointer_event_init {};
+        Bindings::PointerEventInit pointer_event_init;
         pointer_event_init.bubbles = true;
         pointer_event_init.cancelable = true;
         pointer_event_init.composed = true;
-        pointer_event_init.related_target = GC::Root<DOM::EventTarget> { old_hovered_node.ptr() };
+        pointer_event_init.related_target = old_hovered_node;
         pointer_event_init.is_primary = true;
         pointer_event_init.pointer_type = UIEvents::PointerTypes::Mouse;
         pointer_event_init.view = window_proxy;
@@ -2647,7 +2649,7 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
         mouse_event_init.bubbles = true;
         mouse_event_init.cancelable = true;
         mouse_event_init.composed = true;
-        mouse_event_init.related_target = GC::Root<DOM::EventTarget> { old_hovered_node.ptr() };
+        mouse_event_init.related_target = old_hovered_node;
         mouse_event_init.view = window_proxy;
         if (hover_event_data.has_value())
             populate_mouse_event_init_from_hover_event_data(mouse_event_init, *hover_event_data, window_proxy);
@@ -2663,8 +2665,8 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
     // Leave events are dispatched in the opposite order.
     if (!entered_ancestors.is_empty()) {
         for (auto target : entered_ancestors.in_reverse()) {
-            Bindings::PointerEventInit pointer_event_init {};
-            pointer_event_init.related_target = GC::Root<DOM::EventTarget> { old_hovered_node.ptr() };
+            Bindings::PointerEventInit pointer_event_init;
+            pointer_event_init.related_target = old_hovered_node;
             pointer_event_init.is_primary = true;
             pointer_event_init.pointer_type = UIEvents::PointerTypes::Mouse;
             pointer_event_init.view = window_proxy;
@@ -2675,7 +2677,7 @@ void Document::set_hovered_node(GC::Ptr<Node> node, Optional<HoverEventData> hov
             mark_mouse_transition_event_as_trusted_if_needed(pointer_event, hover_event_data);
             target.node->dispatch_event(pointer_event);
             Bindings::MouseEventInit mouse_event_init {};
-            mouse_event_init.related_target = GC::Root<DOM::EventTarget> { old_hovered_node.ptr() };
+            mouse_event_init.related_target = old_hovered_node;
             if (hover_event_data.has_value())
                 populate_mouse_event_init_from_hover_event_data(mouse_event_init, *hover_event_data, window_proxy);
             auto mouse_event = UIEvents::MouseEvent::create(realm(), UIEvents::EventNames::mouseenter, mouse_event_init, page_offset.x().to_double(), page_offset.y().to_double(), offset.x().to_double(), offset.y().to_double());
@@ -2958,7 +2960,7 @@ WebIDL::ExceptionOr<GC::Ref<Event>> Document::create_event(StringView interface)
     } else if (interface.equals_ignoring_ascii_case("keyboardevent"sv)) {
         event = UIEvents::KeyboardEvent::create(realm, String {});
     } else if (interface.equals_ignoring_ascii_case("messageevent"sv)) {
-        event = HTML::MessageEvent::create(realm, String {});
+        event = HTML::MessageEvent::create(realm, FlyString {}, Bindings::MessageEventInit {});
     } else if (interface.equals_ignoring_ascii_case("mouseevent"sv)
         || interface.equals_ignoring_ascii_case("mouseevents"sv)) {
         event = UIEvents::MouseEvent::create(realm, FlyString {});
@@ -3091,8 +3093,8 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Document::import_node(GC::Ref<Node> node, Var
             subtree = !options.self_only;
 
             // 2. If options["customElementRegistry"] exists, then set registry to it.
-            if (options.custom_element_registry.has_value())
-                registry = options.custom_element_registry->ptr();
+            if (options.custom_element_registry)
+                registry = options.custom_element_registry;
 
             // 3. If registry’s is scoped is false and registry is not this’s custom element registry, then throw a
             //    "NotSupportedError" DOMException.

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -386,7 +386,7 @@ GC::Ptr<Attr> Element::get_attribute_node_ns(Optional<FlyString> const& namespac
 }
 
 // https://dom.spec.whatwg.org/#dom-element-setattribute
-WebIDL::ExceptionOr<void> Element::set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, Utf16String> const& value)
+WebIDL::ExceptionOr<void> Element::set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> const& value)
 {
     // 1. If qualifiedName is not a valid attribute local name, then throw an "InvalidCharacterError" DOMException.
     if (!is_valid_attribute_local_name(qualified_name))
@@ -421,12 +421,12 @@ WebIDL::ExceptionOr<void> Element::set_attribute_for_bindings(FlyString qualifie
 }
 
 // https://dom.spec.whatwg.org/#dom-element-setattribute
-WebIDL::ExceptionOr<void> Element::set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, String> const& value)
+WebIDL::ExceptionOr<void> Element::set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, String> const& value)
 {
     return set_attribute_for_bindings(move(qualified_name),
         value.visit(
-            [](auto const& trusted_type) -> Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, Utf16String> { return trusted_type; },
-            [](String const& string) -> Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, Utf16String> { return Utf16String::from_utf8(string); }));
+            [](auto const& trusted_type) -> Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> { return trusted_type; },
+            [](String const& string) -> Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> { return Utf16String::from_utf8(string); }));
 }
 
 // https://dom.spec.whatwg.org/#valid-namespace-prefix
@@ -540,7 +540,7 @@ WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm& realm, Option
 }
 
 // https://dom.spec.whatwg.org/#dom-element-setattributens
-WebIDL::ExceptionOr<void> Element::set_attribute_ns_for_bindings(Optional<FlyString> const& namespace_, FlyString const& qualified_name, Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, Utf16String> const& value)
+WebIDL::ExceptionOr<void> Element::set_attribute_ns_for_bindings(Optional<FlyString> const& namespace_, FlyString const& qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> const& value)
 {
     // 1. Let (namespace, prefix, localName) be the result of validating and extracting namespace and qualifiedName given "attribute".
     auto extracted_qualified_name = TRY(validate_and_extract(realm(), namespace_, qualified_name, ValidationContext::Attribute));

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -129,10 +129,10 @@ public:
     Optional<String> lang() const;
     void invalidate_lang_value();
 
-    WebIDL::ExceptionOr<void> set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, Utf16String> const& value);
-    WebIDL::ExceptionOr<void> set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, String> const& value);
+    WebIDL::ExceptionOr<void> set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> const& value);
+    WebIDL::ExceptionOr<void> set_attribute_for_bindings(FlyString qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, String> const& value);
 
-    WebIDL::ExceptionOr<void> set_attribute_ns_for_bindings(Optional<FlyString> const& namespace_, FlyString const& qualified_name, Variant<GC::Root<TrustedTypes::TrustedHTML>, GC::Root<TrustedTypes::TrustedScript>, GC::Root<TrustedTypes::TrustedScriptURL>, Utf16String> const& value);
+    WebIDL::ExceptionOr<void> set_attribute_ns_for_bindings(Optional<FlyString> const& namespace_, FlyString const& qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> const& value);
     void set_attribute_value(FlyString const& local_name, String const& value, Optional<FlyString> const& prefix = {}, Optional<FlyString> const& namespace_ = {});
     WebIDL::ExceptionOr<GC::Ptr<Attr>> set_attribute_node_for_bindings(Attr&);
     WebIDL::ExceptionOr<GC::Ptr<Attr>> set_attribute_node_ns_for_bindings(Attr&);

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -158,8 +158,8 @@ static FlattenedAddEventListenerOptions flatten_add_event_listener_options(Varia
             passive = add_event_listener_options.passive;
 
         // 3. If options["signal"] exists, then set signal to options["signal"].
-        if (add_event_listener_options.signal.has_value())
-            signal = add_event_listener_options.signal->ptr();
+        if (add_event_listener_options.signal)
+            signal = add_event_listener_options.signal;
     }
 
     // 5. Return capture, passive, once, and signal.

--- a/Libraries/LibWeb/DOM/NodeOperations.cpp
+++ b/Libraries/LibWeb/DOM/NodeOperations.cpp
@@ -16,12 +16,12 @@
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#convert-nodes-into-a-node
-WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes, Document& document)
+WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> nodes, Document& document)
 {
     // 1. Replace each string of nodes with a new Text node whose data is the string and node document is document.
-    auto potentially_convert_string_to_text_node = [&document](Variant<GC::Root<Node>, Utf16String> const& node) -> GC::Ref<Node> {
-        if (node.has<GC::Root<Node>>())
-            return *node.get<GC::Root<Node>>();
+    auto potentially_convert_string_to_text_node = [&document](Variant<GC::Ref<Node>, Utf16String> const& node) -> GC::Ref<Node> {
+        if (node.has<GC::Ref<Node>>())
+            return node.get<GC::Ref<Node>>();
 
         return document.realm().create<Text>(document, node.get<Utf16String>());
     };

--- a/Libraries/LibWeb/DOM/NodeOperations.h
+++ b/Libraries/LibWeb/DOM/NodeOperations.h
@@ -13,6 +13,6 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes, DOM::Document& document);
+WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> nodes, DOM::Document& document);
 
 }

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -187,7 +187,7 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Optional<FlyStri
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-prepend
-WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::prepend(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
@@ -198,7 +198,7 @@ WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<GC::Root<Node>, Utf
     return {};
 }
 
-WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::append(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
@@ -209,7 +209,7 @@ WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<GC::Root<Node>, Utf1
     return {};
 }
 
-WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::replace_children(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));

--- a/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Libraries/LibWeb/DOM/ParentNode.h
@@ -33,9 +33,9 @@ public:
     GC::Ref<HTMLCollection> get_elements_by_tag_name(FlyString const&);
     GC::Ref<HTMLCollection> get_elements_by_tag_name_ns(Optional<FlyString>, FlyString const&);
 
-    WebIDL::ExceptionOr<void> prepend(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes);
-    WebIDL::ExceptionOr<void> append(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes);
-    WebIDL::ExceptionOr<void> replace_children(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes);
+    WebIDL::ExceptionOr<void> prepend(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes);
+    WebIDL::ExceptionOr<void> append(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes);
+    WebIDL::ExceptionOr<void> replace_children(ReadonlySpan<Variant<GC::Ref<Node>, Utf16String>> const& nodes);
     WebIDL::ExceptionOr<void> move_before(GC::Ref<Node> node, GC::Ptr<Node> child);
 
     GC::Ref<HTMLCollection> get_elements_by_class_name(StringView);

--- a/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -467,13 +467,13 @@ Optional<URL::URL> parse(StringView input, Optional<URL::URL const&> base_url, O
     if (blob_url_entry.has_value()) {
         url->set_blob_url_entry(URL::BlobURLEntry {
             .object = blob_url_entry->object.visit(
-                [](GC::Root<FileAPI::Blob> const& blob) -> URL::BlobURLEntry::Object {
+                [](GC::Ref<FileAPI::Blob> const& blob) -> URL::BlobURLEntry::Object {
                     return URL::BlobURLEntry::Blob {
                         .type = blob->type(),
                         .data = MUST(ByteBuffer::copy(blob->raw_bytes())),
                     };
                 },
-                [](GC::Root<MediaSourceExtensions::MediaSource> const&) -> URL::BlobURLEntry::Object { return URL::BlobURLEntry::MediaSource {}; }),
+                [](GC::Ref<MediaSourceExtensions::MediaSource> const&) -> URL::BlobURLEntry::Object { return URL::BlobURLEntry::MediaSource {}; }),
             .environment { .origin = blob_url_entry->environment->origin() },
         });
     }

--- a/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -63,13 +63,13 @@ void TextDecoder::initialize(JS::Realm& realm)
 }
 
 // https://encoding.spec.whatwg.org/#dom-textdecoder-decode
-WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<GC::Root<WebIDL::BufferSource>> const& input, Optional<Bindings::TextDecodeOptions> const&) const
+WebIDL::ExceptionOr<String> TextDecoder::decode(GC::Ptr<WebIDL::BufferSource> input, Optional<Bindings::TextDecodeOptions> const&) const
 {
-    if (!input.has_value())
+    if (!input)
         return TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({}));
 
     // FIXME: Implement the streaming stuff.
-    auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input.value()->raw_object());
+    auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input->raw_object());
     if (data_buffer_or_error.is_error())
         return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer"_utf16);
     auto& data_buffer = data_buffer_or_error.value();

--- a/Libraries/LibWeb/Encoding/TextDecoder.h
+++ b/Libraries/LibWeb/Encoding/TextDecoder.h
@@ -30,7 +30,7 @@ public:
 
     virtual ~TextDecoder() override;
 
-    WebIDL::ExceptionOr<String> decode(Optional<GC::Root<WebIDL::BufferSource>> const&, Optional<Bindings::TextDecodeOptions> const& options = {}) const;
+    WebIDL::ExceptionOr<String> decode(GC::Ptr<WebIDL::BufferSource>, Optional<Bindings::TextDecodeOptions> const& options = {}) const;
 
 private:
     TextDecoder(JS::Realm&, TextCodec::Decoder&, FlyString encoding, ErrorMode error_mode, bool ignore_bom);

--- a/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Libraries/LibWeb/Fetch/Body.cpp
@@ -444,10 +444,11 @@ MultipartParsingErrorOr<GC::ConservativeVector<XHR::FormDataEntry>> parse_multip
             }
 
             // 3. Let value be a new File object with name filename, type contentType, and body body.
-            auto blob = FileAPI::Blob::create(realm, MUST(ByteBuffer::copy(body.bytes())), header.content_type.release_value());
+            auto content_type = header.content_type.release_value();
+            auto blob = FileAPI::Blob::create(realm, MUST(ByteBuffer::copy(body.bytes())), content_type);
             Bindings::FilePropertyBag options {};
-            options.type = blob->type();
-            value = MUST(FileAPI::File::create(realm, { GC::make_root(blob) }, header.filename.release_value(), move(options)));
+            options.type = move(content_type);
+            value = MUST(FileAPI::File::create(realm, { { blob } }, header.filename.release_value(), move(options)));
         }
         // 11. Otherwise:
         else {

--- a/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -26,7 +26,7 @@ namespace Web::Fetch {
 Infrastructure::BodyWithType safely_extract_body(JS::Realm& realm, BodyInitOrReadableBytes const& object)
 {
     // 1. If object is a ReadableStream object, then:
-    if (auto const* stream = object.get_pointer<GC::Root<Streams::ReadableStream>>()) {
+    if (auto const* stream = object.get_pointer<GC::Ref<Streams::ReadableStream>>()) {
         // 1. Assert: object is neither disturbed nor locked.
         VERIFY(!((*stream)->is_disturbed() || (*stream)->is_locked()));
     }
@@ -46,12 +46,12 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
     GC::Ptr<Streams::ReadableStream> stream;
 
     // 2. If object is a ReadableStream object, then set stream to object.
-    if (auto const* stream_handle = object.get_pointer<GC::Root<Streams::ReadableStream>>()) {
-        stream = const_cast<Streams::ReadableStream*>(stream_handle->cell());
+    if (auto const* maybe_stream = object.get_pointer<GC::Ref<Streams::ReadableStream>>()) {
+        stream = *maybe_stream;
     }
     // 3. Otherwise, if object is a Blob object, set stream to the result of running object’s get stream.
-    else if (auto const* blob_handle = object.get_pointer<GC::Root<FileAPI::Blob>>()) {
-        stream = blob_handle->cell()->get_stream();
+    else if (auto* blob = object.get_pointer<GC::Ref<FileAPI::Blob>>()) {
+        stream = (*blob)->get_stream();
     }
     // 4. Otherwise, set stream to a new ReadableStream object, and set up stream with byte reading support.
     else {
@@ -76,7 +76,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
 
     // 10. Switch on object.
     TRY(object.visit(
-        [&](GC::Root<FileAPI::Blob> const& blob) -> WebIDL::ExceptionOr<void> {
+        [&](GC::Ref<FileAPI::Blob> blob) -> WebIDL::ExceptionOr<void> {
             // Set source to object.
             source = blob;
             // Set length to object’s size.
@@ -96,12 +96,12 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
             source = bytes;
             return {};
         },
-        [&](GC::Root<WebIDL::BufferSource> const& buffer_source) -> WebIDL::ExceptionOr<void> {
+        [&](GC::Ref<WebIDL::BufferSource> buffer_source) -> WebIDL::ExceptionOr<void> {
             // Set source to a copy of the bytes held by object.
             source = MUST(WebIDL::get_buffer_source_copy(*buffer_source->raw_object()));
             return {};
         },
-        [&](GC::Root<XHR::FormData> const& form_data) -> WebIDL::ExceptionOr<void> {
+        [&](GC::Ref<XHR::FormData> form_data) -> WebIDL::ExceptionOr<void> {
             // Set action to this step: run the multipart/form-data encoding algorithm, with object’s entry list and UTF-8.
             auto serialized_form_data = MUST(HTML::serialize_to_multipart_form_data(form_data->entry_list()));
             // Set source to object.
@@ -111,7 +111,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
             type = ByteString::formatted("multipart/form-data; boundary={}", serialized_form_data.boundary);
             return {};
         },
-        [&](GC::Root<DOMURL::URLSearchParams> const& url_search_params) -> WebIDL::ExceptionOr<void> {
+        [&](GC::Ref<DOMURL::URLSearchParams> url_search_params) -> WebIDL::ExceptionOr<void> {
             // Set source to the result of running the application/x-www-form-urlencoded serializer with object’s list.
             auto search_params_string = url_search_params->to_string();
             source = MUST(ByteBuffer::copy(search_params_string.bytes()));
@@ -127,7 +127,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
             type = "text/plain;charset=UTF-8"sv;
             return {};
         },
-        [&](GC::Root<Streams::ReadableStream> const& stream) -> WebIDL::ExceptionOr<void> {
+        [&](GC::Ref<Streams::ReadableStream> stream) -> WebIDL::ExceptionOr<void> {
             // If keepalive is true, then throw a TypeError.
             if (keepalive)
                 return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Cannot extract body from stream when keepalive is set"sv };

--- a/Libraries/LibWeb/Fetch/BodyInit.h
+++ b/Libraries/LibWeb/Fetch/BodyInit.h
@@ -16,10 +16,10 @@
 namespace Web::Fetch {
 
 // https://fetch.spec.whatwg.org/#bodyinit
-using BodyInit = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String>;
-using NullableBodyInit = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String, Empty>;
+using BodyInit = Variant<GC::Ref<Streams::ReadableStream>, GC::Ref<FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<DOMURL::URLSearchParams>, String>;
+using NullableBodyInit = Variant<GC::Ref<Streams::ReadableStream>, GC::Ref<FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<DOMURL::URLSearchParams>, String, Empty>;
 
-using BodyInitOrReadableBytes = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String, ReadonlyBytes, Core::ImmutableBytes>;
+using BodyInitOrReadableBytes = Variant<GC::Ref<Streams::ReadableStream>, GC::Ref<FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<DOMURL::URLSearchParams>, String, ReadonlyBytes, Core::ImmutableBytes>;
 WEB_API Infrastructure::BodyWithType safely_extract_body(JS::Realm&, BodyInitOrReadableBytes const&);
 WEB_API WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm&, BodyInitOrReadableBytes const&, bool keepalive = false);
 

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1546,7 +1546,7 @@ GC::Ptr<PendingResponse> http_redirect_fetch(JS::Realm& realm, Infrastructure::F
         auto converted_source = source.visit(
             [](ByteBuffer const& byte_buffer) -> BodyInitOrReadableBytes { return byte_buffer.bytes(); },
             [](Core::ImmutableBytes const& bytes) -> BodyInitOrReadableBytes { return bytes; },
-            [](GC::Ref<FileAPI::Blob> const& blob) -> BodyInitOrReadableBytes { return GC::make_root(blob); },
+            [](GC::Ref<FileAPI::Blob> blob) -> BodyInitOrReadableBytes { return blob; },
             [](Empty) -> BodyInitOrReadableBytes { VERIFY_NOT_REACHED(); });
         auto [body, _] = safely_extract_body(realm, converted_source);
         request->set_body(body);
@@ -2005,7 +2005,7 @@ GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm& realm, Infrastru
                 auto converted_source = source.visit(
                     [](ByteBuffer const& byte_buffer) -> BodyInitOrReadableBytes { return byte_buffer.bytes(); },
                     [](Core::ImmutableBytes const& bytes) -> BodyInitOrReadableBytes { return bytes; },
-                    [](GC::Ref<FileAPI::Blob> const& blob) -> BodyInitOrReadableBytes { return GC::make_root(blob); },
+                    [](GC::Ref<FileAPI::Blob> blob) -> BodyInitOrReadableBytes { return blob; },
                     [](Empty) -> BodyInitOrReadableBytes { VERIFY_NOT_REACHED(); });
                 auto [body, _] = safely_extract_body(realm, converted_source);
                 request->set_body(body);

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -19,26 +19,12 @@ namespace Web::Fetch::Infrastructure {
 
 GC_DEFINE_ALLOCATOR(Body);
 
-static Body::SourceTypeInternal to_source_type_internal(Body::SourceType&& source_type)
-{
-    return source_type.visit(
-        [](Empty) -> Body::SourceTypeInternal { return Empty {}; },
-        [](ByteBuffer& buffer) -> Body::SourceTypeInternal { return move(buffer); },
-        [](Core::ImmutableBytes& bytes) -> Body::SourceTypeInternal { return move(bytes); },
-        [](GC::Root<FileAPI::Blob> const& blob) -> Body::SourceTypeInternal { return GC::Ref { *blob }; });
-}
-
 GC::Ref<Body> Body::create(JS::VM& vm, GC::Ref<Streams::ReadableStream> stream)
 {
     return vm.heap().allocate<Body>(stream);
 }
 
 GC::Ref<Body> Body::create(JS::VM& vm, GC::Ref<Streams::ReadableStream> stream, SourceType source, Optional<u64> length)
-{
-    return create(vm, stream, to_source_type_internal(move(source)), length);
-}
-
-GC::Ref<Body> Body::create(JS::VM& vm, GC::Ref<Streams::ReadableStream> stream, SourceTypeInternal source, Optional<u64> length)
 {
     return vm.heap().allocate<Body>(stream, source, length);
 }
@@ -48,7 +34,7 @@ Body::Body(GC::Ref<Streams::ReadableStream> stream)
 {
 }
 
-Body::Body(GC::Ref<Streams::ReadableStream> stream, SourceTypeInternal source, Optional<u64> length)
+Body::Body(GC::Ref<Streams::ReadableStream> stream, SourceType source, Optional<u64> length)
     : m_stream(stream)
     , m_source(move(source))
     , m_length(move(length))

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -31,8 +31,7 @@ class WEB_API Body final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(Body);
 
 public:
-    using SourceType = Variant<Empty, ByteBuffer, Core::ImmutableBytes, GC::Root<FileAPI::Blob>>;
-    using SourceTypeInternal = Variant<Empty, ByteBuffer, Core::ImmutableBytes, GC::Ref<FileAPI::Blob>>;
+    using SourceType = Variant<Empty, ByteBuffer, Core::ImmutableBytes, GC::Ref<FileAPI::Blob>>;
     // processBody must be an algorithm accepting a byte sequence.
     using ProcessBodyCallback = GC::Ref<GC::Function<void(ByteBuffer)>>;
     // processBodyError must be an algorithm optionally accepting an exception.
@@ -44,11 +43,10 @@ public:
 
     [[nodiscard]] static GC::Ref<Body> create(JS::VM&, GC::Ref<Streams::ReadableStream>);
     [[nodiscard]] static GC::Ref<Body> create(JS::VM&, GC::Ref<Streams::ReadableStream>, SourceType, Optional<u64>);
-    [[nodiscard]] static GC::Ref<Body> create(JS::VM&, GC::Ref<Streams::ReadableStream>, SourceTypeInternal, Optional<u64>);
 
     [[nodiscard]] GC::Ref<Streams::ReadableStream> stream() const { return *m_stream; }
     void set_stream(GC::Ref<Streams::ReadableStream> value) { m_stream = value; }
-    [[nodiscard]] SourceTypeInternal const& source() const { return m_source; }
+    [[nodiscard]] SourceType const& source() const { return m_source; }
     void set_source(Core::ImmutableBytes, Optional<u64> length);
     [[nodiscard]] Optional<u64> const& length() const { return m_length; }
 
@@ -76,7 +74,7 @@ public:
 
 private:
     explicit Body(GC::Ref<Streams::ReadableStream>);
-    Body(GC::Ref<Streams::ReadableStream>, SourceTypeInternal, Optional<u64>);
+    Body(GC::Ref<Streams::ReadableStream>, SourceType, Optional<u64>);
 
     // https://fetch.spec.whatwg.org/#concept-body-stream
     // A stream (a ReadableStream object).
@@ -84,7 +82,7 @@ private:
 
     // https://fetch.spec.whatwg.org/#concept-body-source
     // A source (null, a byte sequence, a Blob object, or a FormData object), initially null.
-    SourceTypeInternal m_source;
+    SourceType m_source;
 
     // https://fetch.spec.whatwg.org/#concept-body-total-bytes
     // A length (null or an integer), initially null.

--- a/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Libraries/LibWeb/Fetch/Request.cpp
@@ -160,13 +160,13 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
     // 6. Otherwise:
     else {
         // 1. Assert: input is a Request object.
-        VERIFY(input.has<GC::Root<Request>>());
+        VERIFY(input.has<GC::Ref<Request>>());
 
         // 2. Set request to input’s request.
-        input_request = input.get<GC::Root<Request>>()->request();
+        input_request = input.get<GC::Ref<Request>>()->request();
 
         // 3. Set signal to input’s signal.
-        input_signal = input.get<GC::Root<Request>>()->signal();
+        input_signal = input.get<GC::Ref<Request>>()->signal();
     }
 
     // 7. Let origin be this’s relevant settings object’s origin.
@@ -402,7 +402,7 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
 
     // 26. If init["signal"] exists, then set signal to it.
     if (init.signal.has_value())
-        input_signal = *init.signal;
+        input_signal = init.signal->ptr();
 
     // 27. If init["priority"] exists, then:
     if (init.priority.has_value())
@@ -414,7 +414,7 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
 
     // 29. Let signals be « signal » if signal is non-null; otherwise « ».
     auto& this_relevant_realm = HTML::relevant_realm(*request_object);
-    Vector<GC::Root<DOM::AbortSignal>> signals;
+    GC::RootVector<GC::Ref<DOM::AbortSignal>> signals;
     if (input_signal != nullptr)
         signals.append(*input_signal);
 
@@ -464,8 +464,8 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
 
     // 34. Let inputBody be input’s request’s body if input is a Request object; otherwise null.
     Optional<Infrastructure::Request::BodyType const&> input_body;
-    if (input.has<GC::Root<Request>>())
-        input_body = input.get<GC::Root<Request>>()->request()->body();
+    if (input.has<GC::Ref<Request>>())
+        input_body = input.get<GC::Ref<Request>>()->request()->body();
 
     // 35. If either init["body"] exists and is non-null or inputBody is non-null, and request’s method is `GET` or `HEAD`, then throw a TypeError.
     if (((init.body.has_value() && !init.body->has<Empty>()) || (input_body.has_value() && !input_body.value().has<Empty>())) && request->method().is_one_of("GET"sv, "HEAD"sv))
@@ -477,7 +477,7 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
     // 37. If init["body"] exists and is non-null, then:
     if (init.body.has_value() && !init.body->has<Empty>()) {
         // 1. Let bodyWithType be the result of extracting init["body"], with keepalive set to request's keepalive.
-        auto body_with_type = TRY(extract_body(realm, init.body->downcast<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String>(), request->keepalive()));
+        auto body_with_type = TRY(extract_body(realm, init.body->downcast<GC::Ref<Streams::ReadableStream>, GC::Ref<FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<DOMURL::URLSearchParams>, String>(), request->keepalive()));
 
         // 2. Set initBody to bodyWithType’s body.
         init_body = body_with_type.body;
@@ -514,7 +514,7 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
     // 41. If initBody is null and inputBody is non-null, then:
     if (!init_body.has_value() && input_body.has_value()) {
         // 2. If input is unusable, then throw a TypeError.
-        if (input.has<GC::Root<Request>>() && input.get<GC::Root<Request>>()->is_unusable())
+        if (input.has<GC::Ref<Request>>() && input.get<GC::Ref<Request>>()->is_unusable())
             return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Request is unusable"sv };
 
         // FIXME: 2. Set finalBody to the result of creating a proxy for inputBody.
@@ -671,7 +671,7 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::clone() const
 
     // 4. Let clonedSignal be the result of creating a dependent abort signal from « this’s signal », using AbortSignal and this’s relevant realm.
     auto& relevant_realm = HTML::relevant_realm(*this);
-    auto cloned_signal = TRY(DOM::AbortSignal::create_dependent_abort_signal(relevant_realm, { m_signal }));
+    auto cloned_signal = TRY(DOM::AbortSignal::create_dependent_abort_signal(relevant_realm, { { *m_signal } }));
 
     // 5. Let clonedRequestObject be the result of creating a Request object, given clonedRequest, this’s headers’s guard, clonedSignal and this’s relevant realm.
     auto cloned_request_object = Request::create(relevant_realm, cloned_request, m_headers->guard(), cloned_signal);

--- a/Libraries/LibWeb/Fetch/Request.h
+++ b/Libraries/LibWeb/Fetch/Request.h
@@ -20,7 +20,7 @@
 namespace Web::Fetch {
 
 // https://fetch.spec.whatwg.org/#requestinfo
-using RequestInfo = Variant<GC::Root<Request>, String>;
+using RequestInfo = Variant<GC::Ref<Request>, String>;
 
 // https://fetch.spec.whatwg.org/#request
 class Request final

--- a/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Libraries/LibWeb/Fetch/Response.cpp
@@ -156,7 +156,7 @@ WebIDL::ExceptionOr<GC::Ref<Response>> Response::construct_impl(JS::Realm& realm
 
     // 4. If body is non-null, then set bodyWithType to the result of extracting body.
     if (!body.has<Empty>())
-        body_with_type = TRY(extract_body(realm, body.downcast<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String>()));
+        body_with_type = TRY(extract_body(realm, body.downcast<GC::Ref<Streams::ReadableStream>, GC::Ref<FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<DOMURL::URLSearchParams>, String>()));
 
     // 5. Perform initialize a response given this, init, and bodyWithType.
     TRY(response_object->initialize_response(init, body_with_type));

--- a/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -107,12 +107,12 @@ ErrorOr<ByteBuffer> process_blob_parts(BlobParts const& blob_parts, Optional<Bin
                 return bytes.try_append(s.bytes());
             },
             // 2. If element is a BufferSource, get a copy of the bytes held by the buffer source, and append those bytes to bytes.
-            [&](GC::Root<WebIDL::BufferSource> const& buffer_source) -> ErrorOr<void> {
+            [&](GC::Ref<WebIDL::BufferSource> const& buffer_source) -> ErrorOr<void> {
                 auto data_buffer = TRY(WebIDL::get_buffer_source_copy(*buffer_source->raw_object()));
                 return bytes.try_append(data_buffer.bytes());
             },
             // 3. If element is a Blob, append the bytes it represents to bytes.
-            [&](GC::Root<Blob> const& blob) -> ErrorOr<void> {
+            [&](GC::Ref<Blob> const& blob) -> ErrorOr<void> {
                 return bytes.try_append(blob->raw_bytes());
             }));
     }
@@ -223,7 +223,9 @@ GC::Ref<Blob> Blob::create(JS::Realm& realm, Optional<BlobPartsOrByteBuffer> con
 
 WebIDL::ExceptionOr<GC::Ref<Blob>> Blob::construct_impl(JS::Realm& realm, Optional<BlobParts> const& blob_parts, Optional<Bindings::BlobPropertyBag> const& options)
 {
-    return create(realm, blob_parts.has_value() ? blob_parts.value() : Optional<BlobPartsOrByteBuffer> {}, options);
+    if (blob_parts.has_value())
+        return create(realm, BlobPartsOrByteBuffer { blob_parts.value() }, options);
+    return create(realm, {}, options);
 }
 
 // https://w3c.github.io/FileAPI/#dfn-slice

--- a/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Libraries/LibWeb/FileAPI/Blob.h
@@ -17,8 +17,8 @@
 
 namespace Web::FileAPI {
 
-using BlobPart = Variant<GC::Root<WebIDL::BufferSource>, GC::Root<Blob>, String>;
-using BlobParts = Vector<BlobPart>;
+using BlobPart = Variant<GC::Ref<WebIDL::BufferSource>, GC::Ref<Blob>, String>;
+using BlobParts = GC::ConservativeVector<BlobPart>;
 using BlobPartsOrByteBuffer = Variant<BlobParts, ByteBuffer>;
 
 [[nodiscard]] ErrorOr<String> convert_line_endings_to_native(StringView string);

--- a/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
+++ b/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
@@ -20,7 +20,7 @@ namespace Web::FileAPI {
 
 BlobURLStore& blob_url_store()
 {
-    static HashMap<String, BlobURLEntry> store;
+    static GC::ConservativeHashMap<String, BlobURLEntry> store;
     return store;
 }
 

--- a/Libraries/LibWeb/FileAPI/BlobURLStore.h
+++ b/Libraries/LibWeb/FileAPI/BlobURLStore.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/HashMap.h>
 #include <AK/String.h>
+#include <LibGC/ConservativeHashMap.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
 #include <LibURL/URL.h>
@@ -17,14 +17,14 @@ namespace Web::FileAPI {
 
 // https://w3c.github.io/FileAPI/#blob-url-entry
 struct BlobURLEntry {
-    using Object = Variant<GC::Root<Blob>, GC::Root<MediaSourceExtensions::MediaSource>>;
+    using Object = Variant<GC::Ref<Blob>, GC::Ref<MediaSourceExtensions::MediaSource>>;
 
     Object object;
-    GC::Root<HTML::EnvironmentSettingsObject> environment;
+    GC::Ref<HTML::EnvironmentSettingsObject> environment;
 };
 
 // https://w3c.github.io/FileAPI/#BlobURLStore
-using BlobURLStore = HashMap<String, BlobURLEntry>;
+using BlobURLStore = GC::ConservativeHashMap<String, BlobURLEntry>;
 
 BlobURLStore& blob_url_store();
 ErrorOr<Utf16String> generate_new_blob_url();

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -485,7 +485,7 @@ struct StyleSheetIdentifier;
 struct TransitionProperties;
 
 // https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-cssnumberish
-using CSSNumberish = Variant<double, GC::Root<CSSNumericValue>>;
+using CSSNumberish = Variant<double, GC::Ref<CSSNumericValue>>;
 using PaintOrderList = Array<PaintOrder, 3>;
 using StyleValueVector = Vector<ValueComparingNonnullRefPtr<StyleValue const>>;
 using StyleValueTuple = Vector<ValueComparingRefPtr<StyleValue const>>;

--- a/Libraries/LibWeb/HTML/BroadcastChannel.cpp
+++ b/Libraries/LibWeb/HTML/BroadcastChannel.cpp
@@ -11,12 +11,14 @@
 #include <LibWeb/Bindings/BroadcastChannel.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
@@ -208,7 +210,7 @@ void BroadcastChannel::deliver_message_locally(BroadcastChannelMessage const& me
             //    origin initialized to sourceOrigin, and then abort these steps.
             auto data_or_error = structured_deserialize(vm, message.serialized_message, target_realm);
             if (data_or_error.is_exception()) {
-                Bindings::MessageEventInit event_init {};
+                Bindings::MessageEventInit event_init;
                 auto event = MessageEvent::create(target_realm, HTML::EventNames::messageerror, event_init, message.source_origin);
                 event->set_is_trusted(true);
                 destination->dispatch_event(event);
@@ -217,7 +219,7 @@ void BroadcastChannel::deliver_message_locally(BroadcastChannelMessage const& me
 
             // 4. Fire an event named message at destination, using MessageEvent, with the data attribute initialized to data and
             //    its origin initialized to sourceOrigin.
-            Bindings::MessageEventInit event_init {};
+            Bindings::MessageEventInit event_init;
             event_init.data = data_or_error.release_value();
             auto event = MessageEvent::create(target_realm, HTML::EventNames::message, event_init, message.source_origin);
             event->set_is_trusted(true);

--- a/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
@@ -16,36 +16,36 @@ namespace Web::HTML {
 Gfx::IntSize canvas_image_source_dimensions(CanvasImageSource const& image)
 {
     return image.visit(
-        [](GC::Root<HTMLImageElement> const& source) -> Gfx::IntSize {
+        [](GC::Ref<HTMLImageElement> source) -> Gfx::IntSize {
             if (auto frame = source->current_image_frame(); frame.has_value())
                 return frame->size();
 
             // FIXME: This is very janky and not correct.
             return { source->width(), source->height() };
         },
-        [](GC::Root<SVG::SVGImageElement> const& source) -> Gfx::IntSize {
+        [](GC::Ref<SVG::SVGImageElement> source) -> Gfx::IntSize {
             if (auto decoded_image_frame = source->current_image_frame(); decoded_image_frame.has_value())
                 return decoded_image_frame->size();
 
             // FIXME: This is very janky and not correct.
             return { source->width()->anim_val()->value(), source->height()->anim_val()->value() };
         },
-        [](GC::Root<HTMLCanvasElement> const& source) -> Gfx::IntSize {
+        [](GC::Ref<HTMLCanvasElement> source) -> Gfx::IntSize {
             if (auto painting_surface = source->surface())
                 return painting_surface->size();
             return { source->width(), source->height() };
         },
-        [](GC::Root<ImageBitmap> const& source) -> Gfx::IntSize {
+        [](GC::Ref<ImageBitmap> source) -> Gfx::IntSize {
             if (auto* bitmap = source->bitmap())
                 return bitmap->size();
             return { source->width(), source->height() };
         },
-        [](GC::Root<OffscreenCanvas> const& source) -> Gfx::IntSize {
+        [](GC::Ref<OffscreenCanvas> source) -> Gfx::IntSize {
             if (auto bitmap = source->bitmap())
                 return bitmap->size();
             return {};
         },
-        [](GC::Root<HTMLVideoElement> const& source) -> Gfx::IntSize {
+        [](GC::Ref<HTMLVideoElement> source) -> Gfx::IntSize {
             return { source->video_width(), source->video_height() };
         });
 }
@@ -53,7 +53,7 @@ Gfx::IntSize canvas_image_source_dimensions(CanvasImageSource const& image)
 Optional<Gfx::DecodedImageFrame> canvas_image_source_frame(CanvasImageSource const& image)
 {
     return image.visit(
-        [](OneOf<GC::Root<HTMLImageElement>, GC::Root<SVG::SVGImageElement>> auto const& element) -> Optional<Gfx::DecodedImageFrame> {
+        [](OneOf<GC::Ref<HTMLImageElement>, GC::Ref<SVG::SVGImageElement>> auto const& element) -> Optional<Gfx::DecodedImageFrame> {
             auto image_data = element->decoded_image_data();
             if (!image_data)
                 return {};
@@ -66,20 +66,20 @@ Optional<Gfx::DecodedImageFrame> canvas_image_source_frame(CanvasImageSource con
 
             return image_data->frame(0, size);
         },
-        [](GC::Root<HTMLCanvasElement> const& canvas) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTMLCanvasElement> const& canvas) -> Optional<Gfx::DecodedImageFrame> {
             canvas->present();
             auto surface = canvas->surface();
             if (!surface)
                 return Gfx::DecodedImageFrame { *canvas->get_bitmap_from_surface() };
             return Gfx::DecodedImageFrame { *surface->snapshot_bitmap() };
         },
-        [](OneOf<GC::Root<ImageBitmap>, GC::Root<OffscreenCanvas>> auto const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](OneOf<GC::Ref<ImageBitmap>, GC::Ref<OffscreenCanvas>> auto const& source) -> Optional<Gfx::DecodedImageFrame> {
             auto bitmap = source->bitmap();
             if (!bitmap)
                 return {};
             return Gfx::DecodedImageFrame { *bitmap };
         },
-        [](GC::Root<HTMLVideoElement> const& source) -> Optional<Gfx::DecodedImageFrame> {
+        [](GC::Ref<HTMLVideoElement> const& source) -> Optional<Gfx::DecodedImageFrame> {
             return source->current_decoded_image_frame();
         });
 }

--- a/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.h
@@ -22,7 +22,7 @@ namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesource
 // NOTE: This is the Variant created by the IDL wrapper generator, and needs to be updated accordingly.
-using CanvasImageSource = Variant<GC::Root<HTMLImageElement>, GC::Root<SVG::SVGImageElement>, GC::Root<HTMLCanvasElement>, GC::Root<ImageBitmap>, GC::Root<OffscreenCanvas>, GC::Root<HTMLVideoElement>>;
+using CanvasImageSource = Variant<GC::Ref<HTMLImageElement>, GC::Ref<SVG::SVGImageElement>, GC::Ref<HTMLCanvasElement>, GC::Ref<ImageBitmap>, GC::Ref<OffscreenCanvas>, GC::Ref<HTMLVideoElement>>;
 
 Gfx::IntSize canvas_image_source_dimensions(CanvasImageSource const&);
 Optional<Gfx::DecodedImageFrame> canvas_image_source_frame(CanvasImageSource const&);

--- a/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
@@ -19,7 +19,7 @@ template<typename IncludingClass>
 class CanvasFillStrokeStyles {
 public:
     ~CanvasFillStrokeStyles() = default;
-    using FillOrStrokeStyleVariant = Variant<String, GC::Root<CanvasGradient>, GC::Root<CanvasPattern>>;
+    using FillOrStrokeStyleVariant = Variant<String, GC::Ref<CanvasGradient>, GC::Ref<CanvasPattern>>;
 
     void set_fill_style(FillOrStrokeStyleVariant style);
     FillOrStrokeStyleVariant fill_style() const;

--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -59,7 +59,7 @@ public:
         Optional<Gfx::Color> as_color() const;
         Gfx::Color to_color_but_fixme_should_accept_any_paint_style() const;
 
-        using JsFillOrStrokeStyle = Variant<String, GC::Root<CanvasGradient>, GC::Root<CanvasPattern>>;
+        using JsFillOrStrokeStyle = Variant<String, GC::Ref<CanvasGradient>, GC::Ref<CanvasPattern>>;
 
         JsFillOrStrokeStyle to_js_fill_or_stroke_style() const
         {
@@ -68,7 +68,7 @@ public:
                     return color.to_string(Gfx::Color::HTMLCompatibleSerialization::Yes);
                 },
                 [&](auto handle) -> JsFillOrStrokeStyle {
-                    return GC::make_root(handle);
+                    return handle;
                 });
         }
 

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -911,7 +911,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
     // 1. Switch on image:
     auto usability = TRY(image.visit(
         // HTMLOrSVGImageElement
-        [](GC::Root<HTMLImageElement> const& image_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
+        [](GC::Ref<HTMLImageElement> image_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // If image's current request's state is broken, then throw an "InvalidStateError" DOMException.
             if (image_element->current_request().state() == HTML::ImageRequest::State::Broken)
                 return WebIDL::InvalidStateError::create(image_element->realm(), "Image element state is broken"_utf16);
@@ -927,7 +927,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
             return Optional<CanvasImageSourceUsability> {};
         },
         // FIXME: Don't duplicate this for HTMLImageElement and SVGImageElement.
-        [](GC::Root<SVG::SVGImageElement> const& image_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
+        [](GC::Ref<SVG::SVGImageElement> image_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // FIXME: If image's current request's state is broken, then throw an "InvalidStateError" DOMException.
 
             // If image is not fully decodable, then return bad.
@@ -941,7 +941,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
             return Optional<CanvasImageSourceUsability> {};
         },
 
-        [](GC::Root<HTML::HTMLVideoElement> const& video_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
+        [](GC::Ref<HTML::HTMLVideoElement> video_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // If image's readyState attribute is either HAVE_NOTHING or HAVE_METADATA, then return bad.
             if (video_element->ready_state() == HTML::HTMLMediaElement::ReadyState::HaveNothing || video_element->ready_state() == HTML::HTMLMediaElement::ReadyState::HaveMetadata) {
                 return { CanvasImageSourceUsability::Bad };
@@ -950,14 +950,14 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
         },
 
         // OffscreenCanvas
-        [](GC::Root<OffscreenCanvas> const& offscreen_canvas) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
+        [](GC::Ref<OffscreenCanvas> offscreen_canvas) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // If image has either a horizontal dimension or a vertical dimension equal to zero, then throw an "InvalidStateError" DOMException.
             if (offscreen_canvas->width() == 0 || offscreen_canvas->height() == 0)
                 return WebIDL::InvalidStateError::create(offscreen_canvas->realm(), "OffscreenCanvas width or height is zero"_utf16);
             return Optional<CanvasImageSourceUsability> {};
         },
         // HTMLCanvasElement
-        [](GC::Root<HTMLCanvasElement> const& canvas_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
+        [](GC::Ref<HTMLCanvasElement> canvas_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // If image has either a horizontal dimension or a vertical dimension equal to zero, then throw an "InvalidStateError" DOMException.
             if (canvas_element->width() == 0 || canvas_element->height() == 0)
                 return WebIDL::InvalidStateError::create(canvas_element->realm(), "Canvas width or height is zero"_utf16);
@@ -966,7 +966,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
 
         // ImageBitmap
         // FIXME: VideoFrame
-        [](GC::Root<ImageBitmap> const& image_bitmap) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
+        [](GC::Ref<ImageBitmap> image_bitmap) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             if (image_bitmap->is_detached())
                 return WebIDL::InvalidStateError::create(image_bitmap->realm(), "Image bitmap is detached"_utf16);
             return Optional<CanvasImageSourceUsability> {};
@@ -984,20 +984,20 @@ bool image_is_not_origin_clean(CanvasImageSource const& image)
     // An object image is not origin-clean if, switching on image's type:
     return image.visit(
         // HTMLOrSVGImageElement
-        [](GC::Root<HTMLImageElement> const&) {
+        [](GC::Ref<HTMLImageElement>) {
             // FIXME: image's current request's image data is CORS-cross-origin.
             return false;
         },
-        [](GC::Root<SVG::SVGImageElement> const&) {
+        [](GC::Ref<SVG::SVGImageElement>) {
             // FIXME: image's current request's image data is CORS-cross-origin.
             return false;
         },
-        [](GC::Root<HTML::HTMLVideoElement> const&) {
+        [](GC::Ref<HTML::HTMLVideoElement>) {
             // FIXME: image's media data is CORS-cross-origin.
             return false;
         },
         // HTMLCanvasElement, ImageBitmap or OffscreenCanvas
-        [](OneOf<GC::Root<HTMLCanvasElement>, GC::Root<ImageBitmap>, GC::Root<OffscreenCanvas>> auto const&) {
+        [](OneOf<GC::Ref<HTMLCanvasElement>, GC::Ref<ImageBitmap>, GC::Ref<OffscreenCanvas>> auto const&) {
             // FIXME: image's bitmap's origin-clean flag is false.
             return false;
         });

--- a/Libraries/LibWeb/HTML/CloseWatcher.cpp
+++ b/Libraries/LibWeb/HTML/CloseWatcher.cpp
@@ -69,9 +69,7 @@ WebIDL::ExceptionOr<GC::Ref<CloseWatcher>> CloseWatcher::construct_impl(JS::Real
     auto close_watcher = establish(window, GC::create_function(realm.heap(), [] { return true; }));
 
     // 3. If options["signal"] exists, then:
-    if (options.signal.has_value()) {
-        auto signal = options.signal->ptr();
-
+    if (auto signal = options.signal) {
         // 3.1 If options["signal"]'s aborted, then destroy closeWatcher.
         if (signal->aborted()) {
             close_watcher->destroy();

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -330,7 +330,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 }
 
 // https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-get
-Variant<GC::Root<WebIDL::CallbackType>, Empty> CustomElementRegistry::get(String const& name) const
+Variant<GC::Ref<WebIDL::CallbackType>, Empty> CustomElementRegistry::get(String const& name) const
 {
     // 1. If this's custom element definition set contains an item with name name, then return that item's constructor.
     auto existing_definition_iterator = m_custom_element_definitions.find_if([&name](auto const& definition) {
@@ -338,18 +338,18 @@ Variant<GC::Root<WebIDL::CallbackType>, Empty> CustomElementRegistry::get(String
     });
 
     if (!existing_definition_iterator.is_end())
-        return GC::make_root((*existing_definition_iterator)->constructor());
+        return GC::Ref { (*existing_definition_iterator)->constructor() };
 
     // 2. Return undefined.
     return Empty {};
 }
 
 // https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-getname
-Optional<String> CustomElementRegistry::get_name(GC::Root<WebIDL::CallbackType> const& constructor) const
+Optional<String> CustomElementRegistry::get_name(GC::Ref<WebIDL::CallbackType> constructor) const
 {
     // 1. If this's custom element definition set contains an item with constructor constructor, then return that item's name.
     auto existing_definition_iterator = m_custom_element_definitions.find_if([&constructor](auto const& definition) {
-        return definition->constructor().callback == constructor.cell()->callback;
+        return definition->constructor().callback == constructor->callback;
     });
 
     if (!existing_definition_iterator.is_end())

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
@@ -25,8 +25,8 @@ public:
     virtual ~CustomElementRegistry() override;
 
     JS::ThrowCompletionOr<void> define(String const& name, WebIDL::CallbackType* constructor, Bindings::ElementDefinitionOptions const&);
-    Variant<GC::Root<WebIDL::CallbackType>, Empty> get(String const& name) const;
-    Optional<String> get_name(GC::Root<WebIDL::CallbackType> const& constructor) const;
+    Variant<GC::Ref<WebIDL::CallbackType>, Empty> get(String const& name) const;
+    Optional<String> get_name(GC::Ref<WebIDL::CallbackType> constructor) const;
     WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> when_defined(String const& name);
     void upgrade(GC::Ref<DOM::Node> root) const;
     WebIDL::ExceptionOr<void> initialize_for_bindings(GC::Ref<DOM::Node> root);

--- a/Libraries/LibWeb/HTML/DataTransfer.cpp
+++ b/Libraries/LibWeb/HTML/DataTransfer.cpp
@@ -255,7 +255,7 @@ GC::Ref<FileAPI::FileList> DataTransfer::files() const
         Bindings::FilePropertyBag options {};
         options.type = item.type_string;
 
-        auto file = MUST(FileAPI::File::create(realm, { GC::make_root(blob) }, file_name, move(options)));
+        auto file = MUST(FileAPI::File::create(realm, { { blob } }, file_name, move(options)));
         files->add_file(file);
     }
 

--- a/Libraries/LibWeb/HTML/DataTransferItem.cpp
+++ b/Libraries/LibWeb/HTML/DataTransferItem.cpp
@@ -146,7 +146,9 @@ GC::Ptr<FileAPI::File> DataTransferItem::get_as_file() const
     Bindings::FilePropertyBag options {};
     options.type = item.type_string;
 
-    return MUST(FileAPI::File::create(realm, { GC::make_root(blob) }, file_name, move(options)));
+    FileAPI::BlobParts file_bits {};
+    file_bits.append(blob);
+    return MUST(FileAPI::File::create(realm, file_bits, file_name, move(options)));
 }
 
 // https://wicg.github.io/entries-api/#dom-datatransferitem-webkitgetasentry

--- a/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.cpp
@@ -58,7 +58,7 @@ WebIDL::ExceptionOr<void> DedicatedWorkerGlobalScope::post_message(JS::Value mes
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-postmessage
-WebIDL::ExceptionOr<void> DedicatedWorkerGlobalScope::post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer)
+WebIDL::ExceptionOr<void> DedicatedWorkerGlobalScope::post_message(JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer)
 {
     // The postMessage(message, transfer) and postMessage(message, options) methods on DedicatedWorkerGlobalScope objects act as if,
     // when invoked, it immediately invoked the respective postMessage(message, transfer) and postMessage(message, options)

--- a/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.h
@@ -25,7 +25,7 @@ public:
     virtual ~DedicatedWorkerGlobalScope() override;
 
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Bindings::StructuredSerializeOptions const&);
-    WebIDL::ExceptionOr<void> post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer);
 
     void close();
 

--- a/Libraries/LibWeb/HTML/ElementInternals.cpp
+++ b/Libraries/LibWeb/HTML/ElementInternals.cpp
@@ -60,13 +60,13 @@ WebIDL::ExceptionOr<void> ElementInternals::set_form_value(ElementInternalsFormV
 
     // 3. Set target element's submission value to value if value is not a FormData object, or to a clone of value's entry list otherwise.
     auto submission_value = value.visit(
-        [](GC::Root<FileAPI::File> const& file) -> FormAssociatedElement::FACESubmissionValue {
-            return GC::Ref { *file };
+        [](GC::Ref<FileAPI::File> file) -> FormAssociatedElement::FACESubmissionValue {
+            return file;
         },
         [](String const& string) -> FormAssociatedElement::FACESubmissionValue {
             return string;
         },
-        [](GC::Root<XHR::FormData> const& form_data) -> FormAssociatedElement::FACESubmissionValue {
+        [](GC::Ref<XHR::FormData> form_data) -> FormAssociatedElement::FACESubmissionValue {
             return form_data->entry_list();
         },
         [](Empty const& empty) -> FormAssociatedElement::FACESubmissionValue {

--- a/Libraries/LibWeb/HTML/ElementInternals.h
+++ b/Libraries/LibWeb/HTML/ElementInternals.h
@@ -27,7 +27,7 @@ public:
 
     GC::Ptr<DOM::ShadowRoot> shadow_root() const;
 
-    using ElementInternalsFormValue = Variant<GC::Root<FileAPI::File>, String, GC::Root<XHR::FormData>, Empty>;
+    using ElementInternalsFormValue = Variant<GC::Ref<FileAPI::File>, String, GC::Ref<XHR::FormData>, Empty>;
     WebIDL::ExceptionOr<void> set_form_value(ElementInternalsFormValue value, Optional<ElementInternalsFormValue> state);
 
     WebIDL::ExceptionOr<GC::Ptr<HTMLFormElement>> form() const;

--- a/Libraries/LibWeb/HTML/EventSource.cpp
+++ b/Libraries/LibWeb/HTML/EventSource.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/EventSource.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
@@ -23,6 +24,7 @@
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/EventSource.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
@@ -442,7 +444,7 @@ void EventSource::dispatch_the_event()
     //    the event source.
     // 6. If the event type buffer has a value other than the empty string, change the type of the newly created event to equal
     //    the value of the event type buffer.
-    Bindings::MessageEventInit init {};
+    Bindings::MessageEventInit init;
     init.data = JS::PrimitiveString::create(vm(), data_buffer);
     init.last_event_id = last_event_id;
 

--- a/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -39,7 +39,7 @@ WebIDL::ExceptionOr<XHR::FormDataEntry> create_entry(JS::Realm& realm, String co
                 Bindings::FilePropertyBag options {};
                 options.type = blob->type();
 
-                blob = TRY(FileAPI::File::create(realm, { GC::make_root(*blob) }, "blob"_string, move(options)));
+                blob = TRY(FileAPI::File::create(realm, { { blob } }, "blob"_string, move(options)));
             }
 
             // 2. If filename is given, then set value to a new File object, representing the same bytes, whose name
@@ -49,7 +49,7 @@ WebIDL::ExceptionOr<XHR::FormDataEntry> create_entry(JS::Realm& realm, String co
                 options.type = blob->type();
                 options.last_modified = as<FileAPI::File>(*blob).last_modified();
 
-                blob = TRY(FileAPI::File::create(realm, { GC::make_root(*blob) }, *filename, move(options)));
+                blob = TRY(FileAPI::File::create(realm, { { blob } }, *filename, move(options)));
             }
 
             return GC::Ref { as<FileAPI::File>(*blob) };
@@ -249,8 +249,7 @@ WebIDL::ExceptionOr<Optional<GC::ConservativeVector<XHR::FormDataEntry>>> constr
     auto form_data = TRY(XHR::FormData::construct_impl(realm, move(entry_list)));
 
     // 7. Fire an event named formdata at form using FormDataEvent, with the formData attribute initialized to form data and the bubbles attribute initialized to true.
-    Bindings::FormDataEventInit init {};
-    init.form_data = form_data;
+    Bindings::FormDataEventInit init { Bindings::EventInit {}, form_data };
     auto form_data_event = TRY(FormDataEvent::construct_impl(realm, HTML::EventNames::formdata, init));
     form_data_event->set_bubbles(true);
     form.dispatch_event(form_data_event);

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -288,7 +288,7 @@ JS::ThrowCompletionOr<HTMLCanvasElement::RenderingContext> HTMLCanvasElement::ge
     // NOTE: See the spec for the full table.
     if (type == "2d"sv) {
         if (TRY(create_2d_context(options)) == HasOrCreatedContext::Yes)
-            return GC::make_root(*m_context.get<GC::Ref<HTML::CanvasRenderingContext2D>>());
+            return m_context.get<GC::Ref<HTML::CanvasRenderingContext2D>>();
 
         return Empty {};
     }
@@ -296,14 +296,14 @@ JS::ThrowCompletionOr<HTMLCanvasElement::RenderingContext> HTMLCanvasElement::ge
     // NOTE: The WebGL spec says "experimental-webgl" is also acceptable and must be equivalent to "webgl". Other engines accept this, so we do too.
     if (type.is_one_of("webgl"sv, "experimental-webgl"sv)) {
         if (TRY(create_webgl_context<WebGL::WebGLRenderingContext>(options)) == HasOrCreatedContext::Yes)
-            return GC::make_root(*m_context.get<GC::Ref<WebGL::WebGLRenderingContext>>());
+            return m_context.get<GC::Ref<WebGL::WebGLRenderingContext>>();
 
         return Empty {};
     }
 
     if (type == "webgl2"sv) {
         if (TRY(create_webgl_context<WebGL::WebGL2RenderingContext>(options)) == HasOrCreatedContext::Yes)
-            return GC::make_root(*m_context.get<GC::Ref<WebGL::WebGL2RenderingContext>>());
+            return m_context.get<GC::Ref<WebGL::WebGL2RenderingContext>>();
 
         return Empty {};
     }
@@ -331,7 +331,7 @@ Gfx::IntSize HTMLCanvasElement::bitmap_size_for_canvas(size_t minimum_width, siz
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-todataurl
-String HTMLCanvasElement::to_data_url(StringView type, JS::Value js_quality)
+String HTMLCanvasElement::to_data_url(StringView type, Optional<JS::Value> js_quality)
 {
     // It is possible the canvas doesn't have an associated bitmap so create one
     allocate_painting_surface_if_needed();
@@ -351,7 +351,7 @@ String HTMLCanvasElement::to_data_url(StringView type, JS::Value js_quality)
 
     // 3. Let file be a serialization of this canvas element's bitmap as a file, passing type and quality if given.
     auto bitmap = surface->snapshot_bitmap();
-    Optional<double> quality = js_quality.is_number() ? js_quality.as_double() : Optional<double>();
+    Optional<double> quality = js_quality.has_value() && js_quality->is_number() ? js_quality->as_double() : Optional<double>();
     auto file = serialize_bitmap(bitmap, type, quality);
 
     // 4. If file is null, then return "data:,".
@@ -369,7 +369,7 @@ String HTMLCanvasElement::to_data_url(StringView type, JS::Value js_quality)
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-toblob
-WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackType> callback, StringView type, JS::Value js_quality)
+WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackType> callback, StringView type, Optional<JS::Value> js_quality)
 {
     // FIXME: 1. If this canvas element's bitmap's origin-clean flag is set to false, then throw a "SecurityError" DOMException.
 
@@ -378,7 +378,7 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackTyp
     //    then set result to a copy of this canvas element's bitmap.
     auto bitmap_result = get_bitmap_from_surface();
 
-    Optional<double> quality = js_quality.is_number() ? js_quality.as_double() : Optional<double>();
+    Optional<double> quality = js_quality.has_value() && js_quality->is_number() ? js_quality->as_double() : Optional<double>();
 
     // 4. Run these steps in parallel:
     Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [this, callback, bitmap_result, type, quality] {

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -22,7 +22,7 @@ class HTMLCanvasElement final : public HTMLElement {
 public:
     static constexpr bool OVERRIDES_FINALIZE = true;
 
-    using RenderingContext = Variant<GC::Root<CanvasRenderingContext2D>, GC::Root<WebGL::WebGLRenderingContext>, GC::Root<WebGL::WebGL2RenderingContext>, Empty>;
+    using RenderingContext = Variant<GC::Ref<CanvasRenderingContext2D>, GC::Ref<WebGL::WebGLRenderingContext>, GC::Ref<WebGL::WebGL2RenderingContext>, Empty>;
 
     virtual ~HTMLCanvasElement() override;
 
@@ -43,8 +43,8 @@ public:
 
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
-    String to_data_url(StringView type, JS::Value quality);
-    WebIDL::ExceptionOr<void> to_blob(GC::Ref<WebIDL::CallbackType> callback, StringView type, JS::Value quality);
+    String to_data_url(StringView type, Optional<JS::Value> quality);
+    WebIDL::ExceptionOr<void> to_blob(GC::Ref<WebIDL::CallbackType> callback, StringView type, Optional<JS::Value> quality);
     RefPtr<Gfx::Bitmap> get_bitmap_from_surface();
 
     void present();

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -272,12 +272,12 @@ void HTMLDetailsElement::update_shadow_tree_slots()
     if (!shadow_root())
         return;
 
-    Vector<HTMLSlotElement::SlottableHandle> summary_assignment;
-    Vector<HTMLSlotElement::SlottableHandle> descendants_assignment;
+    GC::ConservativeVector<HTMLSlotElement::SlottableHandle> summary_assignment;
+    GC::ConservativeVector<HTMLSlotElement::SlottableHandle> descendants_assignment;
 
     auto* summary = first_child_of_type<HTMLSummaryElement>();
     if (summary != nullptr)
-        summary_assignment.append(GC::make_root(static_cast<DOM::Element&>(*summary)));
+        summary_assignment.append(GC::Ref { static_cast<DOM::Element&>(*summary) });
 
     for_each_in_subtree([&](auto& child) {
         if (&child == summary)
@@ -286,7 +286,7 @@ void HTMLDetailsElement::update_shadow_tree_slots()
             return TraversalDecision::Continue;
 
         child.as_slottable().visit([&](auto& node) {
-            descendants_assignment.append(GC::make_root(node));
+            descendants_assignment.append(node);
         });
 
         return TraversalDecision::Continue;

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLElement.h>
+#include <LibWeb/Bindings/PointerEvent.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
@@ -1205,7 +1206,7 @@ WebIDL::ExceptionOr<bool> HTMLElement::check_popover_validity(ExpectedToBeShowin
 WebIDL::ExceptionOr<void> HTMLElement::show_popover_for_bindings(Bindings::ShowPopoverOptions const& options)
 {
     // 1. Let source be options["source"] if it exists; otherwise, null.
-    auto source = options.source.has_value() ? GC::Ptr<HTMLElement> { options.source->ptr() } : GC::Ptr<HTMLElement> {};
+    auto source = GC::Ptr<HTMLElement> { options.source };
     // 2. Run show popover given this, true, and source.
     return show_popover(ThrowExceptions::Yes, source);
 }
@@ -1579,8 +1580,7 @@ WebIDL::ExceptionOr<bool> HTMLElement::toggle_popover(TogglePopoverOptionsOrForc
             // 3. Otherwise, if options["force"] exists, set force to options["force"].
             force = options.force;
             // 4. Let source be options["source"] if it exists; otherwise, null.
-            if (options.source.has_value())
-                source = options.source->ptr();
+            source = options.source;
         });
 
     // 5. If this's popover visibility state is showing, and force is null or false, then run the hide popover algorithm given this, true, true, true, false, and null.

--- a/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormControlsCollection.cpp
@@ -35,7 +35,7 @@ void HTMLFormControlsCollection::initialize(JS::Realm& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlformcontrolscollection-nameditem
-Variant<Empty, DOM::Element*, GC::Root<RadioNodeList>> HTMLFormControlsCollection::named_item_or_radio_node_list(FlyString const& name) const
+Variant<Empty, GC::Ref<DOM::Element>, GC::Ref<RadioNodeList>> HTMLFormControlsCollection::named_item_or_radio_node_list(FlyString const& name) const
 {
     // 1. If name is the empty string, return null and stop the algorithm.
     if (name.is_empty())
@@ -63,18 +63,18 @@ Variant<Empty, DOM::Element*, GC::Root<RadioNodeList>> HTMLFormControlsCollectio
         return {};
 
     if (!multiple_matching)
-        return matching_element;
+        return GC::Ref { *matching_element };
 
     // 4. Otherwise, create a new RadioNodeList object representing a live view of the HTMLFormControlsCollection object, further filtered so that the only nodes in the
     //    RadioNodeList object are those that have either an id attribute or a name attribute equal to name. The nodes in the RadioNodeList object must be sorted in tree
     //    order. Return that RadioNodeList object.
-    return GC::make_root(RadioNodeList::create(realm(), root(), DOM::LiveNodeList::Scope::Descendants, [name](auto const& node) {
+    return RadioNodeList::create(realm(), root(), DOM::LiveNodeList::Scope::Descendants, [name](auto const& node) {
         if (!is<DOM::Element>(node))
             return false;
 
         auto const& element = as<DOM::Element>(node);
         return element.id() == name || element.name() == name;
-    }));
+    });
 }
 
 JS::Value HTMLFormControlsCollection::named_item_value(FlyString const& name) const

--- a/Libraries/LibWeb/HTML/HTMLFormControlsCollection.h
+++ b/Libraries/LibWeb/HTML/HTMLFormControlsCollection.h
@@ -19,7 +19,7 @@ public:
 
     virtual ~HTMLFormControlsCollection() override;
 
-    Variant<Empty, DOM::Element*, GC::Root<RadioNodeList>> named_item_or_radio_node_list(FlyString const& name) const;
+    Variant<Empty, GC::Ref<DOM::Element>, GC::Ref<RadioNodeList>> named_item_or_radio_node_list(FlyString const& name) const;
 
 protected:
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -642,7 +642,7 @@ void HTMLInputElement::did_select_files(Span<SelectedFile> selected_files, Multi
         Bindings::FilePropertyBag options {};
         options.type = mime_type.essence();
 
-        auto file = MUST(FileAPI::File::create(realm(), { GC::make_root(blob) }, file_name, move(options)));
+        auto file = MUST(FileAPI::File::create(realm(), { { blob } }, file_name, move(options)));
         files->add_file(file);
     }
 
@@ -2958,22 +2958,22 @@ JS::Object* HTMLInputElement::value_as_date() const
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-valueasdate
-WebIDL::ExceptionOr<void> HTMLInputElement::set_value_as_date(Optional<GC::Root<JS::Object>> const& value)
+WebIDL::ExceptionOr<void> HTMLInputElement::set_value_as_date(GC::Ptr<JS::Object> value)
 {
     // On setting, if the valueAsDate attribute does not apply, as defined for the input element's type attribute's current state, then throw an "InvalidStateError" DOMException;
     if (!value_as_date_applies())
         return WebIDL::InvalidStateError::create(realm(), "valueAsDate: Invalid input type used"_utf16);
 
     // otherwise, if the new value is not null and not a Date object throw a TypeError exception;
-    if (value.has_value() && !is<JS::Date>(**value))
+    if (value && !is<JS::Date>(*value))
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "valueAsDate: input is not a Date"sv };
 
     // otherwise if the new value is null or a Date object representing the NaN time value, then set the value of the element to the empty string;
-    if (!value.has_value()) {
+    if (!value) {
         TRY(set_value({}));
         return {};
     }
-    auto& date = static_cast<JS::Date&>(**value);
+    auto& date = static_cast<JS::Date&>(*value);
     if (!isfinite(date.date_value())) {
         TRY(set_value({}));
         return {};

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -153,7 +153,7 @@ public:
     SelectedCoordinate selected_coordinate() const { return m_selected_coordinate; }
 
     JS::Object* value_as_date() const;
-    WebIDL::ExceptionOr<void> set_value_as_date(Optional<GC::Root<JS::Object>> const&);
+    WebIDL::ExceptionOr<void> set_value_as_date(GC::Ptr<JS::Object>);
 
     double value_as_number() const;
     WebIDL::ExceptionOr<void> set_value_as_number(double value);

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -206,32 +206,14 @@ OptionalMediaProvider HTMLMediaElement::src_object() const
 {
     // The srcObject IDL attribute, on getting, must return the element's assigned media provider
     // object, if any, or null otherwise.
-    return assigned_media_provider_object().visit(
-        [](Empty) -> OptionalMediaProvider {
-            return Empty();
-        },
-        [](GC::Ref<FileAPI::Blob> blob) -> OptionalMediaProvider {
-            return { GC::Root(blob) };
-        },
-        [](GC::Ref<MediaSourceExtensions::MediaSource> media_source) -> OptionalMediaProvider {
-            return { GC::Root(media_source) };
-        });
+    return assigned_media_provider_object();
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-srcobject
 WebIDL::ExceptionOr<void> HTMLMediaElement::set_src_object(OptionalMediaProvider src_object)
 {
     // On setting, it must set the element's assigned media provider object to the new value,
-    set_assigned_media_provider_object(src_object.visit(
-        [](Empty) -> MediaProviderObject {
-            return Empty();
-        },
-        [](GC::Root<FileAPI::Blob> const& blob) -> MediaProviderObject {
-            return GC::Ref(*blob);
-        },
-        [](GC::Root<MediaSourceExtensions::MediaSource> const& media_source) -> MediaProviderObject {
-            return GC::Ref(*media_source);
-        }));
+    set_assigned_media_provider_object(src_object);
 
     // and then invoke the element's media element load algorithm.
     return load_element();
@@ -689,7 +671,7 @@ GC::Ref<TextTrack> HTMLMediaElement::add_text_track(Bindings::TextTrackKind kind
     //    text track's TextTrack object.
     queue_a_media_element_task([this, text_track] {
         Bindings::TrackEventInit event_init {};
-        event_init.track = GC::Root { text_track };
+        event_init.track = text_track;
 
         auto event = TrackEvent::create(this->realm(), HTML::EventNames::addtrack, move(event_init));
         m_text_tracks->dispatch_event(event);
@@ -1187,7 +1169,7 @@ void HTMLMediaElement::load_url_resource(URL::URL const& url_record, Function<vo
 
             // NB: The subsequent steps for local resources are contained in load_local_resource().
             auto const& blob_entry = FileAPI::resolve_a_blob_url(url_record).value();
-            load_local_resource(GC::Ref(*blob_entry.object.get<GC::Root<MediaSourceExtensions::MediaSource>>()), move(failure_callback));
+            load_local_resource(blob_entry.object.get<GC::Ref<MediaSourceExtensions::MediaSource>>(), move(failure_callback));
             return;
         }
     }
@@ -1672,7 +1654,7 @@ void HTMLMediaElement::on_audio_track_added(Media::Track const& track)
 
     // 7. Fire an event named addtrack at this AudioTrackList object, using TrackEvent, with the track attribute initialized to the new AudioTrack object.
     Bindings::TrackEventInit event_init {};
-    event_init.track = GC::make_root(audio_track);
+    event_init.track = audio_track;
 
     auto event = TrackEvent::create(realm, EventNames::addtrack, move(event_init));
     m_audio_tracks->dispatch_event(event);
@@ -1715,7 +1697,7 @@ void HTMLMediaElement::on_video_track_added(Media::Track const& track)
 
     // 7. Fire an event named addtrack at this VideoTrackList object, using TrackEvent, with the track attribute initialized to the new VideoTrack object.
     Bindings::TrackEventInit event_init {};
-    event_init.track = GC::make_root(video_track);
+    event_init.track = video_track;
 
     auto event = TrackEvent::create(realm, HTML::EventNames::addtrack, move(event_init));
     m_video_tracks->dispatch_event(event);

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -35,7 +35,7 @@ enum class MediaSeekMode : u8 {
 
 class SourceElementSelector;
 
-using OptionalMediaProvider = Variant<Empty, GC::Root<MediaSourceExtensions::MediaSource>, GC::Root<FileAPI::Blob>>;
+using OptionalMediaProvider = Variant<Empty, GC::Ref<MediaSourceExtensions::MediaSource>, GC::Ref<FileAPI::Blob>>;
 
 class HTMLMediaElement : public HTMLElement {
     WEB_PLATFORM_OBJECT(HTMLMediaElement, HTMLElement);

--- a/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -122,13 +122,13 @@ WebIDL::ExceptionOr<void> HTMLOptionsCollection::set_value_of_indexed_property(u
 WebIDL::ExceptionOr<void> HTMLOptionsCollection::add(HTMLOptionOrOptGroupElement element, NullableHTMLElementOrElementIndex before)
 {
     auto resolved_element = element.visit(
-        [](auto& e) -> GC::Root<HTMLElement> {
-            return GC::make_root(static_cast<HTML::HTMLElement&>(*e));
+        [](auto& e) -> GC::Ref<HTMLElement> {
+            return static_cast<HTML::HTMLElement&>(*e);
         });
 
     GC::Ptr<DOM::Node> before_element;
-    if (before.has<GC::Root<HTMLElement>>())
-        before_element = before.get<GC::Root<HTMLElement>>().ptr();
+    if (before.has<GC::Ref<HTMLElement>>())
+        before_element = before.get<GC::Ref<HTMLElement>>().ptr();
 
     // 1. If element is an ancestor of the select element on which the HTMLOptionsCollection is rooted, then throw a "HierarchyRequestError" DOMException.
     if (resolved_element->is_ancestor_of(root()))

--- a/Libraries/LibWeb/HTML/HTMLOptionsCollection.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionsCollection.h
@@ -13,9 +13,9 @@
 
 namespace Web::HTML {
 
-using HTMLOptionOrOptGroupElement = Variant<GC::Root<HTMLOptionElement>, GC::Root<HTMLOptGroupElement>>;
-using HTMLElementOrElementIndex = Variant<GC::Root<HTMLElement>, i32>;
-using NullableHTMLElementOrElementIndex = Variant<GC::Root<HTMLElement>, i32, Empty>;
+using HTMLOptionOrOptGroupElement = Variant<GC::Ref<HTMLOptionElement>, GC::Ref<HTMLOptGroupElement>>;
+using HTMLElementOrElementIndex = Variant<GC::Ref<HTMLElement>, i32>;
+using NullableHTMLElementOrElementIndex = Variant<GC::Ref<HTMLElement>, i32, Empty>;
 
 class HTMLOptionsCollection final : public DOM::HTMLCollection {
     WEB_PLATFORM_OBJECT(HTMLOptionsCollection, DOM::HTMLCollection);

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -764,7 +764,7 @@ WebIDL::ExceptionOr<void> HTMLScriptElement::set_src(TrustedTypes::TrustedScript
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#the-textContent-idl-attribute
-Variant<GC::Root<TrustedTypes::TrustedScript>, Utf16String, Empty> HTMLScriptElement::text_content() const
+Variant<GC::Ref<TrustedTypes::TrustedScript>, Utf16String, Empty> HTMLScriptElement::text_content() const
 {
     // 1. Return the result of running get text content with this.
     return descendant_text_content();

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -65,7 +65,7 @@ public:
     TrustedTypes::TrustedScriptURLOrString src() const;
     WebIDL::ExceptionOr<void> set_src(TrustedTypes::TrustedScriptURLOrString);
 
-    Variant<GC::Root<TrustedTypes::TrustedScript>, Utf16String, Empty> text_content() const;
+    Variant<GC::Ref<TrustedTypes::TrustedScript>, Utf16String, Empty> text_content() const;
     WebIDL::ExceptionOr<void> set_text_content(TrustedTypes::NullableTrustedScriptOrString);
 
     TrustedTypes::TrustedScriptOrString inner_text();

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -93,7 +93,7 @@ Vector<GC::Root<DOM::Element>> HTMLSlotElement::assigned_elements(Bindings::Assi
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#dom-slot-assign
-void HTMLSlotElement::assign(Vector<SlottableHandle> nodes)
+void HTMLSlotElement::assign(GC::ConservativeVector<SlottableHandle> nodes)
 {
     // 1. For each node of this's manually assigned nodes, set node's manual slot assignment to null.
     for (auto& node : m_manually_assigned_nodes) {

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.h
@@ -9,6 +9,7 @@
 
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibGC/ConservativeVector.h>
 #include <LibGC/Root.h>
 #include <LibWeb/Bindings/HTMLSlotElement.h>
 #include <LibWeb/DOM/Slot.h>
@@ -29,8 +30,8 @@ public:
     Vector<GC::Root<DOM::Node>> assigned_nodes(Bindings::AssignedNodesOptions options = {}) const;
     Vector<GC::Root<DOM::Element>> assigned_elements(Bindings::AssignedNodesOptions options = {}) const;
 
-    using SlottableHandle = Variant<GC::Root<DOM::Element>, GC::Root<DOM::Text>>;
-    void assign(Vector<SlottableHandle> nodes);
+    using SlottableHandle = Variant<GC::Ref<DOM::Element>, GC::Ref<DOM::Text>>;
+    void assign(GC::ConservativeVector<SlottableHandle> nodes);
 
     ReadonlySpan<DOM::Slottable> manually_assigned_nodes() const { return m_manually_assigned_nodes; }
 

--- a/Libraries/LibWeb/HTML/ImageBitmap.h
+++ b/Libraries/LibWeb/HTML/ImageBitmap.h
@@ -17,7 +17,7 @@
 
 namespace Web::HTML {
 
-using ImageBitmapSource = FlattenVariant<CanvasImageSource, Variant<GC::Root<FileAPI::Blob>, GC::Root<ImageData>>>;
+using ImageBitmapSource = FlattenVariant<CanvasImageSource, Variant<GC::Ref<FileAPI::Blob>, GC::Ref<ImageData>>>;
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapoptions
 struct ImageBitmapOptions {

--- a/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -32,13 +32,6 @@ WebIDL::ExceptionOr<GC::Ref<MessageEvent>> MessageEvent::construct_impl(JS::Real
     return create(realm, event_name, event_init);
 }
 
-MessageEvent::MessageEventSourceInternal MessageEvent::to_message_event_source_internal(NullableMessageEventSource const& source)
-{
-    return source.visit(
-        [](Empty) -> MessageEventSourceInternal { return Empty {}; },
-        [](auto const& root) -> MessageEventSourceInternal { return GC::Ref { *root }; });
-}
-
 MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, Bindings::MessageEventInit const& event_init)
     : MessageEvent(realm, event_name, event_init, String { event_init.origin })
 {
@@ -54,13 +47,12 @@ MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, Bindin
     , m_data(event_init.data)
     , m_origin(move(origin))
     , m_last_event_id(event_init.last_event_id)
-    , m_source(to_message_event_source_internal(event_init.source))
+    , m_source(event_init.source)
 
 {
     m_ports.ensure_capacity(event_init.ports.size());
     for (auto const& port : event_init.ports) {
-        VERIFY(port);
-        m_ports.unchecked_append(static_cast<JS::Object&>(*port));
+        m_ports.unchecked_append(port);
     }
 }
 
@@ -101,9 +93,7 @@ String MessageEvent::origin() const
 
 NullableMessageEventSource MessageEvent::source() const
 {
-    return m_source.visit(
-        [](Empty) -> NullableMessageEventSource { return Empty {}; },
-        [](auto const& ref) -> NullableMessageEventSource { return GC::Root { *ref }; });
+    return m_source;
 }
 
 GC::Ref<JS::Object> MessageEvent::ports() const
@@ -120,7 +110,7 @@ GC::Ref<JS::Object> MessageEvent::ports() const
 }
 
 // https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-initmessageevent
-void MessageEvent::init_message_event(String const& type, bool bubbles, bool cancelable, JS::Value data, String const& origin, String const& last_event_id, NullableMessageEventSource source, Vector<GC::Root<MessagePort>> const& ports)
+void MessageEvent::init_message_event(String const& type, bool bubbles, bool cancelable, JS::Value data, String const& origin, String const& last_event_id, NullableMessageEventSource source, GC::RootVector<GC::Ref<MessagePort>> const& ports)
 {
     // The initMessageEvent(type, bubbles, cancelable, data, origin, lastEventId, source, ports) method must initialize the event in a
     // manner analogous to the similarly-named initEvent() method.
@@ -136,13 +126,12 @@ void MessageEvent::init_message_event(String const& type, bool bubbles, bool can
     m_data = data;
     m_origin = origin;
     m_last_event_id = last_event_id;
-    m_source = to_message_event_source_internal(source);
+    m_source = source;
 
     m_ports_array = nullptr;
     m_ports.clear();
     m_ports.ensure_capacity(ports.size());
     for (auto const& port : ports) {
-        VERIFY(port);
         m_ports.unchecked_append(static_cast<JS::Object&>(*port));
     }
 }

--- a/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Libraries/LibWeb/HTML/MessageEvent.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
-#include <LibWeb/Bindings/MessageEvent.h>
+#include <LibGC/RootVector.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/Export.h>
 
@@ -17,8 +17,8 @@ namespace Web::HTML {
 
 // FIXME: Include ServiceWorker
 // https://html.spec.whatwg.org/multipage/comms.html#messageeventsource
-using MessageEventSource = Variant<GC::Root<WindowProxy>, GC::Root<MessagePort>>;
-using NullableMessageEventSource = Variant<GC::Root<WindowProxy>, GC::Root<MessagePort>, Empty>;
+using MessageEventSource = Variant<GC::Ref<WindowProxy>, GC::Ref<MessagePort>>;
+using NullableMessageEventSource = Variant<GC::Ref<WindowProxy>, GC::Ref<MessagePort>, Empty>;
 
 // https://html.spec.whatwg.org/multipage/comms.html#messageevent
 class WEB_API MessageEvent : public DOM::Event {
@@ -26,7 +26,7 @@ class WEB_API MessageEvent : public DOM::Event {
     GC_DECLARE_ALLOCATOR(MessageEvent);
 
 public:
-    [[nodiscard]] static GC::Ref<MessageEvent> create(JS::Realm&, FlyString const& event_name, Bindings::MessageEventInit const& = {});
+    [[nodiscard]] static GC::Ref<MessageEvent> create(JS::Realm&, FlyString const& event_name, Bindings::MessageEventInit const&);
     [[nodiscard]] static GC::Ref<MessageEvent> create(JS::Realm&, FlyString const& event_name, Bindings::MessageEventInit const&, URL::Origin const&);
     static WebIDL::ExceptionOr<GC::Ref<MessageEvent>> construct_impl(JS::Realm&, FlyString const& event_name, Bindings::MessageEventInit const&);
 
@@ -43,14 +43,12 @@ public:
 
     virtual Optional<URL::Origin> extract_an_origin() const override;
 
-    void init_message_event(String const& type, bool bubbles, bool cancelable, JS::Value data, String const& origin, String const& last_event_id, NullableMessageEventSource source, Vector<GC::Root<MessagePort>> const& ports);
+    void init_message_event(String const& type, bool bubbles, bool cancelable, JS::Value data, String const& origin, String const& last_event_id, NullableMessageEventSource source, GC::RootVector<GC::Ref<MessagePort>> const& ports);
 
 private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    using MessageEventSourceInternal = Variant<Empty, GC::Ref<WindowProxy>, GC::Ref<MessagePort>>;
-    static MessageEventSourceInternal to_message_event_source_internal(NullableMessageEventSource const&);
     MessageEvent(JS::Realm&, FlyString const& event_name, Bindings::MessageEventInit const& event_init, Variant<URL::Origin, String, Empty>);
 
     JS::Value m_data;
@@ -60,7 +58,7 @@ private:
     Variant<URL::Origin, String, Empty> m_origin;
 
     String m_last_event_id;
-    MessageEventSourceInternal m_source;
+    NullableMessageEventSource m_source;
     Vector<GC::Ref<JS::Object>> m_ports;
     mutable GC::Ptr<JS::Array> m_ports_array;
 };

--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -16,6 +16,7 @@
 #include <LibIPC/TransportHandle.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/Bindings/MessagePort.h>
 #include <LibWeb/DOM/EventDispatcher.h>
 #include <LibWeb/HTML/EventNames.h>
@@ -229,7 +230,7 @@ void MessagePort::entangle_with(MessagePort& remote_port)
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage-options
-WebIDL::ExceptionOr<void> MessagePort::post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer)
+WebIDL::ExceptionOr<void> MessagePort::post_message(JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer)
 {
     // 1. Let targetPort be the port with which this MessagePort is entangled, if any; otherwise let it be null.
     GC::Ptr<MessagePort> target_port = m_remote_port;
@@ -406,7 +407,7 @@ void MessagePort::post_message_task_steps(SerializedTransferRecord& serialize_wi
     if (deserialize_record_or_error.is_error()) {
         // If this throws an exception, catch it, fire an event named messageerror at finalTargetPort, using MessageEvent, and then return.
         auto exception = deserialize_record_or_error.release_error();
-        Bindings::MessageEventInit event_init {};
+        Bindings::MessageEventInit event_init;
         message_event_target->dispatch_event(MessageEvent::create(target_realm, HTML::EventNames::messageerror, event_init));
         return;
     }
@@ -417,7 +418,7 @@ void MessagePort::post_message_task_steps(SerializedTransferRecord& serialize_wi
 
     // 5. Let newPorts be a new frozen array consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]], if any, maintaining their relative order.
     // FIXME: Use a FrozenArray
-    Vector<GC::Root<MessagePort>> new_ports;
+    GC::RootVector<GC::Ref<MessagePort>> new_ports;
     for (auto const& object : deserialize_record.transferred_values) {
         if (is<HTML::MessagePort>(*object)) {
             new_ports.append(as<MessagePort>(*object));
@@ -425,9 +426,7 @@ void MessagePort::post_message_task_steps(SerializedTransferRecord& serialize_wi
     }
 
     // 6. Fire an event named message at finalTargetPort, using MessageEvent, with the data attribute initialized to messageClone and the ports attribute initialized to newPorts.
-    Bindings::MessageEventInit event_init {};
-    event_init.data = message_clone;
-    event_init.ports = move(new_ports);
+    Bindings::MessageEventInit event_init { Bindings::EventInit {}, message_clone, String {}, String {}, move(new_ports), Empty {} };
     auto event = MessageEvent::create(target_realm, HTML::EventNames::message, event_init);
     event->set_is_trusted(true);
     message_event_target->dispatch_event(event);

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -45,7 +45,7 @@ public:
     GC::Ptr<MessagePort const> entangled_port() const { return m_remote_port; }
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage
-    WebIDL::ExceptionOr<void> post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer);
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage-options
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Bindings::StructuredSerializeOptions const& options);

--- a/Libraries/LibWeb/HTML/NavigateEvent.cpp
+++ b/Libraries/LibWeb/HTML/NavigateEvent.cpp
@@ -98,7 +98,7 @@ WebIDL::ExceptionOr<void> NavigateEvent::intercept(Bindings::NavigationIntercept
     m_interception_state = InterceptionState::Intercepted;
 
     // 6. If options["handler"] exists, then append it to this's navigation handler list.
-    if (options.handler != nullptr)
+    if (options.handler)
         TRY_OR_THROW_OOM(vm, m_navigation_handler_list.try_append(*options.handler));
 
     // 7. If options["focusReset"] exists, then:

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -146,9 +146,7 @@ WebIDL::ExceptionOr<void> Navigation::update_current_entry(Bindings::NavigationU
 
     // 5. Fire an event named currententrychange at this using NavigationCurrentEntryChangeEvent,
     //    with its navigationType attribute initialized to null and its from initialized to current.
-    Bindings::NavigationCurrentEntryChangeEventInit event_init = {};
-    event_init.navigation_type = {};
-    event_init.from = current;
+    Bindings::NavigationCurrentEntryChangeEventInit event_init { Bindings::EventInit {}, *current, {} };
     dispatch_event(HTML::NavigationCurrentEntryChangeEvent::construct_impl(realm(), HTML::EventNames::currententrychange, event_init));
 
     return {};
@@ -314,7 +312,7 @@ WebIDL::ExceptionOr<Bindings::NavigationResult> Navigation::reload(Bindings::Nav
     // NOTE: It is important to perform this step early, since serialization can invoke web developer code, which in
     //       turn might change various things we check in later steps.
     if (options.state.has_value()) {
-        auto serialized_state_or_error = structured_serialize_for_storage(vm, options.state.value());
+        auto serialized_state_or_error = structured_serialize_for_storage(vm, *options.state);
         if (serialized_state_or_error.is_error())
             return early_error_result(serialized_state_or_error.release_error());
         serialized_state = serialized_state_or_error.release_value();
@@ -989,9 +987,13 @@ bool Navigation::inner_navigate_event_firing_algorithm(
     // 8. Let document be navigation's relevant global object's associated Document.
     auto& document = relevant_global_object.associated_document();
 
+    // 19. Set event's abort controller to a new AbortController created in navigation's relevant realm.
+    // AD-HOC: Set on the NavigateEvent later after construction
+    auto abort_controller = MUST(DOM::AbortController::construct_impl(realm));
+
     // Note: We create the Event in this algorithm instead of passing it in,
     //       and have all the following "initialize" steps set up the event init
-    Bindings::NavigateEventInit event_init = {};
+    Bindings::NavigateEventInit event_init { Bindings::EventInit {}, false, destination, {}, {}, false, false, {}, Bindings::NavigationType::Push, abort_controller->signal(), {}, false };
 
     // 9.  If document can have its URL rewritten to destination's URL,
     //     and either destination's is same document is true or navigationType is not "traverse",
@@ -1041,12 +1043,8 @@ bool Navigation::inner_navigate_event_firing_algorithm(
     // 18. Initialize event's sourceElement to sourceElement.
     event_init.source_element = source_element;
 
-    // 19. Set event's abort controller to a new AbortController created in navigation's relevant realm.
-    // AD-HOC: Set on the NavigateEvent later after construction
-    auto abort_controller = MUST(DOM::AbortController::construct_impl(realm));
-
     // 20. Initialize event's signal to event's abort controller's signal.
-    event_init.signal = abort_controller->signal();
+    // AD-HOC: Done when event_init is created.
 
     // 21. Let currentURL be document's URL.
     auto current_url = document.url();
@@ -1543,9 +1541,7 @@ void Navigation::update_the_navigation_api_entries_for_a_same_document_navigatio
 
     // 10. Fire an event named currententrychange at navigation using NavigationCurrentEntryChangeEvent,
     //     with its navigationType attribute initialized to navigationType and its from initialized to oldCurrentNHE.
-    Bindings::NavigationCurrentEntryChangeEventInit event_init = {};
-    event_init.navigation_type = navigation_type;
-    event_init.from = old_current_nhe;
+    Bindings::NavigationCurrentEntryChangeEventInit event_init { Bindings::EventInit {}, *old_current_nhe, navigation_type };
     dispatch_event(NavigationCurrentEntryChangeEvent::construct_impl(realm, EventNames::currententrychange, event_init));
 
     // 11. For each disposedNHE of disposedNHEs:

--- a/Libraries/LibWeb/HTML/NavigationCurrentEntryChangeEvent.cpp
+++ b/Libraries/LibWeb/HTML/NavigationCurrentEntryChangeEvent.cpp
@@ -22,7 +22,7 @@ GC::Ref<NavigationCurrentEntryChangeEvent> NavigationCurrentEntryChangeEvent::co
 
 NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent(JS::Realm& realm, FlyString const& event_name, Bindings::NavigationCurrentEntryChangeEventInit const& event_init)
     : DOM::Event(realm, event_name, event_init)
-    , m_navigation_type(event_init.navigation_type)
+    , m_navigation_type(event_init.navigation_type.value_or({}))
     , m_from(*event_init.from)
 {
 }

--- a/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
+++ b/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
@@ -48,7 +48,7 @@ WebIDL::ExceptionOr<bool> NavigatorBeaconPartial::send_beacon(String const& url,
     GC::Ptr<Fetch::Infrastructure::Body> transmitted_data;
     if (!data.has<Empty>()) {
         // 6.1 Set transmittedData and contentType to the result of extracting data's byte stream with the keepalive flag set.
-        auto body_with_type = TRY(Fetch::extract_body(realm, data.downcast<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String>(), true));
+        auto body_with_type = TRY(Fetch::extract_body(realm, data.downcast<GC::Ref<Streams::ReadableStream>, GC::Ref<FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<DOMURL::URLSearchParams>, String>(), true));
         transmitted_data = body_with_type.body;
         auto& content_type = body_with_type.type;
 

--- a/Libraries/LibWeb/HTML/OffscreenCanvas.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvas.cpp
@@ -214,7 +214,7 @@ JS::ThrowCompletionOr<OffscreenRenderingContext> OffscreenCanvas::get_context(Bi
     // NOTE: See the spec for the full table.
     if (contextId == Bindings::OffscreenRenderingContextId::_2d) {
         if (TRY(create_2d_context(options)) == HasOrCreatedContext::Yes)
-            return GC::make_root(*m_context.get<GC::Ref<HTML::OffscreenCanvasRenderingContext2D>>());
+            return *m_context.get<GC::Ref<HTML::OffscreenCanvasRenderingContext2D>>();
 
         return Empty {};
     }

--- a/Libraries/LibWeb/HTML/OffscreenCanvas.h
+++ b/Libraries/LibWeb/HTML/OffscreenCanvas.h
@@ -17,7 +17,7 @@ namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/canvas.html#offscreenrenderingcontext
 // NOTE: This is the Variant created by the IDL wrapper generator, and needs to be updated accordingly.
-using OffscreenRenderingContext = Variant<GC::Root<OffscreenCanvasRenderingContext2D>, GC::Root<WebGL::WebGLRenderingContext>, GC::Root<WebGL::WebGL2RenderingContext>, Empty>;
+using OffscreenRenderingContext = Variant<GC::Ref<OffscreenCanvasRenderingContext2D>, GC::Ref<WebGL::WebGLRenderingContext>, GC::Ref<WebGL::WebGL2RenderingContext>, Empty>;
 
 // https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas
 class OffscreenCanvas : public DOM::EventTarget

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <AK/Debug.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
@@ -1093,7 +1094,7 @@ static String escape_string(ViewType const& string, AttributeMode attribute_mode
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-serialisation-algorithm
-String HTMLParser::serialize_html_fragment(DOM::Node const& node, SerializableShadowRoots serializable_shadow_roots, Vector<GC::Root<DOM::ShadowRoot>> const& shadow_roots, DOM::FragmentSerializationMode fragment_serialization_mode)
+String HTMLParser::serialize_html_fragment(DOM::Node const& node, SerializableShadowRoots serializable_shadow_roots, ReadonlySpan<GC::Ref<DOM::ShadowRoot>> shadow_roots, DOM::FragmentSerializationMode fragment_serialization_mode)
 {
     // NOTE: Steps in this function are jumbled a bit to accommodate the Element.outerHTML API.
     //       When called with FragmentSerializationMode::Outer, we will serialize the element itself,
@@ -1228,7 +1229,7 @@ String HTMLParser::serialize_html_fragment(DOM::Node const& node, SerializableSh
             //    - serializableShadowRoots is true and shadow's serializable is true; or
             //    - shadowRoots contains shadow,
             if ((serializable_shadow_roots == SerializableShadowRoots::Yes && shadow->serializable())
-                || shadow_roots.contains([&](auto& entry) { return entry == shadow; })) {
+                || any_of(shadow_roots, [&](auto& entry) { return entry == shadow; })) {
                 // then:
                 // 1. Append "<template shadowrootmode="".
                 builder.append("<template shadowrootmode=\""sv);

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -60,7 +60,7 @@ public:
         No,
         Yes,
     };
-    static String serialize_html_fragment(DOM::Node const&, SerializableShadowRoots, Vector<GC::Root<DOM::ShadowRoot>> const&, DOM::FragmentSerializationMode = DOM::FragmentSerializationMode::Inner);
+    static String serialize_html_fragment(DOM::Node const&, SerializableShadowRoots, ReadonlySpan<GC::Ref<DOM::ShadowRoot>>, DOM::FragmentSerializationMode = DOM::FragmentSerializationMode::Inner);
 
     HTMLTokenizer& tokenizer() { return m_tokenizer; }
 

--- a/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Libraries/LibWeb/HTML/Path2D.cpp
@@ -17,13 +17,13 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(Path2D);
 
-WebIDL::ExceptionOr<GC::Ref<Path2D>> Path2D::construct_impl(JS::Realm& realm, Optional<Variant<GC::Root<Path2D>, String>> const& path)
+WebIDL::ExceptionOr<GC::Ref<Path2D>> Path2D::construct_impl(JS::Realm& realm, Optional<Variant<GC::Ref<Path2D>, String>> const& path)
 {
     return realm.create<Path2D>(realm, path);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d
-Path2D::Path2D(JS::Realm& realm, Optional<Variant<GC::Root<Path2D>, String>> const& path)
+Path2D::Path2D(JS::Realm& realm, Optional<Variant<GC::Ref<Path2D>, String>> const& path)
     : PlatformObject(realm)
     , CanvasPath(static_cast<Bindings::PlatformObject&>(*this))
 {
@@ -34,8 +34,8 @@ Path2D::Path2D(JS::Realm& realm, Optional<Variant<GC::Root<Path2D>, String>> con
 
     // 3. If path is a Path2D object, then add all subpaths of path to output and return output.
     //    (In other words, it returns a copy of the argument.)
-    if (path->has<GC::Root<Path2D>>()) {
-        this->path() = path->get<GC::Root<Path2D>>()->path();
+    if (path->has<GC::Ref<Path2D>>()) {
+        this->path() = path->get<GC::Ref<Path2D>>()->path();
         return;
     }
 

--- a/Libraries/LibWeb/HTML/Path2D.h
+++ b/Libraries/LibWeb/HTML/Path2D.h
@@ -22,14 +22,14 @@ class Path2D final
     GC_DECLARE_ALLOCATOR(Path2D);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<Path2D>> construct_impl(JS::Realm&, Optional<Variant<GC::Root<Path2D>, String>> const& path);
+    static WebIDL::ExceptionOr<GC::Ref<Path2D>> construct_impl(JS::Realm&, Optional<Variant<GC::Ref<Path2D>, String>> const& path);
 
     virtual ~Path2D() override;
 
     WebIDL::ExceptionOr<void> add_path(GC::Ref<Path2D> path, Bindings::DOMMatrix2DInit& transform);
 
 private:
-    Path2D(JS::Realm&, Optional<Variant<GC::Root<Path2D>, String>> const&);
+    Path2D(JS::Realm&, Optional<Variant<GC::Ref<Path2D>, String>> const&);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -11,7 +11,6 @@
 #include <LibGC/Root.h>
 #include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/Value.h>
-#include <LibWeb/Bindings/PromiseRejectionEvent.h>
 #include <LibWeb/DOM/Event.h>
 
 namespace Web::HTML {
@@ -21,7 +20,7 @@ class PromiseRejectionEvent final : public DOM::Event {
     GC_DECLARE_ALLOCATOR(PromiseRejectionEvent);
 
 public:
-    [[nodiscard]] static GC::Ref<PromiseRejectionEvent> create(JS::Realm&, FlyString const& event_name, Bindings::PromiseRejectionEventInit const& = {});
+    [[nodiscard]] static GC::Ref<PromiseRejectionEvent> create(JS::Realm&, FlyString const& event_name, Bindings::PromiseRejectionEventInit const&);
     static WebIDL::ExceptionOr<GC::Ref<PromiseRejectionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, Bindings::PromiseRejectionEventInit const&);
 
     virtual ~PromiseRejectionEvent() override;

--- a/Libraries/LibWeb/HTML/SharedWorker.cpp
+++ b/Libraries/LibWeb/HTML/SharedWorker.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/Bindings/SharedWorker.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
@@ -151,7 +152,7 @@ WebIDL::ExceptionOr<GC::Ref<SharedWorker>> SharedWorker::construct_impl(JS::Real
                 Bindings::MessageEventInit init;
                 init.data = JS::PrimitiveString::create(realm.vm(), String {});
                 init.ports.append(inside_port);
-                init.source = GC::Root { inside_port };
+                init.source = inside_port;
 
                 worker_global_scope->dispatch_event(MessageEvent::create(realm, EventNames::connect, init));
             }));

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -986,7 +986,7 @@ private:
 };
 
 // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer
-WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM& vm, JS::Value value, Vector<GC::Root<JS::Object>> const& transfer_list)
+WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM& vm, JS::Value value, ReadonlySpan<GC::Ref<JS::Object>> transfer_list)
 {
     // 1. Let memory be an empty map.
     SerializationMemory memory = {};

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -86,7 +86,7 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM&, 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM&, SerializationRecord const&, JS::Realm&, Optional<DeserializationMemory> = {});
 WebIDL::ExceptionOr<JS::Value> structured_deserialize_internal(JS::VM&, TransferDataDecoder&, JS::Realm&, DeserializationMemory&);
 
-WEB_API WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM&, JS::Value, Vector<GC::Root<JS::Object>> const& transfer_list);
+WEB_API WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM&, JS::Value, ReadonlySpan<GC::Ref<JS::Object>> transfer_list);
 WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(SerializedTransferRecord&, JS::Realm&);
 WEB_API WebIDL::ExceptionOr<JS::Value> structured_deserialize_with_transfer_internal(TransferDataDecoder&, JS::Realm&);
 

--- a/Libraries/LibWeb/HTML/TrackEvent.cpp
+++ b/Libraries/LibWeb/HTML/TrackEvent.cpp
@@ -26,16 +26,9 @@ WebIDL::ExceptionOr<GC::Ref<TrackEvent>> TrackEvent::construct_impl(JS::Realm& r
     return create(realm, event_name, move(event_init));
 }
 
-TrackEvent::TrackTypeInternal TrackEvent::to_track_type_internal(NullableTrackType const& track_type)
-{
-    return track_type.visit(
-        [](Empty) -> TrackTypeInternal { return Empty {}; },
-        [](auto const& root) -> TrackTypeInternal { return GC::Ref { *root }; });
-}
-
 TrackEvent::TrackEvent(JS::Realm& realm, FlyString const& event_name, Bindings::TrackEventInit const& event_init)
     : DOM::Event(realm, event_name, event_init)
-    , m_track(to_track_type_internal(event_init.track))
+    , m_track(event_init.track)
 {
 }
 
@@ -53,9 +46,7 @@ void TrackEvent::visit_edges(Visitor& visitor)
 
 NullableTrackType TrackEvent::track() const
 {
-    return m_track.visit(
-        [](Empty) -> NullableTrackType { return Empty {}; },
-        [](auto const& ref) -> NullableTrackType { return GC::Root { *ref }; });
+    return m_track;
 }
 
 }

--- a/Libraries/LibWeb/HTML/TrackEvent.h
+++ b/Libraries/LibWeb/HTML/TrackEvent.h
@@ -16,7 +16,7 @@
 
 namespace Web::HTML {
 
-using NullableTrackType = Variant<GC::Root<VideoTrack>, GC::Root<AudioTrack>, GC::Root<TextTrack>, Empty>;
+using NullableTrackType = Variant<GC::Ref<VideoTrack>, GC::Ref<AudioTrack>, GC::Ref<TextTrack>, Empty>;
 
 class TrackEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(TrackEvent, DOM::Event);
@@ -35,10 +35,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Visitor&) override;
 
-    using TrackTypeInternal = Variant<Empty, GC::Ref<VideoTrack>, GC::Ref<AudioTrack>, GC::Ref<TextTrack>>;
-    static TrackTypeInternal to_track_type_internal(NullableTrackType const&);
-
-    TrackTypeInternal m_track;
+    NullableTrackType m_track;
 };
 
 }

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/MessagePort.h>
+#include <LibWeb/Bindings/PromiseRejectionEvent.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
 #include <LibWeb/HTML/StructuredSerialize.h>

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -20,6 +20,7 @@
 #include <LibTextCodec/Decoder.h>
 #include <LibURL/Origin.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/Bindings/Window.h>
 #include <LibWeb/Bindings/WindowExposedInterfaces.h>
 #include <LibWeb/CSS/CSSStyleProperties.h>
@@ -1281,8 +1282,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, B
         // If this throws an exception, catch it, fire an event named messageerror at targetWindow, using MessageEvent,
         // with its origin initialized to origin and the source attribute initialized to source, and then return.
         if (deserialize_record_or_error.is_exception()) {
-            Bindings::MessageEventInit message_event_init {};
-            message_event_init.source = GC::make_root(source);
+            Bindings::MessageEventInit message_event_init { Bindings::EventInit {}, JS::js_null(), String {}, String {}, {}, GC::Ref { source } };
 
             auto message_error_event = MessageEvent::create(target_realm, EventNames::messageerror, message_event_init, origin);
             dispatch_event(message_error_event);
@@ -1296,7 +1296,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, B
         // 6. Let newPorts be a new frozen array consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]],
         //    if any, maintaining their relative order.
         // FIXME: Use a FrozenArray
-        Vector<GC::Root<MessagePort>> new_ports;
+        GC::RootVector<GC::Ref<MessagePort>> new_ports;
         for (auto const& object : deserialize_record.transferred_values) {
             if (auto* message_port = as_if<HTML::MessagePort>(*object)) {
                 new_ports.append(*message_port);
@@ -1306,10 +1306,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, B
         // 7. Fire an event named message at targetWindow, using MessageEvent, with its origin initialized to origin,
         //    the source attribute initialized to source, the data attribute initialized to messageClone, and the ports
         //    attribute initialized to newPorts.
-        Bindings::MessageEventInit message_event_init {};
-        message_event_init.source = GC::make_root(source);
-        message_event_init.data = message_clone;
-        message_event_init.ports = move(new_ports);
+        Bindings::MessageEventInit message_event_init { Bindings::EventInit {}, message_clone, String {}, String {}, move(new_ports), GC::Ref { source } };
 
         auto message_event = MessageEvent::create(target_realm, EventNames::message, message_event_init, origin);
         message_event->set_is_trusted(true);
@@ -1328,7 +1325,7 @@ WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, Bindings::Wind
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage
-WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, String const& target_origin, Vector<GC::Root<JS::Object>> const& transfer)
+WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, String const& target_origin, GC::RootVector<GC::Ref<JS::Object>> const& transfer)
 {
     // The Window interface's postMessage(message, targetOrigin, transfer) method steps are to run the window post message
     // steps given this, message, and «[ "targetOrigin" → targetOrigin, "transfer" → transfer ]».
@@ -1336,11 +1333,11 @@ WebIDL::ExceptionOr<void> Window::post_message(JS::Value message, String const& 
 }
 
 // https://dom.spec.whatwg.org/#dom-window-event
-Variant<GC::Root<DOM::Event>, Empty> Window::event() const
+Variant<GC::Ref<DOM::Event>, Empty> Window::event() const
 {
     // The event getter steps are to return this’s current event.
     if (auto* current_event = this->current_event())
-        return make_root(const_cast<DOM::Event&>(*current_event));
+        return GC::Ref<DOM::Event> { const_cast<DOM::Event&>(*current_event) };
     return Empty {};
 }
 

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -194,10 +194,10 @@ public:
     bool confirm(Optional<String> const& message);
     Optional<String> prompt(Optional<String> const& message, Optional<String> const& default_);
 
-    WebIDL::ExceptionOr<void> post_message(JS::Value message, String const&, Vector<GC::Root<JS::Object>> const&);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, String const&, GC::RootVector<GC::Ref<JS::Object>> const&);
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Bindings::WindowPostMessageOptions const&);
 
-    Variant<GC::Root<DOM::Event>, Empty> event() const;
+    Variant<GC::Ref<DOM::Event>, Empty> event() const;
 
     [[nodiscard]] GC::Ref<CSS::CSSStyleProperties> get_computed_style(DOM::Element&, Optional<String> const& pseudo_element) const;
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -280,10 +280,10 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
 
     // 3. Check the usability of the image argument. If this throws an exception or returns bad, then return a promise rejected with an "InvalidStateError" DOMException.
     auto error_promise = image.visit(
-        [](GC::Root<FileAPI::Blob>&) -> Optional<GC::Ref<WebIDL::Promise>> {
+        [](GC::Ref<FileAPI::Blob>) -> Optional<GC::Ref<WebIDL::Promise>> {
             return {};
         },
-        [](GC::Root<ImageData>&) -> Optional<GC::Ref<WebIDL::Promise>> {
+        [](GC::Ref<ImageData>) -> Optional<GC::Ref<WebIDL::Promise>> {
             return {};
         },
         [&](auto& canvas_image_source) -> Optional<GC::Ref<WebIDL::Promise>> {
@@ -309,7 +309,7 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
     // 6. Switch on image:
     image.visit(
         // -> Blob
-        [&](GC::Root<FileAPI::Blob>& blob) {
+        [&](GC::Ref<FileAPI::Blob> blob) {
             // Run these step in parallel:
             Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(realm.heap(), [=]() {
                 // 1. Let imageData be the result of reading image's data. If an error occurs during reading of the
@@ -367,7 +367,7 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
             }));
         },
         // -> ImageData
-        [&](GC::Root<ImageData> const& image_data) -> void {
+        [&](GC::Ref<ImageData> image_data) -> void {
             // 1. Let buffer be image's data attribute value's [[ViewedArrayBuffer]] internal slot.
             auto const buffer = image_data->data()->viewed_array_buffer();
 
@@ -397,7 +397,7 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
         [&](CanvasImageSource const& image_source) {
             image_source.visit(
                 // -> canvas
-                [&](GC::Root<HTMLCanvasElement> const& canvas_element) {
+                [&](GC::Ref<HTMLCanvasElement> canvas_element) {
                     // 1. Set imageBitmap's bitmap data to a copy of image's bitmap data, cropped to the source rectangle with formatting.
                     auto canvas_bitmap = canvas_element->get_bitmap_from_surface();
                     // AD-HOC: Reject promise with an "InvalidStateError" DOMException on allocation failure
@@ -425,7 +425,7 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
                     }));
                 },
                 // -> ImageBitmap
-                [&](GC::Root<ImageBitmap> const& source_image_bitmap) {
+                [&](GC::Ref<ImageBitmap> source_image_bitmap) {
                     // 1. Set imageBitmap's bitmap data to a copy of image's bitmap data, cropped to the source rectangle with formatting.
                     auto cropped_bitmap_or_error = crop_to_the_source_rectangle_with_formatting(source_image_bitmap->bitmap(), sx, sy, sw, sh, options);
                     // AD-HOC: Reject promise with an "InvalidStateError" DOMException on allocation failure
@@ -445,14 +445,14 @@ GC::Ref<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitmap_imp
                         WebIDL::resolve_promise(realm, *p, image_bitmap);
                     }));
                 },
-                [&](GC::Root<OffscreenCanvas> const&) {
+                [&](GC::Ref<OffscreenCanvas>) {
                     dbgln("(STUBBED) createImageBitmap() for OffscreenCanvas");
                     auto const error = JS::Error::create(realm, "Not Implemented: createImageBitmap() for OffscreenCanvas"sv);
                     TemporaryExecutionContext const context { relevant_realm(p->promise()), TemporaryExecutionContext::CallbacksEnabled::Yes };
                     WebIDL::reject_promise(realm, *p, error);
                 },
                 // -> video
-                [&](GC::Root<HTMLVideoElement> const&) {
+                [&](GC::Ref<HTMLVideoElement>) {
                     dbgln("(STUBBED) createImageBitmap() for HTMLVideoElement");
                     auto const error = JS::Error::create(realm, "Not Implemented: createImageBitmap() for HTMLVideoElement"sv);
                     TemporaryExecutionContext const context { relevant_realm(p->promise()), TemporaryExecutionContext::CallbacksEnabled::Yes };

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -24,7 +24,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#timerhandler
-using TimerHandler = Variant<GC::Root<WebIDL::CallbackType>, String>;
+using TimerHandler = Variant<GC::Ref<WebIDL::CallbackType>, String>;
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope
 class WEB_API WindowOrWorkerGlobalScopeMixin {

--- a/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Libraries/LibWeb/HTML/Worker.cpp
@@ -139,7 +139,7 @@ WebIDL::ExceptionOr<void> Worker::post_message(JS::Value message, Bindings::Stru
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage
-WebIDL::ExceptionOr<void> Worker::post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer)
+WebIDL::ExceptionOr<void> Worker::post_message(JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer)
 {
     // The postMessage(message, transfer) and postMessage(message, options) methods on Worker objects act as if,
     // when invoked, they immediately invoked the respective postMessage(message, transfer) and

--- a/Libraries/LibWeb/HTML/Worker.h
+++ b/Libraries/LibWeb/HTML/Worker.h
@@ -35,7 +35,7 @@ public:
     WebIDL::ExceptionOr<void> terminate();
 
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Bindings::StructuredSerializeOptions const&);
-    WebIDL::ExceptionOr<void> post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, GC::RootVector<GC::Ref<JS::Object>> const& transfer);
 
     virtual ~Worker() = default;
 

--- a/Libraries/LibWeb/IndexedDB/IDBCursor.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBCursor.cpp
@@ -122,7 +122,7 @@ JS::Value IDBCursor::key()
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbcursor-continue
-WebIDL::ExceptionOr<void> IDBCursor::continue_(JS::Value key)
+WebIDL::ExceptionOr<void> IDBCursor::continue_(Optional<JS::Value> key)
 {
     auto& realm = this->realm();
 
@@ -143,9 +143,9 @@ WebIDL::ExceptionOr<void> IDBCursor::continue_(JS::Value key)
 
     // 5. If key is given, then:
     GC::Ptr<Key> key_value;
-    if (!key.is_undefined()) {
+    if (key.has_value()) {
         // 1. Let r be the result of converting a value to a key with key. Rethrow any exceptions.
-        auto r = TRY(convert_a_value_to_a_key(realm, key));
+        auto r = TRY(convert_a_value_to_a_key(realm, *key));
 
         // 2. If r is invalid, throw a "DataError" DOMException.
         if (r->is_invalid())

--- a/Libraries/LibWeb/IndexedDB/IDBCursor.h
+++ b/Libraries/LibWeb/IndexedDB/IDBCursor.h
@@ -47,7 +47,7 @@ public:
     [[nodiscard]] GC::Ptr<IDBRequest> request() { return m_request; }
 
     WebIDL::ExceptionOr<void> advance(WebIDL::UnsignedLong);
-    WebIDL::ExceptionOr<void> continue_(JS::Value);
+    WebIDL::ExceptionOr<void> continue_(Optional<JS::Value>);
     WebIDL::ExceptionOr<void> continue_primary_key(JS::Value, JS::Value);
 
     WebIDL::ExceptionOr<GC::Ref<IDBRequest>> update(JS::Value);

--- a/Libraries/LibWeb/IndexedDB/IDBIndex.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBIndex.cpp
@@ -112,7 +112,7 @@ JS::Value IDBIndex::key_path() const
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbindex-opencursor
-WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_cursor(JS::Value query, Bindings::IDBCursorDirection direction)
+WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_cursor(Optional<JS::Value> query, Bindings::IDBCursorDirection direction)
 {
     auto& realm = this->realm();
 
@@ -222,7 +222,7 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::get_all(Optional<JS::Value> q
 {
     // 1. Return the result of creating a request to retrieve multiple items with the current Realm record, this,
     //    "value", queryOrOptions, and count if given. Rethrow any exceptions.
-    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Value, *query_or_options, count);
+    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Value, query_or_options.value_or(JS::js_undefined()), count);
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbindex-getallkeys
@@ -230,11 +230,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::get_all_keys(Optional<JS::Val
 {
     // 1. Return the result of creating a request to retrieve multiple items with the current Realm record, this, "key",
     //    queryOrOptions, and count if given. Rethrow any exceptions.
-    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Key, *query_or_options, count);
+    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Key, query_or_options.value_or(JS::js_undefined()), count);
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbindex-count
-WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::count(JS::Value query)
+WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::count(Optional<JS::Value> query)
 {
     auto& realm = this->realm();
 
@@ -267,7 +267,7 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::count(JS::Value query)
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbindex-openkeycursor
-WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_key_cursor(JS::Value query, Bindings::IDBCursorDirection direction)
+WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_key_cursor(Optional<JS::Value> query, Bindings::IDBCursorDirection direction)
 {
     auto& realm = this->realm();
 

--- a/Libraries/LibWeb/IndexedDB/IDBIndex.h
+++ b/Libraries/LibWeb/IndexedDB/IDBIndex.h
@@ -35,9 +35,9 @@ public:
     [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> get_all(Optional<JS::Value>, Optional<WebIDL::UnsignedLong>);
     [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> get_all_keys(Optional<JS::Value>, Optional<WebIDL::UnsignedLong>);
     [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> get_all_records(Bindings::IDBGetAllOptions const&);
-    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> count(JS::Value);
-    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_cursor(JS::Value, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
-    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_key_cursor(JS::Value, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
+    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> count(Optional<JS::Value>);
+    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_cursor(Optional<JS::Value>, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
+    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_key_cursor(Optional<JS::Value>, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
 
     // The transaction of an index handle is the transaction of its associated object store handle.
     GC::Ref<IDBTransaction> transaction() { return m_object_store_handle->transaction(); }

--- a/Libraries/LibWeb/IndexedDB/IDBObjectStore.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBObjectStore.cpp
@@ -448,7 +448,7 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::get(JS::Value query)
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbobjectstore-opencursor
-WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::open_cursor(JS::Value query, Bindings::IDBCursorDirection direction)
+WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::open_cursor(Optional<JS::Value> query, Bindings::IDBCursorDirection direction)
 {
     auto& realm = this->realm();
 
@@ -598,11 +598,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::get_all(Optional<JS::Va
 {
     // 1. Return the result of creating a request to retrieve multiple items with the current Realm record, this,
     //    "value", queryOrOptions, and count if given. Rethrow any exceptions.
-    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Value, *query_or_options, count);
+    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Value, query_or_options.value_or(JS::js_undefined()), count);
 }
 
 // https://w3c.github.io/IndexedDB/#dom-idbobjectstore-openkeycursor
-WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::open_key_cursor(JS::Value query, Bindings::IDBCursorDirection direction)
+WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::open_key_cursor(Optional<JS::Value> query, Bindings::IDBCursorDirection direction)
 {
     auto& realm = this->realm();
 
@@ -647,7 +647,7 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::get_all_keys(Optional<J
 {
     // 1. Return the result of creating a request to retrieve multiple items with the current Realm record, this, "key",
     //    queryOrOptions, and count if given. Rethrow any exceptions.
-    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Key, *query_or_options, count);
+    return create_a_request_to_retrieve_multiple_items(realm(), GC::Ref(*this), RecordKind::Key, query_or_options.value_or(JS::js_undefined()), count);
 }
 
 // https://pr-preview.s3.amazonaws.com/w3c/IndexedDB/pull/461.html#dom-idbobjectstore-getallrecords

--- a/Libraries/LibWeb/IndexedDB/IDBObjectStore.h
+++ b/Libraries/LibWeb/IndexedDB/IDBObjectStore.h
@@ -43,8 +43,8 @@ public:
     [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> get_all_keys(Optional<JS::Value>, Optional<WebIDL::UnsignedLong>);
     [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> get_all_records(Bindings::IDBGetAllOptions const&);
     [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> count(Optional<JS::Value>);
-    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_cursor(JS::Value, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
-    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_key_cursor(JS::Value, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
+    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_cursor(Optional<JS::Value>, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
+    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<IDBRequest>> open_key_cursor(Optional<JS::Value>, Bindings::IDBCursorDirection = Bindings::IDBCursorDirection::Next);
 
     WebIDL::ExceptionOr<GC::Ref<IDBIndex>> index(String const&);
 

--- a/Libraries/LibWeb/IndexedDB/IDBVersionChangeEvent.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBVersionChangeEvent.cpp
@@ -21,7 +21,7 @@ GC::Ref<IDBVersionChangeEvent> IDBVersionChangeEvent::create(JS::Realm& realm, F
 IDBVersionChangeEvent::IDBVersionChangeEvent(JS::Realm& realm, FlyString const& event_name, Bindings::IDBVersionChangeEventInit const& event_init)
     : DOM::Event(realm, event_name, event_init)
     , m_old_version(event_init.old_version)
-    , m_new_version(event_init.new_version)
+    , m_new_version(event_init.new_version.value_or({}))
 {
 }
 

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -93,7 +93,7 @@ IntersectionObserver::IntersectionObserver(JS::Realm& realm, GC::Ptr<WebIDL::Cal
     , m_delay(delay)
     , m_track_visibility(track_visibility)
 {
-    m_root = root.has<Empty>() ? nullptr : root.visit([](GC::Root<DOM::Element> const& value) -> GC::Ptr<DOM::Node> { return *value; }, [](GC::Root<DOM::Document> const& value) -> GC::Ptr<DOM::Node> { return *value; }, [](Empty) -> GC::Ptr<DOM::Node> { return nullptr; });
+    m_root = root.has<Empty>() ? nullptr : root.visit([](GC::Ref<DOM::Element> const& value) -> GC::Ptr<DOM::Node> { return value; }, [](GC::Ref<DOM::Document> const& value) -> GC::Ptr<DOM::Node> { return value; }, [](Empty) -> GC::Ptr<DOM::Node> { return nullptr; });
     intersection_root().visit([this](auto& node) {
         m_document = node->document();
     });
@@ -206,9 +206,9 @@ NullableIntersectionObserverRoot IntersectionObserver::root() const
     if (!m_root)
         return Empty {};
     if (m_root->is_element())
-        return GC::make_root(static_cast<DOM::Element&>(*m_root));
+        return GC::Ref { static_cast<DOM::Element&>(*m_root) };
     if (m_root->is_document())
-        return GC::make_root(static_cast<DOM::Document&>(*m_root));
+        return GC::Ref { static_cast<DOM::Document&>(*m_root) };
     VERIFY_NOT_REACHED();
 }
 
@@ -251,12 +251,12 @@ String IntersectionObserver::scroll_margin() const
 }
 
 // https://www.w3.org/TR/intersection-observer/#intersectionobserver-intersection-root
-Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>> IntersectionObserver::intersection_root() const
+Variant<GC::Ref<DOM::Element>, GC::Ref<DOM::Document>> IntersectionObserver::intersection_root() const
 {
     auto root_node = intersection_root_node();
     if (root_node->is_element())
-        return GC::make_root(static_cast<DOM::Element&>(*root_node));
-    return GC::make_root(static_cast<DOM::Document&>(*root_node));
+        return GC::Ref { static_cast<DOM::Element&>(*root_node) };
+    return GC::Ref { static_cast<DOM::Document&>(*root_node) };
 }
 
 GC::Ref<DOM::Node> IntersectionObserver::intersection_root_node() const
@@ -279,8 +279,8 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
 
     // If the intersection root is a document,
     //    it’s the size of the document's viewport (note that this processing step can only be reached if the document is fully active).
-    if (intersection_root.has<GC::Root<DOM::Document>>()) {
-        auto document = intersection_root.get<GC::Root<DOM::Document>>();
+    if (intersection_root.has<GC::Ref<DOM::Document>>()) {
+        auto document = intersection_root.get<GC::Ref<DOM::Document>>();
 
         // Since the spec says that this is only reach if the document is fully active, that means it must have a navigable.
         VERIFY(document->navigable());
@@ -289,8 +289,8 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
         //       as intersections are computed using viewport-relative element rects.
         rect = CSSPixelRect { CSSPixelPoint { 0, 0 }, document->viewport_rect().size() };
     } else {
-        VERIFY(intersection_root.has<GC::Root<DOM::Element>>());
-        auto element = intersection_root.get<GC::Root<DOM::Element>>();
+        VERIFY(intersection_root.has<GC::Ref<DOM::Element>>());
+        auto element = intersection_root.get<GC::Ref<DOM::Element>>();
 
         // FIXME: Otherwise, if the intersection root has a content clip,
         //          it’s the element’s content area.
@@ -306,10 +306,10 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
     // edges, respectively, are offset by, with positive lengths indicating an outward offset. Percentages
     // are resolved relative to the width of the undilated rectangle.
     DOM::Document* document = { nullptr };
-    if (intersection_root.has<GC::Root<DOM::Document>>()) {
-        document = intersection_root.get<GC::Root<DOM::Document>>().cell();
+    if (intersection_root.has<GC::Ref<DOM::Document>>()) {
+        document = intersection_root.get<GC::Ref<DOM::Document>>().ptr();
     } else {
-        document = &intersection_root.get<GC::Root<DOM::Element>>().cell()->document();
+        document = &intersection_root.get<GC::Ref<DOM::Element>>()->document();
     }
     if (m_document && document->origin().is_same_origin(m_document->origin())) {
         if (auto layout_node = intersection_root.visit([&](auto& node) -> GC::Ptr<Layout::Node> { return node->layout_node(); })) {

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -7,14 +7,13 @@
 #pragma once
 
 #include <AK/Optional.h>
-#include <LibGC/Root.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserverEntry.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::IntersectionObserver {
 
-using NullableIntersectionObserverRoot = Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>, Empty>;
+using NullableIntersectionObserverRoot = Variant<GC::Ref<DOM::Element>, GC::Ref<DOM::Document>, Empty>;
 using IntersectionObserverRoot = NullableIntersectionObserverRoot;
 
 struct ObservationTarget {
@@ -51,7 +50,7 @@ public:
     long delay() const { return m_delay; }
     bool track_visibility() const { return m_track_visibility; }
 
-    Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>> intersection_root() const;
+    Variant<GC::Ref<DOM::Element>, GC::Ref<DOM::Document>> intersection_root() const;
     GC::Ref<DOM::Node> intersection_root_node() const;
     bool is_implicit_root() const { return !m_root; }
     CSSPixelRect root_intersection_rectangle() const;

--- a/Libraries/LibWeb/MediaCapture/MediaStream.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaStream.cpp
@@ -31,7 +31,7 @@ GC::Ref<MediaStream> MediaStream::create(JS::Realm& realm)
 }
 
 // https://w3c.github.io/mediacapture-main/#mediastream
-GC::Ref<MediaStream> MediaStream::construct_impl(JS::Realm& realm, Vector<GC::Root<MediaStreamTrack>> const& tracks)
+GC::Ref<MediaStream> MediaStream::construct_impl(JS::Realm& realm, ReadonlySpan<GC::Ref<MediaStreamTrack>> const& tracks)
 {
     // 1. Let stream be a newly constructed MediaStream object.
     // 2. Initialize stream.id attribute to a newly generated value.
@@ -120,8 +120,7 @@ void MediaStream::add_track(GC::Ref<MediaStreamTrack> track)
     m_tracks.append(track);
 
     // 4. Fire a track event named addtrack with track at stream.
-    Bindings::MediaStreamTrackEventInit event_init {};
-    event_init.track = track;
+    Bindings::MediaStreamTrackEventInit event_init { Bindings::EventInit {}, track };
     auto event = MediaStreamTrackEvent::create(realm(), HTML::EventNames::addtrack, event_init);
     dispatch_event(event);
 }
@@ -139,8 +138,7 @@ void MediaStream::remove_track(GC::Ref<MediaStreamTrack> track)
         return;
 
     // 4. Fire a track event named removetrack with track at stream.
-    Bindings::MediaStreamTrackEventInit event_init;
-    event_init.track = track;
+    Bindings::MediaStreamTrackEventInit event_init { Bindings::EventInit {}, track };
     auto event = MediaStreamTrackEvent::create(realm(), HTML::EventNames::removetrack, event_init);
     dispatch_event(event);
 }

--- a/Libraries/LibWeb/MediaCapture/MediaStream.h
+++ b/Libraries/LibWeb/MediaCapture/MediaStream.h
@@ -20,7 +20,7 @@ class MediaStream final : public DOM::EventTarget {
 
 public:
     static GC::Ref<MediaStream> create(JS::Realm&);
-    static GC::Ref<MediaStream> construct_impl(JS::Realm&, Vector<GC::Root<MediaStreamTrack>> const&);
+    static GC::Ref<MediaStream> construct_impl(JS::Realm&, ReadonlySpan<GC::Ref<MediaStreamTrack>> const&);
 
     virtual ~MediaStream() override = default;
 

--- a/Libraries/LibWeb/MediaCapture/MediaStreamTrackEvent.cpp
+++ b/Libraries/LibWeb/MediaCapture/MediaStreamTrackEvent.cpp
@@ -10,12 +10,6 @@
 
 namespace Web::MediaCapture {
 
-static GC::Ref<MediaStreamTrack> require_track(Bindings::MediaStreamTrackEventInit const& event_init)
-{
-    VERIFY(event_init.track);
-    return *event_init.track;
-}
-
 GC_DEFINE_ALLOCATOR(MediaStreamTrackEvent);
 
 GC::Ref<MediaStreamTrackEvent> MediaStreamTrackEvent::create(JS::Realm& realm, FlyString const& event_name, Bindings::MediaStreamTrackEventInit const& event_init)
@@ -30,14 +24,8 @@ GC::Ref<MediaStreamTrackEvent> MediaStreamTrackEvent::construct_impl(JS::Realm& 
 
 // https://w3c.github.io/mediacapture-main/#mediastreamtrackevent
 MediaStreamTrackEvent::MediaStreamTrackEvent(JS::Realm& realm, FlyString const& event_name, Bindings::MediaStreamTrackEventInit const& event_init)
-    : DOM::Event(realm, event_name, [&] {
-        Bindings::EventInit base_init {};
-        base_init.bubbles = event_init.bubbles;
-        base_init.cancelable = event_init.cancelable;
-        base_init.composed = event_init.composed;
-        return base_init;
-    }())
-    , m_track(require_track(event_init))
+    : DOM::Event(realm, event_name, event_init)
+    , m_track(event_init.track)
 {
 }
 

--- a/Libraries/LibWeb/ServiceWorker/Cache.cpp
+++ b/Libraries/LibWeb/ServiceWorker/Cache.cpp
@@ -226,7 +226,7 @@ GC::Ref<WebIDL::Promise> Cache::add_all(ReadonlySpan<Fetch::RequestInfo> request
 
     // 3. For each request whose type is Request in requests:
     for (auto const& request_info : requests) {
-        if (auto const* request = request_info.get_pointer<GC::Root<Fetch::Request>>()) {
+        if (auto const* request = request_info.get_pointer<GC::Ref<Fetch::Request>>()) {
             // 1. Let r be request’s request.
             auto inner_request = (*request)->request();
 

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<void> pack_and_post_message(JS::Realm& realm, HTML::MessageP
     auto target_port = port.entangled_port();
 
     // 5. Let options be «[ "transfer" → « » ]».
-    Bindings::StructuredSerializeOptions options { .transfer = {} };
+    Bindings::StructuredSerializeOptions options;
 
     // 6. Run the message port post message steps providing targetPort, message, and options.
     return port.message_port_post_message_steps(target_port, message, options);

--- a/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -62,10 +62,10 @@ WebIDL::ExceptionOr<void> ReadableByteStreamController::close()
 }
 
 // https://streams.spec.whatwg.org/#rbs-controller-error
-void ReadableByteStreamController::error(JS::Value error)
+void ReadableByteStreamController::error(Optional<JS::Value> error)
 {
     // 1. Perform ! ReadableByteStreamControllerError(this, e).
-    readable_byte_stream_controller_error(*this, error);
+    readable_byte_stream_controller_error(*this, error.value_or(JS::js_undefined()));
 }
 
 ReadableByteStreamController::ReadableByteStreamController(JS::Realm& realm)
@@ -80,7 +80,7 @@ void ReadableByteStreamController::initialize(JS::Realm& realm)
 }
 
 // https://streams.spec.whatwg.org/#rbs-controller-enqueue
-WebIDL::ExceptionOr<void> ReadableByteStreamController::enqueue(GC::Root<WebIDL::ArrayBufferView>& chunk)
+WebIDL::ExceptionOr<void> ReadableByteStreamController::enqueue(GC::Ref<WebIDL::ArrayBufferView> chunk)
 {
     // 1. If chunk.[[ByteLength]] is 0, throw a TypeError exception.
     // 2. If chunk.[[ViewedArrayBuffer]].[[ByteLength]] is 0, throw a TypeError exception.

--- a/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -122,8 +122,8 @@ public:
 
     Optional<double> desired_size() const;
     WebIDL::ExceptionOr<void> close();
-    void error(JS::Value error);
-    WebIDL::ExceptionOr<void> enqueue(GC::Root<WebIDL::ArrayBufferView>&);
+    void error(Optional<JS::Value> error);
+    WebIDL::ExceptionOr<void> enqueue(GC::Ref<WebIDL::ArrayBufferView>);
 
     Optional<u64> const& auto_allocate_chunk_size() { return m_auto_allocate_chunk_size; }
     void set_auto_allocate_chunk_size(Optional<u64> value) { m_auto_allocate_chunk_size = value; }

--- a/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -34,14 +34,14 @@ namespace Web::Streams {
 GC_DEFINE_ALLOCATOR(ReadableStream);
 
 // https://streams.spec.whatwg.org/#rs-constructor
-WebIDL::ExceptionOr<GC::Ref<ReadableStream>> ReadableStream::construct_impl(JS::Realm& realm, Optional<GC::Root<JS::Object>> const& underlying_source_object, Bindings::QueuingStrategy const& strategy)
+WebIDL::ExceptionOr<GC::Ref<ReadableStream>> ReadableStream::construct_impl(JS::Realm& realm, GC::Ptr<JS::Object> underlying_source_object, Bindings::QueuingStrategy const& strategy)
 {
     auto& vm = realm.vm();
 
     auto readable_stream = realm.create<ReadableStream>(realm);
 
     // 1. If underlyingSource is missing, set it to null.
-    auto underlying_source = underlying_source_object.has_value() ? JS::Value(underlying_source_object.value()) : JS::js_null();
+    auto underlying_source = underlying_source_object ? JS::Value(underlying_source_object) : JS::js_null();
 
     // 2. Let underlyingSourceDict be underlyingSource, converted to an IDL value of type UnderlyingSource.
     auto underlying_source_dict = TRY(Bindings::convert_to_idl_value_for_underlying_source(vm, underlying_source));
@@ -116,7 +116,7 @@ bool ReadableStream::locked() const
 }
 
 // https://streams.spec.whatwg.org/#rs-cancel
-GC::Ref<WebIDL::Promise> ReadableStream::cancel(JS::Value reason)
+GC::Ref<WebIDL::Promise> ReadableStream::cancel(Optional<JS::Value> reason)
 {
     auto& realm = this->realm();
 
@@ -127,7 +127,7 @@ GC::Ref<WebIDL::Promise> ReadableStream::cancel(JS::Value reason)
     }
 
     // 2. Return ! ReadableStreamCancel(this, reason).
-    return readable_stream_cancel(*this, reason);
+    return readable_stream_cancel(*this, reason.value_or(JS::js_undefined()));
 }
 
 // https://streams.spec.whatwg.org/#rs-get-reader
@@ -156,7 +156,7 @@ WebIDL::ExceptionOr<GC::Ref<ReadableStream>> ReadableStream::pipe_through(Bindin
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Failed to execute 'pipeThrough' on 'ReadableStream': parameter 1's 'writable' is locked"sv };
 
     // 3. Let signal be options["signal"] if it exists, or undefined otherwise.
-    GC::Ptr<DOM::AbortSignal> signal = options.signal.has_value() ? options.signal->ptr() : nullptr;
+    GC::Ptr<DOM::AbortSignal> signal = options.signal;
 
     // 4. Let promise be ! ReadableStreamPipeTo(this, transform["writable"], options["preventClose"], options["preventAbort"], options["preventCancel"], signal).
     auto promise = readable_stream_pipe_to(*this, *transform.writable, options.prevent_close, options.prevent_abort, options.prevent_cancel, signal);
@@ -185,7 +185,7 @@ GC::Ref<WebIDL::Promise> ReadableStream::pipe_to(WritableStream& destination, Bi
     }
 
     // 3. Let signal be options["signal"] if it exists, or undefined otherwise.
-    GC::Ptr<DOM::AbortSignal> signal = options.signal.has_value() ? options.signal->ptr() : nullptr;
+    GC::Ptr<DOM::AbortSignal> signal = options.signal;
 
     // 4. Return ! ReadableStreamPipeTo(this, destination, options["preventClose"], options["preventAbort"], options["preventCancel"], signal).
     return readable_stream_pipe_to(*this, destination, options.prevent_close, options.prevent_abort, options.prevent_cancel, signal);
@@ -489,7 +489,7 @@ WebIDL::ExceptionOr<void> ReadableStream::transfer_steps(HTML::TransferDataEncod
     WebIDL::mark_promise_as_handled(promise);
 
     // 9. Set dataHolder.[[port]] to ! StructuredSerializeWithTransfer(port2, « port2 »).
-    auto result = MUST(HTML::structured_serialize_with_transfer(vm, port2, { { GC::Root { port2 } } }));
+    auto result = MUST(HTML::structured_serialize_with_transfer(vm, port2, { { port2 } }));
     data_holder.extend(move(result.transfer_data_holders));
 
     return {};

--- a/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Libraries/LibWeb/Streams/ReadableStream.h
@@ -55,14 +55,14 @@ public:
         Errored,
     };
 
-    static WebIDL::ExceptionOr<GC::Ref<ReadableStream>> construct_impl(JS::Realm&, Optional<GC::Root<JS::Object>> const& underlying_source, Bindings::QueuingStrategy const& = {});
+    static WebIDL::ExceptionOr<GC::Ref<ReadableStream>> construct_impl(JS::Realm&, GC::Ptr<JS::Object> underlying_source, Bindings::QueuingStrategy const& = {});
 
     static WebIDL::ExceptionOr<GC::Ref<ReadableStream>> from(JS::VM& vm, JS::Value async_iterable);
 
     virtual ~ReadableStream() override;
 
     bool locked() const;
-    GC::Ref<WebIDL::Promise> cancel(JS::Value reason);
+    GC::Ref<WebIDL::Promise> cancel(Optional<JS::Value> reason);
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader(Bindings::ReadableStreamGetReaderOptions const& = {});
     WebIDL::ExceptionOr<GC::Ref<ReadableStream>> pipe_through(Bindings::ReadableWritablePair transform, Bindings::StreamPipeOptions const& = {});
     GC::Ref<WebIDL::Promise> pipe_to(WritableStream& destination, Bindings::StreamPipeOptions const& = {});

--- a/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -107,7 +107,7 @@ private:
 GC_DEFINE_ALLOCATOR(BYOBReaderReadIntoRequest);
 
 // https://streams.spec.whatwg.org/#byob-reader-read
-GC::Ref<WebIDL::Promise> ReadableStreamBYOBReader::read(GC::Root<WebIDL::ArrayBufferView>& view, Bindings::ReadableStreamBYOBReaderReadOptions options)
+GC::Ref<WebIDL::Promise> ReadableStreamBYOBReader::read(GC::Ref<WebIDL::ArrayBufferView> view, Bindings::ReadableStreamBYOBReaderReadOptions options)
 {
     auto& realm = this->realm();
 

--- a/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
@@ -47,7 +47,7 @@ public:
 
     virtual ~ReadableStreamBYOBReader() override = default;
 
-    GC::Ref<WebIDL::Promise> read(GC::Root<WebIDL::ArrayBufferView>&, Bindings::ReadableStreamBYOBReaderReadOptions options = {});
+    GC::Ref<WebIDL::Promise> read(GC::Ref<WebIDL::ArrayBufferView>, Bindings::ReadableStreamBYOBReaderReadOptions options = {});
 
     void release_lock();
 

--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultController.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultController.cpp
@@ -45,23 +45,23 @@ WebIDL::ExceptionOr<void> ReadableStreamDefaultController::close()
 }
 
 // https://streams.spec.whatwg.org/#rs-default-controller-enqueue
-WebIDL::ExceptionOr<void> ReadableStreamDefaultController::enqueue(JS::Value chunk)
+WebIDL::ExceptionOr<void> ReadableStreamDefaultController::enqueue(Optional<JS::Value> chunk)
 {
     // 1. If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false, throw a TypeError exception.
     if (!readable_stream_default_controller_can_close_or_enqueue(*this))
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Cannot enqueue chunk to stream"sv };
 
     // 2. Perform ? ReadableStreamDefaultControllerEnqueue(this, chunk).
-    TRY(readable_stream_default_controller_enqueue(*this, chunk));
+    TRY(readable_stream_default_controller_enqueue(*this, chunk.value_or(JS::js_undefined())));
 
     return {};
 }
 
 // https://streams.spec.whatwg.org/#rs-default-controller-error
-void ReadableStreamDefaultController::error(JS::Value error)
+void ReadableStreamDefaultController::error(Optional<JS::Value> error)
 {
     // 1. Perform ! ReadableStreamDefaultControllerError(this, e).
-    readable_stream_default_controller_error(*this, error);
+    readable_stream_default_controller_error(*this, error.value_or(JS::js_undefined()));
 }
 
 // https://streams.spec.whatwg.org/#rs-default-controller-private-cancel

--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultController.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultController.h
@@ -29,8 +29,8 @@ public:
     Optional<double> desired_size();
 
     WebIDL::ExceptionOr<void> close();
-    WebIDL::ExceptionOr<void> enqueue(JS::Value chunk);
-    void error(JS::Value error);
+    WebIDL::ExceptionOr<void> enqueue(Optional<JS::Value> chunk);
+    void error(Optional<JS::Value> error);
 
     GC::Ptr<CancelAlgorithm> cancel_algorithm() { return m_cancel_algorithm; }
     void set_cancel_algorithm(GC::Ptr<CancelAlgorithm> value) { m_cancel_algorithm = value; }

--- a/Libraries/LibWeb/Streams/ReadableStreamGenericReader.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStreamGenericReader.cpp
@@ -21,7 +21,7 @@ GC::Ptr<WebIDL::Promise> ReadableStreamGenericReaderMixin::closed()
 }
 
 // https://streams.spec.whatwg.org/#generic-reader-cancel
-GC::Ref<WebIDL::Promise> ReadableStreamGenericReaderMixin::cancel(JS::Value reason)
+GC::Ref<WebIDL::Promise> ReadableStreamGenericReaderMixin::cancel(Optional<JS::Value> reason)
 {
     // 1. If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
     if (!m_stream) {
@@ -30,7 +30,7 @@ GC::Ref<WebIDL::Promise> ReadableStreamGenericReaderMixin::cancel(JS::Value reas
     }
 
     // 2. Return ! ReadableStreamReaderGenericCancel(this, reason).
-    return readable_stream_reader_generic_cancel(*this, reason);
+    return readable_stream_reader_generic_cancel(*this, reason.value_or(JS::js_undefined()));
 }
 
 ReadableStreamGenericReaderMixin::ReadableStreamGenericReaderMixin(JS::Realm& realm)

--- a/Libraries/LibWeb/Streams/ReadableStreamGenericReader.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamGenericReader.h
@@ -21,7 +21,7 @@ public:
 
     GC::Ptr<WebIDL::Promise> closed();
 
-    GC::Ref<WebIDL::Promise> cancel(JS::Value reason);
+    GC::Ref<WebIDL::Promise> cancel(Optional<JS::Value> reason);
 
     GC::Ptr<ReadableStream> stream() const { return m_stream; }
     void set_stream(GC::Ptr<ReadableStream> stream) { m_stream = stream; }

--- a/Libraries/LibWeb/Streams/TransformStream.cpp
+++ b/Libraries/LibWeb/Streams/TransformStream.cpp
@@ -25,14 +25,14 @@ namespace Web::Streams {
 GC_DEFINE_ALLOCATOR(TransformStream);
 
 // https://streams.spec.whatwg.org/#ts-constructor
-WebIDL::ExceptionOr<GC::Ref<TransformStream>> TransformStream::construct_impl(JS::Realm& realm, Optional<GC::Root<JS::Object>> transformer_object, Bindings::QueuingStrategy const& writable_strategy, Bindings::QueuingStrategy const& readable_strategy)
+WebIDL::ExceptionOr<GC::Ref<TransformStream>> TransformStream::construct_impl(JS::Realm& realm, GC::Ptr<JS::Object> transformer_object, Bindings::QueuingStrategy const& writable_strategy, Bindings::QueuingStrategy const& readable_strategy)
 {
     auto& vm = realm.vm();
 
     auto stream = realm.create<TransformStream>(realm);
 
     // 1. If transformer is missing, set it to null.
-    auto transformer = transformer_object.has_value() ? JS::Value { transformer_object.value() } : JS::js_null();
+    auto transformer = transformer_object ? JS::Value { transformer_object } : JS::js_null();
 
     // 2. Let transformerDict be transformer, converted to an IDL value of type Transformer.
     auto transformer_dict = TRY(Bindings::convert_to_idl_value_for_transformer(vm, transformer));
@@ -208,11 +208,11 @@ WebIDL::ExceptionOr<void> TransformStream::transfer_steps(HTML::TransferDataEnco
         return WebIDL::DataCloneError::create(realm, "Cannot transfer locked WritableStream"_utf16);
 
     // 5. Set dataHolder.[[readable]] to ! StructuredSerializeWithTransfer(readable, « readable »).
-    auto readable_result = MUST(HTML::structured_serialize_with_transfer(vm, readable, { { GC::Root { readable } } }));
+    auto readable_result = MUST(HTML::structured_serialize_with_transfer(vm, readable, { { readable } }));
     data_holder.extend(move(readable_result.transfer_data_holders));
 
     // 6. Set dataHolder.[[writable]] to ! StructuredSerializeWithTransfer(writable, « writable »).
-    auto writable_result = MUST(HTML::structured_serialize_with_transfer(vm, writable, { { GC::Root { writable } } }));
+    auto writable_result = MUST(HTML::structured_serialize_with_transfer(vm, writable, { { writable } }));
     data_holder.extend(move(writable_result.transfer_data_holders));
 
     return {};

--- a/Libraries/LibWeb/Streams/TransformStream.h
+++ b/Libraries/LibWeb/Streams/TransformStream.h
@@ -25,7 +25,7 @@ class TransformStream final
 public:
     virtual ~TransformStream() override;
 
-    static WebIDL::ExceptionOr<GC::Ref<TransformStream>> construct_impl(JS::Realm&, Optional<GC::Root<JS::Object>> transformer_object = {}, Bindings::QueuingStrategy const& writable_strategy = {}, Bindings::QueuingStrategy const& readable_strategy = {});
+    static WebIDL::ExceptionOr<GC::Ref<TransformStream>> construct_impl(JS::Realm&, GC::Ptr<JS::Object> transformer_object = {}, Bindings::QueuingStrategy const& writable_strategy = {}, Bindings::QueuingStrategy const& readable_strategy = {});
 
     // https://streams.spec.whatwg.org/#ts-readable
     GC::Ref<ReadableStream> readable() { return *m_readable; }

--- a/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -25,14 +25,14 @@ namespace Web::Streams {
 GC_DEFINE_ALLOCATOR(WritableStream);
 
 // https://streams.spec.whatwg.org/#ws-constructor
-WebIDL::ExceptionOr<GC::Ref<WritableStream>> WritableStream::construct_impl(JS::Realm& realm, Optional<GC::Root<JS::Object>> const& underlying_sink_object, Bindings::QueuingStrategy const& strategy)
+WebIDL::ExceptionOr<GC::Ref<WritableStream>> WritableStream::construct_impl(JS::Realm& realm, GC::Ptr<JS::Object> underlying_sink_object, Bindings::QueuingStrategy const& strategy)
 {
     auto& vm = realm.vm();
 
     auto writable_stream = realm.create<WritableStream>(realm);
 
     // 1. If underlyingSink is missing, set it to null.
-    auto underlying_sink = underlying_sink_object.has_value() ? JS::Value(underlying_sink_object.value()) : JS::js_null();
+    auto underlying_sink = underlying_sink_object ? JS::Value(underlying_sink_object) : JS::js_null();
 
     // 2. Let underlyingSinkDict be underlyingSink, converted to an IDL value of type UnderlyingSink.
     auto underlying_sink_dict = TRY(Bindings::convert_to_idl_value_for_underlying_sink(vm, underlying_sink));
@@ -113,7 +113,7 @@ GC::Ref<WebIDL::Promise> WritableStream::close()
 }
 
 // https://streams.spec.whatwg.org/#ws-abort
-GC::Ref<WebIDL::Promise> WritableStream::abort(JS::Value reason)
+GC::Ref<WebIDL::Promise> WritableStream::abort(Optional<JS::Value> reason)
 {
     auto& realm = this->realm();
 
@@ -124,7 +124,7 @@ GC::Ref<WebIDL::Promise> WritableStream::abort(JS::Value reason)
     }
 
     // 2. Return ! WritableStreamAbort(this, reason).
-    return writable_stream_abort(*this, reason);
+    return writable_stream_abort(*this, reason.value_or(JS::js_undefined()));
 }
 
 // https://streams.spec.whatwg.org/#ws-get-writer
@@ -168,7 +168,7 @@ WebIDL::ExceptionOr<void> WritableStream::transfer_steps(HTML::TransferDataEncod
     WebIDL::mark_promise_as_handled(promise);
 
     // 9. Set dataHolder.[[port]] to ! StructuredSerializeWithTransfer(port2, « port2 »).
-    auto result = MUST(HTML::structured_serialize_with_transfer(vm, port2, { { GC::Root { port2 } } }));
+    auto result = MUST(HTML::structured_serialize_with_transfer(vm, port2, { { port2 } }));
     data_holder.extend(move(result.transfer_data_holders));
 
     return {};

--- a/Libraries/LibWeb/Streams/WritableStream.h
+++ b/Libraries/LibWeb/Streams/WritableStream.h
@@ -47,12 +47,12 @@ public:
         Errored,
     };
 
-    static WebIDL::ExceptionOr<GC::Ref<WritableStream>> construct_impl(JS::Realm& realm, Optional<GC::Root<JS::Object>> const& underlying_sink, Bindings::QueuingStrategy const& = {});
+    static WebIDL::ExceptionOr<GC::Ref<WritableStream>> construct_impl(JS::Realm& realm, GC::Ptr<JS::Object> underlying_sink, Bindings::QueuingStrategy const& = {});
 
     virtual ~WritableStream() = default;
 
     bool locked() const;
-    GC::Ref<WebIDL::Promise> abort(JS::Value reason);
+    GC::Ref<WebIDL::Promise> abort(Optional<JS::Value> reason);
     GC::Ref<WebIDL::Promise> close();
     WebIDL::ExceptionOr<GC::Ref<WritableStreamDefaultWriter>> get_writer();
 

--- a/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
+++ b/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
@@ -35,7 +35,7 @@ void WritableStreamDefaultController::initialize(JS::Realm& realm)
 }
 
 // https://streams.spec.whatwg.org/#ws-default-controller-error
-void WritableStreamDefaultController::error(JS::Value error)
+void WritableStreamDefaultController::error(Optional<JS::Value> error)
 {
     // 1. Let state be this.[[stream]].[[state]].
     auto state = m_stream->state();
@@ -45,7 +45,7 @@ void WritableStreamDefaultController::error(JS::Value error)
         return;
 
     // 3. Perform ! WritableStreamDefaultControllerError(this, e).
-    writable_stream_default_controller_error(*this, error);
+    writable_stream_default_controller_error(*this, error.value_or(JS::js_undefined()));
 }
 
 // https://streams.spec.whatwg.org/#ws-default-controller-private-abort

--- a/Libraries/LibWeb/Streams/WritableStreamDefaultController.h
+++ b/Libraries/LibWeb/Streams/WritableStreamDefaultController.h
@@ -20,7 +20,7 @@ class WritableStreamDefaultController final : public Bindings::PlatformObject {
 public:
     virtual ~WritableStreamDefaultController() override = default;
 
-    void error(JS::Value error);
+    void error(Optional<JS::Value> error);
     GC::Ref<DOM::AbortSignal> signal() { return *m_signal; }
     void set_signal(GC::Ref<DOM::AbortSignal> value) { m_signal = value; }
 

--- a/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
+++ b/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
@@ -52,7 +52,7 @@ GC::Ptr<WebIDL::Promise> WritableStreamDefaultWriter::ready()
 }
 
 // https://streams.spec.whatwg.org/#default-writer-abort
-GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::abort(JS::Value reason)
+GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::abort(Optional<JS::Value> reason)
 {
     auto& realm = this->realm();
 
@@ -63,7 +63,7 @@ GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::abort(JS::Value reason)
     }
 
     // 2. Return ! WritableStreamDefaultWriterAbort(this, reason).
-    return writable_stream_default_writer_abort(*this, reason);
+    return writable_stream_default_writer_abort(*this, reason.value_or(JS::js_undefined()));
 }
 
 // https://streams.spec.whatwg.org/#default-writer-close
@@ -106,7 +106,7 @@ void WritableStreamDefaultWriter::release_lock()
 }
 
 // https://streams.spec.whatwg.org/#default-writer-write
-GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::write(JS::Value chunk)
+GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::write(Optional<JS::Value> chunk)
 {
     auto& realm = this->realm();
 
@@ -117,7 +117,7 @@ GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::write(JS::Value chunk)
     }
 
     // 2. Return ! WritableStreamDefaultWriterWrite(this, chunk).
-    return writable_stream_default_writer_write(*this, chunk);
+    return writable_stream_default_writer_write(*this, chunk.value_or(JS::js_undefined()));
 }
 
 WritableStreamDefaultWriter::WritableStreamDefaultWriter(JS::Realm& realm)

--- a/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.h
+++ b/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.h
@@ -28,10 +28,10 @@ public:
     GC::Ptr<WebIDL::Promise> closed();
     WebIDL::ExceptionOr<Optional<double>> desired_size() const;
     GC::Ptr<WebIDL::Promise> ready();
-    GC::Ref<WebIDL::Promise> abort(JS::Value reason);
+    GC::Ref<WebIDL::Promise> abort(Optional<JS::Value> reason);
     GC::Ref<WebIDL::Promise> close();
     void release_lock();
-    GC::Ref<WebIDL::Promise> write(JS::Value chunk);
+    GC::Ref<WebIDL::Promise> write(Optional<JS::Value> chunk);
 
     GC::Ptr<WebIDL::Promise> closed_promise() { return m_closed_promise; }
     void set_closed_promise(GC::Ptr<WebIDL::Promise> value) { m_closed_promise = value; }

--- a/Libraries/LibWeb/TrustedTypes/RequireTrustedTypesForDirective.cpp
+++ b/Libraries/LibWeb/TrustedTypes/RequireTrustedTypesForDirective.cpp
@@ -60,7 +60,7 @@ ContentSecurityPolicy::Directives::Directive::Result RequireTrustedTypesForDirec
     if (converted_script_source.is_error() || !converted_script_source.value().has_value())
         return Result::Blocked;
 
-    auto const* converted_script_source_value = converted_script_source.value().value().get_pointer<GC::Root<TrustedScript>>();
+    auto const* converted_script_source_value = converted_script_source.value().value().get_pointer<GC::Ref<TrustedScript>>();
 
     if (!converted_script_source_value)
         return Result::Blocked;

--- a/Libraries/LibWeb/TrustedTypes/TrustedHTML.h
+++ b/Libraries/LibWeb/TrustedTypes/TrustedHTML.h
@@ -12,7 +12,7 @@
 
 namespace Web::TrustedTypes {
 
-using TrustedHTMLOrString = Variant<GC::Root<TrustedHTML>, Utf16String>;
+using TrustedHTMLOrString = Variant<GC::Ref<TrustedHTML>, Utf16String>;
 
 class TrustedHTML final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TrustedHTML, Bindings::PlatformObject);

--- a/Libraries/LibWeb/TrustedTypes/TrustedScript.h
+++ b/Libraries/LibWeb/TrustedTypes/TrustedScript.h
@@ -12,8 +12,8 @@
 
 namespace Web::TrustedTypes {
 
-using TrustedScriptOrString = Variant<GC::Root<TrustedScript>, Utf16String>;
-using NullableTrustedScriptOrString = Variant<GC::Root<TrustedScript>, Utf16String, Empty>;
+using TrustedScriptOrString = Variant<GC::Ref<TrustedScript>, Utf16String>;
+using NullableTrustedScriptOrString = Variant<GC::Ref<TrustedScript>, Utf16String, Empty>;
 
 class TrustedScript final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TrustedScript, Bindings::PlatformObject);

--- a/Libraries/LibWeb/TrustedTypes/TrustedScriptURL.h
+++ b/Libraries/LibWeb/TrustedTypes/TrustedScriptURL.h
@@ -12,7 +12,7 @@
 
 namespace Web::TrustedTypes {
 
-using TrustedScriptURLOrString = Variant<GC::Root<TrustedScriptURL>, Utf16String>;
+using TrustedScriptURLOrString = Variant<GC::Ref<TrustedScriptURL>, Utf16String>;
 
 class TrustedScriptURL final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TrustedScriptURL, Bindings::PlatformObject);

--- a/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.cpp
+++ b/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.cpp
@@ -65,7 +65,7 @@ Utf16String to_string(TrustedTypeName trusted_type_name)
     }
 }
 // https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-createhtml
-WebIDL::ExceptionOr<GC::Root<TrustedHTML>> TrustedTypePolicy::create_html(Utf16String const& input, GC::RootVector<JS::Value> const& arguments)
+WebIDL::ExceptionOr<GC::Ref<TrustedHTML>> TrustedTypePolicy::create_html(Utf16String const& input, GC::RootVector<JS::Value> const& arguments)
 {
     // 1. Returns the result of executing the Create a Trusted Type algorithm, with the following arguments:
     //    policy
@@ -77,11 +77,11 @@ WebIDL::ExceptionOr<GC::Root<TrustedHTML>> TrustedTypePolicy::create_html(Utf16S
     //    arguments
     //      arguments
     auto const trusted_type = TRY(create_a_trusted_type(TrustedTypeName::TrustedHTML, input, arguments));
-    return trusted_type.get<GC::Root<TrustedHTML>>();
+    return trusted_type.get<GC::Ref<TrustedHTML>>();
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-createscript
-WebIDL::ExceptionOr<GC::Root<TrustedScript>> TrustedTypePolicy::create_script(Utf16String const& input, GC::RootVector<JS::Value> const& arguments)
+WebIDL::ExceptionOr<GC::Ref<TrustedScript>> TrustedTypePolicy::create_script(Utf16String const& input, GC::RootVector<JS::Value> const& arguments)
 {
     // 1. Returns the result of executing the Create a Trusted Type algorithm, with the following arguments:
     //    policy
@@ -93,11 +93,11 @@ WebIDL::ExceptionOr<GC::Root<TrustedScript>> TrustedTypePolicy::create_script(Ut
     //    arguments
     //      arguments
     auto const trusted_type = TRY(create_a_trusted_type(TrustedTypeName::TrustedScript, input, arguments));
-    return trusted_type.get<GC::Root<TrustedScript>>();
+    return trusted_type.get<GC::Ref<TrustedScript>>();
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#dom-trustedtypepolicy-createscripturl
-WebIDL::ExceptionOr<GC::Root<TrustedScriptURL>> TrustedTypePolicy::create_script_url(Utf16String const& input, GC::RootVector<JS::Value> const& arguments)
+WebIDL::ExceptionOr<GC::Ref<TrustedScriptURL>> TrustedTypePolicy::create_script_url(Utf16String const& input, GC::RootVector<JS::Value> const& arguments)
 {
     // 1. Returns the result of executing the Create a Trusted Type algorithm, with the following arguments:
     //    policy
@@ -109,7 +109,7 @@ WebIDL::ExceptionOr<GC::Root<TrustedScriptURL>> TrustedTypePolicy::create_script
     //    arguments
     //      arguments
     auto const trusted_type = TRY(create_a_trusted_type(TrustedTypeName::TrustedScriptURL, input, arguments));
-    return trusted_type.get<GC::Root<TrustedScriptURL>>();
+    return trusted_type.get<GC::Ref<TrustedScriptURL>>();
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#create-a-trusted-type-algorithm
@@ -144,11 +144,11 @@ TrustedTypesVariants TrustedTypePolicy::create_a_trusted_type(TrustedTypeName tr
     // 5. Return a new instance of an interface with a type name trustedTypeName, with its associated data value set to dataString.
     switch (trusted_type_name) {
     case TrustedTypeName::TrustedHTML:
-        return realm.create<TrustedHTML>(realm, move(data_string));
+        return TrustedType { realm.create<TrustedHTML>(realm, move(data_string)) };
     case TrustedTypeName::TrustedScript:
-        return realm.create<TrustedScript>(realm, move(data_string));
+        return TrustedType { realm.create<TrustedScript>(realm, move(data_string)) };
     case TrustedTypeName::TrustedScriptURL:
-        return realm.create<TrustedScriptURL>(realm, move(data_string));
+        return TrustedType { realm.create<TrustedScriptURL>(realm, move(data_string)) };
     default:
         VERIFY_NOT_REACHED();
     }
@@ -201,7 +201,7 @@ WebIDL::ExceptionOr<JS::Value> TrustedTypePolicy::get_trusted_type_policy_value(
 }
 
 // https://www.w3.org/TR/trusted-types/#process-value-with-a-default-policy-algorithm
-WebIDL::ExceptionOr<Optional<TrustedType>> process_value_with_a_default_policy(TrustedTypeName trusted_type_name, JS::Object& global, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String> input, InjectionSink sink)
+WebIDL::ExceptionOr<Optional<TrustedType>> process_value_with_a_default_policy(TrustedTypeName trusted_type_name, JS::Object& global, Variant<GC::Ref<TrustedHTML>, GC::Ref<TrustedScript>, GC::Ref<TrustedScriptURL>, Utf16String> input, InjectionSink sink)
 {
     auto& vm = global.vm();
     auto& realm = HTML::relevant_realm(global);
@@ -259,30 +259,30 @@ WebIDL::ExceptionOr<Optional<TrustedType>> process_value_with_a_default_policy(T
     //  6. Return a new instance of an interface with a type name trustedTypeName, with its associated data value set to dataString.
     switch (trusted_type_name) {
     case TrustedTypeName::TrustedHTML:
-        return realm.create<TrustedHTML>(realm, move(data_string));
+        return TrustedType { realm.create<TrustedHTML>(realm, move(data_string)) };
     case TrustedTypeName::TrustedScript:
-        return realm.create<TrustedScript>(realm, move(data_string));
+        return TrustedType { realm.create<TrustedScript>(realm, move(data_string)) };
     case TrustedTypeName::TrustedScriptURL:
-        return realm.create<TrustedScriptURL>(realm, move(data_string));
+        return TrustedType { realm.create<TrustedScriptURL>(realm, move(data_string)) };
     }
     VERIFY_NOT_REACHED();
 }
 
 // https://www.w3.org/TR/trusted-types/#get-trusted-type-compliant-string-algorithm
-WebIDL::ExceptionOr<Utf16String> get_trusted_type_compliant_string(TrustedTypeName expected_type, JS::Object& global, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String> input, InjectionSink sink, String sink_group)
+WebIDL::ExceptionOr<Utf16String> get_trusted_type_compliant_string(TrustedTypeName expected_type, JS::Object& global, Variant<GC::Ref<TrustedHTML>, GC::Ref<TrustedScript>, GC::Ref<TrustedScriptURL>, Utf16String> input, InjectionSink sink, String sink_group)
 {
     // 1. If input is an instance of expectedType, return stringified input and abort these steps.
     switch (expected_type) {
     case TrustedTypeName::TrustedHTML:
-        if (auto* const value = input.get_pointer<GC::Root<TrustedHTML>>(); value)
+        if (auto* const value = input.get_pointer<GC::Ref<TrustedHTML>>(); value)
             return (*value)->to_string();
         break;
     case TrustedTypeName::TrustedScript:
-        if (auto* const value = input.get_pointer<GC::Root<TrustedScript>>(); value)
+        if (auto* const value = input.get_pointer<GC::Ref<TrustedScript>>(); value)
             return (*value)->to_string();
         break;
     case TrustedTypeName::TrustedScriptURL:
-        if (auto* const value = input.get_pointer<GC::Root<TrustedScriptURL>>(); value)
+        if (auto* const value = input.get_pointer<GC::Ref<TrustedScriptURL>>(); value)
             return (*value)->to_string();
         break;
     }
@@ -341,13 +341,13 @@ WebIDL::ExceptionOr<Utf16String> get_trusted_type_compliant_string(TrustedTypeNa
     return converted_input.value().visit([&]<typename Type>(Type const& trusted_type) {
         switch (expected_type) {
         case TrustedTypeName::TrustedHTML:
-            VERIFY(IsSame<Type, GC::Root<TrustedHTML>>);
+            VERIFY(IsSame<Type, GC::Ref<TrustedHTML>>);
             break;
         case TrustedTypeName::TrustedScript:
-            VERIFY(IsSame<Type, GC::Root<TrustedScript>>);
+            VERIFY(IsSame<Type, GC::Ref<TrustedScript>>);
             break;
         case TrustedTypeName::TrustedScriptURL:
-            VERIFY(IsSame<Type, GC::Root<TrustedScriptURL>>);
+            VERIFY(IsSame<Type, GC::Ref<TrustedScriptURL>>);
             break;
         }
         return trusted_type->to_string();
@@ -355,7 +355,7 @@ WebIDL::ExceptionOr<Utf16String> get_trusted_type_compliant_string(TrustedTypeNa
 }
 
 // https://w3c.github.io/trusted-types/dist/spec/#validate-attribute-mutation
-WebIDL::ExceptionOr<Utf16String> get_trusted_types_compliant_attribute_value(FlyString const& attribute_name, Optional<Utf16String> attribute_ns, DOM::Element const& element, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String> const& new_value)
+WebIDL::ExceptionOr<Utf16String> get_trusted_types_compliant_attribute_value(FlyString const& attribute_name, Optional<Utf16String> attribute_ns, DOM::Element const& element, Variant<GC::Ref<TrustedHTML>, GC::Ref<TrustedScript>, GC::Ref<TrustedScriptURL>, Utf16String> const& new_value)
 {
     // 1. If attributeNs is the empty string, set attributeNs to null.
     if (attribute_ns.has_value() && attribute_ns.value().is_empty())
@@ -379,7 +379,7 @@ WebIDL::ExceptionOr<Utf16String> get_trusted_types_compliant_attribute_value(Fly
             return new_value.get<Utf16String>();
 
         // 2. Assert: newValue is TrustedHTML or TrustedScript or TrustedScriptURL.
-        VERIFY(new_value.has<GC::Root<TrustedHTML>>() || new_value.has<GC::Root<TrustedScript>>() || new_value.has<GC::Root<TrustedScriptURL>>());
+        VERIFY(new_value.has<GC::Ref<TrustedHTML>>() || new_value.has<GC::Ref<TrustedScript>>() || new_value.has<GC::Ref<TrustedScriptURL>>());
 
         // 3. Return value’s associated data.
         // FIXME: This is badly worded in the spec it should say "Return stringified newvalues's"

--- a/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.h
+++ b/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.h
@@ -16,9 +16,9 @@ namespace Web::TrustedTypes {
 
 // https://www.w3.org/TR/trusted-types/#typedefdef-trustedtype
 using TrustedType = Variant<
-    GC::Root<TrustedHTML>,
-    GC::Root<TrustedScript>,
-    GC::Root<TrustedScriptURL>>;
+    GC::Ref<TrustedHTML>,
+    GC::Ref<TrustedScript>,
+    GC::Ref<TrustedScriptURL>>;
 
 using TrustedTypesVariants = WebIDL::ExceptionOr<TrustedType>;
 
@@ -44,9 +44,9 @@ public:
 
     Utf16String const& name() const { return m_name; }
 
-    WebIDL::ExceptionOr<GC::Root<TrustedHTML>> create_html(Utf16String const&, GC::RootVector<JS::Value> const&);
-    WebIDL::ExceptionOr<GC::Root<TrustedScript>> create_script(Utf16String const&, GC::RootVector<JS::Value> const&);
-    WebIDL::ExceptionOr<GC::Root<TrustedScriptURL>> create_script_url(Utf16String const&, GC::RootVector<JS::Value> const&);
+    WebIDL::ExceptionOr<GC::Ref<TrustedHTML>> create_html(Utf16String const&, GC::RootVector<JS::Value> const&);
+    WebIDL::ExceptionOr<GC::Ref<TrustedScript>> create_script(Utf16String const&, GC::RootVector<JS::Value> const&);
+    WebIDL::ExceptionOr<GC::Ref<TrustedScriptURL>> create_script_url(Utf16String const&, GC::RootVector<JS::Value> const&);
 
     WebIDL::ExceptionOr<JS::Value> get_trusted_type_policy_value(TrustedTypeName, Utf16String const& value, GC::RootVector<JS::Value> const& values, ThrowIfCallbackMissing throw_if_missing);
 
@@ -64,11 +64,11 @@ private:
     GC::Ptr<WebIDL::CallbackType> const m_create_script_url;
 };
 
-WebIDL::ExceptionOr<Optional<TrustedType>> process_value_with_a_default_policy(TrustedTypeName, JS::Object&, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String>, InjectionSink);
+WebIDL::ExceptionOr<Optional<TrustedType>> process_value_with_a_default_policy(TrustedTypeName, JS::Object&, Variant<GC::Ref<TrustedHTML>, GC::Ref<TrustedScript>, GC::Ref<TrustedScriptURL>, Utf16String>, InjectionSink);
 
-WebIDL::ExceptionOr<Utf16String> get_trusted_type_compliant_string(TrustedTypeName, JS::Object&, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String> input, InjectionSink sink, String sink_group);
+WebIDL::ExceptionOr<Utf16String> get_trusted_type_compliant_string(TrustedTypeName, JS::Object&, Variant<GC::Ref<TrustedHTML>, GC::Ref<TrustedScript>, GC::Ref<TrustedScriptURL>, Utf16String> input, InjectionSink sink, String sink_group);
 
-WebIDL::ExceptionOr<Utf16String> get_trusted_types_compliant_attribute_value(FlyString const& attribute_name, Optional<Utf16String> attribute_ns, DOM::Element const& element, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String> const& new_value);
+WebIDL::ExceptionOr<Utf16String> get_trusted_types_compliant_attribute_value(FlyString const& attribute_name, Optional<Utf16String> attribute_ns, DOM::Element const& element, Variant<GC::Ref<TrustedHTML>, GC::Ref<TrustedScript>, GC::Ref<TrustedScriptURL>, Utf16String> const& new_value);
 
 // FIXME: Add-hoc definition of an element interface
 struct ElementInterface {

--- a/Libraries/LibWeb/UIEvents/PointerEvent.cpp
+++ b/Libraries/LibWeb/UIEvents/PointerEvent.cpp
@@ -41,7 +41,7 @@ double PointerEvent::offset_y() const { return should_have_fractional_coordinate
 
 WebIDL::ExceptionOr<GC::Ref<PointerEvent>> PointerEvent::create_from_platform_event(JS::Realm& realm, GC::Ptr<HTML::WindowProxy> window_proxy, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    Bindings::PointerEventInit event_init {};
+    Bindings::PointerEventInit event_init;
     event_init.ctrl_key = modifiers & Mod_Ctrl;
     event_init.shift_key = modifiers & Mod_Shift;
     event_init.alt_key = modifiers & Mod_Alt;
@@ -109,7 +109,7 @@ void PointerEvent::visit_edges(Cell::Visitor& visitor)
 
 GC::Ref<MouseEvent> PointerEvent::clone() const
 {
-    Bindings::PointerEventInit init {};
+    Bindings::PointerEventInit init;
     init.screen_x = screen_x();
     init.screen_y = screen_y();
     init.client_x = client_x();

--- a/Libraries/LibWeb/UIEvents/PointerEvent.h
+++ b/Libraries/LibWeb/UIEvents/PointerEvent.h
@@ -20,7 +20,7 @@ class PointerEvent : public MouseEvent {
 public:
     [[nodiscard]] static GC::Ref<PointerEvent> create(JS::Realm&, FlyString const& type, Bindings::PointerEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
     [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<PointerEvent>> create_from_platform_event(JS::Realm&, GC::Ptr<HTML::WindowProxy>, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons, unsigned modifiers);
-    static WebIDL::ExceptionOr<GC::Ref<PointerEvent>> construct_impl(JS::Realm&, FlyString const& type, Bindings::PointerEventInit const&);
+    static WebIDL::ExceptionOr<GC::Ref<PointerEvent>> construct_impl(JS::Realm&, FlyString const& type, Bindings::PointerEventInit const& = {});
 
     virtual ~PointerEvent() override;
 

--- a/Libraries/LibWeb/WebAssembly/Global.cpp
+++ b/Libraries/LibWeb/WebAssembly/Global.cpp
@@ -40,7 +40,7 @@ static Wasm::ValueType to_value_type(Bindings::ValueType type)
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-global-global
-WebIDL::ExceptionOr<GC::Ref<Global>> Global::construct_impl(JS::Realm& realm, Bindings::GlobalDescriptor const& descriptor, JS::Value v)
+WebIDL::ExceptionOr<GC::Ref<Global>> Global::construct_impl(JS::Realm& realm, Bindings::GlobalDescriptor const& descriptor, Optional<JS::Value> v)
 {
     auto& vm = realm.vm();
 
@@ -61,9 +61,9 @@ WebIDL::ExceptionOr<GC::Ref<Global>> Global::construct_impl(JS::Realm& realm, Bi
     // 5.1 Let value be ToWebAssemblyValue(v, valuetype).
     // FIXME: https://github.com/WebAssembly/spec/issues/1861
     //        Is there a difference between *missing* and undefined for optional any values?
-    auto value = v.is_undefined()
+    auto value = !v.has_value()
         ? Detail::default_webassembly_value(vm, value_type)
-        : TRY(Detail::to_webassembly_value(vm, v, value_type));
+        : TRY(Detail::to_webassembly_value(vm, *v, value_type));
 
     // 6. If mutable is true, let globaltype be var valuetype; otherwise, let globaltype be const valuetype.
     auto global_type = Wasm::GlobalType { value_type, mutable_ };

--- a/Libraries/LibWeb/WebAssembly/Global.h
+++ b/Libraries/LibWeb/WebAssembly/Global.h
@@ -18,7 +18,7 @@ class Global : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(Global);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<Global>> construct_impl(JS::Realm&, Bindings::GlobalDescriptor const&, JS::Value v);
+    static WebIDL::ExceptionOr<GC::Ref<Global>> construct_impl(JS::Realm&, Bindings::GlobalDescriptor const&, Optional<JS::Value>);
 
     WebIDL::ExceptionOr<JS::Value> value_of() const;
 

--- a/Libraries/LibWeb/WebAssembly/Instance.cpp
+++ b/Libraries/LibWeb/WebAssembly/Instance.cpp
@@ -22,10 +22,8 @@ namespace Web::WebAssembly {
 
 GC_DEFINE_ALLOCATOR(Instance);
 
-WebIDL::ExceptionOr<GC::Ref<Instance>> Instance::construct_impl(JS::Realm& realm, Module& module, Optional<GC::Root<JS::Object>>& import_object_handle)
+WebIDL::ExceptionOr<GC::Ref<Instance>> Instance::construct_impl(JS::Realm& realm, Module& module, GC::Ptr<JS::Object> import_object)
 {
-    GC::Ptr<JS::Object> import_object = import_object_handle.has_value() ? import_object_handle.value().ptr() : nullptr;
-
     auto& vm = realm.vm();
 
     auto module_instance = TRY(Detail::instantiate_module(vm, module.compiled_module()->module, import_object));

--- a/Libraries/LibWeb/WebAssembly/Instance.h
+++ b/Libraries/LibWeb/WebAssembly/Instance.h
@@ -23,7 +23,7 @@ class Instance : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(Instance);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<Instance>> construct_impl(JS::Realm&, Module& module, Optional<GC::Root<JS::Object>>& import_object);
+    static WebIDL::ExceptionOr<GC::Ref<Instance>> construct_impl(JS::Realm&, Module& module, GC::Ptr<JS::Object> import_object);
 
     Object const* exports() const { return m_exports.ptr(); }
     Wasm::ModuleInstance const* module_instance() const { return m_module_instance.ptr(); }

--- a/Libraries/LibWeb/WebAssembly/Module.cpp
+++ b/Libraries/LibWeb/WebAssembly/Module.cpp
@@ -19,7 +19,7 @@ namespace Web::WebAssembly {
 
 GC_DEFINE_ALLOCATOR(Module);
 
-WebIDL::ExceptionOr<GC::Ref<Module>> Module::construct_impl(JS::Realm& realm, GC::Root<WebIDL::BufferSource>& bytes)
+WebIDL::ExceptionOr<GC::Ref<Module>> Module::construct_impl(JS::Realm& realm, GC::Ref<WebIDL::BufferSource> bytes)
 {
     auto& vm = realm.vm();
 

--- a/Libraries/LibWeb/WebAssembly/Module.h
+++ b/Libraries/LibWeb/WebAssembly/Module.h
@@ -41,7 +41,7 @@ class Module : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(Module);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<Module>> construct_impl(JS::Realm&, GC::Root<WebIDL::BufferSource>& bytes);
+    static WebIDL::ExceptionOr<GC::Ref<Module>> construct_impl(JS::Realm&, GC::Ref<WebIDL::BufferSource> bytes);
     static WebIDL::ExceptionOr<Vector<ModuleImportDescriptor>> imports(JS::VM&, GC::Ref<Module>);
     static WebIDL::ExceptionOr<Vector<ModuleExportDescriptor>> exports(JS::VM&, GC::Ref<Module>);
     static WebIDL::ExceptionOr<GC::RootVector<GC::Ref<JS::ArrayBuffer>>> custom_sections(JS::VM&, GC::Ref<Module>, String section_name);

--- a/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -29,14 +29,14 @@ static Wasm::ValueType table_kind_to_value_type(Bindings::TableKind kind)
     VERIFY_NOT_REACHED();
 }
 
-WebIDL::ExceptionOr<GC::Ref<Table>> Table::construct_impl(JS::Realm& realm, Bindings::TableDescriptor& descriptor, JS::Value value)
+WebIDL::ExceptionOr<GC::Ref<Table>> Table::construct_impl(JS::Realm& realm, Bindings::TableDescriptor& descriptor, Optional<JS::Value> value)
 {
     auto& vm = realm.vm();
 
     auto reference_type = table_kind_to_value_type(descriptor.element);
-    auto reference_value = vm.argument_count() == 1
+    auto reference_value = !value.has_value()
         ? Detail::default_webassembly_value(vm, reference_type)
-        : TRY(Detail::to_webassembly_value(vm, value, reference_type));
+        : TRY(Detail::to_webassembly_value(vm, *value, reference_type));
 
     if (descriptor.maximum.has_value() && descriptor.maximum.value() < descriptor.initial)
         return vm.throw_completion<JS::RangeError>("Maximum should not be less than initial in table type"sv);
@@ -70,7 +70,7 @@ void Table::initialize(JS::Realm& realm)
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-table-grow
-WebIDL::ExceptionOr<u32> Table::grow(u32 delta, JS::Value value)
+WebIDL::ExceptionOr<u32> Table::grow(u32 delta, Optional<JS::Value> value)
 {
     auto& vm = this->vm();
 
@@ -81,9 +81,9 @@ WebIDL::ExceptionOr<u32> Table::grow(u32 delta, JS::Value value)
 
     auto initial_size = table->elements().size();
 
-    auto reference_value = vm.argument_count() == 1
+    auto reference_value = !value.has_value()
         ? Detail::default_webassembly_value(vm, table->type().element_type())
-        : TRY(Detail::to_webassembly_value(vm, value, table->type().element_type()));
+        : TRY(Detail::to_webassembly_value(vm, *value, table->type().element_type()));
     auto const& reference = reference_value.to<Wasm::Reference>();
 
     if (!table->grow(delta, reference))
@@ -112,7 +112,7 @@ WebIDL::ExceptionOr<JS::Value> Table::get(u32 index) const
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-table-set
-WebIDL::ExceptionOr<void> Table::set(u32 index, JS::Value value)
+WebIDL::ExceptionOr<void> Table::set(u32 index, Optional<JS::Value> value)
 {
     auto& vm = this->vm();
 
@@ -124,9 +124,9 @@ WebIDL::ExceptionOr<void> Table::set(u32 index, JS::Value value)
     if (table->elements().size() <= index)
         return vm.throw_completion<JS::RangeError>("Table element index out of range"sv);
 
-    auto reference_value = vm.argument_count() == 1
+    auto reference_value = !value.has_value()
         ? Detail::default_webassembly_value(vm, table->type().element_type())
-        : TRY(Detail::to_webassembly_value(vm, value, table->type().element_type()));
+        : TRY(Detail::to_webassembly_value(vm, *value, table->type().element_type()));
     auto const& reference = reference_value.to<Wasm::Reference>();
 
     table->elements()[index] = reference;

--- a/Libraries/LibWeb/WebAssembly/Table.h
+++ b/Libraries/LibWeb/WebAssembly/Table.h
@@ -23,12 +23,12 @@ class Table : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(Table);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<Table>> construct_impl(JS::Realm&, Bindings::TableDescriptor& descriptor, JS::Value value);
+    static WebIDL::ExceptionOr<GC::Ref<Table>> construct_impl(JS::Realm&, Bindings::TableDescriptor& descriptor, Optional<JS::Value> value);
 
-    WebIDL::ExceptionOr<u32> grow(u32 delta, JS::Value value);
+    WebIDL::ExceptionOr<u32> grow(u32 delta, Optional<JS::Value> value);
 
     WebIDL::ExceptionOr<JS::Value> get(u32 index) const;
-    WebIDL::ExceptionOr<void> set(u32 index, JS::Value value);
+    WebIDL::ExceptionOr<void> set(u32 index, Optional<JS::Value> value);
 
     WebIDL::ExceptionOr<u32> length() const;
 

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -98,7 +98,7 @@ void initialize(JS::Object& self, JS::Realm&)
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-webassembly-validate
-bool validate(JS::VM& vm, GC::Root<WebIDL::BufferSource>& bytes)
+bool validate(JS::VM& vm, GC::Ref<WebIDL::BufferSource> bytes)
 {
     // 1. Let stableBytes be a copy of the bytes held by the buffer bytes.
     auto stable_bytes = WebIDL::get_buffer_source_copy(*bytes->raw_object());
@@ -119,7 +119,7 @@ bool validate(JS::VM& vm, GC::Root<WebIDL::BufferSource>& bytes)
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-webassembly-compile
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile(JS::VM& vm, GC::Root<WebIDL::BufferSource>& bytes)
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile(JS::VM& vm, GC::Ref<WebIDL::BufferSource> bytes)
 {
     auto& realm = *vm.current_realm();
 
@@ -135,15 +135,15 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile(JS::VM& vm, GC::Root<WebID
 }
 
 // https://webassembly.github.io/spec/web-api/index.html#dom-webassembly-compilestreaming
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile_streaming(JS::VM& vm, GC::Root<WebIDL::Promise> source)
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile_streaming(JS::VM& vm, GC::Ref<WebIDL::Promise> source)
 {
     //  The compileStreaming(source) method, when invoked, returns the result of compiling a potential WebAssembly response with source.
-    return compile_potential_webassembly_response(vm, *source);
+    return compile_potential_webassembly_response(vm, source);
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-webassembly-instantiate
 // https://webassembly.github.io/content-security-policy/js-api/#dom-webassembly-instantiate
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM& vm, GC::Root<WebIDL::BufferSource>& bytes, Optional<GC::Root<JS::Object>>& import_object_handle)
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM& vm, GC::Ref<WebIDL::BufferSource> bytes, GC::Ptr<JS::Object> import_object)
 {
     auto& realm = *vm.current_realm();
 
@@ -161,30 +161,26 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM& vm, GC::Root<W
     auto promise_of_module = asynchronously_compile_webassembly_module(vm, stable_bytes.release_value());
 
     // 4. Instantiate promiseOfModule with imports importObject and return the result.
-    GC::Ptr<JS::Object> const import_object = import_object_handle.has_value() ? import_object_handle.value().ptr() : nullptr;
     return instantiate_promise_of_module(vm, promise_of_module, import_object);
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-webassembly-instantiate-moduleobject-importobject
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM& vm, Module const& module_object, Optional<GC::Root<JS::Object>>& import_object)
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM& vm, GC::Ref<Module> module_object, GC::Ptr<JS::Object> import_object)
 {
     // 1. Asynchronously instantiate the WebAssembly module moduleObject importing importObject, and return the result.
-    GC::Ref<Module> module { const_cast<Module&>(module_object) };
-    GC::Ptr<JS::Object> const imports = import_object.has_value() ? import_object.value().ptr() : nullptr;
-    return asynchronously_instantiate_webassembly_module(vm, module, imports);
+    return asynchronously_instantiate_webassembly_module(vm, module_object, import_object);
 }
 
 // https://webassembly.github.io/spec/web-api/index.html#dom-webassembly-instantiatestreaming
-WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate_streaming(JS::VM& vm, GC::Root<WebIDL::Promise> source, Optional<GC::Root<JS::Object>>& import_object)
+WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate_streaming(JS::VM& vm, GC::Ref<WebIDL::Promise> source, GC::Ptr<JS::Object> import_object)
 {
     // The instantiateStreaming(source, importObject) method, when invoked, performs the following steps:
 
     // 1. Let promiseOfModule be the result of compiling a potential WebAssembly response with source.
-    auto promise_of_module = compile_potential_webassembly_response(vm, *source);
+    auto promise_of_module = compile_potential_webassembly_response(vm, source);
 
     // 2. Return the result of instantiating the promise of a module promiseOfModule with imports importObject.
-    auto imports = GC::Ptr { import_object.has_value() ? import_object.value().ptr() : nullptr };
-    return instantiate_promise_of_module(vm, promise_of_module, imports);
+    return instantiate_promise_of_module(vm, promise_of_module, import_object);
 }
 
 namespace Detail {

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -24,13 +24,13 @@ WEB_API void visit_edges(JS::Object&, JS::Cell::Visitor&);
 WEB_API void finalize(JS::Object&);
 WEB_API void initialize(JS::Object&, JS::Realm&);
 
-WEB_API bool validate(JS::VM&, GC::Root<WebIDL::BufferSource>& bytes);
-WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile(JS::VM&, GC::Root<WebIDL::BufferSource>& bytes);
-WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile_streaming(JS::VM&, GC::Root<WebIDL::Promise> source);
+WEB_API bool validate(JS::VM&, GC::Ref<WebIDL::BufferSource> bytes);
+WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile(JS::VM&, GC::Ref<WebIDL::BufferSource> bytes);
+WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile_streaming(JS::VM&, GC::Ref<WebIDL::Promise> source);
 
-WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM&, GC::Root<WebIDL::BufferSource>& bytes, Optional<GC::Root<JS::Object>>& import_object);
-WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM&, Module const& module_object, Optional<GC::Root<JS::Object>>& import_object);
-WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate_streaming(JS::VM&, GC::Root<WebIDL::Promise> source, Optional<GC::Root<JS::Object>>& import_object);
+WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM&, GC::Ref<WebIDL::BufferSource> bytes, GC::Ptr<JS::Object> import_object);
+WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate(JS::VM&, GC::Ref<Module> module_object, GC::Ptr<JS::Object> import_object);
+WEB_API WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> instantiate_streaming(JS::VM&, GC::Ref<WebIDL::Promise> source, GC::Ptr<JS::Object> import_object);
 
 namespace Detail {
 

--- a/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.cpp
@@ -17,7 +17,7 @@ GC_DEFINE_ALLOCATOR(AudioBufferSourceNode);
 
 AudioBufferSourceNode::AudioBufferSourceNode(JS::Realm& realm, GC::Ref<BaseAudioContext> context, Bindings::AudioBufferSourceOptions const& options)
     : AudioScheduledSourceNode(realm, context)
-    , m_buffer(options.buffer.has_value() ? options.buffer->ptr() : nullptr)
+    , m_buffer(options.buffer.value_or(nullptr))
     , m_playback_rate(AudioParam::create(realm, context, options.playback_rate, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::KRate, AudioParam::FixedAutomationRate::Yes))
     , m_detune(AudioParam::create(realm, context, options.detune, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::KRate, AudioParam::FixedAutomationRate::Yes))
     , m_loop(options.loop)

--- a/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -355,8 +355,7 @@ bool AudioContext::start_rendering_audio_graph()
 // https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediaelementsource
 WebIDL::ExceptionOr<GC::Ref<MediaElementAudioSourceNode>> AudioContext::create_media_element_source(GC::Ptr<HTML::HTMLMediaElement> media_element)
 {
-    Bindings::MediaElementAudioSourceOptions options;
-    options.media_element = media_element;
+    Bindings::MediaElementAudioSourceOptions options { .media_element = *media_element };
     return MediaElementAudioSourceNode::create(realm(), *this, options);
 }
 

--- a/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
+++ b/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
@@ -154,7 +154,7 @@ void OfflineAudioContext::begin_offline_rendering(GC::Ref<WebIDL::Promise> promi
                     .cancelable = false,
                     .composed = false,
                 },
-                this->m_rendered_buffer,
+                *this->m_rendered_buffer,
             };
             auto event = MUST(OfflineAudioCompletionEvent::construct_impl(this->realm(), HTML::EventNames::complete, event_init));
             this->dispatch_event(event);

--- a/Libraries/LibWeb/WebAudio/OscillatorNode.cpp
+++ b/Libraries/LibWeb/WebAudio/OscillatorNode.cpp
@@ -26,13 +26,13 @@ WebIDL::ExceptionOr<GC::Ref<OscillatorNode>> OscillatorNode::create(JS::Realm& r
 // https://webaudio.github.io/web-audio-api/#dom-oscillatornode-oscillatornode
 WebIDL::ExceptionOr<GC::Ref<OscillatorNode>> OscillatorNode::construct_impl(JS::Realm& realm, GC::Ref<BaseAudioContext> context, Bindings::OscillatorOptions const& options)
 {
-    if (options.type == Bindings::OscillatorType::Custom && !options.periodic_wave.has_value())
+    if (options.type == Bindings::OscillatorType::Custom && !options.periodic_wave)
         return WebIDL::InvalidStateError::create(realm, "Oscillator node type 'custom' requires PeriodicWave to be provided"_utf16);
 
     auto node = realm.create<OscillatorNode>(realm, context, options);
 
     if (options.type == Bindings::OscillatorType::Custom)
-        node->set_periodic_wave(options.periodic_wave->ptr());
+        node->set_periodic_wave(options.periodic_wave);
 
     // Default options for channel count and interpretation
     // https://webaudio.github.io/web-audio-api/#OscillatorNode

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -37,18 +37,18 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
     glBufferData(target, size, 0, usage);
 }
 
-void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, Optional<GC::Root<WebIDL::BufferSource>> src_data, WebIDL::UnsignedLong usage)
+void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, GC::Ptr<WebIDL::BufferSource> src_data, WebIDL::UnsignedLong usage)
 {
     m_context->make_current();
 
     // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5
     // If the passed data is null then an INVALID_VALUE error is generated.
-    if (!src_data.has_value()) {
+    if (!src_data) {
         set_error(GL_INVALID_VALUE);
         return;
     }
 
-    auto data = MUST(get_offset_span<u8 const>(*src_data.value(), /* src_offset= */ 0));
+    auto data = MUST(get_offset_span<u8 const>(*src_data, /* src_offset= */ 0));
     glBufferData(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
 }
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
@@ -25,7 +25,7 @@ public:
     WebGL2RenderingContextOverloads(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 
     void buffer_data(WebIDL::UnsignedLong target, WebIDL::LongLong size, WebIDL::UnsignedLong usage);
-    void buffer_data(WebIDL::UnsignedLong target, Optional<GC::Root<WebIDL::BufferSource>> src_data, WebIDL::UnsignedLong usage);
+    void buffer_data(WebIDL::UnsignedLong target, GC::Ptr<WebIDL::BufferSource> src_data, WebIDL::UnsignedLong usage);
     void buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, GC::Root<WebIDL::BufferSource> src_data);
     void buffer_data(WebIDL::UnsignedLong target, GC::Root<WebIDL::ArrayBufferView> src_data, WebIDL::UnsignedLong usage, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length);
     void buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, GC::Root<WebIDL::ArrayBufferView> src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -296,7 +296,7 @@ Optional<Gfx::BitmapExportResult> WebGLRenderingContextBase::read_and_pixel_conv
 
     // FIXME: Respect unpackColorSpace
     auto export_flags = 0;
-    if (m_unpack_flip_y && !source.has<GC::Root<HTML::ImageBitmap>>())
+    if (m_unpack_flip_y && !source.has<GC::Ref<HTML::ImageBitmap>>())
         // The first pixel transferred from the source to the WebGL implementation corresponds to the upper left corner of
         // the source. This behavior is modified by the UNPACK_FLIP_Y_WEBGL pixel storage parameter, except for ImageBitmap
         // arguments, as described in the abovementioned section.

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -35,15 +35,15 @@ static constexpr int BROWSER_DEFAULT_WEBGL = 0x9244;
 static constexpr int MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x9247;
 
 // NOTE: This is the Variant created by the IDL wrapper generator, and needs to be updated accordingly.
-using TexImageSource = Variant<GC::Root<HTML::ImageBitmap>, GC::Root<HTML::ImageData>, GC::Root<HTML::HTMLImageElement>, GC::Root<HTML::HTMLCanvasElement>, GC::Root<HTML::OffscreenCanvas>, GC::Root<HTML::HTMLVideoElement>>;
+using TexImageSource = Variant<GC::Ref<HTML::ImageBitmap>, GC::Ref<HTML::ImageData>, GC::Ref<HTML::HTMLImageElement>, GC::Ref<HTML::HTMLCanvasElement>, GC::Ref<HTML::OffscreenCanvas>, GC::Ref<HTML::HTMLVideoElement>>;
 
 class WebGLRenderingContextBase : public Bindings::PlatformObject {
     WEB_NON_IDL_PLATFORM_OBJECT(WebGLRenderingContextBase, Bindings::PlatformObject);
 
 public:
-    using Float32List = Variant<GC::Root<JS::Float32Array>, Vector<float>>;
-    using Int32List = Variant<GC::Root<JS::Int32Array>, Vector<WebIDL::Long>>;
-    using Uint32List = Variant<GC::Root<JS::Uint32Array>, Vector<WebIDL::UnsignedLong>>;
+    using Float32List = Variant<GC::Ref<JS::Float32Array>, Vector<float>>;
+    using Int32List = Variant<GC::Ref<JS::Int32Array>, Vector<WebIDL::Long>>;
+    using Uint32List = Variant<GC::Ref<JS::Uint32Array>, Vector<WebIDL::UnsignedLong>>;
 
     virtual OpenGLContext& context() = 0;
 
@@ -117,7 +117,7 @@ protected:
             auto& vector = float32_list.get<Vector<float>>();
             return get_offset_span(vector.span(), src_offset, src_length_override);
         }
-        auto& buffer = float32_list.get<GC::Root<JS::Float32Array>>();
+        auto& buffer = float32_list.get<GC::Ref<JS::Float32Array>>();
         return get_offset_span(buffer->data(), src_offset, src_length_override);
     }
 
@@ -127,7 +127,7 @@ protected:
             auto& vector = int32_list.get<Vector<int>>();
             return get_offset_span(vector.span(), src_offset, src_length_override);
         }
-        auto& buffer = int32_list.get<GC::Root<JS::Int32Array>>();
+        auto& buffer = int32_list.get<GC::Ref<JS::Int32Array>>();
         return get_offset_span(buffer->data(), src_offset, src_length_override);
     }
 
@@ -137,7 +137,7 @@ protected:
             auto& vector = uint32_list.get<Vector<u32>>();
             return get_offset_span(vector.span(), src_offset, src_length_override);
         }
-        auto& buffer = uint32_list.get<GC::Root<JS::Uint32Array>>();
+        auto& buffer = uint32_list.get<GC::Ref<JS::Uint32Array>>();
         return get_offset_span(buffer->data(), src_offset, src_length_override);
     }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
@@ -34,18 +34,18 @@ void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, We
     glBufferData(target, size, 0, usage);
 }
 
-void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, Optional<GC::Root<WebIDL::BufferSource>> data, WebIDL::UnsignedLong usage)
+void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, GC::Ptr<WebIDL::BufferSource> data, WebIDL::UnsignedLong usage)
 {
     m_context->make_current();
 
     // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5
     // If the passed data is null then an INVALID_VALUE error is generated.
-    if (!data.has_value()) {
+    if (!data) {
         set_error(GL_INVALID_VALUE);
         return;
     }
 
-    auto span = MUST(get_offset_span<u8 const>(*data.value(), /* src_offset= */ 0));
+    auto span = MUST(get_offset_span<u8 const>(*data, /* src_offset= */ 0));
     glBufferData(target, static_cast<GLsizeiptr>(span.size()), span.data(), usage);
 }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.h
@@ -25,7 +25,7 @@ public:
     WebGLRenderingContextOverloads(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 
     void buffer_data(WebIDL::UnsignedLong target, WebIDL::LongLong size, WebIDL::UnsignedLong usage);
-    void buffer_data(WebIDL::UnsignedLong target, Optional<GC::Root<WebIDL::BufferSource>> data, WebIDL::UnsignedLong usage);
+    void buffer_data(WebIDL::UnsignedLong target, GC::Ptr<WebIDL::BufferSource> data, WebIDL::UnsignedLong usage);
     void buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong offset, GC::Root<WebIDL::BufferSource> data);
     void compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, GC::Root<WebIDL::ArrayBufferView> data);
     void compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, GC::Root<WebIDL::ArrayBufferView> data);

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -10,6 +10,7 @@
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibRequests/RequestClient.h>
 #include <LibURL/Origin.h>
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/Bindings/WebSocket.h>
 #include <LibWeb/DOM/Document.h>
@@ -23,6 +24,7 @@
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/Page.h>
@@ -303,7 +305,7 @@ WebIDL::ExceptionOr<void> WebSocket::close(Optional<u16> code, Optional<String> 
 }
 
 // https://websockets.spec.whatwg.org/#dom-websocket-send
-WebIDL::ExceptionOr<void> WebSocket::send(Variant<GC::Root<WebIDL::BufferSource>, GC::Root<FileAPI::Blob>, String> const& data)
+WebIDL::ExceptionOr<void> WebSocket::send(Variant<GC::Ref<WebIDL::BufferSource>, GC::Ref<FileAPI::Blob>, String> const& data)
 {
     auto state = ready_state();
     if (state == Requests::WebSocket::ReadyState::Connecting)
@@ -313,7 +315,7 @@ WebIDL::ExceptionOr<void> WebSocket::send(Variant<GC::Root<WebIDL::BufferSource>
             [this](String const& string) {
                 m_websocket->send(string);
             },
-            [this](GC::Root<WebIDL::BufferSource> const& buffer_source) {
+            [this](GC::Ref<WebIDL::BufferSource> buffer_source) {
                 ReadonlyBytes buffer;
 
                 if (auto array_buffer = buffer_source->viewed_array_buffer(); array_buffer && !array_buffer->is_detached())
@@ -321,7 +323,7 @@ WebIDL::ExceptionOr<void> WebSocket::send(Variant<GC::Root<WebIDL::BufferSource>
 
                 m_websocket->send(buffer, false);
             },
-            [this](GC::Root<FileAPI::Blob> const& blob) {
+            [this](GC::Ref<FileAPI::Blob> blob) {
                 m_websocket->send(blob->raw_bytes(), false);
             });
         // TODO : If the data cannot be sent, e.g. because it would need to be buffered but the buffer is full, the user agent must flag the WebSocket as full and then close the WebSocket connection.

--- a/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -55,7 +55,7 @@ public:
     void set_binary_type(String const& type) { m_binary_type = type; }
 
     WebIDL::ExceptionOr<void> close(Optional<u16> code, Optional<String> reason);
-    WebIDL::ExceptionOr<void> send(Variant<GC::Root<WebIDL::BufferSource>, GC::Root<FileAPI::Blob>, String> const& data);
+    WebIDL::ExceptionOr<void> send(Variant<GC::Ref<WebIDL::BufferSource>, GC::Ref<FileAPI::Blob>, String> const& data);
 
     void make_disappear();
 

--- a/Libraries/LibWeb/WebXR/XRSession.cpp
+++ b/Libraries/LibWeb/WebXR/XRSession.cpp
@@ -127,8 +127,7 @@ void XRSession::shut_down()
 
     // 6. Queue a task that fires an XRSessionEvent named end on session.
     HTML::queue_a_task(HTML::Task::Source::Unspecified, nullptr, nullptr, GC::create_function(realm.heap(), [this, &realm]() {
-        Bindings::XRSessionEventInit init;
-        init.session = this;
+        Bindings::XRSessionEventInit init { Bindings::EventInit {}, *this };
         auto event = XRSessionEvent::create(realm, HTML::EventNames::end, init);
         this->dispatch_event(event);
     }));

--- a/Libraries/LibWeb/WebXR/XRWebGLLayer.h
+++ b/Libraries/LibWeb/WebXR/XRWebGLLayer.h
@@ -19,7 +19,7 @@ class XRWebGLLayer : public XRLayer {
     GC_DECLARE_ALLOCATOR(XRWebGLLayer);
 
 public:
-    using XRWebGLRenderingContext = Variant<GC::Root<WebGL::WebGLRenderingContext>, GC::Root<WebGL::WebGL2RenderingContext>>;
+    using XRWebGLRenderingContext = Variant<GC::Ref<WebGL::WebGLRenderingContext>, GC::Ref<WebGL::WebGL2RenderingContext>>;
 
     [[nodiscard]] static GC::Ref<XRWebGLLayer> create(JS::Realm&);
     static WebIDL::ExceptionOr<GC::Ref<XRWebGLLayer>> construct_impl(JS::Realm&, XRSession const& session, XRWebGLRenderingContext const&, Bindings::XRWebGLLayerInit const&);

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -570,8 +570,8 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
         Optional<ByteString> extracted_content_type;
 
         // 2. If body is a Document, then set this’s request body to body, serialized, converted, and UTF-8 encoded.
-        if (body.has<GC::Root<DOM::Document>>()) {
-            auto string_serialized_document = TRY(body.get<GC::Root<DOM::Document>>().cell()->serialize_fragment(HTML::RequireWellFormed::No));
+        if (body.has<GC::Ref<DOM::Document>>()) {
+            auto string_serialized_document = TRY(body.get<GC::Ref<DOM::Document>>()->serialize_fragment(HTML::RequireWellFormed::No));
             auto string_serialized_document_utf8 = string_serialized_document.to_utf8();
             m_request_body = Fetch::Infrastructure::byte_sequence_as_body(realm, string_serialized_document_utf8.bytes());
         }
@@ -593,7 +593,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
         // 5. If originalAuthorContentType is non-null, then:
         if (original_author_content_type.has_value()) {
             // 1. If body is a Document or a USVString, then:
-            if (body.has<GC::Root<DOM::Document>>() || body.has<String>()) {
+            if (body.has<GC::Ref<DOM::Document>>() || body.has<String>()) {
                 // 1. Let contentTypeRecord be the result of parsing originalAuthorContentType.
                 auto content_type_record = MimeSniff::MimeType::parse(original_author_content_type.value());
 
@@ -616,8 +616,8 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(NullableDocumentOrXMLHttpRequestB
         }
         // 6. Otherwise:
         else {
-            if (body.has<GC::Root<DOM::Document>>()) {
-                auto document = body.get<GC::Root<DOM::Document>>();
+            if (body.has<GC::Ref<DOM::Document>>()) {
+                auto document = body.get<GC::Ref<DOM::Document>>();
 
                 // NOTE: A document can only be an HTML document or XML document.
                 // 1. If body is an HTML document, then set (`Content-Type`, `text/html;charset=UTF-8`) in this’s author request headers.

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -28,8 +28,8 @@
 namespace Web::XHR {
 
 // https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit
-using DocumentOrXMLHttpRequestBodyInit = Variant<GC::Root<Web::DOM::Document>, GC::Root<Web::FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<Web::DOMURL::URLSearchParams>, AK::String>;
-using NullableDocumentOrXMLHttpRequestBodyInit = Variant<GC::Root<Web::DOM::Document>, GC::Root<Web::FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<Web::DOMURL::URLSearchParams>, AK::String, Empty>;
+using DocumentOrXMLHttpRequestBodyInit = Variant<GC::Ref<Web::DOM::Document>, GC::Ref<Web::FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<Web::DOMURL::URLSearchParams>, AK::String>;
+using NullableDocumentOrXMLHttpRequestBodyInit = Variant<GC::Ref<Web::DOM::Document>, GC::Ref<Web::FileAPI::Blob>, GC::Ref<WebIDL::BufferSource>, GC::Ref<XHR::FormData>, GC::Ref<Web::DOMURL::URLSearchParams>, AK::String, Empty>;
 
 class XMLHttpRequest final : public XMLHttpRequestEventTarget {
     WEB_PLATFORM_OBJECT(XMLHttpRequest, XMLHttpRequestEventTarget);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -23,9 +23,37 @@ namespace IDL {
 
 Vector<StringView> g_header_search_paths;
 
+enum class TypeOptionality {
+    Required,
+    OptionalArgument,
+    OptionalDictionaryMember,
+};
+
 template<typename ParameterType>
-static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const&, bool optional = false, Optional<ByteString> optional_default_value = {}, bool variadic = false, size_t recursion_depth = 0);
-static ByteString dictionary_member_cpp_type(Context const& context, DictionaryMember const& member);
+static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const&, bool optional = false, Optional<ByteString> optional_default_value = {}, bool variadic = false, size_t recursion_depth = 0, TypeOptionality = TypeOptionality::OptionalArgument);
+static bool dictionary_member_needs_builder(Context const& context, DictionaryMember const& member);
+
+enum class ContainedStorageType {
+    Vector,             // Used to store values that do not need GC-aware storage.
+    ConservativeVector, // Used to conservatively root aggregate values that may contain GC pointers.
+    RootVector,         // Used to root GC values directly.
+};
+
+struct CppType {
+    ByteString name;
+    bool is_nullable { false };
+    bool is_optional_presence { false };
+    ContainedStorageType contained_storage_type { ContainedStorageType::Vector };
+    ByteString gc_ref_target_type;
+};
+
+static CppType make_cpp_type(ByteString name, ContainedStorageType contained_storage_type = ContainedStorageType::Vector)
+{
+    CppType cpp_type;
+    cpp_type.name = move(name);
+    cpp_type.contained_storage_type = contained_storage_type;
+    return cpp_type;
+}
 
 // https://webidl.spec.whatwg.org/#dfn-platform-object
 static bool is_platform_object(Context const& context, Type const& type)
@@ -94,12 +122,14 @@ static Interface const* callback_interface_for_type(Context const& context, Type
     return nullptr;
 }
 
-static StringView sequence_storage_type_to_cpp_storage_type_name(SequenceStorageType sequence_storage_type)
+static StringView contained_storage_type_to_cpp_name(ContainedStorageType contained_storage_type)
 {
-    switch (sequence_storage_type) {
-    case SequenceStorageType::Vector:
+    switch (contained_storage_type) {
+    case ContainedStorageType::Vector:
         return "Vector"sv;
-    case SequenceStorageType::RootVector:
+    case ContainedStorageType::ConservativeVector:
+        return "GC::ConservativeVector"sv;
+    case ContainedStorageType::RootVector:
         return "GC::RootVector"sv;
     default:
         VERIFY_NOT_REACHED();
@@ -118,7 +148,7 @@ static bool is_nullable_frozen_array_of_single_type(Type const& type, StringView
     return parameters.first()->name() == type_name;
 }
 
-static CppType nullable_parameter_cpp_type(Context const& context, Type const& type, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {});
+static CppType cpp_type_for_idl_type(Context const& context, Type const& type, TypeOptionality, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {});
 
 static ByteString union_type_to_variant(UnionType const& union_type, Context const& context)
 {
@@ -132,7 +162,7 @@ static ByteString union_type_to_variant(UnionType const& union_type, Context con
         if (type_index > 0)
             builder.append(", "sv);
 
-        auto cpp_type = idl_type_name_to_cpp_type(type, context);
+        auto cpp_type = cpp_type_for_idl_type(context, type, TypeOptionality::Required);
         builder.append(cpp_type.name);
     }
 
@@ -143,119 +173,252 @@ static ByteString union_type_to_variant(UnionType const& union_type, Context con
     return builder.to_byte_string();
 }
 
-CppType idl_type_name_to_cpp_type(Type const& type, Context const& context, Optional<HashMap<ByteString, ByteString> const&> extended_attributes)
+static bool type_contains_gc_like_value(Context const&, Type const&);
+
+static bool dictionary_contains_gc_like_value(Context const& context, ByteString const& dictionary_name)
 {
-    if (type.is_nullable() && !is<UnionType>(type))
-        return nullable_parameter_cpp_type(context, type, extended_attributes);
+    auto dictionary = context.dictionaries.find(dictionary_name);
+    VERIFY(dictionary != context.dictionaries.end());
+
+    if (!dictionary->value.parent_name.is_empty() && dictionary_contains_gc_like_value(context, dictionary->value.parent_name))
+        return true;
+
+    for (auto const& member : dictionary->value.members) {
+        if (type_contains_gc_like_value(context, *member.type))
+            return true;
+    }
+
+    return false;
+}
+
+static bool type_contains_gc_like_value(Context const& context, Type const& type)
+{
+    if (is_platform_object(context, type)
+        || is_javascript_builtin_buffer_source_type(type)
+        || callback_interface_for_type(context, type)
+        || context.callback_functions.contains(type.name())
+        || type.name().is_one_of("any"sv, "object"sv, "BufferSource"sv, "ArrayBufferView"sv, "Promise"sv)) {
+        return true;
+    }
+
+    if (type.name().is_one_of("sequence"sv, "FrozenArray"sv)) {
+        auto const& parameterized_type = as<ParameterizedType>(type);
+        return type_contains_gc_like_value(context, parameterized_type.parameters().first());
+    }
+
+    if (type.name() == "record"sv) {
+        auto const& parameterized_type = as<ParameterizedType>(type);
+        return type_contains_gc_like_value(context, parameterized_type.parameters()[0])
+            || type_contains_gc_like_value(context, parameterized_type.parameters()[1]);
+    }
+
+    if (is<UnionType>(type)) {
+        for (auto const& member_type : as<UnionType>(type).flattened_member_types()) {
+            if (type_contains_gc_like_value(context, member_type))
+                return true;
+        }
+        return false;
+    }
+
+    if (context.dictionaries.contains(type.name()))
+        return dictionary_contains_gc_like_value(context, type.name());
+
+    return false;
+}
+
+static ContainedStorageType contained_storage_type_for_aggregate_type(Context const& context, Type const& type)
+{
+    return type_contains_gc_like_value(context, type) ? ContainedStorageType::ConservativeVector : ContainedStorageType::Vector;
+}
+
+static CppType gc_ref_type(ByteString referent_type)
+{
+    auto type = make_cpp_type(ByteString::formatted("GC::Ref<{}>", referent_type), ContainedStorageType::RootVector);
+    type.gc_ref_target_type = move(referent_type);
+    return type;
+}
+
+static CppType gc_ptr_type(ByteString referent_type)
+{
+    auto type = make_cpp_type(ByteString::formatted("GC::Ptr<{}>", referent_type), ContainedStorageType::RootVector);
+    type.is_nullable = true;
+    type.gc_ref_target_type = move(referent_type);
+    return type;
+}
+
+static bool is_direct_gc_ref_cpp_type(CppType const& cpp_type)
+{
+    return !cpp_type.gc_ref_target_type.is_empty() && !cpp_type.is_nullable;
+}
+
+static CppType cpp_type_for_non_nullable_idl_type(Context const& context, Type const& type, Optional<HashMap<ByteString, ByteString> const&> extended_attributes)
+{
+    VERIFY(!type.is_nullable() || is<UnionType>(type));
 
     if (is_platform_object(context, type))
-        return { .name = ByteString::formatted("GC::Root<{}>", interface_cpp_type_name(context, type)), .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type(interface_cpp_type_name(context, type));
 
     if (is_javascript_builtin_buffer_source_type(type))
-        return { .name = ByteString::formatted("GC::Root<JS::{}>", type.name()), .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type(ByteString::formatted("JS::{}", type.name()));
 
     if (auto const* callback_interface = callback_interface_for_type(context, type))
-        return { .name = ByteString::formatted("GC::Root<{}>", interface_cpp_type_name(*callback_interface)), .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type(interface_cpp_type_name(*callback_interface));
 
     if (context.callback_functions.contains(type.name()))
-        return { .name = "GC::Root<WebIDL::CallbackType>", .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type("WebIDL::CallbackType"sv);
 
     if (type.is_string()) {
         auto is_fly_string = extended_attributes.has_value() && extended_attributes->contains("FlyString"sv);
         if (type.name().contains("Utf16"sv))
-            return { .name = is_fly_string ? "Utf16FlyString" : "Utf16String", .sequence_storage_type = SequenceStorageType::Vector };
-        return { .name = is_fly_string ? "FlyString" : "String", .sequence_storage_type = SequenceStorageType::Vector };
+            return make_cpp_type(is_fly_string ? "Utf16FlyString"sv : "Utf16String"sv);
+        return make_cpp_type(is_fly_string ? "FlyString"sv : "String"sv);
     }
 
     if (type.name() == "double" || type.name() == "unrestricted double")
-        return { .name = "double", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("double"sv);
 
     if (type.name() == "float" || type.name() == "unrestricted float")
-        return { .name = "float", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("float"sv);
 
     if (type.name() == "boolean")
-        return { .name = "bool", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("bool"sv);
 
     if (type.name() == "byte")
-        return { .name = "WebIDL::Byte", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::Byte"sv);
 
     if (type.name() == "octet")
-        return { .name = "WebIDL::Octet", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::Octet"sv);
 
     if (type.name() == "short")
-        return { .name = "WebIDL::Short", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::Short"sv);
 
     if (type.name() == "unsigned short")
-        return { .name = "WebIDL::UnsignedShort", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::UnsignedShort"sv);
 
     if (type.name() == "long")
-        return { .name = "WebIDL::Long", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::Long"sv);
 
     if (type.name() == "unsigned long")
-        return { .name = "WebIDL::UnsignedLong", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::UnsignedLong"sv);
 
     if (type.name() == "long long")
-        return { .name = "WebIDL::LongLong", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::LongLong"sv);
 
     if (type.name() == "unsigned long long")
-        return { .name = "WebIDL::UnsignedLongLong", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("WebIDL::UnsignedLongLong"sv);
 
     if (type.name() == "any")
-        return { .name = "JS::Value", .sequence_storage_type = SequenceStorageType::RootVector };
+        return make_cpp_type("JS::Value"sv, ContainedStorageType::RootVector);
 
     // NOTE: undefined is a somewhat special case that may be used in a union to represent the javascript 'undefined' (and
     //       only ever js_undefined). Therefore, we say that the type is Empty here, so that a union of (T, undefined) is
     //       generated as Variant<T, Empty>, which is then returned in the Variant's visit as undefined if it is Empty.
     if (type.name() == "undefined")
-        return { .name = "Empty", .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type("Empty"sv);
 
     if (type.name() == "object")
-        return { .name = "GC::Root<JS::Object>", .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type("JS::Object"sv);
 
     if (type.name() == "BufferSource")
-        return { .name = "GC::Root<WebIDL::BufferSource>", .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type("WebIDL::BufferSource"sv);
 
     if (type.name() == "ArrayBufferView")
-        return { .name = "GC::Root<WebIDL::ArrayBufferView>", .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type("WebIDL::ArrayBufferView"sv);
 
     if (type.name() == "Promise")
-        return { .name = "GC::Root<WebIDL::Promise>", .sequence_storage_type = SequenceStorageType::Vector };
+        return gc_ref_type("WebIDL::Promise"sv);
 
     if (type.name().is_one_of("sequence"sv, "FrozenArray"sv)) {
         auto& parameterized_type = as<ParameterizedType>(type);
         auto& sequence_type = parameterized_type.parameters().first();
-        auto sequence_cpp_type = idl_type_name_to_cpp_type(sequence_type, context);
-        auto storage_type_name = sequence_storage_type_to_cpp_storage_type_name(sequence_cpp_type.sequence_storage_type);
-
-        if (sequence_cpp_type.sequence_storage_type == SequenceStorageType::RootVector)
-            return { .name = storage_type_name, .sequence_storage_type = SequenceStorageType::Vector };
-
-        return { .name = ByteString::formatted("{}<{}>", storage_type_name, sequence_cpp_type.name), .sequence_storage_type = SequenceStorageType::Vector };
+        auto sequence_cpp_type = cpp_type_for_idl_type(context, sequence_type, TypeOptionality::Required);
+        auto storage_type_name = contained_storage_type_to_cpp_name(sequence_cpp_type.contained_storage_type);
+        return make_cpp_type(ByteString::formatted("{}<{}>", storage_type_name, sequence_cpp_type.name));
     }
 
     if (type.name() == "record") {
         auto& parameterized_type = as<ParameterizedType>(type);
         auto& record_key_type = parameterized_type.parameters()[0];
         auto& record_value_type = parameterized_type.parameters()[1];
-        auto record_key_cpp_type = idl_type_name_to_cpp_type(record_key_type, context);
-        auto record_value_cpp_type = idl_type_name_to_cpp_type(record_value_type, context);
+        auto record_key_cpp_type = cpp_type_for_idl_type(context, record_key_type, TypeOptionality::Required);
+        auto record_value_cpp_type = cpp_type_for_idl_type(context, record_value_type, TypeOptionality::Required);
 
-        return { .name = ByteString::formatted("OrderedHashMap<{}, {}>", record_key_cpp_type.name, record_value_cpp_type.name), .sequence_storage_type = SequenceStorageType::Vector };
+        if (record_key_cpp_type.contained_storage_type == ContainedStorageType::ConservativeVector || record_value_cpp_type.contained_storage_type == ContainedStorageType::ConservativeVector)
+            return make_cpp_type(ByteString::formatted("GC::ConservativeHashMap<{}, {}>", record_key_cpp_type.name, record_value_cpp_type.name));
+
+        if (record_key_cpp_type.contained_storage_type == ContainedStorageType::RootVector || record_value_cpp_type.contained_storage_type == ContainedStorageType::RootVector)
+            return make_cpp_type(ByteString::formatted("GC::OrderedRootHashMap<{}, {}>", record_key_cpp_type.name, record_value_cpp_type.name));
+
+        return make_cpp_type(ByteString::formatted("OrderedHashMap<{}, {}>", record_key_cpp_type.name, record_value_cpp_type.name));
     }
 
     if (is<UnionType>(type)) {
         auto& union_type = as<UnionType>(type);
-        return { .name = union_type_to_variant(union_type, context), .sequence_storage_type = SequenceStorageType::Vector };
+        auto cpp_type = make_cpp_type(union_type_to_variant(union_type, context), contained_storage_type_for_aggregate_type(context, type));
+        cpp_type.is_nullable = union_type.includes_undefined() || union_type.includes_nullable_type();
+        return cpp_type;
     }
 
     if (context.dictionaries.contains(type.name()))
-        return { .name = type.name(), .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type(type.name(), contained_storage_type_for_aggregate_type(context, type));
 
     if (context.enumerations.contains(type.name()))
-        return { .name = type.name(), .sequence_storage_type = SequenceStorageType::Vector };
+        return make_cpp_type(type.name());
 
     dbgln("Unimplemented type for idl_type_name_to_cpp_type: {}", type.name());
     TODO();
+}
+
+static CppType with_nullable_cpp_type(CppType cpp_type)
+{
+    if (cpp_type.name == "JS::Value"sv) {
+        cpp_type.is_nullable = true;
+        return cpp_type;
+    }
+
+    if (!cpp_type.gc_ref_target_type.is_empty())
+        return gc_ptr_type(move(cpp_type.gc_ref_target_type));
+
+    auto nullable_cpp_type = make_cpp_type(ByteString::formatted("Optional<{}>", cpp_type.name));
+    nullable_cpp_type.is_nullable = true;
+    return nullable_cpp_type;
+}
+
+static CppType with_optional_cpp_type(CppType cpp_type)
+{
+    if (is_direct_gc_ref_cpp_type(cpp_type)) {
+        cpp_type.name = ByteString::formatted("GC::Ptr<{}>", cpp_type.gc_ref_target_type);
+        cpp_type.is_nullable = true;
+        cpp_type.is_optional_presence = true;
+        cpp_type.contained_storage_type = ContainedStorageType::RootVector;
+        return cpp_type;
+    }
+
+    cpp_type.name = ByteString::formatted("Optional<{}>", cpp_type.name);
+    cpp_type.is_optional_presence = true;
+    cpp_type.contained_storage_type = ContainedStorageType::Vector;
+    return cpp_type;
+}
+
+static CppType cpp_type_for_idl_type(Context const& context, Type const& type, TypeOptionality presence, Optional<HashMap<ByteString, ByteString> const&> extended_attributes)
+{
+    auto cpp_type = [&] {
+        if (!type.is_nullable() || is<UnionType>(type))
+            return cpp_type_for_non_nullable_idl_type(context, type, extended_attributes);
+
+        auto inner_type = clone_type(type, false);
+        return with_nullable_cpp_type(cpp_type_for_non_nullable_idl_type(context, *inner_type, extended_attributes));
+    }();
+
+    if (presence == TypeOptionality::Required || (presence == TypeOptionality::OptionalArgument && cpp_type.is_nullable))
+        return cpp_type;
+
+    return with_optional_cpp_type(move(cpp_type));
+}
+
+static CppType idl_type_name_to_cpp_type(Type const& type, Context const& context, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {})
+{
+    return cpp_type_for_idl_type(context, type, TypeOptionality::Required, extended_attributes);
 }
 
 static ByteString make_input_acceptable_cpp(ByteString const& input)
@@ -629,119 +792,6 @@ static void emit_includes_for_module_idl_value_conversion_dependencies(Module co
     }
 }
 
-template<typename ParameterType>
-static ByteString optional_parameter_cpp_type(Context const& context, ParameterType const& parameter, Optional<ByteString> const& optional_default_value)
-{
-    auto const& type = *parameter.type;
-    auto has_non_null_default_value = optional_default_value.has_value() && *optional_default_value != "null"sv;
-
-    if (type.is_nullable() && !is<UnionType>(type))
-        return nullable_parameter_cpp_type(context, type, parameter.extended_attributes).name;
-
-    if (type.is_string()) {
-        auto cpp_type = idl_type_name_to_cpp_type(type, context, parameter.extended_attributes).name;
-        if (type.is_nullable() || !has_non_null_default_value)
-            return ByteString::formatted("Optional<{}>", cpp_type);
-        return cpp_type;
-    }
-
-    if (type.is_boolean() || type.is_integer()) {
-        auto cpp_type = idl_type_name_to_cpp_type(type, context).name;
-        if (type.is_nullable() || !has_non_null_default_value)
-            return ByteString::formatted("Optional<{}>", cpp_type);
-        return cpp_type;
-    }
-
-    if (auto const* callback_interface = callback_interface_for_type(context, type))
-        return ByteString::formatted("GC::Ptr<{}>", interface_cpp_type_name(*callback_interface));
-
-    if (IDL::is_platform_object(context, type))
-        return ByteString::formatted("GC::Ptr<{}>", cpp_type_name(type, context));
-
-    if (type.is_floating_point()) {
-        auto cpp_type = idl_type_name_to_cpp_type(type, context).name;
-        if (type.is_nullable() || !has_non_null_default_value)
-            return ByteString::formatted("Optional<{}>", cpp_type);
-        return cpp_type;
-    }
-
-    if (type.name() == "Promise"sv)
-        return "GC::Ptr<WebIDL::Promise>"sv;
-
-    if (type.name() == "object"sv)
-        return "Optional<GC::Root<JS::Object>>"sv;
-
-    if (is_javascript_builtin_buffer_source_type(type) || type.name() == "BufferSource"sv) {
-        auto buffer_cpp_type = is_javascript_builtin_buffer_source_type(type) ? ByteString::formatted("JS::{}", type.name()) : ByteString { "WebIDL::BufferSource"sv };
-        return ByteString::formatted("Optional<GC::Root<{}>>", buffer_cpp_type);
-    }
-
-    if (type.name() == "ArrayBufferView"sv)
-        return "Optional<GC::Root<WebIDL::ArrayBufferView>>"sv;
-
-    if (type.name() == "any"sv)
-        return "JS::Value"sv;
-
-    if (context.enumerations.contains(type.name()))
-        return cpp_type_name(type, context);
-
-    if (context.dictionaries.contains(type.name()))
-        return cpp_type_name(type, context);
-
-    if (context.callback_functions.contains(type.name()))
-        return "GC::Ptr<WebIDL::CallbackType>"sv;
-
-    if (type.name().is_one_of("sequence"sv, "FrozenArray"sv, "record"sv)) {
-        auto cpp_type = idl_type_name_to_cpp_type(type, context).name;
-        if (type.is_nullable() || !has_non_null_default_value)
-            return ByteString::formatted("Optional<{}>", cpp_type);
-        return cpp_type;
-    }
-
-    if (is<UnionType>(type)) {
-        auto cpp_type = idl_type_name_to_cpp_type(type, context).name;
-        auto const& union_type = as<UnionType>(type);
-        if (optional_default_value == "null"sv && union_type.includes_nullable_type())
-            return cpp_type;
-        if (!has_non_null_default_value)
-            return ByteString::formatted("Optional<{}>", cpp_type);
-        return cpp_type;
-    }
-
-    dbgln("Unimplemented optional JS-to-C++ conversion type: {}", type.name());
-    VERIFY_NOT_REACHED();
-}
-
-static CppType nullable_parameter_cpp_type(Context const& context, Type const& type, Optional<HashMap<ByteString, ByteString> const&> extended_attributes)
-{
-    VERIFY(type.is_nullable());
-
-    if (is<UnionType>(type))
-        return idl_type_name_to_cpp_type(type, context, extended_attributes);
-
-    if (type.name() == "any"sv)
-        return { .name = "JS::Value"sv, .sequence_storage_type = SequenceStorageType::RootVector };
-
-    if (auto const* callback_interface = callback_interface_for_type(context, type))
-        return { .name = ByteString::formatted("GC::Ptr<{}>", interface_cpp_type_name(*callback_interface)), .sequence_storage_type = SequenceStorageType::RootVector };
-
-    if (IDL::is_platform_object(context, type))
-        return { .name = ByteString::formatted("GC::Ptr<{}>", cpp_type_name(type, context)), .sequence_storage_type = SequenceStorageType::RootVector };
-
-    if (context.callback_functions.contains(type.name()))
-        return { .name = "GC::Ptr<WebIDL::CallbackType>"sv, .sequence_storage_type = SequenceStorageType::RootVector };
-
-    if (type.name() == "BufferSource"sv)
-        return { .name = "GC::Root<WebIDL::BufferSource>"sv, .sequence_storage_type = SequenceStorageType::Vector };
-
-    if (type.name() == "ArrayBufferView"sv)
-        return { .name = "GC::Root<WebIDL::ArrayBufferView>"sv, .sequence_storage_type = SequenceStorageType::Vector };
-
-    auto inner_type = clone_type(type, false);
-    auto inner_cpp_type = idl_type_name_to_cpp_type(*inner_type, context, extended_attributes);
-    return { .name = ByteString::formatted("Optional<{}>", inner_cpp_type.name), .sequence_storage_type = SequenceStorageType::Vector };
-}
-
 static bool nullable_callback_function_treats_non_object_as_null(Context const& context, Type const& type)
 {
     auto callback_function = context.callback_functions.find(type.name());
@@ -767,22 +817,67 @@ static ByteString optional_string_default_value_expression(ByteString const& cpp
     TODO();
 }
 
-static ByteString optional_type_default_constructed_value_expression(Context const& context, Type const& type, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {});
+static TypeOptionality dictionary_member_presence(DictionaryMember const& member)
+{
+    return !member.required && !member.default_value.has_value()
+        ? TypeOptionality::OptionalDictionaryMember
+        : TypeOptionality::Required;
+}
 
-static ByteString optional_union_default_value_expression(Context const& context, UnionType const& union_type, ByteString const& default_value)
+static CppType cpp_type_for_dictionary_member(Context const& context, DictionaryMember const& member)
+{
+    return cpp_type_for_idl_type(context, *member.type, dictionary_member_presence(member), member.extended_attributes);
+}
+
+static bool dictionary_needs_builder_for_default_construction(Context const& context, ByteString const& dictionary_name)
+{
+    auto dictionary = context.dictionaries.find(dictionary_name);
+    VERIFY(dictionary != context.dictionaries.end());
+
+    if (!dictionary->value.parent_name.is_empty() && dictionary_needs_builder_for_default_construction(context, dictionary->value.parent_name))
+        return true;
+
+    for (auto const& member : dictionary->value.members) {
+        if (dictionary_member_needs_builder(context, member))
+            return true;
+    }
+
+    return false;
+}
+
+static Optional<ByteString> dictionary_default_initializers(Context const& context, ByteString const& dictionary_name)
+{
+    auto dictionary = context.dictionaries.find(dictionary_name);
+    VERIFY(dictionary != context.dictionaries.end());
+
+    Vector<ByteString> initializers;
+
+    if (!dictionary->value.parent_name.is_empty()) {
+        if (auto parent_initializers = dictionary_default_initializers(context, dictionary->value.parent_name); parent_initializers.has_value())
+            initializers.append(ByteString::formatted("{} {{ {} }}", dictionary->value.parent_name, *parent_initializers));
+    }
+
+    for (auto const& member : dictionary->value.members) {
+        if (!dictionary_member_needs_builder(context, member))
+            continue;
+        initializers.append(ByteString::formatted(".{} = {{}}", make_input_acceptable_cpp(member.name.to_snakecase())));
+    }
+
+    if (initializers.is_empty())
+        return {};
+    return ByteString::join(", "sv, initializers);
+}
+
+static ByteString cpp_default_expression(Context const& context, Type const& type, Optional<ByteString> const& default_value = {}, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {});
+
+static Type const& union_member_type_for_default_value(Context const& context, UnionType const& union_type, ByteString const& default_value)
 {
     auto types = union_type.flattened_member_types();
-
-    if (default_value == "null"sv) {
-        if (union_type.includes_undefined() || union_type.includes_nullable_type())
-            return "Empty {}"sv;
-        return "{}"sv;
-    }
 
     if (default_value == "[]"sv) {
         auto sequence_type = types.find_if([](auto const& type) { return type->name().is_one_of("sequence"sv, "FrozenArray"sv); });
         VERIFY(sequence_type != types.end());
-        return ByteString::formatted("{} {{}}", idl_type_name_to_cpp_type(**sequence_type, context).name);
+        return **sequence_type;
     }
 
     if (default_value == "{}"sv) {
@@ -790,7 +885,7 @@ static ByteString optional_union_default_value_expression(Context const& context
             return type->name() == "record"sv || context.dictionaries.contains(type->name());
         });
         VERIFY(object_type != types.end());
-        return ByteString::formatted("{} {{}}", idl_type_name_to_cpp_type(**object_type, context).name);
+        return **object_type;
     }
 
     if (default_value.starts_with("\""sv) && default_value.ends_with("\""sv)) {
@@ -801,52 +896,113 @@ static ByteString optional_union_default_value_expression(Context const& context
                 return enumeration->value.translated_cpp_names.contains(enum_member_name);
             return false;
         });
-        if (enumeration_type != types.end()) {
-            auto const& enumeration_name = (*enumeration_type)->name();
-            auto const& enumeration = context.enumerations.find(enumeration_name)->value;
-            auto default_value_cpp_name = enumeration.translated_cpp_names.get(enum_member_name);
-            VERIFY(default_value_cpp_name.has_value());
-            return ByteString::formatted("{}::{}", enumeration_name, *default_value_cpp_name);
-        }
+        if (enumeration_type != types.end())
+            return **enumeration_type;
 
         auto string_type = types.find_if([](auto const& type) { return type->is_string(); });
         VERIFY(string_type != types.end());
-        return optional_string_default_value_expression(idl_type_name_to_cpp_type(**string_type, context).name, default_value);
+        return **string_type;
     }
 
     if (default_value == "true"sv || default_value == "false"sv) {
         auto boolean_type = types.find_if([](auto const& type) { return type->is_boolean(); });
         VERIFY(boolean_type != types.end());
-        return default_value;
+        return **boolean_type;
     }
 
     if (default_value.to_number<i32>().has_value() || default_value.to_number<u32>().has_value() || default_value.to_number<double>().has_value()) {
         auto numeric_type = types.find_if([](auto const& type) { return type->is_numeric(); });
         VERIFY(numeric_type != types.end());
-        return default_value;
+        return **numeric_type;
     }
 
     TODO();
 }
 
-static ByteString optional_type_default_value_expression(Context const& context, Type const& type, ByteString const& default_value, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {})
+static ByteString cpp_default_expression(Context const& context, Type const& type, Optional<ByteString> const& default_value, Optional<HashMap<ByteString, ByteString> const&> extended_attributes)
 {
+    auto cpp_type = cpp_type_for_idl_type(context, type, TypeOptionality::Required, extended_attributes);
+
+    if (is<UnionType>(type)) {
+        auto const& union_type = as<UnionType>(type);
+        if (!default_value.has_value()) {
+            if (union_type.includes_undefined() || union_type.includes_nullable_type())
+                return "Empty {}"sv;
+
+            auto types = union_type.flattened_member_types();
+            VERIFY(!types.is_empty());
+            return cpp_default_expression(context, *types.first());
+        }
+
+        if (*default_value == "null"sv) {
+            if (union_type.includes_undefined() || union_type.includes_nullable_type())
+                return "Empty {}"sv;
+            return "{}"sv;
+        }
+
+        auto const& union_member_type = union_member_type_for_default_value(context, union_type, *default_value);
+        auto expression = cpp_default_expression(context, union_member_type, default_value);
+        if (expression == "{}"sv)
+            return ByteString::formatted("{} {{}}", cpp_type_for_idl_type(context, union_member_type, TypeOptionality::Required).name);
+        return expression;
+    }
+
+    if (!default_value.has_value()) {
+        if (type.is_nullable())
+            return "{}"sv;
+
+        if (type.is_string())
+            return ByteString::formatted("{} {{}}", cpp_type.name);
+
+        if (type.is_boolean())
+            return "false"sv;
+
+        if (type.is_numeric())
+            return "0"sv;
+
+        if (context.enumerations.contains(type.name())) {
+            auto const& enumeration = context.enumerations.find(type.name())->value;
+            auto default_value_cpp_name = enumeration.translated_cpp_names.get(enumeration.first_member);
+            VERIFY(default_value_cpp_name.has_value());
+            return ByteString::formatted("{}::{}", type.name(), *default_value_cpp_name);
+        }
+
+        if (type.name() == "any"sv)
+            return "JS::js_undefined()"sv;
+
+        if (type.name().is_one_of("sequence"sv, "FrozenArray"sv, "record"sv))
+            return "{}"sv;
+
+        if (context.dictionaries.contains(type.name())) {
+            if (auto initializers = dictionary_default_initializers(context, type.name()); initializers.has_value())
+                return ByteString::formatted("{} {{ {} }}", cpp_type.name, *initializers);
+            return ByteString::formatted("{} {{}}", cpp_type.name);
+        }
+
+        if (IDL::is_platform_object(context, type)
+            || callback_interface_for_type(context, type)
+            || context.callback_functions.contains(type.name())
+            || type.name().is_one_of("Promise"sv, "object"sv, "BufferSource"sv, "ArrayBufferView"sv)) {
+            return "{}"sv;
+        }
+
+        TODO();
+    }
+
+    auto const& explicit_default_value = *default_value;
     auto inner_type = clone_type(type, false);
-    auto cpp_type = idl_type_name_to_cpp_type(*inner_type, context, extended_attributes).name;
+    auto inner_cpp_type = cpp_type_for_idl_type(context, *inner_type, TypeOptionality::Required, extended_attributes);
 
-    if (is<UnionType>(type))
-        return optional_union_default_value_expression(context, as<UnionType>(type), default_value);
-
-    if (type.is_nullable() && default_value == "null"sv)
+    if (type.is_nullable() && explicit_default_value == "null"sv)
         return "{}"sv;
 
     if (type.name() == "any"sv) {
-        if (default_value == "null"sv)
+        if (explicit_default_value == "null"sv)
             return "JS::js_null()"sv;
-        if (default_value == "true"sv || default_value == "false"sv)
-            return ByteString::formatted("JS::Value({})", default_value);
-        if (default_value.to_number<int>().has_value() || default_value.to_number<unsigned>().has_value() || default_value.to_number<double>().has_value())
-            return ByteString::formatted("JS::Value({})", default_value);
+        if (explicit_default_value == "true"sv || explicit_default_value == "false"sv)
+            return ByteString::formatted("JS::Value({})", explicit_default_value);
+        if (explicit_default_value.to_number<int>().has_value() || explicit_default_value.to_number<unsigned>().has_value() || explicit_default_value.to_number<double>().has_value())
+            return ByteString::formatted("JS::Value({})", explicit_default_value);
     }
 
     if ((IDL::is_platform_object(context, type)
@@ -854,29 +1010,36 @@ static ByteString optional_type_default_value_expression(Context const& context,
             || context.callback_functions.contains(type.name())
             || type.name() == "Promise"sv
             || type.name() == "object"sv)
-        && default_value == "null"sv) {
+        && explicit_default_value == "null"sv) {
         return "{}"sv;
     }
 
     if (type.is_string())
-        return optional_string_default_value_expression(cpp_type, default_value);
+        return optional_string_default_value_expression(inner_cpp_type.name, explicit_default_value);
 
     if (type.is_boolean() || type.is_numeric())
-        return default_value;
+        return explicit_default_value;
 
     if (type.name().is_one_of("sequence"sv, "FrozenArray"sv)) {
-        VERIFY(default_value == "[]"sv);
-        return ByteString::formatted("{} {{}}", cpp_type);
+        VERIFY(explicit_default_value == "[]"sv);
+        return "{}"sv;
     }
 
-    if (type.name() == "record"sv || context.dictionaries.contains(type.name())) {
-        VERIFY(default_value == "{}"sv);
-        return ByteString::formatted("{} {{}}", cpp_type);
+    if (type.name() == "record"sv) {
+        VERIFY(explicit_default_value == "{}"sv);
+        return "{}"sv;
+    }
+
+    if (context.dictionaries.contains(type.name())) {
+        VERIFY(explicit_default_value == "{}"sv);
+        if (auto initializers = dictionary_default_initializers(context, type.name()); initializers.has_value())
+            return ByteString::formatted("{} {{ {} }}", inner_cpp_type.name, *initializers);
+        return ByteString::formatted("{} {{}}", inner_cpp_type.name);
     }
 
     if (context.enumerations.contains(type.name())) {
-        VERIFY(default_value.length() >= 2 && default_value[0] == '"' && default_value[default_value.length() - 1] == '"');
-        auto enum_member_name = default_value.substring_view(1, default_value.length() - 2);
+        VERIFY(explicit_default_value.length() >= 2 && explicit_default_value[0] == '"' && explicit_default_value[explicit_default_value.length() - 1] == '"');
+        auto enum_member_name = explicit_default_value.substring_view(1, explicit_default_value.length() - 2);
         auto default_value_cpp_name = context.enumerations.find(type.name())->value.translated_cpp_names.get(enum_member_name);
         VERIFY(default_value_cpp_name.has_value());
         return ByteString::formatted("{}::{}", type.name(), *default_value_cpp_name);
@@ -886,89 +1049,35 @@ static ByteString optional_type_default_value_expression(Context const& context,
 }
 
 template<typename ParameterType>
-static ByteString optional_parameter_default_value_expression(Context const& context, ParameterType const& parameter, ByteString const& default_value)
-{
-    return optional_type_default_value_expression(context, *parameter.type, default_value, parameter.extended_attributes);
-}
-
-static ByteString optional_type_default_constructed_value_expression(Context const& context, Type const& type, Optional<HashMap<ByteString, ByteString> const&> extended_attributes)
-{
-    auto cpp_type = idl_type_name_to_cpp_type(type, context, extended_attributes).name;
-
-    if (is<UnionType>(type)) {
-        auto const& union_type = as<UnionType>(type);
-        if (union_type.includes_undefined() || union_type.includes_nullable_type())
-            return "Empty {}"sv;
-
-        auto types = union_type.flattened_member_types();
-        VERIFY(!types.is_empty());
-        return optional_type_default_constructed_value_expression(context, *types.first());
-    }
-
-    if (type.is_nullable())
-        return "{}"sv;
-
-    if (type.is_string())
-        return ByteString::formatted("{} {{}}", cpp_type);
-
-    if (type.is_boolean())
-        return "false"sv;
-
-    if (type.is_numeric())
-        return "0"sv;
-
-    if (context.enumerations.contains(type.name())) {
-        auto const& enumeration = context.enumerations.find(type.name())->value;
-        auto default_value_cpp_name = enumeration.translated_cpp_names.get(enumeration.first_member);
-        VERIFY(default_value_cpp_name.has_value());
-        return ByteString::formatted("{}::{}", type.name(), *default_value_cpp_name);
-    }
-
-    if (type.name() == "any"sv)
-        return "JS::js_undefined()"sv;
-
-    if (type.name().is_one_of("sequence"sv, "FrozenArray"sv, "record"sv) || context.dictionaries.contains(type.name()))
-        return ByteString::formatted("{} {{}}", cpp_type);
-
-    if (IDL::is_platform_object(context, type)
-        || callback_interface_for_type(context, type)
-        || context.callback_functions.contains(type.name())
-        || type.name() == "Promise"sv
-        || type.name() == "object"sv) {
-        return "{}"sv;
-    }
-
-    TODO();
-}
-
-template<typename ParameterType>
-static ByteString optional_parameter_default_constructed_value_expression(Context const& context, ParameterType const& parameter)
-{
-    return optional_type_default_constructed_value_expression(context, *parameter.type, parameter.extended_attributes);
-}
-
-template<typename ParameterType>
-static void generate_optional_to_cpp(SourceGenerator& generator, ParameterType& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const& context, Optional<ByteString> optional_default_value, size_t recursion_depth)
+static void generate_optional_to_cpp(SourceGenerator& generator, ParameterType& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const& context, Optional<ByteString> optional_default_value, TypeOptionality optionality, size_t recursion_depth)
 {
     auto optional_generator = generator.fork();
-    auto optional_cpp_type = optional_parameter_cpp_type(context, parameter, optional_default_value);
+    auto declaration_optionality = optional_default_value.has_value() ? TypeOptionality::Required : optionality;
+    auto optional_cpp_type = cpp_type_for_idl_type(context, *parameter.type, declaration_optionality, parameter.extended_attributes);
     auto inner_cpp_name = ByteString::formatted("{}_non_optional", cpp_name);
 
-    optional_generator.set("optional.cpp_type", optional_cpp_type);
+    optional_generator.set("optional.cpp_type", optional_cpp_type.name);
     optional_generator.set("optional.inner_cpp_name", inner_cpp_name);
 
-    Optional<ByteString> initial_value;
-    if (parameter.type->name() == "any"sv) {
-        initial_value = optional_default_value.has_value()
-            ? optional_parameter_default_value_expression(context, parameter, *optional_default_value)
-            : ByteString { "JS::js_undefined()"sv };
-    } else if (context.enumerations.contains(parameter.type->name())) {
-        initial_value = optional_default_value.has_value()
-            ? optional_parameter_default_value_expression(context, parameter, *optional_default_value)
-            : optional_parameter_default_constructed_value_expression(context, parameter);
-    } else if (optional_default_value.has_value()) {
-        initial_value = optional_parameter_default_value_expression(context, parameter, *optional_default_value);
+    if (optional_default_value == "{}"sv && context.dictionaries.contains(parameter.type->name()) && dictionary_needs_builder_for_default_construction(context, parameter.type->name())) {
+        optional_generator.set("parameter.type.idl_value_conversion_function", idl_value_conversion_function_name(parameter.type->name()));
+        optional_generator.append(R"~~~(
+    auto @cpp_name@ = TRY(@parameter.type.idl_value_conversion_function@(vm, JS::js_undefined()));
+    if (!@js_name@@js_suffix@.is_undefined()) {
+)~~~");
+
+        generate_to_cpp(optional_generator, parameter, js_name, js_suffix, inner_cpp_name, context, false, {}, false, recursion_depth);
+
+        optional_generator.append(R"~~~(
+        @cpp_name@ = @optional.inner_cpp_name@;
     }
+)~~~");
+        return;
+    }
+
+    Optional<ByteString> initial_value;
+    if (optional_default_value.has_value())
+        initial_value = cpp_default_expression(context, *parameter.type, optional_default_value, parameter.extended_attributes);
 
     if (initial_value == "{}"sv) {
         optional_generator.append(R"~~~(
@@ -1001,7 +1110,7 @@ template<typename ParameterType>
 static void generate_nullable_to_cpp(SourceGenerator& generator, ParameterType const& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const& context, size_t recursion_depth)
 {
     auto nullable_generator = generator.fork();
-    auto nullable_cpp_type = nullable_parameter_cpp_type(context, *parameter.type, parameter.extended_attributes).name;
+    auto nullable_cpp_type = cpp_type_for_idl_type(context, *parameter.type, TypeOptionality::Required, parameter.extended_attributes).name;
     auto inner_cpp_name = ByteString::formatted("{}_non_nullable", cpp_name);
     auto inner_type = clone_type(*parameter.type, false);
     auto inner_parameter = parameter;
@@ -1061,7 +1170,7 @@ static void generate_variadic_to_cpp(SourceGenerator& generator, ParameterType& 
 {
     auto variadic_generator = generator.fork();
     auto variadic_cpp_type = idl_type_name_to_cpp_type(*parameter.type, context, parameter.extended_attributes);
-    auto variadic_storage_type = sequence_storage_type_to_cpp_storage_type_name(variadic_cpp_type.sequence_storage_type);
+    auto variadic_storage_type = contained_storage_type_to_cpp_name(variadic_cpp_type.contained_storage_type);
     auto inner_cpp_name = ByteString::formatted("{}_item", cpp_name);
     auto value_name = ByteString::formatted("variadic_argument_{}", recursion_depth);
 
@@ -1199,26 +1308,40 @@ static void generate_to_integral(SourceGenerator& scoped_generator, ParameterTyp
 // https://webidl.spec.whatwg.org/#es-dictionary
 static void generate_dictionary_to_cpp(SourceGenerator& generator, Context const& context, IDL::Dictionary const& dictionary, ByteString dictionary_name)
 {
-    auto const* current_dictionary = &dictionary;
+    struct DictionaryConversion {
+        ByteString name;
+        Dictionary const* dictionary { nullptr };
+        Vector<ByteString> designated_member_initializers;
+        Vector<ByteString> positional_member_initializers;
+    };
+
+    Vector<DictionaryConversion> dictionaries;
     auto current_dictionary_name = move(dictionary_name);
+    auto const* current_dictionary = &dictionary;
+    while (true) {
+        dictionaries.append({ current_dictionary_name, current_dictionary, {}, {} });
+
+        if (current_dictionary->parent_name.is_empty())
+            break;
+
+        VERIFY(context.dictionaries.contains(current_dictionary->parent_name));
+        current_dictionary_name = current_dictionary->parent_name;
+        current_dictionary = &context.dictionaries.find(current_dictionary_name)->value;
+    }
 
     generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_nullish() && !@js_name@@js_suffix@.is_object())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
-
-    @parameter.type.name.normalized@ @cpp_name@ {};
 )~~~");
     // FIXME: This (i) is a hack to make sure we don't generate duplicate variable names.
     static auto i = 0;
-    while (true) {
-        auto const& members = current_dictionary->members;
 
-        for (auto& member : members) {
+    for (auto& dictionary_conversion : dictionaries) {
+        for (auto& member : dictionary_conversion.dictionary->members) {
             generator.set("member_key", member.name);
             auto member_js_name = make_input_acceptable_cpp(member.name.to_snakecase());
             auto member_value_name = ByteString::formatted("{}_value_{}", member_js_name, i);
             auto member_property_value_name = ByteString::formatted("{}_property_value_{}", member_js_name, i);
-            generator.set("member_name", member_js_name);
             generator.set("member_value_name", member_value_name);
             generator.set("member_property_value_name", member_property_value_name);
             generator.append(R"~~~(
@@ -1231,33 +1354,44 @@ static void generate_dictionary_to_cpp(SourceGenerator& generator, Context const
     if (@member_property_value_name@.is_undefined())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::MissingRequiredProperty, "@member_key@");
 )~~~");
-            } else if (!member.default_value.has_value()) {
-                // Assume struct member is Optional<T> and _don't_ assign the generated default
-                // value (e.g. first enum member) when the dictionary member is optional (i.e.
-                // no `required` and doesn't have a default value).
-                // This is needed so that "dictionary has member" checks work as expected.
-                generator.append(R"~~~(
-    if (!@member_property_value_name@.is_undefined()) {
-)~~~");
             }
 
-            generate_to_cpp(generator, member, member_property_value_name, "", member_value_name, context, !member.required, member.default_value);
+            generate_to_cpp(generator, member, member_property_value_name, "", member_value_name, context, !member.required, member.default_value, false, 0, dictionary_member_presence(member));
 
-            generator.append(R"~~~(
-    @cpp_name@.@member_name@ = @member_value_name@;
-)~~~");
-            if (!member.required && !member.default_value.has_value()) {
-                generator.append(R"~~~(
-    }
-)~~~");
-            }
+            dictionary_conversion.designated_member_initializers.append(ByteString::formatted(".{} = {}", member_js_name, member_value_name));
+            dictionary_conversion.positional_member_initializers.append(member_value_name);
             i++;
         }
-        if (current_dictionary->parent_name.is_empty())
-            break;
-        VERIFY(context.dictionaries.contains(current_dictionary->parent_name));
-        current_dictionary_name = current_dictionary->parent_name;
-        current_dictionary = &context.dictionaries.find(current_dictionary_name)->value;
+    }
+
+    ByteString initializer;
+    for (size_t dictionary_index = dictionaries.size(); dictionary_index > 0; --dictionary_index) {
+        auto& dictionary_conversion = dictionaries[dictionary_index - 1];
+        Vector<ByteString> initializers;
+        auto has_parent_initializer = dictionary_index < dictionaries.size();
+
+        if (has_parent_initializer) {
+            auto& parent_dictionary = dictionaries[dictionary_index];
+            initializers.append(initializer.is_empty()
+                    ? ByteString::formatted("{} {{}}", parent_dictionary.name)
+                    : ByteString::formatted("{} {{ {} }}", parent_dictionary.name, initializer));
+        }
+
+        initializers.extend(has_parent_initializer
+                ? dictionary_conversion.positional_member_initializers
+                : dictionary_conversion.designated_member_initializers);
+        initializer = ByteString::join(", "sv, initializers);
+    }
+
+    if (initializer.is_empty()) {
+        generator.append(R"~~~(
+    @parameter.type.name.normalized@ @cpp_name@ {};
+)~~~");
+    } else {
+        generator.set("dictionary.initializers", initializer);
+        generator.append(R"~~~(
+    @parameter.type.name.normalized@ @cpp_name@ { @dictionary.initializers@ };
+)~~~");
     }
 }
 
@@ -1314,7 +1448,7 @@ static void generate_promise_to_cpp(SourceGenerator& scoped_generator)
     // 2. Perform ? Call(promiseCapability.[[Resolve]], undefined, « V »).
     TRY(JS::call(vm, *promise_capability->resolve(), JS::js_undefined(), @js_name@@js_suffix@));
     // 3. Return promiseCapability.
-    auto @cpp_name@ = GC::make_root(promise_capability);
+    GC::Ref<WebIDL::Promise> @cpp_name@ = promise_capability;
 )~~~");
 }
 
@@ -1326,7 +1460,7 @@ static void generate_object_to_cpp(SourceGenerator& scoped_generator)
     scoped_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_object())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObject, @js_name@@js_suffix@);
-    auto @cpp_name@ = GC::make_root(@js_name@@js_suffix@.as_object());
+    GC::Ref<JS::Object> @cpp_name@ = @js_name@@js_suffix@.as_object();
 )~~~");
 }
 
@@ -1338,10 +1472,6 @@ static void generate_buffer_source_to_cpp(SourceGenerator& scoped_generator, IDL
     else
         scoped_generator.set("parameter.type.buffer_cpp", "WebIDL::BufferSource");
 
-    scoped_generator.append(R"~~~(
-    GC::Root<@parameter.type.buffer_cpp@> @cpp_name@;
-)~~~");
-
     if (is_exact_javascript_buffer_source_type) {
         scoped_generator.append(R"~~~(
     auto @cpp_name@_builtin_buffer = @js_name@@js_suffix@.as_if<@parameter.type.buffer_cpp@>();
@@ -1349,7 +1479,7 @@ static void generate_buffer_source_to_cpp(SourceGenerator& scoped_generator, IDL
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
     }
 
-    @cpp_name@ = GC::make_root(*@cpp_name@_builtin_buffer);
+    GC::Ref<@parameter.type.buffer_cpp@> @cpp_name@ = *@cpp_name@_builtin_buffer;
 )~~~");
     } else {
         scoped_generator.append(R"~~~(
@@ -1357,7 +1487,7 @@ static void generate_buffer_source_to_cpp(SourceGenerator& scoped_generator, IDL
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
     }
 
-    @cpp_name@ = GC::make_root(realm.create<WebIDL::BufferSource>(@js_name@@js_suffix@.as_object()));
+    GC::Ref<WebIDL::BufferSource> @cpp_name@ = realm.create<WebIDL::BufferSource>(@js_name@@js_suffix@.as_object());
 )~~~");
     }
 }
@@ -1365,14 +1495,10 @@ static void generate_buffer_source_to_cpp(SourceGenerator& scoped_generator, IDL
 static void generate_array_buffer_view_to_cpp(SourceGenerator& scoped_generator)
 {
     scoped_generator.append(R"~~~(
-    GC::Root<WebIDL::ArrayBufferView> @cpp_name@;
-)~~~");
-
-    scoped_generator.append(R"~~~(
         if (!@js_name@@js_suffix@.is_object() || !(is<JS::TypedArrayBase>(@js_name@@js_suffix@.as_object()) || is<JS::DataView>(@js_name@@js_suffix@.as_object())))
             return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
 
-        @cpp_name@ = GC::make_root(realm.create<WebIDL::ArrayBufferView>(@js_name@@js_suffix@.as_object()));
+        GC::Ref<WebIDL::ArrayBufferView> @cpp_name@ = realm.create<WebIDL::ArrayBufferView>(@js_name@@js_suffix@.as_object());
 )~~~");
 }
 
@@ -1452,7 +1578,7 @@ static void generate_record_to_cpp(SourceGenerator& scoped_generator, IDL::Param
     //       4. Set result[typedKey] to typedValue.
     // 5. Return result.
 
-    auto record_cpp_type = IDL::idl_type_name_to_cpp_type(type, context);
+    auto record_cpp_type = idl_type_name_to_cpp_type(type, context);
     record_generator.set("record.type", record_cpp_type.name);
 
     // If this is a recursive call to generate_to_cpp, assume that the caller has already handled converting the JS value to an object for us.
@@ -1650,14 +1776,14 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
 
             union_platform_object_type_generator.append(R"~~~(
                 if (auto* @js_name@@js_suffix@_result = as_if<@platform_object_type@>(@js_name@@js_suffix@_object))
-                    return GC::make_root(*@js_name@@js_suffix@_result);
+                    return @union_type@ { GC::Ref { *@js_name@@js_suffix@_result } };
 )~~~");
         }
 
         //    2. If types includes object, then return the IDL value that is a reference to the object V.
         if (includes_object) {
             union_generator.append(R"~~~(
-                return GC::make_root(@js_name@@js_suffix@_object);
+                return @union_type@ { GC::Ref { @js_name@@js_suffix@_object } };
 )~~~");
         }
 
@@ -1671,7 +1797,7 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
     if (includes_window_proxy) {
         union_generator.append(R"~~~(
             if (auto* @js_name@@js_suffix@_result = as_if<HTML::WindowProxy>(@js_name@@js_suffix@_object))
-                return GC::make_root(*@js_name@@js_suffix@_result);
+                return @union_type@ { GC::Ref { *@js_name@@js_suffix@_result } };
 )~~~");
     }
 
@@ -1681,7 +1807,7 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
         union_generator.append(R"~~~(
             if (is<JS::ArrayBuffer>(@js_name@@js_suffix@_object) || is<JS::DataView>(@js_name@@js_suffix@_object) || is<JS::TypedArrayBase>(@js_name@@js_suffix@_object)) {
                 GC::Ref<WebIDL::BufferSource> source_object = realm.create<WebIDL::BufferSource>(@js_name@@js_suffix@_object);
-                return GC::make_root(source_object);
+                return source_object;
             }
 )~~~");
     }
@@ -1691,8 +1817,8 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
     //    2. If types includes object, then return the IDL value that is a reference to the object V.
     if (any_of(types, [](auto const& type) { return type->name() == "ArrayBuffer"; }) || includes_object) {
         union_generator.append(R"~~~(
-            if (is<JS::ArrayBuffer>(@js_name@@js_suffix@_object))
-                return GC::make_root(@js_name@@js_suffix@_object);
+            if (auto* array_buffer = as_if<JS::ArrayBuffer>(@js_name@@js_suffix@_object))
+                return *array_buffer;
 )~~~");
     }
 
@@ -1701,8 +1827,8 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
     //    2. If types includes object, then return the IDL value that is a reference to the object V.
     if (any_of(types, [](auto const& type) { return type->name() == "DataView"; }) || includes_object) {
         union_generator.append(R"~~~(
-            if (is<JS::DataView>(@js_name@@js_suffix@_object))
-                return GC::make_root(@js_name@@js_suffix@_object);
+            if (auto* data_view = as_if<JS::DataView>(@js_name@@js_suffix@_object))
+                return *data_view;
 )~~~");
     }
 
@@ -1717,12 +1843,12 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
         union_generator.set("typed_array_type", (*typed_array_name)->name());
         union_generator.append(R"~~~(
             if (auto* typed_array = as_if<JS::@typed_array_type@>(@js_name@@js_suffix@_object))
-                return GC::make_root(*typed_array);
+                return *typed_array;
 )~~~");
     } else if (includes_object) {
         union_generator.append(R"~~~(
-            if (is<JS::TypedArrayBase>(@js_name@@js_suffix@_object))
-                return GC::make_root(@js_name@@js_suffix@_object);
+            if (auto* typed_array = as_if<JS::TypedArrayBase>(@js_name@@js_suffix@_object))
+                return *typed_array;
 )~~~");
     }
 
@@ -1998,7 +2124,7 @@ static void generate_union_to_cpp(SourceGenerator& scoped_generator, ParameterTy
 }
 
 template<typename ParameterType>
-static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const& context, bool optional, Optional<ByteString> optional_default_value, bool variadic, size_t recursion_depth)
+static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter, ByteString const& js_name, ByteString const& js_suffix, ByteString const& cpp_name, Context const& context, bool optional, Optional<ByteString> optional_default_value, bool variadic, size_t recursion_depth, TypeOptionality optionality)
 {
     auto scoped_generator = generator.fork();
     auto acceptable_cpp_name = make_input_acceptable_cpp(cpp_name);
@@ -2022,7 +2148,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     }
 
     if (optional) {
-        generate_optional_to_cpp(scoped_generator, parameter, js_name, js_suffix, acceptable_cpp_name, context, optional_default_value, recursion_depth);
+        generate_optional_to_cpp(scoped_generator, parameter, js_name, js_suffix, acceptable_cpp_name, context, optional_default_value, optionality, recursion_depth);
         return;
     }
 
@@ -2141,7 +2267,7 @@ void IDL::ParameterizedType::generate_sequence_from_iterable(SourceGenerator& ge
     sequence_generator.set("recursion_depth", ByteString::number(recursion_depth));
     auto sequence_cpp_type = idl_type_name_to_cpp_type(parameters().first(), context);
     sequence_generator.set("sequence.type", sequence_cpp_type.name);
-    sequence_generator.set("sequence.storage_type", sequence_storage_type_to_cpp_storage_type_name(sequence_cpp_type.sequence_storage_type));
+    sequence_generator.set("sequence.storage_type", contained_storage_type_to_cpp_name(sequence_cpp_type.contained_storage_type));
 
     // To create an IDL value of type sequence<T> given an iterable iterable and an iterator getter method, perform the following steps:
     // 1. Let iter be ? GetIterator(iterable, sync, method).
@@ -2192,7 +2318,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
     if (is_optional) {
         optional_uses_value_access = is<UnionType>(type)
             || type.is_string()
-            || type.name().is_one_of("sequence"sv, "FrozenArray"sv, "Promise"sv, "record"sv)
+            || type.name().is_one_of("sequence"sv, "FrozenArray"sv, "record"sv)
             || type.is_primitive()
             || context.enumerations.contains(type.name())
             || context.dictionaries.contains(type.name());
@@ -2225,7 +2351,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
             scoped_generator.append(R"~~~(
     if (@value@.has_value()) {
 )~~~");
-        } else if (type.is_primitive() || context.enumerations.contains(type.name()) || context.dictionaries.contains(type.name()) || type.name() == "Promise"sv) {
+        } else if (type.is_primitive() || context.enumerations.contains(type.name()) || context.dictionaries.contains(type.name())) {
             generate_optional_integral_type = true;
             scoped_generator.append(R"~~~(
     if (@value@.has_value()) {
@@ -2277,9 +2403,8 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
 )~~~");
         }
 
-        // If the type is a platform object we currently return a Vector<GC::Root<T>> from the
-        // C++ implementation, thus allowing us to unwrap the element (a handle) like below.
-        // This might need to change if we switch to a RootVector.
+        // If the type is a platform object we currently return a GC-aware vector from the
+        // C++ implementation, thus allowing us to unwrap the element like below.
         if (is_platform_object(context, sequence_generic_type.parameters().first())) {
             scoped_generator.append(R"~~~(
         auto* wrapped_element@recursion_depth@ = &(*element@recursion_depth@);
@@ -2338,7 +2463,15 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
     }
 )~~~");
     } else if (type.name() == "boolean" || type.is_floating_point()) {
-        if (type.is_nullable()) {
+        if (type.is_nullable() && is_optional) {
+            scoped_generator.append(R"~~~(
+    if (@value_non_optional@.has_value()) {
+        @result_expression@ JS::Value(@value_non_optional@.release_value());
+    } else {
+        @result_expression@ JS::js_null();
+    }
+)~~~");
+        } else if (type.is_nullable()) {
             scoped_generator.append(R"~~~(
     @result_expression@ JS::Value(@value@.release_value());
 )~~~");
@@ -2376,7 +2509,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
 
         for (size_t current_union_type_index = 0; current_union_type_index < union_types.size(); ++current_union_type_index) {
             auto& current_union_type = union_types.at(current_union_type_index);
-            auto cpp_type = IDL::idl_type_name_to_cpp_type(current_union_type, context);
+            auto cpp_type = idl_type_name_to_cpp_type(current_union_type, context);
             union_generator.set("current_type", cpp_type.name);
             union_generator.append(R"~~~(
         [&vm, &realm]([[maybe_unused]] @current_type@ const& visited_union_value@recursion_depth@) -> JS::Value {
@@ -2472,8 +2605,9 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
                 //      the generated code to do some metaprogramming to inspect the type of the member in the C++ struct to
                 //      determine whether the type is present or not (e.g through a has_value() on an Optional<T>, or a null
                 //      check on a GC::Ptr<T>). So to save some complexity in the generator, give ourselves a hint of what to do.
-                bool is_optional_storage = !member.required && !member.default_value.has_value();
-                bool is_optional_property = !member.required && !member.extended_attributes.contains("GenerateAsRequired") && !member.default_value.has_value() && !member.type->is_nullable();
+                auto member_cpp_type = cpp_type_for_dictionary_member(context, member);
+                bool is_optional_storage = member_cpp_type.is_optional_presence;
+                bool is_optional_property = is_optional_storage && !member.extended_attributes.contains("GenerateAsRequired");
                 if (is_optional_storage) {
                     dictionary_generator.append(R"~~~(
         Optional<JS::Value> @wrapped_value_name@;
@@ -2529,7 +2663,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
 )~~~");
     }
 
-    if (type.is_nullable() && !is<UnionType>(type)) {
+    if (type.is_nullable() && !is<UnionType>(type) && !is_optional) {
         scoped_generator.append(R"~~~(
     } else {
         @result_expression@ JS::js_null();
@@ -3545,8 +3679,11 @@ static void emit_dictionary_support_includes(StringBuilder& builder)
 #include <AK/Utf16String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibGC/ConservativeVector.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
+#include <LibGC/RootHashMap.h>
+#include <LibGC/RootVector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Value.h>
@@ -3568,215 +3705,64 @@ static void emit_idl_value_conversion_support_includes(StringBuilder& builder)
 )~~~"sv);
 }
 
-static bool nullable_type_uses_optional_cpp_type(Context const& context, Type const& type)
+static bool cpp_default_expression_needs_builder(Context const& context, Type const& type, ByteString const& default_value)
 {
-    if (!type.is_nullable() || type.is_union())
-        return false;
-
-    if (type.name() == "any"sv)
-        return false;
-
-    if (callback_interface_for_type(context, type))
-        return false;
-
-    if (IDL::is_platform_object(context, type))
-        return false;
-
-    if (context.callback_functions.contains(type.name()))
-        return false;
-
-    return true;
-}
-
-static ByteString dictionary_member_cpp_type(Context const& context, DictionaryMember const& member)
-{
-    auto const& type = *member.type;
-    auto base_type = idl_type_name_to_cpp_type(type, context).name;
-    if (nullable_type_uses_optional_cpp_type(context, type))
-        base_type = idl_type_name_to_cpp_type(*clone_type(type, false), context).name;
-    bool is_callback_like_type = callback_interface_for_type(context, type)
-        || context.callback_functions.contains(type.name());
-
-    bool should_wrap_in_optional = (!member.required && !member.default_value.has_value() && !is_callback_like_type)
-        || nullable_type_uses_optional_cpp_type(context, type);
-
-    if (should_wrap_in_optional)
-        return ByteString::formatted("Optional<{}>", base_type);
-
-    return base_type;
-}
-
-static ByteString dictionary_default_value_expression(Context const&, Type const&, ByteString const&);
-static ByteString dictionary_default_constructed_value_expression(Context const&, Type const&);
-
-static ByteString dictionary_union_default_value_expression(Context const& context, UnionType const& union_type, ByteString const& default_value)
-{
-    auto types = union_type.flattened_member_types();
-
-    if (default_value == "null"sv) {
-        if (union_type.includes_undefined() || union_type.includes_nullable_type())
-            return "Empty {}"sv;
-        return "{}"sv;
-    }
-
-    if (default_value == "[]"sv) {
-        auto sequence_type = types.find_if([](auto const& type) { return type->name().is_one_of("sequence"sv, "FrozenArray"sv); });
-        VERIFY(sequence_type != types.end());
-        return ByteString::formatted("{} {{}}", idl_type_name_to_cpp_type(**sequence_type, context).name);
-    }
-
-    if (default_value == "{}"sv) {
-        auto object_type = types.find_if([&context](auto const& type) {
-            return type->name() == "record"sv || context.dictionaries.contains(type->name());
-        });
-        VERIFY(object_type != types.end());
-        return ByteString::formatted("{} {{}}", idl_type_name_to_cpp_type(**object_type, context).name);
-    }
-
-    if (default_value.starts_with("\""sv) && default_value.ends_with("\""sv)) {
-        auto default_string_value = default_value.substring_view(1, default_value.length() - 2);
-
-        auto enumeration_type = types.find_if([&](auto const& type) {
-            if (auto enumeration = context.enumerations.find(type->name()); enumeration != context.enumerations.end())
-                return enumeration->value.translated_cpp_names.contains(default_string_value);
-            return false;
-        });
-        if (enumeration_type != types.end())
-            return dictionary_default_value_expression(context, **enumeration_type, default_value);
-
-        auto string_type = types.find_if([](auto const& type) { return type->is_string(); });
-        VERIFY(string_type != types.end());
-        return dictionary_default_value_expression(context, **string_type, default_value);
-    }
-
-    if (default_value == "true"sv || default_value == "false"sv) {
-        auto boolean_type = types.find_if([](auto const& type) { return type->is_boolean(); });
-        VERIFY(boolean_type != types.end());
-        return default_value;
-    }
-
-    if (default_value.to_number<i32>().has_value() || default_value.to_number<u32>().has_value() || default_value.to_number<double>().has_value()) {
-        auto numeric_type = types.find_if([](auto const& type) { return type->is_numeric(); });
-        VERIFY(numeric_type != types.end());
-        return default_value;
-    }
-
-    TODO();
-}
-
-static ByteString dictionary_default_value_expression(Context const& context, Type const& type, ByteString const& default_value)
-{
-    auto cpp_type = idl_type_name_to_cpp_type(type, context).name;
-
-    if (is<UnionType>(type))
-        return dictionary_union_default_value_expression(context, as<UnionType>(type), default_value);
-
-    if (type.is_nullable() && default_value == "null"sv)
-        return "{}"sv;
-
-    if (type.name() == "any"sv && default_value == "null"sv)
-        return "JS::js_null()"sv;
-
-    if (type.name() == "object"sv && default_value == "null"sv)
-        return "{}"sv;
-
-    if (type.is_string()) {
-        if (cpp_type == "String"sv)
-            return default_value == "\"\""sv ? ByteString { "String {}"sv } : ByteString::formatted("{}_string", default_value);
-        if (cpp_type == "ByteString"sv)
-            return default_value == "\"\""sv ? ByteString { "ByteString {}"sv } : ByteString::formatted("ByteString {{ {}sv }}", default_value);
-        if (cpp_type == "Utf16String"sv)
-            return default_value == "\"\""sv ? ByteString { "Utf16String {}"sv } : ByteString::formatted("Utf16String::from_utf8_without_validation({}sv)", default_value);
-    }
-
-    if (type.is_boolean() || type.is_numeric())
-        return default_value;
-
-    if (type.name().is_one_of("sequence"sv, "FrozenArray"sv)) {
-        VERIFY(default_value == "[]"sv);
-        return ByteString::formatted("{} {{}}", cpp_type);
-    }
-
-    if (type.name() == "record"sv || context.dictionaries.contains(type.name())) {
-        VERIFY(default_value == "{}"sv);
-        return ByteString::formatted("{} {{}}", cpp_type);
-    }
-
-    if (context.enumerations.contains(type.name())) {
-        VERIFY(default_value.length() >= 2 && default_value[0] == '"' && default_value[default_value.length() - 1] == '"');
-        auto enum_member_name = default_value.substring_view(1, default_value.length() - 2);
-        auto default_value_cpp_name = context.enumerations.find(type.name())->value.translated_cpp_names.get(enum_member_name);
-        VERIFY(default_value_cpp_name.has_value());
-        return ByteString::formatted("{}::{}", type.name(), *default_value_cpp_name);
-    }
-
-    TODO();
-}
-
-static ByteString dictionary_default_constructed_value_expression(Context const& context, Type const& type)
-{
-    auto cpp_type = idl_type_name_to_cpp_type(type, context).name;
-
     if (is<UnionType>(type)) {
-        auto const& union_type = as<UnionType>(type);
-        if (union_type.includes_undefined() || union_type.includes_nullable_type())
-            return "Empty {}"sv;
-
-        auto types = union_type.flattened_member_types();
-        VERIFY(!types.is_empty());
-        return dictionary_default_constructed_value_expression(context, *types.first());
+        if (default_value == "null"sv)
+            return false;
+        return cpp_default_expression_needs_builder(context, union_member_type_for_default_value(context, as<UnionType>(type), default_value), default_value);
     }
 
-    if (type.is_nullable())
-        return "{}"sv;
+    if (context.dictionaries.contains(type.name()) && default_value == "{}"sv)
+        return dictionary_needs_builder_for_default_construction(context, type.name());
 
-    if (type.is_string())
-        return ByteString::formatted("{} {{}}", cpp_type);
+    return false;
+}
 
-    if (type.is_boolean())
-        return "false"sv;
+static bool dictionary_member_needs_builder(Context const& context, DictionaryMember const& member)
+{
+    if (!member.required && !member.default_value.has_value())
+        return false;
 
-    if (type.is_numeric())
-        return "0"sv;
+    auto member_cpp_type = cpp_type_for_dictionary_member(context, member);
+    if (member_cpp_type.is_optional_presence)
+        return false;
 
-    if (type.name().is_one_of("sequence"sv, "FrozenArray"sv, "record"sv))
-        return ByteString::formatted("{} {{}}", cpp_type);
+    if (is_direct_gc_ref_cpp_type(member_cpp_type))
+        return true;
 
-    if (context.dictionaries.contains(type.name()))
-        return ByteString::formatted("{} {{}}", cpp_type);
-
-    if (context.enumerations.contains(type.name())) {
-        auto& enumeration = context.enumerations.find(type.name())->value;
-        VERIFY(!enumeration.translated_cpp_names.is_empty());
-        return ByteString::formatted("{}::{}", type.name(), enumeration.translated_cpp_names.begin()->value);
+    if (is<UnionType>(*member.type)
+        && member.required
+        && !member.default_value.has_value()) {
+        return true;
     }
 
-    if (is_platform_object(context, type)
-        || callback_interface_for_type(context, type)
-        || context.callback_functions.contains(type.name())
-        || type.name().is_one_of("any"sv, "object"sv, "BufferSource"sv, "ArrayBufferView"sv, "Promise"sv))
-        return "{}"sv;
+    if (member.default_value.has_value() && cpp_default_expression_needs_builder(context, *member.type, *member.default_value))
+        return true;
 
-    TODO();
+    return false;
 }
 
 static ByteString dictionary_member_initializer(Context const& context, DictionaryMember const& member)
 {
-    auto member_cpp_type = dictionary_member_cpp_type(context, member);
+    auto member_cpp_type = cpp_type_for_dictionary_member(context, member);
+
+    if (dictionary_member_needs_builder(context, member))
+        return ""sv;
 
     if (member.default_value.has_value()) {
-        if (member_cpp_type.starts_with("Optional<"sv) && *member.default_value == "null"sv)
+        if (member_cpp_type.is_optional_presence && *member.default_value == "null"sv)
             return " {}"sv;
 
-        auto default_value_expression = dictionary_default_value_expression(context, *member.type, *member.default_value);
+        auto default_value_expression = cpp_default_expression(context, *member.type, member.default_value, member.extended_attributes);
         if (default_value_expression == "{}"sv)
             return " {}"sv;
 
         return ByteString::formatted(" {{ {} }}", default_value_expression);
     }
 
-    if (is<UnionType>(*member.type) && !member_cpp_type.starts_with("Optional<"sv))
-        return ByteString::formatted(" {{ {} }}", dictionary_default_constructed_value_expression(context, *member.type));
+    if (is<UnionType>(*member.type) && !member_cpp_type.is_optional_presence)
+        return ByteString::formatted(" {{ {} }}", cpp_default_expression(context, *member.type, {}, member.extended_attributes));
 
     return " {}"sv;
 }
@@ -3816,7 +3802,7 @@ static void generate_dictionary_struct(Context const& context, ByteString const&
 
     for (auto const& member : members) {
         auto member_generator = generator.fork();
-        member_generator.set("member.type", dictionary_member_cpp_type(context, member));
+        member_generator.set("member.type", cpp_type_for_dictionary_member(context, member).name);
         member_generator.set("member.name", make_input_acceptable_cpp(member.name.to_snakecase()));
         member_generator.set("member.initializer", dictionary_member_initializer(context, member));
         member_generator.append("    @member.type@ @member.name@@member.initializer@;\n");

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.h
@@ -20,8 +20,6 @@ namespace IDL {
 void generate_header(Module const&, StringBuilder&);
 void generate_implementation(Module const&, StringBuilder&);
 
-CppType idl_type_name_to_cpp_type(Type const& type, Context const& context, Optional<HashMap<ByteString, ByteString> const&> extended_attributes = {});
-
 extern Vector<StringView> g_header_search_paths;
 
 }

--- a/Services/WebWorker/WorkerHost.cpp
+++ b/Services/WebWorker/WorkerHost.cpp
@@ -6,6 +6,7 @@
 
 #include <LibIPC/File.h>
 #include <LibJS/Runtime/ConsoleObject.h>
+#include <LibWeb/Bindings/MessageEvent.h>
 #include <LibWeb/Fetch/Enums.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
@@ -275,10 +276,10 @@ void WorkerHost::run(GC::Ref<Web::Page> page, Web::HTML::TransferDataEncoder mes
                 auto& vm = realm.vm();
                 Web::HTML::TemporaryExecutionContext const context(realm);
 
-                Web::Bindings::MessageEventInit event_init {};
+                Web::Bindings::MessageEventInit event_init;
                 event_init.data = GC::Ref { vm.empty_string() };
-                event_init.ports = { inside_port };
                 event_init.source = Web::HTML::NullableMessageEventSource { inside_port };
+                event_init.ports.append(inside_port);
 
                 auto message_event = Web::HTML::MessageEvent::create(realm, Web::HTML::EventNames::connect, event_init);
                 worker_global_scope->dispatch_event(message_event);


### PR DESCRIPTION
Represent WebIDL C++ types with a single CppType model that tracks
nullability, optional presence, and contained storage.

GC-like values now use GC::Ref/GC::Ptr directly, while containers choose
"plain", "Root", or "Conservative" container types depending on what
they contain. For example, sequence<Element> becomes a RootVector of
GC::Ref values, while sequence<SomeDictionary> becomes a
ConservativeVector only when the dictionary contains GC-like values.
This moves the generated bindings away from wrapping GC values in
GC::Root by default.

This has broad fallout as the types passed to interfaces for GC
objects changes almost fully across the board.