### PR TITLE
LibMedia: Make PlaybackStream error clearer

### DIFF
--- a/Libraries/LibMedia/Audio/PlaybackStream.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStream.cpp
@@ -15,7 +15,7 @@ NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStream::create(OutputState,
 #endif
 {
     auto promise = CreatePromise::construct();
-    promise->reject(Error::from_string_literal("Audio output is not available for this platform"));
+    promise->reject(Error::from_string_literal("Could not find audio backend on this platform"));
     return promise;
 }
 


### PR DESCRIPTION
It took me sometime to figure out why there was no audio and error message wasn't clear.

This provides clearer error message when there is no audio backend installed.