### PR TITLE
LibWeb: Apply the CSS clip property to display:table elements

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1226,6 +1226,7 @@ void NodeWithStyle::reset_table_box_computed_values_used_by_wrapper_to_init_valu
     // even if the spec does not mention that: https://github.com/w3c/csswg-drafts/issues/11689
     // Note that there may be more properties that need to be added to this list.
     mutable_computed_values.set_z_index(CSS::InitialValues::z_index());
+    mutable_computed_values.set_clip(CSS::InitialValues::clip());
 }
 
 void NodeWithStyle::transfer_table_box_computed_values_to_wrapper_computed_values(CSS::ComputedValues& wrapper_computed_values)
@@ -1258,6 +1259,8 @@ void NodeWithStyle::transfer_table_box_computed_values_to_wrapper_computed_value
     // even if the spec does not mention that: https://github.com/w3c/csswg-drafts/issues/11689
     // Note that there may be more properties that need to be added to this list.
     mutable_wrapper_computed_values.set_z_index(computed_values().z_index());
+    // "clip" only takes effect on absolutely-positioned elements; the table box isn't one — the wrapper is.
+    mutable_wrapper_computed_values.set_clip(computed_values().clip());
 
     reset_table_box_computed_values_used_by_wrapper_to_init_values();
 }

--- a/Tests/LibWeb/Ref/expected/clip-rect-applies-to-display-table.html
+++ b/Tests/LibWeb/Ref/expected/clip-rect-applies-to-display-table.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<!-- The clipped element in the matching test paints nothing, so this reference is intentionally empty. -->

--- a/Tests/LibWeb/Ref/input/clip-rect-applies-to-display-table.html
+++ b/Tests/LibWeb/Ref/input/clip-rect-applies-to-display-table.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/clip-rect-applies-to-display-table.html" />
+<!-- An absolutely positioned element with clip: rect(1px, 1px, 1px, 1px) is clipped to a zero-area region.
+     With display: table, position: absolute moves to the generated table wrapper box; clip must move with it
+     so the element is still clipped away and paints nothing. Regression test for issue #9349. -->
+<style>
+  .visually-hidden {
+    position: absolute;
+    clip: rect(1px, 1px, 1px, 1px);
+    display: table;
+  }
+</style>
+<p class="visually-hidden">This text must be clipped away and not painted</p>


### PR DESCRIPTION
**Problem:** Absolutely-positioned elements with `clip: rect(...)` stay visible when `display: table` is also applied.

**Cause:** `display: table` elements generate an anonymous table-wrapper box — and the `position` property is used on that wrapper rather than on the table box itself. `PaintableBox::get_clip_rect()` only applies `clip` to absolutely-positioned boxes — so it checks the table box, finds it’s not absolutely positioned, and never applies the clip.

**Fix:** Transfer the `clip` property from the table box to the table-wrapper box. That wrapper is the absolutely-positioned box — so `get_clip_rect()` applies the clip correctly.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/9349
