### PR TITLE
LibWeb: Skip no-op custom property updates

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -259,13 +259,20 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_internal(PropertyName
     // 9. Otherwise,
     else {
         if (property.is_custom_property()) {
+            auto important = !priority.is_empty() ? Important::Yes : Important::No;
             StyleProperty style_property {
-                .important = !priority.is_empty() ? Important::Yes : Important::No,
+                .important = important,
                 .property_id = property.id(),
                 .value = component_value_list.release_nonnull(),
             };
-            m_custom_properties.set(property.name(), style_property);
-            updated = true;
+            if (auto existing_property = custom_property(property.name()); existing_property.has_value()
+                && existing_property->important == important
+                && *existing_property->value == *style_property.value) {
+                updated = false;
+            } else {
+                m_custom_properties.set(property.name(), style_property);
+                updated = true;
+            }
         } else {
             // let updated be the result of set the CSS declaration property with value component value list,
             // with the important flag set if priority is not the empty string, and unset otherwise,
@@ -422,7 +429,12 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_style_value(PropertyN
     }
 
     if (property.is_custom_property()) {
-        m_custom_properties.remove(property.name());
+        if (auto existing_property = custom_property(property.name()); existing_property.has_value()
+            && existing_property->important == Important::No
+            && *existing_property->value == *style_value) {
+            return {};
+        }
+
         m_custom_properties.set(property.name(),
             StyleProperty {
                 Important::No,

--- a/Tests/LibWeb/Text/expected/css/style-attribute-no-op-invalidation-counters.txt
+++ b/Tests/LibWeb/Text/expected/css/style-attribute-no-op-invalidation-counters.txt
@@ -1,2 +1,4 @@
 setting identical style text: 1 invalidations
 setting changed style text: 1 invalidations
+setting identical custom property: 0 invalidations
+setting changed custom property: 1 invalidations

--- a/Tests/LibWeb/Text/input/css/style-attribute-no-op-invalidation-counters.html
+++ b/Tests/LibWeb/Text/input/css/style-attribute-no-op-invalidation-counters.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
+<style>
+    #custom-property-target {
+        height: var(--vh);
+    }
+</style>
 <div id="target">target</div>
+<div id="custom-property-target"></div>
 <script>
     function settleAndReset(triggerElement) {
         getComputedStyle(triggerElement).color;
@@ -26,5 +32,18 @@
         target.setAttribute("style", "color: green");
         getComputedStyle(target).color;
         report("setting changed style text");
+
+        const customPropertyTarget = document.getElementById("custom-property-target");
+        document.documentElement.style.setProperty("--vh", "9px");
+        settleAndReset(customPropertyTarget);
+
+        document.documentElement.style.setProperty("--vh", "9px");
+        getComputedStyle(customPropertyTarget).height;
+        report("setting identical custom property");
+
+        settleAndReset(customPropertyTarget);
+        document.documentElement.style.setProperty("--vh", "10px");
+        getComputedStyle(customPropertyTarget).height;
+        report("setting changed custom property");
     });
 </script>


### PR DESCRIPTION
Avoid rewriting CSSOM custom properties when the parsed value and priority match the existing declaration. This mirrors the longhand setProperty path and prevents repeated identical root custom property writes from invalidating inherited style across the whole document.

Extend the style invalidation counter test to cover identical and changed custom property assignments.