### PR TITLE
LibWeb: Fix inline static position and baseline line sizing

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -770,20 +770,19 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (m_layout_mode == LayoutMode::Normal) {
             auto& box_state = m_state.get_mutable(box);
             StaticPositionRect static_position;
+            auto static_position_x = CSSPixels(0);
             auto static_position_y = m_y_offset_of_current_block_container.value();
-            // FIXME: This is a heuristic approximation. Ideally, originally-inline abspos
-            //        elements would have their static position determined by the IFC that
-            //        laid out the surrounding inline content, but our architecture currently
-            //        routes all abspos elements through the BFC as block-level children.
-            //        When the previous sibling is the anonymous wrapper that contains the
-            //        inline content this element would have been part of, use that wrapper's
-            //        y-offset as a rough approximation of the correct static position.
             if (box.display_before_box_type_transformation().is_inline_outside()) {
-                if (auto const* sibling = as_if<NodeWithStyle>(box.previous_sibling());
-                    sibling && sibling->is_anonymous() && sibling->children_are_inline())
-                    static_position_y = m_state.get(*sibling).offset.y();
+                auto const* sibling = as_if<Box>(box.previous_sibling());
+                if (sibling && sibling->is_anonymous() && sibling->children_are_inline()) {
+                    auto const& sibling_state = m_state.get(*sibling);
+                    if (auto const& inline_end_static_position_rect = sibling_state.inline_end_static_position_rect(); inline_end_static_position_rect.has_value()) {
+                        static_position_x = sibling_state.offset.x() + inline_end_static_position_rect->rect.x();
+                        static_position_y = sibling_state.offset.y() + inline_end_static_position_rect->rect.y();
+                    }
+                }
             }
-            static_position.rect = { { 0, static_position_y }, { 0, 0 } };
+            static_position.rect = { { static_position_x, static_position_y }, { 0, 0 } };
             box_state.set_static_position_rect(static_position);
         }
         return;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -504,6 +504,7 @@ void InlineFormattingContext::generate_line_boxes()
     }
 
     line_builder.update_last_line();
+    m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 
     if (m_layout_mode == LayoutMode::Normal) {
         for (auto* box : absolute_boxes) {
@@ -592,6 +593,52 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
     }
 
     return { .rect = { position, { 0, 0 } } };
+}
+
+StaticPositionRect InlineFormattingContext::calculate_inline_end_static_position_rect() const
+{
+    CSSPixels logical_inline_position = 0;
+    CSSPixels logical_block_position = 0;
+
+    auto to_physical_position = [](CSS::WritingMode writing_mode, CSSPixels logical_inline_position, CSSPixels logical_block_position) {
+        if (writing_mode != CSS::WritingMode::HorizontalTb)
+            return CSSPixelPoint { logical_block_position, logical_inline_position };
+        return CSSPixelPoint { logical_inline_position, logical_block_position };
+    };
+    auto writing_mode = containing_block().computed_values().writing_mode();
+
+    if (m_containing_block_used_values.line_boxes.is_empty())
+        return { .rect = { to_physical_position(writing_mode, logical_inline_position, logical_block_position), { 0, 0 } } };
+
+    CSSPixels line_boxes_bottom = 0;
+    for (auto const& line_box : m_containing_block_used_values.line_boxes)
+        line_boxes_bottom = max(line_boxes_bottom, line_box.bottom());
+
+    auto const& last_line_box = m_containing_block_used_values.line_boxes.last();
+    if (last_line_box.has_forced_break()) {
+        logical_block_position = line_boxes_bottom;
+        return { .rect = { to_physical_position(writing_mode, logical_inline_position, logical_block_position), { 0, 0 } } };
+    }
+
+    if (last_line_box.fragments().is_empty()) {
+        logical_block_position = line_boxes_bottom;
+        return { .rect = { to_physical_position(writing_mode, logical_inline_position, logical_block_position), { 0, 0 } } };
+    }
+
+    auto const& last_fragment = last_line_box.fragments().last();
+    auto direction = containing_block().computed_values().direction();
+    if (containing_block().is_anonymous() && containing_block().parent())
+        direction = containing_block().parent()->computed_values().direction();
+
+    if (direction == CSS::Direction::Rtl) {
+        logical_inline_position = last_fragment.inline_offset();
+    } else {
+        auto last_fragment_visual_inline_end = last_fragment.inline_offset() + last_fragment.inline_length();
+        logical_inline_position = max(last_fragment_visual_inline_end, last_line_box.inline_length());
+    }
+    logical_block_position = last_fragment.block_offset();
+
+    return { .rect = { to_physical_position(last_fragment.writing_mode(), logical_inline_position, logical_block_position), { 0, 0 } } };
 }
 
 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -42,6 +42,7 @@ private:
     void generate_line_boxes();
     void apply_text_overflow_ellipsis(Vector<LineBox>&);
     void apply_justification_to_fragments(CSS::TextJustify, LineBox&, bool is_last_line);
+    StaticPositionRect calculate_inline_end_static_position_rect() const;
 
     LayoutState::UsedValues& m_containing_block_used_values;
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -220,6 +220,13 @@ struct LayoutState {
 
         Optional<LineBoxFragmentCoordinate> containing_line_box_fragment;
 
+        void set_inline_end_static_position_rect(StaticPositionRect const& static_position_rect) { ensure_rare_data().inline_end_static_position_rect = static_position_rect; }
+        Optional<StaticPositionRect> const& inline_end_static_position_rect() const
+        {
+            static Optional<StaticPositionRect> const empty;
+            return m_rare ? m_rare->inline_end_static_position_rect : empty;
+        }
+
         void add_floating_descendant(Box const& box) { ensure_rare_data().floating_descendants.set(&box); }
         HashTable<GC::Ptr<Box const>> const& floating_descendants() const
         {
@@ -308,6 +315,7 @@ struct LayoutState {
             Optional<Painting::PaintableBox::BordersDataWithElementKind> override_borders_data;
             Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> computed_svg_transforms;
             Optional<StaticPositionRect> static_position_rect;
+            Optional<StaticPositionRect> inline_end_static_position_rect;
         };
 
         RareData& ensure_rare_data()

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -37,6 +37,7 @@ public:
 
     bool is_empty_or_ends_in_whitespace() const;
     bool is_empty() const { return m_fragments.is_empty() && !m_has_break; }
+    bool has_forced_break() const { return m_has_forced_break; }
 
     AvailableSize original_available_width() const { return m_original_available_width; }
 

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -52,7 +52,10 @@ void LineBuilder::begin_new_line(bool increment_y, bool is_first_break_in_sequen
     if (increment_y) {
         if (is_first_break_in_sequence) {
             // First break is simple, just go to the start of the next line.
-            m_current_block_offset += max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
+            if (m_should_advance_to_last_line_box_bottom && m_containing_block_used_values.line_boxes.size() > 1)
+                m_current_block_offset = m_containing_block_used_values.line_boxes[m_containing_block_used_values.line_boxes.size() - 2].bottom();
+            else
+                m_current_block_offset += max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
         } else {
             // We're doing more than one break in a row.
             // This means we're trying to squeeze past intruding floats.
@@ -72,6 +75,7 @@ void LineBuilder::begin_new_line(bool increment_y, bool is_first_break_in_sequen
     line_box.m_original_available_width = m_available_width_for_current_line;
     m_max_height_on_current_line = 0;
     m_last_line_needs_update = true;
+    m_should_advance_to_last_line_box_bottom = false;
 
     bool should_indent = m_containing_block_used_values.line_boxes.size() <= 1
         || (m_text_indent_each_line && forced_break == ForcedBreak::Yes);
@@ -267,6 +271,7 @@ void LineBuilder::update_last_line()
         return CSSPixels::nearest_value_for(font_metrics.ascent) + half_leading;
     }();
 
+    bool should_align_strut_to_line_box_baseline = false;
     auto line_box_baseline = [&] {
         CSSPixels line_box_baseline = strut_baseline;
         for (auto& fragment : line_box.fragments()) {
@@ -296,14 +301,27 @@ void LineBuilder::update_last_line()
                 fragment_baseline += length_percentage->to_px(fragment.layout_node(), line_height);
             }
 
-            line_box_baseline = max(line_box_baseline, fragment_baseline);
+            if (fragment_baseline > line_box_baseline) {
+                if (!fragment.layout_node().is_text_node()) {
+                    auto const& box = as<Layout::Box>(fragment.layout_node());
+                    auto const& vertical_align = fragment.layout_node().computed_values().vertical_align();
+                    should_align_strut_to_line_box_baseline |= box.display().is_inline_outside()
+                        && box.display().is_flex_inside()
+                        && vertical_align.has<CSS::VerticalAlign>()
+                        && vertical_align.get<CSS::VerticalAlign>() == CSS::VerticalAlign::Baseline;
+                }
+                line_box_baseline = fragment_baseline;
+            }
         }
         return line_box_baseline;
     }();
 
     // Start with the "strut", an imaginary zero-width box at the start of each line box.
+    auto const strut_line_height = m_context.containing_block().computed_values().line_height();
     auto strut_top = m_current_block_offset;
-    auto strut_bottom = m_current_block_offset + m_context.containing_block().computed_values().line_height();
+    auto strut_bottom = should_align_strut_to_line_box_baseline
+        ? m_current_block_offset + line_box_baseline + (strut_line_height - strut_baseline)
+        : m_current_block_offset + strut_line_height;
 
     CSSPixels uppermost_box_top = strut_top;
     CSSPixels lowermost_box_bottom = strut_bottom;
@@ -395,6 +413,7 @@ void LineBuilder::update_last_line()
 
     // 3. The line box height is the distance between the uppermost box top and the lowermost box bottom.
     line_box.m_block_length = lowermost_box_bottom - uppermost_box_top;
+    m_should_advance_to_last_line_box_bottom = should_align_strut_to_line_box_baseline;
 
     line_box.m_bottom = m_current_block_offset + line_box.m_block_length;
     line_box.m_baseline = line_box_baseline;

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -69,6 +69,7 @@ private:
     CSS::WritingMode m_writing_mode { CSS::WritingMode::HorizontalTb };
 
     bool m_last_line_needs_update { false };
+    bool m_should_advance_to_last_line_box_bottom { false };
 };
 
 }

--- a/Tests/LibWeb/Layout/expected/abspos-after-consecutive-forced-breaks-static-position.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-after-consecutive-forced-breaks-static-position.txt
@@ -1,0 +1,37 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] children: not-inline
+      BlockContainer <ul> at [0,0] [0+0+0 800 0+0+0] [0+0+0 40 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [0,0] positioned [0+0+0 100 0+0+700] [0+0+0 40 0+0+0] children: not-inline
+          BlockContainer <(anonymous)> at [0,0] [0+0+0 100 0+0+0] [0+0+0 40 0+0+0] children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [0,0 30x20] baseline: 13
+                "XXX"
+            TextNode <#text> (not painted)
+            BreakNode <br> (not painted)
+            BreakNode <br> (not painted)
+          BlockContainer <(anonymous)> at [0,40] positioned [0+0+0 10 0+0+0] [0+0+0 20 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [0,40 10x20] baseline: 13
+                "X"
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,40] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,40] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x40]
+      PaintableWithLines (BlockContainer<UL>) [0,0 800x40]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+        PaintableWithLines (ListItemBox<LI>) [0,0 100x40]
+          PaintableWithLines (BlockContainer(anonymous)) [0,0 100x40]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [0,40 10x20]
+            TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,40 800x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,40 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
@@ -1,18 +1,18 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 42 0+1+0] [BFC] children: not-inline
-    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 24 0+1+8] children: not-inline
-      BlockContainer <div.first> at [11,11] [0+1+0 778 0+1+0] [0+1+0 22 0+1+0] children: inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 46.203125 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 28.203125 0+1+8] children: not-inline
+      BlockContainer <div.first> at [11,11] [0+1+0 778 0+1+0] [0+1+0 26.203125 0+1+0] children: inline
         frag 0 from Box start: 0, length: 0, rect: [22,22 0x0] baseline: 22
         Box <span.second> at [22,22] flex-container(row) [0+1+10 0 10+1+0] [0+1+10 0 10+1+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> at [22,22] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
             TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
-    PaintableWithLines (BlockContainer<BODY>) [9,9 782x26]
-      PaintableWithLines (BlockContainer<DIV>.first) [10,10 780x24]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48.203125]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x30.203125]
+      PaintableWithLines (BlockContainer<DIV>.first) [10,10 780x28.203125]
         PaintableBox (Box<SPAN>.second) [11,11 22x22]
           PaintableWithLines (BlockContainer(anonymous)) [22,22 0x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [1,1 798x42] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x46.203125] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-after-consecutive-forced-breaks-static-position.html
+++ b/Tests/LibWeb/Layout/input/abspos-after-consecutive-forced-breaks-static-position.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../Ref/data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+li::after {
+    content: "X";
+    position: absolute;
+}
+</style>
+<ul>
+    <li>XXX<br><br></li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/abspos-after-centered-inline-static-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-centered-inline-static-position-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+div {
+    font: 10px/20px Ahem;
+    position: relative;
+    width: 100px;
+}
+
+.text {
+    left: 40px;
+    position: absolute;
+    top: 0;
+}
+
+.abspos {
+    left: 60px;
+    position: absolute;
+    top: 0;
+}
+</style>
+<div><span class="text">XX</span><span class="abspos">X</span></div>

--- a/Tests/LibWeb/Ref/expected/abspos-after-consecutive-forced-breaks-static-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-consecutive-forced-breaks-static-position-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+.separator {
+    left: 0;
+    position: absolute;
+    top: 40px;
+}
+</style>
+<ul>
+    <li>XXX<br><br><span class="separator">X</span></li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/abspos-after-flex-item-static-inline-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-flex-item-static-inline-position-ref.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../data/fonts/Ahem.ttf");
+    }
+
+    * {
+        box-sizing: border-box;
+    }
+
+    body {
+        margin: 0;
+        font: 20px Ahem;
+    }
+
+    ul {
+        display: flex;
+        gap: 24px;
+        list-style: none;
+        margin: 20px;
+        padding: 0;
+    }
+
+    li {
+        position: relative;
+    }
+
+    a {
+        margin: -14px 0 -14px -14px;
+        padding: 14px 0 14px 14px;
+    }
+
+    a span {
+        display: inline-flex;
+        margin: 0 16px 0 0;
+    }
+
+    .separator {
+        position: absolute;
+        bottom: 9px;
+        left: 100%;
+        font-size: 110%;
+        line-height: 26px;
+    }
+</style>
+<ul>
+    <li><a><span>Tech</span></a><span class="separator">X</span></li>
+    <li><a><span>Reviews</span></a><span class="separator">X</span></li>
+    <li>Science</li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/abspos-after-forced-break-static-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-forced-break-static-position-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+.separator {
+    left: 0;
+    position: absolute;
+    top: 20px;
+}
+</style>
+<ul>
+    <li>XXX<br><span class="separator">X</span></li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/abspos-after-rtl-inline-static-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-rtl-inline-static-position-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+.text {
+    left: 80px;
+    position: absolute;
+    top: 0;
+}
+
+.abspos {
+    left: 80px;
+    position: absolute;
+    top: 0;
+}
+</style>
+<ul>
+    <li><span class="text">XX</span><span class="abspos">X</span></li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/abspos-after-tall-forced-break-static-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-tall-forced-break-static-position-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/40px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+.inline-block {
+    background: black;
+    display: inline-block;
+    height: 10px;
+    width: 20px;
+}
+
+.abspos {
+    left: 0;
+    position: absolute;
+    top: 40px;
+}
+</style>
+<ul>
+    <li><span class="inline-block"></span><br><span class="abspos">X</span></li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/abspos-after-vertical-inline-static-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-after-vertical-inline-static-position-ref.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    writing-mode: vertical-rl;
+}
+
+li {
+    height: 100px;
+    position: relative;
+    width: 100px;
+}
+
+.abspos {
+    position: absolute;
+    right: 0;
+    top: 20px;
+}
+</style>
+<ul>
+    <li>XX<span class="abspos">X</span></li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/inline-flex-baseline-affects-flex-line-height-ref.html
+++ b/Tests/LibWeb/Ref/expected/inline-flex-baseline-affects-flex-line-height-ref.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../data/fonts/Ahem.ttf");
+    }
+
+    body {
+        background: #111;
+        margin: 0;
+    }
+
+    nav {
+        border-bottom: 1px solid white;
+        color: white;
+        left: 18px;
+        padding-bottom: 2px;
+        position: absolute;
+        top: 55px;
+        width: 808px;
+    }
+
+    ul {
+        display: flex;
+        gap: 21px;
+        height: 33.953125px;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .logo {
+        background: white;
+        height: 27px;
+        width: 135px;
+    }
+
+    li {
+        height: 33.953125px;
+        position: relative;
+    }
+
+    a,
+    button {
+        color: inherit;
+        font: 16px/24px Ahem;
+        margin: -14px 0 -14px -14px;
+        padding: 14px 0 14px 14px;
+    }
+
+    button {
+        background: transparent;
+        border: 0;
+    }
+
+    .word {
+        background: white;
+        display: inline-flex;
+        height: 23px;
+        margin-right: 16px;
+        width: 40px;
+    }
+
+    .hamburger {
+        height: 38.953125px;
+        margin-top: -5px;
+    }
+
+    .icon {
+        background: white;
+        display: inline-flex;
+        height: 32px;
+        width: 32px;
+    }
+</style>
+<nav>
+    <ul>
+        <div class="logo"></div>
+        <li><a><span class="word"></span></a></li>
+        <li><a><span class="word"></span></a></li>
+        <li class="hamburger"><button><span class="icon"></span></button></li>
+    </ul>
+</nav>

--- a/Tests/LibWeb/Ref/input/abspos-after-centered-inline-static-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-centered-inline-static-position.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-centered-inline-static-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+div {
+    font: 10px/20px Ahem;
+    position: relative;
+    text-align: center;
+    width: 100px;
+}
+
+.abspos {
+    position: absolute;
+}
+</style>
+<div>XX<span class="abspos">X</span></div>

--- a/Tests/LibWeb/Ref/input/abspos-after-consecutive-forced-breaks-static-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-consecutive-forced-breaks-static-position.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-consecutive-forced-breaks-static-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+li::after {
+    content: "X";
+    position: absolute;
+}
+</style>
+<ul>
+    <li>XXX<br><br></li>
+</ul>

--- a/Tests/LibWeb/Ref/input/abspos-after-flex-item-static-inline-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-flex-item-static-inline-position.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-flex-item-static-inline-position-ref.html">
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../data/fonts/Ahem.ttf");
+    }
+
+    * {
+        box-sizing: border-box;
+    }
+
+    body {
+        margin: 0;
+        font: 20px Ahem;
+    }
+
+    ul {
+        display: flex;
+        gap: 24px;
+        list-style: none;
+        margin: 20px;
+        padding: 0;
+    }
+
+    li {
+        position: relative;
+    }
+
+    a {
+        margin: -14px 0 -14px -14px;
+        padding: 14px 0 14px 14px;
+    }
+
+    a span {
+        display: inline-flex;
+        margin: 0 16px 0 0;
+    }
+
+    li:not(:last-child)::after {
+        content: "X";
+        position: absolute;
+        bottom: 9px;
+        font-size: 110%;
+        line-height: 26px;
+    }
+</style>
+<ul>
+    <li><a><span>Tech</span></a></li>
+    <li><a><span>Reviews</span></a></li>
+    <li>Science</li>
+</ul>

--- a/Tests/LibWeb/Ref/input/abspos-after-forced-break-static-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-forced-break-static-position.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-forced-break-static-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+li::after {
+    content: "X";
+    position: absolute;
+}
+</style>
+<ul>
+    <li>XXX<br></li>
+</ul>

--- a/Tests/LibWeb/Ref/input/abspos-after-rtl-inline-static-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-rtl-inline-static-position.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-rtl-inline-static-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    direction: rtl;
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+li::after {
+    content: "X";
+    position: absolute;
+}
+</style>
+<ul>
+    <li>XX</li>
+</ul>

--- a/Tests/LibWeb/Ref/input/abspos-after-tall-forced-break-static-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-tall-forced-break-static-position.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-tall-forced-break-static-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/40px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    position: relative;
+    width: 100px;
+}
+
+.inline-block {
+    background: black;
+    display: inline-block;
+    height: 10px;
+    width: 20px;
+}
+
+li::after {
+    content: "X";
+    position: absolute;
+}
+</style>
+<ul>
+    <li><span class="inline-block"></span><br></li>
+</ul>

--- a/Tests/LibWeb/Ref/input/abspos-after-vertical-inline-static-position.html
+++ b/Tests/LibWeb/Ref/input/abspos-after-vertical-inline-static-position.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-after-vertical-inline-static-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+ul {
+    font: 10px/20px Ahem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    writing-mode: vertical-rl;
+}
+
+li {
+    height: 100px;
+    position: relative;
+    width: 100px;
+}
+
+li::after {
+    content: "X";
+    position: absolute;
+}
+</style>
+<ul>
+    <li>XX</li>
+</ul>

--- a/Tests/LibWeb/Ref/input/inline-flex-baseline-affects-flex-line-height.html
+++ b/Tests/LibWeb/Ref/input/inline-flex-baseline-affects-flex-line-height.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/inline-flex-baseline-affects-flex-line-height-ref.html">
+<style>
+    @font-face {
+        font-family: Ahem;
+        src: url("../data/fonts/Ahem.ttf");
+    }
+
+    body {
+        background: #111;
+        margin: 0;
+    }
+
+    nav {
+        border-bottom: 1px solid white;
+        color: white;
+        left: 18px;
+        padding-bottom: 2px;
+        position: absolute;
+        top: 55px;
+        width: 808px;
+    }
+
+    ul {
+        display: flex;
+        gap: 21px;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .logo {
+        background: white;
+        height: 27px;
+        width: 135px;
+    }
+
+    li {
+        position: relative;
+    }
+
+    a,
+    button {
+        color: inherit;
+        font: 16px/24px Ahem;
+        margin: -14px 0 -14px -14px;
+        padding: 14px 0 14px 14px;
+    }
+
+    button {
+        background: transparent;
+        border: 0;
+    }
+
+    .word {
+        background: white;
+        display: inline-flex;
+        height: 23px;
+        margin-right: 16px;
+        width: 40px;
+    }
+
+    .hamburger {
+        margin-top: -5px;
+    }
+
+    .icon {
+        background: white;
+        display: inline-flex;
+        height: 32px;
+        width: 32px;
+    }
+</style>
+<nav>
+    <ul>
+        <div class="logo"></div>
+        <li><a><span class="word"></span></a></li>
+        <li><a><span class="word"></span></a></li>
+        <li class="hamburger"><button><span class="icon"></span></button></li>
+    </ul>
+</nav>

--- a/Tests/LibWeb/Text/expected/css/abspos-inline-static-position-after-wrapped-inline.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-inline-static-position-after-wrapped-inline.txt
@@ -1,0 +1,2 @@
+target x: 20
+target y: 20

--- a/Tests/LibWeb/Text/expected/css/inline-flex-baseline-advances-next-line.txt
+++ b/Tests/LibWeb/Text/expected/css/inline-flex-baseline-advances-next-line.txt
@@ -1,0 +1,1 @@
+baseline advances next line: PASS

--- a/Tests/LibWeb/Text/expected/css/top-aligned-inline-flex-does-not-advance-next-line-from-baseline.txt
+++ b/Tests/LibWeb/Text/expected/css/top-aligned-inline-flex-does-not-advance-next-line-from-baseline.txt
@@ -1,0 +1,1 @@
+top aligned inline-flex matches inline-block: PASS

--- a/Tests/LibWeb/Text/input/css/abspos-inline-static-position-after-wrapped-inline.html
+++ b/Tests/LibWeb/Text/input/css/abspos-inline-static-position-after-wrapped-inline.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../../../Ref/data/fonts/Ahem.ttf");
+}
+
+body {
+    margin: 0;
+}
+
+#container {
+    font: 10px/20px Ahem;
+    position: relative;
+    width: 40px;
+}
+
+#target {
+    height: 10px;
+    position: absolute;
+    width: 10px;
+}
+</style>
+<div id="container">XXXX XX<span id="target"></span></div>
+<script>
+promiseTest(async () => {
+    await document.fonts.ready;
+    await animationFrame();
+
+    const containerRect = document.getElementById("container").getBoundingClientRect();
+    const targetRect = document.getElementById("target").getBoundingClientRect();
+
+    println(`target x: ${Math.round(targetRect.x - containerRect.x)}`);
+    println(`target y: ${Math.round(targetRect.y - containerRect.y)}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/inline-flex-baseline-advances-next-line.html
+++ b/Tests/LibWeb/Text/input/css/inline-flex-baseline-advances-next-line.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.container {
+    font: 16px/24px sans-serif;
+}
+
+.icon {
+    display: inline-flex;
+    height: 32px;
+    width: 32px;
+}
+
+.top {
+    vertical-align: top;
+}
+
+.next {
+    display: inline-block;
+    height: 1px;
+    width: 1px;
+}
+</style>
+<div id="baseline" class="container"><span class="icon"></span><br><span class="next"></span></div>
+<div id="top" class="container"><span class="icon top"></span><br><span class="next"></span></div>
+<script>
+test(() => {
+    const baselineRect = document.getElementById("baseline").getBoundingClientRect();
+    const baselineNextRect = document.querySelector("#baseline .next").getBoundingClientRect();
+    const topRect = document.getElementById("top").getBoundingClientRect();
+    const topNextRect = document.querySelector("#top .next").getBoundingClientRect();
+
+    const baselineNextLineY = Math.round(baselineNextRect.y - baselineRect.y);
+    const topNextLineY = Math.round(topNextRect.y - topRect.y);
+    println(`baseline advances next line: ${baselineNextLineY > topNextLineY ? "PASS" : "FAIL"}`);
+});
+</script>

--- a/Tests/LibWeb/Text/input/css/top-aligned-inline-flex-does-not-advance-next-line-from-baseline.html
+++ b/Tests/LibWeb/Text/input/css/top-aligned-inline-flex-does-not-advance-next-line-from-baseline.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+body {
+    margin: 0;
+}
+
+.container {
+    font: 16px/24px sans-serif;
+}
+
+.icon {
+    display: inline-flex;
+    height: 32px;
+    vertical-align: top;
+    width: 32px;
+}
+
+.block {
+    display: inline-block;
+}
+
+.next {
+    display: inline-block;
+    height: 1px;
+    width: 1px;
+}
+</style>
+<div id="flex" class="container"><span class="icon"></span><br><span class="next"></span></div>
+<div id="block" class="container"><span class="icon block"></span><br><span class="next"></span></div>
+<script>
+test(() => {
+    const flexRect = document.getElementById("flex").getBoundingClientRect();
+    const flexNextRect = document.querySelector("#flex .next").getBoundingClientRect();
+    const blockRect = document.getElementById("block").getBoundingClientRect();
+    const blockNextRect = document.querySelector("#block .next").getBoundingClientRect();
+
+    const flexNextLineY = Math.round(flexNextRect.y - flexRect.y);
+    const blockNextLineY = Math.round(blockNextRect.y - blockRect.y);
+    println(`top aligned inline-flex matches inline-block: ${flexNextLineY == blockNextLineY ? "PASS" : "FAIL"}`);
+});
+</script>


### PR DESCRIPTION
This teaches inline formatting contexts to publish the static-position insertion point at the inline end of their generated line boxes, so originally-inline absolutely positioned boxes no longer rely on block formatting context heuristics for wrapped, aligned, RTL, forced-break, and vertical-writing-mode inline content.

It also fixes inline-flex baseline line sizing so baseline-aligned inline-flex fragments preserve the parent strut descent when they raise the line box baseline, while non-baseline alignment such as vertical-align: top does not inflate following line placement.

Added layout and text coverage for the affected static-position and inline-flex line-height cases.

Visual progression on https://theverge.com - the nav bar specifically.

Before:
<img width="840" height="90" alt="Screenshot 2026-05-23 at 02 18 10" src="https://github.com/user-attachments/assets/271e50a7-a24f-4b3a-9c20-384bd339b5d5" />

After:
<img width="836" height="95" alt="Screenshot 2026-05-23 at 02 17 47" src="https://github.com/user-attachments/assets/87f4b8a8-dee6-4f07-b4c8-70afdce8a18e" />
