### PR TITLE
Refactor/playbackstream error string

### DIFF
--- a/Libraries/LibMedia/Audio/PlaybackStream.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStream.cpp
@@ -15,7 +15,7 @@ NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStream::create(OutputState,
 #endif
 {
     auto promise = CreatePromise::construct();
-    promise->reject(Error::from_string_literal("Audio output is not available for this platform"));
+    promise->reject(Error::from_string_literal("No audio backend available on this platform"));
     return promise;
 }
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -592,6 +592,8 @@ void BrowserWindow::create_close_button_for_tab(Tab* tab)
     m_tabs_container->set_tab_icon(index, tab->favicon());
 
     auto* button = new TabBarButton(create_tvg_icon_with_theme_colors("close", palette()));
+    button->setToolTip("Close Tab");
+
     auto position = audio_button_position_for_tab(index) == QTabBar::LeftSide ? QTabBar::RightSide : QTabBar::LeftSide;
 
     connect(button, &QPushButton::clicked, this, [this, tab]() {


### PR DESCRIPTION
It took me sometime to figure out why there was no audio, and error message was not clear.

This will provide clearer error message when there is no audio backend installed on the machine.