### PR TITLE
UI+LibWebView: Fix query hijacking, improve heuristics

### DIFF
--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -5,8 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteString.h>
 #include <AK/Debug.h>
 #include <AK/Find.h>
+#include <AK/String.h>
 #include <LibCore/EventLoop.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
@@ -43,7 +45,10 @@ Optional<AutocompleteEngine const&> find_autocomplete_engine_by_name(StringView 
 }
 
 Autocomplete::Autocomplete() = default;
-Autocomplete::~Autocomplete() = default;
+Autocomplete::~Autocomplete()
+{
+    cancel_pending_query();
+}
 
 void Autocomplete::cancel_pending_query()
 {
@@ -56,20 +61,6 @@ void Autocomplete::cancel_pending_query()
     // the active query as well and let the stale-response check discard them.
     m_query = {};
     m_history_suggestions.clear();
-}
-
-StringView autocomplete_section_title(AutocompleteSuggestionSection section)
-{
-    switch (section) {
-    case AutocompleteSuggestionSection::None:
-        return {};
-    case AutocompleteSuggestionSection::History:
-        return "History"sv;
-    case AutocompleteSuggestionSection::SearchSuggestions:
-        return "Search Suggestions"sv;
-    }
-
-    VERIFY_NOT_REACHED();
 }
 
 [[maybe_unused]] static ByteString log_autocomplete_suggestions(Vector<AutocompleteSuggestion> const& suggestions)
@@ -91,7 +82,7 @@ static Vector<AutocompleteSuggestion> make_history_suggestions(Vector<HistoryEnt
     for (auto& entry : history_entries) {
         suggestions.unchecked_append({
             .source = AutocompleteSuggestionSource::History,
-            .section = AutocompleteSuggestionSection::History,
+            .relevance_score = entry.relevance_score,
             .text = move(entry.url),
             .title = move(entry.title),
             .subtitle = {},
@@ -116,7 +107,7 @@ static Optional<AutocompleteSuggestion> search_for_query_suggestion(StringView q
 
     return AutocompleteSuggestion {
         .source = AutocompleteSuggestionSource::Search,
-        .section = AutocompleteSuggestionSection::SearchSuggestions,
+        .relevance_score = 1300,
         .text = query_string,
         .title = query_string,
         .subtitle = move(subtitle),
@@ -131,7 +122,7 @@ static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
 
     return AutocompleteSuggestion {
         .source = AutocompleteSuggestionSource::LiteralURL,
-        .section = AutocompleteSuggestionSection::None,
+        .relevance_score = 1600,
         .text = MUST(String::from_utf8(query)),
         .title = {},
         .subtitle = {},
@@ -197,7 +188,7 @@ static Vector<AutocompleteSuggestion> merge_suggestions(
     Optional<AutocompleteSuggestion> search_for_query_suggestion,
     Optional<AutocompleteSuggestion> literal_url_suggestion,
     Vector<AutocompleteSuggestion> history_suggestions,
-    Vector<String> remote_suggestions,
+    Vector<AutocompleteSuggestion> remote_suggestions,
     size_t max_suggestions)
 {
     Vector<AutocompleteSuggestion> suggestions;
@@ -221,17 +212,16 @@ static Vector<AutocompleteSuggestion> merge_suggestions(
     if (search_for_query_suggestion.has_value())
         append_suggestion_if_unique(suggestions, max_suggestions, search_for_query_suggestion.release_value());
 
+    int remote_score = 1100;
     for (auto& suggestion : remote_suggestions) {
-        auto remote_suggestion = AutocompleteSuggestion {
-            .source = AutocompleteSuggestionSource::Search,
-            .section = AutocompleteSuggestionSection::SearchSuggestions,
-            .text = move(suggestion),
-            .title = {},
-            .subtitle = {},
-            .favicon_base64_png = {},
-        };
-        append_suggestion_if_unique(suggestions, max_suggestions, move(remote_suggestion));
+        suggestion.relevance_score = remote_score;
+        remote_score = max(600, remote_score - 100);
+        append_suggestion_if_unique(suggestions, max_suggestions, move(suggestion));
     }
+
+    quick_sort(suggestions, [](auto const& a, auto const& b) {
+        return a.relevance_score > b.relevance_score;
+    });
 
     return suggestions;
 }
@@ -302,6 +292,10 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
         return;
 
     m_request = Application::request_server_client().start_request("GET"sv, *url);
+    if (!m_request) {
+        invoke_autocomplete_query_complete(merge_suggestions(search_suggestion, literal_suggestion, m_history_suggestions, {}, m_max_suggestions), AutocompleteResultKind::Final);
+        return;
+    }
 
     m_request->set_buffered_request_finished_callback(
         [this, engine = engine.release_value(), query = m_query, literal_suggestion, search_suggestion](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Core::ImmutableBytes payload) {
@@ -331,7 +325,7 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
             } else {
                 auto remote_suggestions = result.release_value();
 
-                dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Remote autocomplete suggestions for '{}': {}", query, history_log_suggestions(remote_suggestions));
+                dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Remote autocomplete suggestions for '{}': {}", query, log_autocomplete_suggestions(remote_suggestions));
 
                 auto merged_suggestions = merge_suggestions(search_suggestion, literal_suggestion, m_history_suggestions, move(remote_suggestions), m_max_suggestions);
 
@@ -342,20 +336,28 @@ void Autocomplete::query_autocomplete_engine(String query, size_t max_suggestion
         });
 }
 
-static ErrorOr<Vector<String>> parse_duckduckgo_autocomplete(JsonValue const& json)
+static ErrorOr<Vector<AutocompleteSuggestion>> parse_duckduckgo_autocomplete(JsonValue const& json)
 {
     if (!json.is_array())
         return Error::from_string_literal("Expected DuckDuckGo autocomplete response to be a JSON array");
 
-    Vector<String> results;
+    Vector<AutocompleteSuggestion> results;
     results.ensure_capacity(json.as_array().size());
 
     TRY(json.as_array().try_for_each([&](JsonValue const& suggestion) -> ErrorOr<void> {
         if (!suggestion.is_object())
             return Error::from_string_literal("Invalid DuckDuckGo autocomplete response, expected value to be an object");
 
-        if (auto value = suggestion.as_object().get_string("phrase"sv); value.has_value())
-            results.unchecked_append(*value);
+        if (auto value = suggestion.as_object().get_string("phrase"sv); value.has_value()) {
+            results.unchecked_append(AutocompleteSuggestion {
+                .source = AutocompleteSuggestionSource::Search,
+                .relevance_score = 0,
+                .text = *value,
+                .title = {},
+                .subtitle = {},
+                .favicon_base64_png = {},
+            });
+        }
 
         return {};
     }));
@@ -363,35 +365,42 @@ static ErrorOr<Vector<String>> parse_duckduckgo_autocomplete(JsonValue const& js
     return results;
 }
 
-static ErrorOr<Vector<String>> parse_google_autocomplete(JsonValue const& json)
+static ErrorOr<Vector<AutocompleteSuggestion>> parse_google_autocomplete(JsonValue const& json)
 {
     if (!json.is_array())
         return Error::from_string_literal("Expected Google autocomplete response to be a JSON array");
 
     auto const& values = json.as_array();
 
-    if (values.size() != 5)
-        return Error::from_string_literal("Invalid Google autocomplete response, expected 5 elements in array");
+    if (values.size() < 4)
+        return Error::from_string_literal("Invalid Google autocomplete response, expected at least 4 elements in array");
     if (!values[1].is_array())
         return Error::from_string_literal("Invalid Google autocomplete response, expected second element to be an array");
 
     auto const& suggestions = values[1].as_array();
 
-    Vector<String> results;
+    Vector<AutocompleteSuggestion> results;
     results.ensure_capacity(suggestions.size());
 
-    TRY(suggestions.try_for_each([&](JsonValue const& suggestion) -> ErrorOr<void> {
+    for (size_t i = 0; i < suggestions.size(); ++i) {
+        auto const& suggestion = suggestions[i];
         if (!suggestion.is_string())
             return Error::from_string_literal("Invalid Google autocomplete response, expected value to be a string");
 
-        results.unchecked_append(suggestion.as_string());
-        return {};
-    }));
+        results.unchecked_append(AutocompleteSuggestion {
+            .source = AutocompleteSuggestionSource::Search,
+            .relevance_score = 0,
+            .text = suggestion.as_string(),
+            .title = {},
+            .subtitle = {},
+            .favicon_base64_png = {},
+        });
+    }
 
     return results;
 }
 
-static ErrorOr<Vector<String>> parse_yahoo_autocomplete(JsonValue const& json)
+static ErrorOr<Vector<AutocompleteSuggestion>> parse_yahoo_autocomplete(JsonValue const& json)
 {
     if (!json.is_object())
         return Error::from_string_literal("Expected Yahoo autocomplete response to be a JSON array");
@@ -400,25 +409,32 @@ static ErrorOr<Vector<String>> parse_yahoo_autocomplete(JsonValue const& json)
     if (!suggestions.has_value())
         return Error::from_string_literal("Invalid Yahoo autocomplete response, expected \"r\" to be an object");
 
-    Vector<String> results;
+    Vector<AutocompleteSuggestion> results;
     results.ensure_capacity(suggestions->size());
 
     TRY(suggestions->try_for_each([&](JsonValue const& suggestion) -> ErrorOr<void> {
         if (!suggestion.is_object())
             return Error::from_string_literal("Invalid Yahoo autocomplete response, expected value to be an object");
 
-        auto result = suggestion.as_object().get_string("k"sv);
-        if (!result.has_value())
+        auto yahoo_suggestion_text = suggestion.as_object().get_string("k"sv);
+        if (!yahoo_suggestion_text.has_value())
             return Error::from_string_literal("Invalid Yahoo autocomplete response, expected \"k\" to be a string");
 
-        results.unchecked_append(*result);
+        results.unchecked_append(AutocompleteSuggestion {
+            .source = AutocompleteSuggestionSource::Search,
+            .relevance_score = 0,
+            .text = *yahoo_suggestion_text,
+            .title = {},
+            .subtitle = {},
+            .favicon_base64_png = {},
+        });
         return {};
     }));
 
     return results;
 }
 
-ErrorOr<Vector<String>> Autocomplete::received_autocomplete_respsonse(AutocompleteEngine const& engine, Optional<ByteString const&> content_type, StringView response)
+ErrorOr<Vector<AutocompleteSuggestion>> Autocomplete::received_autocomplete_respsonse(AutocompleteEngine const& engine, Optional<ByteString const&> content_type, StringView response)
 {
     auto decoder = [&]() -> Optional<TextCodec::Decoder&> {
         if (!content_type.has_value())

--- a/Libraries/LibWebView/Autocomplete.h
+++ b/Libraries/LibWebView/Autocomplete.h
@@ -37,15 +37,9 @@ enum class AutocompleteSuggestionSource {
     Search,
 };
 
-enum class AutocompleteSuggestionSection {
-    None,
-    History,
-    SearchSuggestions,
-};
-
 struct WEBVIEW_API AutocompleteSuggestion {
     AutocompleteSuggestionSource source { AutocompleteSuggestionSource::Search };
-    AutocompleteSuggestionSection section { AutocompleteSuggestionSection::None };
+    int relevance_score { 0 };
     String text;
     Optional<String> title;
     Optional<String> subtitle;
@@ -54,7 +48,6 @@ struct WEBVIEW_API AutocompleteSuggestion {
 
 WEBVIEW_API ReadonlySpan<AutocompleteEngine> autocomplete_engines();
 WEBVIEW_API Optional<AutocompleteEngine const&> find_autocomplete_engine_by_name(StringView name);
-WEBVIEW_API StringView autocomplete_section_title(AutocompleteSuggestionSection);
 WEBVIEW_API bool autocomplete_urls_match(StringView left, StringView right);
 WEBVIEW_API bool autocomplete_url_can_complete(StringView query, StringView suggestion);
 
@@ -69,7 +62,7 @@ public:
     void cancel_pending_query();
 
 private:
-    static ErrorOr<Vector<String>> received_autocomplete_respsonse(AutocompleteEngine const&, Optional<ByteString const&> content_type, StringView response);
+    static ErrorOr<Vector<AutocompleteSuggestion>> received_autocomplete_respsonse(AutocompleteEngine const&, Optional<ByteString const&> content_type, StringView response);
     void invoke_autocomplete_query_complete(Vector<AutocompleteSuggestion> suggestions, AutocompleteResultKind) const;
 
     String m_query;

--- a/Libraries/LibWebView/HistoryStore.cpp
+++ b/Libraries/LibWebView/HistoryStore.cpp
@@ -175,14 +175,13 @@ ErrorOr<NonnullOwnPtr<HistoryStore>> HistoryStore::create(Database::Database& da
         WHERE url = ?;
     )#"sv));
     statements.search_entries = TRY(database.prepare_statement(R"#(
-        SELECT url, title, visit_count, last_visited_time, COALESCE(favicon, '')
+        SELECT url, title, visit_count, last_visited_time
         FROM (
             SELECT
                 url,
                 title,
                 visit_count,
                 last_visited_time,
-                COALESCE(favicon, '') AS favicon,
                 CASE
                     WHEN LOWER(CASE
                         WHEN INSTR(url, '://') > 0 THEN SUBSTR(url, INSTR(url, '://') + 3)
@@ -408,7 +407,65 @@ Vector<HistoryEntry> HistoryStore::autocomplete_entries(StringView query, size_t
     auto title_query = autocomplete_title_query(trimmed_query);
     auto url_query = autocomplete_url_query(trimmed_query);
 
-    auto entries = m_storage->autocomplete_entries(title_query, url_query, limit);
+    // Fetch a larger pool of candidates to score them mathematically
+    auto entries = m_storage->autocomplete_entries(title_query, url_query, 50);
+
+    auto now = UnixDateTime::now().seconds_since_epoch();
+    for (auto& entry : entries) {
+        auto rank = match_rank(entry, title_query, url_query);
+        int base_score = 0;
+        if (rank == 0) {
+            base_score = 1900;
+        } else if (rank == 1) {
+            auto searchable_url = autocomplete_searchable_url(entry.url.bytes_as_string_view());
+            auto first_slash = searchable_url.find('/');
+            auto host = first_slash.has_value() ? searchable_url.substring_view(0, *first_slash) : searchable_url;
+            if (host.starts_with(url_query, CaseSensitivity::CaseInsensitive)) {
+                bool is_root = !first_slash.has_value() || *first_slash == searchable_url.length() - 1;
+                if (is_root)
+                    base_score = 1800;
+                else
+                    base_score = 1400;
+            } else {
+                base_score = 1000;
+            }
+        } else if (rank == 2) {
+            base_score = 800;
+        } else {
+            base_score = 500;
+        }
+
+        auto age_seconds = now > entry.last_visited_time.seconds_since_epoch() ? now - entry.last_visited_time.seconds_since_epoch() : 0;
+        auto age_days = age_seconds / 86400;
+
+        double decay = 0.1;
+        if (age_days < 1)
+            decay = 1.0;
+        else if (age_days < 7)
+            decay = 0.7;
+        else if (age_days < 30)
+            decay = 0.5;
+
+        int frecency_bonus = static_cast<int>(entry.visit_count * decay * 10.0);
+        frecency_bonus = min(frecency_bonus, 300);
+
+        entry.relevance_score = base_score + frecency_bonus;
+    }
+
+    quick_sort(entries, [](auto const& a, auto const& b) {
+        if (a.relevance_score != b.relevance_score)
+            return a.relevance_score > b.relevance_score;
+        return a.visit_count > b.visit_count;
+    });
+
+    if (entries.size() > limit)
+        entries.shrink(limit);
+
+    for (auto& entry : entries) {
+        auto db_entry = entry_for_url(URL::Parser::basic_parse(entry.url).value());
+        if (db_entry.has_value() && db_entry->favicon_base64_png.has_value())
+            entry.favicon_base64_png = move(db_entry->favicon_base64_png);
+    }
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] {} history autocomplete suggestions for '{}' (title_query='{}', url_query='{}', limit={}): {}",
         m_storage->name(),
@@ -598,12 +655,11 @@ Vector<HistoryEntry> HistoryStore::PersistedStorage::autocomplete_entries(String
         m_statements.search_entries,
         [&](auto statement_id) {
             auto title = m_database.result_column<String>(statement_id, 1);
-            auto favicon = m_database.result_column<String>(statement_id, 4);
 
             entries.append(HistoryEntry {
                 .url = m_database.result_column<String>(statement_id, 0),
                 .title = title.is_empty() ? Optional<String> {} : Optional<String> { move(title) },
-                .favicon_base64_png = favicon.is_empty() ? Optional<String> {} : Optional<String> { move(favicon) },
+                .favicon_base64_png = {},
                 .visit_count = m_database.result_column<u64>(statement_id, 2),
                 .last_visited_time = m_database.result_column<UnixDateTime>(statement_id, 3),
             });

--- a/Libraries/LibWebView/HistoryStore.h
+++ b/Libraries/LibWebView/HistoryStore.h
@@ -24,6 +24,7 @@ struct WEBVIEW_API HistoryEntry {
     Optional<String> favicon_base64_png;
     u64 visit_count { 0 };
     UnixDateTime last_visited_time;
+    int relevance_score { 0 };
 };
 
 struct WEBVIEW_API RecentlyClosedEntry {

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -39,18 +39,32 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
 
     auto url = URL::create_with_url_or_path(location);
 
-    if (!url.has_value() || url->scheme() == "localhost"sv) {
-        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
-        if (!url.has_value())
-            return search_url_or_error();
+    static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
+    bool scheme_is_supported = url.has_value() && any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url->scheme(); });
 
-        https_scheme_was_guessed = true;
+    // Check if the query looks like "host:port", where the port starts with a digit.
+    // This allows us to distinguish hostnames with ports (e.g. google.com:80) from unsupported schemes (e.g. mailto:example).
+    bool is_likely_host_and_port = false;
+    if (url.has_value() && !scheme_is_supported) {
+        if (auto colon_index = location.find(':'); colon_index.has_value()) {
+            auto remainder = location.substring_view(*colon_index + 1);
+            if (!remainder.is_empty() && remainder[0] >= '0' && remainder[0] <= '9') {
+                is_likely_host_and_port = true;
+            }
+        }
     }
 
-    // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.
-    static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
-    if (!any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url->scheme(); }))
+    if (!url.has_value() || url->scheme() == "localhost"sv || (url.has_value() && !scheme_is_supported && is_likely_host_and_port)) {
+        auto guessed_url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
+        if (guessed_url.has_value()) {
+            url = move(guessed_url);
+            https_scheme_was_guessed = true;
+        } else if (!url.has_value() || !scheme_is_supported) {
+            return search_url_or_error();
+        }
+    } else if (url.has_value() && !scheme_is_supported) {
         return search_url_or_error();
+    }
 
     if (auto const& host = url->host(); host.has_value() && host->is_domain()) {
         auto const& domain = host->get<String>();
@@ -63,12 +77,18 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         if (any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); }))
             return url;
 
-        auto public_suffix = URL::PublicSuffixData::the()->get_public_suffix(domain);
-        if (!public_suffix.has_value() || *public_suffix == domain) {
-            if (append_tld == AppendTLD::Yes)
+        auto domain_to_check = domain.bytes_as_string_view().trim("."sv, TrimMode::Right);
+        auto public_suffix = URL::PublicSuffixData::the()->get_public_suffix(domain_to_check);
+        if (!public_suffix.has_value() || public_suffix->bytes_as_string_view() == domain_to_check) {
+            if (append_tld == AppendTLD::Yes) {
                 url->set_host(MUST(String::formatted("{}.com", domain)));
-            else if (https_scheme_was_guessed && domain != "localhost"sv)
-                return search_url_or_error();
+            } else if (https_scheme_was_guessed && domain != "localhost"sv) {
+                // Allow registry-less hosts if they contain a port or the user explicitly added a trailing slash (e.g. "foo/" or "foo:80/").
+                bool has_port = url->port().has_value();
+                bool ends_with_slash = location.ends_with('/') || location.ends_with('\\');
+                if (!has_port && !ends_with_slash)
+                    return search_url_or_error();
+            }
         }
     }
 

--- a/Tests/LibWebView/TestHistoryStore.cpp
+++ b/Tests/LibWebView/TestHistoryStore.cpp
@@ -120,6 +120,38 @@ TEST_CASE(history_autocomplete_prefers_url_prefix_then_recency)
     EXPECT_EQ(entries[2].url, "https://beta.example.com/"_string);
 }
 
+TEST_CASE(history_autocomplete_frecency_breaks_same_rank_ties)
+{
+    auto store = WebView::HistoryStore::create();
+
+    auto high_frequency_url = parse_url("https://alpha-docs.example.com/"sv);
+    auto low_frequency_url = parse_url("https://alpha-blog.example.com/"sv);
+
+    store->record_visit(low_frequency_url, "Alpha blog"_string, UnixDateTime::now());
+    for (int i = 0; i < 5; ++i)
+        store->record_visit(high_frequency_url, "Alpha docs"_string, UnixDateTime::now());
+
+    auto entries = store->autocomplete_entries("alpha"sv, 8);
+
+    VERIFY(entries.size() == 2);
+    EXPECT_EQ(entries[0].url, "https://alpha-docs.example.com/"_string);
+    EXPECT_EQ(entries[1].url, "https://alpha-blog.example.com/"_string);
+}
+
+TEST_CASE(history_autocomplete_prefers_host_root_over_host_path)
+{
+    auto store = WebView::HistoryStore::create();
+
+    store->record_visit(parse_url("https://alpha.example.com/docs"sv), "Alpha docs"_string, UnixDateTime::now());
+    store->record_visit(parse_url("https://alpha.example.com/"sv), "Alpha"_string, UnixDateTime::now());
+
+    auto entries = store->autocomplete_entries("alpha"sv, 8);
+
+    VERIFY(entries.size() == 2);
+    EXPECT_EQ(entries[0].url, "https://alpha.example.com/"_string);
+    EXPECT_EQ(entries[1].url, "https://alpha.example.com/docs"_string);
+}
+
 TEST_CASE(history_autocomplete_trims_whitespace)
 {
     auto store = WebView::HistoryStore::create();

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -229,6 +229,14 @@ TEST_CASE(location_to_search_or_url)
     expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv); // For now, unsupported scheme.
     // FIXME: Add support for opening mailto: scheme (below). Firefox opens mailto: locations
     // expect_url_equals_sanitized_url("mailto:hello@example.com"sv, "mailto:hello@example.com"sv);
+
+    // Test cases for registry-less hosts with trailing slashes or explicit port numbers (Chromium-like heuristics)
+    expect_url_equals_sanitized_url("https://foo/"sv, "foo/"sv);
+    expect_url_equals_sanitized_url("https://foo/bar/"sv, "foo/bar/"sv);
+    expect_search_url_equals_sanitized_url("foo/bar"sv);
+    expect_url_equals_sanitized_url("https://google.com:80/"sv, "google.com:80"sv);
+    expect_url_equals_sanitized_url("https://myrouter:80/"sv, "myrouter:80"sv);
+    expect_search_url_equals_sanitized_url("foo:bar"sv);
 }
 
 TEST_CASE(location_looks_like_url)
@@ -244,6 +252,13 @@ TEST_CASE(location_looks_like_url)
     expect_location_does_not_look_like_url("example.def"sv);
 
     expect_location_looks_like_url("example"sv, WebView::AppendTLD::Yes);
+
+    expect_location_looks_like_url("foo/"sv);
+    expect_location_looks_like_url("foo/bar/"sv);
+    expect_location_does_not_look_like_url("foo/bar"sv);
+    expect_location_looks_like_url("google.com:80"sv);
+    expect_location_looks_like_url("myrouter:80"sv);
+    expect_location_does_not_look_like_url("foo:bar"sv);
 }
 
 TEST_CASE(autocomplete_url_matching)

--- a/UI/AppKit/Interface/Autocomplete.h
+++ b/UI/AppKit/Interface/Autocomplete.h
@@ -32,6 +32,7 @@ static constexpr auto MAXIMUM_VISIBLE_AUTOCOMPLETE_SUGGESTIONS = 8uz;
 - (void)clearSelection;
 - (BOOL)close;
 - (BOOL)isVisible;
+- (BOOL)isUserSelected;
 
 - (Optional<String>)selectedSuggestion;
 

--- a/UI/AppKit/Interface/Autocomplete.mm
+++ b/UI/AppKit/Interface/Autocomplete.mm
@@ -8,37 +8,21 @@
 #import <Utilities/Conversions.h>
 
 static NSString* const AUTOCOMPLETE_IDENTIFIER = @"Autocomplete";
-static NSString* const AUTOCOMPLETE_SECTION_HEADER_IDENTIFIER = @"AutocompleteSectionHeader";
-static constexpr CGFloat const POPOVER_PADDING = 8;
+static constexpr CGFloat const POPOVER_PADDING = 0;
 static constexpr CGFloat const MINIMUM_WIDTH = 100;
 static constexpr CGFloat const CELL_HORIZONTAL_PADDING = 8;
 static constexpr CGFloat const CELL_VERTICAL_PADDING = 10;
 static constexpr CGFloat const CELL_ICON_SIZE = 16;
 static constexpr CGFloat const CELL_ICON_TEXT_SPACING = 6;
 static constexpr CGFloat const CELL_LABEL_VERTICAL_SPACING = 5;
-static constexpr CGFloat const SECTION_HEADER_HORIZONTAL_PADDING = 10;
-static constexpr CGFloat const SECTION_HEADER_VERTICAL_PADDING = 4;
 
 static NSFont* autocomplete_primary_font();
 static NSFont* autocomplete_secondary_font();
-static NSFont* autocomplete_section_header_font();
-
-enum class AutocompleteRowKind {
-    SectionHeader,
-    Suggestion,
-};
-
-struct AutocompleteRowModel {
-    AutocompleteRowKind kind;
-    String text;
-    size_t suggestion_index { 0 };
-};
 
 static CGFloat autocomplete_text_field_height(NSFont* font)
 {
     static CGFloat primary_text_field_height = 0;
     static CGFloat secondary_text_field_height = 0;
-    static CGFloat section_header_text_field_height = 0;
     static dispatch_once_t token;
     dispatch_once(&token, ^{
         auto* text_field = [[NSTextField alloc] initWithFrame:NSZeroRect];
@@ -52,15 +36,10 @@ static CGFloat autocomplete_text_field_height(NSFont* font)
 
         [text_field setFont:autocomplete_secondary_font()];
         secondary_text_field_height = ceil([text_field fittingSize].height);
-
-        [text_field setFont:autocomplete_section_header_font()];
-        section_header_text_field_height = ceil([text_field fittingSize].height);
     });
 
     if (font == autocomplete_secondary_font())
         return secondary_text_field_height;
-    if (font == autocomplete_section_header_font())
-        return section_header_text_field_height;
     return primary_text_field_height;
 }
 
@@ -74,16 +53,6 @@ static CGFloat autocomplete_row_height()
                 + CELL_LABEL_VERTICAL_SPACING
                 + autocomplete_text_field_height(autocomplete_secondary_font()));
         row_height = ceil(content_height + (CELL_VERTICAL_PADDING * 2));
-    });
-    return row_height;
-}
-
-static CGFloat autocomplete_section_header_height()
-{
-    static CGFloat row_height = 0;
-    static dispatch_once_t token;
-    dispatch_once(&token, ^{
-        row_height = ceil(autocomplete_text_field_height(autocomplete_section_header_font()) + (SECTION_HEADER_VERTICAL_PADDING * 2));
     });
     return row_height;
 }
@@ -104,16 +73,6 @@ static NSFont* autocomplete_secondary_font()
     static dispatch_once_t token;
     dispatch_once(&token, ^{
         font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
-    });
-    return font;
-}
-
-static NSFont* autocomplete_section_header_font()
-{
-    static NSFont* font;
-    static dispatch_once_t token;
-    dispatch_once(&token, ^{
-        font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize] weight:NSFontWeightSemibold];
     });
     return font;
 }
@@ -178,15 +137,6 @@ static CGFloat autocomplete_visible_width(NSView* view)
 @end
 
 @implementation AutocompleteSuggestionView
-@end
-
-@interface AutocompleteSectionHeaderView : NSTableCellView
-
-@property (nonatomic, strong) NSTextField* text_field;
-
-@end
-
-@implementation AutocompleteSectionHeaderView
 @end
 
 @interface AutocompleteScrollView : NSScrollView
@@ -259,7 +209,6 @@ static CGFloat autocomplete_visible_width(NSView* view)
 @interface Autocomplete () <AutocompleteTableViewHoverObserver, NSTableViewDataSource, NSTableViewDelegate>
 {
     Vector<WebView::AutocompleteSuggestion> m_suggestions;
-    Vector<AutocompleteRowModel> m_rows;
 }
 
 @property (nonatomic, weak) id<AutocompleteObserver> observer;
@@ -270,12 +219,12 @@ static CGFloat autocomplete_visible_width(NSView* view)
 @property (nonatomic, strong) NSScrollView* scroll_view;
 @property (nonatomic, strong) NSTableView* table_view;
 @property (nonatomic, strong) NSMutableDictionary<NSString*, NSImage*>* suggestion_icons;
+@property (nonatomic, assign) BOOL user_selected;
 
 - (NSInteger)tableRowForSuggestionIndex:(NSInteger)suggestion_index;
 - (BOOL)isSelectableRow:(NSInteger)row;
 - (CGFloat)heightOfRowAtIndex:(size_t)row;
 - (CGFloat)tableHeightForVisibleSuggestionCount:(size_t)visible_suggestion_count;
-- (void)rebuildRows;
 - (void)selectRow:(NSInteger)row notifyObserver:(BOOL)notify_observer;
 - (NSInteger)stepToSelectableRowFrom:(NSInteger)row direction:(NSInteger)direction;
 
@@ -347,9 +296,10 @@ static CGFloat autocomplete_visible_width(NSView* view)
 - (void)showWithSuggestions:(Vector<WebView::AutocompleteSuggestion>)suggestions
                 selectedRow:(NSInteger)selected_row
 {
+    auto previously_selected = [self selectedSuggestion];
+    auto had_user_selection = self.user_selected;
+
     m_suggestions = move(suggestions);
-    [self rebuildRows];
-    [self.suggestion_icons removeAllObjects];
 
     for (auto const& suggestion : m_suggestions) {
         if (suggestion.favicon_base64_png.has_value()) {
@@ -361,12 +311,25 @@ static CGFloat autocomplete_visible_width(NSView* view)
 
     [self.table_view reloadData];
 
-    if (m_rows.is_empty())
+    if (m_suggestions.is_empty())
         [self close];
     else
         [self show];
 
-    auto table_row = [self tableRowForSuggestionIndex:selected_row];
+    NSInteger table_row = NSNotFound;
+    if (had_user_selection && previously_selected.has_value()) {
+        for (size_t i = 0; i < m_suggestions.size(); ++i) {
+            if (m_suggestions[i].text == *previously_selected) {
+                table_row = static_cast<NSInteger>(i);
+                break;
+            }
+        }
+    }
+
+    self.user_selected = table_row != NSNotFound && had_user_selection;
+    if (table_row == NSNotFound)
+        table_row = [self tableRowForSuggestionIndex:selected_row];
+
     if (table_row == NSNotFound)
         [self clearSelection];
     else if (table_row != self.table_view.selectedRow) {
@@ -384,6 +347,7 @@ static CGFloat autocomplete_visible_width(NSView* view)
     if (auto* parent_window = [self.toolbar_item.view window])
         [parent_window removeChildWindow:self.popup_window];
 
+    self.user_selected = NO;
     [self.popup_window orderOut:nil];
     [self.observer onAutocompleteDidClose];
     return YES;
@@ -394,8 +358,14 @@ static CGFloat autocomplete_visible_width(NSView* view)
     return self.popup_window.isVisible;
 }
 
+- (BOOL)isUserSelected
+{
+    return self.user_selected;
+}
+
 - (void)clearSelection
 {
+    self.user_selected = NO;
     [self.table_view deselectAll:nil];
 }
 
@@ -408,7 +378,7 @@ static CGFloat autocomplete_visible_width(NSView* view)
     if (![self isSelectableRow:row])
         return {};
 
-    return m_suggestions[m_rows[row].suggestion_index].text;
+    return m_suggestions[row].text;
 }
 
 - (BOOL)selectNextSuggestion
@@ -418,13 +388,17 @@ static CGFloat autocomplete_visible_width(NSView* view)
 
     if (!self.popup_window.isVisible) {
         [self show];
-        if (auto row = [self stepToSelectableRowFrom:-1 direction:1]; row != NSNotFound)
+        if (auto row = [self stepToSelectableRowFrom:-1 direction:1]; row != NSNotFound) {
+            self.user_selected = YES;
             [self selectRow:row notifyObserver:YES];
+        }
         return YES;
     }
 
-    if (auto row = [self stepToSelectableRowFrom:[self.table_view selectedRow] direction:1]; row != NSNotFound)
+    if (auto row = [self stepToSelectableRowFrom:[self.table_view selectedRow] direction:1]; row != NSNotFound) {
+        self.user_selected = YES;
         [self selectRow:row notifyObserver:YES];
+    }
     return YES;
 }
 
@@ -435,13 +409,17 @@ static CGFloat autocomplete_visible_width(NSView* view)
 
     if (!self.popup_window.isVisible) {
         [self show];
-        if (auto row = [self stepToSelectableRowFrom:0 direction:-1]; row != NSNotFound)
+        if (auto row = [self stepToSelectableRowFrom:0 direction:-1]; row != NSNotFound) {
+            self.user_selected = YES;
             [self selectRow:row notifyObserver:YES];
+        }
         return YES;
     }
 
-    if (auto row = [self stepToSelectableRowFrom:[self.table_view selectedRow] direction:-1]; row != NSNotFound)
+    if (auto row = [self stepToSelectableRowFrom:[self.table_view selectedRow] direction:-1]; row != NSNotFound) {
+        self.user_selected = YES;
         [self selectRow:row notifyObserver:YES];
+    }
     return YES;
 }
 
@@ -453,74 +431,30 @@ static CGFloat autocomplete_visible_width(NSView* view)
 
 #pragma mark - Private methods
 
-- (void)rebuildRows
-{
-    m_rows.clear();
-    m_rows.ensure_capacity(m_suggestions.size() * 2);
-
-    auto current_section = WebView::AutocompleteSuggestionSection::None;
-    for (size_t suggestion_index = 0; suggestion_index < m_suggestions.size(); ++suggestion_index) {
-        auto const& suggestion = m_suggestions[suggestion_index];
-        if (suggestion.section != WebView::AutocompleteSuggestionSection::None && suggestion.section != current_section) {
-            current_section = suggestion.section;
-            m_rows.append({
-                .kind = AutocompleteRowKind::SectionHeader,
-                .text = MUST(String::from_utf8(WebView::autocomplete_section_title(current_section))),
-            });
-        }
-
-        m_rows.append({ .kind = AutocompleteRowKind::Suggestion, .text = {}, .suggestion_index = suggestion_index });
-    }
-}
-
 - (BOOL)isSelectableRow:(NSInteger)row
 {
-    if (row < 0 || row >= static_cast<NSInteger>(m_rows.size()))
+    if (row < 0 || row >= static_cast<NSInteger>(m_suggestions.size()))
         return NO;
-    return m_rows[row].kind == AutocompleteRowKind::Suggestion;
+    return YES;
 }
 
 - (NSInteger)tableRowForSuggestionIndex:(NSInteger)suggestion_index
 {
-    if (suggestion_index < 0)
+    if (suggestion_index < 0 || suggestion_index >= static_cast<NSInteger>(m_suggestions.size()))
         return NSNotFound;
 
-    for (size_t row = 0; row < m_rows.size(); ++row) {
-        auto const& row_model = m_rows[row];
-        if (row_model.kind == AutocompleteRowKind::Suggestion
-            && row_model.suggestion_index == static_cast<size_t>(suggestion_index))
-            return static_cast<NSInteger>(row);
-    }
-
-    return NSNotFound;
+    return suggestion_index;
 }
 
 - (CGFloat)heightOfRowAtIndex:(size_t)row
 {
-    VERIFY(row < m_rows.size());
-    return m_rows[row].kind == AutocompleteRowKind::SectionHeader
-        ? autocomplete_section_header_height()
-        : autocomplete_row_height();
+    VERIFY(row < m_suggestions.size());
+    return autocomplete_row_height();
 }
 
 - (CGFloat)tableHeightForVisibleSuggestionCount:(size_t)visible_suggestion_count
 {
-    if (visible_suggestion_count == 0)
-        return 0;
-
-    CGFloat total_height = 0;
-    size_t seen_suggestion_count = 0;
-
-    for (size_t row = 0; row < m_rows.size(); ++row) {
-        total_height += [self heightOfRowAtIndex:row];
-        if (m_rows[row].kind == AutocompleteRowKind::Suggestion) {
-            ++seen_suggestion_count;
-            if (seen_suggestion_count >= visible_suggestion_count)
-                break;
-        }
-    }
-
-    return ceil(total_height);
+    return ceil(visible_suggestion_count * autocomplete_row_height());
 }
 
 - (NSInteger)stepToSelectableRowFrom:(NSInteger)row direction:(NSInteger)direction
@@ -562,11 +496,7 @@ static CGFloat autocomplete_visible_width(NSView* view)
         return;
     auto was_visible = self.popup_window.isVisible;
 
-    size_t visible_suggestion_count = 0;
-    for (auto const& row_model : m_rows) {
-        if (row_model.kind == AutocompleteRowKind::Suggestion)
-            ++visible_suggestion_count;
-    }
+    size_t visible_suggestion_count = min(m_suggestions.size(), MAXIMUM_VISIBLE_AUTOCOMPLETE_SUGGESTIONS);
 
     auto visible_table_height = [self tableHeightForVisibleSuggestionCount:visible_suggestion_count];
     auto width = max<CGFloat>(toolbar_view.frame.size.width, MINIMUM_WIDTH);
@@ -617,7 +547,7 @@ static CGFloat autocomplete_visible_width(NSView* view)
 
 - (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView
 {
-    return static_cast<NSInteger>(m_rows.size());
+    return static_cast<NSInteger>(m_suggestions.size());
 }
 
 #pragma mark - NSTableViewDelegate
@@ -640,37 +570,7 @@ static CGFloat autocomplete_visible_width(NSView* view)
 {
     auto visible_width = autocomplete_visible_width(table_view);
 
-    auto const& row_model = m_rows[row];
-    if (row_model.kind == AutocompleteRowKind::SectionHeader) {
-        AutocompleteSectionHeaderView* view = (AutocompleteSectionHeaderView*)[table_view makeViewWithIdentifier:AUTOCOMPLETE_SECTION_HEADER_IDENTIFIER owner:self];
-
-        if (view == nil) {
-            view = [[AutocompleteSectionHeaderView alloc] initWithFrame:NSZeroRect];
-
-            NSTextField* text_field = [[NSTextField alloc] initWithFrame:NSZeroRect];
-            [text_field setBezeled:NO];
-            [text_field setDrawsBackground:NO];
-            [text_field setEditable:NO];
-            [text_field setFont:autocomplete_section_header_font()];
-            [text_field setSelectable:NO];
-            [view addSubview:text_field];
-            [view setText_field:text_field];
-            [view setIdentifier:AUTOCOMPLETE_SECTION_HEADER_IDENTIFIER];
-        }
-
-        auto* header_text = Ladybird::string_to_ns_string(row_model.text);
-        auto header_height = autocomplete_text_field_height(autocomplete_section_header_font());
-        [view setFrame:NSMakeRect(0, 0, visible_width, [self tableView:table_view heightOfRow:row])];
-        [view.text_field setStringValue:header_text];
-        [view.text_field setTextColor:[NSColor tertiaryLabelColor]];
-        [view.text_field setFrame:NSMakeRect(
-                                      SECTION_HEADER_HORIZONTAL_PADDING,
-                                      floor((NSHeight(view.bounds) - header_height) / 2.f),
-                                      NSWidth(view.bounds) - (SECTION_HEADER_HORIZONTAL_PADDING * 2),
-                                      header_height)];
-        return view;
-    }
-
+    // Reuse or create a suggestion cell view.
     AutocompleteSuggestionView* view = (AutocompleteSuggestionView*)[table_view makeViewWithIdentifier:AUTOCOMPLETE_IDENTIFIER owner:self];
 
     if (view == nil) {
@@ -703,15 +603,16 @@ static CGFloat autocomplete_visible_width(NSView* view)
         [view setIdentifier:AUTOCOMPLETE_IDENTIFIER];
     }
 
-    auto const& suggestion = m_suggestions[row_model.suggestion_index];
+    auto const& suggestion = m_suggestions[row];
     auto* suggestion_text = Ladybird::string_to_ns_string(suggestion.text);
     auto* title_text = suggestion.title.has_value() ? Ladybird::string_to_ns_string(*suggestion.title) : nil;
     auto* secondary_text = suggestion.subtitle.has_value() ? Ladybird::string_to_ns_string(*suggestion.subtitle) : suggestion_text;
     auto* favicon = [self.suggestion_icons objectForKey:suggestion_text];
-    auto* icon = suggestion.source == WebView::AutocompleteSuggestionSource::LiteralURL
-        ? literal_url_suggestion_icon()
-        : suggestion.source == WebView::AutocompleteSuggestionSource::Search ? search_suggestion_icon()
-                                                                             : favicon;
+    auto* icon = favicon != nil
+        ? favicon
+        : (suggestion.source == WebView::AutocompleteSuggestionSource::LiteralURL
+                  ? literal_url_suggestion_icon()
+                  : (suggestion.source == WebView::AutocompleteSuggestionSource::Search ? search_suggestion_icon() : nil));
 
     [view setFrame:NSMakeRect(0, 0, visible_width, [self tableView:table_view heightOfRow:row])];
 

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -49,6 +49,18 @@ static NSString* inline_autocomplete_text_for_candidate(NSString* query, NSStrin
     if (prefix_range.location == NSNotFound)
         return nil;
 
+    auto slash_range = [candidate rangeOfString:@"/"];
+    if (slash_range.location != NSNotFound) {
+        auto* host = [candidate substringToIndex:slash_range.location];
+        if (host.length > query.length) {
+            auto host_prefix_range = [host rangeOfString:query options:NSCaseInsensitiveSearch | NSAnchoredSearch];
+            if (host_prefix_range.location != NSNotFound) {
+                auto* host_suffix = [host substringFromIndex:query.length];
+                return [query stringByAppendingString:host_suffix];
+            }
+        }
+    }
+
     auto* suffix = [candidate substringFromIndex:query.length];
     return [query stringByAppendingString:suffix];
 }
@@ -373,6 +385,82 @@ static NSImage* location_field_globe_icon()
                 return;
             }
 
+            auto* query = [self currentLocationFieldQuery];
+
+            bool has_inline_history = false;
+            for (auto const& suggestion : suggestions) {
+                if (suggestion.source != WebView::AutocompleteSuggestionSource::History)
+                    continue;
+
+                auto* suggestion_text = Ladybird::string_to_ns_string(suggestion.text);
+                if (suggestion_matches_query_exactly(query, suggestion_text) || inline_autocomplete_text_for_suggestion(query, suggestion_text) != nil) {
+                    has_inline_history = true;
+                    break;
+                }
+            }
+
+            auto query_string = Ladybird::ns_string_to_string(query);
+            auto trimmed_query = MUST(query_string.trim_whitespace());
+            bool is_backspace_suppressed = self.suppressed_inline_autocomplete_query != nil && [self.suppressed_inline_autocomplete_query isEqualToString:query];
+            bool should_promote_fallback = is_backspace_suppressed || !has_inline_history;
+
+            if (should_promote_fallback && !trimmed_query.is_empty()) {
+                if (WebView::location_looks_like_url(trimmed_query)) {
+                    size_t literal_index = static_cast<size_t>(-1);
+                    for (size_t i = 0; i < suggestions.size(); ++i) {
+                        if (suggestions[i].source == WebView::AutocompleteSuggestionSource::LiteralURL && suggestions[i].text == trimmed_query) {
+                            literal_index = i;
+                            break;
+                        }
+                    }
+                    if (literal_index != static_cast<size_t>(-1)) {
+                        if (literal_index != 0) {
+                            auto literal_suggestion = move(suggestions[literal_index]);
+                            suggestions.remove(literal_index);
+                            suggestions.insert(0, move(literal_suggestion));
+                        }
+                    } else {
+                        suggestions.insert(0, WebView::AutocompleteSuggestion {
+                                                  .source = WebView::AutocompleteSuggestionSource::LiteralURL,
+                                                  .text = trimmed_query,
+                                                  .title = {},
+                                                  .subtitle = {},
+                                                  .favicon_base64_png = {},
+                                              });
+                    }
+                } else {
+                    size_t search_index = static_cast<size_t>(-1);
+                    for (size_t i = 0; i < suggestions.size(); ++i) {
+                        if (suggestions[i].source == WebView::AutocompleteSuggestionSource::Search && suggestions[i].text == trimmed_query) {
+                            search_index = i;
+                            break;
+                        }
+                    }
+                    if (search_index != static_cast<size_t>(-1)) {
+                        if (search_index != 0) {
+                            auto search_suggestion = move(suggestions[search_index]);
+                            suggestions.remove(search_index);
+                            suggestions.insert(0, move(search_suggestion));
+                        }
+                    } else {
+                        auto const& search_engine = WebView::Application::settings().search_engine();
+                        Optional<String> title;
+                        Optional<String> subtitle;
+                        if (search_engine.has_value()) {
+                            title = trimmed_query;
+                            subtitle = MUST(String::formatted("Search with {}", search_engine->name));
+                        }
+                        suggestions.insert(0, WebView::AutocompleteSuggestion {
+                                                  .source = WebView::AutocompleteSuggestionSource::Search,
+                                                  .text = trimmed_query,
+                                                  .title = move(title),
+                                                  .subtitle = move(subtitle),
+                                                  .favicon_base64_png = {},
+                                              });
+                    }
+                }
+            }
+
             auto selected_row = [self applyInlineAutocomplete:suggestions];
             if (result_kind == WebView::AutocompleteResultKind::Intermediate && [self.autocomplete isVisible]) {
                 if (auto selected_suggestion = [self.autocomplete selectedSuggestion];
@@ -595,10 +683,23 @@ static NSImage* location_field_globe_icon()
     if (suggestions.is_empty())
         return NSNotFound;
 
+    auto query_string = Ladybird::ns_string_to_string(query);
+    auto trimmed_query = MUST(query_string.trim_whitespace());
+
+    if ((suggestions.first().source == WebView::AutocompleteSuggestionSource::Search || suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL)
+        && suggestions.first().text == trimmed_query) {
+        self.current_inline_autocomplete_suggestion = nil;
+        if (selected_range.length != 0 || ![current_text isEqualToString:query])
+            [self restoreLocationFieldQuery];
+        return 0;
+    }
+
     // Row 0 drives both the visible highlight and (if its text prefix-matches
     // the query) the inline completion preview. The user-visible rule is
     // "the top row is the default action"; see the Qt implementation in
     // UI/Qt/LocationEdit.cpp for a longer discussion.
+
+    auto* row_0_text = Ladybird::string_to_ns_string(suggestions.first().text);
 
     // A literal URL always wins: no preview, restore the typed text.
     if (suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL) {
@@ -609,12 +710,22 @@ static NSImage* location_field_globe_icon()
     }
 
     // Backspace suppression: the user just deleted into this query, so don't
-    // re-apply an inline preview — but still honor the "highlight the top
-    // row" rule.
+    // re-apply an inline preview.
     if (self.suppressed_inline_autocomplete_query != nil && [self.suppressed_inline_autocomplete_query isEqualToString:query]) {
         self.current_inline_autocomplete_suggestion = nil;
         if (selected_range.length != 0 || ![current_text isEqualToString:query])
             [self restoreLocationFieldQuery];
+
+        if ([row_0_text isEqualToString:query])
+            return 0;
+
+        return NSNotFound;
+    }
+
+    // Try to inline-preview row 0 specifically.
+    if (auto* row_0_inline = inline_autocomplete_text_for_suggestion(query, row_0_text); row_0_inline != nil) {
+        self.current_inline_autocomplete_suggestion = row_0_text;
+        [self applyLocationFieldInlineAutocompleteText:row_0_inline forQuery:query];
         return 0;
     }
 
@@ -631,20 +742,12 @@ static NSImage* location_field_globe_icon()
         }
     }
 
-    // Try to inline-preview row 0 specifically.
-    auto* row_0_text = Ladybird::string_to_ns_string(suggestions.first().text);
-    if (auto* row_0_inline = inline_autocomplete_text_for_suggestion(query, row_0_text); row_0_inline != nil) {
-        self.current_inline_autocomplete_suggestion = row_0_text;
-        [self applyLocationFieldInlineAutocompleteText:row_0_inline forQuery:query];
-        return 0;
-    }
-
     // Row 0 does not prefix-match the query: clear any stale inline preview,
-    // restore the typed text, and still highlight row 0.
+    // restore the typed text.
     self.current_inline_autocomplete_suggestion = nil;
     if (selected_range.length != 0 || ![current_text isEqualToString:query])
         [self restoreLocationFieldQuery];
-    return 0;
+    return NSNotFound;
 }
 
 - (BOOL)applyInlineAutocompleteSuggestionText:(NSString*)suggestion_text
@@ -1108,11 +1211,22 @@ static NSImage* location_field_globe_icon()
         return NO;
     }
 
-    auto location = [self.autocomplete selectedSuggestion].value_or_lazy_evaluated([&]() {
-        return Ladybird::ns_string_to_string([[text_view textStorage] string]);
-    });
+    Optional<String> location;
+    if ([self.autocomplete isVisible] && [self.autocomplete isUserSelected])
+        location = [self.autocomplete selectedSuggestion];
 
-    [self navigateToLocation:move(location)];
+    if (!location.has_value()) {
+        if ([self.autocomplete isVisible] && self.current_inline_autocomplete_suggestion != nil) {
+            auto* text = [[text_view textStorage] string];
+            auto selected_range = [text_view selectedRange];
+            if (selected_range.location != NSNotFound && selected_range.length != 0 && NSMaxRange(selected_range) == text.length)
+                [text_view setSelectedRange:NSMakeRange(text.length, 0)];
+        }
+
+        location = Ladybird::ns_string_to_string([self currentLocationFieldQuery]);
+    }
+
+    [self navigateToLocation:location.release_value()];
     return YES;
 }
 

--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Base64.h>
+#include <AK/HashMap.h>
 #include <LibWebView/Autocomplete.h>
 #include <UI/Qt/Autocomplete.h>
 #include <UI/Qt/ChromeStyle.h>
@@ -33,37 +34,22 @@
 
 namespace Ladybird {
 
-static constexpr int POPUP_PADDING = 6;
+static constexpr int POPUP_PADDING = 0;
 static constexpr int CELL_HORIZONTAL_PADDING = 8;
 static constexpr int CELL_VERTICAL_PADDING = 8;
 static constexpr int CELL_ICON_SIZE = 16;
 static constexpr int CELL_ICON_TEXT_SPACING = 6;
 static constexpr int CELL_LABEL_VERTICAL_SPACING = 3;
-static constexpr int SECTION_HEADER_HORIZONTAL_PADDING = 10;
-static constexpr int SECTION_HEADER_VERTICAL_PADDING = 4;
 static constexpr int MINIMUM_POPUP_WIDTH = 100;
 static constexpr size_t MAXIMUM_VISIBLE_AUTOCOMPLETE_SUGGESTIONS = 8;
 
 enum AutocompleteRole {
-    RowKindRole = Qt::UserRole + 1,
-    HeaderTextRole,
-    TitleRole,
+    TitleRole = Qt::UserRole + 1,
     SubtitleRole,
     UrlRole,
     FaviconRole,
     SourceRole,
     SuggestionIndexRole,
-};
-
-enum class RowKind {
-    SectionHeader,
-    Suggestion,
-};
-
-struct RowModel {
-    RowKind kind;
-    String header_text;
-    size_t suggestion_index { 0 };
 };
 
 static QFont autocomplete_primary_font()
@@ -78,13 +64,6 @@ static QFont autocomplete_secondary_font()
     QFont font = QApplication::font();
     if (font.pointSizeF() > 0)
         font.setPointSizeF(font.pointSizeF() - 1.0);
-    return font;
-}
-
-static QFont autocomplete_section_header_font()
-{
-    QFont font = autocomplete_secondary_font();
-    font.setWeight(QFont::DemiBold);
     return font;
 }
 
@@ -114,27 +93,14 @@ public:
     {
         beginResetModel();
         m_suggestions = move(suggestions);
-        m_rows.clear();
-        m_favicon_cache.clear();
-
-        auto current_section = WebView::AutocompleteSuggestionSection::None;
-        for (size_t index = 0; index < m_suggestions.size(); ++index) {
-            auto const& suggestion = m_suggestions[index];
-            if (suggestion.section != WebView::AutocompleteSuggestionSection::None
-                && suggestion.section != current_section) {
-                current_section = suggestion.section;
-                m_rows.append({
-                    .kind = RowKind::SectionHeader,
-                    .header_text = MUST(String::from_utf8(WebView::autocomplete_section_title(current_section))),
-                });
-            }
-            m_rows.append({ .kind = RowKind::Suggestion, .header_text = {}, .suggestion_index = index });
-        }
 
         for (size_t index = 0; index < m_suggestions.size(); ++index) {
             auto const& suggestion = m_suggestions[index];
             if (!suggestion.favicon_base64_png.has_value())
                 continue;
+            if (m_favicon_cache.contains(suggestion.text))
+                continue;
+
             auto decoded = decode_base64(*suggestion.favicon_base64_png);
             if (decoded.is_error())
                 continue;
@@ -142,7 +108,7 @@ public:
             QPixmap pixmap;
             if (!pixmap.loadFromData(reinterpret_cast<uchar const*>(bytes.data()), static_cast<uint>(bytes.size())))
                 continue;
-            m_favicon_cache.append({ index, QIcon(pixmap) });
+            m_favicon_cache.set(suggestion.text, QIcon(pixmap));
         }
 
         endResetModel();
@@ -152,25 +118,15 @@ public:
     {
         if (parent.isValid())
             return 0;
-        return static_cast<int>(m_rows.size());
+        return static_cast<int>(m_suggestions.size());
     }
 
     QVariant data(QModelIndex const& index, int role) const override
     {
-        if (!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_rows.size()))
+        if (!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_suggestions.size()))
             return {};
 
-        auto const& row = m_rows[index.row()];
-        if (role == RowKindRole)
-            return static_cast<int>(row.kind);
-
-        if (row.kind == RowKind::SectionHeader) {
-            if (role == HeaderTextRole || role == Qt::DisplayRole)
-                return qstring_from_ak_string(row.header_text);
-            return {};
-        }
-
-        auto const& suggestion = m_suggestions[row.suggestion_index];
+        auto const& suggestion = m_suggestions[index.row()];
 
         switch (role) {
         case Qt::DisplayRole:
@@ -185,15 +141,13 @@ public:
                 return qstring_from_ak_string(*suggestion.subtitle);
             return {};
         case FaviconRole:
-            for (auto const& entry : m_favicon_cache) {
-                if (entry.suggestion_index == row.suggestion_index)
-                    return entry.icon;
-            }
+            if (auto it = m_favicon_cache.find(suggestion.text); it != m_favicon_cache.end())
+                return it->value;
             return {};
         case SourceRole:
             return static_cast<int>(suggestion.source);
         case SuggestionIndexRole:
-            return static_cast<int>(row.suggestion_index);
+            return index.row();
         default:
             return {};
         }
@@ -201,48 +155,28 @@ public:
 
     Qt::ItemFlags flags(QModelIndex const& index) const override
     {
-        if (!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_rows.size()))
+        if (!index.isValid() || index.row() < 0 || index.row() >= static_cast<int>(m_suggestions.size()))
             return Qt::NoItemFlags;
-        auto const& row = m_rows[index.row()];
-        if (row.kind == RowKind::SectionHeader)
-            return Qt::ItemIsEnabled;
         return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
     }
 
-    Vector<RowModel> const& rows() const { return m_rows; }
     Vector<WebView::AutocompleteSuggestion> const& suggestions() const { return m_suggestions; }
 
     int table_row_for_suggestion_index(int suggestion_index) const
     {
-        if (suggestion_index < 0)
+        if (suggestion_index < 0 || suggestion_index >= static_cast<int>(m_suggestions.size()))
             return -1;
-        for (size_t i = 0; i < m_rows.size(); ++i) {
-            if (m_rows[i].kind == RowKind::Suggestion
-                && m_rows[i].suggestion_index == static_cast<size_t>(suggestion_index))
-                return static_cast<int>(i);
-        }
-        return -1;
+        return suggestion_index;
     }
 
     size_t visible_suggestion_count() const
     {
-        size_t count = 0;
-        for (auto const& row : m_rows) {
-            if (row.kind == RowKind::Suggestion)
-                ++count;
-        }
-        return count;
+        return m_suggestions.size();
     }
 
 private:
-    struct FaviconEntry {
-        size_t suggestion_index;
-        QIcon icon;
-    };
-
     Vector<WebView::AutocompleteSuggestion> m_suggestions;
-    Vector<RowModel> m_rows;
-    Vector<FaviconEntry> m_favicon_cache;
+    HashMap<String, QIcon> m_favicon_cache;
 };
 
 class AutocompleteDelegate final : public QStyledItemDelegate {
@@ -253,11 +187,6 @@ public:
     {
         if (!index.isValid())
             return {};
-        auto kind = static_cast<RowKind>(index.data(RowKindRole).toInt());
-        if (kind == RowKind::SectionHeader) {
-            QFontMetrics fm(autocomplete_section_header_font());
-            return QSize(0, fm.height() + SECTION_HEADER_VERTICAL_PADDING * 2);
-        }
         QFontMetrics primary_fm(autocomplete_primary_font());
         QFontMetrics secondary_fm(autocomplete_secondary_font());
         int content_height = std::max(CELL_ICON_SIZE,
@@ -268,22 +197,6 @@ public:
     void paint(QPainter* painter, QStyleOptionViewItem const& option, QModelIndex const& index) const override
     {
         painter->save();
-        auto kind = static_cast<RowKind>(index.data(RowKindRole).toInt());
-
-        if (kind == RowKind::SectionHeader) {
-            auto text = index.data(HeaderTextRole).toString();
-            painter->setFont(autocomplete_section_header_font());
-            auto header_color = ChromeStyle::chrome_muted_text(option.palette);
-            header_color.setAlpha(170);
-            painter->setPen(header_color);
-            auto rect = option.rect.adjusted(
-                SECTION_HEADER_HORIZONTAL_PADDING, SECTION_HEADER_VERTICAL_PADDING,
-                -SECTION_HEADER_HORIZONTAL_PADDING, -SECTION_HEADER_VERTICAL_PADDING);
-            painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, text);
-            painter->restore();
-            return;
-        }
-
         bool selected = option.state & QStyle::State_Selected;
         if (selected) {
             auto rect = option.rect.adjusted(3, 2, -3, -2);
@@ -305,10 +218,10 @@ public:
         int icon_y = option.rect.top() + (option.rect.height() - CELL_ICON_SIZE) / 2;
         QRect icon_rect(icon_x, icon_y, CELL_ICON_SIZE, CELL_ICON_SIZE);
 
-        if (source == WebView::AutocompleteSuggestionSource::Search) {
-            create_chrome_icon(ChromeIcon::Search, option.palette).paint(painter, icon_rect);
-        } else if (source == WebView::AutocompleteSuggestionSource::History && !favicon.isNull()) {
+        if (!favicon.isNull()) {
             favicon.paint(painter, icon_rect);
+        } else if (source == WebView::AutocompleteSuggestionSource::Search) {
+            create_chrome_icon(ChromeIcon::Search, option.palette).paint(painter, icon_rect);
         } else {
             create_chrome_icon(ChromeIcon::Globe, option.palette).paint(painter, icon_rect);
         }
@@ -457,6 +370,9 @@ void Autocomplete::schedule_chrome_style_update()
 
 void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion> suggestions, int selected_suggestion_index)
 {
+    auto previously_selected = selected_suggestion();
+    bool had_user_selection = m_user_selected;
+
     m_model->set_suggestions(move(suggestions));
     if (m_model->rowCount() == 0) {
         close();
@@ -468,7 +384,21 @@ void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion>
     if (!m_popup->isVisible())
         m_popup->show();
 
-    int table_row = m_model->table_row_for_suggestion_index(selected_suggestion_index);
+    int table_row = -1;
+    if (had_user_selection && previously_selected.has_value()) {
+        auto const& model_suggestions = m_model->suggestions();
+        for (size_t i = 0; i < model_suggestions.size(); ++i) {
+            if (model_suggestions[i].text == *previously_selected) {
+                table_row = static_cast<int>(i);
+                break;
+            }
+        }
+    }
+
+    m_user_selected = table_row != -1 && had_user_selection;
+    if (table_row == -1)
+        table_row = m_model->table_row_for_suggestion_index(selected_suggestion_index);
+
     if (table_row == -1)
         clear_selection();
     else
@@ -479,6 +409,7 @@ bool Autocomplete::close()
 {
     if (!m_popup->isVisible())
         return false;
+    m_user_selected = false;
     m_popup->hide();
     emit did_close();
     return true;
@@ -491,6 +422,7 @@ bool Autocomplete::is_visible() const
 
 void Autocomplete::clear_selection()
 {
+    m_user_selected = false;
     m_list_view->setCurrentIndex({});
 }
 
@@ -516,16 +448,20 @@ bool Autocomplete::select_next_suggestion()
         position_popup();
         m_popup->show();
         int row = step_to_selectable_row(-1, 1);
-        if (row != -1)
+        if (row != -1) {
+            m_user_selected = true;
             select_row(row);
+        }
         return true;
     }
 
     auto current = m_list_view->currentIndex();
     int start = current.isValid() ? current.row() : -1;
     int row = step_to_selectable_row(start, 1);
-    if (row != -1)
+    if (row != -1) {
+        m_user_selected = true;
         select_row(row);
+    }
     return true;
 }
 
@@ -538,16 +474,20 @@ bool Autocomplete::select_previous_suggestion()
         position_popup();
         m_popup->show();
         int row = step_to_selectable_row(0, -1);
-        if (row != -1)
+        if (row != -1) {
+            m_user_selected = true;
             select_row(row);
+        }
         return true;
     }
 
     auto current = m_list_view->currentIndex();
     int start = current.isValid() ? current.row() : 0;
     int row = step_to_selectable_row(start, -1);
-    if (row != -1)
+    if (row != -1) {
+        m_user_selected = true;
         select_row(row);
+    }
     return true;
 }
 
@@ -584,11 +524,9 @@ void Autocomplete::position_popup()
         option.initFrom(m_list_view);
         int h = m_delegate->sizeHint(option, index).height();
         total_height += h;
-        if (static_cast<RowKind>(index.data(RowKindRole).toInt()) == RowKind::Suggestion) {
-            ++seen_suggestions;
-            if (seen_suggestions >= visible_count)
-                break;
-        }
+        ++seen_suggestions;
+        if (seen_suggestions >= visible_count)
+            break;
     }
 
     auto* top_window = m_anchor->window();
@@ -611,10 +549,7 @@ void Autocomplete::position_popup()
 
 bool Autocomplete::is_selectable_row(int row) const
 {
-    if (row < 0 || row >= m_model->rowCount())
-        return false;
-    auto const& rows = m_model->rows();
-    return rows[row].kind == RowKind::Suggestion;
+    return row >= 0 && row < m_model->rowCount();
 }
 
 int Autocomplete::step_to_selectable_row(int from, int direction) const

--- a/UI/Qt/Autocomplete.h
+++ b/UI/Qt/Autocomplete.h
@@ -46,6 +46,7 @@ public:
 
     void clear_selection();
     Optional<String> selected_suggestion() const;
+    bool is_user_selected() const { return m_user_selected; }
     bool select_next_suggestion();
     bool select_previous_suggestion();
 
@@ -70,6 +71,7 @@ private:
     AutocompleteDelegate* m_delegate { nullptr };
     bool m_is_updating_chrome_style { false };
     bool m_has_pending_chrome_style_update { false };
+    bool m_user_selected { false };
 
     NonnullOwnPtr<WebView::Autocomplete> m_autocomplete;
 };

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -74,6 +74,15 @@ static QString inline_autocomplete_text_for_candidate(QString const& query, QStr
         return {};
     if (!candidate.startsWith(query, Qt::CaseInsensitive))
         return {};
+
+    int slash_index = candidate.indexOf('/');
+    if (slash_index != -1) {
+        QString host = candidate.left(slash_index);
+        if (host.length() > query.length() && host.startsWith(query, Qt::CaseInsensitive)) {
+            return query + host.mid(query.length());
+        }
+    }
+
     return query + candidate.mid(query.length());
 }
 
@@ -197,6 +206,85 @@ LocationEdit::LocationEdit(QWidget* parent)
     update_location_icon();
 
     m_autocomplete->on_query_complete = [this](auto suggestions, WebView::AutocompleteResultKind result_kind) {
+        auto query = current_query();
+
+        bool has_inline_history = false;
+        auto query_q = current_query();
+        for (auto const& suggestion : suggestions) {
+            if (suggestion.source == WebView::AutocompleteSuggestionSource::History) {
+                auto text_q = qstring_from_ak_string(suggestion.text);
+                if (suggestion_matches_query_exactly(query_q, text_q) || !inline_autocomplete_text_for_suggestion(query_q, text_q).isEmpty()) {
+                    has_inline_history = true;
+                    break;
+                }
+            }
+        }
+
+        auto query_str = ak_string_from_qstring(query);
+        auto trimmed_query_str = MUST(query_str.trim_whitespace());
+
+        bool is_backspace_suppressed = !m_suppressed_inline_autocomplete_query.isNull() && m_suppressed_inline_autocomplete_query == query;
+        bool should_promote_fallback = is_backspace_suppressed || !has_inline_history;
+
+        if (should_promote_fallback && !trimmed_query_str.is_empty()) {
+            if (WebView::location_looks_like_url(trimmed_query_str)) {
+                size_t literal_index = -1;
+                for (size_t i = 0; i < suggestions.size(); ++i) {
+                    if (suggestions[i].source == WebView::AutocompleteSuggestionSource::LiteralURL && suggestions[i].text == trimmed_query_str) {
+                        literal_index = i;
+                        break;
+                    }
+                }
+                if (literal_index != (size_t)-1) {
+                    if (literal_index != 0) {
+                        auto literal_suggestion = AK::move(suggestions[literal_index]);
+                        suggestions.remove(literal_index);
+                        suggestions.insert(0, AK::move(literal_suggestion));
+                    }
+                } else {
+                    WebView::AutocompleteSuggestion literal_suggestion {
+                        .source = WebView::AutocompleteSuggestionSource::LiteralURL,
+                        .text = trimmed_query_str,
+                        .title = {},
+                        .subtitle = {},
+                        .favicon_base64_png = {},
+                    };
+                    suggestions.insert(0, AK::move(literal_suggestion));
+                }
+            } else {
+                size_t search_index = -1;
+                for (size_t i = 0; i < suggestions.size(); ++i) {
+                    if (suggestions[i].source == WebView::AutocompleteSuggestionSource::Search && suggestions[i].text == trimmed_query_str) {
+                        search_index = i;
+                        break;
+                    }
+                }
+                if (search_index != (size_t)-1) {
+                    if (search_index != 0) {
+                        auto search_suggestion = AK::move(suggestions[search_index]);
+                        suggestions.remove(search_index);
+                        suggestions.insert(0, AK::move(search_suggestion));
+                    }
+                } else {
+                    auto const& search_engine = WebView::Application::settings().search_engine();
+                    Optional<String> title;
+                    Optional<String> subtitle;
+                    if (search_engine.has_value()) {
+                        title = trimmed_query_str;
+                        subtitle = MUST(String::formatted("Search with {}", search_engine->name));
+                    }
+                    WebView::AutocompleteSuggestion search_suggestion {
+                        .source = WebView::AutocompleteSuggestionSource::Search,
+                        .text = trimmed_query_str,
+                        .title = AK::move(title),
+                        .subtitle = AK::move(subtitle),
+                        .favicon_base64_png = {},
+                    };
+                    suggestions.insert(0, AK::move(search_suggestion));
+                }
+            }
+        }
+
         int selected_row = apply_inline_autocomplete(suggestions);
 
         if (result_kind == WebView::AutocompleteResultKind::Intermediate && m_autocomplete->is_visible()) {
@@ -373,16 +461,32 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
     }
 
     if ((event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) && m_autocomplete->is_visible()) {
-        if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
+        if (m_autocomplete->is_user_selected()) {
+            // The user explicitly moved the selection via arrow keys,
+            // so navigate to the chosen suggestion.
+            if (auto selected = m_autocomplete->selected_suggestion(); selected.has_value()) {
+                m_is_applying_inline_autocomplete = true;
+                setText(qstring_from_ak_string(*selected));
+                m_is_applying_inline_autocomplete = false;
+            }
+        } else if (hasSelectedText() && !m_current_inline_autocomplete_suggestion.isEmpty()) {
+            // Chromium-style: If there is an active inline autocomplete preview, commit it
+            // by clearing the selection before the autocomplete popup closes. This ensures
+            // restore_query() won't slice the suffix off.
             m_is_applying_inline_autocomplete = true;
-            setText(qstring_from_ak_string(*selected));
+            setCursorPosition(text().length());
             m_is_applying_inline_autocomplete = false;
         }
         m_autocomplete->close();
     }
 
-    if (should_suppress_inline_autocomplete_for_key(event))
+    // Suppress inline autocomplete on backspace/delete keys to prevent aggressive auto-fill while backspacing.
+    // Clear the suppression on any other key presses (normal typing).
+    if (should_suppress_inline_autocomplete_for_key(event)) {
         m_should_suppress_inline_autocomplete_on_next_change = true;
+    } else {
+        m_suppressed_inline_autocomplete_query = QString();
+    }
 
     QLineEdit::keyPressEvent(event);
 }
@@ -613,6 +717,19 @@ int LocationEdit::apply_inline_autocomplete(Vector<WebView::AutocompleteSuggesti
         return -1;
     }
 
+    auto query_str = ak_string_from_qstring(query);
+    auto trimmed_query_str = MUST(query_str.trim_whitespace());
+
+    // If the top suggestion is the fallback suggestion itself, highlight it.
+    if ((suggestions.first().source == WebView::AutocompleteSuggestionSource::Search || suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL)
+        && suggestions.first().text == trimmed_query_str) {
+        m_current_inline_autocomplete_suggestion.clear();
+        if (hasSelectedText() || current_text != query)
+            restore_query();
+        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: fallback query at top, selected=0");
+        return 0;
+    }
+
     // Row 0 drives both the visible highlight and (if its text prefix-matches
     // the query) the inline completion preview. This is a deliberate
     // simplification over the exact/inline/fallback fan-out we used to have:
@@ -630,13 +747,29 @@ int LocationEdit::apply_inline_autocomplete(Vector<WebView::AutocompleteSuggesti
     }
 
     // Backspace suppression: the user just deleted into this query, so don't
-    // re-apply an inline preview — but still honor the "highlight the top row"
-    // rule.
+    // re-apply an inline preview.
     if (!m_suppressed_inline_autocomplete_query.isNull() && m_suppressed_inline_autocomplete_query == query) {
         m_current_inline_autocomplete_suggestion.clear();
         if (hasSelectedText() || current_text != query)
             restore_query();
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: suppressed query, selected=0 (no preview)");
+
+        // Allow an exact query match to be selected as the default action without an inline preview.
+        if (row_0_text_q == query) {
+            dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: suppressed query, but exact match, selected=0");
+            return 0;
+        }
+
+        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: suppressed query, selected=-1 (no preview)");
+        return -1;
+    }
+
+    // Try to inline-preview row 0 specifically.
+    auto row_0_inline = inline_autocomplete_text_for_suggestion(query, row_0_text_q);
+    if (!row_0_inline.isEmpty()) {
+        m_current_inline_autocomplete_suggestion = row_0_text_q;
+        apply_inline_autocomplete_text(row_0_inline, query);
+        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: row 0 inline match, inline='{}'",
+            ak_string_from_qstring(row_0_inline));
         return 0;
     }
 
@@ -656,23 +789,13 @@ int LocationEdit::apply_inline_autocomplete(Vector<WebView::AutocompleteSuggesti
         }
     }
 
-    // Try to inline-preview row 0 specifically.
-    auto row_0_inline = inline_autocomplete_text_for_suggestion(query, row_0_text_q);
-    if (!row_0_inline.isEmpty()) {
-        m_current_inline_autocomplete_suggestion = row_0_text_q;
-        apply_inline_autocomplete_text(row_0_inline, query);
-        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: row 0 inline match, inline='{}'",
-            ak_string_from_qstring(row_0_inline));
-        return 0;
-    }
-
     // Row 0 does not prefix-match the query: clear any stale inline preview,
-    // restore the typed text, and still highlight row 0.
+    // restore the typed text.
     m_current_inline_autocomplete_suggestion.clear();
     if (hasSelectedText() || current_text != query)
         restore_query();
-    dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: row 0 not a prefix match, selected=0 (highlight only)");
-    return 0;
+    dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] apply_inline_autocomplete: row 0 not a prefix match, selected=-1 (no highlight)");
+    return -1;
 }
 
 bool LocationEdit::apply_inline_autocomplete_suggestion_text(QString const& suggestion_text, QString const& query)


### PR DESCRIPTION
When typing a URL into the address bar, the autocomplete popup is
opened with the first suggestion highlighted. If the user presses
Enter without moving the selection (via arrow keys), Ladybird would
incorrectly select the highlighted suggestion and navigate to it
instead of the typed URL.

Additionally, mouse hover over the autocomplete popup would trigger
row selection, erroneously marking it as selected and hijacking the
Enter key navigation.

Fixes #9235

Additional improvements in this overhaul include:

Replaced rigid category headers with a unified, relevance-based
suggestion list sorted by a mathematical "frecency" (frequency +
recency) score.
Introduced a favicon cache that persists across refreshes to
ensure synchronous-feeling, high-performance query execution.
Fixed URL sanitization for registry-less hostnames containing a port
or trailing slash.
Improved inline experience to seamlessly fall back to search
suggestions when history completions are canceled via Backspace.
Aligned AppKit autocomplete behavior with Qt (explicit selection
tracking, fallback promotion, capped visible rows, and inline
handling).
Added comprehensive HistoryStore tests for frecency tie breaking
and host-root ordering.
Added LibWebView unit tests to verify:

Autocomplete candidate sorting based on visit count / frecency.
Priority of host roots over deeper path URLs in autocomplete.
Sanitizing registry-less hosts with trailing slashes or ports
(correctly guessing HTTPS instead of falling back to search).
Special thanks to @kunlinglio for helping with AppKit test
Co-authored-by: kunlinglio <kunlinglio@users.noreply.github.com>
