### PR TITLE
LibWeb: Stop idle animated CSS image timers

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ComputedValues.h>
@@ -23,6 +24,8 @@
 #include <LibWeb/Platform/Timer.h>
 
 namespace Web::CSS {
+
+static HashTable<ImageStyleValue const*> s_active_animation_timers;
 
 ValueComparingNonnullRefPtr<ImageStyleValue const> ImageStyleValue::create(URL const& url)
 {
@@ -41,6 +44,18 @@ ImageStyleValue::ImageStyleValue(URL const& url)
 }
 
 ImageStyleValue::~ImageStyleValue() = default;
+
+u64 ImageStyleValue::active_animation_timer_count(DOM::Document const& document)
+{
+    u64 count = 0;
+    for (auto const* image_style_value : s_active_animation_timers) {
+        if (any_of(image_style_value->m_clients, [&](auto const* client) {
+                return client->document() == &document;
+            }))
+            ++count;
+    }
+    return count;
+}
 
 void ImageStyleValue::visit_edges(JS::Cell::Visitor& visitor) const
 {
@@ -78,18 +93,70 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
 
                 auto image_data = self.m_resource_request->image_data();
                 if (image_data->is_animated() && image_data->frame_count() > 1) {
-                    self.m_timer = Platform::Timer::create(self.m_document->heap());
-                    self.m_timer->set_interval(image_data->frame_duration(0));
-                    auto weak_self = self.template make_weak_ptr<ImageStyleValue>();
-                    self.m_timer->on_timeout = GC::create_function(self.m_document->heap(), [weak_self] {
-                        if (weak_self)
-                            weak_self->animate();
-                    });
-                    self.m_timer->start();
+                    for (auto* client : self.m_clients) {
+                        if (auto document = client->document()) {
+                            self.start_animation_timer_if_needed(*document);
+                            break;
+                        }
+                    }
                 }
             }),
             nullptr);
     }
+}
+
+void ImageStyleValue::start_animation_timer_if_needed(DOM::Document& document) const
+{
+    if (m_clients.is_empty() || !is_animatable())
+        return;
+
+    if (m_timer && m_timer->is_active())
+        return;
+
+    if (!m_timer) {
+        m_timer = Platform::Timer::create(document.heap());
+        auto weak_self = make_weak_ptr<ImageStyleValue>();
+        m_timer->on_timeout = GC::create_function(document.heap(), [weak_self] {
+            if (weak_self)
+                weak_self->animate();
+        });
+    }
+
+    m_timer->set_interval(current_frame_duration());
+    m_timer->start();
+    s_active_animation_timers.set(this);
+}
+
+void ImageStyleValue::stop_animation_timer() const
+{
+    if (m_timer && m_timer->is_active()) {
+        m_timer->stop();
+        s_active_animation_timers.remove(this);
+    }
+}
+
+bool ImageStyleValue::is_animatable() const
+{
+    auto image_data = this->image_data();
+    if (!image_data || !image_data->is_animated() || image_data->frame_count() <= 1)
+        return false;
+
+    return !animation_has_completed();
+}
+
+bool ImageStyleValue::animation_has_completed() const
+{
+    auto image_data = this->image_data();
+    return image_data && image_data->loop_count() > 0 && m_loops_completed == image_data->loop_count();
+}
+
+int ImageStyleValue::current_frame_duration() const
+{
+    auto image_data = this->image_data();
+    if (!image_data)
+        return 0;
+
+    return image_data->frame_duration(m_current_frame_index);
 }
 
 void ImageStyleValue::animate()
@@ -104,13 +171,13 @@ void ImageStyleValue::animate()
     m_current_frame_index = image_data->notify_frame_advanced(m_current_frame_index);
     auto current_frame_duration = image_data->frame_duration(m_current_frame_index);
 
-    if (current_frame_duration != m_timer->interval())
+    if (m_timer && current_frame_duration != m_timer->interval())
         m_timer->restart(current_frame_duration);
 
     if (m_current_frame_index == image_data->frame_count() - 1) {
         ++m_loops_completed;
-        if (m_loops_completed > 0 && m_loops_completed == image_data->loop_count())
-            m_timer->stop();
+        if (animation_has_completed())
+            stop_animation_timer();
     }
 
     if (on_animate)
@@ -238,16 +305,22 @@ void ImageStyleValue::register_client(Client& client) const
 {
     auto result = m_clients.set(&client);
     VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+    if (auto document = client.document())
+        start_animation_timer_if_needed(*document);
 }
 
 void ImageStyleValue::unregister_client(Client& client) const
 {
     auto did_remove = m_clients.remove(&client);
     VERIFY(did_remove);
+
+    if (m_clients.is_empty())
+        stop_animation_timer();
 }
 
-ImageStyleValue::Client::Client(ImageStyleValue const& image_style_value)
+ImageStyleValue::Client::Client(DOM::Document& document, ImageStyleValue const& image_style_value)
     : m_image_style_value(image_style_value)
+    , m_document(document)
 {
     m_image_style_value.register_client(*this);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/HashTable.h>
 #include <AK/Optional.h>
 #include <LibGC/Weak.h>
 #include <LibGfx/DecodedImageFrame.h>
@@ -28,20 +29,25 @@ class ImageStyleValue final
 
 public:
     class Client {
+        friend class ImageStyleValue;
+
     public:
-        Client(ImageStyleValue const&);
+        Client(DOM::Document&, ImageStyleValue const&);
         virtual ~Client();
         virtual void image_style_value_did_update(ImageStyleValue&) = 0;
 
     protected:
         void image_style_value_finalize();
+        GC::Ptr<DOM::Document> document() const { return m_document.ptr(); }
 
         ImageStyleValue const& m_image_style_value;
+        GC::Weak<DOM::Document> m_document;
     };
 
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(URL const&);
     static ValueComparingNonnullRefPtr<ImageStyleValue const> create(::URL::URL const&);
     virtual ~ImageStyleValue() override;
+    static u64 active_animation_timer_count(DOM::Document const&);
 
     virtual void visit_edges(JS::Cell::Visitor& visitor) const override;
 
@@ -68,7 +74,6 @@ public:
 
 private:
     friend class Client;
-
     ImageStyleValue(URL const&);
 
     void register_client(Client&) const;
@@ -77,6 +82,11 @@ private:
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
+    void start_animation_timer_if_needed(DOM::Document&) const;
+    void stop_animation_timer() const;
+    bool is_animatable() const;
+    bool animation_has_completed() const;
+    int current_frame_duration() const;
     void animate();
     Optional<Gfx::DecodedImageFrame> frame(size_t frame_index, Gfx::IntSize = {}) const;
 
@@ -88,9 +98,9 @@ private:
 
     size_t m_current_frame_index { 0 };
     size_t m_loops_completed { 0 };
-    GC::Ptr<Platform::Timer> m_timer;
 
     mutable HashTable<Client*> m_clients;
+    mutable GC::Ptr<Platform::Timer> m_timer;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1265,6 +1265,8 @@ WebIDL::ExceptionOr<void> Document::set_title(Utf16String const& title)
 
 void Document::tear_down_layout_tree()
 {
+    if (m_layout_root)
+        m_layout_root->prepare_subtree_for_detach_from_layout_tree();
     m_layout_root = nullptr;
     m_paintable = nullptr;
     m_needs_full_layout_tree_update = true;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1942,6 +1942,8 @@ bool Element::has_synthetic_pseudo_elements() const
 void Element::clear_synthetic_pseudo_element_layout_nodes()
 {
     for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement& pseudo_element) {
+        if (auto layout_node = pseudo_element.layout_node())
+            layout_node->prepare_subtree_for_detach_from_layout_tree();
         pseudo_element.set_layout_node(nullptr);
     });
 }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1674,12 +1674,16 @@ void Node::set_layout_node(Badge<Layout::Node>, GC::Ref<Layout::Node> layout_nod
 
 void Node::clear_layout_node_and_paintable(Badge<Document>)
 {
+    if (m_layout_node)
+        m_layout_node->prepare_for_detach_from_layout_tree();
     m_layout_node = nullptr;
     m_paintable = nullptr;
 }
 
 void Node::detach_layout_node(Badge<Layout::TreeBuilder>)
 {
+    if (m_layout_node)
+        m_layout_node->prepare_for_detach_from_layout_tree();
     m_layout_node = nullptr;
 }
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Bindings/Internals.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
 #include <LibWeb/DOM/Document.h>
@@ -699,6 +700,11 @@ JS::Object* Internals::get_style_invalidation_counters()
 void Internals::reset_style_invalidation_counters()
 {
     window().associated_document().reset_style_invalidation_counters();
+}
+
+WebIDL::UnsignedLongLong Internals::active_image_style_value_animation_count()
+{
+    return CSS::ImageStyleValue::active_animation_timer_count(window().associated_document());
 }
 
 struct AsyncScrollingStateSnapshot {

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -114,6 +114,7 @@ public:
 
     JS::Object* get_style_invalidation_counters();
     void reset_style_invalidation_counters();
+    WebIDL::UnsignedLongLong active_image_style_value_animation_count();
     JS::Object* async_scrolling_state();
     bool async_scrolling_state_blocks_wheel_event_at(double x, double y);
     bool async_scrolling_state_can_wheel_scroll_at(double x, double y, double delta_x, double delta_y, bool force_stale_wheel_event_regions);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -94,6 +94,7 @@ interface Internals {
     // elementStyleNoopRecomputations.
     object getStyleInvalidationCounters();
     undefined resetStyleInvalidationCounters();
+    unsigned long long activeImageStyleValueAnimationCount();
 
     object asyncScrollingState();
     boolean asyncScrollingStateBlocksWheelEventAt(double x, double y);

--- a/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Libraries/LibWeb/Layout/ImageProvider.h
@@ -37,6 +37,7 @@ public:
     virtual Optional<Gfx::DecodedImageFrame> default_image_frame_sized(Gfx::IntSize) const;
 
     virtual void set_visible_in_viewport(bool) = 0;
+    virtual void layout_node_was_detached() const { }
 
     virtual void image_provider_visit_edges(GC::Cell::Visitor& visitor) const
     {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/FormattingContext.h>
+#include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
@@ -55,6 +56,22 @@ Node::Node(DOM::Document& document, DOM::Node* node, AttachToDOMNode attach_to_d
 }
 
 Node::~Node() = default;
+
+void Node::prepare_for_detach_from_layout_tree()
+{
+    if (auto* node_with_style = as_if<NodeWithStyle>(*this))
+        node_with_style->clear_image_observers();
+    if (auto* image_box = as_if<ImageBox>(*this))
+        image_box->image_provider().layout_node_was_detached();
+}
+
+void Node::prepare_subtree_for_detach_from_layout_tree()
+{
+    for_each_in_inclusive_subtree([](Node& node) {
+        node.prepare_for_detach_from_layout_tree();
+        return TraversalDecision::Continue;
+    });
+}
 
 void Node::visit_edges(Cell::Visitor& visitor)
 {
@@ -592,7 +609,7 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullOw
 }
 
 NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)
-    : CSS::ImageStyleValue::Client(*image)
+    : CSS::ImageStyleValue::Client(owner.document(), *image)
     , m_owner(owner)
     , m_image(move(image))
 {
@@ -632,6 +649,11 @@ void NodeWithStyle::ImageObserver::visit_edges(JS::Cell::Visitor& visitor) const
 void NodeWithStyle::finalize()
 {
     Base::finalize();
+    clear_image_observers();
+}
+
+void NodeWithStyle::clear_image_observers()
+{
     m_image_observers.clear();
 }
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -84,6 +84,8 @@ public:
     PaintableList const& paintables() const { return m_paintable; }
     void add_paintable(RefPtr<Painting::Paintable>);
     void clear_paintables();
+    void prepare_for_detach_from_layout_tree();
+    void prepare_subtree_for_detach_from_layout_tree();
 
     virtual RefPtr<Painting::Paintable> create_paintable() const;
 
@@ -303,6 +305,7 @@ public:
     CSS::ImmutableComputedValues const& computed_values() const { return static_cast<CSS::ImmutableComputedValues const&>(*m_computed_values); }
     CSS::MutableComputedValues& mutable_computed_values() { return static_cast<CSS::MutableComputedValues&>(*m_computed_values); }
 
+    void clear_image_observers();
     void apply_style(CSS::ComputedProperties const&);
 
     Gfx::Font const& first_available_font() const;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -213,7 +213,7 @@ public:
     virtual void finalize() override
     {
         Base::finalize();
-        image_style_value_finalize();
+        unregister_image_style_value_client();
     }
 
     virtual bool is_image_available() const override { return m_image->is_paintable(); }
@@ -229,12 +229,17 @@ public:
     }
 
     virtual void set_visible_in_viewport(bool) override { }
+    virtual void layout_node_was_detached() const override
+    {
+        unregister_image_style_value_client();
+        m_layout_node = nullptr;
+    }
 
     virtual GC::Ptr<DOM::Element const> to_html_element() const override { return nullptr; }
 
-    static GC::Ref<GeneratedContentImageProvider> create(GC::Heap& heap, NonnullRefPtr<CSS::ImageStyleValue> image)
+    static GC::Ref<GeneratedContentImageProvider> create(GC::Heap& heap, DOM::Document& document, NonnullRefPtr<CSS::ImageStyleValue> image)
     {
-        return heap.allocate<GeneratedContentImageProvider>(move(image));
+        return heap.allocate<GeneratedContentImageProvider>(document, move(image));
     }
 
     void set_layout_node(GC::Ref<Layout::Node> layout_node)
@@ -249,8 +254,8 @@ public:
     }
 
 private:
-    GeneratedContentImageProvider(NonnullRefPtr<CSS::ImageStyleValue> image)
-        : Client(image)
+    GeneratedContentImageProvider(DOM::Document& document, NonnullRefPtr<CSS::ImageStyleValue> image)
+        : Client(document, image)
         , m_image(move(image))
     {
     }
@@ -270,11 +275,22 @@ private:
 
     virtual void image_style_value_did_update(CSS::ImageStyleValue&) override
     {
+        if (!m_layout_node)
+            return;
         m_layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::GeneratedContentImageFinishedLoading);
     }
 
-    GC::Ptr<Layout::Node> m_layout_node;
+    void unregister_image_style_value_client() const
+    {
+        if (!m_registered_as_image_style_value_client)
+            return;
+        const_cast<GeneratedContentImageProvider&>(*this).image_style_value_finalize();
+        m_registered_as_image_style_value_client = false;
+    }
+
+    mutable GC::Ptr<Layout::Node> m_layout_node;
     NonnullRefPtr<CSS::ImageStyleValue> m_image;
+    mutable bool m_registered_as_image_style_value_client { true };
 };
 
 GC_DEFINE_ALLOCATOR(GeneratedContentImageProvider);
@@ -580,7 +596,7 @@ GC::Ptr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element
                 } else {
                     auto& image = *item.get<NonnullRefPtr<CSS::ImageStyleValue>>();
                     image.load_any_resources(document);
-                    auto image_provider = GeneratedContentImageProvider::create(element.heap(), image);
+                    auto image_provider = GeneratedContentImageProvider::create(element.heap(), document, image);
                     layout_node = document.heap().allocate<ImageBox>(document, nullptr, *pseudo_element_style, image_provider);
                     image_provider->set_layout_node(*layout_node);
                 }
@@ -947,6 +963,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         m_layout_root = layout_node;
     } else if (should_create_layout_node) {
         if (may_replace_existing_layout_node) {
+            old_layout_node->prepare_subtree_for_detach_from_layout_tree();
             old_layout_node->parent()->replace_child(*layout_node, *old_layout_node);
         } else if (layout_node->is_svg_box()) {
             m_ancestor_stack.last()->append_child(*layout_node);

--- a/Tests/LibWeb/Text/expected/css/animated-background-image-timer-count-is-document-scoped.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-background-image-timer-count-is-document-scoped.txt
@@ -1,0 +1,2 @@
+top document active animations: 0
+iframe document active animations: 1

--- a/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-after-full-layout-tree-teardown.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-after-full-layout-tree-teardown.txt
@@ -1,0 +1,3 @@
+active animations before teardown: 1
+active animations after teardown: 1
+active animations after hiding: 0

--- a/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-after-layout-node-replacement.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-after-layout-node-replacement.txt
@@ -1,0 +1,3 @@
+active animations before replacement: 1
+active animations after replacement: 1
+active animations after hiding: 0

--- a/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-when-hidden.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-background-image-timer-stops-when-hidden.txt
@@ -1,0 +1,2 @@
+active animations before hiding: 1
+active animations after hiding: 0

--- a/Tests/LibWeb/Text/expected/css/animated-generated-content-image-timer-stops-when-hidden.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-generated-content-image-timer-stops-when-hidden.txt
@@ -1,0 +1,2 @@
+active animations before hiding: 1
+active animations after hiding: 0

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-count-is-document-scoped.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-count-is-document-scoped.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        const iframeLoaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                #target {
+                    width: 100px;
+                    height: 50px;
+                    background-image: url("../wpt-import/images/anim-gr.gif");
+                }
+            </style>
+            <div id="target"></div>
+        `;
+        document.body.appendChild(iframe);
+        await iframeLoaded;
+
+        internals.dumpLayoutTree(iframe.contentDocument);
+
+        println(`top document active animations: ${internals.activeImageStyleValueAnimationCount()}`);
+        println(`iframe document active animations: ${iframe.contentWindow.internals.activeImageStyleValueAnimationCount()}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-after-full-layout-tree-teardown.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-after-full-layout-tree-teardown.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target {
+        width: 100px;
+        height: 50px;
+        background-image: url("../wpt-import/images/anim-gr.gif");
+    }
+</style>
+<div id="target"></div>
+<dialog id="dialog">Hello</dialog>
+<script>
+    asyncTest(async done => {
+        await new Promise(resolve => window.addEventListener("load", resolve));
+
+        internals.dumpLayoutTree(document);
+        println(`active animations before teardown: ${internals.activeImageStyleValueAnimationCount()}`);
+
+        dialog.showModal();
+        internals.dumpLayoutTree(document);
+        println(`active animations after teardown: ${internals.activeImageStyleValueAnimationCount()}`);
+
+        target.style.display = "none";
+        internals.dumpLayoutTree(document);
+        println(`active animations after hiding: ${internals.activeImageStyleValueAnimationCount()}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-after-layout-node-replacement.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-after-layout-node-replacement.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target {
+        width: 100px;
+        height: 50px;
+        background-image: url("../wpt-import/images/anim-gr.gif");
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        await new Promise(resolve => window.addEventListener("load", resolve));
+
+        internals.dumpLayoutTree(document);
+        println(`active animations before replacement: ${internals.activeImageStyleValueAnimationCount()}`);
+
+        target.style.display = "inline";
+        internals.dumpLayoutTree(document);
+        println(`active animations after replacement: ${internals.activeImageStyleValueAnimationCount()}`);
+
+        target.style.display = "none";
+        internals.dumpLayoutTree(document);
+        println(`active animations after hiding: ${internals.activeImageStyleValueAnimationCount()}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-when-hidden.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-stops-when-hidden.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target {
+        width: 100px;
+        height: 50px;
+        background-image: url("../wpt-import/images/anim-gr.gif");
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        await new Promise(resolve => window.addEventListener("load", resolve));
+
+        internals.dumpLayoutTree(document);
+        println(`active animations before hiding: ${internals.activeImageStyleValueAnimationCount()}`);
+
+        target.style.display = "none";
+        internals.dumpLayoutTree(document);
+
+        println(`active animations after hiding: ${internals.activeImageStyleValueAnimationCount()}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animated-generated-content-image-timer-stops-when-hidden.html
+++ b/Tests/LibWeb/Text/input/css/animated-generated-content-image-timer-stops-when-hidden.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target::before {
+        content: url("../wpt-import/images/anim-gr.gif");
+    }
+</style>
+<div id="target"></div>
+<script>
+    asyncTest(async done => {
+        await new Promise(resolve => window.addEventListener("load", resolve));
+
+        internals.dumpLayoutTree(document);
+        println(`active animations before hiding: ${internals.activeImageStyleValueAnimationCount()}`);
+
+        target.style.display = "none";
+        internals.dumpLayoutTree(document);
+
+        println(`active animations after hiding: ${internals.activeImageStyleValueAnimationCount()}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Keep animated ImageStyleValue frame advancement owned by the style value. The current frame and loop state live there, so a separate document scheduler would duplicate ownership of that state.

Start the ImageStyleValue timer only while it has layout clients. Stop it when the last client unregisters, or when a finite animation completes. Expose a document-scoped active timer count through internals for focused regression tests.

Clear image observers when layout nodes detach. Use current-node cleanup for per-DOM-node clearing, and explicit subtree cleanup for tree replacement, full tree teardown, and synthetic pseudo-elements. This keeps large document clearing linear.

Unregister generated-content image providers during layout detach instead of waiting for GC to finalize the provider.

Cover hidden animated background images, generated content images, layout node replacement, full layout tree teardown, and document scoping for the internals counter.