### PR TITLE
Tests/LibWeb: Ignore stale initial iframe load in a-element-target.html

### DIFF
--- a/Tests/LibWeb/Text/input/base/a-element-target.html
+++ b/Tests/LibWeb/Text/input/base/a-element-target.html
@@ -4,12 +4,15 @@
 <script>
     asyncTest(done => {
         window.onload = () => {
+            const initialFrameLocation = frame.contentDocument.location.href;
             frame.onload = () => {
-                frame.onload = () => {
-                    println(frame.contentDocument.location.href.includes("a-element-target-sub-alt.html")? "Parent frame navigated successfully!" : "Parent frame incorrectly navigated to " + frame.contentDocument.location.href);
-                    done();
-                }
-            }
+                const frameLocation = frame.contentDocument.location.href;
+                if (frameLocation === initialFrameLocation)
+                    return;
+
+                println(frameLocation.includes("a-element-target-sub-alt.html") ? "Parent frame navigated successfully!" : "Parent frame incorrectly navigated to " + frameLocation);
+                done();
+            };
             frame.contentDocument.getElementById("frame").contentDocument.getElementById("a").click();
         };
     });


### PR DESCRIPTION
This test currently passes due to a bug in iframe load ordering. After fixing that issue, the outer iframe's initial load event is no longer delivered before the parent window load handler runs. That means this test can install its iframe.onload handler while the initial iframe load event is still pending.

The test only cares about the navigation triggered by clicking the nested targeted link, so ignore a load event whose frame URL is still the initial frame URL. This keeps the test focused on whether the parent frame navigates to a-element-target-sub-alt.html.

This allows the test to also pass in Chromium.


NB: The was found while working on fixing an issue with iframe load event firing, which I still am in the works of figuring out a fix for (seems like we have 3 separate bugs there).