### PR TITLE
LibWeb: Follow CSS Tables cell baseline rules

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1003,7 +1003,7 @@ void TableFormattingContext::compute_table_height()
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }
 
-        cell.baseline = box_baseline(cell.box);
+        cell.baseline = table_cell_baseline(cell.box);
 
         // Implements https://www.w3.org/TR/css-tables-3/#computing-the-table-height
 
@@ -1095,7 +1095,7 @@ void TableFormattingContext::compute_table_height()
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }
 
-        cell.baseline = box_baseline(cell.box);
+        cell.baseline = table_cell_baseline(cell.box);
 
         if (!row.is_collapsed) {
             row.reference_height = max(row.reference_height, cell_state.border_box_height());
@@ -1985,6 +1985,119 @@ template<>
 CSSPixels TableFormattingContext::border_spacing<TableFormattingContext::Column>()
 {
     return border_spacing_horizontal();
+}
+
+CSSPixels TableFormattingContext::table_cell_baseline(Box const& cell_box) const
+{
+    auto const& cell_state = m_state.get(cell_box);
+    auto cell_margin_box_top = cell_state.cumulative_offset().y() - cell_state.margin_box_top();
+
+    // https://drafts.csswg.org/css-tables-3/#row-layout
+    //
+    // The baseline of a cell is defined as the baseline of the first in-flow line box in the cell, or the first
+    // in-flow table-row in the cell, whichever comes first.
+    //
+    // If there is no such line box or table-row, the baseline is the bottom of content edge of the cell box.
+    auto is_in_flow_descendant = [&](Box const& descendant) {
+        for (Node const* node = &descendant; node && node != &cell_box; node = node->parent()) {
+            auto const* box = as_if<Box>(*node);
+            if (box && box->is_out_of_flow(*this))
+                return false;
+        }
+        return true;
+    };
+
+    Optional<CSSPixels> baseline;
+    cell_box.for_each_in_inclusive_subtree_of_type<Box>([&](Box const& descendant) {
+        if (!is_in_flow_descendant(descendant))
+            return TraversalDecision::Continue;
+
+        auto const* descendant_state = m_state.try_get(descendant);
+        if (!descendant_state)
+            return TraversalDecision::Continue;
+
+        // "The baseline of a cell is defined as the baseline of the first in-flow line box in the cell..."
+        if (!descendant_state->line_boxes.is_empty()) {
+            auto const& first_line_box = descendant_state->line_boxes.first();
+            auto first_line_box_top = first_line_box.bottom() - first_line_box.block_length();
+            baseline = descendant_state->cumulative_offset().y() + first_line_box_top + first_line_box.baseline() - cell_margin_box_top;
+            return TraversalDecision::Break;
+        }
+
+        // "...or the first in-flow table-row in the cell, whichever comes first."
+        if (descendant.display().is_table_row()) {
+            auto row_margin_box_top = descendant_state->cumulative_offset().y() - descendant_state->margin_box_top();
+            baseline = row_margin_box_top - cell_margin_box_top + table_row_baseline(descendant);
+            return TraversalDecision::Break;
+        }
+
+        return TraversalDecision::Continue;
+    });
+
+    if (baseline.has_value())
+        return baseline.value();
+
+    // "If there is no such line box or table-row, the baseline is the bottom of content edge of the cell box."
+    return cell_state.margin_box_top() + cell_state.content_height();
+}
+
+CSSPixels TableFormattingContext::table_row_baseline(Box const& row_box) const
+{
+    auto const& row_state = m_state.get(row_box);
+    auto row_margin_box_top = row_state.cumulative_offset().y() - row_state.margin_box_top();
+
+    // https://drafts.csswg.org/css-tables-3/#row-layout
+    //
+    // The maximum distance between the top of the cell box and the baseline over all cells that have
+    // 'vertical-align: baseline' is used to set the baseline of the row.
+    //
+    // If a row doesn’t have any cell that has 'vertical-align: baseline', the baseline of that row is the bottom
+    // content edge of the lowest cell in the row.
+    auto cell_aligns_to_baseline = [](Box const& cell_box) {
+        auto const& vertical_align = cell_box.computed_values().vertical_align();
+        if (!vertical_align.has<CSS::VerticalAlign>())
+            return true;
+
+        switch (vertical_align.get<CSS::VerticalAlign>()) {
+        case CSS::VerticalAlign::Middle:
+        case CSS::VerticalAlign::Top:
+        case CSS::VerticalAlign::Bottom:
+            return false;
+        default:
+            return true;
+        }
+    };
+
+    Optional<CSSPixels> baseline;
+    Optional<CSSPixels> lowest_cell_content_bottom;
+    row_box.for_each_child_of_type<Box>([&](Box const& child_box) {
+        if (!child_box.display().is_table_cell() || child_box.is_out_of_flow(*this))
+            return IterationDecision::Continue;
+
+        auto const* child_state = m_state.try_get(child_box);
+        if (!child_state)
+            return IterationDecision::Continue;
+
+        auto child_margin_box_top = child_state->cumulative_offset().y() - child_state->margin_box_top();
+        auto child_offset_from_row = child_margin_box_top - row_margin_box_top;
+
+        // "...the bottom content edge of the lowest cell in the row."
+        lowest_cell_content_bottom = max(lowest_cell_content_bottom.value_or(0), child_offset_from_row + child_state->margin_box_top() + child_state->content_height());
+
+        // "The maximum distance between the top of the cell box and the baseline over all cells that have
+        // 'vertical-align: baseline' is used to set the baseline of the row."
+        if (cell_aligns_to_baseline(child_box))
+            baseline = max(baseline.value_or(0), child_offset_from_row + table_cell_baseline(child_box));
+        return IterationDecision::Continue;
+    });
+
+    if (baseline.has_value())
+        return baseline.value();
+    if (lowest_cell_content_bottom.has_value())
+        return lowest_cell_content_bottom.value();
+
+    // Empty rows use their bottom content edge as a fallback baseline.
+    return row_state.margin_box_top() + row_state.content_height();
 }
 
 CSSPixels TableFormattingContext::border_spacing_horizontal() const

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -135,6 +135,8 @@ private:
     Vector<RowOrColumn>& table_rows_or_columns();
 
     CSSPixels compute_row_content_height(Cell const& cell) const;
+    CSSPixels table_cell_baseline(Box const&) const;
+    CSSPixels table_row_baseline(Box const&) const;
 
     enum class ConflictingSide {
         Top,

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-baseline-multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-baseline-multi-line-cell.txt
@@ -1,0 +1,42 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 136 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 120 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 179.6875 0+0+604.3125] [0+0+0 120 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 179.6875 0+0+0] [0+0+0 120 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,8] table-row-group [0+0+0 179.6875 0+0+0] [0+0+0 120 0+0+0] children: not-inline
+            Box <tr> at [8,8] table-row [0+0+0 179.6875 0+0+0] [0+0+0 120 0+0+0] children: not-inline
+              BlockContainer <td> at [10,10] table-cell [0+1+1 81.78125 1+1+0] [0+1+1 18 99+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 11, rect: [10,10 81.78125x18] baseline: 13.796875
+                    "Single line"
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [95.78125,10] table-cell [0+1+1 89.90625 1+1+0] [0+1+1 36 81+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 10, rect: [95.78125,10 77.265625x18] baseline: 13.796875
+                    "First line"
+                frag 1 from TextNode start: 0, length: 11, rect: [95.78125,28 89.90625x18] baseline: 13.796875
+                    "second line"
+                TextNode <#text> (not painted)
+                BreakNode <br> (not painted)
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,128] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 179.6875x120]
+        PaintableBox (Box<TABLE>) [8,8 179.6875x120]
+          PaintableBox (Box<TBODY>) [8,8 179.6875x120]
+            PaintableBox (Box<TR>) [8,8 179.6875x120]
+              PaintableWithLines (BlockContainer<TD>) [8,8 85.78125x120]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [93.78125,8 93.90625x120]
+                TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,128 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x136] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-baseline-table-row-and-empty-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-baseline-table-row-and-empty-cell.txt
@@ -1,0 +1,83 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 256 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 240 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 311.078125 0+0+472.921875] [0+0+0 240 0+0+0] [BFC] children: not-inline
+        Box <table.outer> at [8,8] table-box [0+0+0 311.078125 0+0+0] [0+0+0 240 0+0+0] [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <tbody> at [8,8] table-row-group [0+0+0 311.078125 0+0+0] [0+0+0 240 0+0+0] children: not-inline
+            Box <tr> at [8,8] table-row [0+0+0 311.078125 0+0+0] [0+0+0 80 0+0+0] children: not-inline
+              BlockContainer <td> at [10,33.203125] table-cell [0+1+1 81.78125 1+1+0] [0+1+24.203125 18 35.796875+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 11, rect: [10,33.203125 81.78125x18] baseline: 13.796875
+                    "Single line"
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [95.78125,10] table-cell [0+1+1 221.296875 1+1+0] [0+1+1 68 9+1+0] [BFC] children: not-inline
+                TableWrapper <(anonymous)> at [95.78125,10] [0+0+0 221.296875 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+                  Box <table.nested> at [95.78125,10] table-box [0+0+0 221.296875 0+0+0] [0+0+0 50 0+0+0] [TFC] children: not-inline
+                    Box <tbody> at [95.78125,10] table-row-group [0+0+0 221.296875 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+                      Box <tr> at [95.78125,10] table-row [0+0+0 221.296875 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+                        BlockContainer <td> at [97.78125,12] table-cell [0+1+1 217.296875 1+1+0] [0+1+1 46 1+1+0] [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 11, rect: [97.78125,12 217.296875x46] baseline: 35
+                              "Nested line"
+                          TextNode <#text> (not painted)
+                BlockContainer <(anonymous)> at [95.78125,60] [0+0+0 221.296875 0+0+0] [0+0+0 18 0+0+0] children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [95.78125,60 45.109375x18] baseline: 13.796875
+                      "After"
+                  TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [8,88] table-row [0+0+0 311.078125 0+0+0] [0+0+0 80 0+0+0] children: not-inline
+              BlockContainer <td> at [10,111.203125] table-cell [0+1+1 81.78125 1+1+0] [0+1+22.203125 18 37.796875+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 11, rect: [10,111.203125 81.78125x18] baseline: 13.796875
+                    "Single line"
+                TextNode <#text> (not painted)
+              BlockContainer <td> at [95.78125,90] table-cell [0+1+1 221.296875 1+1+0] [0+1+1 46 31+1+0] [BFC] children: not-inline
+                BlockContainer <div.block-line> at [95.78125,90] [0+0+0 221.296875 0+0+0] [0+0+0 46 0+0+0] children: inline
+                  frag 0 from TextNode start: 0, length: 10, rect: [95.78125,90 189.21875x46] baseline: 35
+                      "Block line"
+                  TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [8,168] table-row [0+0+0 311.078125 0+0+0] [0+0+0 80 0+0+0] children: not-inline
+              BlockContainer <td> at [10,175.203125] table-cell [0+1+1 81.78125 1+1+0] [0+1+6.203125 18 53.796875+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 11, rect: [10,175.203125 81.78125x18] baseline: 13.796875
+                    "Single line"
+                TextNode <#text> (not painted)
+              BlockContainer <td.empty> at [95.78125,189] table-cell [0+1+1 221.296875 1+1+0] [0+1+20 0 58+1+0] [BFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,248] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x256]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x240]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 311.078125x240]
+        PaintableBox (Box<TABLE>.outer) [8,8 311.078125x240]
+          PaintableBox (Box<TBODY>) [8,8 311.078125x240]
+            PaintableBox (Box<TR>) [8,8 311.078125x80]
+              PaintableWithLines (BlockContainer<TD>) [8,8 85.78125x80]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [93.78125,8 225.296875x80]
+                PaintableWithLines (TableWrapper(anonymous)) [95.78125,10 221.296875x50]
+                  PaintableBox (Box<TABLE>.nested) [95.78125,10 221.296875x50]
+                    PaintableBox (Box<TBODY>) [95.78125,10 221.296875x50]
+                      PaintableBox (Box<TR>) [95.78125,10 221.296875x50]
+                        PaintableWithLines (BlockContainer<TD>) [95.78125,10 221.296875x50]
+                          TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [95.78125,60 221.296875x18]
+                  TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,88 311.078125x80]
+              PaintableWithLines (BlockContainer<TD>) [8,88 85.78125x80]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [93.78125,88 225.296875x80]
+                PaintableWithLines (BlockContainer<DIV>.block-line) [95.78125,90 221.296875x46]
+                  TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,168 311.078125x80]
+              PaintableWithLines (BlockContainer<TD>) [8,168 85.78125x80]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>.empty) [93.78125,168 225.296875x80]
+      PaintableWithLines (BlockContainer(anonymous)) [8,248 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x256] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/vertical-align-baseline-multi-line-cell.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-baseline-multi-line-cell.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+table {
+    border-collapse: collapse;
+}
+
+td {
+    border: 1px solid black;
+    height: 120px;
+    vertical-align: baseline;
+}
+</style>
+<table>
+<tr><td>Single line</td><td>First line<br>second line</td></tr>
+</table>

--- a/Tests/LibWeb/Layout/input/table/vertical-align-baseline-table-row-and-empty-cell.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-baseline-table-row-and-empty-cell.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<style>
+table {
+    border-collapse: collapse;
+}
+
+td {
+    border: 1px solid black;
+    vertical-align: baseline;
+}
+
+.outer td {
+    height: 80px;
+}
+
+.nested td {
+    font-size: 40px;
+    height: auto;
+}
+
+.block-line {
+    font-size: 40px;
+}
+
+.empty {
+    height: 30px;
+    padding-bottom: 40px;
+    padding-top: 20px;
+}
+</style>
+<table class="outer">
+<tr><td>Single line</td><td><table class="nested"><tr><td>Nested line</td></tr></table>After</td></tr>
+<tr><td>Single line</td><td><div class="block-line">Block line</div></td></tr>
+<tr><td>Single line</td><td class="empty"></td></tr>
+</table>


### PR DESCRIPTION
This fixes table cell baseline alignment to follow the CSS Tables rules.

A table cell baseline is now computed from the first in-flow line box in the cell, or the first in-flow table-row if that comes first. If neither exists, it falls back to the bottom content edge of the cell box.

Fixes #2164 