### PR TITLE
LibWeb: Use `GetFunctionRealm` for `FinalizationRegistry` cleanup callbacks

### DIFF
--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -10,6 +10,7 @@
 
 #include <LibGC/DeferGC.h>
 #include <LibJS/Module.h>
+#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/FinalizationRegistry.h>
@@ -247,7 +248,15 @@ void initialize_main_thread_vm(AgentType type)
         // 2. Queue a global task on the JavaScript engine task source given global to perform the following steps:
         HTML::queue_global_task(HTML::Task::Source::JavaScriptEngine, global, GC::create_function(s_main_thread_vm->heap(), [&finalization_registry] {
             // 1. Let entry be finalizationRegistry.[[CleanupCallback]].[[Callback]].[[Realm]]'s environment settings object.
-            auto& entry = HTML::principal_realm_settings_object(*finalization_registry.cleanup_callback().callback().realm());
+            // AD-HOC: The spec assumes [[Callback]] has a [[Realm]] internal slot, but Proxy and BoundFunction
+            //         exotic objects do not. Use GetFunctionRealm to unwrap these exotic objects, falling back to
+            //         the FinalizationRegistry's own realm on failure.
+            // Spec issue: https://github.com/whatwg/html/issues/12326
+            HTML::TemporaryExecutionContext context { finalization_registry.realm() };
+            auto& callback = finalization_registry.cleanup_callback().callback();
+            auto callback_realm = JS::get_function_realm(callback.vm(), callback);
+            auto& realm = callback_realm.is_throw_completion() ? finalization_registry.realm() : *callback_realm.value();
+            auto& entry = HTML::principal_realm_settings_object(realm);
 
             // 2. Prepare to run script with entry.
             HTML::prepare_to_run_script(entry);

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -267,9 +267,9 @@ void initialize_main_thread_vm(AgentType type)
             // 4. Clean up after running script with entry.
             HTML::clean_up_after_running_script(entry);
 
-            // 5. If result is an abrupt completion, then report the exception given by result.[[Value]].
+            // 5. If result is an abrupt completion, then report the exception given by result.[[Value]] for global.
             if (result.is_error())
-                HTML::report_exception(result, entry.realm());
+                HTML::report_exception(result, finalization_registry.realm());
         }));
     };
 

--- a/Tests/LibWeb/Crash/JS/finalization-registry-proxy-callback.html
+++ b/Tests/LibWeb/Crash/JS/finalization-registry-proxy-callback.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../../Text/input/include.js"></script>
+<script>
+const callback = new Proxy(function() {}, {});
+const registry = new FinalizationRegistry(callback);
+
+(function() {
+    registry.register({}, "held");
+})();
+
+internals.gc();
+</script>

--- a/Tests/LibWeb/Crash/JS/finalization-registry-revoked-proxy-callback.html
+++ b/Tests/LibWeb/Crash/JS/finalization-registry-revoked-proxy-callback.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../../Text/input/include.js"></script>
+<script>
+const { proxy, revoke } = Proxy.revocable(function() {}, {});
+const registry = new FinalizationRegistry(proxy);
+revoke();
+
+(function() {
+    registry.register({}, "held");
+})();
+
+internals.gc();
+</script>


### PR DESCRIPTION
The callback passed to `FinalizationRegistry` may be a Proxy or BoundFunction, which lack a `[[Realm]]` internal slot. Dereferencing the callback realm directly returned null and led to a crash in `HostEnqueueFinalizationRegistryCleanupJob`. We now use the `GetFunctionRealm` AO to unwrap these exotic objects and find the underlying realm.

Fixes a crash when opening a donation page on https://gofundme.com.

Relevant spec issue: https://github.com/whatwg/html/issues/12326