### PR TITLE
Compositor+LibWebView: Tolerate stale UI mouse contexts

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -596,8 +596,10 @@ bool Application::dispatch_mouse_event_to_web_content(Web::Compositor::Composito
         return false;
     VERIFY(m_compositor_client);
 
-    m_compositor_client->async_dispatch_mouse_event_to_web_content(context_id, event.clone_without_browser_data());
-    return true;
+    auto result = m_compositor_client->try_dispatch_mouse_event_to_web_content(context_id, event.clone_without_browser_data());
+    if (result.is_error())
+        return false;
+    return result.release_value();
 }
 
 void Application::notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id)

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -16,7 +16,7 @@ endpoint CompositorControlServer
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|
 
     handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool handled)
-    dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) =|
+    dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event) => (bool dispatched)
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) => (bool handled)
     presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id) =|
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -333,7 +333,8 @@ void CompositorState::invalidate_wheel_event_listener_state(Web::Compositor::Com
 bool CompositorState::handle_mouse_event(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
 {
     auto* context = context_if_present(context_id);
-    VERIFY(context);
+    if (!context)
+        return false;
 
     auto& context_state = *context;
     if (!context_state.presents_to_client)
@@ -392,10 +393,12 @@ bool CompositorState::handle_mouse_event(Web::Compositor::CompositorContextId co
     VERIFY_NOT_REACHED();
 }
 
-void CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
+bool CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent const& event)
 {
     auto* context = context_if_present(context_id);
-    VERIFY(context);
+    if (!context)
+        return false;
+
     VERIFY(context->web_content_client);
 
     auto page_id = context->page_id;
@@ -404,6 +407,7 @@ void CompositorState::dispatch_mouse_event_to_web_content(Web::Compositor::Compo
     VERIFY(page_id.has_value());
 
     context->web_content_client->dispatch_mouse_event_to_web_content(*page_id, event);
+    return true;
 }
 
 Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking)
@@ -451,7 +455,8 @@ bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId conte
         return false;
 
     auto* context = context_if_present(context_id);
-    VERIFY(context);
+    if (!context)
+        return false;
 
     auto& context_state = *context;
     if (!context_state.presents_to_client)

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -82,7 +82,7 @@ public:
     void clear_compositor_surface(Web::Compositor::CompositorContextId, Web::Painting::CompositorSurfaceId);
     void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation);
     bool handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
-    void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
+    bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
     bool async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta);
     void present_deferred_async_scroll_frame(Web::Compositor::CompositorContextId);

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -79,9 +79,9 @@ Messages::CompositorControlServer::HandleMouseEventResponse ConnectionFromClient
     return m_compositor_state->handle_mouse_event(context_id, event);
 }
 
-void ConnectionFromClient::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)
+Messages::CompositorControlServer::DispatchMouseEventToWebContentResponse ConnectionFromClient::dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId context_id, Web::MouseEvent event)
 {
-    m_compositor_state->dispatch_mouse_event_to_web_content(context_id, event);
+    return m_compositor_state->dispatch_mouse_event_to_web_content(context_id, event);
 }
 
 Messages::CompositorControlServer::AsyncScrollByResponse ConnectionFromClient::async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels)

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -40,7 +40,7 @@ private:
     virtual void create_context(Web::Compositor::CompositorContextId, Optional<u64> page_id, Web::Compositor::PagePresentationRegistration, i32 web_content_connection_id) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, bool is_top_level_traversable, Web::Compositor::WindowResizingInProgress) override;
     virtual Messages::CompositorControlServer::HandleMouseEventResponse handle_mouse_event(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
-    virtual void dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
+    virtual Messages::CompositorControlServer::DispatchMouseEventToWebContentResponse dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent) override;
     virtual Messages::CompositorControlServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override;
     virtual void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id) override;
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -249,6 +249,12 @@ void ConnectionFromClient::key_event(u64 page_id, Web::KeyEvent event)
 
 void ConnectionFromClient::mouse_event(u64 page_id, Web::MouseEvent event)
 {
+    auto page = m_page_host->page(page_id);
+    if (!page.has_value()) {
+        async_did_finish_handling_input_event(page_id, Web::EventResult::Dropped);
+        return;
+    }
+
     // OPTIMIZATION: Coalesce consecutive unprocessed mouse move and wheel events.
     auto event_to_coalesce = [&]() -> Web::MouseEvent const* {
         if (m_input_event_queue.is_empty())
@@ -274,8 +280,7 @@ void ConnectionFromClient::mouse_event(u64 page_id, Web::MouseEvent event)
         m_input_event_queue.tail().event = move(event);
         ++m_input_event_queue.tail().coalesced_event_count;
 
-        if (auto page = this->page(page_id); page.has_value())
-            page->page().client().request_frame();
+        page->page().client().request_frame();
         return;
     }
 
@@ -295,10 +300,14 @@ void ConnectionFromClient::pinch_event(u64 page_id, Web::PinchEvent event)
 void ConnectionFromClient::enqueue_input_event(Web::QueuedInputEvent event)
 {
     auto page_id = event.page_id;
-    m_input_event_queue.enqueue(move(event));
+    auto page = m_page_host->page(page_id);
+    if (!page.has_value()) {
+        async_did_finish_handling_input_event(page_id, Web::EventResult::Dropped);
+        return;
+    }
 
-    if (auto page = this->page(page_id); page.has_value())
-        page->page().client().request_frame();
+    m_input_event_queue.enqueue(move(event));
+    page->page().client().request_frame();
 }
 
 void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteString argument)


### PR DESCRIPTION
Browser UI input can race with compositor context teardown during tab
close. The control connection may ask the compositor to handle, scroll,
or forward a mouse event after WebContent has already destroyed the
context. Treating that as an invariant crashes the compositor even
though the event is stale.

Make the UI-facing mouse handling and async scroll entry points return
false when the context is gone. Mouse forwarding now reports whether it
actually dispatched the event, letting LibWebView fall back to direct
WebContent IPC and preserve the normal input-event acknowledgement flow.
