### PR TITLE
LibWeb: Avoid crashing when selecting text in a shadow root

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1577,7 +1577,7 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
         }
 
         if (
-            potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
+            potential_contain_node->layout_node() && potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
             if (focus_node->is_before(*potential_contain_node)) {
                 focus_offset = 0;
             } else {
@@ -1601,7 +1601,7 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
                 potential_contain_node = potential_contain_node->parent();
             }
             if (
-                potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*anchor_node)) {
+                potential_contain_node->layout_node() && potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*anchor_node)) {
                 if (potential_contain_node->is_before(*anchor_node)) {
                     focus_node = potential_contain_node->next_in_pre_order();
                     while (potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {

--- a/Tests/LibWeb/Crash/UIEvents/selection-across-shadow-root-boundary.html
+++ b/Tests/LibWeb/Crash/UIEvents/selection-across-shadow-root-boundary.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<body>
+  <template shadowrootmode=open>
+    <style>span { font-size: 50px; }</style>
+    <span>Well Hello </span>
+    <span>friends!</span>
+  </template>
+</body>
+<script>
+    // Drag-select starting in the first shadow-tree span and crossing into the second. This used to SIGSEGV in
+    // set_user_selection(): the user-select:contain ancestor walk stopped at the shadow root (a DocumentFragment with
+    // no parent), then dereferenced its null layout node. Regression test for issue #9332.
+    onload = () => {
+        internals.mouseDown(60, 35);
+        internals.mouseMove(360, 35);
+        internals.mouseUp(360, 35);
+        document.documentElement.classList.remove("test-wait");
+    };
+</script>
+</html>


### PR DESCRIPTION
**Problem:** Selecting text with the mouse across the boundary between two nodes inside a shadow root crashes the browser.

**Cause:** To honor `user-select: contain`, `set_user_selection()` walks the ancestor chain up from the selection anchor. For a selection inside a shadow tree, the walk stops at the shadow root — which has no parent node. The check after the walk then dereferences that node’s `layout_node()`. A shadow root has no layout node — so that dereferences a null pointer.

**Fix:** Null-check `layout_node()` in the two checks after the ancestor walk. A node with no layout node isn’t a `user-select: contain` element — so the selection is not clamped to it.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/9332
