### PR TITLE
LibWeb+Tests: Upgrade custom elements in ShadowRoot innerHTML

### DIFF
--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -120,6 +120,14 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(TrustedTypes::TrustedHTMLOr
     // 3. Let fragment be the result of invoking the fragment parsing algorithm steps with context and compliantString.
     auto fragment = TRY(context->parse_fragment(compliant_string.to_utf8_but_should_be_ported_to_utf16()));
 
+    if (auto registry = custom_element_registry()) {
+        fragment->for_each_in_subtree_of_type<Element>([&](auto& element) {
+            element.set_custom_element_registry(registry);
+            element.try_to_upgrade();
+            return TraversalDecision::Continue;
+        });
+    }
+
     // 4. Replace all with fragment within this.
     this->replace_all(fragment);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/reactions/ShadowRoot.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/reactions/ShadowRoot.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	innerHTML on ShadowRoot must upgrade a custom element
+Pass	innerHTML on ShadowRoot must enqueue connectedCallback on newly upgraded custom elements when the shadow root is connected
+Pass	innerHTML on ShadowRoot must enqueue disconnectedCallback when removing a custom element

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/ShadowRoot-innerHTML.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/ShadowRoot-innerHTML.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 4 tests
 
-4 Fail
-Fail	innerHTML on a shadow root should use the scoped registry
-Fail	innerHTML on a connected shadow root should use the associated scoped registry
-Fail	innerHTML on a connected shadow root should not upgrade a custom element inside a template element
-Fail	innerHTML on a connected shadow root should be able to create an unknown element
+4 Pass
+Pass	innerHTML on a shadow root should use the scoped registry
+Pass	innerHTML on a connected shadow root should use the associated scoped registry
+Pass	innerHTML on a connected shadow root should not upgrade a custom element inside a template element
+Pass	innerHTML on a connected shadow root should be able to create an unknown element

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/constructor-reentry-with-different-definition.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/constructor-reentry-with-different-definition.txt
@@ -2,8 +2,9 @@ Harness status: OK
 
 Found 4 tests
 
-4 Fail
+2 Pass
+2 Fail
 Fail	Re-entry via upgrade before calling super()
-Fail	Re-entry via upgrade after calling super()
-Fail	Re-entry via direct constructor call before calling super()
+Pass	Re-entry via upgrade after calling super()
+Pass	Re-entry via direct constructor call before calling super()
 Fail	Re-entry via direct constructor call after calling super()

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/scoped-registry-define-upgrade-criteria.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/scoped-registry-define-upgrade-criteria.txt
@@ -2,18 +2,17 @@ Harness status: OK
 
 Found 14 tests
 
-7 Pass
-7 Fail
+14 Pass
 Pass	Adding definition to scoped registry should upgrade nodes associated with the registry.
-Fail	Adding definition to global registry should not affect shadow roots using scoped registry
+Pass	Adding definition to global registry should not affect shadow roots using scoped registry
 Pass	Adding definition to global registry should affect shadow roots also using global registry
-Fail	Adding definition to scoped registry should affect all associated shadow roots
-Fail	Adding definition to scoped registry should not affect document tree scope
-Fail	Adding definition to scoped registry should not affect shadow roots using other registries
+Pass	Adding definition to scoped registry should affect all associated shadow roots
+Pass	Adding definition to scoped registry should not affect document tree scope
+Pass	Adding definition to scoped registry should not affect shadow roots using other registries
 Pass	Adding definition to scoped registry should upgrade nodes even after the node is moved into a separate shadow tree.
-Fail	Adding definition to scoped registry should upgrade nodes even after the node is moved to a separate shadow tree using a different registry.
-Fail	Adding definition to scoped registry affects associated shadow roots in all iframes
-Fail	Adding definition to scoped registry affects associated shadow roots in other frame trees
+Pass	Adding definition to scoped registry should upgrade nodes even after the node is moved to a separate shadow tree using a different registry.
+Pass	Adding definition to scoped registry affects associated shadow roots in all iframes
+Pass	Adding definition to scoped registry affects associated shadow roots in other frame trees
 Pass	Adding definition to scoped registry should not upgrade disconnected elements
 Pass	Adding definition to scoped registry should not upgrade nodes in constructed documents
 Pass	Adding definition to scoped registry should not upgrade nodes in detached frames

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/scoped-registry-initialize-upgrades.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/scoped-registry-initialize-upgrades.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 12 tests
 
-11 Pass
-1 Fail
+12 Pass
 Pass	Document: CustomElementRegistry.prototype.initialize should upgrade the element given to the first argument
 Pass	Document: CustomElementRegistry.prototype.initialize should upgrade elements in tree order
 Pass	Document: CustomElementRegistry.prototype.initialize only upgrades elements beloning to the registry
@@ -15,4 +14,4 @@ Pass	XHTMLDocument: CustomElementRegistry.prototype.initialize should upgrade el
 Pass	XHTMLDocument: CustomElementRegistry.prototype.initialize only upgrades elements beloning to the registry
 Pass	CustomElementRegistry.prototype.initialize upgrades already initialized elements
 Pass	CustomElementRegistry.prototype.initialize upgrades custom elements in declarative shadow root when initialize() runs before define()
-Fail	CustomElementRegistry.prototype.initialize upgrades custom elements in imperative shadow root when inserted before define()
+Pass	CustomElementRegistry.prototype.initialize upgrades custom elements in imperative shadow root when inserted before define()

--- a/Tests/LibWeb/Text/input/wpt-import/custom-elements/reactions/ShadowRoot.html
+++ b/Tests/LibWeb/Text/input/wpt-import/custom-elements/reactions/ShadowRoot.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on ShadowRoot interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="innerHTML of ShadowRoot interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const host = contentDocument.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<custom-element></custom-element>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+}, 'innerHTML on ShadowRoot must upgrade a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const host = contentDocument.createElement('div');
+    contentDocument.body.appendChild(host);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<custom-element></custom-element>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+}, 'innerHTML on ShadowRoot must enqueue connectedCallback on newly upgraded custom elements when the shadow root is connected');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const host = contentDocument.createElement('div');
+    contentDocument.body.appendChild(host);
+
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<custom-element></custom-element>';
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    shadowRoot.innerHTML = '';
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+
+}, 'innerHTML on ShadowRoot must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Use the shadow root's custom element registry for parsed fragments.

This fixes the failing detached ShadowRoot innerHTML WPT case where the custom element was not upgraded before the CEReactions queue was popped.

Import the upstream WPT and rebaseline existing custom element registry coverage.