### PR TITLE
LibGfx+LibWeb: Share Skia resource cache purging

### DIFF
--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/Time.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/SkiaBackendContext.h>
 
@@ -30,8 +31,45 @@ namespace Gfx {
 #if defined(AK_OS_MACOS) || USE_VULKAN
 static constexpr size_t skia_resource_cache_limit = 256 * MiB;
 #endif
+static constexpr auto skia_deferred_cleanup_interval = AK::Duration::from_seconds(1);
+static constexpr auto skia_aggressive_cleanup_interval = AK::Duration::from_seconds(5);
+static constexpr auto skia_deferred_cleanup_resource_age = std::chrono::seconds(5);
+static constexpr auto skia_resource_cache_high_watermark = 384 * MiB;
+static constexpr auto skia_resource_cache_critical_watermark = 512 * MiB;
 
 static RefPtr<SkiaBackendContext> s_main_thread_context;
+
+void SkiaBackendContext::flush_and_submit(SkSurface* surface)
+{
+    flush_and_submit_impl(surface);
+
+    auto* context = sk_context();
+    if (!context)
+        return;
+
+    static thread_local Optional<MonotonicTime> s_last_deferred_cleanup;
+    static thread_local Optional<MonotonicTime> s_last_aggressive_cleanup;
+
+    auto const now = MonotonicTime::now();
+    if (s_last_deferred_cleanup.has_value() && now - *s_last_deferred_cleanup < skia_deferred_cleanup_interval)
+        return;
+
+    s_last_deferred_cleanup = now;
+    context->performDeferredCleanup(skia_deferred_cleanup_resource_age);
+
+    size_t resource_bytes = 0;
+    context->getResourceCacheUsage(nullptr, &resource_bytes);
+    if (resource_bytes < skia_resource_cache_high_watermark)
+        return;
+    if (s_last_aggressive_cleanup.has_value() && now - *s_last_aggressive_cleanup < skia_aggressive_cleanup_interval)
+        return;
+
+    s_last_aggressive_cleanup = now;
+    context->performDeferredCleanup(std::chrono::milliseconds(0));
+    context->getResourceCacheUsage(nullptr, &resource_bytes);
+    if (resource_bytes >= skia_resource_cache_critical_watermark)
+        context->purgeUnlockedResources(GrPurgeResourceOptions::kScratchResourcesOnly);
+}
 
 void SkiaBackendContext::initialize_gpu_backend()
 {
@@ -91,7 +129,7 @@ public:
             vkDestroyInstance(m_vulkan_context.instance, nullptr);
     }
 
-    void flush_and_submit(SkSurface* surface) override
+    void flush_and_submit_impl(SkSurface* surface) override
     {
         GrFlushInfo const flush_info {};
         m_context->flush(surface, SkSurfaces::BackendSurfaceAccess::kPresent, flush_info);
@@ -156,7 +194,7 @@ public:
         m_context.reset();
     }
 
-    void flush_and_submit(SkSurface* surface) override
+    void flush_and_submit_impl(SkSurface* surface) override
     {
         GrFlushInfo const flush_info {};
         m_context->flush(surface, SkSurfaces::BackendSurfaceAccess::kPresent, flush_info);

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -45,11 +45,14 @@ public:
     SkiaBackendContext() { }
     virtual ~SkiaBackendContext() { }
 
-    virtual void flush_and_submit(SkSurface*) { }
+    void flush_and_submit(SkSurface*);
     virtual GrDirectContext* sk_context() const = 0;
 
     virtual MetalContext& metal_context() = 0;
     virtual VulkanContext const& vulkan_context() = 0;
+
+protected:
+    virtual void flush_and_submit_impl(SkSurface*) = 0;
 };
 
 }

--- a/Libraries/LibWeb/Compositor/CompositorThread.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorThread.cpp
@@ -23,21 +23,13 @@
 #include <AK/Debug.h>
 #include <AK/HashMap.h>
 #include <AK/Queue.h>
-#include <AK/Time.h>
 
 #include <core/SkCanvas.h>
 #include <core/SkColor.h>
-#include <gpu/ganesh/GrDirectContext.h>
 
 #include <LibCore/Platform/ScopedAutoreleasePool.h>
 
 namespace Web::Compositor {
-
-static constexpr auto skia_deferred_cleanup_interval = AK::Duration::from_seconds(1);
-static constexpr auto skia_aggressive_cleanup_interval = AK::Duration::from_seconds(5);
-static constexpr auto skia_deferred_cleanup_resource_age = std::chrono::seconds(5);
-static constexpr auto skia_resource_cache_high_watermark = 384 * MiB;
-static constexpr auto skia_resource_cache_critical_watermark = 512 * MiB;
 
 struct UpdateDisplayListCommand {
     NonnullRefPtr<Painting::DisplayList> display_list;
@@ -107,29 +99,8 @@ struct CompositorCommandEnvelope {
 
 static void flush_surface(Gfx::PaintingSurface& surface)
 {
-    if (auto context = surface.skia_backend_context()) {
+    if (auto context = surface.skia_backend_context())
         context->flush_and_submit(&surface.sk_surface());
-        auto* skia_context = context->sk_context();
-
-        static thread_local Optional<MonotonicTime> s_last_deferred_cleanup;
-        static thread_local Optional<MonotonicTime> s_last_aggressive_cleanup;
-
-        auto const now = MonotonicTime::now();
-        if (!s_last_deferred_cleanup.has_value() || now - *s_last_deferred_cleanup >= skia_deferred_cleanup_interval) {
-            s_last_deferred_cleanup = now;
-            skia_context->performDeferredCleanup(skia_deferred_cleanup_resource_age);
-
-            size_t resource_bytes = 0;
-            skia_context->getResourceCacheUsage(nullptr, &resource_bytes);
-            if (resource_bytes >= skia_resource_cache_high_watermark && (!s_last_aggressive_cleanup.has_value() || now - *s_last_aggressive_cleanup >= skia_aggressive_cleanup_interval)) {
-                s_last_aggressive_cleanup = now;
-                skia_context->performDeferredCleanup(std::chrono::milliseconds(0));
-                skia_context->getResourceCacheUsage(nullptr, &resource_bytes);
-                if (resource_bytes >= skia_resource_cache_critical_watermark)
-                    skia_context->purgeUnlockedResources(GrPurgeResourceOptions::kScratchResourcesOnly);
-            }
-        }
-    }
     surface.flush();
 }
 


### PR DESCRIPTION
The compositor thread had local Skia resource cache cleanup in its surface flush helper, but the compositor process uses the same backend through its own paint and present path. That left the new process path without the deferred and high-watermark purging policy.

Move the cleanup into SkiaBackendContext::flush_and_submit(), keeping the public flush API shared while letting the Vulkan and Metal backends provide only the backend-specific submit implementation. This keeps the existing compositor thread behavior and applies the same cache pressure handling to compositor process flushes.