### PR TITLE
UI/Qt: Modernize browser window chrome

### DIFF
--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -150,8 +150,11 @@ Gfx::Palette PageClient::palette() const
 void PageClient::set_palette_impl(Gfx::PaletteImpl& impl)
 {
     m_palette_impl = impl;
-    if (auto* document = page().top_level_browsing_context().active_document())
+    if (auto* document = page().top_level_browsing_context().active_document()) {
         document->invalidate_style(Web::DOM::StyleInvalidationReason::SettingsChange);
+        document->set_needs_media_query_evaluation();
+    }
+    request_frame();
 }
 
 void PageClient::set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme)

--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -9,6 +9,7 @@
 #include <AK/Base64.h>
 #include <LibWebView/Autocomplete.h>
 #include <UI/Qt/Autocomplete.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/StringUtils.h>
 
@@ -356,13 +357,16 @@ Autocomplete::Autocomplete(QLineEdit* anchor)
     // position_popup() rather than made its own window, so that showing
     // it never causes the address bar to lose keyboard focus.
     m_popup = new QFrame();
+    m_popup->setObjectName("LadybirdAutocompletePopup");
     m_popup->setFocusPolicy(Qt::NoFocus);
     m_popup->setFrameShape(QFrame::StyledPanel);
     m_popup->setFrameShadow(QFrame::Raised);
     m_popup->setAutoFillBackground(true);
+    m_popup->setStyleSheet(ChromeStyle::autocomplete_popup_style_sheet(m_anchor->palette()));
     m_popup->hide();
 
     m_list_view = new QListView(m_popup);
+    m_list_view->setObjectName("LadybirdAutocompleteList");
     m_list_view->setFocusPolicy(Qt::NoFocus);
     m_list_view->setSelectionMode(QAbstractItemView::SingleSelection);
     m_list_view->setMouseTracking(true);
@@ -426,6 +430,7 @@ void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion>
         return;
     }
 
+    m_popup->setStyleSheet(ChromeStyle::autocomplete_popup_style_sheet(m_anchor->palette()));
     position_popup();
     if (!m_popup->isVisible())
         m_popup->show();

--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -28,6 +28,7 @@
 #include <QPixmap>
 #include <QPoint>
 #include <QStyledItemDelegate>
+#include <QTimer>
 #include <QVBoxLayout>
 
 namespace Ladybird {
@@ -85,6 +86,21 @@ static QFont autocomplete_section_header_font()
     QFont font = autocomplete_secondary_font();
     font.setWeight(QFont::DemiBold);
     return font;
+}
+
+static QColor autocomplete_selection_fill(QPalette const& palette)
+{
+    auto surface = ChromeStyle::chrome_surface(palette);
+    return ChromeStyle::is_dark(palette)
+        ? ChromeStyle::mix(surface, QColor(92, 112, 140), 0.54)
+        : ChromeStyle::mix(surface, palette.color(QPalette::Highlight), 0.10);
+}
+
+static QColor autocomplete_selection_border(QPalette const& palette)
+{
+    return ChromeStyle::is_dark(palette)
+        ? ChromeStyle::mix(autocomplete_selection_fill(palette), QColor(160, 176, 198), 0.32)
+        : ChromeStyle::mix(ChromeStyle::chrome_border(palette), palette.color(QPalette::Highlight), 0.12);
 }
 
 class AutocompleteModel final : public QAbstractListModel {
@@ -257,7 +273,7 @@ public:
         if (kind == RowKind::SectionHeader) {
             auto text = index.data(HeaderTextRole).toString();
             painter->setFont(autocomplete_section_header_font());
-            auto header_color = option.palette.color(QPalette::PlaceholderText);
+            auto header_color = ChromeStyle::chrome_muted_text(option.palette);
             header_color.setAlpha(170);
             painter->setPen(header_color);
             auto rect = option.rect.adjusted(
@@ -270,14 +286,10 @@ public:
 
         bool selected = option.state & QStyle::State_Selected;
         if (selected) {
-            auto fill = ChromeStyle::chrome_surface_hover(option.palette);
-            fill.setAlpha(190);
-            auto border = ChromeStyle::chrome_border(option.palette);
-            border.setAlpha(76);
             auto rect = option.rect.adjusted(3, 2, -3, -2);
             painter->setRenderHint(QPainter::Antialiasing, true);
-            painter->setPen(QPen(border, 1));
-            painter->setBrush(fill);
+            painter->setPen(QPen(autocomplete_selection_border(option.palette), 1));
+            painter->setBrush(autocomplete_selection_fill(option.palette));
             painter->drawRoundedRect(rect, 7, 7);
         }
 
@@ -314,13 +326,13 @@ public:
             int block_y = option.rect.top() + (option.rect.height() - block_height) / 2;
 
             painter->setFont(autocomplete_primary_font());
-            painter->setPen(option.palette.color(QPalette::Text));
+            painter->setPen(ChromeStyle::chrome_text(option.palette));
             auto elided_title = primary_fm.elidedText(title_text, Qt::ElideRight, text_width);
             painter->drawText(QRect(text_x, block_y, text_width, primary_fm.height()),
                 Qt::AlignLeft | Qt::AlignVCenter, elided_title);
 
             painter->setFont(autocomplete_secondary_font());
-            auto secondary_color = option.palette.color(QPalette::PlaceholderText);
+            auto secondary_color = ChromeStyle::chrome_muted_text(option.palette);
             secondary_color.setAlpha(180);
             painter->setPen(secondary_color);
             auto elided_secondary = secondary_fm.elidedText(secondary_text, Qt::ElideRight, text_width);
@@ -330,7 +342,7 @@ public:
                 Qt::AlignLeft | Qt::AlignVCenter, elided_secondary);
         } else {
             painter->setFont(QApplication::font());
-            painter->setPen(option.palette.color(QPalette::Text));
+            painter->setPen(ChromeStyle::chrome_text(option.palette));
             QFontMetrics fm(QApplication::font());
             auto elided_url = fm.elidedText(url_text, Qt::ElideRight, text_width);
             painter->drawText(
@@ -356,7 +368,6 @@ Autocomplete::Autocomplete(QLineEdit* anchor)
     m_popup->setFrameShape(QFrame::StyledPanel);
     m_popup->setFrameShadow(QFrame::Raised);
     m_popup->setAutoFillBackground(true);
-    m_popup->setStyleSheet(ChromeStyle::autocomplete_popup_style_sheet(m_anchor->palette()));
     m_popup->hide();
 
     m_list_view = new QListView(m_popup);
@@ -372,6 +383,7 @@ Autocomplete::Autocomplete(QLineEdit* anchor)
     m_delegate = new AutocompleteDelegate(this);
     m_list_view->setModel(m_model);
     m_list_view->setItemDelegate(m_delegate);
+    update_chrome_style();
 
     auto* layout = new QVBoxLayout(m_popup);
     layout->setContentsMargins(0, POPUP_PADDING, 0, POPUP_PADDING);
@@ -416,6 +428,33 @@ void Autocomplete::cancel_pending_query()
     m_autocomplete->cancel_pending_query();
 }
 
+void Autocomplete::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    auto palette = m_anchor->palette();
+    m_popup->setPalette(palette);
+    m_list_view->setPalette(palette);
+    m_popup->setStyleSheet(ChromeStyle::autocomplete_popup_style_sheet(palette));
+    m_popup->update();
+    m_list_view->viewport()->update();
+    m_is_updating_chrome_style = false;
+}
+
+void Autocomplete::schedule_chrome_style_update()
+{
+    if (m_has_pending_chrome_style_update)
+        return;
+
+    m_has_pending_chrome_style_update = true;
+    QTimer::singleShot(0, this, [this] {
+        m_has_pending_chrome_style_update = false;
+        update_chrome_style();
+    });
+}
+
 void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion> suggestions, int selected_suggestion_index)
 {
     m_model->set_suggestions(move(suggestions));
@@ -424,7 +463,7 @@ void Autocomplete::show_with_suggestions(Vector<WebView::AutocompleteSuggestion>
         return;
     }
 
-    m_popup->setStyleSheet(ChromeStyle::autocomplete_popup_style_sheet(m_anchor->palette()));
+    update_chrome_style();
     position_popup();
     if (!m_popup->isVisible())
         m_popup->show();
@@ -514,6 +553,11 @@ bool Autocomplete::select_previous_suggestion()
 
 bool Autocomplete::eventFilter(QObject* watched, QEvent* event)
 {
+    auto type = event->type();
+    if (type == QEvent::ApplicationPaletteChange || type == QEvent::ThemeChange
+        || (type == QEvent::PaletteChange && (watched == m_anchor || watched == m_popup || watched == m_list_view)))
+        schedule_chrome_style_update();
+
     if (event->type() == QEvent::MouseButtonPress && is_visible()) {
         auto* mouse_event = static_cast<QMouseEvent*>(event);
         auto global = mouse_event->globalPosition().toPoint();

--- a/UI/Qt/Autocomplete.cpp
+++ b/UI/Qt/Autocomplete.cpp
@@ -32,12 +32,12 @@
 
 namespace Ladybird {
 
-static constexpr int POPUP_PADDING = 8;
+static constexpr int POPUP_PADDING = 6;
 static constexpr int CELL_HORIZONTAL_PADDING = 8;
-static constexpr int CELL_VERTICAL_PADDING = 10;
+static constexpr int CELL_VERTICAL_PADDING = 8;
 static constexpr int CELL_ICON_SIZE = 16;
 static constexpr int CELL_ICON_TEXT_SPACING = 6;
-static constexpr int CELL_LABEL_VERTICAL_SPACING = 4;
+static constexpr int CELL_LABEL_VERTICAL_SPACING = 3;
 static constexpr int SECTION_HEADER_HORIZONTAL_PADDING = 10;
 static constexpr int SECTION_HEADER_VERTICAL_PADDING = 4;
 static constexpr int MINIMUM_POPUP_WIDTH = 100;
@@ -85,18 +85,6 @@ static QFont autocomplete_section_header_font()
     QFont font = autocomplete_secondary_font();
     font.setWeight(QFont::DemiBold);
     return font;
-}
-
-static QIcon globe_icon()
-{
-    static QIcon icon = create_tvg_icon_with_theme_colors("globe", QApplication::palette());
-    return icon;
-}
-
-static QIcon search_icon()
-{
-    static QIcon icon = create_tvg_icon_with_theme_colors("search", QApplication::palette());
-    return icon;
 }
 
 class AutocompleteModel final : public QAbstractListModel {
@@ -269,7 +257,9 @@ public:
         if (kind == RowKind::SectionHeader) {
             auto text = index.data(HeaderTextRole).toString();
             painter->setFont(autocomplete_section_header_font());
-            painter->setPen(option.palette.color(QPalette::PlaceholderText));
+            auto header_color = option.palette.color(QPalette::PlaceholderText);
+            header_color.setAlpha(170);
+            painter->setPen(header_color);
             auto rect = option.rect.adjusted(
                 SECTION_HEADER_HORIZONTAL_PADDING, SECTION_HEADER_VERTICAL_PADDING,
                 -SECTION_HEADER_HORIZONTAL_PADDING, -SECTION_HEADER_VERTICAL_PADDING);
@@ -280,13 +270,15 @@ public:
 
         bool selected = option.state & QStyle::State_Selected;
         if (selected) {
-            auto accent = option.palette.color(QPalette::Highlight);
-            accent.setAlpha(64);
-            auto rect = option.rect.adjusted(2, 3, -2, -3);
+            auto fill = ChromeStyle::chrome_surface_hover(option.palette);
+            fill.setAlpha(190);
+            auto border = ChromeStyle::chrome_border(option.palette);
+            border.setAlpha(76);
+            auto rect = option.rect.adjusted(3, 2, -3, -2);
             painter->setRenderHint(QPainter::Antialiasing, true);
-            painter->setPen(Qt::NoPen);
-            painter->setBrush(accent);
-            painter->drawRoundedRect(rect, 6, 6);
+            painter->setPen(QPen(border, 1));
+            painter->setBrush(fill);
+            painter->drawRoundedRect(rect, 7, 7);
         }
 
         auto favicon = index.data(FaviconRole).value<QIcon>();
@@ -302,11 +294,11 @@ public:
         QRect icon_rect(icon_x, icon_y, CELL_ICON_SIZE, CELL_ICON_SIZE);
 
         if (source == WebView::AutocompleteSuggestionSource::Search) {
-            search_icon().paint(painter, icon_rect);
+            create_chrome_icon(ChromeIcon::Search, option.palette).paint(painter, icon_rect);
         } else if (source == WebView::AutocompleteSuggestionSource::History && !favicon.isNull()) {
             favicon.paint(painter, icon_rect);
         } else {
-            globe_icon().paint(painter, icon_rect);
+            create_chrome_icon(ChromeIcon::Globe, option.palette).paint(painter, icon_rect);
         }
 
         int text_x = icon_x + CELL_ICON_SIZE + CELL_ICON_TEXT_SPACING;
@@ -328,7 +320,9 @@ public:
                 Qt::AlignLeft | Qt::AlignVCenter, elided_title);
 
             painter->setFont(autocomplete_secondary_font());
-            painter->setPen(option.palette.color(QPalette::PlaceholderText));
+            auto secondary_color = option.palette.color(QPalette::PlaceholderText);
+            secondary_color.setAlpha(180);
+            painter->setPen(secondary_color);
             auto elided_secondary = secondary_fm.elidedText(secondary_text, Qt::ElideRight, text_width);
             painter->drawText(
                 QRect(text_x, block_y + primary_fm.height() + CELL_LABEL_VERTICAL_SPACING,

--- a/UI/Qt/Autocomplete.h
+++ b/UI/Qt/Autocomplete.h
@@ -37,6 +37,8 @@ public:
 
     void query_autocomplete_engine(String);
     void cancel_pending_query();
+    void update_chrome_style();
+    void schedule_chrome_style_update();
 
     void show_with_suggestions(Vector<WebView::AutocompleteSuggestion>, int selected_suggestion_index);
     bool close();
@@ -66,6 +68,8 @@ private:
     QListView* m_list_view { nullptr };
     AutocompleteModel* m_model { nullptr };
     AutocompleteDelegate* m_delegate { nullptr };
+    bool m_is_updating_chrome_style { false };
+    bool m_has_pending_chrome_style_update { false };
 
     NonnullOwnPtr<WebView::Autocomplete> m_autocomplete;
 };

--- a/UI/Qt/BookmarksBar.cpp
+++ b/UI/Qt/BookmarksBar.cpp
@@ -7,11 +7,13 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/BookmarkStore.h>
 #include <UI/Qt/BookmarksBar.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/StringUtils.h>
 
 #include <QAction>
+#include <QEvent>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QToolButton>
@@ -35,13 +37,34 @@ static void install_menu_event_filter(QObject* filter, QMenu* menu)
 BookmarksBar::BookmarksBar(QWidget* parent)
     : QToolBar(parent)
 {
+    setObjectName("LadybirdBookmarksBar");
     setIconSize({ BOOKMARK_BUTTON_ICON_SIZE, BOOKMARK_BUTTON_ICON_SIZE });
     setVisible(WebView::Application::settings().show_bookmarks_bar());
     setMovable(false);
+    setFloatable(false);
+    update_chrome_style();
 
     installEventFilter(this);
 
     rebuild();
+}
+
+bool BookmarksBar::event(QEvent* event)
+{
+    if (event->type() == QEvent::PaletteChange)
+        update_chrome_style();
+
+    return QToolBar::event(event);
+}
+
+void BookmarksBar::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    setStyleSheet(ChromeStyle::bookmarks_bar_style_sheet(palette()));
+    m_is_updating_chrome_style = false;
 }
 
 void BookmarksBar::rebuild()

--- a/UI/Qt/BookmarksBar.h
+++ b/UI/Qt/BookmarksBar.h
@@ -28,12 +28,14 @@ public:
     void show_context_menu(QPoint, Optional<WebView::BookmarkItem const&>, Optional<String const&> target_folder_id);
 
 private:
+    virtual bool event(QEvent*) override;
     virtual bool eventFilter(QObject* object, QEvent* event) override;
 
     bool handle_left_mouse_click(QMouseEvent*, QObject*);
     bool handle_middle_mouse_click(QMouseEvent*, QObject*);
     bool handle_right_mouse_click(QMouseEvent*, QObject*);
     void extract_item_properties(QObject*);
+    void update_chrome_style();
 
     QMenu& bookmarks_bar_context_menu();
     QMenu& bookmark_context_menu();
@@ -46,6 +48,7 @@ private:
     String m_selected_bookmark_menu_item_id;
     QString m_selected_bookmark_menu_item_type;
     Optional<String> m_selected_bookmark_menu_target_folder_id;
+    bool m_is_updating_chrome_style { false };
 };
 
 }

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <AK/RefPtr.h>
+#include <AK/StdLibExtras.h>
 #include <AK/TypeCasts.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HistoryStore.h>
@@ -559,6 +560,70 @@ void BrowserWindow::initialize_tab(Tab* tab)
 
     m_tabs_container->set_tab_icon(m_tabs_container->index_of(tab), tab->tab_icon());
     create_close_button_for_tab(tab);
+}
+
+void BrowserWindow::uninitialize_tab(Tab* tab)
+{
+    QObject::disconnect(tab, nullptr, this, nullptr);
+    QObject::disconnect(&tab->view(), nullptr, this, nullptr);
+}
+
+void BrowserWindow::adopt_tab(Tab& tab, int index)
+{
+    index = clamp(index, 0, m_tabs_container->count());
+
+    tab.set_window(*this);
+    m_tabs_container->insert_tab(index, &tab, "New Tab");
+    initialize_tab(&tab);
+    tab_title_changed(index, tab.title());
+
+    tab.view().set_device_pixel_ratio(m_device_pixel_ratio);
+    tab.view().set_maximum_frames_per_second(m_refresh_rate);
+
+    m_tabs_container->set_current_tab(&tab);
+}
+
+void BrowserWindow::move_tab_to_window(int index, BrowserWindow& target_window, int target_index)
+{
+    if (index < 0 || index >= m_tabs_container->count())
+        return;
+
+    if (&target_window == this) {
+        if (target_index > index)
+            --target_index;
+        target_index = clamp(target_index, 0, m_tabs_container->count() - 1);
+        move_tab(index, target_index);
+        return;
+    }
+
+    auto* tab = m_tabs_container->tab(index);
+    uninitialize_tab(tab);
+    m_tabs_container->take_tab(index);
+    if (m_current_tab == tab)
+        set_current_tab(m_tabs_container->count() > 0 ? m_tabs_container->tab(m_tabs_container->current_index()) : nullptr);
+
+    target_window.adopt_tab(*tab, target_index);
+
+    if (m_tabs_container->count() == 0) {
+        m_should_record_closed_window_on_close = false;
+        close();
+    }
+}
+
+void BrowserWindow::detach_tab_to_new_window(int index, QPoint global_position)
+{
+    if (index < 0 || index >= m_tabs_container->count())
+        return;
+
+    WindowConfiguration configuration {
+        .x = Web::DevicePixels { global_position.x() - 160 },
+        .y = Web::DevicePixels { global_position.y() - 18 },
+        .width = Web::DevicePixels { width() },
+        .height = Web::DevicePixels { height() },
+    };
+
+    auto& window = Application::the().new_window({}, configuration);
+    move_tab_to_window(index, window, 0);
 }
 
 void BrowserWindow::set_current_tab(Tab* tab)

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -27,6 +27,7 @@
 #include <QAction>
 #include <QActionGroup>
 #include <QApplication>
+#include <QCursor>
 #include <QGuiApplication>
 #include <QInputDialog>
 #include <QMenuBar>
@@ -191,6 +192,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     auto const& browser_options = WebView::Application::browser_options();
 
     setWindowFlag(Qt::FramelessWindowHint);
+    setAttribute(Qt::WA_OpaquePaintEvent);
     setWindowIcon(app_icon());
     qApp->installEventFilter(this);
 
@@ -732,7 +734,7 @@ void BrowserWindow::create_close_button_for_tab(Tab* tab)
     auto index = m_tabs_container->index_of(tab);
     m_tabs_container->set_tab_icon(index, tab->tab_icon());
 
-    auto* button = new TabBarButton(create_tvg_icon_with_theme_colors("close", palette()));
+    auto* button = new TabBarButton(create_chrome_icon(ChromeIcon::Close, palette()));
     button->setToolTip("Close Tab");
 
     auto position = audio_button_position_for_tab(index) == QTabBar::LeftSide ? QTabBar::RightSide : QTabBar::LeftSide;
@@ -889,22 +891,44 @@ bool BrowserWindow::event(QEvent* event)
 
     if (event->type() == QEvent::WindowActivate)
         Application::the().set_active_window(*this);
+    else if (event->type() == QEvent::WindowDeactivate || event->type() == QEvent::Hide)
+        clear_resize_cursor();
 
     return QMainWindow::event(event);
 }
 
 bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
 {
+    auto* widget = as_if<QWidget>(object);
+    if (!widget || widget->window() != this)
+        return QMainWindow::eventFilter(object, event);
+
+    auto const is_button = qobject_cast<QAbstractButton*>(object) != nullptr;
+
+    if (is_button && (event->type() == QEvent::Enter || event->type() == QEvent::MouseMove || event->type() == QEvent::Leave)) {
+        clear_resize_cursor();
+    } else if (event->type() == QEvent::Enter) {
+        update_resize_cursor(mapFromGlobal(QCursor::pos()));
+    } else if (event->type() == QEvent::MouseMove) {
+        auto* mouse_event = static_cast<QMouseEvent*>(event);
+        update_resize_cursor(widget->mapTo(this, mouse_event->position().toPoint()));
+    } else if (event->type() == QEvent::Leave) {
+        auto position = mapFromGlobal(QCursor::pos());
+        if (rect().contains(position))
+            update_resize_cursor(position);
+        else
+            clear_resize_cursor();
+    } else if (event->type() != QEvent::MouseButtonPress) {
+        return QMainWindow::eventFilter(object, event);
+    }
+
     if (event->type() != QEvent::MouseButtonPress)
         return QMainWindow::eventFilter(object, event);
 
     if (isMaximized() || isFullScreen())
         return QMainWindow::eventFilter(object, event);
 
-    auto* widget = as_if<QWidget>(object);
-    if (!widget || widget->window() != this)
-        return QMainWindow::eventFilter(object, event);
-    if (qobject_cast<QAbstractButton*>(object))
+    if (is_button)
         return QMainWindow::eventFilter(object, event);
 
     auto* mouse_event = static_cast<QMouseEvent*>(event);
@@ -931,13 +955,59 @@ Qt::Edges BrowserWindow::resize_edges_for_position(QPoint const& position) const
         edges |= Qt::LeftEdge;
     if (position.x() >= width() - resize_border_width)
         edges |= Qt::RightEdge;
-    if (position.y() <= resize_border_width
-        && (position.x() <= resize_border_width * 2 || position.x() >= width() - resize_border_width * 2))
+    if (position.y() <= resize_border_width)
         edges |= Qt::TopEdge;
     if (position.y() >= height() - resize_border_width)
         edges |= Qt::BottomEdge;
 
     return edges;
+}
+
+Optional<Qt::CursorShape> BrowserWindow::resize_cursor_for_edges(Qt::Edges edges) const
+{
+    if (edges == Qt::Edges {})
+        return {};
+
+    if ((edges & Qt::TopEdge && edges & Qt::LeftEdge) || (edges & Qt::BottomEdge && edges & Qt::RightEdge))
+        return Qt::SizeFDiagCursor;
+    if ((edges & Qt::TopEdge && edges & Qt::RightEdge) || (edges & Qt::BottomEdge && edges & Qt::LeftEdge))
+        return Qt::SizeBDiagCursor;
+    if (edges & Qt::LeftEdge || edges & Qt::RightEdge)
+        return Qt::SizeHorCursor;
+    if (edges & Qt::TopEdge || edges & Qt::BottomEdge)
+        return Qt::SizeVerCursor;
+
+    return {};
+}
+
+void BrowserWindow::update_resize_cursor(QPoint const& position)
+{
+    if (isMaximized() || isFullScreen() || !rect().contains(position)) {
+        clear_resize_cursor();
+        return;
+    }
+
+    auto cursor_shape = resize_cursor_for_edges(resize_edges_for_position(position));
+    if (!cursor_shape.has_value()) {
+        clear_resize_cursor();
+        return;
+    }
+
+    if (m_resize_cursor_active)
+        QApplication::changeOverrideCursor(*cursor_shape);
+    else {
+        QApplication::setOverrideCursor(*cursor_shape);
+        m_resize_cursor_active = true;
+    }
+}
+
+void BrowserWindow::clear_resize_cursor()
+{
+    if (!m_resize_cursor_active)
+        return;
+
+    QApplication::restoreOverrideCursor();
+    m_resize_cursor_active = false;
 }
 
 void BrowserWindow::resizeEvent(QResizeEvent* event)
@@ -991,6 +1061,8 @@ void BrowserWindow::wheelEvent(QWheelEvent* event)
 
 void BrowserWindow::closeEvent(QCloseEvent* event)
 {
+    clear_resize_cursor();
+
     Optional<Vector<URL::URL>> recently_closed_window_urls;
     size_t recently_closed_window_active_tab_index { 0 };
     if (m_should_record_closed_window_on_close && m_tabs_container->count() > 0) {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -22,8 +22,10 @@
 #include <UI/Qt/TabBar.h>
 #include <UI/Qt/WebContentView.h>
 
+#include <QAbstractButton>
 #include <QAction>
 #include <QActionGroup>
+#include <QApplication>
 #include <QGuiApplication>
 #include <QInputDialog>
 #include <QMenuBar>
@@ -187,7 +189,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 {
     auto const& browser_options = WebView::Application::browser_options();
 
+    setWindowFlag(Qt::FramelessWindowHint);
     setWindowIcon(app_icon());
+    qApp->installEventFilter(this);
 
     // Listen for DPI changes
     m_device_pixel_ratio = devicePixelRatio();
@@ -427,6 +431,11 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 
     if (browser_options.devtools_port.has_value())
         on_devtools_enabled();
+}
+
+BrowserWindow::~BrowserWindow()
+{
+    qApp->removeEventFilter(this);
 }
 
 void BrowserWindow::rebuild_bookmarks_menu()
@@ -817,6 +826,53 @@ bool BrowserWindow::event(QEvent* event)
         Application::the().set_active_window(*this);
 
     return QMainWindow::event(event);
+}
+
+bool BrowserWindow::eventFilter(QObject* object, QEvent* event)
+{
+    if (event->type() != QEvent::MouseButtonPress)
+        return QMainWindow::eventFilter(object, event);
+
+    if (isMaximized() || isFullScreen())
+        return QMainWindow::eventFilter(object, event);
+
+    auto* widget = as_if<QWidget>(object);
+    if (!widget || widget->window() != this)
+        return QMainWindow::eventFilter(object, event);
+    if (qobject_cast<QAbstractButton*>(object))
+        return QMainWindow::eventFilter(object, event);
+
+    auto* mouse_event = static_cast<QMouseEvent*>(event);
+    if (mouse_event->button() != Qt::LeftButton)
+        return QMainWindow::eventFilter(object, event);
+
+    auto edges = resize_edges_for_position(widget->mapTo(this, mouse_event->position().toPoint()));
+    if (edges == Qt::Edges {})
+        return QMainWindow::eventFilter(object, event);
+
+    auto* handle = windowHandle();
+    if (!handle || !handle->startSystemResize(edges))
+        return QMainWindow::eventFilter(object, event);
+
+    return true;
+}
+
+Qt::Edges BrowserWindow::resize_edges_for_position(QPoint const& position) const
+{
+    static constexpr int resize_border_width = 6;
+
+    Qt::Edges edges;
+    if (position.x() <= resize_border_width)
+        edges |= Qt::LeftEdge;
+    if (position.x() >= width() - resize_border_width)
+        edges |= Qt::RightEdge;
+    if (position.y() <= resize_border_width
+        && (position.x() <= resize_border_width * 2 || position.x() >= width() - resize_border_width * 2))
+        edges |= Qt::TopEdge;
+    if (position.y() >= height() - resize_border_width)
+        edges |= Qt::BottomEdge;
+
+    return edges;
 }
 
 void BrowserWindow::resizeEvent(QResizeEvent* event)

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -152,6 +152,9 @@ private:
 
     void set_current_tab(Tab* tab);
     Qt::Edges resize_edges_for_position(QPoint const&) const;
+    Optional<Qt::CursorShape> resize_cursor_for_edges(Qt::Edges) const;
+    void update_resize_cursor(QPoint const&);
+    void clear_resize_cursor();
 
     template<typename Callback>
     void for_each_tab(Callback&& callback)
@@ -188,6 +191,7 @@ private:
     // Determine if window should restore to maximized or normal, when exiting fullscreen.
     bool m_restore_to_maximized { false };
     bool m_should_record_closed_window_on_close { true };
+    bool m_resize_cursor_active { false };
 };
 
 }

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -106,6 +106,9 @@ public:
     void rebuild_bookmarks_menu();
     void update_bookmarks_bar_display(bool show_bookmarks_bar);
     void update_reopen_recently_closed_action();
+    void detach_tab_to_new_window(int index, QPoint global_position);
+    void move_tab_to_window(int index, BrowserWindow& target_window, int target_index);
+    void adopt_tab(Tab&, int index);
 
     double refresh_rate() const { return m_refresh_rate; }
 
@@ -145,6 +148,7 @@ private:
 
     Tab& create_new_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
     void initialize_tab(Tab*);
+    void uninitialize_tab(Tab*);
 
     void set_current_tab(Tab* tab);
     Qt::Edges resize_edges_for_position(QPoint const&) const;

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -86,6 +86,7 @@ public:
     };
 
     BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    virtual ~BrowserWindow() override;
 
     WebContentView& view() const { return m_current_tab->view(); }
 
@@ -135,6 +136,7 @@ public slots:
 
 private:
     virtual bool event(QEvent*) override;
+    virtual bool eventFilter(QObject*, QEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
     virtual void changeEvent(QEvent* event) override;
     virtual void moveEvent(QMoveEvent*) override;
@@ -145,6 +147,7 @@ private:
     void initialize_tab(Tab*);
 
     void set_current_tab(Tab* tab);
+    Qt::Edges resize_edges_for_position(QPoint const&) const;
 
     template<typename Callback>
     void for_each_tab(Callback&& callback)

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(ladybird PRIVATE
     Autocomplete.cpp
     BookmarksBar.cpp
     BrowserWindow.cpp
+    ChromeStyle.cpp
     EventLoopImplementationQt.cpp
     EventLoopImplementationQtEventTarget.cpp
     FindInPageWidget.cpp

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -30,15 +30,15 @@ QColor chrome_background(QPalette const& palette)
 {
     auto window = palette.color(QPalette::Window);
     return is_dark(palette)
-        ? mix(window, QColor(18, 22, 28), 0.42)
-        : mix(window, QColor(240, 244, 248), 0.58);
+        ? mix(window, QColor(10, 16, 24), 0.72)
+        : mix(window, QColor(241, 245, 249), 0.62);
 }
 
 QColor chrome_surface(QPalette const& palette)
 {
     auto base = palette.color(QPalette::Base);
     return is_dark(palette)
-        ? mix(base, QColor(40, 45, 54), 0.46)
+        ? mix(base, QColor(31, 39, 52), 0.64)
         : mix(base, QColor(255, 255, 255), 0.72);
 }
 
@@ -46,7 +46,7 @@ QColor chrome_surface_hover(QPalette const& palette)
 {
     auto accent = palette.color(QPalette::Highlight);
     return is_dark(palette)
-        ? mix(chrome_surface(palette), accent.lighter(135), 0.18)
+        ? mix(chrome_surface(palette), QColor(61, 77, 100), 0.34)
         : mix(chrome_surface(palette), accent.lighter(165), 0.22);
 }
 
@@ -54,14 +54,14 @@ QColor chrome_surface_pressed(QPalette const& palette)
 {
     auto accent = palette.color(QPalette::Highlight);
     return is_dark(palette)
-        ? mix(chrome_surface(palette), accent.lighter(125), 0.28)
+        ? mix(chrome_surface(palette), accent.lighter(120), 0.32)
         : mix(chrome_surface(palette), accent.lighter(145), 0.32);
 }
 
 QColor chrome_border(QPalette const& palette)
 {
     return is_dark(palette)
-        ? mix(chrome_surface(palette), QColor(255, 255, 255), 0.16)
+        ? mix(chrome_surface(palette), QColor(151, 169, 190), 0.22)
         : mix(chrome_background(palette), QColor(92, 105, 120), 0.22);
 }
 
@@ -83,59 +83,66 @@ QString style_sheet_color(QColor const& color)
 QString navigation_toolbar_style_sheet(QPalette const& palette)
 {
     auto background = style_sheet_color(chrome_background(palette));
+    auto background_bottom = style_sheet_color(mix(chrome_background(palette), QColor(3, 8, 14), is_dark(palette) ? 0.34 : 0.0));
     auto surface_hover = style_sheet_color(chrome_surface_hover(palette));
     auto surface_pressed = style_sheet_color(chrome_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
+    auto separator = style_sheet_color(mix(chrome_background(palette), chrome_border(palette), is_dark(palette) ? 0.28 : 0.56));
     auto text = style_sheet_color(palette.color(QPalette::ButtonText));
     auto disabled_text = style_sheet_color(chrome_muted_text(palette));
 
     return QStringLiteral(R"(
-QToolBar#LadybirdNavigationToolbar {
-    background: %1;
+QWidget#LadybirdNavigationToolbar {
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 %1, stop:1 %2);
     border: 0;
-    border-bottom: 1px solid %4;
-    padding: 5px 8px 6px 8px;
-    spacing: 6px;
+    border-bottom: 1px solid %8;
 }
 
-QToolBar#LadybirdNavigationToolbar QToolButton {
-    color: %5;
+QWidget#LadybirdNavigationToolbar QToolButton {
+    color: %6;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 6px;
-    min-width: 30px;
-    min-height: 30px;
-    padding: 0 5px;
+    border-radius: 18px;
+    min-width: 36px;
+    min-height: 36px;
+    padding: 0;
 }
 
-QToolBar#LadybirdNavigationToolbar QToolButton:hover {
-    background: %2;
-    border-color: %4;
-}
-
-QToolBar#LadybirdNavigationToolbar QToolButton:pressed,
-QToolBar#LadybirdNavigationToolbar QToolButton:checked {
+QWidget#LadybirdNavigationToolbar QToolButton:hover {
     background: %3;
-    border-color: %4;
+    border-color: %5;
 }
 
-QToolBar#LadybirdNavigationToolbar QToolButton:disabled {
-    color: %6;
+QWidget#LadybirdNavigationToolbar QToolButton:pressed,
+QWidget#LadybirdNavigationToolbar QToolButton:checked {
+    background: %4;
+    border-color: %5;
 }
 
-QToolBar#LadybirdNavigationToolbar QToolButton::menu-indicator {
+QWidget#LadybirdNavigationToolbar QToolButton:disabled {
+    color: %7;
+}
+
+QWidget#LadybirdNavigationToolbar QToolButton::menu-indicator {
     image: none;
 }
 )")
-        .arg(background, surface_hover, surface_pressed, border, text, disabled_text);
+        .arg(background, background_bottom, surface_hover, surface_pressed, border, text, disabled_text, separator);
 }
 
 QString location_edit_style_sheet(QPalette const& palette)
 {
-    auto surface = style_sheet_color(chrome_surface(palette));
-    auto hover = style_sheet_color(chrome_surface_hover(palette));
+    auto surface_color = chrome_surface(palette);
+    if (is_dark(palette))
+        surface_color = mix(surface_color, QColor(44, 54, 70), 0.10);
+    auto hover_color = chrome_surface_hover(palette);
+    if (is_dark(palette))
+        hover_color = mix(hover_color, QColor(72, 88, 112), 0.08);
+
+    auto surface = style_sheet_color(surface_color);
+    auto hover = style_sheet_color(hover_color);
     auto border = style_sheet_color(chrome_border(palette));
-    auto accent = style_sheet_color(chrome_accent(palette));
+    auto focus_border = style_sheet_color(mix(chrome_border(palette), chrome_accent(palette), is_dark(palette) ? 0.46 : 0.58));
     auto text = style_sheet_color(palette.color(QPalette::Text));
     auto placeholder = style_sheet_color(chrome_muted_text(palette));
     auto selection = style_sheet_color(chrome_accent(palette));
@@ -146,9 +153,9 @@ QLineEdit#LadybirdLocationEdit {
     color: %5;
     background: %1;
     border: 1px solid %3;
-    border-radius: 8px;
-    min-height: 30px;
-    padding: 3px 12px;
+    border-radius: 20px;
+    min-height: 40px;
+    padding: 0 16px;
     selection-background-color: %7;
     selection-color: %8;
 }
@@ -158,15 +165,32 @@ QLineEdit#LadybirdLocationEdit:hover {
 }
 
 QLineEdit#LadybirdLocationEdit:focus {
-    background: %1;
+    background: %2;
     border-color: %4;
 }
 
 QLineEdit#LadybirdLocationEdit:disabled {
     color: %6;
 }
+
+QToolButton#LadybirdLocationIcon {
+    background: transparent;
+    border: 0;
+    padding: 0;
+}
+
+QToolButton#LadybirdLocationAction {
+    background: transparent;
+    border: 0;
+    border-radius: 12px;
+    padding: 0;
+}
+
+QToolButton#LadybirdLocationAction:hover {
+    background: %2;
+}
 )")
-        .arg(surface, hover, border, accent, text, placeholder, selection, selection_text);
+        .arg(surface, hover, border, focus_border, text, placeholder, selection, selection_text);
 }
 
 QString bookmarks_bar_style_sheet(QPalette const& palette)
@@ -269,6 +293,7 @@ QWidget#LadybirdFindInPageBar QLabel {
 QString tab_widget_style_sheet(QPalette const& palette)
 {
     auto background = style_sheet_color(chrome_background(palette));
+    auto background_bottom = style_sheet_color(mix(chrome_background(palette), QColor(3, 8, 14), is_dark(palette) ? 0.26 : 0.0));
     auto hover = style_sheet_color(chrome_surface_hover(palette));
     auto pressed = style_sheet_color(chrome_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
@@ -279,65 +304,75 @@ QString tab_widget_style_sheet(QPalette const& palette)
     return QStringLiteral(R"(
 QWidget#LadybirdTabStrip {
     color: %5;
-    background: %1;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 %1, stop:1 %2);
     border: 0;
-    border-bottom: 1px solid %4;
 }
 
 QToolButton#LadybirdNewTabButton,
 QPushButton#LadybirdTabButton {
-    color: %5;
+    color: %7;
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 6px;
-    min-width: 24px;
-    min-height: 24px;
+    border-radius: 11px;
     padding: 0;
+}
+
+QToolButton#LadybirdNewTabButton {
+    min-width: 32px;
+    min-height: 32px;
+    border-radius: 16px;
+}
+
+QPushButton#LadybirdTabButton {
+    min-width: 20px;
+    min-height: 20px;
+    max-width: 20px;
+    max-height: 20px;
 }
 
 QToolButton#LadybirdNewTabButton:hover,
 QPushButton#LadybirdTabButton:hover {
-    background: %2;
-    border-color: %4;
+    background: %3;
+    border-color: %6;
 }
 
 QToolButton#LadybirdNewTabButton:pressed,
 QPushButton#LadybirdTabButton:pressed,
 QPushButton#LadybirdTabButton:checked {
-    background: %3;
-    border-color: %4;
+    background: %4;
+    border-color: %6;
 }
 
 QToolButton#LadybirdWindowButton,
 QToolButton#LadybirdCloseWindowButton {
-    color: %5;
+    color: %7;
     background: transparent;
     border: 0;
     border-radius: 0;
     min-width: 40px;
-    min-height: 32px;
+    min-height: 40px;
     padding: 0;
 }
 
 QToolButton#LadybirdWindowButton:hover {
-    background: %2;
-}
-
-QToolButton#LadybirdWindowButton:pressed {
     background: %3;
 }
 
+QToolButton#LadybirdWindowButton:pressed {
+    background: %4;
+}
+
 QToolButton#LadybirdCloseWindowButton:hover {
-    color: %7;
-    background: %6;
+    color: %9;
+    background: %8;
 }
 
 QToolButton#LadybirdCloseWindowButton:pressed {
-    color: %7;
-    background: %6;
+    color: %9;
+    background: %8;
 }
 )")
-        .arg(background, hover, pressed, border, text, close_hover, close_text);
+        .arg(background, background_bottom, hover, pressed, text, border, text, close_hover, close_text);
 }
 
 QString autocomplete_popup_style_sheet(QPalette const& palette)
@@ -351,7 +386,7 @@ QFrame#LadybirdAutocompletePopup {
     color: %3;
     background: %1;
     border: 1px solid %2;
-    border-radius: 10px;
+    border-radius: 8px;
 }
 
 QListView#LadybirdAutocompleteList {

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -6,14 +6,75 @@
 
 #include <UI/Qt/ChromeStyle.h>
 
+#include <QGuiApplication>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#    include <QStyleHints>
+#endif
+
 namespace Ladybird::ChromeStyle {
 
-static bool is_dark(QPalette const& palette)
+static bool color_is_dark(QColor const& color)
 {
-    return palette.color(QPalette::Window).lightness() < 128;
+    return color.lightness() < 128;
 }
 
-static QColor mix(QColor const& from, QColor const& to, double amount)
+static bool palette_is_dark(QPalette const& palette)
+{
+    return color_is_dark(palette.color(QPalette::Window));
+}
+
+bool is_dark(QPalette const& palette)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    auto color_scheme = QGuiApplication::styleHints()->colorScheme();
+    if (color_scheme != Qt::ColorScheme::Unknown)
+        return color_scheme == Qt::ColorScheme::Dark;
+#endif
+
+    return palette_is_dark(palette);
+}
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+static bool palette_roles_match_color_scheme(QPalette const& palette, bool dark)
+{
+    return color_is_dark(palette.color(QPalette::Window)) == dark
+        && color_is_dark(palette.color(QPalette::Base)) == dark
+        && color_is_dark(palette.color(QPalette::Text)) != dark
+        && color_is_dark(palette.color(QPalette::ButtonText)) != dark;
+}
+#endif
+
+static bool palette_matches_current_color_scheme(QPalette const& palette)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    auto color_scheme = QGuiApplication::styleHints()->colorScheme();
+    if (color_scheme == Qt::ColorScheme::Dark)
+        return palette_roles_match_color_scheme(palette, true);
+    if (color_scheme == Qt::ColorScheme::Light)
+        return palette_roles_match_color_scheme(palette, false);
+#endif
+
+    Q_UNUSED(palette);
+    return true;
+}
+
+static QColor chrome_window(QPalette const& palette)
+{
+    if (palette_matches_current_color_scheme(palette))
+        return palette.color(QPalette::Window);
+
+    return is_dark(palette) ? QColor(26, 29, 36) : QColor(244, 246, 248);
+}
+
+static QColor chrome_base(QPalette const& palette)
+{
+    if (palette_matches_current_color_scheme(palette))
+        return palette.color(QPalette::Base);
+
+    return is_dark(palette) ? QColor(24, 29, 38) : QColor(255, 255, 255);
+}
+
+QColor mix(QColor const& from, QColor const& to, double amount)
 {
     auto channel = [&](int from_channel, int to_channel) {
         return static_cast<int>(from_channel + (to_channel - from_channel) * amount);
@@ -28,7 +89,7 @@ static QColor mix(QColor const& from, QColor const& to, double amount)
 
 QColor chrome_background(QPalette const& palette)
 {
-    auto window = palette.color(QPalette::Window);
+    auto window = chrome_window(palette);
     return is_dark(palette)
         ? mix(window, QColor(10, 16, 24), 0.72)
         : mix(window, QColor(241, 245, 249), 0.62);
@@ -36,7 +97,7 @@ QColor chrome_background(QPalette const& palette)
 
 QColor chrome_surface(QPalette const& palette)
 {
-    auto base = palette.color(QPalette::Base);
+    auto base = chrome_base(palette);
     return is_dark(palette)
         ? mix(base, QColor(31, 39, 52), 0.64)
         : mix(base, QColor(255, 255, 255), 0.72);
@@ -70,8 +131,27 @@ QColor chrome_accent(QPalette const& palette)
     return palette.color(QPalette::Highlight);
 }
 
+QColor chrome_text(QPalette const& palette)
+{
+    if (palette_matches_current_color_scheme(palette))
+        return palette.color(QPalette::Text);
+
+    return is_dark(palette) ? QColor(238, 241, 246) : QColor(24, 29, 36);
+}
+
+QColor chrome_button_text(QPalette const& palette)
+{
+    if (palette_matches_current_color_scheme(palette))
+        return palette.color(QPalette::ButtonText);
+
+    return chrome_text(palette);
+}
+
 QColor chrome_muted_text(QPalette const& palette)
 {
+    if (!palette_matches_current_color_scheme(palette))
+        return is_dark(palette) ? QColor(154, 163, 176) : QColor(98, 108, 122);
+
     return palette.color(QPalette::PlaceholderText);
 }
 
@@ -88,7 +168,7 @@ QString navigation_toolbar_style_sheet(QPalette const& palette)
     auto surface_pressed = style_sheet_color(chrome_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
     auto separator = style_sheet_color(mix(chrome_background(palette), chrome_border(palette), is_dark(palette) ? 0.28 : 0.56));
-    auto text = style_sheet_color(palette.color(QPalette::ButtonText));
+    auto text = style_sheet_color(chrome_button_text(palette));
     auto disabled_text = style_sheet_color(chrome_muted_text(palette));
 
     return QStringLiteral(R"(
@@ -143,7 +223,7 @@ QString location_edit_style_sheet(QPalette const& palette)
     auto hover = style_sheet_color(hover_color);
     auto border = style_sheet_color(chrome_border(palette));
     auto focus_border = style_sheet_color(mix(chrome_border(palette), chrome_accent(palette), is_dark(palette) ? 0.46 : 0.58));
-    auto text = style_sheet_color(palette.color(QPalette::Text));
+    auto text = style_sheet_color(chrome_text(palette));
     auto placeholder = style_sheet_color(chrome_muted_text(palette));
     auto selection = style_sheet_color(chrome_accent(palette));
     auto selection_text = style_sheet_color(palette.color(QPalette::HighlightedText));
@@ -199,7 +279,7 @@ QString bookmarks_bar_style_sheet(QPalette const& palette)
     auto hover = style_sheet_color(chrome_surface_hover(palette));
     auto pressed = style_sheet_color(chrome_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
-    auto text = style_sheet_color(palette.color(QPalette::ButtonText));
+    auto text = style_sheet_color(chrome_button_text(palette));
 
     return QStringLiteral(R"(
 QToolBar#LadybirdBookmarksBar {
@@ -241,7 +321,7 @@ QString find_in_page_style_sheet(QPalette const& palette)
     auto pressed = style_sheet_color(chrome_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
     auto accent = style_sheet_color(chrome_accent(palette));
-    auto text = style_sheet_color(palette.color(QPalette::Text));
+    auto text = style_sheet_color(chrome_text(palette));
     auto muted = style_sheet_color(chrome_muted_text(palette));
 
     return QStringLiteral(R"(
@@ -297,7 +377,7 @@ QString tab_widget_style_sheet(QPalette const& palette)
     auto hover = style_sheet_color(chrome_surface_hover(palette));
     auto pressed = style_sheet_color(chrome_surface_pressed(palette));
     auto border = style_sheet_color(chrome_border(palette));
-    auto text = style_sheet_color(palette.color(QPalette::ButtonText));
+    auto text = style_sheet_color(chrome_button_text(palette));
     auto close_hover = style_sheet_color(QColor(196, 43, 28));
     auto close_text = style_sheet_color(QColor(255, 255, 255));
 
@@ -379,7 +459,7 @@ QString autocomplete_popup_style_sheet(QPalette const& palette)
 {
     auto surface = style_sheet_color(chrome_surface(palette));
     auto border = style_sheet_color(chrome_border(palette));
-    auto text = style_sheet_color(palette.color(QPalette::Text));
+    auto text = style_sheet_color(chrome_text(palette));
 
     return QStringLiteral(R"(
 QFrame#LadybirdAutocompletePopup {

--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <UI/Qt/ChromeStyle.h>
+
+namespace Ladybird::ChromeStyle {
+
+static bool is_dark(QPalette const& palette)
+{
+    return palette.color(QPalette::Window).lightness() < 128;
+}
+
+static QColor mix(QColor const& from, QColor const& to, double amount)
+{
+    auto channel = [&](int from_channel, int to_channel) {
+        return static_cast<int>(from_channel + (to_channel - from_channel) * amount);
+    };
+
+    return QColor {
+        channel(from.red(), to.red()),
+        channel(from.green(), to.green()),
+        channel(from.blue(), to.blue()),
+    };
+}
+
+QColor chrome_background(QPalette const& palette)
+{
+    auto window = palette.color(QPalette::Window);
+    return is_dark(palette)
+        ? mix(window, QColor(18, 22, 28), 0.42)
+        : mix(window, QColor(240, 244, 248), 0.58);
+}
+
+QColor chrome_surface(QPalette const& palette)
+{
+    auto base = palette.color(QPalette::Base);
+    return is_dark(palette)
+        ? mix(base, QColor(40, 45, 54), 0.46)
+        : mix(base, QColor(255, 255, 255), 0.72);
+}
+
+QColor chrome_surface_hover(QPalette const& palette)
+{
+    auto accent = palette.color(QPalette::Highlight);
+    return is_dark(palette)
+        ? mix(chrome_surface(palette), accent.lighter(135), 0.18)
+        : mix(chrome_surface(palette), accent.lighter(165), 0.22);
+}
+
+QColor chrome_surface_pressed(QPalette const& palette)
+{
+    auto accent = palette.color(QPalette::Highlight);
+    return is_dark(palette)
+        ? mix(chrome_surface(palette), accent.lighter(125), 0.28)
+        : mix(chrome_surface(palette), accent.lighter(145), 0.32);
+}
+
+QColor chrome_border(QPalette const& palette)
+{
+    return is_dark(palette)
+        ? mix(chrome_surface(palette), QColor(255, 255, 255), 0.16)
+        : mix(chrome_background(palette), QColor(92, 105, 120), 0.22);
+}
+
+QColor chrome_accent(QPalette const& palette)
+{
+    return palette.color(QPalette::Highlight);
+}
+
+QColor chrome_muted_text(QPalette const& palette)
+{
+    return palette.color(QPalette::PlaceholderText);
+}
+
+QString style_sheet_color(QColor const& color)
+{
+    return QStringLiteral("rgb(%1, %2, %3)").arg(color.red()).arg(color.green()).arg(color.blue());
+}
+
+QString navigation_toolbar_style_sheet(QPalette const& palette)
+{
+    auto background = style_sheet_color(chrome_background(palette));
+    auto surface_hover = style_sheet_color(chrome_surface_hover(palette));
+    auto surface_pressed = style_sheet_color(chrome_surface_pressed(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto text = style_sheet_color(palette.color(QPalette::ButtonText));
+    auto disabled_text = style_sheet_color(chrome_muted_text(palette));
+
+    return QStringLiteral(R"(
+QToolBar#LadybirdNavigationToolbar {
+    background: %1;
+    border: 0;
+    border-bottom: 1px solid %4;
+    padding: 5px 8px 6px 8px;
+    spacing: 6px;
+}
+
+QToolBar#LadybirdNavigationToolbar QToolButton {
+    color: %5;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    min-width: 30px;
+    min-height: 30px;
+    padding: 0 5px;
+}
+
+QToolBar#LadybirdNavigationToolbar QToolButton:hover {
+    background: %2;
+    border-color: %4;
+}
+
+QToolBar#LadybirdNavigationToolbar QToolButton:pressed,
+QToolBar#LadybirdNavigationToolbar QToolButton:checked {
+    background: %3;
+    border-color: %4;
+}
+
+QToolBar#LadybirdNavigationToolbar QToolButton:disabled {
+    color: %6;
+}
+
+QToolBar#LadybirdNavigationToolbar QToolButton::menu-indicator {
+    image: none;
+}
+)")
+        .arg(background, surface_hover, surface_pressed, border, text, disabled_text);
+}
+
+QString location_edit_style_sheet(QPalette const& palette)
+{
+    auto surface = style_sheet_color(chrome_surface(palette));
+    auto hover = style_sheet_color(chrome_surface_hover(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto accent = style_sheet_color(chrome_accent(palette));
+    auto text = style_sheet_color(palette.color(QPalette::Text));
+    auto placeholder = style_sheet_color(chrome_muted_text(palette));
+    auto selection = style_sheet_color(chrome_accent(palette));
+    auto selection_text = style_sheet_color(palette.color(QPalette::HighlightedText));
+
+    return QStringLiteral(R"(
+QLineEdit#LadybirdLocationEdit {
+    color: %5;
+    background: %1;
+    border: 1px solid %3;
+    border-radius: 8px;
+    min-height: 30px;
+    padding: 3px 12px;
+    selection-background-color: %7;
+    selection-color: %8;
+}
+
+QLineEdit#LadybirdLocationEdit:hover {
+    background: %2;
+}
+
+QLineEdit#LadybirdLocationEdit:focus {
+    background: %1;
+    border-color: %4;
+}
+
+QLineEdit#LadybirdLocationEdit:disabled {
+    color: %6;
+}
+)")
+        .arg(surface, hover, border, accent, text, placeholder, selection, selection_text);
+}
+
+QString bookmarks_bar_style_sheet(QPalette const& palette)
+{
+    auto background = style_sheet_color(chrome_background(palette));
+    auto hover = style_sheet_color(chrome_surface_hover(palette));
+    auto pressed = style_sheet_color(chrome_surface_pressed(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto text = style_sheet_color(palette.color(QPalette::ButtonText));
+
+    return QStringLiteral(R"(
+QToolBar#LadybirdBookmarksBar {
+    color: %5;
+    background: %1;
+    border: 0;
+    border-bottom: 1px solid %4;
+    padding: 4px 8px;
+    spacing: 3px;
+}
+
+QToolBar#LadybirdBookmarksBar QToolButton {
+    color: %5;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    padding: 4px 7px;
+}
+
+QToolBar#LadybirdBookmarksBar QToolButton:hover {
+    background: %2;
+    border-color: %4;
+}
+
+QToolBar#LadybirdBookmarksBar QToolButton:pressed,
+QToolBar#LadybirdBookmarksBar QToolButton:checked {
+    background: %3;
+    border-color: %4;
+}
+)")
+        .arg(background, hover, pressed, border, text);
+}
+
+QString find_in_page_style_sheet(QPalette const& palette)
+{
+    auto background = style_sheet_color(chrome_background(palette));
+    auto surface = style_sheet_color(chrome_surface(palette));
+    auto hover = style_sheet_color(chrome_surface_hover(palette));
+    auto pressed = style_sheet_color(chrome_surface_pressed(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto accent = style_sheet_color(chrome_accent(palette));
+    auto text = style_sheet_color(palette.color(QPalette::Text));
+    auto muted = style_sheet_color(chrome_muted_text(palette));
+
+    return QStringLiteral(R"(
+QWidget#LadybirdFindInPageBar {
+    background: %1;
+    border-top: 1px solid %5;
+}
+
+QWidget#LadybirdFindInPageBar QLineEdit {
+    color: %7;
+    background: %2;
+    border: 1px solid %5;
+    border-radius: 8px;
+    min-height: 26px;
+    padding: 2px 9px;
+    selection-background-color: %6;
+}
+
+QWidget#LadybirdFindInPageBar QLineEdit:focus {
+    border-color: %6;
+}
+
+QWidget#LadybirdFindInPageBar QPushButton {
+    color: %7;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    min-height: 26px;
+}
+
+QWidget#LadybirdFindInPageBar QPushButton:hover {
+    background: %3;
+    border-color: %5;
+}
+
+QWidget#LadybirdFindInPageBar QPushButton:pressed {
+    background: %4;
+    border-color: %5;
+}
+
+QWidget#LadybirdFindInPageBar QCheckBox,
+QWidget#LadybirdFindInPageBar QLabel {
+    color: %8;
+}
+)")
+        .arg(background, surface, hover, pressed, border, accent, text, muted);
+}
+
+QString tab_widget_style_sheet(QPalette const& palette)
+{
+    auto background = style_sheet_color(chrome_background(palette));
+    auto hover = style_sheet_color(chrome_surface_hover(palette));
+    auto pressed = style_sheet_color(chrome_surface_pressed(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto text = style_sheet_color(palette.color(QPalette::ButtonText));
+    auto close_hover = style_sheet_color(QColor(196, 43, 28));
+    auto close_text = style_sheet_color(QColor(255, 255, 255));
+
+    return QStringLiteral(R"(
+QWidget#LadybirdTabStrip {
+    color: %5;
+    background: %1;
+    border: 0;
+    border-bottom: 1px solid %4;
+}
+
+QToolButton#LadybirdNewTabButton,
+QPushButton#LadybirdTabButton {
+    color: %5;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    min-width: 24px;
+    min-height: 24px;
+    padding: 0;
+}
+
+QToolButton#LadybirdNewTabButton:hover,
+QPushButton#LadybirdTabButton:hover {
+    background: %2;
+    border-color: %4;
+}
+
+QToolButton#LadybirdNewTabButton:pressed,
+QPushButton#LadybirdTabButton:pressed,
+QPushButton#LadybirdTabButton:checked {
+    background: %3;
+    border-color: %4;
+}
+
+QToolButton#LadybirdWindowButton,
+QToolButton#LadybirdCloseWindowButton {
+    color: %5;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    min-width: 40px;
+    min-height: 32px;
+    padding: 0;
+}
+
+QToolButton#LadybirdWindowButton:hover {
+    background: %2;
+}
+
+QToolButton#LadybirdWindowButton:pressed {
+    background: %3;
+}
+
+QToolButton#LadybirdCloseWindowButton:hover {
+    color: %7;
+    background: %6;
+}
+
+QToolButton#LadybirdCloseWindowButton:pressed {
+    color: %7;
+    background: %6;
+}
+)")
+        .arg(background, hover, pressed, border, text, close_hover, close_text);
+}
+
+QString autocomplete_popup_style_sheet(QPalette const& palette)
+{
+    auto surface = style_sheet_color(chrome_surface(palette));
+    auto border = style_sheet_color(chrome_border(palette));
+    auto text = style_sheet_color(palette.color(QPalette::Text));
+
+    return QStringLiteral(R"(
+QFrame#LadybirdAutocompletePopup {
+    color: %3;
+    background: %1;
+    border: 1px solid %2;
+    border-radius: 10px;
+}
+
+QListView#LadybirdAutocompleteList {
+    color: %3;
+    background: transparent;
+    border: 0;
+    outline: 0;
+}
+)")
+        .arg(surface, border, text);
+}
+
+}

--- a/UI/Qt/ChromeStyle.h
+++ b/UI/Qt/ChromeStyle.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <QColor>
+#include <QPalette>
+#include <QString>
+
+namespace Ladybird::ChromeStyle {
+
+QColor chrome_background(QPalette const&);
+QColor chrome_surface(QPalette const&);
+QColor chrome_surface_hover(QPalette const&);
+QColor chrome_surface_pressed(QPalette const&);
+QColor chrome_border(QPalette const&);
+QColor chrome_accent(QPalette const&);
+QColor chrome_muted_text(QPalette const&);
+
+QString style_sheet_color(QColor const&);
+QString navigation_toolbar_style_sheet(QPalette const&);
+QString location_edit_style_sheet(QPalette const&);
+QString bookmarks_bar_style_sheet(QPalette const&);
+QString find_in_page_style_sheet(QPalette const&);
+QString tab_widget_style_sheet(QPalette const&);
+QString autocomplete_popup_style_sheet(QPalette const&);
+
+}

--- a/UI/Qt/ChromeStyle.h
+++ b/UI/Qt/ChromeStyle.h
@@ -12,6 +12,10 @@
 
 namespace Ladybird::ChromeStyle {
 
+bool is_dark(QPalette const&);
+QColor mix(QColor const& from, QColor const& to, double amount);
+QColor chrome_text(QPalette const&);
+QColor chrome_button_text(QPalette const&);
 QColor chrome_background(QPalette const&);
 QColor chrome_surface(QPalette const&);
 QColor chrome_surface_hover(QPalette const&);

--- a/UI/Qt/FindInPageWidget.cpp
+++ b/UI/Qt/FindInPageWidget.cpp
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/FindInPageWidget.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/Tab.h>
 
+#include <QEvent>
 #include <QKeyEvent>
 
 namespace Ladybird {
@@ -18,8 +20,10 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     , m_tab(tab)
     , m_content_view(content_view)
 {
+    setObjectName("LadybirdFindInPageBar");
     setFocusPolicy(Qt::FocusPolicy::StrongFocus);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    update_chrome_style();
 
     auto* layout = new QHBoxLayout(this);
     setLayout(layout);
@@ -87,6 +91,28 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
 }
 
 FindInPageWidget::~FindInPageWidget() = default;
+
+bool FindInPageWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::PaletteChange) {
+        update_chrome_style();
+        m_previous_button->setIcon(create_tvg_icon_with_theme_colors("up", palette()));
+        m_next_button->setIcon(create_tvg_icon_with_theme_colors("down", palette()));
+        m_exit_button->setIcon(create_tvg_icon_with_theme_colors("close", palette()));
+    }
+
+    return QWidget::event(event);
+}
+
+void FindInPageWidget::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    setStyleSheet(ChromeStyle::find_in_page_style_sheet(palette()));
+    m_is_updating_chrome_style = false;
+}
 
 void FindInPageWidget::find_text_changed()
 {

--- a/UI/Qt/FindInPageWidget.h
+++ b/UI/Qt/FindInPageWidget.h
@@ -36,12 +36,14 @@ public:
 public slots:
 
 private:
+    virtual bool event(QEvent*) override;
     virtual void keyPressEvent(QKeyEvent*) override;
     virtual void focusInEvent(QFocusEvent*) override;
     virtual void showEvent(QShowEvent*) override;
     virtual void hideEvent(QHideEvent*) override;
 
     void find_text_changed();
+    void update_chrome_style();
 
     Tab* m_tab { nullptr };
     WebContentView* m_content_view { nullptr };
@@ -52,6 +54,7 @@ private:
     QPushButton* m_exit_button { nullptr };
     QCheckBox* m_match_case { nullptr };
     QLabel* m_result_label { nullptr };
+    bool m_is_updating_chrome_style { false };
 };
 
 }

--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/Resource.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/TVGIconEngine.h>
@@ -198,12 +199,17 @@ static QIcon create_y_offset_icon(QIcon const& source, int y_offset)
 
 QIcon create_chrome_icon(ChromeIcon icon, QPalette const& palette)
 {
-    if (icon == ChromeIcon::Reload)
-        return create_y_offset_icon(create_tvg_icon_with_theme_colors("reload", palette), 1);
-    if (icon == ChromeIcon::Globe)
-        return create_y_offset_icon(create_tvg_icon_with_theme_colors("globe", palette, 202, 96, 236, 236), 1);
+    auto chrome_palette = palette;
+    chrome_palette.setColor(QPalette::Normal, QPalette::ButtonText, ChromeStyle::chrome_button_text(palette));
+    chrome_palette.setColor(QPalette::Active, QPalette::ButtonText, ChromeStyle::chrome_button_text(palette));
+    chrome_palette.setColor(QPalette::Disabled, QPalette::ButtonText, ChromeStyle::chrome_muted_text(palette));
 
-    auto normal = palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText);
+    if (icon == ChromeIcon::Reload)
+        return create_y_offset_icon(create_tvg_icon_with_theme_colors("reload", chrome_palette), 1);
+    if (icon == ChromeIcon::Globe)
+        return create_y_offset_icon(create_tvg_icon_with_theme_colors("globe", chrome_palette, 202, 96, 236, 236), 1);
+
+    auto normal = ChromeStyle::chrome_button_text(palette);
     auto normal_alpha = 216;
     if (icon == ChromeIcon::Close)
         normal_alpha = 172;
@@ -211,10 +217,10 @@ QIcon create_chrome_icon(ChromeIcon icon, QPalette const& palette)
         normal_alpha = 204;
     normal.setAlpha(normal_alpha);
 
-    auto active = palette.color(QPalette::ColorGroup::Active, QPalette::ColorRole::ButtonText);
+    auto active = ChromeStyle::chrome_button_text(palette);
     active.setAlpha(icon == ChromeIcon::Close ? 220 : 236);
 
-    auto disabled = palette.color(QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText);
+    auto disabled = ChromeStyle::chrome_muted_text(palette);
     disabled.setAlpha(icon == ChromeIcon::Close ? 78 : 96);
 
     QIcon qicon;
@@ -237,7 +243,7 @@ QIcon loading_spinner_icon(QPalette const& palette, int frame)
     painter.setRenderHint(QPainter::Antialiasing);
     painter.translate(icon_size / 2.0, icon_size / 2.0);
 
-    auto color = palette.color(QPalette::Text);
+    auto color = ChromeStyle::chrome_text(palette);
     for (int segment = 0; segment < segment_count; ++segment) {
         auto segment_color = color;
         segment_color.setAlpha(((segment - frame + segment_count) % segment_count + 1) * 255 / segment_count);

--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -10,10 +10,12 @@
 #include <UI/Qt/TVGIconEngine.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QPalette>
 #include <QPen>
 #include <QPixmap>
 #include <QPointF>
+#include <QRectF>
 
 namespace Ladybird {
 
@@ -25,24 +27,202 @@ QIcon load_icon_from_uri(StringView uri)
     return QIcon { path };
 }
 
-QIcon create_tvg_icon_with_theme_colors(QString const& name, QPalette const& palette)
+static QIcon create_tvg_icon_with_theme_colors(QString const& name, QPalette const& palette, int normal_alpha, int disabled_alpha, int active_alpha, int selected_alpha)
 {
     auto path = QString(":/Icons/%1.tvg").arg(name);
 
     auto* icon_engine = TVGIconEngine::from_file(path);
     VERIFY(icon_engine);
 
-    auto icon_filter = [](QColor color) {
+    auto icon_filter = [](QColor color, int alpha) {
+        color.setAlpha((color.alpha() * alpha) / 255);
         return [color = Color::from_bgra(color.rgba64().toArgb32())](Gfx::Color icon_color) {
             return color.with_alpha((icon_color.alpha() * color.alpha()) / 255);
         };
     };
-    icon_engine->add_filter(QIcon::Mode::Normal, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText)));
-    icon_engine->add_filter(QIcon::Mode::Disabled, icon_filter(palette.color(QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText)));
-    icon_engine->add_filter(QIcon::Mode::Active, icon_filter(palette.color(QPalette::ColorGroup::Active, QPalette::ColorRole::ButtonText)));
-    icon_engine->add_filter(QIcon::Mode::Selected, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText)));
+    icon_engine->add_filter(QIcon::Mode::Normal, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText), normal_alpha));
+    icon_engine->add_filter(QIcon::Mode::Disabled, icon_filter(palette.color(QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText), disabled_alpha));
+    icon_engine->add_filter(QIcon::Mode::Active, icon_filter(palette.color(QPalette::ColorGroup::Active, QPalette::ColorRole::ButtonText), active_alpha));
+    icon_engine->add_filter(QIcon::Mode::Selected, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText), selected_alpha));
 
     return QIcon(icon_engine);
+}
+
+QIcon create_tvg_icon_with_theme_colors(QString const& name, QPalette const& palette)
+{
+    return create_tvg_icon_with_theme_colors(name, palette, 255, 255, 255, 255);
+}
+
+static QPen chrome_icon_pen(QColor const& color, qreal width)
+{
+    return QPen(color, width, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+}
+
+static void draw_star_icon(QPainter& painter, QColor const& color, bool filled)
+{
+    QPainterPath path;
+    path.moveTo(10.0, 2.6);
+    path.lineTo(12.5, 7.5);
+    path.lineTo(18.0, 8.0);
+    path.lineTo(13.9, 11.7);
+    path.lineTo(15.1, 17.2);
+    path.lineTo(10.0, 14.3);
+    path.lineTo(4.9, 17.2);
+    path.lineTo(6.1, 11.7);
+    path.lineTo(2.0, 8.0);
+    path.lineTo(7.5, 7.5);
+    path.closeSubpath();
+
+    painter.setPen(chrome_icon_pen(color, filled ? 1.2 : 1.8));
+    if (filled)
+        painter.setBrush(color);
+    else
+        painter.setBrush(Qt::NoBrush);
+    painter.drawPath(path);
+}
+
+static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color)
+{
+    QPixmap pixmap(20, 20);
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(chrome_icon_pen(color, 1.7));
+
+    switch (icon) {
+    case ChromeIcon::Back:
+        painter.setPen(chrome_icon_pen(color, 2.05));
+        painter.drawLine(QPointF(15.4, 10.0), QPointF(6.0, 10.0));
+        painter.drawLine(QPointF(10.8, 5.5), QPointF(5.3, 10.0));
+        painter.drawLine(QPointF(5.3, 10.0), QPointF(10.8, 14.5));
+        break;
+    case ChromeIcon::Forward:
+        painter.setPen(chrome_icon_pen(color, 2.05));
+        painter.drawLine(QPointF(4.6, 10.0), QPointF(14.0, 10.0));
+        painter.drawLine(QPointF(9.4, 5.6), QPointF(14.7, 10.0));
+        painter.drawLine(QPointF(14.7, 10.0), QPointF(9.4, 14.4));
+        break;
+    case ChromeIcon::Reload: {
+        painter.setPen(chrome_icon_pen(color, 1.9));
+        QPainterPath path;
+        path.arcMoveTo(QRectF(4.0, 4.0, 12.2, 12.2), 34.0);
+        path.arcTo(QRectF(4.0, 4.0, 12.2, 12.2), 34.0, 288.0);
+        painter.drawPath(path);
+        painter.drawLine(QPointF(15.4, 3.7), QPointF(16.0, 7.5));
+        painter.drawLine(QPointF(15.4, 3.7), QPointF(11.8, 4.4));
+        break;
+    }
+    case ChromeIcon::Stop:
+        painter.setPen(chrome_icon_pen(color, 1.75));
+        painter.drawLine(QPointF(6.0, 6.0), QPointF(14.0, 14.0));
+        painter.drawLine(QPointF(14.0, 6.0), QPointF(6.0, 14.0));
+        break;
+    case ChromeIcon::NewTab:
+        painter.setPen(chrome_icon_pen(color, 1.75));
+        painter.drawLine(QPointF(10.0, 5.0), QPointF(10.0, 15.0));
+        painter.drawLine(QPointF(5.0, 10.0), QPointF(15.0, 10.0));
+        break;
+    case ChromeIcon::Close:
+        painter.setPen(chrome_icon_pen(color, 1.75));
+        painter.drawLine(QPointF(6.0, 6.4), QPointF(14.0, 14.4));
+        painter.drawLine(QPointF(14.0, 6.4), QPointF(6.0, 14.4));
+        break;
+    case ChromeIcon::Menu:
+        painter.setPen(chrome_icon_pen(color, 1.8));
+        painter.drawLine(QPointF(3.8, 6.4), QPointF(16.2, 6.4));
+        painter.drawLine(QPointF(3.8, 10.0), QPointF(16.2, 10.0));
+        painter.drawLine(QPointF(3.8, 13.6), QPointF(16.2, 13.6));
+        break;
+    case ChromeIcon::Star:
+        draw_star_icon(painter, color, false);
+        break;
+    case ChromeIcon::StarFilled:
+        draw_star_icon(painter, color, true);
+        break;
+    case ChromeIcon::Search:
+        painter.setPen(chrome_icon_pen(color, 1.65));
+        painter.drawEllipse(QRectF(4.2, 4.0, 9.7, 9.7));
+        painter.drawLine(QPointF(12.1, 12.1), QPointF(16.0, 16.0));
+        break;
+    case ChromeIcon::Globe:
+        painter.setPen(chrome_icon_pen(color, 1.75));
+        painter.drawEllipse(QRectF(4.4, 4.4, 11.2, 11.2));
+        painter.drawLine(QPointF(5.5, 10.0), QPointF(14.5, 10.0));
+        painter.drawArc(QRectF(7.1, 4.4, 5.8, 11.2), 90 * 16, 180 * 16);
+        break;
+    case ChromeIcon::WindowMinimize:
+        painter.setPen(chrome_icon_pen(color, 1.65));
+        painter.drawLine(QPointF(5.2, 12.5), QPointF(14.8, 12.5));
+        break;
+    case ChromeIcon::WindowMaximize:
+        painter.setPen(chrome_icon_pen(color, 1.55));
+        painter.drawRoundedRect(QRectF(5.0, 5.0, 10.0, 10.0), 1.4, 1.4);
+        break;
+    case ChromeIcon::WindowRestore:
+        painter.setPen(chrome_icon_pen(color, 1.55));
+        painter.drawRoundedRect(QRectF(5.1, 7.0, 7.9, 7.9), 1.2, 1.2);
+        painter.drawLine(QPointF(7.2, 5.1), QPointF(14.9, 5.1));
+        painter.drawLine(QPointF(14.9, 5.1), QPointF(14.9, 12.9));
+        break;
+    case ChromeIcon::WindowClose:
+        painter.setPen(chrome_icon_pen(color, 1.65));
+        painter.drawLine(QPointF(5.5, 5.5), QPointF(14.5, 14.5));
+        painter.drawLine(QPointF(14.5, 5.5), QPointF(5.5, 14.5));
+        break;
+    }
+
+    return pixmap;
+}
+
+static QIcon create_y_offset_icon(QIcon const& source, int y_offset)
+{
+    constexpr int icon_size = 20;
+
+    auto create_pixmap = [&](QIcon::Mode mode) {
+        QPixmap pixmap(icon_size, icon_size);
+        pixmap.fill(Qt::transparent);
+
+        QPainter painter(&pixmap);
+        source.paint(&painter, QRect(0, y_offset, icon_size, icon_size), Qt::AlignCenter, mode);
+        return pixmap;
+    };
+
+    QIcon icon;
+    icon.addPixmap(create_pixmap(QIcon::Normal), QIcon::Normal);
+    icon.addPixmap(create_pixmap(QIcon::Active), QIcon::Active);
+    icon.addPixmap(create_pixmap(QIcon::Disabled), QIcon::Disabled);
+    icon.addPixmap(create_pixmap(QIcon::Selected), QIcon::Selected);
+    return icon;
+}
+
+QIcon create_chrome_icon(ChromeIcon icon, QPalette const& palette)
+{
+    if (icon == ChromeIcon::Reload)
+        return create_y_offset_icon(create_tvg_icon_with_theme_colors("reload", palette), 1);
+    if (icon == ChromeIcon::Globe)
+        return create_y_offset_icon(create_tvg_icon_with_theme_colors("globe", palette, 202, 96, 236, 236), 1);
+
+    auto normal = palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText);
+    auto normal_alpha = 216;
+    if (icon == ChromeIcon::Close)
+        normal_alpha = 172;
+    else if (icon == ChromeIcon::Star)
+        normal_alpha = 204;
+    normal.setAlpha(normal_alpha);
+
+    auto active = palette.color(QPalette::ColorGroup::Active, QPalette::ColorRole::ButtonText);
+    active.setAlpha(icon == ChromeIcon::Close ? 220 : 236);
+
+    auto disabled = palette.color(QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText);
+    disabled.setAlpha(icon == ChromeIcon::Close ? 78 : 96);
+
+    QIcon qicon;
+    qicon.addPixmap(create_chrome_icon_pixmap(icon, normal), QIcon::Normal);
+    qicon.addPixmap(create_chrome_icon_pixmap(icon, active), QIcon::Active);
+    qicon.addPixmap(create_chrome_icon_pixmap(icon, disabled), QIcon::Disabled);
+    qicon.addPixmap(create_chrome_icon_pixmap(icon, active), QIcon::Selected);
+    return qicon;
 }
 
 QIcon loading_spinner_icon(QPalette const& palette, int frame)

--- a/UI/Qt/Icon.h
+++ b/UI/Qt/Icon.h
@@ -10,10 +10,31 @@
 
 #include <QIcon>
 
+class QPalette;
+
 namespace Ladybird {
+
+enum class ChromeIcon {
+    Back,
+    Forward,
+    Reload,
+    Stop,
+    NewTab,
+    Close,
+    Menu,
+    Star,
+    StarFilled,
+    Search,
+    Globe,
+    WindowMinimize,
+    WindowMaximize,
+    WindowRestore,
+    WindowClose,
+};
 
 QIcon load_icon_from_uri(StringView);
 QIcon create_tvg_icon_with_theme_colors(QString const& name, QPalette const& palette);
+QIcon create_chrome_icon(ChromeIcon, QPalette const&);
 QIcon loading_spinner_icon(QPalette const& palette, int frame);
 
 }

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -18,13 +18,25 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QEasingCurve>
+#include <QGraphicsDropShadowEffect>
 #include <QKeyEvent>
 #include <QLatin1String>
 #include <QPalette>
+#include <QResizeEvent>
 #include <QTextLayout>
 #include <QTimer>
+#include <QToolButton>
+#include <QVariantAnimation>
 
 namespace Ladybird {
+
+static QColor location_focus_glow_color(QPalette const& palette, int alpha)
+{
+    auto color = palette.color(QPalette::Highlight);
+    color.setAlpha(alpha);
+    return color;
+}
 
 static QString candidate_by_trimming_root_trailing_slash(QString const& candidate)
 {
@@ -135,11 +147,40 @@ LocationEdit::LocationEdit(QWidget* parent)
     , m_autocomplete(new Autocomplete(this))
 {
     setObjectName("LadybirdLocationEdit");
-    setMinimumHeight(34);
+    setMinimumHeight(41);
+    setTextMargins(40, 0, 40, 0);
     update_chrome_style();
 
-    m_leading_icon_action = addAction(create_tvg_icon_with_theme_colors("search", palette()), QLineEdit::LeadingPosition);
-    m_leading_icon_action->setToolTip("Search");
+    m_focus_glow_effect = new QGraphicsDropShadowEffect(this);
+    m_focus_glow_effect->setBlurRadius(10);
+    m_focus_glow_effect->setOffset(0, 0);
+    update_focus_glow(0);
+    setGraphicsEffect(m_focus_glow_effect);
+
+    m_focus_glow_animation = new QVariantAnimation(this);
+    m_focus_glow_animation->setDuration(130);
+    m_focus_glow_animation->setEasingCurve(QEasingCurve::OutCubic);
+    connect(m_focus_glow_animation, &QVariantAnimation::valueChanged, this, [this](QVariant const& value) {
+        update_focus_glow(value.toInt());
+    });
+
+    m_leading_icon_button = new QToolButton(this);
+    m_leading_icon_button->setObjectName("LadybirdLocationIcon");
+    m_leading_icon_button->setIconSize({ 20, 20 });
+    m_leading_icon_button->setFixedSize(22, 22);
+    m_leading_icon_button->setAutoRaise(true);
+    m_leading_icon_button->setFocusPolicy(Qt::NoFocus);
+    m_leading_icon_button->setCursor(Qt::ArrowCursor);
+    m_leading_icon_button->setToolTip("Search");
+
+    m_trailing_action_button = new QToolButton(this);
+    m_trailing_action_button->setObjectName("LadybirdLocationAction");
+    m_trailing_action_button->setIconSize({ 20, 20 });
+    m_trailing_action_button->setFixedSize(24, 24);
+    m_trailing_action_button->setAutoRaise(true);
+    m_trailing_action_button->setFocusPolicy(Qt::NoFocus);
+    m_trailing_action_button->setCursor(Qt::ArrowCursor);
+    m_trailing_action_button->hide();
 
     m_loading_animation_timer = new QTimer(this);
     m_loading_animation_timer->setInterval(80);
@@ -231,11 +272,18 @@ LocationEdit::LocationEdit(QWidget* parent)
     });
 }
 
+void LocationEdit::set_trailing_action(QAction* action)
+{
+    m_trailing_action_button->setDefaultAction(action);
+    m_trailing_action_button->setVisible(action != nullptr);
+}
+
 void LocationEdit::changeEvent(QEvent* event)
 {
     QLineEdit::changeEvent(event);
     if (event->type() == QEvent::PaletteChange) {
         update_chrome_style();
+        update_focus_glow(m_focus_glow_alpha);
         update_location_icon();
     }
 }
@@ -244,6 +292,7 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 {
     QLineEdit::focusInEvent(event);
     highlight_location();
+    animate_focus_glow(58);
 
     if (event->reason() != Qt::PopupFocusReason)
         QTimer::singleShot(0, this, &QLineEdit::selectAll);
@@ -252,6 +301,7 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 void LocationEdit::focusOutEvent(QFocusEvent* event)
 {
     QLineEdit::focusOutEvent(event);
+    animate_focus_glow(0);
 
     reset_autocomplete_state();
     m_autocomplete->cancel_pending_query();
@@ -267,6 +317,24 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
         setCursorPosition(0);
         highlight_location();
     }
+}
+
+void LocationEdit::update_focus_glow(int alpha)
+{
+    m_focus_glow_alpha = alpha;
+    if (m_focus_glow_effect)
+        m_focus_glow_effect->setColor(location_focus_glow_color(palette(), alpha));
+}
+
+void LocationEdit::animate_focus_glow(int target_alpha)
+{
+    if (!m_focus_glow_animation)
+        return;
+
+    m_focus_glow_animation->stop();
+    m_focus_glow_animation->setStartValue(m_focus_glow_alpha);
+    m_focus_glow_animation->setEndValue(target_alpha);
+    m_focus_glow_animation->start();
 }
 
 void LocationEdit::keyPressEvent(QKeyEvent* event)
@@ -306,6 +374,19 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
     QLineEdit::keyPressEvent(event);
 }
 
+void LocationEdit::resizeEvent(QResizeEvent* event)
+{
+    QLineEdit::resizeEvent(event);
+
+    auto button_size = m_leading_icon_button->sizeHint();
+    auto y = (height() - button_size.height()) / 2 + 2;
+    m_leading_icon_button->move(12, y);
+
+    auto trailing_button_size = m_trailing_action_button->sizeHint();
+    auto trailing_y = (height() - trailing_button_size.height()) / 2 + 2;
+    m_trailing_action_button->move(width() - trailing_button_size.width() - 12, trailing_y);
+}
+
 void LocationEdit::search_engine_changed()
 {
     update_placeholder();
@@ -333,7 +414,7 @@ void LocationEdit::update_placeholder()
 
 void LocationEdit::update_location_icon()
 {
-    if (!m_leading_icon_action)
+    if (!m_leading_icon_button)
         return;
 
     if (m_is_loading) {
@@ -342,22 +423,22 @@ void LocationEdit::update_location_icon()
     }
 
     if (text_matches_current_url()) {
-        m_leading_icon_action->setIcon(m_favicon.isNull() ? create_tvg_icon_with_theme_colors("globe", palette()) : m_favicon);
-        m_leading_icon_action->setToolTip("Page icon");
+        m_leading_icon_button->setIcon(m_favicon.isNull() ? create_chrome_icon(ChromeIcon::Globe, palette()) : m_favicon);
+        m_leading_icon_button->setToolTip("Page icon");
         return;
     }
 
-    m_leading_icon_action->setIcon(create_tvg_icon_with_theme_colors("search", palette()));
-    m_leading_icon_action->setToolTip("Search");
+    m_leading_icon_button->setIcon(create_chrome_icon(ChromeIcon::Search, palette()));
+    m_leading_icon_button->setToolTip("Search");
 }
 
 void LocationEdit::update_loading_icon()
 {
-    if (!m_leading_icon_action)
+    if (!m_leading_icon_button)
         return;
 
-    m_leading_icon_action->setIcon(loading_spinner_icon(palette(), m_loading_animation_frame));
-    m_leading_icon_action->setToolTip("Loading");
+    m_leading_icon_button->setIcon(loading_spinner_icon(palette(), m_loading_animation_frame));
+    m_leading_icon_button->setToolTip("Loading");
 }
 
 void LocationEdit::highlight_location()

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -11,6 +11,7 @@
 #include <LibWebView/Autocomplete.h>
 #include <LibWebView/URL.h>
 #include <UI/Qt/Autocomplete.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/LocationEdit.h>
 #include <UI/Qt/StringUtils.h>
@@ -133,6 +134,10 @@ LocationEdit::LocationEdit(QWidget* parent)
     : QLineEdit(parent)
     , m_autocomplete(new Autocomplete(this))
 {
+    setObjectName("LadybirdLocationEdit");
+    setMinimumHeight(34);
+    update_chrome_style();
+
     m_leading_icon_action = addAction(create_tvg_icon_with_theme_colors("search", palette()), QLineEdit::LeadingPosition);
     m_leading_icon_action->setToolTip("Search");
 
@@ -229,8 +234,10 @@ LocationEdit::LocationEdit(QWidget* parent)
 void LocationEdit::changeEvent(QEvent* event)
 {
     QLineEdit::changeEvent(event);
-    if (event->type() == QEvent::PaletteChange)
+    if (event->type() == QEvent::PaletteChange) {
+        update_chrome_style();
         update_location_icon();
+    }
 }
 
 void LocationEdit::focusInEvent(QFocusEvent* event)
@@ -302,6 +309,16 @@ void LocationEdit::keyPressEvent(QKeyEvent* event)
 void LocationEdit::search_engine_changed()
 {
     update_placeholder();
+}
+
+void LocationEdit::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    setStyleSheet(ChromeStyle::location_edit_style_sheet(palette()));
+    m_is_updating_chrome_style = false;
 }
 
 void LocationEdit::update_placeholder()

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -20,10 +20,14 @@
 #include <QApplication>
 #include <QEasingCurve>
 #include <QGraphicsDropShadowEffect>
+#include <QGuiApplication>
 #include <QKeyEvent>
 #include <QLatin1String>
 #include <QPalette>
 #include <QResizeEvent>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#    include <QStyleHints>
+#endif
 #include <QTextLayout>
 #include <QTimer>
 #include <QToolButton>
@@ -33,7 +37,7 @@ namespace Ladybird {
 
 static QColor location_focus_glow_color(QPalette const& palette, int alpha)
 {
-    auto color = palette.color(QPalette::Highlight);
+    auto color = ChromeStyle::chrome_accent(palette);
     color.setAlpha(alpha);
     return color;
 }
@@ -270,6 +274,12 @@ LocationEdit::LocationEdit(QWidget* parent)
         highlight_location();
         update_location_icon();
     });
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this] {
+        schedule_chrome_style_update();
+    });
+#endif
 }
 
 void LocationEdit::set_trailing_action(QAction* action)
@@ -278,13 +288,16 @@ void LocationEdit::set_trailing_action(QAction* action)
     m_trailing_action_button->setVisible(action != nullptr);
 }
 
+QAction* LocationEdit::trailing_action() const
+{
+    return m_trailing_action_button->defaultAction();
+}
+
 void LocationEdit::changeEvent(QEvent* event)
 {
     QLineEdit::changeEvent(event);
-    if (event->type() == QEvent::PaletteChange) {
-        update_chrome_style();
-        update_focus_glow(m_focus_glow_alpha);
-        update_location_icon();
+    if (event->type() == QEvent::PaletteChange || event->type() == QEvent::ApplicationPaletteChange || event->type() == QEvent::ThemeChange) {
+        schedule_chrome_style_update();
     }
 }
 
@@ -402,6 +415,23 @@ void LocationEdit::update_chrome_style()
     m_is_updating_chrome_style = false;
 }
 
+void LocationEdit::schedule_chrome_style_update()
+{
+    if (m_has_pending_chrome_style_update)
+        return;
+
+    m_has_pending_chrome_style_update = true;
+    QTimer::singleShot(0, this, [this] {
+        m_has_pending_chrome_style_update = false;
+        update_chrome_style();
+        m_autocomplete->schedule_chrome_style_update();
+        update_focus_glow(m_focus_glow_alpha);
+        update_location_icon();
+        highlight_location();
+        update();
+    });
+}
+
 void LocationEdit::update_placeholder()
 {
     if (auto const& search_engine = WebView::Application::settings().search_engine(); search_engine.has_value()) {
@@ -447,14 +477,14 @@ void LocationEdit::highlight_location()
     QList<QInputMethodEvent::Attribute> attributes;
 
     if (auto url_parts = WebView::break_url_into_parts(url); url_parts.has_value()) {
-        auto darkened_text_color = QPalette().color(QPalette::Text);
+        auto darkened_text_color = ChromeStyle::chrome_text(palette());
         darkened_text_color.setAlpha(127);
 
         QTextCharFormat dark_attributes;
         dark_attributes.setForeground(darkened_text_color);
 
         QTextCharFormat highlight_attributes;
-        highlight_attributes.setForeground(QPalette().color(QPalette::Text));
+        highlight_attributes.setForeground(ChromeStyle::chrome_text(palette()));
 
         attributes.append({
             QInputMethodEvent::TextFormat,

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -18,7 +18,11 @@
 
 class QAction;
 class QEvent;
+class QGraphicsDropShadowEffect;
+class QResizeEvent;
 class QTimer;
+class QToolButton;
+class QVariantAnimation;
 
 namespace Ladybird {
 
@@ -31,6 +35,8 @@ class LocationEdit final
 
 public:
     explicit LocationEdit(QWidget*);
+
+    void set_trailing_action(QAction*);
 
     Optional<URL::URL const&> url() const { return m_url; }
     void set_url(Optional<URL::URL>);
@@ -45,6 +51,7 @@ private:
     virtual void focusInEvent(QFocusEvent* event) override;
     virtual void focusOutEvent(QFocusEvent* event) override;
     virtual void keyPressEvent(QKeyEvent* event) override;
+    virtual void resizeEvent(QResizeEvent* event) override;
 
     virtual void search_engine_changed() override;
 
@@ -52,6 +59,8 @@ private:
     void update_chrome_style();
     void update_location_icon();
     void update_loading_icon();
+    void update_focus_glow(int alpha);
+    void animate_focus_glow(int target_alpha);
     void highlight_location();
     bool text_matches_current_url() const;
 
@@ -63,14 +72,18 @@ private:
     void reset_autocomplete_state();
 
     Autocomplete* m_autocomplete { nullptr };
-    QAction* m_leading_icon_action { nullptr };
+    QToolButton* m_leading_icon_button { nullptr };
+    QToolButton* m_trailing_action_button { nullptr };
     QTimer* m_loading_animation_timer { nullptr };
+    QVariantAnimation* m_focus_glow_animation { nullptr };
+    QGraphicsDropShadowEffect* m_focus_glow_effect { nullptr };
 
     Optional<URL::URL> m_url;
     QIcon m_favicon;
     bool m_url_is_hidden { false };
     bool m_is_loading { false };
     bool m_is_updating_chrome_style { false };
+    int m_focus_glow_alpha { 0 };
     int m_loading_animation_frame { 0 };
 
     bool m_is_applying_inline_autocomplete { false };

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -49,6 +49,7 @@ private:
     virtual void search_engine_changed() override;
 
     void update_placeholder();
+    void update_chrome_style();
     void update_location_icon();
     void update_loading_icon();
     void highlight_location();
@@ -69,6 +70,7 @@ private:
     QIcon m_favicon;
     bool m_url_is_hidden { false };
     bool m_is_loading { false };
+    bool m_is_updating_chrome_style { false };
     int m_loading_animation_frame { 0 };
 
     bool m_is_applying_inline_autocomplete { false };

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -37,6 +37,7 @@ public:
     explicit LocationEdit(QWidget*);
 
     void set_trailing_action(QAction*);
+    QAction* trailing_action() const;
 
     Optional<URL::URL const&> url() const { return m_url; }
     void set_url(Optional<URL::URL>);
@@ -60,6 +61,7 @@ private:
     void update_location_icon();
     void update_loading_icon();
     void update_focus_glow(int alpha);
+    void schedule_chrome_style_update();
     void animate_focus_glow(int target_alpha);
     void highlight_location();
     bool text_matches_current_url() const;
@@ -83,6 +85,7 @@ private:
     bool m_url_is_hidden { false };
     bool m_is_loading { false };
     bool m_is_updating_chrome_style { false };
+    bool m_has_pending_chrome_style_update { false };
     int m_focus_glow_alpha { 0 };
     int m_loading_animation_frame { 0 };
 

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -57,8 +57,8 @@ public:
         case WebView::ActionID::ToggleBookmark:
         case WebView::ActionID::ToggleBookmarkViaToolbar:
             if (auto* parent = as_if<QWidget>(m_action->parent())) {
-                auto const* icon = action.engaged() ? "star-filled" : "star-countour";
-                m_action->setIcon(create_tvg_icon_with_theme_colors(icon, parent->palette()));
+                auto icon = action.engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star;
+                m_action->setIcon(create_chrome_icon(icon, parent->palette()));
             }
             break;
         default:
@@ -118,15 +118,15 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
 {
     switch (action.id()) {
     case WebView::ActionID::NavigateBack:
-        qaction.setIcon(create_tvg_icon_with_theme_colors("back", palette));
+        qaction.setIcon(create_chrome_icon(ChromeIcon::Back, palette));
         qaction.setShortcut(QKeySequence::StandardKey::Back);
         break;
     case WebView::ActionID::NavigateForward:
-        qaction.setIcon(create_tvg_icon_with_theme_colors("forward", palette));
+        qaction.setIcon(create_chrome_icon(ChromeIcon::Forward, palette));
         qaction.setShortcut(QKeySequence::StandardKey::Forward);
         break;
     case WebView::ActionID::Reload:
-        qaction.setIcon(create_tvg_icon_with_theme_colors("reload", palette));
+        qaction.setIcon(create_chrome_icon(ChromeIcon::Reload, palette));
         qaction.setShortcuts({ QKeySequence(Qt::CTRL | Qt::Key_R), QKeySequence(Qt::Key_F5) });
         break;
 
@@ -152,7 +152,11 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         break;
 
     case WebView::ActionID::ToggleBookmark:
+        qaction.setIcon(create_chrome_icon(action.engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star, palette));
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_D));
+        break;
+    case WebView::ActionID::ToggleBookmarkViaToolbar:
+        qaction.setIcon(create_chrome_icon(action.engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star, palette));
         break;
     case WebView::ActionID::ToggleBookmarksBar:
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_B));

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -22,6 +22,7 @@
 #include <QFileDialog>
 #include <QFont>
 #include <QFontMetrics>
+#include <QHBoxLayout>
 #include <QImage>
 #include <QInputDialog>
 #include <QMenu>
@@ -73,6 +74,17 @@ static QIcon default_favicon()
     return icon;
 }
 
+static QToolButton* create_toolbar_button(QWidget& parent, QAction& action)
+{
+    auto* button = new QToolButton(&parent);
+    button->setDefaultAction(&action);
+    button->setAutoRaise(true);
+    button->setFocusPolicy(Qt::NoFocus);
+    button->setIconSize({ 20, 20 });
+    button->setFixedSize(38, 38);
+    return button;
+}
+
 Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
     : QWidget(window)
     , m_window(window)
@@ -88,8 +100,15 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_view = new WebContentView(this, parent_client, page_index, AK::move(view_initial_state));
     m_find_in_page = new FindInPageWidget(this, m_view);
     m_find_in_page->setVisible(false);
-    m_toolbar = new QToolBar(this);
+    m_toolbar = new QWidget(this);
     m_toolbar->setObjectName("LadybirdNavigationToolbar");
+    m_toolbar->setFixedHeight(54);
+    m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+
+    auto* toolbar_layout = new QHBoxLayout(m_toolbar);
+    toolbar_layout->setSpacing(8);
+    toolbar_layout->setContentsMargins(18, 4, 18, 6);
+
     m_location_edit = new LocationEdit(this);
     m_bookmarks_bar = new BookmarksBar(this);
     m_loading_animation_timer = new QTimer(this);
@@ -121,6 +140,10 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_hamburger_button->setText("Show &Menu");
     m_hamburger_button->setToolTip("Show Menu");
     m_hamburger_button->setIcon(create_tvg_icon_with_theme_colors("hamburger", palette()));
+    m_hamburger_button->setIconSize({ 20, 20 });
+    m_hamburger_button->setFixedSize(38, 38);
+    m_hamburger_button->setAutoRaise(true);
+    m_hamburger_button->setFocusPolicy(Qt::NoFocus);
     m_hamburger_button->setPopupMode(QToolButton::InstantPopup);
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
     connect_hamburger_menu();
@@ -138,24 +161,19 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_image_context_menu = create_context_menu(*this, view(), view().image_context_menu());
     m_media_context_menu = create_context_menu(*this, view(), view().media_context_menu());
 
-    m_toolbar->addAction(m_navigate_back_action);
-    m_toolbar->addAction(m_navigate_forward_action);
-    m_toolbar->addAction(m_reload_action);
-    m_toolbar->addWidget(m_location_edit);
-    m_toolbar->addAction(create_application_action(*m_toolbar, view().toggle_bookmark_action()));
-    m_toolbar->addAction(create_application_action(*m_toolbar, view().reset_zoom_action()));
-    m_hamburger_button_action = m_toolbar->addWidget(m_hamburger_button);
+    toolbar_layout->addWidget(create_toolbar_button(*m_toolbar, *m_navigate_back_action));
+    toolbar_layout->addWidget(create_toolbar_button(*m_toolbar, *m_navigate_forward_action));
+    toolbar_layout->addWidget(create_toolbar_button(*m_toolbar, *m_reload_action));
+    m_location_edit->set_trailing_action(create_application_action(*m_location_edit, view().toggle_bookmark_action()));
+    toolbar_layout->addWidget(m_location_edit, 1);
+    toolbar_layout->addWidget(m_hamburger_button);
 
-    m_toolbar->setIconSize({ 16, 16 });
-    m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-    m_toolbar->setMovable(false);
-    m_toolbar->setFloatable(false);
     update_chrome_style();
 
-    m_hamburger_button_action->setVisible(!Settings::the()->show_menubar());
+    m_hamburger_button->setVisible(!Settings::the()->show_menubar());
 
     QObject::connect(Settings::the(), &Settings::show_menubar_changed, this, [this](bool show_menubar) {
-        m_hamburger_button_action->setVisible(!show_menubar);
+        m_hamburger_button->setVisible(!show_menubar);
     });
 
     view().on_activate_tab = [this] {
@@ -500,8 +518,7 @@ void Tab::set_window(BrowserWindow& window)
     m_window = &window;
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
     connect_hamburger_menu();
-    if (m_hamburger_button_action)
-        m_hamburger_button_action->setVisible(!Settings::the()->show_menubar());
+    m_hamburger_button->setVisible(!Settings::the()->show_menubar());
     recreate_toolbar_icons();
 }
 
@@ -652,11 +669,11 @@ void Tab::update_chrome_style()
 
 void Tab::recreate_toolbar_icons()
 {
-    m_navigate_back_action->setIcon(create_tvg_icon_with_theme_colors("back", palette()));
-    m_navigate_forward_action->setIcon(create_tvg_icon_with_theme_colors("forward", palette()));
-    m_reload_action->setIcon(create_tvg_icon_with_theme_colors("reload", palette()));
-    m_window->new_tab_action().setIcon(create_tvg_icon_with_theme_colors("new_tab", palette()));
-    m_hamburger_button->setIcon(create_tvg_icon_with_theme_colors("hamburger", palette()));
+    m_navigate_back_action->setIcon(create_chrome_icon(ChromeIcon::Back, palette()));
+    m_navigate_forward_action->setIcon(create_chrome_icon(ChromeIcon::Forward, palette()));
+    m_reload_action->setIcon(create_chrome_icon(ChromeIcon::Reload, palette()));
+    m_window->new_tab_action().setIcon(create_chrome_icon(ChromeIcon::NewTab, palette()));
+    m_hamburger_button->setIcon(create_chrome_icon(ChromeIcon::Menu, palette()));
 }
 
 void Tab::show_find_in_page()

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -674,6 +674,10 @@ void Tab::recreate_toolbar_icons()
     m_reload_action->setIcon(create_chrome_icon(ChromeIcon::Reload, palette()));
     m_window->new_tab_action().setIcon(create_chrome_icon(ChromeIcon::NewTab, palette()));
     m_hamburger_button->setIcon(create_chrome_icon(ChromeIcon::Menu, palette()));
+    if (auto* action = m_location_edit->trailing_action()) {
+        auto icon = view().toggle_bookmark_action().engaged() ? ChromeIcon::StarFilled : ChromeIcon::Star;
+        action->setIcon(create_chrome_icon(icon, palette()));
+    }
 }
 
 void Tab::show_find_in_page()

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -12,6 +12,7 @@
 #include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/Qt/BrowserWindow.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/Settings.h>
@@ -88,6 +89,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_find_in_page = new FindInPageWidget(this, m_view);
     m_find_in_page->setVisible(false);
     m_toolbar = new QToolBar(this);
+    m_toolbar->setObjectName("LadybirdNavigationToolbar");
     m_location_edit = new LocationEdit(this);
     m_bookmarks_bar = new BookmarksBar(this);
     m_loading_animation_timer = new QTimer(this);
@@ -121,7 +123,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_hamburger_button->setIcon(create_tvg_icon_with_theme_colors("hamburger", palette()));
     m_hamburger_button->setPopupMode(QToolButton::InstantPopup);
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
-    m_hamburger_button->setStyleSheet(":menu-indicator {image: none}");
 
     QObject::connect(&m_window->hamburger_menu(), &QMenu::aboutToShow, m_hamburger_button, [this]() {
         m_hamburger_button->setDown(true);
@@ -153,9 +154,9 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     m_toolbar->setIconSize({ 16, 16 });
     m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-    // This is a little awkward, but without this Qt shrinks the button to the size of the icon.
-    // Note: toolButtonStyle="0" -> ToolButtonIconOnly.
-    m_toolbar->setStyleSheet("QToolButton[toolButtonStyle=\"0\"]{padding:0px 4px 0px 4px;height:24px}");
+    m_toolbar->setMovable(false);
+    m_toolbar->setFloatable(false);
+    update_chrome_style();
 
     m_hamburger_button_action->setVisible(!Settings::the()->show_menubar());
 
@@ -609,6 +610,7 @@ void Tab::update_hover_label()
 bool Tab::event(QEvent* event)
 {
     if (event->type() == QEvent::PaletteChange) {
+        update_chrome_style();
         recreate_toolbar_icons();
         if (m_is_loading)
             update_tab_icon();
@@ -616,6 +618,17 @@ bool Tab::event(QEvent* event)
     }
 
     return QWidget::event(event);
+}
+
+void Tab::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    m_toolbar->setStyleSheet(ChromeStyle::navigation_toolbar_style_sheet(palette()));
+    m_hover_label->setStyleSheet(QStringLiteral("padding: 2px 6px; border-radius: 6px;"));
+    m_is_updating_chrome_style = false;
 }
 
 void Tab::recreate_toolbar_icons()

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -123,13 +123,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_hamburger_button->setIcon(create_tvg_icon_with_theme_colors("hamburger", palette()));
     m_hamburger_button->setPopupMode(QToolButton::InstantPopup);
     m_hamburger_button->setMenu(&m_window->hamburger_menu());
-
-    QObject::connect(&m_window->hamburger_menu(), &QMenu::aboutToShow, m_hamburger_button, [this]() {
-        m_hamburger_button->setDown(true);
-    });
-    QObject::connect(&m_window->hamburger_menu(), &QMenu::aboutToHide, m_hamburger_button, [this]() {
-        m_hamburger_button->setDown(false);
-    });
+    connect_hamburger_menu();
 
     m_navigate_back_action = create_application_action(*this, view().navigate_back_action());
     m_navigate_forward_action = create_application_action(*this, view().navigate_forward_action());
@@ -494,6 +488,31 @@ void Tab::focus_location_editor()
 {
     m_location_edit->setFocus();
     m_location_edit->selectAll();
+}
+
+void Tab::set_window(BrowserWindow& window)
+{
+    if (&window == m_window)
+        return;
+
+    QObject::disconnect(&m_window->hamburger_menu(), nullptr, m_hamburger_button, nullptr);
+
+    m_window = &window;
+    m_hamburger_button->setMenu(&m_window->hamburger_menu());
+    connect_hamburger_menu();
+    if (m_hamburger_button_action)
+        m_hamburger_button_action->setVisible(!Settings::the()->show_menubar());
+    recreate_toolbar_icons();
+}
+
+void Tab::connect_hamburger_menu()
+{
+    QObject::connect(&m_window->hamburger_menu(), &QMenu::aboutToShow, m_hamburger_button, [this]() {
+        m_hamburger_button->setDown(true);
+    });
+    QObject::connect(&m_window->hamburger_menu(), &QMenu::aboutToHide, m_hamburger_button, [this]() {
+        m_hamburger_button->setDown(false);
+    });
 }
 
 void Tab::navigate(URL::URL const& url)

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -100,6 +100,7 @@ private:
     virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     void recreate_toolbar_icons();
+    void update_chrome_style();
     void update_tab_title();
     void set_loading(bool);
     void update_tab_icon();
@@ -119,6 +120,7 @@ private:
     QIcon m_favicon;
     QTimer* m_loading_animation_timer { nullptr };
     bool m_is_loading { false };
+    bool m_is_updating_chrome_style { false };
     int m_loading_animation_frame { 0 };
 
     QMenu* m_context_menu { nullptr };

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -18,7 +18,6 @@
 #include <QLabel>
 #include <QMenu>
 #include <QPointer>
-#include <QToolBar>
 #include <QToolButton>
 #include <QWidget>
 
@@ -109,10 +108,9 @@ private:
     int tab_index();
 
     QBoxLayout* m_layout { nullptr };
-    QToolBar* m_toolbar { nullptr };
+    QWidget* m_toolbar { nullptr };
     BookmarksBar* m_bookmarks_bar { nullptr };
     QToolButton* m_hamburger_button { nullptr };
-    QAction* m_hamburger_button_action { nullptr };
     LocationEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     FindInPageWidget* m_find_in_page { nullptr };

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -80,6 +80,7 @@ public:
 
     QToolButton* hamburger_button() const { return m_hamburger_button; }
 
+    void set_window(BrowserWindow&);
     void update_hover_label();
 
     bool url_is_hidden() const { return m_location_edit->url_is_hidden(); }
@@ -100,6 +101,7 @@ private:
     virtual void config_variable_changed(WebView::ConfigVariableID) override;
 
     void recreate_toolbar_icons();
+    void connect_hamburger_menu();
     void update_chrome_style();
     void update_tab_title();
     void set_loading(bool);

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -7,19 +7,30 @@
  */
 
 #include <AK/StdLibExtras.h>
+#include <UI/Qt/Application.h>
+#include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
 
+#include <QApplication>
 #include <QContextMenuEvent>
+#include <QCursor>
+#include <QDrag>
+#include <QDragEnterEvent>
+#include <QDragLeaveEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
 #include <QEvent>
 #include <QFontMetrics>
 #include <QHBoxLayout>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPixmap>
 #include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
@@ -27,15 +38,26 @@
 
 namespace Ladybird {
 
+static constexpr auto LADYBIRD_TAB_MIME_TYPE = "application/x-ladybird-tab";
+
+static QPointer<TabWidget> s_active_tab_drag_source;
+static QPointer<Tab> s_active_tab_dragged_tab;
+static QPointer<TabWidget> s_pending_tab_drop_target;
+static int s_pending_tab_drop_index { -1 };
+
 static QPainterPath active_tab_path(QRectF const& rect, qreal radius)
 {
+    constexpr qreal shoulder = 9.0;
+
     QPainterPath path;
     path.moveTo(rect.left(), rect.bottom());
-    path.lineTo(rect.left(), rect.top() + radius);
-    path.quadTo(rect.left(), rect.top(), rect.left() + radius, rect.top());
+    path.cubicTo(rect.left() + 4.0, rect.bottom(), rect.left() + 6.0, rect.bottom() - 5.0, rect.left() + shoulder, rect.bottom() - 8.0);
+    path.lineTo(rect.left() + shoulder, rect.top() + radius);
+    path.quadTo(rect.left() + shoulder, rect.top(), rect.left() + shoulder + radius, rect.top());
     path.lineTo(rect.right() - radius, rect.top());
     path.quadTo(rect.right(), rect.top(), rect.right(), rect.top() + radius);
-    path.lineTo(rect.right(), rect.bottom());
+    path.lineTo(rect.right() - shoulder, rect.bottom() - 8.0);
+    path.cubicTo(rect.right() - 6.0, rect.bottom() - 5.0, rect.right() - 4.0, rect.bottom(), rect.right(), rect.bottom());
     path.closeSubpath();
     return path;
 }
@@ -45,6 +67,7 @@ TabBar::TabBar(TabWidget* tab_widget)
     , m_tab_widget(tab_widget)
 {
     setMouseTracking(true);
+    setAcceptDrops(true);
     setMinimumHeight(38);
 }
 
@@ -150,6 +173,18 @@ void TabBar::paintEvent(QPaintEvent* event)
         painter.setPen(is_selected || is_hovered ? text_color : muted_text_color);
         painter.drawText(contents_rect, Qt::AlignLeft | Qt::AlignVCenter, title);
     }
+
+    if (m_drop_indicator_index >= 0 && count() > 0) {
+        auto indicator_x = m_drop_indicator_index >= count()
+            ? tabRect(count() - 1).right() + 3
+            : tabRect(m_drop_indicator_index).left() + 1;
+        indicator_x = max(2, min(width() - 3, indicator_x));
+        auto indicator_color = ChromeStyle::chrome_accent(palette());
+        indicator_color.setAlpha(220);
+
+        painter.setPen(QPen(indicator_color, 3, Qt::SolidLine, Qt::RoundCap));
+        painter.drawLine(QPointF(indicator_x, 9), QPointF(indicator_x, height() - 7));
+    }
 }
 
 void TabBar::contextMenuEvent(QContextMenuEvent* event)
@@ -165,28 +200,77 @@ void TabBar::contextMenuEvent(QContextMenuEvent* event)
         tab->context_menu()->exec(event->globalPos());
 }
 
+void TabBar::dragEnterEvent(QDragEnterEvent* event)
+{
+    if (!m_tab_widget || !s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+        event->ignore();
+        return;
+    }
+
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
+}
+
+void TabBar::dragLeaveEvent(QDragLeaveEvent* event)
+{
+    m_drop_indicator_index = -1;
+    update();
+    QTabBar::dragLeaveEvent(event);
+}
+
+void TabBar::dragMoveEvent(QDragMoveEvent* event)
+{
+    if (!m_tab_widget || !s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+        event->ignore();
+        return;
+    }
+
+    auto drop_indicator_index = drop_indicator_index_for_insertion_index(insertion_index_at(event->position().toPoint()));
+    if (m_drop_indicator_index != drop_indicator_index) {
+        m_drop_indicator_index = drop_indicator_index;
+        update();
+    }
+
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
+}
+
+void TabBar::dropEvent(QDropEvent* event)
+{
+    if (!m_tab_widget || !s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+        event->ignore();
+        return;
+    }
+
+    s_pending_tab_drop_target = m_tab_widget;
+    s_pending_tab_drop_index = insertion_index_at(event->position().toPoint());
+    m_drop_indicator_index = -1;
+    update();
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
+}
+
 void TabBar::mousePressEvent(QMouseEvent* event)
 {
-    event->ignore();
-
     auto pressed_tab = tabAt(event->pos());
-    if (pressed_tab < 0 && event->button() == Qt::LeftButton) {
-        if (start_window_move())
-            return;
-    }
+    m_pressed_tab = (m_tab_widget && pressed_tab >= 0) ? m_tab_widget->tab(pressed_tab) : nullptr;
 
     if (pressed_tab >= 0) {
         auto rect_of_current_tab = tabRect(pressed_tab);
-        m_x_position_in_selected_tab_while_dragging = event->pos().x() - rect_of_current_tab.x();
+        m_position_in_selected_tab_while_dragging = event->pos() - rect_of_current_tab.topLeft();
+        m_drag_start_position = event->pos();
     }
 
     QTabBar::mousePressEvent(event);
+
+    if (m_pressed_tab)
+        event->accept();
+    else
+        event->ignore();
 }
 
 void TabBar::mouseMoveEvent(QMouseEvent* event)
 {
-    event->ignore();
-
     if (auto hovered_tab = tabAt(event->pos()); hovered_tab != m_hovered_tab_index) {
         m_hovered_tab_index = hovered_tab;
         update();
@@ -197,23 +281,21 @@ void TabBar::mouseMoveEvent(QMouseEvent* event)
         return;
     }
 
-    auto rect_of_first_tab = tabRect(0);
-    auto rect_of_last_tab = tabRect(count() - 1);
-
-    auto boundary_limit_for_dragging_tab = QRect(rect_of_first_tab.x() + m_x_position_in_selected_tab_while_dragging, 0,
-        rect_of_last_tab.x() + m_x_position_in_selected_tab_while_dragging, 0);
-
-    if (event->pos().x() >= boundary_limit_for_dragging_tab.x() && event->pos().x() <= boundary_limit_for_dragging_tab.width()) {
-        QTabBar::mouseMoveEvent(event);
-    } else {
-        auto pos = event->pos();
-        if (event->pos().x() > boundary_limit_for_dragging_tab.width())
-            pos.setX(boundary_limit_for_dragging_tab.width());
-        else if (event->pos().x() < boundary_limit_for_dragging_tab.x())
-            pos.setX(boundary_limit_for_dragging_tab.x());
-        QMouseEvent ev(event->type(), pos, event->globalPosition(), event->button(), event->buttons(), event->modifiers());
-        QTabBar::mouseMoveEvent(&ev);
+    if (m_pressed_tab && event->buttons().testFlag(Qt::LeftButton)) {
+        auto pressed_tab_index = m_tab_widget ? m_tab_widget->index_of(m_pressed_tab) : -1;
+        if (pressed_tab_index < 0) {
+            m_pressed_tab = nullptr;
+        } else if ((event->pos() - m_drag_start_position).manhattanLength() >= QApplication::startDragDistance()) {
+            start_tab_drag(pressed_tab_index);
+            event->accept();
+            return;
+        }
     }
+
+    if (m_pressed_tab)
+        event->accept();
+    else
+        event->ignore();
 }
 
 void TabBar::leaveEvent(QEvent* event)
@@ -221,6 +303,15 @@ void TabBar::leaveEvent(QEvent* event)
     m_hovered_tab_index = -1;
     update();
     QTabBar::leaveEvent(event);
+}
+
+void TabBar::mouseReleaseEvent(QMouseEvent* event)
+{
+    auto had_pressed_tab = !!m_pressed_tab;
+    m_pressed_tab = nullptr;
+    QTabBar::mouseReleaseEvent(event);
+    if (had_pressed_tab)
+        event->accept();
 }
 
 void TabBar::mouseDoubleClickEvent(QMouseEvent* event)
@@ -234,12 +325,86 @@ void TabBar::mouseDoubleClickEvent(QMouseEvent* event)
     QTabBar::mouseDoubleClickEvent(event);
 }
 
-bool TabBar::start_window_move()
+int TabBar::insertion_index_at(QPoint const& position) const
 {
-    auto* handle = window()->windowHandle();
-    if (!handle)
-        return false;
-    return handle->startSystemMove();
+    if (count() == 0)
+        return 0;
+
+    auto index = tabAt(position);
+    if (index < 0)
+        return position.x() < tabRect(0).center().x() ? 0 : count();
+
+    if (position.x() > tabRect(index).center().x())
+        return index + 1;
+    return index;
+}
+
+int TabBar::drop_indicator_index_for_insertion_index(int insertion_index) const
+{
+    if (s_active_tab_drag_source == m_tab_widget && s_active_tab_dragged_tab) {
+        auto dragged_tab_index = m_tab_widget->index_of(s_active_tab_dragged_tab);
+        if (dragged_tab_index >= 0 && (insertion_index == dragged_tab_index || insertion_index == dragged_tab_index + 1))
+            return -1;
+    }
+
+    return insertion_index;
+}
+
+QPixmap TabBar::render_tab_drag_pixmap(int index) const
+{
+    auto tab_rect = tabRect(index);
+    QPixmap pixmap(tab_rect.size() * devicePixelRatioF());
+    pixmap.setDevicePixelRatio(devicePixelRatioF());
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    const_cast<TabBar&>(*this).render(&painter, QPoint(-tab_rect.x(), -tab_rect.y()), QRegion(tab_rect), QWidget::DrawChildren);
+    return pixmap;
+}
+
+void TabBar::start_tab_drag(int index)
+{
+    if (!m_tab_widget)
+        return;
+
+    auto* tab = m_tab_widget->tab(index);
+    if (!tab)
+        return;
+
+    QPointer<Tab> dragged_tab = tab;
+    auto* drag = new QDrag(this);
+    auto* mime_data = new QMimeData;
+    mime_data->setData(LADYBIRD_TAB_MIME_TYPE, QByteArray {});
+    mime_data->setText(tab->title());
+    drag->setMimeData(mime_data);
+    drag->setPixmap(render_tab_drag_pixmap(index));
+    drag->setHotSpot(m_position_in_selected_tab_while_dragging);
+
+    s_active_tab_drag_source = m_tab_widget;
+    s_active_tab_dragged_tab = dragged_tab;
+    s_pending_tab_drop_target = nullptr;
+    s_pending_tab_drop_index = -1;
+
+    auto action = drag->exec(Qt::MoveAction, Qt::MoveAction);
+
+    auto* source_window = qobject_cast<BrowserWindow*>(window());
+    if (source_window && dragged_tab) {
+        auto current_index = source_window->tab_index(dragged_tab);
+        if (current_index >= 0) {
+            if (action == Qt::MoveAction && s_pending_tab_drop_target) {
+                if (auto* target_window = qobject_cast<BrowserWindow*>(s_pending_tab_drop_target->window()))
+                    source_window->move_tab_to_window(current_index, *target_window, s_pending_tab_drop_index);
+            } else if (action == Qt::IgnoreAction && !source_window->geometry().contains(QCursor::pos())) {
+                source_window->detach_tab_to_new_window(current_index, QCursor::pos());
+            }
+        }
+    }
+
+    s_active_tab_drag_source = nullptr;
+    s_active_tab_dragged_tab = nullptr;
+    s_pending_tab_drop_target = nullptr;
+    s_pending_tab_drop_index = -1;
+    m_pressed_tab = nullptr;
 }
 
 void TabBar::toggle_window_maximized()
@@ -255,10 +420,11 @@ TabWidget::TabWidget(QWidget* parent)
     : QWidget(parent)
 {
     m_tab_bar = new TabBar(this);
+    setAcceptDrops(true);
 
     m_tab_bar->setDocumentMode(true);
     m_tab_bar->setElideMode(Qt::TextElideMode::ElideRight);
-    m_tab_bar->setMovable(true);
+    m_tab_bar->setMovable(false);
     m_tab_bar->setTabsClosable(true);
     m_tab_bar->setExpanding(false);
     m_tab_bar->setUsesScrollButtons(true);
@@ -342,15 +508,28 @@ TabWidget::TabWidget(QWidget* parent)
 
 void TabWidget::add_tab(Tab* widget, QString const& label)
 {
-    m_stacked_widget->addWidget(widget);
-    m_tab_bar->addTab(label);
+    insert_tab(m_tab_bar->count(), widget, label);
+}
+
+void TabWidget::insert_tab(int index, Tab* widget, QString const& label)
+{
+    m_stacked_widget->insertWidget(index, widget);
+    m_tab_bar->insertTab(index, label);
 
     update_tab_layout();
 }
 
 void TabWidget::remove_tab(int index)
 {
+    take_tab(index);
+}
+
+Tab* TabWidget::take_tab(int index)
+{
     auto* widget = m_stacked_widget->widget(index);
+    if (!widget)
+        return nullptr;
+
     m_stacked_widget->removeWidget(widget);
 
     m_tab_bar->removeTab(index);
@@ -359,6 +538,7 @@ void TabWidget::remove_tab(int index)
         m_stacked_widget->setCurrentIndex(m_tab_bar->currentIndex());
 
     update_tab_layout();
+    return as<Tab>(widget);
 }
 
 void TabWidget::set_current_tab(Tab* widget)
@@ -403,12 +583,31 @@ bool TabWidget::event(QEvent* event)
     return QWidget::event(event);
 }
 
+void TabWidget::dragEnterEvent(QDragEnterEvent* event)
+{
+    accept_tab_drag(event);
+}
+
+void TabWidget::dragMoveEvent(QDragMoveEvent* event)
+{
+    accept_tab_drag(event);
+}
+
+void TabWidget::dropEvent(QDropEvent* event)
+{
+    accept_tab_drop(event, m_tab_bar->count());
+}
+
 bool TabWidget::eventFilter(QObject* watched, QEvent* event)
 {
     if (watched == m_tab_bar_row) {
+        auto is_empty_tab_strip_area = [this](QMouseEvent const& mouse_event) {
+            return m_tab_bar_row->childAt(mouse_event.pos()) == nullptr;
+        };
+
         if (event->type() == QEvent::MouseButtonDblClick) {
             auto* mouse_event = static_cast<QMouseEvent*>(event);
-            if (mouse_event->button() == Qt::LeftButton) {
+            if (mouse_event->button() == Qt::LeftButton && is_empty_tab_strip_area(*mouse_event)) {
                 toggle_window_maximized();
                 return true;
             }
@@ -416,12 +615,36 @@ bool TabWidget::eventFilter(QObject* watched, QEvent* event)
 
         if (event->type() == QEvent::MouseButtonPress) {
             auto* mouse_event = static_cast<QMouseEvent*>(event);
-            if (mouse_event->button() == Qt::LeftButton && start_window_move())
+            if (mouse_event->button() == Qt::LeftButton && is_empty_tab_strip_area(*mouse_event) && start_window_move())
                 return true;
         }
     }
 
     return QWidget::eventFilter(watched, event);
+}
+
+void TabWidget::accept_tab_drag(QDragMoveEvent* event)
+{
+    if (!s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+        event->ignore();
+        return;
+    }
+
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
+}
+
+void TabWidget::accept_tab_drop(QDropEvent* event, int index)
+{
+    if (!s_active_tab_drag_source || !event->mimeData()->hasFormat(LADYBIRD_TAB_MIME_TYPE)) {
+        event->ignore();
+        return;
+    }
+
+    s_pending_tab_drop_target = this;
+    s_pending_tab_drop_index = index;
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
 }
 
 void TabWidget::resizeEvent(QResizeEvent* event)

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -7,55 +7,45 @@
  */
 
 #include <AK/StdLibExtras.h>
+#include <UI/Qt/ChromeStyle.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
 
 #include <QContextMenuEvent>
 #include <QEvent>
+#include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QMouseEvent>
+#include <QPaintEvent>
 #include <QPainter>
-#include <QProxyStyle>
-#include <QStyleOption>
+#include <QPainterPath>
+#include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
+#include <QWindow>
 
 namespace Ladybird {
 
-class LeftAlignedTabStyle final : public QProxyStyle {
-public:
-    virtual void drawControl(ControlElement element, QStyleOption const* option, QPainter* painter, QWidget const* widget = nullptr) const override
-    {
-        if (element != QStyle::CE_TabBarTabLabel) {
-            QProxyStyle::drawControl(element, option, painter, widget);
-            return;
-        }
-
-        auto const* tab = qstyleoption_cast<QStyleOptionTab const*>(option);
-        if (!tab) {
-            QProxyStyle::drawControl(element, option, painter, widget);
-            return;
-        }
-
-        QStyleOptionTab tab_without_text(*tab);
-        tab_without_text.text.clear();
-        QProxyStyle::drawControl(element, &tab_without_text, painter, widget);
-
-        auto text_rect = subElementRect(QStyle::SE_TabBarTabText, tab, widget);
-        int text_alignment = Qt::AlignLeft | Qt::AlignVCenter | Qt::TextShowMnemonic;
-        if (!styleHint(QStyle::SH_UnderlineShortcut, tab, widget))
-            text_alignment |= Qt::TextHideMnemonic;
-
-        drawItemText(painter, text_rect, text_alignment, tab->palette, tab->state & QStyle::State_Enabled, tab->text,
-            widget ? widget->foregroundRole() : QPalette::WindowText);
-    }
-};
+static QPainterPath active_tab_path(QRectF const& rect, qreal radius)
+{
+    QPainterPath path;
+    path.moveTo(rect.left(), rect.bottom());
+    path.lineTo(rect.left(), rect.top() + radius);
+    path.quadTo(rect.left(), rect.top(), rect.left() + radius, rect.top());
+    path.lineTo(rect.right() - radius, rect.top());
+    path.quadTo(rect.right(), rect.top(), rect.right(), rect.top() + radius);
+    path.lineTo(rect.right(), rect.bottom());
+    path.closeSubpath();
+    return path;
+}
 
 TabBar::TabBar(TabWidget* tab_widget)
     : QTabBar(tab_widget)
     , m_tab_widget(tab_widget)
 {
+    setMouseTracking(true);
+    setMinimumHeight(38);
 }
 
 void TabBar::set_available_width(int width)
@@ -72,13 +62,94 @@ QSize TabBar::tabSizeHint(int index) const
 
     if (auto count = this->count(); count > 0) {
         auto width = (m_available_width > 0 ? m_available_width : this->width()) / count;
-        width = min(225, width);
+        width = min(240, width);
         width = max(128, width);
 
         hint.setWidth(width);
     }
 
+    hint.setHeight(34);
     return hint;
+}
+
+void TabBar::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.fillRect(rect(), ChromeStyle::chrome_background(palette()));
+
+    auto border = ChromeStyle::chrome_border(palette());
+    auto accent = ChromeStyle::chrome_accent(palette());
+    auto text_color = palette().color(QPalette::Text);
+    auto muted_text_color = ChromeStyle::chrome_muted_text(palette());
+
+    for (int index = 0; index < count(); ++index) {
+        auto tab_rect = tabRect(index);
+        if (!tab_rect.isValid() || tab_rect.right() < 0 || tab_rect.left() > width())
+            continue;
+
+        bool is_selected = index == currentIndex();
+        bool is_hovered = index == m_hovered_tab_index;
+
+        if (is_selected || is_hovered) {
+            auto shape_rect = QRectF(tab_rect).adjusted(2.0, is_selected ? 4.0 : 7.0, -2.0, is_selected ? 0.0 : -6.0);
+            auto surface = is_selected ? ChromeStyle::chrome_surface(palette()) : ChromeStyle::chrome_surface_hover(palette());
+
+            auto tab_path = is_selected
+                ? active_tab_path(shape_rect, 7.0)
+                : [&] {
+                      QPainterPath path;
+                      path.addRoundedRect(shape_rect, 7.0, 7.0);
+                      return path;
+                  }();
+
+            painter.setBrush(surface);
+            painter.setPen(is_selected ? QPen(border, 1) : Qt::NoPen);
+            painter.drawPath(tab_path);
+
+            if (is_selected) {
+                painter.setPen(QPen(accent, 2));
+                painter.drawLine(QPointF(shape_rect.left() + 9.0, shape_rect.top() + 1.0),
+                    QPointF(shape_rect.right() - 9.0, shape_rect.top() + 1.0));
+            }
+        } else if (index > 0 && index != currentIndex() + 1) {
+            auto separator = border;
+            separator.setAlpha(110);
+            painter.setPen(separator);
+            painter.drawLine(tab_rect.topLeft() + QPoint(0, 11), tab_rect.bottomLeft() - QPoint(0, 10));
+        }
+
+        auto contents_rect = tab_rect.adjusted(13, 1, -13, 0);
+        if (auto* left_button = tabButton(index, QTabBar::LeftSide); left_button && left_button->isVisible())
+            contents_rect.setLeft(max(contents_rect.left(), left_button->geometry().right() + 6));
+        if (auto* right_button = tabButton(index, QTabBar::RightSide); right_button && right_button->isVisible())
+            contents_rect.setRight(min(contents_rect.right(), right_button->geometry().left() - 6));
+
+        auto icon = tabIcon(index);
+        if (!icon.isNull() && contents_rect.width() > 26) {
+            constexpr int icon_size = 16;
+            QRect icon_rect {
+                contents_rect.left(),
+                contents_rect.top() + (contents_rect.height() - icon_size) / 2,
+                icon_size,
+                icon_size,
+            };
+            icon.paint(&painter, icon_rect);
+            contents_rect.setLeft(icon_rect.right() + 7);
+        }
+
+        QFont tab_font = font();
+        if (is_selected)
+            tab_font.setWeight(QFont::DemiBold);
+        painter.setFont(tab_font);
+
+        QFontMetrics font_metrics(tab_font);
+        auto title = font_metrics.elidedText(tabText(index), Qt::ElideRight, max(0, contents_rect.width()));
+        painter.setPen(is_selected || is_hovered ? text_color : muted_text_color);
+        painter.drawText(contents_rect, Qt::AlignLeft | Qt::AlignVCenter, title);
+    }
 }
 
 void TabBar::contextMenuEvent(QContextMenuEvent* event)
@@ -86,7 +157,11 @@ void TabBar::contextMenuEvent(QContextMenuEvent* event)
     if (!m_tab_widget)
         return;
 
-    if (auto* tab = m_tab_widget->tab(tabAt(event->pos())))
+    auto tab_index = tabAt(event->pos());
+    if (tab_index < 0)
+        return;
+
+    if (auto* tab = m_tab_widget->tab(tab_index))
         tab->context_menu()->exec(event->globalPos());
 }
 
@@ -94,8 +169,16 @@ void TabBar::mousePressEvent(QMouseEvent* event)
 {
     event->ignore();
 
-    auto rect_of_current_tab = tabRect(tabAt(event->pos()));
-    m_x_position_in_selected_tab_while_dragging = event->pos().x() - rect_of_current_tab.x();
+    auto pressed_tab = tabAt(event->pos());
+    if (pressed_tab < 0 && event->button() == Qt::LeftButton) {
+        if (start_window_move())
+            return;
+    }
+
+    if (pressed_tab >= 0) {
+        auto rect_of_current_tab = tabRect(pressed_tab);
+        m_x_position_in_selected_tab_while_dragging = event->pos().x() - rect_of_current_tab.x();
+    }
 
     QTabBar::mousePressEvent(event);
 }
@@ -103,6 +186,16 @@ void TabBar::mousePressEvent(QMouseEvent* event)
 void TabBar::mouseMoveEvent(QMouseEvent* event)
 {
     event->ignore();
+
+    if (auto hovered_tab = tabAt(event->pos()); hovered_tab != m_hovered_tab_index) {
+        m_hovered_tab_index = hovered_tab;
+        update();
+    }
+
+    if (count() == 0) {
+        QTabBar::mouseMoveEvent(event);
+        return;
+    }
 
     auto rect_of_first_tab = tabRect(0);
     auto rect_of_last_tab = tabRect(count() - 1);
@@ -123,13 +216,45 @@ void TabBar::mouseMoveEvent(QMouseEvent* event)
     }
 }
 
+void TabBar::leaveEvent(QEvent* event)
+{
+    m_hovered_tab_index = -1;
+    update();
+    QTabBar::leaveEvent(event);
+}
+
+void TabBar::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (tabAt(event->pos()) < 0 && event->button() == Qt::LeftButton) {
+        toggle_window_maximized();
+        event->accept();
+        return;
+    }
+
+    QTabBar::mouseDoubleClickEvent(event);
+}
+
+bool TabBar::start_window_move()
+{
+    auto* handle = window()->windowHandle();
+    if (!handle)
+        return false;
+    return handle->startSystemMove();
+}
+
+void TabBar::toggle_window_maximized()
+{
+    auto* top_level_window = window();
+    if (top_level_window->isMaximized())
+        top_level_window->showNormal();
+    else
+        top_level_window->showMaximized();
+}
+
 TabWidget::TabWidget(QWidget* parent)
     : QWidget(parent)
 {
     m_tab_bar = new TabBar(this);
-    auto* tab_style = new LeftAlignedTabStyle;
-    tab_style->setParent(m_tab_bar);
-    m_tab_bar->setStyle(tab_style);
 
     m_tab_bar->setDocumentMode(true);
     m_tab_bar->setElideMode(Qt::TextElideMode::ElideRight);
@@ -142,27 +267,48 @@ TabWidget::TabWidget(QWidget* parent)
     m_stacked_widget = new QStackedWidget(this);
 
     m_new_tab_button = new QToolButton(this);
+    m_new_tab_button->setObjectName("LadybirdNewTabButton");
     m_new_tab_button->setIconSize(QSize(16, 16));
-    m_new_tab_button->setAutoRaise(true);
     m_new_tab_button->setToolTip("New Tab");
+
+    m_minimize_window_button = new QToolButton(this);
+    m_minimize_window_button->setObjectName("LadybirdWindowButton");
+    m_minimize_window_button->setToolTip("Minimize");
+    m_minimize_window_button->setIconSize(QSize(14, 14));
+
+    m_maximize_window_button = new QToolButton(this);
+    m_maximize_window_button->setObjectName("LadybirdWindowButton");
+    m_maximize_window_button->setIconSize(QSize(14, 14));
+
+    m_close_window_button = new QToolButton(this);
+    m_close_window_button->setObjectName("LadybirdCloseWindowButton");
+    m_close_window_button->setToolTip("Close");
+    m_close_window_button->setIconSize(QSize(14, 14));
 
     recreate_icons();
 
     auto* tab_bar_row_layout = new QHBoxLayout();
     tab_bar_row_layout->setSpacing(0);
-    tab_bar_row_layout->setContentsMargins(0, 0, 0, 0);
+    tab_bar_row_layout->setContentsMargins(8, 0, 8, 0);
     tab_bar_row_layout->addWidget(m_tab_bar);
     tab_bar_row_layout->addWidget(m_new_tab_button);
     tab_bar_row_layout->addStretch(1);
+    tab_bar_row_layout->addWidget(m_minimize_window_button);
+    tab_bar_row_layout->addWidget(m_maximize_window_button);
+    tab_bar_row_layout->addWidget(m_close_window_button);
 
     m_tab_bar_row = new QWidget(this);
+    m_tab_bar_row->setObjectName("LadybirdTabStrip");
+    m_tab_bar_row->setMinimumHeight(40);
     m_tab_bar_row->setLayout(tab_bar_row_layout);
+    m_tab_bar_row->installEventFilter(this);
 
     auto* main_layout = new QVBoxLayout(this);
     main_layout->setSpacing(0);
     main_layout->setContentsMargins(0, 0, 0, 0);
     main_layout->addWidget(m_tab_bar_row);
     main_layout->addWidget(m_stacked_widget, 1);
+    update_chrome_style();
 
     connect(m_tab_bar, &QTabBar::currentChanged, this, [this](int index) {
         if (index >= 0 && index < m_stacked_widget->count())
@@ -181,6 +327,16 @@ TabWidget::TabWidget(QWidget* parent)
         m_stacked_widget->removeWidget(widget);
         m_stacked_widget->insertWidget(to, widget);
         m_stacked_widget->setCurrentIndex(m_tab_bar->currentIndex());
+    });
+
+    connect(m_minimize_window_button, &QToolButton::clicked, this, [this] {
+        window()->showMinimized();
+    });
+    connect(m_maximize_window_button, &QToolButton::clicked, this, [this] {
+        toggle_window_maximized();
+    });
+    connect(m_close_window_button, &QToolButton::clicked, this, [this] {
+        window()->close();
     });
 }
 
@@ -239,9 +395,33 @@ bool TabWidget::event(QEvent* event)
         }
     } else if (type == QEvent::PaletteChange) {
         recreate_icons();
+        update_chrome_style();
+    } else if (type == QEvent::WindowStateChange) {
+        update_window_button_icons();
     }
 
     return QWidget::event(event);
+}
+
+bool TabWidget::eventFilter(QObject* watched, QEvent* event)
+{
+    if (watched == m_tab_bar_row) {
+        if (event->type() == QEvent::MouseButtonDblClick) {
+            auto* mouse_event = static_cast<QMouseEvent*>(event);
+            if (mouse_event->button() == Qt::LeftButton) {
+                toggle_window_maximized();
+                return true;
+            }
+        }
+
+        if (event->type() == QEvent::MouseButtonPress) {
+            auto* mouse_event = static_cast<QMouseEvent*>(event);
+            if (mouse_event->button() == Qt::LeftButton && start_window_move())
+                return true;
+        }
+    }
+
+    return QWidget::eventFilter(watched, event);
 }
 
 void TabWidget::resizeEvent(QResizeEvent* event)
@@ -261,12 +441,53 @@ void TabWidget::update_tab_layout()
 void TabWidget::recreate_icons()
 {
     m_new_tab_button->setIcon(create_tvg_icon_with_theme_colors("new_tab", palette()));
+    update_window_button_icons();
+}
+
+void TabWidget::update_chrome_style()
+{
+    if (m_is_updating_chrome_style)
+        return;
+
+    m_is_updating_chrome_style = true;
+    m_tab_bar_row->setStyleSheet(ChromeStyle::tab_widget_style_sheet(palette()));
+    m_is_updating_chrome_style = false;
+}
+
+void TabWidget::update_window_button_icons()
+{
+    auto* top_level_window = window();
+    auto* button_style = top_level_window->style();
+    m_minimize_window_button->setIcon(button_style->standardIcon(QStyle::SP_TitleBarMinButton));
+    m_maximize_window_button->setIcon(button_style->standardIcon(top_level_window->isMaximized() ? QStyle::SP_TitleBarNormalButton : QStyle::SP_TitleBarMaxButton));
+    m_maximize_window_button->setToolTip(top_level_window->isMaximized() ? "Restore" : "Maximize");
+    m_close_window_button->setIcon(button_style->standardIcon(QStyle::SP_TitleBarCloseButton));
+}
+
+void TabWidget::toggle_window_maximized()
+{
+    auto* top_level_window = window();
+    if (top_level_window->isMaximized())
+        top_level_window->showNormal();
+    else
+        top_level_window->showMaximized();
+    update_window_button_icons();
+}
+
+bool TabWidget::start_window_move()
+{
+    auto* handle = window()->windowHandle();
+    if (!handle)
+        return false;
+    return handle->startSystemMove();
 }
 
 TabBarButton::TabBarButton(QIcon const& icon, QWidget* parent)
     : QPushButton(icon, {}, parent)
 {
-    resize({ 20, 20 });
+    setObjectName("LadybirdTabButton");
+    setFixedSize({ 24, 24 });
+    setIconSize({ 14, 14 });
     setFlat(true);
 }
 

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -22,18 +22,20 @@
 #include <QDragLeaveEvent>
 #include <QDragMoveEvent>
 #include <QDropEvent>
+#include <QEasingCurve>
 #include <QEvent>
 #include <QFontMetrics>
 #include <QHBoxLayout>
+#include <QLinearGradient>
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPixmap>
-#include <QStyle>
 #include <QToolButton>
 #include <QVBoxLayout>
+#include <QVariantAnimation>
 #include <QWindow>
 
 namespace Ladybird {
@@ -45,19 +47,21 @@ static QPointer<Tab> s_active_tab_dragged_tab;
 static QPointer<TabWidget> s_pending_tab_drop_target;
 static int s_pending_tab_drop_index { -1 };
 
-static QPainterPath active_tab_path(QRectF const& rect, qreal radius)
+static QPainterPath tab_shape_path(QRectF const& rect, qreal top_radius, qreal bottom_radius)
 {
-    constexpr qreal shoulder = 9.0;
+    top_radius = min(top_radius, rect.height() / 2.0);
+    bottom_radius = min(bottom_radius, rect.height() / 2.0);
 
     QPainterPath path;
-    path.moveTo(rect.left(), rect.bottom());
-    path.cubicTo(rect.left() + 4.0, rect.bottom(), rect.left() + 6.0, rect.bottom() - 5.0, rect.left() + shoulder, rect.bottom() - 8.0);
-    path.lineTo(rect.left() + shoulder, rect.top() + radius);
-    path.quadTo(rect.left() + shoulder, rect.top(), rect.left() + shoulder + radius, rect.top());
-    path.lineTo(rect.right() - radius, rect.top());
-    path.quadTo(rect.right(), rect.top(), rect.right(), rect.top() + radius);
-    path.lineTo(rect.right() - shoulder, rect.bottom() - 8.0);
-    path.cubicTo(rect.right() - 6.0, rect.bottom() - 5.0, rect.right() - 4.0, rect.bottom(), rect.right(), rect.bottom());
+    path.moveTo(rect.left() + top_radius, rect.top());
+    path.lineTo(rect.right() - top_radius, rect.top());
+    path.quadTo(rect.right(), rect.top(), rect.right(), rect.top() + top_radius);
+    path.lineTo(rect.right(), rect.bottom() - bottom_radius);
+    path.quadTo(rect.right(), rect.bottom(), rect.right() - bottom_radius, rect.bottom());
+    path.lineTo(rect.left() + bottom_radius, rect.bottom());
+    path.quadTo(rect.left(), rect.bottom(), rect.left(), rect.bottom() - bottom_radius);
+    path.lineTo(rect.left(), rect.top() + top_radius);
+    path.quadTo(rect.left(), rect.top(), rect.left() + top_radius, rect.top());
     path.closeSubpath();
     return path;
 }
@@ -68,7 +72,21 @@ TabBar::TabBar(TabWidget* tab_widget)
 {
     setMouseTracking(true);
     setAcceptDrops(true);
-    setMinimumHeight(38);
+    setFocusPolicy(Qt::NoFocus);
+    setIconSize({ 16, 16 });
+    setMinimumHeight(44);
+
+    m_hover_animation = new QVariantAnimation(this);
+    m_hover_animation->setDuration(120);
+    m_hover_animation->setEasingCurve(QEasingCurve::OutCubic);
+    connect(m_hover_animation, &QVariantAnimation::valueChanged, this, [this](QVariant const& value) {
+        m_hover_progress = value.toReal();
+        update();
+    });
+    connect(m_hover_animation, &QVariantAnimation::finished, this, [this] {
+        if (m_hover_progress <= 0.0)
+            m_hover_animation_tab_index = -1;
+    });
 }
 
 void TabBar::set_available_width(int width)
@@ -91,7 +109,7 @@ QSize TabBar::tabSizeHint(int index) const
         hint.setWidth(width);
     }
 
-    hint.setHeight(34);
+    hint.setHeight(39);
     return hint;
 }
 
@@ -101,10 +119,21 @@ void TabBar::paintEvent(QPaintEvent* event)
 
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.fillRect(rect(), ChromeStyle::chrome_background(palette()));
 
     auto border = ChromeStyle::chrome_border(palette());
-    auto accent = ChromeStyle::chrome_accent(palette());
+    auto dark = ChromeStyle::is_dark(palette());
+    auto background = ChromeStyle::chrome_background(palette());
+    auto background_gradient = QLinearGradient(rect().topLeft(), rect().bottomLeft());
+    if (dark) {
+        background_gradient.setColorAt(0.0, background.lighter(118));
+        background_gradient.setColorAt(1.0, background.darker(116));
+    } else {
+        auto tab_strip_background = ChromeStyle::mix(background, QColor(224, 229, 236), 0.18);
+        background_gradient.setColorAt(0.0, ChromeStyle::mix(tab_strip_background, QColor(255, 255, 255), 0.015));
+        background_gradient.setColorAt(1.0, ChromeStyle::mix(tab_strip_background, QColor(210, 216, 224), 0.025));
+    }
+    painter.fillRect(rect(), background_gradient);
+
     auto text_color = palette().color(QPalette::Text);
     auto muted_text_color = ChromeStyle::chrome_muted_text(palette());
 
@@ -114,37 +143,58 @@ void TabBar::paintEvent(QPaintEvent* event)
             continue;
 
         bool is_selected = index == currentIndex();
-        bool is_hovered = index == m_hovered_tab_index;
+        auto hover_progress = index == m_hover_animation_tab_index ? m_hover_progress : (index == m_hovered_tab_index ? 1.0 : 0.0);
+        bool is_hovered = hover_progress > 0.0;
 
-        if (is_selected || is_hovered) {
-            auto shape_rect = QRectF(tab_rect).adjusted(2.0, is_selected ? 4.0 : 7.0, -2.0, is_selected ? 0.0 : -6.0);
-            auto surface = is_selected ? ChromeStyle::chrome_surface(palette()) : ChromeStyle::chrome_surface_hover(palette());
+        auto shape_rect = QRectF(tab_rect).adjusted(4.0, 1.0, -4.0, is_selected ? 6.0 : -1.0);
+        auto tab_path = tab_shape_path(shape_rect, 10.0, is_selected ? 1.0 : 9.0);
+        auto surface = ChromeStyle::chrome_surface(palette());
 
-            auto tab_path = is_selected
-                ? active_tab_path(shape_rect, 7.0)
-                : [&] {
-                      QPainterPath path;
-                      path.addRoundedRect(shape_rect, 7.0, 7.0);
-                      return path;
-                  }();
+        if (is_selected) {
+            auto shadow_path = tab_shape_path(shape_rect.translated(0, 1), 11.0, 2.0);
+            painter.setBrush(QColor(0, 0, 0, 22));
+            painter.setPen(Qt::NoPen);
+            painter.drawPath(shadow_path);
 
-            painter.setBrush(surface);
-            painter.setPen(is_selected ? QPen(border, 1) : Qt::NoPen);
+            auto selected_gradient = QLinearGradient(shape_rect.topLeft(), shape_rect.bottomLeft());
+            selected_gradient.setColorAt(0.0, dark ? surface.lighter(108) : ChromeStyle::mix(surface, QColor(255, 255, 255), 0.18));
+            selected_gradient.setColorAt(1.0, surface);
+            auto active_border = border;
+            active_border.setAlpha(62);
+            painter.setBrush(selected_gradient);
+            painter.setPen(QPen(active_border, 1));
             painter.drawPath(tab_path);
 
-            if (is_selected) {
-                painter.setPen(QPen(accent, 2));
-                painter.drawLine(QPointF(shape_rect.left() + 9.0, shape_rect.top() + 1.0),
-                    QPointF(shape_rect.right() - 9.0, shape_rect.top() + 1.0));
-            }
-        } else if (index > 0 && index != currentIndex() + 1) {
-            auto separator = border;
-            separator.setAlpha(110);
-            painter.setPen(separator);
-            painter.drawLine(tab_rect.topLeft() + QPoint(0, 11), tab_rect.bottomLeft() - QPoint(0, 10));
+            auto highlight = QColor(255, 255, 255, 16);
+            painter.setPen(QPen(highlight, 1));
+            painter.drawLine(QPointF(shape_rect.left() + 14.0, shape_rect.top() + 1.0),
+                QPointF(shape_rect.right() - 14.0, shape_rect.top() + 1.0));
+        } else if (is_hovered) {
+            auto hover = ChromeStyle::chrome_surface_hover(palette());
+            hover.setAlpha(static_cast<int>(120 * hover_progress));
+            auto hover_border = border;
+            hover_border.setAlpha(static_cast<int>(44 * hover_progress));
+            painter.setBrush(hover);
+            painter.setPen(QPen(hover_border, 1));
+            painter.drawPath(tab_path);
+        } else {
+            auto inactive = background.lighter(108);
+            inactive.setAlpha(48);
+            auto inactive_border = border;
+            inactive_border.setAlpha(14);
+            painter.setBrush(inactive);
+            painter.setPen(QPen(inactive_border, 1));
+            painter.drawPath(tab_path);
         }
 
-        auto contents_rect = tab_rect.adjusted(13, 1, -13, 0);
+        if (!is_selected && !is_hovered && index > 0 && index != currentIndex() + 1) {
+            auto separator = border;
+            separator.setAlpha(32);
+            painter.setPen(separator);
+            painter.drawLine(QPoint(tab_rect.left(), 17), QPoint(tab_rect.left(), height() - 17));
+        }
+
+        auto contents_rect = shape_rect.toAlignedRect().adjusted(16, 0, -14, 0);
         if (auto* left_button = tabButton(index, QTabBar::LeftSide); left_button && left_button->isVisible())
             contents_rect.setLeft(max(contents_rect.left(), left_button->geometry().right() + 6));
         if (auto* right_button = tabButton(index, QTabBar::RightSide); right_button && right_button->isVisible())
@@ -170,7 +220,12 @@ void TabBar::paintEvent(QPaintEvent* event)
 
         QFontMetrics font_metrics(tab_font);
         auto title = font_metrics.elidedText(tabText(index), Qt::ElideRight, max(0, contents_rect.width()));
-        painter.setPen(is_selected || is_hovered ? text_color : muted_text_color);
+        auto tab_text_color = is_selected ? text_color : muted_text_color;
+        if (is_hovered)
+            tab_text_color.setAlpha(static_cast<int>(160 + 54 * hover_progress));
+        else if (!is_selected)
+            tab_text_color.setAlpha(154);
+        painter.setPen(tab_text_color);
         painter.drawText(contents_rect, Qt::AlignLeft | Qt::AlignVCenter, title);
     }
 
@@ -273,6 +328,7 @@ void TabBar::mouseMoveEvent(QMouseEvent* event)
 {
     if (auto hovered_tab = tabAt(event->pos()); hovered_tab != m_hovered_tab_index) {
         m_hovered_tab_index = hovered_tab;
+        start_hover_animation(hovered_tab, hovered_tab >= 0 ? 1.0 : 0.0);
         update();
     }
 
@@ -300,7 +356,9 @@ void TabBar::mouseMoveEvent(QMouseEvent* event)
 
 void TabBar::leaveEvent(QEvent* event)
 {
+    auto previous_hovered_tab = m_hovered_tab_index;
     m_hovered_tab_index = -1;
+    start_hover_animation(previous_hovered_tab, 0.0);
     update();
     QTabBar::leaveEvent(event);
 }
@@ -407,6 +465,26 @@ void TabBar::start_tab_drag(int index)
     m_pressed_tab = nullptr;
 }
 
+void TabBar::start_hover_animation(int tab_index, qreal target_progress)
+{
+    if (!m_hover_animation)
+        return;
+
+    if (tab_index < 0) {
+        m_hover_animation_tab_index = -1;
+        m_hover_progress = 0.0;
+        update();
+        return;
+    }
+
+    m_hover_animation->stop();
+    auto start_progress = (m_hover_animation_tab_index == tab_index) ? m_hover_progress : 0.0;
+    m_hover_animation_tab_index = tab_index;
+    m_hover_animation->setStartValue(start_progress);
+    m_hover_animation->setEndValue(target_progress);
+    m_hover_animation->start();
+}
+
 void TabBar::toggle_window_maximized()
 {
     auto* top_level_window = window();
@@ -434,28 +512,36 @@ TabWidget::TabWidget(QWidget* parent)
 
     m_new_tab_button = new QToolButton(this);
     m_new_tab_button->setObjectName("LadybirdNewTabButton");
-    m_new_tab_button->setIconSize(QSize(16, 16));
+    m_new_tab_button->setIconSize(QSize(18, 18));
+    m_new_tab_button->setFixedSize(32, 32);
+    m_new_tab_button->setFocusPolicy(Qt::NoFocus);
     m_new_tab_button->setToolTip("New Tab");
 
     m_minimize_window_button = new QToolButton(this);
     m_minimize_window_button->setObjectName("LadybirdWindowButton");
     m_minimize_window_button->setToolTip("Minimize");
-    m_minimize_window_button->setIconSize(QSize(14, 14));
+    m_minimize_window_button->setIconSize(QSize(18, 18));
+    m_minimize_window_button->setFixedSize(40, 40);
+    m_minimize_window_button->setFocusPolicy(Qt::NoFocus);
 
     m_maximize_window_button = new QToolButton(this);
     m_maximize_window_button->setObjectName("LadybirdWindowButton");
-    m_maximize_window_button->setIconSize(QSize(14, 14));
+    m_maximize_window_button->setIconSize(QSize(18, 18));
+    m_maximize_window_button->setFixedSize(40, 40);
+    m_maximize_window_button->setFocusPolicy(Qt::NoFocus);
 
     m_close_window_button = new QToolButton(this);
     m_close_window_button->setObjectName("LadybirdCloseWindowButton");
     m_close_window_button->setToolTip("Close");
-    m_close_window_button->setIconSize(QSize(14, 14));
+    m_close_window_button->setIconSize(QSize(18, 18));
+    m_close_window_button->setFixedSize(40, 40);
+    m_close_window_button->setFocusPolicy(Qt::NoFocus);
 
     recreate_icons();
 
     auto* tab_bar_row_layout = new QHBoxLayout();
-    tab_bar_row_layout->setSpacing(0);
-    tab_bar_row_layout->setContentsMargins(8, 0, 8, 0);
+    tab_bar_row_layout->setSpacing(4);
+    tab_bar_row_layout->setContentsMargins(12, 4, 8, 0);
     tab_bar_row_layout->addWidget(m_tab_bar);
     tab_bar_row_layout->addWidget(m_new_tab_button);
     tab_bar_row_layout->addStretch(1);
@@ -465,7 +551,7 @@ TabWidget::TabWidget(QWidget* parent)
 
     m_tab_bar_row = new QWidget(this);
     m_tab_bar_row->setObjectName("LadybirdTabStrip");
-    m_tab_bar_row->setMinimumHeight(40);
+    m_tab_bar_row->setMinimumHeight(50);
     m_tab_bar_row->setLayout(tab_bar_row_layout);
     m_tab_bar_row->installEventFilter(this);
 
@@ -655,15 +741,15 @@ void TabWidget::resizeEvent(QResizeEvent* event)
 
 void TabWidget::update_tab_layout()
 {
-    auto button_width = m_new_tab_button->sizeHint().width();
-    auto available_for_tabs = width() - button_width;
+    auto controls_width = m_new_tab_button->width() + m_minimize_window_button->width() + m_maximize_window_button->width() + m_close_window_button->width();
+    auto available_for_tabs = width() - controls_width - 36;
 
     m_tab_bar->set_available_width(available_for_tabs);
 }
 
 void TabWidget::recreate_icons()
 {
-    m_new_tab_button->setIcon(create_tvg_icon_with_theme_colors("new_tab", palette()));
+    m_new_tab_button->setIcon(create_chrome_icon(ChromeIcon::NewTab, palette()));
     update_window_button_icons();
 }
 
@@ -679,12 +765,11 @@ void TabWidget::update_chrome_style()
 
 void TabWidget::update_window_button_icons()
 {
-    auto* top_level_window = window();
-    auto* button_style = top_level_window->style();
-    m_minimize_window_button->setIcon(button_style->standardIcon(QStyle::SP_TitleBarMinButton));
-    m_maximize_window_button->setIcon(button_style->standardIcon(top_level_window->isMaximized() ? QStyle::SP_TitleBarNormalButton : QStyle::SP_TitleBarMaxButton));
-    m_maximize_window_button->setToolTip(top_level_window->isMaximized() ? "Restore" : "Maximize");
-    m_close_window_button->setIcon(button_style->standardIcon(QStyle::SP_TitleBarCloseButton));
+    auto is_maximized = window()->isMaximized();
+    m_minimize_window_button->setIcon(create_chrome_icon(ChromeIcon::WindowMinimize, palette()));
+    m_maximize_window_button->setIcon(create_chrome_icon(is_maximized ? ChromeIcon::WindowRestore : ChromeIcon::WindowMaximize, palette()));
+    m_maximize_window_button->setToolTip(is_maximized ? "Restore" : "Maximize");
+    m_close_window_button->setIcon(create_chrome_icon(ChromeIcon::WindowClose, palette()));
 }
 
 void TabWidget::toggle_window_maximized()
@@ -709,8 +794,9 @@ TabBarButton::TabBarButton(QIcon const& icon, QWidget* parent)
     : QPushButton(icon, {}, parent)
 {
     setObjectName("LadybirdTabButton");
-    setFixedSize({ 24, 24 });
-    setIconSize({ 14, 14 });
+    setFixedSize({ 20, 20 });
+    setIconSize({ 12, 12 });
+    setFocusPolicy(Qt::NoFocus);
     setFlat(true);
 }
 

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -18,10 +18,15 @@
 
 class QAction;
 class QContextMenuEvent;
+class QDragEnterEvent;
+class QDragLeaveEvent;
+class QDragMoveEvent;
+class QDropEvent;
 class QEvent;
 class QIcon;
 class QMouseEvent;
 class QPaintEvent;
+class QPixmap;
 class QToolButton;
 
 namespace Ladybird {
@@ -41,20 +46,31 @@ public:
     virtual void contextMenuEvent(QContextMenuEvent* event) override;
 
 private:
+    virtual void dragEnterEvent(QDragEnterEvent*) override;
+    virtual void dragLeaveEvent(QDragLeaveEvent*) override;
+    virtual void dragMoveEvent(QDragMoveEvent*) override;
+    virtual void dropEvent(QDropEvent*) override;
     virtual void paintEvent(QPaintEvent*) override;
     virtual void leaveEvent(QEvent*) override;
     virtual void mouseDoubleClickEvent(QMouseEvent*) override;
-    void mousePressEvent(QMouseEvent*) override;
-    void mouseMoveEvent(QMouseEvent*) override;
+    virtual void mousePressEvent(QMouseEvent*) override;
+    virtual void mouseMoveEvent(QMouseEvent*) override;
+    virtual void mouseReleaseEvent(QMouseEvent*) override;
 
-    bool start_window_move();
+    int insertion_index_at(QPoint const&) const;
+    int drop_indicator_index_for_insertion_index(int insertion_index) const;
+    QPixmap render_tab_drag_pixmap(int index) const;
     void toggle_window_maximized();
+    void start_tab_drag(int index);
 
     QPointer<TabWidget> m_tab_widget;
 
     int m_available_width { 0 };
     int m_hovered_tab_index { -1 };
-    int m_x_position_in_selected_tab_while_dragging { 0 };
+    int m_drop_indicator_index { -1 };
+    QPointer<Tab> m_pressed_tab;
+    QPoint m_position_in_selected_tab_while_dragging;
+    QPoint m_drag_start_position;
 };
 
 class TabWidget final : public QWidget {
@@ -66,7 +82,9 @@ public:
     TabBar* tab_bar() const { return m_tab_bar; }
 
     void add_tab(Tab* widget, QString const& label);
+    void insert_tab(int index, Tab* widget, QString const& label);
     void remove_tab(int index);
+    Tab* take_tab(int index);
 
     int count() const { return m_tab_bar->count(); }
 
@@ -90,6 +108,9 @@ signals:
     void tab_close_requested(int index);
 
 protected:
+    virtual void dragEnterEvent(QDragEnterEvent*) override;
+    virtual void dragMoveEvent(QDragMoveEvent*) override;
+    virtual void dropEvent(QDropEvent*) override;
     virtual bool event(QEvent* event) override;
     virtual bool eventFilter(QObject*, QEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
@@ -101,6 +122,8 @@ private:
     void update_window_button_icons();
     void toggle_window_maximized();
     bool start_window_move();
+    void accept_tab_drag(QDragMoveEvent*);
+    void accept_tab_drop(QDropEvent*, int index);
 
     TabBar* m_tab_bar { nullptr };
     QStackedWidget* m_stacked_widget { nullptr };

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -20,6 +20,8 @@ class QAction;
 class QContextMenuEvent;
 class QEvent;
 class QIcon;
+class QMouseEvent;
+class QPaintEvent;
 class QToolButton;
 
 namespace Ladybird {
@@ -39,12 +41,19 @@ public:
     virtual void contextMenuEvent(QContextMenuEvent* event) override;
 
 private:
+    virtual void paintEvent(QPaintEvent*) override;
+    virtual void leaveEvent(QEvent*) override;
+    virtual void mouseDoubleClickEvent(QMouseEvent*) override;
     void mousePressEvent(QMouseEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;
+
+    bool start_window_move();
+    void toggle_window_maximized();
 
     QPointer<TabWidget> m_tab_widget;
 
     int m_available_width { 0 };
+    int m_hovered_tab_index { -1 };
     int m_x_position_in_selected_tab_while_dragging { 0 };
 };
 
@@ -82,16 +91,25 @@ signals:
 
 protected:
     virtual bool event(QEvent* event) override;
+    virtual bool eventFilter(QObject*, QEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
 
 private:
     void update_tab_layout();
     void recreate_icons();
+    void update_chrome_style();
+    void update_window_button_icons();
+    void toggle_window_maximized();
+    bool start_window_move();
 
     TabBar* m_tab_bar { nullptr };
     QStackedWidget* m_stacked_widget { nullptr };
     QToolButton* m_new_tab_button { nullptr };
+    QToolButton* m_minimize_window_button { nullptr };
+    QToolButton* m_maximize_window_button { nullptr };
+    QToolButton* m_close_window_button { nullptr };
     QWidget* m_tab_bar_row { nullptr };
+    bool m_is_updating_chrome_style { false };
 };
 
 class TabBarButton final : public QPushButton {

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -28,6 +28,7 @@ class QMouseEvent;
 class QPaintEvent;
 class QPixmap;
 class QToolButton;
+class QVariantAnimation;
 
 namespace Ladybird {
 
@@ -62,12 +63,16 @@ private:
     QPixmap render_tab_drag_pixmap(int index) const;
     void toggle_window_maximized();
     void start_tab_drag(int index);
+    void start_hover_animation(int tab_index, qreal target_progress);
 
     QPointer<TabWidget> m_tab_widget;
 
     int m_available_width { 0 };
     int m_hovered_tab_index { -1 };
+    int m_hover_animation_tab_index { -1 };
+    qreal m_hover_progress { 0.0 };
     int m_drop_indicator_index { -1 };
+    QVariantAnimation* m_hover_animation { nullptr };
     QPointer<Tab> m_pressed_tab;
     QPoint m_position_in_selected_tab_while_dragging;
     QPoint m_drag_start_position;

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -40,6 +40,9 @@
 #include <QPainter>
 #include <QPalette>
 #include <QScrollBar>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#    include <QStyleHints>
+#endif
 #include <QTextEdit>
 #include <QTimer>
 #include <QToolTip>
@@ -70,6 +73,15 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     QObject::connect(qGuiApp, &QGuiApplication::screenAdded, [this](QScreen*) {
         update_screen_rects();
     });
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    QObject::connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this] {
+        QTimer::singleShot(0, this, [this] {
+            update_palette();
+            update();
+        });
+    });
+#endif
 
     m_tooltip_hover_timer.setSingleShot(true);
 
@@ -784,8 +796,11 @@ bool WebContentView::event(QEvent* event)
         return true;
     }
 
-    if (event->type() == QEvent::PaletteChange) {
-        update_palette();
+    if (event->type() == QEvent::PaletteChange || event->type() == QEvent::ApplicationPaletteChange || event->type() == QEvent::ThemeChange) {
+        QTimer::singleShot(0, this, [this] {
+            update_palette();
+            update();
+        });
         return QWidget::event(event);
     }
 


### PR DESCRIPTION
This replaces the stock-looking Qt browser chrome with an integrated custom chrome surface for the tab strip, toolbar, omnibox, and window controls. The new styling keeps the UI compact and restrained while improving visual hierarchy, light and dark theme polish, icon consistency, tab geometry, and omnibox/dropdown cohesion.

Tabs now support browser-like drag behavior, including reordering, full-tab drag previews, detaching tabs, and reparenting tabs between windows. Frameless windows also expose resize cursors at the edges and mark themselves opaque for window manager optimization.

Theme changes now refresh the Qt chrome, autocomplete dropdown, omnibox text and colors, and WebContent painting immediately, without requiring focus, mouseover, or restart.

| Dark mode | Light mode |
|-----------|------------|
| <img width="1269" height="889" alt="Screenshot from 2026-05-25 21-17-48" src="https://github.com/user-attachments/assets/ca0ff413-1ad5-4471-a6bb-0a9d29667bed" /> | <img width="1269" height="889" alt="Screenshot from 2026-05-25 21-18-05" src="https://github.com/user-attachments/assets/95841eb3-2c1d-4f23-ae4e-c6cef726edc9" /> |
