### PR TITLE
LibWeb: Pass `is` to XML parser-created HTML elements

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -123,7 +123,13 @@ void XMLDocumentBuilder::element_start(XML::Name const& name, OrderedHashMap<XML
 
     auto qualified_name = qualified_name_or_error.value();
 
-    auto node_or_error = DOM::create_element(m_document, qualified_name.local_name(), qualified_name.namespace_(), qualified_name.prefix());
+    Optional<String> is_value;
+    if (qualified_name.namespace_() == Namespace::HTML) {
+        if (auto it = attributes.find("is"sv); it != attributes.end())
+            is_value = MUST(String::from_byte_string(it->value));
+    }
+
+    auto node_or_error = DOM::create_element(m_document, qualified_name.local_name(), qualified_name.namespace_(), qualified_name.prefix(), move(is_value));
 
     if (node_or_error.is_error()) {
         m_has_error = true;

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	XML parser should create autonomous custom elements.
+Pass	XML parser should create custom built-in elements.

--- a/Tests/LibWeb/Text/input/wpt-import/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg:svg xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/1999/xhtml"
+   width="100%" height="100%" viewBox="0 0 800 600">
+<svg:title>XML parser should use "create an element for a token"</svg:title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/xhtml.html#parsing-xhtml-documents:create-an-element-for-the-token"/>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script><![CDATA[
+class MyElement1 extends HTMLElement {}
+customElements.define('my-element', MyElement1);
+class MyElement2 extends HTMLDivElement {}
+customElements.define('my-div', MyElement2, { extends: 'div' });
+
+var test1 = async_test('XML parser should create autonomous custom elements.');
+window.addEventListener('load', test1.step_func_done(() => {
+  assert_true(document.getElementById('me1') instanceof MyElement1);
+}));
+
+var test2 = async_test('XML parser should create custom built-in elements.');
+window.addEventListener('load', test2.step_func_done(() => {
+  assert_true(document.getElementById('me2') instanceof MyElement2);
+}));
+]]></script>
+<my-element id="me1"></my-element>
+<div is="my-div" id="me2"></div>
+</svg:svg>


### PR DESCRIPTION
Extract `is` before calling DOM::create_element() so XML-parsed
  customized built-ins are created with the right custom element
  definition.

  Import and rebaseline
  custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg.