### PR TITLE
LibWebView: Use page background color while resizing

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1381,6 +1381,17 @@ Color Document::background_color() const
     return Color::Transparent;
 }
 
+Color Document::canvas_background_color() const
+{
+    auto color_scheme = CSS::PreferredColorScheme::Light;
+    if (auto* html_element = this->html_element(); html_element && html_element->layout_node()) {
+        if (html_element->layout_node()->computed_values().color_scheme() == CSS::PreferredColorScheme::Dark)
+            color_scheme = CSS::PreferredColorScheme::Dark;
+    }
+
+    return CSS::SystemColor::canvas(color_scheme).blend(background_color());
+}
+
 Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
 {
     auto* body_element = body();
@@ -8209,7 +8220,11 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     if (opaque_canvas)
         display_list_recorder.fill_rect(bitmap_rect, CSS::SystemColor::canvas(color_scheme));
 
-    display_list_recorder.fill_rect(bitmap_rect, background_color());
+    auto background_color = this->background_color();
+    if (navigable()->is_top_level_traversable())
+        page().client().page_did_change_background_color(canvas_background_color());
+
+    display_list_recorder.fill_rect(bitmap_rect, background_color);
 
     Web::DisplayListRecordingContext context(display_list_recorder, page().palette(), page().client().device_pixels_per_css_pixel(), page().chrome_metrics());
     context.set_device_viewport_rect(viewport_rect);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -354,6 +354,7 @@ public:
     Page const& page() const;
 
     Color background_color() const;
+    Color canvas_background_color() const;
     Vector<CSS::BackgroundLayerData> const* background_layers() const;
     CSS::ImageRendering background_image_rendering() const;
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -504,6 +504,7 @@ public:
     virtual void page_did_set_device_pixel_ratio_for_testing([[maybe_unused]] double ratio) { }
 
     virtual void page_did_change_theme_color(Gfx::Color) { }
+    virtual void page_did_change_background_color(Gfx::Color) { }
 
     virtual void page_did_insert_clipboard_entry(Clipboard::SystemClipboardRepresentation const&, [[maybe_unused]] StringView presentation_style) { }
     virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -672,6 +672,13 @@ void ViewImplementation::did_update_navigation_buttons_state(Badge<WebContentCli
     m_navigate_forward_action->set_enabled(forward_enabled);
 }
 
+void ViewImplementation::did_change_background_color(Badge<WebContentClient>, Gfx::Color color)
+{
+    m_page_background_color = color;
+    if (on_page_background_color_change)
+        on_page_background_color_change(color);
+}
+
 void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store)
 {
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] UI installing backing stores for page {} front={} back={} had_usable_bitmap={}",

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -19,6 +19,7 @@
 #include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
 #include <LibCore/SharedVersion.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/Cursor.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/SharedImage.h>
@@ -170,6 +171,8 @@ public:
     Web::HTML::AudioPlayState audio_play_state() const { return m_audio_play_state; }
 
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
+    void did_change_background_color(Badge<WebContentClient>, Gfx::Color);
+    Gfx::Color page_background_color() const { return m_page_background_color; }
 
     void did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::SharedImage front_backing_store, i32 back_bitmap_id, Gfx::SharedImage back_backing_store);
 
@@ -258,6 +261,7 @@ public:
     Function<void(JsonValue)> on_test_variant_metadata;
     Function<void(size_t current_match_index, Optional<size_t> const& total_match_count)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
+    Function<void(Gfx::Color)> on_page_background_color_change;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
     Function<void()> on_web_content_crashed;
     Function<void()> on_web_content_process_change_for_cross_site_navigation;
@@ -395,6 +399,7 @@ protected:
 
     OwnPtr<Gfx::SharedImageBuffer> m_backup_shared_image_buffer;
     Web::DevicePixelSize m_backup_bitmap_size;
+    Gfx::Color m_page_background_color { 255, 255, 255 };
 
     bool m_should_suppress_history_for_current_load { false };
     bool m_should_suppress_history_for_next_load { false };

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1105,6 +1105,12 @@ void WebContentClient::did_change_theme_color(u64 page_id, Gfx::Color color)
     }
 }
 
+void WebContentClient::did_change_background_color(u64 page_id, Gfx::Color color)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_change_background_color({}, color);
+}
+
 void WebContentClient::did_insert_clipboard_entry(u64, Web::Clipboard::SystemClipboardRepresentation entry, String)
 {
     Application::the().insert_clipboard_entry(move(entry));

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -172,6 +172,7 @@ private:
     virtual void did_set_browser_zoom(u64 page_id, double factor) override;
     virtual void did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> total_match_count) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
+    virtual void did_change_background_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation, String presentation_style) override;
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
     virtual void did_request_paste(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -737,6 +737,11 @@ void PageClient::page_did_change_theme_color(Gfx::Color color)
     client().async_did_change_theme_color(m_id, color);
 }
 
+void PageClient::page_did_change_background_color(Gfx::Color color)
+{
+    client().async_did_change_background_color(m_id, color);
+}
+
 void PageClient::page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const& entry, StringView presentation_style)
 {
     client().async_did_insert_clipboard_entry(m_id, entry, presentation_style);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -190,6 +190,7 @@ private:
     virtual void page_did_set_browser_zoom(double factor) override;
     virtual void page_did_set_device_pixel_ratio_for_testing(double ratio) override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;
+    virtual void page_did_change_background_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_request_paste() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -114,6 +114,7 @@ endpoint WebContentClient
     did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) =|
     did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|
+    did_change_background_color(u64 page_id, Gfx::Color color) =|
 
     did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style) =|
     did_request_clipboard_entries(u64 page_id, u64 request_id) =|

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -876,7 +876,7 @@ struct HideCursor {
         [self.observer onExitFullscreenWindow];
     };
 
-    m_web_view_bridge->on_theme_color_change = [weak_self](auto color) {
+    m_web_view_bridge->on_page_background_color_change = [weak_self](auto color) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return;

--- a/UI/Gtk/WebContentView.cpp
+++ b/UI/Gtk/WebContentView.cpp
@@ -20,6 +20,16 @@
 
 namespace Ladybird {
 
+static GdkRGBA to_gdk_rgba(Gfx::Color color)
+{
+    return GdkRGBA {
+        static_cast<float>(color.red()) / 255.0f,
+        static_cast<float>(color.green()) / 255.0f,
+        static_cast<float>(color.blue()) / 255.0f,
+        static_cast<float>(color.alpha()) / 255.0f
+    };
+}
+
 WebContentView::WebContentView(LadybirdWebView* widget, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
     : m_widget(widget)
 {
@@ -196,9 +206,7 @@ void WebContentView::paint(GtkSnapshot* snapshot)
         graphene_rect_t texture_rect = GRAPHENE_RECT_INIT(0, 0, draw_width, draw_height);
         gtk_snapshot_append_texture(snapshot, m_cached_texture, &texture_rect);
 
-        // Fill uncovered areas with theme-appropriate background
-        auto is_dark = adw_style_manager_get_dark(adw_style_manager_get_default());
-        GdkRGBA bg = is_dark ? GdkRGBA { 0.14, 0.14, 0.14, 1.0 } : GdkRGBA { 1.0, 1.0, 1.0, 1.0 };
+        auto bg = to_gdk_rgba(page_background_color());
 
         if (draw_width < width) {
             graphene_rect_t right_rect = GRAPHENE_RECT_INIT(draw_width, 0, static_cast<float>(width) - draw_width, static_cast<float>(height));
@@ -209,8 +217,7 @@ void WebContentView::paint(GtkSnapshot* snapshot)
             gtk_snapshot_append_color(snapshot, &bg, &bottom_rect);
         }
     } else {
-        auto is_dark = adw_style_manager_get_dark(adw_style_manager_get_default());
-        GdkRGBA bg = is_dark ? GdkRGBA { 0.14, 0.14, 0.14, 1.0 } : GdkRGBA { 1.0, 1.0, 1.0, 1.0 };
+        auto bg = to_gdk_rgba(page_background_color());
         graphene_rect_t full_rect = GRAPHENE_RECT_INIT(0, 0, static_cast<float>(width), static_cast<float>(height));
         gtk_snapshot_append_color(snapshot, &bg, &full_rect);
     }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -523,17 +523,20 @@ void WebContentView::paintEvent(QPaintEvent*)
         QImage q_image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), bitmap->pitch(), QImage::Format_RGB32);
         painter.drawImage(QPoint(0, 0), q_image, QRect(0, 0, bitmap_size.width(), bitmap_size.height()));
 
+        auto background_color = page_background_color();
+        auto fallback_color = QColor(background_color.red(), background_color.green(), background_color.blue());
         if (bitmap_size.width() < width()) {
-            painter.fillRect(bitmap_size.width(), 0, width() - bitmap_size.width(), bitmap->height(), palette().base());
+            painter.fillRect(bitmap_size.width(), 0, width() - bitmap_size.width(), bitmap->height(), fallback_color);
         }
         if (bitmap_size.height() < height()) {
-            painter.fillRect(0, bitmap_size.height(), width(), height() - bitmap_size.height(), palette().base());
+            painter.fillRect(0, bitmap_size.height(), width(), height() - bitmap_size.height(), fallback_color);
         }
 
         return;
     }
 
-    painter.fillRect(rect(), palette().base());
+    auto background_color = page_background_color();
+    painter.fillRect(rect(), QColor(background_color.red(), background_color.green(), background_color.blue()));
 }
 
 void WebContentView::resizeEvent(QResizeEvent* event)


### PR DESCRIPTION
Notify the UI process with the solid canvas background color recorded for the top-level document. This is the Canvas system color with the effective document background composited over it, matching the color used before normal painting.

Store that color on the view and use it when AppKit, Qt, and Gtk need to fill areas exposed while an older bitmap is still on screen during a window resize.