### PR TITLE
LibWeb: Keep repaints pending inside visibility:hidden iframes

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7948,10 +7948,6 @@ void Document::set_needs_repaint(InvalidateDisplayList should_invalidate_display
 {
     auto navigable = this->navigable();
 
-    // OPTIMIZATION: Ignore set_needs_repaint() inside navigable containers (i.e frames) with visibility: hidden.
-    if (navigable && navigable->has_inclusive_ancestor_with_visibility_hidden())
-        return;
-
     if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
         set_needs_to_record_display_list();
     }

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -534,6 +534,10 @@ void EventLoop::update_the_rendering()
         auto navigable = doc->navigable();
         if (!navigable->needs_repaint())
             continue;
+        // OPTIMIZATION: Don't paint navigables hidden by an ancestor iframe with visibility: hidden.
+        //               needs_repaint() stays true — so, once the navigable becomes visible, it's painted.
+        if (navigable->has_inclusive_ancestor_with_visibility_hidden())
+            continue;
         if (navigable->is_svg_page())
             continue;
         if (auto document = navigable->active_document())

--- a/Tests/LibWeb/Ref/expected/iframe-repaint-after-visibility-hidden-ref.html
+++ b/Tests/LibWeb/Ref/expected/iframe-repaint-after-visibility-hidden-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            body {
+                margin: 0;
+            }
+            iframe {
+                display: block;
+                width: 100px;
+                height: 100px;
+                border: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <iframe srcdoc="<body style='background: green'></body>"></iframe>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/iframe-repaint-after-visibility-hidden.html
+++ b/Tests/LibWeb/Ref/input/iframe-repaint-after-visibility-hidden.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <link rel="match" href="../expected/iframe-repaint-after-visibility-hidden-ref.html" />
+        <style>
+            body {
+                margin: 0;
+            }
+            iframe {
+                display: block;
+                width: 100px;
+                height: 100px;
+                border: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <!-- Regression test for https://github.com/LadybirdBrowser/ladybird/issues/9305 -->
+        <!-- An iframe whose content changes while it has a visibility:hidden ancestor must be -->
+        <!-- painted once that ancestor becomes visible again. -->
+        <iframe id="frame" srcdoc="<body style='background: red'></body>"></iframe>
+        <script>
+            const frame = document.getElementById("frame");
+            let phase = 0;
+            frame.addEventListener("load", () => {
+                if (phase === 0) {
+                    // The red document has loaded and been painted; hide the iframe and swap in green.
+                    phase = 1;
+                    requestAnimationFrame(() => requestAnimationFrame(() => {
+                        frame.style.visibility = "hidden";
+                        frame.srcdoc = "<body style='background: green'></body>";
+                    }));
+                } else if (phase === 1) {
+                    // The green document loaded while the iframe was hidden; reveal it again.
+                    phase = 2;
+                    requestAnimationFrame(() => requestAnimationFrame(() => {
+                        frame.style.visibility = "visible";
+                        requestAnimationFrame(() => requestAnimationFrame(() => {
+                            document.documentElement.className = "";
+                        }));
+                    }));
+                }
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
**Problem:** An iframe whose content changes while it (or an ancestor) has `visibility:hidden` isn’t painted once it becomes visible again. The stale previous frame stays on screen until an unrelated repaint (e.g., window resize) happens to occur.

**Cause:** `set_needs_repaint()` returns early for any document inside an iframe with a `visibility:hidden` ancestor — discarding the request entirely. The navigable’s `needs_repaint` flag is never set. Nothing sets it again when the iframe becomes visible — so the rendering loop keeps skipping it — and its display list stays stale.

**Fix:** Stop discarding the request in `set_needs_repaint()`. Instead, skip painting hidden navigables in the rendering loop — while leaving `needs_repaint` set. Once an ancestor iframe becomes visible, the still-set flag makes the rendering loop paint the navigable on the next frame.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/9305
