### PR TITLE
Add feature-gated Compositor process backend

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -13,6 +13,7 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/ScrollState.h>
 
@@ -47,7 +48,7 @@ struct CachedBlockingWheelEventTarget {
 
 // Mutable compositor-side copy of AsyncScrollingState. Current scroll offsets live in ScrollStateSnapshot; this tree
 // owns scroll node geometry and derived hit-test targets.
-class AsyncScrollTree {
+class WEB_API AsyncScrollTree {
 public:
     void set_state(AsyncScrollingState&&);
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -14,6 +14,7 @@
 #include <LibGfx/CornerRadii.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
+#include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/ScrollFrame.h>
@@ -154,13 +155,13 @@ enum class WheelScrollAdmission {
     BlockedByWheelEventRegion,
 };
 
-void initialize_async_scrolling_metadata_recording(DisplayListRecordingContext&, Painting::ViewportPaintable&);
-void record_async_scrolling_metadata_for_paintable(Painting::PaintableBox const&, DisplayListRecordingContext&);
-void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext&, HTML::Navigable&, Gfx::IntRect viewport_rect);
-AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const&);
-WheelRoutingAdmission wheel_routing_admission_for(AsyncScrollingState const&);
-StringView wheel_routing_admission_to_string(WheelRoutingAdmission);
-bool blocks_wheel_event_at_position(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position);
-WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current);
+WEB_API void initialize_async_scrolling_metadata_recording(DisplayListRecordingContext&, Painting::ViewportPaintable&);
+WEB_API void record_async_scrolling_metadata_for_paintable(Painting::PaintableBox const&, DisplayListRecordingContext&);
+WEB_API void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext&, HTML::Navigable&, Gfx::IntRect viewport_rect);
+WEB_API AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const&);
+WEB_API WheelRoutingAdmission wheel_routing_admission_for(AsyncScrollingState const&);
+WEB_API StringView wheel_routing_admission_to_string(WheelRoutingAdmission);
+WEB_API bool blocks_wheel_event_at_position(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position);
+WEB_API WheelScrollAdmission admit_wheel_scroll(AsyncScrollingState const&, RefPtr<Painting::DisplayList> const&, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint position, Gfx::FloatPoint delta, bool blocking_wheel_event_regions_are_current);
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -114,9 +114,9 @@ void CompositorContextHandle::request_screenshot(NonnullRefPtr<Gfx::PaintingSurf
 
 CompositorHost::~CompositorHost() = default;
 
-OwnPtr<CompositorContextHandle> CompositorHost::create_context(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
+OwnPtr<CompositorContextHandle> CompositorHost::create_context(CompositorContextId context_id, Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
 {
-    auto context_id = allocate_context(page_id, page_presentation_registration);
+    register_context(context_id, page_id, page_presentation_registration);
     return adopt_own(*new CompositorContextHandle(*this, context_id));
 }
 

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -81,7 +81,7 @@ public:
     virtual ~CompositorHost();
 
     virtual void start(DisplayListPlayerType) = 0;
-    OwnPtr<CompositorContextHandle> create_context(Optional<u64> page_id, PagePresentationRegistration);
+    OwnPtr<CompositorContextHandle> create_context(CompositorContextId, Optional<u64> page_id, PagePresentationRegistration);
 
     virtual void destroy_context(CompositorContextId) = 0;
     virtual void stop_presenting_to_client(CompositorContextId) = 0;
@@ -110,7 +110,7 @@ protected:
     CompositorHost() = default;
 
 private:
-    virtual CompositorContextId allocate_context(Optional<u64> page_id, PagePresentationRegistration) = 0;
+    virtual void register_context(CompositorContextId, Optional<u64> page_id, PagePresentationRegistration) = 0;
 };
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -133,19 +133,6 @@ static void flush_surface(Gfx::PaintingSurface& surface)
     surface.flush();
 }
 
-static constexpr u64 page_presenting_context_id_tag = 1ull << 63;
-
-static CompositorContextId compositor_context_id_for_page(u64 page_id)
-{
-    VERIFY((page_id & page_presenting_context_id_tag) == 0);
-    return CompositorContextId { page_presenting_context_id_tag | page_id };
-}
-
-static bool is_page_presenting_context_id(CompositorContextId context_id)
-{
-    return (context_id.value() & page_presenting_context_id_tag) != 0;
-}
-
 class CompositorThread::ThreadData final : public AtomicRefCounted<ThreadData> {
 public:
     explicit ThreadData(NonnullRefPtr<CompositorMainThreadClient> main_thread_client)
@@ -172,10 +159,9 @@ public:
         VERIFY(!m_contexts.contains(context_id));
         if (page_presentation_registration == PagePresentationRegistration::Yes) {
             VERIFY(page_id.has_value());
-            VERIFY(context_id == compositor_context_id_for_page(*page_id));
         } else {
             VERIFY(!page_id.has_value());
-            VERIFY(!is_page_presenting_context_id(context_id));
+            VERIFY(!is_page_presenting_compositor_context_id(context_id));
         }
         m_contexts.set(context_id, adopt_ref(*new ContextState(page_id, page_presentation_registration)));
     }
@@ -190,6 +176,20 @@ public:
     {
         Sync::MutexLocker const locker { m_mutex };
         return m_contexts.get(context_id).value_or(nullptr);
+    }
+
+    RefPtr<ContextState> page_presenting_context_state(u64 page_id, Optional<CompositorContextId>* context_id = nullptr)
+    {
+        Sync::MutexLocker const locker { m_mutex };
+        for (auto& entry : m_contexts) {
+            auto& context = entry.value;
+            if (context->page_id != page_id || !context->presents_to_client)
+                continue;
+            if (context_id)
+                *context_id = entry.key;
+            return context;
+        }
+        return nullptr;
     }
 
     void stop_presenting_to_client(CompositorContextId context_id)
@@ -356,8 +356,8 @@ public:
 
     bool enqueue_async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
     {
-        auto context_id = compositor_context_id_for_page(page_id);
-        auto context_state = this->context_state(context_id);
+        Optional<CompositorContextId> context_id;
+        auto context_state = page_presenting_context_state(page_id, &context_id);
         if (!context_state)
             return false;
         auto& context = *context_state;
@@ -401,14 +401,14 @@ public:
 
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Compositor accepted async scroll enqueue at {},{} device delta {},{} for scroll node {} viewport={}x{} at {},{}",
             position.x(), position.y(), delta_in_device_pixels.x(), delta_in_device_pixels.y(), scroll_target.node_id->scroll_frame_index.value(), viewport_rect.width(), viewport_rect.height(), viewport_rect.x(), viewport_rect.y());
-        enqueue_command(context_id, AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
+        enqueue_command(*context_id, AsyncScrollByCommand { position, delta_in_device_pixels, viewport_rect, *scroll_target.node_id, {} });
         return true;
     }
 
     bool handle_viewport_scrollbar_mouse_event(u64 page_id, MouseEvent const& event)
     {
-        auto context_id = compositor_context_id_for_page(page_id);
-        auto context_state = this->context_state(context_id);
+        Optional<CompositorContextId> context_id;
+        auto context_state = page_presenting_context_state(page_id, &context_id);
         if (!context_state)
             return false;
         auto& context = *context_state;
@@ -432,7 +432,7 @@ public:
                 return false;
 
             schedule_viewport_scrollbar_present(context);
-            enqueue_command(context_id, ViewportScrollbarDragCommand { drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position });
+            enqueue_command(*context_id, ViewportScrollbarDragCommand { drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseMove: {
@@ -446,7 +446,7 @@ public:
             if (had_capture) {
                 if (!drag.has_value())
                     return false;
-                enqueue_command(context_id, ViewportScrollbarDragCommand { drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position });
+                enqueue_command(*context_id, ViewportScrollbarDragCommand { drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position });
                 return true;
             }
             auto hovered_scrollbar_index = [&] {
@@ -464,7 +464,7 @@ public:
             if (!drag.has_value())
                 return false;
             schedule_viewport_scrollbar_present(context);
-            enqueue_command(context_id, ViewportScrollbarDragCommand { drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position });
+            enqueue_command(*context_id, ViewportScrollbarDragCommand { drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position });
             return true;
         }
         case MouseEvent::Type::MouseLeave: {
@@ -1042,7 +1042,7 @@ public:
 
     void mark_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
     {
-        auto context_state = this->context_state(compositor_context_id_for_page(page_id));
+        auto context_state = page_presenting_context_state(page_id);
         if (!context_state)
             return;
         auto& context = *context_state;
@@ -1072,19 +1072,9 @@ CompositorThread::~CompositorThread()
     m_thread_data->exit();
 }
 
-CompositorContextId CompositorThread::create_context(Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
+void CompositorThread::register_context(CompositorContextId context_id, Optional<u64> page_id, PagePresentationRegistration page_presentation_registration)
 {
-    CompositorContextId context_id;
-    if (page_presentation_registration == PagePresentationRegistration::Yes) {
-        VERIFY(page_id.has_value());
-        context_id = compositor_context_id_for_page(*page_id);
-    } else {
-        VERIFY(!page_id.has_value());
-        context_id = allocate_compositor_context_id();
-        VERIFY(!is_page_presenting_context_id(context_id));
-    }
     m_thread_data->register_context(context_id, page_id, page_presentation_registration);
-    return context_id;
 }
 
 void CompositorThread::destroy_context(CompositorContextId context_id)

--- a/Libraries/LibWeb/Compositor/CompositorThread.h
+++ b/Libraries/LibWeb/Compositor/CompositorThread.h
@@ -55,7 +55,7 @@ public:
     bool async_scroll_by(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     bool handle_mouse_event(u64 page_id, MouseEvent const&);
 
-    CompositorContextId create_context(Optional<u64> page_id, PagePresentationRegistration);
+    void register_context(CompositorContextId, Optional<u64> page_id, PagePresentationRegistration);
     void destroy_context(CompositorContextId);
     void stop_presenting_to_client(CompositorContextId);
     void set_presentation_mode(CompositorContextId, PresentationMode);

--- a/Libraries/LibWeb/Compositor/Types.h
+++ b/Libraries/LibWeb/Compositor/Types.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/Optional.h>
@@ -22,10 +23,29 @@ namespace Web::Compositor {
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, CompositorContextId);
 AK_TYPEDEF_DISTINCT_ORDERED_ID(u64, ScreenshotRequestId);
 
+static constexpr u64 page_presenting_context_id_tag = 1ull << 63;
+
 inline CompositorContextId allocate_compositor_context_id()
 {
     static Atomic<u64> s_next_id { 1 };
     return CompositorContextId { s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed) };
+}
+
+inline CompositorContextId compositor_context_id_for_page(u64 page_id)
+{
+    VERIFY((page_id & page_presenting_context_id_tag) == 0);
+    return CompositorContextId { page_presenting_context_id_tag | page_id };
+}
+
+inline bool is_page_presenting_compositor_context_id(CompositorContextId context_id)
+{
+    return (context_id.value() & page_presenting_context_id_tag) != 0;
+}
+
+inline u64 page_id_for_compositor_context_id(CompositorContextId context_id)
+{
+    VERIFY(is_page_presenting_compositor_context_id(context_id));
+    return context_id.value() & ~page_presenting_context_id_tag;
 }
 
 enum class WindowResizingInProgress : u8 {

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -289,7 +289,8 @@ Navigable::Navigable(
         Optional<u64> page_id;
         if (page_presentation_registration == Compositor::PagePresentationRegistration::Yes)
             page_id = page->client().id();
-        m_compositor_context = page->compositor_host().create_context(page_id, page_presentation_registration);
+        auto context_id = page->client().allocate_compositor_context_id(page_presentation_registration);
+        m_compositor_context = page->compositor_host().create_context(context_id, page_id, page_presentation_registration);
     }
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -33,6 +33,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/DOM/RequestFullscreenError.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -417,6 +418,14 @@ public:
     virtual size_t screen_count() const = 0;
     virtual Queue<QueuedInputEvent>& input_event_queue() = 0;
     virtual void report_finished_handling_input_event(u64 page_id, EventResult event_was_handled) = 0;
+    virtual Compositor::CompositorContextId allocate_compositor_context_id(Compositor::PagePresentationRegistration page_presentation_registration)
+    {
+        if (page_presentation_registration == Compositor::PagePresentationRegistration::Yes)
+            return Compositor::compositor_context_id_for_page(id());
+        auto context_id = Compositor::allocate_compositor_context_id();
+        VERIFY(!Compositor::is_page_presenting_compositor_context_id(context_id));
+        return context_id;
+    }
     virtual void request_frame() = 0;
     virtual void page_did_change_title(Utf16String const&) { }
     virtual void page_did_change_url(URL::URL const&) { }

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -350,6 +350,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayList const& display
     return {};
 }
 
+template<>
 ErrorOr<void> encode(Encoder& encoder, NonnullRefPtr<Web::Painting::DisplayList> const& display_list)
 {
     return encoder.encode(*display_list);

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -64,7 +64,7 @@ private:
     ByteBuffer m_command_bytes;
 };
 
-class DisplayListPlayer {
+class WEB_API DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
 
@@ -239,6 +239,7 @@ WEB_API ErrorOr<Web::Painting::DisplayList::AsyncScrollingMetadata> decode(Decod
 
 template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::DisplayList const&);
+template<>
 WEB_API ErrorOr<void> encode(Encoder&, NonnullRefPtr<Web::Painting::DisplayList> const&);
 template<>
 WEB_API ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder&);

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -16,7 +16,7 @@ class SkPaint;
 
 namespace Web::Painting {
 
-class DisplayListPlayerSkia final : public DisplayListPlayer {
+class WEB_API DisplayListPlayerSkia final : public DisplayListPlayer {
 public:
     DisplayListPlayerSkia();
     explicit DisplayListPlayerSkia(RefPtr<Gfx::SkiaBackendContext>);

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -59,7 +59,7 @@ struct DisplayListResourceTransaction {
     Vector<DisplayListResourceId> display_list_ids_to_remove;
 };
 
-class DisplayListResourceStorage {
+class WEB_API DisplayListResourceStorage {
     AK_MAKE_NONCOPYABLE(DisplayListResourceStorage);
     AK_MAKE_DEFAULT_MOVABLE(DisplayListResourceStorage);
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -492,6 +492,15 @@ static ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Option
     return client;
 }
 
+static bool should_skip_compositor_process_ipc(RefPtr<CompositorClient> const& compositor_client)
+{
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::No)
+        return true;
+    if (!compositor_client && Core::EventLoop::current().was_exit_requested())
+        return true;
+    return false;
+}
+
 ErrorOr<void> Application::connect_web_content_to_compositor(WebContentClient& web_content_client)
 {
     if (m_browser_options.enable_compositor_process == EnableCompositorProcess::No)
@@ -505,6 +514,31 @@ ErrorOr<void> Application::connect_web_content_to_compositor(WebContentClient& w
     web_content_client.set_compositor_connection_id({}, response.web_content_connection_id());
     web_content_client.async_connect_to_compositor_process(response.take_handle());
     return {};
+}
+
+void Application::register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+{
+    if (should_skip_compositor_process_ipc(m_compositor_client))
+        return;
+    VERIFY(m_compositor_client);
+
+    auto web_content_connection_id = web_content_client.compositor_connection_id({});
+    if (!web_content_connection_id.has_value()) {
+        MUST(connect_web_content_to_compositor(web_content_client));
+        web_content_connection_id = web_content_client.compositor_connection_id({});
+    }
+    VERIFY(web_content_connection_id.has_value());
+
+    m_compositor_client->create_context(context_id, page_id, page_presentation_registration, *web_content_connection_id);
+}
+
+void Application::destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
+{
+    if (should_skip_compositor_process_ipc(m_compositor_client))
+        return;
+    VERIFY(m_compositor_client);
+
+    m_compositor_client->async_destroy_context(context_id);
 }
 
 ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process(ViewImplementation& view)

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/CompositorClient.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/HeadlessWebView.h>
 #include <LibWebView/HelperProcess.h>
@@ -97,6 +98,8 @@ Application::~Application()
     // Explicitly delete the observers first, as the observer destructors will refer to Application::the().
     m_settings_observer.clear();
     m_bookmark_store_observer.clear();
+    if (m_compositor_client)
+        m_compositor_client->on_death = nullptr;
 
     s_the = nullptr;
 }
@@ -164,6 +167,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     bool disable_http_memory_cache = false;
     bool disable_http_disk_cache = false;
     bool disable_content_blocker = false;
+    bool enable_compositor_process = false;
     Vector<StringView> content_blocker_list_paths;
     Optional<StringView> resource_substitution_map_path;
     bool enable_autoplay = false;
@@ -238,6 +242,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(disable_http_memory_cache, "Disable HTTP memory cache", "disable-http-memory-cache");
     args_parser.add_option(disable_http_disk_cache, "Disable HTTP disk cache", "disable-http-disk-cache");
     args_parser.add_option(disable_content_blocker, "Disable content blocker", "disable-content-blocker");
+    args_parser.add_option(enable_compositor_process, "Enable the out-of-process compositor", "enable-compositor-process");
     args_parser.add_option(Core::ArgsParser::Option {
         .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
         .help_string = "Path to a content blocker list. May be specified multiple times.",
@@ -353,6 +358,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
                 : OptionalNone()),
         .devtools_port = devtools_port,
         .enable_content_blocker = disable_content_blocker ? EnableContentBlocker::No : EnableContentBlocker::Yes,
+        .enable_compositor_process = enable_compositor_process ? EnableCompositorProcess::Yes : EnableCompositorProcess::No,
         .content_blocker_list_paths = move(content_blocker_list_paths_as_byte_strings),
     };
 
@@ -481,8 +487,24 @@ static ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Option
 
     client->async_connect_to_request_server(move(request_server_handle));
     client->async_connect_to_image_decoder(move(image_decoder_handle));
+    TRY(Application::the().connect_web_content_to_compositor(*client));
 
     return client;
+}
+
+ErrorOr<void> Application::connect_web_content_to_compositor(WebContentClient& web_content_client)
+{
+    if (m_browser_options.enable_compositor_process == EnableCompositorProcess::No)
+        return {};
+    if (web_content_client.compositor_connection_id({}).has_value())
+        return {};
+
+    VERIFY(m_compositor_client);
+    auto response = m_compositor_client->connect_web_content();
+
+    web_content_client.set_compositor_connection_id({}, response.web_content_connection_id());
+    web_content_client.async_connect_to_compositor_process(response.take_handle());
+    return {};
 }
 
 ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process(ViewImplementation& view)
@@ -582,9 +604,28 @@ ErrorOr<void> Application::launch_services()
 
     TRY(launch_request_server());
     TRY(launch_image_decoder_server());
+    if (m_browser_options.enable_compositor_process == EnableCompositorProcess::Yes)
+        TRY(launch_compositor_process());
 
     if (m_browser_options.devtools_port.has_value())
         TRY(launch_devtools_server());
+
+    return {};
+}
+
+ErrorOr<void> Application::launch_compositor_process()
+{
+    VERIFY(!m_compositor_client);
+    m_compositor_client = TRY(WebView::launch_compositor_process());
+    m_compositor_client->on_death = [this]() {
+        m_compositor_client = nullptr;
+
+        if (Core::EventLoop::current().was_exit_requested())
+            return;
+
+        dbgln("Compositor process died");
+        VERIFY_NOT_REACHED();
+    };
 
     return {};
 }
@@ -806,6 +847,12 @@ void Application::process_did_exit(Process&& process, Optional<int> exit_status)
     dbgln_if(WEBVIEW_PROCESS_DEBUG, "Process {} died, type: {}", process.pid(), process_name_from_type(process.type()));
 
     switch (process.type()) {
+    case ProcessType::Compositor:
+        if (auto client = process.client<CompositorClient>(); client.has_value()) {
+            if (auto on_death = move(client->on_death))
+                on_death();
+        }
+        break;
     case ProcessType::ImageDecoder:
         if (auto client = process.client<ImageDecoderClient::Client>(); client.has_value()) {
             dbgln_if(WEBVIEW_PROCESS_DEBUG, "Restart ImageDecoder process");

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -20,6 +20,7 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/Loader/UserAgent.h>
+#include <LibWeb/Page/InputEvent.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/CompositorClient.h>
 #include <LibWebView/CookieJar.h>
@@ -532,13 +533,43 @@ void Application::register_compositor_context(WebContentClient& web_content_clie
     m_compositor_client->create_context(context_id, page_id, page_presentation_registration, *web_content_connection_id);
 }
 
-void Application::destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
+void Application::update_compositor_viewport(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     if (should_skip_compositor_process_ipc(m_compositor_client))
         return;
     VERIFY(m_compositor_client);
 
-    m_compositor_client->async_destroy_context(context_id);
+    m_compositor_client->async_viewport_size_updated(context_id, viewport_size, true, window_resize_in_progress);
+}
+
+bool Application::send_async_scroll_to_compositor(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
+{
+    VERIFY(m_compositor_client);
+    return m_compositor_client->async_scroll_by(context_id, position, delta_in_device_pixels);
+}
+
+bool Application::handle_mouse_event_in_compositor(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
+{
+    VERIFY(m_compositor_client);
+    return m_compositor_client->handle_mouse_event(context_id, event.clone_without_browser_data());
+}
+
+void Application::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
+{
+    if (should_skip_compositor_process_ipc(m_compositor_client))
+        return;
+    VERIFY(m_compositor_client);
+
+    m_compositor_client->async_dispatch_mouse_event_to_web_content(context_id, event.clone_without_browser_data());
+}
+
+void Application::notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)
+{
+    if (should_skip_compositor_process_ipc(m_compositor_client))
+        return;
+    VERIFY(m_compositor_client);
+
+    m_compositor_client->async_presented_bitmap_ready_to_paint(context_id, bitmap_id);
 }
 
 ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process(ViewImplementation& view)

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -16,6 +16,8 @@
 #include <LibDatabase/Forward.h>
 #include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/Forward.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Size.h>
 #include <LibIPC/Forward.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibMain/Main.h>
@@ -39,6 +41,12 @@
 #if defined(AK_OS_MACOS)
 #    include <LibIPC/TransportBootstrapMach.h>
 #endif
+
+namespace Web {
+
+struct MouseEvent;
+
+}
 
 namespace WebView {
 
@@ -85,7 +93,11 @@ public:
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
     void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
-    void destroy_compositor_context(Web::Compositor::CompositorContextId);
+    void update_compositor_viewport(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress = Web::Compositor::WindowResizingInProgress::No);
+    bool send_async_scroll_to_compositor(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
+    bool handle_mouse_event_in_compositor(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
+    void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
+    void notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
 
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
     virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -25,6 +25,7 @@
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/Clipboard/SystemClipboard.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/FileDownloader.h>
@@ -83,6 +84,8 @@ public:
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
+    void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
+    void destroy_compositor_context(Web::Compositor::CompositorContextId);
 
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
     virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -82,6 +82,7 @@ public:
 #endif
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
+    ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
 
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
     virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
@@ -207,6 +208,7 @@ protected:
 private:
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
+    ErrorOr<void> launch_compositor_process();
     ErrorOr<void> launch_request_server();
     ErrorOr<void> launch_image_decoder_server();
     ErrorOr<void> launch_devtools_server();
@@ -277,6 +279,7 @@ private:
 
     RefPtr<Requests::RequestClient> m_request_server_client;
     RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
+    RefPtr<CompositorClient> m_compositor_client;
 
     RefPtr<WebContentClient> m_spare_web_content_process;
     bool m_has_queued_task_to_launch_spare_web_content_process { false };

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     WebUI/ProcessesUI.cpp
     WebUI/SettingsUI.cpp
     WebUI/VersionUI.cpp
+    CompositorClient.cpp
 )
 
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
@@ -48,12 +49,18 @@ embed_as_string(
 compile_ipc(UIProcessServer.ipc UIProcessServerEndpoint.h)
 compile_ipc(UIProcessClient.ipc UIProcessClientEndpoint.h)
 
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/Services/Compositor)
+
 if (NOT APPLE AND NOT CMAKE_INSTALL_LIBEXECDIR STREQUAL "libexec")
     set_source_files_properties(Utilities.cpp PROPERTIES COMPILE_DEFINITIONS LADYBIRD_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}")
 endif()
 
 set(GENERATED_SOURCES
     ${GENERATED_SOURCES}
+    ../../Services/Compositor/CompositorControlClientEndpoint.h
+    ../../Services/Compositor/CompositorControlServerEndpoint.h
+    ../../Services/Compositor/CompositorWebContentClientEndpoint.h
+    ../../Services/Compositor/CompositorWebContentServerEndpoint.h
     ../../Services/RequestServer/RequestClientEndpoint.h
     ../../Services/RequestServer/RequestServerEndpoint.h
     ../../Services/WebContent/CompositorClientEndpoint.h
@@ -71,6 +78,10 @@ set(GENERATED_SOURCES
     UIProcessServerEndpoint.h
 )
 
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorControlClient.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorControlClientEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorControlServer.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorControlServerEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorWebContentClient.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorWebContentClientEndpoint.h)
+compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/Compositor/CompositorWebContentServer.ipc ${CMAKE_BINARY_DIR}/Services/Compositor/CompositorWebContentServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/CompositorClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/CompositorClientEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/CompositorServer.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/CompositorServerEndpoint.h)
 compile_ipc(${LADYBIRD_SOURCE_DIR}/Services/WebContent/WebContentClient.ipc ${CMAKE_BINARY_DIR}/Services/WebContent/WebContentClientEndpoint.h)

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/CompositorClient.h>
+
+#include <LibCore/EventLoop.h>
+
+namespace WebView {
+
+CompositorClient::CompositorClient(NonnullOwnPtr<IPC::Transport> transport)
+    : IPC::ConnectionToServer<CompositorControlClientEndpoint, CompositorControlServerEndpoint>(*this, move(transport))
+{
+}
+
+void CompositorClient::die()
+{
+    if (auto callback = move(on_death)) {
+        Core::deferred_invoke([callback = move(callback)]() mutable {
+            callback();
+        });
+    }
+}
+
+void CompositorClient::did_connect_web_content(i32)
+{
+}
+
+}

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -7,6 +7,7 @@
 #include <LibWebView/CompositorClient.h>
 
 #include <LibCore/EventLoop.h>
+#include <LibWebView/WebContentClient.h>
 
 namespace WebView {
 
@@ -24,12 +25,29 @@ void CompositorClient::die()
     }
 }
 
-void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32, Gfx::SharedImage, i32, Gfx::SharedImage)
+void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)
 {
+    auto web_content_client = WebContentClient::client_for_compositor_context_id(context_id);
+    if (!web_content_client.has_value())
+        return;
+
+    auto page_id = web_content_client->page_id_for_compositor_context_id(context_id);
+    VERIFY(page_id.has_value());
+
+    web_content_client->did_present_backing_stores(*page_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
 }
 
-void CompositorClient::did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect, i32)
+void CompositorClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id)
 {
+    auto web_content_client = WebContentClient::client_for_compositor_context_id(context_id);
+    if (web_content_client.has_value()) {
+        auto page_id = web_content_client->page_id_for_compositor_context_id(context_id);
+        VERIFY(page_id.has_value());
+        web_content_client->did_present_bitmap(*page_id, content_rect, bitmap_id);
+        return;
+    }
+
+    async_presented_bitmap_ready_to_paint(context_id, bitmap_id);
 }
 
 }

--- a/Libraries/LibWebView/CompositorClient.cpp
+++ b/Libraries/LibWebView/CompositorClient.cpp
@@ -24,7 +24,11 @@ void CompositorClient::die()
     }
 }
 
-void CompositorClient::did_connect_web_content(i32)
+void CompositorClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32, Gfx::SharedImage, i32, Gfx::SharedImage)
+{
+}
+
+void CompositorClient::did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect, i32)
 {
 }
 

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -9,7 +9,10 @@
 #include <AK/Function.h>
 #include <Compositor/CompositorControlClientEndpoint.h>
 #include <Compositor/CompositorControlServerEndpoint.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/SharedImage.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWebView/Forward.h>
 
 namespace WebView {
@@ -29,7 +32,8 @@ public:
 private:
     virtual void die() override;
 
-    virtual void did_connect_web_content(i32 web_content_connection_id) override;
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) override;
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) override;
 };
 
 }

--- a/Libraries/LibWebView/CompositorClient.h
+++ b/Libraries/LibWebView/CompositorClient.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <Compositor/CompositorControlClientEndpoint.h>
+#include <Compositor/CompositorControlServerEndpoint.h>
+#include <LibIPC/ConnectionToServer.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+class WEBVIEW_API CompositorClient final
+    : public IPC::ConnectionToServer<CompositorControlClientEndpoint, CompositorControlServerEndpoint>
+    , public CompositorControlClientEndpoint {
+    C_OBJECT_ABSTRACT(CompositorClient)
+
+public:
+    using InitTransport = Messages::CompositorControlServer::InitTransport;
+
+    explicit CompositorClient(NonnullOwnPtr<IPC::Transport>);
+
+    Function<void()> on_death;
+
+private:
+    virtual void die() override;
+
+    virtual void did_connect_web_content(i32 web_content_connection_id) override;
+};
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -16,6 +16,7 @@ class Action;
 class Application;
 class Autocomplete;
 class BookmarkStore;
+class CompositorClient;
 class CookieJar;
 class HistoryStore;
 class Menu;

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -60,7 +60,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         m_viewport_size = size.template to_type<Web::DevicePixels>();
 
         client().async_set_window_size(m_client_state.page_index, m_viewport_size);
-        client().async_set_viewport(m_client_state.page_index, m_viewport_size, m_device_pixel_ratio, Web::ViewportIsFullscreen::No);
+        handle_resize();
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -79,7 +79,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
         client().async_set_window_position(m_client_state.page_index, screen_rect.location());
         client().async_set_window_size(m_client_state.page_index, screen_rect.size());
-        client().async_set_viewport(m_client_state.page_index, screen_rect.size(), m_device_pixel_ratio, m_is_fullscreen);
+        handle_resize();
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -91,7 +91,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
         client().async_set_window_position(m_client_state.page_index, screen_rect.location());
         client().async_set_window_size(m_client_state.page_index, screen_rect.size());
-        client().async_set_viewport(m_client_state.page_index, screen_rect.size(), m_device_pixel_ratio, Web::ViewportIsFullscreen::Yes);
+        handle_resize();
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -102,7 +102,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
         client().async_set_window_position(m_client_state.page_index, m_previous_dimensions.location());
         client().async_set_window_size(m_client_state.page_index, m_previous_dimensions.size());
-        client().async_set_viewport(m_client_state.page_index, m_previous_dimensions.size(), m_device_pixel_ratio, Web::ViewportIsFullscreen::No);
+        handle_resize();
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -171,7 +171,7 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
     ViewImplementation::initialize_client(create_new_client);
 
     client().async_update_system_theme(m_client_state.page_index, m_theme);
-    client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
+    handle_resize();
     client().async_set_window_size(m_client_state.page_index, viewport_size());
     client().async_update_screen_rects(m_client_state.page_index, { { screen_rect } }, 0);
 }
@@ -181,7 +181,7 @@ void HeadlessWebView::reset_viewport_size(Web::DevicePixelSize size)
     m_viewport_size = size;
 
     client().async_set_window_size(m_client_state.page_index, m_viewport_size);
-    client().async_set_viewport(m_client_state.page_index, m_viewport_size, m_device_pixel_ratio, m_is_fullscreen);
+    handle_resize();
 
     client().async_did_update_window_rect(m_client_state.page_index);
 }

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/CompositorClient.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/Utilities.h>
 
@@ -163,6 +164,25 @@ ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(
     }
 
     return launch_server_process<ImageDecoderClient::Client>("ImageDecoder"sv, arguments);
+}
+
+ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process()
+{
+    auto const& web_content_options = WebView::Application::web_content_options();
+
+    Vector<ByteString> arguments;
+    if (web_content_options.force_cpu_painting == WebView::ForceCPUPainting::Yes)
+        arguments.append("--force-cpu-painting"sv);
+    if (web_content_options.force_fontconfig == WebView::ForceFontconfig::Yes)
+        arguments.append("--force-fontconfig"sv);
+    if (web_content_options.enable_async_scrolling == EnableAsyncScrolling::No)
+        arguments.append("--disable-async-scrolling"sv);
+    if (auto server = mach_server_name(); server.has_value()) {
+        arguments.append("--mach-server-name"sv);
+        arguments.append(server.value());
+    }
+
+    return launch_server_process<WebView::CompositorClient>("Compositor"sv, move(arguments));
 }
 
 ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType type)

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -121,6 +121,8 @@ static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_proc
         arguments.append("--disable-scrollbar-painting"sv);
     if (web_content_options.enable_async_scrolling == EnableAsyncScrolling::No)
         arguments.append("--disable-async-scrolling"sv);
+    if (browser_options.enable_compositor_process == EnableCompositorProcess::Yes)
+        arguments.append("--enable-compositor-process"sv);
     if (web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)
         arguments.append("--tuple-file-origins"sv);
 

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -24,6 +24,7 @@ WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content
 WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_spare_web_content_process();
 
 WEBVIEW_API ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
+WEBVIEW_API ErrorOr<NonnullRefPtr<WebView::CompositorClient>> launch_compositor_process();
 WEBVIEW_API ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(Web::Bindings::AgentType);
 WEBVIEW_API ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process();
 

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -74,6 +74,11 @@ enum class EnableContentBlocker {
     Yes,
 };
 
+enum class EnableCompositorProcess {
+    No,
+    Yes,
+};
+
 struct BrowserOptions {
     Vector<URL::URL> urls;
     Vector<ByteString> raw_urls;
@@ -92,6 +97,7 @@ struct BrowserOptions {
     Optional<DNSSettings> dns_settings {};
     Optional<u16> devtools_port;
     EnableContentBlocker enable_content_blocker { EnableContentBlocker::Yes };
+    EnableCompositorProcess enable_compositor_process { EnableCompositorProcess::No };
     Vector<ByteString> content_blocker_list_paths {};
 };
 

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -17,6 +17,8 @@ ProcessType process_type_from_name(StringView name)
 {
     if (name == "Browser"sv)
         return ProcessType::Browser;
+    if (name == "Compositor"sv)
+        return ProcessType::Compositor;
     if (name == "WebContent"sv)
         return ProcessType::WebContent;
     if (name == "WebWorker"sv)
@@ -35,6 +37,8 @@ StringView process_name_from_type(ProcessType type)
     switch (type) {
     case ProcessType::Browser:
         return "Browser"sv;
+    case ProcessType::Compositor:
+        return "Compositor"sv;
     case ProcessType::WebContent:
         return "WebContent"sv;
     case ProcessType::WebWorker:

--- a/Libraries/LibWebView/ProcessType.h
+++ b/Libraries/LibWebView/ProcessType.h
@@ -12,6 +12,7 @@ namespace WebView {
 
 enum class ProcessType : u8 {
     Browser,
+    Compositor,
     WebContent,
     WebWorker,
     RequestServer,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -292,7 +292,7 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
                 mouse_event->async_scroll_performed_default_action = true;
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor wheel bypass result for page {}: {}",
                 m_client_state.page_index, mouse_event->async_scroll_performed_default_action ? "accepted"sv : "rejected"sv);
-        } else if (client().send_mouse_event_to_compositor(m_client_state.page_index, *mouse_event)) {
+        } else if (client().handle_mouse_event_in_compositor(m_client_state.page_index, *mouse_event)) {
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor handled mouse event for page {} at {},{}",
                 m_client_state.page_index, mouse_event->position.x().value(), mouse_event->position.y().value());
             return;
@@ -309,7 +309,7 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
             client().async_key_event(m_client_state.page_index, event.clone_without_browser_data());
         },
         [this](Web::MouseEvent const& event) {
-            client().async_mouse_event(m_client_state.page_index, event.clone_without_browser_data());
+            client().dispatch_mouse_event_to_web_content(m_client_state.page_index, event);
         },
         [this](Web::DragEvent& event) {
             auto cloned_event = event.clone_without_browser_data();
@@ -720,6 +720,8 @@ void ViewImplementation::apply_zoom_for_current_host()
 void ViewImplementation::handle_resize()
 {
     client().async_set_viewport(page_id(), viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes)
+        Application::the().update_compositor_viewport(client().compositor_context_id_for_page(page_id()), viewport_size().to_type<int>());
 }
 
 void ViewImplementation::initialize_client(CreateNewClient create_new_client)
@@ -739,6 +741,10 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+        auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
+        Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
+    }
     client().async_set_document_cookie_version_buffer(m_client_state.page_index, m_document_cookie_version_buffer);
 
     if (auto webdriver_endpoint = Application::browser_options().webdriver_endpoint; webdriver_endpoint.has_value())

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -117,9 +117,70 @@ WebContentClient::~WebContentClient()
     s_clients.remove(this);
 }
 
+Optional<WebContentClient&> WebContentClient::client_for_compositor_context_id(Web::Compositor::CompositorContextId context_id)
+{
+    Optional<WebContentClient&> client;
+    for_each_client([&](auto& candidate) {
+        if (!candidate.page_id_for_compositor_context_id(context_id).has_value())
+            return IterationDecision::Continue;
+        client = candidate;
+        return IterationDecision::Break;
+    });
+    return client;
+}
+
 void WebContentClient::die()
 {
     // Intentionally empty. Restart is handled at another level.
+}
+
+Web::Compositor::CompositorContextId WebContentClient::compositor_context_id_for_page(u64 page_id)
+{
+    if (auto context_id = m_page_compositor_context_ids.get(page_id); context_id.has_value())
+        return *context_id;
+
+    auto context_id = Web::Compositor::allocate_compositor_context_id();
+    VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
+    m_compositor_context_ids.set(context_id);
+    m_page_compositor_context_ids.set(page_id, context_id);
+    m_page_ids_for_compositor_context_ids.set(context_id, page_id);
+    Application::the().register_compositor_context(*this, context_id, page_id, Web::Compositor::PagePresentationRegistration::Yes);
+    return context_id;
+}
+
+Optional<u64> WebContentClient::page_id_for_compositor_context_id(Web::Compositor::CompositorContextId context_id) const
+{
+    if (auto page_id = m_page_ids_for_compositor_context_ids.get(context_id); page_id.has_value())
+        return *page_id;
+    return {};
+}
+
+Messages::WebContentClient::AllocateCompositorContextIdResponse WebContentClient::allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+{
+    if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes)
+        return compositor_context_id_for_page(page_id);
+
+    auto context_id = Web::Compositor::allocate_compositor_context_id();
+    VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
+    m_compositor_context_ids.set(context_id);
+    Application::the().register_compositor_context(*this, context_id, {}, page_presentation_registration);
+    return context_id;
+}
+
+void WebContentClient::destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
+{
+    if (!forget_compositor_context(context_id))
+        return;
+    Application::the().destroy_compositor_context(context_id);
+}
+
+bool WebContentClient::forget_compositor_context(Web::Compositor::CompositorContextId context_id)
+{
+    if (!m_compositor_context_ids.remove(context_id))
+        return false;
+    if (auto page_id = m_page_ids_for_compositor_context_ids.take(context_id); page_id.has_value())
+        m_page_compositor_context_ids.remove(*page_id);
+    return true;
 }
 
 void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
@@ -142,6 +203,8 @@ void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 
 void WebContentClient::unregister_view(u64 page_id)
 {
+    if (auto context_id = m_page_compositor_context_ids.get(page_id); context_id.has_value())
+        forget_compositor_context(*context_id);
     m_views.remove(page_id);
     m_history_recorded_urls_for_current_load.remove(page_id);
     if (m_views.is_empty())
@@ -153,8 +216,17 @@ void WebContentClient::web_ui_disconnected(Badge<WebUI>)
     m_web_ui.clear();
 }
 
+void WebContentClient::destroy_all_compositor_contexts()
+{
+    m_compositor_context_ids.clear();
+    m_page_compositor_context_ids.clear();
+    m_page_ids_for_compositor_context_ids.clear();
+}
+
 void WebContentClient::notify_all_views_of_crash()
 {
+    destroy_all_compositor_contexts();
+
     // Collect view IDs first, then use deferred_invoke to handle crashes safely
     // (avoids signal handler deadlock and allows views to be looked up by ID
     // in case they're destroyed before the deferred_invoke runs).

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -101,14 +101,16 @@ WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, View
 {
     s_clients.set(this);
     m_views.set(0, view);
-    initialize_compositor_connection(*this);
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::No)
+        initialize_compositor_connection(*this);
 }
 
 WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
 {
     s_clients.set(this);
-    initialize_compositor_connection(*this);
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::No)
+        initialize_compositor_connection(*this);
 }
 
 WebContentClient::~WebContentClient()
@@ -167,11 +169,9 @@ Messages::WebContentClient::AllocateCompositorContextIdResponse WebContentClient
     return context_id;
 }
 
-void WebContentClient::destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
+void WebContentClient::did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
 {
-    if (!forget_compositor_context(context_id))
-        return;
-    Application::the().destroy_compositor_context(context_id);
+    forget_compositor_context(context_id);
 }
 
 bool WebContentClient::forget_compositor_context(Web::Compositor::CompositorContextId context_id)
@@ -249,32 +249,63 @@ void WebContentClient::notify_all_views_of_crash()
 
 bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
-    auto connection = compositor_connections().get(this);
-    VERIFY(connection.has_value());
-    VERIFY(connection.value()->is_open());
-
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
-    auto handled = connection.value()->async_scroll_by(page_id, position, delta_in_device_pixels);
+
+    bool handled = false;
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+        handled = Application::the().send_async_scroll_to_compositor(compositor_context_id_for_page(page_id), position, delta_in_device_pixels);
+    } else {
+        auto connection = compositor_connections().get(this);
+        VERIFY(connection.has_value());
+        VERIFY(connection.value()->is_open());
+        handled = connection.value()->async_scroll_by(page_id, position, delta_in_device_pixels);
+    }
+
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC async_scroll_by page {} returned {} in {} us",
         page_id, handled, timer.elapsed_time().to_microseconds());
     return handled;
 }
 
-bool WebContentClient::send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const& event)
+bool WebContentClient::handle_mouse_event_in_compositor(u64 page_id, Web::MouseEvent const& event)
 {
-    auto connection = compositor_connections().get(this);
-    VERIFY(connection.has_value());
-    VERIFY(connection.value()->is_open());
-
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
-    auto handled = connection.value()->mouse_event(page_id, event.clone_without_browser_data());
+
+    bool handled = false;
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+        handled = Application::the().handle_mouse_event_in_compositor(compositor_context_id_for_page(page_id), event);
+    } else {
+        auto connection = compositor_connections().get(this);
+        VERIFY(connection.has_value());
+        VERIFY(connection.value()->is_open());
+        handled = connection.value()->mouse_event(page_id, event.clone_without_browser_data());
+    }
+
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI compositor IPC mouse_event page {} returned {} in {} us",
         page_id, handled, timer.elapsed_time().to_microseconds());
     return handled;
 }
 
+void WebContentClient::dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const& event)
+{
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+        Application::the().dispatch_mouse_event_to_web_content(compositor_context_id_for_page(page_id), event);
+        return;
+    }
+
+    async_mouse_event(page_id, event.clone_without_browser_data());
+}
+
 void WebContentClient::notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
 {
+    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+        auto context_id = m_page_compositor_context_ids.get(page_id);
+        if (!context_id.has_value())
+            return;
+
+        Application::the().notify_compositor_presented_bitmap_ready_to_paint(*context_id, bitmap_id);
+        return;
+    }
+
     VERIFY(try_notify_presented_bitmap_ready_to_paint(*this, page_id, bitmap_id));
 }
 
@@ -287,7 +318,10 @@ void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, i32 bi
     } else {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI dropping did_paint for page {} bitmap {}: no view",
             page_id, bitmap_id);
-        try_notify_presented_bitmap_ready_to_paint(*this, page_id, bitmap_id);
+        if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes)
+            notify_presented_bitmap_ready_to_paint(page_id, bitmap_id);
+        else
+            try_notify_presented_bitmap_ready_to_paint(*this, page_id, bitmap_id);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -128,6 +128,11 @@ void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
     m_views.set(0, view);
 }
 
+void WebContentClient::set_compositor_connection_id(Badge<Application>, i32 compositor_connection_id)
+{
+    m_compositor_connection_id = compositor_connection_id;
+}
+
 void WebContentClient::register_view(u64 page_id, ViewImplementation& view)
 {
     VERIFY(page_id > 0);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -21,6 +21,7 @@
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
@@ -48,6 +49,8 @@ public:
     static void for_each_client(Callback callback);
 
     static size_t client_count() { return s_clients.size(); }
+    static Optional<WebContentClient&> client_for_compositor_context_id(Web::Compositor::CompositorContextId);
+
     explicit WebContentClient(NonnullOwnPtr<IPC::Transport>);
     WebContentClient(NonnullOwnPtr<IPC::Transport>, ViewImplementation&);
     ~WebContentClient();
@@ -63,6 +66,8 @@ public:
     bool has_views() const { return !m_views.is_empty(); }
 
     void notify_all_views_of_crash();
+    Web::Compositor::CompositorContextId compositor_context_id_for_page(u64 page_id);
+    Optional<u64> page_id_for_compositor_context_id(Web::Compositor::CompositorContextId) const;
     bool send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     bool send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const&);
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
@@ -74,8 +79,13 @@ public:
 
 private:
     void maybe_record_history_visit_for_current_load(u64 page_id, URL::URL const&, Optional<String> title, StringView reason);
+    bool forget_compositor_context(Web::Compositor::CompositorContextId);
+    void destroy_all_compositor_contexts();
+
     virtual void die() override;
 
+    virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
+    virtual void destroy_compositor_context(Web::Compositor::CompositorContextId) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
@@ -167,6 +177,9 @@ private:
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
+    HashTable<Web::Compositor::CompositorContextId> m_compositor_context_ids;
+    HashMap<u64, Web::Compositor::CompositorContextId> m_page_compositor_context_ids;
+    HashMap<Web::Compositor::CompositorContextId, u64> m_page_ids_for_compositor_context_ids;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
     Optional<i32> m_compositor_connection_id;
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -69,7 +69,8 @@ public:
     Web::Compositor::CompositorContextId compositor_context_id_for_page(u64 page_id);
     Optional<u64> page_id_for_compositor_context_id(Web::Compositor::CompositorContextId) const;
     bool send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
-    bool send_mouse_event_to_compositor(u64 page_id, Web::MouseEvent const&);
+    bool handle_mouse_event_in_compositor(u64 page_id, Web::MouseEvent const&);
+    void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&);
     void notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id);
     void did_present_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
     void did_present_bitmap(u64 page_id, Gfx::IntRect, i32 bitmap_id);
@@ -85,7 +86,7 @@ private:
     virtual void die() override;
 
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
-    virtual void destroy_compositor_context(Web::Compositor::CompositorContextId) override;
+    virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -48,7 +48,6 @@ public:
     static void for_each_client(Callback callback);
 
     static size_t client_count() { return s_clients.size(); }
-
     explicit WebContentClient(NonnullOwnPtr<IPC::Transport>);
     WebContentClient(NonnullOwnPtr<IPC::Transport>, ViewImplementation&);
     ~WebContentClient();
@@ -75,7 +74,6 @@ public:
 
 private:
     void maybe_record_history_visit_for_current_load(u64 page_id, URL::URL const&, Optional<String> title, StringView reason);
-
     virtual void die() override;
 
     virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -54,6 +54,8 @@ public:
     ~WebContentClient();
 
     void assign_view(Badge<Application>, ViewImplementation&);
+    void set_compositor_connection_id(Badge<Application>, i32);
+    Optional<i32> compositor_connection_id(Badge<Application>) const { return m_compositor_connection_id; }
     void register_view(u64 page_id, ViewImplementation&);
     void unregister_view(u64 page_id);
 
@@ -168,6 +170,7 @@ private:
 
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;
+    Optional<i32> m_compositor_connection_id;
 
     ProcessHandle m_process_handle;
 

--- a/Services/CMakeLists.txt
+++ b/Services/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(Compositor)
 add_subdirectory(ImageDecoder)
 add_subdirectory(RequestServer)
 add_subdirectory(WebContent)

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    CompositorState.cpp
     ConnectionFromClient.cpp
     ConnectionFromWebContent.cpp
 )
@@ -18,8 +19,8 @@ add_executable(Compositor main.cpp)
 target_include_directories(compositorservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../..)
 target_include_directories(compositorservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/)
 
-target_link_libraries(Compositor PRIVATE compositorservice LibCore LibGfx LibIPC LibMain LibWebView)
-target_link_libraries(compositorservice PRIVATE LibCore LibIPC)
+target_link_libraries(Compositor PRIVATE compositorservice LibCore LibMain LibWebView)
+target_link_libraries(compositorservice PRIVATE LibCore LibGfx LibIPC LibMedia LibWeb)
 
 if (WIN32)
     target_include_directories(Compositor PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)

--- a/Services/Compositor/CMakeLists.txt
+++ b/Services/Compositor/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(SOURCES
+    ConnectionFromClient.cpp
+    ConnectionFromWebContent.cpp
+)
+
+set(GENERATED_SOURCES
+    CompositorControlClientEndpoint.h
+    CompositorControlServerEndpoint.h
+    CompositorWebContentClientEndpoint.h
+    CompositorWebContentServerEndpoint.h
+)
+
+add_library(compositorservice STATIC ${SOURCES} ${GENERATED_SOURCES})
+ladybird_generated_sources(compositorservice)
+
+add_executable(Compositor main.cpp)
+
+target_include_directories(compositorservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../..)
+target_include_directories(compositorservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/)
+
+target_link_libraries(Compositor PRIVATE compositorservice LibCore LibGfx LibIPC LibMain LibWebView)
+target_link_libraries(compositorservice PRIVATE LibCore LibIPC)
+
+if (WIN32)
+    target_include_directories(Compositor PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)
+    target_include_directories(compositorservice PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)
+    ladybird_windows_bin(Compositor CONSOLE)
+endif()

--- a/Services/Compositor/CompositorControlClient.ipc
+++ b/Services/Compositor/CompositorControlClient.ipc
@@ -1,4 +1,9 @@
+#include <LibGfx/Rect.h>
+#include <LibGfx/SharedImage.h>
+#include <LibWeb/Compositor/Types.h>
+
 endpoint CompositorControlClient
 {
-    did_connect_web_content(i32 web_content_connection_id) =|
+    did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store) =|
+    did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorControlClient.ipc
+++ b/Services/Compositor/CompositorControlClient.ipc
@@ -1,0 +1,4 @@
+endpoint CompositorControlClient
+{
+    did_connect_web_content(i32 web_content_connection_id) =|
+}

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -1,0 +1,8 @@
+#include <LibIPC/TransportHandle.h>
+
+endpoint CompositorControlServer
+{
+    init_transport(int peer_pid) => (int peer_pid)
+
+    connect_web_content() => (IPC::TransportHandle handle, i32 web_content_connection_id)
+}

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -12,7 +12,6 @@ endpoint CompositorControlServer
     connect_web_content() => (IPC::TransportHandle handle, i32 web_content_connection_id)
 
     create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id) => ()
-    destroy_context(Web::Compositor::CompositorContextId context_id) =|
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
 

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -1,8 +1,23 @@
+#include <AK/Optional.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Size.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Page/InputEvent.h>
 
 endpoint CompositorControlServer
 {
     init_transport(int peer_pid) => (int peer_pid)
 
     connect_web_content() => (IPC::TransportHandle handle, i32 web_content_connection_id)
+
+    create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id) => ()
+    destroy_context(Web::Compositor::CompositorContextId context_id) =|
+
+    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
+
+    handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool handled)
+    dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) =|
+    async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) => (bool handled)
+    presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -1,0 +1,930 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StdLibExtras.h>
+#include <Compositor/CompositorState.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Color.h>
+#include <LibGfx/PainterSkia.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibGfx/Path.h>
+#include <LibWeb/Page/InputEvent.h>
+
+namespace Compositor {
+
+static void set_or_append_pending_scroll_offset(Vector<Web::Compositor::AsyncScrollOffset>& pending_scroll_offsets, Web::Compositor::AsyncScrollOffset const& scroll_offset)
+{
+    for (auto& existing : pending_scroll_offsets) {
+        if (existing.stable_node_id == scroll_offset.stable_node_id) {
+            existing.compositor_scroll_offset = scroll_offset.compositor_scroll_offset;
+            existing.unadopted_scroll_delta.translate_by(scroll_offset.unadopted_scroll_delta);
+            return;
+        }
+    }
+    pending_scroll_offsets.append(scroll_offset);
+}
+
+static Gfx::Orientation orientation_for_scrollbar(Web::Compositor::ViewportScrollbar const& scrollbar)
+{
+    return scrollbar.vertical ? Gfx::Orientation::Vertical : Gfx::Orientation::Horizontal;
+}
+
+struct ViewportScrollbarIdentity {
+    Web::Compositor::AsyncScrollNodeID scroll_node_id;
+    bool vertical { false };
+};
+
+static ViewportScrollbarIdentity viewport_scrollbar_identity(Web::Compositor::ViewportScrollbar const& scrollbar)
+{
+    return { scrollbar.scroll_node_id, scrollbar.vertical };
+}
+
+static Optional<ViewportScrollbarIdentity> viewport_scrollbar_identity_at(ReadonlySpan<Web::Compositor::ViewportScrollbar> scrollbars, Optional<size_t> scrollbar_index)
+{
+    if (!scrollbar_index.has_value() || *scrollbar_index >= scrollbars.size())
+        return {};
+    return viewport_scrollbar_identity(scrollbars[*scrollbar_index]);
+}
+
+static Optional<size_t> find_viewport_scrollbar_index(ReadonlySpan<Web::Compositor::ViewportScrollbar> scrollbars, ViewportScrollbarIdentity identity)
+{
+    for (size_t i = 0; i < scrollbars.size(); ++i) {
+        if (scrollbars[i].scroll_node_id == identity.scroll_node_id && scrollbars[i].vertical == identity.vertical)
+            return i;
+    }
+    return {};
+}
+
+static Gfx::IntRect scrollbar_gutter_rect(Web::Compositor::ViewportScrollbar const& scrollbar, bool expanded)
+{
+    return expanded ? scrollbar.expanded_gutter_rect : scrollbar.gutter_rect;
+}
+
+static double scrollbar_scroll_size(Web::Compositor::ViewportScrollbar const& scrollbar, bool expanded)
+{
+    return expanded ? scrollbar.expanded_scroll_size : scrollbar.scroll_size;
+}
+
+static Gfx::IntRect translated_thumb_rect(Web::Compositor::ViewportScrollbar const& scrollbar, Gfx::FloatPoint scroll_offset, bool expanded)
+{
+    auto orientation = orientation_for_scrollbar(scrollbar);
+    auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
+    thumb_rect.translate_primary_offset_for_orientation(orientation, static_cast<int>(scroll_offset.primary_offset_for_orientation(orientation) * scrollbar_scroll_size(scrollbar, expanded)));
+    return thumb_rect;
+}
+
+static Gfx::IntRect translated_thumb_rect(Web::Compositor::ViewportScrollbar const& scrollbar, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot, bool expanded)
+{
+    auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
+    auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);
+    auto device_offset = scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_frame_index);
+    if (scrollbar.vertical)
+        thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * scroll_size));
+    else
+        thumb_rect.translate_by(static_cast<int>(-device_offset.x() * scroll_size), 0);
+    return thumb_rect;
+}
+
+static Gfx::IntRect scrollbar_hit_rect(Web::Compositor::ViewportScrollbar const& scrollbar, Gfx::FloatPoint scroll_offset)
+{
+    static constexpr int scrollbar_hit_slop = 4;
+
+    auto rect = translated_thumb_rect(scrollbar, scroll_offset, false).united(translated_thumb_rect(scrollbar, scroll_offset, true));
+    auto expanded_gutter_rect = scrollbar_gutter_rect(scrollbar, true);
+    if (!expanded_gutter_rect.is_empty())
+        rect.unite(expanded_gutter_rect);
+    rect.inflate(scrollbar_hit_slop, scrollbar_hit_slop);
+    return rect;
+}
+
+static Gfx::Path rounded_rect_path(Gfx::FloatRect rect, float radius)
+{
+    Gfx::Path path;
+    if (rect.is_empty())
+        return path;
+
+    radius = min(min(radius, rect.width() / 2), rect.height() / 2);
+
+    path.move_to({ rect.left() + radius, rect.top() });
+    if (radius > 0) {
+        path.line_to({ rect.right() - radius, rect.top() });
+        path.arc_to({ rect.right(), rect.top() + radius }, radius, false, true);
+        path.line_to({ rect.right(), rect.bottom() - radius });
+        path.arc_to({ rect.right() - radius, rect.bottom() }, radius, false, true);
+        path.line_to({ rect.left() + radius, rect.bottom() });
+        path.arc_to({ rect.left(), rect.bottom() - radius }, radius, false, true);
+        path.line_to({ rect.left(), rect.top() + radius });
+        path.arc_to({ rect.left() + radius, rect.top() }, radius, false, true);
+    } else {
+        path.line_to({ rect.right(), rect.top() });
+        path.line_to({ rect.right(), rect.bottom() });
+        path.line_to({ rect.left(), rect.bottom() });
+        path.line_to({ rect.left(), rect.top() });
+    }
+    path.close();
+    return path;
+}
+
+static void paint_viewport_scrollbar(Gfx::Painter& painter, Web::Compositor::ViewportScrollbar const& scrollbar, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot, bool expanded)
+{
+    painter.fill_rect(scrollbar_gutter_rect(scrollbar, expanded).to_type<float>(), scrollbar.track_color);
+
+    auto thumb_rect = translated_thumb_rect(scrollbar, scroll_state_snapshot, expanded);
+    auto thumb_path = rounded_rect_path(thumb_rect.to_type<float>(), static_cast<float>(thumb_rect.width()) / 2);
+    painter.fill_path(thumb_path, scrollbar.thumb_color, Gfx::WindingRule::Nonzero);
+    painter.stroke_path(thumb_path, scrollbar.thumb_color.lightened(), 1);
+}
+
+NonnullRefPtr<CompositorState> CompositorState::create(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, bool async_scrolling_enabled)
+{
+    return adopt_ref(*new CompositorState(move(skia_backend_context), async_scrolling_enabled));
+}
+
+CompositorState::CompositorState(RefPtr<Gfx::SkiaBackendContext> skia_backend_context, bool async_scrolling_enabled)
+    : m_skia_backend_context(move(skia_backend_context))
+    , m_display_list_player(make<Web::Painting::DisplayListPlayerSkia>(m_skia_backend_context))
+    , m_async_scrolling_enabled(async_scrolling_enabled)
+{
+}
+
+void CompositorState::set_client(CompositorStateClient& client)
+{
+    m_client = &client;
+}
+
+CompositorState::ContextOwnerCheckResult CompositorState::check_context_owner(Web::Compositor::CompositorContextId context_id, CompositorStateWebContentClient& client)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return ContextOwnerCheckResult::ContextUnavailable;
+    VERIFY(context->web_content_client);
+    if (context->web_content_client != &client)
+        return ContextOwnerCheckResult::ConflictingOwner;
+
+    return ContextOwnerCheckResult::OwnedByClient;
+}
+
+void CompositorState::destroy_contexts_for_web_content_client(CompositorStateWebContentClient& client)
+{
+    Vector<Web::Compositor::CompositorContextId> context_ids;
+    for (auto& context : m_contexts) {
+        if (context.value->web_content_client == &client)
+            context_ids.append(context.key);
+    }
+
+    for (auto context_id : context_ids) {
+        destroy_context(context_id);
+    }
+}
+
+void CompositorState::create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, CompositorStateWebContentClient& web_content_client)
+{
+    VERIFY(!m_contexts.contains(context_id));
+    if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes) {
+        VERIFY(page_id.has_value());
+    } else {
+        VERIFY(!page_id.has_value());
+        VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
+    }
+
+    auto& context = *m_contexts.ensure(context_id, [] {
+        return make<ContextState>();
+    });
+    context.is_registered = true;
+    context.web_content_client = &web_content_client;
+    context.page_id = page_id;
+    context.page_presentation_registration = page_presentation_registration;
+    context.presents_to_client = page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes;
+    resize_backing_stores_if_needed(context_id, context);
+}
+
+void CompositorState::destroy_context(Web::Compositor::CompositorContextId context_id)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    detach_from_parent_surface(context_id, *context);
+    for (auto& child_context_entry : context->child_contexts_by_surface_id) {
+        auto* child_context = context_if_present(child_context_entry.value);
+        VERIFY(child_context);
+        VERIFY(child_context->published_surface.has_value());
+        VERIFY(child_context->published_surface->parent_context_id == context_id);
+        child_context->published_surface.clear();
+        child_context->presentation_mode = Empty {};
+    }
+    m_contexts.remove(context_id);
+}
+
+void CompositorState::set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    auto& context_state = *context;
+    detach_from_parent_surface(context_id, context_state);
+
+    presentation_mode.visit(
+        [](Empty const&) {},
+        [&](Web::Compositor::PublishToCompositorSurface const& mode) {
+            auto* parent_context = context_if_present(mode.target_context_id);
+            VERIFY(parent_context);
+            parent_context->child_contexts_by_surface_id.set(mode.surface_id, context_id);
+            context_state.published_surface = ContextState::PublishedSurface {
+                .parent_context_id = mode.target_context_id,
+                .surface_id = mode.surface_id,
+            };
+        });
+    context_state.presentation_mode = move(presentation_mode);
+}
+
+void CompositorState::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    context->presents_to_client = false;
+}
+
+void CompositorState::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    context->display_list_resource_storage.apply_transaction(move(resource_transaction));
+    install_display_list_update(*context, move(display_list), move(scroll_state_snapshot));
+}
+
+void CompositorState::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    context->scroll_state_snapshot = move(scroll_state_snapshot);
+    if (!context->has_async_scrolling_state)
+        return;
+
+    auto reconciled_viewport_scroll_offset = reapply_pending_async_scroll_offsets(*context, context->pending_async_scroll_offsets);
+    context->async_scroll_tree.rebuild_wheel_hit_test_targets(context->display_list, context->scroll_state_snapshot);
+    if (reconciled_viewport_scroll_offset.has_value()) {
+        auto reconciled_viewport_rect = context->async_scrolling_viewport_rect;
+        reconciled_viewport_rect.set_location(reconciled_viewport_scroll_offset->to_type<int>());
+        context->async_scrolling_viewport_rect = reconciled_viewport_rect;
+    }
+}
+
+void CompositorState::update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    context->display_list_resource_storage.update_video_frame(frame_id, move(frame));
+    present_current_frame(context_id, *context);
+}
+
+void CompositorState::clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    context->display_list_resource_storage.clear_video_frame(frame_id);
+    present_current_frame(context_id, *context);
+}
+
+void CompositorState::update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    context->display_list_resource_storage.update_compositor_surface(surface_id, move(shared_image));
+    present_current_frame(context_id, *context);
+}
+
+void CompositorState::clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    context->display_list_resource_storage.clear_compositor_surface(surface_id);
+    remove_child_surface(*context, context_id, surface_id);
+    present_current_frame(context_id, *context);
+}
+
+void CompositorState::invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    context->wheel_event_listener_state_generation = max(context->wheel_event_listener_state_generation, generation);
+    context->wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::StaleWheelEventListeners;
+    context->can_accept_async_wheel_events = false;
+}
+
+bool CompositorState::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    auto& context_state = *context;
+    if (!context_state.presents_to_client)
+        return false;
+
+    auto position = Gfx::FloatPoint {
+        static_cast<float>(event.position.x().value()),
+        static_cast<float>(event.position.y().value()),
+    };
+
+    switch (event.type) {
+    case Web::MouseEvent::Type::MouseDown: {
+        if (event.button != Web::UIEvents::MouseButton::Primary)
+            return false;
+
+        auto drag = begin_viewport_scrollbar_drag(context_state, position);
+        if (!drag.has_value())
+            return false;
+
+        present_viewport_scrollbar_overlay(context_id, context_state);
+        apply_viewport_scrollbar_drag(context_id, context_state, drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position);
+        return true;
+    }
+    case Web::MouseEvent::Type::MouseMove: {
+        auto had_capture = context_state.captured_viewport_scrollbar_index.has_value();
+        if (had_capture) {
+            auto drag = captured_viewport_scrollbar_drag(context_state, position);
+            if (!drag.has_value())
+                return false;
+            apply_viewport_scrollbar_drag(context_id, context_state, drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position);
+            return true;
+        }
+
+        auto hovered_scrollbar_index = hit_test_viewport_scrollbar(context_state, position);
+        set_hovered_viewport_scrollbar(context_id, context_state, hovered_scrollbar_index);
+        return hovered_scrollbar_index.has_value();
+    }
+    case Web::MouseEvent::Type::MouseUp: {
+        auto drag = release_captured_viewport_scrollbar_drag(context_state, position);
+        if (!drag.has_value())
+            return false;
+
+        present_viewport_scrollbar_overlay(context_id, context_state);
+        apply_viewport_scrollbar_drag(context_id, context_state, drag->scrollbar_index, drag->primary_position, drag->thumb_grab_position);
+        return true;
+    }
+    case Web::MouseEvent::Type::MouseLeave: {
+        auto had_capture = context_state.captured_viewport_scrollbar_index.has_value();
+        set_hovered_viewport_scrollbar(context_id, context_state, {});
+        return had_capture;
+    }
+    case Web::MouseEvent::Type::MouseWheel:
+        return false;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+void CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    VERIFY(context->web_content_client);
+
+    auto page_id = context->page_id;
+    if (!page_id.has_value() && Web::Compositor::is_page_presenting_compositor_context_id(context_id))
+        page_id = Web::Compositor::page_id_for_compositor_context_id(context_id);
+    VERIFY(page_id.has_value());
+
+    context->web_content_client->dispatch_mouse_event_to_web_content(*page_id, event);
+}
+
+Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking)
+{
+    if (!m_async_scrolling_enabled)
+        return {};
+
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    auto& context_state = *context;
+    if (!context_state.can_accept_async_wheel_events)
+        return {};
+
+    auto scroll_target = context_state.async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
+    if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
+        return {};
+    if (scroll_target.node_id->document_id != expected_document_id)
+        return {};
+
+    Optional<Web::Compositor::AsyncScrollOperationID> operation_id;
+    if (operation_tracking == Web::Compositor::AsyncScrollOperationTracking::Yes)
+        operation_id = ++context_state.next_async_scroll_operation_id;
+
+    auto async_scroll_viewport_rect = viewport_rect;
+    auto scroll_offsets = context_state.async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, delta, context_state.scroll_state_snapshot);
+    if (scroll_offsets.is_empty()) {
+        if (operation_id.has_value())
+            context_state.completed_async_scroll_operation_ids.append(*operation_id);
+        return { true, operation_id };
+    }
+
+    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.scroll_state_snapshot);
+    if (auto viewport_scroll_offset = viewport_scroll_offset_from(context_state, scroll_offsets); viewport_scroll_offset.has_value())
+        async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    store_pending_async_scroll_offsets(context_state, scroll_offsets, operation_id);
+    context_state.async_scrolling_viewport_rect = async_scroll_viewport_rect;
+    present_frame(context_id, context_state, async_scroll_viewport_rect);
+    return { true, operation_id };
+}
+
+bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta)
+{
+    if (!m_async_scrolling_enabled)
+        return false;
+
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    auto& context_state = *context;
+    if (!context_state.presents_to_client)
+        return false;
+    VERIFY(context_state.web_content_client);
+    if (!context_state.can_accept_async_wheel_events)
+        return false;
+
+    auto scroll_target = context_state.async_scroll_tree.hit_test_scroll_node_for_wheel(position, delta);
+    if (scroll_target.blocked_by_main_thread_region || scroll_target.blocked_by_wheel_event_region || !scroll_target.node_id.has_value())
+        return false;
+
+    auto async_scroll_viewport_rect = context_state.async_scrolling_viewport_rect;
+    auto scroll_offsets = context_state.async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, delta, context_state.scroll_state_snapshot);
+    if (scroll_offsets.is_empty())
+        return true;
+
+    context_state.async_scroll_tree.rebuild_wheel_hit_test_targets(context_state.display_list, context_state.scroll_state_snapshot);
+    if (auto viewport_scroll_offset = viewport_scroll_offset_from(context_state, scroll_offsets); viewport_scroll_offset.has_value())
+        async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    store_pending_async_scroll_offsets(context_state, scroll_offsets);
+    context_state.async_scrolling_viewport_rect = async_scroll_viewport_rect;
+    context_state.deferred_async_scroll_present_viewport_rect = async_scroll_viewport_rect;
+    context_state.has_deferred_async_scroll_present = true;
+    context_state.web_content_client->request_rendering_update();
+    return true;
+}
+
+void CompositorState::present_deferred_async_scroll_frame(Web::Compositor::CompositorContextId context_id)
+{
+    auto* context = context_if_present(context_id);
+    if (!context || !context->has_deferred_async_scroll_present)
+        return;
+
+    auto viewport_rect = context->deferred_async_scroll_present_viewport_rect;
+    context->has_deferred_async_scroll_present = false;
+    present_frame(context_id, *context, viewport_rect);
+}
+
+bool CompositorState::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    if (context->pending_async_scroll_offsets.is_empty())
+        return false;
+
+    return context->has_deferred_async_scroll_present
+        || context->pending_present_frame.has_value()
+        || context->presented_bitmap_id_awaiting_ack.has_value();
+}
+
+Web::Compositor::PendingAsyncScrollUpdates CompositorState::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    Web::Compositor::PendingAsyncScrollUpdates updates;
+    AK::swap(updates.scroll_offsets, context->pending_async_scroll_offsets);
+    AK::swap(updates.completed_operation_ids, context->completed_async_scroll_operation_ids);
+    return updates;
+}
+
+void CompositorState::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    context->viewport_size = viewport_size;
+    context->is_top_level_traversable = is_top_level_traversable;
+    context->window_resize_in_progress = window_resize_in_progress;
+    resize_backing_stores_if_needed(context_id, *context);
+}
+
+void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+    present_frame(context_id, *context, viewport_rect);
+}
+
+void CompositorState::present_frame(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect viewport_rect)
+{
+    if (context.presented_bitmap_id_awaiting_ack.has_value()) {
+        context.pending_present_frame = viewport_rect;
+        return;
+    }
+
+    if (!context.display_list || !context.backing_store_manager.is_valid()) {
+        context.presented_frame = viewport_rect;
+        return;
+    }
+
+    auto& back_store = context.backing_store_manager.back_store();
+    context.presentation_mode.visit(
+        [](Empty const&) {},
+        [&](Web::Compositor::PublishToCompositorSurface const&) {
+            Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { back_store } };
+            painter.clear_rect(back_store.rect().to_type<float>(), Gfx::Color::Transparent);
+        });
+    m_display_list_player->execute(*context.display_list, context.display_list_resource_storage, context.scroll_state_snapshot, back_store);
+    auto painted_viewport_scrollbar_overlay = paint_viewport_scrollbar_overlay(context, back_store);
+    if (painted_viewport_scrollbar_overlay) {
+        if (auto skia_backend_context = back_store.skia_backend_context())
+            skia_backend_context->flush_and_submit(&back_store.sk_surface());
+    }
+    back_store.flush();
+    auto rendered_bitmap_id = context.backing_store_manager.back_bitmap_id();
+    context.backing_store_manager.swap();
+
+    context.presentation_mode.visit(
+        [&](Empty const&) {
+            if (present_frame_to_client(context_id, context, viewport_rect, rendered_bitmap_id))
+                context.presented_bitmap_id_awaiting_ack = rendered_bitmap_id;
+            context.presented_frame = viewport_rect;
+        },
+        [&](Web::Compositor::PublishToCompositorSurface const& mode) {
+            publish_to_parent_surface(context, mode);
+            context.presented_frame = viewport_rect;
+        });
+}
+
+bool CompositorState::request_screenshot(Web::Compositor::CompositorContextId context_id, Gfx::ShareableBitmap& target_bitmap)
+{
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    if (!context->display_list || !target_bitmap.is_valid() || !target_bitmap.bitmap())
+        return false;
+
+    auto target_surface = Gfx::PaintingSurface::wrap_bitmap(*target_bitmap.bitmap());
+    m_display_list_player->execute(*context->display_list, context->display_list_resource_storage, context->scroll_state_snapshot, *target_surface);
+    paint_viewport_scrollbar_overlay(*context, *target_surface);
+    target_surface->flush();
+    return true;
+}
+
+void CompositorState::presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return;
+
+    if (context->presented_bitmap_id_awaiting_ack != bitmap_id)
+        return;
+
+    context->presented_bitmap_id_awaiting_ack.clear();
+    if (context->pending_present_frame.has_value()) {
+        auto pending_present_frame = context->pending_present_frame.release_value();
+        present_frame(context_id, *context, pending_present_frame);
+    }
+}
+
+CompositorState::ContextState* CompositorState::context_if_present(Web::Compositor::CompositorContextId context_id)
+{
+    auto it = m_contexts.find(context_id);
+    if (it == m_contexts.end())
+        return nullptr;
+    return it->value.ptr();
+}
+
+CompositorState::ContextState const* CompositorState::context_if_present(Web::Compositor::CompositorContextId context_id) const
+{
+    auto it = m_contexts.find(context_id);
+    if (it == m_contexts.end())
+        return nullptr;
+    return it->value.ptr();
+}
+
+void CompositorState::detach_from_parent_surface(Web::Compositor::CompositorContextId context_id, ContextState& context)
+{
+    if (!context.published_surface.has_value())
+        return;
+
+    auto published_surface = context.published_surface.release_value();
+    auto* parent_context = context_if_present(published_surface.parent_context_id);
+    VERIFY(parent_context);
+    auto child_context_id = parent_context->child_contexts_by_surface_id.get(published_surface.surface_id);
+    VERIFY(child_context_id.has_value());
+    VERIFY(*child_context_id == context_id);
+    parent_context->child_contexts_by_surface_id.remove(published_surface.surface_id);
+    parent_context->display_list_resource_storage.clear_compositor_surface(published_surface.surface_id);
+    present_current_frame(published_surface.parent_context_id, *parent_context);
+}
+
+void CompositorState::remove_child_surface(ContextState& context, Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId surface_id)
+{
+    auto child_context_id = context.child_contexts_by_surface_id.take(surface_id);
+    if (!child_context_id.has_value())
+        return;
+
+    auto* child_context = context_if_present(*child_context_id);
+    VERIFY(child_context);
+    VERIFY(child_context->published_surface.has_value());
+    VERIFY(child_context->published_surface->parent_context_id == parent_context_id);
+    VERIFY(child_context->published_surface->surface_id == surface_id);
+    child_context->published_surface.clear();
+    child_context->presentation_mode = Empty {};
+}
+
+void CompositorState::install_display_list_update(ContextState& context, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
+{
+    context.display_list = move(display_list);
+    context.scroll_state_snapshot = move(scroll_state_snapshot);
+
+    if (!m_async_scrolling_enabled) {
+        context.async_scroll_tree.set_state({});
+        context.viewport_scrollbars.clear();
+        context.hovered_viewport_scrollbar_index.clear();
+        context.captured_viewport_scrollbar_index.clear();
+        context.pending_async_scroll_offsets.clear();
+        context.completed_async_scroll_operation_ids.clear();
+        context.wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState;
+        context.can_accept_async_wheel_events = false;
+        context.async_scrolling_viewport_rect = {};
+        context.has_async_scrolling_state = false;
+        return;
+    }
+
+    auto async_scrolling_state = Web::Compositor::async_scrolling_state_from_display_list(*context.display_list);
+    auto async_scrolling_viewport_rect = async_scrolling_state.viewport_rect;
+    auto wheel_event_listener_state_generation = async_scrolling_state.wheel_event_listener_state_generation;
+    auto wheel_routing_admission = Web::Compositor::wheel_routing_admission_for(async_scrolling_state);
+    if (wheel_event_listener_state_generation < context.wheel_event_listener_state_generation)
+        wheel_routing_admission = Web::Compositor::WheelRoutingAdmission::StaleWheelEventListeners;
+    else
+        context.wheel_event_listener_state_generation = wheel_event_listener_state_generation;
+
+    context.wheel_routing_admission = wheel_routing_admission;
+    context.can_accept_async_wheel_events = wheel_routing_admission == Web::Compositor::WheelRoutingAdmission::Accepted;
+
+    auto hovered_scrollbar_identity = viewport_scrollbar_identity_at(context.viewport_scrollbars, context.hovered_viewport_scrollbar_index);
+    auto captured_scrollbar_identity = viewport_scrollbar_identity_at(context.viewport_scrollbars, context.captured_viewport_scrollbar_index);
+    context.viewport_scrollbars = async_scrolling_state.viewport_scrollbars;
+    context.hovered_viewport_scrollbar_index = hovered_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(context.viewport_scrollbars, *hovered_scrollbar_identity) : Optional<size_t> {};
+    context.captured_viewport_scrollbar_index = captured_scrollbar_identity.has_value() ? find_viewport_scrollbar_index(context.viewport_scrollbars, *captured_scrollbar_identity) : Optional<size_t> {};
+    context.async_scroll_tree.set_state(move(async_scrolling_state));
+    if (!context.pending_async_scroll_offsets.is_empty()) {
+        if (auto viewport_scroll_offset = reapply_pending_async_scroll_offsets(context, context.pending_async_scroll_offsets); viewport_scroll_offset.has_value())
+            async_scrolling_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    }
+    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.scroll_state_snapshot);
+    context.async_scrolling_viewport_rect = async_scrolling_viewport_rect;
+    context.has_async_scrolling_state = true;
+}
+
+Optional<Gfx::FloatPoint> CompositorState::viewport_scroll_offset_from(ContextState& context, Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets) const
+{
+    Optional<Gfx::FloatPoint> viewport_scroll_offset;
+    for (auto const& scroll_offset : scroll_offsets) {
+        auto node_id = context.async_scroll_tree.scroll_node_id_for_stable_id(scroll_offset.stable_node_id);
+        if (node_id.has_value() && context.async_scroll_tree.scroll_node_is_viewport(*node_id))
+            viewport_scroll_offset = scroll_offset.compositor_scroll_offset;
+    }
+    return viewport_scroll_offset;
+}
+
+Optional<Gfx::FloatPoint> CompositorState::reapply_pending_async_scroll_offsets(ContextState& context, Vector<Web::Compositor::AsyncScrollOffset> const& pending_scroll_offsets)
+{
+    Optional<Gfx::FloatPoint> viewport_scroll_offset;
+    for (auto const& pending_scroll_offset : pending_scroll_offsets) {
+        auto node_id = context.async_scroll_tree.scroll_node_id_for_stable_id(pending_scroll_offset.stable_node_id);
+        if (!node_id.has_value())
+            continue;
+        auto reconciled_scroll_offset = context.async_scroll_tree.set_scroll_offset(*node_id, pending_scroll_offset.compositor_scroll_offset, context.scroll_state_snapshot);
+        if (reconciled_scroll_offset.has_value() && context.async_scroll_tree.scroll_node_is_viewport(*node_id))
+            viewport_scroll_offset = *reconciled_scroll_offset;
+    }
+    return viewport_scroll_offset;
+}
+
+void CompositorState::store_pending_async_scroll_offsets(ContextState& context, Vector<Web::Compositor::AsyncScrollOffset> const& scroll_offsets, Optional<Web::Compositor::AsyncScrollOperationID> operation_id)
+{
+    for (auto const& scroll_offset : scroll_offsets)
+        set_or_append_pending_scroll_offset(context.pending_async_scroll_offsets, scroll_offset);
+    if (operation_id.has_value())
+        context.completed_async_scroll_operation_ids.append(*operation_id);
+}
+
+Optional<size_t> CompositorState::hit_test_viewport_scrollbar(ContextState& context, Gfx::FloatPoint position) const
+{
+    for (size_t i = 0; i < context.viewport_scrollbars.size(); ++i) {
+        auto const& scrollbar = context.viewport_scrollbars[i];
+        auto scroll_offset = context.async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, context.scroll_state_snapshot);
+        if (!scroll_offset.has_value())
+            continue;
+
+        if (scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position))
+            return i;
+    }
+    return {};
+}
+
+Optional<CompositorState::ViewportScrollbarDrag> CompositorState::begin_viewport_scrollbar_drag(ContextState& context, Gfx::FloatPoint position)
+{
+    for (size_t i = 0; i < context.viewport_scrollbars.size(); ++i) {
+        auto const& scrollbar = context.viewport_scrollbars[i];
+        auto scroll_offset = context.async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, context.scroll_state_snapshot);
+        if (!scroll_offset.has_value())
+            continue;
+
+        auto expanded = context.hovered_viewport_scrollbar_index == i || context.captured_viewport_scrollbar_index == i;
+        auto orientation = orientation_for_scrollbar(scrollbar);
+        auto thumb_rect = translated_thumb_rect(scrollbar, *scroll_offset, expanded);
+        auto primary_position = position.primary_offset_for_orientation(orientation);
+        float thumb_grab_position = 0;
+        if (thumb_rect.to_type<float>().contains(position)) {
+            thumb_grab_position = primary_position - static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
+        } else if (scrollbar_hit_rect(scrollbar, *scroll_offset).to_type<float>().contains(position)) {
+            auto gutter_rect = scrollbar_gutter_rect(scrollbar, true);
+            auto thumb_size = static_cast<float>(thumb_rect.primary_size_for_orientation(orientation));
+            auto gutter_start = static_cast<float>(gutter_rect.primary_offset_for_orientation(orientation));
+            auto gutter_size = static_cast<float>(gutter_rect.primary_size_for_orientation(orientation));
+            auto offset_relative_to_gutter = primary_position - gutter_start;
+            thumb_grab_position = max(min(offset_relative_to_gutter, thumb_size / 2), offset_relative_to_gutter - gutter_size + thumb_size);
+        } else {
+            continue;
+        }
+
+        context.captured_viewport_scrollbar_index = i;
+        context.hovered_viewport_scrollbar_index = i;
+        context.viewport_scrollbar_thumb_grab_position = thumb_grab_position;
+        return ViewportScrollbarDrag { i, primary_position, thumb_grab_position };
+    }
+
+    return {};
+}
+
+Optional<CompositorState::ViewportScrollbarDrag> CompositorState::captured_viewport_scrollbar_drag(ContextState& context, Gfx::FloatPoint position)
+{
+    if (!context.captured_viewport_scrollbar_index.has_value())
+        return {};
+    auto scrollbar_index = *context.captured_viewport_scrollbar_index;
+    if (scrollbar_index >= context.viewport_scrollbars.size()) {
+        context.captured_viewport_scrollbar_index.clear();
+        return {};
+    }
+    auto const& scrollbar = context.viewport_scrollbars[scrollbar_index];
+    auto primary_position = position.primary_offset_for_orientation(orientation_for_scrollbar(scrollbar));
+    return ViewportScrollbarDrag { scrollbar_index, primary_position, context.viewport_scrollbar_thumb_grab_position };
+}
+
+Optional<CompositorState::ViewportScrollbarDrag> CompositorState::release_captured_viewport_scrollbar_drag(ContextState& context, Gfx::FloatPoint position)
+{
+    if (!context.captured_viewport_scrollbar_index.has_value())
+        return {};
+    auto scrollbar_index = *context.captured_viewport_scrollbar_index;
+    auto thumb_grab_position = context.viewport_scrollbar_thumb_grab_position;
+    if (scrollbar_index >= context.viewport_scrollbars.size()) {
+        context.captured_viewport_scrollbar_index.clear();
+        return {};
+    }
+    auto const& scrollbar = context.viewport_scrollbars[scrollbar_index];
+    auto primary_position = position.primary_offset_for_orientation(orientation_for_scrollbar(scrollbar));
+    context.captured_viewport_scrollbar_index.clear();
+    return ViewportScrollbarDrag { scrollbar_index, primary_position, thumb_grab_position };
+}
+
+void CompositorState::set_hovered_viewport_scrollbar(Web::Compositor::CompositorContextId context_id, ContextState& context, Optional<size_t> scrollbar_index)
+{
+    if (context.hovered_viewport_scrollbar_index == scrollbar_index)
+        return;
+
+    context.hovered_viewport_scrollbar_index = scrollbar_index;
+    present_viewport_scrollbar_overlay(context_id, context);
+}
+
+bool CompositorState::apply_viewport_scrollbar_drag(Web::Compositor::CompositorContextId context_id, ContextState& context, size_t scrollbar_index, float primary_position, float thumb_grab_position)
+{
+    if (scrollbar_index >= context.viewport_scrollbars.size())
+        return false;
+
+    auto const& scrollbar = context.viewport_scrollbars[scrollbar_index];
+    auto expanded = context.hovered_viewport_scrollbar_index == scrollbar_index || context.captured_viewport_scrollbar_index == scrollbar_index;
+    auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);
+    if (scroll_size == 0)
+        return false;
+
+    auto current_scroll_offset = context.async_scroll_tree.scroll_offset_for_node(scrollbar.scroll_node_id, context.scroll_state_snapshot);
+    if (!current_scroll_offset.has_value())
+        return false;
+
+    auto orientation = orientation_for_scrollbar(scrollbar);
+    auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
+    auto min_thumb_position = static_cast<float>(thumb_rect.primary_offset_for_orientation(orientation));
+    auto max_thumb_position = min_thumb_position + scrollbar.max_scroll_offset * static_cast<float>(scroll_size);
+    auto target_thumb_position = AK::clamp(primary_position - thumb_grab_position, min_thumb_position, max_thumb_position);
+    auto target_scroll_offset = (target_thumb_position - min_thumb_position) / static_cast<float>(scroll_size);
+
+    Gfx::FloatPoint delta;
+    delta.set_primary_offset_for_orientation(orientation, target_scroll_offset - current_scroll_offset->primary_offset_for_orientation(orientation));
+    if (delta.x() == 0 && delta.y() == 0)
+        return false;
+
+    auto scroll_offsets = context.async_scroll_tree.apply_scroll_delta(scrollbar.scroll_node_id, delta, context.scroll_state_snapshot);
+    if (scroll_offsets.is_empty())
+        return false;
+    context.async_scroll_tree.rebuild_wheel_hit_test_targets(context.display_list, context.scroll_state_snapshot);
+
+    auto viewport_scroll_offset = viewport_scroll_offset_from(context, scroll_offsets);
+    if (!viewport_scroll_offset.has_value())
+        return false;
+
+    store_pending_async_scroll_offsets(context, scroll_offsets);
+    auto async_scroll_viewport_rect = context.async_scrolling_viewport_rect;
+    async_scroll_viewport_rect.set_location(viewport_scroll_offset->to_type<int>());
+    context.async_scrolling_viewport_rect = async_scroll_viewport_rect;
+    present_frame(context_id, context, async_scroll_viewport_rect);
+    VERIFY(context.web_content_client);
+    context.web_content_client->request_rendering_update();
+    return true;
+}
+
+void CompositorState::present_viewport_scrollbar_overlay(Web::Compositor::CompositorContextId context_id, ContextState& context)
+{
+    if (context.async_scrolling_viewport_rect.is_empty())
+        return;
+    present_frame(context_id, context, context.async_scrolling_viewport_rect);
+}
+
+bool CompositorState::paint_viewport_scrollbar_overlay(ContextState& context, Gfx::PaintingSurface& surface)
+{
+    if (context.viewport_scrollbars.is_empty())
+        return false;
+
+    Gfx::PainterSkia painter { NonnullRefPtr<Gfx::PaintingSurface> { surface } };
+    for (size_t i = 0; i < context.viewport_scrollbars.size(); ++i) {
+        paint_viewport_scrollbar(painter, context.viewport_scrollbars[i], context.scroll_state_snapshot,
+            context.hovered_viewport_scrollbar_index == i || context.captured_viewport_scrollbar_index == i);
+    }
+    painter.reset();
+    return true;
+}
+
+void CompositorState::resize_backing_stores_if_needed(Web::Compositor::CompositorContextId context_id, ContextState& context)
+{
+    if (!context.is_registered)
+        return;
+
+    auto allocation = context.backing_store_manager.resize_backing_stores_if_needed(context.viewport_size, context.is_top_level_traversable, context.window_resize_in_progress);
+    if (!allocation.has_value())
+        return;
+    if (auto publication = context.backing_store_manager.allocate_backing_stores(*allocation, m_skia_backend_context, context.presents_to_client); publication.has_value()) {
+        publish_backing_stores(context_id, context, publication.release_value());
+        present_current_frame(context_id, context);
+    }
+}
+
+void CompositorState::present_current_frame(Web::Compositor::CompositorContextId context_id, ContextState& context)
+{
+    // A queued frame already captures the newest viewport rect and will pick up
+    // the updated resource when the outstanding bitmap is acknowledged.
+    if (context.pending_present_frame.has_value())
+        return;
+    if (!context.presented_frame.has_value())
+        return;
+    present_frame(context_id, context, *context.presented_frame);
+}
+
+void CompositorState::publish_to_parent_surface(ContextState& context, Web::Compositor::PublishToCompositorSurface const& mode)
+{
+    auto* parent_context = context_if_present(mode.target_context_id);
+    VERIFY(parent_context);
+
+    parent_context->display_list_resource_storage.update_compositor_surface(
+        mode.surface_id,
+        context.backing_store_manager.front_store().snapshot_into_shared_image());
+    present_current_frame(mode.target_context_id, *parent_context);
+}
+
+void CompositorState::publish_backing_stores(Web::Compositor::CompositorContextId context_id, ContextState& context, Web::Compositor::BackingStoreManager::Publication&& publication)
+{
+    VERIFY(m_client);
+    if (!context.presents_to_client)
+        return;
+
+    m_client->did_allocate_backing_stores(context_id, publication.front_bitmap_id, move(publication.front_shared_image), publication.back_bitmap_id, move(publication.back_shared_image));
+}
+
+bool CompositorState::present_frame_to_client(Web::Compositor::CompositorContextId context_id, ContextState& context, Gfx::IntRect const& viewport_rect, i32 bitmap_id)
+{
+    VERIFY(m_client);
+    if (!context.presents_to_client)
+        return false;
+
+    m_client->did_present_frame(context_id, viewport_rect, bitmap_id);
+    return true;
+}
+
+}

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/Vector.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/Size.h>
+#include <LibGfx/SkiaBackendContext.h>
+#include <LibMedia/Forward.h>
+#include <LibWeb/Compositor/AsyncScrollTree.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Compositor/BackingStoreManager.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListPlayerSkia.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+namespace Web {
+
+struct MouseEvent;
+
+}
+
+namespace Compositor {
+
+class CompositorStateClient {
+public:
+    virtual ~CompositorStateClient() = default;
+
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store) = 0;
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) = 0;
+};
+
+class CompositorStateWebContentClient {
+public:
+    virtual ~CompositorStateWebContentClient() = default;
+
+    virtual void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&) = 0;
+    virtual void request_rendering_update() = 0;
+};
+
+class CompositorState final : public RefCounted<CompositorState> {
+public:
+    static NonnullRefPtr<CompositorState> create(RefPtr<Gfx::SkiaBackendContext>, bool async_scrolling_enabled);
+
+    enum class ContextOwnerCheckResult {
+        OwnedByClient,
+        ContextUnavailable,
+        ConflictingOwner,
+    };
+
+    void set_client(CompositorStateClient&);
+    ContextOwnerCheckResult check_context_owner(Web::Compositor::CompositorContextId, CompositorStateWebContentClient&);
+    void destroy_contexts_for_web_content_client(CompositorStateWebContentClient&);
+
+    void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, CompositorStateWebContentClient&);
+    void destroy_context(Web::Compositor::CompositorContextId);
+
+    void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode);
+    void stop_presenting_to_client(Web::Compositor::CompositorContextId);
+    void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::DisplayListResourceTransaction&&, Web::Painting::ScrollStateSnapshot&&);
+    void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot&&);
+    void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
+    void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId);
+    void update_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId, Gfx::SharedImage&&);
+    void clear_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId);
+    void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation);
+    bool handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
+    void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
+    Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
+    bool async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta);
+    void present_deferred_async_scroll_frame(Web::Compositor::CompositorContextId);
+    bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) const;
+    Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
+    void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress);
+    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
+    bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
+    void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
+
+private:
+    CompositorState(RefPtr<Gfx::SkiaBackendContext>, bool async_scrolling_enabled);
+
+    struct ViewportScrollbarDrag {
+        size_t scrollbar_index { 0 };
+        float primary_position { 0 };
+        float thumb_grab_position { 0 };
+    };
+
+    struct ContextState {
+        struct PublishedSurface {
+            Web::Compositor::CompositorContextId parent_context_id;
+            Web::Painting::CompositorSurfaceId surface_id;
+        };
+
+        bool is_registered { false };
+        CompositorStateWebContentClient* web_content_client { nullptr };
+        Optional<u64> page_id;
+        Web::Compositor::PagePresentationRegistration page_presentation_registration { Web::Compositor::PagePresentationRegistration::No };
+
+        bool presents_to_client { false };
+        Web::Compositor::PresentationMode presentation_mode { Empty {} };
+        Optional<PublishedSurface> published_surface;
+        HashMap<Web::Painting::CompositorSurfaceId, Web::Compositor::CompositorContextId> child_contexts_by_surface_id;
+
+        RefPtr<Web::Painting::DisplayList> display_list;
+        Web::Painting::DisplayListResourceStorage display_list_resource_storage;
+        Web::Painting::ScrollStateSnapshot scroll_state_snapshot;
+        Web::Compositor::BackingStoreManager backing_store_manager;
+
+        Web::Compositor::AsyncScrollTree async_scroll_tree;
+        Vector<Web::Compositor::ViewportScrollbar> viewport_scrollbars;
+        Optional<size_t> hovered_viewport_scrollbar_index;
+        Optional<size_t> captured_viewport_scrollbar_index;
+        float viewport_scrollbar_thumb_grab_position { 0 };
+
+        Vector<Web::Compositor::AsyncScrollOffset> pending_async_scroll_offsets;
+        Vector<Web::Compositor::AsyncScrollOperationID> completed_async_scroll_operation_ids;
+        Web::Compositor::AsyncScrollOperationID next_async_scroll_operation_id { 0 };
+        Gfx::IntRect async_scrolling_viewport_rect;
+        bool has_async_scrolling_state { false };
+        bool can_accept_async_wheel_events { false };
+        u64 wheel_event_listener_state_generation { 0 };
+        Web::Compositor::WheelRoutingAdmission wheel_routing_admission { Web::Compositor::WheelRoutingAdmission::NoAsyncScrollingState };
+
+        Gfx::IntSize viewport_size;
+        bool is_top_level_traversable { false };
+        Web::Compositor::WindowResizingInProgress window_resize_in_progress { Web::Compositor::WindowResizingInProgress::No };
+
+        Optional<Gfx::IntRect> pending_present_frame;
+        Optional<Gfx::IntRect> presented_frame;
+        Optional<i32> presented_bitmap_id_awaiting_ack;
+        bool has_deferred_async_scroll_present { false };
+        Gfx::IntRect deferred_async_scroll_present_viewport_rect;
+    };
+
+    ContextState* context_if_present(Web::Compositor::CompositorContextId);
+    ContextState const* context_if_present(Web::Compositor::CompositorContextId) const;
+    void detach_from_parent_surface(Web::Compositor::CompositorContextId, ContextState&);
+    void remove_child_surface(ContextState&, Web::Compositor::CompositorContextId parent_context_id, Web::Painting::CompositorSurfaceId);
+    void install_display_list_update(ContextState&, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::ScrollStateSnapshot&&);
+    Optional<Gfx::FloatPoint> viewport_scroll_offset_from(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&) const;
+    Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&);
+    void store_pending_async_scroll_offsets(ContextState&, Vector<Web::Compositor::AsyncScrollOffset> const&, Optional<Web::Compositor::AsyncScrollOperationID> = {});
+    Optional<size_t> hit_test_viewport_scrollbar(ContextState&, Gfx::FloatPoint position) const;
+    Optional<ViewportScrollbarDrag> begin_viewport_scrollbar_drag(ContextState&, Gfx::FloatPoint position);
+    Optional<ViewportScrollbarDrag> captured_viewport_scrollbar_drag(ContextState&, Gfx::FloatPoint position);
+    Optional<ViewportScrollbarDrag> release_captured_viewport_scrollbar_drag(ContextState&, Gfx::FloatPoint position);
+    void set_hovered_viewport_scrollbar(Web::Compositor::CompositorContextId, ContextState&, Optional<size_t>);
+    bool apply_viewport_scrollbar_drag(Web::Compositor::CompositorContextId, ContextState&, size_t scrollbar_index, float primary_position, float thumb_grab_position);
+    void present_viewport_scrollbar_overlay(Web::Compositor::CompositorContextId, ContextState&);
+    bool paint_viewport_scrollbar_overlay(ContextState&, Gfx::PaintingSurface&);
+    void resize_backing_stores_if_needed(Web::Compositor::CompositorContextId, ContextState&);
+    void present_current_frame(Web::Compositor::CompositorContextId, ContextState&);
+    void publish_to_parent_surface(ContextState&, Web::Compositor::PublishToCompositorSurface const&);
+    void present_frame(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect);
+    void publish_backing_stores(Web::Compositor::CompositorContextId, ContextState&, Web::Compositor::BackingStoreManager::Publication&&);
+    bool present_frame_to_client(Web::Compositor::CompositorContextId, ContextState&, Gfx::IntRect const&, i32 bitmap_id);
+
+    HashMap<Web::Compositor::CompositorContextId, OwnPtr<ContextState>> m_contexts;
+    RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
+    OwnPtr<Web::Painting::DisplayListPlayerSkia> m_display_list_player;
+    CompositorStateClient* m_client { nullptr };
+    bool m_async_scrolling_enabled { true };
+};
+
+}

--- a/Services/Compositor/CompositorWebContentClient.ipc
+++ b/Services/Compositor/CompositorWebContentClient.ipc
@@ -1,4 +1,11 @@
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Page/InputEvent.h>
+
 endpoint CompositorWebContentClient
 {
-    did_connect() =|
+    mouse_event(u64 page_id, Web::MouseEvent event) =|
+    request_rendering_update() =|
+    did_complete_screenshot(Web::Compositor::ScreenshotRequestId request_id) =|
+    did_fail_screenshot(Web::Compositor::ScreenshotRequestId request_id) =|
+    did_lose_compositor() =|
 }

--- a/Services/Compositor/CompositorWebContentClient.ipc
+++ b/Services/Compositor/CompositorWebContentClient.ipc
@@ -1,0 +1,4 @@
+endpoint CompositorWebContentClient
+{
+    did_connect() =|
+}

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -1,0 +1,4 @@
+endpoint CompositorWebContentServer
+{
+    ping() =|
+}

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -1,4 +1,36 @@
+#include <AK/NonnullRefPtr.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/Size.h>
+#include <LibMedia/VideoFrame.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ScrollState.h>
+
 endpoint CompositorWebContentServer
 {
-    ping() =|
+    set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|
+    stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) =|
+    destroy_context(Web::Compositor::CompositorContextId context_id) =|
+
+    update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
+    update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot) =|
+
+    update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) =|
+    clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id) =|
+
+    update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage shared_image) =|
+    clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id) =|
+
+    invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) =|
+    async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) => (Web::Compositor::AsyncScrollEnqueueResult result)
+    should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) => (bool should_defer)
+    take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
+
+    viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
+    present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) =|
+    request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) =|
 }

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -69,11 +69,6 @@ void ConnectionFromClient::create_context(Web::Compositor::CompositorContextId c
     m_compositor_state->create_context(context_id, page_id, page_presentation_registration, *connection);
 }
 
-void ConnectionFromClient::destroy_context(Web::Compositor::CompositorContextId context_id)
-{
-    m_compositor_state->destroy_context(context_id);
-}
-
 void ConnectionFromClient::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
     m_compositor_state->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/IDAllocator.h>
 #include <Compositor/ConnectionFromClient.h>
 #include <Compositor/ConnectionFromWebContent.h>
 #include <LibCore/EventLoop.h>
@@ -12,14 +13,30 @@
 
 namespace Compositor {
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
+static IDAllocator s_web_content_connection_ids;
+
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport, RefPtr<Gfx::SkiaBackendContext> skia_backend_context, bool async_scrolling_enabled)
     : IPC::ConnectionFromClient<CompositorControlClientEndpoint, CompositorControlServerEndpoint>(*this, move(transport), 1)
+    , m_compositor_state(CompositorState::create(move(skia_backend_context), async_scrolling_enabled))
 {
+    m_compositor_state->set_client(*this);
 }
 
 void ConnectionFromClient::die()
 {
+    for (auto& [id, connection] : m_web_content_connections)
+        connection->notify_compositor_lost();
     Core::EventLoop::current().quit(0);
+}
+
+void ConnectionFromClient::did_allocate_backing_stores(Web::Compositor::CompositorContextId context_id, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store)
+{
+    async_did_allocate_backing_stores(context_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
+}
+
+void ConnectionFromClient::did_present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect content_rect, i32 bitmap_id)
+{
+    async_did_present_frame(context_id, content_rect, bitmap_id);
 }
 
 Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
@@ -34,14 +51,68 @@ Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::i
 Messages::CompositorControlServer::ConnectWebContentResponse ConnectionFromClient::connect_web_content()
 {
     auto paired_transport = MUST(IPC::Transport::create_paired());
-    auto web_content_connection_id = m_next_web_content_connection_id++;
-    auto connection = ConnectionFromWebContent::construct(move(paired_transport.local), web_content_connection_id);
-    connection->on_death = [this](auto& dead) {
-        m_web_content_connections.remove(dead.client_id());
-    };
+    auto web_content_connection_id = s_web_content_connection_ids.allocate();
+    auto connection = ConnectionFromWebContent::construct(move(paired_transport.local), m_compositor_state, web_content_connection_id);
+    connection->set_on_death([this](ConnectionFromWebContent& dead) {
+        auto client_id = dead.client_id();
+        m_web_content_connections.remove(client_id);
+        s_web_content_connection_ids.deallocate(client_id);
+    });
     m_web_content_connections.set(web_content_connection_id, move(connection));
-    async_did_connect_web_content(web_content_connection_id);
     return { move(paired_transport.remote_handle), web_content_connection_id };
+}
+
+void ConnectionFromClient::create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration, i32 web_content_connection_id)
+{
+    auto* connection = web_content_connection(web_content_connection_id);
+    VERIFY(connection);
+    m_compositor_state->create_context(context_id, page_id, page_presentation_registration, *connection);
+}
+
+void ConnectionFromClient::destroy_context(Web::Compositor::CompositorContextId context_id)
+{
+    m_compositor_state->destroy_context(context_id);
+}
+
+void ConnectionFromClient::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+{
+    m_compositor_state->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+}
+
+Messages::CompositorControlServer::HandleMouseEventResponse ConnectionFromClient::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)
+{
+    return m_compositor_state->handle_mouse_event(context_id, event);
+}
+
+void ConnectionFromClient::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)
+{
+    m_compositor_state->dispatch_mouse_event_to_web_content(context_id, event);
+}
+
+Messages::CompositorControlServer::AsyncScrollByResponse ConnectionFromClient::async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
+{
+    auto handled = m_compositor_state->async_scroll_by(context_id, position, delta_in_device_pixels);
+    if (handled) {
+        deferred_invoke([this, context_id] {
+            if (!is_open())
+                return;
+            m_compositor_state->present_deferred_async_scroll_frame(context_id);
+        });
+    }
+    return handled;
+}
+
+void ConnectionFromClient::presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)
+{
+    m_compositor_state->presented_bitmap_ready_to_paint(context_id, bitmap_id);
+}
+
+ConnectionFromWebContent* ConnectionFromClient::web_content_connection(i32 web_content_connection_id)
+{
+    auto it = m_web_content_connections.find(web_content_connection_id);
+    if (it == m_web_content_connections.end())
+        return nullptr;
+    return it->value.ptr();
 }
 
 }

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Compositor/ConnectionFromClient.h>
+#include <Compositor/ConnectionFromWebContent.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/System.h>
+#include <LibIPC/Transport.h>
+
+namespace Compositor {
+
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
+    : IPC::ConnectionFromClient<CompositorControlClientEndpoint, CompositorControlServerEndpoint>(*this, move(transport), 1)
+{
+}
+
+void ConnectionFromClient::die()
+{
+    Core::EventLoop::current().quit(0);
+}
+
+Messages::CompositorControlServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    m_transport->set_peer_pid(peer_pid);
+    return Core::System::getpid();
+#endif
+    VERIFY_NOT_REACHED();
+}
+
+Messages::CompositorControlServer::ConnectWebContentResponse ConnectionFromClient::connect_web_content()
+{
+    auto paired_transport = MUST(IPC::Transport::create_paired());
+    auto web_content_connection_id = m_next_web_content_connection_id++;
+    auto connection = ConnectionFromWebContent::construct(move(paired_transport.local), web_content_connection_id);
+    connection->on_death = [this](auto& dead) {
+        m_web_content_connections.remove(dead.client_id());
+    };
+    m_web_content_connections.set(web_content_connection_id, move(connection));
+    async_did_connect_web_content(web_content_connection_id);
+    return { move(paired_transport.remote_handle), web_content_connection_id };
+}
+
+}

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -10,26 +10,45 @@
 #include <AK/NonnullRefPtr.h>
 #include <Compositor/CompositorControlClientEndpoint.h>
 #include <Compositor/CompositorControlServerEndpoint.h>
+#include <Compositor/CompositorState.h>
 #include <Compositor/Forward.h>
 #include <LibIPC/ConnectionFromClient.h>
+#include <LibIPC/TransportHandle.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 namespace Compositor {
 
 class ConnectionFromClient final
-    : public IPC::ConnectionFromClient<CompositorControlClientEndpoint, CompositorControlServerEndpoint> {
-    C_OBJECT(ConnectionFromClient)
+    : public IPC::ConnectionFromClient<CompositorControlClientEndpoint, CompositorControlServerEndpoint>
+    , public CompositorStateClient {
+    C_OBJECT(ConnectionFromClient);
 
 public:
-    virtual void die() override;
+    virtual ~ConnectionFromClient() override = default;
 
 private:
-    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
+    ConnectionFromClient(NonnullOwnPtr<IPC::Transport>, RefPtr<Gfx::SkiaBackendContext>, bool async_scrolling_enabled);
+
+    virtual void die() override;
+
+    virtual void did_allocate_backing_stores(Web::Compositor::CompositorContextId, i32 front_bitmap_id, Gfx::SharedImage&& front_backing_store, i32 back_bitmap_id, Gfx::SharedImage&& back_backing_store) override;
+    virtual void did_present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect content_rect, i32 bitmap_id) override;
 
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
+    virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, i32 web_content_connection_id) override;
+    virtual void destroy_context(Web::Compositor::CompositorContextId) override;
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress) override;
+    virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
+    virtual void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
+    virtual Messages::CompositorControlServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override;
+    virtual void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id) override;
 
-    i32 m_next_web_content_connection_id { 1 };
+    ConnectionFromWebContent* web_content_connection(i32 web_content_connection_id);
+
     HashMap<i32, NonnullRefPtr<ConnectionFromWebContent>> m_web_content_connections;
+    NonnullRefPtr<CompositorState> m_compositor_state;
 };
 
 }

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
+#include <Compositor/CompositorControlClientEndpoint.h>
+#include <Compositor/CompositorControlServerEndpoint.h>
+#include <Compositor/Forward.h>
+#include <LibIPC/ConnectionFromClient.h>
+
+namespace Compositor {
+
+class ConnectionFromClient final
+    : public IPC::ConnectionFromClient<CompositorControlClientEndpoint, CompositorControlServerEndpoint> {
+    C_OBJECT(ConnectionFromClient)
+
+public:
+    virtual void die() override;
+
+private:
+    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
+
+    virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
+    virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
+
+    i32 m_next_web_content_connection_id { 1 };
+    HashMap<i32, NonnullRefPtr<ConnectionFromWebContent>> m_web_content_connections;
+};
+
+}

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -38,7 +38,6 @@ private:
     virtual Messages::CompositorControlServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::CompositorControlServer::ConnectWebContentResponse connect_web_content() override;
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, i32 web_content_connection_id) override;
-    virtual void destroy_context(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress) override;
     virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -5,22 +5,154 @@
  */
 
 #include <Compositor/ConnectionFromWebContent.h>
+#include <LibWeb/Page/InputEvent.h>
 
 namespace Compositor {
 
-ConnectionFromWebContent::ConnectionFromWebContent(NonnullOwnPtr<IPC::Transport> transport, int client_id)
+ConnectionFromWebContent::ConnectionFromWebContent(NonnullOwnPtr<IPC::Transport> transport, NonnullRefPtr<CompositorState> compositor_state, int client_id)
     : IPC::ConnectionFromClient<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint>(*this, move(transport), client_id)
+    , m_compositor_state(move(compositor_state))
 {
 }
 
 void ConnectionFromWebContent::die()
 {
-    if (on_death)
-        on_death(*this);
+    auto protector = NonnullRefPtr { *this };
+    m_compositor_state->destroy_contexts_for_web_content_client(*this);
+    if (m_on_death)
+        m_on_death(*this);
 }
 
-void ConnectionFromWebContent::ping()
+void ConnectionFromWebContent::notify_compositor_lost()
 {
+    async_did_lose_compositor();
+}
+
+void ConnectionFromWebContent::request_rendering_update()
+{
+    async_request_rendering_update();
+}
+
+void ConnectionFromWebContent::dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const& event)
+{
+    async_mouse_event(page_id, event);
+}
+
+void ConnectionFromWebContent::verify_context_is_owned_by_this_connection(Web::Compositor::CompositorContextId context_id)
+{
+    switch (m_compositor_state->check_context_owner(context_id, *this)) {
+    case CompositorState::ContextOwnerCheckResult::OwnedByClient:
+        return;
+    case CompositorState::ContextOwnerCheckResult::ContextUnavailable:
+        VERIFY_NOT_REACHED();
+    case CompositorState::ContextOwnerCheckResult::ConflictingOwner:
+        did_misbehave("WebContent tried to use a compositor context owned by another connection");
+        VERIFY_NOT_REACHED();
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+void ConnectionFromWebContent::set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->set_presentation_mode(context_id, move(presentation_mode));
+}
+
+void ConnectionFromWebContent::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->stop_presenting_to_client(context_id);
+}
+
+void ConnectionFromWebContent::destroy_context(Web::Compositor::CompositorContextId context_id)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->destroy_context(context_id);
+}
+
+void ConnectionFromWebContent::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction resource_transaction, Web::Painting::ScrollStateSnapshot scroll_state_snapshot)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->update_display_list(context_id, move(display_list), move(resource_transaction), move(scroll_state_snapshot));
+}
+
+void ConnectionFromWebContent::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot scroll_state_snapshot)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->update_scroll_state(context_id, move(scroll_state_snapshot));
+}
+
+void ConnectionFromWebContent::update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->update_video_frame(context_id, frame_id, move(frame));
+}
+
+void ConnectionFromWebContent::clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->clear_video_frame(context_id, frame_id);
+}
+
+void ConnectionFromWebContent::update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage shared_image)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->update_compositor_surface(context_id, surface_id, move(shared_image));
+}
+
+void ConnectionFromWebContent::clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->clear_compositor_surface(context_id, surface_id);
+}
+
+void ConnectionFromWebContent::invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->invalidate_wheel_event_listener_state(context_id, generation);
+}
+
+Messages::CompositorWebContentServer::AsyncScrollByResponse ConnectionFromWebContent::async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    auto result = m_compositor_state->async_scroll_by(context_id, document_id, position, delta, viewport_rect, operation_tracking);
+    if (result.accepted)
+        async_request_rendering_update();
+    return result;
+}
+
+Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScrollResponse ConnectionFromWebContent::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    return m_compositor_state->should_defer_main_thread_present_for_async_scroll(context_id);
+}
+
+Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse ConnectionFromWebContent::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    return m_compositor_state->take_pending_async_scroll_updates(context_id);
+}
+
+void ConnectionFromWebContent::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+}
+
+void ConnectionFromWebContent::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    m_compositor_state->present_frame(context_id, viewport_rect);
+}
+
+void ConnectionFromWebContent::request_screenshot(Web::Compositor::CompositorContextId context_id, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap)
+{
+    verify_context_is_owned_by_this_connection(context_id);
+    if (m_compositor_state->request_screenshot(context_id, target_bitmap))
+        async_did_complete_screenshot(request_id);
+    else
+        async_did_fail_screenshot(request_id);
 }
 
 }

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Compositor/ConnectionFromWebContent.h>
+
+namespace Compositor {
+
+ConnectionFromWebContent::ConnectionFromWebContent(NonnullOwnPtr<IPC::Transport> transport, int client_id)
+    : IPC::ConnectionFromClient<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint>(*this, move(transport), client_id)
+{
+}
+
+void ConnectionFromWebContent::die()
+{
+    if (on_death)
+        on_death(*this);
+}
+
+void ConnectionFromWebContent::ping()
+{
+}
+
+}

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -7,25 +7,53 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <Compositor/CompositorState.h>
 #include <Compositor/CompositorWebContentClientEndpoint.h>
 #include <Compositor/CompositorWebContentServerEndpoint.h>
 #include <LibIPC/ConnectionFromClient.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 
 namespace Compositor {
 
 class ConnectionFromWebContent final
-    : public IPC::ConnectionFromClient<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint> {
-    C_OBJECT(ConnectionFromWebContent)
+    : public IPC::ConnectionFromClient<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint>
+    , public CompositorStateWebContentClient {
+    C_OBJECT(ConnectionFromWebContent);
 
 public:
-    virtual void die() override;
-
-    Function<void(ConnectionFromWebContent&)> on_death;
+    virtual ~ConnectionFromWebContent() override = default;
+    void notify_compositor_lost();
+    void set_on_death(Function<void(ConnectionFromWebContent&)> handler) { m_on_death = move(handler); }
 
 private:
-    explicit ConnectionFromWebContent(NonnullOwnPtr<IPC::Transport>, int client_id);
+    explicit ConnectionFromWebContent(NonnullOwnPtr<IPC::Transport>, NonnullRefPtr<CompositorState>, int client_id);
 
-    virtual void ping() override;
+    virtual void die() override;
+
+    virtual void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode) override;
+    virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId) override;
+    virtual void destroy_context(Web::Compositor::CompositorContextId) override;
+    virtual void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList>, Web::Painting::DisplayListResourceTransaction, Web::Painting::ScrollStateSnapshot) override;
+    virtual void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot) override;
+    virtual void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>) override;
+    virtual void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId) override;
+    virtual void update_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId, Gfx::SharedImage) override;
+    virtual void clear_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId) override;
+    virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
+    virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
+    virtual Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScrollResponse should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId) override;
+    virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress) override;
+    virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect) override;
+    virtual void request_screenshot(Web::Compositor::CompositorContextId, Web::Compositor::ScreenshotRequestId request_id, Gfx::ShareableBitmap target_bitmap) override;
+
+    virtual void dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const&) override;
+    virtual void request_rendering_update() override;
+    void verify_context_is_owned_by_this_connection(Web::Compositor::CompositorContextId);
+
+    NonnullRefPtr<CompositorState> m_compositor_state;
+    Function<void(ConnectionFromWebContent&)> m_on_death;
 };
 
 }

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <Compositor/CompositorWebContentClientEndpoint.h>
+#include <Compositor/CompositorWebContentServerEndpoint.h>
+#include <LibIPC/ConnectionFromClient.h>
+
+namespace Compositor {
+
+class ConnectionFromWebContent final
+    : public IPC::ConnectionFromClient<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint> {
+    C_OBJECT(ConnectionFromWebContent)
+
+public:
+    virtual void die() override;
+
+    Function<void(ConnectionFromWebContent&)> on_death;
+
+private:
+    explicit ConnectionFromWebContent(NonnullOwnPtr<IPC::Transport>, int client_id);
+
+    virtual void ping() override;
+};
+
+}

--- a/Services/Compositor/Forward.h
+++ b/Services/Compositor/Forward.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Compositor {
+
+class ConnectionFromClient;
+class ConnectionFromWebContent;
+
+}

--- a/Services/Compositor/Forward.h
+++ b/Services/Compositor/Forward.h
@@ -10,5 +10,6 @@ namespace Compositor {
 
 class ConnectionFromClient;
 class ConnectionFromWebContent;
+class CompositorState;
 
 }

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -43,11 +43,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     if (!force_cpu_painting)
         Gfx::SkiaBackendContext::initialize_gpu_backend();
+    auto skia_backend_context = Gfx::SkiaBackendContext::the_main_thread_context();
 
     Core::EventLoop event_loop;
-    auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(mach_server_name));
-    (void)client;
-    (void)disable_async_scrolling;
+    auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(
+        mach_server_name, move(skia_backend_context), !disable_async_scrolling));
 
     return event_loop.exec();
 }

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Compositor/ConnectionFromClient.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Process.h>
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/PathFontProvider.h>
+#include <LibGfx/SkiaBackendContext.h>
+#include <LibIPC/SingleServer.h>
+#include <LibMain/Main.h>
+#include <LibWebView/Utilities.h>
+
+ErrorOr<int> ladybird_main(Main::Arguments arguments)
+{
+    AK::set_rich_debug_enabled(true);
+
+    StringView mach_server_name;
+    bool wait_for_debugger = false;
+    bool force_cpu_painting = false;
+    bool force_fontconfig = false;
+    bool disable_async_scrolling = false;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
+    args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
+    args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
+    args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
+    args_parser.add_option(disable_async_scrolling, "Disable async scrolling", "disable-async-scrolling");
+    args_parser.parse(arguments);
+
+    if (wait_for_debugger)
+        Core::Process::wait_for_debugger_and_break();
+
+    WebView::platform_init();
+    auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
+    if (force_fontconfig)
+        font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+
+    if (!force_cpu_painting)
+        Gfx::SkiaBackendContext::initialize_gpu_backend();
+
+    Core::EventLoop event_loop;
+    auto client = TRY(IPC::take_over_accepted_client_from_system_server<Compositor::ConnectionFromClient>(mach_server_name));
+    (void)client;
+    (void)disable_async_scrolling;
+
+    return event_loop.exec();
+}

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(audio)
 
 set(SOURCES
+    CompositorConnection.cpp
     ConnectionFromClient.cpp
     ConsoleGlobalEnvironmentExtensions.cpp
     DevToolsConsoleClient.cpp

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -6,6 +6,12 @@
 
 #include <WebContent/CompositorConnection.h>
 
+#include <LibCore/EventLoop.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/PaintingSurface.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <WebContent/WebContentCompositorHost.h>
+
 namespace WebContent {
 
 CompositorConnection::CompositorConnection(NonnullOwnPtr<IPC::Transport> transport)
@@ -15,10 +21,143 @@ CompositorConnection::CompositorConnection(NonnullOwnPtr<IPC::Transport> transpo
 
 void CompositorConnection::die()
 {
+    // The compositor process owns this WebContent's painting and presentation.
+    // WebContent cannot continue without that connection, but the browser
+    // process owns recovery and already treats an active renderer exit as a
+    // crash. Avoid reporting an assertion failure during browser shutdown.
+    Core::EventLoop::current().quit(0);
 }
 
-void CompositorConnection::did_connect()
+void CompositorConnection::set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode const& presentation_mode)
 {
+    async_set_presentation_mode(context_id, presentation_mode);
+}
+
+void CompositorConnection::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
+{
+    async_stop_presenting_to_client(context_id);
+}
+
+void CompositorConnection::destroy_context(Web::Compositor::CompositorContextId context_id)
+{
+    async_destroy_context(context_id);
+}
+
+void CompositorConnection::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> const& display_list, Web::Painting::DisplayListResourceTransaction const& resource_transaction, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+{
+    auto encoded_message = MUST(Messages::CompositorWebContentServer::UpdateDisplayList::static_encode(context_id, display_list, resource_transaction, scroll_state_snapshot));
+    MUST(post_message(encoded_message));
+}
+
+void CompositorConnection::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
+{
+    async_update_scroll_state(context_id, scroll_state_snapshot);
+}
+
+void CompositorConnection::update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> const& frame)
+{
+    auto encoded_message = MUST(Messages::CompositorWebContentServer::UpdateVideoFrame::static_encode(context_id, frame_id, frame));
+    MUST(post_message(encoded_message));
+}
+
+void CompositorConnection::clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id)
+{
+    async_clear_video_frame(context_id, frame_id);
+}
+
+void CompositorConnection::update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage const& shared_image)
+{
+    async_update_compositor_surface(context_id, surface_id, shared_image);
+}
+
+void CompositorConnection::clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id)
+{
+    async_clear_compositor_surface(context_id, surface_id);
+}
+
+void CompositorConnection::invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation)
+{
+    async_invalidate_wheel_event_listener_state(context_id, generation);
+}
+
+Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking)
+{
+    auto response = send_sync<Messages::CompositorWebContentServer::AsyncScrollBy>(context_id, document_id, position, delta, viewport_rect, operation_tracking);
+    return response->take_result();
+}
+
+bool CompositorConnection::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id)
+{
+    auto response = send_sync<Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScroll>(context_id);
+    return response->should_defer();
+}
+
+Web::Compositor::PendingAsyncScrollUpdates CompositorConnection::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
+{
+    auto response = send_sync<Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdates>(context_id);
+    return response->take_updates();
+}
+
+void CompositorConnection::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
+{
+    async_viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+}
+
+void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
+{
+    async_present_frame(context_id, viewport_rect);
+}
+
+void CompositorConnection::request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
+{
+    auto target_bitmap = MUST(Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, target_surface->size()));
+    auto shareable_bitmap = Gfx::ShareableBitmap { target_bitmap, Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
+    auto request_id = Web::Compositor::ScreenshotRequestId { m_next_screenshot_request_id++ };
+    m_screenshots.set(request_id, PendingScreenshot { move(target_surface), move(target_bitmap), move(callback) });
+    async_request_screenshot(context_id, request_id, move(shareable_bitmap));
+}
+
+void CompositorConnection::mouse_event(u64 page_id, Web::MouseEvent event)
+{
+    if (on_mouse_event)
+        on_mouse_event(page_id, move(event));
+}
+
+void CompositorConnection::request_rendering_update()
+{
+    Web::HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
+}
+
+void CompositorConnection::did_complete_screenshot(Web::Compositor::ScreenshotRequestId request_id)
+{
+    auto pending_screenshot = take_screenshot(request_id);
+    VERIFY(pending_screenshot.has_value());
+
+    pending_screenshot->target_surface->write_from_bitmap(*pending_screenshot->target_bitmap);
+    if (pending_screenshot->callback)
+        pending_screenshot->callback();
+}
+
+void CompositorConnection::did_fail_screenshot(Web::Compositor::ScreenshotRequestId request_id)
+{
+    auto pending_screenshot = take_screenshot(request_id);
+    VERIFY(pending_screenshot.has_value());
+
+    if (pending_screenshot->callback)
+        pending_screenshot->callback();
+}
+
+void CompositorConnection::did_lose_compositor()
+{
+    // The Compositor service sends this when its browser-process control
+    // connection is gone. WebContent cannot present without that owner either,
+    // so exit cleanly instead of reporting a renderer crash during shutdown.
+    die();
+}
+
+Optional<CompositorConnection::PendingScreenshot> CompositorConnection::take_screenshot(Web::Compositor::ScreenshotRequestId request_id)
+{
+    return m_screenshots.take(request_id);
 }
 
 }

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <WebContent/CompositorConnection.h>
+
+namespace WebContent {
+
+CompositorConnection::CompositorConnection(NonnullOwnPtr<IPC::Transport> transport)
+    : IPC::ConnectionToServer<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint>(*this, move(transport))
+{
+}
+
+void CompositorConnection::die()
+{
+}
+
+void CompositorConnection::did_connect()
+{
+}
+
+}

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -6,9 +6,25 @@
 
 #pragma once
 
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <Compositor/CompositorWebContentClientEndpoint.h>
 #include <Compositor/CompositorWebContentServerEndpoint.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibGfx/SharedImage.h>
+#include <LibGfx/Size.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibMedia/Forward.h>
+#include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Painting/DisplayList.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
+#include <LibWeb/Painting/ScrollState.h>
 
 namespace WebContent {
 
@@ -20,10 +36,44 @@ class CompositorConnection final
 public:
     explicit CompositorConnection(NonnullOwnPtr<IPC::Transport>);
 
+    void set_presentation_mode(Web::Compositor::CompositorContextId, Web::Compositor::PresentationMode const&);
+    void stop_presenting_to_client(Web::Compositor::CompositorContextId);
+    void destroy_context(Web::Compositor::CompositorContextId);
+    void update_display_list(Web::Compositor::CompositorContextId, NonnullRefPtr<Web::Painting::DisplayList> const&, Web::Painting::DisplayListResourceTransaction const&, Web::Painting::ScrollStateSnapshot const&);
+    void update_scroll_state(Web::Compositor::CompositorContextId, Web::Painting::ScrollStateSnapshot const&);
+    void update_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const> const&);
+    void clear_video_frame(Web::Compositor::CompositorContextId, Web::Painting::VideoFrameResourceId);
+    void update_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId, Gfx::SharedImage const&);
+    void clear_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId);
+    void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation);
+    Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
+    bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId);
+    Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
+    void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress);
+    void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect);
+    void request_screenshot(Web::Compositor::CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&&);
+    Function<void(u64 page_id, Web::MouseEvent)> on_mouse_event;
+
 private:
+    struct PendingScreenshot {
+        NonnullRefPtr<Gfx::PaintingSurface> target_surface;
+        NonnullRefPtr<Gfx::Bitmap> target_bitmap;
+
+        Function<void()> callback;
+    };
+
     virtual void die() override;
 
-    virtual void did_connect() override;
+    virtual void mouse_event(u64 page_id, Web::MouseEvent) override;
+    virtual void request_rendering_update() override;
+    virtual void did_complete_screenshot(Web::Compositor::ScreenshotRequestId) override;
+    virtual void did_fail_screenshot(Web::Compositor::ScreenshotRequestId) override;
+    virtual void did_lose_compositor() override;
+
+    Optional<PendingScreenshot> take_screenshot(Web::Compositor::ScreenshotRequestId);
+
+    HashMap<Web::Compositor::ScreenshotRequestId, PendingScreenshot> m_screenshots;
+    u64 m_next_screenshot_request_id { 1 };
 };
 
 }

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Compositor/CompositorWebContentClientEndpoint.h>
+#include <Compositor/CompositorWebContentServerEndpoint.h>
+#include <LibIPC/ConnectionToServer.h>
+
+namespace WebContent {
+
+class CompositorConnection final
+    : public IPC::ConnectionToServer<CompositorWebContentClientEndpoint, CompositorWebContentServerEndpoint>
+    , public CompositorWebContentClientEndpoint {
+    C_OBJECT_ABSTRACT(CompositorConnection)
+
+public:
+    explicit CompositorConnection(NonnullOwnPtr<IPC::Transport>);
+
+private:
+    virtual void die() override;
+
+    virtual void did_connect() override;
+};
+
+}

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -66,6 +66,7 @@
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
 #include <WebContent/WebContentClientEndpoint.h>
+#include <WebContent/WebContentCompositorHost.h>
 
 namespace WebContent {
 
@@ -76,6 +77,18 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transpo
 }
 
 ConnectionFromClient::~ConnectionFromClient() = default;
+
+CompositorConnection& ConnectionFromClient::compositor_process_connection() const
+{
+    VERIFY(m_compositor_connection);
+    VERIFY(m_compositor_connection->is_open());
+    return *m_compositor_connection;
+}
+
+void ConnectionFromClient::did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
+{
+    async_did_destroy_compositor_context(context_id);
+}
 
 void ConnectionFromClient::die()
 {
@@ -158,7 +171,11 @@ void ConnectionFromClient::connect_to_compositor(IPC::TransportHandle handle)
 
 void ConnectionFromClient::connect_to_compositor_process(IPC::TransportHandle handle)
 {
-    (void)handle;
+    auto transport = MUST(handle.create_transport());
+    m_compositor_connection = adopt_ref(*new CompositorConnection(move(transport)));
+    m_compositor_connection->on_mouse_event = [this](u64 page_id, Web::MouseEvent event) {
+        mouse_event(page_id, move(event));
+    };
 }
 
 void ConnectionFromClient::connect_to_request_server(IPC::TransportHandle handle)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -61,6 +61,7 @@
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ViewImplementation.h>
+#include <WebContent/CompositorConnection.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
@@ -153,6 +154,11 @@ void ConnectionFromClient::connect_to_image_decoder(IPC::TransportHandle handle)
 void ConnectionFromClient::connect_to_compositor(IPC::TransportHandle handle)
 {
     m_page_host->attach_compositor_ui_client(move(handle));
+}
+
+void ConnectionFromClient::connect_to_compositor_process(IPC::TransportHandle handle)
+{
+    (void)handle;
 }
 
 void ConnectionFromClient::connect_to_request_server(IPC::TransportHandle handle)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -10,6 +10,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/Queue.h>
+#include <AK/RefPtr.h>
 #include <AK/SourceLocation.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGC/Root.h>
@@ -68,6 +69,7 @@ private:
     virtual void connect_to_request_server(IPC::TransportHandle handle) override;
     virtual void connect_to_image_decoder(IPC::TransportHandle handle) override;
     virtual void connect_to_compositor(IPC::TransportHandle handle) override;
+    virtual void connect_to_compositor_process(IPC::TransportHandle handle) override;
     virtual void update_system_theme(u64 page_id, Core::AnonymousBuffer) override;
     virtual void update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect>, u32) override;
     virtual void load_url(u64 page_id, URL::URL) override;
@@ -185,6 +187,7 @@ private:
     void enqueue_input_event(Web::QueuedInputEvent);
 
     Queue<Web::QueuedInputEvent> m_input_event_queue;
+    RefPtr<CompositorConnection> m_compositor_connection;
 };
 
 }

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -19,6 +19,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/EventResult.h>
@@ -48,6 +49,8 @@ public:
 
     PageHost& page_host() { return *m_page_host; }
     PageHost const& page_host() const { return *m_page_host; }
+    CompositorConnection& compositor_process_connection() const;
+    void did_destroy_compositor_context(Web::Compositor::CompositorContextId);
 
     Function<void(IPC::TransportHandle const&)> on_request_server_connection;
     Function<void(IPC::TransportHandle const&)> on_image_decoder_connection;
@@ -179,6 +182,7 @@ private:
 
     virtual void exit_fullscreen(u64 page_id) override;
 
+    RefPtr<CompositorConnection> m_compositor_connection;
     NonnullOwnPtr<PageHost> m_page_host;
 
     HashMap<int, Web::FileRequest> m_requested_files {};
@@ -187,7 +191,6 @@ private:
     void enqueue_input_event(Web::QueuedInputEvent);
 
     Queue<Web::QueuedInputEvent> m_input_event_queue;
-    RefPtr<CompositorConnection> m_compositor_connection;
 };
 
 }

--- a/Services/WebContent/Forward.h
+++ b/Services/WebContent/Forward.h
@@ -8,6 +8,7 @@
 
 namespace WebContent {
 
+class CompositorConnection;
 class ConnectionFromClient;
 class ConsoleGlobalEnvironmentExtensions;
 class DevToolsConsoleClient;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -205,6 +205,11 @@ void PageClient::report_finished_handling_input_event(u64 page_id, Web::EventRes
     client().async_did_finish_handling_input_event(page_id, event_was_handled);
 }
 
+Web::Compositor::CompositorContextId PageClient::allocate_compositor_context_id(Web::Compositor::PagePresentationRegistration page_presentation_registration)
+{
+    return client().allocate_compositor_context_id(m_id, page_presentation_registration);
+}
+
 void PageClient::set_viewport(Web::DevicePixelSize const& size, double device_pixel_ratio)
 {
     auto invalidate = m_device_pixel_ratio != device_pixel_ratio

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -51,6 +51,7 @@ public:
 
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override;
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
+    virtual Web::Compositor::CompositorContextId allocate_compositor_context_id(Web::Compositor::PagePresentationRegistration) override;
 
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport(Web::DevicePixelSize const&, double device_pixel_ratio);

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -50,7 +50,7 @@ void PageHost::ensure_compositor_host(Web::DisplayListPlayerType display_list_pl
 {
     if (m_compositor_host)
         return;
-    m_compositor_host = create_web_content_compositor_host();
+    m_compositor_host = create_web_content_compositor_host(m_client);
     m_compositor_host->start(display_list_player_type);
 }
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -11,6 +11,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Clipboard/SystemClipboard.h>
+#include <LibWeb/Compositor/Types.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/ActivateTab.h>
@@ -33,6 +34,9 @@
 
 endpoint WebContentClient
 {
+    allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
+    destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
+
     did_request_new_process_for_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|
     did_finish_loading(u64 page_id, URL::URL url) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -35,7 +35,7 @@
 endpoint WebContentClient
 {
     allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
-    destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
+    did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
     did_request_new_process_for_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -231,9 +231,9 @@ public:
     }
 
 private:
-    virtual Messages::WebContentCompositorServer::CreateContextResponse create_context(Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
+    virtual void create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
     {
-        return m_compositor_thread->create_context(page_id, page_presentation_registration);
+        m_compositor_thread->register_context(context_id, page_id, page_presentation_registration);
     }
 
     virtual void destroy_context(Web::Compositor::CompositorContextId context_id) override
@@ -414,9 +414,9 @@ public:
     }
 
 private:
-    virtual Web::Compositor::CompositorContextId allocate_context(Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
+    virtual void register_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
     {
-        return connection().create_context(page_id, page_presentation_registration);
+        connection().create_context(context_id, page_id, page_presentation_registration);
     }
 
     virtual void destroy_context(Web::Compositor::CompositorContextId context_id) override

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/HashMap.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
@@ -20,12 +21,25 @@
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <WebContent/CompositorClientEndpoint.h>
+#include <WebContent/CompositorConnection.h>
 #include <WebContent/CompositorServerEndpoint.h>
+#include <WebContent/ConnectionFromClient.h>
 #include <WebContent/WebContentCompositorClientEndpoint.h>
 #include <WebContent/WebContentCompositorHost.h>
 #include <WebContent/WebContentCompositorServerEndpoint.h>
 
 namespace WebContent {
+
+static bool& should_use_compositor_process()
+{
+    static bool flag = false;
+    return flag;
+}
+
+void set_should_use_compositor_process(bool enabled)
+{
+    should_use_compositor_process() = enabled;
+}
 
 class WebContentCompositorActor;
 
@@ -388,7 +402,7 @@ void CompositorConnectionFromClient::ready_to_paint(u64 page_id, i32 bitmap_id)
     m_actor.presented_bitmap_ready_to_paint(page_id, bitmap_id);
 }
 
-class WebContentCompositorHost final : public Web::Compositor::CompositorHost {
+class LocalWebContentCompositorHost final : public Web::Compositor::CompositorHost {
 public:
     virtual void start(Web::DisplayListPlayerType display_list_player_type) override
     {
@@ -525,9 +539,128 @@ private:
     RefPtr<Threading::Thread> m_actor_thread;
 };
 
-NonnullOwnPtr<Web::Compositor::CompositorHost> create_web_content_compositor_host()
+class ProcessWebContentCompositorHost final : public Web::Compositor::CompositorHost {
+public:
+    explicit ProcessWebContentCompositorHost(ConnectionFromClient& client)
+        : m_client(client)
+    {
+    }
+
+    virtual void start(Web::DisplayListPlayerType) override
+    {
+    }
+
+private:
+    virtual void register_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) override
+    {
+        if (page_presentation_registration == Web::Compositor::PagePresentationRegistration::Yes) {
+            VERIFY(page_id.has_value());
+        } else {
+            VERIFY(!page_id.has_value());
+            VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
+        }
+    }
+
+    virtual void destroy_context(Web::Compositor::CompositorContextId context_id) override
+    {
+        connection().destroy_context(context_id);
+        m_client.did_destroy_compositor_context(context_id);
+    }
+
+    virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) override
+    {
+        connection().stop_presenting_to_client(context_id);
+    }
+
+    virtual void set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode mode) override
+    {
+        connection().set_presentation_mode(context_id, mode);
+    }
+
+    virtual void update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
+    {
+        connection().update_display_list(context_id, display_list, resource_transaction, scroll_state_snapshot);
+    }
+
+    virtual void update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) override
+    {
+        connection().update_video_frame(context_id, frame_id, frame);
+    }
+
+    virtual void clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id) override
+    {
+        connection().clear_video_frame(context_id, frame_id);
+    }
+
+    virtual void update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image) override
+    {
+        connection().update_compositor_surface(context_id, surface_id, shared_image);
+    }
+
+    virtual void clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id) override
+    {
+        connection().clear_compositor_surface(context_id, surface_id);
+    }
+
+    virtual void update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
+    {
+        connection().update_scroll_state(context_id, scroll_state_snapshot);
+    }
+
+    virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) override
+    {
+        connection().invalidate_wheel_event_listener_state(context_id, generation);
+    }
+
+    virtual Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position,
+        Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) override
+    {
+        return connection().async_scroll_by(context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+    }
+
+    virtual bool should_defer_async_scroll_offset_adoption(Web::Compositor::CompositorContextId) const override
+    {
+        return false;
+    }
+
+    virtual bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const override
+    {
+        return connection().should_defer_main_thread_present_for_async_scroll(context_id);
+    }
+
+    virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) override
+    {
+        return connection().take_pending_async_scroll_updates(context_id);
+    }
+
+    virtual void viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) override
+    {
+        connection().viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+    }
+
+    virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) override
+    {
+        connection().present_frame(context_id, viewport_rect);
+    }
+
+    virtual void request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback) override
+    {
+        connection().request_screenshot(context_id, move(target_surface), move(callback));
+    }
+
+    CompositorConnection& connection() const
+    {
+        return m_client.compositor_process_connection();
+    }
+
+    ConnectionFromClient& m_client;
+};
+
+NonnullOwnPtr<Web::Compositor::CompositorHost> create_web_content_compositor_host(ConnectionFromClient& client)
 {
-    return make<WebContentCompositorHost>();
+    if (should_use_compositor_process())
+        return make<ProcessWebContentCompositorHost>(client);
+    return make<LocalWebContentCompositorHost>();
 }
 
 }

--- a/Services/WebContent/WebContentCompositorHost.h
+++ b/Services/WebContent/WebContentCompositorHost.h
@@ -6,11 +6,15 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/RefPtr.h>
 #include <LibWeb/Compositor/CompositorHost.h>
+#include <WebContent/Forward.h>
 
 namespace WebContent {
 
-NonnullOwnPtr<Web::Compositor::CompositorHost> create_web_content_compositor_host();
+NonnullOwnPtr<Web::Compositor::CompositorHost> create_web_content_compositor_host(ConnectionFromClient&);
+void set_should_use_compositor_process(bool);
 
 }

--- a/Services/WebContent/WebContentCompositorServer.ipc
+++ b/Services/WebContent/WebContentCompositorServer.ipc
@@ -13,7 +13,7 @@
 
 endpoint WebContentCompositorServer
 {
-    create_context(Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => (Web::Compositor::CompositorContextId context_id)
+    create_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration) => ()
     destroy_context(Web::Compositor::CompositorContextId context_id) =|
 
     set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode presentation_mode) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -35,6 +35,7 @@ endpoint WebContentServer
     connect_to_request_server(IPC::TransportHandle handle) =|
     connect_to_image_decoder(IPC::TransportHandle handle) =|
     connect_to_compositor(IPC::TransportHandle handle) =|
+    connect_to_compositor_process(IPC::TransportHandle handle) =|
 
     update_system_theme(u64 page_id, Core::AnonymousBuffer theme_buffer) =|
     update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> rects, u32 main_screen_index) =|

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -39,6 +39,7 @@
 #include <LibWebView/Utilities.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
+#include <WebContent/WebContentCompositorHost.h>
 #include <WebContent/WebDriverConnection.h>
 
 #include <openssl/thread.h>
@@ -149,6 +150,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool is_headless = false;
     bool disable_scrollbar_painting = false;
     bool disable_async_scrolling = false;
+    bool enable_compositor_process = false;
     StringView echo_server_port_string_view {};
     StringView default_time_zone {};
     StringView style_invalidation_counter_dump_interval {};
@@ -171,6 +173,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation");
     args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical viewport scrollbars", "disable-scrollbar-painting");
     args_parser.add_option(disable_async_scrolling, "Disable async scrolling", "disable-async-scrolling");
+    args_parser.add_option(enable_compositor_process, "Use the Compositor helper process", "enable-compositor-process");
     args_parser.add_option(echo_server_port_string_view, "Echo server port used in test internals", "echo-server-port", 0, "echo_server_port");
     args_parser.add_option(is_headless, "Report that the browser is running in headless mode", "headless");
     args_parser.add_option(default_time_zone, "Default time zone", "default-time-zone", 0, "time-zone-id");
@@ -222,6 +225,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     Web::Painting::set_paint_viewport_scrollbars(!disable_scrollbar_painting);
     WebContent::PageClient::set_async_scrolling_enabled(!disable_async_scrolling);
+    WebContent::set_should_use_compositor_process(enable_compositor_process);
 
     if (!echo_server_port_string_view.is_empty()) {
         if (auto maybe_echo_server_port = echo_server_port_string_view.to_number<u16>(); maybe_echo_server_port.has_value())

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -99,7 +99,7 @@ else()
     )
 endif()
 
-set(ladybird_helper_processes ImageDecoder RequestServer WebContent WebWorker)
+set(ladybird_helper_processes Compositor ImageDecoder RequestServer WebContent WebWorker)
 
 add_dependencies(ladybird ${ladybird_helper_processes})
 # FIXME: Increase support for building targets on Windows


### PR DESCRIPTION
We are moving toward an architecture where the browser owns a single process that holds the GPU context, so Skia resources can be shared across every renderer and WebContent processes can be sandboxed away from direct GPU access. A dedicated Compositor helper process is the first step.

This branch lands that helper as a selectable backend, gated behind `--enable-compositor-process` so the existing in-process rendering path stays the shipping default. The six commits build up the foundation in order: process scaffolding and channels, externally allocated context ids, the service-side state machine, the wire protocol, Browser-side context bookkeeping, and finally the runtime switch.

Default topology — one compositor per WebContent, in-process:**

```
      +---------+
      | Browser |
      +---------+
      /    |    \
     v     v     v
   +---+ +---+ +---+    each WebContent runs its own
   |WC | |WC | |WC |    CompositorThread on a dedicated
   |+C+| |+C+| |+C+|    thread, with its own GPU context.
   +---+ +---+ +---+
```

Opt-in topology — one single-threaded Compositor, shared by all WCs:**

```
   +---------+   control   +-------------------+
   | Browser |<----------->|    Compositor     |
   +---------+             |  (single thread,  |
   /    |    \             |   single GPU ctx, |
  v     v     v    data    |   shared by all   |
 [WC] [WC] [WC] ---------->|   connected WCs)  |
                           +-------------------+
```

Three IPC channels carry the work in the opt-in topology. The existing Browser↔WebContent channel gains context allocation. A new Browser↔Compositor channel carries context lifetime, viewport, UI input, and presentation acks plus backing-store and frame upcalls. A new WebContent↔Compositor channel carries display lists, scroll state, video, compositor surfaces, async scrolling, presentation, and screenshots, with upcalls for delegated input and compositor loss.

Context ids are minted in Browser, registered with the helper, enforced on every WebContent-side message, and freed on Navigable detach or WebContent crash. Helper death crashes Browser in opt-in mode (unrecoverable); WebContent death is contained by the helper reaping that connection's contexts.
