### PR TITLE
LibWeb: Use resolved width for intrinsic height sizing

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2289,14 +2289,29 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
 
     VERIFY(!height.is_auto());
 
+    auto const& box_state = m_state.get(box);
+    auto width_for_intrinsic_height = [&] {
+        // https://drafts.csswg.org/css-sizing-3/#max-content-block-size
+        // The max-content block size is the block size of the content after layout.
+        if (box_state.has_definite_width())
+            return box_state.content_width();
+        return available_space.width.to_px_or_zero();
+    };
+
     if (height.is_fit_content()) {
-        return calculate_fit_content_height(box, available_space);
+        // https://drafts.csswg.org/css-sizing-3/#fit-content-size
+        // If the available space in a given axis is indefinite, the
+        // fit-content size is the max-content size in that axis.
+        auto available_space_for_fit_content_height = available_space;
+        if (box_state.has_definite_width())
+            available_space_for_fit_content_height.width = AvailableSize::make_definite(box_state.content_width());
+        return calculate_fit_content_height(box, available_space_for_fit_content_height);
     }
     if (height.is_max_content()) {
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_max_content_height(box, width_for_intrinsic_height());
     }
     if (height.is_min_content()) {
-        return calculate_min_content_height(box, available_space.width.to_px_or_zero());
+        return calculate_min_content_height(box, width_for_intrinsic_height());
     }
 
     CSSPixels height_of_containing_block = available_space.height.to_px_or_zero();

--- a/Tests/LibWeb/Text/expected/fit-content-height-uses-resolved-width.txt
+++ b/Tests/LibWeb/Text/expected/fit-content-height-uses-resolved-width.txt
@@ -1,0 +1,3 @@
+wrapper: 456x260
+canvas: 448x252
+height delta: 8

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/keyword-sizes-on-abspos.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/keyword-sizes-on-abspos.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 60 tests
 
-34 Pass
-26 Fail
+43 Pass
+17 Fail
 Pass	.test 1
 Pass	.test 2
 Fail	.test 3
@@ -35,19 +35,19 @@ Pass	.test 28
 Pass	.test 29
 Fail	.test 30
 Pass	.test 31
-Fail	.test 32
-Fail	.test 33
-Fail	.test 34
+Pass	.test 32
+Pass	.test 33
+Pass	.test 34
 Pass	.test 35
 Pass	.test 36
-Fail	.test 37
-Fail	.test 38
-Fail	.test 39
+Pass	.test 37
+Pass	.test 38
+Pass	.test 39
 Fail	.test 40
 Pass	.test 41
-Fail	.test 42
-Fail	.test 43
-Fail	.test 44
+Pass	.test 42
+Pass	.test 43
+Pass	.test 44
 Fail	.test 45
 Pass	.test 46
 Pass	.test 47

--- a/Tests/LibWeb/Text/input/fit-content-height-uses-resolved-width.html
+++ b/Tests/LibWeb/Text/input/fit-content-height-uses-resolved-width.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #wrapper {
+        display: inline-block;
+        width: 100%;
+        max-width: 448px;
+        height: fit-content;
+        padding: 4px;
+        line-height: 0;
+    }
+
+    canvas {
+        display: block;
+        width: 100%;
+        height: auto;
+    }
+</style>
+<div id="wrapper">
+    <canvas id="canvas" width="448" height="252"></canvas>
+</div>
+<script>
+    asyncTest(done => {
+        const wrapperRect = document.getElementById("wrapper").getBoundingClientRect();
+        const canvasRect = document.getElementById("canvas").getBoundingClientRect();
+        println(`wrapper: ${wrapperRect.width}x${wrapperRect.height}`);
+        println(`canvas: ${canvasRect.width}x${canvasRect.height}`);
+        println(`height delta: ${wrapperRect.height - canvasRect.height}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
This fixes intrinsic height sizing for boxes whose width has already been resolved before their height is calculated.

For `height: fit-content`, CSS Sizing says that when the available space in the block axis is indefinite, the fit-content size is the max-content size in that axis. It also defines max-content block size as the block size of the content after layout.

Before this change, LibWeb could calculate that intrinsic height using the containing block’s available width instead of the box’s resolved content width. This made a box with `width: 100%`, `max-width`, and `height: fit-content` too tall when it contained a replaced child sized with `width: 100%; height: auto`.

For example, with an 800px viewport and a wrapper clamped to `max-width: 448px`, the child is laid out at `448x252`, but the wrapper height was computed as if the child were 800px wide.

This change uses the resolved content width for intrinsic height sizing when it is available.

Spec references:
- https://drafts.csswg.org/css-sizing-3/#fit-content-size
- https://drafts.csswg.org/css-sizing-3/#max-content-block-size

Tests:
- Added a focused text test for `height: fit-content` with a resolved `max-width`.
- Updated `keyword-sizes-on-abspos`, which improves from 34 passing subtests to 43.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/8294