### PR TITLE
LibWeb: Preserve paint cache for transform-only animation updates

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -820,11 +820,7 @@ static bool animated_property_changes_are_visual_context_only(HashMap<CSS::Prope
             CSS::PropertyID::Rotate,
             CSS::PropertyID::Scale,
             CSS::PropertyID::Translate,
-            CSS::PropertyID::Perspective,
-            CSS::PropertyID::TransformOrigin,
-            CSS::PropertyID::PerspectiveOrigin,
-            CSS::PropertyID::Opacity,
-            CSS::PropertyID::Filter);
+            CSS::PropertyID::Opacity);
     };
 
     bool saw_changed_property = false;

--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -811,6 +812,47 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation_f
     return invalidation;
 }
 
+static bool animated_property_changes_are_visual_context_only(HashMap<CSS::PropertyID, NonnullRefPtr<CSS::StyleValue const>> const& old_properties, HashMap<CSS::PropertyID, NonnullRefPtr<CSS::StyleValue const>> const& new_properties)
+{
+    auto is_visual_context_property = [](CSS::PropertyID property_id) {
+        return first_is_one_of(property_id,
+            CSS::PropertyID::Transform,
+            CSS::PropertyID::Rotate,
+            CSS::PropertyID::Scale,
+            CSS::PropertyID::Translate,
+            CSS::PropertyID::Perspective,
+            CSS::PropertyID::TransformOrigin,
+            CSS::PropertyID::PerspectiveOrigin,
+            CSS::PropertyID::Opacity,
+            CSS::PropertyID::Filter);
+    };
+
+    bool saw_changed_property = false;
+    auto changed_property_is_visual_context_only = [&](CSS::PropertyID property_id, CSS::StyleValue const* old_value, CSS::StyleValue const* new_value) {
+        if (!old_value && !new_value)
+            return true;
+        if (old_value == new_value)
+            return true;
+        if (old_value && new_value && old_value->equals(*new_value))
+            return true;
+        saw_changed_property = true;
+        return is_visual_context_property(property_id);
+    };
+
+    for (auto const& [property_id, old_value] : old_properties) {
+        auto const* new_value = new_properties.get(property_id).value_or({});
+        if (!changed_property_is_visual_context_only(property_id, old_value.ptr(), new_value))
+            return false;
+    }
+    for (auto const& [property_id, new_value] : new_properties) {
+        if (old_properties.contains(property_id))
+            continue;
+        if (!changed_property_is_visual_context_only(property_id, nullptr, new_value.ptr()))
+            return false;
+    }
+    return saw_changed_property;
+}
+
 AnimationUpdateContext::~AnimationUpdateContext()
 {
     for (auto& it : elements) {
@@ -820,6 +862,7 @@ AnimationUpdateContext::~AnimationUpdateContext()
         auto& element = it.key;
         GC::Ref<DOM::Element> target = element.element();
         auto invalidation = compute_required_invalidation_for_animated_properties(it.value.animated_properties_before_update, style->animated_property_values());
+        auto visual_context_only_change = animated_property_changes_are_visual_context_only(it.value.animated_properties_before_update, style->animated_property_values());
 
         if (invalidation.is_none())
             continue;
@@ -877,7 +920,20 @@ AnimationUpdateContext::~AnimationUpdateContext()
             if (invalidation.rebuild_accumulated_visual_contexts)
                 element.document().set_needs_accumulated_visual_contexts_update(true);
 
-            target->set_needs_repaint();
+            auto can_keep_paint_cache_for_visual_context_change = visual_context_only_change
+                && invalidation.rebuild_accumulated_visual_contexts
+                && !invalidation.relayout
+                && !invalidation.rebuild_layout_tree
+                && !invalidation.rebuild_stacking_context_tree
+                && !invalidation.recompute_descendant_styles
+                && !invalidation.inherited_style_changed;
+
+            if (can_keep_paint_cache_for_visual_context_change) {
+                element.document().set_needs_to_record_display_list();
+                target->set_needs_repaint(InvalidateDisplayList::No);
+            } else {
+                target->set_needs_repaint();
+            }
         }
         if (invalidation.rebuild_stacking_context_tree)
             element.document().invalidate_stacking_context_tree();


### PR DESCRIPTION
Previously, transform-only animation updates would cause the paint cache to be invalidated on every tick, resulting in a full repaint of all unchanged content in the affected subtree.  Now, cached paint commands are preserved when an animated property update only impacts the accumulated visual context (e.g. transform, opacity). The accumulated visual context is still updated.

This eliminates per-tick repaints of large unchanged subtrees . A visible case is long text runs animated with transform: translateX(...) that used to cause page-wide jank on each frame.

Testing
Tested manually on https://melankorin.net/, https://herz.moe/ (websites with animated text with transform: translateX(...)). This change fixed the strong visible jank on both sites .

All tests in ./Meta/[ladybird.py](http://ladybird.py/) test LibWeb suite pass.

## Before:
https://github.com/user-attachments/assets/0befdaf7-a0dd-40f8-b03c-f2b9be552698

## After:

https://github.com/user-attachments/assets/94d5dfa2-d7ab-4549-96d4-1a8e85f5cf2e


