### PR TITLE
LibJS+LibWeb: Install fresh JS bytecode caches as mapped backing

### DIFF
--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -25,6 +25,7 @@
 namespace JS::Bytecode {
 
 GC_DEFINE_ALLOCATOR(Executable);
+GC_DEFINE_ALLOCATOR(TemplateObjectCache);
 GC_DEFINE_ALLOCATOR(ObjectPropertyIteratorCacheData);
 
 InstructionStream::InstructionStream(Vector<u8> bytecode)
@@ -179,6 +180,17 @@ size_t PropertyLookupCache::external_memory_size() const
     return 0;
 }
 
+void PropertyLookupCache::copy_from(PropertyLookupCache const& other)
+{
+    clear();
+    if (auto* data = other.monomorphic_data()) {
+        set_monomorphic_data(new MonomorphicData(*data));
+        return;
+    }
+    if (auto* data = other.polymorphic_data())
+        set_polymorphic_data(new PolymorphicData(*data));
+}
+
 void PropertyLookupCache::clear()
 {
     if (auto* data = monomorphic_data()) {
@@ -252,6 +264,12 @@ size_t ObjectPropertyIteratorCacheData::external_memory_size() const
     return size;
 }
 
+void TemplateObjectCache::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(cached_template_object);
+}
+
 Executable::Executable(
     InstructionStream bytecode,
     NonnullOwnPtr<IdentifierTable> identifier_table,
@@ -282,7 +300,9 @@ Executable::Executable(
     property_lookup_caches.resize(number_of_property_lookup_caches);
     global_variable_caches.resize(number_of_global_variable_caches);
     environment_coordinate_caches.resize(number_of_environment_coordinate_caches);
-    template_object_caches.resize(number_of_template_object_caches);
+    template_object_caches.ensure_capacity(number_of_template_object_caches);
+    for (size_t i = 0; i < number_of_template_object_caches; ++i)
+        template_object_caches.append(heap().allocate<TemplateObjectCache>());
     object_shape_caches.resize(number_of_object_shape_caches);
     object_property_iterator_caches.resize(number_of_object_property_iterator_caches);
     asm_constants_size = this->constants.size();
@@ -541,8 +561,7 @@ void Executable::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(constants);
-    for (auto& cache : template_object_caches)
-        visitor.visit(cache.cached_template_object);
+    visitor.visit(template_object_caches);
     for (auto& cache : object_property_iterator_caches)
         visitor.visit(cache.data);
     for (auto& cache : object_property_iterator_caches)
@@ -556,6 +575,34 @@ void Executable::visit_edges(Visitor& visitor)
         }
     }
     property_key_table->visit_edges(visitor);
+}
+
+void Executable::copy_runtime_caches_from(Executable const& other)
+{
+    if (this == &other)
+        return;
+
+    if (property_lookup_caches.size() == other.property_lookup_caches.size()) {
+        for (size_t i = 0; i < property_lookup_caches.size(); ++i)
+            property_lookup_caches[i].copy_from(other.property_lookup_caches[i]);
+    }
+
+    if (global_variable_caches.size() == other.global_variable_caches.size())
+        global_variable_caches = other.global_variable_caches;
+
+    if (environment_coordinate_caches.size() == other.environment_coordinate_caches.size())
+        environment_coordinate_caches = other.environment_coordinate_caches;
+
+    if (template_object_caches.size() == other.template_object_caches.size())
+        template_object_caches = other.template_object_caches;
+
+    if (object_shape_caches.size() == other.object_shape_caches.size())
+        object_shape_caches = other.object_shape_caches;
+
+    if (object_property_iterator_caches.size() == other.object_property_iterator_caches.size()) {
+        for (size_t i = 0; i < object_property_iterator_caches.size(); ++i)
+            object_property_iterator_caches[i].data = other.object_property_iterator_caches[i].data;
+    }
 }
 
 size_t Executable::external_memory_size() const

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -98,6 +98,7 @@ struct PropertyLookupCache {
     [[nodiscard]] Span<Entry> entries();
     [[nodiscard]] ReadonlySpan<Entry> entries() const;
     [[nodiscard]] size_t external_memory_size() const;
+    void copy_from(PropertyLookupCache const&);
 
     void update(Entry::Type type, auto callback)
     {
@@ -194,8 +195,17 @@ struct GlobalVariableCache {
 
 // https://tc39.es/ecma262/#sec-gettemplateobject
 // Template objects are cached at the call site.
-struct TemplateObjectCache {
+class JS_API TemplateObjectCache final : public Cell {
+    GC_CELL(TemplateObjectCache, Cell);
+    GC_DECLARE_ALLOCATOR(TemplateObjectCache);
+
+public:
+    virtual ~TemplateObjectCache() override = default;
+
     GC::Ptr<Array> cached_template_object;
+
+private:
+    virtual void visit_edges(Visitor&) override;
 };
 
 // Cache for object literal shapes.
@@ -288,7 +298,7 @@ public:
     Vector<PropertyLookupCache> property_lookup_caches;
     Vector<GlobalVariableCache> global_variable_caches;
     Vector<EnvironmentCoordinate> environment_coordinate_caches;
-    Vector<TemplateObjectCache> template_object_caches;
+    Vector<GC::Ref<TemplateObjectCache>> template_object_caches;
     Vector<ObjectShapeCache> object_shape_caches;
     Vector<ObjectPropertyIteratorCache> object_property_iterator_caches;
     NonnullOwnPtr<StringTable> string_table;
@@ -338,6 +348,7 @@ public:
     }
 
     [[nodiscard]] COLD Optional<size_t> basic_block_index_for_offset(size_t offset) const;
+    void copy_runtime_caches_from(Executable const&);
     [[nodiscard]] COLD Optional<ExceptionHandlers const&> exception_handlers_for_offset(size_t offset) const;
 
     [[nodiscard]] Optional<SourceRange> source_range_at(size_t offset) const;

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -2143,7 +2143,7 @@ void NewPrimitiveArray::execute_impl(VM& vm) const
 // 13.2.8.4 GetTemplateObject ( templateLiteral ), https://tc39.es/ecma262/#sec-gettemplateobject
 void GetTemplateObject::execute_impl(VM& vm) const
 {
-    auto& cache = vm.current_executable().template_object_caches[m_cache];
+    auto& cache = *vm.current_executable().template_object_caches[m_cache];
 
     // 1. Let realm be the current Realm Record.
     auto& realm = *vm.current_realm();

--- a/Libraries/LibJS/ExecutableBacking.h
+++ b/Libraries/LibJS/ExecutableBacking.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+
+namespace JS {
+
+class Script;
+class SourceTextModule;
+
+// Tracks how a Script or SourceTextModule executable is backed. The owner keeps
+// the concrete executable and shared-function-data storage; this object only
+// owns backing state and transition rules.
+class ExecutableBacking {
+private:
+    enum class State {
+        Source,
+        HeapBytecode,
+        GeneratingFreshCacheFromSource,
+        GeneratingFreshCacheFromHeapBytecode,
+        MappedBytecodeCache,
+    };
+
+    explicit ExecutableBacking(State state)
+        : m_state(state)
+    {
+    }
+
+    static ExecutableBacking source()
+    {
+        return ExecutableBacking(State::Source);
+    }
+
+    static ExecutableBacking heap_bytecode()
+    {
+        return ExecutableBacking(State::HeapBytecode);
+    }
+
+    static ExecutableBacking mapped_bytecode_cache()
+    {
+        return ExecutableBacking(State::MappedBytecodeCache);
+    }
+
+public:
+    [[nodiscard]] bool is_source() const
+    {
+        return m_state == State::Source
+            || m_state == State::GeneratingFreshCacheFromSource;
+    }
+
+    [[nodiscard]] bool is_heap_bytecode() const
+    {
+        return m_state == State::HeapBytecode
+            || m_state == State::GeneratingFreshCacheFromHeapBytecode;
+    }
+
+    [[nodiscard]] bool is_mapped_bytecode_cache() const { return m_state == State::MappedBytecodeCache; }
+
+private:
+    friend class Script;
+    friend class SourceTextModule;
+
+    [[nodiscard]] bool can_generate_bytecode_cache() const
+    {
+        return m_state == State::Source
+            || m_state == State::HeapBytecode;
+    }
+
+    [[nodiscard]] bool can_install_generated_bytecode_cache() const { return is_generating_bytecode_cache(); }
+
+    [[nodiscard]] bool requires_non_bytecode_cache_compile_inputs_to_be_cleared() const
+    {
+        return is_mapped_bytecode_cache();
+    }
+
+    [[nodiscard]] bool is_generating_bytecode_cache() const
+    {
+        return m_state == State::GeneratingFreshCacheFromSource
+            || m_state == State::GeneratingFreshCacheFromHeapBytecode;
+    }
+
+    void begin_bytecode_cache_generation()
+    {
+        switch (m_state) {
+        case State::Source:
+            m_state = State::GeneratingFreshCacheFromSource;
+            return;
+        case State::HeapBytecode:
+            m_state = State::GeneratingFreshCacheFromHeapBytecode;
+            return;
+        case State::GeneratingFreshCacheFromSource:
+        case State::GeneratingFreshCacheFromHeapBytecode:
+        case State::MappedBytecodeCache:
+            VERIFY_NOT_REACHED();
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    void finish_bytecode_cache_generation_without_install()
+    {
+        switch (m_state) {
+        case State::GeneratingFreshCacheFromSource:
+            m_state = State::Source;
+            return;
+        case State::GeneratingFreshCacheFromHeapBytecode:
+            m_state = State::HeapBytecode;
+            return;
+        case State::Source:
+        case State::HeapBytecode:
+        case State::MappedBytecodeCache:
+            VERIFY_NOT_REACHED();
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    void finish_bytecode_cache_install()
+    {
+        VERIFY(!is_mapped_bytecode_cache());
+        m_state = State::MappedBytecodeCache;
+    }
+
+    State m_state { State::Source };
+};
+
+}

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.cpp
@@ -23,6 +23,7 @@ SharedFunctionInstanceData::SharedFunctionInstanceData(
     bool is_arrow_function,
     bool has_simple_parameter_list,
     Vector<Utf16FlyString> parameter_names_for_mapped_arguments,
+    SharedFunctionInstanceDataList& owner_shared_function_data_list,
     void* rust_function_ast)
     : m_name(move(name))
     , m_function_length(function_length)
@@ -34,6 +35,38 @@ SharedFunctionInstanceData::SharedFunctionInstanceData(
     , m_has_simple_parameter_list(has_simple_parameter_list)
     , m_rust_function_ast(rust_function_ast)
     , m_use_rust_compilation(true)
+{
+    initialize_after_construction();
+    owner_shared_function_data_list.append(*this);
+}
+
+SharedFunctionInstanceData::SharedFunctionInstanceData(
+    VM&,
+    FunctionKind kind,
+    Utf16FlyString name,
+    i32 function_length,
+    u32 formal_parameter_count,
+    bool strict,
+    bool is_arrow_function,
+    bool has_simple_parameter_list,
+    Vector<Utf16FlyString> parameter_names_for_mapped_arguments,
+    NoSharedFunctionDataList,
+    void* rust_function_ast)
+    : m_name(move(name))
+    , m_function_length(function_length)
+    , m_formal_parameter_count(formal_parameter_count)
+    , m_parameter_names_for_mapped_arguments(move(parameter_names_for_mapped_arguments))
+    , m_kind(kind)
+    , m_strict(strict)
+    , m_is_arrow_function(is_arrow_function)
+    , m_has_simple_parameter_list(has_simple_parameter_list)
+    , m_rust_function_ast(rust_function_ast)
+    , m_use_rust_compilation(true)
+{
+    initialize_after_construction();
+}
+
+void SharedFunctionInstanceData::initialize_after_construction()
 {
     if (m_is_arrow_function)
         m_this_mode = ThisMode::Lexical;
@@ -130,6 +163,9 @@ void SharedFunctionInstanceData::update_asm_call_metadata()
 
 void SharedFunctionInstanceData::finalize()
 {
+    if (m_owner_shared_function_data_list)
+        m_owner_shared_function_data_list->remove(*this);
+
     Base::finalize();
     RustIntegration::free_function_ast(m_rust_function_ast);
     m_rust_function_ast = nullptr;
@@ -141,14 +177,18 @@ void SharedFunctionInstanceData::finalize()
 
 void SharedFunctionInstanceData::clear_compile_inputs()
 {
-    VERIFY(m_executable);
+    clear_non_bytecode_cache_compile_inputs();
+    RustIntegration::free_cached_bytecode_executable(m_cached_bytecode_executable);
+    m_cached_bytecode_executable = nullptr;
+}
+
+void SharedFunctionInstanceData::clear_non_bytecode_cache_compile_inputs()
+{
     m_functions_to_initialize.clear();
     m_var_names_to_initialize_binding.clear();
     m_lexical_bindings.clear();
     RustIntegration::free_function_ast(m_rust_function_ast);
     m_rust_function_ast = nullptr;
-    RustIntegration::free_cached_bytecode_executable(m_cached_bytecode_executable);
-    m_cached_bytecode_executable = nullptr;
     RustIntegration::free_precompiled_bytecode_executable(m_precompiled_bytecode_executable);
     m_precompiled_bytecode_executable = nullptr;
 }
@@ -157,6 +197,68 @@ void SharedFunctionInstanceData::update_can_inline_call()
 {
     m_can_inline_call = m_executable && m_kind == FunctionKind::Normal && !m_is_class_constructor;
     update_asm_call_metadata();
+}
+
+SharedFunctionInstanceDataList::~SharedFunctionInstanceDataList()
+{
+    clear();
+}
+
+void SharedFunctionInstanceDataList::append(SharedFunctionInstanceData& shared_data)
+{
+    if (shared_data.m_owner_shared_function_data_list == this)
+        return;
+    if (shared_data.m_owner_shared_function_data_list)
+        shared_data.m_owner_shared_function_data_list->remove(shared_data);
+    VERIFY(!shared_data.m_script_or_module_list_node.is_in_list());
+
+    m_list.append(shared_data);
+    shared_data.m_owner_shared_function_data_list = this;
+}
+
+void SharedFunctionInstanceDataList::visit_edges(GC::Cell::Visitor& visitor)
+{
+    for (auto& shared_data : m_list)
+        visitor.visit(shared_data);
+}
+
+void SharedFunctionInstanceDataList::clear_non_bytecode_cache_compile_inputs()
+{
+    for (auto& shared_data : m_list)
+        shared_data.clear_non_bytecode_cache_compile_inputs();
+}
+
+bool SharedFunctionInstanceDataList::contains_rust_function_ast() const
+{
+    for (auto const& shared_data : m_list) {
+        if (shared_data.m_rust_function_ast)
+            return true;
+    }
+    return false;
+}
+
+bool SharedFunctionInstanceDataList::contains_precompiled_bytecode() const
+{
+    for (auto const& shared_data : m_list) {
+        if (shared_data.m_precompiled_bytecode_executable)
+            return true;
+    }
+    return false;
+}
+
+void SharedFunctionInstanceDataList::clear()
+{
+    while (!m_list.is_empty()) {
+        auto* shared_data = m_list.first();
+        remove(*shared_data);
+    }
+}
+
+void SharedFunctionInstanceDataList::remove(SharedFunctionInstanceData& shared_data)
+{
+    VERIFY(shared_data.m_owner_shared_function_data_list == this);
+    m_list.remove(shared_data);
+    shared_data.m_owner_shared_function_data_list = nullptr;
 }
 
 }

--- a/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
+++ b/Libraries/LibJS/Runtime/SharedFunctionInstanceData.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/IntrusiveList.h>
 #include <LibGC/Cell.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
@@ -16,6 +17,11 @@
 #include <LibJS/Runtime/PropertyKey.h>
 
 namespace JS {
+
+class SharedFunctionInstanceDataList;
+
+struct NoSharedFunctionDataList {
+};
 
 // NB: This mirrors Identifier::Local from AST.h, defined here to avoid
 //     including the full AST header in this file.
@@ -46,9 +52,13 @@ enum class ConstructorKind : u8 {
 class JS_API SharedFunctionInstanceData final : public GC::Cell {
     GC_CELL(SharedFunctionInstanceData, GC::Cell);
     GC_DECLARE_ALLOCATOR(SharedFunctionInstanceData);
+    friend class SharedFunctionInstanceDataList;
     static constexpr bool OVERRIDES_FINALIZE = true;
 
 public:
+    IntrusiveListNode<SharedFunctionInstanceData> m_script_or_module_list_node;
+    SharedFunctionInstanceDataList* m_owner_shared_function_data_list { nullptr };
+
     static constexpr u64 asm_call_metadata_can_inline_call = 1ull << 32;
     static constexpr u64 asm_call_metadata_needs_environment_or_this_value_resolution = 1ull << 33;
     static constexpr u64 asm_call_metadata_uses_this = 1ull << 34;
@@ -67,6 +77,20 @@ public:
         bool is_arrow_function,
         bool has_simple_parameter_list,
         Vector<Utf16FlyString> parameter_names_for_mapped_arguments,
+        SharedFunctionInstanceDataList&,
+        void* rust_function_ast);
+
+    SharedFunctionInstanceData(
+        VM& vm,
+        FunctionKind,
+        Utf16FlyString name,
+        i32 function_length,
+        u32 formal_parameter_count,
+        bool strict,
+        bool is_arrow_function,
+        bool has_simple_parameter_list,
+        Vector<Utf16FlyString> parameter_names_for_mapped_arguments,
+        NoSharedFunctionDataList,
         void* rust_function_ast);
 
     void set_executable(GC::Ptr<Bytecode::Executable>);
@@ -93,6 +117,12 @@ public:
     size_t m_source_text_offset { 0 };
     size_t m_source_text_length { 0 }; // [[SourceText]]
 
+    // NB: Some runtime operations replace [[SourceText]] with a wider range
+    //     (e.g. class constructors use the full class source). Keep the
+    //     original parsed function range for bytecode cache identity.
+    size_t m_bytecode_cache_source_text_offset { 0 };
+    size_t m_bytecode_cache_source_text_length { 0 };
+
     Vector<LocalVariable> m_local_variables_names;
 
     i32 m_function_length { 0 };
@@ -108,6 +138,7 @@ public:
     bool m_is_arrow_function { false };
     bool m_has_simple_parameter_list { false };
     bool m_is_module_wrapper { false };
+    bool m_has_bytecode_cache_source_text_range { false };
 
     struct VarBinding {
         Utf16FlyString name;
@@ -166,13 +197,45 @@ public:
     bool m_use_rust_compilation { false };
 
     void clear_compile_inputs();
+    void clear_non_bytecode_cache_compile_inputs();
 
 private:
+    void initialize_after_construction();
+
     virtual void visit_edges(Visitor&) override;
     virtual size_t external_memory_size() const override;
     void update_can_inline_call();
 
     bool m_can_inline_call { false };
+};
+
+class JS_API SharedFunctionInstanceDataList {
+    friend class SharedFunctionInstanceData;
+
+public:
+    ~SharedFunctionInstanceDataList();
+
+    void append(SharedFunctionInstanceData&);
+    void visit_edges(GC::Cell::Visitor&);
+    void clear_non_bytecode_cache_compile_inputs();
+    [[nodiscard]] size_t size_slow() const { return m_list.size_slow(); }
+    [[nodiscard]] bool contains_rust_function_ast() const;
+    [[nodiscard]] bool contains_precompiled_bytecode() const;
+
+    template<typename Callback>
+    void for_each(Callback callback)
+    {
+        for (auto& shared_data : m_list)
+            callback(shared_data);
+    }
+
+private:
+    using List = IntrusiveList<&SharedFunctionInstanceData::m_script_or_module_list_node>;
+
+    void clear();
+    void remove(SharedFunctionInstanceData&);
+
+    List m_list;
 };
 
 }

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -35,6 +35,19 @@ use crate::u32_from_usize;
 /// Opaque pointer returned from rust_create_executable.
 pub type ExecutableHandle = *mut c_void;
 
+#[derive(Clone, Copy)]
+pub enum SharedFunctionDataOwner {
+    None,
+    List(*mut c_void),
+}
+
+#[derive(Clone, Copy)]
+pub struct SharedFunctionDataCreationContext {
+    pub vm_ptr: *mut c_void,
+    pub source_code_ptr: *const c_void,
+    pub owner: SharedFunctionDataOwner,
+}
+
 /// Exception handler range (C++ `BytecodeFactory::ExceptionHandlerData`).
 #[repr(C)]
 pub struct FFIExceptionHandler {
@@ -240,6 +253,12 @@ unsafe extern "C" {
         source_code_ptr: *const c_void,
         data: *const FFISharedFunctionData,
     ) -> *mut c_void;
+    pub fn rust_create_sfd_in_list(
+        vm_ptr: *mut c_void,
+        source_code_ptr: *const c_void,
+        shared_function_data_list_ptr: *mut c_void,
+        data: *const FFISharedFunctionData,
+    ) -> *mut c_void;
 
     pub fn rust_sfd_set_class_field_initializer_name(
         sfd_ptr: *mut c_void,
@@ -275,6 +294,34 @@ unsafe extern "C" {
     pub fn rust_sfd_set_precompiled_bytecode_executable(
         sfd_ptr: *mut c_void,
         precompiled_executable_ptr: *mut c_void,
+        uses_this: bool,
+        this_value_needs_environment_resolution: bool,
+        function_environment_needed: bool,
+        function_environment_bindings_count: usize,
+        var_environment_bindings_count: usize,
+        might_need_arguments_object: bool,
+        contains_direct_call_to_eval: bool,
+    );
+
+    pub fn rust_executable_shared_function_data_count(executable_ptr: *const c_void) -> usize;
+    pub fn rust_executable_shared_function_data_at(executable_ptr: *const c_void, index: usize) -> *mut c_void;
+    pub fn rust_sfd_executable(sfd_ptr: *const c_void) -> *mut c_void;
+    pub fn rust_sfd_matches_bytecode_cache_function(sfd_ptr: *const c_void, data: *const FFISharedFunctionData)
+    -> bool;
+    pub fn rust_sfd_install_bytecode_cache_executable(
+        sfd_ptr: *mut c_void,
+        executable_ptr: *mut c_void,
+        uses_this: bool,
+        this_value_needs_environment_resolution: bool,
+        function_environment_needed: bool,
+        function_environment_bindings_count: usize,
+        var_environment_bindings_count: usize,
+        might_need_arguments_object: bool,
+        contains_direct_call_to_eval: bool,
+    );
+    pub fn rust_sfd_install_cached_bytecode_executable(
+        sfd_ptr: *mut c_void,
+        cached_executable_ptr: *mut c_void,
         uses_this: bool,
         this_value_needs_environment_resolution: bool,
         function_environment_needed: bool,
@@ -345,8 +392,7 @@ unsafe extern "C" {
 pub unsafe fn create_shared_function_data(
     function_data: Box<crate::ast::FunctionData>,
     subtable: crate::ast::FunctionTable,
-    vm_ptr: *mut c_void,
-    source_code_ptr: *const c_void,
+    context: SharedFunctionDataCreationContext,
     is_strict: bool,
     name_override: Option<&[u16]>,
     arena: std::sync::Arc<crate::ast::AstArena>,
@@ -420,7 +466,15 @@ pub unsafe fn create_shared_function_data(
             uses_this_from_environment,
         };
 
-        let sfd_ptr = rust_create_sfd(vm_ptr, source_code_ptr, &raw const ffi_data);
+        let sfd_ptr = match context.owner {
+            SharedFunctionDataOwner::None => {
+                rust_create_sfd(context.vm_ptr, context.source_code_ptr, &raw const ffi_data)
+            }
+            SharedFunctionDataOwner::List(list_ptr) => {
+                assert!(!list_ptr.is_null(), "SharedFunctionDataOwner::List must not be null");
+                rust_create_sfd_in_list(context.vm_ptr, context.source_code_ptr, list_ptr, &raw const ffi_data)
+            }
+        };
 
         assert!(
             !sfd_ptr.is_null(),
@@ -437,18 +491,16 @@ pub unsafe fn create_shared_function_data(
 pub unsafe fn create_sfd_for_gdi(
     function_data: Box<crate::ast::FunctionData>,
     subtable: crate::ast::FunctionTable,
-    vm_ptr: *mut c_void,
-    source_code_ptr: *const c_void,
+    context: SharedFunctionDataCreationContext,
     is_strict: bool,
     arena: std::sync::Arc<crate::ast::AstArena>,
 ) -> *mut c_void {
-    unsafe { create_shared_function_data(function_data, subtable, vm_ptr, source_code_ptr, is_strict, None, arena) }
+    unsafe { create_shared_function_data(function_data, subtable, context, is_strict, None, arena) }
 }
 
 unsafe fn materialize_shared_function_data(
     generator: &mut Generator,
-    vm_ptr: *mut c_void,
-    source_code_ptr: *const c_void,
+    context: SharedFunctionDataCreationContext,
 ) -> Vec<*const c_void> {
     unsafe {
         let mut sfd_ptrs = Vec::with_capacity(generator.shared_function_data.len());
@@ -465,8 +517,7 @@ unsafe fn materialize_shared_function_data(
             let sfd_ptr = create_shared_function_data(
                 function_data,
                 subtable,
-                vm_ptr,
-                source_code_ptr,
+                context,
                 generator.strict,
                 pending.name_override.as_ref().map(|name| name.as_slice()),
                 arena,
@@ -651,9 +702,17 @@ pub unsafe fn create_executable(
     assembled: &AssembledBytecode,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    owner: SharedFunctionDataOwner,
 ) -> ExecutableHandle {
     unsafe {
-        let sfd_ptrs = materialize_shared_function_data(generator, vm_ptr, source_code_ptr);
+        let sfd_ptrs = materialize_shared_function_data(
+            generator,
+            SharedFunctionDataCreationContext {
+                vm_ptr,
+                source_code_ptr,
+                owner,
+            },
+        );
         let bp_ptrs = materialize_class_blueprints(generator, vm_ptr, source_code_ptr);
         create_executable_with_dependencies(generator, assembled, vm_ptr, source_code_ptr, &sfd_ptrs, &bp_ptrs)
     }

--- a/Libraries/LibJS/Rust/src/bytecode_cache.rs
+++ b/Libraries/LibJS/Rust/src/bytecode_cache.rs
@@ -64,14 +64,6 @@ pub fn serialize_compiled_program(
     encoder.finish()
 }
 
-pub(crate) fn decode_blob(
-    bytes: &[u8],
-    expected_program_type: ast::ProgramType,
-    expected_source_hash: &[u8; SOURCE_HASH_SIZE],
-) -> Option<DecodedCacheBlob> {
-    decode_blob_impl(bytes, expected_program_type, expected_source_hash, None)
-}
-
 pub(crate) type FreeBytecodeCacheBlobOwner = unsafe extern "C" fn(*mut c_void);
 pub(crate) type CloneBytecodeCacheBlobOwner = unsafe extern "C" fn(*const c_void) -> *mut c_void;
 
@@ -215,15 +207,12 @@ impl<'a> Decoder<'a> {
 
     fn bytecode_bytes(&mut self, length: usize) -> Option<DecodedBytecodeBytes> {
         let offset = self.offset;
-        let bytes = self.bytes(length)?;
-        if let Some(foreign_blob) = &self.foreign_blob {
-            return Some(DecodedBytecodeBytes::Foreign {
-                blob: foreign_blob.clone(),
-                range: offset..offset + length,
-            });
-        }
-
-        Some(DecodedBytecodeBytes::Owned(bytes.to_vec()))
+        self.bytes(length)?;
+        let foreign_blob = self.foreign_blob.as_ref()?;
+        Some(DecodedBytecodeBytes::Foreign {
+            blob: foreign_blob.clone(),
+            range: offset..offset + length,
+        })
     }
 
     fn expect_bytes(&mut self, expected: &[u8]) -> Option<()> {
@@ -535,11 +524,12 @@ impl ByteVector {
 }
 
 enum DecodedBytecodeBytes {
-    Owned(Vec<u8>),
     Foreign {
         blob: Rc<ForeignBytecodeCacheBlob>,
         range: Range<usize>,
     },
+    #[cfg(test)]
+    Owned(Vec<u8>),
 }
 
 impl DecodedBytecodeBytes {
@@ -550,22 +540,24 @@ impl DecodedBytecodeBytes {
 
     fn as_slice(&self) -> &[u8] {
         match self {
-            Self::Owned(bytes) => bytes,
             Self::Foreign { blob, range } => {
                 debug_assert!(range.end <= blob.length);
                 unsafe { std::slice::from_raw_parts(blob.data.add(range.start), range.len()) }
             }
+            #[cfg(test)]
+            Self::Owned(bytes) => bytes,
         }
     }
 
     fn owner_for_ffi(&self) -> *mut c_void {
         match self {
-            Self::Owned(_) => std::ptr::null_mut(),
             // The C++ executable retains the immutable blob so the hot
             // instruction stream can point directly into the cache file. Clone
             // the small owner wrapper here; the original decoded blob still
             // owns its copy until materialization finishes.
             Self::Foreign { blob, .. } => unsafe { (blob.clone_owner)(blob.owner.cast_const()) },
+            #[cfg(test)]
+            Self::Owned(_) => std::ptr::null_mut(),
         }
     }
 
@@ -575,15 +567,16 @@ impl DecodedBytecodeBytes {
 
     fn decoder(&self) -> Decoder<'_> {
         match self {
-            Self::Owned(bytes) => Decoder {
-                bytes,
-                offset: 0,
-                foreign_blob: None,
-            },
             Self::Foreign { blob, range } => Decoder {
                 bytes: self.as_slice(),
                 offset: range.start,
                 foreign_blob: Some(blob.clone()),
+            },
+            #[cfg(test)]
+            Self::Owned(bytes) => Decoder {
+                bytes,
+                offset: 0,
+                foreign_blob: None,
             },
         }
     }
@@ -734,6 +727,7 @@ impl DecodedCacheBlob {
         self,
         vm_ptr: *mut c_void,
         source_code_ptr: *const c_void,
+        shared_function_data_list_ptr: *mut c_void,
         gdi_context: *mut c_void,
     ) -> *mut c_void {
         unsafe {
@@ -761,17 +755,20 @@ impl DecodedCacheBlob {
                 return std::ptr::null_mut();
             }
 
+            let shared_function_data_owner =
+                crate::bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr);
             if !materialize_script_declaration_metadata(
                 metadata,
                 declaration_functions,
                 is_strict_mode,
                 vm_ptr,
                 source_code_ptr,
+                shared_function_data_owner,
                 gdi_context,
             ) {
                 return std::ptr::null_mut();
             }
-            materialize_executable(program.executable, vm_ptr, source_code_ptr)
+            materialize_executable(program.executable, vm_ptr, source_code_ptr, shared_function_data_owner)
         }
     }
 
@@ -779,6 +776,7 @@ impl DecodedCacheBlob {
         self,
         vm_ptr: *mut c_void,
         source_code_ptr: *const c_void,
+        shared_function_data_list_ptr: *mut c_void,
         module_context: *mut c_void,
         callbacks: *const ModuleCallbacks,
         tla_executable_out: *mut *mut c_void,
@@ -809,12 +807,15 @@ impl DecodedCacheBlob {
                 return std::ptr::null_mut();
             }
 
+            let shared_function_data_owner =
+                crate::bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr);
             (cb.set_has_top_level_await)(module_context, has_top_level_await);
             if !materialize_module_declaration_metadata(
                 metadata,
                 declaration_functions,
                 vm_ptr,
                 source_code_ptr,
+                shared_function_data_owner,
                 module_context,
                 cb,
             ) {
@@ -823,7 +824,8 @@ impl DecodedCacheBlob {
 
             match program.kind {
                 ProgramKind::AsyncModule => {
-                    let exec_ptr = materialize_executable(program.executable, vm_ptr, source_code_ptr);
+                    let exec_ptr =
+                        materialize_executable(program.executable, vm_ptr, source_code_ptr, shared_function_data_owner);
                     if !tla_executable_out.is_null() {
                         *tla_executable_out = exec_ptr;
                     }
@@ -833,10 +835,208 @@ impl DecodedCacheBlob {
                     if !tla_executable_out.is_null() {
                         *tla_executable_out = std::ptr::null_mut();
                     }
-                    materialize_executable(program.executable, vm_ptr, source_code_ptr)
+                    materialize_executable(program.executable, vm_ptr, source_code_ptr, shared_function_data_owner)
                 }
             }
         }
+    }
+
+    pub(crate) unsafe fn install_script(
+        self,
+        vm_ptr: *mut c_void,
+        source_code_ptr: *const c_void,
+        existing_executable_ptr: *const c_void,
+        existing_shared_function_data_ptrs: &[*mut c_void],
+    ) -> *mut c_void {
+        unsafe {
+            if existing_executable_ptr.is_null() {
+                return std::ptr::null_mut();
+            }
+
+            let Self {
+                program_type,
+                is_strict_mode,
+                metadata,
+                program,
+                ..
+            } = self;
+            if program_type != ast::ProgramType::Script {
+                return std::ptr::null_mut();
+            }
+            let DecodedDeclarationMetadata::Script {
+                metadata,
+                declaration_functions,
+            } = metadata
+            else {
+                return std::ptr::null_mut();
+            };
+            let ProgramKind::ScriptOrModule = program.kind else {
+                return std::ptr::null_mut();
+            };
+
+            let mut existing_shared_function_data = ExistingSharedFunctionData::new(existing_shared_function_data_ptrs);
+            let mut pending_function_installs = Vec::new();
+            if !prepare_declaration_function_installs(
+                declaration_functions,
+                metadata.function_names.len(),
+                &mut existing_shared_function_data,
+                is_strict_mode,
+                vm_ptr,
+                source_code_ptr,
+                &mut pending_function_installs,
+            ) {
+                return std::ptr::null_mut();
+            }
+            let executable_ptr = materialize_executable_for_install(
+                program.executable,
+                Some(&mut existing_shared_function_data),
+                crate::bytecode::ffi::SharedFunctionDataOwner::None,
+                vm_ptr,
+                source_code_ptr,
+                &mut pending_function_installs,
+            );
+            if executable_ptr.is_null() {
+                return std::ptr::null_mut();
+            }
+            if !existing_shared_function_data.all_matched() {
+                return std::ptr::null_mut();
+            }
+            for install in pending_function_installs {
+                install.commit();
+            }
+            executable_ptr
+        }
+    }
+
+    pub(crate) unsafe fn install_module(
+        self,
+        vm_ptr: *mut c_void,
+        source_code_ptr: *const c_void,
+        existing_executable_ptr: *const c_void,
+        existing_shared_function_data_ptrs: &[*mut c_void],
+        existing_tla_sfd_ptr: *mut c_void,
+        tla_executable_out: *mut *mut c_void,
+    ) -> *mut c_void {
+        unsafe {
+            let Self {
+                program_type,
+                has_top_level_await,
+                metadata,
+                program,
+                ..
+            } = self;
+            if program_type != ast::ProgramType::Module {
+                return std::ptr::null_mut();
+            }
+            let DecodedDeclarationMetadata::Module {
+                metadata,
+                declaration_functions,
+            } = metadata
+            else {
+                return std::ptr::null_mut();
+            };
+
+            let mut existing_shared_function_data = ExistingSharedFunctionData::new(existing_shared_function_data_ptrs);
+            let mut pending_function_installs = Vec::new();
+            if !prepare_declaration_function_installs(
+                declaration_functions,
+                metadata.function_names.len(),
+                &mut existing_shared_function_data,
+                true,
+                vm_ptr,
+                source_code_ptr,
+                &mut pending_function_installs,
+            ) {
+                return std::ptr::null_mut();
+            }
+            match program.kind {
+                ProgramKind::AsyncModule => {
+                    if !has_top_level_await || existing_tla_sfd_ptr.is_null() {
+                        return std::ptr::null_mut();
+                    }
+                    let exec_ptr = materialize_executable_for_install(
+                        program.executable,
+                        Some(&mut existing_shared_function_data),
+                        crate::bytecode::ffi::SharedFunctionDataOwner::None,
+                        vm_ptr,
+                        source_code_ptr,
+                        &mut pending_function_installs,
+                    );
+                    if exec_ptr.is_null() {
+                        return std::ptr::null_mut();
+                    }
+                    if !existing_shared_function_data.all_matched() {
+                        return std::ptr::null_mut();
+                    }
+                    for install in pending_function_installs {
+                        install.commit();
+                    }
+                    if !tla_executable_out.is_null() {
+                        *tla_executable_out = exec_ptr;
+                    }
+                    std::ptr::null_mut()
+                }
+                ProgramKind::ScriptOrModule => {
+                    if has_top_level_await || existing_executable_ptr.is_null() {
+                        return std::ptr::null_mut();
+                    }
+                    if !tla_executable_out.is_null() {
+                        *tla_executable_out = std::ptr::null_mut();
+                    }
+                    let executable_ptr = materialize_executable_for_install(
+                        program.executable,
+                        Some(&mut existing_shared_function_data),
+                        crate::bytecode::ffi::SharedFunctionDataOwner::None,
+                        vm_ptr,
+                        source_code_ptr,
+                        &mut pending_function_installs,
+                    );
+                    if executable_ptr.is_null() {
+                        return std::ptr::null_mut();
+                    }
+                    if !existing_shared_function_data.all_matched() {
+                        return std::ptr::null_mut();
+                    }
+                    for install in pending_function_installs {
+                        install.commit();
+                    }
+                    executable_ptr
+                }
+            }
+        }
+    }
+}
+
+unsafe fn prepare_declaration_function_installs(
+    declaration_functions: Vec<DecodedFunctionRecord>,
+    expected_function_count: usize,
+    existing_shared_function_data: &mut ExistingSharedFunctionData<'_>,
+    outer_strict: bool,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    pending_function_installs: &mut Vec<PendingFunctionInstall>,
+) -> bool {
+    unsafe {
+        if declaration_functions.len() != expected_function_count {
+            return false;
+        }
+
+        for function in declaration_functions {
+            if prepare_function_install(
+                function,
+                outer_strict,
+                existing_shared_function_data,
+                vm_ptr,
+                source_code_ptr,
+                pending_function_installs,
+            )
+            .is_null()
+            {
+                return false;
+            }
+        }
+
+        true
     }
 }
 
@@ -846,6 +1046,7 @@ unsafe fn materialize_script_declaration_metadata(
     is_strict_mode: bool,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
     gdi_context: *mut c_void,
 ) -> bool {
     unsafe {
@@ -861,7 +1062,13 @@ unsafe fn materialize_script_declaration_metadata(
             script_gdi_push_var_name(gdi_context, name.as_ptr(), name.len());
         }
         for (function, name) in declaration_functions.into_iter().zip(metadata.function_names.iter()) {
-            let sfd_ptr = materialize_function(function, is_strict_mode, vm_ptr, source_code_ptr);
+            let sfd_ptr = materialize_function(
+                function,
+                is_strict_mode,
+                vm_ptr,
+                source_code_ptr,
+                shared_function_data_owner,
+            );
             if sfd_ptr.is_null() {
                 return false;
             }
@@ -891,6 +1098,7 @@ unsafe fn materialize_module_declaration_metadata(
     declaration_functions: Vec<DecodedFunctionRecord>,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
     module_context: *mut c_void,
     cb: &ModuleCallbacks,
 ) -> bool {
@@ -944,7 +1152,7 @@ unsafe fn materialize_module_declaration_metadata(
             (cb.push_var_name)(module_context, name.as_ptr(), name.len());
         }
         for (function, name) in declaration_functions.into_iter().zip(metadata.function_names.iter()) {
-            let sfd_ptr = materialize_function(function, true, vm_ptr, source_code_ptr);
+            let sfd_ptr = materialize_function(function, true, vm_ptr, source_code_ptr, shared_function_data_owner);
             if sfd_ptr.is_null() {
                 return false;
             }
@@ -1033,11 +1241,92 @@ unsafe fn push_module_export_entry(
     }
 }
 
+enum PendingFunctionInstallReplacement {
+    CachedBytecode(DecodedCachedExecutableRecord),
+    Executable(*mut c_void),
+}
+
+struct ExistingSharedFunctionData<'a> {
+    ptrs: &'a [*mut c_void],
+    matched: Vec<bool>,
+}
+
+impl<'a> ExistingSharedFunctionData<'a> {
+    fn new(ptrs: &'a [*mut c_void]) -> Self {
+        Self {
+            ptrs,
+            matched: vec![false; ptrs.len()],
+        }
+    }
+
+    unsafe fn take_matching(&mut self, data: &FFISharedFunctionData) -> *mut c_void {
+        unsafe {
+            for (index, ptr) in self.ptrs.iter().copied().enumerate() {
+                if self.matched[index] || ptr.is_null() {
+                    continue;
+                }
+                if crate::bytecode::ffi::rust_sfd_matches_bytecode_cache_function(ptr, data) {
+                    self.matched[index] = true;
+                    return ptr;
+                }
+            }
+            std::ptr::null_mut()
+        }
+    }
+
+    fn all_matched(&self) -> bool {
+        self.matched.iter().all(|matched| *matched)
+    }
+}
+
+struct PendingFunctionInstall {
+    existing_sfd_ptr: *mut c_void,
+    replacement: PendingFunctionInstallReplacement,
+    metadata: FunctionSfdMetadata,
+}
+
+impl PendingFunctionInstall {
+    unsafe fn commit(self) {
+        unsafe {
+            match self.replacement {
+                PendingFunctionInstallReplacement::CachedBytecode(cached_executable) => {
+                    let cached_executable_ptr = Box::into_raw(Box::new(cached_executable)) as *mut c_void;
+                    crate::bytecode::ffi::rust_sfd_install_cached_bytecode_executable(
+                        self.existing_sfd_ptr,
+                        cached_executable_ptr,
+                        self.metadata.uses_this,
+                        self.metadata.this_value_needs_environment_resolution,
+                        self.metadata.function_environment_needed,
+                        self.metadata.function_environment_bindings_count,
+                        self.metadata.var_environment_bindings_count,
+                        self.metadata.might_need_arguments,
+                        self.metadata.contains_eval,
+                    );
+                }
+                PendingFunctionInstallReplacement::Executable(executable_ptr) => {
+                    crate::bytecode::ffi::rust_sfd_install_bytecode_cache_executable(
+                        self.existing_sfd_ptr,
+                        executable_ptr,
+                        self.metadata.uses_this,
+                        self.metadata.this_value_needs_environment_resolution,
+                        self.metadata.function_environment_needed,
+                        self.metadata.function_environment_bindings_count,
+                        self.metadata.var_environment_bindings_count,
+                        self.metadata.might_need_arguments,
+                        self.metadata.contains_eval,
+                    );
+                }
+            }
+        }
+    }
+}
+
 unsafe fn materialize_function(
     function: DecodedFunctionRecord,
     outer_strict: bool,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
 ) -> *mut c_void {
     unsafe {
         if function.precompiled.validate_cached_bytecode().is_err() {
@@ -1079,7 +1368,15 @@ unsafe fn materialize_function(
             uses_this_from_environment: function.uses_this_from_environment,
         };
 
-        let sfd_ptr = crate::bytecode::ffi::rust_create_sfd(vm_ptr, source_code_ptr, &raw const data);
+        let sfd_ptr = match shared_function_data_owner {
+            crate::bytecode::ffi::SharedFunctionDataOwner::None => {
+                crate::bytecode::ffi::rust_create_sfd(vm_ptr, source_code_ptr, &raw const data)
+            }
+            crate::bytecode::ffi::SharedFunctionDataOwner::List(list_ptr) => {
+                assert!(!list_ptr.is_null(), "SharedFunctionDataOwner::List must not be null");
+                crate::bytecode::ffi::rust_create_sfd_in_list(vm_ptr, source_code_ptr, list_ptr, &raw const data)
+            }
+        };
         if sfd_ptr.is_null() {
             return std::ptr::null_mut();
         }
@@ -1107,10 +1404,101 @@ unsafe fn materialize_function(
     }
 }
 
+unsafe fn prepare_function_install(
+    function: DecodedFunctionRecord,
+    outer_strict: bool,
+    existing_shared_function_data: &mut ExistingSharedFunctionData<'_>,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    pending_function_installs: &mut Vec<PendingFunctionInstall>,
+) -> *mut c_void {
+    unsafe {
+        let (_parameter_name_storage, parameter_names): (Vec<Vec<u16>>, Vec<FFIUtf16Slice>) = function
+            .parameter_names
+            .as_ref()
+            .map(|names| utf16_slice_storage(names.iter()))
+            .unwrap_or_default();
+        let name_storage = function.name.as_ref().map(PreparedUtf16Slice::new);
+        let (name, name_len) = name_storage
+            .as_ref()
+            .map(PreparedUtf16Slice::as_ptr_len)
+            .unwrap_or((std::ptr::null(), 0));
+        let source_text_offset = function.source_text_start as usize;
+        let source_text_length = function
+            .source_text_end
+            .checked_sub(function.source_text_start)
+            .map(|length| length as usize)
+            .unwrap_or(0);
+
+        let data = FFISharedFunctionData {
+            name,
+            name_len,
+            function_kind: function.kind as u8,
+            function_length: function.function_length,
+            formal_parameter_count: function.formal_parameter_count,
+            strict: function.is_strict_mode || outer_strict,
+            is_arrow: function.is_arrow_function,
+            has_simple_parameter_list: function.parameter_names.is_some(),
+            parameter_names: parameter_names.as_ptr(),
+            parameter_name_count: parameter_names.len(),
+            source_text_offset,
+            source_text_length,
+            rust_function_ast: std::ptr::null_mut(),
+            uses_this: function.uses_this,
+            uses_this_from_environment: function.uses_this_from_environment,
+        };
+
+        let existing_sfd_ptr = existing_shared_function_data.take_matching(&data);
+        if existing_sfd_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        if crate::bytecode::ffi::rust_sfd_executable(existing_sfd_ptr).is_null() {
+            if function.precompiled.validate_cached_bytecode().is_err() {
+                return std::ptr::null_mut();
+            }
+
+            pending_function_installs.push(PendingFunctionInstall {
+                existing_sfd_ptr,
+                replacement: PendingFunctionInstallReplacement::CachedBytecode(function.precompiled),
+                metadata: function.metadata,
+            });
+            return existing_sfd_ptr;
+        }
+
+        let Some(executable) = function.precompiled.decode_executable() else {
+            return std::ptr::null_mut();
+        };
+        if executable.validate_cached_bytecode().is_err() {
+            return std::ptr::null_mut();
+        }
+        let executable_ptr = materialize_executable_for_install(
+            executable,
+            Some(existing_shared_function_data),
+            crate::bytecode::ffi::SharedFunctionDataOwner::None,
+            vm_ptr,
+            source_code_ptr,
+            pending_function_installs,
+        );
+        if executable_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+
+        pending_function_installs.push(PendingFunctionInstall {
+            existing_sfd_ptr,
+            replacement: PendingFunctionInstallReplacement::Executable(executable_ptr),
+            metadata: function.metadata,
+        });
+
+        existing_sfd_ptr
+    }
+}
+
 pub(crate) unsafe fn materialize_cached_function(
     cached_executable_ptr: *mut c_void,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
 ) -> *mut c_void {
     unsafe {
         if cached_executable_ptr.is_null() {
@@ -1123,7 +1511,12 @@ pub(crate) unsafe fn materialize_cached_function(
         if executable.validate_cached_bytecode().is_err() {
             return std::ptr::null_mut();
         }
-        materialize_executable(executable, vm_ptr, source_code_ptr)
+        let shared_function_data_owner = if shared_function_data_list_ptr.is_null() {
+            crate::bytecode::ffi::SharedFunctionDataOwner::None
+        } else {
+            crate::bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr)
+        };
+        materialize_executable(executable, vm_ptr, source_code_ptr, shared_function_data_owner)
     }
 }
 
@@ -1141,6 +1534,28 @@ unsafe fn materialize_executable(
     executable: DecodedExecutableRecord,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
+) -> *mut c_void {
+    unsafe {
+        let mut pending_function_installs = Vec::new();
+        materialize_executable_for_install(
+            executable,
+            None,
+            shared_function_data_owner,
+            vm_ptr,
+            source_code_ptr,
+            &mut pending_function_installs,
+        )
+    }
+}
+
+unsafe fn materialize_executable_for_install(
+    executable: DecodedExecutableRecord,
+    mut existing_shared_function_data: Option<&mut ExistingSharedFunctionData<'_>>,
+    shared_function_data_owner: crate::bytecode::ffi::SharedFunctionDataOwner,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    pending_function_installs: &mut Vec<PendingFunctionInstall>,
 ) -> *mut c_void {
     unsafe {
         let DecodedExecutableRecord {
@@ -1190,10 +1605,23 @@ unsafe fn materialize_executable(
         let Some(shared_functions) = shared_functions.into_values() else {
             return std::ptr::null_mut();
         };
-        let sfd_ptrs: Vec<*const c_void> = shared_functions
-            .into_iter()
-            .map(|function| materialize_function(function, strict, vm_ptr, source_code_ptr) as *const c_void)
-            .collect();
+        let mut sfd_ptrs = Vec::with_capacity(shared_functions.len());
+        for function in shared_functions {
+            let sfd_ptr = if let Some(registry) = existing_shared_function_data.as_deref_mut() {
+                prepare_function_install(
+                    function,
+                    strict,
+                    registry,
+                    vm_ptr,
+                    source_code_ptr,
+                    pending_function_installs,
+                ) as *const c_void
+            } else {
+                materialize_function(function, strict, vm_ptr, source_code_ptr, shared_function_data_owner)
+                    as *const c_void
+            };
+            sfd_ptrs.push(sfd_ptr);
+        }
         if sfd_ptrs.iter().any(|ptr| ptr.is_null()) {
             return std::ptr::null_mut();
         }
@@ -3577,7 +4005,19 @@ mod tests {
         bytes.push(ast::ProgramType::Script as u8);
         bytes.extend_from_slice(&stored_source_hash);
 
-        assert!(decode_blob(&bytes, ast::ProgramType::Script, &expected_source_hash).is_none());
+        assert!(
+            decode_blob_with_foreign_owner(
+                &bytes,
+                ast::ProgramType::Script,
+                &expected_source_hash,
+                ForeignBytecodeCacheBlobOwner {
+                    owner: std::ptr::null_mut(),
+                    clone_owner: ignore_clone_foreign_owner,
+                    free_owner: ignore_foreign_owner,
+                },
+            )
+            .is_none()
+        );
     }
 
     unsafe extern "C" fn ignore_foreign_owner(_: *mut c_void) {}

--- a/Libraries/LibJS/Rust/src/lib.rs
+++ b/Libraries/LibJS/Rust/src/lib.rs
@@ -336,11 +336,18 @@ unsafe fn create_executable_from_compiled_bytecode(
     bytecode: &mut CompiledBytecode,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: bytecode::ffi::SharedFunctionDataOwner,
 ) -> *mut c_void {
     unsafe {
         bytecode.generator.vm_ptr = vm_ptr;
         bytecode.generator.source_code_ptr = source_code_ptr;
-        bytecode::ffi::create_executable(&mut bytecode.generator, &bytecode.assembled, vm_ptr, source_code_ptr)
+        bytecode::ffi::create_executable(
+            &mut bytecode.generator,
+            &bytecode.assembled,
+            vm_ptr,
+            source_code_ptr,
+            shared_function_data_owner,
+        )
     }
 }
 
@@ -529,9 +536,18 @@ unsafe fn compile_program_body(
     scope_id: ast::ScopeId,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: bytecode::ffi::SharedFunctionDataOwner,
 ) -> *mut c_void {
     let assembled = compile_program_body_to_bytecode(generator, program, scope_id);
-    unsafe { bytecode::ffi::create_executable(generator, &assembled, vm_ptr, source_code_ptr) }
+    unsafe {
+        bytecode::ffi::create_executable(
+            generator,
+            &assembled,
+            vm_ptr,
+            source_code_ptr,
+            shared_function_data_owner,
+        )
+    }
 }
 
 // =============================================================================
@@ -834,41 +850,7 @@ pub unsafe extern "C" fn rust_free_bytecode_cache_blob(data: *mut u8, length: us
     }
 }
 
-/// Decode a bytecode cache blob into an owned parser-free cache handle.
-///
-/// # Safety
-/// `data` must point to `length` readable bytes.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_decode_bytecode_cache_blob(
-    data: *const u8,
-    length: usize,
-    expected_program_type: u8,
-    expected_source_hash: *const u8,
-    expected_source_hash_len: usize,
-) -> *mut DecodedBytecodeCacheBlob {
-    unsafe {
-        abort_on_panic(|| {
-            if data.is_null() || expected_source_hash.is_null() || expected_source_hash_len != 32 {
-                return std::ptr::null_mut();
-            }
-            let expected_program_type = match expected_program_type {
-                0 => ast::ProgramType::Script,
-                1 => ast::ProgramType::Module,
-                _ => return std::ptr::null_mut(),
-            };
-            let expected_source_hash = std::slice::from_raw_parts(expected_source_hash, expected_source_hash_len)
-                .try_into()
-                .expect("source hash length was checked");
-            let bytes = std::slice::from_raw_parts(data, length);
-            let Some(blob) = bytecode_cache::decode_blob(bytes, expected_program_type, expected_source_hash) else {
-                return std::ptr::null_mut();
-            };
-            Box::into_raw(Box::new(DecodedBytecodeCacheBlob { _blob: blob }))
-        })
-    }
-}
-
-/// Decode an mmap-backed bytecode cache blob into an owned parser-free cache handle.
+/// Decode an ImmutableBytes-backed bytecode cache blob into a parser-free cache handle.
 ///
 /// # Safety
 /// - `data` must point to `length` readable bytes.
@@ -925,7 +907,7 @@ pub unsafe extern "C" fn rust_decode_bytecode_cache_blob_with_owner(
 /// Free a decoded bytecode cache blob.
 ///
 /// # Safety
-/// `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob()`.
+/// `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_free_decoded_bytecode_cache_blob(blob: *mut DecodedBytecodeCacheBlob) {
     unsafe {
@@ -936,7 +918,7 @@ pub unsafe extern "C" fn rust_free_decoded_bytecode_cache_blob(blob: *mut Decode
 /// Materialize a decoded script bytecode cache blob. Consumes and frees the blob.
 ///
 /// # Safety
-/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob()`.
+/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
 /// - `vm_ptr` must be a valid `JS::VM*`.
 /// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
 /// - `gdi_context` must be a valid pointer to a C++ ScriptGdiBuilder.
@@ -946,6 +928,7 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_script(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     source_len: usize,
+    shared_function_data_list_ptr: *mut c_void,
     gdi_context: *mut c_void,
 ) -> *mut c_void {
     unsafe {
@@ -957,7 +940,8 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_script(
             if !blob._blob.source_ranges_are_valid(source_len) {
                 return std::ptr::null_mut();
             }
-            blob._blob.materialize_script(vm_ptr, source_code_ptr, gdi_context)
+            blob._blob
+                .materialize_script(vm_ptr, source_code_ptr, shared_function_data_list_ptr, gdi_context)
         })
     }
 }
@@ -965,7 +949,7 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_script(
 /// Materialize a decoded module bytecode cache blob. Consumes and frees the blob.
 ///
 /// # Safety
-/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob()`.
+/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
 /// - `vm_ptr` must be a valid `JS::VM*`.
 /// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
 /// - `module_context` must be a valid `ModuleBuilder*`.
@@ -976,6 +960,7 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_module(
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
     source_len: usize,
+    shared_function_data_list_ptr: *mut c_void,
     module_context: *mut c_void,
     callbacks: *const ModuleCallbacks,
     tla_executable_out: *mut *mut c_void,
@@ -989,8 +974,115 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_module(
             if !blob._blob.source_ranges_are_valid(source_len) {
                 return std::ptr::null_mut();
             }
-            blob._blob
-                .materialize_module(vm_ptr, source_code_ptr, module_context, callbacks, tla_executable_out)
+            blob._blob.materialize_module(
+                vm_ptr,
+                source_code_ptr,
+                shared_function_data_list_ptr,
+                module_context,
+                callbacks,
+                tla_executable_out,
+            )
+        })
+    }
+}
+
+/// Install a decoded script bytecode cache blob into an existing program.
+/// Consumes and frees the blob.
+///
+/// # Safety
+/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
+/// - `vm_ptr` must be a valid `JS::VM*`.
+/// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
+/// - `existing_executable_ptr` must be a valid `Bytecode::Executable*`.
+/// - `existing_declaration_function_ptrs` must be null when
+///   `existing_declaration_function_count` is zero, otherwise it must point to
+///   `existing_declaration_function_count` valid `SharedFunctionInstanceData*`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_install_bytecode_cache_script(
+    blob: *mut DecodedBytecodeCacheBlob,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    source_len: usize,
+    existing_executable_ptr: *const c_void,
+    existing_declaration_function_ptrs: *const *mut c_void,
+    existing_declaration_function_count: usize,
+) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if blob.is_null() {
+                return std::ptr::null_mut();
+            }
+            let blob = Box::from_raw(blob);
+            let existing_declaration_functions = if existing_declaration_function_count == 0 {
+                &[]
+            } else {
+                if existing_declaration_function_ptrs.is_null() {
+                    return std::ptr::null_mut();
+                }
+                std::slice::from_raw_parts(existing_declaration_function_ptrs, existing_declaration_function_count)
+            };
+            if !blob._blob.source_ranges_are_valid(source_len) {
+                return std::ptr::null_mut();
+            }
+            blob._blob.install_script(
+                vm_ptr,
+                source_code_ptr,
+                existing_executable_ptr,
+                existing_declaration_functions,
+            )
+        })
+    }
+}
+
+/// Install a decoded module bytecode cache blob into an existing program.
+/// Consumes and frees the blob.
+///
+/// # Safety
+/// - `blob` must be a valid pointer from `rust_decode_bytecode_cache_blob_with_owner()`.
+/// - `vm_ptr` must be a valid `JS::VM*`.
+/// - `source_code_ptr` must be a valid `JS::SourceCode const*`.
+/// - `existing_executable_ptr` must be null or a valid `Bytecode::Executable*`.
+/// - `existing_declaration_function_ptrs` must be null when
+///   `existing_declaration_function_count` is zero, otherwise it must point to
+///   `existing_declaration_function_count` valid `SharedFunctionInstanceData*`.
+/// - `existing_tla_sfd_ptr` must be null or a valid `SharedFunctionInstanceData*`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_install_bytecode_cache_module(
+    blob: *mut DecodedBytecodeCacheBlob,
+    vm_ptr: *mut c_void,
+    source_code_ptr: *const c_void,
+    source_len: usize,
+    existing_executable_ptr: *const c_void,
+    existing_declaration_function_ptrs: *const *mut c_void,
+    existing_declaration_function_count: usize,
+    existing_tla_sfd_ptr: *mut c_void,
+    tla_executable_out: *mut *mut c_void,
+) -> *mut c_void {
+    unsafe {
+        abort_on_panic(|| {
+            if blob.is_null() {
+                return std::ptr::null_mut();
+            }
+            let blob = Box::from_raw(blob);
+            let existing_declaration_functions = if existing_declaration_function_count == 0 {
+                &[]
+            } else {
+                if existing_declaration_function_ptrs.is_null() {
+                    return std::ptr::null_mut();
+                }
+                std::slice::from_raw_parts(existing_declaration_function_ptrs, existing_declaration_function_count)
+            };
+            if !blob._blob.source_ranges_are_valid(source_len) {
+                return std::ptr::null_mut();
+            }
+            blob._blob.install_module(
+                vm_ptr,
+                source_code_ptr,
+                existing_executable_ptr,
+                existing_declaration_functions,
+                existing_tla_sfd_ptr,
+                tla_executable_out,
+            )
         })
     }
 }
@@ -1008,9 +1100,17 @@ pub unsafe extern "C" fn rust_materialize_bytecode_cache_function(
     cached_executable: *mut c_void,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
 ) -> *mut c_void {
     unsafe {
-        abort_on_panic(|| bytecode_cache::materialize_cached_function(cached_executable, vm_ptr, source_code_ptr))
+        abort_on_panic(|| {
+            bytecode_cache::materialize_cached_function(
+                cached_executable,
+                vm_ptr,
+                source_code_ptr,
+                shared_function_data_list_ptr,
+            )
+        })
     }
 }
 
@@ -1041,6 +1141,7 @@ pub unsafe extern "C" fn rust_materialize_precompiled_bytecode_function(
     precompiled_executable: *mut c_void,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
 ) -> *mut c_void {
     unsafe {
         abort_on_panic(|| {
@@ -1056,6 +1157,11 @@ pub unsafe extern "C" fn rust_materialize_precompiled_bytecode_function(
                 &precompiled.assembled,
                 vm_ptr,
                 source_code_ptr,
+                if shared_function_data_list_ptr.is_null() {
+                    bytecode::ffi::SharedFunctionDataOwner::None
+                } else {
+                    bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr)
+                },
             )
         })
     }
@@ -1120,6 +1226,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
     parsed: *mut ParsedProgram,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
     gdi_context: *mut c_void,
     source_len: usize,
 ) -> *mut c_void {
@@ -1130,12 +1237,18 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
             let mut generator = new_program_generator(parsed.is_strict_mode, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parsed.function_table);
             generator.arena = parsed.arena.clone();
+            let shared_function_data_context = bytecode::ffi::SharedFunctionDataCreationContext {
+                vm_ptr,
+                source_code_ptr,
+                owner: bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr),
+            };
             let exec_ptr = compile_program_body(
                 &mut generator,
                 &parsed.program,
                 parsed.scope_ref,
                 vm_ptr,
                 source_code_ptr,
+                shared_function_data_context.owner,
             );
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
@@ -1144,8 +1257,7 @@ pub unsafe extern "C" fn rust_compile_parsed_script(
             extract_script_gdi(
                 &parsed.arena.scopes[parsed.scope_ref],
                 parsed.is_strict_mode,
-                vm_ptr,
-                source_code_ptr,
+                shared_function_data_context,
                 gdi_context,
                 &mut generator.function_table,
                 &parsed.arena,
@@ -1168,6 +1280,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_script(
     compiled: *mut CompiledProgram,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
     gdi_context: *mut c_void,
 ) -> *mut c_void {
     unsafe {
@@ -1181,7 +1294,17 @@ pub unsafe extern "C" fn rust_materialize_compiled_script(
                 return std::ptr::null_mut();
             };
 
-            let exec_ptr = create_executable_from_compiled_bytecode(bytecode, vm_ptr, source_code_ptr);
+            let shared_function_data_context = bytecode::ffi::SharedFunctionDataCreationContext {
+                vm_ptr,
+                source_code_ptr,
+                owner: bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr),
+            };
+            let exec_ptr = create_executable_from_compiled_bytecode(
+                bytecode,
+                vm_ptr,
+                source_code_ptr,
+                shared_function_data_context.owner,
+            );
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
             }
@@ -1189,8 +1312,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_script(
             extract_script_gdi(
                 &compiled.parsed.arena.scopes[compiled.parsed.scope_ref],
                 compiled.parsed.is_strict_mode,
-                vm_ptr,
-                source_code_ptr,
+                shared_function_data_context,
                 gdi_context,
                 &mut bytecode.generator.function_table,
                 &compiled.parsed.arena,
@@ -1279,7 +1401,14 @@ pub unsafe extern "C" fn rust_compile_eval(
             let mut generator = new_program_generator(is_strict, vm_ptr, source_code_ptr, source_len);
             generator.function_table = std::mem::take(&mut parser.function_table);
             generator.arena = arena_arc.clone();
-            let exec_ptr = compile_program_body(&mut generator, &program, scope_id, vm_ptr, source_code_ptr);
+            let exec_ptr = compile_program_body(
+                &mut generator,
+                &program,
+                scope_id,
+                vm_ptr,
+                source_code_ptr,
+                bytecode::ffi::SharedFunctionDataOwner::None,
+            );
             if exec_ptr.is_null() {
                 return std::ptr::null_mut();
             }
@@ -1507,7 +1636,17 @@ pub unsafe extern "C" fn rust_compile_dynamic_function(
                 .extract_reachable(&function_data, &parser.arena.scopes);
             let arena = std::sync::Arc::new(std::mem::take(&mut parser.arena));
 
-            bytecode::ffi::create_sfd_for_gdi(function_data, subtable, vm_ptr, source_code_ptr, is_strict, arena)
+            bytecode::ffi::create_sfd_for_gdi(
+                function_data,
+                subtable,
+                bytecode::ffi::SharedFunctionDataCreationContext {
+                    vm_ptr,
+                    source_code_ptr,
+                    owner: bytecode::ffi::SharedFunctionDataOwner::None,
+                },
+                is_strict,
+                arena,
+            )
         })
     }
 }
@@ -1590,8 +1729,11 @@ pub unsafe extern "C" fn rust_compile_builtin_file(
                     let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
                         function_data,
                         subtable,
-                        vm_ptr,
-                        source_code_ptr,
+                        bytecode::ffi::SharedFunctionDataCreationContext {
+                            vm_ptr,
+                            source_code_ptr,
+                            owner: bytecode::ffi::SharedFunctionDataOwner::None,
+                        },
                         true, // strict
                         arena.clone(),
                     );
@@ -1630,6 +1772,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
     parsed: *mut ParsedProgram,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
     module_context: *mut c_void,
     callbacks: *const ModuleCallbacks,
     tla_executable_out: *mut *mut c_void,
@@ -1639,6 +1782,11 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
         abort_on_panic(|| {
             let mut parsed = Box::from_raw(parsed);
             let cb = &*callbacks;
+            let shared_function_data_context = bytecode::ffi::SharedFunctionDataCreationContext {
+                vm_ptr,
+                source_code_ptr,
+                owner: bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr),
+            };
 
             // 1. Report has_top_level_await.
             (cb.set_has_top_level_await)(module_context, parsed.has_top_level_await);
@@ -1649,8 +1797,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
             // 3. Extract var declared names and lexical bindings.
             extract_module_declarations(
                 &parsed.arena.scopes[parsed.scope_ref],
-                vm_ptr,
-                source_code_ptr,
+                shared_function_data_context,
                 module_context,
                 cb,
                 &mut parsed.function_table,
@@ -1666,8 +1813,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                     &parsed.program,
                     parsed.scope_ref,
                     parsed.arena.clone(),
-                    vm_ptr,
-                    source_code_ptr,
+                    shared_function_data_context,
                     source_len,
                     std::mem::take(&mut parsed.function_table),
                 );
@@ -1688,6 +1834,7 @@ pub unsafe extern "C" fn rust_compile_parsed_module(
                     parsed.scope_ref,
                     vm_ptr,
                     source_code_ptr,
+                    shared_function_data_context.owner,
                 )
             }
         })
@@ -1707,6 +1854,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
     compiled: *mut CompiledProgram,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
     module_context: *mut c_void,
     callbacks: *const ModuleCallbacks,
     tla_executable_out: *mut *mut c_void,
@@ -1719,6 +1867,11 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
 
             let mut compiled = Box::from_raw(compiled);
             let cb = &*callbacks;
+            let shared_function_data_context = bytecode::ffi::SharedFunctionDataCreationContext {
+                vm_ptr,
+                source_code_ptr,
+                owner: bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr),
+            };
 
             (cb.set_has_top_level_await)(module_context, compiled.parsed.has_top_level_await);
             extract_module_metadata(
@@ -1732,8 +1885,7 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
             };
             extract_module_declarations(
                 &compiled.parsed.arena.scopes[compiled.parsed.scope_ref],
-                vm_ptr,
-                source_code_ptr,
+                shared_function_data_context,
                 module_context,
                 cb,
                 &mut bytecode.generator.function_table,
@@ -1747,7 +1899,12 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
 
             match &mut compiled.bytecode {
                 CompiledProgramBytecode::AsyncModule(bytecode) => {
-                    let exec_ptr = create_executable_from_compiled_bytecode(bytecode, vm_ptr, source_code_ptr);
+                    let exec_ptr = create_executable_from_compiled_bytecode(
+                        bytecode,
+                        vm_ptr,
+                        source_code_ptr,
+                        shared_function_data_context.owner,
+                    );
                     if !tla_executable_out.is_null() {
                         *tla_executable_out = exec_ptr;
                     }
@@ -1757,7 +1914,12 @@ pub unsafe extern "C" fn rust_materialize_compiled_module(
                     if !tla_executable_out.is_null() {
                         *tla_executable_out = std::ptr::null_mut();
                     }
-                    create_executable_from_compiled_bytecode(bytecode, vm_ptr, source_code_ptr)
+                    create_executable_from_compiled_bytecode(
+                        bytecode,
+                        vm_ptr,
+                        source_code_ptr,
+                        shared_function_data_context.owner,
+                    )
                 }
             }
         })
@@ -1910,6 +2072,7 @@ pub unsafe extern "C" fn rust_compile_module(
     source_len: usize,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_list_ptr: *mut c_void,
     module_context: *mut c_void,
     callbacks: *const ModuleCallbacks,
     dump_ast: bool,
@@ -1949,6 +2112,7 @@ pub unsafe extern "C" fn rust_compile_module(
                 parsed,
                 vm_ptr,
                 source_code_ptr,
+                shared_function_data_list_ptr,
                 module_context,
                 callbacks,
                 tla_executable_out,
@@ -2106,8 +2270,7 @@ unsafe fn extract_module_metadata(scope: &ast::ScopeData, ctx: *mut c_void, cb: 
 /// Extract var declared names and lexical bindings from a module scope.
 unsafe fn extract_module_declarations(
     scope: &ast::ScopeData,
-    vm_ptr: *mut c_void,
-    source_code_ptr: *const c_void,
+    shared_function_data_context: bytecode::ffi::SharedFunctionDataCreationContext,
     ctx: *mut c_void,
     cb: &ModuleCallbacks,
     function_table: &mut ast::FunctionTable,
@@ -2149,8 +2312,7 @@ unsafe fn extract_module_declarations(
                     let sfd_ptr = bytecode::ffi::create_sfd_for_gdi(
                         function_data,
                         subtable,
-                        vm_ptr,
-                        source_code_ptr,
+                        shared_function_data_context,
                         true,
                         arena.clone(),
                     );
@@ -2353,19 +2515,24 @@ unsafe fn compile_module_as_async(
     program: &ast::Statement,
     scope_id: ast::ScopeId,
     arena: std::sync::Arc<ast::AstArena>,
-    vm_ptr: *mut c_void,
-    source_code_ptr: *const c_void,
+    shared_function_data_context: bytecode::ffi::SharedFunctionDataCreationContext,
     source_len: usize,
     function_table: ast::FunctionTable,
 ) -> *mut c_void {
     unsafe {
         let mut generator = new_module_async_generator(source_len, function_table);
         generator.arena = arena;
-        generator.vm_ptr = vm_ptr;
-        generator.source_code_ptr = source_code_ptr;
+        generator.vm_ptr = shared_function_data_context.vm_ptr;
+        generator.source_code_ptr = shared_function_data_context.source_code_ptr;
 
         let assembled = compile_module_as_async_to_bytecode(program, scope_id, &mut generator);
-        bytecode::ffi::create_executable(&mut generator, &assembled, vm_ptr, source_code_ptr)
+        bytecode::ffi::create_executable(
+            &mut generator,
+            &assembled,
+            shared_function_data_context.vm_ptr,
+            shared_function_data_context.source_code_ptr,
+            shared_function_data_context.owner,
+        )
     }
 }
 
@@ -2408,6 +2575,7 @@ fn extract_gdi_common(
     scope: &ast::ScopeData,
     vm_ptr: *mut c_void,
     source_code_ptr: *const c_void,
+    shared_function_data_owner: bytecode::ffi::SharedFunctionDataOwner,
     is_strict: bool,
     push_var_name: &mut dyn FnMut(&[u16]),
     push_function: &mut dyn FnMut(*mut c_void, &[u16]),
@@ -2451,8 +2619,11 @@ fn extract_gdi_common(
                 bytecode::ffi::create_sfd_for_gdi(
                     function_data,
                     subtable,
-                    vm_ptr,
-                    source_code_ptr,
+                    bytecode::ffi::SharedFunctionDataCreationContext {
+                        vm_ptr,
+                        source_code_ptr,
+                        owner: shared_function_data_owner,
+                    },
                     is_strict,
                     arena.clone(),
                 )
@@ -2523,6 +2694,7 @@ unsafe fn extract_eval_gdi(
             scope,
             vm_ptr,
             source_code_ptr,
+            bytecode::ffi::SharedFunctionDataOwner::None,
             is_strict,
             &mut |name| eval_gdi_push_var_name(ctx, name.as_ptr(), name.len()),
             &mut |sfd_ptr, name| eval_gdi_push_function(ctx, sfd_ptr, name.as_ptr(), name.len()),
@@ -2546,8 +2718,7 @@ unsafe fn extract_eval_gdi(
 unsafe fn extract_script_gdi(
     scope: &ast::ScopeData,
     is_strict: bool,
-    vm_ptr: *mut c_void,
-    source_code_ptr: *const c_void,
+    shared_function_data_context: bytecode::ffi::SharedFunctionDataCreationContext,
     ctx: *mut c_void,
     function_table: &mut ast::FunctionTable,
     arena: &std::sync::Arc<ast::AstArena>,
@@ -2588,8 +2759,9 @@ unsafe fn extract_script_gdi(
 
         extract_gdi_common(
             scope,
-            vm_ptr,
-            source_code_ptr,
+            shared_function_data_context.vm_ptr,
+            shared_function_data_context.source_code_ptr,
+            shared_function_data_context.owner,
             is_strict,
             &mut |name| script_gdi_push_var_name(ctx, name.as_ptr(), name.len()),
             &mut |sfd_ptr, name| script_gdi_push_function(ctx, sfd_ptr, name.as_ptr(), name.len()),
@@ -2773,6 +2945,7 @@ pub unsafe extern "C" fn rust_compile_function(
     sfd_ptr: *mut c_void,
     rust_function_ast: *mut c_void,
     builtin_abstract_operations_enabled: bool,
+    shared_function_data_list_ptr: *mut c_void,
 ) -> *mut c_void {
     unsafe {
         abort_on_panic(|| {
@@ -2799,6 +2972,11 @@ pub unsafe extern "C" fn rust_compile_function(
                 &precompiled.assembled,
                 vm_ptr,
                 source_code_ptr,
+                if shared_function_data_list_ptr.is_null() {
+                    bytecode::ffi::SharedFunctionDataOwner::None
+                } else {
+                    bytecode::ffi::SharedFunctionDataOwner::List(shared_function_data_list_ptr)
+                },
             )
         })
     }

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -95,6 +95,15 @@ static void collect_single_parse_error(void* ctx, uint8_t const* message, size_t
 
 struct ScriptGdiBuilder {
     ScriptResult result;
+    SharedFunctionInstanceDataList shared_function_data;
+
+    void collect_shared_function_data()
+    {
+        result.shared_function_data.clear();
+        shared_function_data.for_each([&](auto& shared_data) {
+            result.shared_function_data.append(shared_data);
+        });
+    }
 };
 
 }
@@ -219,6 +228,15 @@ namespace JS::RustIntegration {
 
 struct ModuleBuilder {
     ModuleResult result;
+    SharedFunctionInstanceDataList shared_function_data;
+
+    void collect_shared_function_data()
+    {
+        result.shared_function_data.clear();
+        shared_function_data.for_each([&](auto& shared_data) {
+            result.shared_function_data.append(shared_data);
+        });
+    }
 };
 
 static Vector<ImportAttribute> attributes_from_ffi(FFIUtf16Slice const* keys, FFIUtf16Slice const* values, size_t count)
@@ -411,11 +429,6 @@ ByteBuffer serialize_compiled_program_for_bytecode_cache(CompiledProgram const& 
     return bytes;
 }
 
-DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes bytes, ProgramType expected_type, ReadonlyBytes source_hash)
-{
-    return rust_decode_bytecode_cache_blob(bytes.data(), bytes.size(), static_cast<u8>(expected_type), source_hash.data(), source_hash.size());
-}
-
 static void free_bytecode_cache_blob_owner(void* owner)
 {
     delete static_cast<Core::ImmutableBytes*>(owner);
@@ -454,11 +467,12 @@ Optional<Result<ScriptResult, Vector<ParserError>>> compile_parsed_script(Parsed
     GC::DeferGC defer_gc(realm.vm().heap());
     ScriptGdiBuilder builder;
 
-    void* exec_ptr = rust_compile_parsed_script(parsed, &realm.vm(), source_code.ptr(), &builder, length);
+    void* exec_ptr = rust_compile_parsed_script(parsed, &realm.vm(), source_code.ptr(), &builder.shared_function_data, &builder, length);
 
     if (!exec_ptr)
         return Vector<ParserError> {};
 
+    builder.collect_shared_function_data();
     builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
     return builder.result;
 }
@@ -471,11 +485,12 @@ Optional<Result<ScriptResult, Vector<ParserError>>> materialize_compiled_script(
     GC::DeferGC defer_gc(realm.vm().heap());
     ScriptGdiBuilder builder;
 
-    void* exec_ptr = rust_materialize_compiled_script(compiled, &realm.vm(), source_code.ptr(), &builder);
+    void* exec_ptr = rust_materialize_compiled_script(compiled, &realm.vm(), source_code.ptr(), &builder.shared_function_data, &builder);
 
     if (!exec_ptr)
         return Vector<ParserError> {};
 
+    builder.collect_shared_function_data();
     builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
     return builder.result;
 }
@@ -489,11 +504,12 @@ Optional<Result<ScriptResult, Vector<ParserError>>> materialize_bytecode_cache_s
     TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
     ScriptGdiBuilder builder;
 
-    void* exec_ptr = rust_materialize_bytecode_cache_script(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &builder);
+    void* exec_ptr = rust_materialize_bytecode_cache_script(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &builder.shared_function_data, &builder);
 
     if (!exec_ptr)
         return Vector<ParserError> { ParserError { "Failed to materialize bytecode cache"_string, {} } };
 
+    builder.collect_shared_function_data();
     builder.result.executable = static_cast<Bytecode::Executable*>(exec_ptr);
     return builder.result;
 }
@@ -578,12 +594,13 @@ Optional<Result<ModuleResult, Vector<ParserError>>> compile_parsed_module(Parsed
 
     void* tla_executable = nullptr;
 
-    void* exec_ptr = rust_compile_parsed_module(parsed, &realm.vm(), source_code.ptr(),
+    void* exec_ptr = rust_compile_parsed_module(parsed, &realm.vm(), source_code.ptr(), &builder.shared_function_data,
         &builder, &callbacks, &tla_executable, length);
 
     if (!exec_ptr && !tla_executable)
         return Vector<ParserError> {};
 
+    builder.collect_shared_function_data();
     if (tla_executable) {
         auto& vm = realm.vm();
         auto* tla_exec = static_cast<Bytecode::Executable*>(tla_executable);
@@ -592,7 +609,7 @@ Optional<Result<ModuleResult, Vector<ParserError>>> compile_parsed_module(Parsed
             vm, FunctionKind::Async,
             "module code with top-level await"_utf16_fly_string,
             0, 0, true, false, true,
-            Vector<Utf16FlyString> {}, nullptr);
+            Vector<Utf16FlyString> {}, NoSharedFunctionDataList {}, nullptr);
         builder.result.tla_shared_data->m_is_module_wrapper = true;
         builder.result.tla_shared_data->m_uses_this = true;
         builder.result.tla_shared_data->m_function_environment_needed = true;
@@ -627,12 +644,13 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_compiled_module(
 
     void* tla_executable = nullptr;
 
-    void* exec_ptr = rust_materialize_compiled_module(compiled, &realm.vm(), source_code.ptr(),
+    void* exec_ptr = rust_materialize_compiled_module(compiled, &realm.vm(), source_code.ptr(), &builder.shared_function_data,
         &builder, &callbacks, &tla_executable);
 
     if (!exec_ptr && !tla_executable)
         return Vector<ParserError> {};
 
+    builder.collect_shared_function_data();
     if (tla_executable) {
         auto& vm = realm.vm();
         auto* tla_exec = static_cast<Bytecode::Executable*>(tla_executable);
@@ -641,7 +659,7 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_compiled_module(
             vm, FunctionKind::Async,
             "module code with top-level await"_utf16_fly_string,
             0, 0, true, false, true,
-            Vector<Utf16FlyString> {}, nullptr);
+            Vector<Utf16FlyString> {}, NoSharedFunctionDataList {}, nullptr);
         builder.result.tla_shared_data->m_is_module_wrapper = true;
         builder.result.tla_shared_data->m_uses_this = true;
         builder.result.tla_shared_data->m_function_environment_needed = true;
@@ -677,12 +695,13 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_m
 
     void* tla_executable = nullptr;
 
-    void* exec_ptr = rust_materialize_bytecode_cache_module(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(),
+    void* exec_ptr = rust_materialize_bytecode_cache_module(blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &builder.shared_function_data,
         &builder, &callbacks, &tla_executable);
 
     if (!exec_ptr && !tla_executable)
         return Vector<ParserError> { ParserError { "Failed to materialize bytecode cache"_string, {} } };
 
+    builder.collect_shared_function_data();
     if (tla_executable) {
         auto& vm = realm.vm();
         auto* tla_exec = static_cast<Bytecode::Executable*>(tla_executable);
@@ -691,7 +710,7 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_m
             vm, FunctionKind::Async,
             "module code with top-level await"_utf16_fly_string,
             0, 0, true, false, true,
-            Vector<Utf16FlyString> {}, nullptr);
+            Vector<Utf16FlyString> {}, NoSharedFunctionDataList {}, nullptr);
         builder.result.tla_shared_data->m_is_module_wrapper = true;
         builder.result.tla_shared_data->m_uses_this = true;
         builder.result.tla_shared_data->m_function_environment_needed = true;
@@ -702,6 +721,82 @@ Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_m
     }
 
     return builder.result;
+}
+
+GC::Ptr<Bytecode::Executable> try_install_bytecode_cache_script(DecodedBytecodeCacheBlob* blob, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Bytecode::Executable& existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data)
+{
+    if (!blob)
+        return {};
+
+    Vector<void*> existing_shared_function_data_ptrs;
+    existing_shared_function_data_ptrs.ensure_capacity(existing_shared_function_data.size());
+    for (auto* function : existing_shared_function_data)
+        existing_shared_function_data_ptrs.unchecked_append(function);
+
+    GC::Root<Bytecode::Executable> executable;
+    {
+        GC::DeferGC defer_gc(realm.vm().heap());
+        TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+
+        executable = static_cast<Bytecode::Executable*>(rust_install_bytecode_cache_script(
+            blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(), &existing_executable,
+            existing_shared_function_data_ptrs.data(), existing_shared_function_data_ptrs.size()));
+    }
+
+    if (executable)
+        executable->copy_runtime_caches_from(existing_executable);
+    return executable.ptr();
+}
+
+GC::Ref<Bytecode::Executable> install_generated_bytecode_cache_script(DecodedBytecodeCacheBlob* blob, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Bytecode::Executable& existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data)
+{
+    auto executable = try_install_bytecode_cache_script(blob, move(source_code), realm, existing_executable, existing_shared_function_data);
+    VERIFY(executable);
+    return *executable;
+}
+
+Optional<ModuleBytecodeCacheInstallResult> try_install_bytecode_cache_module(DecodedBytecodeCacheBlob* blob, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Bytecode::Executable* existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data, SharedFunctionInstanceData* existing_top_level_await_shared_data)
+{
+    if (!blob)
+        return {};
+
+    Vector<void*> existing_shared_function_data_ptrs;
+    existing_shared_function_data_ptrs.ensure_capacity(existing_shared_function_data.size());
+    for (auto* function : existing_shared_function_data)
+        existing_shared_function_data_ptrs.unchecked_append(function);
+
+    GC::DeferGC defer_gc(realm.vm().heap());
+    TemporaryChange validate_cache_executables { s_validate_materialized_bytecode_cache_executables, true };
+
+    void* top_level_await_executable = nullptr;
+    auto* exec = static_cast<Bytecode::Executable*>(rust_install_bytecode_cache_module(
+        blob, &realm.vm(), source_code.ptr(), source_code->length_in_code_units(),
+        existing_executable, existing_shared_function_data_ptrs.data(), existing_shared_function_data_ptrs.size(),
+        existing_top_level_await_shared_data, &top_level_await_executable));
+
+    if (!exec && !top_level_await_executable)
+        return {};
+
+    ModuleBytecodeCacheInstallResult result;
+    if (exec) {
+        if (existing_executable)
+            exec->copy_runtime_caches_from(*existing_executable);
+        result.executable = exec;
+    }
+    if (top_level_await_executable) {
+        auto* executable = static_cast<Bytecode::Executable*>(top_level_await_executable);
+        if (existing_top_level_await_shared_data && existing_top_level_await_shared_data->m_executable)
+            executable->copy_runtime_caches_from(*existing_top_level_await_shared_data->m_executable);
+        result.top_level_await_executable = executable;
+    }
+    return result;
+}
+
+ModuleBytecodeCacheInstallResult install_generated_bytecode_cache_module(DecodedBytecodeCacheBlob* blob, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Bytecode::Executable* existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data, SharedFunctionInstanceData* existing_top_level_await_shared_data)
+{
+    auto result = try_install_bytecode_cache_module(blob, move(source_code), realm, existing_executable, existing_shared_function_data, existing_top_level_await_shared_data);
+    VERIFY(result.has_value());
+    return result.release_value();
 }
 
 Optional<Result<ModuleResult, Vector<ParserError>>> compile_module(StringView source_text, Realm& realm, StringView filename)
@@ -791,7 +886,8 @@ GC::Ptr<Bytecode::Executable> compile_function(VM& vm, SharedFunctionInstanceDat
         auto* exec = static_cast<Bytecode::Executable*>(rust_materialize_precompiled_bytecode_function(
             shared_data.m_precompiled_bytecode_executable,
             &vm,
-            shared_data.m_source_code.ptr()));
+            shared_data.m_source_code.ptr(),
+            shared_data.m_owner_shared_function_data_list));
         shared_data.m_precompiled_bytecode_executable = nullptr;
         return exec;
     }
@@ -802,7 +898,8 @@ GC::Ptr<Bytecode::Executable> compile_function(VM& vm, SharedFunctionInstanceDat
         auto* exec = static_cast<Bytecode::Executable*>(rust_materialize_bytecode_cache_function(
             shared_data.m_cached_bytecode_executable,
             &vm,
-            shared_data.m_source_code.ptr()));
+            shared_data.m_source_code.ptr(),
+            shared_data.m_owner_shared_function_data_list));
         shared_data.m_cached_bytecode_executable = nullptr;
         return exec;
     }
@@ -820,7 +917,8 @@ GC::Ptr<Bytecode::Executable> compile_function(VM& vm, SharedFunctionInstanceDat
         shared_data.m_source_code->length_in_code_units(),
         &shared_data,
         shared_data.m_rust_function_ast,
-        builtin_abstract_operations_enabled));
+        builtin_abstract_operations_enabled,
+        shared_data.m_owner_shared_function_data_list));
     shared_data.m_rust_function_ast = nullptr;
 
     return exec;
@@ -1176,10 +1274,12 @@ extern "C" void* rust_create_executable(
     return executable.ptr();
 }
 
-extern "C" void* rust_create_sfd(
+template<typename SharedFunctionDataList>
+static GC::Ref<JS::SharedFunctionInstanceData> create_shared_function_instance_data(
     void* vm_ptr,
     void const* source_code_ptr,
-    FFISharedFunctionData const* data)
+    FFISharedFunctionData const* data,
+    SharedFunctionDataList&& shared_function_data_list)
 {
     auto& vm = *static_cast<JS::VM*>(vm_ptr);
     auto& source_code = *static_cast<JS::SourceCode const*>(source_code_ptr);
@@ -1205,6 +1305,7 @@ extern "C" void* rust_create_sfd(
         data->is_arrow,
         data->has_simple_parameter_list,
         move(mapped_param_names),
+        forward<SharedFunctionDataList>(shared_function_data_list),
         data->rust_function_ast);
 
     // Set parsing insights that must be available before lazy compilation.
@@ -1215,8 +1316,28 @@ extern "C" void* rust_create_sfd(
     shared->update_asm_call_metadata();
 
     shared->set_source_text_range(source_code, data->source_text_offset, data->source_text_length);
+    shared->m_bytecode_cache_source_text_offset = data->source_text_offset;
+    shared->m_bytecode_cache_source_text_length = data->source_text_length;
+    shared->m_has_bytecode_cache_source_text_range = true;
+    return shared;
+}
 
-    return shared.ptr();
+extern "C" void* rust_create_sfd(
+    void* vm_ptr,
+    void const* source_code_ptr,
+    FFISharedFunctionData const* data)
+{
+    return create_shared_function_instance_data(vm_ptr, source_code_ptr, data, JS::NoSharedFunctionDataList {}).ptr();
+}
+
+extern "C" void* rust_create_sfd_in_list(
+    void* vm_ptr,
+    void const* source_code_ptr,
+    void* shared_function_data_list_ptr,
+    FFISharedFunctionData const* data)
+{
+    auto& shared_function_data_list = *static_cast<JS::SharedFunctionInstanceDataList*>(shared_function_data_list_ptr);
+    return create_shared_function_instance_data(vm_ptr, source_code_ptr, data, shared_function_data_list).ptr();
 }
 
 extern "C" void rust_sfd_set_metadata(
@@ -1268,6 +1389,9 @@ extern "C" void rust_sfd_set_precompiled_executable(
 {
     auto& shared = *static_cast<JS::SharedFunctionInstanceData*>(sfd_ptr);
     auto& executable = *static_cast<JS::Bytecode::Executable*>(executable_ptr);
+    auto previous_executable = shared.m_executable;
+    if (previous_executable)
+        executable.copy_runtime_caches_from(*previous_executable);
 
     shared.m_uses_this = uses_this;
     shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
@@ -1320,6 +1444,7 @@ extern "C" void rust_sfd_set_precompiled_bytecode_executable(
 {
     auto& shared = *static_cast<JS::SharedFunctionInstanceData*>(sfd_ptr);
 
+    shared.clear_compile_inputs();
     shared.m_uses_this = uses_this;
     shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
     shared.m_function_environment_needed = function_environment_needed;
@@ -1328,8 +1453,117 @@ extern "C" void rust_sfd_set_precompiled_bytecode_executable(
     shared.m_might_need_arguments_object = might_need_arguments_object;
     shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
     shared.m_precompiled_bytecode_executable = precompiled_executable_ptr;
-    RustIntegration::free_function_ast(shared.m_rust_function_ast);
-    shared.m_rust_function_ast = nullptr;
+    shared.update_asm_call_metadata();
+}
+
+extern "C" size_t rust_executable_shared_function_data_count(void const* executable_ptr)
+{
+    if (!executable_ptr)
+        return 0;
+    auto& executable = *static_cast<JS::Bytecode::Executable const*>(executable_ptr);
+    return executable.shared_function_data.size();
+}
+
+extern "C" void* rust_executable_shared_function_data_at(void const* executable_ptr, size_t index)
+{
+    if (!executable_ptr)
+        return nullptr;
+    auto& executable = *static_cast<JS::Bytecode::Executable const*>(executable_ptr);
+    if (index >= executable.shared_function_data.size())
+        return nullptr;
+    return executable.shared_function_data[index].ptr();
+}
+
+extern "C" void* rust_sfd_executable(void const* sfd_ptr)
+{
+    if (!sfd_ptr)
+        return nullptr;
+    auto& shared = *static_cast<JS::SharedFunctionInstanceData const*>(sfd_ptr);
+    return shared.m_executable.ptr();
+}
+
+static size_t bytecode_cache_source_text_offset(JS::SharedFunctionInstanceData const& shared)
+{
+    if (shared.m_has_bytecode_cache_source_text_range)
+        return shared.m_bytecode_cache_source_text_offset;
+    return shared.m_source_text_offset;
+}
+
+static size_t bytecode_cache_source_text_length(JS::SharedFunctionInstanceData const& shared)
+{
+    if (shared.m_has_bytecode_cache_source_text_range)
+        return shared.m_bytecode_cache_source_text_length;
+    return shared.m_source_text_length;
+}
+
+extern "C" bool rust_sfd_matches_bytecode_cache_function(void const* sfd_ptr, FFISharedFunctionData const* data)
+{
+    if (!sfd_ptr || !data)
+        return false;
+    auto& shared = *static_cast<JS::SharedFunctionInstanceData const*>(sfd_ptr);
+    return bytecode_cache_source_text_offset(shared) == data->source_text_offset
+        && bytecode_cache_source_text_length(shared) == data->source_text_length
+        && shared.m_function_length == data->function_length
+        && shared.m_formal_parameter_count == data->formal_parameter_count
+        && shared.m_kind == static_cast<JS::FunctionKind>(data->function_kind)
+        && shared.m_strict == data->strict
+        && shared.m_is_arrow_function == data->is_arrow
+        && shared.m_has_simple_parameter_list == data->has_simple_parameter_list;
+}
+
+extern "C" void rust_sfd_install_bytecode_cache_executable(
+    void* sfd_ptr,
+    void* executable_ptr,
+    bool uses_this,
+    bool this_value_needs_environment_resolution,
+    bool function_environment_needed,
+    size_t function_environment_bindings_count,
+    size_t var_environment_bindings_count,
+    bool might_need_arguments_object,
+    bool contains_direct_call_to_eval)
+{
+    auto& shared = *static_cast<JS::SharedFunctionInstanceData*>(sfd_ptr);
+    auto& executable = *static_cast<JS::Bytecode::Executable*>(executable_ptr);
+    auto previous_executable = shared.m_executable;
+    if (previous_executable)
+        executable.copy_runtime_caches_from(*previous_executable);
+
+    shared.m_uses_this = uses_this;
+    shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
+    shared.m_function_environment_needed = function_environment_needed;
+    shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_var_environment_bindings_count = var_environment_bindings_count;
+    shared.m_might_need_arguments_object = might_need_arguments_object;
+    shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
+    shared.set_executable(executable);
+    executable.name = shared.m_name;
+    if (Bytecode::g_dump_bytecode)
+        executable.dump();
+    shared.clear_compile_inputs();
+}
+
+extern "C" void rust_sfd_install_cached_bytecode_executable(
+    void* sfd_ptr,
+    void* cached_executable_ptr,
+    bool uses_this,
+    bool this_value_needs_environment_resolution,
+    bool function_environment_needed,
+    size_t function_environment_bindings_count,
+    size_t var_environment_bindings_count,
+    bool might_need_arguments_object,
+    bool contains_direct_call_to_eval)
+{
+    auto& shared = *static_cast<JS::SharedFunctionInstanceData*>(sfd_ptr);
+
+    shared.clear_compile_inputs();
+    shared.m_uses_this = uses_this;
+    shared.m_this_value_needs_environment_resolution = this_value_needs_environment_resolution;
+    shared.m_function_environment_needed = function_environment_needed;
+    shared.m_function_environment_bindings_count = function_environment_bindings_count;
+    shared.m_var_environment_bindings_count = var_environment_bindings_count;
+    shared.m_might_need_arguments_object = might_need_arguments_object;
+    shared.m_contains_direct_call_to_eval = contains_direct_call_to_eval;
+    shared.m_cached_bytecode_executable = cached_executable_ptr;
     shared.update_asm_call_metadata();
 }
 

--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -11,6 +11,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/Result.h>
+#include <AK/Span.h>
 #include <AK/Utf16FlyString.h>
 #include <LibCore/ImmutableBytes.h>
 #include <LibGC/Ptr.h>
@@ -45,6 +46,7 @@ enum class ProgramType : u8 {
 //     between compile_script() and the Script constructor.
 struct ScriptResult {
     GC::Root<Bytecode::Executable> executable;
+    Vector<GC::Root<SharedFunctionInstanceData>> shared_function_data;
     bool is_strict_mode { false };
     Vector<Utf16FlyString> lexical_names;
     Vector<Utf16FlyString> var_names;
@@ -85,6 +87,7 @@ struct ModuleResult {
     };
     Vector<FunctionToInitialize> functions_to_initialize;
     GC::Root<Bytecode::Executable> executable;
+    Vector<GC::Root<SharedFunctionInstanceData>> shared_function_data;
     GC::Root<SharedFunctionInstanceData> tla_shared_data;
 };
 
@@ -112,8 +115,7 @@ JS_API void free_compiled_program(FFI::CompiledProgram*);
 // Serialize a fully compiled program into a versioned bytecode cache blob.
 JS_API ByteBuffer serialize_compiled_program_for_bytecode_cache(FFI::CompiledProgram const&, ProgramType, ReadonlyBytes source_hash);
 
-// Decode a bytecode cache blob into an owned parser-free cache handle.
-JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(ReadonlyBytes, ProgramType, ReadonlyBytes source_hash);
+// Decode an ImmutableBytes-backed bytecode cache blob into a parser-free cache handle.
 JS_API FFI::DecodedBytecodeCacheBlob* decode_bytecode_cache_blob(Core::ImmutableBytes, ProgramType, ReadonlyBytes source_hash);
 
 // Free a decoded bytecode cache blob.
@@ -126,6 +128,27 @@ JS_API Optional<Result<ScriptResult, Vector<ParserError>>> materialize_bytecode_
 // Materialize a decoded module bytecode cache blob. Must be called on the main thread.
 // Consumes and frees the decoded blob.
 JS_API Optional<Result<ModuleResult, Vector<ParserError>>> materialize_bytecode_cache_module(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&);
+
+struct ModuleBytecodeCacheInstallResult {
+    GC::Root<Bytecode::Executable> executable;
+    GC::Root<Bytecode::Executable> top_level_await_executable;
+};
+
+// Try to install a decoded script bytecode cache blob into an existing script executable tree.
+// Must be called on the main thread. Consumes and frees the decoded blob.
+JS_API GC::Ptr<Bytecode::Executable> try_install_bytecode_cache_script(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, Bytecode::Executable& existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data);
+
+// Install a decoded script bytecode cache blob produced by the current process.
+// Must be called on the main thread. Consumes and frees the decoded blob.
+JS_API GC::Ref<Bytecode::Executable> install_generated_bytecode_cache_script(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, Bytecode::Executable& existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data);
+
+// Try to install a decoded module bytecode cache blob into an existing module executable tree.
+// Must be called on the main thread. Consumes and frees the decoded blob.
+JS_API Optional<ModuleBytecodeCacheInstallResult> try_install_bytecode_cache_module(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, Bytecode::Executable* existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data, SharedFunctionInstanceData* existing_top_level_await_shared_data);
+
+// Install a decoded module bytecode cache blob produced by the current process.
+// Must be called on the main thread. Consumes and frees the decoded blob.
+JS_API ModuleBytecodeCacheInstallResult install_generated_bytecode_cache_module(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code, Realm&, Bytecode::Executable* existing_executable, ReadonlySpan<SharedFunctionInstanceData*> existing_shared_function_data, SharedFunctionInstanceData* existing_top_level_await_shared_data);
 
 // Compile a previously parsed script. Must be called on the main thread.
 // Consumes and frees the Rust ParsedProgram.

--- a/Libraries/LibJS/Script.cpp
+++ b/Libraries/LibJS/Script.cpp
@@ -29,7 +29,7 @@ Result<GC::Ref<Script>, Vector<ParserError>> Script::parse(StringView source_tex
         return Vector<ParserError> {};
     if (rust_compilation->is_error())
         return rust_compilation->release_error();
-    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
+    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), ExecutableBacking::source(), host_defined);
 }
 
 Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_parsed(FFI::ParsedProgram* parsed, NonnullRefPtr<SourceCode const> source_code, Realm& realm, HostDefined* host_defined)
@@ -40,7 +40,7 @@ Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_parsed(FFI::Par
         return Vector<ParserError> {};
     if (rust_compilation->is_error())
         return rust_compilation->release_error();
-    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
+    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), ExecutableBacking::source(), host_defined);
 }
 
 Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm, HostDefined* host_defined)
@@ -51,7 +51,7 @@ Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_compiled(FFI::C
         return Vector<ParserError> {};
     if (rust_compilation->is_error())
         return rust_compilation->release_error();
-    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
+    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), ExecutableBacking::heap_bytecode(), host_defined);
 }
 
 Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code, Realm& realm, HostDefined* host_defined)
@@ -62,12 +62,85 @@ Result<GC::Ref<Script>, Vector<ParserError>> Script::create_from_bytecode_cache(
         return Vector<ParserError> {};
     if (rust_compilation->is_error())
         return rust_compilation->release_error();
-    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), host_defined);
+    return realm.heap().allocate<Script>(realm, filename, move(rust_compilation->value()), ExecutableBacking::mapped_bytecode_cache(), host_defined);
 }
 
-Script::Script(Realm& realm, StringView filename, RustIntegration::ScriptResult&& result, HostDefined* host_defined)
+bool Script::try_install_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code)
+{
+    if (m_executable_backing.is_mapped_bytecode_cache()) {
+        RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+        return false;
+    }
+
+    if (!m_executable) {
+        RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+        return false;
+    }
+
+    auto shared_function_data = collect_shared_function_data();
+    auto executable = RustIntegration::try_install_bytecode_cache_script(bytecode_cache, move(source_code), realm(), *m_executable, shared_function_data);
+    if (!executable)
+        return false;
+
+    complete_bytecode_cache_install(*executable);
+    return true;
+}
+
+void Script::install_generated_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code)
+{
+    VERIFY(can_install_generated_bytecode_cache());
+    VERIFY(m_executable);
+
+    auto shared_function_data = collect_shared_function_data();
+    auto executable = RustIntegration::install_generated_bytecode_cache_script(bytecode_cache, move(source_code), realm(), *m_executable, shared_function_data);
+    complete_bytecode_cache_install(executable);
+}
+
+bool Script::can_generate_bytecode_cache() const
+{
+    return m_executable && m_executable_backing.can_generate_bytecode_cache();
+}
+
+bool Script::can_install_generated_bytecode_cache() const
+{
+    return m_executable && m_executable_backing.can_install_generated_bytecode_cache();
+}
+
+void Script::begin_bytecode_cache_generation()
+{
+    VERIFY(can_generate_bytecode_cache());
+    m_executable_backing.begin_bytecode_cache_generation();
+    verify_executable_backing_invariants();
+}
+
+void Script::finish_bytecode_cache_generation_without_install()
+{
+    m_executable_backing.finish_bytecode_cache_generation_without_install();
+    verify_executable_backing_invariants();
+}
+
+Vector<SharedFunctionInstanceData*> Script::collect_shared_function_data()
+{
+    Vector<SharedFunctionInstanceData*> shared_function_data;
+    shared_function_data.ensure_capacity(m_shared_function_data.size_slow());
+    m_shared_function_data.for_each([&](auto& shared_data) {
+        shared_function_data.unchecked_append(&shared_data);
+    });
+    return shared_function_data;
+}
+
+void Script::complete_bytecode_cache_install(GC::Ref<Bytecode::Executable> executable)
+{
+    m_executable = executable;
+    m_shared_function_data.clear_non_bytecode_cache_compile_inputs();
+    m_executable_backing.finish_bytecode_cache_install();
+    verify_executable_backing_invariants();
+}
+
+Script::Script(Realm& realm, StringView filename, RustIntegration::ScriptResult&& result, ExecutableBacking executable_backing, HostDefined* host_defined)
     : m_realm(realm)
     , m_executable(result.executable)
+    , m_executable_backing(executable_backing)
     , m_lexical_names(move(result.lexical_names))
     , m_var_names(move(result.var_names))
     , m_declared_function_names(move(result.declared_function_names))
@@ -78,9 +151,25 @@ Script::Script(Realm& realm, StringView filename, RustIntegration::ScriptResult&
     , m_filename(filename)
     , m_host_defined(host_defined)
 {
+    for (auto& shared_data : result.shared_function_data)
+        m_shared_function_data.append(*shared_data);
+
     m_functions_to_initialize.ensure_capacity(result.functions_to_initialize.size());
     for (auto& f : result.functions_to_initialize)
         m_functions_to_initialize.append({ *f.shared_data, move(f.name) });
+
+    verify_executable_backing_invariants();
+}
+
+void Script::verify_executable_backing_invariants()
+{
+    VERIFY(m_executable);
+
+    if (!m_executable_backing.requires_non_bytecode_cache_compile_inputs_to_be_cleared())
+        return;
+
+    VERIFY(!m_shared_function_data.contains_rust_function_ast());
+    VERIFY(!m_shared_function_data.contains_precompiled_bytecode());
 }
 
 // 16.1.7 GlobalDeclarationInstantiation ( script, env ), https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
@@ -223,6 +312,7 @@ void Script::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_realm);
     visitor.visit(m_executable);
+    m_shared_function_data.visit_edges(visitor);
     for (auto const& function : m_functions_to_initialize)
         visitor.visit(function.shared_data);
     if (m_host_defined)

--- a/Libraries/LibJS/Script.h
+++ b/Libraries/LibJS/Script.h
@@ -10,10 +10,12 @@
 #include <AK/Utf16FlyString.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
+#include <LibJS/ExecutableBacking.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 #include <LibJS/ParserError.h>
 #include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/SharedFunctionInstanceData.h>
 
 namespace JS {
 
@@ -67,6 +69,13 @@ public:
     StringView filename() const LIFETIME_BOUND { return m_filename; }
 
     Bytecode::Executable* cached_executable() const { return m_executable; }
+    ExecutableBacking const& executable_backing() const { return m_executable_backing; }
+    [[nodiscard]] bool can_generate_bytecode_cache() const;
+    [[nodiscard]] bool can_install_generated_bytecode_cache() const;
+    void begin_bytecode_cache_generation();
+    void finish_bytecode_cache_generation_without_install();
+    bool try_install_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code);
+    void install_generated_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code);
 
     ThrowCompletionOr<void> global_declaration_instantiation(VM&, GlobalEnvironment&);
 
@@ -83,15 +92,20 @@ public:
     };
 
 private:
-    Script(Realm&, StringView filename, RustIntegration::ScriptResult&&, HostDefined*);
+    Script(Realm&, StringView filename, RustIntegration::ScriptResult&&, ExecutableBacking, HostDefined*);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual size_t external_memory_size() const override;
+    Vector<SharedFunctionInstanceData*> collect_shared_function_data();
+    void complete_bytecode_cache_install(GC::Ref<Bytecode::Executable>);
+    void verify_executable_backing_invariants();
 
     GC::Ptr<Realm> m_realm;                       // [[Realm]]
     Vector<LoadedModuleRequest> m_loaded_modules; // [[LoadedModules]]
 
     mutable GC::Ptr<Bytecode::Executable> m_executable;
+    SharedFunctionInstanceDataList m_shared_function_data;
+    ExecutableBacking m_executable_backing;
 
     Vector<Utf16FlyString> m_lexical_names;
     Vector<Utf16FlyString> m_var_names;

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -65,8 +65,10 @@ SourceTextModule::SourceTextModule(Realm& realm, StringView filename, Script::Ho
     Vector<ExportEntry> star_export_entries, Optional<Utf16FlyString> default_export_binding_name,
     Vector<Utf16FlyString> var_declared_names, Vector<LexicalBinding> lexical_bindings,
     Vector<FunctionToInitialize> functions_to_initialize,
+    Vector<GC::Root<SharedFunctionInstanceData>> shared_function_data,
     GC::Ptr<Bytecode::Executable> executable,
-    GC::Ptr<SharedFunctionInstanceData> tla_shared_data)
+    GC::Ptr<SharedFunctionInstanceData> tla_shared_data,
+    ExecutableBacking executable_backing)
     : CyclicModule(realm, filename, has_top_level_await, move(requested_modules), host_defined)
     , m_execution_context(ExecutionContext::create(0, ReadonlySpan<Value> {}, 0))
     , m_import_entries(move(import_entries))
@@ -79,7 +81,12 @@ SourceTextModule::SourceTextModule(Realm& realm, StringView filename, Script::Ho
     , m_default_export_binding_name(move(default_export_binding_name))
     , m_executable(executable)
     , m_tla_shared_data(tla_shared_data)
+    , m_executable_backing(executable_backing)
 {
+    for (auto& shared_data : shared_function_data)
+        m_shared_function_data.append(*shared_data);
+
+    verify_executable_backing_invariants();
 }
 
 SourceTextModule::~SourceTextModule() = default;
@@ -89,6 +96,7 @@ void SourceTextModule::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_import_meta);
     m_execution_context->visit_edges(visitor);
+    m_shared_function_data.visit_edges(visitor);
     for (auto const& function : m_functions_to_initialize)
         visitor.visit(function.shared_data);
     visitor.visit(m_executable);
@@ -128,7 +136,8 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_f
         move(module_result.star_export_entries), move(module_result.default_export_binding_name),
         move(module_result.var_declared_names), move(module_result.lexical_bindings),
         move(functions_to_initialize),
-        module_result.executable.ptr(), module_result.tla_shared_data.ptr());
+        move(module_result.shared_function_data),
+        module_result.executable.ptr(), module_result.tla_shared_data.ptr(), ExecutableBacking::source());
 }
 
 Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_from_pre_compiled(FFI::CompiledProgram* compiled, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Script::HostDefined* host_defined)
@@ -151,7 +160,8 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_f
         move(module_result.star_export_entries), move(module_result.default_export_binding_name),
         move(module_result.var_declared_names), move(module_result.lexical_bindings),
         move(functions_to_initialize),
-        module_result.executable.ptr(), module_result.tla_shared_data.ptr());
+        move(module_result.shared_function_data),
+        module_result.executable.ptr(), module_result.tla_shared_data.ptr(), ExecutableBacking::heap_bytecode());
 }
 
 Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_from_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code, Realm& realm, Script::HostDefined* host_defined)
@@ -174,7 +184,85 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse_f
         move(module_result.star_export_entries), move(module_result.default_export_binding_name),
         move(module_result.var_declared_names), move(module_result.lexical_bindings),
         move(functions_to_initialize),
-        module_result.executable.ptr(), module_result.tla_shared_data.ptr());
+        move(module_result.shared_function_data),
+        module_result.executable.ptr(), module_result.tla_shared_data.ptr(), ExecutableBacking::mapped_bytecode_cache());
+}
+
+bool SourceTextModule::try_install_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code)
+{
+    if (m_executable_backing.is_mapped_bytecode_cache()) {
+        RustIntegration::free_decoded_bytecode_cache_blob(bytecode_cache);
+        return false;
+    }
+
+    auto shared_function_data = collect_shared_function_data();
+    auto result = RustIntegration::try_install_bytecode_cache_module(bytecode_cache, move(source_code), realm(), m_executable, shared_function_data, m_tla_shared_data);
+    if (!result.has_value())
+        return false;
+
+    complete_bytecode_cache_install(result->executable.ptr(), result->top_level_await_executable.ptr());
+    return true;
+}
+
+void SourceTextModule::install_generated_bytecode_cache(FFI::DecodedBytecodeCacheBlob* bytecode_cache, NonnullRefPtr<SourceCode const> source_code)
+{
+    VERIFY(can_install_generated_bytecode_cache());
+
+    auto shared_function_data = collect_shared_function_data();
+    auto result = RustIntegration::install_generated_bytecode_cache_module(bytecode_cache, move(source_code), realm(), m_executable, shared_function_data, m_tla_shared_data);
+    complete_bytecode_cache_install(result.executable.ptr(), result.top_level_await_executable.ptr());
+}
+
+bool SourceTextModule::can_generate_bytecode_cache() const
+{
+    auto has_executable = m_executable || (m_tla_shared_data && m_tla_shared_data->m_executable);
+    return has_executable && m_executable_backing.can_generate_bytecode_cache();
+}
+
+bool SourceTextModule::can_install_generated_bytecode_cache() const
+{
+    auto has_executable = m_executable || (m_tla_shared_data && m_tla_shared_data->m_executable);
+    return has_executable && m_executable_backing.can_install_generated_bytecode_cache();
+}
+
+void SourceTextModule::begin_bytecode_cache_generation()
+{
+    VERIFY(can_generate_bytecode_cache());
+    m_executable_backing.begin_bytecode_cache_generation();
+    verify_executable_backing_invariants();
+}
+
+void SourceTextModule::finish_bytecode_cache_generation_without_install()
+{
+    m_executable_backing.finish_bytecode_cache_generation_without_install();
+    verify_executable_backing_invariants();
+}
+
+Vector<SharedFunctionInstanceData*> SourceTextModule::collect_shared_function_data()
+{
+    Vector<SharedFunctionInstanceData*> shared_function_data;
+    shared_function_data.ensure_capacity(m_shared_function_data.size_slow());
+    m_shared_function_data.for_each([&](auto& shared_data) {
+        shared_function_data.unchecked_append(&shared_data);
+    });
+    return shared_function_data;
+}
+
+void SourceTextModule::complete_bytecode_cache_install(GC::Ptr<Bytecode::Executable> executable, GC::Ptr<Bytecode::Executable> top_level_await_executable)
+{
+    VERIFY(executable || top_level_await_executable);
+    if (executable) {
+        VERIFY(m_executable);
+        m_executable = executable;
+    }
+    if (top_level_await_executable) {
+        VERIFY(m_tla_shared_data);
+        m_tla_shared_data->set_executable(top_level_await_executable);
+        m_tla_shared_data->clear_non_bytecode_cache_compile_inputs();
+    }
+    m_shared_function_data.clear_non_bytecode_cache_compile_inputs();
+    m_executable_backing.finish_bytecode_cache_install();
+    verify_executable_backing_invariants();
 }
 
 // 16.2.1.7.1 ParseModule ( sourceText, realm, hostDefined ), https://tc39.es/ecma262/#sec-parsemodule
@@ -198,7 +286,19 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(S
         move(module_result.star_export_entries), move(module_result.default_export_binding_name),
         move(module_result.var_declared_names), move(module_result.lexical_bindings),
         move(functions_to_initialize),
-        module_result.executable.ptr(), module_result.tla_shared_data.ptr());
+        move(module_result.shared_function_data),
+        module_result.executable.ptr(), module_result.tla_shared_data.ptr(), ExecutableBacking::source());
+}
+
+void SourceTextModule::verify_executable_backing_invariants()
+{
+    VERIFY(m_executable || (m_tla_shared_data && m_tla_shared_data->m_executable));
+
+    if (!m_executable_backing.requires_non_bytecode_cache_compile_inputs_to_be_cleared())
+        return;
+
+    VERIFY(!m_shared_function_data.contains_rust_function_ast());
+    VERIFY(!m_shared_function_data.contains_precompiled_bytecode());
 }
 
 // 16.2.1.7.2.1 GetExportedNames ( [ exportStarSet ] ), https://tc39.es/ecma262/#sec-getexportednames

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibJS/CyclicModule.h>
+#include <LibJS/ExecutableBacking.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 #include <LibJS/ModuleEntry.h>
@@ -57,16 +58,26 @@ public:
 
     Bytecode::Executable* cached_executable() const { return m_executable; }
     SharedFunctionInstanceData* top_level_await_shared_data() const { return m_tla_shared_data; }
+    ExecutableBacking const& executable_backing() const { return m_executable_backing; }
+    [[nodiscard]] bool can_generate_bytecode_cache() const;
+    [[nodiscard]] bool can_install_generated_bytecode_cache() const;
+    void begin_bytecode_cache_generation();
+    void finish_bytecode_cache_generation_without_install();
+    bool try_install_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code);
+    void install_generated_bytecode_cache(FFI::DecodedBytecodeCacheBlob*, NonnullRefPtr<SourceCode const> source_code);
 
 protected:
     virtual ThrowCompletionOr<void> initialize_environment(VM& vm) override;
     virtual ThrowCompletionOr<void> execute_module(VM& vm, GC::Ptr<PromiseCapability> capability) override;
 
 private:
-    SourceTextModule(Realm&, StringView filename, Script::HostDefined* host_defined, bool has_top_level_await, Vector<ModuleRequest> requested_modules, Vector<ImportEntry> import_entries, Vector<ExportEntry> local_export_entries, Vector<ExportEntry> indirect_export_entries, Vector<ExportEntry> star_export_entries, Optional<Utf16FlyString> default_export_binding_name, Vector<Utf16FlyString> var_declared_names, Vector<LexicalBinding> lexical_bindings, Vector<FunctionToInitialize> functions_to_initialize, GC::Ptr<Bytecode::Executable> executable, GC::Ptr<SharedFunctionInstanceData> tla_shared_data);
+    SourceTextModule(Realm&, StringView filename, Script::HostDefined* host_defined, bool has_top_level_await, Vector<ModuleRequest> requested_modules, Vector<ImportEntry> import_entries, Vector<ExportEntry> local_export_entries, Vector<ExportEntry> indirect_export_entries, Vector<ExportEntry> star_export_entries, Optional<Utf16FlyString> default_export_binding_name, Vector<Utf16FlyString> var_declared_names, Vector<LexicalBinding> lexical_bindings, Vector<FunctionToInitialize> functions_to_initialize, Vector<GC::Root<SharedFunctionInstanceData>> shared_function_data, GC::Ptr<Bytecode::Executable> executable, GC::Ptr<SharedFunctionInstanceData> tla_shared_data, ExecutableBacking);
 
     virtual void visit_edges(Cell::Visitor&) override;
     virtual size_t external_memory_size() const override;
+    Vector<SharedFunctionInstanceData*> collect_shared_function_data();
+    void complete_bytecode_cache_install(GC::Ptr<Bytecode::Executable>, GC::Ptr<Bytecode::Executable> top_level_await_executable);
+    void verify_executable_backing_invariants();
 
     NonnullOwnPtr<ExecutionContext> m_execution_context; // [[Context]]
     GC::Ptr<Object> m_import_meta;                       // [[ImportMeta]]
@@ -80,8 +91,10 @@ private:
     Vector<FunctionToInitialize> m_functions_to_initialize;
     Optional<Utf16FlyString> m_default_export_binding_name;
 
+    SharedFunctionInstanceDataList m_shared_function_data;
     GC::Ptr<Bytecode::Executable> m_executable;
     GC::Ptr<SharedFunctionInstanceData> m_tla_shared_data;
+    ExecutableBacking m_executable_backing;
 };
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -16,6 +16,7 @@
 #include <LibCrypto/Hash/SHA2.h>
 #include <LibGC/Function.h>
 #include <LibGC/Root.h>
+#include <LibGC/Weak.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/ModuleRequest.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
@@ -60,6 +61,48 @@ struct BytecodeCacheContext {
     ByteString method;
     NonnullRefPtr<HTTP::HeaderList> request_headers;
     u64 vary_key { 0 };
+};
+
+struct BytecodeCacheInstallTarget {
+    GC::Weak<JS::Script> script;
+    GC::Weak<JS::SourceTextModule> module;
+
+    void begin_generation()
+    {
+        if (auto script_record = script.ptr())
+            script_record->begin_bytecode_cache_generation();
+        if (auto module_record = module.ptr())
+            module_record->begin_bytecode_cache_generation();
+    }
+
+    void finish_generation_without_install()
+    {
+        if (auto script_record = script.ptr())
+            script_record->finish_bytecode_cache_generation_without_install();
+        if (auto module_record = module.ptr())
+            module_record->finish_bytecode_cache_generation_without_install();
+    }
+
+    void install_generated_bytecode_cache(JS::RustIntegration::ProgramType type, NonnullRefPtr<JS::SourceCode const> source_code, ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> const& source_hash, Core::ImmutableBytes blob)
+    {
+        switch (type) {
+        case JS::RustIntegration::ProgramType::Script:
+            if (auto script_record = script.ptr()) {
+                auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(move(blob), type, source_hash.bytes());
+                VERIFY(bytecode_cache);
+                script_record->install_generated_bytecode_cache(bytecode_cache, move(source_code));
+            }
+            return;
+        case JS::RustIntegration::ProgramType::Module:
+            if (auto module_record = module.ptr()) {
+                auto* bytecode_cache = JS::RustIntegration::decode_bytecode_cache_blob(move(blob), type, source_hash.bytes());
+                VERIFY(bytecode_cache);
+                module_record->install_generated_bytecode_cache(bytecode_cache, move(source_code));
+            }
+            return;
+        }
+        VERIFY_NOT_REACHED();
+    }
 };
 
 static ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8> bytecode_cache_source_hash(JS::SourceCode const& source_code)
@@ -191,46 +234,57 @@ static Optional<BytecodeCacheContext> bytecode_cache_context_for_request(Fetch::
     };
 }
 
-// Schedule a fresh, fully off-thread compile of the script source for the sole purpose of producing a bytecode cache
-// blob to hand to RequestServer. The execution path has already received its (latency-trimmed) compile artifact and is
-// running, so this work happens entirely on a background thread and never blocks the main thread on cache generation.
+// Schedule a fresh, fully off-thread compile of the script source for the purpose of producing a bytecode cache blob.
+// The execution path has already received its (latency-trimmed) compile artifact and is running, so this work happens
+// entirely on a background thread and never blocks the main thread on cache generation.
 // Reparsing here is intentional: the execution-path compile only eagerly generates top-level bytecode plus direct
-// IIFEs, while the cache wants every nested function compiled so that warm loads avoid lazy compile work entirely.
-static void schedule_bytecode_cache_generation(JS::SourceCode const& original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context)
+// IIFEs, while the cache wants every nested function compiled so that warm loads avoid lazy compile work entirely. Once
+// the blob is back on the main thread, try to install that same blob into the live script/module before storing it.
+static void schedule_bytecode_cache_generation(NonnullRefPtr<JS::SourceCode const> original_source_code, JS::RustIntegration::ProgramType type, size_t line_number_offset, BytecodeCacheContext cache_context, BytecodeCacheInstallTarget install_target)
 {
-    auto filename = original_source_code.filename();
-    auto source_code = original_source_code.code();
+    auto filename = original_source_code->filename();
+    auto source_code = original_source_code->code();
     auto event_loop_weak = Core::EventLoop::current_weak();
+    auto* callback = new Function<void(ByteBuffer, ::Crypto::Hash::Digest<::Crypto::Hash::SHA256::DigestSize * 8>)>(
+        [cache_context = move(cache_context), install_target = move(install_target), original_source_code = move(original_source_code), type](ByteBuffer blob, auto source_hash) mutable {
+            if (blob.is_empty()) {
+                install_target.finish_generation_without_install();
+                return;
+            }
 
-    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, cache_context = move(cache_context), event_loop_weak = move(event_loop_weak)]() mutable {
+            auto immutable_blob = Core::ImmutableBytes::adopt(move(blob));
+            install_target.install_generated_bytecode_cache(type, original_source_code, source_hash, immutable_blob);
+
+            if (!ResourceLoader::is_initialized() || !ResourceLoader::the().request_client())
+                return;
+            (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, cache_context.vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, immutable_blob.bytes());
+        });
+
+    Threading::ThreadPool::the().submit([filename = move(filename), source_code = move(source_code), type, line_number_offset, callback, event_loop_weak = move(event_loop_weak)]() mutable {
         auto source = JS::SourceCode::create(move(filename), move(source_code));
-        auto* parsed = JS::RustIntegration::parse_program(source->utf16_data(), source->length_in_code_units(), type, line_number_offset);
-        if (!parsed)
-            return;
-
-        if (JS::RustIntegration::parsed_program_has_errors(parsed)) {
-            JS::RustIntegration::free_parsed_program(parsed);
-            return;
-        }
-
-        auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(parsed, source->length_in_code_units());
-        if (!compiled)
-            return;
-
         auto source_hash = bytecode_cache_source_hash(*source);
-        auto blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled, type, source_hash.bytes());
-        JS::RustIntegration::free_compiled_program(compiled);
-        if (blob.is_empty())
-            return;
+        ByteBuffer blob;
+
+        auto* parsed = JS::RustIntegration::parse_program(source->utf16_data(), source->length_in_code_units(), type, line_number_offset);
+        if (parsed) {
+            if (JS::RustIntegration::parsed_program_has_errors(parsed)) {
+                JS::RustIntegration::free_parsed_program(parsed);
+            } else {
+                auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(parsed, source->length_in_code_units());
+                if (compiled) {
+                    blob = JS::RustIntegration::serialize_compiled_program_for_bytecode_cache(*compiled, type, source_hash.bytes());
+                    JS::RustIntegration::free_compiled_program(compiled);
+                }
+            }
+        }
 
         auto origin = event_loop_weak->take();
         if (!origin)
             return;
 
-        origin->deferred_invoke([cache_context = move(cache_context), blob = move(blob)]() mutable {
-            if (!ResourceLoader::is_initialized() || !ResourceLoader::the().request_client())
-                return;
-            (void)ResourceLoader::the().request_client()->store_cache_associated_data(cache_context.url, cache_context.method, *cache_context.request_headers, cache_context.vary_key, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, blob.bytes());
+        origin->deferred_invoke([blob = move(blob), source_hash, callback]() mutable {
+            (*callback)(move(blob), source_hash);
+            delete callback;
         });
     });
 }
@@ -268,6 +322,12 @@ static void compile_remaining_functions_off_thread(JS::Bytecode::Executable& exe
                 auto& shared_data = *shared_data_roots[i];
                 if (shared_data.m_executable) {
                     compile_remaining_functions_off_thread(*shared_data.m_executable, source_code);
+                    JS::RustIntegration::free_compiled_function(compiled_function);
+                    continue;
+                }
+
+                // Bytecode-cache installation may have cleared this while the worker compiled an AST clone.
+                if (!shared_data.m_rust_function_ast) {
                     JS::RustIntegration::free_compiled_function(compiled_function);
                     continue;
                 }
@@ -748,18 +808,24 @@ void fetch_classic_script(GC::Ref<HTMLScriptElement> element, URL::URL const& ur
                     bytecode_cache_context = move(bytecode_cache_context),
                     muted_errors, on_complete_root = move(on_complete_root),
                     settings_root = move(settings_root)](auto result, auto source_code) mutable {
-                    auto source_code_for_background_compile = source_code;
                     auto source_code_for_cache = source_code;
+                    auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
                     auto script = result.compiled
                         ? ClassicScript::create_from_pre_compiled(move(response_url_string), move(source_code), *settings_root, move(response_url), result.compiled, muted_errors)
                         : ClassicScript::create_from_pre_parsed(move(response_url_string), move(source_code), *settings_root, move(response_url), result.parsed, muted_errors);
+                    BytecodeCacheInstallTarget install_target;
                     if (auto* script_record = script->script_record()) {
-                        if (auto* executable = script_record->cached_executable())
-                            compile_remaining_functions_off_thread(*executable, move(source_code_for_background_compile));
+                        install_target.script = *script_record;
+                        if (!should_generate_bytecode_cache) {
+                            if (auto* executable = script_record->cached_executable())
+                                compile_remaining_functions_off_thread(*executable, source_code_for_cache);
+                        }
                     }
                     on_complete_root->function()(script);
-                    if (result.compiled && bytecode_cache_context.has_value())
-                        schedule_bytecode_cache_generation(*source_code_for_cache, JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value());
+                    if (should_generate_bytecode_cache) {
+                        install_target.begin_generation();
+                        schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Script, 1, bytecode_cache_context.release_value(), move(install_target));
+                    }
                 });
         } else {
             auto source_text = decode_source_text(*fallback_decoder, body_bytes_view(body_bytes)).release_value_but_fixme_should_propagate_errors();
@@ -1145,17 +1211,27 @@ void fetch_single_module_script(JS::Realm& realm,
                             bytecode_cache_context = move(bytecode_cache_context),
                             on_complete_root = move(on_complete_root),
                             settings_root = move(settings_root)](auto result, auto source_code) mutable {
-                            auto source_code_for_background_compile = source_code;
                             auto source_code_for_cache = source_code;
+                            auto should_generate_bytecode_cache = result.compiled && bytecode_cache_context.has_value();
                             auto module_script = result.compiled
                                 ? ModuleScript::create_from_pre_compiled(url_string, move(source_code), *settings_root, move(response_url), result.compiled).release_value_but_fixme_should_propagate_errors()
                                 : ModuleScript::create_from_pre_parsed(url_string, move(source_code), *settings_root, move(response_url), result.parsed).release_value_but_fixme_should_propagate_errors();
-                            if (module_script)
-                                compile_remaining_module_functions_off_thread(*module_script, move(source_code_for_background_compile));
+                            BytecodeCacheInstallTarget install_target;
+                            if (module_script) {
+                                module_script->record().visit(
+                                    [](Empty) {},
+                                    [&](GC::Ref<JS::SourceTextModule> module) { install_target.module = module; },
+                                    [](GC::Ref<JS::SyntheticModule>) {},
+                                    [](GC::Ref<WebAssembly::WebAssemblyModule>) {});
+                                if (!should_generate_bytecode_cache)
+                                    compile_remaining_module_functions_off_thread(*module_script, source_code_for_cache);
+                            }
                             settings_root->module_map().set(url, module_type_string, { ModuleMap::EntryType::ModuleScript, module_script });
                             on_complete_root->function()(module_script);
-                            if (result.compiled && bytecode_cache_context.has_value())
-                                schedule_bytecode_cache_generation(*source_code_for_cache, JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value());
+                            if (should_generate_bytecode_cache) {
+                                install_target.begin_generation();
+                                schedule_bytecode_cache_generation(move(source_code_for_cache), JS::RustIntegration::ProgramType::Module, 0, bytecode_cache_context.release_value(), move(install_target));
+                            }
                         });
                     return;
                 }

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/System.h>
 #include <LibCrypto/Hash/SHA2.h>
 #include <LibJS/Bytecode/Instruction.h>
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/ModuleRequest.h>
 #include <LibJS/Runtime/SharedFunctionInstanceData.h>
@@ -23,7 +24,7 @@
 
 struct BytecodeCacheTestData {
     NonnullRefPtr<JS::SourceCode const> source_code;
-    ByteBuffer blob;
+    Core::ImmutableBytes blob;
     Crypto::Hash::SHA256::DigestType source_hash;
 };
 
@@ -271,7 +272,7 @@ static BytecodeCacheTestData create_bytecode_cache_blob(StringView source)
 
     return {
         .source_code = source_code,
-        .blob = move(blob),
+        .blob = Core::ImmutableBytes::adopt(move(blob)),
         .source_hash = source_hash,
     };
 }
@@ -300,9 +301,48 @@ static BytecodeCacheTestData create_module_bytecode_cache_blob(StringView source
 
     return {
         .source_code = source_code,
-        .blob = move(blob),
+        .blob = Core::ImmutableBytes::adopt(move(blob)),
         .source_hash = source_hash,
     };
+}
+
+static JS::SharedFunctionInstanceData& first_shared_function_with_template_object_cache(JS::Bytecode::Executable& executable)
+{
+    for (auto& shared_data : executable.shared_function_data) {
+        if (!shared_data || !shared_data->m_executable)
+            continue;
+        if (!shared_data->m_executable->template_object_caches.is_empty())
+            return *shared_data;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static size_t count_shared_functions_with_rust_ast(JS::Bytecode::Executable& executable)
+{
+    size_t count = 0;
+    for (auto& shared_data : executable.shared_function_data) {
+        if (!shared_data)
+            continue;
+        if (shared_data->m_rust_function_ast)
+            ++count;
+        if (shared_data->m_executable)
+            count += count_shared_functions_with_rust_ast(*shared_data->m_executable);
+    }
+    return count;
+}
+
+static size_t count_shared_functions_with_cached_bytecode(JS::Bytecode::Executable& executable)
+{
+    size_t count = 0;
+    for (auto& shared_data : executable.shared_function_data) {
+        if (!shared_data)
+            continue;
+        if (shared_data->m_cached_bytecode_executable)
+            ++count;
+        if (shared_data->m_executable)
+            count += count_shared_functions_with_cached_bytecode(*shared_data->m_executable);
+    }
+    return count;
 }
 
 static size_t first_declaration_function_bytecode_payload_offset(ReadonlyBytes blob)
@@ -384,7 +424,7 @@ TEST_CASE(bytecode_cache_materialization_failure_has_parser_error)
 
     // Structural decode still succeeds because the blob is internally well-formed; the corruption is in the bytecode
     // payload, which is only checked by the validator that runs during materialization.
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(corrupted_blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(Core::ImmutableBytes::adopt(move(corrupted_blob)), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto materialized = JS::RustIntegration::materialize_bytecode_cache_script(decoded_blob, test_data.source_code, realm);
@@ -409,7 +449,7 @@ TEST_CASE(bytecode_cache_rejects_corrupt_declaration_function)
 
     // Structural decode still succeeds (the blob layout is intact); the corruption is in a function's bytecode payload
     // and is only caught when the materializer asks the validator to check it.
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(corrupted_blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(Core::ImmutableBytes::adopt(move(corrupted_blob)), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto materialized = JS::RustIntegration::materialize_bytecode_cache_script(decoded_blob, test_data.source_code, realm);
@@ -433,7 +473,7 @@ TEST_CASE(bytecode_cache_rejects_out_of_range_declaration_function_source_span)
 
     // The source hash still matches and the blob layout is intact, but the cached function source span points outside
     // the current SourceCode. Materialization should reject it as a cache miss instead of handing the range to C++.
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(corrupted_blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(Core::ImmutableBytes::adopt(move(corrupted_blob)), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto materialized = JS::RustIntegration::materialize_bytecode_cache_script(decoded_blob, test_data.source_code, realm);
@@ -451,12 +491,13 @@ TEST_CASE(bytecode_cache_materializes_function_executables_lazily)
 
     auto test_data = create_bytecode_cache_blob("let f = function lazy() { return 1; }; f();"_string);
 
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto script_or_error = JS::Script::create_from_bytecode_cache(decoded_blob, test_data.source_code, realm);
     VERIFY(!script_or_error.is_error());
     auto script = script_or_error.release_value();
+    EXPECT(script->executable_backing().is_mapped_bytecode_cache());
 
     auto* executable = script->cached_executable();
     VERIFY(executable);
@@ -471,6 +512,286 @@ TEST_CASE(bytecode_cache_materializes_function_executables_lazily)
     EXPECT(!shared_data.m_cached_bytecode_executable);
 }
 
+TEST_CASE(bytecode_cache_install_shares_template_object_cache_slots)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "var tag = function(strings) { return strings; };\n"
+                  "var f = function(useTemplate) { if (useTemplate) return tag`hello`; return null; };\n"
+                  "f(false);"_string;
+    auto test_data = create_bytecode_cache_blob(source);
+
+    auto script_or_error = JS::Script::parse(source, realm, "test.js"sv);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+    EXPECT(script->executable_backing().is_source());
+    EXPECT(script->can_generate_bytecode_cache());
+
+    auto result = vm->run(script);
+    VERIFY(!result.is_throw_completion());
+    EXPECT(result.value().is_null());
+
+    auto* old_executable = script->cached_executable();
+    VERIFY(old_executable);
+    auto& shared_data = first_shared_function_with_template_object_cache(*old_executable);
+    auto old_function_executable = shared_data.m_executable;
+    VERIFY(old_function_executable);
+    VERIFY(old_function_executable->template_object_caches.size() == 1);
+
+    auto old_template_cache = old_function_executable->template_object_caches[0];
+    EXPECT(!old_template_cache->cached_template_object);
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    EXPECT(script->try_install_bytecode_cache(decoded_blob, test_data.source_code));
+    auto new_function_executable = shared_data.m_executable;
+    VERIFY(new_function_executable);
+    EXPECT_NE(new_function_executable.ptr(), old_function_executable.ptr());
+    VERIFY(new_function_executable->template_object_caches.size() == 1);
+    EXPECT_EQ(new_function_executable->template_object_caches[0].ptr(), old_template_cache.ptr());
+
+    auto late_template_object = MUST(JS::Array::create(realm, 0));
+    old_template_cache->cached_template_object = late_template_object;
+    EXPECT_EQ(new_function_executable->template_object_caches[0]->cached_template_object.ptr(), late_template_object.ptr());
+}
+
+TEST_CASE(bytecode_cache_install_rejects_corrupt_declaration_function)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "function f() { return 1; } f();"_string;
+    auto test_data = create_bytecode_cache_blob(source);
+    auto corrupted_blob = MUST(ByteBuffer::copy(test_data.blob.bytes()));
+
+    auto declaration_function_bytecode_offset = first_declaration_function_bytecode_payload_offset(corrupted_blob.bytes());
+    VERIFY(declaration_function_bytecode_offset < corrupted_blob.size());
+    corrupted_blob[declaration_function_bytecode_offset] ^= 0xff;
+
+    auto script_or_error = JS::Script::parse(source, realm, "test.js"sv);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+
+    auto* old_executable = script->cached_executable();
+    VERIFY(old_executable);
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(Core::ImmutableBytes::adopt(move(corrupted_blob)), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    EXPECT(!script->try_install_bytecode_cache(decoded_blob, test_data.source_code));
+    EXPECT_EQ(script->cached_executable(), old_executable);
+}
+
+TEST_CASE(bytecode_cache_install_failure_preserves_existing_shared_functions)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "var f = function() { return 1; }; f();"_string;
+    auto test_data = create_bytecode_cache_blob(source);
+
+    auto script_or_error = JS::Script::parse(source, realm, "test.js"sv);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+
+    auto result = vm->run(script);
+    VERIFY(!result.is_throw_completion());
+    EXPECT_EQ(result.value().as_i32(), 1);
+
+    auto* old_executable = script->cached_executable();
+    VERIFY(old_executable);
+    VERIFY(old_executable->shared_function_data.size() == 1);
+    auto& shared_data = *old_executable->shared_function_data[0];
+    auto old_function_executable = shared_data.m_executable;
+    VERIFY(old_function_executable);
+
+    auto corrupted_blob = MUST(ByteBuffer::copy(test_data.blob.bytes()));
+    auto bytecode_payload_offset = top_level_bytecode_payload_offset(corrupted_blob.bytes());
+    VERIFY(bytecode_payload_offset < corrupted_blob.size());
+    corrupted_blob[bytecode_payload_offset] ^= 0xff;
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(Core::ImmutableBytes::adopt(move(corrupted_blob)), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    EXPECT(!script->try_install_bytecode_cache(decoded_blob, test_data.source_code));
+    EXPECT_EQ(script->cached_executable(), old_executable);
+    EXPECT_EQ(shared_data.m_executable.ptr(), old_function_executable.ptr());
+}
+
+TEST_CASE(bytecode_cache_install_clears_lazy_nested_function_inputs)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "let f = function outer() { function inner() { return 1; } return inner; }; let g = f();"_string;
+    auto test_data = create_bytecode_cache_blob(source);
+
+    auto script_or_error = JS::Script::parse(source, realm, "test.js"sv);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+
+    auto* executable = script->cached_executable();
+    VERIFY(executable);
+    VERIFY(executable->shared_function_data.size() == 1);
+    auto& outer_shared_data = *executable->shared_function_data[0];
+    EXPECT(outer_shared_data.m_owner_shared_function_data_list);
+
+    auto result = vm->run(script);
+    VERIFY(!result.is_throw_completion());
+
+    VERIFY(outer_shared_data.m_executable);
+    VERIFY(outer_shared_data.m_executable->shared_function_data.size() == 1);
+    auto& inner_shared_data = *outer_shared_data.m_executable->shared_function_data[0];
+    EXPECT_EQ(inner_shared_data.m_owner_shared_function_data_list, outer_shared_data.m_owner_shared_function_data_list);
+    EXPECT(inner_shared_data.m_rust_function_ast);
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    EXPECT(script->try_install_bytecode_cache(decoded_blob, test_data.source_code));
+    EXPECT(!inner_shared_data.m_rust_function_ast);
+    EXPECT(inner_shared_data.m_cached_bytecode_executable);
+}
+
+TEST_CASE(bytecode_cache_install_matches_class_constructor_after_source_text_expands)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "let C = class { constructor() { this.value = 1; } method() { return this.value; } }; C;"_string;
+    auto test_data = create_bytecode_cache_blob(source);
+
+    auto script_or_error = JS::Script::parse(source, realm, "test.js"sv);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+
+    auto result = vm->run(script);
+    VERIFY(!result.is_throw_completion());
+
+    auto* old_executable = script->cached_executable();
+    VERIFY(old_executable);
+    EXPECT(count_shared_functions_with_rust_ast(*old_executable) > 0);
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    script->begin_bytecode_cache_generation();
+    EXPECT(script->executable_backing().is_source());
+    EXPECT(!script->can_generate_bytecode_cache());
+    EXPECT(script->can_install_generated_bytecode_cache());
+    script->finish_bytecode_cache_generation_without_install();
+    EXPECT(script->executable_backing().is_source());
+    EXPECT(script->can_generate_bytecode_cache());
+    EXPECT(!script->can_install_generated_bytecode_cache());
+
+    script->begin_bytecode_cache_generation();
+    EXPECT(script->can_install_generated_bytecode_cache());
+    script->install_generated_bytecode_cache(decoded_blob, test_data.source_code);
+    EXPECT(script->executable_backing().is_mapped_bytecode_cache());
+    EXPECT(!script->can_generate_bytecode_cache());
+    EXPECT(!script->can_install_generated_bytecode_cache());
+    auto* new_executable = script->cached_executable();
+    VERIFY(new_executable);
+    EXPECT_EQ(count_shared_functions_with_rust_ast(*new_executable), static_cast<size_t>(0));
+    EXPECT(count_shared_functions_with_cached_bytecode(*new_executable) > 0);
+}
+
+TEST_CASE(bytecode_cache_install_clears_precompiled_lazy_function_inputs)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "let f = function lazy() { return 1; }; f;"_string;
+    auto test_data = create_bytecode_cache_blob(source);
+
+    auto* parsed = JS::RustIntegration::parse_program(test_data.source_code->utf16_data(), test_data.source_code->length_in_code_units(), JS::RustIntegration::ProgramType::Script);
+    VERIFY(parsed);
+    ArmedScopeGuard free_parsed = [&] {
+        JS::RustIntegration::free_parsed_program(parsed);
+    };
+    EXPECT(!JS::RustIntegration::parsed_program_has_errors(parsed));
+
+    auto* compiled = JS::RustIntegration::compile_parsed_program_fully_off_thread(parsed, test_data.source_code->length_in_code_units());
+    VERIFY(compiled);
+    free_parsed.disarm();
+
+    auto script_or_error = JS::Script::create_from_compiled(compiled, test_data.source_code, realm);
+    VERIFY(!script_or_error.is_error());
+    auto script = script_or_error.release_value();
+    EXPECT(script->executable_backing().is_heap_bytecode());
+
+    auto* executable = script->cached_executable();
+    VERIFY(executable);
+    VERIFY(executable->shared_function_data.size() == 1);
+    auto& shared_data = *executable->shared_function_data[0];
+    EXPECT(!shared_data.m_executable);
+    EXPECT(shared_data.m_precompiled_bytecode_executable);
+    EXPECT(!shared_data.m_cached_bytecode_executable);
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    script->begin_bytecode_cache_generation();
+    EXPECT(script->executable_backing().is_heap_bytecode());
+    EXPECT(!script->can_generate_bytecode_cache());
+    EXPECT(script->can_install_generated_bytecode_cache());
+    script->finish_bytecode_cache_generation_without_install();
+    EXPECT(script->executable_backing().is_heap_bytecode());
+    EXPECT(script->can_generate_bytecode_cache());
+    EXPECT(!script->can_install_generated_bytecode_cache());
+
+    script->begin_bytecode_cache_generation();
+    script->install_generated_bytecode_cache(decoded_blob, test_data.source_code);
+    EXPECT(script->executable_backing().is_mapped_bytecode_cache());
+    EXPECT(!script->can_generate_bytecode_cache());
+    EXPECT(!script->can_install_generated_bytecode_cache());
+    EXPECT(!shared_data.m_rust_function_ast);
+    EXPECT(!shared_data.m_precompiled_bytecode_executable);
+    EXPECT(shared_data.m_cached_bytecode_executable);
+}
+
+TEST_CASE(bytecode_cache_install_updates_top_level_await_module_executable)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto source = "await 1;"_string;
+    auto test_data = create_module_bytecode_cache_blob(source);
+
+    auto module_or_error = JS::SourceTextModule::parse(source, realm, "test.mjs"sv);
+    VERIFY(!module_or_error.is_error());
+    auto module = module_or_error.release_value();
+    EXPECT(module->executable_backing().is_source());
+
+    auto* top_level_await_shared_data = module->top_level_await_shared_data();
+    VERIFY(top_level_await_shared_data);
+    auto old_executable = top_level_await_shared_data->m_executable;
+    VERIFY(old_executable);
+
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Module, test_data.source_hash.bytes());
+    VERIFY(decoded_blob);
+
+    module->begin_bytecode_cache_generation();
+    EXPECT(module->can_install_generated_bytecode_cache());
+    module->install_generated_bytecode_cache(decoded_blob, test_data.source_code);
+
+    EXPECT(module->executable_backing().is_mapped_bytecode_cache());
+    EXPECT(!module->can_generate_bytecode_cache());
+    EXPECT(!module->can_install_generated_bytecode_cache());
+    EXPECT_EQ(module->top_level_await_shared_data(), top_level_await_shared_data);
+    VERIFY(top_level_await_shared_data->m_executable);
+    EXPECT_NE(top_level_await_shared_data->m_executable.ptr(), old_executable.ptr());
+}
+
 TEST_CASE(bytecode_cache_to_string_caches_lazy_ascii_source_text)
 {
     auto vm = JS::VM::create();
@@ -483,7 +804,7 @@ TEST_CASE(bytecode_cache_to_string_caches_lazy_ascii_source_text)
     auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source.bytes()));
     auto source_code = JS::SourceCode::create("test.js"_string, test_data.source_code->length_in_code_units(), "UTF-8"_string, move(source_bytes));
 
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto script_or_error = JS::Script::create_from_bytecode_cache(decoded_blob, source_code, realm);
@@ -517,7 +838,7 @@ TEST_CASE(bytecode_cache_to_string_uses_lazy_utf8_offset_map)
     auto source_bytes = TRY_OR_FAIL(Core::ImmutableBytes::copy(source.bytes()));
     auto source_code = JS::SourceCode::create("test.js"_string, test_data.source_code->length_in_code_units(), "UTF-8"_string, move(source_bytes));
 
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob.bytes(), JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Script, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto script_or_error = JS::Script::create_from_bytecode_cache(decoded_blob, source_code, realm);
@@ -576,7 +897,7 @@ TEST_CASE(fresh_precompiled_function_executables_materialize_lazily)
     auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
     auto& realm = *root_execution_context->realm;
 
-    auto source_code = JS::SourceCode::create("test.js"_string, Utf16String::from_utf8("let f = function lazy() { return 1; }; f();"_string));
+    auto source_code = JS::SourceCode::create("test.js"_string, Utf16String::from_utf8("let f = function lazy() { function inner() { return 1; } return inner(); }; f();"_string));
     auto* parsed = JS::RustIntegration::parse_program(source_code->utf16_data(), source_code->length_in_code_units(), JS::RustIntegration::ProgramType::Script);
     VERIFY(parsed);
     ArmedScopeGuard free_parsed = [&] {
@@ -591,6 +912,7 @@ TEST_CASE(fresh_precompiled_function_executables_materialize_lazily)
     auto script_or_error = JS::Script::create_from_compiled(compiled, source_code, realm);
     VERIFY(!script_or_error.is_error());
     auto script = script_or_error.release_value();
+    EXPECT(script->executable_backing().is_heap_bytecode());
 
     auto* executable = script->cached_executable();
     VERIFY(executable);
@@ -598,9 +920,12 @@ TEST_CASE(fresh_precompiled_function_executables_materialize_lazily)
     auto& shared_data = *executable->shared_function_data[0];
     EXPECT(!shared_data.m_executable);
     EXPECT(shared_data.m_precompiled_bytecode_executable);
+    EXPECT(!shared_data.m_rust_function_ast);
+    EXPECT(shared_data.m_functions_to_initialize.is_empty());
 
     auto result = vm->run(script);
     VERIFY(!result.is_throw_completion());
+    EXPECT_EQ(result.value().as_i32(), 1);
     EXPECT(shared_data.m_executable);
     EXPECT(!shared_data.m_precompiled_bytecode_executable);
 }
@@ -613,13 +938,14 @@ TEST_CASE(bytecode_cache_preserves_re_exported_import_names)
 
     auto test_data = create_module_bytecode_cache_blob("import { pass as renamed } from './source.mjs'; export { renamed as default };"sv);
 
-    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob.bytes(), JS::RustIntegration::ProgramType::Module, test_data.source_hash.bytes());
+    auto* decoded_blob = JS::RustIntegration::decode_bytecode_cache_blob(test_data.blob, JS::RustIntegration::ProgramType::Module, test_data.source_hash.bytes());
     VERIFY(decoded_blob);
 
     auto source_module = JS::SourceTextModule::parse("export function pass() {}"sv, realm, "./source.mjs"sv).release_value();
     source_module->set_status(JS::ModuleStatus::Unlinked);
 
     auto cached_module = JS::SourceTextModule::parse_from_bytecode_cache(decoded_blob, test_data.source_code, realm).release_value();
+    EXPECT(cached_module->executable_backing().is_mapped_bytecode_cache());
     cached_module->set_status(JS::ModuleStatus::Unlinked);
     cached_module->loaded_modules().append(JS::LoadedModuleRequest {
         .specifier = Utf16String::from_utf8("./source.mjs"sv),


### PR DESCRIPTION
Teach cold-cache script and module loads to install the bytecode cache blob we just generated, using the same mapped `ImmutableBytes` backed path as a later warm-cache load.

The branch introduces `ExecutableBacking` as the owner-side state machine for script/module executable storage, gives scripts and modules an explicit `SharedFunctionData` owner list, and routes bytecode cache installation through `Script` / `SourceTextModule`. Once a generated cache blob is available, LibWeb maps it as `ImmutableBytes`, decodes it, and asks the live JS owner to install that mapped blob immediately.

```mermaid
flowchart LR
    subgraph Live["Live script/module owner"]
        A["Source or heap-bytecode backing"]
        B["Current executable runs page"]
        C["SharedFunctionData list tracks all functions"]
        D["Install mapped cache backing"]
        E["MappedBytecodeCache backing"]
    end

    subgraph Cache["Background cache generation"]
        F["Full off-thread compile"]
        G["Serialize bytecode cache blob"]
        H["Adopt blob as ImmutableBytes"]
        I["Decode from ImmutableBytes"]
    end

    A --> B
    A --> C
    A --> F
    F --> G --> H --> I --> D
    C --> D
    B --> D
    D --> E
```

At install time, the owner replaces executable backing, preserves compatible runtime caches, updates every tracked `SharedFunctionData`, and clears AST / heap-bytecode compile inputs. From that point on, lazy functions materialize from the mapped cache blob instead of retaining source-backed or heap-backed compile artifacts.

The bytecode cache tests cover live cache installation for scripts and modules, stable shared-function-data identity, lazy function cleanup, runtime template object cache preservation, corrupt-cache rejection, and top-level-await module executable replacement.