### PR TITLE
CI: Pass CMake options in the Fuzzers build

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -155,11 +155,13 @@ jobs:
           VCPKG_CACHE_MODE: ${{ github.ref == 'refs/heads/master' && 'write' || '' }}
         run: |
           cmake --preset=Host_Tools -B "${GITHUB_WORKSPACE}/Build/host-tools-build" \
+            ${{ steps.build-parameters.outputs.cmake_options }} \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python
 
           ninja -C "${GITHUB_WORKSPACE}/Build/host-tools-build" install
 
           cmake --preset ${{ inputs.build_preset }} -B Build \
+            ${{ steps.build-parameters.outputs.cmake_options }} \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \


### PR DESCRIPTION
We were forgetting to pass CMake options in the Fuzzers build. These CMake options contain -DENABLE_CI_BASELINE_CPU=ON, which sets a baseline architecture to properly allow ccache sharing between different runners. Without it, it defaults to the native architecture, which is then cached and can be used on a runner that doesn't have the same instruction set.

This is targetted at fixing the "Illegal instruction" crash we've been seeing with the bindings generator.