### PR TITLE
LibWeb: Position inline-outside abspos after preceding left float in IFC

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -565,13 +565,17 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
     VERIFY(box.parent());
     VERIFY(box.parent()->children_are_inline());
 
+    // We're calculating the position for an absolutely positioned box with a previous sibling in an IFC.
+    // We need to position the box...
+    // ...below the last fragment of this sibling, if the display-outside value (before box type transformation) is block.
+    // ...at the top right corner of the last fragment of this sibling otherwise.
+    // ...at the outer end of a preceding left-float — if the box is originally inline-outside and no line-box fragment
+    //    is found (floats don't produce line-box fragments).
     CSSPixelPoint position;
-    if (auto const* sibling = box.previous_sibling()) {
-        // We're calculating the position for an absolutely positioned box with a previous sibling in an IFC.
-        // We need to position the box...
-        // ...below the last fragment of this sibling, if the display-outside value (before box type transformation) is block.
-        // ...at the top right corner of the last fragment of this sibling otherwise.
-        LineBoxFragment const* last_fragment = nullptr;
+    LineBoxFragment const* last_fragment = nullptr;
+    Box const* preceding_left_float = nullptr;
+    auto box_is_inline_outside = !box.display_before_box_type_transformation().is_block_outside();
+    for (auto const* sibling = box.previous_sibling(); sibling; sibling = sibling->previous_sibling()) {
         auto const& cb_state = m_state.get(*sibling->containing_block());
         for (auto const& line_box : cb_state.line_boxes) {
             for (auto const& fragment : line_box.fragments()) {
@@ -579,17 +583,34 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
                     last_fragment = &fragment;
             }
         }
-        if (last_fragment) {
-            if (box.display_before_box_type_transformation().is_block_outside()) {
-                // Display-outside value is block => position below
-                position.set_x(0);
-                position.set_y(last_fragment->offset().y() + last_fragment->height());
-            } else {
-                // Display-outside value is not block => position to the right
-                position.set_x(last_fragment->offset().x() + last_fragment->width());
-                position.set_y(last_fragment->offset().y());
-            }
+        if (last_fragment)
+            break;
+        if (!box_is_inline_outside)
+            continue;
+        if (auto const* sibling_box = as_if<Box>(sibling); sibling_box && sibling_box->is_floating()
+            && sibling_box->computed_values().float_() == CSS::Float::Left) {
+            preceding_left_float = sibling_box;
+            break;
         }
+    }
+    if (last_fragment) {
+        if (box.display_before_box_type_transformation().is_block_outside()) {
+            // Display-outside value is block => position below
+            position.set_x(0);
+            position.set_y(last_fragment->offset().y() + last_fragment->height());
+        } else {
+            // Display-outside value is not block => position to the right
+            position.set_x(last_fragment->offset().x() + last_fragment->width());
+            position.set_y(last_fragment->offset().y());
+        }
+    } else if (preceding_left_float) {
+        // https://drafts.csswg.org/css2/#abs-non-replaced-width: the hypothetical box assumes float:none — so, an
+        // originally inline-outside box following a left float would've been inline-level content in the line box
+        // wrapping the float. At this layout phase, the float's content offset isn't finalized yet — so approximate the
+        // static position using the float's margin-box width (valid for a single float touching the left edge of the
+        // containing block).
+        auto const& float_state = m_state.get(*preceding_left_float);
+        position.set_x(float_state.margin_box_width());
     }
 
     return { .rect = { position, { 0, 0 } } };

--- a/Tests/LibWeb/Layout/expected/abspos-static-position-after-float-sibling.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-static-position-after-float-sibling.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 108 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: inline
+      BlockContainer <div.float-sibling> at [8,8] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+      BlockContainer <div.absolute> at [108,8] positioned [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x108]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.float-sibling) [8,8 100x100]
+      PaintableWithLines (BlockContainer<DIV>.absolute) [108,8 200x100]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x108] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-static-position-after-float-sibling.html
+++ b/Tests/LibWeb/Layout/input/abspos-static-position-after-float-sibling.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+.float-sibling { display: inline-block; float: left; width: 100px; height: 100px; background: lime; }
+.absolute { display: inline-block; float: left; position: absolute; width: 200px; height: 100px; background: gray; }
+</style>
+<div class="float-sibling"></div>
+<div class="absolute"></div>


### PR DESCRIPTION
**Problem:** An originally-inline-outside element with both `position: absolute` and `float: left` (where per-spec `float` becomes `none`) is positioned at the top left of its containing block, overlapping any preceding left-floated sibling — rather than being placed next to that float (where Firefox and Chrome place it).

**Cause:** `InlineFormattingContext::calculate_static_position_rect()` locates the previous sibling and looks it up in the IFC’s line-box fragments. Floats don’t produce line-box fragments — so when the only preceding sibling is a left float (with collapsed whitespace text nodes in between), the lookup finds nothing and the static position falls through to `(0, 0)`.

**Fix:** When no fragment is found and the abspos is originally inline-outside: Walk back through siblings to find a preceding left-float and use its margin-box width as the static position `x`. The hypothetical box (per spec, computed with `float: none`) would have been inline-level content in the line box wrapping the float — so placing it at the float’s outer end is correct for the single-left-edge-float case. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9621.