### PR TITLE
LibWeb: Allow HTMLLabelElement to delegate activation behavior

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -101,8 +101,7 @@ void HTMLLabelElement::activation_behavior(DOM::Event const& event)
         control_element->dispatch_event(click_event);
     }
 
-    if (control_element->is_focusable())
-        HTML::run_focusing_steps(control_element);
+    HTML::run_focusing_steps(control_element);
 }
 
 // https://html.spec.whatwg.org/multipage/forms.html#labeled-control

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/label-delegatesFocus.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/form-associated/label-delegatesFocus.txt
@@ -2,6 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	Clicking on a label for a form associated custom element with delegatesFocus should focus the custom element's focus delegate.
-Fail	Clicking on a span in a label for a form associated custom element with delegatesFocus should focus the custom element's focus delegate.
+2 Pass
+Pass	Clicking on a label for a form associated custom element with delegatesFocus should focus the custom element's focus delegate.
+Pass	Clicking on a span in a label for a form associated custom element with delegatesFocus should focus the custom element's focus delegate.


### PR DESCRIPTION
When a label's activation behavior runs for a form-associated custom element whose shadow root has delegatesFocus: true, the shadow host is not itself a focusable area. The old is_focusable() check prevented run_focusing_steps from ever being called, which means get_focusable_area never got a chance to descend into the shadow root via focus_delegate.

Fixes WPT custom-elements/form-associated/label-delegatesFocus.html.