### PR TITLE
LibWebView: Add advanced config variables

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -114,6 +114,7 @@
             }
 
             input[type="number"],
+            input[type="search"],
             input[type="text"],
             input[type="url"],
             select {
@@ -283,6 +284,56 @@
                 flex-grow: 1;
             }
 
+            #config-filter {
+                width: 100%;
+            }
+
+            .config-row {
+                display: grid;
+                grid-template-columns: minmax(0, 1fr) auto;
+                gap: 20px;
+                align-items: center;
+            }
+
+            .config-row + .config-row {
+                border-top: 1px solid var(--border-color);
+                padding-top: 16px;
+                margin-top: 16px;
+            }
+
+            .config-name {
+                font-family: monospace;
+                font-size: 13px;
+                opacity: 0.7;
+                overflow-wrap: anywhere;
+            }
+
+            .config-title {
+                margin-top: 6px;
+
+                font-size: 14px;
+            }
+
+            .config-control {
+                min-width: 180px;
+            }
+
+            .config-control input[type="text"],
+            .config-control input[type="number"] {
+                width: 100%;
+            }
+
+            @media (max-width: 600px) {
+                .config-row {
+                    grid-template-columns: minmax(0, 1fr);
+                    align-items: stretch;
+                }
+
+                .config-control {
+                    min-width: 0;
+                }
+            }
+
             .tab-bar {
                 display: flex;
                 gap: 4px;
@@ -339,6 +390,7 @@
             <button class="tab-button" data-tab="permissions">Permissions</button>
             <button class="tab-button" data-tab="privacy">Privacy</button>
             <button class="tab-button" data-tab="network">Network</button>
+            <button class="tab-button" data-tab="advanced">Advanced</button>
         </div>
 
         <div class="tab-panel active" id="tab-general">
@@ -532,6 +584,18 @@
             </div>
         </div>
 
+        <div class="tab-panel" id="tab-advanced">
+            <h3 class="card-title">Configuration Variables</h3>
+            <div class="card">
+                <div class="card-body">
+                    <div class="card-group">
+                        <input id="config-filter" type="search" placeholder="Filter configuration keys" />
+                    </div>
+                    <div id="config-list"></div>
+                </div>
+            </div>
+        </div>
+
         <dialog id="languages-dialog" closedby="any">
             <div class="dialog-header">
                 <h3 class="dialog-title">Languages</h3>
@@ -652,6 +716,7 @@
             };
         </script>
 
+        <script src="resource://ladybird/about-pages/settings/advanced.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/browsing-behavior.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/default-zoom-level.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/languages.js" type="module"></script>

--- a/Base/res/ladybird/about-pages/settings/advanced.js
+++ b/Base/res/ladybird/about-pages/settings/advanced.js
@@ -1,0 +1,99 @@
+const configFilter = document.querySelector("#config-filter");
+const configList = document.querySelector("#config-list");
+
+function sendConfigVariableValue(variable, value) {
+    ladybird.sendMessage("setConfigVariable", {
+        name: variable.name,
+        value,
+    });
+}
+
+function createControl(variable) {
+    const control = document.createElement("div");
+    control.classList.add("config-control");
+
+    if (variable.type === "boolean") {
+        const input = document.createElement("input");
+        input.type = "checkbox";
+        input.toggleAttribute("switch", true);
+        input.checked = !!variable.value;
+        input.addEventListener("change", () => {
+            sendConfigVariableValue(variable, input.checked);
+        });
+        control.append(input);
+        return control;
+    }
+
+    const input = document.createElement("input");
+    input.value = variable.value ?? "";
+
+    if (variable.type === "number") {
+        input.type = "number";
+        input.step = "any";
+        input.addEventListener("change", () => {
+            const value = Number.parseFloat(input.value);
+            if (!Number.isNaN(value)) {
+                sendConfigVariableValue(variable, value);
+            }
+        });
+    } else {
+        input.type = "text";
+        input.addEventListener("change", () => {
+            sendConfigVariableValue(variable, input.value);
+        });
+    }
+
+    control.append(input);
+    return control;
+}
+
+function createRow(variable) {
+    const row = document.createElement("div");
+    row.classList.add("config-row");
+    row.dataset.filterText = `${variable.name} ${variable.title} ${variable.description}`.toLowerCase();
+
+    const details = document.createElement("div");
+
+    const name = document.createElement("div");
+    name.classList.add("config-name");
+    name.textContent = variable.name;
+
+    const title = document.createElement("div");
+    title.classList.add("config-title");
+    title.textContent = variable.title;
+
+    const description = document.createElement("p");
+    description.classList.add("config-description", "description");
+    description.textContent = variable.description;
+
+    details.append(name, title, description);
+    row.append(details, createControl(variable));
+    return row;
+}
+
+function applyFilter() {
+    const filter = configFilter.value.trim().toLowerCase();
+
+    document.querySelectorAll(".config-row").forEach(row => {
+        row.classList.toggle("hidden", filter.length !== 0 && !row.dataset.filterText.includes(filter));
+    });
+}
+
+function loadConfigVariables(settings) {
+    const configVariables = settings.configVariableDefinitions || [];
+    configList.innerHTML = "";
+
+    configVariables.forEach(variable => {
+        configList.append(createRow(variable));
+    });
+
+    applyFilter();
+}
+
+configFilter.addEventListener("input", applyFilter);
+
+document.addEventListener("WebUIMessage", event => {
+    if (event.detail.name === "loadSettings") {
+        loadConfigVariables(event.detail.data);
+    }
+});

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -58,6 +58,48 @@ static constexpr auto GLOBAL_PRIVACY_CONTROL_KEY = "globalPrivacyControl"sv;
 
 static constexpr auto DNS_SETTINGS_KEY = "dnsSettings"sv;
 
+static constexpr auto CONFIG_VARIABLES_KEY = "configVariables"sv;
+
+static Array<ConfigVariableDefinition, static_cast<size_t>(ConfigVariableID::Count)> const CONFIG_VARIABLE_DEFINITIONS {};
+
+ReadonlySpan<ConfigVariableDefinition const> config_variable_definitions()
+{
+    return CONFIG_VARIABLE_DEFINITIONS;
+}
+
+Optional<ConfigVariableID> config_variable_id_from_name(StringView name)
+{
+    for (auto const& variable : config_variable_definitions()) {
+        if (variable.name == name)
+            return variable.id;
+    }
+
+    return {};
+}
+
+static ConfigVariableDefinition const& config_variable_definition(ConfigVariableID id)
+{
+    return config_variable_definitions()[static_cast<size_t>(id)];
+}
+
+static bool config_variable_value_matches_type(JsonValue const& default_value, JsonValue const& value)
+{
+    switch (default_value.type()) {
+    case JsonValue::Type::Bool:
+        return value.is_bool();
+    case JsonValue::Type::Number:
+        return value.is_number();
+    case JsonValue::Type::String:
+        return value.is_string();
+    case JsonValue::Type::Null:
+    case JsonValue::Type::Array:
+    case JsonValue::Type::Object:
+        return value.type() == default_value.type();
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
 Settings Settings::create(Badge<Application>)
 {
     // FIXME: Move this to a generic "Ladybird config directory" helper.
@@ -147,6 +189,15 @@ Settings Settings::create(Badge<Application>)
     if (auto dns_settings = settings_json.value().get(DNS_SETTINGS_KEY); dns_settings.has_value())
         settings.m_dns_settings = parse_dns_settings(*dns_settings);
 
+    if (auto config_variables = settings_json.value().get_object(CONFIG_VARIABLES_KEY); config_variables.has_value()) {
+        for (auto const& variable : config_variable_definitions()) {
+            if (auto value = config_variables->get(variable.name); value.has_value()) {
+                if (config_variable_value_matches_type(variable.default_value, *value))
+                    settings.m_config_variables[static_cast<size_t>(variable.id)] = *value;
+            }
+        }
+    }
+
     return settings;
 }
 
@@ -157,6 +208,9 @@ Settings::Settings(ByteString settings_path)
     , m_default_zoom_level_factor(INITIAL_ZOOM_LEVEL_FACTOR)
     , m_languages({ DEFAULT_LANGUAGE })
 {
+    for (auto const& variable : config_variable_definitions()) {
+        m_config_variables[static_cast<size_t>(variable.id)] = variable.default_value;
+    }
 }
 
 JsonValue Settings::serialize_json() const
@@ -261,6 +315,11 @@ JsonValue Settings::serialize_json() const
             dns_settings.set("forciblyEnabled"sv, m_dns_override_by_command_line);
         });
     settings.set(DNS_SETTINGS_KEY, move(dns_settings));
+
+    JsonObject config_variables;
+    for (auto const& variable : config_variable_definitions())
+        config_variables.set(variable.name, m_config_variables[static_cast<size_t>(variable.id)]);
+    settings.set(CONFIG_VARIABLES_KEY, move(config_variables));
 
     return settings;
 }
@@ -567,6 +626,46 @@ void Settings::set_dns_settings(DNSSettings const& dns_settings, bool override_b
 
     for (auto& observer : m_observers)
         observer.dns_settings_changed();
+}
+
+JsonValue const& Settings::config_variable(ConfigVariableID id) const
+{
+    return m_config_variables[static_cast<size_t>(id)];
+}
+
+bool Settings::config_variable_as_bool(ConfigVariableID id) const
+{
+    auto const& variable = config_variable_definition(id);
+    VERIFY(variable.default_value.is_bool());
+
+    auto value = config_variable(id).get_bool();
+    VERIFY(value.has_value());
+    return *value;
+}
+
+void Settings::set_config_variable(ConfigVariableID id, JsonValue value)
+{
+    auto const& variable = config_variable_definition(id);
+    if (!config_variable_value_matches_type(variable.default_value, value))
+        return;
+
+    if (m_config_variables[static_cast<size_t>(id)].equals(value))
+        return;
+
+    m_config_variables[static_cast<size_t>(id)] = move(value);
+    persist_settings();
+
+    for (auto& observer : m_observers)
+        observer.config_variable_changed(id);
+}
+
+void Settings::set_config_variable(StringView name, JsonValue const& value)
+{
+    auto id = config_variable_id_from_name(name);
+    if (!id.has_value())
+        return;
+
+    set_config_variable(*id, value);
 }
 
 void Settings::persist_settings()

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -60,7 +60,15 @@ static constexpr auto DNS_SETTINGS_KEY = "dnsSettings"sv;
 
 static constexpr auto CONFIG_VARIABLES_KEY = "configVariables"sv;
 
-static Array<ConfigVariableDefinition, static_cast<size_t>(ConfigVariableID::Count)> const CONFIG_VARIABLE_DEFINITIONS {};
+static Array<ConfigVariableDefinition, static_cast<size_t>(ConfigVariableID::Count)> const CONFIG_VARIABLE_DEFINITIONS { {
+    {
+        .id = ConfigVariableID::ShowWebContentProcessIDInTabTitle,
+        .name = "debug.process.show_web_content_process_id"sv,
+        .title = "Show WebContent process ID in tab titles"sv,
+        .description = "Append the active WebContent process ID to each tab title and tooltip."sv,
+        .default_value = false,
+    },
+} };
 
 ReadonlySpan<ConfigVariableDefinition const> config_variable_definitions()
 {

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Badge.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
@@ -42,6 +43,21 @@ enum class GlobalPrivacyControl {
     Yes,
 };
 
+enum class ConfigVariableID : u8 {
+    Count,
+};
+
+struct ConfigVariableDefinition {
+    ConfigVariableID id;
+    StringView name;
+    StringView title;
+    StringView description;
+    JsonValue default_value;
+};
+
+WEBVIEW_API ReadonlySpan<ConfigVariableDefinition const> config_variable_definitions();
+WEBVIEW_API Optional<ConfigVariableID> config_variable_id_from_name(StringView);
+
 class WEBVIEW_API SettingsObserver {
 public:
     explicit SettingsObserver();
@@ -59,6 +75,7 @@ public:
     virtual void browsing_data_settings_changed() { }
     virtual void global_privacy_control_changed() { }
     virtual void dns_settings_changed() { }
+    virtual void config_variable_changed(ConfigVariableID) { }
 };
 
 class WEBVIEW_API Settings {
@@ -114,6 +131,11 @@ public:
     DNSSettings const& dns_settings() const { return m_dns_settings; }
     void set_dns_settings(DNSSettings const&, bool override_by_command_line = false);
 
+    JsonValue const& config_variable(ConfigVariableID) const;
+    bool config_variable_as_bool(ConfigVariableID) const;
+    void set_config_variable(ConfigVariableID, JsonValue);
+    void set_config_variable(StringView name, JsonValue const&);
+
     static void add_observer(Badge<SettingsObserver>, SettingsObserver&);
     static void remove_observer(Badge<SettingsObserver>, SettingsObserver&);
 
@@ -140,6 +162,7 @@ private:
     GlobalPrivacyControl m_global_privacy_control { GlobalPrivacyControl::No };
     DNSSettings m_dns_settings { SystemDNS() };
     bool m_dns_override_by_command_line { false };
+    Array<JsonValue, static_cast<size_t>(ConfigVariableID::Count)> m_config_variables {};
 
     Vector<SettingsObserver&> m_observers;
 };

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -44,6 +44,7 @@ enum class GlobalPrivacyControl {
 };
 
 enum class ConfigVariableID : u8 {
+    ShowWebContentProcessIDInTabTitle,
     Count,
 };
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -277,6 +277,9 @@ public:
     Action& toggle_bookmark_action() { return *m_toggle_bookmark_action; }
     Action& reset_zoom_action() { return *m_reset_zoom_action; }
 
+    WebContentClient& client();
+    WebContentClient const& client() const;
+
     virtual Web::DevicePixelSize viewport_size() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const = 0;
@@ -288,8 +291,6 @@ protected:
 
     ViewImplementation();
 
-    WebContentClient& client();
-    WebContentClient const& client() const;
     u64 page_id() const;
 
     void set_url(URL::URL);

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -12,6 +12,26 @@
 
 namespace WebView {
 
+static StringView config_variable_type_to_string(JsonValue const& value)
+{
+    switch (value.type()) {
+    case JsonValue::Type::Null:
+        return "null"sv;
+    case JsonValue::Type::Bool:
+        return "boolean"sv;
+    case JsonValue::Type::Number:
+        return "number"sv;
+    case JsonValue::Type::String:
+        return "string"sv;
+    case JsonValue::Type::Array:
+        return "array"sv;
+    case JsonValue::Type::Object:
+        return "object"sv;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
 void SettingsUI::register_interfaces()
 {
     register_interface("loadCurrentSettings"sv, [this](auto const&) {
@@ -29,6 +49,9 @@ void SettingsUI::register_interfaces()
     });
     register_interface("setBrowsingBehavior"sv, [this](auto const& data) {
         set_browsing_behavior(data);
+    });
+    register_interface("setConfigVariable"sv, [this](auto const& data) {
+        set_config_variable(data);
     });
 
     register_interface("loadAvailableEngines"sv, [this](auto const&) {
@@ -84,6 +107,21 @@ void SettingsUI::register_interfaces()
 void SettingsUI::load_current_settings()
 {
     auto settings = WebView::Application::settings().serialize_json();
+
+    JsonArray config_variables;
+    for (auto const& variable : config_variable_definitions()) {
+        JsonObject variable_object;
+        variable_object.set("name"sv, variable.name);
+        variable_object.set("title"sv, variable.title);
+        variable_object.set("description"sv, variable.description);
+        variable_object.set("type"sv, config_variable_type_to_string(variable.default_value));
+        variable_object.set("defaultValue"sv, variable.default_value);
+        variable_object.set("value"sv, WebView::Application::settings().config_variable(variable.id));
+
+        config_variables.must_append(move(variable_object));
+    }
+
+    settings.as_object().set("configVariableDefinitions"sv, move(config_variables));
     async_send_message("loadSettings"sv, settings);
 }
 
@@ -120,6 +158,21 @@ void SettingsUI::set_browsing_behavior(JsonValue const& browsing_behavior)
 {
     auto parsed_browsing_behavior = Settings::parse_browsing_behavior(browsing_behavior);
     WebView::Application::settings().set_browsing_behavior(parsed_browsing_behavior);
+
+    load_current_settings();
+}
+
+void SettingsUI::set_config_variable(JsonValue const& variable)
+{
+    if (!variable.is_object())
+        return;
+
+    auto name = variable.as_object().get_string("name"sv);
+    auto value = variable.as_object().get("value"sv);
+    if (!name.has_value() || !value.has_value())
+        return;
+
+    WebView::Application::settings().set_config_variable(*name, *value);
 
     load_current_settings();
 }

--- a/Libraries/LibWebView/WebUI/SettingsUI.h
+++ b/Libraries/LibWebView/WebUI/SettingsUI.h
@@ -23,6 +23,7 @@ private:
     void set_default_zoom_level_factor(JsonValue const&);
     void set_languages(JsonValue const&);
     void set_browsing_behavior(JsonValue const&);
+    void set_config_variable(JsonValue const&);
 
     void load_available_engines();
     void set_search_engine(JsonValue const&);

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Function.h>
+#include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <LibCore/Resource.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Settings.h>
 #include <LibWebView/ViewImplementation.h>
+#include <LibWebView/WebContentClient.h>
 
 #import <Application/ApplicationDelegate.h>
 #import <Interface/BookmarksBar.h>
@@ -27,6 +30,22 @@ static constexpr CGFloat const WINDOW_WIDTH = 1000;
 static constexpr CGFloat const WINDOW_HEIGHT = 800;
 static constexpr CGFloat const TAB_ICON_SIZE = 16;
 static constexpr NSUInteger const TAB_LOADING_SPINNER_SEGMENT_COUNT = 12;
+
+class TabSettingsObserver final : public WebView::SettingsObserver {
+public:
+    explicit TabSettingsObserver(Function<void(WebView::ConfigVariableID)> callback)
+        : m_callback(move(callback))
+    {
+    }
+
+    virtual void config_variable_changed(WebView::ConfigVariableID variable) override
+    {
+        m_callback(variable);
+    }
+
+private:
+    Function<void(WebView::ConfigVariableID)> m_callback;
+};
 
 static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 {
@@ -66,6 +85,7 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
     BOOL m_loading;
     NSUInteger m_loading_spinner_frame;
     __strong NSTimer* m_loading_spinner_timer;
+    OwnPtr<TabSettingsObserver> m_settings_observer;
 }
 
 @property (nonatomic, strong) NSString* title;
@@ -121,6 +141,15 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
 
         self.favicon = [Tab defaultFavicon];
         self.title = @"New Tab";
+        __weak Tab* weak_self = self;
+        m_settings_observer = make<TabSettingsObserver>([weak_self](WebView::ConfigVariableID variable) {
+            if (variable != WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle)
+                return;
+            Tab* strong_self = weak_self;
+            if (strong_self == nil)
+                return;
+            [strong_self updateTabTitleAndFavicon];
+        });
         [self updateTabTitleAndFavicon];
 
         [self setTitleVisibility:NSWindowTitleHidden];
@@ -193,6 +222,15 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
     return self.favicon;
 }
 
+- (NSString*)displayTitle
+{
+    if (!WebView::Application::settings().config_variable_as_bool(WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle))
+        return self.title;
+
+    auto title = MUST(String::formatted("{} [{}]", Ladybird::ns_string_to_string(self.title), [[self web_view] view].client().pid()));
+    return Ladybird::string_to_ns_string(title);
+}
+
 - (void)updateLoadingSpinner
 {
     if (!m_loading)
@@ -255,7 +293,8 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
         NSFontAttributeName : title_font
     };
 
-    auto* title_attribute = [[NSAttributedString alloc] initWithString:self.title
+    auto* display_title = [self displayTitle];
+    auto* title_attribute = [[NSAttributedString alloc] initWithString:display_title
                                                             attributes:title_attributes];
 
     auto* spacing_attribute = [[NSAttributedString alloc] initWithString:@"  "
@@ -267,6 +306,8 @@ static NSImage* tab_loading_spinner_icon(NSUInteger frame)
     [title_and_favicon appendAttributedString:title_attribute];
 
     [[self tab] setAttributedTitle:title_and_favicon];
+    if ([[self tab] respondsToSelector:@selector(setToolTip:)])
+        [(id)[self tab] setToolTip:display_title];
 }
 
 - (void)togglePageMuteState:(id)button

--- a/UI/Gtk/Tab.cpp
+++ b/UI/Gtk/Tab.cpp
@@ -8,8 +8,10 @@
 #include <LibGfx/Cursor.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectItem.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/Menu.h>
 #include <LibWebView/URL.h>
+#include <LibWebView/WebContentClient.h>
 #include <UI/Gtk/BrowserWindow.h>
 #include <UI/Gtk/Dialogs.h>
 #include <UI/Gtk/Events.h>
@@ -89,16 +91,20 @@ Tab::Tab(BrowserWindow& window, RefPtr<WebView::WebContentClient> parent_client,
 
 Tab::~Tab() = default;
 
+void Tab::set_tab_page(AdwTabPage* page)
+{
+    m_tab_page = page;
+    update_tab_title();
+}
+
 void Tab::setup_callbacks()
 {
     auto* root = GTK_WIDGET(m_web_view);
 
     m_view->on_title_change = [this](auto const& title) {
-        if (m_tab_page) {
-            auto utf8 = title.to_utf8();
-            auto byte_str = ByteString(utf8.bytes_as_string_view());
-            adw_tab_page_set_title(m_tab_page, byte_str.characters());
-        }
+        auto utf8 = title.to_utf8();
+        m_title = ByteString(utf8.bytes_as_string_view());
+        update_tab_title();
     };
 
     m_view->on_url_change = [this](auto const& url) {
@@ -271,6 +277,30 @@ void Tab::setup_callbacks()
     create_context_menu(*root, *m_view, m_view->link_context_menu());
     create_context_menu(*root, *m_view, m_view->image_context_menu());
     create_context_menu(*root, *m_view, m_view->media_context_menu());
+}
+
+ByteString Tab::tab_title() const
+{
+    if (!WebView::Application::settings().config_variable_as_bool(WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle))
+        return m_title;
+
+    return ByteString::formatted("{} [{}]", m_title, m_view->client().pid());
+}
+
+void Tab::update_tab_title()
+{
+    if (!m_tab_page)
+        return;
+
+    auto title = tab_title();
+    adw_tab_page_set_title(m_tab_page, title.characters());
+    adw_tab_page_set_tooltip(m_tab_page, title.characters());
+}
+
+void Tab::config_variable_changed(WebView::ConfigVariableID variable)
+{
+    if (variable == WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle)
+        update_tab_title();
 }
 
 void Tab::navigate(URL::URL const& url)

--- a/UI/Gtk/Tab.h
+++ b/UI/Gtk/Tab.h
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/Settings.h>
 #include <UI/Gtk/GLibPtr.h>
 #include <UI/Gtk/Widgets/LadybirdWebView.h>
 
@@ -24,11 +25,11 @@ namespace Ladybird {
 class BrowserWindow;
 class WebContentView;
 
-class Tab {
+class Tab : public WebView::SettingsObserver {
 public:
     Tab(BrowserWindow& window, URL::URL url = {});
     Tab(BrowserWindow& window, WebView::WebContentClient& parent_client, u64 page_index);
-    ~Tab();
+    virtual ~Tab() override;
 
     GtkWidget* widget() const { return GTK_WIDGET(m_web_view); }
     WebContentView& view() { return *m_view; }
@@ -39,11 +40,14 @@ public:
     bool is_loading() const { return m_is_loading; }
 
     AdwTabPage* tab_page() const { return m_tab_page; }
-    void set_tab_page(AdwTabPage* page) { m_tab_page = page; }
+    void set_tab_page(AdwTabPage*);
 
 private:
     Tab(BrowserWindow& window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index);
     void setup_callbacks();
+    void update_tab_title();
+    ByteString tab_title() const;
+    virtual void config_variable_changed(WebView::ConfigVariableID) override;
     void show_select_dropdown(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items);
 
     BrowserWindow& m_window;
@@ -53,6 +57,7 @@ private:
     AdwTabPage* m_tab_page { nullptr };
 
     URL::URL m_initial_url;
+    ByteString m_title { "New Tab" };
     GObjectPtr<GdkPaintable> m_favicon;
     bool m_is_loading { false };
 };

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Utilities.h>
+#include <LibWebView/WebContentClient.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
@@ -184,7 +185,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         auto url_serialized = qstring_from_ak_string(url.serialize());
 
         m_title = url_serialized;
-        emit title_changed(tab_index(), url_serialized);
+        update_tab_title();
 
         m_favicon = default_favicon();
         set_loading(true);
@@ -213,7 +214,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     view().on_title_change = [this](auto const& title) {
         m_title = qstring_from_utf16_string(title);
-        emit title_changed(tab_index(), m_title);
+        update_tab_title();
     };
 
     view().on_favicon_change = [this](auto const& bitmap) {
@@ -523,6 +524,25 @@ QIcon Tab::tab_icon() const
     if (m_is_loading)
         return loading_spinner_icon(palette(), m_loading_animation_frame);
     return m_favicon;
+}
+
+QString Tab::title() const
+{
+    if (!WebView::Application::settings().config_variable_as_bool(WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle))
+        return m_title;
+
+    return QString("%1 [%2]").arg(m_title).arg(view().client().pid());
+}
+
+void Tab::update_tab_title()
+{
+    emit title_changed(tab_index(), title());
+}
+
+void Tab::config_variable_changed(WebView::ConfigVariableID variable)
+{
+    if (variable == WebView::ConfigVariableID::ShowWebContentProcessIDInTabTitle)
+        update_tab_title();
 }
 
 void Tab::set_loading(bool is_loading)

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/HTML/AudioPlayState.h>
+#include <LibWebView/Settings.h>
 #include <UI/Qt/BookmarksBar.h>
 #include <UI/Qt/FindInPageWidget.h>
 #include <UI/Qt/LocationEdit.h>
@@ -46,7 +47,9 @@ signals:
     void mouse_entered(QEnterEvent*);
 };
 
-class Tab final : public QWidget {
+class Tab final
+    : public QWidget
+    , public WebView::SettingsObserver {
     Q_OBJECT
 
 public:
@@ -54,6 +57,7 @@ public:
     virtual ~Tab() override;
 
     WebContentView& view() { return *m_view; }
+    WebContentView const& view() const { return *m_view; }
 
     void navigate(URL::URL const&);
     void load_html(StringView);
@@ -70,7 +74,7 @@ public:
 
     QIcon const& favicon() const { return m_favicon; }
     QIcon tab_icon() const;
-    QString const& title() const { return m_title; }
+    QString title() const;
 
     QMenu* context_menu() const { return m_context_menu; }
 
@@ -93,8 +97,10 @@ signals:
 private:
     virtual void resizeEvent(QResizeEvent*) override;
     virtual bool event(QEvent*) override;
+    virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     void recreate_toolbar_icons();
+    void update_tab_title();
     void set_loading(bool);
     void update_tab_icon();
     int tab_index();

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -81,6 +81,7 @@ set(ABOUT_PAGES
 list(TRANSFORM ABOUT_PAGES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/about-pages/")
 
 set(ABOUT_SETTINGS_RESOURCES
+    advanced.js
     browsing-behavior.js
     default-zoom-level.js
     languages.js


### PR DESCRIPTION
Add a JSON-backed config variable registry to LibWebView and expose it in about:settings under a new Advanced tab. The UI lists all registered keys, supports filtering, and sends typed `JsonValue` values back through `SettingsUI`.

Register` debug.process.show_web_content_process_id` as the first variable. When enabled, we append the active WebContent PID to tab titles and tab tooltips while keeping the stored page title unchanged, so toggling the preference refreshes existing tabs.