### PR TITLE
LibWeb: Avoid creating RAF driver when canceling frames

### DIFF
--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -52,6 +52,7 @@ public:
     template<typename T, typename... Args>
     Ref<T> allocate(Args&&... args)
     {
+        VERIFY(!m_collecting_garbage);
         auto* memory = allocate_cell<T>();
         defer_gc();
         new (memory) T(forward<Args>(args)...);

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1738,7 +1738,8 @@ void Window::cancel_animation_frame(WebIDL::UnsignedLong handle)
 
     // 2. Let callbacks be this's target object's map of animation frame callbacks.
     // 3. Remove callbacks[handle].
-    (void)animation_frame_callback_driver().remove(handle);
+    if (m_animation_frame_callback_driver)
+        (void)m_animation_frame_callback_driver->remove(handle);
 }
 
 AnimationFrameCallbackDriver& Window::animation_frame_callback_driver()

--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-controls-gc.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-controls-gc.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-controls-gc.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-controls-gc.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    function createUnreachableMediaElementWithControls() {
+        const video = document.createElement("video");
+        video.controls = true;
+    }
+
+    asyncTest(done => {
+        createUnreachableMediaElementWithControls();
+
+        requestIdleCallback(() => {
+            internals.gc();
+            println("PASS (didn't crash)");
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
Treat a missing animation frame callback driver as an empty map when canceling a frame. This keeps media controls finalization from allocating while GC is collecting unreachable media elements.
    
Bonus: add VERIFY to crash immediately if we're trying to allocate from the GC heap during an ongoing collection.
