### PR TITLE
LibWeb: Cache TextNode chunks between layouts

### DIFF
--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -423,21 +423,12 @@ void InlineLevelIterator::enter_text_node(Layout::TextNode const& text_node)
     bool do_wrap_lines = text_wrap_mode == CSS::TextWrapMode::Wrap;
     bool do_respect_linebreaks = first_is_one_of(white_space_collapse, CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces);
 
-    // Pre-generate all chunks for this text node upfront.
-    // This allows O(1) peek() and next() operations instead of lazy generation with O(n) queue operations.
-    TextNode::ChunkIterator chunk_iterator { text_node, do_wrap_lines, do_respect_linebreaks };
-    Vector<TextNode::Chunk> chunks;
-    while (true) {
-        auto chunk = chunk_iterator.next();
-        if (!chunk.has_value())
-            break;
-        chunks.append(chunk.release_value());
-    }
+    auto const& chunks = text_node.chunks_for_layout(do_wrap_lines, do_respect_linebreaks);
 
     m_text_node_context = TextNodeContext {
-        .chunks = move(chunks),
+        .chunks = chunks.chunks,
         .next_chunk_index = 0,
-        .should_collapse_whitespace = chunk_iterator.should_collapse_whitespace(),
+        .should_collapse_whitespace = chunks.should_collapse_whitespace,
         .should_wrap_lines = do_wrap_lines,
         .should_respect_linebreaks = do_respect_linebreaks,
     };

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -316,42 +316,69 @@ static Utf16String apply_text_transform(Utf16String const& string, CSS::TextTran
     VERIFY_NOT_REACHED();
 }
 
+TextNode::TextForRenderingCacheKey TextNode::create_text_for_rendering_cache_key() const
+{
+    auto text_transform = computed_values().text_transform();
+    Optional<String> lang;
+    if (first_is_one_of(text_transform, CSS::TextTransform::Uppercase, CSS::TextTransform::Lowercase, CSS::TextTransform::Capitalize)) {
+        if (auto parent_element = dom_node().parent_element())
+            lang = parent_element->lang();
+    }
+
+    return {
+        .text_transform = text_transform,
+        .white_space_collapse = computed_values().white_space_collapse(),
+        .lang = move(lang),
+        .is_password_input = dom_node().is_password_input(),
+        .dom_start_offset = dom_start_offset(),
+        .dom_length = dom_length(),
+    };
+}
+
 void TextNode::invalidate_text_for_rendering()
 {
-    m_text_for_rendering = {};
-    m_grapheme_segmenter.clear();
-    m_line_segmenter.clear();
+    m_text_dependent_cache = {};
 }
 
 Utf16String const& TextNode::text_for_rendering() const
 {
-    if (!m_text_for_rendering.has_value())
-        const_cast<TextNode*>(this)->compute_text_for_rendering();
-    return *m_text_for_rendering;
+    return ensure_text_dependent_cache().text_for_rendering;
 }
 
-void TextNode::compute_text_for_rendering()
+TextNode::TextDependentCache const& TextNode::ensure_text_dependent_cache() const
 {
-    if (dom_node().is_password_input()) {
-        m_text_for_rendering = Utf16String::repeated(u'●', dom_node().data().length_in_code_points());
-        return;
+    auto key = create_text_for_rendering_cache_key();
+    if (!m_text_dependent_cache.has_value() || m_text_dependent_cache->key != key) {
+        auto text_for_rendering = compute_text_for_rendering(key);
+        m_text_dependent_cache = TextDependentCache {
+            .key = move(key),
+            .text_for_rendering = move(text_for_rendering),
+            .grapheme_segmenter = {},
+            .line_segmenter = {},
+            .chunk_cache = {},
+        };
+    }
+    return *m_text_dependent_cache;
+}
+
+Utf16String TextNode::compute_text_for_rendering(TextForRenderingCacheKey const& cache_key) const
+{
+    if (cache_key.is_password_input) {
+        return Utf16String::repeated(u'●', dom_node().data().length_in_code_points());
     }
 
     // Apply text-transform
     // FIXME: This can generate more code points than there were before; we need to find a better way to map the
     //        resulting paintable fragments' offsets into the original text node data.
     //        See: https://github.com/LadybirdBrowser/ladybird/issues/6177
-    auto parent_element = dom_node().parent_element();
-    auto const maybe_lang = parent_element ? parent_element->lang() : Optional<String> {};
-    auto const lang = maybe_lang.has_value() ? maybe_lang.value() : Optional<StringView> {};
-    auto text = apply_text_transform(dom_node().data(), computed_values().text_transform(), lang);
-    if (dom_start_offset() > 0 || dom_length() < dom_node().data().length_in_code_units())
-        text = Utf16String::from_utf16(text.utf16_view().substring_view(dom_start_offset(), dom_length()));
+    auto const lang = cache_key.lang.has_value() ? Optional<StringView> { cache_key.lang->bytes_as_string_view() } : Optional<StringView> {};
+    auto text = apply_text_transform(dom_node().data(), cache_key.text_transform, lang);
+    if (cache_key.dom_start_offset > 0 || cache_key.dom_length < dom_node().data().length_in_code_units())
+        text = Utf16String::from_utf16(text.utf16_view().substring_view(cache_key.dom_start_offset, cache_key.dom_length));
 
     // The logic below deals with converting whitespace characters. If we don't have them, return early.
     if (text.is_empty() || !any_of(text, is_ascii_space)) {
-        m_text_for_rendering = move(text);
-        return;
+        return text;
     }
 
     // https://drafts.csswg.org/css-text-4/#white-space-phase-1
@@ -360,7 +387,7 @@ void TextNode::compute_text_for_rendering()
 
     // If white-space-collapse is set to collapse or preserve-breaks, white space characters are considered collapsible
     // and are processed by performing the following steps:
-    auto white_space_collapse = computed_values().white_space_collapse();
+    auto white_space_collapse = cache_key.white_space_collapse;
     if (first_is_one_of(white_space_collapse, CSS::WhiteSpaceCollapse::Collapse, CSS::WhiteSpaceCollapse::PreserveBreaks)) {
         // 1. FIXME: Any sequence of collapsible spaces and tabs immediately preceding or following a segment break is removed.
 
@@ -401,8 +428,7 @@ void TextNode::compute_text_for_rendering()
 
     // AD-HOC: Prevent allocating a StringBuilder for a single space/newline/tab.
     if (text == " "sv || (convert_tabs && text == "\t"sv) || (convert_newlines && text == "\n"sv)) {
-        m_text_for_rendering = " "_utf16;
-        return;
+        return " "_utf16;
     }
 
     // AD-HOC: It's important to not change the amount of code units in the resulting transformed text, so ChunkIterator
@@ -417,39 +443,76 @@ void TextNode::compute_text_for_rendering()
         text = text_builder.to_utf16_string();
     }
 
-    m_text_for_rendering = move(text);
+    return text;
 }
 
 Unicode::Segmenter& TextNode::grapheme_segmenter() const
 {
-    if (!m_grapheme_segmenter) {
-        auto const& text = text_for_rendering();
+    auto const& cache = ensure_text_dependent_cache();
+    auto const& text = cache.text_for_rendering;
+    if (!cache.grapheme_segmenter) {
         // Fast path: For ASCII text, every character is its own grapheme.
         // We can use a trivial segmenter that avoids all ICU overhead.
         if (text.is_ascii()) {
-            m_grapheme_segmenter = Unicode::Segmenter::create_for_ascii_grapheme(text.length_in_code_units());
+            cache.grapheme_segmenter = Unicode::Segmenter::create_for_ascii_grapheme(text.length_in_code_units());
         } else {
-            m_grapheme_segmenter = document().grapheme_segmenter().clone();
-            m_grapheme_segmenter->set_segmented_text(text);
+            cache.grapheme_segmenter = document().grapheme_segmenter().clone();
+            cache.grapheme_segmenter->set_segmented_text(text);
         }
     }
 
-    return *m_grapheme_segmenter;
+    return *cache.grapheme_segmenter;
 }
 
 Unicode::Segmenter& TextNode::line_segmenter() const
 {
-    if (!m_line_segmenter) {
-        auto const& text = text_for_rendering();
+    auto const& cache = ensure_text_dependent_cache();
+    auto const& text = cache.text_for_rendering;
+    if (!cache.line_segmenter) {
         if (auto ascii = Unicode::Segmenter::try_create_for_ascii_line(text.utf16_view())) {
-            m_line_segmenter = ascii.release_nonnull();
+            cache.line_segmenter = ascii.release_nonnull();
         } else {
-            m_line_segmenter = document().line_segmenter().clone();
-            m_line_segmenter->set_segmented_text(text);
+            cache.line_segmenter = document().line_segmenter().clone();
+            cache.line_segmenter->set_segmented_text(text);
         }
     }
 
-    return *m_line_segmenter;
+    return *cache.line_segmenter;
+}
+
+TextNode::ChunkList const& TextNode::chunks_for_layout(bool should_wrap_lines, bool should_respect_linebreaks) const
+{
+    auto const& cache = ensure_text_dependent_cache();
+
+    auto const& computed_values = this->computed_values();
+    ChunkCacheKey key {
+        .should_wrap_lines = should_wrap_lines,
+        .should_respect_linebreaks = should_respect_linebreaks,
+        .white_space_collapse = computed_values.white_space_collapse(),
+        .word_break = computed_values.word_break(),
+        .font_cascade_list = computed_values.font_list(),
+    };
+
+    if (cache.chunk_cache.has_value() && cache.chunk_cache->key == key)
+        return cache.chunk_cache->chunk_list;
+
+    TextNode::ChunkIterator chunk_iterator { *this, should_wrap_lines, should_respect_linebreaks };
+    Vector<TextNode::Chunk> chunks;
+    while (true) {
+        auto chunk = chunk_iterator.next();
+        if (!chunk.has_value())
+            break;
+        chunks.append(chunk.release_value());
+    }
+
+    cache.chunk_cache = ChunkCacheEntry {
+        .key = key,
+        .chunk_list = {
+            .chunks = move(chunks),
+            .should_collapse_whitespace = chunk_iterator.should_collapse_whitespace(),
+        },
+    };
+    return cache.chunk_cache->chunk_list;
 }
 
 static bool is_interword_space(u32 code_point)

--- a/Libraries/LibWeb/Layout/TextNode.h
+++ b/Libraries/LibWeb/Layout/TextNode.h
@@ -6,10 +6,12 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <LibGfx/TextLayout.h>
 #include <LibUnicode/Segmenter.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Layout/Node.h>
 
@@ -83,6 +85,13 @@ public:
         mutable RefPtr<Gfx::Font const> m_last_non_whitespace_font;
     };
 
+    struct ChunkList {
+        Vector<Chunk> chunks;
+        bool should_collapse_whitespace { false };
+    };
+
+    ChunkList const& chunks_for_layout(bool should_wrap_lines, bool should_respect_linebreaks) const;
+
     void invalidate_text_for_rendering();
 
     Unicode::Segmenter& grapheme_segmenter() const;
@@ -96,11 +105,45 @@ protected:
 private:
     virtual bool is_text_node() const final { return true; }
 
-    void compute_text_for_rendering();
+    struct TextForRenderingCacheKey {
+        CSS::TextTransform text_transform { CSS::TextTransform::None };
+        CSS::WhiteSpaceCollapse white_space_collapse { CSS::WhiteSpaceCollapse::Collapse };
+        Optional<String> lang;
+        bool is_password_input { false };
+        size_t dom_start_offset { 0 };
+        size_t dom_length { 0 };
 
-    Optional<Utf16String> m_text_for_rendering;
-    mutable OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
-    mutable OwnPtr<Unicode::Segmenter> m_line_segmenter;
+        bool operator==(TextForRenderingCacheKey const&) const = default;
+    };
+
+    struct ChunkCacheKey {
+        bool should_wrap_lines { false };
+        bool should_respect_linebreaks { false };
+        CSS::WhiteSpaceCollapse white_space_collapse { CSS::WhiteSpaceCollapse::Collapse };
+        CSS::WordBreak word_break { CSS::WordBreak::Normal };
+        RefPtr<Gfx::FontCascadeList const> font_cascade_list;
+
+        bool operator==(ChunkCacheKey const&) const = default;
+    };
+
+    struct ChunkCacheEntry {
+        ChunkCacheKey key;
+        ChunkList chunk_list;
+    };
+
+    struct TextDependentCache {
+        TextForRenderingCacheKey key;
+        Utf16String text_for_rendering;
+        mutable OwnPtr<Unicode::Segmenter> grapheme_segmenter;
+        mutable OwnPtr<Unicode::Segmenter> line_segmenter;
+        mutable Optional<ChunkCacheEntry> chunk_cache;
+    };
+
+    TextForRenderingCacheKey create_text_for_rendering_cache_key() const;
+    Utf16String compute_text_for_rendering(TextForRenderingCacheKey const&) const;
+    TextDependentCache const& ensure_text_dependent_cache() const;
+
+    mutable Optional<TextDependentCache> m_text_dependent_cache;
 };
 
 class TextSliceNode final : public TextNode {

--- a/Tests/LibWeb/Text/expected/DOM/Element-innerText-style-change-refreshes-segmenters.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-innerText-style-change-refreshes-segmenters.txt
@@ -1,0 +1,3 @@
+initial: "a b"
+after text-transform: "A B"
+after white-space: "A  B"

--- a/Tests/LibWeb/Text/input/DOM/Element-innerText-style-change-refreshes-segmenters.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-innerText-style-change-refreshes-segmenters.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target">a  b</div>
+<script>
+    test(() => {
+        const target = document.getElementById("target");
+        println(`initial: "${target.innerText}"`);
+
+        target.style.textTransform = "uppercase";
+        println(`after text-transform: "${target.innerText}"`);
+
+        target.style.whiteSpace = "pre";
+        println(`after white-space: "${target.innerText}"`);
+    });
+</script>


### PR DESCRIPTION
Keep one per-TextNode chunk list so repeated inline layouts can skip segmenting text and resolving fonts for each chunk. The cache entry is keyed by the wrapping mode, whitespace behavior, word-break value, and font cascade used to produce it.

Store rendered text, segmenters, and chunks behind one text-dependent cache key. This keeps cached Utf16Views and segmenter state anchored to current text when inherited text style changes without rebuilding the layout tree.

Keep the cached font cascade alive while chunks are cached so a later font-list allocation cannot compare equal by reusing the same address.

Add innerText coverage for style-only text-transform and white-space changes, since that path constructs ChunkIterator directly.