### PR TITLE
LibWeb: Remove unused ReportTime include from StyleScope

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <AK/StringBuilder.h>
-#include <LibCore/ReportTime.h>
 #include <LibWeb/CSS/CSSConditionRule.h>
 #include <LibWeb/CSS/CSSContainerRule.h>
 #include <LibWeb/CSS/CSSGroupingRule.h>


### PR DESCRIPTION
Remove an unused `LibCore/ReportTime.h` include from `StyleScope.cpp`.