### PR TITLE
Visual splitting for fragmented boxes inside multicol containers! :D

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -768,6 +768,7 @@ set(SOURCES
     Layout/FieldSetBox.cpp
     Layout/FlexFormattingContext.cpp
     Layout/FormattingContext.cpp
+    Layout/Fragmentation.cpp
     Layout/GridFormattingContext.cpp
     Layout/ImageBox.cpp
     Layout/ImageProvider.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1564,7 +1564,7 @@ static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
     auto content_height = svg_state.content_height();
 
     Layout::SVGFormattingContext svg_context(layout_state, Layout::LayoutMode::Normal, svg_root, nullptr);
-    svg_context.run(Layout::AvailableSpace(Layout::AvailableSize::make_definite(content_width), Layout::AvailableSize::make_definite(content_height)));
+    svg_context.run(Layout::AvailableSpace(Layout::AvailableSize::make_definite(content_width), Layout::AvailableSize::make_definite(content_height)), {});
     layout_state.commit(svg_root);
 
     svg_root.for_each_in_inclusive_subtree([](auto& node) {
@@ -1783,10 +1783,10 @@ void Document::update_layout(UpdateLayoutReason reason)
                 auto content_height = layout_state.get(*svg_root.containing_block()).content_height();
                 layout_state.get_mutable(svg_root).set_content_height(content_height);
                 Layout::SVGFormattingContext svg_formatting_context(layout_state, Layout::LayoutMode::Normal, svg_root, nullptr);
-                svg_formatting_context.run(available_space);
+                svg_formatting_context.run(available_space, {});
             } else {
                 Layout::BlockFormattingContext root_formatting_context(layout_state, Layout::LayoutMode::Normal, *m_layout_root, nullptr);
-                root_formatting_context.run(available_space);
+                root_formatting_context.run(available_space, {});
             }
         }
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -942,6 +942,8 @@ class CheckBox;
 class FieldSetBox;
 class FlexFormattingContext;
 class FormattingContext;
+class FragmentationContext;
+class ColumnFragmentationContext;
 class ImageBox;
 class InlineFormattingContext;
 class InlineNode;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -907,9 +907,10 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         inline_space_used_before_children_formatted = intrusion_by_floats_into_box(list_item_state, offset_y);
     }
 
-    auto unfragmented_box_y = box_state.offset.y();
+    // Place the box in the correct fragmentainer, but remember the original, unfragmented position.
+    auto unfragmented_box_position = box_state.offset;
     if (fragmentation_context.has_value()) {
-        auto fragmented_flow_block_offset = content_box_rect_in_ancestor_coordinate_space(box_state, fragmentation_context.value().root()).y();
+        auto fragmented_flow_block_offset = y_position_in_ancestor_coordinate_space(box_state, 0, fragmentation_context.value().root());
         box_state.set_content_y(box_state.offset.y() + fragmentation_context.value().fragmentainer_y_offset_at(fragmented_flow_block_offset));
         box_state.set_content_x(box_state.offset.x() + fragmentation_context.value().fragmentainer_x_offset_at(fragmented_flow_block_offset));
     }
@@ -956,10 +957,10 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 m_margin_state.reset();
             } else if (!m_margin_state.has_block_container_waiting_for_final_y_position()) {
                 // margin-top of block container can be updated during children layout hence it's final y position yet to be determined
-                m_margin_state.register_block_container_y_position_update_callback([this, &box, &box_state, y, introduce_clearance, &unfragmented_box_y](CSSPixels margin_top) {
+                m_margin_state.register_block_container_y_position_update_callback([this, &box, &box_state, y, introduce_clearance, &unfragmented_box_position](CSSPixels margin_top) {
                     if (introduce_clearance == DidIntroduceClearance::No) {
                         place_block_level_element_in_normal_flow_vertically(box, margin_top + y);
-                        unfragmented_box_y = box_state.offset.y();
+                        unfragmented_box_position.set_y(box_state.offset.y());
                         // FIXME: This might've bumped the box down into a subsequent fragmentainer, so we need to
                         //        translate it if that is the case.
                     }
@@ -991,7 +992,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_y_offset_of_current_block_container = unfragmented_box_y + box_state.content_height() + box_state.border_box_bottom();
+        m_y_offset_of_current_block_container = unfragmented_box_position.y() + box_state.content_height() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -1001,10 +1002,32 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto const& block_container_state = m_state.get(block_container);
     compute_inset(box, content_box_rect(block_container_state).size());
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, unfragmented_box_y + box_state.content_height() + box_state.margin_box_bottom());
+    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, unfragmented_box_position.y() + box_state.content_height() + box_state.margin_box_bottom());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
+
+    // If the box spans multiple fragmentainers, actually slice it into multiple fragments.
+    if (fragmentation_context.has_value()) {
+        FragmentationContext const* context = &fragmentation_context.value();
+        auto box_top_fragmented_flow_block_offset = y_position_in_ancestor_coordinate_space(*box_state.containing_block_used_values(), unfragmented_box_position.y(), context->root());
+        auto remaining_box_height = box_state.content_height() + box_state.border_box_bottom();
+        CSSPixels used_box_height = 0;
+        if (auto remaining_fragmentainer_extent = context->remaining_fragmentainer_extent_at(box_top_fragmented_flow_block_offset); remaining_fragmentainer_extent < remaining_box_height) {
+            while (remaining_fragmentainer_extent < remaining_box_height) {
+                box_state.add_box_fragment(LayoutState::UsedValues::BoxFragment(
+                    { unfragmented_box_position.x() + context->fragmentainer_x_offset_at(box_top_fragmented_flow_block_offset), unfragmented_box_position.y() + used_box_height + context->fragmentainer_y_offset_at(box_top_fragmented_flow_block_offset) },
+                    remaining_fragmentainer_extent));
+                remaining_box_height -= remaining_fragmentainer_extent;
+                used_box_height += remaining_fragmentainer_extent;
+                box_top_fragmented_flow_block_offset += remaining_fragmentainer_extent;
+                remaining_fragmentainer_extent = context->remaining_fragmentainer_extent_at(box_top_fragmented_flow_block_offset);
+            }
+            box_state.add_box_fragment(LayoutState::UsedValues::BoxFragment(
+                { unfragmented_box_position.x() + context->fragmentainer_x_offset_at(box_top_fragmented_flow_block_offset), unfragmented_box_position.y() + used_box_height + context->fragmentainer_y_offset_at(box_top_fragmented_flow_block_offset) },
+                remaining_box_height));
+        }
+    }
 }
 
 void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/FieldSetBox.h>
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/LegendBox.h>
 #include <LibWeb/Layout/LineBuilder.h>
@@ -97,27 +98,37 @@ static bool margins_collapse_through(Box const& box, LayoutState& state)
     return true;
 }
 
-void BlockFormattingContext::run(AvailableSpace const& available_space)
+void BlockFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     FORMATTING_CONTEXT_TRACE();
     // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
     auto const& root_state = m_state.get(root());
     auto column_count = determine_used_value_for_column_count(root_state.content_width());
-    if (column_count.has_value()) {
+    // FIXME: Figure out how to implement multicol layout with unconstrained (indefinite) height.
+    // FIXME: Support nested fragmentation contexts.
+    if (column_count.has_value() && available_space.height.is_definite() && !fragmentation_context.has_value()) {
         auto column_width = determine_used_value_for_column_width(root_state.content_width(), column_count.value());
-        // FIXME: Do multi-column layout.
-        (void)column_width;
+        auto multicol_fragmentation_context = ColumnFragmentationContext(root(), column_width, available_space.height.to_px_or_zero(), get_column_gap_used_value_for_multicol(root_state.content_width()));
+        auto multicol_available_space = AvailableSpace(AvailableSize::make_definite(column_width), AvailableSize::make_indefinite());
+
+        layout_children(multicol_available_space, multicol_fragmentation_context);
+        return;
     }
 
+    layout_children(available_space, fragmentation_context);
+}
+
+void BlockFormattingContext::layout_children(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
+{
     if (auto const* fieldset_box = as_if<FieldSetBox>(root()); fieldset_box && fieldset_box->rendered_legend()) {
-        layout_fieldset_with_rendered_legend(*fieldset_box, available_space);
+        layout_fieldset_with_rendered_legend(*fieldset_box, available_space, fragmentation_context);
         return;
     }
 
     if (root().children_are_inline())
-        layout_inline_children(root(), available_space);
+        layout_inline_children(root(), available_space, fragmentation_context);
     else
-        layout_block_level_children(root(), available_space);
+        layout_block_level_children(root(), available_space, fragmentation_context);
 
     // Fieldsets without a rendered legend skip collapsed margin assignment.
     if (is<FieldSetBox>(root()))
@@ -596,14 +607,14 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
     box_state.set_content_height(height);
 }
 
-void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     VERIFY(block_container.children_are_inline());
 
     auto& block_container_state = m_state.get_mutable(block_container);
 
     InlineFormattingContext context(m_state, m_layout_mode, block_container, block_container_state, *this);
-    context.run(available_space);
+    context.run(available_space, fragmentation_context);
 
     if (!block_container_state.has_definite_width()) {
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
@@ -764,7 +775,7 @@ static CSSPixels containing_block_height_to_resolve_percentage_in_quirks_mode(Bo
     VERIFY_NOT_REACHED();
 }
 
-void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContainer const& block_container, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     if (box.is_absolutely_positioned()) {
         if (m_layout_mode == LayoutMode::Normal) {
@@ -896,6 +907,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         inline_space_used_before_children_formatted = intrusion_by_floats_into_box(list_item_state, offset_y);
     }
 
+    auto unfragmented_box_y = box_state.offset.y();
+    if (fragmentation_context.has_value()) {
+        auto fragmented_flow_block_offset = content_box_rect_in_ancestor_coordinate_space(box_state, fragmentation_context.value().root()).y();
+        box_state.set_content_y(box_state.offset.y() + fragmentation_context.value().fragmentainer_y_offset_at(fragmented_flow_block_offset));
+        box_state.set_content_x(box_state.offset.x() + fragmentation_context.value().fragmentainer_x_offset_at(fragmented_flow_block_offset));
+    }
+
     if (independent_formatting_context) {
         // Margins of elements that establish new formatting contexts do not collapse with their in-flow children
         m_margin_state.reset();
@@ -917,7 +935,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             }
 
             auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
-            measuring_context->run(inner_available_space);
+            measuring_context->run(inner_available_space, {});
             auto content_height = measuring_context->automatic_content_height();
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height());
             if (content_height < min_height) {
@@ -925,12 +943,12 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             }
         }
 
-        independent_formatting_context->run(inner_available_space);
+        independent_formatting_context->run(inner_available_space, fragmentation_context);
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
         if (box.children_are_inline()) {
-            layout_inline_children(as<BlockContainer>(box), space_available_for_children);
+            layout_inline_children(as<BlockContainer>(box), space_available_for_children, fragmentation_context);
         } else {
             auto registered_block_container_y_position_update_callback = false;
             if (box_state.border_top > 0 || box_state.padding_top > 0) {
@@ -938,15 +956,18 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                 m_margin_state.reset();
             } else if (!m_margin_state.has_block_container_waiting_for_final_y_position()) {
                 // margin-top of block container can be updated during children layout hence it's final y position yet to be determined
-                m_margin_state.register_block_container_y_position_update_callback([this, &box, y, introduce_clearance](CSSPixels margin_top) {
+                m_margin_state.register_block_container_y_position_update_callback([this, &box, &box_state, y, introduce_clearance, &unfragmented_box_y](CSSPixels margin_top) {
                     if (introduce_clearance == DidIntroduceClearance::No) {
                         place_block_level_element_in_normal_flow_vertically(box, margin_top + y);
+                        unfragmented_box_y = box_state.offset.y();
+                        // FIXME: This might've bumped the box down into a subsequent fragmentainer, so we need to
+                        //        translate it if that is the case.
                     }
                 });
                 registered_block_container_y_position_update_callback = true;
             }
 
-            layout_block_level_children(as<BlockContainer>(box), space_available_for_children);
+            layout_block_level_children(as<BlockContainer>(box), space_available_for_children, fragmentation_context);
 
             if (registered_block_container_y_position_update_callback) {
                 m_margin_state.unregister_block_container_y_position_update_callback();
@@ -970,7 +991,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_y_offset_of_current_block_container = box_state.offset.y() + box_state.content_height() + box_state.border_box_bottom();
+        m_y_offset_of_current_block_container = unfragmented_box_y + box_state.content_height() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -980,13 +1001,13 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto const& block_container_state = m_state.get(block_container);
     compute_inset(box, content_box_rect(block_container_state).size());
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.offset.y() + box_state.content_height() + box_state.margin_box_bottom());
+    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, unfragmented_box_y + box_state.content_height() + box_state.margin_box_bottom());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_block_level_children(BlockContainer const& block_container, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     VERIFY(!block_container.children_are_inline());
 
@@ -994,7 +1015,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 
     TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
     block_container.for_each_child_of_type<Box>([&](Box& box) {
-        layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, available_space);
+        layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, available_space, fragmentation_context);
         return IterationDecision::Continue;
     });
 
@@ -1027,7 +1048,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 }
 
 // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox const& fieldset_box, AvailableSpace const& available_space)
+void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox const& fieldset_box, AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     auto& fieldset_state = m_state.get_mutable(fieldset_box);
 
@@ -1038,7 +1059,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     {
         TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
         CSSPixels dummy_bottom = 0;
-        layout_block_level_box(*legend, fieldset_box, dummy_bottom, available_space);
+        layout_block_level_box(*legend, fieldset_box, dummy_bottom, available_space, fragmentation_context);
     }
 
     // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
@@ -1063,7 +1084,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         fieldset_box.for_each_child_of_type<Box>([&](Box& child) {
             if (&child == legend)
                 return IterationDecision::Continue;
-            layout_block_level_box(child, fieldset_box, bottom_of_lowest_margin_box, available_space);
+            layout_block_level_box(child, fieldset_box, bottom_of_lowest_margin_box, available_space, fragmentation_context);
             return IterationDecision::Continue;
         });
     }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -22,7 +22,7 @@ public:
     explicit BlockFormattingContext(LayoutState&, LayoutMode layout_mode, BlockContainer const&, FormattingContext* parent);
     ~BlockFormattingContext();
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 
@@ -62,7 +62,7 @@ public:
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, AvailableSpace const&, CSSPixels y, LineBuilder* = nullptr);
 
-    void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&);
+    void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&, Optional<FragmentationContext&>);
 
     void resolve_vertical_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
     void resolve_horizontal_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
@@ -102,9 +102,10 @@ private:
 
     void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&);
 
-    void layout_block_level_children(BlockContainer const&, AvailableSpace const&);
-    void layout_inline_children(BlockContainer const&, AvailableSpace const&);
-    void layout_fieldset_with_rendered_legend(FieldSetBox const&, AvailableSpace const&);
+    void layout_children(AvailableSpace const&, Optional<FragmentationContext&>);
+    void layout_block_level_children(BlockContainer const&, AvailableSpace const&, Optional<FragmentationContext&>);
+    void layout_inline_children(BlockContainer const&, AvailableSpace const&, Optional<FragmentationContext&>);
+    void layout_fieldset_with_rendered_legend(FieldSetBox const&, AvailableSpace const&, Optional<FragmentationContext&>);
 
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
@@ -163,7 +164,7 @@ private:
             }
         }
 
-        void register_block_container_y_position_update_callback(ESCAPING Function<void(CSSPixels)> callback)
+        void register_block_container_y_position_update_callback(Function<void(CSSPixels)> callback)
         {
             m_block_container_y_position_update_callback = move(callback);
         }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -54,8 +54,11 @@ CSSPixels FlexFormattingContext::automatic_content_height() const
     return m_flex_container_state.content_height();
 }
 
-void FlexFormattingContext::run(AvailableSpace const& available_space)
+void FlexFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
+    // FIXME: Actually deal with fragmentation
+    (void)fragmentation_context;
+
     // This implements https://www.w3.org/TR/css-flexbox-1/#layout-algorithm
 
     // OPTIMIZATION: If we're in intrinsic sizing layout, but the flex container is not the

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -18,7 +18,7 @@ public:
 
     virtual bool inhibits_floating() const override { return true; }
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2672,6 +2672,17 @@ CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(Box
     return margin_box_rect_in_ancestor_coordinate_space(m_state.get(box), ancestor_box);
 }
 
+CSSPixels FormattingContext::y_position_in_ancestor_coordinate_space(LayoutState::UsedValues const& used_values, CSSPixels y, Box const& ancestor_box) const
+{
+    for (auto const* current = &used_values; current; current = current->containing_block_used_values()) {
+        if (&current->node() == &ancestor_box)
+            return y;
+        y += current->offset.y();
+    }
+    // If we get here, ancestor_box was not a containing block ancestor of `box`!
+    VERIFY_NOT_REACHED();
+}
+
 bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, AvailableSpace const& available_space) const
 {
     // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -344,7 +344,7 @@ struct ReplacedFormattingContext : public FormattingContext {
     }
     virtual CSSPixels automatic_content_width() const override { return 0; }
     virtual CSSPixels automatic_content_height() const override { return 0; }
-    virtual void run(AvailableSpace const&) override { }
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override { }
 };
 
 // FIXME: This is a hack. Get rid of it.
@@ -355,7 +355,7 @@ struct DummyFormattingContext : public FormattingContext {
     }
     virtual CSSPixels automatic_content_width() const override { return 0; }
     virtual CSSPixels automatic_content_height() const override { return 0; }
-    virtual void run(AvailableSpace const&) override { }
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override { }
 };
 
 OwnPtr<FormattingContext> FormattingContext::create_independent_formatting_context_if_needed(LayoutState& state, LayoutMode layout_mode, Box const& child_box)
@@ -424,9 +424,9 @@ OwnPtr<FormattingContext> FormattingContext::layout_inside(Box const& child_box,
 
     auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, layout_mode, child_box);
     if (independent_formatting_context)
-        independent_formatting_context->run(available_space);
+        independent_formatting_context->run(available_space, {});
     else
-        run(available_space);
+        run(available_space, {});
 
     return independent_formatting_context;
 }
@@ -676,7 +676,7 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
 
     auto context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     VERIFY(context);
-    context->run(m_state.get(box).available_inner_space_or_constraints_from(available_space));
+    context->run(m_state.get(box).available_inner_space_or_constraints_from(available_space), {});
 
     Optional<Box const&> table_box;
     box.for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
@@ -2102,7 +2102,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
         ? AvailableSize::make_definite(box_state.content_height())
         : AvailableSize::make_indefinite();
 
-    context->run(AvailableSpace(available_width, available_height));
+    context->run(AvailableSpace(available_width, available_height), {});
 
     auto min_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     cache.emplace(min_content_width);
@@ -2170,7 +2170,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
         ? AvailableSize::make_definite(box_state.content_height())
         : AvailableSize::make_indefinite();
 
-    context->run(AvailableSpace(available_width, available_height));
+    context->run(AvailableSpace(available_width, available_height), {});
 
     auto max_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     cache.emplace(max_content_width);
@@ -2208,7 +2208,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box);
 
-    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content()));
+    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content()), {});
 
     auto min_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     cache.emplace(min_content_height);
@@ -2243,7 +2243,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box);
 
-    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content()));
+    context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content()), {});
 
     auto max_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     cache_slot.emplace(max_content_height);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -105,7 +105,7 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-    virtual void run(AvailableSpace const&) = 0;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) = 0;
 
     // These functions return the automatic content dimensions of the context's root box.
     virtual CSSPixels automatic_content_width() const = 0;

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -156,6 +156,7 @@ public:
     [[nodiscard]] CSSPixelRect content_box_rect(Box const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
+    [[nodiscard]] CSSPixels y_position_in_ancestor_coordinate_space(LayoutState::UsedValues const&, CSSPixels y, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixels box_baseline(Box const&) const;
     [[nodiscard]] CSSPixels containing_block_width_for(NodeWithStyleAndBoxModelMetrics const&) const;
 

--- a/Libraries/LibWeb/Layout/Fragmentation.cpp
+++ b/Libraries/LibWeb/Layout/Fragmentation.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026-present, Psychpsyo <psychpsyo@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/Fragmentation.h>
+
+namespace Web::Layout {
+
+FragmentationContext::FragmentationContext(GC::Ref<Box const> root_box)
+    : m_root_box(root_box)
+{
+}
+
+FragmentationContext::~FragmentationContext() = default;
+
+ColumnFragmentationContext::ColumnFragmentationContext(GC::Ref<Box const> root_box, CSSPixels column_width, CSSPixels column_height, CSSPixels column_gap)
+    : FragmentationContext(root_box)
+    , m_column_width(column_width)
+    , m_column_height(column_height)
+    , m_column_gap(column_gap)
+{
+}
+
+ColumnFragmentationContext::~ColumnFragmentationContext() = default;
+
+CSSPixels ColumnFragmentationContext::fragmentainer_x_offset_at(CSSPixels progress) const
+{
+    auto current_fragmentainer = floor(progress / m_column_height);
+    return (m_column_width + m_column_gap) * current_fragmentainer;
+}
+
+CSSPixels ColumnFragmentationContext::fragmentainer_y_offset_at(CSSPixels progress) const
+{
+    auto current_fragmentainer = floor(progress / m_column_height);
+    return -m_column_height * current_fragmentainer;
+}
+
+// https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
+CSSPixels ColumnFragmentationContext::remaining_fragmentainer_extent_at(CSSPixels progress) const
+{
+    return m_column_height - (progress % m_column_height);
+}
+
+}

--- a/Libraries/LibWeb/Layout/Fragmentation.h
+++ b/Libraries/LibWeb/Layout/Fragmentation.h
@@ -12,6 +12,16 @@
 
 namespace Web::Layout {
 
+enum class FragmentationState {
+    Unfragmented,
+    HorizontalStart,
+    HorizontalMiddle,
+    HorizontalEnd,
+    VerticalStart,
+    VerticalMiddle,
+    VerticalEnd
+};
+
 // https://drafts.csswg.org/css-break/#fragmentation-context
 // FIXME: Some of this will need to be merged with AvailableSpace in some form once we get to fragmentation contexts
 //        with variable-width fragmentainers.

--- a/Libraries/LibWeb/Layout/Fragmentation.h
+++ b/Libraries/LibWeb/Layout/Fragmentation.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026-present, Psychpsyo <psychpsyo@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/Ptr.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::Layout {
+
+// https://drafts.csswg.org/css-break/#fragmentation-context
+// FIXME: Some of this will need to be merged with AvailableSpace in some form once we get to fragmentation contexts
+//        with variable-width fragmentainers.
+//        (print mode under the influence of @page rules that turn only some pages sideways comes to mind)
+class FragmentationContext {
+public:
+    virtual ~FragmentationContext();
+
+    virtual CSSPixels fragmentainer_x_offset_at(CSSPixels) const { return 0; }
+    virtual CSSPixels fragmentainer_y_offset_at(CSSPixels) const { return 0; }
+
+    // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
+    virtual CSSPixels remaining_fragmentainer_extent_at(CSSPixels) const { return 0; }
+
+    GC::Ref<Box const> root() const { return m_root_box; }
+
+protected:
+    FragmentationContext(GC::Ref<Box const> root_box);
+
+private:
+    CSSPixels m_used_fragmentainer_extent;
+    // This is the box that hosts the fragmented flow. It is used to determine the fragmentation-relative position of
+    // elements in said flow. A containing block for fragmentation-related positioning, if you will.
+    GC::Ref<Box const> m_root_box;
+};
+
+// https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
+class ColumnFragmentationContext : public FragmentationContext {
+public:
+    ColumnFragmentationContext(GC::Ref<Box const> root_box, CSSPixels column_width, CSSPixels column_height, CSSPixels column_gap);
+    virtual ~ColumnFragmentationContext();
+
+    CSSPixels fragmentainer_x_offset_at(CSSPixels progress) const override;
+    CSSPixels fragmentainer_y_offset_at(CSSPixels progress) const override;
+
+    // https://drafts.csswg.org/css-break/#remaining-fragmentainer-extent
+    CSSPixels remaining_fragmentainer_extent_at(CSSPixels progress) const override;
+
+private:
+    CSSPixels m_column_width;
+    CSSPixels m_column_height;
+    CSSPixels m_column_gap;
+};
+
+}

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2122,8 +2122,11 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
     return area_rect;
 }
 
-void GridFormattingContext::run(AvailableSpace const& available_space)
+void GridFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
+    // FIXME: Actually deal with fragmentation
+    (void)fragmentation_context;
+
     // OPTIMIZATION: If we're in intrinsic sizing layout, but the grid container is not the
     //               box being measured, we can skip everything here.
     //               The parent formatting context has already figured out our size anyway.

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -170,7 +170,7 @@ public:
 
     virtual bool inhibits_floating() const override { return true; }
 
-    virtual void run(AvailableSpace const& available_space) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
     StaticPositionRect calculate_static_position_rect(Box const&) const;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -80,12 +80,12 @@ CSSPixels InlineFormattingContext::automatic_content_height() const
     return m_automatic_content_height;
 }
 
-void InlineFormattingContext::run(AvailableSpace const& available_space)
+void InlineFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     FORMATTING_CONTEXT_TRACE();
     VERIFY(containing_block().children_are_inline());
     m_available_space = available_space;
-    generate_line_boxes();
+    generate_line_boxes(fragmentation_context);
 
     CSSPixels content_height = 0;
 
@@ -340,7 +340,7 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
     }
 }
 
-void InlineFormattingContext::generate_line_boxes()
+void InlineFormattingContext::generate_line_boxes(Optional<FragmentationContext&> fragmentation_context)
 {
     auto& line_boxes = m_containing_block_used_values.line_boxes;
     line_boxes.clear_with_capacity();
@@ -371,7 +371,7 @@ void InlineFormattingContext::generate_line_boxes()
             if (item.node->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 auto next_width = iterator.next_non_whitespace_sequence_width();
                 if (next_width > 0)
-                    line_builder.break_if_needed(next_width);
+                    line_builder.break_if_needed(next_width, fragmentation_context);
             }
             leading_margin_from_collapsible_whitespace += item.margin_start;
             leading_border_from_collapsible_whitespace += item.border_start;
@@ -388,7 +388,7 @@ void InlineFormattingContext::generate_line_boxes()
 
         switch (item.type) {
         case InlineLevelIterator::Item::Type::ForcedBreak: {
-            line_builder.break_line(LineBuilder::ForcedBreak::Yes);
+            line_builder.break_line(LineBuilder::ForcedBreak::Yes, fragmentation_context);
             if (item.node) {
                 auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this);
                 if (introduce_clearance == BlockFormattingContext::DidIntroduceClearance::Yes) {
@@ -407,7 +407,7 @@ void InlineFormattingContext::generate_line_boxes()
                     minimum_space_needed_on_line += item.margin_start;
                 if (item.margin_end < 0)
                     minimum_space_needed_on_line += item.margin_end;
-                line_builder.break_if_needed(minimum_space_needed_on_line);
+                line_builder.break_if_needed(minimum_space_needed_on_line, fragmentation_context);
             }
             line_builder.append_box(box, item.border_start + item.padding_start, item.padding_end + item.border_end, item.margin_start, item.margin_end);
             break;
@@ -447,7 +447,7 @@ void InlineFormattingContext::generate_line_boxes()
                 }
 
                 // If whitespace caused us to break, don't put it on the next line.
-                if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width)) {
+                if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width, fragmentation_context)) {
                     // Record that the previous line has trailing whitespace for text selection.
                     line_builder.set_trailing_whitespace_on_previous_line();
                     break;
@@ -457,7 +457,7 @@ void InlineFormattingContext::generate_line_boxes()
                 // If a shortened line box is too small to contain any content, then the line box is shifted downward
                 // (and its width recomputed) until either some content fits or there are no more floats present.
                 if (!is_whitespace && (item.can_break_before || line_boxes.last().is_empty()))
-                    line_builder.break_if_needed(item.border_box_width());
+                    line_builder.break_if_needed(item.border_box_width(), fragmentation_context);
             }
             line_builder.append_text_chunk(
                 text_node,
@@ -503,7 +503,7 @@ void InlineFormattingContext::generate_line_boxes()
         }
     }
 
-    line_builder.update_last_line();
+    line_builder.update_last_line(fragmentation_context);
     m_containing_block_used_values.set_inline_end_static_position_rect(calculate_inline_end_static_position_rect());
 
     if (m_layout_mode == LayoutMode::Normal) {

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -23,7 +23,7 @@ public:
 
     BlockContainer const& containing_block() const { return static_cast<BlockContainer const&>(context_box()); }
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_height() const override;
     virtual CSSPixels automatic_content_width() const override;
     StaticPositionRect calculate_static_position_rect(Box const&) const;
@@ -39,7 +39,7 @@ public:
     void set_vertical_float_clearance(CSSPixels);
 
 private:
-    void generate_line_boxes();
+    void generate_line_boxes(Optional<FragmentationContext&>);
     void apply_text_overflow_ellipsis(Vector<LineBox>&);
     void apply_justification_to_fragments(CSS::TextJustify, LineBox&, bool is_last_line);
     StaticPositionRect calculate_inline_end_static_position_rect() const;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -1050,4 +1050,13 @@ void LayoutState::UsedValues::set_indefinite_content_height()
     m_has_definite_height = false;
 }
 
+void LayoutState::UsedValues::add_box_fragment(BoxFragment box_fragment)
+{
+    if (!m_box_fragments.has_value()) {
+        m_box_fragments = Vector<BoxFragment>();
+    }
+
+    m_box_fragments.value().append(box_fragment);
+}
+
 }

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -465,7 +465,7 @@ void LayoutState::commit(Box& root)
         box_model.margin = { used_values.margin_top, used_values.margin_right, used_values.margin_bottom, used_values.margin_left };
     };
 
-    auto try_to_relocate_fragment_in_inline_node = [&](auto& fragment, size_t line_index, Painting::PaintableBox::FragmentationState fragmentation_state) -> bool {
+    auto try_to_relocate_fragment_in_inline_node = [&](auto& fragment, size_t line_index, FragmentationState fragmentation_state) -> bool {
         for (auto const* parent = fragment.layout_node().parent(); parent; parent = parent->parent()) {
             if (parent->is_atomic_inline())
                 break;
@@ -492,81 +492,100 @@ void LayoutState::commit(Box& root)
         if (m_subtree_root && !m_subtree_root->is_inclusive_ancestor_of(node))
             return;
 
-        RefPtr<Painting::Paintable> paintable;
+        Vector<RefPtr<Painting::Paintable>> paintables;
 
-        // Try to reuse cached paintable for Box nodes
-        if (auto cached = paintable_cache.get(&node); cached.has_value()) {
+        auto fragments = used_values.box_fragments().value_or({ UsedValues::BoxFragment(used_values.offset, used_values.content_height()) });
+
+        // Try to reuse cached paintable for Box nodes, as long as they are not fragmented into multiple.
+        if (auto cached = paintable_cache.get(&node); cached.has_value() && fragments.size() == 1) {
             auto cached_paintable = cached.value();
             cached_paintable->reset_for_relayout();
-            paintable = cached_paintable;
+            paintables.append(cached_paintable);
         }
 
-        // Fall back to creating new if no reusable paintable
-        if (!paintable)
-            paintable = node.create_paintable();
+        // Fall back to creating new if no reusable paintables
+        if (paintables.size() == 0) {
+            for (size_t i = 0; i < fragments.size(); i++) {
+                paintables.append(node.create_paintable());
+            }
+        }
 
-        node.add_paintable(paintable);
+        for (auto paintable : paintables)
+            node.add_paintable(paintable);
 
         // For boxes, transfer all the state needed for painting.
-        if (auto* paintable_box = as_if<Painting::PaintableBox>(paintable.ptr())) {
-            transfer_box_model_metrics(paintable_box->box_model(), used_values);
+        for (size_t i = 0; i < fragments.size(); i++) {
+            if (auto* paintable_box = as_if<Painting::PaintableBox>(paintables[i].ptr())) {
+                transfer_box_model_metrics(paintable_box->box_model(), used_values);
 
-            paintable_box->set_offset(used_values.offset);
-            paintable_box->set_content_size(used_values.content_width(), used_values.content_height());
-            if (used_values.override_borders_data().has_value())
-                paintable_box->set_override_borders_data(used_values.override_borders_data().value());
-            if (used_values.table_cell_coordinates().has_value())
-                paintable_box->set_table_cell_coordinates(used_values.table_cell_coordinates().value());
+                paintable_box->set_offset(fragments[i].offset);
+                // FIXME: Support non-vertical fragmentation direction.
+                paintable_box->set_content_size(used_values.content_width(), fragments[i].size_in_fragmentation_direction);
+                if (used_values.override_borders_data().has_value())
+                    paintable_box->set_override_borders_data(used_values.override_borders_data().value());
+                if (used_values.table_cell_coordinates().has_value())
+                    paintable_box->set_table_cell_coordinates(used_values.table_cell_coordinates().value());
 
-            if (auto* paintable_with_lines = as_if<Painting::PaintableWithLines>(*paintable_box)) {
-                for (size_t line_index = 0; line_index < used_values.line_boxes.size(); ++line_index) {
-                    auto& line_box = used_values.line_boxes[line_index];
-                    auto first_fragment_continues_last_line_box = false;
-                    if (line_index > 0 && used_values.line_boxes[line_index - 1].fragments().size() > 0 && used_values.line_boxes[line_index].fragments().size() > 0) {
-                        first_fragment_continues_last_line_box = &used_values.line_boxes[line_index - 1].fragments().last().layout_node() == &used_values.line_boxes[line_index].fragments().first().layout_node();
-                    }
-                    auto last_fragment_is_continued_in_next_line_box = false;
-                    if (line_index < used_values.line_boxes.size() - 1 && used_values.line_boxes[line_index].fragments().size() > 0 && used_values.line_boxes[line_index + 1].fragments().size() > 0) {
-                        last_fragment_is_continued_in_next_line_box = &used_values.line_boxes[line_index].fragments().last().layout_node() == &used_values.line_boxes[line_index + 1].fragments().first().layout_node();
-                    }
-                    for (auto const& fragment : line_box.fragments()) {
-                        if (fragment.is_fully_truncated())
-                            continue;
-                        if (auto const* text_node = as_if<TextNode>(fragment.layout_node()))
-                            text_nodes.set(const_cast<TextNode*>(text_node));
-
-                        auto fragmentation_state = Painting::PaintableBox::FragmentationState::Unfragmented;
-                        auto is_first_fragment = &line_box.fragments().first() == &fragment;
-                        auto is_last_fragment = &line_box.fragments().last() == &fragment;
-                        if (is_first_fragment && is_last_fragment && first_fragment_continues_last_line_box && last_fragment_is_continued_in_next_line_box) {
-                            fragmentation_state = Painting::PaintableBox::FragmentationState::HorizontalMiddle;
-                        } else if (is_first_fragment && first_fragment_continues_last_line_box) {
-                            fragmentation_state = Painting::PaintableBox::FragmentationState::HorizontalEnd;
-                        } else if (is_last_fragment && last_fragment_is_continued_in_next_line_box) {
-                            fragmentation_state = Painting::PaintableBox::FragmentationState::HorizontalStart;
-                        }
-
-                        auto did_relocate_fragment = try_to_relocate_fragment_in_inline_node(fragment, line_index, fragmentation_state);
-                        first_fragment_continues_last_line_box = false;
-                        if (!did_relocate_fragment)
-                            paintable_with_lines->add_fragment(fragment);
+                if (fragments.size() > 1) {
+                    if (i == 0) {
+                        paintable_box->set_fragmentation_state(FragmentationState::VerticalStart);
+                    } else if (i == fragments.size() - 1) {
+                        paintable_box->set_fragmentation_state(FragmentationState::VerticalEnd);
+                    } else {
+                        paintable_box->set_fragmentation_state(FragmentationState::VerticalMiddle);
                     }
                 }
-            }
 
-            if (auto* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(paintable.ptr());
-                svg_graphics_paintable && used_values.computed_svg_transforms().has_value()) {
-                svg_graphics_paintable->set_computed_transforms(*used_values.computed_svg_transforms());
-            }
+                if (auto* paintable_with_lines = as_if<Painting::PaintableWithLines>(*paintable_box); i == 0) {
+                    for (size_t line_index = 0; line_index < used_values.line_boxes.size(); ++line_index) {
+                        auto& line_box = used_values.line_boxes[line_index];
+                        auto first_fragment_continues_last_line_box = false;
+                        if (line_index > 0 && used_values.line_boxes[line_index - 1].fragments().size() > 0 && used_values.line_boxes[line_index].fragments().size() > 0) {
+                            first_fragment_continues_last_line_box = &used_values.line_boxes[line_index - 1].fragments().last().layout_node() == &used_values.line_boxes[line_index].fragments().first().layout_node();
+                        }
+                        auto last_fragment_is_continued_in_next_line_box = false;
+                        if (line_index < used_values.line_boxes.size() - 1 && used_values.line_boxes[line_index].fragments().size() > 0 && used_values.line_boxes[line_index + 1].fragments().size() > 0) {
+                            last_fragment_is_continued_in_next_line_box = &used_values.line_boxes[line_index].fragments().last().layout_node() == &used_values.line_boxes[line_index + 1].fragments().first().layout_node();
+                        }
+                        for (auto const& fragment : line_box.fragments()) {
+                            if (fragment.is_fully_truncated())
+                                continue;
+                            if (auto const* text_node = as_if<TextNode>(fragment.layout_node()))
+                                text_nodes.set(const_cast<TextNode*>(text_node));
 
-            if (auto* svg_path_paintable = as_if<Painting::SVGPathPaintable>(paintable.ptr())) {
-                if (auto* path = used_values.computed_svg_path())
-                    svg_path_paintable->set_computed_path(move(*path));
-            }
+                            auto fragmentation_state = FragmentationState::Unfragmented;
+                            auto is_first_fragment = &line_box.fragments().first() == &fragment;
+                            auto is_last_fragment = &line_box.fragments().last() == &fragment;
+                            if (is_first_fragment && is_last_fragment && first_fragment_continues_last_line_box && last_fragment_is_continued_in_next_line_box) {
+                                fragmentation_state = FragmentationState::HorizontalMiddle;
+                            } else if (is_first_fragment && first_fragment_continues_last_line_box) {
+                                fragmentation_state = FragmentationState::HorizontalEnd;
+                            } else if (is_last_fragment && last_fragment_is_continued_in_next_line_box) {
+                                fragmentation_state = FragmentationState::HorizontalStart;
+                            }
 
-            if (node.display().is_grid_inside()) {
-                paintable_box->set_used_values_for_grid_template_columns(used_values.grid_template_columns());
-                paintable_box->set_used_values_for_grid_template_rows(used_values.grid_template_rows());
+                            auto did_relocate_fragment = try_to_relocate_fragment_in_inline_node(fragment, line_index, fragmentation_state);
+                            first_fragment_continues_last_line_box = false;
+                            if (!did_relocate_fragment)
+                                paintable_with_lines->add_fragment(fragment);
+                        }
+                    }
+                }
+
+                if (auto* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(paintable_box);
+                    svg_graphics_paintable && used_values.computed_svg_transforms().has_value()) {
+                    svg_graphics_paintable->set_computed_transforms(*used_values.computed_svg_transforms());
+                }
+
+                if (auto* svg_path_paintable = as_if<Painting::SVGPathPaintable>(paintable_box)) {
+                    if (auto* path = used_values.computed_svg_path())
+                        svg_path_paintable->set_computed_path(move(*path));
+                }
+
+                if (node.display().is_grid_inside()) {
+                    paintable_box->set_used_values_for_grid_template_columns(used_values.grid_template_columns());
+                    paintable_box->set_used_values_for_grid_template_rows(used_values.grid_template_rows());
+                }
             }
         }
     });
@@ -646,6 +665,7 @@ void LayoutState::commit(Box& root)
         paintable.set_offset(offset);
     });
 
+    // FIXME: Make these fragment.
     for (auto* text_node : text_nodes)
         text_node->add_paintable(text_node->create_paintable());
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -298,6 +298,7 @@ struct LayoutState {
             CSSPixels size_in_fragmentation_direction;
         };
         Optional<Vector<BoxFragment>> box_fragments() const { return m_box_fragments; }
+        void add_box_fragment(BoxFragment);
 
     private:
         friend struct LayoutState;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -292,6 +292,13 @@ struct LayoutState {
             return m_rare->static_position_rect->aligned_position_for_box_with_size({ margin_box_width(), margin_box_height() });
         }
 
+        // https://drafts.csswg.org/css-break/#box-fragment
+        struct BoxFragment {
+            CSSPixelPoint offset;
+            CSSPixels size_in_fragmentation_direction;
+        };
+        Optional<Vector<BoxFragment>> box_fragments() const { return m_box_fragments; }
+
     private:
         friend struct LayoutState;
 
@@ -336,6 +343,9 @@ struct LayoutState {
         bool m_has_definite_height { false };
 
         OwnPtr<RareData> m_rare;
+
+        // If this has a value, this box is fragmented into the given fragments.
+        Optional<Vector<BoxFragment>> m_box_fragments;
     };
 
     LayoutState() = default;

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -24,7 +24,7 @@ LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_s
     begin_new_line(false);
 }
 
-void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_item_width)
+void LineBuilder::break_line(ForcedBreak forced_break, Optional<FragmentationContext&> fragmentation_context, Optional<CSSPixels> next_item_width)
 {
     // FIXME: Respect inline direction.
 
@@ -33,7 +33,7 @@ void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_
     last_line_box.m_has_forced_break = forced_break == ForcedBreak::Yes;
 
     m_last_line_needs_update = true;
-    update_last_line();
+    update_last_line(fragmentation_context);
 
     size_t break_count = 0;
     bool floats_intrude_at_current_y = false;
@@ -208,7 +208,7 @@ bool LineBuilder::should_break(CSSPixels next_item_width)
     return (current_line_width + next_item_width) > m_available_width_for_current_line;
 }
 
-void LineBuilder::update_last_line()
+void LineBuilder::update_last_line(Optional<FragmentationContext&> fragmentation_context)
 {
     if (!m_last_line_needs_update)
         return;
@@ -266,6 +266,25 @@ void LineBuilder::update_last_line()
         default:
             break;
         }
+    }
+
+    auto line_height = m_context.containing_block().computed_values().line_height();
+
+    CSSPixels inline_fragmentainer_offset = 0;
+    CSSPixels block_fragmentainer_offset = 0;
+    if (fragmentation_context.has_value()) {
+        // FIXME: Block doesn't always mean Y-axis and inline doesn't always mean X-axis, so account for writing mode.
+        auto fragmented_flow_block_offset = m_context.content_box_rect_in_ancestor_coordinate_space(
+                                                         m_layout_state.get(m_context.containing_block()), fragmentation_context.value().root())
+                                                .y();
+
+        auto remaining_fragmentainer_extent = fragmentation_context.value().remaining_fragmentainer_extent_at(fragmented_flow_block_offset + m_current_block_offset);
+        if (remaining_fragmentainer_extent < line_height) {
+            m_current_block_offset += remaining_fragmentainer_extent;
+        }
+
+        inline_fragmentainer_offset = fragmentation_context.value().fragmentainer_x_offset_at(fragmented_flow_block_offset + m_current_block_offset);
+        block_fragmentainer_offset = fragmentation_context.value().fragmentainer_y_offset_at(fragmented_flow_block_offset + m_current_block_offset);
     }
 
     auto strut_baseline = [&] {
@@ -334,7 +353,7 @@ void LineBuilder::update_last_line()
     CSSPixels lowermost_box_bottom = strut_bottom;
 
     for (auto& fragment : line_box.fragments()) {
-        CSSPixels new_fragment_inline_offset = inline_offset + fragment.inline_offset();
+        CSSPixels new_fragment_inline_offset = inline_offset + inline_fragmentainer_offset + fragment.inline_offset();
         CSSPixels new_fragment_block_offset = 0;
 
         auto block_offset_value_for_alignment = [&](CSS::VerticalAlign vertical_align) {
@@ -391,7 +410,7 @@ void LineBuilder::update_last_line()
         }
 
         fragment.set_inline_offset(new_fragment_inline_offset);
-        fragment.set_block_offset(floor(new_fragment_block_offset) + block_offset);
+        fragment.set_block_offset(floor(new_fragment_block_offset) + block_offset + block_fragmentainer_offset);
 
         CSSPixels top_of_inline_box = 0;
         CSSPixels bottom_of_inline_box = 0;
@@ -422,7 +441,7 @@ void LineBuilder::update_last_line()
     line_box.m_block_length = lowermost_box_bottom - uppermost_box_top;
     m_should_advance_to_last_line_box_bottom = should_align_strut_to_line_box_baseline;
 
-    line_box.m_bottom = m_current_block_offset + line_box.m_block_length;
+    line_box.m_bottom = m_current_block_offset + block_fragmentainer_offset + line_box.m_block_length;
     line_box.m_baseline = line_box_baseline;
 }
 

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -274,9 +274,7 @@ void LineBuilder::update_last_line(Optional<FragmentationContext&> fragmentation
     CSSPixels block_fragmentainer_offset = 0;
     if (fragmentation_context.has_value()) {
         // FIXME: Block doesn't always mean Y-axis and inline doesn't always mean X-axis, so account for writing mode.
-        auto fragmented_flow_block_offset = m_context.content_box_rect_in_ancestor_coordinate_space(
-                                                         m_layout_state.get(m_context.containing_block()), fragmentation_context.value().root())
-                                                .y();
+        auto fragmented_flow_block_offset = m_context.y_position_in_ancestor_coordinate_space(m_layout_state.get(m_context.containing_block()), 0, fragmentation_context.value().root());
 
         auto remaining_fragmentainer_extent = fragmentation_context.value().remaining_fragmentainer_extent_at(fragmented_flow_block_offset + m_current_block_offset);
         if (remaining_fragmentainer_extent < line_height) {

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 
 namespace Web::Layout {
@@ -22,21 +23,21 @@ public:
         Yes,
     };
 
-    void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
+    void break_line(ForcedBreak, Optional<FragmentationContext&> fragmentation_context, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
 
     // Returns whether a line break occurred.
-    bool break_if_needed(CSSPixels next_item_width)
+    bool break_if_needed(CSSPixels next_item_width, Optional<FragmentationContext&> fragmentation_context)
     {
         if (should_break(next_item_width)) {
-            break_line(LineBuilder::ForcedBreak::No, next_item_width);
+            break_line(LineBuilder::ForcedBreak::No, fragmentation_context, next_item_width);
             return true;
         }
         return false;
     }
 
-    void update_last_line();
+    void update_last_line(Optional<FragmentationContext&>);
 
     void remove_last_line_if_empty();
 

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -14,8 +14,11 @@ ReplacedWithChildrenFormattingContext::ReplacedWithChildrenFormattingContext(Lay
 {
 }
 
-void ReplacedWithChildrenFormattingContext::run(AvailableSpace const& available_space)
+void ReplacedWithChildrenFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
+    // FIXME: Actually deal with fragmentation
+    (void)fragmentation_context;
+
     auto& root_state = m_state.get_mutable(context_box());
     auto content_width = root_state.content_width();
 
@@ -48,7 +51,7 @@ void ReplacedWithChildrenFormattingContext::run(AvailableSpace const& available_
     wrapper_state.set_content_offset({ 0, 0 });
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
-    bfc->run(child_available_space);
+    bfc->run(child_available_space, {});
 
     m_automatic_content_width = content_width;
     m_automatic_content_height = bfc->automatic_content_height();

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.h
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.h
@@ -14,7 +14,7 @@ class ReplacedWithChildrenFormattingContext final : public FormattingContext {
 public:
     explicit ReplacedWithChildrenFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent);
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
     virtual void parent_context_did_dimension_child_root_box() override;

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -176,7 +176,7 @@ static bool is_container_element(Node const& node)
     return false;
 }
 
-void SVGFormattingContext::run(AvailableSpace const& available_space)
+void SVGFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&>)
 {
     FORMATTING_CONTEXT_TRACE();
     // NOTE: SVG doesn't have a "formatting context" in the spec, but this is the most
@@ -315,7 +315,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
         child_state.set_content_width(transformed_rect.width());
         child_state.set_content_height(transformed_rect.height());
 
-        bfc.run(AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height())));
+        bfc.run(AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height())), {});
 
         if (auto* mask_box = child.first_child_of_type<SVGMaskBox>())
             layout_mask_or_clip(*mask_box);
@@ -370,7 +370,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform);
-    nested_context.run(*m_available_space);
+    nested_context.run(*m_available_space, {});
 }
 
 Gfx::Path SVGFormattingContext::compute_path_for_text(SVGTextBox const& text_box) const
@@ -581,7 +581,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform);
     layout_state.set_has_definite_width(true);
     layout_state.set_has_definite_height(true);
-    nested_context.run(*m_available_space);
+    nested_context.run(*m_available_space, {});
 }
 
 void SVGFormattingContext::layout_container_element(SVGBox const& container)

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -20,7 +20,7 @@ public:
     explicit SVGFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent, Gfx::AffineTransform parent_viewbox_transform = {});
     ~SVGFormattingContext();
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/TableFormattingContext.h>
 
@@ -56,7 +57,7 @@ static inline bool is_table_column(Box const& box)
     return box.display().is_table_column();
 }
 
-CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, AvailableSpace const& caption_available_space)
+CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, AvailableSpace const& caption_available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     CSSPixels caption_height = 0;
     for (auto* child = table_box().first_child(); child; child = child->next_sibling()) {
@@ -76,7 +77,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
             }
 
-            caption_context->run(inner_available_space);
+            caption_context->run(inner_available_space, fragmentation_context);
 
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
@@ -1788,7 +1789,7 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
     layout_absolutely_positioned_children();
 }
 
-void TableFormattingContext::run(AvailableSpace const& available_space)
+void TableFormattingContext::run(AvailableSpace const& available_space, Optional<FragmentationContext&> fragmentation_context)
 {
     FORMATTING_CONTEXT_TRACE();
     m_available_space = available_space;
@@ -1804,7 +1805,7 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
         AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_width())),
         available_space.height);
 
-    auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
+    auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space, fragmentation_context);
 
     // Distribute the width of the table among columns.
     distribute_width_to_columns();
@@ -1818,7 +1819,7 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
 
     m_state.get_mutable(table_box()).set_content_height(m_table_height);
 
-    total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space);
+    total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space, fragmentation_context);
 
     // Table captions are positioned between the table margins and its borders (outside the grid box borders) as described in
     // https://www.w3.org/TR/css-tables-3/#bounding-box-assignment

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -25,7 +25,7 @@ public:
 
     void run_until_width_calculation(AvailableSpace const& available_space);
 
-    virtual void run(AvailableSpace const&) override;
+    virtual void run(AvailableSpace const&, Optional<FragmentationContext&>) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
     StaticPositionRect calculate_static_position_rect(Box const&) const;
@@ -41,7 +41,7 @@ public:
     virtual void parent_context_did_dimension_child_root_box() override;
 
 private:
-    CSSPixels run_caption_layout(CSS::CaptionSide, AvailableSpace const&);
+    CSSPixels run_caption_layout(CSS::CaptionSide, AvailableSpace const&, Optional<FragmentationContext&>);
     CSSPixels compute_capmin();
     void compute_constrainedness();
     void compute_cell_measures();

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -336,29 +336,29 @@ void PaintableBox::set_content_size(CSSPixelSize size)
     invalidate_descendant_styles_for_container_query_size_change(*this, old_size, size);
 }
 
-void PaintableBox::set_fragmentation_state(FragmentationState fragmentation_state)
+void PaintableBox::set_fragmentation_state(Layout::FragmentationState fragmentation_state)
 {
     switch (fragmentation_state) {
-    case FragmentationState::Unfragmented:
+    case Layout::FragmentationState::Unfragmented:
         break;
-    case FragmentationState::HorizontalStart:
+    case Layout::FragmentationState::HorizontalStart:
         m_fragment_right_edge_away = true;
         break;
-    case FragmentationState::HorizontalMiddle:
+    case Layout::FragmentationState::HorizontalMiddle:
         m_fragment_left_edge_away = true;
         m_fragment_right_edge_away = true;
         break;
-    case FragmentationState::HorizontalEnd:
+    case Layout::FragmentationState::HorizontalEnd:
         m_fragment_left_edge_away = true;
         break;
-    case FragmentationState::VerticalStart:
+    case Layout::FragmentationState::VerticalStart:
         m_fragment_bottom_edge_away = true;
         break;
-    case FragmentationState::VerticalMiddle:
+    case Layout::FragmentationState::VerticalMiddle:
         m_fragment_top_edge_away = true;
         m_fragment_bottom_edge_away = true;
         break;
-    case FragmentationState::VerticalEnd:
+    case Layout::FragmentationState::VerticalEnd:
         m_fragment_top_edge_away = true;
         break;
     }

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/Fragmentation.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/BoxModelMetrics.h>
@@ -94,16 +95,7 @@ public:
     CSSPixels content_width() const { return m_content_size.width(); }
     CSSPixels content_height() const { return m_content_size.height(); }
 
-    enum class FragmentationState {
-        Unfragmented,
-        HorizontalStart,
-        HorizontalMiddle,
-        HorizontalEnd,
-        VerticalStart,
-        VerticalMiddle,
-        VerticalEnd
-    };
-    void set_fragmentation_state(FragmentationState);
+    void set_fragmentation_state(Layout::FragmentationState);
 
     CSSPixelRect absolute_rect() const;
     CSSPixelRect absolute_padding_box_rect() const;

--- a/Libraries/LibWeb/PixelUnits.h
+++ b/Libraries/LibWeb/PixelUnits.h
@@ -219,6 +219,11 @@ public:
     constexpr CSSPixelFraction operator/(CSSPixels const& other) const;
     constexpr CSSPixels operator/(CSSPixelFraction const& other) const;
 
+    constexpr CSSPixels operator%(CSSPixels const& other) const
+    {
+        return from_raw(raw_value() % other.raw_value());
+    }
+
     constexpr CSSPixels& operator+=(CSSPixels const& other)
     {
         *this = *this + other;

--- a/Tests/LibWeb/Ref/expected/css/css-multicol/block-positioning-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/css-multicol/block-positioning-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+  body {
+    display: flex;
+  }
+  div {
+    width: 20em;
+    background-color: lightgray;
+    border: 2px solid;
+    box-sizing: border-box;
+  }
+</style>
+<div>VeryLongUnbrokenWord1</div>
+<div>VeryLongUnbrokenWord2</div>

--- a/Tests/LibWeb/Ref/expected/css/css-multicol/block-splitting-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/css-multicol/block-splitting-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  body {
+    display: flex;
+  }
+  div {
+    height: calc(1lh + 4px);
+    width: 20em;
+    background-color: lightgray;
+    border: 2px solid;
+    box-sizing: border-box;
+  }
+</style>
+<div style="border-bottom: none;">VeryLongUnbrokenWord1</div>
+<div style="border-top: none;">VeryLongUnbrokenWord2</div>

--- a/Tests/LibWeb/Ref/expected/css/css-multicol/text-basic-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/css-multicol/text-basic-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+  div {
+    display: flex;
+  }
+  span {
+    width: 20em;
+  }
+</style>
+<div>
+  <span>VeryLongUnbrokenWord1</span>
+  <span>VeryLongUnbrokenWord2</span>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-001-ref.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-001-ref.xht
@@ -1,0 +1,40 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Opera Software ASA" href="http://www.opera.com/" />
+  <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-07-30 -->
+  <meta name="flags" content="ahem" />
+  <link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  color: black;
+  font: 1.25em/1 Ahem;
+  float: left;
+  width: 10em;
+  margin-right: 1em;
+  }
+  ]]></style>
+ </head>
+ <body>
+
+  <div>1 22 333
+  4444 55555
+  666666
+  7777777
+  999999999
+  1 22 333
+  4444 55555
+  666666
+  7777777
+  999999999</div>
+
+  <div>1 22 333
+  4444 55555
+  666666
+  7777777
+  999999999</div>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-002-ref.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-multicol/multicol-fill-auto-002-ref.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>multicolumn | column-fill-auto</title>
+<link rel="author" title="howcome@opera.com" href="http://www.opera.com/"/>
+<meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+<style type="text/css"><![CDATA[
+body>div {
+	font-family: Ahem;
+	font-size: 1.25em;
+	line-height: 1em;
+	color: green;
+	height: 3em;
+	width: 2em;
+	orphans: 1;
+	widows: 1;
+	position: relative;
+	margin: 1em;
+}
+div.col {
+	column-count: 2;
+	column-fill: auto;
+	column-gap: 0;
+}
+div.red {
+	background: red; position: absolute; z-index: -1;
+}
+]]></style>
+</head>
+
+<body>
+
+<div class='ref'>
+oo<br/>t<br/>o
+</div>
+
+<div class='ref'>
+oo<br/>t<br/>o
+</div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/css/css-multicol/block-positioning.html
+++ b/Tests/LibWeb/Ref/input/css/css-multicol/block-positioning.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/css-multicol/block-positioning-ref.html" />
+<style>
+  body {
+    columns: 2;
+    height: calc(1lh + 4px);
+	  column-width: 1em;
+    max-width: 40em;
+    column-gap: 0;
+  }
+  div {
+    background-color: lightgray;
+    border: 2px solid;
+  }
+</style>
+<div>VeryLongUnbrokenWord1</div>
+<div>VeryLongUnbrokenWord2</div>

--- a/Tests/LibWeb/Ref/input/css/css-multicol/block-splitting.html
+++ b/Tests/LibWeb/Ref/input/css/css-multicol/block-splitting.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/css-multicol/block-splitting-ref.html" />
+<style>
+  body {
+    columns: 2;
+    height: calc(1lh + 4px);
+	  column-width: 1em;
+    max-width: 40em;
+    column-gap: 0;
+  }
+  #outer {
+    background-color: lightgray;
+    border: 2px solid;
+  }
+</style>
+<div id="outer">
+VeryLongUnbrokenWord1
+VeryLongUnbrokenWord2
+</div>

--- a/Tests/LibWeb/Ref/input/css/css-multicol/text-basic.html
+++ b/Tests/LibWeb/Ref/input/css/css-multicol/text-basic.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/css-multicol/text-basic-ref.html" />
+<style>
+  div {
+    columns: 2;
+    height: 1lh;
+	  column-width: 1em;
+    max-width: 40em;
+    column-gap: 0;
+  }
+</style>
+<div>
+	VeryLongUnbrokenWord1
+	VeryLongUnbrokenWord2
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-001.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-001.xht
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Multi-column Layout Test: 'column-fill: auto' (basic)</title>
+  <link rel="author" title="Opera Software ASA" href="http://www.opera.com/" />
+  <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-07-30 -->
+  <link rel="help" href="http://www.w3.org/TR/css3-multicol/#cf" title="7.1 'column-fill'" />
+  <link rel="match" href="../../../../expected/wpt-import/css/css-multicol/multicol-fill-auto-001-ref.xht" />
+  <meta name="flags" content="ahem" />
+  <meta name="assert" content="This test checks that 'column-fill: auto' fills the column boxes of a multi-colum element sequentially with inline content and does not bother about balancing content of column boxes." />
+  <link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  color: black;
+  font: 1.25em/1 Ahem;
+  height: 10em;
+  orphans: 1;
+  widows: 1;
+  width: 32em;
+
+  column-count: 3;
+  column-fill: auto;
+  column-gap: 1em;
+  }
+  ]]></style>
+ </head>
+
+ <body>
+
+  <div>1 22 333 4444 55555 666666 7777777 999999999 1 22 333 4444 55555 666666 7777777 999999999 1 22 333 4444 55555 666666 7777777 999999999</div>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-002.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-multicol/multicol-fill-auto-002.xht
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>multicolumn | column-fill-auto</title>
+<meta name="assert" content="This test checks that columns are not balanced when 'column-fill: auto' is set"/>
+<link rel="author" title="howcome@opera.com" href="http://www.opera.com/"/>
+<link rel="help" href="http://www.w3.org/TR/css3-multicol/#filling-columns"/>
+<link rel="match" href="../../../../expected/wpt-import/css/css-multicol/multicol-fill-auto-002-ref.xht"/>
+<meta name="flags" content="ahem"/>
+<link rel="stylesheet" type="text/css" href="../../../../data/fonts/ahem.css" />
+<style type="text/css"><![CDATA[
+body>div {
+	font-family: Ahem;
+	font-size: 1.25em;
+	line-height: 1em;
+	color: green;
+	height: 3em;
+	width: 2em;
+	orphans: 1;
+	widows: 1;
+	position: relative;
+	margin: 1em;
+}
+div.col {
+	column-count: 2;
+	column-fill: auto;
+	column-gap: 0;
+}
+div.red {
+	background: red; position: absolute; z-index: -1;
+}
+]]></style>
+</head>
+
+<body>
+
+<div class='col'>
+<div class='red' style="top: 0; left: 0; height: 3em; width: 1em;"></div>
+<div class='red' style="top: 0; left: 0; height: 1em; width: 2em;"></div>
+o<br/>t<br/>
+o<br/>t<br/>
+</div>
+
+<div class='ref'>
+oo<br/>t<br/>o
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This builds upon #8557.
It moves the `FragmentationState` enum from #8761 over into Fragmentation.cpp, since it is better housed there and doesn't cause any circular include problems like that.

Apart from that, here's an image that I was way too excited about at 3am yesterday:
<img width="1920" height="264" alt="image" src="https://github.com/user-attachments/assets/99a56ad1-bf8b-4867-864b-aa69364d2e34" />
That's this HTML:
```html
<!DOCTYPE html>
<style>
    body {
        height: 3em;
        column-width: 10em;
    }
    div {
        border: 2px solid;
        background: lightgray;
    }
</style>
In the traditional CSS box model, the content of an element is flowed into the content box of the corresponding element.
<div>
    Multi-column layout introduces a fragmentation context formed of anonymous fragmentation containers called column boxes (or columns for short).
</div>
These column boxes establish an independent block formatting context into which the multi-column container’s content flows, and form the containing block for its non-positioned children.
```