### PR TITLE
LibWeb: Only fire fully active observers when the state actually changes

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5200,15 +5200,10 @@ void Document::destroy()
     abort();
 
     // AD-HOC: Notify document observers that this document became inactive.
-    //         This allows observers (e.g. HTMLImageElement) to clear resources like
-    //         DocumentLoadEventDelayers that would otherwise block the parent
-    //         document's load event forever.
-    //         Note: did_stop_being_active_document_in_navigable() handles the navigation case,
-    //         but document destruction (e.g. iframe removal) takes a different path.
-    //         The flag ensures we don't fire the callback twice for the same document
-    //         (once from navigation, then again from destruction).
-    if (!m_has_fired_document_became_inactive) {
-        m_has_fired_document_became_inactive = true;
+    //         This handles iframe-removal destruction, which doesn't otherwise go through
+    //         did_stop_being_active_document_in_navigable().
+    if (m_observers_consider_document_fully_active) {
+        m_observers_consider_document_fully_active = false;
         notify_each_document_observer([&](auto const& document_observer) {
             return document_observer.document_became_inactive();
         });
@@ -5644,8 +5639,8 @@ void Document::did_stop_being_active_document_in_navigable()
 
     schedule_html_parser_end_check();
 
-    if (!m_has_fired_document_became_inactive) {
-        m_has_fired_document_became_inactive = true;
+    if (m_observers_consider_document_fully_active) {
+        m_observers_consider_document_fully_active = false;
         notify_each_document_observer([&](auto const& document_observer) {
             return document_observer.document_became_inactive();
         });
@@ -5764,9 +5759,12 @@ void Document::make_active()
         m_needs_to_call_page_did_load = false;
     }
 
-    notify_each_document_observer([&](auto const& document_observer) {
-        return document_observer.document_became_active();
-    });
+    if (!m_observers_consider_document_fully_active) {
+        m_observers_consider_document_fully_active = true;
+        notify_each_document_observer([&](auto const& document_observer) {
+            return document_observer.document_became_active();
+        });
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#set-the-initial-visibility-state

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1204,7 +1204,7 @@ private:
     bool m_active_parser_was_aborted { false };
 
     bool m_has_been_destroyed { false };
-    bool m_has_fired_document_became_inactive { false };
+    bool m_observers_consider_document_fully_active { false };
 
     String m_source;
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1192,6 +1192,10 @@ void HTMLMediaElement::load_url_resource(URL::URL const& url_record, Function<vo
         }
     }
 
+    // This is only reached via a media element task which is only processed once the document is fully active.
+    // The observer callbacks that stop/restart the fetch depend on this invariant, so ensure it here.
+    VERIFY(document().is_fully_active());
+
     m_remote_fetch_data = make<RemoteFetchData>();
     m_remote_fetch_data->url_record = url_record;
     m_remote_fetch_data->stream = Media::IncrementallyPopulatedStream::create_empty();

--- a/Tests/LibWeb/Crash/HTML/media-fetch-during-history-back.html
+++ b/Tests/LibWeb/Crash/HTML/media-fetch-during-history-back.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!-- Test: A <video> element starts loading a remote resource. A pushState adds a new session history entry that points
+     to the same Document. The back button then traverses to a different session history entry that still resolves to
+     the same Document. In apply_the_history_step's deactivate decision, "resolved == displayed" causes the deactivate
+     path to be skipped (so the inactive observer never fires and fetch_controller is not cleared), but
+     activate_history_entry is still called, firing document_became_active on the already-active document while a fetch
+     is in flight. -->
+<html class="test-wait">
+<body>
+<video id="video" src="../../Assets/test-webm.webm" preload="auto"></video>
+<script>
+    video.addEventListener("progress", () => {
+        history.pushState({}, "", "#second");
+        setTimeout(() => {
+            history.back();
+            setTimeout(() => {
+                document.documentElement.classList.remove("test-wait");
+            }, 200);
+        }, 50);
+    }, { once: true });
+</script>
+</body>
+</html>


### PR DESCRIPTION
This fixes a crash when navigating to a Reddit comments page and then pressing the back button.