### PR TITLE
LibWeb: Avoid stale CSS image style GC pointers

### DIFF
--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -22,13 +22,9 @@ namespace GC {
 template<typename T>
 struct IsVisitable;
 
-// This instrumentation tells analysis tooling to ignore a potentially mis-wrapped GC-allocated member variable
-// It should only be used when the lifetime of the GC-allocated member is always longer than the object
 #if defined(AK_COMPILER_CLANG)
-#    define IGNORE_GC [[clang::annotate("serenity::ignore_gc")]]
 #    define GC_ALLOW_CELL_DESTRUCTOR [[clang::annotate("ladybird::allow_cell_destructor")]]
 #else
-#    define IGNORE_GC
 #    define GC_ALLOW_CELL_DESTRUCTOR
 #endif
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -164,7 +164,7 @@ private:
 
     Vector<Subresource&> m_critical_subresources;
 
-    IGNORE_GC Vector<WeakPtr<ImageStyleValue>> m_pending_image_values;
+    Vector<WeakPtr<ImageStyleValue>> m_pending_image_values;
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -127,7 +127,7 @@ void ImageSetStyleValue::load_any_resources(DOM::Document& document)
 {
     auto dpr = document.page().client().device_pixels_per_css_pixel();
     if (auto const* image = select_image(dpr); image && image != m_selected_image) {
-        const_cast<AbstractImageStyleValue&>(*image).set_style_sheet(m_style_sheet);
+        const_cast<AbstractImageStyleValue&>(*image).set_style_sheet(m_style_sheet.ptr());
         m_selected_image = image;
     }
     if (m_selected_image)

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibGC/Weak.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 
 namespace Web::CSS {
@@ -54,7 +55,7 @@ private:
     AbstractImageStyleValue const* select_image(double device_pixels_per_css_pixel) const;
 
     Vector<Option> m_options;
-    GC::Ptr<CSSStyleSheet> m_style_sheet;
+    GC::Weak<CSSStyleSheet> m_style_sheet;
     mutable AbstractImageStyleValue const* m_selected_image { nullptr };
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -76,7 +76,7 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
     RuleOrDeclaration rule_or_declaration {
         .environment_settings_object = document.relevant_settings_object(),
         .value = RuleOrDeclaration::Rule {
-            .parent_style_sheet = m_style_sheet,
+            .parent_style_sheet = m_style_sheet.ptr(),
         }
     };
 
@@ -114,9 +114,10 @@ void ImageStyleValue::start_animation_timer_if_needed(DOM::Document& document) c
         return;
 
     if (!m_timer) {
-        m_timer = Platform::Timer::create(document.heap());
+        auto timer = Platform::Timer::create(document.heap());
+        m_timer = timer;
         auto weak_self = make_weak_ptr<ImageStyleValue>();
-        m_timer->on_timeout = GC::create_function(document.heap(), [weak_self] {
+        timer->on_timeout = GC::create_function(document.heap(), [weak_self] {
             if (weak_self)
                 weak_self->animate();
         });

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -90,8 +90,8 @@ private:
     void animate();
     Optional<Gfx::DecodedImageFrame> frame(size_t frame_index, Gfx::IntSize = {}) const;
 
-    GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
-    GC::Ptr<CSSStyleSheet> m_style_sheet;
+    GC::Weak<HTML::SharedResourceRequest> m_resource_request;
+    GC::Weak<CSSStyleSheet> m_style_sheet;
 
     URL m_url;
     GC::Weak<DOM::Document> m_document;
@@ -100,7 +100,7 @@ private:
     size_t m_loops_completed { 0 };
 
     mutable HashTable<Client*> m_clients;
-    mutable GC::Ptr<Platform::Timer> m_timer;
+    mutable GC::Weak<Platform::Timer> m_timer;
 };
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5857,8 +5857,8 @@ void Document::inform_all_viewport_clients_about_the_current_viewport_rect()
 
 void Document::register_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, IntersectionObserver::IntersectionObserver& observer)
 {
-    auto result = m_intersection_observers.set(observer);
-    VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+    VERIFY(!m_intersection_observers.contains(observer));
+    m_intersection_observers.set(observer);
 }
 
 void Document::unregister_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, IntersectionObserver::IntersectionObserver& observer)
@@ -5900,7 +5900,9 @@ void Document::queue_intersection_observer_task()
         m_intersection_observer_task_queued = false;
 
         // 2. Let notify list be a list of all IntersectionObservers whose root is in the DOM tree of document.
-        auto notify_list = GC::RootVector { m_intersection_observers.values() };
+        GC::RootVector<GC::Ref<IntersectionObserver::IntersectionObserver>> notify_list;
+        for (auto& observer : m_intersection_observers)
+            notify_list.append(observer);
 
         // 3. For each IntersectionObserver object observer in notify list, run these steps:
         for (auto& observer : notify_list) {
@@ -6014,7 +6016,9 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
     // 2. For each observer in observer list:
 
     // NOTE: We make a copy of the intersection observers list to avoid modifying it while iterating.
-    auto intersection_observers = GC::RootVector { m_intersection_observers.values() };
+    GC::RootVector<GC::Ref<IntersectionObserver::IntersectionObserver>> intersection_observers;
+    for (auto& observer : m_intersection_observers)
+        intersection_observers.append(observer);
 
     update_paint_and_hit_testing_properties_if_needed();
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1403,7 +1403,7 @@ private:
     GC::Ptr<CSS::VisualViewport> m_visual_viewport;
 
     // NOTE: Not in the spec per se, but Document must be able to access all IntersectionObservers whose root is in the document.
-    IGNORE_GC OrderedHashTable<GC::Ref<IntersectionObserver::IntersectionObserver>> m_intersection_observers;
+    GC::WeakHashSet<IntersectionObserver::IntersectionObserver> m_intersection_observers;
 
     // https://www.w3.org/TR/intersection-observer/#document-intersectionobservertaskqueued
     // Each document has an IntersectionObserverTaskQueued flag which is initialized to false.

--- a/Meta/Lagom/ClangPlugins/LibJSGCPluginAction.cpp
+++ b/Meta/Lagom/ClangPlugins/LibJSGCPluginAction.cpp
@@ -363,9 +363,6 @@ bool LibJSGCVisitor::VisitCXXRecordDecl(clang::CXXRecordDecl* record)
     auto record_is_cell = record_inherits_from_cell(*record);
 
     for (clang::FieldDecl const* field : record->fields()) {
-        if (decl_has_annotation(field, "serenity::ignore_gc"))
-            continue;
-
         // Skip anonymous structs/unions - their members are accessed indirectly
         // and may be handled specially (e.g., tagged unions with type checks)
         if (field->isAnonymousStructOrUnion())


### PR DESCRIPTION
ImageStyleValue stored GC-managed request, stylesheet, and animation
timer references as strong GC::Ptr fields even though image style values
are refcounted objects. When such a style value outlives the GC object
that normally visits it, those fields can keep stale pointers after GC
collects the referents. On Steam this allowed a stale image resource
request to be read as unrelated image data, making carousel SVG arrows
render at the wrong size.

Store these back references as GC::Weak instead. Reachable style values
still use live requests, stylesheets, and timers normally, but detached
values observe null after the GC collects the referent and can reload or
skip the now-dead association instead of dereferencing reused GC memory.
Keep a local timer handle while installing the timeout callback so setup
does not rely on the weak member.

With the image style values no longer hiding strong GC edges, remove the
obsolete IGNORE_GC annotation from CSSStyleSheet's pending image list.

Before:
<img width="2112" height="854" alt="CleanShot 2026-05-25 at 04 44 41@2x" src="https://github.com/user-attachments/assets/842d1fad-09c5-4874-9f69-283a5999ec09" />


After:
<img width="2192" height="874" alt="CleanShot 2026-05-25 at 04 40 57@2x" src="https://github.com/user-attachments/assets/a58f53f2-839c-4408-bb14-2127f65400fa" />
