### PR TITLE
LibWeb: Fix a crash when Element::computed_properties returns no value

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -889,6 +889,8 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                 element.set_needs_style_update(false);
             }
             style = element.computed_properties();
+            if (!style)
+                return;
             display = style->display();
             if (display.is_none())
                 return;


### PR DESCRIPTION
This occurs right after login in to Jellyfin.