### PR TITLE
Meta: Use baseline CPU for fuzzer host tools

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -155,6 +155,7 @@ jobs:
           VCPKG_CACHE_MODE: ${{ github.ref == 'refs/heads/master' && 'write' || '' }}
         run: |
           cmake --preset=Host_Tools -B "${GITHUB_WORKSPACE}/Build/host-tools-build" \
+            -DENABLE_CI_BASELINE_CPU=ON \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python
 
           ninja -C "${GITHUB_WORKSPACE}/Build/host-tools-build" install

--- a/Meta/CMake/compile_options.cmake
+++ b/Meta/CMake/compile_options.cmake
@@ -48,7 +48,7 @@ function(add_cxx_link_option_if_supported option)
 endfunction()
 
 if (ENABLE_CI_BASELINE_CPU)
-    # In CI, we want to target a common architecture so different runners can share ccache caches effectively.
+    # In CI, target a common architecture so ccache artifacts and built tools are portable across runners.
     if (APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         add_cxx_compile_options(-mcpu=apple-m1)
     elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")


### PR DESCRIPTION
The fuzzer CI build first builds and installs LagomTools, then imports those tools into the fuzzer build. This host-tools configure path skipped ENABLE_CI_BASELINE_CPU, so tools such as BindingsGenerator could be built with -march=native.

That is unsafe with shared CI caches and mixed runner CPUs, since a cached host tool may contain instructions unsupported by the runner that later executes it.

Pass ENABLE_CI_BASELINE_CPU when configuring fuzzer host tools.