### PR TITLE
LibWeb: Avoid full style invalidation for media query changes

### DIFF
--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -123,6 +123,19 @@ WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> Animatable::get_animations_inter
     return relevant_animations;
 }
 
+bool Animatable::has_relevant_animations() const
+{
+    if (!m_impl)
+        return false;
+
+    for (auto const& animation : m_impl->associated_animations) {
+        if (animation->is_relevant())
+            return true;
+    }
+
+    return false;
+}
+
 void Animatable::associate_with_animation(GC::Ref<Animation> animation)
 {
     auto& impl = ensure_impl();

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -42,6 +42,7 @@ public:
     WebIDL::ExceptionOr<GC::Ref<Animation>> animate(GC::Ptr<JS::Object> keyframes, Variant<Empty, double, Bindings::KeyframeAnimationOptions> const& options = {});
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations(Optional<Bindings::GetAnimationsOptions> const& options = {});
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations_internal(GetAnimationsSorted sorted, Optional<Bindings::GetAnimationsOptions> const& options = {});
+    bool has_relevant_animations() const;
 
     void associate_with_animation(GC::Ref<Animation>);
     void disassociate_with_animation(GC::Ref<Animation>);

--- a/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -250,29 +250,34 @@ void CSSRuleList::for_each_effective_rule(TraversalOrder order, Function<void(We
 
 bool CSSRuleList::evaluate_media_queries(DOM::Document const& document)
 {
+    return evaluate_media_queries(document, [](CSSRule const&) { });
+}
+
+bool CSSRuleList::evaluate_media_queries(DOM::Document const& document, Function<void(CSSRule const&)> const& changed_rule_callback)
+{
     bool any_media_queries_changed_match_state = false;
 
     for (auto& rule : m_rules) {
         switch (rule->type()) {
         case CSSRule::Type::Container: {
             auto& container_rule = as<CSSContainerRule>(*rule);
-            if (container_rule.css_rules().evaluate_media_queries(document))
+            if (container_rule.css_rules().evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
             break;
         }
         case CSSRule::Type::Function: {
-            any_media_queries_changed_match_state |= as<CSSFunctionRule>(*rule).css_rules().evaluate_media_queries(document);
+            any_media_queries_changed_match_state |= as<CSSFunctionRule>(*rule).css_rules().evaluate_media_queries(document, changed_rule_callback);
             break;
         }
         case CSSRule::Type::Import: {
             auto& import_rule = as<CSSImportRule>(*rule);
-            if (import_rule.loaded_style_sheet() && import_rule.loaded_style_sheet()->evaluate_media_queries(document))
+            if (import_rule.loaded_style_sheet() && import_rule.loaded_style_sheet()->evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
             break;
         }
         case CSSRule::Type::LayerBlock: {
             auto& layer_rule = as<CSSLayerBlockRule>(*rule);
-            if (layer_rule.css_rules().evaluate_media_queries(document))
+            if (layer_rule.css_rules().evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
             break;
         }
@@ -286,25 +291,27 @@ bool CSSRuleList::evaluate_media_queries(DOM::Document const& document)
             // first time it gets evaluated against a matching state.
             if (!was_first_evaluation && did_match != now_matches)
                 any_media_queries_changed_match_state = true;
-            if (now_matches && media_rule.css_rules().evaluate_media_queries(document))
+            if (now_matches && media_rule.css_rules().evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
+            if (!was_first_evaluation && did_match != now_matches)
+                media_rule.css_rules().for_each_effective_rule(TraversalOrder::Preorder, changed_rule_callback);
             break;
         }
         case CSSRule::Type::Scope: {
             auto& scope_rule = as<CSSScopeRule>(*rule);
-            if (scope_rule.css_rules().evaluate_media_queries(document))
+            if (scope_rule.css_rules().evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
             break;
         }
         case CSSRule::Type::Supports: {
             auto& supports_rule = as<CSSSupportsRule>(*rule);
-            if (supports_rule.condition_matches() && supports_rule.css_rules().evaluate_media_queries(document))
+            if (supports_rule.condition_matches() && supports_rule.css_rules().evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
             break;
         }
         case CSSRule::Type::Style: {
             auto& style_rule = as<CSSStyleRule>(*rule);
-            if (style_rule.css_rules().evaluate_media_queries(document))
+            if (style_rule.css_rules().evaluate_media_queries(document, changed_rule_callback))
                 any_media_queries_changed_match_state = true;
             break;
         }

--- a/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -63,6 +63,7 @@ public:
     void for_each_effective_rule(TraversalOrder, Function<void(CSSRule const&)> const& callback) const;
     // Returns whether the match state of any media queries changed after evaluation.
     bool evaluate_media_queries(DOM::Document const&);
+    bool evaluate_media_queries(DOM::Document const&, Function<void(CSSRule const&)> const& changed_rule_callback);
 
     void set_owner_rule(GC::Ref<CSSRule> owner_rule) { m_owner_rule = owner_rule; }
     void set_rules(Badge<CSSStyleSheet>, Vector<GC::Ref<CSSRule>> rules) { m_rules = move(rules); }

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -518,6 +518,11 @@ void CSSStyleSheet::load_pending_image_resources(DOM::Document& document)
 
 bool CSSStyleSheet::evaluate_media_queries(DOM::Document const& document)
 {
+    return evaluate_media_queries(document, [](CSSRule const&) { });
+}
+
+bool CSSStyleSheet::evaluate_media_queries(DOM::Document const& document, Function<void(CSSRule const&)> const& changed_rule_callback)
+{
     bool any_media_queries_changed_match_state = false;
 
     bool now_matches = m_media->evaluate(document);
@@ -525,10 +530,18 @@ bool CSSStyleSheet::evaluate_media_queries(DOM::Document const& document)
     // StyleSheetListAddSheet, AdoptedStyleSheetsList, or invalidate_owners (each of which performs its own
     // invalidation), so we don't need to also report a match-state change just because no prior result was
     // recorded.
-    if (m_did_match.has_value() && m_did_match.value() != now_matches)
+    bool did_match_state_change = m_did_match.has_value() && m_did_match.value() != now_matches;
+    if (did_match_state_change)
         any_media_queries_changed_match_state = true;
-    if (now_matches && m_rules->evaluate_media_queries(document))
+    if (now_matches && m_rules->evaluate_media_queries(document, changed_rule_callback))
         any_media_queries_changed_match_state = true;
+    if (did_match_state_change) {
+        // Imported stylesheets can also have cascade effects through their owning @import rule itself, for example
+        // when a layered import's media gate starts or stops contributing its layer declaration.
+        if (auto rule = owner_rule())
+            changed_rule_callback(*rule);
+        m_rules->for_each_effective_rule(TraversalOrder::Preorder, changed_rule_callback);
+    }
 
     m_did_match = now_matches;
     if (any_media_queries_changed_match_state)

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -87,6 +87,7 @@ public:
     void for_each_effective_style_producing_rule(Function<void(CSSRule const&)> const& callback) const;
     // Returns whether the match state of any media queries changed after evaluation.
     bool evaluate_media_queries(DOM::Document const&);
+    bool evaluate_media_queries(DOM::Document const&, Function<void(CSSRule const&)> const& changed_rule_callback);
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
     void for_each_effective_counter_style_at_rule(Function<void(CSSCounterStyleRule const&)> const& callback) const;
 

--- a/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/MediaQueryInvalidator.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/Invalidation/MediaQueryInvalidator.h>
 #include <LibWeb/CSS/StyleScope.h>
@@ -14,18 +15,51 @@
 
 namespace Web::CSS::Invalidation {
 
+struct MediaQueryRuleInvalidation {
+    StyleSheetInvalidationSet style_sheet_invalidation_set;
+    Vector<FlyString> keyframes_animation_names;
+
+    void add_rule(CSSRule const& rule)
+    {
+        extend_style_sheet_invalidation_set_with_rule(style_sheet_invalidation_set, rule);
+
+        if (auto const* keyframes_rule = as_if<CSSKeyframesRule>(rule))
+            keyframes_animation_names.append(keyframes_rule->name());
+    }
+};
+
+static void invalidate_style_after_media_rule_changes(DOM::Node& root, MediaQueryRuleInvalidation const& invalidation)
+{
+    auto style_sheet_invalidation_set = invalidation.style_sheet_invalidation_set;
+    add_shadow_root_stylesheet_effects_for_broad_invalidation(
+        root,
+        style_sheet_invalidation_set,
+        style_sheet_invalidation_set.invalidation_set.needs_invalidate_whole_subtree());
+
+    invalidate_root_for_style_sheet_change(root, style_sheet_invalidation_set, DOM::StyleInvalidationReason::MediaQueryChangedMatchState);
+
+    for (auto const& animation_name : invalidation.keyframes_animation_names)
+        invalidate_root_for_keyframes_rule(root, animation_name);
+}
+
 void evaluate_media_rules_and_invalidate_style(DOM::Document& document)
 {
     bool document_media_queries_changed_match_state = false;
+    MediaQueryRuleInvalidation document_invalidation;
     document.style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
-        if (style_sheet.evaluate_media_queries(document))
+        if (style_sheet.evaluate_media_queries(document, [&](CSSRule const& changed_rule) {
+                document_invalidation.add_rule(changed_rule);
+            }))
             document_media_queries_changed_match_state = true;
     });
 
     document.for_each_shadow_root([&](auto& shadow_root) {
         bool shadow_root_media_queries_changed_match_state = false;
+        MediaQueryRuleInvalidation shadow_root_invalidation;
         shadow_root.style_scope().for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
-            if (style_sheet.evaluate_media_queries(document))
+            if (style_sheet.evaluate_media_queries(document, [&](CSSRule const& changed_rule) {
+                    shadow_root_invalidation.add_rule(changed_rule);
+                }))
                 shadow_root_media_queries_changed_match_state = true;
         });
 
@@ -33,16 +67,12 @@ void evaluate_media_rules_and_invalidate_style(DOM::Document& document)
             return;
 
         shadow_root.style_scope().invalidate_rule_cache();
-        shadow_root.invalidate_style(DOM::StyleInvalidationReason::MediaQueryChangedMatchState);
-        CSS::invalidate_assigned_elements_for_dirty_slots(shadow_root);
-
-        if (auto* host = shadow_root.host())
-            host->root().invalidate_style(DOM::StyleInvalidationReason::MediaQueryChangedMatchState);
+        invalidate_style_after_media_rule_changes(shadow_root, shadow_root_invalidation);
     });
 
     if (document_media_queries_changed_match_state) {
         document.style_scope().invalidate_rule_cache();
-        document.invalidate_style(DOM::StyleInvalidationReason::MediaQueryChangedMatchState);
+        invalidate_style_after_media_rule_changes(document, document_invalidation);
     }
 }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2340,9 +2340,7 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
 
         // Store the resolved specified value for properties whose computation depends on inherited info, so they can
         // be re-resolved when an ancestor changes without keeping CascadedProperties alive on the element.
-        // FIXME: Consider other style values that rely on relative lengths (e.g. CalculatedStyleValue, StyleValues
-        //        which contain lengths (e.g. StyleValueList)) - maybe we can use `is_computationally_independent()`
-        bool depends_on_inherited_info = (value->is_length() && value->as_length().length().is_font_relative())
+        bool depends_on_inherited_info = !value->is_computationally_independent()
             || (property_id == PropertyID::FontWeight && first_is_one_of(value->to_keyword(), Keyword::Bolder, Keyword::Lighter))
             || (property_id == PropertyID::FontSize && font_size_value_depends_on_inherited_font_size(*value))
             || (property_id == PropertyID::LineHeight && line_height_value_depends_on_computed_font_size(*value));

--- a/Libraries/LibWeb/CSS/StyleSheetInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetInvalidation.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
+#include <LibWeb/CSS/CSSNestedDeclarations.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/ComputedProperties.h>
@@ -155,6 +157,8 @@ static bool is_pseudo_element_targeting_compound(Selector::CompoundSelector cons
         && compound_selector.simple_selectors.first().type == Selector::SimpleSelector::Type::PseudoElement;
 }
 
+static bool rule_requires_broad_add_or_remove_invalidation(CSSRule const&);
+
 // :has() in the rightmost set filters by an element's previously recorded "affected by :has()" flags. Those flags
 // are not yet set for a brand-new rule that has never been matched, so :has() on its own can't narrow the walk.
 // Treat a rightmost set whose only targetable feature is :has() as if it had no targetable features, so we fall
@@ -223,13 +227,11 @@ static Optional<AnchorInvalidationRule> try_build_anchor_for_leading_compounds(V
     return {};
 }
 
-void extend_style_sheet_invalidation_set_with_style_rule(StyleSheetInvalidationSet& result, CSSStyleRule const& style_rule)
+static void extend_style_sheet_invalidation_set_with_selectors(StyleSheetInvalidationSet& result, SelectorList const& selectors, GC::Ptr<CSSStyleSheet const> style_sheet_for_rule)
 {
-    auto* style_sheet_for_rule = const_cast<CSSStyleRule&>(style_rule).parent_style_sheet();
-
     StyleInvalidationData throwaway_data;
 
-    for (auto const& selector : style_rule.absolutized_selectors()) {
+    for (auto const& selector : selectors) {
         result.may_match_light_dom_under_shadow_host |= selector_may_match_light_dom_under_shadow_host(*selector);
         result.may_match_light_dom_outside_shadow_host |= selector_may_match_light_dom_outside_shadow_host(*selector);
         result.may_match_shadow_host |= selector->contains_pseudo_class(PseudoClass::Host);
@@ -312,6 +314,29 @@ void extend_style_sheet_invalidation_set_with_style_rule(StyleSheetInvalidationS
         result.invalidation_set.set_needs_invalidate_whole_subtree();
         return;
     }
+}
+
+void extend_style_sheet_invalidation_set_with_style_rule(StyleSheetInvalidationSet& result, CSSStyleRule const& style_rule)
+{
+    auto* style_sheet_for_rule = const_cast<CSSStyleRule&>(style_rule).parent_style_sheet();
+    extend_style_sheet_invalidation_set_with_selectors(result, style_rule.absolutized_selectors(), style_sheet_for_rule);
+}
+
+void extend_style_sheet_invalidation_set_with_rule(StyleSheetInvalidationSet& result, CSSRule const& rule)
+{
+    if (auto const* style_rule = as_if<CSSStyleRule>(rule)) {
+        extend_style_sheet_invalidation_set_with_style_rule(result, *style_rule);
+        return;
+    }
+
+    if (auto const* nested_declarations = as_if<CSSNestedDeclarations>(rule)) {
+        auto* style_sheet_for_rule = const_cast<CSSNestedDeclarations&>(*nested_declarations).parent_style_sheet();
+        extend_style_sheet_invalidation_set_with_selectors(result, nested_declarations->absolutized_selectors(), style_sheet_for_rule);
+        return;
+    }
+
+    if (rule_requires_broad_add_or_remove_invalidation(rule))
+        result.invalidation_set.set_needs_invalidate_whole_subtree();
 }
 
 static GC::Ptr<DOM::Element const> shadow_host_for_targeted_shadow_root_invalidation(DOM::Node const& root)
@@ -520,8 +545,26 @@ void invalidate_root_for_style_sheet_change(DOM::Node& root, StyleSheetInvalidat
     }
 }
 
+void add_shadow_root_stylesheet_effects_for_broad_invalidation(DOM::Node& root, StyleSheetInvalidationSet& result, bool requires_broad_invalidation)
+{
+    if (!requires_broad_invalidation)
+        return;
+
+    auto* shadow_root = as_if<DOM::ShadowRoot>(root);
+    if (!shadow_root)
+        return;
+
+    auto effects = determine_shadow_root_stylesheet_effects(*shadow_root);
+    result.may_match_shadow_host |= effects.may_match_shadow_host;
+    result.may_match_light_dom_under_shadow_host |= effects.may_match_light_dom_under_shadow_host;
+    result.may_match_light_dom_outside_shadow_host |= effects.may_match_light_dom_outside_shadow_host;
+}
+
 static bool rule_requires_broad_add_or_remove_invalidation(CSSRule const& rule)
 {
+    if (auto const* import_rule = as_if<CSSImportRule>(rule))
+        return import_rule->layer_name().has_value();
+
     switch (rule.type()) {
     case CSSRule::Type::Property:
     case CSSRule::Type::CounterStyle:
@@ -586,14 +629,7 @@ void invalidate_style_for_stylesheet_change(DOM::Node& document_or_shadow_root, 
 
     bool requires_broad_invalidation = invalidation_set_result.invalidation_set.needs_invalidate_whole_subtree()
         || sheet_contains_broad_invalidation_rule;
-    if (requires_broad_invalidation) {
-        if (auto* shadow_root = as_if<DOM::ShadowRoot>(document_or_shadow_root)) {
-            auto effects = determine_shadow_root_stylesheet_effects(*shadow_root);
-            invalidation_set_result.may_match_shadow_host |= effects.may_match_shadow_host;
-            invalidation_set_result.may_match_light_dom_under_shadow_host |= effects.may_match_light_dom_under_shadow_host;
-            invalidation_set_result.may_match_light_dom_outside_shadow_host |= effects.may_match_light_dom_outside_shadow_host;
-        }
-    }
+    add_shadow_root_stylesheet_effects_for_broad_invalidation(document_or_shadow_root, invalidation_set_result, requires_broad_invalidation);
 
     invalidate_root_for_style_sheet_change(document_or_shadow_root, invalidation_set_result, reason, requires_broad_invalidation);
 
@@ -838,7 +874,7 @@ void invalidate_style_for_style_sheet_owners(CSSStyleSheet const& style_sheet, D
     });
 }
 
-void invalidate_root_for_keyframes_rules_in_sheet(DOM::Node& root, CSSStyleSheet const& sheet)
+void invalidate_root_for_keyframes_rule(DOM::Node& root, FlyString const& animation_name)
 {
     // Shadow-scoped keyframes can still affect elements outside the shadow subtree when an active rule in the same
     // scope sets `animation-name` via :host or ::slotted(...). Mirror the fan-out used by the per-rule helper so the
@@ -851,17 +887,22 @@ void invalidate_root_for_keyframes_rules_in_sheet(DOM::Node& root, CSSStyleSheet
         include_light_dom_under_shadow_host = effects.may_match_light_dom_under_shadow_host;
     }
 
+    for_each_tree_affected_by_shadow_root_stylesheet_change(
+        root,
+        include_host,
+        include_light_dom_under_shadow_host,
+        [&](DOM::Node& affected_root) {
+            invalidate_elements_affected_by_inserted_keyframes_rule(affected_root, animation_name);
+        });
+}
+
+void invalidate_root_for_keyframes_rules_in_sheet(DOM::Node& root, CSSStyleSheet const& sheet)
+{
     sheet.for_each_effective_rule(TraversalOrder::Preorder, [&](CSSRule const& rule) {
         auto const* keyframes_rule = as_if<CSSKeyframesRule>(rule);
         if (!keyframes_rule)
             return;
-        for_each_tree_affected_by_shadow_root_stylesheet_change(
-            root,
-            include_host,
-            include_light_dom_under_shadow_host,
-            [&](DOM::Node& affected_root) {
-                invalidate_elements_affected_by_inserted_keyframes_rule(affected_root, keyframes_rule->name());
-            });
+        invalidate_root_for_keyframes_rule(root, keyframes_rule->name());
     });
 }
 
@@ -876,21 +917,7 @@ void invalidate_owners_for_inserted_keyframes_rule(CSSStyleSheet const& style_sh
         if (!document_or_shadow_root->is_shadow_root() && document_or_shadow_root->entire_subtree_needs_style_update())
             continue;
 
-        bool include_host = false;
-        bool include_light_dom_under_shadow_host = false;
-        if (auto* shadow_root = as_if<DOM::ShadowRoot>(*document_or_shadow_root)) {
-            auto effects = determine_shadow_root_stylesheet_effects(*shadow_root);
-            include_host = effects.may_match_shadow_host;
-            include_light_dom_under_shadow_host = effects.may_match_light_dom_under_shadow_host;
-        }
-
-        for_each_tree_affected_by_shadow_root_stylesheet_change(
-            *document_or_shadow_root,
-            include_host,
-            include_light_dom_under_shadow_host,
-            [&](DOM::Node& affected_root) {
-                invalidate_elements_affected_by_inserted_keyframes_rule(affected_root, keyframes_rule.name());
-            });
+        invalidate_root_for_keyframes_rule(*document_or_shadow_root, keyframes_rule.name());
     }
 }
 

--- a/Libraries/LibWeb/CSS/StyleSheetInvalidation.h
+++ b/Libraries/LibWeb/CSS/StyleSheetInvalidation.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibGC/Ptr.h>
@@ -64,6 +65,11 @@ enum class ShouldInvalidateRuleCache {
 // invalidation flag inside `result` when a selector is not amenable to targeted invalidation.
 void extend_style_sheet_invalidation_set_with_style_rule(StyleSheetInvalidationSet& result, CSSStyleRule const& style_rule);
 
+// Extend `result` with the invalidation effects of `rule` when the rule becomes effective or ineffective. Style
+// rules and nested declaration rules contribute their selector-derived invalidation sets. Rule kinds that affect
+// cascade or computed-value resolution globally fall back to whole-subtree invalidation.
+void extend_style_sheet_invalidation_set_with_rule(StyleSheetInvalidationSet& result, CSSRule const& rule);
+
 // Shadow-root rules can escape the shadow tree either through ::slotted(...) or through :host with a combinator to
 // another compound, such as :host > * or :host + .foo. Those selectors must fan out invalidation to the host side
 // instead of treating the change as shadow-local.
@@ -79,6 +85,11 @@ WEB_API bool selector_may_match_light_dom_outside_shadow_host(StringView selecto
 // schedule a tree-wide restyle regardless of the targeted set; this is used when the sheet contains rule kinds (such
 // as @property or @keyframes) whose effects are not captured by selector invalidation alone.
 void invalidate_root_for_style_sheet_change(DOM::Node& root, StyleSheetInvalidationSet const&, DOM::StyleInvalidationReason, bool force_broad_invalidation = false);
+
+// When a broad shadow-root stylesheet invalidation can change the cascade for rules outside the immediate changed
+// rule set, merge in the current shadow-scope selector reach so the broad invalidation fans out to :host and
+// ::slotted(...) targets as needed.
+void add_shadow_root_stylesheet_effects_for_broad_invalidation(DOM::Node& root, StyleSheetInvalidationSet&, bool requires_broad_invalidation);
 
 // Targeted invalidation used after a stylesheet is added to or removed from a Document or ShadowRoot, either via a
 // <style> element or via adoptedStyleSheets. The caller is responsible for updating the sheet's
@@ -115,5 +126,9 @@ void invalidate_owners_for_inserted_keyframes_rule(CSSStyleSheet const& style_sh
 // by the sheet add/remove paths so a sheet that contains @keyframes does not have to fall back to a whole-subtree
 // invalidation.
 void invalidate_root_for_keyframes_rules_in_sheet(DOM::Node& root, CSSStyleSheet const& sheet);
+
+// Dirty only the elements (and pseudo-elements) under `root` that already reference `animation_name`. When `root` is
+// a shadow root, the walk also fans out to the shadow host side if active rules in the same scope can match there.
+void invalidate_root_for_keyframes_rule(DOM::Node& root, FlyString const& animation_name);
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
@@ -30,7 +30,7 @@ public:
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const& computation_context) const override;
     bool properties_equal(EdgeStyleValue const& other) const { return m_properties == other.m_properties; }
 
-    virtual bool is_computationally_independent() const override { return m_properties.offset->is_computationally_independent(); }
+    virtual bool is_computationally_independent() const override { return !m_properties.offset || m_properties.offset->is_computationally_independent(); }
 
 private:
     EdgeStyleValue(Optional<PositionEdge> edge, RefPtr<StyleValue const> const& offset)

--- a/Libraries/LibWeb/CSS/StyleValues/TupleStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TupleStyleValue.h
@@ -29,7 +29,7 @@ public:
 
     virtual bool is_computationally_independent() const override
     {
-        return all_of(m_tuple, [](auto& value) { return value->is_computationally_independent(); });
+        return all_of(m_tuple, [](auto& value) { return !value || value->is_computationally_independent(); });
     }
 
     struct Indices {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2005,7 +2005,7 @@ static void apply_document_style_invalidation_after_style_change(Document& docum
             node_invalidation = element.recompute_style(did_change_custom_properties);
         } else {
             if (needs_inherited_style_update)
-                node_invalidation = element.recompute_inherited_style();
+                node_invalidation = element.recompute_inherited_style(ScheduleAnimationUpdate::Yes);
             if (recompute_elements_depending_on_custom_properties && element.refresh_inherited_custom_property_data())
                 did_change_custom_properties = true;
         }
@@ -2155,6 +2155,7 @@ void Document::update_style()
     }
 
     apply_document_style_invalidation_after_style_change(*this, invalidation);
+    update_animated_style_if_needed();
 }
 
 static bool element_or_pseudo_depends_on_viewport_metrics(Element const& element)

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1095,7 +1095,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
     return invalidation;
 }
 
-CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
+CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style(ScheduleAnimationUpdate schedule_animation_update)
 {
     auto& counters = document().style_invalidation_counters();
     counters.element_inherited_style_recomputations++;
@@ -1135,6 +1135,9 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
         invalidation |= CSS::compute_property_invalidation(property_id, old_value.ptr(), &computed_properties->property(property_id));
     }
 
+    if (schedule_animation_update == ScheduleAnimationUpdate::Yes && has_relevant_animations())
+        document().set_needs_animated_style_update();
+
     if (invalidation.is_none() && property_values_affected_by_inherited_style.is_empty()) {
         counters.element_inherited_style_noop_recomputations++;
         return invalidation;
@@ -1151,9 +1154,6 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
             invalidation.inherited_style_changed = true;
         invalidation |= CSS::compute_property_invalidation(property_id, old_value.ptr(), &new_value);
     }
-
-    if (!invalidation.is_none() && !computed_properties->animated_property_values().is_empty())
-        document().set_needs_animated_style_update();
 
     bool did_change_custom_properties = false;
     invalidation |= recompute_pseudo_element_styles(did_change_custom_properties, had_list_marker);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -72,6 +72,11 @@ enum class ProximityToTheViewport : u8 {
     NotDetermined,
 };
 
+enum class ScheduleAnimationUpdate : u8 {
+    No,
+    Yes,
+};
+
 class WEB_API Element
     : public ParentNode
     , public ChildNode<Element>
@@ -191,7 +196,7 @@ public:
     void run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
 
     CSS::RequiredInvalidationAfterStyleChange recompute_style(bool& did_change_custom_properties);
-    CSS::RequiredInvalidationAfterStyleChange recompute_inherited_style();
+    CSS::RequiredInvalidationAfterStyleChange recompute_inherited_style(ScheduleAnimationUpdate = ScheduleAnimationUpdate::No);
 
     Optional<CSS::PseudoElement> associated_shadow_host_pseudo_element() const { return m_associated_shadow_host_pseudo_element; }
     void set_associated_shadow_host_pseudo_element(CSS::PseudoElement pseudo_element);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2938,7 +2938,10 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
     }
 
     if (auto document = active_document()) {
-        document->invalidate_style_for_viewport_change();
+        if (invalidate_display_list == InvalidateDisplayList::Yes)
+            document->invalidate_style(DOM::StyleInvalidationReason::NavigableSetViewportSize);
+        else
+            document->invalidate_style_for_viewport_change();
         document->set_needs_media_query_evaluation();
         document->set_needs_layout_update(DOM::SetNeedsLayoutReason::NavigableSetViewportSize);
     }

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-animation-root-font-media.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-animation-root-font-media.txt
@@ -1,0 +1,4 @@
+initial animated left: 10px
+resized animated left: 20px
+resized full invalidations: 0
+resized back animated left: 10px

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-compound-font-relative-values.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-compound-font-relative-values.txt
@@ -1,0 +1,6 @@
+initial box shadow: rgb(0, 0, 0) 0px 0px 10px 0px
+initial filter: blur(10px)
+resized box shadow: rgb(0, 0, 0) 0px 0px 20px 0px
+resized filter: blur(20px)
+resized back box shadow: rgb(0, 0, 0) 0px 0px 10px 0px
+resized back filter: blur(10px)

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-device-pixel-ratio-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-device-pixel-ratio-invalidation.txt
@@ -1,0 +1,7 @@
+initial device pixel ratio: 1
+initial border width: 1px
+initial outline width: 1px
+updated device pixel ratio: 2
+updated border width: 0.5px
+updated outline width: 0.5px
+full invalidation happened: true

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-layered-import-broad-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-layered-import-broad-invalidation.txt
@@ -1,0 +1,3 @@
+initial layered import color: rgb(255, 0, 0)
+resized layered import color: rgb(0, 128, 0)
+resized back layered import color: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-media-query-evaluation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-media-query-evaluation.txt
@@ -1,5 +1,12 @@
 initial color: rgb(255, 0, 0)
 initial canvas fill style: #ff0000
+initial nested color: rgb(255, 0, 0)
 targeted canvas fill style: #008000
 resized color: rgb(0, 128, 0)
-media query full invalidations: 1
+resized nested color: rgb(0, 0, 255)
+media query full invalidations: 0
+media query recomputations bounded: true
+resized back color: rgb(255, 0, 0)
+resized back nested color: rgb(255, 0, 0)
+media query full invalidations after resize back: 0
+media query recomputations bounded after resize back: true

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-shadow-broad-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/viewport-resize-shadow-broad-invalidation.txt
@@ -1,0 +1,5 @@
+initial shadow host color: rgb(255, 0, 0)
+resized shadow host color: rgb(255, 0, 0)
+resized recomputed host side: true
+resized back shadow host color: rgb(255, 0, 0)
+resized back recomputed host side: true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/animations/font-stretch-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/animations/font-stretch-interpolation.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 185 tests
 
-184 Pass
-1 Fail
+185 Pass
 Pass	CSS Transitions: property <font-stretch> from [100%] to [200%] at (-2) should be [0%]
 Pass	CSS Transitions: property <font-stretch> from [100%] to [200%] at (-0.25) should be [75%]
 Pass	CSS Transitions: property <font-stretch> from [100%] to [200%] at (0) should be [100%]
@@ -188,4 +187,4 @@ Pass	Web Animations: property <font-stretch> from [normal] to [extra-expanded] a
 Pass	Web Animations: property <font-stretch> from [normal] to [extra-expanded] at (0.25) should be [112.5%]
 Pass	Web Animations: property <font-stretch> from [normal] to [extra-expanded] at (0.5) should be [125%]
 Pass	Web Animations: property <font-stretch> from [normal] to [extra-expanded] at (1) should be [150%]
-Fail	An interpolation to inherit updates correctly on a parent style change.
+Pass	An interpolation to inherit updates correctly on a parent style change.

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-root-font-media.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-root-font-media.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    async function resizeIframe(iframe, child, width) {
+        iframe.style.width = `${width}px`;
+        document.body.offsetWidth;
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                html {
+                    font-size: 10px;
+                }
+
+                @media (min-width: 400px) {
+                    html {
+                        font-size: 20px;
+                    }
+                }
+
+                #target {
+                    font-size: 10px;
+                    left: 0;
+                    position: relative;
+                }
+            </style>
+            <div id="target"></div>
+            <script>
+                const animation = document.getElementById("target").animate([{ left: "1rem" }, { left: "1rem" }], {
+                    duration: 1000,
+                    fill: "both",
+                });
+                animation.pause();
+                animation.currentTime = 500;
+            <\/script>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const target = child.document.getElementById("target");
+
+        child.internals.updateStyle();
+        println(`initial animated left: ${child.getComputedStyle(target).left}`);
+
+        child.internals.resetStyleInvalidationCounters();
+        await resizeIframe(iframe, child, 500);
+        const resizedCounters = child.internals.getStyleInvalidationCounters();
+        println(`resized animated left: ${child.getComputedStyle(target).left}`);
+        println(`resized full invalidations: ${resizedCounters.fullStyleInvalidations}`);
+
+        await resizeIframe(iframe, child, 300);
+        println(`resized back animated left: ${child.getComputedStyle(target).left}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-compound-font-relative-values.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-compound-font-relative-values.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    async function resizeIframe(iframe, child, width) {
+        iframe.style.width = `${width}px`;
+        document.body.offsetWidth;
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                html {
+                    font-size: 10px;
+                }
+
+                @media (min-width: 400px) {
+                    html {
+                        font-size: 20px;
+                    }
+                }
+
+                #target {
+                    box-shadow: 0 0 1em rgb(0, 0, 0);
+                    filter: blur(1em);
+                }
+            </style>
+            <div id="target">target</div>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const target = child.document.getElementById("target");
+
+        child.internals.updateStyle();
+        println(`initial box shadow: ${child.getComputedStyle(target).boxShadow}`);
+        println(`initial filter: ${child.getComputedStyle(target).filter}`);
+
+        await resizeIframe(iframe, child, 500);
+        println(`resized box shadow: ${child.getComputedStyle(target).boxShadow}`);
+        println(`resized filter: ${child.getComputedStyle(target).filter}`);
+
+        await resizeIframe(iframe, child, 300);
+        println(`resized back box shadow: ${child.getComputedStyle(target).boxShadow}`);
+        println(`resized back filter: ${child.getComputedStyle(target).filter}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-device-pixel-ratio-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-device-pixel-ratio-invalidation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    #target {
+        border: 0.75px solid black;
+        outline: 0.75px solid black;
+    }
+</style>
+<div id="target">target</div>
+<script>
+    test(() => {
+        const target = document.getElementById("target");
+
+        internals.setDevicePixelRatio(1);
+        internals.updateStyle();
+
+        println(`initial device pixel ratio: ${devicePixelRatio}`);
+        println(`initial border width: ${getComputedStyle(target).borderTopWidth}`);
+        println(`initial outline width: ${getComputedStyle(target).outlineWidth}`);
+
+        internals.resetStyleInvalidationCounters();
+        internals.setDevicePixelRatio(2);
+        internals.updateStyle();
+
+        const counters = internals.getStyleInvalidationCounters();
+        println(`updated device pixel ratio: ${devicePixelRatio}`);
+        println(`updated border width: ${getComputedStyle(target).borderTopWidth}`);
+        println(`updated outline width: ${getComputedStyle(target).outlineWidth}`);
+        println(`full invalidation happened: ${counters.fullStyleInvalidations > 0}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-layered-import-broad-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-layered-import-broad-invalidation.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    async function resizeIframe(iframe, child, width) {
+        iframe.style.width = `${width}px`;
+        document.body.offsetWidth;
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+    }
+
+    async function waitForImportedSheet(styleElement) {
+        while (styleElement.sheet.cssRules.length === 0 || styleElement.sheet.cssRules[0].styleSheet === null)
+            await animationFrame();
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style id="style">
+                @import "data:text/css;base64," layer(late) (min-width: 400px);
+
+                @layer early {
+                    #target {
+                        color: rgb(0, 128, 0);
+                    }
+                }
+
+                @layer late {
+                    #target {
+                        color: rgb(255, 0, 0);
+                    }
+                }
+            </style>
+            <div id="target">target</div>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const target = child.document.getElementById("target");
+        const styleElement = child.document.getElementById("style");
+        await waitForImportedSheet(styleElement);
+
+        child.internals.updateStyle();
+        println(`initial layered import color: ${child.getComputedStyle(target).color}`);
+
+        await resizeIframe(iframe, child, 500);
+        println(`resized layered import color: ${child.getComputedStyle(target).color}`);
+
+        await resizeIframe(iframe, child, 300);
+        println(`resized back layered import color: ${child.getComputedStyle(target).color}`);
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-media-query-evaluation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-media-query-evaluation.html
@@ -23,15 +23,40 @@
                     color: rgb(255, 0, 0);
                 }
 
+                #nested-parent .nested-target {
+                    color: rgb(255, 0, 0);
+                }
+
                 @media (min-width: 400px) {
                     #target,
                     #canvas-target {
                         color: rgb(0, 128, 0);
                     }
                 }
+
+                #nested-parent {
+                    @media (min-width: 400px) {
+                        & .nested-target {
+                            color: rgb(0, 0, 255);
+                        }
+                    }
+                }
+
+                .bystander {
+                    color: rgb(0, 0, 0);
+                }
             </style>
             <div id="target">target</div>
             <canvas id="canvas-target"></canvas>
+            <div id="nested-parent"><span class="nested-target">nested target</span></div>
+            <script>
+                for (let i = 0; i < 40; ++i) {
+                    const bystander = document.createElement("div");
+                    bystander.className = "bystander";
+                    bystander.textContent = "bystander " + i;
+                    document.body.appendChild(bystander);
+                }
+            <\/script>
         `;
         document.body.appendChild(iframe);
         await loaded;
@@ -40,11 +65,13 @@
         const target = child.document.getElementById("target");
         const canvasTarget = child.document.getElementById("canvas-target");
         const context = canvasTarget.getContext("2d");
+        const nestedTarget = child.document.querySelector(".nested-target");
 
         child.internals.updateStyle();
         println(`initial color: ${child.getComputedStyle(target).color}`);
         context.fillStyle = "currentColor";
         println(`initial canvas fill style: ${context.fillStyle}`);
+        println(`initial nested color: ${child.getComputedStyle(nestedTarget).color}`);
 
         child.internals.resetStyleInvalidationCounters();
         iframe.style.width = "500px";
@@ -57,8 +84,24 @@
         child.internals.updateStyle();
 
         const counters = child.internals.getStyleInvalidationCounters();
+        const elementCount = child.document.querySelectorAll("*").length;
         println(`resized color: ${child.getComputedStyle(target).color}`);
+        println(`resized nested color: ${child.getComputedStyle(nestedTarget).color}`);
         println(`media query full invalidations: ${counters.fullStyleInvalidations}`);
+        println(`media query recomputations bounded: ${counters.elementStyleRecomputations < elementCount / 2}`);
+
+        child.internals.resetStyleInvalidationCounters();
+        iframe.style.width = "300px";
+        document.body.offsetWidth;
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+
+        const resizedBackCounters = child.internals.getStyleInvalidationCounters();
+        println(`resized back color: ${child.getComputedStyle(target).color}`);
+        println(`resized back nested color: ${child.getComputedStyle(nestedTarget).color}`);
+        println(`media query full invalidations after resize back: ${resizedBackCounters.fullStyleInvalidations}`);
+        println(`media query recomputations bounded after resize back: ${resizedBackCounters.elementStyleRecomputations < elementCount / 2}`);
 
         done();
     });

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-shadow-broad-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-shadow-broad-invalidation.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script>
+    function animationFrame() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
+
+    async function resizeIframe(iframe, child, width) {
+        iframe.style.width = `${width}px`;
+        document.body.offsetWidth;
+        await animationFrame();
+        child.document.body.offsetWidth;
+        child.internals.updateStyle();
+    }
+
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        iframe.style.border = "0";
+        iframe.style.width = "300px";
+        iframe.style.height = "200px";
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <x-property-host id="host">host</x-property-host>
+        `;
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const child = iframe.contentWindow;
+        const host = child.document.getElementById("host");
+        const shadowRoot = host.attachShadow({ mode: "open" });
+        const sheet = new child.CSSStyleSheet();
+        sheet.replaceSync(`
+            :host {
+                color: rgb(255, 0, 0);
+            }
+
+            @media (min-width: 400px) {
+                @property --shadow-media-broad {
+                    syntax: '<color>';
+                    inherits: false;
+                    initial-value: rgb(0, 128, 0);
+                }
+            }
+        `);
+        shadowRoot.adoptedStyleSheets = [sheet];
+        shadowRoot.appendChild(child.document.createElement("slot"));
+
+        child.internals.updateStyle();
+        println(`initial shadow host color: ${child.getComputedStyle(host).color}`);
+
+        child.internals.resetStyleInvalidationCounters();
+        await resizeIframe(iframe, child, 500);
+        let counters = child.internals.getStyleInvalidationCounters();
+        println(`resized shadow host color: ${child.getComputedStyle(host).color}`);
+        println(`resized recomputed host side: ${counters.elementStyleRecomputations > 1}`);
+
+        child.internals.resetStyleInvalidationCounters();
+        await resizeIframe(iframe, child, 300);
+        counters = child.internals.getStyleInvalidationCounters();
+        println(`resized back shadow host color: ${child.getComputedStyle(host).color}`);
+        println(`resized back recomputed host side: ${counters.elementStyleRecomputations > 1}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Avoid forcing a full document style invalidation when media queries change match state. Instead, collect the rules that became active or inactive and feed them through the existing stylesheet invalidation machinery, falling back to broad invalidation only for rule types with cascade-wide effects.

This keeps viewport-driven media query changes on the targeted invalidation path while preserving correctness for shadow-root fallout, layered imports, inherited font-relative values, DPR and zoom changes, and animations whose keyframes depend on inherited or root font metrics.