### PR TITLE
LibWeb: Fix TradingView chart rendering issues

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -440,6 +440,13 @@ static Gfx::Path::JoinStyle to_gfx_join(Bindings::CanvasLineJoin const& join_sty
     VERIFY_NOT_REACHED();
 }
 
+static bool transparent_source_paint_can_be_ignored(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
+{
+    // https://html.spec.whatwg.org/multipage/canvas.html#drawing-model
+    // Composite B within the clipping region over the current output bitmap using the current compositing and blending operator.
+    return compositing_and_blending_operator == Gfx::CompositingAndBlendingOperator::SourceOver;
+}
+
 // https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-settings:concept-canvas-alpha
 Gfx::Color CanvasRenderingContext2D::clear_color() const
 {
@@ -454,7 +461,7 @@ void CanvasRenderingContext2D::stroke_internal(Gfx::Path const& path)
 
     auto& state = drawing_state();
     auto paint_style = state.stroke_style.to_gfx_paint_style();
-    if (!paint_style->is_visible())
+    if (!paint_style->is_visible() && transparent_source_paint_can_be_ignored(state.current_compositing_and_blending_operator))
         return;
 
     auto line_cap = to_gfx_cap(state.line_cap);
@@ -500,7 +507,7 @@ void CanvasRenderingContext2D::fill_internal(Gfx::Path const& path, Gfx::Winding
 
     auto& state = this->drawing_state();
     auto paint_style = state.fill_style.to_gfx_paint_style();
-    if (!paint_style->is_visible())
+    if (!paint_style->is_visible() && transparent_source_paint_can_be_ignored(state.current_compositing_and_blending_operator))
         return;
 
     paint_shadow_for_fill_internal(path, winding_rule);

--- a/Libraries/LibWeb/ServiceWorker/Registration.cpp
+++ b/Libraries/LibWeb/ServiceWorker/Registration.cpp
@@ -13,7 +13,7 @@ namespace Web::ServiceWorker {
 
 // FIXME: Surely this needs hooks to be cleared and manipulated at the UA level
 //        Does this need to be serialized to disk as well?
-static HashMap<RegistrationKey, Registration> s_registrations;
+static OrderedHashMap<RegistrationKey, Registration> s_registrations;
 
 Registration::Registration(StorageAPI::StorageKey storage_key, URL::URL scope, Bindings::ServiceWorkerUpdateViaCache update_via_cache)
     : m_storage_key(move(storage_key))
@@ -124,6 +124,18 @@ Optional<Registration&> Registration::match(StorageAPI::StorageKey const& storag
 
     // 9. Return the result of running Get Registration given storage key and matchingScope.
     return get(storage_key, matching_scope);
+}
+
+Vector<Registration*> Registration::for_storage_key(StorageAPI::StorageKey const& storage_key)
+{
+    Vector<Registration*> registrations;
+
+    for (auto& [registration_key, registration] : s_registrations) {
+        if (registration_key.key == storage_key)
+            registrations.append(&registration);
+    }
+
+    return registrations;
 }
 
 void Registration::remove(StorageAPI::StorageKey const& key, URL::URL const& scope)

--- a/Libraries/LibWeb/ServiceWorker/Registration.h
+++ b/Libraries/LibWeb/ServiceWorker/Registration.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/Time.h>
 #include <AK/Traits.h>
+#include <AK/Vector.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/ServiceWorkerRegistration.h>
 #include <LibWeb/ServiceWorker/ServiceWorkerRecord.h>
@@ -33,6 +34,8 @@ public:
 
     // https://w3c.github.io/ServiceWorker/#scope-match-algorithm
     static Optional<Registration&> match(StorageAPI::StorageKey const&, URL::URL const&);
+
+    static Vector<Registration*> for_storage_key(StorageAPI::StorageKey const&);
 
     static void remove(StorageAPI::StorageKey const&, URL::URL const&);
 

--- a/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.cpp
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/RootVector.h>
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ServiceWorkerContainer.h>
@@ -147,6 +149,63 @@ GC::Ref<WebIDL::Promise> ServiceWorkerContainer::get_registration(String const& 
         WebIDL::resolve_promise(realm, promise, registration_object);
     }));
 
+    return promise;
+}
+
+// https://w3c.github.io/ServiceWorker/#navigator-service-worker-getRegistrations
+GC::Ref<WebIDL::Promise> ServiceWorkerContainer::get_registrations()
+{
+    auto& realm = this->realm();
+
+    // 1. Let client be this's service worker client.
+    auto client = m_service_worker_client;
+
+    // 2. Let client storage key be the result of running obtain a storage key given client.
+    auto client_storage_key = StorageAPI::obtain_a_storage_key(client);
+
+    if (!client_storage_key.has_value())
+        return WebIDL::create_rejected_promise(realm, JS::TypeError::create(realm, "Failed to obtain a storage key"sv));
+
+    // 3. Let promise be a new promise.
+    auto promise = WebIDL::create_promise(realm);
+
+    // 4. Run the following steps in parallel:
+    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(realm.heap(), [promise, client_storage_key = client_storage_key.release_value()]() {
+        auto& realm = HTML::relevant_realm(promise->promise());
+
+        // 1. Let registrations be a new list.
+        // 2. For each (storage key, scope) → registration of registration map:
+        //     1. If storage key equals client storage key, then append registration to registrations.
+        auto registrations = Registration::for_storage_key(client_storage_key);
+
+        GC::RootVector<GC::Ref<ServiceWorkerRegistration>> registration_objects;
+        for (auto const* registration : registrations)
+            registration_objects.append(HTML::relevant_settings_object(promise->promise()).get_service_worker_registration_object(*registration));
+
+        // 3. Queue a task on promise's relevant settings object's responsible event loop, using the DOM manipulation task source, to run the following steps:
+        HTML::queue_a_task(HTML::Task::Source::DOMManipulation, HTML::relevant_settings_object(promise->promise()).responsible_event_loop(), {}, GC::create_function(realm.heap(), [promise, registration_objects = move(registration_objects)]() {
+            auto& realm = HTML::relevant_realm(promise->promise());
+            HTML::TemporaryExecutionContext const execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+            // 1. Let registrationObjects be a new list.
+            GC::RootVector<JS::Value> registration_object_values;
+
+            // 2. For each registration of registrations:
+            for (auto registration_object : registration_objects) {
+                // 1. Let registrationObj be the result of getting the service worker registration object that represents registration in promise's relevant settings object.
+
+                // 2. Append registrationObj to registrationObjects.
+                registration_object_values.append(registration_object);
+            }
+
+            // 3. Resolve promise with a new frozen array of registrationObjects in promise's relevant Realm.
+            auto array = JS::Array::create_from(realm, registration_object_values);
+            MUST(array->set_integrity_level(JS::Object::IntegrityLevel::Frozen));
+            WebIDL::resolve_promise(realm, promise, array);
+        }));
+    }));
+
+    // 5. Return promise.
     return promise;
 }
 

--- a/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.h
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.h
@@ -33,6 +33,7 @@ public:
     GC::Ref<WebIDL::Promise> register_(TrustedTypes::TrustedScriptURLOrString script_url, Bindings::RegistrationOptions const&);
 
     GC::Ref<WebIDL::Promise> get_registration(String const& client_url);
+    GC::Ref<WebIDL::Promise> get_registrations();
 
     GC::Ref<WebIDL::Promise> ready();
 

--- a/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.idl
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.idl
@@ -7,7 +7,7 @@ interface ServiceWorkerContainer : EventTarget {
     [NewObject, ImplementedAs=register_] Promise<ServiceWorkerRegistration> register((TrustedScriptURL or Utf16USVString) scriptURL, optional RegistrationOptions options = {});
 
     [NewObject] Promise<(ServiceWorkerRegistration or undefined)> getRegistration(optional USVString clientURL = "");
-    [FIXME, NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
+    [NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
 
     [FIXME] undefined startMessages();
 

--- a/Tests/LibWeb/Text/expected/HTML/canvas-transparent-copy-composite.txt
+++ b/Tests/LibWeb/Text/expected/HTML/canvas-transparent-copy-composite.txt
@@ -1,0 +1,3 @@
+first draw: 255,0,0,51
+transparent copy: 0,0,0,0
+second draw: 255,0,0,51

--- a/Tests/LibWeb/Text/expected/ServiceWorker/service-worker-get-registrations.txt
+++ b/Tests/LibWeb/Text/expected/ServiceWorker/service-worker-get-registrations.txt
@@ -1,0 +1,4 @@
+getRegistrations is a function: true
+getRegistrations resolves with an array: true
+getRegistrations resolves with a frozen array: true
+getRegistrations resolves with an empty array: true

--- a/Tests/LibWeb/Text/input/HTML/canvas-transparent-copy-composite.html
+++ b/Tests/LibWeb/Text/input/HTML/canvas-transparent-copy-composite.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 1;
+        canvas.height = 1;
+
+        const context = canvas.getContext("2d");
+
+        context.fillStyle = "rgba(255, 0, 0, 0.2)";
+        context.fillRect(0, 0, 1, 1);
+        println(`first draw: ${Array.from(context.getImageData(0, 0, 1, 1).data).join(",")}`);
+
+        context.globalCompositeOperation = "copy";
+        context.fillStyle = "rgba(0, 0, 0, 0)";
+        context.fillRect(0, 0, 1, 1);
+        println(`transparent copy: ${Array.from(context.getImageData(0, 0, 1, 1).data).join(",")}`);
+
+        context.globalCompositeOperation = "source-over";
+        context.fillStyle = "rgba(255, 0, 0, 0.2)";
+        context.fillRect(0, 0, 1, 1);
+        println(`second draw: ${Array.from(context.getImageData(0, 0, 1, 1).data).join(",")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/ServiceWorker/service-worker-get-registrations.html
+++ b/Tests/LibWeb/Text/input/ServiceWorker/service-worker-get-registrations.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        setTimeout(async () => {
+            // We need to do this spoofing later in the event loop so that we don't end up
+            // telling the test runner the wrong URL in page_did_finish_loading.
+            spoofCurrentURL("https://example.com/service-worker-get-registrations.html");
+
+            println(`getRegistrations is a function: ${typeof navigator.serviceWorker.getRegistrations === "function"}`);
+
+            const registrations = await navigator.serviceWorker.getRegistrations();
+            println(`getRegistrations resolves with an array: ${Array.isArray(registrations)}`);
+            println(`getRegistrations resolves with a frozen array: ${Object.isFrozen(registrations)}`);
+            println(`getRegistrations resolves with an empty array: ${registrations.length === 0}`);
+
+            done();
+        }, 0);
+    });
+</script>


### PR DESCRIPTION
`ServiceWorkerContainer.getRegistrations()` is now implemented, which lets TradingView get past its startup feature checks and render their charts in Ladybird.

This also fixes canvas compositing with transparent source paints. We were skipping fully transparent fill and stroke styles before applying `globalCompositeOperation`, but operators like copy still need to replace destination pixels with transparent source pixels. TradingView uses that path while repainting the chart, so old translucent chart pixels accumulated during mouse movement.

Before:

<img width="1433" height="989" alt="Screenshot from 2026-05-23 17-05-37" src="https://github.com/user-attachments/assets/7bca284e-9317-4bd6-8918-400003c2e7ab" />

After:

<img width="1433" height="989" alt="Screenshot from 2026-05-23 17-04-46" src="https://github.com/user-attachments/assets/268aede1-e7c4-464e-92dd-3b5bc1525061" />