### PR TITLE
LibWeb: Avoid full style invalidation on viewport resize

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -72,10 +72,14 @@ public:
     bool is_property_inherited(PropertyID property_id) const;
     bool is_animated_property_inherited(PropertyID property_id) const;
     bool is_animated_property_result_of_transition(PropertyID property_id) const;
+    bool depends_on_viewport_metrics() const { return m_depends_on_viewport_metrics; }
+    bool font_metrics_depend_on_viewport_metrics() const { return m_font_metrics_depend_on_viewport_metrics; }
     void set_property_important(PropertyID, Important);
     void set_property_inherited(PropertyID, Inherited);
     void set_animated_property_inherited(PropertyID, Inherited);
     void set_animated_property_result_of_transition(PropertyID, AnimatedPropertyResultOfTransition);
+    void set_depends_on_viewport_metrics() { m_depends_on_viewport_metrics = true; }
+    void set_font_metrics_depend_on_viewport_metrics() { m_font_metrics_depend_on_viewport_metrics = true; }
 
     void set_property(PropertyID, NonnullRefPtr<StyleValue const> value, Inherited = Inherited::No, Important = Important::No);
     void set_property_without_modifying_flags(PropertyID, NonnullRefPtr<StyleValue const> value);
@@ -311,6 +315,8 @@ private:
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> m_animated_property_values;
 
     Display m_display_before_box_type_transformation { InitialValues::display() };
+    bool m_depends_on_viewport_metrics { false };
+    bool m_font_metrics_depend_on_viewport_metrics { false };
 
     RefPtr<Gfx::FontCascadeList const> m_cached_computed_font_list;
     RefPtr<Gfx::Font const> m_cached_first_available_computed_font;

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -133,7 +133,9 @@ Length::ResolutionContext Length::ResolutionContext::for_element(DOM::AbstractEl
     return Length::ResolutionContext {
         .viewport_rect = element.element().navigable()->viewport_rect(),
         .font_metrics = { element.computed_properties()->font_size(), element.computed_properties()->first_available_computed_font(element.document().font_computer())->pixel_metrics(), element.computed_properties()->line_height() },
-        .root_font_metrics = { root_element->computed_properties()->font_size(), root_element->computed_properties()->first_available_computed_font(element.document().font_computer())->pixel_metrics(), element.computed_properties()->line_height() }
+        .root_font_metrics = { root_element->computed_properties()->font_size(), root_element->computed_properties()->first_available_computed_font(element.document().font_computer())->pixel_metrics(), element.computed_properties()->line_height() },
+        .font_metrics_depend_on_viewport_metrics = element.computed_properties()->font_metrics_depend_on_viewport_metrics(),
+        .root_font_metrics_depend_on_viewport_metrics = root_element->computed_properties()->font_metrics_depend_on_viewport_metrics(),
     };
 }
 
@@ -177,7 +179,7 @@ Length::ResolutionContext Length::ResolutionContext::for_layout_node(Layout::Nod
 
 CSSPixels Length::to_px(ResolutionContext const& context) const
 {
-    return to_px(context.viewport_rect, context.font_metrics, context.root_font_metrics);
+    return CSSPixels::nearest_value_for(to_px_without_rounding(context));
 }
 
 CSSPixels Length::to_px_slow_case(Layout::Node const& layout_node) const

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -65,8 +65,59 @@ public:
         CSSPixelRect viewport_rect;
         FontMetrics font_metrics;
         FontMetrics root_font_metrics;
+        bool font_metrics_depend_on_viewport_metrics { false };
+        bool root_font_metrics_depend_on_viewport_metrics { false };
 
-        bool operator==(ResolutionContext const&) const = default;
+        void set_did_resolve_viewport_relative_length(bool& did_resolve_viewport_relative_length) const
+        {
+            m_did_resolve_viewport_relative_length = &did_resolve_viewport_relative_length;
+        }
+
+        void record_viewport_relative_length_resolution() const
+        {
+            if (m_did_resolve_viewport_relative_length)
+                *m_did_resolve_viewport_relative_length = true;
+        }
+
+        void record_font_relative_length_resolution(LengthUnit unit) const
+        {
+            if (!m_did_resolve_viewport_relative_length)
+                return;
+
+            switch (unit) {
+            case LengthUnit::Rem:
+            case LengthUnit::Rex:
+            case LengthUnit::Rcap:
+            case LengthUnit::Rch:
+            case LengthUnit::Ric:
+            case LengthUnit::Rlh:
+                if (root_font_metrics_depend_on_viewport_metrics)
+                    *m_did_resolve_viewport_relative_length = true;
+                return;
+            case LengthUnit::Em:
+            case LengthUnit::Ex:
+            case LengthUnit::Cap:
+            case LengthUnit::Ch:
+            case LengthUnit::Ic:
+            case LengthUnit::Lh:
+                if (font_metrics_depend_on_viewport_metrics)
+                    *m_did_resolve_viewport_relative_length = true;
+                return;
+            default:
+                return;
+            }
+        }
+
+        bool operator==(ResolutionContext const& other) const
+        {
+            return viewport_rect == other.viewport_rect
+                && font_metrics == other.font_metrics
+                && root_font_metrics == other.root_font_metrics
+                && font_metrics_depend_on_viewport_metrics == other.font_metrics_depend_on_viewport_metrics
+                && root_font_metrics_depend_on_viewport_metrics == other.root_font_metrics_depend_on_viewport_metrics;
+        }
+
+        mutable bool* m_did_resolve_viewport_relative_length { nullptr };
     };
 
     [[nodiscard]] CSSPixels to_px(ResolutionContext const&) const;
@@ -82,10 +133,14 @@ public:
     {
         if (is_absolute())
             return absolute_length_to_px_without_rounding();
-        if (is_font_relative())
+        if (is_font_relative()) {
+            context.record_font_relative_length_resolution(m_unit);
             return font_relative_length_to_px_without_rounding(context.font_metrics, context.root_font_metrics);
-        if (is_viewport_relative())
+        }
+        if (is_viewport_relative()) {
+            context.record_viewport_relative_length_resolution();
             return viewport_relative_length_to_px_without_rounding(context.viewport_rect);
+        }
 
         VERIFY_NOT_REACHED();
     }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -96,6 +96,11 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(StyleComputer);
 
+static bool property_affects_font_metrics(PropertyID property_id)
+{
+    return property_id == PropertyID::FontSize || property_id == PropertyID::LineHeight;
+}
+
 CSSStyleProperties const& MatchingRule::declaration() const
 {
     if (rule->type() == CSSRule::Type::Style)
@@ -953,7 +958,13 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
 
             auto const& computation_context = get_computation_context_for_property(property_id, computed_properties, abstract_element);
 
+            computation_context.reset_viewport_metric_dependency_tracking();
             result.set(property_id, compute_value_of_property(property_id, *style_value, get_property_specified_value, computation_context, m_document->page().client().device_pixels_per_css_pixel()));
+            if (computation_context.depends_on_viewport_metrics()) {
+                computed_properties.set_depends_on_viewport_metrics();
+                if (property_affects_font_metrics(property_id))
+                    computed_properties.set_font_metrics_depend_on_viewport_metrics();
+            }
         }
 
         return result;
@@ -1566,6 +1577,19 @@ CSSPixels StyleComputer::relative_size_mapping(RelativeSize relative_size, CSSPi
     VERIFY_NOT_REACHED();
 }
 
+static bool font_size_value_depends_on_inherited_font_size(StyleValue const& value)
+{
+    return value.is_percentage()
+        || (value.is_calculated() && value.as_calculated().contains_percentage())
+        || first_is_one_of(value.to_keyword(), Keyword::Larger, Keyword::Smaller, Keyword::Math);
+}
+
+static bool line_height_value_depends_on_computed_font_size(StyleValue const& value)
+{
+    return value.is_percentage()
+        || (value.is_calculated() && value.as_calculated().contains_percentage());
+}
+
 void StyleComputer::compute_property_values(ComputedProperties& style, Optional<DOM::AbstractElement> abstract_element) const
 {
     VERIFY(computation_context_cache_is_empty());
@@ -1581,15 +1605,23 @@ void StyleComputer::compute_property_values(ComputedProperties& style, Optional<
 
         auto const& specified_value = style.property(property_id, ComputedProperties::WithAnimationsApplied::No);
 
+        computation_context.reset_viewport_metric_dependency_tracking();
         auto const& computed_value = compute_value_of_property(property_id, specified_value, get_property_specified_value, computation_context, device_pixels_per_css_pixel);
+        if (computation_context.depends_on_viewport_metrics()) {
+            style.set_depends_on_viewport_metrics();
+            if (property_affects_font_metrics(property_id))
+                style.set_font_metrics_depend_on_viewport_metrics();
+        }
 
         style.set_property_without_modifying_flags(property_id, computed_value);
     }
 
     clear_computation_context_caches();
 
-    if (abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element()))
+    if (abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element())) {
         m_root_element_font_metrics = calculate_root_element_font_metrics(style);
+        m_root_element_font_metrics_depend_on_viewport_metrics = style.font_metrics_depend_on_viewport_metrics();
+    }
 }
 
 ComputationContext const& StyleComputer::get_computation_context_for_property(PropertyID property_id, ComputedProperties const& style, Optional<DOM::AbstractElement> abstract_element) const
@@ -1647,6 +1679,10 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
                     .root_font_metrics = abstract_element.has_value() && abstract_element->element().is_html_html_element()
                         ? line_height_font_metrics
                         : m_root_element_font_metrics,
+                    .font_metrics_depend_on_viewport_metrics = style.font_metrics_depend_on_viewport_metrics(),
+                    .root_font_metrics_depend_on_viewport_metrics = abstract_element.has_value() && abstract_element->element().is_html_html_element()
+                        ? style.font_metrics_depend_on_viewport_metrics()
+                        : m_root_element_font_metrics_depend_on_viewport_metrics,
                 },
                 .abstract_element = abstract_element
             };
@@ -1664,6 +1700,8 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
                         style.first_available_computed_font(document().font_computer())->pixel_metrics(),
                         style.line_height() },
                     .root_font_metrics = m_root_element_font_metrics,
+                    .font_metrics_depend_on_viewport_metrics = style.font_metrics_depend_on_viewport_metrics(),
+                    .root_font_metrics_depend_on_viewport_metrics = abstract_element.has_value() && abstract_element->element().is_html_html_element() ? style.font_metrics_depend_on_viewport_metrics() : m_root_element_font_metrics_depend_on_viewport_metrics,
                 },
                 .abstract_element = abstract_element,
                 .color_scheme = style.color_scheme(document().page().preferred_color_scheme(), document().supported_color_schemes())
@@ -2076,7 +2114,7 @@ static bool is_monospace(StyleValue const& value)
 //       instead of the default font size (16px).
 //       See this blog post for a lot more details about this weirdness:
 //       https://manishearth.github.io/blog/2017/08/10/font-size-an-unexpectedly-complex-css-property/
-RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties) const
+RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::AbstractElement abstract_element, CascadedProperties& cascaded_properties, bool& depends_on_viewport_metrics) const
 {
     // Check for `font-family: monospace`. Note that `font-family: monospace, AnythingElse` does not trigger this path.
     // Some CSS frameworks use `font-family: monospace, monospace` to work around this behavior.
@@ -2097,6 +2135,7 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
 
     NonnullRefPtr<StyleValue const> new_font_size = CSS::LengthStyleValue::create(CSS::Length::make_px(default_monospace_font_size_in_px));
     CSSPixels current_size_in_px = default_monospace_font_size_in_px;
+    bool current_size_depends_on_viewport_metrics = false;
 
     for (auto& ancestor : ancestors.in_reverse()) {
         auto ancestor_computed_properties = ancestor.computed_properties();
@@ -2108,6 +2147,7 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
             continue;
         if (font_size_value->is_initial() || font_size_value->is_unset()) {
             current_size_in_px = default_monospace_font_size_in_px;
+            current_size_depends_on_viewport_metrics = false;
             continue;
         }
         if (font_size_value->is_inherit()) {
@@ -2117,6 +2157,7 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
 
         if (auto absolute_size = keyword_to_absolute_size(font_size_value->to_keyword()); absolute_size.has_value()) {
             current_size_in_px = absolute_size_mapping(absolute_size.value(), default_monospace_font_size_in_px);
+            current_size_depends_on_viewport_metrics = false;
             continue;
         }
 
@@ -2142,11 +2183,28 @@ RefPtr<StyleValue const> StyleComputer::recascade_font_size_if_needed(DOM::Abstr
 
         VERIFY(font_size_value->is_length());
 
-        auto inherited_line_height = ancestor.element_to_inherit_style_from().map([](auto&& parent_element) { return parent_element.computed_properties()->line_height(); }).value_or(InitialValues::line_height());
+        bool inherited_font_metrics_depend_on_viewport_metrics = false;
+        auto inherited_line_height = ancestor.element_to_inherit_style_from()
+                                         .map([&](auto&& parent_element) {
+                                             inherited_font_metrics_depend_on_viewport_metrics = parent_element.computed_properties()->font_metrics_depend_on_viewport_metrics();
+                                             return parent_element.computed_properties()->line_height();
+                                         })
+                                         .value_or(InitialValues::line_height());
 
-        current_size_in_px = font_size_value->as_length().length().to_px(viewport_rect(), Length::FontMetrics { current_size_in_px, monospace_font->with_size(current_size_in_px * 0.75f)->pixel_metrics(), inherited_line_height }, m_root_element_font_metrics);
+        bool did_resolve_viewport_relative_length = false;
+        Length::ResolutionContext resolution_context {
+            .viewport_rect = viewport_rect(),
+            .font_metrics = { current_size_in_px, monospace_font->with_size(current_size_in_px * 0.75f)->pixel_metrics(), inherited_line_height },
+            .root_font_metrics = m_root_element_font_metrics,
+            .font_metrics_depend_on_viewport_metrics = current_size_depends_on_viewport_metrics || inherited_font_metrics_depend_on_viewport_metrics,
+            .root_font_metrics_depend_on_viewport_metrics = m_root_element_font_metrics_depend_on_viewport_metrics,
+        };
+        resolution_context.set_did_resolve_viewport_relative_length(did_resolve_viewport_relative_length);
+        current_size_in_px = font_size_value->as_length().length().to_px(resolution_context);
+        current_size_depends_on_viewport_metrics = did_resolve_viewport_relative_length;
     };
 
+    depends_on_viewport_metrics = current_size_depends_on_viewport_metrics;
     return CSS::LengthStyleValue::create(CSS::Length::make_px(current_size_in_px));
 }
 
@@ -2156,9 +2214,15 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
 
     auto computed_style = document().heap().allocate<CSS::ComputedProperties>();
 
-    auto new_font_size = recascade_font_size_if_needed(abstract_element, cascaded_properties);
-    if (new_font_size)
+    bool recascaded_font_size_depends_on_viewport_metrics = false;
+    auto new_font_size = recascade_font_size_if_needed(abstract_element, cascaded_properties, recascaded_font_size_depends_on_viewport_metrics);
+    if (new_font_size) {
         computed_style->set_property(PropertyID::FontSize, *new_font_size, ComputedProperties::Inherited::No, Important::No);
+        if (recascaded_font_size_depends_on_viewport_metrics) {
+            computed_style->set_depends_on_viewport_metrics();
+            computed_style->set_font_metrics_depend_on_viewport_metrics();
+        }
+    }
 
     auto const& computed_properties_to_inherit_from = abstract_element.element_to_inherit_style_from().map([](auto const& element) { return element.computed_properties(); }).value_or(nullptr);
 
@@ -2168,9 +2232,13 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
 
     auto const device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel();
 
-    auto const compute_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> const& style_value) {
+    auto const compute_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> const& style_value, bool& depends_on_viewport_metrics) {
         auto const& computation_context = get_computation_context_for_property(property_id, *computed_style, abstract_element);
-        return compute_value_of_property(property_id, style_value, get_property_specified_value, computation_context, device_pixels_per_css_pixel);
+        computation_context.reset_viewport_metric_dependency_tracking();
+        auto computed_value = compute_value_of_property(property_id, style_value, get_property_specified_value, computation_context, device_pixels_per_css_pixel);
+        if (computation_context.depends_on_viewport_metrics())
+            depends_on_viewport_metrics = true;
+        return computed_value;
     };
 
     Optional<LogicalAliasMappingContext> logical_alias_mapping_context;
@@ -2251,6 +2319,8 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
             computed_style->set_property_inherited(property_id, ComputedProperties::Inherited::Yes);
             value = computed_properties_to_inherit_from->property(inherited_property_id, ComputedProperties::WithAnimationsApplied::No);
             requires_computation = property_requires_computation_with_inherited_value(property_id);
+            if (property_affects_font_metrics(inherited_property_id) && computed_properties_to_inherit_from->font_metrics_depend_on_viewport_metrics())
+                computed_style->set_font_metrics_depend_on_viewport_metrics();
 
             // FIXME: Do we need to recompute animated inherited values?
             if (auto animated_value = computed_properties_to_inherit_from->animated_property_values().get(inherited_property_id); animated_value.has_value())
@@ -2274,17 +2344,29 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
         //        which contain lengths (e.g. StyleValueList)) - maybe we can use `is_computationally_independent()`
         bool depends_on_inherited_info = (value->is_length() && value->as_length().length().is_font_relative())
             || (property_id == PropertyID::FontWeight && first_is_one_of(value->to_keyword(), Keyword::Bolder, Keyword::Lighter))
-            || (property_id == PropertyID::FontSize && first_is_one_of(value->to_keyword(), Keyword::Larger, Keyword::Smaller));
+            || (property_id == PropertyID::FontSize && font_size_value_depends_on_inherited_font_size(*value))
+            || (property_id == PropertyID::LineHeight && line_height_value_depends_on_computed_font_size(*value));
         if (depends_on_inherited_info)
             computed_style->add_inheritance_dependent_specified_value(property_id, *value);
 
         // NB: We compute using the inherited (physical) property to avoid having to add cases for all the logical
         //     alias properties in `compute_value_of_property`
-        computed_style->set_property_without_modifying_flags(property_id, requires_computation ? compute_property(inherited_property_id, value.release_nonnull()) : value.release_nonnull());
+        bool depends_on_viewport_metrics = false;
+        auto computed_value = requires_computation
+            ? compute_property(inherited_property_id, value.release_nonnull(), depends_on_viewport_metrics)
+            : value.release_nonnull();
+        if (depends_on_viewport_metrics) {
+            computed_style->set_depends_on_viewport_metrics();
+            if (property_affects_font_metrics(inherited_property_id))
+                computed_style->set_font_metrics_depend_on_viewport_metrics();
+        }
+        computed_style->set_property_without_modifying_flags(property_id, move(computed_value));
     }
 
-    if (is<HTML::HTMLHtmlElement>(abstract_element.element()))
+    if (is<HTML::HTMLHtmlElement>(abstract_element.element())) {
         m_root_element_font_metrics = calculate_root_element_font_metrics(computed_style);
+        m_root_element_font_metrics_depend_on_viewport_metrics = computed_style->font_metrics_depend_on_viewport_metrics();
+    }
 
     // Compute the value of custom properties
     compute_custom_properties(computed_style, abstract_element);
@@ -2556,8 +2638,15 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(
     case PropertyID::CornerTopLeftShape:
     case PropertyID::CornerTopRightShape:
         return compute_corner_shape(absolutized_value);
-    case PropertyID::FontSize:
-        return compute_font_size(absolutized_value, get_property_specified_value(PropertyID::MathDepth)->as_integer().integer(), inheritance_parent());
+    case PropertyID::FontSize: {
+        auto parent = inheritance_parent();
+        if (font_size_value_depends_on_inherited_font_size(*absolutized_value) && parent.has_value()) {
+            auto parent_properties = parent->computed_properties();
+            if (parent_properties && parent_properties->font_metrics_depend_on_viewport_metrics())
+                computation_context.length_resolution_context.record_viewport_relative_length_resolution();
+        }
+        return compute_font_size(absolutized_value, get_property_specified_value(PropertyID::MathDepth)->as_integer().integer(), parent);
+    }
     case PropertyID::FontStyle:
         return compute_font_style(absolutized_value);
     case PropertyID::FontWeight:

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -121,7 +121,7 @@ public:
     static CSSPixels default_user_font_size();
     static CSSPixels absolute_size_mapping(AbsoluteSize, CSSPixels default_font_size);
     static CSSPixels relative_size_mapping(RelativeSize, CSSPixels inherited_font_size);
-    [[nodiscard]] RefPtr<StyleValue const> recascade_font_size_if_needed(DOM::AbstractElement, CascadedProperties&) const;
+    [[nodiscard]] RefPtr<StyleValue const> recascade_font_size_if_needed(DOM::AbstractElement, CascadedProperties&, bool& depends_on_viewport_metrics) const;
 
     void set_viewport_rect(Badge<DOM::Document>, CSSPixelRect const& viewport_rect) { m_viewport_rect = viewport_rect; }
 
@@ -211,6 +211,7 @@ private:
 
     Length::FontMetrics m_default_font_metrics;
     mutable Length::FontMetrics m_root_element_font_metrics;
+    mutable bool m_root_element_font_metrics_depend_on_viewport_metrics { false };
 
     mutable Optional<ComputationContext> m_cached_font_computation_context;
     mutable Optional<ComputationContext> m_cached_line_height_computation_context;

--- a/Libraries/LibWeb/CSS/StyleValues/ComputationContext.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ComputationContext.h
@@ -17,11 +17,24 @@ struct ComputationContext {
     Optional<DOM::AbstractElement> abstract_element {};
     Optional<PreferredColorScheme> color_scheme {};
 
+    void reset_viewport_metric_dependency_tracking() const
+    {
+        m_did_resolve_viewport_relative_length = false;
+        length_resolution_context.set_did_resolve_viewport_relative_length(m_did_resolve_viewport_relative_length);
+    }
+
+    bool depends_on_viewport_metrics() const
+    {
+        return m_did_resolve_viewport_relative_length;
+    }
+
     void visit_edges(GC::Cell::Visitor& visitor)
     {
         if (abstract_element.has_value())
             abstract_element->visit(visitor);
     }
+
+    mutable bool m_did_resolve_viewport_relative_length { false };
 };
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2108,6 +2108,9 @@ void Document::update_style()
     if (!browsing_context())
         return;
 
+    // Fetch the viewport rect once, instead of repeatedly, during style computation.
+    style_computer().set_viewport_rect({}, viewport_rect());
+
     update_animated_style_if_needed();
 
     // Associated with each top-level browsing context is a current transition generation that is incremented on each
@@ -2119,20 +2122,20 @@ void Document::update_style()
         CSS::Invalidation::invalidate_style_for_pending_has_mutations(*this);
     }
 
-    if (!m_style_invalidator->has_pending_invalidations() && !needs_full_style_update() && !needs_style_update() && !child_needs_style_update())
+    if (!m_style_invalidator->has_pending_invalidations() && !needs_full_style_update() && !needs_style_update() && !child_needs_style_update() && !m_needs_media_query_evaluation)
         return;
-
-    m_style_invalidator->invalidate(*this);
 
     // NOTE: If this is a document hosting <template> contents, style update is unnecessary.
     if (m_created_for_appropriate_template_contents)
         return;
 
-    // Fetch the viewport rect once, instead of repeatedly, during style computation.
-    style_computer().set_viewport_rect({}, viewport_rect());
-
     if (m_needs_media_query_evaluation)
         evaluate_media_rules();
+
+    if (!m_style_invalidator->has_pending_invalidations() && !needs_full_style_update() && !needs_style_update() && !child_needs_style_update())
+        return;
+
+    m_style_invalidator->invalidate(*this);
 
     build_registered_properties_cache();
 
@@ -2152,6 +2155,37 @@ void Document::update_style()
     }
 
     apply_document_style_invalidation_after_style_change(*this, invalidation);
+}
+
+static bool element_or_pseudo_depends_on_viewport_metrics(Element const& element)
+{
+    if (auto computed_properties = element.computed_properties(); computed_properties && computed_properties->depends_on_viewport_metrics())
+        return true;
+
+    bool depends_on_viewport_metrics = false;
+    element.for_each_synthetic_pseudo_element([&](CSS::PseudoElement, SyntheticPseudoElement const& pseudo_element) {
+        if (auto computed_properties = pseudo_element.computed_properties(); computed_properties && computed_properties->depends_on_viewport_metrics()) {
+            depends_on_viewport_metrics = true;
+            return IterationDecision::Break;
+        }
+        return IterationDecision::Continue;
+    });
+    return depends_on_viewport_metrics;
+}
+
+void Document::invalidate_style_for_viewport_change()
+{
+    for_each_shadow_including_inclusive_descendant([](Node& node) {
+        auto* element = as_if<Element>(node);
+        if (!element)
+            return TraversalDecision::Continue;
+
+        // Descendants that inherit changed values are reached by the normal inherited-style invalidation path.
+        if (element_or_pseudo_depends_on_viewport_metrics(*element) || element->style_uses_if_css_function())
+            element->set_needs_style_update(true);
+
+        return TraversalDecision::Continue;
+    });
 }
 
 void Document::update_style_if_needed_for_element(AbstractElement const& abstract_element)
@@ -2207,9 +2241,9 @@ GC::Ptr<CSS::ComputedProperties const> Document::update_style_for_element(Abstra
         navigable->container()->document().update_layout(UpdateLayoutReason::ChildDocumentStyleUpdate);
 
     if (browsing_context()) {
-        update_animated_style_if_needed();
-
         style_computer().set_viewport_rect({}, viewport_rect());
+
+        update_animated_style_if_needed();
 
         // Media query evaluation can enqueue normal style invalidations, so do it before deciding whether the full
         // style traversal needs to run.
@@ -2336,6 +2370,8 @@ bool Document::element_needs_style_update(AbstractElement const& abstract_elemen
     if (m_needs_animated_style_update)
         return true;
     if (m_needs_invalidation_of_elements_affected_by_has)
+        return true;
+    if (m_needs_media_query_evaluation)
         return true;
     if (m_style_invalidator->has_pending_invalidations())
         return true;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -373,6 +373,7 @@ public:
     void obtain_theme_color();
 
     void update_style();
+    void invalidate_style_for_viewport_change();
     void update_style_if_needed_for_element(AbstractElement const&);
     enum class StyleUpdateMode : u8 {
         Normal,

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -944,6 +944,67 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
     return invalidation;
 }
 
+CSS::RequiredInvalidationAfterStyleChange Element::recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker)
+{
+    CSS::RequiredInvalidationAfterStyleChange invalidation;
+
+    auto& style_computer = document().style_computer();
+
+    // Any document change that can cause this element's style to change, could also affect its pseudo-elements.
+    auto recompute_pseudo_element_style = [&](CSS::PseudoElement pseudo_element) {
+        style_computer.push_ancestor(*this);
+
+        auto pseudo_element_style = computed_properties(pseudo_element);
+        auto new_pseudo_element_style = style_computer.compute_pseudo_element_style_if_needed({ *this, pseudo_element }, did_change_custom_properties);
+
+        // TODO: Can we be smarter about invalidation?
+        if (pseudo_element_style && new_pseudo_element_style) {
+            DOM::AbstractElement abstract_element { *this, pseudo_element };
+            invalidation |= compute_required_invalidation(*pseudo_element_style, *new_pseudo_element_style, document().font_computer(), pseudo_element_unsafe_layout_node(pseudo_element), abstract_element);
+        } else if (pseudo_element_style || new_pseudo_element_style) {
+            invalidation = CSS::RequiredInvalidationAfterStyleChange::full();
+        }
+
+        set_computed_properties(pseudo_element, move(new_pseudo_element_style));
+        style_computer.pop_ancestor(*this);
+    };
+
+    recompute_pseudo_element_style(CSS::PseudoElement::Before);
+    recompute_pseudo_element_style(CSS::PseudoElement::After);
+    recompute_pseudo_element_style(CSS::PseudoElement::FirstLetter);
+    recompute_pseudo_element_style(CSS::PseudoElement::Selection);
+    if (m_rendered_in_top_layer)
+        recompute_pseudo_element_style(CSS::PseudoElement::Backdrop);
+    if (had_list_marker || m_computed_properties->display().is_list_item())
+        recompute_pseudo_element_style(CSS::PseudoElement::Marker);
+
+    return invalidation;
+}
+
+void Element::apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const& invalidation)
+{
+    if (invalidation.rebuild_layout_tree || !unsafe_layout_node())
+        return;
+
+    // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
+    unsafe_layout_node()->apply_style(*m_computed_properties);
+    if (invalidation.repaint)
+        set_needs_repaint();
+
+    // Do the same for pseudo-elements.
+    for_each_synthetic_pseudo_element([&](CSS::PseudoElement pseudo_element_type, SyntheticPseudoElement const& pseudo_element) {
+        auto pseudo_element_style = computed_properties(pseudo_element_type);
+        if (!pseudo_element_style)
+            return;
+
+        if (auto node_with_style = pseudo_element.unsafe_layout_node()) {
+            node_with_style->apply_style(*pseudo_element_style);
+            if (invalidation.repaint && node_with_style->first_paintable())
+                node_with_style->first_paintable()->set_needs_repaint();
+        }
+    });
+}
+
 CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_change_custom_properties)
 {
     VERIFY(parent());
@@ -1022,58 +1083,14 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
         });
     }
 
-    // Any document change that can cause this element's style to change, could also affect its pseudo-elements.
-    auto recompute_pseudo_element_style = [&](CSS::PseudoElement pseudo_element) {
-        style_computer.push_ancestor(*this);
-
-        auto pseudo_element_style = computed_properties(pseudo_element);
-        auto new_pseudo_element_style = style_computer.compute_pseudo_element_style_if_needed({ *this, pseudo_element }, did_change_custom_properties);
-
-        // TODO: Can we be smarter about invalidation?
-        if (pseudo_element_style && new_pseudo_element_style) {
-            DOM::AbstractElement abstract_element { *this, pseudo_element };
-            invalidation |= compute_required_invalidation(*pseudo_element_style, *new_pseudo_element_style, document().font_computer(), pseudo_element_unsafe_layout_node(pseudo_element), abstract_element);
-        } else if (pseudo_element_style || new_pseudo_element_style) {
-            invalidation = CSS::RequiredInvalidationAfterStyleChange::full();
-        }
-
-        set_computed_properties(pseudo_element, move(new_pseudo_element_style));
-        style_computer.pop_ancestor(*this);
-    };
-
-    recompute_pseudo_element_style(CSS::PseudoElement::Before);
-    recompute_pseudo_element_style(CSS::PseudoElement::After);
-    recompute_pseudo_element_style(CSS::PseudoElement::FirstLetter);
-    recompute_pseudo_element_style(CSS::PseudoElement::Selection);
-    if (m_rendered_in_top_layer)
-        recompute_pseudo_element_style(CSS::PseudoElement::Backdrop);
-    if (had_list_marker || m_computed_properties->display().is_list_item())
-        recompute_pseudo_element_style(CSS::PseudoElement::Marker);
+    invalidation |= recompute_pseudo_element_styles(did_change_custom_properties, had_list_marker);
 
     if (invalidation.is_none()) {
         counters.element_style_noop_recomputations++;
         return invalidation;
     }
 
-    if (!invalidation.rebuild_layout_tree && unsafe_layout_node()) {
-        // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
-        unsafe_layout_node()->apply_style(*m_computed_properties);
-        if (invalidation.repaint)
-            set_needs_repaint();
-
-        // Do the same for pseudo-elements.
-        for_each_synthetic_pseudo_element([&](CSS::PseudoElement pseudo_element_type, SyntheticPseudoElement const& pseudo_element) {
-            auto pseudo_element_style = computed_properties(pseudo_element_type);
-            if (!pseudo_element_style)
-                return;
-
-            if (auto node_with_style = pseudo_element.unsafe_layout_node()) {
-                node_with_style->apply_style(*pseudo_element_style);
-                if (invalidation.repaint && node_with_style->first_paintable())
-                    node_with_style->first_paintable()->set_needs_repaint();
-            }
-        });
-    }
+    apply_computed_style_to_layout_node_if_needed(invalidation);
 
     return invalidation;
 }
@@ -1085,6 +1102,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
 
     auto computed_properties = this->computed_properties();
     VERIFY(computed_properties);
+    auto had_list_marker = computed_properties->display().is_list_item();
 
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
@@ -1134,17 +1152,18 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
         invalidation |= CSS::compute_property_invalidation(property_id, old_value.ptr(), &new_value);
     }
 
+    if (!invalidation.is_none() && !computed_properties->animated_property_values().is_empty())
+        document().set_needs_animated_style_update();
+
+    bool did_change_custom_properties = false;
+    invalidation |= recompute_pseudo_element_styles(did_change_custom_properties, had_list_marker);
+
     if (invalidation.is_none()) {
         counters.element_inherited_style_noop_recomputations++;
         return invalidation;
     }
 
-    // NB: unsafe_layout_node() because we're applying recomputed inherited styles during
-    //     style recalculation, before layout has been updated.
-    if (unsafe_layout_node())
-        unsafe_layout_node()->apply_style(*computed_properties);
-    if (invalidation.repaint)
-        set_needs_repaint();
+    apply_computed_style_to_layout_node_if_needed(invalidation);
     return invalidation;
 }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -668,6 +668,8 @@ private:
     FlyString make_html_uppercased_qualified_name() const;
 
     void exit_fullscreen_on_element_removal();
+    CSS::RequiredInvalidationAfterStyleChange recompute_pseudo_element_styles(bool& did_change_custom_properties, bool had_list_marker);
+    void apply_computed_style_to_layout_node_if_needed(CSS::RequiredInvalidationAfterStyleChange const&);
 
     WebIDL::ExceptionOr<GC::Ptr<Node>> insert_adjacent(StringView where, GC::Ref<Node> node);
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2938,8 +2938,7 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
     }
 
     if (auto document = active_document()) {
-        // NOTE: Resizing the viewport changes the reference value for viewport-relative CSS lengths.
-        document->invalidate_style(DOM::StyleInvalidationReason::NavigableSetViewportSize);
+        document->invalidate_style_for_viewport_change();
         document->set_needs_media_query_evaluation();
         document->set_needs_layout_update(DOM::SetNeedsLayoutReason::NavigableSetViewportSize);
     }

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-animation-targeted-restyle.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-animation-targeted-restyle.txt
@@ -1,0 +1,13 @@
+initial viewport animated width: 45px
+initial inherited-font animated width: 45px
+initial root-font animated width: 45px
+initial animated font size: 45px
+initial animated inherited-font width: 67.5px
+targeted pending animated outline width: 75px
+resized viewport animated width: 75px
+resized inherited-font animated width: 75px
+resized root-font animated width: 75px
+resized animated font size: 75px
+resized animated inherited-font width: 112.5px
+full invalidations: 0
+style recomputations bounded: true

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-media-query-evaluation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-media-query-evaluation.txt
@@ -1,0 +1,5 @@
+initial color: rgb(255, 0, 0)
+initial canvas fill style: #ff0000
+targeted canvas fill style: #008000
+resized color: rgb(0, 128, 0)
+media query full invalidations: 1

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-targeted-restyle.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-targeted-restyle.txt
@@ -1,0 +1,14 @@
+viewport width: 50px
+inherited font size: 50px
+monospace recascaded font size: 50px
+percentage font size: 75px
+percentage em width: 75px
+percentage line height: 75px
+calc percentage line height: 67.5px
+explicit inherit width: 50px
+pseudo width: 50px
+pseudo originating font size: 50px
+pseudo inherited font size: 50px
+full invalidations: 0
+style recomputations bounded: true
+inherited recomputations present: true

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-targeted-restyle.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-targeted-restyle.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                html {
+                    font-size: 10vw;
+                }
+
+                #font-source {
+                    font-size: 10vw;
+                }
+
+                #animated-font-source {
+                    font-size: 16px;
+                }
+            </style>
+            <div id="viewport-target"></div>
+            <div id="font-source"><div id="inherited-font-target"></div></div>
+            <div id="root-font-target"></div>
+            <div id="animated-font-source"><div id="animated-inherited-font-target"></div></div>
+            <div id="pending-outline-animation-target"></div>
+            <script>
+                function pauseHalfway(animation) {
+                    animation.pause();
+                    animation.currentTime = 500;
+                }
+
+                pauseHalfway(document.getElementById("viewport-target").animate([{ width: "10vw" }, { width: "20vw" }], {
+                    duration: 1000,
+                    fill: "both",
+                }));
+                pauseHalfway(document.getElementById("inherited-font-target").animate([{ width: "1em" }, { width: "2em" }], {
+                    duration: 1000,
+                    fill: "both",
+                }));
+                pauseHalfway(document.getElementById("root-font-target").animate([{ width: "1rem" }, { width: "2rem" }], {
+                    duration: 1000,
+                    fill: "both",
+                }));
+                pauseHalfway(document.getElementById("animated-font-source").animate([{ fontSize: "10vw" }, { fontSize: "20vw" }], {
+                    duration: 1000,
+                    fill: "both",
+                }));
+                pauseHalfway(document.getElementById("animated-inherited-font-target").animate([{ width: "1em" }, { width: "2em" }], {
+                    duration: 1000,
+                    fill: "both",
+                }));
+            <\/script>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const viewportTarget = child.document.getElementById("viewport-target");
+        const inheritedFontTarget = child.document.getElementById("inherited-font-target");
+        const rootFontTarget = child.document.getElementById("root-font-target");
+        const animatedFontSource = child.document.getElementById("animated-font-source");
+        const animatedInheritedFontTarget = child.document.getElementById("animated-inherited-font-target");
+        const pendingOutlineAnimationTarget = child.document.getElementById("pending-outline-animation-target");
+
+        child.internals.updateStyle();
+        println(`initial viewport animated width: ${child.getComputedStyle(viewportTarget).width}`);
+        println(`initial inherited-font animated width: ${child.getComputedStyle(inheritedFontTarget).width}`);
+        println(`initial root-font animated width: ${child.getComputedStyle(rootFontTarget).width}`);
+        println(`initial animated font size: ${child.getComputedStyle(animatedFontSource).fontSize}`);
+        println(`initial animated inherited-font width: ${child.getComputedStyle(animatedInheritedFontTarget).width}`);
+
+        const pendingOutlineAnimation = pendingOutlineAnimationTarget.animate([{ outlineWidth: "10vw" }, { outlineWidth: "20vw" }], {
+            duration: 1000,
+            fill: "both",
+        });
+        pendingOutlineAnimation.pause();
+        pendingOutlineAnimation.currentTime = 500;
+
+        child.internals.resetStyleInvalidationCounters();
+        iframe.style.width = "500px";
+        document.body.offsetWidth;
+        child.internals.updateStyle();
+        println(`targeted pending animated outline width: ${child.getComputedStyle(pendingOutlineAnimationTarget).outlineWidth}`);
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+
+        const counters = child.internals.getStyleInvalidationCounters();
+        const elementCount = child.document.querySelectorAll("*").length;
+        println(`resized viewport animated width: ${child.getComputedStyle(viewportTarget).width}`);
+        println(`resized inherited-font animated width: ${child.getComputedStyle(inheritedFontTarget).width}`);
+        println(`resized root-font animated width: ${child.getComputedStyle(rootFontTarget).width}`);
+        println(`resized animated font size: ${child.getComputedStyle(animatedFontSource).fontSize}`);
+        println(`resized animated inherited-font width: ${child.getComputedStyle(animatedInheritedFontTarget).width}`);
+        println(`full invalidations: ${counters.fullStyleInvalidations}`);
+        println(`style recomputations bounded: ${counters.elementStyleRecomputations < elementCount}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-media-query-evaluation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-media-query-evaluation.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                #target {
+                    color: rgb(255, 0, 0);
+                }
+
+                #canvas-target {
+                    color: rgb(255, 0, 0);
+                }
+
+                @media (min-width: 400px) {
+                    #target,
+                    #canvas-target {
+                        color: rgb(0, 128, 0);
+                    }
+                }
+            </style>
+            <div id="target">target</div>
+            <canvas id="canvas-target"></canvas>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const target = child.document.getElementById("target");
+        const canvasTarget = child.document.getElementById("canvas-target");
+        const context = canvasTarget.getContext("2d");
+
+        child.internals.updateStyle();
+        println(`initial color: ${child.getComputedStyle(target).color}`);
+        context.fillStyle = "currentColor";
+        println(`initial canvas fill style: ${context.fillStyle}`);
+
+        child.internals.resetStyleInvalidationCounters();
+        iframe.style.width = "500px";
+        document.body.offsetWidth;
+        context.fillStyle = "currentColor";
+        println(`targeted canvas fill style: ${context.fillStyle}`);
+
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+
+        const counters = child.internals.getStyleInvalidationCounters();
+        println(`resized color: ${child.getComputedStyle(target).color}`);
+        println(`media query full invalidations: ${counters.fullStyleInvalidations}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-targeted-restyle.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-targeted-restyle.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    function childDocumentSource() {
+        return `
+            <!DOCTYPE html>
+            <style>
+                #viewport {
+                    width: 10vw;
+                    height: 4px;
+                }
+
+                #font-source {
+                    font-size: 10vw;
+                }
+
+                #monospace-ancestor {
+                    font-size: 10vw;
+                }
+
+                #monospace-target {
+                    font-family: monospace;
+                }
+
+                html {
+                    font-size: 10vw;
+                }
+
+                #percentage-font-source {
+                    font-size: 150%;
+                }
+
+                #percentage-font-target {
+                    width: 1em;
+                    height: 1px;
+                }
+
+                #line-height-source {
+                    font-size: 10vw;
+                }
+
+                #line-height-percentage {
+                    line-height: 150%;
+                }
+
+                #line-height-calc {
+                    line-height: calc(125% + 5px);
+                }
+
+                #inherit-source {
+                    width: 10vw;
+                }
+
+                #inherit-child {
+                    width: inherit;
+                }
+
+                #pseudo::before {
+                    content: "";
+                    display: block;
+                    width: 10vw;
+                    height: 1px;
+                }
+
+                #pseudo-font-source {
+                    font-size: 10vw;
+                }
+
+                #pseudo-font-target::before {
+                    content: "pseudo";
+                }
+
+                .bystander {
+                    color: rgb(0, 0, 0);
+                }
+            </style>
+            <div id="viewport"></div>
+            <div id="font-source"><span id="font-child">font child</span></div>
+            <div id="monospace-ancestor"><span id="monospace-target">monospace target</span></div>
+            <div id="percentage-font-source"><div id="percentage-font-target"></div></div>
+            <div id="line-height-source">
+                <div id="line-height-percentage"></div>
+                <div id="line-height-calc"></div>
+            </div>
+            <div id="inherit-source"><div id="inherit-child"></div></div>
+            <div id="pseudo"></div>
+            <div id="pseudo-font-source"><span id="pseudo-font-target"></span></div>
+            <script>
+                for (let i = 0; i < 40; ++i) {
+                    const bystander = document.createElement("div");
+                    bystander.className = "bystander";
+                    bystander.textContent = "bystander " + i;
+                    document.body.appendChild(bystander);
+                }
+            <\/script>
+        `;
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = childDocumentSource();
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        child.internals.updateStyle();
+        child.document.body.offsetWidth;
+
+        child.internals.resetStyleInvalidationCounters();
+        iframe.style.width = "500px";
+        document.body.offsetWidth;
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+
+        const counters = child.internals.getStyleInvalidationCounters();
+        const elementCount = child.document.querySelectorAll("*").length;
+
+        println(`viewport width: ${child.getComputedStyle(child.document.getElementById("viewport")).width}`);
+        println(`inherited font size: ${child.getComputedStyle(child.document.getElementById("font-child")).fontSize}`);
+        println(`monospace recascaded font size: ${child.getComputedStyle(child.document.getElementById("monospace-target")).fontSize}`);
+        println(`percentage font size: ${child.getComputedStyle(child.document.getElementById("percentage-font-source")).fontSize}`);
+        println(`percentage em width: ${child.getComputedStyle(child.document.getElementById("percentage-font-target")).width}`);
+        println(`percentage line height: ${child.getComputedStyle(child.document.getElementById("line-height-percentage")).lineHeight}`);
+        println(`calc percentage line height: ${child.getComputedStyle(child.document.getElementById("line-height-calc")).lineHeight}`);
+        println(`explicit inherit width: ${child.getComputedStyle(child.document.getElementById("inherit-child")).width}`);
+        println(`pseudo width: ${child.getComputedStyle(child.document.getElementById("pseudo"), "::before").width}`);
+        println(`pseudo originating font size: ${child.getComputedStyle(child.document.getElementById("pseudo-font-target")).fontSize}`);
+        println(`pseudo inherited font size: ${child.getComputedStyle(child.document.getElementById("pseudo-font-target"), "::before").fontSize}`);
+        println(`full invalidations: ${counters.fullStyleInvalidations}`);
+        println(`style recomputations bounded: ${counters.elementStyleRecomputations < elementCount / 2}`);
+        println(`inherited recomputations present: ${counters.elementInheritedStyleRecomputations > 0}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Track which computed styles and font metrics depend on viewport metrics, then use that dependency information to avoid full document style invalidation after viewport resizes.

The targeted path preserves the existing inherited-style update behavior for descendants while keeping observable style reads correct for media query changes, viewport-unit animations, inherited font metrics, pseudo-elements, and canvas `currentColor` resolution.

This adds regression coverage for viewport units, inherited and recascaded font sizes, line-height percentages, font-relative animations, pending viewport-unit animations, pseudo-element inheritance, media query evaluation, and bounded restyling after iframe resizes.