### PR TITLE
LibWeb: Keep dirty style descendants reachable after style update

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1995,8 +1995,18 @@ bool Document::layout_is_up_to_date() const
         });
     }
 
-    if (!skip_display_none_descent)
-        node.set_child_needs_style_update(false);
+    if (!skip_display_none_descent && node.child_needs_style_update()) {
+        auto any_child_still_dirty = false;
+        node.for_each_child([&](auto& child) {
+            if (child.needs_style_update() || child.child_needs_style_update()) {
+                any_child_still_dirty = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
+        if (!any_child_still_dirty)
+            node.set_child_needs_style_update(false);
+    }
 
     if (node.is_element())
         style_computer.pop_ancestor(static_cast<Element const&>(node));

--- a/Tests/LibWeb/Crash/Layout/style-update-display-none-animation-move.html
+++ b/Tests/LibWeb/Crash/Layout/style-update-display-none-animation-move.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style>
+    #hidden {
+        animation: reveal 1s linear paused both;
+    }
+
+    @keyframes reveal {
+        from {
+            display: none;
+        }
+
+        to {
+            display: block;
+        }
+    }
+</style>
+<div id="hidden"></div>
+<script>
+    const hiddenContainer = document.getElementById("hidden");
+    const revealAnimation = hiddenContainer.getAnimations()[0];
+    revealAnimation.currentTime = 0;
+
+    hiddenContainer.appendChild(document.createElement("em"));
+    document.body.offsetWidth;
+
+    revealAnimation.currentTime = 500;
+    document.body.offsetWidth;
+</script>


### PR DESCRIPTION
A descendant can become marked for style update while `update_style_recursively()` is still unwinding through one of its ancestors. Previously that ancestor would unconditionally clear `child_needs_style_update`, which could break the dirty-bit chain back to the document.

When that happened, the next style update could skip the subtree even though a descendant was still marked for style update. Layout tree construction could then reach the unstyled element, find null `computed_properties()`, and crash when reading its display value.

We now only clear child_needs_style_update after a style update when no direct child remains marked for style update. This keeps the dirty path intact so the next style pass descends into the affected subtree.

Fixes #9526