### PR TITLE
Allow button content boxes to shrink below intrinsic height

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1101,6 +1101,10 @@ void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, GC::
         flex_computed_values.set_min_height(parent.computed_values().min_height());
 
         auto content_box_wrapper = parent.create_anonymous_wrapper();
+        auto& content_computed_values = content_box_wrapper->mutable_computed_values();
+        // Let percentage-sized descendants shrink to fixed-height buttons instead of the flex
+        // item's automatic minimum size.
+        content_computed_values.set_min_height(CSS::Size::make_px(CSSPixels(0)));
         content_box_wrapper->set_children_are_inline(parent.children_are_inline());
 
         Vector<GC::Root<Node>> sequence;

--- a/Tests/LibWeb/Text/expected/HTML/button-layout-image-percentage-height.txt
+++ b/Tests/LibWeb/Text/expected/HTML/button-layout-image-percentage-height.txt
@@ -1,0 +1,2 @@
+button 1207x32
+image 229x32

--- a/Tests/LibWeb/Text/input/HTML/button-layout-image-percentage-height.html
+++ b/Tests/LibWeb/Text/input/HTML/button-layout-image-percentage-height.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .header-logo {
+        height: 32px;
+        width: 1207px;
+    }
+
+    button {
+        background: transparent;
+        border: 0;
+        display: inline-block;
+        height: 100%;
+        padding: 0;
+        width: 100%;
+    }
+
+    img {
+        height: 100%;
+        margin: 0 32px 24px;
+        max-height: 100%;
+        object-fit: contain;
+        width: auto;
+    }
+</style>
+<script>
+    asyncTest(done => {
+        const logo = document.createElement("div");
+        logo.className = "header-logo";
+
+        const button = document.createElement("button");
+        const image = document.createElement("img");
+
+        image.onload = () => {
+            requestAnimationFrame(() => {
+                const buttonRect = button.getBoundingClientRect();
+                const imageRect = image.getBoundingClientRect();
+
+                println(`button ${Math.round(buttonRect.width)}x${Math.round(buttonRect.height)}`);
+                println(`image ${Math.round(imageRect.width)}x${Math.round(imageRect.height)}`);
+                done();
+            });
+        };
+
+        button.appendChild(image);
+        logo.appendChild(button);
+        document.body.appendChild(logo);
+
+        image.src = "data:image/svg+xml;base64,"
+            + "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMTQzIiBo"
+            + "ZWlnaHQ9IjE2MCI+PHJlY3Qgd2lkdGg9IjExNDMiIGhlaWdodD0iMTYwIiBmaWxsPSJibGFj"
+            + "ayIvPjwvc3ZnPg==";
+    });
+</script>


### PR DESCRIPTION
Button layout wraps non-flex/grid button contents in an anonymous flex item. That flex item kept the default automatic minimum height, so a descendant with height: 100% and width: auto could make a fixed-height button grow to the descendant's intrinsic height. This made image-only controls, such as site header logos, render much taller than the height specified by author styles.

Set min-height: 0 on the anonymous button content box so percentage-height descendants can resolve against and shrink to the button's used height.

<img width="2902" height="1318" alt="subnautica-before-after-full" src="https://github.com/user-attachments/assets/02b93ffb-5868-416e-833d-55df79107bdf" />

