### PR TITLE
LibWeb/CSS: Implement `@supports at-rule(@foo)`

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -341,11 +341,44 @@ OwnPtr<BooleanExpression> Parser::parse_supports_condition(TokenStream<Component
     return maybe_condition;
 }
 
+static bool at_rule_is_supported(FlyString const& name)
+{
+    // https://drafts.csswg.org/css-conditional-5/#support-definition-at-rules
+    // A CSS processor supports an at-rule if it would accept an at-rule beginning with that
+    // at-keyword within any context. @charset is intentionally excluded: it is not a valid at-rule.
+    if (name.equals_ignoring_ascii_case("charset"sv))
+        return false;
+
+    if (name.equals_ignoring_ascii_case("container"sv)
+        || name.equals_ignoring_ascii_case("counter-style"sv)
+        || name.equals_ignoring_ascii_case("font-face"sv)
+        || name.equals_ignoring_ascii_case("font-feature-values"sv)
+        || name.equals_ignoring_ascii_case("function"sv)
+        || name.equals_ignoring_ascii_case("import"sv)
+        || name.equals_ignoring_ascii_case("keyframes"sv)
+        || name.equals_ignoring_ascii_case("-webkit-keyframes"sv)
+        || name.equals_ignoring_ascii_case("layer"sv)
+        || name.equals_ignoring_ascii_case("media"sv)
+        || name.equals_ignoring_ascii_case("namespace"sv)
+        || name.equals_ignoring_ascii_case("page"sv)
+        || name.equals_ignoring_ascii_case("property"sv)
+        || name.equals_ignoring_ascii_case("supports"sv))
+        return true;
+
+    if (CSSFontFeatureValuesRule::is_font_feature_value_type_at_keyword(name))
+        return true;
+
+    if (is_margin_rule_name(name))
+        return true;
+
+    return false;
+}
+
 // https://drafts.csswg.org/css-conditional-5/#typedef-supports-feature
 OwnPtr<BooleanExpression> Parser::parse_supports_feature(TokenStream<ComponentValue>& tokens)
 {
     // <supports-feature> = <supports-selector-fn> | <supports-font-tech-fn>
-    //                    | <supports-font-format-fn> | <supports-env-fn>
+    //                    | <supports-font-format-fn> | <supports-at-rule-fn> | <supports-env-fn>
     //                    | <supports-decl>
     auto transaction = tokens.begin_transaction();
     tokens.discard_whitespace();
@@ -405,6 +438,21 @@ OwnPtr<BooleanExpression> Parser::parse_supports_feature(TokenStream<ComponentVa
         auto format_name = format_token.token().ident();
         bool matches = font_format_is_supported(format_name);
         return Supports::FontFormat::create(move(format_name), matches);
+    }
+
+    // `<supports-at-rule-fn> = at-rule( <at-keyword-token> )`
+    if (first_token.is_function("at-rule"sv)) {
+        TokenStream at_rule_tokens { first_token.function().value };
+        at_rule_tokens.discard_whitespace();
+        auto at_rule_token = at_rule_tokens.consume_a_token();
+        at_rule_tokens.discard_whitespace();
+        if (at_rule_tokens.has_next_token() || !at_rule_token.is(Token::Type::AtKeyword))
+            return {};
+
+        transaction.commit();
+        auto at_rule_name = at_rule_token.token().at_keyword();
+        bool matches = at_rule_is_supported(at_rule_name);
+        return Supports::AtRule::create(move(at_rule_name), matches);
     }
 
     // `<supports-env-fn> = env( <ident> )`

--- a/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Libraries/LibWeb/CSS/Supports.cpp
@@ -97,6 +97,26 @@ void Supports::Env::dump(StringBuilder& builder, int indent_levels) const
     builder.appendff("Env: `{}` matches={}\n", m_variable_name, m_matches);
 }
 
+MatchResult Supports::AtRule::evaluate(BooleanExpressionEvaluationContext const&) const
+{
+    return as_match_result(m_matches);
+}
+
+String Supports::AtRule::to_string() const
+{
+    StringBuilder builder;
+    builder.append("at-rule(@"sv);
+    serialize_an_identifier(builder, m_name);
+    builder.append(')');
+    return builder.to_string_without_validation();
+}
+
+void Supports::AtRule::dump(StringBuilder& builder, int indent_levels) const
+{
+    indent(builder, indent_levels);
+    builder.appendff("AtRule: `@{}` matches={}\n", m_name, m_matches);
+}
+
 String Supports::to_string() const
 {
     return m_condition->to_string();

--- a/Libraries/LibWeb/CSS/Supports.h
+++ b/Libraries/LibWeb/CSS/Supports.h
@@ -128,6 +128,29 @@ public:
         bool m_matches;
     };
 
+    class AtRule final : public BooleanExpression {
+    public:
+        static NonnullOwnPtr<AtRule> create(FlyString name, bool matches)
+        {
+            return adopt_own(*new AtRule(move(name), matches));
+        }
+        virtual ~AtRule() override = default;
+
+        virtual MatchResult evaluate(BooleanExpressionEvaluationContext const&) const override;
+        virtual String to_string() const override;
+        virtual void dump(StringBuilder&, int indent_levels = 0) const override;
+
+    private:
+        AtRule(FlyString name, bool matches)
+            : m_name(move(name))
+            , m_matches(matches)
+        {
+        }
+
+        FlyString m_name;
+        bool m_matches;
+    };
+
     static NonnullRefPtr<Supports> create(NonnullOwnPtr<BooleanExpression>&& condition)
     {
         return adopt_ref(*new Supports(move(condition)));

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/supports-at-rule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/supports-at-rule.txt
@@ -1,0 +1,31 @@
+Harness status: OK
+
+Found 25 tests
+
+24 Pass
+1 Fail
+Pass	@supports at-rule
+Pass	@supports at-rule 1
+Pass	@supports at-rule 2
+Pass	@supports at-rule 3
+Pass	@supports at-rule 4
+Pass	@supports at-rule 5
+Pass	@supports at-rule 6
+Pass	@supports at-rule 7
+Fail	@supports at-rule 8
+Pass	@supports at-rule 9
+Pass	@supports at-rule 10
+Pass	@supports at-rule 11
+Pass	@supports at-rule 12
+Pass	@supports at-rule 13
+Pass	@supports at-rule 14
+Pass	@supports at-rule 15
+Pass	@supports at-rule 16
+Pass	@supports at-rule 17
+Pass	@supports at-rule 18
+Pass	@supports at-rule 19
+Pass	@supports at-rule 20
+Pass	@supports at-rule 21
+Pass	@supports at-rule 22
+Pass	@supports at-rule 23
+Pass	@supports at-rule 24

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/js/supports-at-rule.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/js/supports-at-rule.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>@supports at-rule</title>
+<link rel="help" href="https://www.w3.org/TR/css-conditional-4/#the-css-namespace">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+  function test_supports(rule, expected, desc) {
+    test(() => {
+      assert_equals(CSS.supports(rule), expected, 'CSS.supports(' + rule + ')');
+    }, desc);
+  }
+
+  // Basic at-rule support.
+  test_supports("at-rule(@supports)", true);
+  test_supports("at-rule( @supports)", true);
+  test_supports("at-rule(@supports )", true);
+  test_supports("at-rule(@media)", true);
+  test_supports("at-rule(@counter-style)", true);
+  test_supports("at-rule(@doesnotexist)", false);
+
+  // At-rules with special positioning requirements.
+  test_supports("at-rule(@import)", true);
+  test_supports("at-rule(@swash)", true);
+  test_supports("at-rule(@starting-style)", true);
+
+  // @charset is not an at-rule.
+  test_supports("at-rule(@charset)", false);
+
+  // Descriptors are not accepted.
+  test_supports("at-rule(@counter-style; system: fixed)", false);
+
+  // Combining at-rule() with <supports-decl> using 'and'.
+  test_supports("at-rule(@supports) and (color: red)", true);
+  test_supports("at-rule(@media) and (display: flex)", true);
+  test_supports("at-rule(@doesnotexist) and (color: red)", false);
+  test_supports("at-rule(@supports) and (doesnotexist: red)", false);
+
+  // Combining at-rule() with <supports-decl> using 'or'.
+  test_supports("at-rule(@supports) or (color: red)", true);
+  test_supports("at-rule(@doesnotexist) or (color: red)", true);
+  test_supports("at-rule(@supports) or (doesnotexist: red)", true);
+  test_supports("at-rule(@doesnotexist) or (doesnotexist: red)", false);
+
+  // 'not' with at-rule().
+  test_supports("not at-rule(@supports)", false);
+  test_supports("not at-rule(@doesnotexist)", true);
+
+  // <supports-decl> first, at-rule() second.
+  test_supports("(color: red) and at-rule(@supports)", true);
+  test_supports("(color: red) and at-rule(@doesnotexist)", false);
+  test_supports("(color: red) or at-rule(@doesnotexist)", true);
+  test_supports("(doesnotexist: red) or at-rule(@doesnotexist)", false);
+</script>


### PR DESCRIPTION
Matches if we support the at-rule in some form.

Keeping this list up to date is a bit awkward, but we don't add at-rules too often, and having all at-rules defined in JSON would just move the awkward-to-maintain list somewhere else.

Amusingly, I have a PR open right now which adds a new at-rule. :sweat_smile: So this will need a follow-up after that's merged.