### PR TITLE
LibWeb: Use brave/adblock-rust for content blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "adblock"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6fe7702c798519299bcbe011ff6f1dc9e3aedc1f3171178cddf71e1736bf95"
+dependencies = [
+ "addr",
+ "arrayvec",
+ "base64",
+ "bitflags",
+ "flatbuffers",
+ "idna",
+ "itertools",
+ "memchr",
+ "percent-encoding",
+ "precomputed-hash",
+ "regex",
+ "rustc-hash 1.1.0",
+ "seahash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "addr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
+dependencies = [
+ "psl",
+ "psl-types",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,16 +115,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bumpalo"
@@ -225,7 +275,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -316,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,10 +409,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "getrandom"
@@ -482,6 +557,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
 name = "icu_provider"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +620,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +657,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -606,6 +751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libweb_content_blocker_rust"
+version = "0.1.0"
+dependencies = [
+ "adblock",
+ "cbindgen",
+ "serde_json",
+]
+
+[[package]]
 name = "libweb_html_tokenizer"
 version = "0.1.0"
 dependencies = [
@@ -686,6 +840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +855,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -714,6 +880,21 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "quote"
@@ -740,7 +921,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -775,9 +956,24 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -791,6 +987,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -910,6 +1112,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1192,18 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -1216,6 +1450,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
+ "yoke",
+ "zerofrom",
  "zerovec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "Libraries/LibRegex/Rust",
     "Libraries/LibUnicode/Rust",
     "Libraries/LibWasm/Rust",
+    "Libraries/LibWeb/ContentBlocker/Rust",
     "Libraries/LibWeb/Rust",
     "Libraries/LibWeb/HTML/Parser/Rust",
 ]

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1254,8 +1254,10 @@ ladybird_lib(LibWeb web EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibWeb PRIVATE LibCore LibCompress LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests LibGC LibSync LibThreading skia ${ANGLE_TARGETS} SDL3::SDL3 LibXml2::LibXml2)
 
 import_rust_crate(MANIFEST_PATH Rust/Cargo.toml CRATE_NAME libweb_rust FFI_HEADER RustFFI.h)
-target_link_libraries(LibWeb PRIVATE libweb_rust)
+import_rust_crate(MANIFEST_PATH ContentBlocker/Rust/Cargo.toml CRATE_NAME libweb_content_blocker_rust FFI_HEADER ContentBlockerRustFFI.h)
+target_link_libraries(LibWeb PRIVATE libweb_rust libweb_content_blocker_rust)
 get_target_property(_libweb_rust_lib libweb_rust IMPORTED_LOCATION)
+get_target_property(_libweb_content_blocker_rust_lib libweb_content_blocker_rust IMPORTED_LOCATION)
 set_property(SOURCE HTML/Parser/HTMLTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
 set_property(SOURCE HTML/Parser/HTMLParser.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
 set_property(SOURCE HTML/Parser/SpeculativeHTMLParser.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
@@ -1266,6 +1268,7 @@ endif()
 if(NOT BUILD_SHARED_LIBS)
     add_custom_command(TARGET LibWeb POST_BUILD
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_rust>
+        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_content_blocker_rust>
         COMMAND ${CMAKE_AR} -qS $<TARGET_FILE:LibWeb> *.o
         COMMAND ${CMAKE_RANLIB} $<TARGET_FILE:LibWeb>
         COMMAND ${CMAKE_COMMAND} -E remove -f *.o
@@ -1274,14 +1277,14 @@ if(NOT BUILD_SHARED_LIBS)
     )
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/rust_merge_tmp)
 
-    # POST_BUILD steps don't track inputs, so when libweb_rust.a changes
+    # POST_BUILD steps don't track inputs, so when a Rust archive changes
     # ninja leaves liblagom-web.a alone and the merged archive ends up with
-    # stale Rust objects. Force both FFI bridge files to depend on the
-    # Rust archive: when it changes, they recompile, LibWeb re-archives, and
-    # POST_BUILD re-merges the fresh Rust objects.
-    get_target_property(_libweb_rust_lib libweb_rust IMPORTED_LOCATION)
+    # stale Rust objects. Force the C++ FFI bridge files to depend on the
+    # Rust archives: when they change, LibWeb re-archives, and POST_BUILD
+    # re-merges the fresh Rust objects.
     set_property(SOURCE CSS/Parser/RustTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
     set_property(SOURCE HTML/Parser/HTMLEncodingDetection.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
+    set_property(SOURCE Loader/ContentBlocker.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_content_blocker_rust_lib})
 endif()
 
 if (HAS_FONTCONFIG)

--- a/Libraries/LibWeb/ContentBlocker/Rust/Cargo.toml
+++ b/Libraries/LibWeb/ContentBlocker/Rust/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "libweb_content_blocker_rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["staticlib"]
+
+# After changing dependencies, regenerate the Flatpak sources:
+#   python3 Meta/CMake/flatpak/generate-cargo-sources.py
+[dependencies]
+adblock = "0.12.5"
+serde_json = "1.0"
+
+[build-dependencies]
+cbindgen = "0.29"
+
+[lints]
+workspace = true

--- a/Libraries/LibWeb/ContentBlocker/Rust/build.rs
+++ b/Libraries/LibWeb/ContentBlocker/Rust/build.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::env;
+use std::error::Error;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
+    println!("cargo:rerun-if-changed=src");
+
+    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| out_dir.clone());
+
+    cbindgen::generate(manifest_dir).map_or_else(
+        |error| match error {
+            cbindgen::Error::ParseSyntaxError { .. } => {}
+            other => panic!("{other:?}"),
+        },
+        |bindings| {
+            let header_path = out_dir.join("ContentBlockerRustFFI.h");
+            bindings.write_to_file(&header_path);
+
+            if ffi_out_dir != out_dir {
+                bindings.write_to_file(ffi_out_dir.join("ContentBlockerRustFFI.h"));
+            }
+        },
+    );
+
+    Ok(())
+}

--- a/Libraries/LibWeb/ContentBlocker/Rust/cbindgen.toml
+++ b/Libraries/LibWeb/ContentBlocker/Rust/cbindgen.toml
@@ -1,0 +1,26 @@
+language = "C++"
+header = """/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */"""
+pragma_once = true
+include_version = true
+namespaces = ["Web", "ContentBlocking", "FFI"]
+line_length  = 120
+tab_width = 4
+no_includes = true
+sys_includes = ["stdint.h", "stddef.h"]
+usize_is_size_t = true
+
+[parse]
+parse_deps = false
+
+[parse.expand]
+all_features = false
+
+[export]
+include = ["ContentBlockerString"]
+
+[export.mangle]
+rename_types = "PascalCase"

--- a/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
+++ b/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
@@ -267,6 +267,31 @@ impl GenericSelectorListRules {
 
         selectors
     }
+
+    fn has_hidden_selectors_for_class_or_id(
+        &self,
+        classes: impl IntoIterator<Item = impl AsRef<str>>,
+        ids: impl IntoIterator<Item = impl AsRef<str>>,
+        exceptions: &HashSet<String>,
+    ) -> bool {
+        for class in classes {
+            if let Some(class_selectors) = self.by_class.get(class.as_ref())
+                && class_selectors.iter().any(|selector| !exceptions.contains(selector))
+            {
+                return true;
+            }
+        }
+
+        for id in ids {
+            if let Some(id_selectors) = self.by_id.get(id.as_ref())
+                && id_selectors.iter().any(|selector| !exceptions.contains(selector))
+            {
+                return true;
+            }
+        }
+
+        false
+    }
 }
 
 fn cosmetic_css_for_url(engine: &ContentBlockerEngine, url: &str, classes: &[&str], ids: &[&str]) -> String {
@@ -315,6 +340,28 @@ fn cosmetic_css_for_url(engine: &ContentBlockerEngine, url: &str, classes: &[&st
         css.push_str(" }\n");
     }
     css
+}
+
+fn has_generic_cosmetic_selectors_for_url(
+    engine: &ContentBlockerEngine,
+    url: &str,
+    classes: &[&str],
+    ids: &[&str],
+) -> bool {
+    let resources = engine.engine.url_cosmetic_resources(url);
+    if resources.generichide {
+        return false;
+    }
+
+    !engine
+        .engine
+        .hidden_class_id_selectors(classes.iter().copied(), ids.iter().copied(), &resources.exceptions)
+        .is_empty()
+        || engine.generic_selector_list_rules.has_hidden_selectors_for_class_or_id(
+            classes.iter().copied(),
+            ids.iter().copied(),
+            &resources.exceptions,
+        )
 }
 
 /// # Safety
@@ -414,6 +461,39 @@ pub unsafe extern "C" fn rust_content_blocker_cosmetic_css(
         let classes: Vec<_> = classes.lines().collect();
         let ids: Vec<_> = ids.lines().collect();
         string_to_ffi(cosmetic_css_for_url(engine, url, &classes, &ids))
+    })
+}
+
+/// # Safety
+/// - `engine` must be null or a valid pointer returned by `rust_content_blocker_create`
+/// - String pointers and lengths must point to valid UTF-8 strings
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_content_blocker_has_generic_cosmetic_selectors(
+    engine: *const c_void,
+    url: *const u8,
+    url_len: usize,
+    classes: *const u8,
+    classes_len: usize,
+    ids: *const u8,
+    ids_len: usize,
+) -> bool {
+    abort_on_panic(|| {
+        let Some(engine) = (unsafe { engine_from_raw(engine) }) else {
+            return false;
+        };
+        let Some(url) = (unsafe { string_from_raw(url, url_len) }) else {
+            return false;
+        };
+        let Some(classes) = (unsafe { string_from_raw(classes, classes_len) }) else {
+            return false;
+        };
+        let Some(ids) = (unsafe { string_from_raw(ids, ids_len) }) else {
+            return false;
+        };
+
+        let classes: Vec<_> = classes.lines().collect();
+        let ids: Vec<_> = ids.lines().collect();
+        has_generic_cosmetic_selectors_for_url(engine, url, &classes, &ids)
     })
 }
 

--- a/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
+++ b/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -11,6 +12,23 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 pub struct ContentBlockerString {
     data: *mut u8,
     length: usize,
+}
+
+struct ContentBlockerEngine {
+    engine: adblock::engine::Engine,
+    generic_selector_list_rules: GenericSelectorListRules,
+}
+
+#[derive(Default)]
+struct GenericSelectorListRules {
+    always_needed: HashSet<String>,
+    by_class: HashMap<String, Vec<String>>,
+    by_id: HashMap<String, Vec<String>>,
+}
+
+enum SelectorKey {
+    Class(String),
+    Id(String),
 }
 
 fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
@@ -45,11 +63,11 @@ unsafe fn string_from_raw<'a>(bytes: *const u8, len: usize) -> Option<&'a str> {
     std::str::from_utf8(bytes).ok()
 }
 
-unsafe fn engine_from_raw<'a>(engine: *const c_void) -> Option<&'a adblock::engine::Engine> {
+unsafe fn engine_from_raw<'a>(engine: *const c_void) -> Option<&'a ContentBlockerEngine> {
     if engine.is_null() {
         return None;
     }
-    Some(unsafe { &*engine.cast::<adblock::engine::Engine>() })
+    Some(unsafe { &*engine.cast::<ContentBlockerEngine>() })
 }
 
 fn string_to_ffi(string: String) -> ContentBlockerString {
@@ -67,17 +85,205 @@ fn string_to_ffi(string: String) -> ContentBlockerString {
     ContentBlockerString { data, length }
 }
 
-fn cosmetic_css_for_url(
-    engine: &adblock::engine::Engine,
-    url: &str,
-    classes: impl IntoIterator<Item = impl AsRef<str>>,
-    ids: impl IntoIterator<Item = impl AsRef<str>>,
-) -> String {
-    let resources = engine.url_cosmetic_resources(url);
+fn for_each_selector_list_item(selector: &str, mut callback: impl FnMut(&str)) {
+    let mut start = 0;
+    let mut parenthesis_depth: u32 = 0;
+    let mut bracket_depth: u32 = 0;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (index, character) in selector.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if character == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if let Some(quote_character) = quote {
+            if character == quote_character {
+                quote = None;
+            }
+            continue;
+        }
+
+        match character {
+            '"' | '\'' => quote = Some(character),
+            '(' => parenthesis_depth += 1,
+            ')' => parenthesis_depth = parenthesis_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            ',' if parenthesis_depth == 0 && bracket_depth == 0 => {
+                callback(&selector[start..index]);
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    callback(&selector[start..]);
+}
+
+fn selector_key_from_start(selector: &str) -> Option<SelectorKey> {
+    let selector = selector.trim_start();
+    let marker = selector.chars().next()?;
+    if marker != '.' && marker != '#' {
+        return None;
+    }
+
+    let mut end = marker.len_utf8();
+    for (offset, character) in selector[end..].char_indices() {
+        if character == '\\' {
+            return None;
+        }
+        if !character.is_alphanumeric() && character != '_' && character != '-' {
+            break;
+        }
+        end = marker.len_utf8() + offset + character.len_utf8();
+    }
+
+    if end == marker.len_utf8() {
+        return None;
+    }
+
+    let key = selector[marker.len_utf8()..end].to_string();
+    match marker {
+        '.' => Some(SelectorKey::Class(key)),
+        '#' => Some(SelectorKey::Id(key)),
+        _ => None,
+    }
+}
+
+impl GenericSelectorListRules {
+    fn from_rules(rules: &str) -> Self {
+        let mut selector_list_rules = Self::default();
+
+        for line in rules.lines() {
+            let trimmed_line = line.trim();
+            if trimmed_line.is_empty() || trimmed_line.starts_with('!') || trimmed_line.starts_with('[') {
+                continue;
+            }
+
+            let Ok(filter) = adblock::filters::cosmetic::CosmeticFilter::parse(
+                trimmed_line,
+                false,
+                adblock::resources::PermissionMask::default(),
+            ) else {
+                continue;
+            };
+
+            let generic_filter = if filter.has_hostname_constraint() {
+                filter.hidden_generic_rule()
+            } else {
+                Some(filter)
+            };
+
+            let Some(generic_filter) = generic_filter else {
+                continue;
+            };
+            let Some(selector) = generic_filter.plain_css_selector() else {
+                continue;
+            };
+            selector_list_rules.add_selector(selector);
+        }
+
+        selector_list_rules
+    }
+
+    fn add_selector(&mut self, selector: &str) {
+        let mut selector_list_item_count = 0;
+        let mut has_unkeyable_item = false;
+        let mut class_keys = HashSet::new();
+        let mut id_keys = HashSet::new();
+        for_each_selector_list_item(selector, |selector_list_item| {
+            selector_list_item_count += 1;
+
+            match selector_key_from_start(selector_list_item) {
+                Some(SelectorKey::Class(class)) => {
+                    class_keys.insert(class);
+                }
+                Some(SelectorKey::Id(id)) => {
+                    id_keys.insert(id);
+                }
+                None => has_unkeyable_item = true,
+            }
+        });
+
+        if selector_list_item_count < 2 {
+            return;
+        }
+
+        let selector = selector.to_string();
+        if has_unkeyable_item {
+            self.always_needed.insert(selector);
+            return;
+        }
+
+        for class in class_keys {
+            self.by_class.entry(class).or_default().push(selector.clone());
+        }
+        for id in id_keys {
+            self.by_id.entry(id).or_default().push(selector.clone());
+        }
+    }
+
+    fn hidden_selectors(
+        &self,
+        classes: impl IntoIterator<Item = impl AsRef<str>>,
+        ids: impl IntoIterator<Item = impl AsRef<str>>,
+        exceptions: &HashSet<String>,
+    ) -> Vec<String> {
+        let mut selectors: Vec<_> = self
+            .always_needed
+            .iter()
+            .filter(|selector| !exceptions.contains(*selector))
+            .cloned()
+            .collect();
+
+        for class in classes {
+            if let Some(class_selectors) = self.by_class.get(class.as_ref()) {
+                selectors.extend(
+                    class_selectors
+                        .iter()
+                        .filter(|selector| !exceptions.contains(*selector))
+                        .cloned(),
+                );
+            }
+        }
+
+        for id in ids {
+            if let Some(id_selectors) = self.by_id.get(id.as_ref()) {
+                selectors.extend(
+                    id_selectors
+                        .iter()
+                        .filter(|selector| !exceptions.contains(*selector))
+                        .cloned(),
+                );
+            }
+        }
+
+        selectors
+    }
+}
+
+fn cosmetic_css_for_url(engine: &ContentBlockerEngine, url: &str, classes: &[&str], ids: &[&str]) -> String {
+    let resources = engine.engine.url_cosmetic_resources(url);
     let mut selectors = resources.hide_selectors;
 
     if !resources.generichide {
-        selectors.extend(engine.hidden_class_id_selectors(classes, ids, &resources.exceptions));
+        selectors.extend(engine.engine.hidden_class_id_selectors(
+            classes.iter().copied(),
+            ids.iter().copied(),
+            &resources.exceptions,
+        ));
+        selectors.extend(engine.generic_selector_list_rules.hidden_selectors(
+            classes.iter().copied(),
+            ids.iter().copied(),
+            &resources.exceptions,
+        ));
     }
 
     let mut selector_styles: Vec<_> = selectors
@@ -122,6 +328,11 @@ pub unsafe extern "C" fn rust_content_blocker_create(rules: *const u8, rules_len
         };
 
         let engine = adblock::engine::Engine::from_rules(rules.lines(), adblock::lists::ParseOptions::default());
+        let generic_selector_list_rules = GenericSelectorListRules::from_rules(rules);
+        let engine = ContentBlockerEngine {
+            engine,
+            generic_selector_list_rules,
+        };
         Box::into_raw(Box::new(engine)).cast()
     })
 }
@@ -132,7 +343,7 @@ pub unsafe extern "C" fn rust_content_blocker_create(rules: *const u8, rules_len
 pub unsafe extern "C" fn rust_content_blocker_free(engine: *mut c_void) {
     abort_on_panic(|| {
         if !engine.is_null() {
-            drop(unsafe { Box::from_raw(engine.cast::<adblock::engine::Engine>()) });
+            drop(unsafe { Box::from_raw(engine.cast::<ContentBlockerEngine>()) });
         }
     });
 }
@@ -168,7 +379,7 @@ pub unsafe extern "C" fn rust_content_blocker_matches(
             return false;
         };
 
-        engine.check_network_request(&request).matched
+        engine.engine.check_network_request(&request).matched
     })
 }
 
@@ -200,7 +411,9 @@ pub unsafe extern "C" fn rust_content_blocker_cosmetic_css(
             return string_to_ffi(String::new());
         };
 
-        string_to_ffi(cosmetic_css_for_url(engine, url, classes.lines(), ids.lines()))
+        let classes: Vec<_> = classes.lines().collect();
+        let ids: Vec<_> = ids.lines().collect();
+        string_to_ffi(cosmetic_css_for_url(engine, url, &classes, &ids))
     })
 }
 

--- a/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
+++ b/Libraries/LibWeb/ContentBlocker/Rust/src/lib.rs
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+#[repr(C)]
+pub struct ContentBlockerString {
+    data: *mut u8,
+    length: usize,
+}
+
+fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = if let Some(message) = payload.downcast_ref::<&str>() {
+                (*message).to_string()
+            } else if let Some(message) = payload.downcast_ref::<String>() {
+                message.clone()
+            } else {
+                "unknown panic".to_string()
+            };
+            eprintln!("Rust panic at FFI boundary: {message}");
+            std::process::abort();
+        }
+    }
+}
+
+unsafe fn bytes_from_raw<'a>(bytes: *const u8, len: usize) -> Option<&'a [u8]> {
+    if len == 0 {
+        return Some(&[]);
+    }
+    if bytes.is_null() {
+        return None;
+    }
+    Some(unsafe { std::slice::from_raw_parts(bytes, len) })
+}
+
+unsafe fn string_from_raw<'a>(bytes: *const u8, len: usize) -> Option<&'a str> {
+    let bytes = unsafe { bytes_from_raw(bytes, len)? };
+    std::str::from_utf8(bytes).ok()
+}
+
+unsafe fn engine_from_raw<'a>(engine: *const c_void) -> Option<&'a adblock::engine::Engine> {
+    if engine.is_null() {
+        return None;
+    }
+    Some(unsafe { &*engine.cast::<adblock::engine::Engine>() })
+}
+
+fn string_to_ffi(string: String) -> ContentBlockerString {
+    if string.is_empty() {
+        return ContentBlockerString {
+            data: std::ptr::null_mut(),
+            length: 0,
+        };
+    }
+
+    let bytes = Box::leak(string.into_bytes().into_boxed_slice());
+    let data = bytes.as_mut_ptr();
+    let length = bytes.len();
+
+    ContentBlockerString { data, length }
+}
+
+fn cosmetic_css_for_url(
+    engine: &adblock::engine::Engine,
+    url: &str,
+    classes: impl IntoIterator<Item = impl AsRef<str>>,
+    ids: impl IntoIterator<Item = impl AsRef<str>>,
+) -> String {
+    let resources = engine.url_cosmetic_resources(url);
+    let mut selectors = resources.hide_selectors;
+
+    if !resources.generichide {
+        selectors.extend(engine.hidden_class_id_selectors(classes, ids, &resources.exceptions));
+    }
+
+    let mut selector_styles: Vec<_> = selectors
+        .into_iter()
+        .map(|selector| (selector, "display: none !important".to_string()))
+        .collect();
+
+    for action in resources.procedural_actions {
+        let Ok(filter) = serde_json::from_str::<adblock::cosmetic_filter_cache::ProceduralOrActionFilter>(&action)
+        else {
+            continue;
+        };
+        if let Some((selector, style)) = filter.as_css() {
+            selector_styles.push((selector, style));
+        }
+    }
+
+    selector_styles.sort_unstable();
+    selector_styles.dedup();
+
+    let mut css = String::new();
+    for (selector, style) in selector_styles {
+        css.push_str(&selector);
+        css.push_str(" { ");
+        css.push_str(&style);
+        if !style.trim_end().ends_with(';') {
+            css.push(';');
+        }
+        css.push_str(" }\n");
+    }
+    css
+}
+
+/// # Safety
+/// - `rules` and `rules_len` must point to a valid UTF-8 string
+/// - The returned pointer must be freed with `rust_content_blocker_free`
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_content_blocker_create(rules: *const u8, rules_len: usize) -> *mut c_void {
+    abort_on_panic(|| {
+        let Some(rules) = (unsafe { string_from_raw(rules, rules_len) }) else {
+            return std::ptr::null_mut();
+        };
+
+        let engine = adblock::engine::Engine::from_rules(rules.lines(), adblock::lists::ParseOptions::default());
+        Box::into_raw(Box::new(engine)).cast()
+    })
+}
+
+/// # Safety
+/// - `engine` must be null or a valid pointer returned by `rust_content_blocker_create`
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_content_blocker_free(engine: *mut c_void) {
+    abort_on_panic(|| {
+        if !engine.is_null() {
+            drop(unsafe { Box::from_raw(engine.cast::<adblock::engine::Engine>()) });
+        }
+    });
+}
+
+/// # Safety
+/// - `engine` must be null or a valid pointer returned by `rust_content_blocker_create`
+/// - String pointers and lengths must point to valid UTF-8 strings
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_content_blocker_matches(
+    engine: *const c_void,
+    url: *const u8,
+    url_len: usize,
+    source_url: *const u8,
+    source_url_len: usize,
+    request_type: *const u8,
+    request_type_len: usize,
+) -> bool {
+    abort_on_panic(|| {
+        let Some(engine) = (unsafe { engine_from_raw(engine) }) else {
+            return false;
+        };
+        let Some(url) = (unsafe { string_from_raw(url, url_len) }) else {
+            return false;
+        };
+        let Some(source_url) = (unsafe { string_from_raw(source_url, source_url_len) }) else {
+            return false;
+        };
+        let Some(request_type) = (unsafe { string_from_raw(request_type, request_type_len) }) else {
+            return false;
+        };
+
+        let Ok(request) = adblock::request::Request::new(url, source_url, request_type) else {
+            return false;
+        };
+
+        engine.check_network_request(&request).matched
+    })
+}
+
+/// # Safety
+/// - `engine` must be null or a valid pointer returned by `rust_content_blocker_create`
+/// - String pointers and lengths must point to valid UTF-8 strings
+/// - The returned string must be freed with `rust_content_blocker_free_string`
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_content_blocker_cosmetic_css(
+    engine: *const c_void,
+    url: *const u8,
+    url_len: usize,
+    classes: *const u8,
+    classes_len: usize,
+    ids: *const u8,
+    ids_len: usize,
+) -> ContentBlockerString {
+    abort_on_panic(|| {
+        let Some(engine) = (unsafe { engine_from_raw(engine) }) else {
+            return string_to_ffi(String::new());
+        };
+        let Some(url) = (unsafe { string_from_raw(url, url_len) }) else {
+            return string_to_ffi(String::new());
+        };
+        let Some(classes) = (unsafe { string_from_raw(classes, classes_len) }) else {
+            return string_to_ffi(String::new());
+        };
+        let Some(ids) = (unsafe { string_from_raw(ids, ids_len) }) else {
+            return string_to_ffi(String::new());
+        };
+
+        string_to_ffi(cosmetic_css_for_url(engine, url, classes.lines(), ids.lines()))
+    })
+}
+
+/// # Safety
+/// - `data` and `length` must match a string returned by `rust_content_blocker_cosmetic_css`
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_content_blocker_free_string(data: *mut u8, length: usize) {
+    abort_on_panic(|| {
+        if !data.is_null() {
+            drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(data, length)) });
+        }
+    });
+}

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -775,14 +775,68 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
 String const& Document::content_blocker_style_sheet()
 {
-    if (!m_content_blocker_style_sheet.has_value())
-        m_content_blocker_style_sheet = ContentBlocker::the().cosmetic_style_sheet_for_document(*this);
+    if (!m_content_blocker_style_sheet.has_value()) {
+        m_content_blocker_style_sheet_checked_classes.clear();
+        m_content_blocker_style_sheet_checked_ids.clear();
+
+        Vector<String> classes;
+        Vector<String> ids;
+        for_each_shadow_including_descendant([&](DOM::Node& node) {
+            auto* element = as_if<DOM::Element>(node);
+            if (!element)
+                return TraversalDecision::Continue;
+
+            if (auto const& id = element->id(); id.has_value()) {
+                auto id_string = id->to_string();
+                if (!id_string.is_empty() && m_content_blocker_style_sheet_checked_ids.set(*id) == AK::HashSetResult::InsertedNewEntry)
+                    ids.append(move(id_string));
+            }
+
+            for (auto const& class_name : element->class_names()) {
+                auto class_string = class_name.to_string();
+                if (!class_string.is_empty() && m_content_blocker_style_sheet_checked_classes.set(class_name) == AK::HashSetResult::InsertedNewEntry)
+                    classes.append(move(class_string));
+            }
+
+            return TraversalDecision::Continue;
+        });
+
+        m_content_blocker_style_sheet = ContentBlocker::the().cosmetic_style_sheet_for_url(fallback_base_url(), classes, ids);
+    }
+
     return m_content_blocker_style_sheet.value();
 }
 
 void Document::invalidate_content_blocker_style_sheet()
 {
     m_content_blocker_style_sheet.clear();
+    m_content_blocker_style_sheet_checked_classes.clear();
+    m_content_blocker_style_sheet_checked_ids.clear();
+}
+
+bool Document::content_blocker_style_sheet_may_need_refresh_for_class_or_id(FlyString const* id, ReadonlySpan<FlyString> class_names)
+{
+    if (!m_content_blocker_style_sheet.has_value())
+        return false;
+
+    Vector<String> classes_to_check;
+    Vector<String> ids_to_check;
+    auto append_new_token = [](FlyString const& token, HashTable<FlyString>& checked_tokens, Vector<String>& tokens_to_check) {
+        auto token_string = token.to_string();
+        if (!token_string.is_empty() && checked_tokens.set(token) == AK::HashSetResult::InsertedNewEntry)
+            tokens_to_check.append(move(token_string));
+    };
+
+    if (id)
+        append_new_token(*id, m_content_blocker_style_sheet_checked_ids, ids_to_check);
+
+    for (auto const& class_name : class_names)
+        append_new_token(class_name, m_content_blocker_style_sheet_checked_classes, classes_to_check);
+
+    if (classes_to_check.is_empty() && ids_to_check.is_empty())
+        return false;
+
+    return ContentBlocker::the().has_generic_cosmetic_selectors_for_url(fallback_base_url(), classes_to_check, ids_to_check);
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
@@ -1099,6 +1100,7 @@ public:
     CSS::StyleScope& style_scope() { return m_style_scope; }
     String const& content_blocker_style_sheet();
     void invalidate_content_blocker_style_sheet();
+    bool content_blocker_style_sheet_may_need_refresh_for_class_or_id(FlyString const* id, ReadonlySpan<FlyString> class_names);
 
     void exit_pointer_lock();
 
@@ -1469,6 +1471,9 @@ private:
     ShadowRoot::DocumentShadowRootList m_shadow_roots;
 
     Optional<String> m_content_blocker_style_sheet;
+    // Class/id tokens already covered by the cached content blocker stylesheet.
+    HashTable<FlyString> m_content_blocker_style_sheet_checked_classes;
+    HashTable<FlyString> m_content_blocker_style_sheet_checked_ids;
 
     Optional<AK::UnixDateTime> m_last_modified;
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -110,6 +110,7 @@
 #include <LibWeb/Layout/ListItemBox.h>
 #include <LibWeb/Layout/TreeBuilder.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Loader/ContentBlocker.h>
 #include <LibWeb/MathML/MathMLElement.h>
 #include <LibWeb/MathML/TagNames.h>
 #include <LibWeb/Namespace.h>
@@ -132,6 +133,20 @@
 namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(Element);
+
+static void invalidate_content_blocker_style_if_needed(Element& element)
+{
+    if (!element.is_connected())
+        return;
+    if (!ContentBlocker::the().filtering_enabled() || !ContentBlocker::the().has_cosmetic_rules())
+        return;
+
+    auto const& id = element.id();
+    if (!element.document().content_blocker_style_sheet_may_need_refresh_for_class_or_id(id.has_value() ? &id.value() : nullptr, element.class_names()))
+        return;
+
+    element.document().page().invalidate_user_style();
+}
 
 Element::Element(Document& document, DOM::QualifiedName qualified_name)
     : ParentNode(document, NodeType::ELEMENT_NODE)
@@ -862,6 +877,8 @@ void Element::run_attribute_change_steps(FlyString const& local_name, Optional<S
 
     if (old_value != value) {
         CSS::Invalidation::invalidate_style_after_attribute_change(*this, local_name, old_value, value);
+        if (local_name == HTML::AttributeNames::id || local_name == HTML::AttributeNames::class_)
+            invalidate_content_blocker_style_if_needed(*this);
         document().bump_dom_tree_version();
     }
 }
@@ -1708,6 +1725,8 @@ void Element::inserted()
             document().element_with_id_was_added({}, *this);
         if (m_name.has_value())
             document().element_with_name_was_added({}, *this);
+        if (m_id.has_value() || !m_classes.is_empty())
+            invalidate_content_blocker_style_if_needed(*this);
     }
 
     play_or_cancel_animations_after_display_property_change();

--- a/Libraries/LibWeb/Loader/ContentBlocker.cpp
+++ b/Libraries/LibWeb/Loader/ContentBlocker.cpp
@@ -1,17 +1,16 @@
 /*
- * Copyright (c) 2021, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2025, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ * Copyright (c) 2026-present, the Ladybird developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/BinarySearch.h>
-#include <AK/Queue.h>
-#include <AK/QuickSort.h>
-#include <AK/Span.h>
+#include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
+#include <AK/Vector.h>
 #include <LibURL/Parser.h>
+#include <LibWeb/ContentBlockerRustFFI.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 
 namespace Web {
@@ -24,23 +23,153 @@ ContentBlocker& ContentBlocker::the()
 
 ContentBlocker::ContentBlocker() = default;
 
-ContentBlocker::~ContentBlocker() = default;
+ContentBlocker::~ContentBlocker()
+{
+    ContentBlocking::FFI::rust_content_blocker_free(m_engine);
+}
+
+static StringView resource_type_to_adblock_request_type(ContentBlocker::ResourceType type)
+{
+    switch (type) {
+    case ContentBlocker::ResourceType::Document:
+        return "document"sv;
+    case ContentBlocker::ResourceType::Font:
+        return "font"sv;
+    case ContentBlocker::ResourceType::Image:
+        return "image"sv;
+    case ContentBlocker::ResourceType::Media:
+        return "media"sv;
+    case ContentBlocker::ResourceType::Object:
+        return "object"sv;
+    case ContentBlocker::ResourceType::Other:
+        return "other"sv;
+    case ContentBlocker::ResourceType::Ping:
+        return "ping"sv;
+    case ContentBlocker::ResourceType::Script:
+        return "script"sv;
+    case ContentBlocker::ResourceType::Stylesheet:
+        return "stylesheet"sv;
+    case ContentBlocker::ResourceType::Subdocument:
+        return "subdocument"sv;
+    case ContentBlocker::ResourceType::WebSocket:
+        return "websocket"sv;
+    case ContentBlocker::ResourceType::XMLHttpRequest:
+        return "xmlhttprequest"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static ByteString serialized_url(URL::URL const& url)
+{
+    return url.serialize().to_byte_string();
+}
+
+static ByteString serialized_url_for_matching(URL::URL const& url)
+{
+    if (url.scheme() == "file"sv)
+        return ByteString::formatted("http://local-file.invalid/{}", serialized_url(url));
+    return serialized_url(url);
+}
+
+static String take_rust_string(ContentBlocking::FFI::ContentBlockerString rust_string)
+{
+    if (!rust_string.data)
+        return {};
+
+    ArmedScopeGuard free_string = [&] {
+        ContentBlocking::FFI::rust_content_blocker_free_string(rust_string.data, rust_string.length);
+    };
+
+    auto maybe_string = String::from_utf8({ reinterpret_cast<char const*>(rust_string.data), rust_string.length });
+    if (maybe_string.is_error())
+        return {};
+    return maybe_string.release_value();
+}
+
+static ErrorOr<String> join_lines(ReadonlySpan<String> lines)
+{
+    StringBuilder builder;
+    for (auto const& line : lines) {
+        builder.append(line);
+        builder.append('\n');
+    }
+    return builder.to_string();
+}
+
+static bool line_looks_like_supported_cosmetic_rule(StringView line)
+{
+    auto trimmed_line = line.trim_whitespace();
+    if (trimmed_line.is_empty() || trimmed_line.starts_with('!') || trimmed_line.starts_with('['))
+        return false;
+
+    auto sharp_index = trimmed_line.find('#');
+    if (!sharp_index.has_value())
+        return false;
+
+    auto after_sharp_index = *sharp_index + 1;
+    if (after_sharp_index >= trimmed_line.length())
+        return false;
+
+    auto second_sharp_index = trimmed_line.find('#', after_sharp_index);
+    if (!second_sharp_index.has_value())
+        return false;
+
+    auto between_sharps = trimmed_line.substring_view(after_sharp_index, *second_sharp_index - after_sharp_index);
+    if (between_sharps.starts_with('@')) {
+        if (*sharp_index == 0)
+            return false;
+        between_sharps = between_sharps.substring_view(1);
+    }
+    if (between_sharps.starts_with('?'))
+        between_sharps = between_sharps.substring_view(1);
+
+    return between_sharps.is_empty();
+}
+
+static bool rules_contain_cosmetic_rules(ReadonlyBytes rules_bytes)
+{
+    bool has_cosmetic_rules = false;
+    StringView { rules_bytes }.for_each_split_view('\n', SplitBehavior::Nothing, [&](StringView line) {
+        if (line_looks_like_supported_cosmetic_rule(line))
+            has_cosmetic_rules = true;
+    });
+    return has_cosmetic_rules;
+}
+
+ErrorOr<void> ContentBlocker::set_patterns(ReadonlySpan<String> patterns)
+{
+    StringBuilder builder;
+    for (auto const& pattern : patterns) {
+        if (pattern.is_empty())
+            continue;
+        builder.append(pattern);
+        builder.append('\n');
+    }
+
+    auto patterns_string = TRY(builder.to_string());
+    auto patterns_bytes = patterns_string.bytes_as_string_view().bytes();
+    return set_rules_from_bytes(patterns_bytes);
+}
+
+ErrorOr<void> ContentBlocker::set_rules_from_bytes(ReadonlyBytes rules_bytes)
+{
+    auto* engine = ContentBlocking::FFI::rust_content_blocker_create(
+        rules_bytes.data(),
+        rules_bytes.size());
+    if (!engine)
+        return Error::from_string_literal("Failed to create content blocker");
+
+    auto has_cosmetic_rules = rules_contain_cosmetic_rules(rules_bytes);
+
+    ContentBlocking::FFI::rust_content_blocker_free(m_engine);
+    m_engine = engine;
+    m_has_cosmetic_rules = has_cosmetic_rules;
+    return {};
+}
 
 bool ContentBlocker::is_filtered(URL::URL const& url) const
 {
-    if (!filtering_enabled())
-        return false;
-
-    if (url.scheme() == "data")
-        return false;
-    return contains(url.to_string());
-}
-
-bool ContentBlocker::is_filtered(URL::URL const& url, URL::URL const& source_url, ResourceType resource_type) const
-{
-    (void)source_url;
-    (void)resource_type;
-    return is_filtered(url);
+    return is_filtered(url, url, ResourceType::Other);
 }
 
 bool ContentBlocker::is_filtered(URL::URL const& url, URL::URL const& source_url, Optional<Fetch::Infrastructure::Request::Destination> const& destination, Optional<Fetch::Infrastructure::Request::InitiatorType> const& initiator_type, Fetch::Infrastructure::Request::Mode mode) const
@@ -48,90 +177,87 @@ bool ContentBlocker::is_filtered(URL::URL const& url, URL::URL const& source_url
     return is_filtered(url, source_url_for_matching(source_url), resource_type_from_fetch_metadata(destination, initiator_type, mode));
 }
 
-bool ContentBlocker::contains(StringView text) const
+bool ContentBlocker::is_filtered(URL::URL const& url, URL::URL const& source_url, ResourceType resource_type) const
 {
-    if (!m_matcher)
-        return false;
-    return m_matcher->contains(text);
-}
-
-ErrorOr<void> ContentBlocker::set_patterns(ReadonlySpan<String> patterns)
-{
-    Vector<String> network_patterns;
-    m_cosmetic_rules.clear();
-
-    for (auto const& pattern : patterns) {
-        auto pattern_view = pattern.bytes_as_string_view();
-        auto cosmetic_marker = pattern_view.find("##"sv);
-        if (!cosmetic_marker.has_value()) {
-            network_patterns.append(pattern);
-            continue;
-        }
-
-        auto selector = pattern_view.substring_view(cosmetic_marker.value() + 2);
-        if (selector.is_empty())
-            continue;
-
-        auto domains = pattern_view.substring_view(0, cosmetic_marker.value());
-        if (domains.is_empty()) {
-            CosmeticRule rule;
-            rule.selector = TRY(String::from_utf8(selector));
-            m_cosmetic_rules.append(move(rule));
-            continue;
-        }
-
-        for (auto domain : domains.split_view(',')) {
-            if (domain.is_empty())
-                continue;
-            CosmeticRule rule;
-            rule.domain = TRY(String::from_utf8(domain));
-            rule.selector = TRY(String::from_utf8(selector));
-            m_cosmetic_rules.append(move(rule));
-        }
-    }
-
-    m_matcher = make<AsciiStringMatcher>(network_patterns);
-    return {};
-}
-
-static bool cosmetic_rule_domain_matches(StringView domain, URL::URL const& url)
-{
-    auto const& host = url.host();
-    if (!host.has_value())
+    if (!filtering_enabled() || !m_engine)
         return false;
 
-    auto host_string = host->serialize();
-    auto host_view = host_string.bytes_as_string_view();
-    if (host_view == domain)
-        return true;
-
-    if (!host_view.ends_with(domain))
-        return false;
-    if (host_view.length() <= domain.length())
+    if (url.scheme() == "data"sv)
         return false;
 
-    return host_view[host_view.length() - domain.length() - 1] == '.';
-}
+    auto url_string = serialized_url_for_matching(url);
+    auto normalized_source_url = source_url_for_matching(source_url);
+    auto source_url_string = serialized_url_for_matching(normalized_source_url);
+    auto request_type = resource_type_to_adblock_request_type(resource_type);
 
-String ContentBlocker::cosmetic_style_sheet_for_document(DOM::Document const& document) const
-{
-    return cosmetic_style_sheet_for_url(document.fallback_base_url());
+    return ContentBlocking::FFI::rust_content_blocker_matches(
+        m_engine,
+        reinterpret_cast<u8 const*>(url_string.characters()),
+        url_string.length(),
+        reinterpret_cast<u8 const*>(source_url_string.characters()),
+        source_url_string.length(),
+        reinterpret_cast<u8 const*>(request_type.characters_without_null_termination()),
+        request_type.length());
 }
 
 String ContentBlocker::cosmetic_style_sheet_for_url(URL::URL const& url) const
 {
-    if (!filtering_enabled())
+    return cosmetic_style_sheet_for_url(url, {}, {});
+}
+
+String ContentBlocker::cosmetic_style_sheet_for_url(URL::URL const& url, ReadonlySpan<String> classes, ReadonlySpan<String> ids) const
+{
+    if (!filtering_enabled() || !m_engine || !m_has_cosmetic_rules)
         return {};
 
-    StringBuilder builder;
-    for (auto const& rule : m_cosmetic_rules) {
-        if (rule.domain.has_value() && !cosmetic_rule_domain_matches(rule.domain->bytes_as_string_view(), url))
-            continue;
+    auto url_string = serialized_url(url);
+    auto classes_string = join_lines(classes);
+    if (classes_string.is_error())
+        return {};
 
-        builder.append(rule.selector);
-        builder.append(" { display: none !important; }\n"sv);
-    }
-    return builder.to_string_without_validation();
+    auto ids_string = join_lines(ids);
+    if (ids_string.is_error())
+        return {};
+
+    auto classes_bytes = classes_string.value().bytes_as_string_view();
+    auto ids_bytes = ids_string.value().bytes_as_string_view();
+
+    return take_rust_string(ContentBlocking::FFI::rust_content_blocker_cosmetic_css(
+        m_engine,
+        reinterpret_cast<u8 const*>(url_string.characters()),
+        url_string.length(),
+        reinterpret_cast<u8 const*>(classes_bytes.characters_without_null_termination()),
+        classes_bytes.length(),
+        reinterpret_cast<u8 const*>(ids_bytes.characters_without_null_termination()),
+        ids_bytes.length()));
+}
+
+String ContentBlocker::cosmetic_style_sheet_for_document(DOM::Document const& document) const
+{
+    if (!filtering_enabled() || !m_engine || !m_has_cosmetic_rules)
+        return {};
+
+    Vector<String> classes;
+    Vector<String> ids;
+    const_cast<DOM::Document&>(document).for_each_shadow_including_descendant([&](DOM::Node& node) {
+        auto* element = as_if<DOM::Element>(node);
+        if (!element)
+            return TraversalDecision::Continue;
+
+        if (auto const& id = element->id(); id.has_value()) {
+            if (auto id_string = id->to_string(); !id_string.is_empty())
+                ids.append(move(id_string));
+        }
+
+        for (auto const& class_name : element->class_names()) {
+            if (auto class_string = class_name.to_string(); !class_string.is_empty())
+                classes.append(move(class_string));
+        }
+
+        return TraversalDecision::Continue;
+    });
+
+    return cosmetic_style_sheet_for_url(document.fallback_base_url(), classes, ids);
 }
 
 ContentBlocker::ResourceType ContentBlocker::resource_type_from_fetch_metadata(Optional<Fetch::Infrastructure::Request::Destination> const& destination, Optional<Fetch::Infrastructure::Request::InitiatorType> const& initiator_type, Fetch::Infrastructure::Request::Mode mode)
@@ -204,6 +330,7 @@ ContentBlocker::ResourceType ContentBlocker::resource_type_from_fetch_metadata(O
         case Request::InitiatorType::Script:
             return ResourceType::Script;
         case Request::InitiatorType::CSS:
+            return ResourceType::Stylesheet;
         case Request::InitiatorType::EarlyHint:
         case Request::InitiatorType::Body:
         case Request::InitiatorType::Input:
@@ -227,140 +354,6 @@ URL::URL ContentBlocker::source_url_for_matching(URL::URL const& source_url)
         return source_url;
 
     return parsed_url.release_value();
-}
-
-AsciiStringMatcher::AsciiStringMatcher(ReadonlySpan<String> patterns)
-{
-    struct BuildTimeNode {
-        Vector<Transition> children;
-        bool is_output { false };
-    };
-
-    Vector<BuildTimeNode> build_time_nodes;
-    build_time_nodes.append({});
-
-    for (u32 i = 0; i < patterns.size(); ++i) {
-        auto const& pattern = patterns[i];
-        u32 node = 0;
-        for (u8 ch : pattern.bytes_as_string_view()) {
-            VERIFY(is_ascii(ch));
-            auto it = build_time_nodes[node].children.find_if(
-                [ch](Transition const& t) { return t.character == ch; });
-
-            if (it != build_time_nodes[node].children.end()) {
-                node = it->next_state;
-            } else {
-                u32 new_node = build_time_nodes.size();
-                build_time_nodes.append({});
-                build_time_nodes[node].children.empend(ch, new_node);
-                node = new_node;
-            }
-        }
-
-        if (!build_time_nodes[node].is_output)
-            build_time_nodes[node].is_output = true;
-    }
-
-    Vector<u32> failure_links;
-    failure_links.resize(build_time_nodes.size());
-
-    Queue<u32> queue;
-    for (auto const& transition : build_time_nodes[0].children) {
-        u32 child = transition.next_state;
-        failure_links[child] = 0;
-        queue.enqueue(child);
-    }
-
-    while (!queue.is_empty()) {
-        u32 current = queue.dequeue();
-        for (auto& [character, child] : build_time_nodes[current].children) {
-            u32 failure_link = failure_links[current];
-            while (failure_link != 0) {
-                auto it = build_time_nodes[failure_link].children.find_if(
-                    [character](Transition const& tr) { return tr.character == character; });
-                if (it != build_time_nodes[failure_link].children.end()) {
-                    failure_link = it->next_state;
-                    break;
-                }
-                failure_link = failure_links[failure_link];
-            }
-
-            u32 next_failure_link = failure_link;
-            failure_links[child] = next_failure_link;
-
-            bool inherited = build_time_nodes[next_failure_link].is_output;
-            if (inherited && !build_time_nodes[child].is_output)
-                build_time_nodes[child].is_output = true;
-
-            queue.enqueue(child);
-        }
-    }
-
-    for (auto& node : build_time_nodes) {
-        quick_sort(node.children, [](Transition const& a, Transition const& b) {
-            return a.character < b.character;
-        });
-    }
-
-    m_nodes.resize(build_time_nodes.size());
-    m_transitions.clear_with_capacity();
-
-    u32 transition_index = 0;
-    for (u32 i = 0; i < build_time_nodes.size(); ++i) {
-        auto& build_time_node = build_time_nodes[i];
-        m_nodes[i].first_transition = transition_index;
-        m_nodes[i].transition_count = build_time_node.children.size();
-        m_nodes[i].output = build_time_node.is_output;
-        m_transitions.extend(build_time_node.children);
-
-        transition_index += build_time_node.children.size();
-    }
-}
-
-bool AsciiStringMatcher::contains(StringView text) const
-{
-    if (m_nodes.is_empty())
-        return false;
-
-    auto get_children = [this](u32 state) -> ReadonlySpan<Transition> {
-        return m_transitions.span().slice(m_nodes[state].first_transition, m_nodes[state].transition_count);
-    };
-
-    u32 state = 0;
-    for (u8 ch : text.bytes()) {
-        auto const& children = get_children(state);
-
-        auto const* found = AK::binary_search(
-            children,
-            ch,
-            nullptr,
-            [](u8 needle, Transition const& transition) {
-                if (needle > transition.character)
-                    return needle < transition.character ? -1 : 1;
-                return needle < transition.character ? -1 : 0;
-            });
-
-        if (!found) {
-            state = 0;
-            auto const& root_children = get_children(0);
-            found = AK::binary_search(
-                root_children,
-                ch,
-                nullptr,
-                [](u8 needle, Transition const& transition) {
-                    if (needle > transition.character)
-                        return needle < transition.character ? -1 : 1;
-                    return needle < transition.character ? -1 : 0;
-                });
-            if (!found)
-                continue;
-        }
-
-        state = found->next_state;
-        if (m_nodes[state].output)
-            return true;
-    }
-    return false;
 }
 
 }

--- a/Libraries/LibWeb/Loader/ContentBlocker.cpp
+++ b/Libraries/LibWeb/Loader/ContentBlocker.cpp
@@ -9,8 +9,6 @@
 #include <AK/Vector.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/ContentBlockerRustFFI.h>
-#include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/Element.h>
 #include <LibWeb/Loader/ContentBlocker.h>
 
 namespace Web {
@@ -232,32 +230,31 @@ String ContentBlocker::cosmetic_style_sheet_for_url(URL::URL const& url, Readonl
         ids_bytes.length()));
 }
 
-String ContentBlocker::cosmetic_style_sheet_for_document(DOM::Document const& document) const
+bool ContentBlocker::has_generic_cosmetic_selectors_for_url(URL::URL const& url, ReadonlySpan<String> classes, ReadonlySpan<String> ids) const
 {
     if (!filtering_enabled() || !m_engine || !m_has_cosmetic_rules)
-        return {};
+        return false;
 
-    Vector<String> classes;
-    Vector<String> ids;
-    const_cast<DOM::Document&>(document).for_each_shadow_including_descendant([&](DOM::Node& node) {
-        auto* element = as_if<DOM::Element>(node);
-        if (!element)
-            return TraversalDecision::Continue;
+    auto url_string = serialized_url(url);
+    auto classes_string = join_lines(classes);
+    if (classes_string.is_error())
+        return false;
 
-        if (auto const& id = element->id(); id.has_value()) {
-            if (auto id_string = id->to_string(); !id_string.is_empty())
-                ids.append(move(id_string));
-        }
+    auto ids_string = join_lines(ids);
+    if (ids_string.is_error())
+        return false;
 
-        for (auto const& class_name : element->class_names()) {
-            if (auto class_string = class_name.to_string(); !class_string.is_empty())
-                classes.append(move(class_string));
-        }
+    auto classes_bytes = classes_string.value().bytes_as_string_view();
+    auto ids_bytes = ids_string.value().bytes_as_string_view();
 
-        return TraversalDecision::Continue;
-    });
-
-    return cosmetic_style_sheet_for_url(document.fallback_base_url(), classes, ids);
+    return ContentBlocking::FFI::rust_content_blocker_has_generic_cosmetic_selectors(
+        m_engine,
+        reinterpret_cast<u8 const*>(url_string.characters()),
+        url_string.length(),
+        reinterpret_cast<u8 const*>(classes_bytes.characters_without_null_termination()),
+        classes_bytes.length(),
+        reinterpret_cast<u8 const*>(ids_bytes.characters_without_null_termination()),
+        ids_bytes.length());
 }
 
 ContentBlocker::ResourceType ContentBlocker::resource_type_from_fetch_metadata(Optional<Fetch::Infrastructure::Request::Destination> const& destination, Optional<Fetch::Infrastructure::Request::InitiatorType> const& initiator_type, Fetch::Infrastructure::Request::Mode mode)

--- a/Libraries/LibWeb/Loader/ContentBlocker.h
+++ b/Libraries/LibWeb/Loader/ContentBlocker.h
@@ -7,10 +7,9 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Noncopyable.h>
-#include <AK/OwnPtr.h>
 #include <AK/String.h>
-#include <AK/Vector.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
@@ -18,30 +17,9 @@
 
 namespace Web {
 
-class AsciiStringMatcher {
-public:
-    explicit AsciiStringMatcher(ReadonlySpan<String> patterns);
-
-    bool contains(StringView text) const;
-
-private:
-    struct Transition {
-        u8 character { 0 };
-        u32 next_state { 0 };
-    };
-
-    struct Node {
-        u32 first_transition { 0 };
-        u8 transition_count { 0 };
-        bool output { false };
-    };
-
-    Vector<Node> m_nodes;
-    Vector<Transition> m_transitions;
-};
-
 class WEB_API ContentBlocker {
     AK_MAKE_NONCOPYABLE(ContentBlocker);
+    AK_MAKE_NONMOVABLE(ContentBlocker);
 
 public:
     enum class ResourceType : u8 {
@@ -61,6 +39,8 @@ public:
 
     static ContentBlocker& the();
 
+    bool has_rules() const { return m_engine != nullptr; }
+    bool has_cosmetic_rules() const { return m_has_cosmetic_rules; }
     bool filtering_enabled() const { return m_filtering_enabled; }
     void set_filtering_enabled(bool const enabled) { m_filtering_enabled = enabled; }
 
@@ -68,10 +48,11 @@ public:
     bool is_filtered(URL::URL const&, URL::URL const& source_url, ResourceType) const;
     bool is_filtered(URL::URL const&, URL::URL const& source_url, Optional<Fetch::Infrastructure::Request::Destination> const&, Optional<Fetch::Infrastructure::Request::InitiatorType> const&, Fetch::Infrastructure::Request::Mode) const;
     ErrorOr<void> set_patterns(ReadonlySpan<String>);
+    ErrorOr<void> set_rules_from_bytes(ReadonlyBytes);
 
-    bool has_cosmetic_rules() const { return !m_cosmetic_rules.is_empty(); }
     String cosmetic_style_sheet_for_document(DOM::Document const&) const;
     String cosmetic_style_sheet_for_url(URL::URL const&) const;
+    String cosmetic_style_sheet_for_url(URL::URL const&, ReadonlySpan<String> classes, ReadonlySpan<String> ids) const;
 
     static ResourceType resource_type_from_fetch_metadata(Optional<Fetch::Infrastructure::Request::Destination> const&, Optional<Fetch::Infrastructure::Request::InitiatorType> const&, Fetch::Infrastructure::Request::Mode);
     static URL::URL source_url_for_matching(URL::URL const&);
@@ -80,16 +61,9 @@ private:
     ContentBlocker();
     ~ContentBlocker();
 
-    bool contains(StringView text) const;
-
-    struct CosmeticRule {
-        Optional<String> domain;
-        String selector;
-    };
-
     bool m_filtering_enabled { true };
-    OwnPtr<AsciiStringMatcher> m_matcher;
-    Vector<CosmeticRule> m_cosmetic_rules;
+    bool m_has_cosmetic_rules { false };
+    void* m_engine { nullptr };
 };
 
 }

--- a/Libraries/LibWeb/Loader/ContentBlocker.h
+++ b/Libraries/LibWeb/Loader/ContentBlocker.h
@@ -13,7 +13,6 @@
 #include <LibURL/URL.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
-#include <LibWeb/Forward.h>
 
 namespace Web {
 
@@ -50,9 +49,9 @@ public:
     ErrorOr<void> set_patterns(ReadonlySpan<String>);
     ErrorOr<void> set_rules_from_bytes(ReadonlyBytes);
 
-    String cosmetic_style_sheet_for_document(DOM::Document const&) const;
     String cosmetic_style_sheet_for_url(URL::URL const&) const;
     String cosmetic_style_sheet_for_url(URL::URL const&, ReadonlySpan<String> classes, ReadonlySpan<String> ids) const;
+    bool has_generic_cosmetic_selectors_for_url(URL::URL const&, ReadonlySpan<String> classes, ReadonlySpan<String> ids) const;
 
     static ResourceType resource_type_from_fetch_metadata(Optional<Fetch::Infrastructure::Request::Destination> const&, Optional<Fetch::Infrastructure::Request::InitiatorType> const&, Fetch::Infrastructure::Request::Mode);
     static URL::URL source_url_for_matching(URL::URL const&);

--- a/Meta/CMake/flatpak/cargo-sources.json
+++ b/Meta/CMake/flatpak/cargo-sources.json
@@ -8,6 +8,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adblock/adblock-0.12.5.crate",
+        "sha256": "db6fe7702c798519299bcbe011ff6f1dc9e3aedc1f3171178cddf71e1736bf95",
+        "dest": "cargo/vendor/adblock-0.12.5"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/addr/addr-0.15.6.crate",
+        "sha256": "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef",
+        "dest": "cargo/vendor/addr-0.15.6"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.4.crate",
         "sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
         "dest": "cargo/vendor/aho-corasick-1.1.4"
@@ -71,9 +85,23 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.6.crate",
+        "sha256": "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50",
+        "dest": "cargo/vendor/arrayvec-0.7.6"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/autocfg/autocfg-1.5.0.crate",
         "sha256": "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8",
         "dest": "cargo/vendor/autocfg-1.5.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
+        "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+        "dest": "cargo/vendor/base64-0.22.1"
     },
     {
         "type": "archive",
@@ -239,6 +267,13 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/either/either-1.16.0.crate",
+        "sha256": "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e",
+        "dest": "cargo/vendor/either-1.16.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.35.crate",
         "sha256": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3",
         "dest": "cargo/vendor/encoding_rs-0.8.35"
@@ -274,9 +309,23 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flatbuffers/flatbuffers-25.12.19.crate",
+        "sha256": "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3",
+        "dest": "cargo/vendor/flatbuffers-25.12.19"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foldhash/foldhash-0.1.5.crate",
         "sha256": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2",
         "dest": "cargo/vendor/foldhash-0.1.5"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.2.crate",
+        "sha256": "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf",
+        "dest": "cargo/vendor/form_urlencoded-1.2.2"
     },
     {
         "type": "archive",
@@ -365,6 +414,34 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_normalizer/icu_normalizer-2.2.0.crate",
+        "sha256": "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4",
+        "dest": "cargo/vendor/icu_normalizer-2.2.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_normalizer_data/icu_normalizer_data-2.2.0.crate",
+        "sha256": "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38",
+        "dest": "cargo/vendor/icu_normalizer_data-2.2.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_properties/icu_properties-2.2.0.crate",
+        "sha256": "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de",
+        "dest": "cargo/vendor/icu_properties-2.2.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.2.0.crate",
+        "sha256": "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14",
+        "dest": "cargo/vendor/icu_properties_data-2.2.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/icu_provider/icu_provider-2.2.0.crate",
         "sha256": "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421",
         "dest": "cargo/vendor/icu_provider-2.2.0"
@@ -379,6 +456,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idna/idna-1.1.0.crate",
+        "sha256": "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de",
+        "dest": "cargo/vendor/idna-1.1.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idna_adapter/idna_adapter-1.2.2.crate",
+        "sha256": "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714",
+        "dest": "cargo/vendor/idna_adapter-1.2.2"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/indexmap/indexmap-2.13.1.crate",
         "sha256": "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff",
         "dest": "cargo/vendor/indexmap-2.13.1"
@@ -389,6 +480,13 @@
         "url": "https://static.crates.io/crates/is_terminal_polyfill/is_terminal_polyfill-1.70.2.crate",
         "sha256": "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695",
         "dest": "cargo/vendor/is_terminal_polyfill-1.70.2"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.13.0.crate",
+        "sha256": "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186",
+        "dest": "cargo/vendor/itertools-0.13.0"
     },
     {
         "type": "archive",
@@ -491,9 +589,23 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.2.crate",
+        "sha256": "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220",
+        "dest": "cargo/vendor/percent-encoding-2.3.2"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.5.crate",
         "sha256": "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564",
         "dest": "cargo/vendor/potential_utf-0.1.5"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/precomputed-hash/precomputed-hash-0.1.1.crate",
+        "sha256": "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c",
+        "dest": "cargo/vendor/precomputed-hash-0.1.1"
     },
     {
         "type": "archive",
@@ -508,6 +620,20 @@
         "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.106.crate",
         "sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
         "dest": "cargo/vendor/proc-macro2-1.0.106"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/psl/psl-2.1.210.crate",
+        "sha256": "27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8",
+        "dest": "cargo/vendor/psl-2.1.210"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/psl-types/psl-types-2.0.11.crate",
+        "sha256": "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac",
+        "dest": "cargo/vendor/psl-types-2.0.11"
     },
     {
         "type": "archive",
@@ -554,6 +680,13 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-1.1.0.crate",
+        "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+        "dest": "cargo/vendor/rustc-hash-1.1.0"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-2.1.2.crate",
         "sha256": "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe",
         "dest": "cargo/vendor/rustc-hash-2.1.2"
@@ -561,9 +694,23 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
+        "sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
+        "dest": "cargo/vendor/rustc_version-0.4.1"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustix/rustix-1.1.4.crate",
         "sha256": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190",
         "dest": "cargo/vendor/rustix-1.1.4"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/seahash/seahash-4.1.0.crate",
+        "sha256": "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b",
+        "dest": "cargo/vendor/seahash-4.1.0"
     },
     {
         "type": "archive",
@@ -659,6 +806,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
+        "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
+        "dest": "cargo/vendor/thiserror-1.0.69"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.69.crate",
+        "sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1",
+        "dest": "cargo/vendor/thiserror-impl-1.0.69"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tinystr/tinystr-0.8.3.crate",
         "sha256": "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d",
         "dest": "cargo/vendor/tinystr-0.8.3"
@@ -704,6 +865,13 @@
         "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
         "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
         "dest": "cargo/vendor/unicode-xid-0.2.6"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/url/url-2.5.8.crate",
+        "sha256": "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed",
+        "dest": "cargo/vendor/url-2.5.8"
     },
     {
         "type": "archive",
@@ -897,6 +1065,8 @@
     {
         "type": "shell",
         "commands": [
+            "echo '{\"files\": {}, \"package\": \"db6fe7702c798519299bcbe011ff6f1dc9e3aedc1f3171178cddf71e1736bf95\"}' > cargo/vendor/adblock-0.12.5/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef\"}' > cargo/vendor/addr-0.15.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\"}' > cargo/vendor/aho-corasick-1.1.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923\"}' > cargo/vendor/allocator-api2-0.2.21/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d\"}' > cargo/vendor/anstream-1.0.0/.cargo-checksum.json",
@@ -906,7 +1076,9 @@
             "echo '{\"files\": {}, \"package\": \"291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d\"}' > cargo/vendor/anstyle-wincon-3.0.11/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\"}' > cargo/vendor/anyhow-1.0.102/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1\"}' > cargo/vendor/arbitrary-1.4.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50\"}' > cargo/vendor/arrayvec-0.7.6/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8\"}' > cargo/vendor/autocfg-1.5.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\"}' > cargo/vendor/base64-0.22.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af\"}' > cargo/vendor/bitflags-2.11.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb\"}' > cargo/vendor/bumpalo-3.20.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26\"}' > cargo/vendor/calendrical_calculations-0.2.4/.cargo-checksum.json",
@@ -930,12 +1102,15 @@
             "echo '{\"files\": {}, \"package\": \"4d55612bebcf16ff7306c8a6f5bdb6d45662b8aa1ee058ecce8807ad87db719b\"}' > cargo/vendor/cranelift-module-0.116.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b8dee82f3f1f2c4cba9177f1cc5e350fe98764379bcd29340caa7b01f85076c7\"}' > cargo/vendor/cranelift-native-0.116.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0\"}' > cargo/vendor/displaydoc-0.2.5/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e\"}' > cargo/vendor/either-1.16.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3\"}' > cargo/vendor/encoding_rs-0.8.35/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\"}' > cargo/vendor/equivalent-1.0.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\"}' > cargo/vendor/errno-0.3.14/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649\"}' > cargo/vendor/fallible-iterator-0.3.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f\"}' > cargo/vendor/fastrand-2.4.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3\"}' > cargo/vendor/flatbuffers-25.12.19/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2\"}' > cargo/vendor/foldhash-0.1.5/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf\"}' > cargo/vendor/form_urlencoded-1.2.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555\"}' > cargo/vendor/getrandom-0.4.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f\"}' > cargo/vendor/gimli-0.31.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1\"}' > cargo/vendor/hashbrown-0.14.5/.cargo-checksum.json",
@@ -948,10 +1123,17 @@
             "echo '{\"files\": {}, \"package\": \"d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26\"}' > cargo/vendor/icu_locale-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29\"}' > cargo/vendor/icu_locale_core-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993\"}' > cargo/vendor/icu_locale_data-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4\"}' > cargo/vendor/icu_normalizer-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38\"}' > cargo/vendor/icu_normalizer_data-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de\"}' > cargo/vendor/icu_properties-2.2.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14\"}' > cargo/vendor/icu_properties_data-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421\"}' > cargo/vendor/icu_provider-2.2.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\"}' > cargo/vendor/id-arena-2.3.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de\"}' > cargo/vendor/idna-1.1.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714\"}' > cargo/vendor/idna_adapter-1.2.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff\"}' > cargo/vendor/indexmap-2.13.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695\"}' > cargo/vendor/is_terminal_polyfill-1.70.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186\"}' > cargo/vendor/itertools-0.13.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\"}' > cargo/vendor/itoa-1.0.18/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1\"}' > cargo/vendor/ixdtf-0.6.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\"}' > cargo/vendor/leb128fmt-0.1.0/.cargo-checksum.json",
@@ -966,17 +1148,24 @@
             "echo '{\"files\": {}, \"package\": \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\"}' > cargo/vendor/num-traits-0.2.19/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50\"}' > cargo/vendor/once_cell-1.21.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe\"}' > cargo/vendor/once_cell_polyfill-1.70.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220\"}' > cargo/vendor/percent-encoding-2.3.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564\"}' > cargo/vendor/potential_utf-0.1.5/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c\"}' > cargo/vendor/precomputed-hash-0.1.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b\"}' > cargo/vendor/prettyplease-0.2.37/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\"}' > cargo/vendor/proc-macro2-1.0.106/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8\"}' > cargo/vendor/psl-2.1.210/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac\"}' > cargo/vendor/psl-types-2.0.11/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924\"}' > cargo/vendor/quote-1.0.45/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf\"}' > cargo/vendor/r-efi-6.0.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a\"}' > cargo/vendor/regalloc2-0.11.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276\"}' > cargo/vendor/regex-1.12.3/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\"}' > cargo/vendor/regex-automata-0.4.14/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a\"}' > cargo/vendor/regex-syntax-0.8.10/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2\"}' > cargo/vendor/rustc-hash-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe\"}' > cargo/vendor/rustc-hash-2.1.2/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\"}' > cargo/vendor/rustc_version-0.4.1/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190\"}' > cargo/vendor/rustix-1.1.4/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b\"}' > cargo/vendor/seahash-4.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd\"}' > cargo/vendor/semver-1.0.28/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e\"}' > cargo/vendor/serde-1.0.228/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad\"}' > cargo/vendor/serde_core-1.0.228/.cargo-checksum.json",
@@ -990,6 +1179,8 @@
             "echo '{\"files\": {}, \"package\": \"728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2\"}' > cargo/vendor/synstructure-0.13.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca\"}' > cargo/vendor/target-lexicon-0.13.5/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\"}' > cargo/vendor/tempfile-3.27.0/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52\"}' > cargo/vendor/thiserror-1.0.69/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1\"}' > cargo/vendor/thiserror-impl-1.0.69/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d\"}' > cargo/vendor/tinystr-0.8.3/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863\"}' > cargo/vendor/toml-0.9.12+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\"}' > cargo/vendor/toml_datetime-0.7.5+spec-1.1.0/.cargo-checksum.json",
@@ -997,6 +1188,7 @@
             "echo '{\"files\": {}, \"package\": \"756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db\"}' > cargo/vendor/toml_writer-1.1.1+spec-1.1.0/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\"}' > cargo/vendor/unicode-ident-1.0.24/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\"}' > cargo/vendor/unicode-xid-0.2.6/.cargo-checksum.json",
+            "echo '{\"files\": {}, \"package\": \"ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed\"}' > cargo/vendor/url-2.5.8/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\"}' > cargo/vendor/utf8_iter-1.0.4/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\"}' > cargo/vendor/utf8parse-0.2.2/.cargo-checksum.json",
             "echo '{\"files\": {}, \"package\": \"9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5\"}' > cargo/vendor/wasip2-1.0.2+wasi-0.2.9/.cargo-checksum.json",

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1167,33 +1167,15 @@ void ConnectionFromClient::paste(u64 page_id, Utf16String text)
         page->page().focused_navigable().paste(text);
 }
 
-static ErrorOr<Vector<String>> parse_content_blocker_patterns(Core::AnonymousBuffer const& patterns_buffer)
-{
-    Vector<String> patterns;
-
-    for (auto line : StringView { patterns_buffer.bytes() }.split_view('\n', SplitBehavior::Nothing)) {
-        if (line.ends_with('\r'))
-            line = line.substring_view(0, line.length() - 1);
-        if (line.is_empty())
-            continue;
-
-        patterns.append(TRY(String::from_utf8(line)));
-    }
-
-    return patterns;
-}
-
 void ConnectionFromClient::set_content_blockers(u64 page_id, Core::AnonymousBuffer patterns_buffer)
 {
-    auto patterns_or_error = parse_content_blocker_patterns(patterns_buffer);
-    if (patterns_or_error.is_error()) {
-        dbgln("Failed to set content blockers: {}", patterns_or_error.error());
-        return;
-    }
-
     auto& blocker = Web::ContentBlocker::the();
     auto had_cosmetic_rules = blocker.has_cosmetic_rules();
-    blocker.set_patterns(patterns_or_error.value()).release_value_but_fixme_should_propagate_errors();
+    auto result = blocker.set_rules_from_bytes(patterns_buffer.bytes());
+    if (result.is_error()) {
+        dbgln("Failed to set content blockers: {}", result.error());
+        return;
+    }
 
     if (had_cosmetic_rules || blocker.has_cosmetic_rules()) {
         if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -296,7 +296,7 @@ static ErrorOr<void> load_content_blockers(StringView config_path)
             continue;
 
         auto pattern = TRY(String::from_utf8(line));
-        TRY(patterns.try_append(move(pattern)));
+        patterns.append(move(pattern));
     }
 
     auto& content_blocker = Web::ContentBlocker::the();

--- a/Tests/LibWeb/TestContentBlocker.cpp
+++ b/Tests/LibWeb/TestContentBlocker.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <LibTest/TestCase.h>
 #include <LibURL/Parser.h>
 #include <LibURL/URL.h>
@@ -11,10 +12,11 @@
 
 namespace Web {
 
-static ContentBlocker& make_blocker(Vector<String> patterns)
+static ContentBlocker& make_blocker(Vector<String> rules)
 {
     auto& blocker = ContentBlocker::the();
-    MUST(blocker.set_patterns(patterns));
+    MUST(blocker.set_patterns(rules));
+    blocker.set_filtering_enabled(true);
     return blocker;
 }
 
@@ -35,95 +37,71 @@ TEST_CASE(empty_pattern_list)
 
 TEST_CASE(basic_blocking)
 {
-    Vector<String> patterns = {
-        "ads."_string,
-        "?banner"_string,
-        "tracker"_string
+    Vector<String> rules = {
+        "||ads.example.com^"_string,
+        "/banner.js"_string,
     };
 
-    auto& blocker = make_blocker(move(patterns));
+    auto& blocker = make_blocker(move(rules));
+    auto source_url = url("https://example.com/"sv);
 
-    EXPECT(blocker.is_filtered(url("https://example.com/ads.js"sv)));
-    EXPECT(blocker.is_filtered(url("http://site.com/page.html?banner=true"sv)));
-    EXPECT(blocker.is_filtered(url("https://tracker.example.org/ping"sv)));
-    EXPECT(!blocker.is_filtered(url("https://ds.example.com/page.html"sv)));
+    EXPECT(blocker.is_filtered(url("https://ads.example.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
+    EXPECT(blocker.is_filtered(url("https://static.example.com/banner.js"sv), source_url, ContentBlocker::ResourceType::Script));
+    EXPECT(!blocker.is_filtered(url("https://example.com/page.html"sv), source_url, ContentBlocker::ResourceType::Document));
 }
 
 TEST_CASE(data_urls_exempt)
 {
-    Vector<String> patterns = {
+    Vector<String> rules = {
         { "data:"_string },
-        { "evil.com"_string }
+        { "||evil.com^"_string }
     };
 
-    auto& blocker = make_blocker(move(patterns));
+    auto& blocker = make_blocker(move(rules));
+    auto source_url = url("https://example.com/"sv);
 
     EXPECT(!blocker.is_filtered(url("data:text/plain,hello"sv)));
     EXPECT(!blocker.is_filtered(url("data:image/png;base64,abc123"sv)));
-    EXPECT(blocker.is_filtered(url("https://evil.com/script.js"sv)));
+    EXPECT(blocker.is_filtered(url("https://evil.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
+}
+
+TEST_CASE(invalid_filter_bytes_keep_previous_rules)
+{
+    Vector<String> rules = {
+        { "||ads.example.com^"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    auto source_url = url("https://example.com/"sv);
+
+    EXPECT(blocker.is_filtered(url("https://ads.example.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
+
+    Array<u8, 1> invalid_utf8 { 0xff };
+    auto result = blocker.set_rules_from_bytes(invalid_utf8.span());
+    EXPECT(result.is_error());
+
+    EXPECT(blocker.is_filtered(url("https://ads.example.com/script.js"sv), source_url, ContentBlocker::ResourceType::Script));
 }
 
 TEST_CASE(disable_filtering)
 {
-    Vector<String> patterns = {
-        { "example.com"_string },
+    Vector<String> rules = {
+        { "||example.com^"_string },
         { "##.ad"_string }
     };
 
-    auto& blocker = make_blocker(move(patterns));
+    auto& blocker = make_blocker(move(rules));
     blocker.set_filtering_enabled(false);
+    Vector<String> classes = { "ad"_string };
+    Vector<String> ids;
 
     EXPECT(!blocker.is_filtered(url("https://example.com"sv)));
     EXPECT(!blocker.is_filtered(url("http://example.com/ads"sv)));
-    EXPECT(blocker.cosmetic_style_sheet_for_url(url("https://example.com"sv)).is_empty());
+    EXPECT(blocker.cosmetic_style_sheet_for_url(url("https://example.com"sv), classes.span(), ids.span()).is_empty());
 
     blocker.set_filtering_enabled(true);
     EXPECT(blocker.is_filtered(url("https://example.com"sv)));
-    EXPECT(!blocker.cosmetic_style_sheet_for_url(url("https://example.com"sv)).is_empty());
-}
-
-TEST_CASE(substring_matches)
-{
-    Vector<String> patterns = {
-        { "ads"_string },
-        { "ad/"_string }
-    };
-
-    auto& blocker = make_blocker(move(patterns));
-
-    EXPECT(blocker.is_filtered(url("https://site.com/ads/banner.jpg"sv)));
-    EXPECT(blocker.is_filtered(url("http://marketing.com/ad/page"sv)));
-    EXPECT(!blocker.is_filtered(url("https://site.com/content/article.html"sv)));
-    EXPECT(!blocker.is_filtered(url("http://advancedtech.com/home"sv)));
-}
-
-TEST_CASE(file_scheme_can_be_filtered)
-{
-    Vector<String> patterns = {
-        { "secret"_string },
-        { ".txt"_string }
-    };
-
-    auto& blocker = make_blocker(move(patterns));
-
-    EXPECT(blocker.is_filtered(url("file:///home/user/secret.txt"sv)));
-    EXPECT(!blocker.is_filtered(url("file:///home/user/document.pdf"sv)));
-}
-
-TEST_CASE(query_parameters_and_fragments)
-{
-    Vector<String> patterns = {
-        { "#ad="_string },
-        { "?ad="_string },
-        { "#sponsored"_string }
-    };
-
-    auto& blocker = make_blocker(move(patterns));
-
-    EXPECT(blocker.is_filtered(url("https://site.com/page?ad=123"sv)));
-    EXPECT(blocker.is_filtered(url("https://site.com/page#ad=456"sv)));
-    EXPECT(blocker.is_filtered(url("https://site.com/page?ref=home&ad=1#sponsored"sv)));
-    EXPECT(!blocker.is_filtered(url("https://site.com/page?ref=home"sv)));
+    EXPECT(!blocker.cosmetic_style_sheet_for_url(url("https://example.com"sv), classes.span(), ids.span()).is_empty());
 }
 
 TEST_CASE(fetch_metadata_maps_to_resource_type)
@@ -145,60 +123,174 @@ TEST_CASE(fetch_metadata_maps_to_resource_type)
     EXPECT(resource_type({}, {}, Request::Mode::WebSocket) == ResourceType::WebSocket);
 }
 
-TEST_CASE(blob_source_urls_are_normalized_for_matching)
+TEST_CASE(resource_type_options)
 {
-    auto normalized = ContentBlocker::source_url_for_matching(url("blob:https://example.com/object-id"sv));
-    EXPECT_EQ(normalized.to_string(), "https://example.com/object-id"sv);
+    using Request = Fetch::Infrastructure::Request;
 
-    auto non_blob = ContentBlocker::source_url_for_matching(url("https://example.com/page"sv));
-    EXPECT_EQ(non_blob.to_string(), "https://example.com/page"sv);
-}
-
-TEST_CASE(contextual_filtering_uses_existing_matcher)
-{
-    Vector<String> patterns = {
-        { "blocked.js"_string }
+    Vector<String> rules = {
+        { "||example.com/ad^$image"_string },
+        { "||example.com/font^$font"_string },
+        { "||example.com/document^$document"_string },
+        { "||example.com/fetch^$xmlhttprequest"_string },
     };
 
-    auto& blocker = make_blocker(move(patterns));
+    auto& blocker = make_blocker(move(rules));
+    auto source_url = url("https://example.com/"sv);
 
+    EXPECT(blocker.is_filtered(url("https://example.com/ad"sv), source_url, ContentBlocker::ResourceType::Image));
+    EXPECT(!blocker.is_filtered(url("https://example.com/ad"sv), source_url, ContentBlocker::ResourceType::Script));
     EXPECT(blocker.is_filtered(
-        url("https://tracker.example/blocked.js"sv),
-        url("https://example.com/page"sv),
-        Fetch::Infrastructure::Request::Destination::Script,
-        Fetch::Infrastructure::Request::InitiatorType::CSS,
-        Fetch::Infrastructure::Request::Mode::NoCORS));
+        url("https://example.com/ad"sv),
+        source_url,
+        Request::Destination::Image,
+        Request::InitiatorType::CSS,
+        Request::Mode::NoCORS));
+    EXPECT(blocker.is_filtered(
+        url("https://example.com/font"sv),
+        source_url,
+        Request::Destination::Font,
+        Request::InitiatorType::CSS,
+        Request::Mode::NoCORS));
+    EXPECT(blocker.is_filtered(
+        url("https://example.com/document"sv),
+        source_url,
+        Request::Destination::Document,
+        Optional<Request::InitiatorType> {},
+        Request::Mode::Navigate));
+    EXPECT(blocker.is_filtered(
+        url("https://example.com/fetch"sv),
+        source_url,
+        Optional<Request::Destination> {},
+        Request::InitiatorType::Fetch,
+        Request::Mode::CORS));
 }
 
-TEST_CASE(cosmetic_rules_generate_user_css)
+TEST_CASE(file_scheme_fallback)
 {
-    Vector<String> patterns = {
-        { "blocked.js"_string },
-        { "##.ad"_string },
-        { "example.com##.sponsored"_string },
-        { "other.example##.other"_string }
+    Vector<String> rules = {
+        { "secret"_string },
     };
 
-    auto& blocker = make_blocker(move(patterns));
+    auto& blocker = make_blocker(move(rules));
 
-    EXPECT(blocker.has_cosmetic_rules());
-    EXPECT(blocker.is_filtered(url("https://tracker.example/blocked.js"sv)));
-    EXPECT(!blocker.is_filtered(url("https://tracker.example/##.ad"sv)));
-
-    auto style_sheet = blocker.cosmetic_style_sheet_for_url(url("https://www.example.com/page"sv));
-    EXPECT(style_sheet.contains(".ad { display: none !important; }"sv));
-    EXPECT(style_sheet.contains(".sponsored { display: none !important; }"sv));
-    EXPECT(!style_sheet.contains(".other { display: none !important; }"sv));
+    EXPECT(blocker.is_filtered(url("file:///home/user/secret.txt"sv)));
+    EXPECT(!blocker.is_filtered(url("file:///home/user/public.txt"sv)));
 }
 
-TEST_CASE(clearing_patterns_clears_cosmetic_rules)
+TEST_CASE(third_party_option)
 {
-    auto& blocker = make_blocker({ "##.ad"_string });
-    EXPECT(blocker.has_cosmetic_rules());
+    Vector<String> rules = {
+        { "||tracker.example^$third-party"_string },
+    };
 
-    MUST(blocker.set_patterns({}));
-    EXPECT(!blocker.has_cosmetic_rules());
-    EXPECT(blocker.cosmetic_style_sheet_for_url(url("https://example.com/"sv)).is_empty());
+    auto& blocker = make_blocker(move(rules));
+
+    EXPECT(blocker.is_filtered(url("https://tracker.example/pixel.gif"sv), url("https://site.example/"sv), ContentBlocker::ResourceType::Image));
+    EXPECT(!blocker.is_filtered(url("https://tracker.example/pixel.gif"sv), url("https://www.tracker.example/"sv), ContentBlocker::ResourceType::Image));
+}
+
+TEST_CASE(blob_source_url_uses_embedded_url)
+{
+    Vector<String> rules = {
+        { "||tracker.example/third-party.gif$third-party"_string },
+        { "||tracker.example/first-party.gif$first-party"_string },
+        { "||ads.example/domain.js$domain=www.tracker.example"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    auto same_site_blob_source = url("blob:https://www.tracker.example/4dd3d7ea-8bd7-4fe0-a121-79c18e2be4b2"sv);
+    auto cross_site_blob_source = url("blob:https://site.example/4dd3d7ea-8bd7-4fe0-a121-79c18e2be4b2"sv);
+
+    EXPECT(!blocker.is_filtered(url("https://tracker.example/third-party.gif"sv), same_site_blob_source, ContentBlocker::ResourceType::Image));
+    EXPECT(blocker.is_filtered(url("https://tracker.example/first-party.gif"sv), same_site_blob_source, ContentBlocker::ResourceType::Image));
+    EXPECT(blocker.is_filtered(url("https://tracker.example/third-party.gif"sv), cross_site_blob_source, ContentBlocker::ResourceType::Image));
+    EXPECT(!blocker.is_filtered(url("https://tracker.example/first-party.gif"sv), cross_site_blob_source, ContentBlocker::ResourceType::Image));
+    EXPECT(blocker.is_filtered(url("https://ads.example/domain.js"sv), same_site_blob_source, ContentBlocker::ResourceType::Script));
+    EXPECT(!blocker.is_filtered(url("https://ads.example/domain.js"sv), cross_site_blob_source, ContentBlocker::ResourceType::Script));
+}
+
+TEST_CASE(document_navigation_is_first_party_to_itself)
+{
+    Vector<String> rules = {
+        { "||localhost^$third-party,document"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    auto target_url = url("http://localhost:1234/content-blocker-target"sv);
+
+    EXPECT(blocker.is_filtered(target_url, url("https://source.example/"sv), ContentBlocker::ResourceType::Document));
+    EXPECT(!blocker.is_filtered(target_url, target_url, ContentBlocker::ResourceType::Document));
+}
+
+TEST_CASE(exception_rules)
+{
+    Vector<String> rules = {
+        { "||ads.example.com^"_string },
+        { "@@||ads.example.com/allowed.js"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    auto source_url = url("https://example.com/"sv);
+
+    EXPECT(blocker.is_filtered(url("https://ads.example.com/blocked.js"sv), source_url, ContentBlocker::ResourceType::Script));
+    EXPECT(!blocker.is_filtered(url("https://ads.example.com/allowed.js"sv), source_url, ContentBlocker::ResourceType::Script));
+}
+
+TEST_CASE(cosmetic_style_sheet)
+{
+    Vector<String> rules = {
+        { "example.com##.ad-banner"_string },
+        { "example.com###sponsor"_string },
+        { "example.com##.styled-sponsor:style(visibility: hidden)"_string },
+        { "##.generic-ad"_string },
+        { "###generic-sponsor"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    Vector<String> classes = { "generic-ad"_string };
+    Vector<String> ids = { "generic-sponsor"_string };
+
+    auto style_sheet = blocker.cosmetic_style_sheet_for_url(url("https://example.com/"sv), classes, ids);
+
+    EXPECT(style_sheet.contains(".ad-banner { display: none !important; }"sv));
+    EXPECT(style_sheet.contains("#sponsor { display: none !important; }"sv));
+    EXPECT(style_sheet.contains(".styled-sponsor { visibility: hidden; }"sv));
+    EXPECT(style_sheet.contains(".generic-ad { display: none !important; }"sv));
+    EXPECT(style_sheet.contains("#generic-sponsor { display: none !important; }"sv));
+}
+
+TEST_CASE(generic_cosmetic_selector_lists_match_later_selectors)
+{
+    Vector<String> rules = {
+        { "##.first-ad-class, .second-ad-class"_string },
+        { "##.first-ad-id, #second-ad-id"_string },
+        { "##.class-keyed-arm, [data-ad]"_string },
+        { "##.class-keyed-arm, div.sponsor"_string },
+    };
+
+    auto& blocker = make_blocker(move(rules));
+    Vector<String> classes = { "second-ad-class"_string };
+    Vector<String> ids = { "second-ad-id"_string };
+    Vector<String> no_classes;
+    Vector<String> no_ids;
+
+    auto style_sheet = blocker.cosmetic_style_sheet_for_url(url("https://example.com/"sv), classes, ids);
+    auto style_sheet_without_class_or_id_hints = blocker.cosmetic_style_sheet_for_url(url("https://example.com/"sv), no_classes, no_ids);
+
+    EXPECT(style_sheet.contains(".first-ad-class, .second-ad-class { display: none !important; }"sv));
+    EXPECT(style_sheet.contains(".first-ad-id, #second-ad-id { display: none !important; }"sv));
+    EXPECT(style_sheet_without_class_or_id_hints.contains(".class-keyed-arm, [data-ad] { display: none !important; }"sv));
+    EXPECT(style_sheet_without_class_or_id_hints.contains(".class-keyed-arm, div.sponsor { display: none !important; }"sv));
+}
+
+TEST_CASE(cosmetic_rule_detection)
+{
+    auto& blocker_without_cosmetics = make_blocker({ "||example.com/ad^"_string });
+    EXPECT(!blocker_without_cosmetics.has_cosmetic_rules());
+    EXPECT(blocker_without_cosmetics.cosmetic_style_sheet_for_url(url("https://example.com/"sv), {}, {}).is_empty());
+
+    auto& blocker_with_cosmetics = make_blocker({ "example.com##.ad-banner"_string });
+    EXPECT(blocker_with_cosmetics.has_cosmetic_rules());
 }
 
 }

--- a/Tests/LibWeb/Text/expected/content-blocker-irrelevant-class-id-change-skips-refresh.txt
+++ b/Tests/LibWeb/Text/expected/content-blocker-irrelevant-class-id-change-skips-refresh.txt
@@ -1,0 +1,7 @@
+block
+block
+rgb(1, 2, 3)
+rgb(4, 5, 6)
+PASS: irrelevant class/id changes skipped content blocker refresh
+none
+none

--- a/Tests/LibWeb/Text/expected/content-blocker-shadow-cache-survives-class-refresh.txt
+++ b/Tests/LibWeb/Text/expected/content-blocker-shadow-cache-survives-class-refresh.txt
@@ -2,4 +2,4 @@ rgb(0, 0, 0)
 inline
 rgb(1, 2, 3)
 none
-hasInvalidationRuleCacheBuilds: 0
+hasInvalidationRuleCacheBuilds: 1

--- a/Tests/LibWeb/Text/input/content-blocker-irrelevant-class-id-change-skips-refresh.html
+++ b/Tests/LibWeb/Text/input/content-blocker-irrelevant-class-id-change-skips-refresh.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="./include.js"></script>
+<style>
+    .irrelevant {
+        color: rgb(1, 2, 3);
+    }
+
+    #unrelated {
+        color: rgb(4, 5, 6);
+    }
+</style>
+<body></body>
+<script>
+    test(() => {
+        internals.setContentBlockers("##.ad\n###sponsor");
+
+        const classTarget = document.createElement("div");
+        document.body.appendChild(classTarget);
+
+        const idTarget = document.createElement("div");
+        document.body.appendChild(idTarget);
+
+        println(getComputedStyle(classTarget).display);
+        println(getComputedStyle(idTarget).display);
+
+        internals.resetStyleInvalidationCounters();
+
+        classTarget.className = "irrelevant";
+        idTarget.id = "unrelated";
+
+        println(getComputedStyle(classTarget).color);
+        println(getComputedStyle(idTarget).color);
+
+        const counters = internals.getStyleInvalidationCounters();
+        if (counters.fullStyleInvalidations == 0)
+            println("PASS: irrelevant class/id changes skipped content blocker refresh");
+        else
+            println(`FAIL: irrelevant class/id changes caused ${counters.fullStyleInvalidations} full invalidations`);
+
+        classTarget.className = "ad";
+        idTarget.id = "sponsor";
+
+        println(getComputedStyle(classTarget).display);
+        println(getComputedStyle(idTarget).display);
+
+        internals.setContentBlockers("");
+    });
+</script>

--- a/UI/Android/src/main/cpp/WebContentService.cpp
+++ b/UI/Android/src/main/cpp/WebContentService.cpp
@@ -120,7 +120,7 @@ static ErrorOr<void> load_content_blockers()
             continue;
 
         auto pattern = TRY(String::from_utf8(line));
-        TRY(patterns.try_append(move(pattern)));
+        patterns.append(move(pattern));
     }
 
     auto& content_blocker = Web::ContentBlocker::the();


### PR DESCRIPTION
Integrate https://github.com/brave/adblock-rust as the backing engine for LibWeb content blocking. The new Rust crate under LibWeb/ContentBlocker exposes FFI for rule parsing, network request matching, and cosmetic CSS generation, while keeping the existing tokenizer Rust bindings separate.

This replaces the local substring matcher, preserves filtering toggles and invalid-list behavior, maps LibWeb resource metadata to adblock request types, and handles source URLs for blob, file, document, and third-party matching.

Cosmetic blocking now comes from adblock-rust as well, including generic class and id selectors collected from shadow-including descendants. Dynamic class and id mutations refresh blocker CSS only when the new tokens can unlock generic cosmetic selectors, avoiding broad user-style invalidation for irrelevant DOM changes.

The branch adds coverage for network rules, exceptions, third-party matching, cosmetic CSS generation, selector-list cosmetics, and class/id mutation refresh behavior.