### PR TITLE
LibWeb: Stop retaining fragment-parsing documents after adoption

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3114,7 +3114,10 @@ void Document::adopt_node(Node& node)
 
             // 3. Otherwise, if inclusiveDescendant is an element:
             else if (auto* element = as_if<Element>(inclusive_descendant)) {
-                // FIXME: 1. Set the node document of each attribute in inclusiveDescendant’s attribute list to document.
+                // 1. Set the node document of each attribute in inclusiveDescendant’s attribute list to document.
+                element->for_each_attribute([this](Attr& attribute) {
+                    attribute.set_document(Badge<Document> {}, *this);
+                });
 
                 // 2. If inclusiveDescendant’s custom element registry is null or inclusiveDescendant’s custom element
                 //    registry’s is scoped is false, then set inclusiveDescendant’s custom element registry to

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3467,6 +3467,14 @@ Optional<String> Element::locate_a_namespace_prefix(Optional<String> const& name
     return {};
 }
 
+void Element::for_each_attribute(Function<void(Attr&)> callback)
+{
+    if (!m_attributes)
+        return;
+    for (size_t i = 0; i < m_attributes->length(); ++i)
+        callback(*m_attributes->item(i));
+}
+
 void Element::for_each_attribute(Function<void(Attr const&)> callback) const
 {
     if (!m_attributes)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -174,6 +174,7 @@ public:
     int client_height() const;
     [[nodiscard]] double current_css_zoom() const;
 
+    void for_each_attribute(Function<void(Attr&)>);
     void for_each_attribute(Function<void(Attr const&)>) const;
 
     void for_each_attribute(Function<void(FlyString const&, String const&)>) const;

--- a/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -73,7 +73,7 @@ Vector<FlyString> NamedNodeMap::supported_property_names() const
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-item
-Attr const* NamedNodeMap::item(u32 index) const
+Attr* NamedNodeMap::item(u32 index)
 {
     // 1. If index is equal to or greater than this’s attribute list’s size, then return null.
     if (index >= m_attributes.size())
@@ -81,6 +81,11 @@ Attr const* NamedNodeMap::item(u32 index) const
 
     // 2. Otherwise, return this’s attribute list[index].
     return m_attributes[index].ptr();
+}
+
+Attr const* NamedNodeMap::item(u32 index) const
+{
+    return const_cast<NamedNodeMap&>(*this).item(index);
 }
 
 // https://dom.spec.whatwg.org/#dom-namednodemap-getnameditem

--- a/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -33,6 +33,7 @@ public:
     bool is_empty() const { return m_attributes.is_empty(); }
 
     // Methods defined by the spec for JavaScript:
+    Attr* item(u32 index);
     Attr const* item(u32 index) const;
     Attr const* get_named_item(FlyString const& qualified_name) const;
     Attr const* get_named_item_ns(Optional<FlyString> const& namespace_, FlyString const& local_name) const;


### PR DESCRIPTION
When adopting an element, we now set the node document of each of its attributes to the new document. Without this, `Attr` objects retained document pointers back to a temporary document created during fragment parsing, these documents were then kept alive after the parsed nodes were moved into the real document.

When loading https://bbc.co.uk, I saw this memory usage on initial page load then after 5 resfreshes (with a manual GC before measuring):

Before
1.01GB -> 2.50GB

After:
1.01GB - 2.29GB

This wasn't the most consistent across runs so I also tested with this script:

```html
<!DOCTYPE html>
<p>Parsed fragments retained in DOM: <span id="count">0</span></p>
<div id="sink" style="display: none"></div>
<script>
// Repeatedly parse small HTML fragments and APPEND the parsed nodes into the  live DOM. Each parse_html_fragment call
// creates a temporary Document, which was previously being kept alive inadvertently.
const sink = document.getElementById('sink');
const counter = document.getElementById('count');
let count = 0;
setInterval(() => {
    for (let i = 0; i < 1000; ++i) {
        const wrapper = document.createElement('div');
        wrapper.innerHTML = '<span class="x"></span>';
        sink.appendChild(wrapper);
    }
    count += 1000;
    counter.textContent = count;
}, 0);
</script>
```

On `master` running this script caused my machine to OOM in less than 1 minute. On this branch, memory usage still grows, but much more slowly and the garbage collector is clearly reclaiming memory where it wasn't previously.