### PR TITLE
LibJS: Remove STL use from various places

### DIFF
--- a/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -91,7 +91,7 @@ JS_DEFINE_NATIVE_FUNCTION(BigIntConstructor::as_int_n)
     if (auto top_bit_index = mod.unsigned_value().one_based_index_of_highest_set_bit(); top_bit_index >= bits) {
         // twos complement decode
         auto decoded = TRY_OR_THROW_OOM(vm, mod.unsigned_value().bitwise_not_fill_to_one_based_index(bits)).plus(1);
-        return BigInt::create(vm, Crypto::SignedBigInteger { std::move(decoded), true });
+        return BigInt::create(vm, Crypto::SignedBigInteger { move(decoded), true });
     }
 
     // ... otherwise, return ℤ(mod).

--- a/Libraries/LibJS/Runtime/DateParser.h
+++ b/Libraries/LibJS/Runtime/DateParser.h
@@ -87,24 +87,30 @@ private:
         VERIFY_NOT_REACHED();
     }
 
+    template<Unsigned T>
+    struct ParsedNumber {
+        T number { 0 };
+        size_t digits { 0 };
+    };
+
     // Reads a contiguous sequence of digits. Ignores digits read past MaxLength.
     // Returns the numeric value of the sequence and the number of digits not ignored.
-    template<typename T, size_t MaxLength>
-    ALWAYS_INLINE std::pair<T, size_t> read_number()
+    template<Unsigned T, size_t MaxLength>
+    ALWAYS_INLINE ParsedNumber<T> read_number()
     {
-        static_assert(std::is_unsigned<T>(), "Type must be unsigned.");
         static_assert(MaxLength < 11, "Number too long.");
         static_assert((sizeof(T) >= 1) || (MaxLength <= 2), "Number too long.");
         static_assert((sizeof(T) >= 2) || (MaxLength <= 4), "Number too long.");
         static_assert((sizeof(T) >= 4) || (MaxLength <= 9), "Number too long.");
         static_assert((sizeof(T) >= 8) || (MaxLength <= 19), "Number too long.");
 
-        auto result = std::make_pair(T(0), size_t(0));
-        for (result.second = 0; result.second < MaxLength; ++result.second) {
+        ParsedNumber<T> result;
+
+        for (; result.digits < MaxLength; ++result.digits) {
             if (is_eof() || !next_is(isdigit))
                 return result;
-            result.first *= 10;
-            result.first += consume() - '0';
+            result.number *= 10;
+            result.number += consume() - '0';
         }
 
         ignore_while(isdigit);
@@ -364,52 +370,52 @@ private:
 
     // H[H]:MM[:SS[.mss[...]]][ ][AM|PM] At this point, H[H]: has already been read.
     ALWAYS_INLINE bool maybe_time(
-        std::pair<u32, size_t> const& hours,
+        ParsedNumber<u32> const& hours,
         bool allow_single_digit_minutes_and_seconds = false)
     {
         if (m_hours.has_value())
             return false; // Time has already been read.
 
-        if (hours.second > 2)
+        if (hours.digits > 2)
             return false; // 123:
-        if (hours.first > 24)
+        if (hours.number > 24)
             return false;
-        m_hours = hours.first; // No precision loss during the conversion u32 -> u8 since the hours has at most 2 digits.
+        m_hours = hours.number; // No precision loss during the conversion u32 -> u8 since the hours has at most 2 digits.
 
-        auto const minutes = read_number<u32, 3>();
-        if (minutes.second != 2 && !(allow_single_digit_minutes_and_seconds && minutes.second == 1))
+        auto [minutes, minutes_digits] = read_number<u32, 3>();
+        if (minutes_digits != 2 && !(allow_single_digit_minutes_and_seconds && minutes_digits == 1))
             return false; // 12:345 or 12:3
-        if (minutes.first > 59)
+        if (minutes > 59)
             return false;
-        m_minutes = minutes.first;
+        m_minutes = minutes;
 
         if (consume_specific('.'))
             return false; // 12:34.
         if (!consume_specific(':'))
             return true;
 
-        auto const seconds = read_number<u32, 3>();
-        if (seconds.second != 2 && !(allow_single_digit_minutes_and_seconds && seconds.second == 1))
+        auto [seconds, seconds_digits] = read_number<u32, 3>();
+        if (seconds_digits != 2 && !(allow_single_digit_minutes_and_seconds && seconds_digits == 1))
             return false; // 12:34:567 or 12:34:5
-        if (seconds.first > 59)
+        if (seconds > 59)
             return false;
-        m_seconds = seconds.first;
+        m_seconds = seconds;
 
         if (!consume_specific('.'))
             return true;
 
-        auto const milliseconds = read_number<u32, 3>();
-        switch (milliseconds.second) {
+        auto [milliseconds, milliseconds_digits] = read_number<u32, 3>();
+        switch (milliseconds_digits) {
         case 0:
             return false; // 12:34:56.
         case 1:
-            m_milliseconds = milliseconds.first * 100;
+            m_milliseconds = milliseconds * 100;
             break;
         case 2:
-            m_milliseconds = milliseconds.first * 10;
+            m_milliseconds = milliseconds * 10;
             break;
         case 3:
-            m_milliseconds = milliseconds.first;
+            m_milliseconds = milliseconds;
             break;
         default:
             VERIFY_NOT_REACHED();
@@ -424,9 +430,9 @@ private:
         m_previous_separator_was_space = false;
 
         auto const number = read_number<u32, 7>();
-        VERIFY(number.second > 0);
+        VERIFY(number.digits > 0);
 
-        if (number.second > 6)
+        if (number.digits > 6)
             return false; // 1234567
 
         if (consume_specific(':')) {
@@ -437,7 +443,7 @@ private:
             return true;
         }
 
-        m_numbers.append(number.first);
+        m_numbers.append(number.number);
 
         return separator(); // Must be followed by a separator.
     }
@@ -447,14 +453,14 @@ private:
         i8 const sign = (consume() == '-') ? -1 : +1;
         auto const number = read_number<u32, 7>();
 
-        switch (number.second) {
+        switch (number.digits) {
         case 0: // Not a sign after all; '+' is forbidden if it is not a sign. '-' is ignored as punctuation.
             return (sign == -1);
         case 1 ... 5: // Too small to be a signed year;
             if (m_hours.has_value())
                 break; // Candidate for timezone offset.
 
-            m_numbers.append(number.first); // Ignore the sign and treat it as a number.
+            m_numbers.append(number.number); // Ignore the sign and treat it as a number.
             return true;
         case 6:
             if (m_hours.has_value())
@@ -463,7 +469,7 @@ private:
             if (m_year.has_value())
                 return false; // To many digits to be anything else than a signed year.
 
-            m_year = sign * number.first; // Candidate for signed year
+            m_year = sign * number.number; // Candidate for signed year
             return true;
         default:
             return false;
@@ -481,13 +487,13 @@ private:
     }
 
     // Continue reading a timezone offset, after the sign and the first number have beeen read.
-    ALWAYS_INLINE bool tz_offset(std::pair<u32, size_t> const& number, bool iso_8601_format = false)
+    ALWAYS_INLINE bool tz_offset(ParsedNumber<u32> const& number, bool iso_8601_format = false)
     {
         if (m_timezone_hours.has_value()) // Cannot have more than one timezone offset or a timezone name followed by a timezone offset.
             return false;
 
         m_timezone_utc = false;
-        switch (number.second) {
+        switch (number.digits) {
         case 0:
             return false;
         case 1:
@@ -501,7 +507,7 @@ private:
                 return false; // +123
             [[fallthrough]];
         case 4: { // "Military" timezone offset
-            u16 const tz_hhmm = number.first;
+            u16 const tz_hhmm = number.number;
             m_timezone_hours = tz_hhmm / 100;
             m_timezone_minutes = tz_hhmm % 100;
             return true;
@@ -511,7 +517,7 @@ private:
                 return false; // +12345
             [[fallthrough]];
         case 6: { // "Military" timezone offset
-            u32 const tz_hhmmss = number.first;
+            u32 const tz_hhmmss = number.number;
             m_timezone_hours = tz_hhmmss / 10000;
             m_timezone_minutes = tz_hhmmss % 10000 / 100;
             m_timezone_seconds = tz_hhmmss % 100;
@@ -521,36 +527,36 @@ private:
             return false;
         }
 
-        auto const timezone_offset_requires_colon = iso_8601_format && number.second == 2;
-        m_timezone_hours = number.first; // Guaranteed to be a 1- or 2-digit number.
+        auto const timezone_offset_requires_colon = iso_8601_format && number.digits == 2;
+        m_timezone_hours = number.number; // Guaranteed to be a 1- or 2-digit number.
 
         if (!consume_specific(':'))
             return !timezone_offset_requires_colon; // +H[H] "military" time offset
 
         // Timezone with colon
-        auto const minutes = read_number<u16, 3>();
-        if (minutes.second != 2)
+        auto [minutes, minutes_digits] = read_number<u16, 3>();
+        if (minutes_digits != 2)
             return false;
-        m_timezone_minutes = minutes.first;
+        m_timezone_minutes = minutes;
 
         if (!consume_specific(':'))
             return true;
 
-        auto const seconds = read_number<u16, 3>();
-        if (seconds.second != 2)
+        auto [seconds, seconds_digits] = read_number<u16, 3>();
+        if (seconds_digits != 2)
             return false;
-        m_timezone_seconds = seconds.first;
+        m_timezone_seconds = seconds;
 
         if (!consume_specific('.'))
             return true;
 
-        auto const nanoseconds = read_number<u64, 10>();
-        if (nanoseconds.second == 0)
+        auto [nanoseconds, nanoseconds_digits] = read_number<u16, 3>();
+        if (nanoseconds_digits == 0)
             return false;
-        if (nanoseconds.second > 9)
+        if (nanoseconds_digits > 9)
             return false;
 
-        m_timezone_nanoseconds = nanoseconds.first * pow10(9 - nanoseconds.second);
+        m_timezone_nanoseconds = nanoseconds * pow10(9 - nanoseconds_digits);
 
         return true;
     }
@@ -624,7 +630,7 @@ private:
 
     ALWAYS_INLINE bool word() // Alphanumeric strings that are not date "keywords".
     {
-        std::ignore = consume_while(isalpha);
+        consume_while(isalpha);
         // Just like Firefox and Chrome:
         // - Ignore junk (bare words) at the beginning (before time or a date fragment has been read).
         // - Fail if a word is read later in the date string (exception: final time zone name, in brackets).
@@ -725,7 +731,7 @@ private:
     {
         auto number = read_number<u32, 7>();
 
-        switch (number.second) {
+        switch (number.digits) {
         case 0:
             return false; // no digits
         case 1:
@@ -743,10 +749,10 @@ private:
         case 5:
         case 6: // Six-digit year number; no sign means not ISO8601 date.
             // At this point, this is not an ISO8601 date.
-            m_numbers.append(number.first);
+            m_numbers.append(number.number);
             return false;
         case 4: // Four-digit year number.
-            m_year = number.first;
+            m_year = number.number;
             return true; // This can be the start of an ISO8601 date.
         }
 
@@ -758,15 +764,16 @@ private:
         i64 sign = +1;
         if (consume() == '-')
             sign = -1;
-        auto number = read_number<u32, 7>();
 
-        switch (number.second) {
+        auto [number, digits] = read_number<u32, 7>();
+
+        switch (digits) {
         case 0:
             if (sign == +1) // Standalone '+' is invalid.
                 return Error::from_string_literal("Invalid character in date string ('+').");
             return false;
         case 1 ... 5:
-            m_numbers.append(number.first); // This is not an ISO8601 date.
+            m_numbers.append(number); // This is not an ISO8601 date.
             return false;
         case 6:
             break;
@@ -774,7 +781,7 @@ private:
             return Error::from_string_literal("String too long to be a 6-digit signed year.");
         }
 
-        m_year = sign * number.first;
+        m_year = sign * number;
 
         // "The representation of the year 0 as -000000 is invalid." https://tc39.es/ecma262/#sec-expanded-years
         // Firefox interprets "-000000" as "Jan 1, 2000".
@@ -791,18 +798,18 @@ private:
 
         m_date_is_iso_like = true;
 
-        auto month = read_number<u16, 3>();
+        auto [month, month_digits] = read_number<u16, 3>();
         if (consume_specific(':')) { // Like "2000-12:34". Firefox and Chrome parse it correctly. We do the same.
-            if (maybe_time(month))
+            if (maybe_time({ month, month_digits }))
                 return false;
             return Error::from_string_literal("Found something that looks like time, but is not.");
         }
 
-        switch (month.second) {
+        switch (month_digits) {
         case 0:
             return false; // Not ISO8601 date format. Continue reading.
         case 1:
-            m_month = month.first;
+            m_month = month;
             if (m_month == 0)
                 return Error::from_string_literal("Month number cannot be zero.");
             return false;
@@ -812,7 +819,7 @@ private:
             return Error::from_string_literal("Month number too long.");
         }
 
-        m_month = month.first;
+        m_month = month;
 
         if ((m_month == 0) || (m_month.value() > 12))
             return Error::from_string_literal("Invalid month number.");
@@ -823,13 +830,13 @@ private:
         if (is_eof())
             return Error::from_string_literal("Expecting month number. Got eof.");
 
-        auto day = read_number<u16, 3>();
+        auto [day, day_digits] = read_number<u16, 3>();
 
-        switch (day.second) {
+        switch (day_digits) {
         case 0:
             return false; // Not ISO8601 date format. Continue reading.
         case 1:
-            m_day = day.first;
+            m_day = day;
             if (m_day == 0)
                 return Error::from_string_literal("Day number cannot be zero.");
             return false;
@@ -839,7 +846,7 @@ private:
             return Error::from_string_literal("Day number too long.");
         }
 
-        m_day = day.first;
+        m_day = day;
         if ((m_day == 0) || (m_day.value() > 31))
             return Error::from_string_literal("Invalid day number.");
 
@@ -855,15 +862,15 @@ private:
             return false;
 
         // After reading the 'T', any failures return NAN (failed parse)
-        auto hours = read_number<u16, 3>();
+        auto [hours, hours_digits] = read_number<u16, 3>();
 
         if (!consume_specific(':')) // 12
             return Error::from_string_literal("Well specified time needs minutes.");
 
-        if (hours.second != 2)
+        if (hours_digits != 2)
             return Error::from_string_literal("Hours: invalid length.");
 
-        if (!maybe_time(hours)) // The only difference is that ISO8601 requires 2-digit hours.
+        if (!maybe_time({ hours, hours_digits })) // The only difference is that ISO8601 requires 2-digit hours.
             return Error::from_string_literal("Cannot parse time.");
 
         return true;

--- a/Libraries/LibJS/Runtime/DateParser.h
+++ b/Libraries/LibJS/Runtime/DateParser.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/CharacterTypes.h>
 #include <AK/Error.h>
 #include <AK/GenericLexer.h>
 #include <AK/Optional.h>
@@ -14,8 +15,6 @@
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibJS/Runtime/Date.h>
-
-#include <cctype> // Not included by default on macOS.
 
 // Parse simplified ISO8601 and non-standard date formats to milliseconds
 // from epoch (double). Synopsis:
@@ -50,6 +49,8 @@ class DateParser : public GenericLexer {
 public:
     ALWAYS_INLINE static double parse(StringView string)
     {
+        if (!string.is_ascii())
+            return NAN;
         return DateParser(string).parse().value_or(NAN);
     }
 
@@ -107,13 +108,13 @@ private:
         ParsedNumber<T> result;
 
         for (; result.digits < MaxLength; ++result.digits) {
-            if (is_eof() || !next_is(isdigit))
+            if (is_eof() || !next_is(is_ascii_digit))
                 return result;
             result.number *= 10;
             result.number += consume() - '0';
         }
 
-        ignore_while(isdigit);
+        ignore_while(is_ascii_digit);
         return result;
     }
 
@@ -331,7 +332,7 @@ private:
         case '(':
             ignore_until(')'); // Consume time zone name (Anything in brackets).
             ignore();
-            ignore_while(isspace);
+            ignore_while(is_ascii_space);
             return true;
         }
 
@@ -342,7 +343,7 @@ private:
     {
         VERIFY(m_hours.has_value());
 
-        consume_while(isspace);
+        consume_while(is_ascii_space);
 
         if (consume_specific("AM"sv)) {
             if (!separator())
@@ -588,7 +589,7 @@ private:
 
         m_timezone_utc = true;
 
-        bool space = consume_while(isspace).length() > 0;
+        bool space = consume_while(is_ascii_space).length() > 0;
         switch (peek()) {
         case '+':
         case '-':
@@ -622,7 +623,7 @@ private:
             if (str[i] != peek(i))
                 return false;
 
-        ignore_while(isalpha); // ... which can followed by anything. Just like Firefox and Chrome.
+        ignore_while(is_ascii_alpha); // ... which can followed by anything. Just like Firefox and Chrome.
         m_month = month;
 
         return separator(); // Must end with a separator.
@@ -630,7 +631,7 @@ private:
 
     ALWAYS_INLINE bool word() // Alphanumeric strings that are not date "keywords".
     {
-        consume_while(isalpha);
+        consume_while(is_ascii_alpha);
         // Just like Firefox and Chrome:
         // - Ignore junk (bare words) at the beginning (before time or a date fragment has been read).
         // - Fail if a word is read later in the date string (exception: final time zone name, in brackets).

--- a/Libraries/LibJS/Runtime/DateParser.h
+++ b/Libraries/LibJS/Runtime/DateParser.h
@@ -47,29 +47,17 @@
 // - Support Firefox less permissive punctuation but more permissive punctuation
 //   syntax.
 class DateParser : public GenericLexer {
+public:
+    ALWAYS_INLINE static double parse(StringView string)
+    {
+        return DateParser(string).parse().value_or(NAN);
+    }
+
 private:
-    Vector<u64> m_numbers;
-
-    Optional<i8> m_sign;
-    Optional<i64> m_year;
-    Optional<u8> m_month;
-    Optional<u8> m_day;
-    Optional<u8> m_hours;
-    Optional<u8> m_minutes;
-    Optional<u8> m_seconds;
-    Optional<u16> m_milliseconds;
-
-    // True if GMT/UTC/Z specified and there is no timezone offset; false if timezone offset.
-    // No value if there is no timezone information: we have to guess whether the date was given in GMT or local time.
-    Optional<bool> m_timezone_utc;
-    Optional<i8> m_timezone_sign; // +1 or -1 if there is a timezone offset.
-    Optional<u8> m_timezone_hours;
-    Optional<u8> m_timezone_minutes;
-    Optional<u8> m_timezone_seconds;
-    Optional<u64> m_timezone_nanoseconds;
-
-    bool m_date_is_iso_like { false };
-    bool m_previous_separator_was_space { false };
+    explicit DateParser(StringView string)
+        : GenericLexer(string)
+    {
+    }
 
     constexpr static u64 pow10(size_t pow)
     {
@@ -98,6 +86,7 @@ private:
 
         VERIFY_NOT_REACHED();
     }
+
     // Reads a contiguous sequence of digits. Ignores digits read past MaxLength.
     // Returns the numeric value of the sequence and the number of digits not ignored.
     template<typename T, size_t MaxLength>
@@ -140,6 +129,7 @@ private:
 
         return false; // Too many numbers
     }
+
     ALWAYS_INLINE bool guess_date_from_3_numbers() // Only "month-day-year" (default) and "year-month-day" are supported (same as firefox and chrome).
     {
         VERIFY(m_numbers.size() == 3);
@@ -182,6 +172,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE bool guess_date_from_2_numbers() // Guess default order "day-year" or adapt.
     {
         VERIFY(m_numbers.size() == 2);
@@ -242,6 +233,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE bool guess_date_from_1_number() // Guess in this order: year, month, day.
     {
         VERIFY(m_numbers.size() == 1);
@@ -267,6 +259,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE static u64 guess_year(u64 const number) // Guess one- or two-digit year.
     {
         switch (number) {
@@ -278,6 +271,7 @@ private:
 
         return number;
     }
+
     ALWAYS_INLINE bool one_number(u64 const number) // The whole input string is just one stand-alone number.}
     {
         switch (number) {
@@ -337,6 +331,7 @@ private:
 
         return false;
     }
+
     ALWAYS_INLINE bool maybe_ampm() // Side effect: consumes space at the end of a time component, even if there is no AM/PM.
     {
         VERIFY(m_hours.has_value());
@@ -366,6 +361,7 @@ private:
 
         return true;
     }
+
     // H[H]:MM[:SS[.mss[...]]][ ][AM|PM] At this point, H[H]: has already been read.
     ALWAYS_INLINE bool maybe_time(
         std::pair<u32, size_t> const& hours,
@@ -421,6 +417,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE bool maybe_number()
     {
         auto const previous_separator_was_space = m_previous_separator_was_space;
@@ -444,6 +441,7 @@ private:
 
         return separator(); // Must be followed by a separator.
     }
+
     ALWAYS_INLINE bool maybe_sign()
     {
         i8 const sign = (consume() == '-') ? -1 : +1;
@@ -481,6 +479,7 @@ private:
         auto const number = read_number<u32, 7>();
         return tz_offset(number);
     }
+
     // Continue reading a timezone offset, after the sign and the first number have beeen read.
     ALWAYS_INLINE bool tz_offset(std::pair<u32, size_t> const& number, bool iso_8601_format = false)
     {
@@ -555,6 +554,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE bool separator() // Ignore space and Firefox punctuation.
     {
         if (is_eof())
@@ -574,6 +574,7 @@ private:
         }
         return false;
     }
+
     ALWAYS_INLINE bool gmt(StringView const& str) // Z or GMT or UTC can be used interchangeably.
     {
         if (!consume_specific(str))
@@ -590,6 +591,7 @@ private:
 
         return space || separator();
     }
+
     // Same as Chrome and Firefox, we only support abbreviations for timezones covering the US mainland.
     ALWAYS_INLINE bool us_timezone(StringView const& str, u8 hours, u8 minutes = 0, i8 sign = -1)
     {
@@ -606,6 +608,7 @@ private:
 
         return separator(); // Must end with a separator.
     }
+
     ALWAYS_INLINE bool month_name(StringView const& str, u8 month)
     {
         VERIFY(str.length() == 3); // Only looking for 3-letter month prefixes.
@@ -618,6 +621,7 @@ private:
 
         return separator(); // Must end with a separator.
     }
+
     ALWAYS_INLINE bool word() // Alphanumeric strings that are not date "keywords".
     {
         std::ignore = consume_while(isalpha);
@@ -626,6 +630,7 @@ private:
         // - Fail if a word is read later in the date string (exception: final time zone name, in brackets).
         return (m_numbers.is_empty() && !m_hours.has_value() && !m_year.has_value());
     }
+
     ALWAYS_INLINE bool maybe_word() // The top of a trie catching date "keywords".
     {
         switch (peek()) {
@@ -696,6 +701,7 @@ private:
 
         return Error::from_string_literal("Read ISO8601 format, but have some input left over.");
     }
+
     ALWAYS_INLINE ErrorOr<bool> maybe_iso_year()
     {
         switch (peek()) {
@@ -714,6 +720,7 @@ private:
 
         return false;
     }
+
     ALWAYS_INLINE ErrorOr<bool> maybe_iso_year4() // Like "2025".
     {
         auto number = read_number<u32, 7>();
@@ -745,6 +752,7 @@ private:
 
         return Error::from_string_literal("String too long to be a year.");
     }
+
     ALWAYS_INLINE ErrorOr<bool> maybe_iso_signed_year6() // Like "+002025".
     {
         i64 sign = +1;
@@ -775,6 +783,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE ErrorOr<bool> maybe_iso_month_day() // [-MM[-DD]]
     {
         if (!consume_specific('-'))
@@ -836,6 +845,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE ErrorOr<bool> maybe_iso_time() // THH:MM[:SS[.M[SS...]]]
     {
         // The ECMA date string format requires uppercase 'T' and 'Z' https://tc39.es/ecma262/#sec-date-time-string-format
@@ -858,6 +868,7 @@ private:
 
         return true;
     }
+
     ALWAYS_INLINE ErrorOr<void> maybe_iso_tz() // After the 'T' for iso_time has been read, reading an ISO8601 timezone either succeeds or the whole parse fails.
     {
         switch (consume()) {
@@ -925,6 +936,7 @@ private:
 
         return JS::time_clip(time_ms);
     }
+
     ALWAYS_INLINE ErrorOr<double> parse()
     {
         if (TRY(maybe_iso_8601()))
@@ -947,14 +959,27 @@ private:
 
         return build_date();
     }
-    DateParser(StringView const& str)
-        : GenericLexer(str)
-    {
-    }
 
-public:
-    ALWAYS_INLINE static double parse(StringView const& str)
-    {
-        return DateParser(str).parse().value_or(NAN);
-    }
+    Vector<u64> m_numbers;
+
+    Optional<i8> m_sign;
+    Optional<i64> m_year;
+    Optional<u8> m_month;
+    Optional<u8> m_day;
+    Optional<u8> m_hours;
+    Optional<u8> m_minutes;
+    Optional<u8> m_seconds;
+    Optional<u16> m_milliseconds;
+
+    // True if GMT/UTC/Z specified and there is no timezone offset; false if timezone offset.
+    // No value if there is no timezone information: we have to guess whether the date was given in GMT or local time.
+    Optional<bool> m_timezone_utc;
+    Optional<i8> m_timezone_sign; // +1 or -1 if there is a timezone offset.
+    Optional<u8> m_timezone_hours;
+    Optional<u8> m_timezone_minutes;
+    Optional<u8> m_timezone_seconds;
+    Optional<u64> m_timezone_nanoseconds;
+
+    bool m_date_is_iso_like { false };
+    bool m_previous_separator_was_space { false };
 };

--- a/Tests/LibJS/Runtime/builtins/Date/Date.parse.nonStandard.js
+++ b/Tests/LibJS/Runtime/builtins/Date/Date.parse.nonStandard.js
@@ -698,3 +698,13 @@ test("multiple month names", () => {
 
     setTimeZone(originalTimeZone);
 });
+
+test("non-ASCII input", () => {
+    expect(Date.parse("2024\uff01")).toBeNaN();
+    expect(Date.parse("1234567\uff01")).toBeNaN();
+    expect(Date.parse("Jan\uff01 01 2024")).toBeNaN();
+    expect(Date.parse("hello\uff01 Jan 01 2024")).toBeNaN();
+    expect(Date.parse("Jan 01 2024 12:34\u00a0PM")).toBeNaN();
+    expect(Date.parse("Jan 01 2024 GMT\u00a0")).toBeNaN();
+    expect(Date.parse("Jan 01 2024 (UTC)\u00a0")).toBeNaN();
+});


### PR DESCRIPTION
While removing STL stuff, I also found our `DateParser` was not particularly safe with non-ASCII input, so that is fixed up here as well.