### PR TITLE
Recover after Compositor process crashes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -451,6 +451,21 @@ void HTMLCanvasElement::present()
             // Do nothing.
         });
 
+    update_compositor_surface();
+}
+
+void HTMLCanvasElement::republish_compositor_surface()
+{
+    if (m_canvas_content_dirty) {
+        present();
+        return;
+    }
+
+    update_compositor_surface();
+}
+
+void HTMLCanvasElement::update_compositor_surface()
+{
     if (auto surface = this->surface()) {
         surface->flush();
         if (auto navigable = document().navigable(); navigable && navigable->has_compositor_context())

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -48,6 +48,7 @@ public:
     RefPtr<Gfx::Bitmap> get_bitmap_from_surface();
 
     void present();
+    void republish_compositor_surface();
     void set_canvas_content_dirty();
 
     RefPtr<Gfx::PaintingSurface> surface() const;
@@ -75,6 +76,7 @@ private:
     void reset_context_to_default_state();
     void notify_context_about_canvas_size_change();
     void clear_compositor_surface();
+    void update_compositor_surface();
 
     Variant<GC::Ref<HTML::CanvasRenderingContext2D>, GC::Ref<WebGL::WebGLRenderingContext>, GC::Ref<WebGL::WebGL2RenderingContext>, Empty> m_context;
     Optional<Painting::CompositorSurfaceId> m_compositor_surface_id;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -3409,6 +3409,33 @@ void Navigable::destroy_compositor_context()
     m_compositor_context.clear();
 }
 
+void Navigable::repaint_after_compositor_process_reconnect()
+{
+    resolve_all_pending_async_scroll_operations();
+
+    if (has_compositor_context()) {
+        if (auto parent = this->parent();
+            parent && parent->has_compositor_context() && has_compositor_surface_id()) {
+            compositor_context().set_presentation_mode(Compositor::PublishToCompositorSurface {
+                .target_context_id = parent->compositor_context().id(),
+                .surface_id = *m_compositor_surface_id,
+            });
+        }
+        compositor_context().viewport_size_updated(
+            page().css_to_device_rect(viewport_rect()).size().to_type<int>(),
+            is_top_level_traversable(),
+            Compositor::WindowResizingInProgress::No);
+
+        m_needs_repaint = true;
+        m_needs_to_record_display_list = true;
+        m_compositor_display_list_paint_config.clear();
+        m_compositor_display_list_resources = {};
+    }
+
+    for (auto const& child_navigable : child_navigables())
+        child_navigable->repaint_after_compositor_process_reconnect();
+}
+
 void Navigable::set_should_show_line_box_borders(bool value)
 {
     m_should_show_line_box_borders = value;

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -239,6 +239,7 @@ public:
     bool needs_repaint() const { return m_needs_repaint; }
     void set_needs_repaint() { m_needs_repaint = true; }
     void set_needs_to_record_display_list() { m_needs_to_record_display_list = true; }
+    void repaint_after_compositor_process_reconnect();
 
     [[nodiscard]] bool has_inclusive_ancestor_with_visibility_hidden() const;
 

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -660,6 +660,13 @@ void Page::present_all_canvas_element_surfaces()
     });
 }
 
+void Page::republish_all_canvas_element_surfaces()
+{
+    for_each_canvas_element([](auto& canvas_element) {
+        canvas_element.republish_compositor_surface();
+    });
+}
+
 void Page::did_request_media_context_menu(UniqueNodeID media_id, CSSPixelPoint position, ByteString const& target, unsigned modifiers, MediaContextMenu const& menu)
 {
     m_media_context_menu_element_id = media_id;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -222,6 +222,7 @@ public:
     void unregister_canvas_element(Badge<HTML::HTMLCanvasElement>, UniqueNodeID canvas_id);
 
     void present_all_canvas_element_surfaces();
+    void republish_all_canvas_element_surfaces();
 
     struct MediaContextMenu {
         URL::URL media_url;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Checked.h>
 #include <AK/Debug.h>
+#include <AK/ScopeGuard.h>
 #include <AK/Time.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ArgsParser.h>
@@ -493,24 +494,29 @@ static ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Option
     return client;
 }
 
-static bool should_skip_compositor_process_ipc(RefPtr<CompositorClient> const& compositor_client)
+static bool can_send_compositor_process_ipc(RefPtr<CompositorClient> const& compositor_client)
 {
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::No)
-        return true;
-    if (!compositor_client && Core::EventLoop::current().was_exit_requested())
-        return true;
-    return false;
+    if (!Application::the().should_use_compositor_process())
+        return false;
+    if (!compositor_client)
+        return false;
+    return compositor_client->is_open();
 }
 
 ErrorOr<void> Application::connect_web_content_to_compositor(WebContentClient& web_content_client)
 {
-    if (m_browser_options.enable_compositor_process == EnableCompositorProcess::No)
+    if (!should_use_compositor_process())
         return {};
     if (web_content_client.compositor_connection_id({}).has_value())
         return {};
 
-    VERIFY(m_compositor_client);
-    auto response = m_compositor_client->connect_web_content();
+    if (!m_compositor_client)
+        return Error::from_string_literal("Compositor process is not available");
+
+    auto response_or_error = m_compositor_client->try_connect_web_content();
+    if (response_or_error.is_error())
+        return Error::from_string_literal("Compositor process disconnected while connecting WebContent");
+    auto response = response_or_error.release_value();
 
     web_content_client.set_compositor_connection_id({}, response.web_content_connection_id());
     web_content_client.async_connect_to_compositor_process(response.take_handle());
@@ -519,7 +525,7 @@ ErrorOr<void> Application::connect_web_content_to_compositor(WebContentClient& w
 
 void Application::register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
 {
-    if (should_skip_compositor_process_ipc(m_compositor_client))
+    if (!can_send_compositor_process_ipc(m_compositor_client))
         return;
     VERIFY(m_compositor_client);
 
@@ -533,9 +539,30 @@ void Application::register_compositor_context(WebContentClient& web_content_clie
     m_compositor_client->create_context(context_id, page_id, page_presentation_registration, *web_content_connection_id);
 }
 
+ErrorOr<void> Application::try_register_compositor_context(WebContentClient& web_content_client, Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+{
+    if (!should_use_compositor_process())
+        return {};
+    if (!m_compositor_client)
+        return Error::from_string_literal("Compositor process is not available");
+
+    auto web_content_connection_id = web_content_client.compositor_connection_id({});
+    if (!web_content_connection_id.has_value()) {
+        TRY(connect_web_content_to_compositor(web_content_client));
+        web_content_connection_id = web_content_client.compositor_connection_id({});
+    }
+    VERIFY(web_content_connection_id.has_value());
+
+    auto result = m_compositor_client->try_create_context(context_id, page_id, page_presentation_registration, *web_content_connection_id);
+    if (result.is_error())
+        return Error::from_string_literal("Compositor process disconnected while creating context");
+
+    return {};
+}
+
 void Application::update_compositor_viewport(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
-    if (should_skip_compositor_process_ipc(m_compositor_client))
+    if (!can_send_compositor_process_ipc(m_compositor_client))
         return;
     VERIFY(m_compositor_client);
 
@@ -544,28 +571,39 @@ void Application::update_compositor_viewport(Web::Compositor::CompositorContextI
 
 bool Application::send_async_scroll_to_compositor(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)
 {
-    VERIFY(m_compositor_client);
-    return m_compositor_client->async_scroll_by(context_id, position, delta_in_device_pixels);
+    if (!can_send_compositor_process_ipc(m_compositor_client))
+        return false;
+
+    auto result = m_compositor_client->try_async_scroll_by(context_id, position, delta_in_device_pixels);
+    if (result.is_error())
+        return false;
+    return result.release_value();
 }
 
 bool Application::handle_mouse_event_in_compositor(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
 {
-    VERIFY(m_compositor_client);
-    return m_compositor_client->handle_mouse_event(context_id, event.clone_without_browser_data());
+    if (!can_send_compositor_process_ipc(m_compositor_client))
+        return false;
+
+    auto result = m_compositor_client->try_handle_mouse_event(context_id, event.clone_without_browser_data());
+    if (result.is_error())
+        return false;
+    return result.release_value();
 }
 
-void Application::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
+bool Application::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
 {
-    if (should_skip_compositor_process_ipc(m_compositor_client))
-        return;
+    if (!can_send_compositor_process_ipc(m_compositor_client))
+        return false;
     VERIFY(m_compositor_client);
 
     m_compositor_client->async_dispatch_mouse_event_to_web_content(context_id, event.clone_without_browser_data());
+    return true;
 }
 
 void Application::notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)
 {
-    if (should_skip_compositor_process_ipc(m_compositor_client))
+    if (!can_send_compositor_process_ipc(m_compositor_client))
         return;
     VERIFY(m_compositor_client);
 
@@ -669,7 +707,7 @@ ErrorOr<void> Application::launch_services()
 
     TRY(launch_request_server());
     TRY(launch_image_decoder_server());
-    if (m_browser_options.enable_compositor_process == EnableCompositorProcess::Yes)
+    if (should_use_compositor_process())
         TRY(launch_compositor_process());
 
     if (m_browser_options.devtools_port.has_value())
@@ -680,19 +718,95 @@ ErrorOr<void> Application::launch_services()
 
 ErrorOr<void> Application::launch_compositor_process()
 {
+    if (!should_use_compositor_process())
+        return {};
+
     VERIFY(!m_compositor_client);
     m_compositor_client = TRY(WebView::launch_compositor_process());
     m_compositor_client->on_death = [this]() {
-        m_compositor_client = nullptr;
-
-        if (Core::EventLoop::current().was_exit_requested())
-            return;
-
-        dbgln("Compositor process died");
-        VERIFY_NOT_REACHED();
+        handle_compositor_process_death();
     };
 
     return {};
+}
+
+bool Application::should_use_compositor_process() const
+{
+    return m_browser_options.enable_compositor_process == EnableCompositorProcess::Yes;
+}
+
+void Application::handle_compositor_process_death()
+{
+    m_compositor_client = nullptr;
+
+    if (Core::EventLoop::current().was_exit_requested())
+        return;
+    switch (m_compositor_recovery_state) {
+    case CompositorRecoveryState::Idle:
+        break;
+    case CompositorRecoveryState::Queued:
+        return;
+    case CompositorRecoveryState::Recovering:
+        warnln("Compositor process died while recovering, crashing Browser");
+        VERIFY_NOT_REACHED();
+    }
+
+    m_compositor_recovery_state = CompositorRecoveryState::Queued;
+    Core::deferred_invoke([this] {
+        VERIFY(m_compositor_recovery_state == CompositorRecoveryState::Queued);
+        m_compositor_recovery_state = CompositorRecoveryState::Idle;
+        recover_compositor_process();
+    });
+}
+
+void Application::recover_compositor_process()
+{
+    if (!should_use_compositor_process() || Core::EventLoop::current().was_exit_requested())
+        return;
+
+    constexpr size_t max_compositor_restart_count = 3;
+    if (m_compositor_restart_count >= max_compositor_restart_count) {
+        warnln("Compositor process crashed repeatedly, crashing Browser");
+        VERIFY_NOT_REACHED();
+    }
+
+    ++m_compositor_restart_count;
+    dbgln("Compositor process died, restarting ({}/{})", m_compositor_restart_count, max_compositor_restart_count);
+
+    VERIFY(m_compositor_recovery_state == CompositorRecoveryState::Idle);
+    m_compositor_recovery_state = CompositorRecoveryState::Recovering;
+    ScopeGuard clear_recovery_flag = [this] {
+        m_compositor_recovery_state = CompositorRecoveryState::Idle;
+    };
+
+    if (auto result = launch_compositor_process(); result.is_error()) {
+        warnln("Unable to restart Compositor process: {}", result.error());
+        VERIFY_NOT_REACHED();
+    }
+
+    Vector<NonnullRefPtr<WebContentClient>> clients;
+    WebContentClient::for_each_client([&](WebContentClient& client) {
+        if (client.is_open())
+            clients.append(NonnullRefPtr { client });
+        return IterationDecision::Continue;
+    });
+
+    for (auto& client : clients) {
+        if (auto result = client->reconnect_to_compositor_process({}); result.is_error()) {
+            warnln("Unable to reconnect WebContent process {} to Compositor: {}", client->pid(), result.error());
+            VERIFY_NOT_REACHED();
+        }
+    }
+    for (auto& client : clients) {
+        if (auto result = client->recreate_compositor_contexts({}); result.is_error()) {
+            warnln("Unable to recreate Compositor contexts for WebContent process {}: {}", client->pid(), result.error());
+            VERIFY_NOT_REACHED();
+        }
+    }
+    for (auto& client : clients)
+        client->update_compositor_viewports_after_reconnect({});
+    for (auto& client : clients)
+        client->notify_compositor_process_reconnected({});
 }
 
 ErrorOr<void> Application::launch_request_server()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -93,10 +93,11 @@ public:
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
     ErrorOr<void> connect_web_content_to_compositor(WebContentClient&);
     void register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
+    ErrorOr<void> try_register_compositor_context(WebContentClient&, Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
     void update_compositor_viewport(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress = Web::Compositor::WindowResizingInProgress::No);
     bool send_async_scroll_to_compositor(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
     bool handle_mouse_event_in_compositor(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
-    void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
+    bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     void notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
 
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
@@ -106,6 +107,7 @@ public:
 
     Main::Arguments const& command_line_arguments() const { return m_arguments; }
     virtual void open_url_in_new_window(URL::URL const& url);
+    bool should_use_compositor_process() const;
 
     void add_child_process(Process&&);
 
@@ -224,6 +226,8 @@ private:
     ErrorOr<void> launch_services();
     void launch_spare_web_content_process();
     ErrorOr<void> launch_compositor_process();
+    void handle_compositor_process_death();
+    void recover_compositor_process();
     ErrorOr<void> launch_request_server();
     ErrorOr<void> launch_image_decoder_server();
     ErrorOr<void> launch_devtools_server();
@@ -295,6 +299,13 @@ private:
     RefPtr<Requests::RequestClient> m_request_server_client;
     RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
     RefPtr<CompositorClient> m_compositor_client;
+    size_t m_compositor_restart_count { 0 };
+    enum class CompositorRecoveryState {
+        Idle,
+        Queued,
+        Recovering,
+    };
+    CompositorRecoveryState m_compositor_recovery_state { CompositorRecoveryState::Idle };
 
     RefPtr<WebContentClient> m_spare_web_content_process;
     bool m_has_queued_task_to_launch_spare_web_content_process { false };

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -121,7 +121,7 @@ static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_proc
         arguments.append("--disable-scrollbar-painting"sv);
     if (web_content_options.enable_async_scrolling == EnableAsyncScrolling::No)
         arguments.append("--disable-async-scrolling"sv);
-    if (browser_options.enable_compositor_process == EnableCompositorProcess::Yes)
+    if (WebView::Application::the().should_use_compositor_process())
         arguments.append("--enable-compositor-process"sv);
     if (web_content_options.file_scheme_urls_have_tuple_origins == FileSchemeUrlsHaveTupleOrigins::Yes)
         arguments.append("--tuple-file-origins"sv);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -720,7 +720,7 @@ void ViewImplementation::apply_zoom_for_current_host()
 void ViewImplementation::handle_resize()
 {
     client().async_set_viewport(page_id(), viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes)
+    if (Application::the().should_use_compositor_process())
         Application::the().update_compositor_viewport(client().compositor_context_id_for_page(page_id()), viewport_size().to_type<int>());
 }
 
@@ -741,7 +741,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio, m_is_fullscreen);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+    if (Application::the().should_use_compositor_process()) {
         auto compositor_context_id = client().compositor_context_id_for_page(m_client_state.page_index);
         Application::the().update_compositor_viewport(compositor_context_id, viewport_size().to_type<int>());
     }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -101,7 +101,7 @@ WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, View
 {
     s_clients.set(this);
     m_views.set(0, view);
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::No)
+    if (!Application::the().should_use_compositor_process())
         initialize_compositor_connection(*this);
 }
 
@@ -109,7 +109,7 @@ WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
 {
     s_clients.set(this);
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::No)
+    if (!Application::the().should_use_compositor_process())
         initialize_compositor_connection(*this);
 }
 
@@ -143,9 +143,7 @@ Web::Compositor::CompositorContextId WebContentClient::compositor_context_id_for
 
     auto context_id = Web::Compositor::allocate_compositor_context_id();
     VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
-    m_compositor_context_ids.set(context_id);
-    m_page_compositor_context_ids.set(page_id, context_id);
-    m_page_ids_for_compositor_context_ids.set(context_id, page_id);
+    remember_compositor_context(context_id, page_id, Web::Compositor::PagePresentationRegistration::Yes);
     Application::the().register_compositor_context(*this, context_id, page_id, Web::Compositor::PagePresentationRegistration::Yes);
     return context_id;
 }
@@ -164,7 +162,7 @@ Messages::WebContentClient::AllocateCompositorContextIdResponse WebContentClient
 
     auto context_id = Web::Compositor::allocate_compositor_context_id();
     VERIFY(!Web::Compositor::is_page_presenting_compositor_context_id(context_id));
-    m_compositor_context_ids.set(context_id);
+    remember_compositor_context(context_id, {}, page_presentation_registration);
     Application::the().register_compositor_context(*this, context_id, {}, page_presentation_registration);
     return context_id;
 }
@@ -176,11 +174,24 @@ void WebContentClient::did_destroy_compositor_context(Web::Compositor::Composito
 
 bool WebContentClient::forget_compositor_context(Web::Compositor::CompositorContextId context_id)
 {
-    if (!m_compositor_context_ids.remove(context_id))
+    if (!m_compositor_contexts.remove(context_id))
         return false;
     if (auto page_id = m_page_ids_for_compositor_context_ids.take(context_id); page_id.has_value())
         m_page_compositor_context_ids.remove(*page_id);
     return true;
+}
+
+void WebContentClient::remember_compositor_context(Web::Compositor::CompositorContextId context_id, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration page_presentation_registration)
+{
+    m_compositor_contexts.set(context_id, CompositorContextRegistration {
+                                              .page_id = page_id,
+                                              .page_presentation_registration = page_presentation_registration,
+                                          });
+
+    if (page_id.has_value()) {
+        m_page_compositor_context_ids.set(*page_id, context_id);
+        m_page_ids_for_compositor_context_ids.set(context_id, *page_id);
+    }
 }
 
 void WebContentClient::assign_view(Badge<Application>, ViewImplementation& view)
@@ -218,9 +229,51 @@ void WebContentClient::web_ui_disconnected(Badge<WebUI>)
 
 void WebContentClient::destroy_all_compositor_contexts()
 {
-    m_compositor_context_ids.clear();
+    m_compositor_contexts.clear();
     m_page_compositor_context_ids.clear();
     m_page_ids_for_compositor_context_ids.clear();
+}
+
+ErrorOr<void> WebContentClient::reconnect_to_compositor_process(Badge<Application>)
+{
+    if (!Application::the().should_use_compositor_process() || !is_open())
+        return {};
+
+    m_compositor_connection_id.clear();
+    TRY(Application::the().connect_web_content_to_compositor(*this));
+    return {};
+}
+
+ErrorOr<void> WebContentClient::recreate_compositor_contexts(Badge<Application>)
+{
+    if (!Application::the().should_use_compositor_process() || !is_open())
+        return {};
+
+    for (auto const& [context_id, registration] : m_compositor_contexts)
+        TRY(Application::the().try_register_compositor_context(*this, context_id, registration.page_id, registration.page_presentation_registration));
+
+    return {};
+}
+
+void WebContentClient::update_compositor_viewports_after_reconnect(Badge<Application>)
+{
+    if (!Application::the().should_use_compositor_process() || !is_open())
+        return;
+
+    for (auto const& [page_id, view] : m_views) {
+        auto context_id = m_page_compositor_context_ids.get(page_id);
+        if (!context_id.has_value())
+            continue;
+        Application::the().update_compositor_viewport(*context_id, view->viewport_size().to_type<int>());
+    }
+}
+
+void WebContentClient::notify_compositor_process_reconnected(Badge<Application>)
+{
+    if (!Application::the().should_use_compositor_process() || !is_open())
+        return;
+
+    async_compositor_process_reconnected();
 }
 
 void WebContentClient::notify_all_views_of_crash()
@@ -252,7 +305,7 @@ bool WebContentClient::send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPo
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
 
     bool handled = false;
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+    if (Application::the().should_use_compositor_process()) {
         handled = Application::the().send_async_scroll_to_compositor(compositor_context_id_for_page(page_id), position, delta_in_device_pixels);
     } else {
         auto connection = compositor_connections().get(this);
@@ -271,7 +324,7 @@ bool WebContentClient::handle_mouse_event_in_compositor(u64 page_id, Web::MouseE
     auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
 
     bool handled = false;
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+    if (Application::the().should_use_compositor_process()) {
         handled = Application::the().handle_mouse_event_in_compositor(compositor_context_id_for_page(page_id), event);
     } else {
         auto connection = compositor_connections().get(this);
@@ -287,9 +340,15 @@ bool WebContentClient::handle_mouse_event_in_compositor(u64 page_id, Web::MouseE
 
 void WebContentClient::dispatch_mouse_event_to_web_content(u64 page_id, Web::MouseEvent const& event)
 {
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
-        Application::the().dispatch_mouse_event_to_web_content(compositor_context_id_for_page(page_id), event);
-        return;
+    if (Application::the().should_use_compositor_process()) {
+        auto context_id = m_page_compositor_context_ids.get(page_id);
+        if (context_id.has_value() && Application::the().dispatch_mouse_event_to_web_content(*context_id, event))
+            return;
+        if (!context_id.has_value()) {
+            auto new_context_id = compositor_context_id_for_page(page_id);
+            if (Application::the().dispatch_mouse_event_to_web_content(new_context_id, event))
+                return;
+        }
     }
 
     async_mouse_event(page_id, event.clone_without_browser_data());
@@ -297,7 +356,7 @@ void WebContentClient::dispatch_mouse_event_to_web_content(u64 page_id, Web::Mou
 
 void WebContentClient::notify_presented_bitmap_ready_to_paint(u64 page_id, i32 bitmap_id)
 {
-    if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes) {
+    if (Application::the().should_use_compositor_process()) {
         auto context_id = m_page_compositor_context_ids.get(page_id);
         if (!context_id.has_value())
             return;
@@ -318,7 +377,7 @@ void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, i32 bi
     } else {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI dropping did_paint for page {} bitmap {}: no view",
             page_id, bitmap_id);
-        if (Application::browser_options().enable_compositor_process == EnableCompositorProcess::Yes)
+        if (Application::the().should_use_compositor_process())
             notify_presented_bitmap_ready_to_paint(page_id, bitmap_id);
         else
             try_notify_presented_bitmap_ready_to_paint(*this, page_id, bitmap_id);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -66,6 +66,10 @@ public:
     bool has_views() const { return !m_views.is_empty(); }
 
     void notify_all_views_of_crash();
+    ErrorOr<void> reconnect_to_compositor_process(Badge<Application>);
+    ErrorOr<void> recreate_compositor_contexts(Badge<Application>);
+    void update_compositor_viewports_after_reconnect(Badge<Application>);
+    void notify_compositor_process_reconnected(Badge<Application>);
     Web::Compositor::CompositorContextId compositor_context_id_for_page(u64 page_id);
     Optional<u64> page_id_for_compositor_context_id(Web::Compositor::CompositorContextId) const;
     bool send_async_scroll_to_compositor(u64 page_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels);
@@ -177,8 +181,15 @@ private:
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
 
+    struct CompositorContextRegistration {
+        Optional<u64> page_id;
+        Web::Compositor::PagePresentationRegistration page_presentation_registration { Web::Compositor::PagePresentationRegistration::No };
+    };
+
+    void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration);
+
     HashMap<u64, NonnullRawPtr<ViewImplementation>> m_views;
-    HashTable<Web::Compositor::CompositorContextId> m_compositor_context_ids;
+    HashMap<Web::Compositor::CompositorContextId, CompositorContextRegistration> m_compositor_contexts;
     HashMap<u64, Web::Compositor::CompositorContextId> m_page_compositor_context_ids;
     HashMap<Web::Compositor::CompositorContextId, u64> m_page_ids_for_compositor_context_ids;
     HashMap<u64, String> m_history_recorded_urls_for_current_load;

--- a/Meta/Generators/generate_ipc_definitions.py
+++ b/Meta/Generators/generate_ipc_definitions.py
@@ -503,9 +503,17 @@ def write_proxy_method(
         else:
             out.write(f"\n        return move(*{sync_call});")
     elif is_try:
+        if inner_return_type == "void":
+            success_return = "{}"
+        elif len(message.outputs) == 1:
+            output = message.outputs[0]
+            accessor = output.name if is_primitive_or_simple_type(output.type) else f"take_{output.name}"
+            success_return = f"result->{accessor}()"
+        else:
+            success_return = "move(*result)"
         out.write(f"""
         if (auto result = m_connection.template send_sync_but_allow_failure<Messages::{endpoint.name}::{pascal_name}>({call_args}))
-            return {"{}" if inner_return_type == "void" else "move(*result)"};
+            return {success_return};
         m_connection.shutdown();
         return IPC::ErrorCode::PeerDisconnected;""")
     else:

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -21,95 +21,146 @@ CompositorConnection::CompositorConnection(NonnullOwnPtr<IPC::Transport> transpo
 
 void CompositorConnection::die()
 {
-    // The compositor process owns this WebContent's painting and presentation.
-    // WebContent cannot continue without that connection, but the browser
-    // process owns recovery and already treats an active renderer exit as a
-    // crash. Avoid reporting an assertion failure during browser shutdown.
-    Core::EventLoop::current().quit(0);
+    did_lose_compositor();
 }
 
 void CompositorConnection::set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode const& presentation_mode)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_set_presentation_mode(context_id, presentation_mode);
 }
 
 void CompositorConnection::stop_presenting_to_client(Web::Compositor::CompositorContextId context_id)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_stop_presenting_to_client(context_id);
 }
 
 void CompositorConnection::destroy_context(Web::Compositor::CompositorContextId context_id)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_destroy_context(context_id);
 }
 
 void CompositorConnection::update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> const& display_list, Web::Painting::DisplayListResourceTransaction const& resource_transaction, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
+    if (!can_send_message_to_compositor())
+        return;
+
     auto encoded_message = MUST(Messages::CompositorWebContentServer::UpdateDisplayList::static_encode(context_id, display_list, resource_transaction, scroll_state_snapshot));
-    MUST(post_message(encoded_message));
+    if (post_message(encoded_message).is_error())
+        did_lose_compositor();
 }
 
 void CompositorConnection::update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_update_scroll_state(context_id, scroll_state_snapshot);
 }
 
 void CompositorConnection::update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> const& frame)
 {
+    if (!can_send_message_to_compositor())
+        return;
+
     auto encoded_message = MUST(Messages::CompositorWebContentServer::UpdateVideoFrame::static_encode(context_id, frame_id, frame));
-    MUST(post_message(encoded_message));
+    if (post_message(encoded_message).is_error())
+        did_lose_compositor();
 }
 
 void CompositorConnection::clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_clear_video_frame(context_id, frame_id);
 }
 
 void CompositorConnection::update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage const& shared_image)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_update_compositor_surface(context_id, surface_id, shared_image);
 }
 
 void CompositorConnection::clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_clear_compositor_surface(context_id, surface_id);
 }
 
 void CompositorConnection::invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_invalidate_wheel_event_listener_state(context_id, generation);
 }
 
 Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking)
 {
-    auto response = send_sync<Messages::CompositorWebContentServer::AsyncScrollBy>(context_id, document_id, position, delta, viewport_rect, operation_tracking);
+    if (!can_send_message_to_compositor())
+        return {};
+
+    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::AsyncScrollBy>(context_id, document_id, position, delta, viewport_rect, operation_tracking);
+    if (!response) {
+        did_lose_compositor();
+        return {};
+    }
     return response->take_result();
 }
 
 bool CompositorConnection::should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id)
 {
-    auto response = send_sync<Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScroll>(context_id);
+    if (!can_send_message_to_compositor())
+        return false;
+
+    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::ShouldDeferMainThreadPresentForAsyncScroll>(context_id);
+    if (!response) {
+        did_lose_compositor();
+        return false;
+    }
     return response->should_defer();
 }
 
 Web::Compositor::PendingAsyncScrollUpdates CompositorConnection::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
-    auto response = send_sync<Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdates>(context_id);
+    if (!can_send_message_to_compositor())
+        return {};
+
+    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdates>(context_id);
+    if (!response) {
+        did_lose_compositor();
+        return {};
+    }
     return response->take_updates();
 }
 
 void CompositorConnection::viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
 }
 
 void CompositorConnection::present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect)
 {
+    if (!can_send_message_to_compositor())
+        return;
     async_present_frame(context_id, viewport_rect);
 }
 
 void CompositorConnection::request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
 {
+    if (!can_send_message_to_compositor()) {
+        if (callback)
+            callback();
+        return;
+    }
+
     auto target_bitmap = MUST(Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, target_surface->size()));
     auto shareable_bitmap = Gfx::ShareableBitmap { target_bitmap, Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
     auto request_id = Web::Compositor::ScreenshotRequestId { m_next_screenshot_request_id++ };
@@ -131,7 +182,8 @@ void CompositorConnection::request_rendering_update()
 void CompositorConnection::did_complete_screenshot(Web::Compositor::ScreenshotRequestId request_id)
 {
     auto pending_screenshot = take_screenshot(request_id);
-    VERIFY(pending_screenshot.has_value());
+    if (!pending_screenshot.has_value())
+        return;
 
     pending_screenshot->target_surface->write_from_bitmap(*pending_screenshot->target_bitmap);
     if (pending_screenshot->callback)
@@ -141,7 +193,8 @@ void CompositorConnection::did_complete_screenshot(Web::Compositor::ScreenshotRe
 void CompositorConnection::did_fail_screenshot(Web::Compositor::ScreenshotRequestId request_id)
 {
     auto pending_screenshot = take_screenshot(request_id);
-    VERIFY(pending_screenshot.has_value());
+    if (!pending_screenshot.has_value())
+        return;
 
     if (pending_screenshot->callback)
         pending_screenshot->callback();
@@ -149,10 +202,20 @@ void CompositorConnection::did_fail_screenshot(Web::Compositor::ScreenshotReques
 
 void CompositorConnection::did_lose_compositor()
 {
-    // The Compositor service sends this when its browser-process control
-    // connection is gone. WebContent cannot present without that owner either,
-    // so exit cleanly instead of reporting a renderer crash during shutdown.
-    die();
+    if (m_has_lost_compositor)
+        return;
+    m_has_lost_compositor = true;
+
+    for (auto& entry : m_screenshots) {
+        if (entry.value.callback)
+            entry.value.callback();
+    }
+    m_screenshots.clear();
+}
+
+bool CompositorConnection::can_send_message_to_compositor() const
+{
+    return !m_has_lost_compositor && is_open();
 }
 
 Optional<CompositorConnection::PendingScreenshot> CompositorConnection::take_screenshot(Web::Compositor::ScreenshotRequestId request_id)

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -70,10 +70,12 @@ private:
     virtual void did_fail_screenshot(Web::Compositor::ScreenshotRequestId) override;
     virtual void did_lose_compositor() override;
 
+    bool can_send_message_to_compositor() const;
     Optional<PendingScreenshot> take_screenshot(Web::Compositor::ScreenshotRequestId);
 
     HashMap<Web::Compositor::ScreenshotRequestId, PendingScreenshot> m_screenshots;
     u64 m_next_screenshot_request_id { 1 };
+    bool m_has_lost_compositor { false };
 };
 
 }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -78,11 +78,11 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transpo
 
 ConnectionFromClient::~ConnectionFromClient() = default;
 
-CompositorConnection& ConnectionFromClient::compositor_process_connection() const
+CompositorConnection* ConnectionFromClient::compositor_process_connection() const
 {
-    VERIFY(m_compositor_connection);
-    VERIFY(m_compositor_connection->is_open());
-    return *m_compositor_connection;
+    if (!m_compositor_connection || !m_compositor_connection->is_open())
+        return nullptr;
+    return m_compositor_connection.ptr();
 }
 
 void ConnectionFromClient::did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id)
@@ -176,6 +176,11 @@ void ConnectionFromClient::connect_to_compositor_process(IPC::TransportHandle ha
     m_compositor_connection->on_mouse_event = [this](u64 page_id, Web::MouseEvent event) {
         mouse_event(page_id, move(event));
     };
+}
+
+void ConnectionFromClient::compositor_process_reconnected()
+{
+    m_page_host->compositor_process_reconnected();
 }
 
 void ConnectionFromClient::connect_to_request_server(IPC::TransportHandle handle)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -49,7 +49,7 @@ public:
 
     PageHost& page_host() { return *m_page_host; }
     PageHost const& page_host() const { return *m_page_host; }
-    CompositorConnection& compositor_process_connection() const;
+    CompositorConnection* compositor_process_connection() const;
     void did_destroy_compositor_context(Web::Compositor::CompositorContextId);
 
     Function<void(IPC::TransportHandle const&)> on_request_server_connection;
@@ -73,6 +73,7 @@ private:
     virtual void connect_to_image_decoder(IPC::TransportHandle handle) override;
     virtual void connect_to_compositor(IPC::TransportHandle handle) override;
     virtual void connect_to_compositor_process(IPC::TransportHandle handle) override;
+    virtual void compositor_process_reconnected() override;
     virtual void update_system_theme(u64 page_id, Core::AnonymousBuffer) override;
     virtual void update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect>, u32) override;
     virtual void load_url(u64 page_id, URL::URL) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/DOM/MutationType.h>
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLLinkElement.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
@@ -193,6 +194,14 @@ void PageClient::set_window_position(Web::DevicePixelPoint position)
 void PageClient::set_window_size(Web::DevicePixelSize size)
 {
     page().set_window_size(size);
+}
+
+void PageClient::compositor_process_reconnected()
+{
+    page().top_level_traversable()->repaint_after_compositor_process_reconnect();
+    page().republish_all_canvas_element_surfaces();
+    page().update_all_media_element_video_sinks();
+    Web::HTML::main_thread_event_loop().queue_task_to_update_the_rendering();
 }
 
 Queue<Web::QueuedInputEvent>& PageClient::input_event_queue()

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -69,6 +69,7 @@ public:
     void set_is_scripting_enabled(bool);
     void set_window_position(Web::DevicePixelPoint);
     void set_window_size(Web::DevicePixelSize);
+    void compositor_process_reconnected();
 
     void toggle_media_play_state();
     void toggle_media_mute_state();

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -60,4 +60,10 @@ void PageHost::attach_compositor_ui_client(IPC::TransportHandle handle)
         m_compositor_host->attach_ui_client(move(handle));
 }
 
+void PageHost::compositor_process_reconnected()
+{
+    for (auto& [_, page] : m_pages)
+        page->compositor_process_reconnected();
+}
+
 }

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -45,6 +45,7 @@ public:
     ConnectionFromClient& client() const { return m_client; }
     void ensure_compositor_host(Web::DisplayListPlayerType);
     void attach_compositor_ui_client(IPC::TransportHandle);
+    void compositor_process_reconnected();
     Web::Compositor::CompositorHost* compositor_host() { return m_compositor_host.ptr(); }
     Web::Compositor::CompositorHost const* compositor_host() const { return m_compositor_host.ptr(); }
 

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -563,59 +563,71 @@ private:
 
     virtual void destroy_context(Web::Compositor::CompositorContextId context_id) override
     {
-        connection().destroy_context(context_id);
+        if (auto* connection = compositor_connection())
+            connection->destroy_context(context_id);
         m_client.did_destroy_compositor_context(context_id);
     }
 
     virtual void stop_presenting_to_client(Web::Compositor::CompositorContextId context_id) override
     {
-        connection().stop_presenting_to_client(context_id);
+        if (auto* connection = compositor_connection())
+            connection->stop_presenting_to_client(context_id);
     }
 
     virtual void set_presentation_mode(Web::Compositor::CompositorContextId context_id, Web::Compositor::PresentationMode mode) override
     {
-        connection().set_presentation_mode(context_id, mode);
+        if (auto* connection = compositor_connection())
+            connection->set_presentation_mode(context_id, mode);
     }
 
     virtual void update_display_list(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Web::Painting::DisplayList> display_list, Web::Painting::DisplayListResourceTransaction&& resource_transaction, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
     {
-        connection().update_display_list(context_id, display_list, resource_transaction, scroll_state_snapshot);
+        if (auto* connection = compositor_connection())
+            connection->update_display_list(context_id, display_list, resource_transaction, scroll_state_snapshot);
     }
 
     virtual void update_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id, NonnullRefPtr<Media::VideoFrame const> frame) override
     {
-        connection().update_video_frame(context_id, frame_id, frame);
+        if (auto* connection = compositor_connection())
+            connection->update_video_frame(context_id, frame_id, frame);
     }
 
     virtual void clear_video_frame(Web::Compositor::CompositorContextId context_id, Web::Painting::VideoFrameResourceId frame_id) override
     {
-        connection().clear_video_frame(context_id, frame_id);
+        if (auto* connection = compositor_connection())
+            connection->clear_video_frame(context_id, frame_id);
     }
 
     virtual void update_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id, Gfx::SharedImage&& shared_image) override
     {
-        connection().update_compositor_surface(context_id, surface_id, shared_image);
+        if (auto* connection = compositor_connection())
+            connection->update_compositor_surface(context_id, surface_id, shared_image);
     }
 
     virtual void clear_compositor_surface(Web::Compositor::CompositorContextId context_id, Web::Painting::CompositorSurfaceId surface_id) override
     {
-        connection().clear_compositor_surface(context_id, surface_id);
+        if (auto* connection = compositor_connection())
+            connection->clear_compositor_surface(context_id, surface_id);
     }
 
     virtual void update_scroll_state(Web::Compositor::CompositorContextId context_id, Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot) override
     {
-        connection().update_scroll_state(context_id, scroll_state_snapshot);
+        if (auto* connection = compositor_connection())
+            connection->update_scroll_state(context_id, scroll_state_snapshot);
     }
 
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) override
     {
-        connection().invalidate_wheel_event_listener_state(context_id, generation);
+        if (auto* connection = compositor_connection())
+            connection->invalidate_wheel_event_listener_state(context_id, generation);
     }
 
     virtual Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) override
     {
-        return connection().async_scroll_by(context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+        if (auto* connection = compositor_connection())
+            return connection->async_scroll_by(context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
+        return {};
     }
 
     virtual bool should_defer_async_scroll_offset_adoption(Web::Compositor::CompositorContextId) const override
@@ -625,30 +637,41 @@ private:
 
     virtual bool should_defer_main_thread_present_for_async_scroll(Web::Compositor::CompositorContextId context_id) const override
     {
-        return connection().should_defer_main_thread_present_for_async_scroll(context_id);
+        if (auto* connection = compositor_connection())
+            return connection->should_defer_main_thread_present_for_async_scroll(context_id);
+        return false;
     }
 
     virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) override
     {
-        return connection().take_pending_async_scroll_updates(context_id);
+        if (auto* connection = compositor_connection())
+            return connection->take_pending_async_scroll_updates(context_id);
+        return {};
     }
 
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) override
     {
-        connection().viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
+        if (auto* connection = compositor_connection())
+            connection->viewport_size_updated(context_id, viewport_size, is_top_level_traversable, window_resize_in_progress);
     }
 
     virtual void present_frame(Web::Compositor::CompositorContextId context_id, Gfx::IntRect viewport_rect) override
     {
-        connection().present_frame(context_id, viewport_rect);
+        if (auto* connection = compositor_connection())
+            connection->present_frame(context_id, viewport_rect);
     }
 
     virtual void request_screenshot(Web::Compositor::CompositorContextId context_id, NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback) override
     {
-        connection().request_screenshot(context_id, move(target_surface), move(callback));
+        if (auto* connection = compositor_connection()) {
+            connection->request_screenshot(context_id, move(target_surface), move(callback));
+            return;
+        }
+        if (callback)
+            callback();
     }
 
-    CompositorConnection& connection() const
+    CompositorConnection* compositor_connection() const
     {
         return m_client.compositor_process_connection();
     }

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -36,6 +36,7 @@ endpoint WebContentServer
     connect_to_image_decoder(IPC::TransportHandle handle) =|
     connect_to_compositor(IPC::TransportHandle handle) =|
     connect_to_compositor_process(IPC::TransportHandle handle) =|
+    compositor_process_reconnected() =|
 
     update_system_theme(u64 page_id, Core::AnonymousBuffer theme_buffer) =|
     update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> rects, u32 main_screen_index) =|


### PR DESCRIPTION
The browser previously treated the out-of-process Compositor as fatal.

Restart the shared Compositor from the browser process, reconnect process-backed WebContent clients, recreate compositor contexts, restore viewport state, and ask WebContent to repaint and republish canvas and media resources. WebContent now marks its compositor connection lost, returns conservative values for synchronous compositor queries while reconnecting, and drops outgoing updates until the replacement transport arrives.

Mouse events queued while the Compositor is unavailable now fall back to direct WebContent dispatch. This keeps input completion in step with the pending-event queue.

Recovery is capped at three automatic restarts. If the restart limit is exceeded, or if restart, reconnect, or context recreation fails, the browser crashes instead of switching process-backed views to a fallback path.