### PR TITLE
LibWeb/SVG: Ignore degenerate active viewBox ratios

### DIFF
--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -306,7 +306,7 @@ CSS::SizeWithAspectRatio SVGSVGElement::negotiate_natural_metrics(SVG::SVGSVGEle
             auto view_box = active_view_element->view_box().value();
 
             // 2. return viewbox.width / viewbox.height
-            if (view_box.width != 0 || view_box.height != 0)
+            if (view_box.width != 0 && view_box.height != 0)
                 return view_box.width / view_box.height;
 
             return {};


### PR DESCRIPTION
## Summary

Do not use an active SVG View's `viewBox` as an intrinsic aspect ratio when either the viewBox width or height is zero.

SVG intrinsic sizing says that when an SVG View is active, the intrinsic aspect ratio is computed from `viewbox.width / viewbox.height`:
https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS

A zero `viewBox` width or height disables rendering of the element, so it should not produce a usable intrinsic aspect ratio:
https://www.w3.org/TR/SVG2/coords.html#ViewBoxAttribute

The normal `<svg viewBox>` path already requires both dimensions to be non-zero. This makes the active SVG View path match that behavior.

## Repro

```html
<!doctype html>
<style>
svg {
    display: block;
    width: 60px;
    height: auto;
}
</style>
<svg id="target">
    <view id="normal" viewBox="0 0 10 5"></view>
    <view id="bad-height" viewBox="0 0 10 0"></view>
    <view id="bad-width" viewBox="0 0 0 10"></view>
</svg>
<p id="result"></p>
<script>
window.addEventListener("load", () => {
    result.textContent = `${location.hash}: ${getComputedStyle(target).height}`;
});
</script>