### PR TITLE
LibWeb: Account for floats when computing IFC abspos static position

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -582,8 +582,9 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
     // We need to position the box...
     // ...below the last fragment, if the display-outside value (before box type transformation) is block.
     // ...at the top right corner of the last fragment otherwise.
+    auto is_block_outside = box.display_before_box_type_transformation().is_block_outside();
     if (last_fragment) {
-        if (box.display_before_box_type_transformation().is_block_outside()) {
+        if (is_block_outside) {
             // Display-outside value is block => position below
             position.set_x(0);
             position.set_y(last_fragment->offset().y() + last_fragment->height());
@@ -592,6 +593,10 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
             position.set_x(last_fragment->offset().x() + last_fragment->width());
             position.set_y(last_fragment->offset().y());
         }
+    } else if (!is_block_outside) {
+        // No preceding sibling has a line box fragment (e.g. only floats and collapsed whitespace precede this box).
+        // For inline-level elements, the static position must account for float intrusion into the line box.
+        position.set_x(leftmost_inline_offset_at(0));
     }
 
     return { .rect = { position, { 0, 0 } } };

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -566,29 +566,31 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
     VERIFY(box.parent()->children_are_inline());
 
     CSSPixelPoint position;
-    if (auto const* sibling = box.previous_sibling()) {
-        // We're calculating the position for an absolutely positioned box with a previous sibling in an IFC.
-        // We need to position the box...
-        // ...below the last fragment of this sibling, if the display-outside value (before box type transformation) is block.
-        // ...at the top right corner of the last fragment of this sibling otherwise.
-        LineBoxFragment const* last_fragment = nullptr;
-        auto const& cb_state = m_state.get(*sibling->containing_block());
-        for (auto const& line_box : cb_state.line_boxes) {
+
+    // We're calculating the position for an absolutely positioned box in an IFC.
+    // Walk backwards through previous siblings to find the most recent one with a line box fragment.
+    LineBoxFragment const* last_fragment = nullptr;
+    for (auto const* sibling = box.previous_sibling(); sibling && !last_fragment; sibling = sibling->previous_sibling()) {
+        for (auto const& line_box : m_containing_block_used_values.line_boxes) {
             for (auto const& fragment : line_box.fragments()) {
                 if (&fragment.layout_node() == sibling)
                     last_fragment = &fragment;
             }
         }
-        if (last_fragment) {
-            if (box.display_before_box_type_transformation().is_block_outside()) {
-                // Display-outside value is block => position below
-                position.set_x(0);
-                position.set_y(last_fragment->offset().y() + last_fragment->height());
-            } else {
-                // Display-outside value is not block => position to the right
-                position.set_x(last_fragment->offset().x() + last_fragment->width());
-                position.set_y(last_fragment->offset().y());
-            }
+    }
+
+    // We need to position the box...
+    // ...below the last fragment, if the display-outside value (before box type transformation) is block.
+    // ...at the top right corner of the last fragment otherwise.
+    if (last_fragment) {
+        if (box.display_before_box_type_transformation().is_block_outside()) {
+            // Display-outside value is block => position below
+            position.set_x(0);
+            position.set_y(last_fragment->offset().y() + last_fragment->height());
+        } else {
+            // Display-outside value is not block => position to the right
+            position.set_x(last_fragment->offset().x() + last_fragment->width());
+            position.set_y(last_fragment->offset().y());
         }
     }
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-static-position-with-float-intrusion.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-static-position-with-float-intrusion.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 216 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 200 0+0+8] children: not-inline
+      BlockContainer <div#wrapper> at [8,8] positioned [0+0+0 400 0+0+384] [0+0+0 200 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        BlockContainer <div#float> at [8,8] floating [0+0+0 100 0+0+0] [0+0+0 200 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+        BlockContainer <div#abspos> at [108,8] positioned [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>#wrapper) [8,8 400x200]
+        PaintableWithLines (BlockContainer<DIV>#float) [8,8 100x200]
+        PaintableWithLines (BlockContainer<DIV>#abspos) [108,8 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-static-position-with-float-intrusion.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-static-position-with-float-intrusion.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+    #wrapper {
+        position: relative;
+        width: 400px;
+        height: 200px;
+    }
+    #float {
+        float: left;
+        width: 100px;
+        height: 200px;
+        background: blue;
+    }
+    #abspos {
+        display: inline-block;
+        position: absolute;
+        width: 50px;
+        height: 50px;
+        background: green;
+    }
+</style>
+<div id="wrapper">
+    <div id="float"></div>
+    <div id="abspos"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-001.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: ltr; text-align: left;">
+  <div id=inflow></div>
+  <div id=float style="float: left;"></div>
+  <div id=abs style="transform: translateX(0%);"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/static-position/inline-level-absolute-in-block-level-context-007.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width" />
+<link rel="match" href="../../../../../expected/wpt-import/css/css-position/static-position/../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Tests the static position of inline-level absolute-positioned elements, with combinations of float, direction, and text-align." />
+<style>
+#container { position: relative; background: red; width: 100px; height: 100px; }
+#container > div { background: green; }
+#inflow { height: 50px; }
+#float { float: left; width: 50px; height: 50px; }
+#abs { display: inline; position: absolute; width: 50px; height: 50px; }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div id=container style="direction: rtl; text-align: right;">
+  <div id=inflow></div>
+  <div id=float style="float: left;"></div>
+  <div id=abs style="transform: translateX(0%);"></div>
+</div>


### PR DESCRIPTION
Previously, when no previous sibling has a line box fragment, the static position for inline-level elements defaulted to (0, 0), ignoring float intrusion into the line box. We now use `leftmost_inline_offset_at()` so the hypothetical box is placed on the float-shortened line.

Fixes #9621