### PR TITLE
LibMedia: A few fixes to the new pipeline

### DIFF
--- a/Libraries/LibMedia/Containers/Matroska/Reader.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/Reader.cpp
@@ -709,12 +709,6 @@ static AK::Duration block_timestamp_to_duration(AK::Duration cluster_timestamp, 
 
 DecoderErrorOr<Vector<ByteBuffer>> SampleIterator::get_frames(Block block)
 {
-    ArmedScopeGuard error_guard = [&] {
-        // Similar to next_block(), we need to clear the last timestamp if we encounter an error, or a subsequent
-        // seek may not move the position to a keyframe to resume decoding properly.
-        m_last_timestamp.clear();
-    };
-
     Streamer streamer { m_stream_cursor };
     TRY(streamer.seek_to_position(block.data_position()));
     Vector<ByteBuffer> frames;
@@ -785,7 +779,6 @@ DecoderErrorOr<Vector<ByteBuffer>> SampleIterator::get_frames(Block block)
         frames.append(TRY(streamer.read_raw_octets(block.data_size())));
     }
 
-    error_guard.disarm();
     return frames;
 }
 
@@ -1205,10 +1198,6 @@ DecoderErrorOr<Block> SampleIterator::next_block()
 {
     Streamer streamer { m_stream_cursor };
     TRY(streamer.seek_to_position(m_position));
-
-    // Remove the last timestamp from this iterator so that if we encounter an error, especially EOS,
-    // we will always seek the sample iterator, ensuring that we will decode the last block again.
-    m_last_timestamp = {};
 
     Optional<Block> block;
 

--- a/Libraries/LibMedia/Processors/AudioMixer.cpp
+++ b/Libraries/LibMedia/Processors/AudioMixer.cpp
@@ -33,20 +33,9 @@ ErrorOr<void> AudioMixer::connect_input(NonnullRefPtr<AudioProducer> const& inpu
     VERIFY(!m_inputs.contains(input));
     m_inputs.set(input, InputMixingData());
     input->set_wake_handler([this, input] {
-        auto input_status = input->status();
         bool should_wake_downstream;
         {
             Sync::MutexLocker locker { m_mutex };
-            auto& input_data = m_inputs.get(input).value();
-            if (input_data.last_status == input_status)
-                return;
-            input_data.last_status = input_status;
-            while (input_data.last_status == PipelineStatus::MovedPosition) {
-                input->pull(input_data.current_block);
-                VERIFY(input_data.current_block.is_empty());
-                input_data.last_status = input->status();
-            }
-
             m_status = combined_input_status();
             should_wake_downstream = m_downstream_needs_wake && !is_waiting_for_data(m_status);
             if (m_moved_position_pending)
@@ -172,6 +161,9 @@ void AudioMixer::seek(AK::Duration timestamp)
 PipelineStatus AudioMixer::status() const
 {
     Sync::MutexLocker locker { m_mutex };
+    m_status = combined_input_status();
+    if (m_moved_position_pending)
+        m_status = PipelineStatus::MovedPosition;
     m_downstream_needs_wake = is_waiting_for_data(m_status);
     return m_status;
 }
@@ -192,8 +184,23 @@ void AudioMixer::dispatch_wake()
 PipelineStatus AudioMixer::combined_input_status() const
 {
     auto status = PipelineStatus::EndOfStream;
-    for (auto const& [input, input_data] : m_inputs)
+    for (auto& [input, input_data] : m_inputs) {
+        if (!input_data.current_block.is_empty()
+            && input_data.current_block.sample_specification() == m_sample_specification
+            && input_data.current_block.end_timestamp_in_frames() > m_next_frame_to_write) {
+            status = select_combined_pipeline_status(status, PipelineStatus::HaveData);
+            continue;
+        }
+
+        if (!can_carry_data(input_data.last_status)) {
+            while ((input_data.last_status = input->status()) == PipelineStatus::MovedPosition) {
+                input->pull(input_data.current_block);
+                VERIFY(input_data.current_block.is_empty());
+            }
+        }
+
         status = select_combined_pipeline_status(status, input_data.last_status);
+    }
     VERIFY(status != PipelineStatus::MovedPosition);
     return status;
 }
@@ -208,6 +215,11 @@ void AudioMixer::pull(AudioBlock& into)
     Sync::MutexLocker locker { m_mutex };
     if (m_moved_position_pending) {
         m_moved_position_pending = false;
+        into.clear();
+        m_status = combined_input_status();
+        return;
+    }
+    if (m_status == PipelineStatus::Pending) {
         into.clear();
         m_status = combined_input_status();
         return;
@@ -325,7 +337,8 @@ void AudioMixer::pull(AudioBlock& into)
 
     if (frame_count == 0) {
         into.clear();
-        VERIFY(combined_status_after_mix != PipelineStatus::HaveData);
+        if (combined_status_after_mix == PipelineStatus::HaveData)
+            combined_status_after_mix = PipelineStatus::Pending;
         VERIFY(combined_status_after_mix != PipelineStatus::MovedPosition);
         VERIFY(combined_status_after_mix != PipelineStatus::EndOfStream);
         m_status = combined_status_after_mix;

--- a/Libraries/LibMedia/Processors/AudioMixer.h
+++ b/Libraries/LibMedia/Processors/AudioMixer.h
@@ -58,14 +58,14 @@ private:
 
     mutable Sync::Mutex m_mutex;
     Audio::SampleSpecification m_sample_specification;
-    HashMap<NonnullRefPtr<AudioProducer>, InputMixingData> m_inputs;
+    mutable HashMap<NonnullRefPtr<AudioProducer>, InputMixingData> m_inputs;
     i64 m_next_frame_to_write { 0 };
     bool m_started { false };
     bool m_moved_position_pending { false };
     mutable bool m_downstream_needs_wake { true };
 
     PipelineWakeHandler m_wake_handler;
-    PipelineStatus m_status { PipelineStatus::Pending };
+    mutable PipelineStatus m_status { PipelineStatus::Pending };
 };
 
 }

--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -407,10 +407,12 @@ DecoderErrorOr<void> DecodedAudioProducer::ThreadData::retrieve_next_block(Audio
 
 void DecodedAudioProducer::ThreadData::resolve_seek(u32 seek_id, bool moved_position)
 {
-    m_queue.clear();
     m_last_processed_seek_id = seek_id;
     VERIFY(m_current_halting_status != PipelineStatus::HaveData);
-    m_moved_position_pending = moved_position;
+    if (moved_position) {
+        m_moved_position_pending = true;
+        m_queue.clear();
+    }
 }
 
 bool DecodedAudioProducer::ThreadData::handle_seek()

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -258,16 +258,15 @@ void DecodedVideoProducer::ThreadData::seek(AK::Duration timestamp)
 {
     auto locker = take_lock();
     note_consumer_activity_while_locked();
-    m_seek_id++;
     m_current_halting_status = PipelineStatus::Pending;
     m_downstream_needs_wake = true;
 
     if (timestamp >= m_earliest_available_timestamp && timestamp < m_latest_available_timestamp) {
-        m_last_processed_seek_id = m_seek_id;
         dispatch_wake_if_needed_while_locked();
         return;
     }
 
+    m_seek_id++;
     m_seek_timestamp = timestamp;
     m_earliest_available_timestamp = timestamp;
     m_latest_available_timestamp = timestamp;

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -393,10 +393,12 @@ void DecodedVideoProducer::ThreadData::dispatch_error(DecoderError&& error)
 
 void DecodedVideoProducer::ThreadData::resolve_seek(u32 seek_id, bool moved_position)
 {
-    m_queue.clear();
     m_last_processed_seek_id = seek_id;
     VERIFY(m_current_halting_status != PipelineStatus::HaveData);
-    m_moved_position_pending = moved_position;
+    if (moved_position) {
+        m_moved_position_pending = true;
+        m_queue.clear();
+    }
 }
 
 bool DecodedVideoProducer::ThreadData::handle_seek()

--- a/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioPlaybackSink.cpp
@@ -135,11 +135,11 @@ ErrorOr<NonnullRefPtr<AudioPlaybackSink>> AudioPlaybackSink::try_create(Pipeline
                         if (output_thread_data->m_playback_stream)
                             output_thread_data->m_playback_stream->notify_data_available();
 
-                        output_thread_data->m_waiting_for_upstream_data = false;
-
                         if (status == PipelineStatus::HaveData)
                             output_thread_data->m_last_real_data_end_in_frames = output_block.end_timestamp_in_frames();
                     }
+
+                    output_thread_data->m_waiting_for_upstream_data = !can_carry_data(status);
 
                     if (!can_carry_data(output_thread_data->m_last_dispatched_status) && can_carry_data(status))
                         output_thread_data->dispatch_state_if_changed(status, seek_id_at_pull);

--- a/Tests/LibMedia/TestMatroskaDemuxer.cpp
+++ b/Tests/LibMedia/TestMatroskaDemuxer.cpp
@@ -31,7 +31,9 @@ TEST_CASE(seek_past_eos)
     EXPECT_EQ(last_timestamp, AK::Duration::from_milliseconds(30126));
 
     auto seek_time = AK::Duration::from_milliseconds(31000);
-    MUST(demuxer->seek_to_most_recent_keyframe(track, seek_time, Media::DemuxerSeekOptions::None));
-    auto sample_after_seek = MUST(demuxer->get_next_sample_for_track(track));
-    EXPECT_EQ(sample_after_seek.timestamp(), AK::Duration::zero());
+    auto seek_result = MUST(demuxer->seek_to_most_recent_keyframe(track, seek_time, Media::DemuxerSeekOptions::None));
+    EXPECT_EQ(seek_result, Media::DemuxerSeekResult::KeptCurrentPosition);
+    auto sample_result_after_seek = demuxer->get_next_sample_for_track(track);
+    EXPECT(sample_result_after_seek.is_error());
+    EXPECT_EQ(sample_result_after_seek.error().category(), Media::DecoderErrorCategory::EndOfStream);
 }


### PR DESCRIPTION
Just fixing a few minor things:
- A crash when seeking with multiple audio tracks enabled (won't happen in the wild, no other browsers even support this)
- A possible race condition in the DecodedVideoProducer seek fast path
- Unnecessary work when scrubbing forward just quickly enough to trigger the demuxer seek fast path