### PR TITLE
LibWeb+WebContent: Route compositor through in-process IPC

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
     SharedImage.cpp
     SharedImageBuffer.cpp
     ShareableBitmap.cpp
+    ShapeFeature.cpp
     Size.cpp
     SkiaBackendContext.cpp
     SkiaUtils.cpp

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     Font/WOFF2/Loader.cpp
     FontCascadeList.cpp
     GradientPainting.cpp
+    Matrix4x4.cpp
     ImageFormats/AVIFLoader.cpp
     ImageFormats/BMPLoader.cpp
     ImageFormats/BMPWriter.cpp

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     Font/Font.cpp
     Font/FontDatabase.cpp
     Font/FontSupport.cpp
+    Font/FontVariationSettings.cpp
     Font/PathFontProvider.cpp
     Font/Typeface.cpp
     Font/TypefaceSkia.cpp

--- a/Libraries/LibGfx/CornerRadii.cpp
+++ b/Libraries/LibGfx/CornerRadii.cpp
@@ -7,6 +7,8 @@
 
 #include <AK/Math.h>
 #include <LibGfx/CornerRadii.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 namespace Gfx {
 
@@ -41,6 +43,48 @@ void CornerRadii::adjust_corners_for_spread_distance(int spread_distance)
     add_spread_distance_to_border_radius(bottom_right.vertical_radius, spread_distance);
     add_spread_distance_to_border_radius(bottom_left.horizontal_radius, spread_distance);
     add_spread_distance_to_border_radius(bottom_left.vertical_radius, spread_distance);
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CornerRadius const& radius)
+{
+    TRY(encoder.encode(radius.horizontal_radius));
+    TRY(encoder.encode(radius.vertical_radius));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CornerRadius> decode(Decoder& decoder)
+{
+    return Gfx::CornerRadius {
+        .horizontal_radius = TRY(decoder.decode<int>()),
+        .vertical_radius = TRY(decoder.decode<int>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::CornerRadii const& radii)
+{
+    TRY(encoder.encode(radii.top_left));
+    TRY(encoder.encode(radii.top_right));
+    TRY(encoder.encode(radii.bottom_right));
+    TRY(encoder.encode(radii.bottom_left));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::CornerRadii> decode(Decoder& decoder)
+{
+    return Gfx::CornerRadii {
+        .top_left = TRY(decoder.decode<Gfx::CornerRadius>()),
+        .top_right = TRY(decoder.decode<Gfx::CornerRadius>()),
+        .bottom_right = TRY(decoder.decode<Gfx::CornerRadius>()),
+        .bottom_left = TRY(decoder.decode<Gfx::CornerRadius>()),
+    };
 }
 
 }

--- a/Libraries/LibGfx/CornerRadii.h
+++ b/Libraries/LibGfx/CornerRadii.h
@@ -9,6 +9,7 @@
 
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -88,5 +89,21 @@ struct CornerRadii {
         return true;
     }
 };
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CornerRadius const&);
+
+template<>
+ErrorOr<Gfx::CornerRadius> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::CornerRadii const&);
+
+template<>
+ErrorOr<Gfx::CornerRadii> decode(Decoder&);
 
 }

--- a/Libraries/LibGfx/Filter.cpp
+++ b/Libraries/LibGfx/Filter.cpp
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
 #include <AK/MemoryStream.h>
 #include <AK/NumericLimits.h>
+#include <LibGfx/ColorSpace.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/Filter.h>
 #include <LibGfx/FilterImpl.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 namespace Gfx {
 
@@ -585,6 +590,66 @@ Filter deserialize_filter(ReadonlyBytes bytes, Function<Gfx::DecodedImageFrame(u
     auto filter = decode_filter(stream, decode_image);
     VERIFY(stream.is_eof());
     return filter;
+}
+
+}
+
+namespace IPC {
+
+static ErrorOr<void> encode_decoded_image_frame(Encoder& encoder, u64 id, Gfx::DecodedImageFrame const& frame)
+{
+    auto bitmap = frame.bitmap().to_shareable_bitmap();
+    if (!bitmap.is_valid())
+        return Error::from_string_literal("IPC encode: failed to create shareable bitmap for filter image");
+    TRY(encoder.encode(id));
+    TRY(encoder.encode(bitmap));
+    TRY(encoder.encode(frame.color_space()));
+    return {};
+}
+
+static ErrorOr<Gfx::DecodedImageFrame> decode_decoded_image_frame(Decoder& decoder)
+{
+    auto bitmap = TRY(decoder.decode<Gfx::ShareableBitmap>());
+    if (!bitmap.is_valid() || !bitmap.bitmap())
+        return Error::from_string_literal("IPC decode: invalid filter image bitmap");
+    auto color_space = TRY(decoder.decode<Gfx::ColorSpace>());
+    return Gfx::DecodedImageFrame { *bitmap.bitmap(), move(color_space) };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::Filter const& filter)
+{
+    HashMap<u64, Gfx::DecodedImageFrame> images;
+    auto filter_data = Gfx::serialize_filter(filter, [&](Gfx::DecodedImageFrame const& frame) {
+        images.ensure(frame.id(), [&] { return frame; });
+        return frame.id();
+    });
+
+    TRY(encoder.encode(filter_data));
+    TRY(encoder.encode_size(images.size()));
+    for (auto const& image : images)
+        TRY(encode_decoded_image_frame(encoder, image.key, image.value));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::Filter> decode(Decoder& decoder)
+{
+    auto filter_data = TRY(decoder.decode<ByteBuffer>());
+    auto image_count = TRY(decoder.decode_size());
+    HashMap<u64, Gfx::DecodedImageFrame> images;
+    TRY(images.try_ensure_capacity(image_count));
+    for (size_t i = 0; i < image_count; ++i) {
+        auto id = TRY(decoder.decode<u64>());
+        auto frame = TRY(decode_decoded_image_frame(decoder));
+        TRY(images.try_set(id, move(frame)));
+    }
+
+    return Gfx::deserialize_filter(filter_data.bytes(), [&](u64 image_id) {
+        auto image = images.get(image_id);
+        VERIFY(image.has_value());
+        return image.value();
+    });
 }
 
 }

--- a/Libraries/LibGfx/Filter.h
+++ b/Libraries/LibGfx/Filter.h
@@ -17,6 +17,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/ScalingMode.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -81,5 +82,15 @@ private:
 
 ByteBuffer serialize_filter(Filter const&, Function<u64(Gfx::DecodedImageFrame const&)> const& encode_image);
 Filter deserialize_filter(ReadonlyBytes, Function<Gfx::DecodedImageFrame(u64)> const& decode_image);
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::Filter const&);
+
+template<>
+ErrorOr<Gfx::Filter> decode(Decoder&);
 
 }

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -75,6 +75,7 @@ public:
 
     Font const& bold_variant() const;
     hb_font_t* harfbuzz_font() const;
+    FontVariationSettings const& variation_settings() const { return m_font_variation_settings; }
     ShapeFeatures const& features() const { return m_shape_features; }
 
     struct ShapingCache {

--- a/Libraries/LibGfx/Font/FontVariationSettings.cpp
+++ b/Libraries/LibGfx/Font/FontVariationSettings.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Font/FontVariationSettings.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::FontVariationSettings const& settings)
+{
+    TRY(encoder.encode_size(settings.axes.size()));
+    for (auto const& axis : settings.axes) {
+        TRY(encoder.encode(axis.key.to_u32()));
+        TRY(encoder.encode(axis.value));
+    }
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::FontVariationSettings> decode(Decoder& decoder)
+{
+    auto axis_count = TRY(decoder.decode_size());
+    Gfx::FontVariationSettings settings;
+    TRY(settings.axes.try_ensure_capacity(axis_count));
+    for (size_t i = 0; i < axis_count; ++i) {
+        auto tag = Gfx::FourCC::from_u32(TRY(decoder.decode<u32>()));
+        auto value = TRY(decoder.decode<float>());
+        TRY(settings.axes.try_set(tag, value));
+    }
+    return settings;
+}
+
+}

--- a/Libraries/LibGfx/Font/FontVariationSettings.h
+++ b/Libraries/LibGfx/Font/FontVariationSettings.h
@@ -10,6 +10,7 @@
 #include <AK/QuickSort.h>
 #include <AK/Vector.h>
 #include <LibGfx/FourCC.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -70,5 +71,15 @@ struct FontVariationSettings {
         return list;
     }
 };
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::FontVariationSettings const&);
+
+template<>
+ErrorOr<Gfx::FontVariationSettings> decode(Decoder&);
 
 }

--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -10,6 +10,8 @@
 #include <LibGfx/Font/FontVariationSettings.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/TypefaceSkia.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 namespace Gfx {
 
@@ -84,20 +86,21 @@ hb_face_t* Typeface::harfbuzz_typeface() const
     return m_harfbuzz_face;
 }
 
-ReadonlyBytes Typeface::font_data_bytes() const
+void Typeface::encode_font_data_for_ipc(IPC::Encoder& encoder) const
 {
-    if (!m_font_data.has_value())
-        return buffer();
-    return m_font_data->visit(
-        [](Core::AnonymousBuffer const& anonymous_buffer) { return anonymous_buffer.bytes(); },
-        [](NonnullRefPtr<Core::Resource const> const& resource) { return resource->data(); });
-}
+    VERIFY(m_font_data.has_value());
 
-Optional<Core::AnonymousBuffer> Typeface::anonymous_font_data() const
-{
-    if (!m_font_data.has_value() || !m_font_data->has<Core::AnonymousBuffer>())
-        return {};
-    return m_font_data->get<Core::AnonymousBuffer>();
+    m_font_data->visit(
+        [&](Core::AnonymousBuffer const& anonymous_buffer) {
+            MUST(encoder.encode(FontDataFormat::RawFontData));
+            MUST(encoder.encode(anonymous_buffer));
+            MUST(encoder.encode(ttc_index()));
+        },
+        [&](NonnullRefPtr<Core::Resource const> const& resource) {
+            MUST(encoder.encode(FontDataFormat::ResourceFontData));
+            MUST(encoder.encode(resource->uri()));
+            MUST(encoder.encode(ttc_index()));
+        });
 }
 
 void Typeface::set_anonymous_font_data(Core::AnonymousBuffer anonymous_buffer)
@@ -113,6 +116,62 @@ void Typeface::set_resource_font_data(Core::Resource const& resource)
 void Typeface::copy_font_data_from(Typeface const& other)
 {
     m_font_data = other.m_font_data;
+}
+
+}
+
+namespace IPC {
+
+static NonnullRefPtr<Gfx::Typeface const> match_system_typeface(Optional<Gfx::SystemUIFontKind> system_ui_font_kind, String family_name, u16 weight, u16 width, u8 slope)
+{
+    if (system_ui_font_kind.has_value()) {
+        auto typeface = MUST(Gfx::TypefaceSkia::match_system_ui(system_ui_font_kind.value(), 0, weight, width, slope));
+        if (typeface)
+            return typeface.release_nonnull();
+    }
+
+    auto typeface = MUST(Gfx::TypefaceSkia::match_family_style(family_name.bytes_as_string_view(), weight, width, slope));
+    VERIFY(typeface);
+    return typeface.release_nonnull();
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::Typeface const& typeface)
+{
+    typeface.encode_font_data_for_ipc(encoder);
+    return {};
+}
+
+template<>
+ErrorOr<NonnullRefPtr<Gfx::Typeface const>> decode(Decoder& decoder)
+{
+    auto format = TRY(decoder.decode<Gfx::Typeface::FontDataFormat>());
+
+    switch (format) {
+    case Gfx::Typeface::FontDataFormat::RawFontData: {
+        auto font_data = TRY(decoder.decode<Core::AnonymousBuffer>());
+        auto ttc_index = TRY(decoder.decode<u32>());
+        if (!font_data.is_valid())
+            return Error::from_string_literal("Typeface IPC data contained invalid font data");
+        return TRY(Gfx::Typeface::try_load_from_anonymous_buffer(move(font_data), ttc_index));
+    }
+    case Gfx::Typeface::FontDataFormat::ResourceFontData: {
+        auto resource_uri = TRY(decoder.decode<String>());
+        auto ttc_index = TRY(decoder.decode<u32>());
+        auto resource = TRY(Core::Resource::load_from_uri(resource_uri.bytes_as_string_view()));
+        return TRY(Gfx::Typeface::try_load_from_resource(*resource, ttc_index));
+    }
+    case Gfx::Typeface::FontDataFormat::SystemFont: {
+        auto system_ui_font_kind = TRY(decoder.decode<Optional<Gfx::SystemUIFontKind>>());
+        auto family_name = TRY(decoder.decode<String>());
+        auto weight = TRY(decoder.decode<u16>());
+        auto width = TRY(decoder.decode<u16>());
+        auto slope = TRY(decoder.decode<u8>());
+        return match_system_typeface(system_ui_font_kind, move(family_name), weight, width, slope);
+    }
+    }
+
+    return Error::from_string_literal("Typeface IPC data contained invalid font data format");
 }
 
 }

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -17,6 +17,7 @@
 #include <LibGfx/Font/FontVariationSettings.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/ShapeFeature.h>
+#include <LibIPC/Forward.h>
 
 #define POINTS_PER_INCH 72.0f
 #define DEFAULT_DPI 96
@@ -69,9 +70,6 @@ public:
     [[nodiscard]] NonnullRefPtr<Font> font(float point_size, FontVariationSettings const& variations = {}, Gfx::ShapeFeatures const& shape_features = {}) const;
 
     hb_face_t* harfbuzz_typeface() const;
-    ReadonlyBytes font_data_bytes() const;
-    Optional<Core::AnonymousBuffer> anonymous_font_data() const;
-    u32 font_data_ttc_index() const { return ttc_index(); }
 
     template<typename T>
     bool fast_is() const = delete;
@@ -79,16 +77,30 @@ public:
     virtual bool is_skia() const { return false; }
 
 protected:
+    enum class FontDataFormat : u8 {
+        RawFontData,
+        ResourceFontData,
+        SystemFont,
+    };
+
     Typeface();
 
     virtual ReadonlyBytes buffer() const = 0;
     virtual u32 ttc_index() const = 0;
+    virtual void encode_font_data_for_ipc(IPC::Encoder&) const;
 
     void set_anonymous_font_data(Core::AnonymousBuffer);
     void set_resource_font_data(Core::Resource const&);
     void copy_font_data_from(Typeface const&);
+    bool has_font_data_backing() const { return m_font_data.has_value(); }
 
 private:
+    template<typename T>
+    friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);
+
+    template<typename T>
+    friend ErrorOr<T> IPC::decode(IPC::Decoder&);
+
     using FontDataBacking = Variant<Core::AnonymousBuffer, NonnullRefPtr<Core::Resource const>>;
     Optional<FontDataBacking> m_font_data;
 
@@ -106,3 +118,13 @@ struct AK::Traits<Gfx::FontCacheKey> : public AK::DefaultTraits<Gfx::FontCacheKe
         return key.hash();
     }
 };
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::Typeface const&);
+
+template<>
+ErrorOr<NonnullRefPtr<Gfx::Typeface const>> decode(Decoder&);
+
+}

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -5,14 +5,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteString.h>
 #include <AK/LsanSuppressions.h>
-#include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/TypefaceSkia.h>
+#include <LibIPC/Encoder.h>
 
 #include <core/SkData.h>
 #include <core/SkFontMgr.h>
 #include <core/SkStream.h>
+#include <core/SkString.h>
 #include <core/SkTypeface.h>
 #if defined(AK_OS_ANDROID)
 #    include <ports/SkFontMgr_android.h>
@@ -34,14 +36,16 @@ namespace Gfx {
 static sk_sp<SkFontMgr> s_font_manager;
 
 struct TypefaceSkia::Impl {
-    Impl(sk_sp<SkTypeface> skia_typeface, std::unique_ptr<SkStreamAsset> stream = {})
+    Impl(sk_sp<SkTypeface> skia_typeface, std::unique_ptr<SkStreamAsset> stream = {}, Optional<SystemUIFontKind> system_ui_font_kind = {})
         : skia_typeface(move(skia_typeface))
         , stream(move(stream))
+        , system_ui_font_kind(move(system_ui_font_kind))
     {
     }
 
     sk_sp<SkTypeface> skia_typeface;
     std::unique_ptr<SkStreamAsset> stream;
+    Optional<SystemUIFontKind> system_ui_font_kind;
 };
 
 static SkFontMgr& font_manager()
@@ -66,6 +70,18 @@ static SkFontMgr& font_manager()
     return *s_font_manager;
 }
 
+static std::unique_ptr<SkMemoryStream> copy_stream_to_memory_stream(SkStreamAsset& stream)
+{
+    auto stream_copy = stream.duplicate();
+    VERIFY(stream_copy);
+
+    auto data = SkData::MakeFromStream(stream_copy.get(), stream_copy->getLength());
+    VERIFY(data);
+    VERIFY(data->size() == stream.getLength());
+
+    return std::make_unique<SkMemoryStream>(move(data));
+}
+
 static SkFontStyle::Slant slope_to_skia_slant(u8 slope)
 {
     switch (slope) {
@@ -78,7 +94,11 @@ static SkFontStyle::Slant slope_to_skia_slant(u8 slope)
     }
 }
 
-ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<SkTypeface> skia_typeface)
+#ifdef AK_OS_MACOS
+static CTFontRef create_system_ui_font(SystemUIFontKind, float point_size, u8 slope);
+#endif
+
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<SkTypeface> skia_typeface, Optional<SystemUIFontKind> system_ui_font_kind)
 {
     if (!skia_typeface)
         return RefPtr<TypefaceSkia> {};
@@ -91,22 +111,20 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::typeface_from_skia_typeface(sk_sp<Sk
         // NB: Safe to reference without copying because we hold on to the stream.
         ReadonlyBytes bytes { static_cast<u8 const*>(stream->getMemoryBase()), stream->getLength() };
         return adopt_ref(*new TypefaceSkia {
-            make<TypefaceSkia::Impl>(skia_typeface, std::move(stream)),
+            make<TypefaceSkia::Impl>(skia_typeface, std::move(stream), system_ui_font_kind),
             bytes,
             ttc_index });
     }
 
-    auto data = skia_typeface->serialize(SkTypeface::SerializeBehavior::kDoIncludeData);
-    if (!data)
+    if (!stream)
         return Error::from_string_literal("Failed to get font data from typeface");
 
-    auto anonymous_buffer = TRY(Core::AnonymousBuffer::create_with_size(data->size()));
-    if (data->size() > 0)
-        memcpy(anonymous_buffer.data<void>(), data->data(), data->size());
-
-    auto result = TRY(TypefaceSkia::load_from_buffer(anonymous_buffer.bytes(), ttc_index));
-    result->set_anonymous_font_data(move(anonymous_buffer));
-    return result;
+    auto memory_stream = copy_stream_to_memory_stream(*stream);
+    auto bytes = ReadonlyBytes { static_cast<u8 const*>(memory_stream->getMemoryBase()), memory_stream->getLength() };
+    return adopt_ref(*new TypefaceSkia {
+        make<TypefaceSkia::Impl>(skia_typeface, move(memory_stream), system_ui_font_kind),
+        bytes,
+        ttc_index });
 }
 
 ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::ReadonlyBytes buffer, u32 ttc_index)
@@ -127,6 +145,23 @@ ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::Readonly
     }
 
     return adopt_ref(*new TypefaceSkia { make<TypefaceSkia::Impl>(skia_typeface), buffer, ttc_index });
+}
+
+void TypefaceSkia::encode_font_data_for_ipc(IPC::Encoder& encoder) const
+{
+    if (has_font_data_backing()) {
+        Typeface::encode_font_data_for_ipc(encoder);
+        return;
+    }
+
+    auto family_name = family().to_string();
+
+    MUST(encoder.encode(FontDataFormat::SystemFont));
+    MUST(encoder.encode(impl().system_ui_font_kind));
+    MUST(encoder.encode(family_name));
+    MUST(encoder.encode(weight()));
+    MUST(encoder.encode(width()));
+    MUST(encoder.encode(slope()));
 }
 
 #ifdef AK_OS_MACOS
@@ -204,7 +239,7 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_system_ui(SystemUIFontKind kin
         return RefPtr<TypefaceSkia> {};
 
     auto skia_typeface = SkMakeTypefaceFromCTFont(ct_font);
-    auto typeface = typeface_from_skia_typeface(move(skia_typeface));
+    auto typeface = typeface_from_skia_typeface(move(skia_typeface), kind);
     CFRelease(ct_font);
     return typeface;
 #else
@@ -215,6 +250,12 @@ ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_system_ui(SystemUIFontKind kin
     (void)slope;
     return RefPtr<TypefaceSkia> {};
 #endif
+}
+
+ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::match_family_style(StringView family_name, u16 weight, u16 width, u8 slope)
+{
+    auto skia_typeface = font_manager().matchFamilyStyle(ByteString(family_name).characters(), SkFontStyle { weight, width, slope_to_skia_slant(slope) });
+    return typeface_from_skia_typeface(move(skia_typeface));
 }
 
 ErrorOr<RefPtr<TypefaceSkia>> TypefaceSkia::find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope)
@@ -273,9 +314,19 @@ RefPtr<TypefaceSkia const> TypefaceSkia::clone_with_variations(Vector<FontVariat
     if (!skia_typeface)
         return {};
 
-    auto typeface = adopt_ref(*new TypefaceSkia { make<TypefaceSkia::Impl>(skia_typeface), m_buffer, m_ttc_index });
-    typeface->copy_font_data_from(*this);
-    return typeface;
+    if (has_font_data_backing()) {
+        auto typeface = adopt_ref(*new TypefaceSkia {
+            make<TypefaceSkia::Impl>(skia_typeface, std::unique_ptr<SkStreamAsset> {}, impl().system_ui_font_kind),
+            m_buffer,
+            m_ttc_index });
+        typeface->copy_font_data_from(*this);
+        return typeface;
+    }
+
+    auto typeface_or_error = typeface_from_skia_typeface(move(skia_typeface), impl().system_ui_font_kind);
+    if (typeface_or_error.is_error())
+        return {};
+    return typeface_or_error.release_value();
 }
 
 SkTypeface const* TypefaceSkia::sk_typeface() const

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -26,6 +26,7 @@ class TypefaceSkia : public Gfx::Typeface {
 public:
     static ErrorOr<NonnullRefPtr<TypefaceSkia>> load_from_buffer(ReadonlyBytes, u32 ttc_index = 0);
     static ErrorOr<RefPtr<TypefaceSkia>> match_system_ui(SystemUIFontKind, float point_size, u16 weight, double width, u8 slope);
+    static ErrorOr<RefPtr<TypefaceSkia>> match_family_style(StringView family_name, u16 weight, u16 width, u8 slope);
     static ErrorOr<RefPtr<TypefaceSkia>> find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope);
     static Optional<FlyString> resolve_generic_family(StringView family_name, u16 weight, u8 slope);
 
@@ -44,12 +45,15 @@ public:
 
     SkTypeface const* sk_typeface() const;
 
+protected:
+    virtual void encode_font_data_for_ipc(IPC::Encoder&) const override;
+
 private:
     struct Impl;
     Impl& impl() const { return *m_impl; }
     NonnullOwnPtr<Impl> m_impl;
 
-    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_skia_typeface(sk_sp<SkTypeface>);
+    static ErrorOr<RefPtr<TypefaceSkia>> typeface_from_skia_typeface(sk_sp<SkTypeface>, Optional<SystemUIFontKind> = {});
 
     TypefaceSkia(NonnullOwnPtr<Impl>, ReadonlyBytes, u32 ttc_index = 0);
 

--- a/Libraries/LibGfx/Matrix4x4.cpp
+++ b/Libraries/LibGfx/Matrix4x4.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Matrix4x4.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::FloatMatrix4x4 const& matrix)
+{
+    static constexpr size_t element_count = Gfx::FloatMatrix4x4::Size * Gfx::FloatMatrix4x4::Size;
+    TRY(encoder.append(reinterpret_cast<u8 const*>(matrix.elements()), element_count * sizeof(float)));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::FloatMatrix4x4> decode(Decoder& decoder)
+{
+    static constexpr size_t element_count = Gfx::FloatMatrix4x4::Size * Gfx::FloatMatrix4x4::Size;
+    Gfx::FloatMatrix4x4 matrix;
+    TRY(decoder.decode_into(Bytes { reinterpret_cast<u8*>(matrix.elements()), element_count * sizeof(float) }));
+    return matrix;
+}
+
+}

--- a/Libraries/LibGfx/Matrix4x4.h
+++ b/Libraries/LibGfx/Matrix4x4.h
@@ -11,6 +11,7 @@
 #include <LibGfx/Matrix.h>
 #include <LibGfx/Vector3.h>
 #include <LibGfx/Vector4.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -96,3 +97,13 @@ typedef Matrix4x4<double> DoubleMatrix4x4;
 using Gfx::DoubleMatrix4x4;
 using Gfx::FloatMatrix4x4;
 using Gfx::Matrix4x4;
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::FloatMatrix4x4 const&);
+
+template<>
+ErrorOr<Gfx::FloatMatrix4x4> decode(Decoder&);
+
+}

--- a/Libraries/LibGfx/Path.cpp
+++ b/Libraries/LibGfx/Path.cpp
@@ -6,6 +6,8 @@
 
 #include <LibGfx/Path.h>
 #include <LibGfx/PathSkia.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 namespace Gfx {
 
@@ -22,5 +24,22 @@ NonnullOwnPtr<Gfx::PathImpl> PathImpl::create()
 }
 
 PathImpl::~PathImpl() = default;
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::Path const& path)
+{
+    return encoder.encode(path.serialize_to_bytes());
+}
+
+template<>
+ErrorOr<Gfx::Path> decode(Decoder& decoder)
+{
+    auto path_data = TRY(decoder.decode<Vector<u8>>());
+    return Gfx::Path::from_serialized_bytes(path_data);
+}
 
 }

--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -15,6 +15,7 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/WindingRule.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -138,5 +139,15 @@ private:
 
     NonnullOwnPtr<PathImpl> m_impl { PathImpl::create() };
 };
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::Path const&);
+
+template<>
+ErrorOr<Gfx::Path> decode(Decoder&);
 
 }

--- a/Libraries/LibGfx/ShapeFeature.cpp
+++ b/Libraries/LibGfx/ShapeFeature.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ShapeFeature.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::ShapeFeature const& feature)
+{
+    TRY(encoder.append(reinterpret_cast<u8 const*>(feature.tag), sizeof(feature.tag)));
+    TRY(encoder.encode(feature.value));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::ShapeFeature> decode(Decoder& decoder)
+{
+    Gfx::ShapeFeature feature {};
+    TRY(decoder.decode_into(Bytes { reinterpret_cast<u8*>(feature.tag), sizeof(feature.tag) }));
+    feature.value = TRY(decoder.decode<u32>());
+    return feature;
+}
+
+}

--- a/Libraries/LibGfx/ShapeFeature.h
+++ b/Libraries/LibGfx/ShapeFeature.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -19,6 +20,16 @@ struct ShapeFeature {
 };
 
 using ShapeFeatures = Vector<ShapeFeature, 4>;
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::ShapeFeature const&);
+
+template<>
+ErrorOr<Gfx::ShapeFeature> decode(Decoder&);
 
 }
 

--- a/Libraries/LibGfx/YUVData.cpp
+++ b/Libraries/LibGfx/YUVData.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Checked.h>
 #include <AK/Time.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/SkiaBackendContext.h>
@@ -35,19 +36,49 @@ struct YUVDataImpl {
 
 }
 
+static ErrorOr<size_t> checked_plane_size(Gfx::IntSize size, size_t component_size)
+{
+    Checked<size_t> plane_size = static_cast<size_t>(size.width());
+    plane_size *= static_cast<size_t>(size.height());
+    plane_size *= component_size;
+    if (plane_size.has_overflow())
+        return Error::from_string_literal("YUVData plane size overflow");
+    return plane_size.value();
+}
+
+ErrorOr<YUVData::PlaneSizes> YUVData::plane_sizes(IntSize size, u8 bit_depth, Media::Subsampling subsampling)
+{
+    if (size.is_empty())
+        return Error::from_string_literal("YUVData size is empty");
+    if (bit_depth == 0 || bit_depth > 16)
+        return Error::from_string_literal("Invalid YUVData bit depth");
+
+    auto component_size = bit_depth <= 8 ? 1 : 2;
+    auto y_buffer_size = TRY(checked_plane_size(size, component_size));
+    auto uv_size = subsampling.subsampled_size(size);
+    auto uv_buffer_size = TRY(checked_plane_size(uv_size, component_size));
+
+    Checked<size_t> total_size = y_buffer_size;
+    total_size += uv_buffer_size;
+    total_size += uv_buffer_size;
+    if (total_size.has_overflow())
+        return Error::from_string_literal("YUVData total size overflow");
+
+    return PlaneSizes {
+        .y = y_buffer_size,
+        .u = uv_buffer_size,
+        .v = uv_buffer_size,
+        .total = total_size.value(),
+    };
+}
+
 ErrorOr<NonnullOwnPtr<YUVData>> YUVData::create(IntSize size, u8 bit_depth, Media::Subsampling subsampling, Media::CodingIndependentCodePoints cicp)
 {
-    VERIFY(bit_depth <= 16);
-    auto component_size = bit_depth <= 8 ? 1 : 2;
+    auto sizes = TRY(plane_sizes(size, bit_depth, subsampling));
 
-    auto y_buffer_size = static_cast<size_t>(size.width()) * size.height() * component_size;
-
-    auto uv_size = subsampling.subsampled_size(size);
-    auto uv_buffer_size = static_cast<size_t>(uv_size.width()) * uv_size.height() * component_size;
-
-    auto y_buffer = TRY(FixedArray<u8>::create(y_buffer_size));
-    auto u_buffer = TRY(FixedArray<u8>::create(uv_buffer_size));
-    auto v_buffer = TRY(FixedArray<u8>::create(uv_buffer_size));
+    auto y_buffer = TRY(FixedArray<u8>::create(sizes.y));
+    auto u_buffer = TRY(FixedArray<u8>::create(sizes.u));
+    auto v_buffer = TRY(FixedArray<u8>::create(sizes.v));
 
     auto impl = TRY(try_make<Details::YUVDataImpl>(Details::YUVDataImpl {
         .size = size,
@@ -60,6 +91,19 @@ ErrorOr<NonnullOwnPtr<YUVData>> YUVData::create(IntSize size, u8 bit_depth, Medi
     }));
 
     return adopt_nonnull_own_or_enomem(new (nothrow) YUVData(move(impl)));
+}
+
+ErrorOr<NonnullOwnPtr<YUVData>> YUVData::create_from_data(IntSize size, u8 bit_depth, Media::Subsampling subsampling, Media::CodingIndependentCodePoints cicp, ReadonlyBytes y_data, ReadonlyBytes u_data, ReadonlyBytes v_data)
+{
+    auto sizes = TRY(plane_sizes(size, bit_depth, subsampling));
+    if (y_data.size() != sizes.y || u_data.size() != sizes.u || v_data.size() != sizes.v)
+        return Error::from_string_literal("YUVData plane data size mismatch");
+
+    auto yuv_data = TRY(create(size, bit_depth, subsampling, cicp));
+    y_data.copy_to(yuv_data->y_data());
+    u_data.copy_to(yuv_data->u_data());
+    v_data.copy_to(yuv_data->v_data());
+    return yuv_data;
 }
 
 YUVData::YUVData(NonnullOwnPtr<Details::YUVDataImpl> impl)
@@ -100,6 +144,21 @@ Bytes YUVData::u_data()
 }
 
 Bytes YUVData::v_data()
+{
+    return m_impl->v_buffer.span();
+}
+
+ReadonlyBytes YUVData::y_data() const
+{
+    return m_impl->y_buffer.span();
+}
+
+ReadonlyBytes YUVData::u_data() const
+{
+    return m_impl->u_buffer.span();
+}
+
+ReadonlyBytes YUVData::v_data() const
 {
     return m_impl->v_buffer.span();
 }

--- a/Libraries/LibGfx/YUVData.h
+++ b/Libraries/LibGfx/YUVData.h
@@ -30,7 +30,16 @@ struct YUVDataImpl;
 // Not ref-counted - owned directly by decoded video frame objects via NonnullOwnPtr.
 class YUVData final {
 public:
+    struct PlaneSizes {
+        size_t y;
+        size_t u;
+        size_t v;
+        size_t total;
+    };
+
+    static ErrorOr<PlaneSizes> plane_sizes(IntSize size, u8 bit_depth, Media::Subsampling);
     static ErrorOr<NonnullOwnPtr<YUVData>> create(IntSize size, u8 bit_depth, Media::Subsampling, Media::CodingIndependentCodePoints);
+    static ErrorOr<NonnullOwnPtr<YUVData>> create_from_data(IntSize size, u8 bit_depth, Media::Subsampling, Media::CodingIndependentCodePoints, ReadonlyBytes y_data, ReadonlyBytes u_data, ReadonlyBytes v_data);
 
     ~YUVData();
 
@@ -43,6 +52,9 @@ public:
     Bytes y_data();
     Bytes u_data();
     Bytes v_data();
+    ReadonlyBytes y_data() const;
+    ReadonlyBytes u_data() const;
+    ReadonlyBytes v_data() const;
 
     ErrorOr<NonnullRefPtr<Bitmap>> to_bitmap() const;
 

--- a/Libraries/LibIPC/Concepts.h
+++ b/Libraries/LibIPC/Concepts.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/DistinctNumeric.h>
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
@@ -63,5 +64,8 @@ concept Optional = SpecializationOf<T, AK::Optional>;
 
 template<typename T>
 concept Variant = SpecializationOf<T, AK::Variant>;
+
+template<typename T>
+concept DistinctNumeric = SpecializationOf<T, AK::DistinctNumeric>;
 
 }

--- a/Libraries/LibIPC/Decoder.h
+++ b/Libraries/LibIPC/Decoder.h
@@ -84,6 +84,12 @@ ErrorOr<T> decode(Decoder& decoder)
     return static_cast<T>(value);
 }
 
+template<Concepts::DistinctNumeric T>
+ErrorOr<T> decode(Decoder& decoder)
+{
+    return T { TRY(decoder.decode<typename T::Type>()) };
+}
+
 template<>
 ErrorOr<String> decode(Decoder&);
 

--- a/Libraries/LibIPC/Encoder.h
+++ b/Libraries/LibIPC/Encoder.h
@@ -18,7 +18,7 @@
 #include <LibIPC/File.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
-#include <LibURL/Forward.h>
+#include <LibURL/URL.h>
 
 namespace IPC {
 

--- a/Libraries/LibIPC/Encoder.h
+++ b/Libraries/LibIPC/Encoder.h
@@ -76,6 +76,12 @@ ErrorOr<void> encode(Encoder& encoder, T const& value)
     return encoder.encode(to_underlying(value));
 }
 
+template<Concepts::DistinctNumeric T>
+ErrorOr<void> encode(Encoder& encoder, T const& value)
+{
+    return encoder.encode(value.value());
+}
+
 template<>
 ErrorOr<void> encode(Encoder&, float const&);
 

--- a/Libraries/LibMedia/VideoFrame.cpp
+++ b/Libraries/LibMedia/VideoFrame.cpp
@@ -5,8 +5,13 @@
  */
 
 #include <LibGfx/YUVData.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 
 #include "VideoFrame.h"
+
+#include <LibCore/AnonymousBuffer.h>
+#include <LibMedia/Color/CodingIndependentCodePoints.h>
 
 namespace Media {
 
@@ -27,5 +32,114 @@ VideoFrame::VideoFrame(
 }
 
 VideoFrame::~VideoFrame() = default;
+
+}
+
+namespace IPC {
+
+static bool color_primaries_ipc_value_valid(Media::ColorPrimaries color_primaries)
+{
+    return color_primaries == Media::ColorPrimaries::Unspecified
+        || Media::color_primaries_valid(color_primaries);
+}
+
+static bool transfer_characteristics_ipc_value_valid(Media::TransferCharacteristics transfer_characteristics)
+{
+    return transfer_characteristics == Media::TransferCharacteristics::Unspecified
+        || Media::transfer_characteristics_valid(transfer_characteristics);
+}
+
+static bool matrix_coefficients_ipc_value_valid(Media::MatrixCoefficients matrix_coefficients)
+{
+    return matrix_coefficients == Media::MatrixCoefficients::Unspecified
+        || Media::matrix_coefficients_valid(matrix_coefficients);
+}
+
+static bool video_full_range_flag_ipc_value_valid(Media::VideoFullRangeFlag video_full_range_flag)
+{
+    return video_full_range_flag == Media::VideoFullRangeFlag::Unspecified
+        || Media::video_full_range_flag_valid(video_full_range_flag);
+}
+
+static ErrorOr<Core::AnonymousBuffer> encode_yuv_data(Gfx::YUVData const& yuv_data)
+{
+    auto sizes = TRY(Gfx::YUVData::plane_sizes(yuv_data.size(), yuv_data.bit_depth(), yuv_data.subsampling()));
+    auto buffer = TRY(Core::AnonymousBuffer::create_with_size(sizes.total));
+
+    auto bytes = Bytes { buffer.data<u8>(), buffer.size() };
+    yuv_data.y_data().copy_to(bytes.slice(0, sizes.y));
+    yuv_data.u_data().copy_to(bytes.slice(sizes.y, sizes.u));
+    yuv_data.v_data().copy_to(bytes.slice(sizes.y + sizes.u, sizes.v));
+    return buffer;
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Media::VideoFrame const& frame)
+{
+    auto const& yuv_data = frame.yuv_data();
+    auto yuv_data_buffer = TRY(encode_yuv_data(yuv_data));
+    TRY(encoder.encode(yuv_data_buffer));
+    TRY(encoder.encode(frame.color_space()));
+    TRY(encoder.encode(frame.timestamp()));
+    TRY(encoder.encode(frame.duration()));
+    TRY(encoder.encode(yuv_data.size()));
+    TRY(encoder.encode(yuv_data.bit_depth()));
+    TRY(encoder.encode(yuv_data.subsampling().x()));
+    TRY(encoder.encode(yuv_data.subsampling().y()));
+    TRY(encoder.encode(yuv_data.cicp().color_primaries()));
+    TRY(encoder.encode(yuv_data.cicp().transfer_characteristics()));
+    TRY(encoder.encode(yuv_data.cicp().matrix_coefficients()));
+    TRY(encoder.encode(yuv_data.cicp().video_full_range_flag()));
+    return {};
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, NonnullRefPtr<Media::VideoFrame const> const& frame)
+{
+    return encoder.encode(*frame);
+}
+
+template<>
+ErrorOr<NonnullRefPtr<Media::VideoFrame const>> decode(Decoder& decoder)
+{
+    auto yuv_data_buffer = TRY(decoder.decode<Core::AnonymousBuffer>());
+    if (!yuv_data_buffer.is_valid())
+        return Error::from_string_literal("IPC: VideoFrame contained invalid YUV data");
+
+    auto color_space = TRY(decoder.decode<Gfx::ColorSpace>());
+    auto timestamp = TRY(decoder.decode<AK::Duration>());
+    auto duration = TRY(decoder.decode<AK::Duration>());
+    auto size = TRY(decoder.decode<Gfx::IntSize>());
+    auto bit_depth = TRY(decoder.decode<u8>());
+    auto subsampling = Media::Subsampling {
+        TRY(decoder.decode<bool>()),
+        TRY(decoder.decode<bool>()),
+    };
+    auto cicp = Media::CodingIndependentCodePoints {
+        TRY(decoder.decode<Media::ColorPrimaries>()),
+        TRY(decoder.decode<Media::TransferCharacteristics>()),
+        TRY(decoder.decode<Media::MatrixCoefficients>()),
+        TRY(decoder.decode<Media::VideoFullRangeFlag>()),
+    };
+
+    if (!color_primaries_ipc_value_valid(cicp.color_primaries())
+        || !transfer_characteristics_ipc_value_valid(cicp.transfer_characteristics())
+        || !matrix_coefficients_ipc_value_valid(cicp.matrix_coefficients())
+        || !video_full_range_flag_ipc_value_valid(cicp.video_full_range_flag()))
+        return Error::from_string_literal("IPC: VideoFrame contained invalid CICP metadata");
+
+    auto sizes = TRY(Gfx::YUVData::plane_sizes(size, bit_depth, subsampling));
+    if (yuv_data_buffer.size() != sizes.total)
+        return Error::from_string_literal("IPC: VideoFrame contained invalid YUV data size");
+
+    auto bytes = yuv_data_buffer.bytes();
+    auto y_data = bytes.slice(0, sizes.y);
+    auto u_data = bytes.slice(sizes.y, sizes.u);
+    auto v_data = bytes.slice(sizes.y + sizes.u, sizes.v);
+
+    auto yuv_data = TRY(Gfx::YUVData::create_from_data(size, bit_depth, subsampling, cicp, y_data, u_data, v_data));
+    auto frame = TRY(try_make_ref_counted<Media::VideoFrame>(timestamp, duration, size.to_type<u32>(), bit_depth, move(color_space), move(yuv_data)));
+    return NonnullRefPtr<Media::VideoFrame const> { *frame };
+}
 
 }

--- a/Libraries/LibMedia/VideoFrame.h
+++ b/Libraries/LibMedia/VideoFrame.h
@@ -7,11 +7,14 @@
 #pragma once
 
 #include <AK/AtomicRefCounted.h>
+#include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/Time.h>
 #include <LibGfx/ColorSpace.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Size.h>
+#include <LibIPC/Forward.h>
 #include <LibMedia/Export.h>
 
 namespace Media {
@@ -48,5 +51,17 @@ private:
     Gfx::ColorSpace m_color_space;
     NonnullOwnPtr<Gfx::YUVData> m_yuv_data;
 };
+
+}
+
+namespace IPC {
+
+template<>
+MEDIA_API ErrorOr<void> encode(Encoder&, Media::VideoFrame const&);
+template<>
+MEDIA_API ErrorOr<void> encode(Encoder&, NonnullRefPtr<Media::VideoFrame const> const&);
+
+template<>
+MEDIA_API ErrorOr<NonnullRefPtr<Media::VideoFrame const>> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -863,6 +863,7 @@ set(SOURCES
     Painting/DisplayListPlayerSkia.cpp
     Painting/DisplayListRecorder.cpp
     Painting/DisplayListRecordingContext.cpp
+    Painting/DisplayListResourceTransaction.cpp
     Painting/DisplayListResourceStorage.cpp
     Painting/FieldSetPaintable.cpp
     Painting/GradientPainting.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -34,7 +34,9 @@ set(SOURCES
     Compositor/AsyncScrollingState.cpp
     Compositor/BackingStoreManager.cpp
     Compositor/CompositorContextState.cpp
+    Compositor/CompositorHost.cpp
     Compositor/CompositorThread.cpp
+    Compositor/Types.cpp
     Compression/CompressionStream.cpp
     Compression/DecompressionStream.cpp
     ContentSecurityPolicy/BlockingAlgorithms.cpp

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -90,6 +90,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/Compositor/BackingStoreManager.cpp
+++ b/Libraries/LibWeb/Compositor/BackingStoreManager.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibWeb/Compositor/BackingStoreManager.h>
-#include <LibWeb/Compositor/CompositorThread.h>
 
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SharedImageBuffer.h>

--- a/Libraries/LibWeb/Compositor/BackingStoreManager.h
+++ b/Libraries/LibWeb/Compositor/BackingStoreManager.h
@@ -13,11 +13,10 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/SharedImage.h>
 #include <LibGfx/Size.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Export.h>
 
 namespace Web::Compositor {
-
-enum class WindowResizingInProgress : u8;
 
 class WEB_API BackingStoreManager {
     AK_MAKE_NONCOPYABLE(BackingStoreManager);

--- a/Libraries/LibWeb/Compositor/CompositorClient.h
+++ b/Libraries/LibWeb/Compositor/CompositorClient.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Types.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/SharedImage.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Export.h>
+
+namespace Web::Compositor {
+
+class WEB_API CompositorMainThreadClient : public AtomicRefCounted<CompositorMainThreadClient> {
+public:
+    virtual ~CompositorMainThreadClient() = default;
+
+    virtual void request_rendering_update() = 0;
+    virtual void did_complete_screenshot(ScreenshotRequestId) = 0;
+    virtual void did_fail_screenshot(ScreenshotRequestId) = 0;
+    virtual void did_lose_compositor() = 0;
+};
+
+class WEB_API CompositorUIPresentationClient : public AtomicRefCounted<CompositorUIPresentationClient> {
+public:
+    virtual ~CompositorUIPresentationClient() = default;
+
+    virtual void publish_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store) = 0;
+    virtual void present_frame_to_ui(u64 page_id, Gfx::IntRect const& content_rect, i32 bitmap_id) = 0;
+};
+
+}

--- a/Libraries/LibWeb/Compositor/CompositorContextState.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorContextState.cpp
@@ -140,8 +140,8 @@ static void paint_viewport_scrollbars(Gfx::PaintingSurface& surface, ReadonlySpa
         paint_viewport_scrollbar(surface, scrollbars[i], scroll_state_snapshot, hovered_scrollbar_index == i || captured_scrollbar_index == i);
 }
 
-CompositorContextState::CompositorContextState(Optional<u64> page_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
-    : presents_to_client(page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes)
+CompositorContextState::CompositorContextState(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
+    : presents_to_client(page_presentation_registration == PagePresentationRegistration::Yes)
     , page_id(page_id)
 {
     VERIFY(!presents_to_client || page_id.has_value());
@@ -166,9 +166,9 @@ bool CompositorContextState::has_pending_async_scroll_updates() const
         || !completed_async_scroll_operation_ids.is_empty();
 }
 
-CompositorThread::PendingAsyncScrollUpdates CompositorContextState::take_pending_async_scroll_updates()
+PendingAsyncScrollUpdates CompositorContextState::take_pending_async_scroll_updates()
 {
-    CompositorThread::PendingAsyncScrollUpdates updates;
+    PendingAsyncScrollUpdates updates;
     AK::swap(updates.scroll_offsets, pending_async_scroll_offsets);
     AK::swap(updates.completed_operation_ids, completed_async_scroll_operation_ids);
     return updates;

--- a/Libraries/LibWeb/Compositor/CompositorContextState.h
+++ b/Libraries/LibWeb/Compositor/CompositorContextState.h
@@ -15,7 +15,7 @@
 #include <LibGfx/Rect.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/BackingStoreManager.h>
-#include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 namespace Web::Compositor {
@@ -42,14 +42,14 @@ public:
         Optional<size_t> captured_scrollbar_index;
     };
 
-    CompositorContextState(Optional<u64> page_id, CompositorThread::PagePresentationRegistration);
+    CompositorContextState(Optional<u64> page_id, PagePresentationRegistration);
     ~CompositorContextState();
 
     bool has_presented_bitmap_awaiting_ack() const { return presented_bitmap_id_awaiting_ack.has_value(); }
     AsyncScrollOperationID next_async_scroll_operation_id();
     void record_completed_async_scroll_operation(Optional<AsyncScrollOperationID>);
     bool has_pending_async_scroll_updates() const;
-    CompositorThread::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
+    PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void store_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const&, Optional<AsyncScrollOperationID> = {});
     Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(Vector<AsyncScrollOffset> const&);
 
@@ -77,7 +77,7 @@ public:
     float viewport_scrollbar_thumb_grab_position { 0 };
     AsyncScrollTree async_scroll_tree;
     BackingStoreManager backing_store_manager;
-    CompositorThread::PresentationMode presentation_mode { CompositorThread::PresentToUI {} };
+    PresentationMode presentation_mode { Empty {} };
 
     Optional<i32> presented_bitmap_id_awaiting_ack;
     bool is_rasterizing { false };

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Timer.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibWeb/Compositor/CompositorHost.h>
+#include <LibWeb/Painting/DisplayList.h>
+
+namespace Web::Compositor {
+
+CompositorContextHandle::CompositorContextHandle(CompositorHost& host, CompositorContextId context_id)
+    : m_host(host)
+    , m_context_id(context_id)
+{
+    m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this] {
+        m_host.viewport_size_updated(m_context_id, m_last_viewport_size, m_last_viewport_size_is_top_level_traversable, WindowResizingInProgress::No);
+    });
+}
+
+CompositorContextHandle::~CompositorContextHandle()
+{
+    m_backing_store_shrink_timer->on_timeout = {};
+    m_backing_store_shrink_timer->stop();
+    m_host.destroy_context(m_context_id);
+}
+
+void CompositorContextHandle::stop_presenting_to_client()
+{
+    m_host.stop_presenting_to_client(m_context_id);
+}
+
+void CompositorContextHandle::set_presentation_mode(PresentationMode mode)
+{
+    m_host.set_presentation_mode(m_context_id, move(mode));
+}
+
+void CompositorContextHandle::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::DisplayListResourceTransaction&& resource_transaction, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    m_host.update_display_list(m_context_id, move(display_list), move(resource_transaction), move(scroll_state_snapshot));
+}
+
+void CompositorContextHandle::update_video_frame(Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
+{
+    m_host.update_video_frame(m_context_id, frame_id, move(frame));
+}
+
+void CompositorContextHandle::clear_video_frame(Painting::VideoFrameResourceId frame_id)
+{
+    m_host.clear_video_frame(m_context_id, frame_id);
+}
+
+void CompositorContextHandle::update_compositor_surface(Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+{
+    m_host.update_compositor_surface(m_context_id, surface_id, move(shared_image));
+}
+
+void CompositorContextHandle::clear_compositor_surface(Painting::CompositorSurfaceId surface_id)
+{
+    m_host.clear_compositor_surface(m_context_id, surface_id);
+}
+
+void CompositorContextHandle::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    m_host.update_scroll_state(m_context_id, move(scroll_state_snapshot));
+}
+
+void CompositorContextHandle::invalidate_wheel_event_listener_state(u64 generation)
+{
+    m_host.invalidate_wheel_event_listener_state(m_context_id, generation);
+}
+
+AsyncScrollEnqueueResult CompositorContextHandle::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+    Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
+{
+    return m_host.async_scroll_by(m_context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+}
+
+bool CompositorContextHandle::should_defer_async_scroll_offset_adoption() const
+{
+    return m_host.should_defer_async_scroll_offset_adoption(m_context_id);
+}
+
+bool CompositorContextHandle::should_defer_main_thread_present_for_async_scroll() const
+{
+    return m_host.should_defer_main_thread_present_for_async_scroll(m_context_id);
+}
+
+PendingAsyncScrollUpdates CompositorContextHandle::take_pending_async_scroll_updates()
+{
+    return m_host.take_pending_async_scroll_updates(m_context_id);
+}
+
+void CompositorContextHandle::viewport_size_updated(Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
+{
+    m_last_viewport_size = viewport_size;
+    m_last_viewport_size_is_top_level_traversable = is_top_level_traversable;
+    if (window_resize_in_progress == WindowResizingInProgress::Yes)
+        m_backing_store_shrink_timer->restart();
+    m_host.viewport_size_updated(m_context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+}
+
+void CompositorContextHandle::present_frame(Gfx::IntRect viewport_rect)
+{
+    m_host.present_frame(m_context_id, viewport_rect);
+}
+
+void CompositorContextHandle::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
+{
+    m_host.request_screenshot(m_context_id, move(target_surface), move(callback));
+}
+
+CompositorHost::~CompositorHost() = default;
+
+OwnPtr<CompositorContextHandle> CompositorHost::create_context(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
+{
+    auto context_id = allocate_context(page_id, page_presentation_registration);
+    return adopt_own(*new CompositorContextHandle(*this, context_id));
+}
+
+}

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Noncopyable.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <LibCore/Forward.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/Size.h>
+#include <LibIPC/TransportHandle.h>
+#include <LibMedia/Forward.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+
+namespace Web {
+
+enum class DisplayListPlayerType;
+
+}
+
+namespace Web::Compositor {
+
+class CompositorHost;
+
+class WEB_API CompositorContextHandle {
+    AK_MAKE_NONCOPYABLE(CompositorContextHandle);
+    AK_MAKE_NONMOVABLE(CompositorContextHandle);
+
+public:
+    ~CompositorContextHandle();
+
+    CompositorContextId id() const { return m_context_id; }
+    void stop_presenting_to_client();
+    void set_presentation_mode(PresentationMode);
+
+    void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
+    void update_video_frame(Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
+    void clear_video_frame(Painting::VideoFrameResourceId);
+    void update_compositor_surface(Painting::CompositorSurfaceId, Gfx::SharedImage&&);
+    void clear_compositor_surface(Painting::CompositorSurfaceId);
+    void update_scroll_state(Painting::ScrollStateSnapshot&&);
+    void invalidate_wheel_event_listener_state(u64 generation);
+    AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
+        Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
+    bool should_defer_async_scroll_offset_adoption() const;
+    bool should_defer_main_thread_present_for_async_scroll() const;
+    PendingAsyncScrollUpdates take_pending_async_scroll_updates();
+    void viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
+    void present_frame(Gfx::IntRect);
+    void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
+
+private:
+    friend class CompositorHost;
+
+    CompositorContextHandle(CompositorHost&, CompositorContextId);
+
+    CompositorHost& m_host;
+    CompositorContextId m_context_id;
+    RefPtr<Core::Timer> m_backing_store_shrink_timer;
+    Gfx::IntSize m_last_viewport_size;
+    bool m_last_viewport_size_is_top_level_traversable { false };
+};
+
+class WEB_API CompositorHost {
+    AK_MAKE_NONCOPYABLE(CompositorHost);
+    AK_MAKE_NONMOVABLE(CompositorHost);
+
+public:
+    virtual ~CompositorHost();
+
+    virtual void start(DisplayListPlayerType) = 0;
+    OwnPtr<CompositorContextHandle> create_context(Optional<u64> page_id, PagePresentationRegistration);
+
+    virtual void destroy_context(CompositorContextId) = 0;
+    virtual void stop_presenting_to_client(CompositorContextId) = 0;
+    virtual void set_presentation_mode(CompositorContextId, PresentationMode) = 0;
+
+    virtual void update_display_list(CompositorContextId, NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&) = 0;
+    virtual void update_video_frame(CompositorContextId, Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>) = 0;
+    virtual void clear_video_frame(CompositorContextId, Painting::VideoFrameResourceId) = 0;
+    virtual void update_compositor_surface(CompositorContextId, Painting::CompositorSurfaceId, Gfx::SharedImage&&) = 0;
+    virtual void clear_compositor_surface(CompositorContextId, Painting::CompositorSurfaceId) = 0;
+    virtual void update_scroll_state(CompositorContextId, Painting::ScrollStateSnapshot&&) = 0;
+    virtual void invalidate_wheel_event_listener_state(CompositorContextId, u64 generation) = 0;
+    virtual AsyncScrollEnqueueResult async_scroll_by(CompositorContextId, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking)
+        = 0;
+    virtual bool should_defer_async_scroll_offset_adoption(CompositorContextId) const = 0;
+    virtual bool should_defer_main_thread_present_for_async_scroll(CompositorContextId) const = 0;
+    virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
+    virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress) = 0;
+    virtual void present_frame(CompositorContextId, Gfx::IntRect) = 0;
+    virtual void request_screenshot(CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback) = 0;
+
+    virtual void attach_ui_client(IPC::TransportHandle) { }
+
+protected:
+    CompositorHost() = default;
+
+private:
+    virtual CompositorContextId allocate_context(Optional<u64> page_id, PagePresentationRegistration) = 0;
+};
+
+}

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/EventLoop.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SharedImage.h>
@@ -14,15 +13,15 @@
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/Compositor/BackingStoreManager.h>
+#include <LibWeb/Compositor/CompositorClient.h>
 #include <LibWeb/Compositor/CompositorContextState.h>
 #include <LibWeb/Compositor/CompositorThread.h>
-#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 #include <AK/Debug.h>
 #include <AK/HashMap.h>
-#include <AK/NeverDestroyed.h>
 #include <AK/Queue.h>
 #include <AK/Time.h>
 
@@ -94,7 +93,7 @@ struct PresentFrameCommand {
 
 struct ScreenshotCommand {
     NonnullRefPtr<Gfx::PaintingSurface> target_surface;
-    Function<void()> callback;
+    ScreenshotRequestId request_id;
 };
 
 using CompositorCommand = Variant<UpdateDisplayListCommand, AsyncScrollByCommand, ViewportScrollbarDragCommand,
@@ -149,8 +148,8 @@ static bool is_page_presenting_context_id(CompositorContextId context_id)
 
 class CompositorThread::ThreadData final : public AtomicRefCounted<ThreadData> {
 public:
-    explicit ThreadData(NonnullRefPtr<Core::WeakEventLoopReference>&& main_thread_event_loop)
-        : m_main_thread_event_loop(move(main_thread_event_loop))
+    explicit ThreadData(NonnullRefPtr<CompositorMainThreadClient> main_thread_client)
+        : m_main_thread_client(move(main_thread_client))
     {
     }
 
@@ -159,7 +158,7 @@ public:
     struct ContextState final
         : public AtomicRefCounted<ContextState>
         , public CompositorContextState {
-        ContextState(Optional<u64> page_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
+        ContextState(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
             : CompositorContextState(page_id, page_presentation_registration)
         {
         }
@@ -167,11 +166,11 @@ public:
         mutable Sync::Mutex state_mutex;
     };
 
-    void register_context(CompositorContextId context_id, Optional<u64> page_id, CompositorThread::PagePresentationRegistration page_presentation_registration)
+    void register_context(CompositorContextId context_id, Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
     {
         Sync::MutexLocker const locker { m_mutex };
         VERIFY(!m_contexts.contains(context_id));
-        if (page_presentation_registration == CompositorThread::PagePresentationRegistration::Yes) {
+        if (page_presentation_registration == PagePresentationRegistration::Yes) {
             VERIFY(page_id.has_value());
             VERIFY(context_id == compositor_context_id_for_page(*page_id));
         } else {
@@ -200,14 +199,30 @@ public:
             context->presents_to_client = false;
     }
 
-    bool context_presents_to_client(CompositorContextId context_id) const
+    void set_ui_presentation_client(NonnullRefPtr<CompositorUIPresentationClient> ui_presentation_client)
     {
         Sync::MutexLocker const locker { m_mutex };
-        auto context = m_contexts.get(context_id).value_or(nullptr);
-        return context && context->presents_to_client;
+        m_ui_presentation_client = move(ui_presentation_client);
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Installed compositor UI presentation client");
     }
 
-    void set_presentation_mode(CompositorContextId context_id, CompositorThread::PresentationMode mode)
+    void clear_ui_presentation_client()
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        m_ui_presentation_client = nullptr;
+        bool did_clear_pending_presentation = false;
+        for (auto& context : m_contexts) {
+            if (!context.value->presented_bitmap_id_awaiting_ack.has_value())
+                continue;
+            context.value->presented_bitmap_id_awaiting_ack.clear();
+            did_clear_pending_presentation = true;
+        }
+        if (did_clear_pending_presentation)
+            m_command_ready.signal();
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cleared compositor UI presentation client");
+    }
+
+    void set_presentation_mode(CompositorContextId context_id, PresentationMode mode)
     {
         Sync::MutexLocker const locker { m_mutex };
         if (auto context = m_contexts.get(context_id).value_or(nullptr))
@@ -245,7 +260,7 @@ public:
         m_command_ready.signal();
     }
 
-    CompositorThread::PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId context_id)
+    PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId context_id)
     {
         Sync::MutexLocker const locker { m_mutex };
         if (auto context = m_contexts.get(context_id).value_or(nullptr))
@@ -270,7 +285,7 @@ public:
         if (!context)
             return false;
         return !context->pending_async_scroll_offsets.is_empty()
-            && (context->is_rasterizing || context->has_deferred_async_scroll_present || has_presented_bitmap_awaiting_ack_while_locked(*context));
+            && (context->is_rasterizing || context->has_deferred_async_scroll_present || context->has_presented_bitmap_awaiting_ack());
     }
 
     void invalidate_wheel_event_listener_state(CompositorContextId context_id, u64 generation)
@@ -285,8 +300,8 @@ public:
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Invalidated compositor wheel listener state (generation={})", generation);
     }
 
-    CompositorThread::AsyncScrollEnqueueResult enqueue_async_scroll_by(CompositorContextId context_id, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
-        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, CompositorThread::AsyncScrollOperationTracking operation_tracking)
+    AsyncScrollEnqueueResult enqueue_async_scroll_by(CompositorContextId context_id, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
     {
         auto context_state = this->context_state(context_id);
         if (!context_state)
@@ -329,7 +344,7 @@ public:
         }
 
         Optional<AsyncScrollOperationID> operation_id;
-        if (operation_tracking == CompositorThread::AsyncScrollOperationTracking::Yes) {
+        if (operation_tracking == AsyncScrollOperationTracking::Yes) {
             Sync::MutexLocker const locker { m_mutex };
             operation_id = context.next_async_scroll_operation_id();
         }
@@ -466,6 +481,51 @@ public:
         VERIFY_NOT_REACHED();
     }
 
+    void install_display_list_update(ContextState& context, NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+    {
+        context.cached_display_list = move(display_list);
+        context.cached_scroll_state_snapshot = move(scroll_state_snapshot);
+        auto async_scrolling_state = async_scrolling_state_from_display_list(*context.cached_display_list);
+        auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
+        auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
+        auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
+        {
+            Sync::MutexLocker const locker { m_mutex };
+            if (wheel_event_listener_state_generation < context.wheel_event_listener_state_generation)
+                wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
+            else
+                context.wheel_event_listener_state_generation = wheel_event_listener_state_generation;
+            context.wheel_routing_admission = wheel_routing_admission;
+            context.can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
+        }
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor wheel routing admission: {} (scroll_nodes={}, sticky_areas={}, blocking_regions={})",
+            wheel_routing_admission_to_string(wheel_routing_admission),
+            async_scrolling_state.scroll_nodes.size(),
+            async_scrolling_state.sticky_areas.size(),
+            async_scrolling_state.blocking_wheel_event_regions.size());
+        auto pending_async_scroll_offsets = [this, &context] {
+            Sync::MutexLocker const locker { m_mutex };
+            return context.pending_async_scroll_offsets;
+        }();
+
+        {
+            Sync::MutexLocker const locker { context.state_mutex };
+            context.set_async_scrolling_state(move(async_scrolling_state));
+            if (!pending_async_scroll_offsets.is_empty()) {
+                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying {} pending async scroll offset(s) to display list update",
+                    pending_async_scroll_offsets.size());
+                if (auto viewport_scroll_offset = context.reapply_pending_async_scroll_offsets(pending_async_scroll_offsets); viewport_scroll_offset.has_value())
+                    async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+            }
+            context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.cached_display_list, context.cached_scroll_state_snapshot);
+        }
+        {
+            Sync::MutexLocker const locker { m_mutex };
+            context.async_scrolling_viewport_rect = async_scrolling_viewport_rect;
+        }
+        context.has_async_scrolling_state = true;
+    }
+
     void compositor_loop(DisplayListPlayerType display_list_player_type)
     {
         initialize_skia_player(display_list_player_type);
@@ -507,47 +567,7 @@ public:
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing display list update (deferred_async_present={})",
                             context.has_deferred_async_scroll_present);
                         context.display_list_resource_storage.apply_transaction(move(cmd.resource_transaction));
-                        context.cached_display_list = move(cmd.display_list);
-                        context.cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
-                        auto async_scrolling_state = async_scrolling_state_from_display_list(*context.cached_display_list);
-                        auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
-                        auto const wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
-                        auto wheel_routing_admission = wheel_routing_admission_for(async_scrolling_state);
-                        {
-                            Sync::MutexLocker const locker { m_mutex };
-                            if (wheel_event_listener_state_generation < context.wheel_event_listener_state_generation)
-                                wheel_routing_admission = WheelRoutingAdmission::StaleWheelEventListeners;
-                            else
-                                context.wheel_event_listener_state_generation = wheel_event_listener_state_generation;
-                            context.wheel_routing_admission = wheel_routing_admission;
-                            context.can_accept_async_wheel_events = wheel_routing_admission == WheelRoutingAdmission::Accepted;
-                        }
-                        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor wheel routing admission: {} (scroll_nodes={}, sticky_areas={}, blocking_regions={})",
-                            wheel_routing_admission_to_string(wheel_routing_admission),
-                            async_scrolling_state.scroll_nodes.size(),
-                            async_scrolling_state.sticky_areas.size(),
-                            async_scrolling_state.blocking_wheel_event_regions.size());
-                        auto pending_async_scroll_offsets = [this, &context] {
-                            Sync::MutexLocker const locker { m_mutex };
-                            return context.pending_async_scroll_offsets;
-                        }();
-
-                        {
-                            Sync::MutexLocker const locker { context.state_mutex };
-                            context.set_async_scrolling_state(move(async_scrolling_state));
-                            if (!pending_async_scroll_offsets.is_empty()) {
-                                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Reapplying {} pending async scroll offset(s) to display list update",
-                                    pending_async_scroll_offsets.size());
-                                if (auto viewport_scroll_offset = context.reapply_pending_async_scroll_offsets(pending_async_scroll_offsets); viewport_scroll_offset.has_value())
-                                    async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
-                            }
-                            context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.cached_display_list, context.cached_scroll_state_snapshot);
-                        }
-                        {
-                            Sync::MutexLocker const locker { m_mutex };
-                            context.async_scrolling_viewport_rect = async_scrolling_viewport_rect;
-                        }
-                        context.has_async_scrolling_state = true;
+                        install_display_list_update(context, move(cmd.display_list), move(cmd.scroll_state_snapshot));
                     },
                     [this, &context, &should_yield_to_async_scroll_present](AsyncScrollByCommand& cmd) {
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor processing async scroll command at {},{} device delta {},{} for scroll node {} (deferred_async_present={})",
@@ -575,9 +595,7 @@ public:
                         }
                         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Stored {} pending async scroll offset(s)",
                             scroll_offsets.size());
-                        invoke_on_main_thread([] {
-                            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
-                        });
+                        m_main_thread_client->request_rendering_update();
                         {
                             Sync::MutexLocker const locker { m_mutex };
                             context.has_deferred_async_scroll_present = true;
@@ -648,7 +666,7 @@ public:
                     [this, &context](PresentFrameCommand& cmd) {
                         {
                             Sync::MutexLocker const locker { m_mutex };
-                            if (has_presented_bitmap_awaiting_ack_while_locked(context)) {
+                            if (context.has_presented_bitmap_awaiting_ack()) {
                                 context.needs_present = true;
                                 context.pending_viewport_rect = cmd.viewport_rect;
                                 return;
@@ -657,16 +675,14 @@ public:
                         present_frame(context, cmd.viewport_rect, PresentFrameDelivery::MainThread);
                     },
                     [this, &context](ScreenshotCommand& cmd) {
-                        if (!context.cached_display_list)
+                        if (!context.cached_display_list) {
+                            m_main_thread_client->did_fail_screenshot(cmd.request_id);
                             return;
+                        }
                         m_skia_player->execute(*context.cached_display_list, context.display_list_resource_storage, context.cached_scroll_state_snapshot, *cmd.target_surface);
                         paint_viewport_scrollbar_overlay(context, *cmd.target_surface);
                         flush_surface(*cmd.target_surface);
-                        if (cmd.callback) {
-                            invoke_on_main_thread([callback = move(cmd.callback)]() mutable {
-                                callback();
-                            });
-                        }
+                        m_main_thread_client->did_complete_screenshot(cmd.request_id);
                     });
 
                 if (m_exit)
@@ -688,7 +704,7 @@ public:
             {
                 Sync::MutexLocker const locker { m_mutex };
                 for (auto& [_, context] : m_contexts) {
-                    if (context->has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked(*context)) {
+                    if (context->has_deferred_async_scroll_present && !context->has_presented_bitmap_awaiting_ack()) {
                         present_context_state = context;
                         should_present_deferred_async_scroll = true;
                         deferred_async_scroll_viewport_rect = context->deferred_async_scroll_present_viewport_rect;
@@ -701,7 +717,7 @@ public:
                         break;
                     }
 
-                    if (context->needs_present && !has_presented_bitmap_awaiting_ack_while_locked(*context)) {
+                    if (context->needs_present && !context->has_presented_bitmap_awaiting_ack()) {
                         present_context_state = context;
                         should_present = true;
                         viewport_rect = context->pending_viewport_rect;
@@ -724,11 +740,6 @@ private:
         AsyncScroll,
     };
 
-    bool has_presented_bitmap_awaiting_ack_while_locked(ContextState const& context) const
-    {
-        return context.has_presented_bitmap_awaiting_ack();
-    }
-
     void complete_async_scroll_operation(ContextState& context, Optional<AsyncScrollOperationID> operation_id)
     {
         if (!operation_id.has_value())
@@ -741,9 +752,7 @@ private:
 
         // No scroll offset was produced, so nothing else will wake the main thread; schedule a rendering update so it
         // drains the completed operation and resolves the awaiting promise.
-        invoke_on_main_thread([] {
-            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
-        });
+        m_main_thread_client->request_rendering_update();
     }
 
     void queue_rendering_update_if_async_scroll_updates_pending(ContextState& context)
@@ -755,9 +764,7 @@ private:
         if (!has_pending_updates)
             return;
 
-        invoke_on_main_thread([] {
-            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
-        });
+        m_main_thread_client->request_rendering_update();
     }
 
     void store_pending_async_scroll_offsets(ContextState& context, Vector<AsyncScrollOffset> const& scroll_offsets, Optional<AsyncScrollOperationID> operation_id = {})
@@ -817,9 +824,7 @@ private:
             context.has_deferred_async_scroll_present = true;
             context.deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
         }
-        invoke_on_main_thread([] {
-            HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
-        });
+        m_main_thread_client->request_rendering_update();
         return true;
     }
 
@@ -827,7 +832,7 @@ private:
     {
         for (auto const& [_, context] : m_contexts) {
             if ((context->has_deferred_async_scroll_present || context->needs_present)
-                && !has_presented_bitmap_awaiting_ack_while_locked(*context)) {
+                && !context->has_presented_bitmap_awaiting_ack()) {
                 return true;
             }
         }
@@ -837,7 +842,7 @@ private:
     bool can_present_deferred_async_scroll(ContextState& context) const
     {
         Sync::MutexLocker const locker { m_mutex };
-        return context.has_deferred_async_scroll_present && !has_presented_bitmap_awaiting_ack_while_locked(context);
+        return context.has_deferred_async_scroll_present && !context.has_presented_bitmap_awaiting_ack();
     }
 
     bool route_compositor_surface_to_context(CompositorContextId context_id, Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
@@ -846,7 +851,7 @@ private:
             target_context->display_list_resource_storage.update_compositor_surface(surface_id, move(shared_image));
             return true;
         }
-        return CompositorThread::update_compositor_surface_for_context(context_id, surface_id, move(shared_image));
+        return false;
     }
 
     void present_frame(ContextState& context, Gfx::IntRect viewport_rect, PresentFrameDelivery delivery)
@@ -858,14 +863,14 @@ private:
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Begin {} present (awaiting_bitmap={}, viewport={}x{} at {},{})",
                 delivery_name, context.presented_bitmap_id_awaiting_ack.value_or(-1), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
 
-            if (delivery == PresentFrameDelivery::AsyncScroll && has_presented_bitmap_awaiting_ack_while_locked(context)) {
+            if (delivery == PresentFrameDelivery::AsyncScroll && context.has_presented_bitmap_awaiting_ack()) {
                 context.has_deferred_async_scroll_present = true;
                 context.deferred_async_scroll_present_viewport_rect = viewport_rect;
                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Deferring async scroll present until bitmap {} is ready to paint",
                     context.presented_bitmap_id_awaiting_ack.value());
                 return;
             }
-            VERIFY(!has_presented_bitmap_awaiting_ack_while_locked(context));
+            VERIFY(!context.has_presented_bitmap_awaiting_ack());
             if (m_exit)
                 return;
             context.is_rasterizing = true;
@@ -878,8 +883,8 @@ private:
 
         if (context.cached_display_list && context.backing_store_manager.is_valid()) {
             auto should_clear_back_store = presentation_mode.visit(
-                [](CompositorThread::PresentToUI) { return false; },
-                [](CompositorThread::PublishToCompositorSurface const&) { return true; });
+                [](Empty) { return false; },
+                [](PublishToCompositorSurface const&) { return true; });
             auto& back_store = context.backing_store_manager.back_store();
             if (should_clear_back_store) {
                 // Embedded navigables leave their PaintConfig canvas unfilled, so double-buffered back stores must be
@@ -895,21 +900,22 @@ private:
                 delivery_name, rendered_bitmap_id);
 
             presentation_mode.visit(
-                [this, &context, viewport_rect, rendered_bitmap_id, delivery](CompositorThread::PresentToUI) {
+                [this, &context, viewport_rect, rendered_bitmap_id, delivery](Empty) {
                     if (context.presents_to_client) {
                         VERIFY(context.page_id.has_value());
-                        finish_rasterizing(context, rendered_bitmap_id);
-                        if (delivery == PresentFrameDelivery::AsyncScroll) {
-                            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Finished async scroll raster into bitmap {}",
-                                rendered_bitmap_id);
+                        if (finish_rasterizing(context, rendered_bitmap_id)) {
+                            if (delivery == PresentFrameDelivery::AsyncScroll) {
+                                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Finished async scroll raster into bitmap {}",
+                                    rendered_bitmap_id);
+                            }
+                            present_frame_to_client(context, viewport_rect, rendered_bitmap_id);
                         }
-                        VERIFY(CompositorThread::present_frame_to_client(*context.page_id, viewport_rect, rendered_bitmap_id));
                     } else {
                         Sync::MutexLocker const locker { m_mutex };
                         context.is_rasterizing = false;
                     }
                 },
-                [this, &context](CompositorThread::PublishToCompositorSurface const& mode) {
+                [this, &context](PublishToCompositorSurface const& mode) {
                     {
                         Sync::MutexLocker const locker { m_mutex };
                         context.is_rasterizing = false;
@@ -952,24 +958,59 @@ private:
             return;
         VERIFY(context.page_id.has_value());
 
-        VERIFY(CompositorThread::present_backing_stores_to_client(
-            *context.page_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image)));
+        present_backing_stores_to_client(context, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image));
     }
 
-    template<typename Invokee>
-    void invoke_on_main_thread(Invokee invokee)
+    bool present_backing_stores_to_client(ContextState& context, i32 front_bitmap_id, Gfx::SharedImage&& front_shared_image, i32 back_bitmap_id, Gfx::SharedImage&& back_shared_image)
     {
-        if (m_exit)
-            return;
-        auto event_loop = m_main_thread_event_loop->take();
-        if (!event_loop)
-            return;
-        event_loop->deferred_invoke([self = NonnullRefPtr(*this), invokee = move(invokee)]() mutable {
-            invokee();
-        });
+        if (!context.presents_to_client || !context.page_id.has_value()) {
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={}: context is not presenting",
+                front_bitmap_id, back_bitmap_id);
+            return false;
+        }
+
+        RefPtr<CompositorUIPresentationClient> ui_presentation_client;
+        {
+            Sync::MutexLocker const locker { m_mutex };
+            if (!m_ui_presentation_client) {
+                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no UI presentation client",
+                    front_bitmap_id, back_bitmap_id, *context.page_id);
+                return false;
+            }
+            ui_presentation_client = m_ui_presentation_client;
+        }
+
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Publishing UI backing stores for page {} front={} back={}",
+            *context.page_id, front_bitmap_id, back_bitmap_id);
+        ui_presentation_client->publish_backing_stores(*context.page_id, front_bitmap_id, move(front_shared_image), back_bitmap_id, move(back_shared_image));
+        return true;
     }
 
-    NonnullRefPtr<Core::WeakEventLoopReference> m_main_thread_event_loop;
+    bool present_frame_to_client(ContextState& context, Gfx::IntRect const& viewport_rect, i32 bitmap_id)
+    {
+        if (!context.presents_to_client || !context.page_id.has_value()) {
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {}: context is not presenting", bitmap_id);
+            return false;
+        }
+
+        RefPtr<CompositorUIPresentationClient> ui_presentation_client;
+        {
+            Sync::MutexLocker const locker { m_mutex };
+            if (!m_ui_presentation_client) {
+                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no UI presentation client",
+                    bitmap_id, *context.page_id);
+                return false;
+            }
+            ui_presentation_client = m_ui_presentation_client;
+        }
+
+        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Publishing UI present for page {} bitmap {} viewport={}x{} at {},{}",
+            *context.page_id, bitmap_id, viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
+        ui_presentation_client->present_frame_to_ui(*context.page_id, viewport_rect, bitmap_id);
+        return true;
+    }
+
+    NonnullRefPtr<CompositorMainThreadClient> m_main_thread_client;
 
     mutable Sync::Mutex m_mutex;
     mutable Sync::ConditionVariable m_command_ready { m_mutex };
@@ -977,19 +1018,26 @@ private:
 
     Queue<CompositorCommandEnvelope> m_command_queue;
     HashMap<CompositorContextId, NonnullRefPtr<ContextState>> m_contexts;
+    RefPtr<CompositorUIPresentationClient> m_ui_presentation_client;
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
 
 public:
-    void finish_rasterizing(ContextState& context, i32 bitmap_id)
+    bool finish_rasterizing(ContextState& context, i32 bitmap_id)
     {
         Sync::MutexLocker const locker { m_mutex };
         context.is_rasterizing = false;
+        if (!m_ui_presentation_client) {
+            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rasterized bitmap {} without a UI presentation client",
+                bitmap_id);
+            return false;
+        }
         VERIFY(!context.presented_bitmap_id_awaiting_ack.has_value());
         context.presented_bitmap_id_awaiting_ack = bitmap_id;
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Rasterized bitmap {} waiting for ready_to_paint",
             bitmap_id);
+        return true;
     }
 
     void mark_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
@@ -1014,77 +1062,8 @@ public:
     }
 };
 
-struct FramePresentationState {
-    RefPtr<Core::WeakEventLoopReference> event_loop;
-    CompositorThread::BackingStorePresentationCallback backing_store_callback;
-    CompositorThread::FramePresentationCallback frame_callback;
-};
-
-static Sync::Mutex& compositor_presentation_state_mutex()
-{
-    static NeverDestroyed<Sync::Mutex> mutex;
-    return *mutex;
-}
-
-static HashMap<CompositorContextId, NonnullRefPtr<CompositorThread::ThreadData>>& context_compositors()
-{
-    static NeverDestroyed<HashMap<CompositorContextId, NonnullRefPtr<CompositorThread::ThreadData>>> compositors;
-    return *compositors;
-}
-
-static RefPtr<CompositorThread::ThreadData> thread_data_for_context(CompositorContextId context_id)
-{
-    Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-    auto compositor = context_compositors().get(context_id);
-    if (!compositor.has_value())
-        return nullptr;
-    return compositor.value();
-}
-
-static RefPtr<CompositorThread::ThreadData> thread_data_for_page(u64 page_id)
-{
-    return thread_data_for_context(compositor_context_id_for_page(page_id));
-}
-
-static bool page_context_presents_to_client(u64 page_id)
-{
-    auto context_id = compositor_context_id_for_page(page_id);
-    auto thread_data = thread_data_for_context(context_id);
-    if (!thread_data)
-        return false;
-    return thread_data->context_presents_to_client(context_id);
-}
-
-static FramePresentationState& frame_presentation_state()
-{
-    static NeverDestroyed<FramePresentationState> state;
-    return *state;
-}
-
-CompositorThread::Context::Context(NonnullRefPtr<ThreadData> thread_data, CompositorContextId context_id)
-    : m_thread_data(move(thread_data))
-    , m_context_id(context_id)
-{
-    m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this] {
-        enqueue_viewport_size_updated(m_last_viewport_size, m_last_viewport_size_is_top_level_traversable, WindowResizingInProgress::No);
-    });
-}
-
-CompositorThread::Context::~Context()
-{
-    m_backing_store_shrink_timer->on_timeout = {};
-    m_backing_store_shrink_timer->stop();
-    m_backing_store_shrink_timer.clear();
-
-    m_thread_data->unregister_context(m_context_id);
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        VERIFY(context_compositors().remove(m_context_id));
-    }
-}
-
-CompositorThread::CompositorThread()
-    : m_thread_data(adopt_ref(*new ThreadData(Core::EventLoop::current_weak())))
+CompositorThread::CompositorThread(NonnullRefPtr<CompositorMainThreadClient> main_thread_client)
+    : m_thread_data(adopt_ref(*new ThreadData(move(main_thread_client))))
 {
 }
 
@@ -1093,7 +1072,7 @@ CompositorThread::~CompositorThread()
     m_thread_data->exit();
 }
 
-OwnPtr<CompositorThread::Context> CompositorThread::create_context(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
+CompositorContextId CompositorThread::create_context(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
 {
     CompositorContextId context_id;
     if (page_presentation_registration == PagePresentationRegistration::Yes) {
@@ -1105,191 +1084,39 @@ OwnPtr<CompositorThread::Context> CompositorThread::create_context(Optional<u64>
         VERIFY(!is_page_presenting_context_id(context_id));
     }
     m_thread_data->register_context(context_id, page_id, page_presentation_registration);
-
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        VERIFY(!context_compositors().contains(context_id));
-        context_compositors().set(context_id, m_thread_data);
-    }
-
-    return adopt_own(*new Context(m_thread_data, context_id));
+    return context_id;
 }
 
-bool CompositorThread::update_compositor_surface_for_context(CompositorContextId context_id, Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+void CompositorThread::destroy_context(CompositorContextId context_id)
 {
-    auto thread_data = thread_data_for_context(context_id);
-    if (!thread_data) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping compositor surface {} update for unknown context {}",
-            surface_id, context_id);
-        return false;
-    }
-    thread_data->enqueue_command(context_id, UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
-    return true;
+    m_thread_data->unregister_context(context_id);
 }
 
-void CompositorThread::set_frame_presentation_callbacks(NonnullRefPtr<Core::WeakEventLoopReference> event_loop, BackingStorePresentationCallback backing_store_callback, FramePresentationCallback frame_callback)
+void CompositorThread::set_ui_presentation_client(NonnullRefPtr<CompositorUIPresentationClient> ui_presentation_client)
 {
-    Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-    auto& state = frame_presentation_state();
-    state.event_loop = move(event_loop);
-    state.backing_store_callback = move(backing_store_callback);
-    state.frame_callback = move(frame_callback);
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Installed compositor presentation callbacks");
+    m_thread_data->set_ui_presentation_client(move(ui_presentation_client));
 }
 
-void CompositorThread::clear_frame_presentation_callbacks()
+void CompositorThread::clear_ui_presentation_client()
 {
-    Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-    auto& state = frame_presentation_state();
-    state.event_loop = nullptr;
-    state.backing_store_callback = {};
-    state.frame_callback = {};
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cleared compositor presentation callbacks");
-}
-
-bool CompositorThread::present_backing_stores_to_client(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage&& front_shared_image, i32 back_bitmap_id, Gfx::SharedImage&& back_shared_image)
-{
-    auto context_id = compositor_context_id_for_page(page_id);
-    auto thread_data = thread_data_for_context(context_id);
-    if (!thread_data || !thread_data->context_presents_to_client(context_id)) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no presenting context registered",
-            front_bitmap_id, back_bitmap_id, page_id);
-        return false;
-    }
-
-    RefPtr<Core::WeakEventLoopReference> event_loop_reference;
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto& state = frame_presentation_state();
-        if (!state.backing_store_callback) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no presentation callback",
-                front_bitmap_id, back_bitmap_id, page_id);
-            return false;
-        }
-        event_loop_reference = state.event_loop;
-    }
-
-    if (!event_loop_reference) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: no presentation event loop",
-            front_bitmap_id, back_bitmap_id, page_id);
-        return false;
-    }
-    auto event_loop = event_loop_reference->take();
-    if (!event_loop) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present backing stores front={} back={} for page {}: presentation event loop is gone",
-            front_bitmap_id, back_bitmap_id, page_id);
-        return false;
-    }
-
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Queueing UI backing stores for page {} front={} back={}",
-        page_id, front_bitmap_id, back_bitmap_id);
-    event_loop->deferred_invoke([page_id, front_bitmap_id, front_shared_image = move(front_shared_image), back_bitmap_id, back_shared_image = move(back_shared_image)]() mutable {
-        if (!page_context_presents_to_client(page_id)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping queued UI backing stores for page {} front={} back={}: page unregistered",
-                page_id, front_bitmap_id, back_bitmap_id);
-            return;
-        }
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto& state = frame_presentation_state();
-        if (state.backing_store_callback) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Delivering UI backing stores for page {} front={} back={}",
-                page_id, front_bitmap_id, back_bitmap_id);
-            state.backing_store_callback(page_id, front_bitmap_id, move(front_shared_image), back_bitmap_id, move(back_shared_image));
-        } else {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping queued UI backing stores for page {} front={} back={}: callback cleared",
-                page_id, front_bitmap_id, back_bitmap_id);
-        }
-    });
-    return true;
-}
-
-bool CompositorThread::present_frame_to_client(u64 page_id, Gfx::IntRect const& viewport_rect, i32 bitmap_id)
-{
-    auto context_id = compositor_context_id_for_page(page_id);
-    auto thread_data = thread_data_for_context(context_id);
-    if (!thread_data || !thread_data->context_presents_to_client(context_id)) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no presenting context registered",
-            bitmap_id, page_id);
-        return false;
-    }
-
-    RefPtr<Core::WeakEventLoopReference> event_loop_reference;
-    {
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto& state = frame_presentation_state();
-        if (!state.frame_callback) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no presentation callback",
-                bitmap_id, page_id);
-            return false;
-        }
-        event_loop_reference = state.event_loop;
-    }
-
-    if (!event_loop_reference) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: no presentation event loop",
-            bitmap_id, page_id);
-        return false;
-    }
-    auto event_loop = event_loop_reference->take();
-    if (!event_loop) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Cannot present bitmap {} for page {}: presentation event loop is gone",
-            bitmap_id, page_id);
-        return false;
-    }
-
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Queueing UI present for page {} bitmap {} viewport={}x{} at {},{}",
-        page_id, bitmap_id, viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-    event_loop->deferred_invoke([page_id, viewport_rect, bitmap_id] {
-        if (!page_context_presents_to_client(page_id)) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping queued UI present for page {} bitmap {}: page unregistered",
-                page_id, bitmap_id);
-            return;
-        }
-        Sync::MutexLocker const locker { compositor_presentation_state_mutex() };
-        auto& state = frame_presentation_state();
-        if (state.frame_callback) {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Delivering UI present for page {} bitmap {} viewport={}x{} at {},{}",
-                page_id, bitmap_id, viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-            state.frame_callback(page_id, viewport_rect, bitmap_id);
-        } else {
-            dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Dropping queued UI present for page {} bitmap {}: callback cleared",
-                page_id, bitmap_id);
-        }
-    });
-    return true;
+    m_thread_data->clear_ui_presentation_client();
 }
 
 void CompositorThread::presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
 {
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Received compositor ready_to_paint for page {} bitmap {}",
         page_id, bitmap_id);
-    auto thread_data = thread_data_for_page(page_id);
-    if (!thread_data) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Ignoring compositor ready_to_paint for page {} bitmap {}: no presenting context registered",
-            page_id, bitmap_id);
-        return;
-    }
-    thread_data->mark_presented_bitmap_ready_to_paint(page_id, bitmap_id);
+    m_thread_data->mark_presented_bitmap_ready_to_paint(page_id, bitmap_id);
 }
 
 bool CompositorThread::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
-    auto thread_data = thread_data_for_page(page_id);
-    if (!thread_data) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll cannot scroll page {}: no presenting context registered", page_id);
-        return false;
-    }
-    return thread_data->enqueue_async_scroll_by(page_id, position, delta_in_device_pixels);
+    return m_thread_data->enqueue_async_scroll_by(page_id, position, delta_in_device_pixels);
 }
 
 bool CompositorThread::handle_mouse_event(u64 page_id, MouseEvent const& event)
 {
-    auto thread_data = thread_data_for_page(page_id);
-    if (!thread_data) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Viewport scrollbar mouse event cannot be handled for page {}: no presenting context registered", page_id);
-        return false;
-    }
-    return thread_data->handle_viewport_scrollbar_mouse_event(page_id, event);
+    return m_thread_data->handle_viewport_scrollbar_mouse_event(page_id, event);
 }
 
 void CompositorThread::start(DisplayListPlayerType display_list_player_type)
@@ -1302,100 +1129,92 @@ void CompositorThread::start(DisplayListPlayerType display_list_player_type)
     m_thread->detach();
 }
 
-void CompositorThread::Context::set_presentation_mode(PresentationMode mode)
+void CompositorThread::set_presentation_mode(CompositorContextId context_id, PresentationMode mode)
 {
-    m_thread_data->set_presentation_mode(m_context_id, move(mode));
+    m_thread_data->set_presentation_mode(context_id, move(mode));
 }
 
-void CompositorThread::Context::stop_presenting_to_client()
+void CompositorThread::stop_presenting_to_client(CompositorContextId context_id)
 {
-    m_thread_data->stop_presenting_to_client(m_context_id);
+    m_thread_data->stop_presenting_to_client(context_id);
 }
 
-void CompositorThread::Context::update_display_list(
+void CompositorThread::update_display_list(
+    CompositorContextId context_id,
     NonnullRefPtr<Painting::DisplayList> display_list,
     Painting::DisplayListResourceTransaction&& resource_transaction,
     Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_thread_data->enqueue_command(m_context_id, UpdateDisplayListCommand { move(display_list), move(resource_transaction), move(scroll_state_snapshot) });
+    m_thread_data->enqueue_command(context_id, UpdateDisplayListCommand { move(display_list), move(resource_transaction), move(scroll_state_snapshot) });
 }
 
-void CompositorThread::Context::update_video_frame(Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
+void CompositorThread::update_video_frame(CompositorContextId context_id, Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
 {
-    m_thread_data->enqueue_command(m_context_id, UpdateVideoFrameCommand { frame_id, move(frame) });
+    m_thread_data->enqueue_command(context_id, UpdateVideoFrameCommand { frame_id, move(frame) });
 }
 
-void CompositorThread::Context::clear_video_frame(Painting::VideoFrameResourceId frame_id)
+void CompositorThread::clear_video_frame(CompositorContextId context_id, Painting::VideoFrameResourceId frame_id)
 {
-    m_thread_data->enqueue_command(m_context_id, ClearVideoFrameCommand { frame_id });
+    m_thread_data->enqueue_command(context_id, ClearVideoFrameCommand { frame_id });
 }
 
-void CompositorThread::Context::update_compositor_surface(Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+void CompositorThread::update_compositor_surface(CompositorContextId context_id, Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
 {
-    m_thread_data->enqueue_command(m_context_id, UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
+    m_thread_data->enqueue_command(context_id, UpdateCompositorSurfaceCommand { surface_id, move(shared_image) });
 }
 
-void CompositorThread::Context::clear_compositor_surface(Painting::CompositorSurfaceId surface_id)
+void CompositorThread::clear_compositor_surface(CompositorContextId context_id, Painting::CompositorSurfaceId surface_id)
 {
-    m_thread_data->enqueue_command(m_context_id, ClearCompositorSurfaceCommand { surface_id });
+    m_thread_data->enqueue_command(context_id, ClearCompositorSurfaceCommand { surface_id });
 }
 
-void CompositorThread::Context::invalidate_wheel_event_listener_state(u64 generation)
+void CompositorThread::invalidate_wheel_event_listener_state(CompositorContextId context_id, u64 generation)
 {
-    m_thread_data->invalidate_wheel_event_listener_state(m_context_id, generation);
+    m_thread_data->invalidate_wheel_event_listener_state(context_id, generation);
 }
 
-CompositorThread::AsyncScrollEnqueueResult CompositorThread::Context::async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+AsyncScrollEnqueueResult CompositorThread::async_scroll_by(CompositorContextId context_id, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
     Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking operation_tracking)
 {
-    return m_thread_data->enqueue_async_scroll_by(m_context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+    return m_thread_data->enqueue_async_scroll_by(context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
-bool CompositorThread::Context::should_defer_async_scroll_offset_adoption() const
+bool CompositorThread::should_defer_async_scroll_offset_adoption(CompositorContextId context_id) const
 {
-    return m_thread_data->should_defer_async_scroll_offset_adoption(m_context_id);
+    return m_thread_data->should_defer_async_scroll_offset_adoption(context_id);
 }
 
-bool CompositorThread::Context::should_defer_main_thread_present_for_async_scroll() const
+bool CompositorThread::should_defer_main_thread_present_for_async_scroll(CompositorContextId context_id) const
 {
-    return m_thread_data->should_defer_main_thread_present_for_async_scroll(m_context_id);
+    return m_thread_data->should_defer_main_thread_present_for_async_scroll(context_id);
 }
 
-CompositorThread::PendingAsyncScrollUpdates CompositorThread::Context::take_pending_async_scroll_updates()
+PendingAsyncScrollUpdates CompositorThread::take_pending_async_scroll_updates(CompositorContextId context_id)
 {
-    return m_thread_data->take_pending_async_scroll_updates(m_context_id);
+    return m_thread_data->take_pending_async_scroll_updates(context_id);
 }
 
-void CompositorThread::Context::update_scroll_state(Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+void CompositorThread::update_scroll_state(CompositorContextId context_id, Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
-    m_thread_data->enqueue_command(m_context_id, UpdateScrollStateCommand { move(scroll_state_snapshot) });
+    m_thread_data->enqueue_command(context_id, UpdateScrollStateCommand { move(scroll_state_snapshot) });
 }
 
-void CompositorThread::Context::viewport_size_updated(
+void CompositorThread::viewport_size_updated(
+    CompositorContextId context_id,
     Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
 {
-    m_last_viewport_size = viewport_size;
-    m_last_viewport_size_is_top_level_traversable = is_top_level_traversable;
-    if (window_resize_in_progress == WindowResizingInProgress::Yes)
-        m_backing_store_shrink_timer->restart();
-    enqueue_viewport_size_updated(viewport_size, is_top_level_traversable, window_resize_in_progress);
-}
-
-void CompositorThread::Context::enqueue_viewport_size_updated(
-    Gfx::IntSize viewport_size, bool is_top_level_traversable, WindowResizingInProgress window_resize_in_progress)
-{
-    m_thread_data->enqueue_command(m_context_id,
+    m_thread_data->enqueue_command(context_id,
         ViewportSizeUpdatedCommand { viewport_size, is_top_level_traversable, window_resize_in_progress });
 }
 
-void CompositorThread::Context::present_frame(Gfx::IntRect viewport_rect)
+void CompositorThread::present_frame(CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
-    m_thread_data->enqueue_present_frame(m_context_id, viewport_rect);
+    m_thread_data->enqueue_present_frame(context_id, viewport_rect);
 }
 
-void CompositorThread::Context::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
+void CompositorThread::request_screenshot(CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, ScreenshotRequestId request_id)
 {
-    m_thread_data->enqueue_command(m_context_id, ScreenshotCommand { move(target_surface), move(callback) });
+    m_thread_data->enqueue_command(context_id, ScreenshotCommand { move(target_surface), request_id });
 }
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -27,14 +27,17 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/DisplayListResourceStorage.h>
+
+namespace Web::Painting {
+
+struct DisplayListResourceTransaction;
+
+}
 
 namespace Web::Compositor {
 
-enum class WindowResizingInProgress : u8 {
-    No,
-    Yes,
-};
+class CompositorMainThreadClient;
+class CompositorUIPresentationClient;
 
 class WEB_API CompositorThread {
     AK_MAKE_NONCOPYABLE(CompositorThread);
@@ -43,93 +46,40 @@ class WEB_API CompositorThread {
 public:
     class ThreadData;
 
-    enum class PagePresentationRegistration {
-        No,
-        Yes,
-    };
-
-    using BackingStorePresentationCallback = Function<void(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage, i32 back_bitmap_id, Gfx::SharedImage)>;
-    using FramePresentationCallback = Function<void(u64 page_id, Gfx::IntRect const&, i32 bitmap_id)>;
-    struct PendingAsyncScrollUpdates {
-        Vector<AsyncScrollOffset> scroll_offsets;
-        Vector<AsyncScrollOperationID> completed_operation_ids;
-    };
-    struct AsyncScrollEnqueueResult {
-        bool accepted { false };
-        Optional<AsyncScrollOperationID> operation_id;
-    };
-    enum class AsyncScrollOperationTracking {
-        No,
-        Yes,
-    };
-    struct PresentToUI {
-    };
-    struct PublishToCompositorSurface {
-        CompositorContextId target_context_id;
-        Painting::CompositorSurfaceId surface_id;
-    };
-    using PresentationMode = Variant<PresentToUI, PublishToCompositorSurface>;
-
-    class WEB_API Context {
-        AK_MAKE_NONCOPYABLE(Context);
-        AK_MAKE_NONMOVABLE(Context);
-
-    public:
-        ~Context();
-
-        CompositorContextId id() const { return m_context_id; }
-        void stop_presenting_to_client();
-        void set_presentation_mode(PresentationMode);
-
-        void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
-        void update_video_frame(Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
-        void clear_video_frame(Painting::VideoFrameResourceId);
-        void update_compositor_surface(Painting::CompositorSurfaceId, Gfx::SharedImage&&);
-        void clear_compositor_surface(Painting::CompositorSurfaceId);
-        void update_scroll_state(Painting::ScrollStateSnapshot&&);
-        void invalidate_wheel_event_listener_state(u64 generation);
-        AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
-            Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
-        bool should_defer_async_scroll_offset_adoption() const;
-        bool should_defer_main_thread_present_for_async_scroll() const;
-        PendingAsyncScrollUpdates take_pending_async_scroll_updates();
-        void viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
-        void present_frame(Gfx::IntRect);
-        void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
-
-    private:
-        friend class CompositorThread;
-
-        Context(NonnullRefPtr<ThreadData>, CompositorContextId);
-
-        void enqueue_viewport_size_updated(Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
-
-        NonnullRefPtr<ThreadData> m_thread_data;
-        CompositorContextId m_context_id;
-        RefPtr<Core::Timer> m_backing_store_shrink_timer;
-        Gfx::IntSize m_last_viewport_size;
-        bool m_last_viewport_size_is_top_level_traversable { false };
-    };
-
-    CompositorThread();
+    explicit CompositorThread(NonnullRefPtr<CompositorMainThreadClient>);
     ~CompositorThread();
 
-    static void set_frame_presentation_callbacks(NonnullRefPtr<Core::WeakEventLoopReference>, BackingStorePresentationCallback, FramePresentationCallback);
-    static void clear_frame_presentation_callbacks();
-    static void presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
-    static bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
-    static bool handle_mouse_event(u64 page_id, MouseEvent const&);
+    void set_ui_presentation_client(NonnullRefPtr<CompositorUIPresentationClient>);
+    void clear_ui_presentation_client();
+    void presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
+    bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
+    bool handle_mouse_event(u64 page_id, MouseEvent const&);
 
-    OwnPtr<Context> create_context(Optional<u64> page_id, PagePresentationRegistration);
+    CompositorContextId create_context(Optional<u64> page_id, PagePresentationRegistration);
+    void destroy_context(CompositorContextId);
+    void stop_presenting_to_client(CompositorContextId);
+    void set_presentation_mode(CompositorContextId, PresentationMode);
+
+    void update_display_list(CompositorContextId, NonnullRefPtr<Painting::DisplayList>, Painting::DisplayListResourceTransaction&&, Painting::ScrollStateSnapshot&&);
+    void update_video_frame(CompositorContextId, Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
+    void clear_video_frame(CompositorContextId, Painting::VideoFrameResourceId);
+    void update_compositor_surface(CompositorContextId, Painting::CompositorSurfaceId, Gfx::SharedImage&&);
+    void clear_compositor_surface(CompositorContextId, Painting::CompositorSurfaceId);
+    void update_scroll_state(CompositorContextId, Painting::ScrollStateSnapshot&&);
+    void invalidate_wheel_event_listener_state(CompositorContextId, u64 generation);
+    AsyncScrollEnqueueResult async_scroll_by(CompositorContextId, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
+    bool should_defer_async_scroll_offset_adoption(CompositorContextId) const;
+    bool should_defer_main_thread_present_for_async_scroll(CompositorContextId) const;
+    PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId);
+    void viewport_size_updated(CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, WindowResizingInProgress);
+    void present_frame(CompositorContextId, Gfx::IntRect);
+    void request_screenshot(CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, ScreenshotRequestId);
     void start(DisplayListPlayerType);
 
 private:
     NonnullRefPtr<ThreadData> m_thread_data;
     RefPtr<Threading::Thread> m_thread;
-
-    static bool update_compositor_surface_for_context(CompositorContextId, Painting::CompositorSurfaceId, Gfx::SharedImage&&);
-    static bool present_backing_stores_to_client(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage&&, i32 back_bitmap_id, Gfx::SharedImage&&);
-    static bool present_frame_to_client(u64 page_id, Gfx::IntRect const&, i32 bitmap_id);
 };
 
 }

--- a/Libraries/LibWeb/Compositor/Types.cpp
+++ b/Libraries/LibWeb/Compositor/Types.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/Compositor/Types.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::AsyncScrollNodeStableID const& stable_node_id)
+{
+    TRY(encoder.encode(stable_node_id.node_id));
+    TRY(encoder.encode(stable_node_id.kind));
+    TRY(encoder.encode(stable_node_id.pseudo_element_type));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::AsyncScrollNodeStableID> decode(Decoder& decoder)
+{
+    return Web::Compositor::AsyncScrollNodeStableID {
+        .node_id = TRY(decoder.decode<Web::UniqueNodeID>()),
+        .kind = TRY(decoder.decode<Web::Compositor::AsyncScrollNodeKind>()),
+        .pseudo_element_type = TRY(decoder.decode<u8>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::AsyncScrollOffset const& offset)
+{
+    TRY(encoder.encode(offset.stable_node_id));
+    TRY(encoder.encode(offset.compositor_scroll_offset));
+    TRY(encoder.encode(offset.unadopted_scroll_delta));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::AsyncScrollOffset> decode(Decoder& decoder)
+{
+    return Web::Compositor::AsyncScrollOffset {
+        .stable_node_id = TRY(decoder.decode<Web::Compositor::AsyncScrollNodeStableID>()),
+        .compositor_scroll_offset = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .unadopted_scroll_delta = TRY(decoder.decode<Gfx::FloatPoint>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::PendingAsyncScrollUpdates const& updates)
+{
+    TRY(encoder.encode(updates.scroll_offsets));
+    TRY(encoder.encode(updates.completed_operation_ids));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::PendingAsyncScrollUpdates> decode(Decoder& decoder)
+{
+    return Web::Compositor::PendingAsyncScrollUpdates {
+        .scroll_offsets = TRY(decoder.decode<Vector<Web::Compositor::AsyncScrollOffset>>()),
+        .completed_operation_ids = TRY(decoder.decode<Vector<Web::Compositor::AsyncScrollOperationID>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::AsyncScrollEnqueueResult const& result)
+{
+    TRY(encoder.encode(result.accepted));
+    TRY(encoder.encode(result.operation_id));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::AsyncScrollEnqueueResult> decode(Decoder& decoder)
+{
+    return Web::Compositor::AsyncScrollEnqueueResult {
+        .accepted = TRY(decoder.decode<bool>()),
+        .operation_id = TRY(decoder.decode<Optional<Web::Compositor::AsyncScrollOperationID>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Compositor::PublishToCompositorSurface const& mode)
+{
+    TRY(encoder.encode(mode.target_context_id));
+    TRY(encoder.encode(mode.surface_id));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Compositor::PublishToCompositorSurface> decode(Decoder& decoder)
+{
+    return Web::Compositor::PublishToCompositorSurface {
+        .target_context_id = TRY(decoder.decode<Web::Compositor::CompositorContextId>()),
+        .surface_id = TRY(decoder.decode<Web::Painting::CompositorSurfaceId>()),
+    };
+}
+
+}

--- a/Libraries/LibWeb/Compositor/Types.h
+++ b/Libraries/LibWeb/Compositor/Types.h
@@ -8,16 +8,85 @@
 
 #include <AK/Atomic.h>
 #include <AK/DistinctNumeric.h>
+#include <AK/Optional.h>
 #include <AK/Types.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Painting/DisplayListResourceIds.h>
 
 namespace Web::Compositor {
 
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, CompositorContextId);
+AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, ScreenshotRequestId);
 
 inline CompositorContextId allocate_compositor_context_id()
 {
     static Atomic<u64> s_next_id { 1 };
     return CompositorContextId { s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed) };
 }
+
+enum class WindowResizingInProgress : u8 {
+    No,
+    Yes,
+};
+
+enum class PagePresentationRegistration {
+    No,
+    Yes,
+};
+
+struct PendingAsyncScrollUpdates {
+    Vector<AsyncScrollOffset> scroll_offsets;
+    Vector<AsyncScrollOperationID> completed_operation_ids;
+};
+
+struct AsyncScrollEnqueueResult {
+    bool accepted { false };
+    Optional<AsyncScrollOperationID> operation_id;
+};
+
+enum class AsyncScrollOperationTracking {
+    No,
+    Yes,
+};
+
+struct PublishToCompositorSurface {
+    CompositorContextId target_context_id;
+    Painting::CompositorSurfaceId surface_id;
+};
+
+using PresentationMode = Variant<Empty, PublishToCompositorSurface>;
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::AsyncScrollNodeStableID const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::AsyncScrollNodeStableID> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::AsyncScrollOffset const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::AsyncScrollOffset> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::PendingAsyncScrollUpdates const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::PendingAsyncScrollUpdates> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::AsyncScrollEnqueueResult const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::AsyncScrollEnqueueResult> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Compositor::PublishToCompositorSurface const&);
+template<>
+WEB_API ErrorOr<Web::Compositor::PublishToCompositorSurface> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -12,8 +12,6 @@
 #include <AK/JsonObjectSerializer.h>
 #include <AK/StringBuilder.h>
 #include <LibGC/DeferGC.h>
-#include <LibIPC/Decoder.h>
-#include <LibIPC/Encoder.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibWeb/Animations/Animation.h>
@@ -3425,23 +3423,6 @@ GC::Ptr<ShadowRoot> Node::containing_shadow_root()
     if (auto* shadow_root = as_if<ShadowRoot>(root()))
         return shadow_root;
     return nullptr;
-}
-
-}
-
-namespace IPC {
-
-template<>
-ErrorOr<void> encode(Encoder& encoder, Web::UniqueNodeID const& value)
-{
-    return encode(encoder, value.value());
-}
-
-template<>
-ErrorOr<Web::UniqueNodeID> decode(Decoder& decoder)
-{
-    auto value = TRY(decoder.decode<i64>());
-    return Web::UniqueNodeID(value);
 }
 
 }

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -1393,16 +1393,6 @@ struct FormDataEntry;
 
 }
 
-namespace IPC {
-
-template<>
-WEB_API ErrorOr<void> encode(Encoder&, Web::UniqueNodeID const&);
-
-template<>
-WEB_API ErrorOr<Web::UniqueNodeID> decode(Decoder&);
-
-}
-
 namespace Web::TrustedTypes {
 
 class TrustedHTML;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/Compositor/CompositorHost.h>
 #include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
@@ -276,18 +277,18 @@ bool Navigable::is_ancestor_of(GC::Ref<Navigable> other) const
 Navigable::Navigable(
     GC::Ref<Page> page,
     bool is_svg_page,
-    Compositor::CompositorThread::PagePresentationRegistration page_presentation_registration)
+    Compositor::PagePresentationRegistration page_presentation_registration)
     : m_page(page)
     , m_event_handler({}, *this)
     , m_is_svg_page(is_svg_page)
 {
     all_navigables().set(*this);
 
-    if (!m_is_svg_page && page->has_compositor_thread()) {
+    if (!m_is_svg_page && page->has_compositor_host()) {
         Optional<u64> page_id;
-        if (page_presentation_registration == Compositor::CompositorThread::PagePresentationRegistration::Yes)
+        if (page_presentation_registration == Compositor::PagePresentationRegistration::Yes)
             page_id = page->client().id();
-        m_compositor_context = page->compositor_thread().create_context(page_id, page_presentation_registration);
+        m_compositor_context = page->compositor_host().create_context(page_id, page_presentation_registration);
     }
 }
 
@@ -295,14 +296,14 @@ Navigable::~Navigable() = default;
 
 void Navigable::set_has_been_destroyed()
 {
-    clear_compositor_surface();
+    destroy_compositor_context();
     m_has_been_destroyed = true;
     resolve_all_pending_async_scroll_operations();
 }
 
 void Navigable::remove_from_all_navigables()
 {
-    clear_compositor_surface();
+    destroy_compositor_context();
     resolve_all_pending_async_scroll_operations();
 
     if (m_active_document)
@@ -312,7 +313,7 @@ void Navigable::remove_from_all_navigables()
 
 void Navigable::finalize()
 {
-    clear_compositor_surface();
+    destroy_compositor_context();
     all_navigables().remove(*this);
     Base::finalize();
 }
@@ -432,7 +433,7 @@ void Navigable::initialize_navigable(NonnullRefPtr<DocumentState> document_state
         m_should_show_line_box_borders = parent->m_should_show_line_box_borders;
     if (parent && !m_is_svg_page && has_compositor_context() && parent->has_compositor_context()) {
         m_compositor_surface_id = Painting::allocate_compositor_surface_id();
-        compositor_context().set_presentation_mode(Compositor::CompositorThread::PublishToCompositorSurface {
+        compositor_context().set_presentation_mode(Compositor::PublishToCompositorSurface {
             .target_context_id = parent->compositor_context().id(),
             .surface_id = *m_compositor_surface_id,
         });
@@ -3366,6 +3367,12 @@ void Navigable::clear_compositor_surface()
     m_compositor_surface_id.clear();
 }
 
+void Navigable::destroy_compositor_context()
+{
+    clear_compositor_surface();
+    m_compositor_context.clear();
+}
+
 void Navigable::set_should_show_line_box_borders(bool value)
 {
     m_should_show_line_box_borders = value;
@@ -3375,15 +3382,15 @@ void Navigable::set_should_show_line_box_borders(bool value)
         child_navigable->set_should_show_line_box_borders(value);
 }
 
-void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
+bool Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
 {
     if (!has_compositor_context())
-        return;
+        return false;
 
     m_needs_repaint = false;
     auto document = active_document();
     if (!document)
-        return;
+        return false;
 
     adopt_pending_async_scroll_offsets();
 
@@ -3392,17 +3399,16 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
         || !(m_rendering_thread_display_list_paint_config.value() == paint_config);
 
     RefPtr<Painting::DisplayList> display_list;
+    Painting::DisplayListResourceSet display_list_resources;
     Painting::DisplayListResourceTransaction resource_transaction;
     if (should_record_display_list) {
         display_list = document->record_display_list(paint_config, m_display_list_resource_storage);
         if (!display_list)
-            return;
-        auto display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
+            return false;
+        display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
         resource_transaction = m_display_list_resource_storage.create_transaction(
             m_rendering_thread_display_list_resources,
             display_list_resources);
-        m_display_list_resource_storage.retain_only(display_list_resources);
-        m_rendering_thread_display_list_resources = move(display_list_resources);
     }
 
     auto document_paintable = document->paintable();
@@ -3412,11 +3418,14 @@ void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
     Painting::ScrollStateSnapshot scroll_state_snapshot { document_paintable->scroll_state_snapshot() };
     if (should_record_display_list) {
         compositor_context().update_display_list(*display_list, move(resource_transaction), move(scroll_state_snapshot));
+        m_display_list_resource_storage.retain_only(display_list_resources);
+        m_rendering_thread_display_list_resources = move(display_list_resources);
         m_needs_to_record_display_list = false;
         m_rendering_thread_display_list_paint_config = paint_config;
     } else {
         compositor_context().update_scroll_state(move(scroll_state_snapshot));
     }
+    return true;
 }
 
 void Navigable::paint_next_frame()
@@ -3446,7 +3455,8 @@ void Navigable::paint_next_frame()
     if (should_defer_main_thread_present_for_async_scroll())
         return;
 
-    record_display_list_and_scroll_state(paint_config);
+    if (!record_display_list_and_scroll_state(paint_config))
+        return;
 
     viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
     if (should_defer_main_thread_present_for_async_scroll()) {
@@ -3464,7 +3474,10 @@ void Navigable::render_screenshot(Gfx::PaintingSurface& painting_surface, PaintC
         return;
     }
 
-    record_display_list_and_scroll_state(paint_config);
+    if (!record_display_list_and_scroll_state(paint_config)) {
+        callback();
+        return;
+    }
     compositor_context().request_screenshot(painting_surface, move(callback));
 }
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -14,7 +14,7 @@
 #include <AK/Tuple.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Bindings/Navigation.h>
-#include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/Compositor/CompositorHost.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -231,7 +231,7 @@ public:
     bool has_pending_navigations() const { return !m_pending_navigations.is_empty(); }
     void clear_pending_navigations() { m_pending_navigations.clear(); }
 
-    void record_display_list_and_scroll_state(PaintConfig);
+    bool record_display_list_and_scroll_state(PaintConfig);
     void paint_next_frame();
     void render_screenshot(Gfx::PaintingSurface&, PaintConfig, Function<void()>&& callback);
 
@@ -241,7 +241,7 @@ public:
 
     [[nodiscard]] bool has_inclusive_ancestor_with_visibility_hidden() const;
 
-    Compositor::CompositorThread::Context& compositor_context()
+    Compositor::CompositorContextHandle& compositor_context()
     {
         VERIFY(m_compositor_context);
         return *m_compositor_context;
@@ -269,7 +269,7 @@ protected:
     explicit Navigable(
         GC::Ref<Page>,
         bool is_svg_page,
-        Compositor::CompositorThread::PagePresentationRegistration = Compositor::CompositorThread::PagePresentationRegistration::No);
+        Compositor::PagePresentationRegistration = Compositor::PagePresentationRegistration::No);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
@@ -286,6 +286,7 @@ private:
 
     void scroll_offset_did_change();
     void clear_compositor_surface();
+    void destroy_compositor_context();
 
     void inform_the_navigation_api_about_aborting_navigation();
     void resolve_async_scroll_operation(Compositor::AsyncScrollOperationID);
@@ -342,7 +343,7 @@ private:
     Optional<PaintConfig> m_rendering_thread_display_list_paint_config;
     Painting::DisplayListResourceStorage m_display_list_resource_storage;
     Painting::DisplayListResourceSet m_rendering_thread_display_list_resources;
-    OwnPtr<Compositor::CompositorThread::Context> m_compositor_context;
+    OwnPtr<Compositor::CompositorContextHandle> m_compositor_context;
     Optional<Painting::CompositorSurfaceId> m_compositor_surface_id;
 
     struct PendingAsyncScrollOperation {

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -38,7 +38,7 @@ TraversableNavigable::TraversableNavigable(GC::Ref<Page> page)
     : Navigable(
           page,
           page->client().is_svg_page_client(),
-          Compositor::CompositorThread::PagePresentationRegistration::Yes)
+          Compositor::PagePresentationRegistration::Yes)
     , m_storage_shed(StorageAPI::StorageShed::create(page->heap()))
     , m_session_history_traversal_queue(vm().heap().allocate<SessionHistoryTraversalQueue>())
 {
@@ -77,7 +77,7 @@ BrowsingContextAndDocument create_a_new_top_level_browsing_context_and_document(
 GC::Ref<TraversableNavigable> TraversableNavigable::create_a_new_top_level_traversable(GC::Ref<Page> page, GC::Ptr<HTML::BrowsingContext> opener, String target_name)
 {
     auto& vm = Bindings::main_thread_vm();
-    page->ensure_compositor_thread();
+    page->ensure_compositor_host();
 
     // 1. Let document be null.
     GC::Ptr<DOM::Document> document = nullptr;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -547,8 +547,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             auto device_pixels_per_css_pixel = static_cast<float>(m_navigable->page().client().device_pixels_per_css_pixel());
             auto async_scroll_delta_in_device_pixels = async_scroll_delta.scaled(device_pixels_per_css_pixel);
             auto operation_tracking = async_scroll_operation
-                ? Compositor::CompositorThread::AsyncScrollOperationTracking::Yes
-                : Compositor::CompositorThread::AsyncScrollOperationTracking::No;
+                ? Compositor::AsyncScrollOperationTracking::Yes
+                : Compositor::AsyncScrollOperationTracking::No;
             auto enqueue_result = m_navigable->compositor_context().async_scroll_by(
                 document->unique_id(), async_scroll_position, async_scroll_delta_in_device_pixels, viewport_rect, operation_tracking);
             async_scroll_performed_default_action = enqueue_result.accepted;

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -12,7 +12,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/Clipboard/SystemClipboard.h>
-#include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/Compositor/CompositorHost.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Range.h>
@@ -49,31 +49,31 @@ Page::Page(GC::Ref<PageClient> client)
 
 Page::~Page() = default;
 
-bool Page::has_compositor_thread() const
+bool Page::has_compositor_host() const
 {
-    return m_client->compositor_thread();
+    return m_client->compositor_host();
 }
 
-void Page::ensure_compositor_thread()
+void Page::ensure_compositor_host()
 {
     if (!m_client->supports_compositor())
         return;
 
-    m_client->ensure_compositor_thread();
+    m_client->ensure_compositor_host();
 }
 
-Compositor::CompositorThread& Page::compositor_thread()
+Compositor::CompositorHost& Page::compositor_host()
 {
-    auto* compositor_thread = m_client->compositor_thread();
-    VERIFY(compositor_thread);
-    return *compositor_thread;
+    auto* compositor_host = m_client->compositor_host();
+    VERIFY(compositor_host);
+    return *compositor_host;
 }
 
-Compositor::CompositorThread const& Page::compositor_thread() const
+Compositor::CompositorHost const& Page::compositor_host() const
 {
-    auto const* compositor_thread = m_client->compositor_thread();
-    VERIFY(compositor_thread);
-    return *compositor_thread;
+    auto const* compositor_host = m_client->compositor_host();
+    VERIFY(compositor_host);
+    return *compositor_host;
 }
 
 void Page::visit_edges(JS::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -58,7 +58,7 @@ namespace Web {
 class PageClient;
 namespace Compositor {
 
-class CompositorThread;
+class CompositorHost;
 
 }
 
@@ -73,10 +73,10 @@ public:
 
     PageClient& client() { return m_client; }
     PageClient const& client() const { return m_client; }
-    bool has_compositor_thread() const;
-    void ensure_compositor_thread();
-    Compositor::CompositorThread& compositor_thread();
-    Compositor::CompositorThread const& compositor_thread() const;
+    bool has_compositor_host() const;
+    void ensure_compositor_host();
+    Compositor::CompositorHost& compositor_host();
+    Compositor::CompositorHost const& compositor_host() const;
 
     void set_top_level_traversable(GC::Ref<HTML::TraversableNavigable>);
 
@@ -525,9 +525,9 @@ public:
 
     virtual bool is_svg_page_client() const { return false; }
     virtual bool supports_compositor() const { return false; }
-    virtual void ensure_compositor_thread() { }
-    virtual Compositor::CompositorThread* compositor_thread() { return nullptr; }
-    virtual Compositor::CompositorThread const* compositor_thread() const { return nullptr; }
+    virtual void ensure_compositor_host() { }
+    virtual Compositor::CompositorHost* compositor_host() { return nullptr; }
+    virtual Compositor::CompositorHost const* compositor_host() const { return nullptr; }
 
 protected:
     virtual ~PageClient() = default;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -7,6 +7,8 @@
 
 #include <AK/StringBuilder.h>
 #include <LibGfx/Matrix4x4.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/ScrollState.h>
 
@@ -261,6 +263,168 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
         [&](ScrollCompensation const& compensation) {
             builder.appendff("scroll_compensation(frame_id={})", compensation.scroll_frame_index.value());
         });
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollData const& data)
+{
+    TRY(encoder.encode(data.scroll_frame_index));
+    TRY(encoder.encode(data.is_sticky));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::ScrollData> decode(Decoder& decoder)
+{
+    return Web::Painting::ScrollData {
+        .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
+        .is_sticky = TRY(decoder.decode<bool>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::ClipData const& data)
+{
+    TRY(encoder.encode(data.rect));
+    TRY(encoder.encode(data.corner_radii));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::ClipData> decode(Decoder& decoder)
+{
+    return Web::Painting::ClipData {
+        TRY(decoder.decode<Web::DevicePixelRect>()),
+        TRY(decoder.decode<Gfx::CornerRadii>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::TransformData const& data)
+{
+    TRY(encoder.encode(data.matrix));
+    TRY(encoder.encode(data.origin));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::TransformData> decode(Decoder& decoder)
+{
+    return Web::Painting::TransformData {
+        .matrix = TRY(decoder.decode<Gfx::FloatMatrix4x4>()),
+        .origin = TRY(decoder.decode<Gfx::FloatPoint>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::PerspectiveData const& data)
+{
+    TRY(encoder.encode(data.matrix));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::PerspectiveData> decode(Decoder& decoder)
+{
+    return Web::Painting::PerspectiveData {
+        .matrix = TRY(decoder.decode<Gfx::FloatMatrix4x4>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::ClipPathData const& data)
+{
+    TRY(encoder.encode(data.path));
+    TRY(encoder.encode(data.bounding_rect));
+    TRY(encoder.encode(data.fill_rule));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::ClipPathData> decode(Decoder& decoder)
+{
+    return Web::Painting::ClipPathData {
+        .path = TRY(decoder.decode<Gfx::Path>()),
+        .bounding_rect = TRY(decoder.decode<Web::DevicePixelRect>()),
+        .fill_rule = TRY(decoder.decode<Gfx::WindingRule>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::EffectsData const& data)
+{
+    TRY(encoder.encode(data.opacity));
+    TRY(encoder.encode(data.blend_mode));
+    TRY(encoder.encode(data.gfx_filter));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::EffectsData> decode(Decoder& decoder)
+{
+    return Web::Painting::EffectsData {
+        .opacity = TRY(decoder.decode<float>()),
+        .blend_mode = TRY(decoder.decode<Gfx::CompositingAndBlendingOperator>()),
+        .gfx_filter = TRY(decoder.decode<Optional<Gfx::Filter>>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollCompensation const& data)
+{
+    TRY(encoder.encode(data.scroll_frame_index));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::ScrollCompensation> decode(Decoder& decoder)
+{
+    return Web::Painting::ScrollCompensation {
+        .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::AccumulatedVisualContextNode const& node)
+{
+    TRY(encoder.encode(node.data));
+    TRY(encoder.encode(node.parent_index));
+    TRY(encoder.encode(node.depth));
+    TRY(encoder.encode(node.has_empty_effective_clip));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::AccumulatedVisualContextNode> decode(Decoder& decoder)
+{
+    return Web::Painting::AccumulatedVisualContextNode {
+        .data = TRY(decoder.decode<Web::Painting::VisualContextData>()),
+        .parent_index = TRY(decoder.decode<Web::Painting::VisualContextIndex>()),
+        .depth = TRY(decoder.decode<size_t>()),
+        .has_empty_effective_clip = TRY(decoder.decode<bool>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::AccumulatedVisualContextTree const& tree)
+{
+    TRY(encoder.encode(tree.m_nodes));
+    return {};
+}
+
+template<>
+ErrorOr<NonnullRefPtr<Web::Painting::AccumulatedVisualContextTree>> decode(Decoder& decoder)
+{
+    auto nodes = TRY(decoder.decode<Vector<Web::Painting::AccumulatedVisualContextNode>>());
+    if (nodes.is_empty())
+        return Error::from_string_literal("IPC decode: AccumulatedVisualContextTree missing sentinel node");
+    auto visual_context_tree = adopt_ref(*new Web::Painting::AccumulatedVisualContextTree());
+    visual_context_tree->m_nodes = move(nodes);
+    return visual_context_tree;
 }
 
 }

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -18,6 +18,8 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/WindingRule.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Painting/ScrollFrame.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -95,6 +97,7 @@ public:
     VisualContextIndex append(VisualContextData data, VisualContextIndex parent_index);
 
     AccumulatedVisualContextNode const& node_at(VisualContextIndex index) const { return m_nodes[index.value()]; }
+    ReadonlySpan<AccumulatedVisualContextNode> nodes() const { return m_nodes.span(); }
 
     VisualContextIndex find_common_ancestor(VisualContextIndex a, VisualContextIndex b) const;
     Optional<Gfx::FloatPoint> transform_point_for_hit_test(VisualContextIndex, Gfx::FloatPoint, ScrollStateSnapshot const&) const;
@@ -110,6 +113,60 @@ private:
     Vector<size_t, 8> build_ancestor_chain(VisualContextIndex index) const;
 
     Vector<AccumulatedVisualContextNode> m_nodes;
+
+    template<typename T>
+    friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);
+    template<typename T>
+    friend ErrorOr<T> IPC::decode(IPC::Decoder&);
 };
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ScrollData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::ScrollData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ClipData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::ClipData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::TransformData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::TransformData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::PerspectiveData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::PerspectiveData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ClipPathData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::ClipPathData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::EffectsData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::EffectsData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ScrollCompensation const&);
+template<>
+WEB_API ErrorOr<Web::Painting::ScrollCompensation> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::AccumulatedVisualContextNode const&);
+template<>
+WEB_API ErrorOr<Web::Painting::AccumulatedVisualContextNode> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::AccumulatedVisualContextTree const&);
+template<>
+WEB_API ErrorOr<NonnullRefPtr<Web::Painting::AccumulatedVisualContextTree>> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -8,6 +8,8 @@
 #include <AK/NumericLimits.h>
 #include <AK/TemporaryChange.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibWeb/Painting/DisplayList.h>
 
 namespace Web::Painting {
@@ -32,6 +34,14 @@ DisplayListCommandSequence::DisplayListCommandSequence() = default;
 DisplayList::DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree)
     : m_visual_context_tree(move(visual_context_tree))
     , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
+{
+}
+
+DisplayList::DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata> async_scrolling_metadata)
+    : m_visual_context_tree(move(visual_context_tree))
+    , m_id(id)
+    , m_command_bytes(move(command_bytes))
+    , m_async_scrolling_metadata(move(async_scrolling_metadata))
 {
 }
 
@@ -303,6 +313,56 @@ void DisplayListPlayer::execute_impl(
         restore({});
         applied_depth--;
     }
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayList::AsyncScrollingMetadata const& metadata)
+{
+    TRY(encoder.encode(metadata.viewport_rect));
+    TRY(encoder.encode(metadata.wheel_event_listener_state_generation));
+    TRY(encoder.encode(metadata.has_blocking_wheel_event_listeners));
+    TRY(encoder.encode(metadata.has_blocking_wheel_event_region_covering_viewport));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::DisplayList::AsyncScrollingMetadata> decode(Decoder& decoder)
+{
+    return Web::Painting::DisplayList::AsyncScrollingMetadata {
+        .viewport_rect = TRY(decoder.decode<Gfx::IntRect>()),
+        .wheel_event_listener_state_generation = TRY(decoder.decode<u64>()),
+        .has_blocking_wheel_event_listeners = TRY(decoder.decode<bool>()),
+        .has_blocking_wheel_event_region_covering_viewport = TRY(decoder.decode<bool>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayList const& display_list)
+{
+    TRY(encoder.encode(display_list.m_id));
+    TRY(encoder.encode(display_list.m_command_bytes));
+    TRY(encoder.encode(*display_list.m_visual_context_tree));
+    TRY(encoder.encode(display_list.m_async_scrolling_metadata));
+    return {};
+}
+
+ErrorOr<void> encode(Encoder& encoder, NonnullRefPtr<Web::Painting::DisplayList> const& display_list)
+{
+    return encoder.encode(*display_list);
+}
+
+template<>
+ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder& decoder)
+{
+    auto id = TRY(decoder.decode<u64>());
+    auto command_bytes = TRY(decoder.decode<ByteBuffer>());
+    auto visual_context_tree = TRY(decoder.decode<NonnullRefPtr<Web::Painting::AccumulatedVisualContextTree>>());
+    auto async_scrolling_metadata = TRY(decoder.decode<Optional<Web::Painting::DisplayList::AsyncScrollingMetadata>>());
+    return adopt_ref(*new Web::Painting::DisplayList(move(visual_context_tree), id, move(command_bytes), move(async_scrolling_metadata)));
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
@@ -18,6 +19,8 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/TextLayout.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
@@ -188,6 +191,7 @@ public:
 
 private:
     explicit DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const> visual_context_tree);
+    DisplayList(NonnullRefPtr<AccumulatedVisualContextTree const>, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata>);
 
     static Optional<Gfx::IntRect> command_bounding_rectangle(auto const& command)
     {
@@ -217,6 +221,26 @@ private:
     u64 m_id { 0 };
     ByteBuffer m_command_bytes;
     Optional<AsyncScrollingMetadata> m_async_scrolling_metadata;
+
+    template<typename T>
+    friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);
+    template<typename T>
+    friend ErrorOr<T> IPC::decode(IPC::Decoder&);
 };
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayList::AsyncScrollingMetadata const&);
+template<>
+WEB_API ErrorOr<Web::Painting::DisplayList::AsyncScrollingMetadata> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayList const&);
+WEB_API ErrorOr<void> encode(Encoder&, NonnullRefPtr<Web::Painting::DisplayList> const&);
+template<>
+WEB_API ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -42,6 +42,26 @@ DisplayListResourceId DisplayListResourceStorage::add_display_list(NonnullRefPtr
     return { id };
 }
 
+void DisplayListResourceStorage::set_font(FontResourceId id, NonnullRefPtr<Gfx::Font const> font)
+{
+    m_fonts.set(id.value(), move(font));
+}
+
+void DisplayListResourceStorage::set_image_frame(ImageFrameResourceId id, Gfx::DecodedImageFrame frame)
+{
+    m_image_frames.set(id.value(), move(frame));
+}
+
+void DisplayListResourceStorage::set_video_frame(VideoFrameResourceId id, RefPtr<Media::VideoFrame const> frame)
+{
+    m_video_frames.set(id.value(), move(frame));
+}
+
+void DisplayListResourceStorage::set_display_list(DisplayListResourceId id, NonnullRefPtr<DisplayList const> display_list)
+{
+    m_display_lists.set(id.value(), move(display_list));
+}
+
 static ReadonlyBytes inline_data(ReadonlyBytes payload, DisplayListDataSpan span)
 {
     VERIFY(static_cast<size_t>(span.offset) + span.size <= payload.size());
@@ -133,11 +153,11 @@ DisplayListResourceTransaction DisplayListResourceStorage::create_transaction(
 
     for (auto id : current.fonts) {
         if (!previous.fonts.contains(id))
-            transaction.fonts.append(font(id));
+            transaction.fonts.append({ id, font(id) });
     }
     for (auto id : current.image_frames) {
         if (!previous.image_frames.contains(id))
-            transaction.image_frames.append(image_frame(id));
+            transaction.image_frames.append({ id, image_frame(id) });
     }
     for (auto id : current.video_frames) {
         if (!previous.video_frames.contains(id))
@@ -169,10 +189,10 @@ DisplayListResourceTransaction DisplayListResourceStorage::create_transaction(
 
 void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransaction&& transaction)
 {
-    for (auto const& font : transaction.fonts)
-        add_font(*font);
-    for (auto const& frame : transaction.image_frames)
-        add_image_frame(frame);
+    for (auto& font : transaction.fonts)
+        set_font(font.id, move(font.font));
+    for (auto& frame : transaction.image_frames)
+        set_image_frame(frame.id, move(frame.frame));
     for (auto& video_frame : transaction.video_frames)
         add_video_frame(video_frame.id, move(video_frame.frame));
     for (auto& display_list : transaction.display_lists)

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
@@ -17,6 +18,7 @@
 #include <AK/Vector.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibGfx/Forward.h>
+#include <LibIPC/Forward.h>
 #include <LibMedia/VideoFrame.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/DisplayListResourceIds.h>
@@ -30,14 +32,24 @@ struct DisplayListResourceSet {
     HashTable<DisplayListResourceId> display_lists;
 };
 
+struct DisplayListFontResource {
+    FontResourceId id;
+    NonnullRefPtr<Gfx::Font const> font;
+};
+
+struct DisplayListImageFrameResource {
+    ImageFrameResourceId id;
+    Gfx::DecodedImageFrame frame;
+};
+
 struct DisplayListVideoFrameResource {
     VideoFrameResourceId id;
     RefPtr<Media::VideoFrame const> frame;
 };
 
 struct DisplayListResourceTransaction {
-    Vector<NonnullRefPtr<Gfx::Font const>> fonts;
-    Vector<Gfx::DecodedImageFrame> image_frames;
+    Vector<DisplayListFontResource> fonts;
+    Vector<DisplayListImageFrameResource> image_frames;
     Vector<DisplayListVideoFrameResource> video_frames;
     Vector<NonnullRefPtr<DisplayList const>> display_lists;
 
@@ -59,6 +71,10 @@ public:
     ImageFrameResourceId add_image_frame(Gfx::DecodedImageFrame const&);
     VideoFrameResourceId add_video_frame(VideoFrameResourceId, RefPtr<Media::VideoFrame const> = nullptr);
     DisplayListResourceId add_display_list(NonnullRefPtr<DisplayList const>);
+    void set_font(FontResourceId, NonnullRefPtr<Gfx::Font const>);
+    void set_image_frame(ImageFrameResourceId, Gfx::DecodedImageFrame);
+    void set_video_frame(VideoFrameResourceId, RefPtr<Media::VideoFrame const> = nullptr);
+    void set_display_list(DisplayListResourceId, NonnullRefPtr<DisplayList const>);
     void append_referenced_resources_from(DisplayListResourceStorage const& source, ReadonlyBytes command_bytes);
     void apply_transaction(DisplayListResourceTransaction&&);
     DisplayListResourceTransaction create_transaction(DisplayListResourceSet const& previous, DisplayListResourceSet const& current) const;
@@ -85,5 +101,29 @@ private:
     HashMap<u64, NonnullRefPtr<DisplayList const>> m_display_lists;
     HashMap<u64, Gfx::DecodedImageFrame> m_compositor_surfaces;
 };
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayListFontResource const&);
+template<>
+WEB_API ErrorOr<Web::Painting::DisplayListFontResource> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayListImageFrameResource const&);
+template<>
+WEB_API ErrorOr<Web::Painting::DisplayListImageFrameResource> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayListVideoFrameResource const&);
+template<>
+WEB_API ErrorOr<Web::Painting::DisplayListVideoFrameResource> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayListResourceTransaction const&);
+template<>
+WEB_API ErrorOr<Web::Painting::DisplayListResourceTransaction> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListResourceTransaction.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceTransaction.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Font/Font.h>
+#include <LibGfx/Font/Typeface.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+
+namespace Web::Painting {
+
+static ErrorOr<Gfx::ShareableBitmap> shareable_bitmap_from_image_frame(Gfx::DecodedImageFrame const& frame)
+{
+    auto bitmap = frame.bitmap().to_shareable_bitmap();
+    if (!bitmap.is_valid())
+        return Error::from_string_literal("Display-list resource transaction failed to create image-frame bitmap");
+    return bitmap;
+}
+
+static ErrorOr<Gfx::DecodedImageFrame> create_image_frame_from_ipc(Gfx::ShareableBitmap bitmap, Gfx::ColorSpace color_space)
+{
+    if (!bitmap.is_valid() || !bitmap.bitmap())
+        return Error::from_string_literal("Display-list resource transaction contained invalid image-frame bitmap");
+    return Gfx::DecodedImageFrame { *bitmap.bitmap(), move(color_space) };
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayListFontResource const& resource)
+{
+    auto& font = *resource.font;
+    TRY(encoder.encode(resource.id));
+    TRY(encoder.encode(font.typeface()));
+    TRY(encoder.encode(font.point_size()));
+    TRY(encoder.encode(font.variation_settings()));
+    TRY(encoder.encode(font.features()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::DisplayListFontResource> decode(Decoder& decoder)
+{
+    auto id = TRY(decoder.decode<Web::Painting::FontResourceId>());
+    auto typeface = TRY(decoder.decode<NonnullRefPtr<Gfx::Typeface const>>());
+    auto point_size = TRY(decoder.decode<float>());
+    auto variations = TRY(decoder.decode<Gfx::FontVariationSettings>());
+    auto features = TRY(decoder.decode<Gfx::ShapeFeatures>());
+
+    return Web::Painting::DisplayListFontResource {
+        .id = id,
+        .font = typeface->font(point_size, move(variations), move(features)),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayListImageFrameResource const& resource)
+{
+    TRY(encoder.encode(resource.id));
+    TRY(encoder.encode(TRY(Web::Painting::shareable_bitmap_from_image_frame(resource.frame))));
+    TRY(encoder.encode(resource.frame.color_space()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::DisplayListImageFrameResource> decode(Decoder& decoder)
+{
+    auto id = TRY(decoder.decode<Web::Painting::ImageFrameResourceId>());
+    auto bitmap = TRY(decoder.decode<Gfx::ShareableBitmap>());
+    auto color_space = TRY(decoder.decode<Gfx::ColorSpace>());
+
+    return Web::Painting::DisplayListImageFrameResource {
+        .id = id,
+        .frame = TRY(Web::Painting::create_image_frame_from_ipc(move(bitmap), move(color_space))),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayListVideoFrameResource const& resource)
+{
+    Optional<NonnullRefPtr<Media::VideoFrame const>> frame;
+    if (resource.frame)
+        frame = NonnullRefPtr<Media::VideoFrame const> { *resource.frame };
+
+    TRY(encoder.encode(resource.id));
+    TRY(encoder.encode(frame));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::DisplayListVideoFrameResource> decode(Decoder& decoder)
+{
+    auto id = TRY(decoder.decode<Web::Painting::VideoFrameResourceId>());
+    auto frame = TRY(decoder.decode<Optional<NonnullRefPtr<Media::VideoFrame const>>>());
+
+    RefPtr<Media::VideoFrame const> decoded_frame;
+    if (frame.has_value())
+        decoded_frame = frame.release_value();
+
+    return Web::Painting::DisplayListVideoFrameResource {
+        .id = id,
+        .frame = move(decoded_frame),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayListResourceTransaction const& transaction)
+{
+    TRY(encoder.encode(transaction.fonts));
+    TRY(encoder.encode(transaction.image_frames));
+    TRY(encoder.encode(transaction.video_frames));
+    TRY(encoder.encode_size(transaction.display_lists.size()));
+    for (auto const& display_list : transaction.display_lists)
+        TRY(encoder.encode(*display_list));
+    TRY(encoder.encode(transaction.font_ids_to_remove));
+    TRY(encoder.encode(transaction.image_frame_ids_to_remove));
+    TRY(encoder.encode(transaction.video_frame_ids_to_remove));
+    TRY(encoder.encode(transaction.display_list_ids_to_remove));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::DisplayListResourceTransaction> decode(Decoder& decoder)
+{
+    auto fonts = TRY(decoder.decode<Vector<Web::Painting::DisplayListFontResource>>());
+    auto image_frames = TRY(decoder.decode<Vector<Web::Painting::DisplayListImageFrameResource>>());
+    auto video_frames = TRY(decoder.decode<Vector<Web::Painting::DisplayListVideoFrameResource>>());
+
+    auto display_list_count = TRY(decoder.decode_size());
+    Vector<NonnullRefPtr<Web::Painting::DisplayList const>> display_lists;
+    TRY(display_lists.try_ensure_capacity(display_list_count));
+    for (size_t i = 0; i < display_list_count; ++i)
+        display_lists.unchecked_append(TRY(decoder.decode<NonnullRefPtr<Web::Painting::DisplayList>>()));
+
+    return Web::Painting::DisplayListResourceTransaction {
+        .fonts = move(fonts),
+        .image_frames = move(image_frames),
+        .video_frames = move(video_frames),
+        .display_lists = move(display_lists),
+        .font_ids_to_remove = TRY(decoder.decode<Vector<Web::Painting::FontResourceId>>()),
+        .image_frame_ids_to_remove = TRY(decoder.decode<Vector<Web::Painting::ImageFrameResourceId>>()),
+        .video_frame_ids_to_remove = TRY(decoder.decode<Vector<Web::Painting::VideoFrameResourceId>>()),
+        .display_list_ids_to_remove = TRY(decoder.decode<Vector<Web::Painting::DisplayListResourceId>>()),
+    };
+}
+
+}

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/Vector.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibWeb/Painting/ScrollState.h>
 
 namespace Web::Painting {
@@ -19,6 +21,30 @@ ScrollStateSnapshot ScrollStateSnapshot::create(Vector<ScrollFrame> const& scrol
         snapshot.m_device_offsets.unchecked_append(offset.to_type<float>() * scale);
     }
     return snapshot;
+}
+
+ScrollStateSnapshot ScrollStateSnapshot::create_from_device_offsets(Vector<Gfx::FloatPoint>&& device_offsets)
+{
+    ScrollStateSnapshot snapshot;
+    snapshot.m_device_offsets = move(device_offsets);
+    return snapshot;
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollStateSnapshot const& snapshot)
+{
+    TRY(encoder.encode(snapshot.device_offsets()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::ScrollStateSnapshot> decode(Decoder& decoder)
+{
+    return Web::Painting::ScrollStateSnapshot::create_from_device_offsets(TRY(decoder.decode<Vector<Gfx::FloatPoint>>()));
 }
 
 }

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <LibGfx/Point.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Painting/ScrollFrame.h>
 
 namespace Web::Painting {
@@ -14,6 +16,9 @@ namespace Web::Painting {
 class ScrollStateSnapshot {
 public:
     static ScrollStateSnapshot create(Vector<ScrollFrame> const& scroll_frames, double device_pixels_per_css_pixel);
+    static ScrollStateSnapshot create_from_device_offsets(Vector<Gfx::FloatPoint>&&);
+
+    ReadonlySpan<Gfx::FloatPoint> device_offsets() const { return m_device_offsets; }
 
     Gfx::FloatPoint device_offset_for_index(ScrollFrameIndex index) const
     {
@@ -116,5 +121,14 @@ private:
 
     Vector<ScrollFrame> m_scroll_frames;
 };
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ScrollStateSnapshot const&);
+template<>
+WEB_API ErrorOr<Web::Painting::ScrollStateSnapshot> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/PixelUnits.cpp
+++ b/Libraries/LibWeb/PixelUnits.cpp
@@ -16,20 +16,6 @@ namespace Web {
 namespace IPC {
 
 template<>
-ErrorOr<void> encode(Encoder& encoder, Web::DevicePixels const& value)
-{
-    TRY(encoder.encode(value.value()));
-    return {};
-}
-
-template<>
-ErrorOr<Web::DevicePixels> decode(Decoder& decoder)
-{
-    auto value = TRY(decoder.decode<int>());
-    return Web::DevicePixels(value);
-}
-
-template<>
 ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelPoint const& value)
 {
     TRY(encoder.encode(value.x()));

--- a/Libraries/LibWeb/PixelUnits.h
+++ b/Libraries/LibWeb/PixelUnits.h
@@ -537,11 +537,6 @@ struct Formatter<Web::DevicePixels> : Formatter<Web::DevicePixels::Type> {
 namespace IPC {
 
 template<>
-WEB_API ErrorOr<void> encode(Encoder& encoder, Web::DevicePixels const& value);
-template<>
-WEB_API ErrorOr<Web::DevicePixels> decode(Decoder& decoder);
-
-template<>
 WEB_API ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelPoint const& value);
 template<>
 WEB_API ErrorOr<Web::DevicePixelPoint> decode(Decoder& decoder);

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -59,6 +59,8 @@ set(GENERATED_SOURCES
     ../../Services/WebContent/CompositorClientEndpoint.h
     ../../Services/WebContent/CompositorServerEndpoint.h
     ../../Services/WebContent/WebContentClientEndpoint.h
+    ../../Services/WebContent/WebContentCompositorClientEndpoint.h
+    ../../Services/WebContent/WebContentCompositorServerEndpoint.h
     ../../Services/WebContent/WebContentServerEndpoint.h
     ../../Services/WebContent/WebDriverClientEndpoint.h
     ../../Services/WebContent/WebDriverServerEndpoint.h
@@ -72,6 +74,8 @@ set(GENERATED_SOURCES
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/CompositorClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/CompositorClientEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/CompositorServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/CompositorServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebContentClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebContentClientEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebContentCompositorClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebContentCompositorClientEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebContentCompositorServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebContentCompositorServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebContentServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebContentServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebDriverClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebDriverClientEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebDriverServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebDriverServerEndpoint.h)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -63,17 +63,25 @@ static HashMap<WebContentClient*, NonnullRefPtr<CompositorConnectionToServer>>& 
     return *connections;
 }
 
+static bool try_notify_presented_bitmap_ready_to_paint(WebContentClient& web_content_client, u64 page_id, i32 bitmap_id)
+{
+    auto connection = compositor_connections().get(&web_content_client);
+    if (!connection.has_value() || !connection.value()->is_open())
+        return false;
+
+    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI sending compositor ready_to_paint for page {} bitmap {}",
+        page_id, bitmap_id);
+    connection.value()->async_ready_to_paint(page_id, bitmap_id);
+    return true;
+}
+
 static void initialize_compositor_connection(WebContentClient& web_content_client)
 {
-    auto paired_transport = IPC::Transport::create_paired();
-    if (paired_transport.is_error()) {
-        dbgln("Failed to create compositor IPC transport: {}", paired_transport.error());
-        return;
-    }
+    auto paired_transport = MUST(IPC::Transport::create_paired());
 
-    auto connection = CompositorConnectionToServer::construct(web_content_client, move(paired_transport.value().local));
+    auto connection = CompositorConnectionToServer::construct(web_content_client, move(paired_transport.local));
     compositor_connections().set(&web_content_client, connection);
-    web_content_client.async_connect_to_compositor(move(paired_transport.value().remote_handle));
+    web_content_client.async_connect_to_compositor(move(paired_transport.remote_handle));
 }
 
 static Optional<String> history_title(Utf16String const& title, URL::URL const& url)
@@ -165,11 +173,8 @@ void WebContentClient::notify_all_views_of_crash()
 bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
     auto connection = compositor_connections().get(this);
-    if (!connection.has_value() || !connection.value()->is_open()) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC unavailable for page {} (connection={}, open={})",
-            page_id, connection.has_value(), connection.has_value() && connection.value()->is_open());
-        return false;
-    }
+    VERIFY(connection.has_value());
+    VERIFY(connection.value()->is_open());
 
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
     auto handled = connection.value()->async_scroll_by(page_id, position, delta_in_device_pixels);
@@ -181,11 +186,8 @@ bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPo
 bool WebContentClient::send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const& event)
 {
     auto connection = compositor_connections().get(this);
-    if (!connection.has_value() || !connection.value()->is_open()) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC unavailable for page {} (connection={}, open={})",
-            page_id, connection.has_value(), connection.has_value() && connection.value()->is_open());
-        return false;
-    }
+    VERIFY(connection.has_value());
+    VERIFY(connection.value()->is_open());
 
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
     auto handled = connection.value()->mouse_event(page_id, event.clone_without_browser_data());
@@ -196,15 +198,7 @@ bool WebContentClient::send_mouse_event_to_compositor(u64 page_id, Web::MouseEve
 
 void WebContentClient::notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
 {
-    auto connection = compositor_connections().get(this);
-    if (!connection.has_value() || !connection.value()->is_open()) {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC unavailable for ready_to_paint page {} bitmap {} (connection={}, open={})",
-            page_id, bitmap_id, connection.has_value(), connection.has_value() && connection.value()->is_open());
-        return;
-    }
-    dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI sending compositor ready_to_paint for page {} bitmap {}",
-        page_id, bitmap_id);
-    connection.value()->async_ready_to_paint(page_id, bitmap_id);
+    VERIFY(try_notify_presented_bitmap_ready_to_paint(*this, page_id, bitmap_id));
 }
 
 void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, i32 bitmap_id)
@@ -216,7 +210,7 @@ void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, i32 bi
     } else {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI dropping did_paint for page {} bitmap {}: no view",
             page_id, bitmap_id);
-        notify_presented_bitmap_ready_to_paint(page_id, bitmap_id);
+        try_notify_presented_bitmap_ready_to_paint(*this, page_id, bitmap_id);
     }
 }
 

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     DevToolsConsoleClient.cpp
     PageClient.cpp
     PageHost.cpp
+    WebContentCompositorHost.cpp
     WebContentConsoleClient.cpp
     WebDriverConnection.cpp
     WebUIConnection.cpp
@@ -48,6 +49,7 @@ target_sources(webcontentservice PUBLIC FILE_SET server TYPE HEADERS
           ConsoleGlobalEnvironmentExtensions.h
           Forward.h
           PageHost.h
+          WebContentCompositorHost.h
           WebContentConsoleClient.h
           WebDriverConnection.h
 )

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -13,7 +13,6 @@
 #include <AK/JsonObject.h>
 #include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
-#include <LibCore/EventLoop.h>
 #include <LibCore/System.h>
 #include <LibGC/Heap.h>
 #include <LibGfx/Bitmap.h>
@@ -21,8 +20,6 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/Date.h>
-#include <LibSync/ConditionVariable.h>
-#include <LibThreading/Thread.h>
 #include <LibUnicode/TimeZone.h>
 #include <LibWeb/ARIA/RoleType.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -31,7 +28,7 @@
 #include <LibWeb/CSS/Parser/ErrorReporter.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleSheetList.h>
-#include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/Compositor/CompositorHost.h>
 #include <LibWeb/CookieStore/CookieStore.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CharacterData.h>
@@ -64,59 +61,12 @@
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ViewImplementation.h>
-#include <WebContent/CompositorClientEndpoint.h>
-#include <WebContent/CompositorServerEndpoint.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
 #include <WebContent/WebContentClientEndpoint.h>
 
 namespace WebContent {
-
-class CompositorConnectionFromClient final
-    : public IPC::ConnectionFromClient<CompositorClientEndpoint, CompositorServerEndpoint> {
-    C_OBJECT(CompositorConnectionFromClient)
-
-public:
-    virtual void die() override
-    {
-        _exit(0);
-    }
-
-private:
-    explicit CompositorConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
-        : IPC::ConnectionFromClient<CompositorClientEndpoint, CompositorServerEndpoint>(*this, move(transport), 1)
-    {
-    }
-
-    virtual Messages::CompositorServer::AsyncScrollByResponse async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override
-    {
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC received async scroll for page {} at {},{} device delta {},{}",
-            page_id, position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y());
-
-        auto handled = Web::Compositor::CompositorThread::async_scroll_by(page_id, position, delta_in_device_pixels);
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC async scroll for page {} returned {}", page_id, handled);
-        return handled;
-    }
-
-    virtual Messages::CompositorServer::MouseEventResponse mouse_event(u64 page_id, Web::MouseEvent event) override
-    {
-        auto handled = Web::Compositor::CompositorThread::handle_mouse_event(page_id, event);
-        dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC mouse event for page {} returned {}", page_id, handled);
-        return handled;
-    }
-
-    virtual void ready_to_paint(u64 page_id, i32 bitmap_id) override
-    {
-        Web::Compositor::CompositorThread::presented_bitmap_ready_to_paint(page_id, bitmap_id);
-    }
-};
-
-struct CompositorIPCStartupState {
-    Sync::Mutex mutex;
-    Sync::ConditionVariable ready { mutex };
-    bool did_install_presentation_callbacks { false };
-};
 
 ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionFromClient<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport), 1)
@@ -202,40 +152,7 @@ void ConnectionFromClient::connect_to_image_decoder(IPC::TransportHandle handle)
 
 void ConnectionFromClient::connect_to_compositor(IPC::TransportHandle handle)
 {
-    auto startup_state = make<CompositorIPCStartupState>();
-
-    auto thread = Threading::Thread::construct("CompositorIPC"sv, [handle = move(handle), startup_state = startup_state.ptr()]() mutable {
-        Core::EventLoop event_loop;
-        auto transport = MUST(handle.create_transport());
-        auto connection = CompositorConnectionFromClient::construct(move(transport));
-        Web::Compositor::CompositorThread::set_frame_presentation_callbacks(
-            Core::EventLoop::current_weak(),
-            [connection = connection.ptr()](u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) {
-                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC sending backing stores for page {} front={} back={}",
-                    page_id, front_bitmap_id, back_bitmap_id);
-                connection->async_did_allocate_backing_stores(page_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
-            },
-            [connection = connection.ptr()](u64 page_id, Gfx::IntRect const& viewport_rect, i32 bitmap_id) {
-                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor IPC sending did_paint for page {} bitmap {} rect={}x{} at {},{}",
-                    page_id, bitmap_id, viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-                connection->async_did_paint(page_id, viewport_rect, bitmap_id);
-            });
-        {
-            Sync::MutexLocker const locker { startup_state->mutex };
-            startup_state->did_install_presentation_callbacks = true;
-            startup_state->ready.signal();
-        }
-        auto result = event_loop.exec();
-        Web::Compositor::CompositorThread::clear_frame_presentation_callbacks();
-        return result;
-    });
-    thread->start();
-    {
-        Sync::MutexLocker const locker { startup_state->mutex };
-        while (!startup_state->did_install_presentation_callbacks)
-            startup_state->ready.wait();
-    }
-    thread->detach();
+    m_page_host->attach_compositor_ui_client(move(handle));
 }
 
 void ConnectionFromClient::connect_to_request_server(IPC::TransportHandle handle)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1013,19 +1013,19 @@ Web::DisplayListPlayerType PageClient::display_list_player_type() const
     }
 }
 
-void PageClient::ensure_compositor_thread()
+void PageClient::ensure_compositor_host()
 {
-    m_owner.ensure_compositor_thread(display_list_player_type());
+    m_owner.ensure_compositor_host(display_list_player_type());
 }
 
-Web::Compositor::CompositorThread* PageClient::compositor_thread()
+Web::Compositor::CompositorHost* PageClient::compositor_host()
 {
-    return m_owner.compositor_thread();
+    return m_owner.compositor_host();
 }
 
-Web::Compositor::CompositorThread const* PageClient::compositor_thread() const
+Web::Compositor::CompositorHost const* PageClient::compositor_host() const
 {
-    return m_owner.compositor_thread();
+    return m_owner.compositor_host();
 }
 
 void PageClient::queue_screenshot_task(Optional<Web::UniqueNodeID> node_id)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -100,9 +100,9 @@ public:
 
     virtual Web::DisplayListPlayerType display_list_player_type() const override;
     virtual bool supports_compositor() const override { return true; }
-    virtual void ensure_compositor_thread() override;
-    virtual Web::Compositor::CompositorThread* compositor_thread() override;
-    virtual Web::Compositor::CompositorThread const* compositor_thread() const override;
+    virtual void ensure_compositor_host() override;
+    virtual Web::Compositor::CompositorHost* compositor_host() override;
+    virtual Web::Compositor::CompositorHost const* compositor_host() const override;
 
     void queue_screenshot_task(Optional<Web::UniqueNodeID> node_id);
 

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -6,12 +6,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibIPC/TransportHandle.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
-#include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/Compositor/CompositorHost.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
+#include <WebContent/WebContentCompositorHost.h>
 #include <WebContent/WebDriverConnection.h>
 
 namespace WebContent {
@@ -44,12 +46,18 @@ Optional<PageClient&> PageHost::page(u64 index)
 
 PageHost::~PageHost() = default;
 
-void PageHost::ensure_compositor_thread(Web::DisplayListPlayerType display_list_player_type)
+void PageHost::ensure_compositor_host(Web::DisplayListPlayerType display_list_player_type)
 {
-    if (m_compositor_thread)
+    if (m_compositor_host)
         return;
-    m_compositor_thread = make<Web::Compositor::CompositorThread>();
-    m_compositor_thread->start(display_list_player_type);
+    m_compositor_host = create_web_content_compositor_host();
+    m_compositor_host->start(display_list_player_type);
+}
+
+void PageHost::attach_compositor_ui_client(IPC::TransportHandle handle)
+{
+    if (m_compositor_host)
+        m_compositor_host->attach_ui_client(move(handle));
 }
 
 }

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -13,6 +13,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <LibGC/Root.h>
+#include <LibIPC/Forward.h>
 #include <WebContent/Forward.h>
 
 namespace Web {
@@ -21,7 +22,7 @@ enum class DisplayListPlayerType;
 
 namespace Compositor {
 
-class CompositorThread;
+class CompositorHost;
 
 }
 
@@ -42,15 +43,16 @@ public:
     void remove_page(Badge<PageClient>, u64 index);
 
     ConnectionFromClient& client() const { return m_client; }
-    void ensure_compositor_thread(Web::DisplayListPlayerType);
-    Web::Compositor::CompositorThread* compositor_thread() { return m_compositor_thread.ptr(); }
-    Web::Compositor::CompositorThread const* compositor_thread() const { return m_compositor_thread.ptr(); }
+    void ensure_compositor_host(Web::DisplayListPlayerType);
+    void attach_compositor_ui_client(IPC::TransportHandle);
+    Web::Compositor::CompositorHost* compositor_host() { return m_compositor_host.ptr(); }
+    Web::Compositor::CompositorHost const* compositor_host() const { return m_compositor_host.ptr(); }
 
 private:
     explicit PageHost(ConnectionFromClient&);
 
     ConnectionFromClient& m_client;
-    OwnPtr<Web::Compositor::CompositorThread> m_compositor_thread;
+    OwnPtr<Web::Compositor::CompositorHost> m_compositor_host;
     HashMap<u64, GC::Root<PageClient>> m_pages;
     u64 m_next_id { 0 };
 };

--- a/Services/WebContent/WebContentCompositorClient.ipc
+++ b/Services/WebContent/WebContentCompositorClient.ipc
@@ -1,0 +1,9 @@
+#include <LibWeb/Compositor/Types.h>
+
+endpoint WebContentCompositorClient
+{
+    request_rendering_update() =|
+    did_complete_screenshot(Web::Compositor::ScreenshotRequestId request_id) =|
+    did_fail_screenshot(Web::Compositor::ScreenshotRequestId request_id) =|
+    did_lose_compositor() =|
+}

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibIPC/ConnectionFromClient.h>
+#include <LibIPC/ConnectionToServer.h>
+#include <LibIPC/Transport.h>
+#include <LibMedia/VideoFrame.h>
+#include <LibThreading/Thread.h>
+#include <LibWeb/Compositor/CompositorClient.h>
+#include <LibWeb/Compositor/CompositorThread.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <WebContent/CompositorClientEndpoint.h>
+#include <WebContent/CompositorServerEndpoint.h>
+#include <WebContent/WebContentCompositorClientEndpoint.h>
+#include <WebContent/WebContentCompositorHost.h>
+#include <WebContent/WebContentCompositorServerEndpoint.h>
+
+namespace WebContent {
+
+class WebContentCompositorActor;
+
+class WebContentCompositorConnectionToServer final
+    : public IPC::ConnectionToServer<WebContentCompositorClientEndpoint, WebContentCompositorServerEndpoint>
+    , public WebContentCompositorClientEndpoint {
+    C_OBJECT(WebContentCompositorConnectionToServer)
+
+public:
+    WebContentCompositorConnectionToServer(NonnullOwnPtr<IPC::Transport> transport)
+        : IPC::ConnectionToServer<WebContentCompositorClientEndpoint, WebContentCompositorServerEndpoint>(*this, move(transport))
+    {
+    }
+
+    Web::Compositor::ScreenshotRequestId register_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, NonnullRefPtr<Gfx::Bitmap> target_bitmap, Function<void()>&& callback)
+    {
+        auto request_id = Web::Compositor::ScreenshotRequestId { m_next_screenshot_request_id++ };
+        m_screenshots.set(request_id, PendingScreenshot { move(target_surface), move(target_bitmap), move(callback) });
+        return request_id;
+    }
+
+private:
+    struct PendingScreenshot {
+        NonnullRefPtr<Gfx::PaintingSurface> target_surface;
+        NonnullRefPtr<Gfx::Bitmap> target_bitmap;
+        Function<void()> callback;
+    };
+
+    virtual void die() override
+    {
+        did_lose_compositor();
+    }
+
+    virtual void request_rendering_update() override
+    {
+        Web::HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
+    }
+
+    virtual void did_complete_screenshot(Web::Compositor::ScreenshotRequestId request_id) override
+    {
+        auto pending_screenshot = take_screenshot(request_id);
+        if (!pending_screenshot.has_value())
+            return;
+
+        pending_screenshot->target_surface->write_from_bitmap(*pending_screenshot->target_bitmap);
+        if (pending_screenshot->callback)
+            pending_screenshot->callback();
+    }
+
+    virtual void did_fail_screenshot(Web::Compositor::ScreenshotRequestId request_id) override
+    {
+        auto pending_screenshot = take_screenshot(request_id);
+        if (!pending_screenshot.has_value())
+            return;
+
+        if (pending_screenshot->callback)
+            pending_screenshot->callback();
+    }
+
+    virtual void did_lose_compositor() override
+    {
+        for (auto& entry : m_screenshots) {
+            if (entry.value.callback)
+                entry.value.callback();
+        }
+        m_screenshots.clear();
+    }
+
+    Optional<PendingScreenshot> take_screenshot(Web::Compositor::ScreenshotRequestId request_id)
+    {
+        return m_screenshots.take(request_id);
+    }
+
+    HashMap<Web::Compositor::ScreenshotRequestId, PendingScreenshot> m_screenshots;
+    u64 m_next_screenshot_request_id { 1 };
+};
+
+template<typename Self, typename Invokee>
+static void invoke_on_event_loop(NonnullRefPtr<Core::WeakEventLoopReference> const& weak_loop, NonnullRefPtr<Self> self, Invokee invokee)
+{
+    auto event_loop = weak_loop->take();
+    if (!event_loop)
+        return;
+    event_loop->deferred_invoke([self = move(self), invokee = move(invokee)]() mutable {
+        invokee();
+    });
+}
+
+class ActorMainThreadClient final : public Web::Compositor::CompositorMainThreadClient {
+public:
+    ActorMainThreadClient(NonnullRefPtr<Core::WeakEventLoopReference> event_loop, WeakPtr<WebContentCompositorActor> actor)
+        : m_event_loop(move(event_loop))
+        , m_actor(move(actor))
+    {
+    }
+
+    virtual void request_rendering_update() override;
+    virtual void did_complete_screenshot(Web::Compositor::ScreenshotRequestId) override;
+    virtual void did_fail_screenshot(Web::Compositor::ScreenshotRequestId) override;
+    virtual void did_lose_compositor() override;
+
+private:
+    template<typename Invokee>
+    void dispatch_to_actor(Invokee invokee)
+    {
+        invoke_on_event_loop(m_event_loop, NonnullRefPtr(*this), [this, invokee = move(invokee)]() mutable {
+            if (auto actor = m_actor.strong_ref())
+                invokee(*actor);
+        });
+    }
+
+    NonnullRefPtr<Core::WeakEventLoopReference> m_event_loop;
+    WeakPtr<WebContentCompositorActor> m_actor;
+};
+
+class CompositorConnectionFromClient final
+    : public IPC::ConnectionFromClient<CompositorClientEndpoint, CompositorServerEndpoint> {
+    C_OBJECT(CompositorConnectionFromClient)
+
+public:
+    CompositorConnectionFromClient(WebContentCompositorActor& actor, NonnullOwnPtr<IPC::Transport> transport)
+        : IPC::ConnectionFromClient<CompositorClientEndpoint, CompositorServerEndpoint>(*this, move(transport), 1)
+        , m_actor(actor)
+    {
+    }
+
+    virtual void die() override;
+
+private:
+    virtual Messages::CompositorServer::AsyncScrollByResponse async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override;
+    virtual Messages::CompositorServer::MouseEventResponse mouse_event(u64 page_id, Web::MouseEvent event) override;
+    virtual void ready_to_paint(u64 page_id, i32 bitmap_id) override;
+
+    WebContentCompositorActor& m_actor;
+};
+
+class ActorUIPresentationClient final : public Web::Compositor::CompositorUIPresentationClient {
+public:
+    ActorUIPresentationClient(NonnullRefPtr<Core::WeakEventLoopReference> event_loop, NonnullRefPtr<CompositorConnectionFromClient> connection)
+        : m_event_loop(move(event_loop))
+        , m_connection(move(connection))
+    {
+    }
+
+    virtual void publish_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store) override
+    {
+        invoke_on_event_loop(m_event_loop, NonnullRefPtr(*this), [this, page_id, front_bitmap_id, front_backing_store = move(front_backing_store), back_bitmap_id, back_backing_store = move(back_backing_store)]() mutable {
+            m_connection->async_did_allocate_backing_stores(page_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+        });
+    }
+
+    virtual void present_frame_to_ui(u64 page_id, Gfx::IntRect const& viewport_rect, i32 bitmap_id) override
+    {
+        invoke_on_event_loop(m_event_loop, NonnullRefPtr(*this), [this, page_id, viewport_rect, bitmap_id] {
+            m_connection->async_did_paint(page_id, viewport_rect, bitmap_id);
+        });
+    }
+
+private:
+    NonnullRefPtr<Core::WeakEventLoopReference> m_event_loop;
+    NonnullRefPtr<CompositorConnectionFromClient> m_connection;
+};
+
+class WebContentCompositorActor final
+    : public IPC::ConnectionFromClient<WebContentCompositorClientEndpoint, WebContentCompositorServerEndpoint> {
+    C_OBJECT(WebContentCompositorActor)
+
+public:
+    WebContentCompositorActor(NonnullOwnPtr<IPC::Transport> transport, Web::DisplayListPlayerType display_list_player_type)
+        : IPC::ConnectionFromClient<WebContentCompositorClientEndpoint, WebContentCompositorServerEndpoint>(*this, move(transport), 1)
+        , m_main_thread_client(adopt_ref(*new ActorMainThreadClient(Core::EventLoop::current_weak(), make_weak_ptr<WebContentCompositorActor>())))
+        , m_compositor_thread(make<Web::Compositor::CompositorThread>(m_main_thread_client))
+    {
+        m_compositor_thread->start(display_list_player_type);
+    }
+
+    virtual void die() override
+    {
+        _exit(0);
+    }
+
+    bool async_scroll_by_from_ui(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
+    {
+        return m_compositor_thread->async_scroll_by(page_id, position, delta_in_device_pixels);
+    }
+
+    bool handle_mouse_event_from_ui(u64 page_id, Web::MouseEvent const& event)
+    {
+        return m_compositor_thread->handle_mouse_event(page_id, event);
+    }
+
+    void presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
+    {
+        m_compositor_thread->presented_bitmap_ready_to_paint(page_id, bitmap_id);
+    }
+
+    void detach_ui_client(CompositorConnectionFromClient& connection)
+    {
+        if (m_ui_connection.ptr() != &connection)
+            return;
+        m_compositor_thread->clear_ui_presentation_client();
+        m_ui_connection = nullptr;
+    }
+
+private:
+    virtual Messages::WebContentCompositorServer::CreateContextResponse create_context(Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
+    {
+        return m_compositor_thread->create_context(page_id, page_presentation_registration);
+    }
+
+    virtual void destroy_context(Web::Compositor::CompositorContextId context_id) override
+    {
+        m_compositor_thread->destroy_context(context_id);
+    }
+
+    virtual void set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) override
+    {
+        m_compositor_thread->set_presentation_mode(context_id, move(presentation_mode));
+    }
+
+    virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) override
+    {
+        m_compositor_thread->stop_presenting_to_client(context_id);
+    }
+
+    virtual void update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) override
+    {
+        m_compositor_thread->update_display_list(context_id, move(display_list), move(resource_transaction), move(scroll_state_snapshot));
+    }
+
+    virtual void update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) override
+    {
+        m_compositor_thread->update_scroll_state(context_id, move(scroll_state_snapshot));
+    }
+
+    virtual void update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) override
+    {
+        m_compositor_thread->update_video_frame(context_id, frame_id, move(frame));
+    }
+
+    virtual void clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id) override
+    {
+        m_compositor_thread->clear_video_frame(context_id, frame_id);
+    }
+
+    virtual void update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage shared_image) override
+    {
+        m_compositor_thread->update_compositor_surface(context_id, surface_id, move(shared_image));
+    }
+
+    virtual void clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id) override
+    {
+        m_compositor_thread->clear_compositor_surface(context_id, surface_id);
+    }
+
+    virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) override
+    {
+        m_compositor_thread->invalidate_wheel_event_listener_state(context_id, generation);
+    }
+
+    virtual Messages::WebContentCompositorServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) override
+    {
+        return m_compositor_thread->async_scroll_by(context_id, document_id, position, delta, viewport_rect, operation_tracking);
+    }
+
+    virtual Messages::WebContentCompositorServer::ShouldDeferAsyncScrollOffsetAdoptionResponse should_defer_async_scroll_offset_adoption(Web::Compositor::CompositorContextId context_id) override
+    {
+        return m_compositor_thread->should_defer_async_scroll_offset_adoption(context_id);
+    }
+
+    virtual Messages::WebContentCompositorServer::ShouldDeferMainThreadPresentForAsyncScrollResponse should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) override
+    {
+        return m_compositor_thread->should_defer_main_thread_present_for_async_scroll(context_id);
+    }
+
+    virtual Messages::WebContentCompositorServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) override
+    {
+        return m_compositor_thread->take_pending_async_scroll_updates(context_id);
+    }
+
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level, Web::Compositor::WindowResizingInProgress window_resize_in_progress) override
+    {
+        m_compositor_thread->viewport_size_updated(context_id, viewport_size, is_top_level, window_resize_in_progress);
+    }
+
+    virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) override
+    {
+        m_compositor_thread->present_frame(context_id, viewport_rect);
+    }
+
+    virtual void request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) override
+    {
+        if (!target_bitmap.is_valid() || !target_bitmap.bitmap()) {
+            async_did_fail_screenshot(request_id);
+            return;
+        }
+        auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
+        m_compositor_thread->request_screenshot(context_id, target_surface, request_id);
+    }
+
+    virtual void attach_ui_client(IPC::TransportHandle handle) override
+    {
+        auto transport = MUST(handle.create_transport());
+        auto connection = CompositorConnectionFromClient::construct(*this, move(transport));
+        m_ui_connection = connection;
+        m_compositor_thread->set_ui_presentation_client(adopt_ref(*new ActorUIPresentationClient(Core::EventLoop::current_weak(), connection)));
+    }
+
+    NonnullRefPtr<ActorMainThreadClient> m_main_thread_client;
+    OwnPtr<Web::Compositor::CompositorThread> m_compositor_thread;
+    RefPtr<CompositorConnectionFromClient> m_ui_connection;
+};
+
+void ActorMainThreadClient::request_rendering_update()
+{
+    dispatch_to_actor([](auto& actor) {
+        actor.async_request_rendering_update();
+    });
+}
+
+void ActorMainThreadClient::did_complete_screenshot(Web::Compositor::ScreenshotRequestId request_id)
+{
+    dispatch_to_actor([request_id](auto& actor) {
+        actor.async_did_complete_screenshot(request_id);
+    });
+}
+
+void ActorMainThreadClient::did_fail_screenshot(Web::Compositor::ScreenshotRequestId request_id)
+{
+    dispatch_to_actor([request_id](auto& actor) {
+        actor.async_did_fail_screenshot(request_id);
+    });
+}
+
+void ActorMainThreadClient::did_lose_compositor()
+{
+    dispatch_to_actor([](auto& actor) {
+        actor.async_did_lose_compositor();
+    });
+}
+
+void CompositorConnectionFromClient::die()
+{
+    NonnullRefPtr protect { *this };
+    m_actor.detach_ui_client(*this);
+}
+
+Messages::CompositorServer::AsyncScrollByResponse CompositorConnectionFromClient::async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
+{
+    return m_actor.async_scroll_by_from_ui(page_id, position, delta_in_device_pixels);
+}
+
+Messages::CompositorServer::MouseEventResponse CompositorConnectionFromClient::mouse_event(u64 page_id, Web::MouseEvent event)
+{
+    return m_actor.handle_mouse_event_from_ui(page_id, event);
+}
+
+void CompositorConnectionFromClient::ready_to_paint(u64 page_id, i32 bitmap_id)
+{
+    m_actor.presented_bitmap_ready_to_paint(page_id, bitmap_id);
+}
+
+class WebContentCompositorHost final : public Web::Compositor::CompositorHost {
+public:
+    virtual void start(Web::DisplayListPlayerType display_list_player_type) override
+    {
+        if (m_connection)
+            return;
+
+        auto paired_transport = MUST(IPC::Transport::create_paired());
+
+        m_connection = WebContentCompositorConnectionToServer::construct(move(paired_transport.local));
+        m_actor_thread = Threading::Thread::construct("WebContentCompositor"sv, [handle = move(paired_transport.remote_handle), display_list_player_type] mutable {
+            Core::EventLoop event_loop;
+            auto transport = MUST(handle.create_transport());
+            auto actor = WebContentCompositorActor::construct(move(transport), display_list_player_type);
+            return event_loop.exec();
+        });
+        m_actor_thread->start();
+        m_actor_thread->detach();
+    }
+
+    virtual void attach_ui_client(IPC::TransportHandle handle) override
+    {
+        connection().async_attach_ui_client(move(handle));
+    }
+
+private:
+    virtual Web::Compositor::CompositorContextId allocate_context(Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
+    {
+        return connection().create_context(page_id, page_presentation_registration);
+    }
+
+    virtual void destroy_context(Web::Compositor::CompositorContextId context_id) override
+    {
+        connection().async_destroy_context(context_id);
+    }
+
+    virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) override
+    {
+        connection().async_stop_presenting_to_client(context_id);
+    }
+
+    virtual void set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode mode) override
+    {
+        connection().async_set_presentation_mode(context_id, move(mode));
+    }
+
+    virtual void update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
+    {
+        auto encoded_message = MUST(Messages::WebContentCompositorServer::UpdateDisplayList::static_encode(context_id, move(display_list), move(resource_transaction), move(scroll_state_snapshot)));
+        MUST(connection().post_message(encoded_message));
+    }
+
+    virtual void update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) override
+    {
+        auto encoded_message = MUST(Messages::WebContentCompositorServer::UpdateVideoFrame::static_encode(context_id, frame_id, move(frame)));
+        MUST(connection().post_message(encoded_message));
+    }
+
+    virtual void clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id) override
+    {
+        connection().async_clear_video_frame(context_id, frame_id);
+    }
+
+    virtual void update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image) override
+    {
+        connection().async_update_compositor_surface(context_id, surface_id, move(shared_image));
+    }
+
+    virtual void clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id) override
+    {
+        connection().async_clear_compositor_surface(context_id, surface_id);
+    }
+
+    virtual void update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
+    {
+        connection().async_update_scroll_state(context_id, move(scroll_state_snapshot));
+    }
+
+    virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) override
+    {
+        connection().async_invalidate_wheel_event_listener_state(context_id, generation);
+    }
+
+    virtual Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) override
+    {
+        auto response = connection().send_sync<Messages::WebContentCompositorServer::AsyncScrollBy>(context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+        return response->take_result();
+    }
+
+    virtual bool should_defer_async_scroll_offset_adoption(Web::Compositor::CompositorContextId context_id) const override
+    {
+        auto response = connection().send_sync<Messages::WebContentCompositorServer::ShouldDeferAsyncScrollOffsetAdoption>(context_id);
+        return response->should_defer();
+    }
+
+    virtual bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const override
+    {
+        auto response = connection().send_sync<Messages::WebContentCompositorServer::ShouldDeferMainThreadPresentForAsyncScroll>(context_id);
+        return response->should_defer();
+    }
+
+    virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) override
+    {
+        auto response = connection().send_sync<Messages::WebContentCompositorServer::TakePendingAsyncScrollUpdates>(context_id);
+        return response->take_updates();
+    }
+
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) override
+    {
+        connection().async_viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+    }
+
+    virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) override
+    {
+        connection().async_present_frame(context_id, viewport_rect);
+    }
+
+    virtual void request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback) override
+    {
+        auto& conn = connection();
+        auto target_bitmap = MUST(Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, target_surface->size()));
+        auto shareable_bitmap = Gfx::ShareableBitmap { target_bitmap, Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
+        auto request_id = conn.register_screenshot(target_surface, target_bitmap, move(callback));
+        conn.async_request_screenshot(context_id, request_id, move(shareable_bitmap));
+    }
+
+    WebContentCompositorConnectionToServer& connection() const
+    {
+        VERIFY(m_connection);
+        return *m_connection;
+    }
+
+    RefPtr<WebContentCompositorConnectionToServer> m_connection;
+    RefPtr<Threading::Thread> m_actor_thread;
+};
+
+NonnullOwnPtr<Web::Compositor::CompositorHost> create_web_content_compositor_host()
+{
+    return make<WebContentCompositorHost>();
+}
+
+}

--- a/Services/WebContent/WebContentCompositorHost.h
+++ b/Services/WebContent/WebContentCompositorHost.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <LibWeb/Compositor/CompositorHost.h>
+
+namespace WebContent {
+
+NonnullOwnPtr<Web::Compositor::CompositorHost> create_web_content_compositor_host();
+
+}

--- a/Services/WebContent/WebContentCompositorServer.ipc
+++ b/Services/WebContent/WebContentCompositorServer.ipc
@@ -1,0 +1,42 @@
+#include <AK/NonnullRefPtr.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/Size.h>
+#include <LibIPC/TransportHandle.h>
+#include <LibMedia/VideoFrame.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+endpoint WebContentCompositorServer
+{
+    create_context(Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
+    destroy_context(Web::Compositor::CompositorContextId context_id) =|
+
+    set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|
+    stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) =|
+
+    update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
+    update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
+
+    update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) =|
+    clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id) =|
+
+    update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage shared_image) =|
+    clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id) =|
+
+    invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) =|
+    async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) => (Web::Compositor::AsyncScrollEnqueueResult result)
+    should_defer_async_scroll_offset_adoption(Web::Compositor::CompositorContextId context_id) => (bool should_defer)
+    should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) => (bool should_defer)
+    take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
+
+    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
+    present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) =|
+    request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) =|
+
+    attach_ui_client(IPC::TransportHandle handle) =|
+}


### PR DESCRIPTION
The intention for introducing IPC here is to prepare for moving the compositor thread into a separate process.