### PR TITLE
LibWeb: Avoid relayout for definite-size image updates

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -87,6 +87,61 @@ static BatchingDispatcher& batching_dispatcher()
     return dispatcher;
 }
 
+static bool image_element_dimensions_may_depend_on_intrinsic_size(Layout::ImageBox const& image_box)
+{
+    auto const& computed_values = image_box.computed_values();
+
+    auto size_is_definite = [](CSS::Size const& size) {
+        return size.is_length() || (size.is_calculated() && !size.contains_percentage());
+    };
+    auto size_constraint_is_definite_or_none = [&](CSS::Size const& size) {
+        return size.is_none() || size_is_definite(size);
+    };
+
+    auto const& width = computed_values.width();
+    auto const& height = computed_values.height();
+    if (!size_is_definite(width) || !size_is_definite(height))
+        return true;
+
+    auto const& min_width = computed_values.min_width();
+    auto const& min_height = computed_values.min_height();
+    if (!size_is_definite(min_width) || !size_is_definite(min_height))
+        return true;
+
+    auto const& max_width = computed_values.max_width();
+    auto const& max_height = computed_values.max_height();
+    if (!size_constraint_is_definite_or_none(max_width) || !size_constraint_is_definite_or_none(max_height))
+        return true;
+
+    return false;
+}
+
+static void reset_intrinsic_size_caches_after_image_data_change(Layout::ImageBox& image_box)
+{
+    image_box.reset_cached_intrinsic_sizes();
+    for (auto* ancestor = image_box.parent(); ancestor; ancestor = ancestor->parent()) {
+        auto* box = as_if<Layout::Box>(ancestor);
+        if (!box)
+            continue;
+        box->reset_cached_intrinsic_sizes();
+        if (box->is_absolutely_positioned() || box->is_svg_svg_box())
+            break;
+    }
+}
+
+static void set_needs_layout_update_or_repaint_after_image_data_change(HTMLImageElement& image_element, DOM::SetNeedsLayoutReason reason)
+{
+    auto layout_node = image_element.unsafe_layout_node();
+    auto* image_box = as_if<Layout::ImageBox>(layout_node.ptr());
+    if (!image_box || image_element_dimensions_may_depend_on_intrinsic_size(*image_box)) {
+        image_element.set_needs_layout_update(reason);
+        return;
+    }
+
+    reset_intrinsic_size_caches_after_image_data_change(*image_box);
+    image_element.set_needs_repaint();
+}
+
 GC_DEFINE_ALLOCATOR(HTMLImageElement);
 
 HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName qualified_name)
@@ -693,7 +748,7 @@ void HTMLImageElement::update_the_image_data_impl(bool restart_animations, bool 
                 m_current_request->set_current_url(realm(), *url_string);
 
                 set_needs_style_update(true);
-                set_needs_layout_update(DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
+                set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
 
                 // 3. If maybe omit events is not set or previousURL is not equal to urlString, then fire an event named load at the img element.
                 if (!maybe_omit_events || previous_url != url_string)
@@ -933,7 +988,7 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
                 document().prune_image_resource_caches();
 
                 set_needs_style_update(true);
-                set_needs_layout_update(DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
+                set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
 
                 // 4. If maybe omit events is not set or previousURL is not equal to urlString, then fire an event named load at the img element.
                 if (!maybe_omit_events || previous_url != url_string)
@@ -1090,7 +1145,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
             image_request->prepare_for_presentation(*this);
             // FIXME: This is ad-hoc, updating the layout here should probably be handled by prepare_for_presentation().
             set_needs_style_update(true);
-            set_needs_layout_update(DOM::SetNeedsLayoutReason::HTMLImageElementReactToChangesInTheEnvironment);
+            set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementReactToChangesInTheEnvironment);
 
             // 7. Fire an event named load at the img element.
             dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -61,7 +61,8 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
     if (phase == PaintPhase::Foreground) {
         auto image_rect = absolute_rect();
         auto image_rect_device_pixels = context.rounded_device_rect(image_rect);
-        if (m_renders_as_alt_text) {
+        auto renders_as_alt_text = m_is_svg_image ? m_renders_as_alt_text : !m_image_provider.is_image_available();
+        if (renders_as_alt_text) {
             if (!m_alt_text.is_empty()) {
                 auto enclosing_rect = context.enclosing_device_rect(image_rect).to_type<int>();
                 context.display_list_recorder().draw_text(enclosing_rect, Utf16String::from_utf8(m_alt_text), layout_node().font(context), Gfx::TextAlignment::Center, computed_values().color());

--- a/Tests/LibWeb/Text/expected/Layout/image-load-intrinsic-size-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/Layout/image-load-intrinsic-size-invalidation.txt
@@ -1,0 +1,12 @@
+auto: container=120 image=120x120
+width-percent: container=120 image=60x60
+width-percent-fixed-height: container=20 image=10x20
+height-percent: container=120 image=120x120
+height-percent-fixed-width: container=20 image=20x20
+both-percent: container=120 image=60x60
+calc-percent: container=120 image=60x60
+calc-percent-fixed-height: container=20 image=10x20
+min-width-percent: container=20 image=20x20
+max-width-percent: container=120 image=60x120
+min-content: container=20 image=20x20
+fixed: container=20 image=20x30

--- a/Tests/LibWeb/Text/input/Layout/image-load-intrinsic-size-invalidation.html
+++ b/Tests/LibWeb/Text/input/Layout/image-load-intrinsic-size-invalidation.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        font-size: 0;
+    }
+
+    .shrink {
+        display: inline-block;
+        line-height: 0;
+        margin-right: 10px;
+    }
+
+    img {
+        display: block;
+    }
+</style>
+
+<div id="auto" class="shrink"><img style="width: auto; height: auto;"></div>
+<div id="width-percent" class="shrink"><img style="width: 50%; height: auto;"></div>
+<div id="width-percent-fixed-height" class="shrink"><img style="width: 50%; height: 20px;"></div>
+<div id="height-percent" class="shrink"><img style="width: auto; height: 50%;"></div>
+<div id="height-percent-fixed-width" class="shrink"><img style="width: 20px; height: 50%;"></div>
+<div id="both-percent" class="shrink"><img style="width: 50%; height: 50%;"></div>
+<div id="calc-percent" class="shrink"><img style="width: calc(50% + 0px); height: auto;"></div>
+<div id="calc-percent-fixed-height" class="shrink"><img style="width: calc(50% + 0px); height: 20px;"></div>
+<div id="min-width-percent" class="shrink"><img style="width: 20px; height: 20px; min-width: 50%; min-height: 0;"></div>
+<div id="max-width-percent" class="shrink"><img style="width: 120px; height: 120px; min-width: 0; min-height: 0; max-width: 50%;"></div>
+<div id="min-content" class="shrink"><img style="width: min-content; height: 20px; min-width: 0; min-height: 0;"></div>
+<div id="fixed" class="shrink"><img style="width: 20px; height: 30px; min-width: 0; min-height: 0;"></div>
+
+<script>
+    const imageSource = "../../../Assets/120.png";
+
+    function waitForLoad(image) {
+        return new Promise(resolve => {
+            image.addEventListener("load", resolve, { once: true });
+        });
+    }
+
+    function roundedRectForCase(id) {
+        const container = document.getElementById(id);
+        const image = container.querySelector("img");
+        const containerRect = container.getBoundingClientRect();
+        const imageRect = image.getBoundingClientRect();
+        return {
+            containerWidth: Math.round(containerRect.width),
+            imageWidth: Math.round(imageRect.width),
+            imageHeight: Math.round(imageRect.height),
+        };
+    }
+
+    asyncTest(async done => {
+        document.body.offsetWidth;
+
+        const cases = Array.from(document.querySelectorAll(".shrink"));
+        const loadPromises = cases.map(container => waitForLoad(container.querySelector("img")));
+        cases.forEach((container, index) => {
+            container.querySelector("img").src = `${imageSource}?${index}`;
+        });
+
+        await Promise.all(loadPromises);
+
+        for (const container of cases) {
+            const rect = roundedRectForCase(container.id);
+            println(`${container.id}: container=${rect.containerWidth} image=${rect.imageWidth}x${rect.imageHeight}`);
+        }
+
+        done();
+    });
+</script>


### PR DESCRIPTION
When image data becomes available, intrinsic dimensions can change, but that does not require relayout for image elements whose computed width, height, and min/max constraints are independent of intrinsic sizing. In that case, invalidate paint and intrinsic-size caches instead of marking layout dirty.

Keep the conservative relayout path for auto, percentage, calc-percentage, and intrinsic sizing constraints, since decoded image dimensions can affect used size in indefinite contexts. Query image availability while painting so an existing paintable can switch from alt text to image content without relayout.

Add text coverage that waits for image load events and checks auto, percentage, calc-percentage, intrinsic keyword, min/max percentage, and fixed-size cases without relying on timeouts.