### PR TITLE
LibWeb: Resume rendering after documents become visible

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4431,6 +4431,9 @@ void Document::update_the_visibility_state(HTML::VisibilityState visibility_stat
     auto event = DOM::Event::create(realm(), HTML::EventNames::visibilitychange);
     event->set_bubbles(true);
     dispatch_event(event);
+
+    if (m_visibility_state == HTML::VisibilityState::Visible)
+        page().client().request_frame();
 }
 
 // https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps


### PR DESCRIPTION
Request a rendering update after document visibility changes back to visible. Hidden documents can leave animation frame callbacks or CSS animation work pending after their last rendering update is skipped, so showing the page needs to schedule a fresh rendering tick.