### PR TITLE
AK: Skip Optional converting constructors when U is same as T

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -209,7 +209,7 @@ public:
     }
 
     template<typename U>
-    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyCopyConstructible<U>)) ALWAYS_INLINE explicit constexpr Optional(Optional<U> const& other)
+    requires(!IsSame<U, T> && IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyCopyConstructible<U>)) ALWAYS_INLINE explicit constexpr Optional(Optional<U> const& other)
         : m_has_value(other.has_value())
     {
         if (other.has_value())
@@ -219,7 +219,7 @@ public:
     }
 
     template<typename U>
-    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyMoveConstructible<U>)) ALWAYS_INLINE explicit constexpr Optional(Optional<U>&& other)
+    requires(!IsSame<U, T> && IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyMoveConstructible<U>)) ALWAYS_INLINE explicit constexpr Optional(Optional<U>&& other)
         : m_has_value(other.has_value())
     {
         if (other.has_value())


### PR DESCRIPTION
This template is causing an "error: satisfaction of atomic constraint ‘IsConstructible<T, const U&> [with T = X; X]’ depends on itself" through a self referential CSSScopeRule on GCC 16.1. Tighten the template requirements to avoid it.