### PR TITLE
LibWeb: Account for transforms when culling effects

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -238,6 +238,18 @@ void DisplayListPlayer::execute_impl(
         auto common_ancestor_index = visual_context_tree.find_common_ancestor(applied_context_index, target_index);
         size_t const common_ancestor_depth = common_ancestor_index.value() ? visual_context_tree.node_at(common_ancestor_index).depth : 0;
 
+        auto has_coordinate_changing_descendant = [&](VisualContextIndex ancestor_index) {
+            for (auto index = target_index; index != ancestor_index; index = visual_context_tree.node_at(index).parent_index) {
+                auto const& node = visual_context_tree.node_at(index);
+                if (node.data.has<TransformData>()
+                    || node.data.has<PerspectiveData>()
+                    || node.data.has<ScrollData>()
+                    || node.data.has<ScrollCompensation>())
+                    return true;
+            }
+            return false;
+        };
+
         while (applied_depth > common_ancestor_depth) {
             restore({});
             applied_depth--;
@@ -249,7 +261,8 @@ void DisplayListPlayer::execute_impl(
             target_index,
             [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node) {
                 if (bounding_rect.has_value() && node.data.has<EffectsData>()) {
-                    if (bounding_rect->is_empty() || would_be_fully_clipped_by_painter(*bounding_rect)) {
+                    auto can_cull_before_effect = !has_coordinate_changing_descendant(node_index);
+                    if (bounding_rect->is_empty() || (can_cull_before_effect && would_be_fully_clipped_by_painter(*bounding_rect))) {
                         result = SwitchResult::CulledByEffect;
                         return IterationDecision::Break;
                     }

--- a/Tests/LibWeb/Ref/expected/effect-culling-with-transformed-descendant-ref.html
+++ b/Tests/LibWeb/Ref/expected/effect-culling-with-transformed-descendant-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .box {
+        position: absolute;
+        left: 40px;
+        top: 380px;
+        width: 80px;
+        height: 400px;
+        background: green;
+        opacity: 0.999;
+    }
+</style>
+<div class="box"></div>

--- a/Tests/LibWeb/Ref/input/effect-culling-with-transformed-descendant.html
+++ b/Tests/LibWeb/Ref/input/effect-culling-with-transformed-descendant.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/effect-culling-with-transformed-descendant-ref.html" />
+<style>
+    body {
+        margin: 0;
+    }
+
+    .box {
+        position: absolute;
+        left: 120px;
+        top: 700px;
+        width: 400px;
+        height: 80px;
+        background: green;
+        opacity: 0.999;
+        transform: rotate(-90deg);
+        transform-origin: bottom left;
+    }
+</style>
+<div class="box"></div>


### PR DESCRIPTION
Skip the early effect culling optimization when the draw command has coordinate-changing visual contexts before the target. Without this, a filter or opacity layer can be rejected using an untransformed bounding rect even though a later transform moves the pixels into view.

Add a reference test where an opacity layer starts below the viewport, then a rotation brings it back on screen.

Visual progression on https://theverge.com/

Before:
<img width="1624" height="986" alt="Screenshot 2026-05-22 at 20 30 40" src="https://github.com/user-attachments/assets/5e0de138-47f3-4296-971a-5f57e2a76290" />

After:
<img width="1624" height="986" alt="Screenshot 2026-05-22 at 20 30 30" src="https://github.com/user-attachments/assets/949d2717-24c0-41ca-934c-88a4706379b4" />