### PR TITLE
LibWeb: Update hover after async scrolling stops

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Timer.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/SystemColor.h>
@@ -296,6 +297,8 @@ Navigable::~Navigable() = default;
 
 void Navigable::set_has_been_destroyed()
 {
+    if (m_async_scroll_hover_update_timer)
+        m_async_scroll_hover_update_timer->stop();
     destroy_compositor_context();
     m_has_been_destroyed = true;
     resolve_all_pending_async_scroll_operations();
@@ -303,6 +306,8 @@ void Navigable::set_has_been_destroyed()
 
 void Navigable::remove_from_all_navigables()
 {
+    if (m_async_scroll_hover_update_timer)
+        m_async_scroll_hover_update_timer->stop();
     destroy_compositor_context();
     resolve_all_pending_async_scroll_operations();
 
@@ -313,6 +318,8 @@ void Navigable::remove_from_all_navigables()
 
 void Navigable::finalize()
 {
+    if (m_async_scroll_hover_update_timer)
+        m_async_scroll_hover_update_timer->stop();
     destroy_compositor_context();
     all_navigables().remove(*this);
     Base::finalize();
@@ -3126,12 +3133,14 @@ void Navigable::adopt_pending_async_scroll_offsets()
     }
 
     auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
+    bool adopted_any_scroll_delta = false;
     for (auto const& async_scroll_offset : async_scroll_updates.scroll_offsets) {
         auto css_scroll_delta = async_scroll_offset_to_css_pixels(async_scroll_offset.unadopted_scroll_delta, device_pixels_per_css_pixel);
         if (async_scroll_offset.stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
             if (async_scroll_offset.stable_node_id.node_id != document->unique_id())
                 continue;
             if (adopt_async_viewport_scroll_delta(*this, css_scroll_delta)) {
+                adopted_any_scroll_delta = true;
                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async viewport delta {},{}",
                     async_scroll_offset.unadopted_scroll_delta.x(), async_scroll_offset.unadopted_scroll_delta.y());
             }
@@ -3139,13 +3148,39 @@ void Navigable::adopt_pending_async_scroll_offsets()
         }
 
         if (adopt_async_element_scroll_delta(*document, async_scroll_offset.stable_node_id, css_scroll_delta)) {
+            adopted_any_scroll_delta = true;
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async element delta {},{}",
                 async_scroll_offset.unadopted_scroll_delta.x(), async_scroll_offset.unadopted_scroll_delta.y());
         }
     }
 
+    if (adopted_any_scroll_delta)
+        schedule_hover_update_after_async_scroll();
+
     for (auto operation_id : async_scroll_updates.completed_operation_ids)
         resolve_async_scroll_operation(operation_id);
+}
+
+void Navigable::schedule_hover_update_after_async_scroll()
+{
+    static constexpr int hover_update_after_async_scroll_delay_ms = 100;
+
+    if (!m_async_scroll_hover_update_timer) {
+        m_async_scroll_hover_update_timer = Core::Timer::create_single_shot(hover_update_after_async_scroll_delay_ms, [this] {
+            update_hover_after_async_scroll_stops();
+        });
+        m_async_scroll_hover_update_timer->start();
+        return;
+    }
+
+    m_async_scroll_hover_update_timer->restart(hover_update_after_async_scroll_delay_ms);
+}
+
+void Navigable::update_hover_after_async_scroll_stops()
+{
+    if (has_been_destroyed())
+        return;
+    event_handler().update_hover_after_scroll();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -12,6 +12,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/Tuple.h>
+#include <LibCore/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/Compositor/CompositorHost.h>
@@ -291,6 +292,8 @@ private:
     void inform_the_navigation_api_about_aborting_navigation();
     void resolve_async_scroll_operation(Compositor::AsyncScrollOperationID);
     void resolve_all_pending_async_scroll_operations();
+    void schedule_hover_update_after_async_scroll();
+    void update_hover_after_async_scroll_stops();
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-id
     String m_id;
@@ -345,6 +348,7 @@ private:
     Painting::DisplayListResourceSet m_rendering_thread_display_list_resources;
     OwnPtr<Compositor::CompositorContextHandle> m_compositor_context;
     Optional<Painting::CompositorSurfaceId> m_compositor_surface_id;
+    RefPtr<Core::Timer> m_async_scroll_hover_update_timer;
 
     struct PendingAsyncScrollOperation {
         Compositor::AsyncScrollOperationID operation_id { 0 };

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -244,6 +244,8 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
 
 EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 buttons, u32 modifiers)
 {
+    record_last_known_mouse_position(visual_viewport_position, screen_position, buttons, modifiers);
+
     if (should_ignore_device_input_event()) {
         if (m_mousedown_target_is_drag_candidate)
             return handle_drag_and_drop_event(DragEvent::Type::DragMove, visual_viewport_position, screen_position, UIEvents::MouseButton::Primary, buttons, modifiers, {});
@@ -509,6 +511,8 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
 
 EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action, Optional<AsyncScrollOperation>* async_scroll_operation)
 {
+    record_last_known_mouse_position(visual_viewport_position, screen_position, buttons, modifiers);
+
     if (should_ignore_device_input_event())
         return EventResult::Dropped;
 
@@ -677,11 +681,84 @@ EventResult EventHandler::handle_mouseleave()
 
     update_hovered_chrome_widget(nullptr);
     update_cursor(nullptr, nullptr, nullptr);
+    m_last_known_mouse_visual_viewport_position.clear();
 
     if (!m_mousedown_target)
         track_the_effective_position_of_the_legacy_mouse_pointer(nullptr);
 
     return EventResult::Handled;
+}
+
+void EventHandler::update_hover_after_scroll()
+{
+    if (!m_last_known_mouse_visual_viewport_position.has_value())
+        return;
+    if (m_mousedown_target)
+        return;
+
+    update_hover_after_scroll(*m_last_known_mouse_visual_viewport_position, m_last_known_mouse_screen_position, UIEvents::MouseButton::None, m_last_known_mouse_buttons, m_last_known_mouse_modifiers);
+}
+
+void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
+{
+    auto document = m_navigable->active_document();
+    if (!document || !document->is_fully_active())
+        return;
+
+    auto viewport_position = document->visual_viewport()->map_to_layout_viewport(visual_viewport_position);
+    document->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseMove);
+
+    if (!paint_root())
+        return;
+
+    RefPtr<Painting::Paintable> paintable;
+    RefPtr<Painting::ChromeWidget> chrome_widget;
+    if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
+        paintable = result->paintable;
+        chrome_widget = result->chrome_widget;
+    }
+
+    ArmedScopeGuard clear_hover = [&] {
+        update_hovered_chrome_widget(nullptr);
+        update_cursor(nullptr, nullptr, nullptr);
+        track_the_effective_position_of_the_legacy_mouse_pointer(nullptr);
+    };
+
+    if (!paintable)
+        return;
+
+    auto node = dom_node_for_event_dispatch(*paintable);
+    if (!node)
+        return;
+
+    auto dispatch_result = dispatch_event_to_nested_navigable(*paintable, visual_viewport_position, [&](EventHandler& event_handler, CSSPixelPoint position) {
+        event_handler.update_hover_after_scroll(position, screen_position, button, buttons, modifiers);
+        return EventResult::Handled;
+    });
+    if (dispatch_result.has_value()) {
+        clear_hover.disarm();
+        return;
+    }
+
+    GC::Ptr<Layout::Node> layout_node;
+    if (!parent_element_for_event_dispatch(*paintable, node, layout_node))
+        return;
+
+    update_hovered_chrome_widget(chrome_widget);
+    update_cursor(*paintable, *node, chrome_widget);
+
+    auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
+    track_the_effective_position_of_the_legacy_mouse_pointer(node, DOM::HoverEventData {
+                                                                       .screen_position = screen_position,
+                                                                       .page_offset = coordinates.page_offset,
+                                                                       .viewport_position = coordinates.viewport_position,
+                                                                       .offset = coordinates.offset,
+                                                                       .movement = {},
+                                                                       .button = button,
+                                                                       .buttons = buttons,
+                                                                       .modifiers = modifiers,
+                                                                   });
+    clear_hover.disarm();
 }
 
 // https://w3c.github.io/uievents/#unicode-character-categories
@@ -2124,6 +2201,14 @@ void EventHandler::track_the_effective_position_of_the_legacy_mouse_pointer(GC::
         page.client().page_did_unhover_link();
         page.set_is_hovering_link(false);
     }
+}
+
+void EventHandler::record_last_known_mouse_position(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers)
+{
+    m_last_known_mouse_visual_viewport_position = visual_viewport_position;
+    m_last_known_mouse_screen_position = screen_position;
+    m_last_known_mouse_buttons = buttons;
+    m_last_known_mouse_modifiers = modifiers;
 }
 
 bool EventHandler::dispatch_chrome_widget_pointer_event(RefPtr<Painting::ChromeWidget> target, FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position)

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -48,6 +48,7 @@ public:
     EventResult handle_mouseup(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
     EventResult handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, double wheel_delta_x, double wheel_delta_y, bool async_scroll_performed_default_action = false, Optional<AsyncScrollOperation>* async_scroll_operation = nullptr);
     EventResult handle_mouseleave();
+    void update_hover_after_scroll();
 
     EventResult handle_keydown(UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);
     EventResult handle_keyup(UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);
@@ -121,6 +122,8 @@ private:
     void clear_mousedown_tracking();
     void stop_updating_selection();
 
+    void update_hover_after_scroll(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
+
     enum class PointerEventType : u8 {
         PointerDown,
         PointerUp,
@@ -134,6 +137,7 @@ private:
     void update_hovered_chrome_widget(RefPtr<Painting::ChromeWidget>);
 
     void update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget> chrome_widget);
+    void record_last_known_mouse_position(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
 
     void handle_gamepad_connected(SDL_JoystickID);
     void handle_gamepad_updated(SDL_JoystickID);
@@ -166,6 +170,10 @@ private:
     bool m_prevent_mouse_event { false };
 
     Optional<CSSPixelPoint> m_mousemove_previous_screen_position;
+    Optional<CSSPixelPoint> m_last_known_mouse_visual_viewport_position;
+    CSSPixelPoint m_last_known_mouse_screen_position;
+    unsigned m_last_known_mouse_buttons { 0 };
+    unsigned m_last_known_mouse_modifiers { 0 };
 
     OwnPtr<Unicode::Segmenter> m_word_segmenter;
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/hover-updates-after-async-scroll.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/hover-updates-after-async-scroll.txt
@@ -1,0 +1,16 @@
+before scroll line1: true
+before scroll line2: false
+before scroll mousemove count: 1
+before scroll pointermove count: 1
+before scroll mouseover count: 1
+before scroll mouseout count: 0
+before scroll stop line1: true
+before scroll stop line2: false
+before scroll stop mouseover count: 1
+before scroll stop mouseout count: 0
+after scroll stop line1: false
+after scroll stop line2: true
+after scroll stop mousemove count: 1
+after scroll stop pointermove count: 1
+after scroll stop mouseover count: 2
+after scroll stop mouseout count: 1

--- a/Tests/LibWeb/Text/input/async-scrolling/hover-updates-after-async-scroll.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/hover-updates-after-async-scroll.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .hoverme {
+        height: 300px;
+    }
+</style>
+<div class="hoverme" id="line1">line 1</div>
+<div class="hoverme" id="line2">line 2</div>
+<div class="hoverme" id="line3">line 3</div>
+<script>
+    async function waitForHover(element) {
+        for (let i = 0; i < 60; ++i) {
+            if (element.matches(":hover"))
+                return;
+            await timeout(50);
+        }
+        println("timed out waiting for hover update");
+    }
+
+    promiseTest(async () => {
+        await animationFrame();
+        await animationFrame();
+
+        let mouseMoves = 0;
+        let pointerMoves = 0;
+        let mouseOvers = 0;
+        let mouseOuts = 0;
+        document.addEventListener("mousemove", () => ++mouseMoves);
+        document.addEventListener("pointermove", () => ++pointerMoves);
+        document.addEventListener("mouseover", () => ++mouseOvers);
+        document.addEventListener("mouseout", () => ++mouseOuts);
+
+        internals.mouseMove(1, 1);
+
+        println(`before scroll line1: ${line1.matches(":hover")}`);
+        println(`before scroll line2: ${line2.matches(":hover")}`);
+        println(`before scroll mousemove count: ${mouseMoves}`);
+        println(`before scroll pointermove count: ${pointerMoves}`);
+        println(`before scroll mouseover count: ${mouseOvers}`);
+        println(`before scroll mouseout count: ${mouseOuts}`);
+
+        await internals.wheel(1, 1, 0, 500);
+
+        println(`before scroll stop line1: ${line1.matches(":hover")}`);
+        println(`before scroll stop line2: ${line2.matches(":hover")}`);
+        println(`before scroll stop mouseover count: ${mouseOvers}`);
+        println(`before scroll stop mouseout count: ${mouseOuts}`);
+
+        await waitForHover(line2);
+
+        println(`after scroll stop line1: ${line1.matches(":hover")}`);
+        println(`after scroll stop line2: ${line2.matches(":hover")}`);
+        println(`after scroll stop mousemove count: ${mouseMoves}`);
+        println(`after scroll stop pointermove count: ${pointerMoves}`);
+        println(`after scroll stop mouseover count: ${mouseOvers}`);
+        println(`after scroll stop mouseout count: ${mouseOuts}`);
+    });
+</script>


### PR DESCRIPTION
Remember the last mouse or wheel position seen by the event handler. Schedule a hover refresh once async scrolling goes idle. This lets hover state and boundary events follow content under a stationary pointer after scrolling has stopped.

Add a text test that keeps hover on the old target while scrolling is active. It then checks that hover moves after the idle update without extra mousemove or pointermove events.